### PR TITLE
fix(audit): remove dead code findings (#5581)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -493,7 +493,7 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-06-20T15:43:14Z",
-      "item_count": 396,
+      "item_count": 395,
       "known_fingerprints": [
         "compiler::src/core/deploy/planning.rs::CompilerWarning",
         "compiler::src/core/extension/test/run.rs::CompilerWarning",
@@ -676,7 +676,6 @@
         "dead_code::src/core/preview_ingress.rs::UnreferencedExport",
         "dead_code::src/core/process.rs::UnreferencedExport",
         "dead_code::src/core/source_snapshot.rs::UnreferencedExport",
-        "dead_code::tests/core/rig/support.rs::DeadCodeMarker",
         "docs::docs/commands/runtime.md::BrokenDocReference",
         "enum_dispatch_contracts::src/commands/agent_task/review.rs::RepeatedEnumDispatchContract",
         "enum_dispatch_contracts::src/core/rig/capabilities.rs::RepeatedEnumDispatchContract",

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -11,7 +11,25 @@ use std::path::Path;
 #[path = "support.rs"]
 mod support;
 
-use support::{minimal_rig, minimal_stack, write_rig, write_stack, GitFixture};
+use support::{minimal_rig, minimal_stack, run_git, write_rig, write_stack, GitFixture};
+
+/// Source-update-only fixture helpers. These live here rather than in the
+/// shared `support.rs` because only the source-update tests attach to an
+/// existing repo and push back to a bare source; keeping them in the shared
+/// module made them appear dead to `install_test.rs`, which includes the same
+/// `#[path]` module but never pushes.
+impl<'a> GitFixture<'a> {
+    /// Attach to an already-initialized repository in `dir` (e.g. one created
+    /// via a raw `git init` elsewhere) to reuse the commit/push helpers.
+    fn attach(dir: &'a Path) -> Self {
+        Self { dir }
+    }
+
+    /// Push the current `HEAD` to the `main` branch of `source`.
+    fn push_main(&self, source: &str) {
+        run_git(self.dir, &["push", source, "HEAD:main"]);
+    }
+}
 
 fn commit_package(package: &Path, message: &str) {
     GitFixture::attach(package).commit(message);

--- a/tests/core/rig/support.rs
+++ b/tests/core/rig/support.rs
@@ -71,24 +71,16 @@ pub(crate) fn run_git(dir: &Path, args: &[&str]) {
 /// Tests that assert *failure* behavior or inspect raw git output should keep
 /// using [`run_git`] / explicit `Command::new("git")` calls instead.
 pub(crate) struct GitFixture<'a> {
-    dir: &'a Path,
+    /// Repository working directory. Exposed within the support module so
+    /// per-test-file extension `impl`s (see `source_test.rs`) can build their
+    /// own fixtures without re-running `git init`.
+    pub(crate) dir: &'a Path,
 }
 
 impl<'a> GitFixture<'a> {
     /// Initialize a git repository in `dir` on the `main` branch.
     pub(crate) fn init(dir: &'a Path) -> Self {
         run_git(dir, &["init", "-b", "main"]);
-        Self { dir }
-    }
-
-    /// Attach to an already-initialized repository in `dir` (e.g. one created
-    /// via a raw `git init` elsewhere) to reuse the commit/push helpers.
-    ///
-    /// `allow(dead_code)`: this shared support module is `#[path]`-included
-    /// separately into each rig test file, so helpers used by only one of them
-    /// (here, the source-update tests) appear unused from the other's view.
-    #[allow(dead_code)]
-    pub(crate) fn attach(dir: &'a Path) -> Self {
         Self { dir }
     }
 
@@ -126,14 +118,6 @@ impl<'a> GitFixture<'a> {
             ],
         );
         bare
-    }
-
-    /// Push the current `HEAD` to the `main` branch of `source`.
-    ///
-    /// `allow(dead_code)`: only the source-update tests push; see `attach`.
-    #[allow(dead_code)]
-    pub(crate) fn push_main(&self, source: &str) {
-        run_git(self.dir, &["push", source, "HEAD:main"]);
     }
 }
 


### PR DESCRIPTION
## Summary
Resolves the 2 `dead_code_marker` audit findings in `tests/core/rig/support.rs` (#5581): `#[allow(dead_code)]` on `GitFixture::attach` (line 90) and `GitFixture::push_main` (line 134).

## Root cause
`support.rs` is `#[path]`-included separately into both `source_test.rs` and `install_test.rs`. `attach`/`push_main` are only used by the source-update tests, so from `install_test.rs`'s compilation view they looked unused — hence the `#[allow(dead_code)]` suppressions, which the dead-code detector flags.

## Fix
- Removed both `#[allow(dead_code)]` markers (and the helpers) from the shared `support.rs`.
- Relocated `attach`/`push_main` into a per-file inherent `impl` block in `source_test.rs` (their only consumer), so no suppression is needed anywhere.
- Exposed `GitFixture::dir` as `pub(crate)` within the support module so the extension `impl` can construct fixtures without re-running `git init`.
- Dropped the now-obsolete `dead_code::tests/core/rig/support.rs::DeadCodeMarker` baseline entry from `homeboy.json` and decremented `item_count` accordingly.

## Verification
- `homeboy audit homeboy --changed-since origin/main` → `passed: true`, no `support.rs` / dead_code_marker entries in active findings.
- `cargo build --lib` compiles clean (only pre-existing baselined warnings).
- `cargo fmt` clean. Core stays language/framework agnostic; `docs/changelog.md` untouched.