### PR TITLE
refactor(agent-task): delegate controller execution policy to reusable core service (#4303)

### DIFF
--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -1,8 +1,6 @@
 //! `agent-task controller` handlers: durable multi-agent loop controller
 //! lifecycle, spec defaults, and the CLI dispatch bridge.
 
-use std::path::{Path, PathBuf};
-
 use serde_json::Value;
 
 use homeboy::core::agent_task_loop_definition::{
@@ -18,7 +16,6 @@ use homeboy::core::agent_tasks::controller_service::{
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_tasks::scheduler::AgentTaskExecutorAdapter;
 use homeboy::core::config;
-use homeboy::core::git;
 use homeboy::core::proof::validate_proof_value;
 
 use homeboy::core::agent_tasks::dispatch_service;
@@ -103,7 +100,7 @@ pub(super) fn controller_materialize(args: AgentTaskControllerMaterializeArgs) -
             None,
         )
     })?;
-    apply_from_spec_dispatch_defaults(&mut spec, &args.spec);
+    agent_task_controller_service::apply_spec_dispatch_defaults(&mut spec, &args.spec);
     let run_inputs = match args.inputs {
         Some(inputs) => {
             serde_json::from_str(&config::read_json_spec_to_string(&inputs)?).map_err(|error| {
@@ -155,7 +152,7 @@ fn controller_plan(args: AgentTaskControllerPlanArgs) -> CmdResult<Value> {
             None,
         )
     })?;
-    apply_from_spec_dispatch_defaults(&mut spec, &args.spec);
+    agent_task_controller_service::apply_spec_dispatch_defaults(&mut spec, &args.spec);
     let report = agent_task_controller_service::plan_from_spec(ControllerPlanRequest { spec })?;
     Ok((command_json_value(report)?, 0))
 }
@@ -170,7 +167,7 @@ pub(super) fn controller_from_spec(args: AgentTaskControllerFromSpecArgs) -> Cmd
             None,
         )
     })?;
-    apply_from_spec_dispatch_defaults(&mut spec, &args.spec);
+    agent_task_controller_service::apply_spec_dispatch_defaults(&mut spec, &args.spec);
     let report = agent_task_controller_service::init_from_spec(ControllerFromSpecRequest { spec })?;
     if !args.resume {
         return Ok((command_json_value(report)?, 0));
@@ -189,96 +186,6 @@ pub(super) fn controller_from_spec(args: AgentTaskControllerFromSpecArgs) -> Cmd
         }),
         exit_code,
     ))
-}
-
-pub(super) fn apply_from_spec_dispatch_defaults(spec: &mut AgentTaskRepoLoopSpec, spec_arg: &str) {
-    apply_from_spec_dispatch_defaults_with_cwd(spec, spec_arg, || std::env::current_dir().ok());
-}
-
-pub(super) fn apply_from_spec_dispatch_defaults_with_cwd(
-    spec: &mut AgentTaskRepoLoopSpec,
-    spec_arg: &str,
-    current_dir: impl FnOnce() -> Option<PathBuf>,
-) {
-    let Some(root) = dispatch_root_for_spec(spec_arg, current_dir) else {
-        return;
-    };
-    apply_dispatch_defaults_for_root(spec, root);
-}
-
-fn dispatch_root_for_spec(
-    spec_arg: &str,
-    current_dir: impl FnOnce() -> Option<PathBuf>,
-) -> Option<PathBuf> {
-    let current_dir = current_dir();
-    let Some(spec_path) = spec_file_path(spec_arg) else {
-        return current_dir.and_then(|path| dispatch_root_for_current_dir(&path));
-    };
-    if let Some(root) = git_root_for_spec(&spec_path) {
-        return Some(root);
-    }
-    current_dir.and_then(|path| dispatch_root_for_current_dir(&path))
-}
-
-fn dispatch_root_for_current_dir(path: &Path) -> Option<PathBuf> {
-    git_root_for_path(path).or_else(|| {
-        path.is_dir()
-            .then(|| std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
-    })
-}
-
-fn apply_dispatch_defaults_for_root(spec: &mut AgentTaskRepoLoopSpec, root: PathBuf) {
-    let repo = root
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default()
-        .to_string();
-    if repo.is_empty() {
-        return;
-    }
-
-    let metadata = match &mut spec.metadata {
-        Value::Object(metadata) => metadata,
-        _ => {
-            spec.metadata = serde_json::json!({});
-            spec.metadata.as_object_mut().expect("metadata object")
-        }
-    };
-    let defaults = metadata
-        .entry("dispatch_defaults".to_string())
-        .or_insert_with(|| serde_json::json!({}));
-    let Value::Object(defaults) = defaults else {
-        return;
-    };
-    let should_set_cwd = defaults
-        .get("cwd")
-        .and_then(Value::as_str)
-        .map(|cwd| !Path::new(cwd).is_dir())
-        .unwrap_or(true);
-    if should_set_cwd {
-        defaults.insert("cwd".to_string(), Value::String(root.display().to_string()));
-    }
-    defaults
-        .entry("repo".to_string())
-        .or_insert_with(|| Value::String(repo));
-}
-
-fn spec_file_path(spec_arg: &str) -> Option<PathBuf> {
-    if spec_arg == "-" || spec_arg.trim_start().starts_with('{') {
-        return None;
-    }
-    let path = spec_arg.strip_prefix('@').unwrap_or(spec_arg);
-    let path = PathBuf::from(path);
-    path.is_file().then_some(path)
-}
-
-fn git_root_for_spec(spec_path: &Path) -> Option<PathBuf> {
-    let dir = spec_path.parent()?;
-    git_root_for_path(dir)
-}
-
-fn git_root_for_path(path: &Path) -> Option<PathBuf> {
-    git::repo_root(path)
 }
 
 /// Bridge controller spawn-task `"dispatch"` requests into the CLI dispatch path.

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -15,10 +15,8 @@ pub(in crate::commands::agent_task) use super::super::args::{
     AgentTaskLoopArgs, CompileLoopArgs, ReviewArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(in crate::commands::agent_task) use super::super::controller::{
-    apply_controller_event, apply_from_spec_dispatch_defaults,
-    apply_from_spec_dispatch_defaults_with_cwd, controller_materialize,
-    controller_run_action_with_executor, controller_run_next_with_executor,
-    dispatch_args_from_controller_request,
+    apply_controller_event, controller_materialize, controller_run_action_with_executor,
+    controller_run_next_with_executor, dispatch_args_from_controller_request,
 };
 pub(in crate::commands::agent_task) use super::super::run::{
     retry, run_loaded_plan, run_loop_with_executor, run_next_with_executor,
@@ -27,6 +25,10 @@ pub(in crate::commands::agent_task) use super::super::run::{
 pub(in crate::commands::agent_task) use super::super::status::{cancel, logs, status};
 pub(in crate::commands::agent_task) use super::super::{
     review, CancelArgs, ProvidersArgs, RetryArgs,
+};
+pub(crate) use homeboy::core::agent_tasks::controller_service::{
+    apply_spec_dispatch_defaults as apply_from_spec_dispatch_defaults,
+    apply_spec_dispatch_defaults_with_cwd as apply_from_spec_dispatch_defaults_with_cwd,
 };
 pub(crate) use homeboy::core::agent_tasks::controller_service::{
     AgentTaskRepoLoopSpec, ControllerFromSpecRequest,

--- a/src/core/agent_task_controller_service/dispatch_defaults.rs
+++ b/src/core/agent_task_controller_service/dispatch_defaults.rs
@@ -1,0 +1,109 @@
+//! Controller spec dispatch-defaults policy.
+//!
+//! Owns the controller execution policy that derives `cwd`/`repo` dispatch
+//! defaults for a repo-authored loop spec from its source path and the
+//! surrounding git checkout. This logic used to live in the CLI adapter; it is
+//! a reusable core service so callers (CLI, daemon, future automation) all apply
+//! the same defaults before initializing or resuming a controller.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::core::git;
+
+use super::AgentTaskRepoLoopSpec;
+
+/// Apply controller dispatch defaults to `spec`, resolving the dispatch root
+/// from the spec source path and the current working directory.
+pub fn apply_spec_dispatch_defaults(spec: &mut AgentTaskRepoLoopSpec, spec_arg: &str) {
+    apply_spec_dispatch_defaults_with_cwd(spec, spec_arg, || std::env::current_dir().ok());
+}
+
+/// Apply controller dispatch defaults to `spec`, resolving the dispatch root
+/// with a caller-provided current-directory source (used by tests).
+pub fn apply_spec_dispatch_defaults_with_cwd(
+    spec: &mut AgentTaskRepoLoopSpec,
+    spec_arg: &str,
+    current_dir: impl FnOnce() -> Option<PathBuf>,
+) {
+    let Some(root) = dispatch_root_for_spec(spec_arg, current_dir) else {
+        return;
+    };
+    apply_dispatch_defaults_for_root(spec, root);
+}
+
+fn dispatch_root_for_spec(
+    spec_arg: &str,
+    current_dir: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    let current_dir = current_dir();
+    let Some(spec_path) = spec_file_path(spec_arg) else {
+        return current_dir.and_then(|path| dispatch_root_for_current_dir(&path));
+    };
+    if let Some(root) = git_root_for_spec(&spec_path) {
+        return Some(root);
+    }
+    current_dir.and_then(|path| dispatch_root_for_current_dir(&path))
+}
+
+fn dispatch_root_for_current_dir(path: &Path) -> Option<PathBuf> {
+    git_root_for_path(path).or_else(|| {
+        path.is_dir()
+            .then(|| std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
+    })
+}
+
+fn apply_dispatch_defaults_for_root(spec: &mut AgentTaskRepoLoopSpec, root: PathBuf) {
+    let repo = root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_string();
+    if repo.is_empty() {
+        return;
+    }
+
+    let metadata = match &mut spec.metadata {
+        Value::Object(metadata) => metadata,
+        _ => {
+            spec.metadata = serde_json::json!({});
+            spec.metadata.as_object_mut().expect("metadata object")
+        }
+    };
+    let defaults = metadata
+        .entry("dispatch_defaults".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let Value::Object(defaults) = defaults else {
+        return;
+    };
+    let should_set_cwd = defaults
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(|cwd| !Path::new(cwd).is_dir())
+        .unwrap_or(true);
+    if should_set_cwd {
+        defaults.insert("cwd".to_string(), Value::String(root.display().to_string()));
+    }
+    defaults
+        .entry("repo".to_string())
+        .or_insert_with(|| Value::String(repo));
+}
+
+fn spec_file_path(spec_arg: &str) -> Option<PathBuf> {
+    if spec_arg == "-" || spec_arg.trim_start().starts_with('{') {
+        return None;
+    }
+    let path = spec_arg.strip_prefix('@').unwrap_or(spec_arg);
+    let path = PathBuf::from(path);
+    path.is_file().then_some(path)
+}
+
+fn git_root_for_spec(spec_path: &Path) -> Option<PathBuf> {
+    let dir = spec_path.parent()?;
+    git_root_for_path(dir)
+}
+
+fn git_root_for_path(path: &Path) -> Option<PathBuf> {
+    git::repo_root(path)
+}

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -54,6 +54,7 @@ pub const PLAN_RESULT_SCHEMA: &str = "homeboy/agent-task-loop-controller-plan-re
 mod action_state;
 mod actions;
 mod artifacts;
+mod dispatch_defaults;
 mod pr_ownership;
 mod reports;
 mod request;
@@ -63,6 +64,7 @@ mod spec_compile;
 use action_state::*;
 use actions::*;
 use artifacts::*;
+pub use dispatch_defaults::*;
 use pr_ownership::*;
 pub use reports::*;
 pub use request::*;

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -139,7 +139,8 @@ pub use super::agent_task_provider::{
 /// Durable controller execution service entry points and report contracts.
 pub mod controller_service {
     pub use super::super::agent_task_controller_service::{
-        apply_event, init, init_from_spec, list, mark_human_ready, optional_bool, optional_string,
+        apply_event, apply_spec_dispatch_defaults, apply_spec_dispatch_defaults_with_cwd, init,
+        init_from_spec, list, mark_human_ready, optional_bool, optional_string,
         optional_string_array, optional_u32, optional_usize, plan_from_controller_request,
         plan_from_spec, resume, run_action, run_next, status, AgentTaskRepoLoopSpec,
         AgentTaskRepoLoopSpecAbility, AgentTaskRepoLoopSpecAgent, AgentTaskRepoLoopSpecArtifact,


### PR DESCRIPTION
## Summary
One reviewable slice of the **#4303** API-boundary-hardening epic, targeting the second named seam:

> `src/commands/agent_task.rs` still owns controller execution policy instead of delegating to a reusable core service.

This extracts the **controller spec dispatch-defaults policy** out of the CLI adapter (`src/commands/agent_task/controller.rs`) and into the core controller service, so the adapter becomes thin and delegates.

## What was extracted
The `apply_from_spec_dispatch_defaults*` logic — which derives `cwd`/`repo` dispatch defaults for a repo-authored loop spec from its source path and the surrounding git checkout, then mutates `spec.metadata.dispatch_defaults` — was pure controller execution policy living in the command adapter. It is now a new core module:

- **New:** `src/core/agent_task_controller_service/dispatch_defaults.rs` with public `apply_spec_dispatch_defaults` / `apply_spec_dispatch_defaults_with_cwd` plus the private root-resolution helpers (`dispatch_root_for_spec`, `dispatch_root_for_current_dir`, `apply_dispatch_defaults_for_root`, `spec_file_path`, `git_root_for_spec`, `git_root_for_path`).
- Wired into `agent_task_controller_service` (`mod.rs`) and re-exported through the narrow `agent_tasks::controller_service` facade.
- `controller.rs` call sites (`controller_materialize`, `controller_plan`, `controller_from_spec`) now call the core service directly; the local wrapper functions and their `Path`/`git` imports are gone (~89 LOC removed from the adapter).
- Tests now exercise the policy through the core facade (aliased to the prior names in test support — no test-body changes).

## Behavior
Behavior-preserving move/delegate refactor — no logic rewrite. CLI envelopes and dispatch-defaults resolution are identical. The CLI-specific dispatch bridge (`CliDispatchHook`, `ControllerDispatchDefaults`, `dispatch_args_from_controller_request`) intentionally stays in the adapter since it maps onto the CLI `DispatchArgs` type.

## Verification
- `cargo build --lib` compiles cleanly.
- `cargo check --lib --tests` compiles cleanly (no codegen — avoids the heavy test build).
- `homeboy audit homeboy`: no new findings (9 outliers / 0.9043 alignment, identical to `origin/main`); this slice also clears the pre-existing `ThinCommandAdapterViolation` on `controller.rs`.
- `cargo fmt` applied.

## Scope
This is **one slice**. The epic **#4303 stays open** for the remaining seams (Lab offload boundaries, facade narrowing + arch checks, command-contract splitting, Runs/artifact observation extraction).