### PR TITLE
Summarize controller resume failures

### DIFF
--- a/src/core/agent_task_controller_service/actions.rs
+++ b/src/core/agent_task_controller_service/actions.rs
@@ -35,6 +35,8 @@ where
                 )?;
             }
             controller::write_controller(record)?;
+            let failure_summary = (exit_code != 0)
+                .then(|| controller_action_failure_summary(record, &action, &execution));
             Ok(AgentTaskRunResult {
                 value: ControllerActionReport {
                     schema: ACTION_RESULT_SCHEMA,
@@ -49,6 +51,7 @@ where
                         }
                         .to_string(),
                     ),
+                    failure_summary,
                     execution: Some(execution),
                     controller: record.clone(),
                 },
@@ -60,6 +63,149 @@ where
             controller::write_controller(record)?;
             Err(error)
         }
+    }
+}
+
+fn controller_action_failure_summary(
+    record: &AgentTaskLoopControllerRecord,
+    action: &AgentTaskLoopPolicyActionRecord,
+    execution: &Value,
+) -> ControllerActionFailureSummary {
+    let request = action_request(&action.action);
+    let context = find_failure_context(execution).unwrap_or_default();
+    ControllerActionFailureSummary {
+        action_id: action.action_id.clone(),
+        dedupe_key: action.dedupe_key.clone(),
+        workflow_id: request.and_then(workflow_id_from_request),
+        run_id: request
+            .and_then(|request| string_field(request, "run_id"))
+            .or_else(|| find_string_field(execution, "run_id")),
+        task_id: context
+            .task_id
+            .or_else(|| find_string_field(execution, "task_id")),
+        phase: Some(record.phase.clone()),
+        provider: context.provider,
+        failure_phase: context.failure_phase,
+        diagnostic: context
+            .diagnostic
+            .or_else(|| first_action_diagnostic_message(record, &action.action_id))
+            .unwrap_or_else(|| "controller action failed".to_string()),
+    }
+}
+
+fn action_request(action: &AgentTaskLoopPolicyAction) -> Option<&Value> {
+    match action {
+        AgentTaskLoopPolicyAction::SpawnTask { request, .. }
+        | AgentTaskLoopPolicyAction::SpawnController { request, .. }
+        | AgentTaskLoopPolicyAction::SpawnSubloop { request, .. } => Some(request),
+        AgentTaskLoopPolicyAction::FanOut {
+            request_template, ..
+        }
+        | AgentTaskLoopPolicyAction::RouteFinding {
+            request_template, ..
+        } => Some(request_template),
+        _ => None,
+    }
+}
+
+fn workflow_id_from_request(request: &Value) -> Option<String> {
+    let context = request.pointer("/dispatch/client_context")?;
+    if let Some(workflow_id) = context.get("workflow_id").and_then(Value::as_str) {
+        return Some(workflow_id.to_string());
+    }
+    let context = context.as_str()?;
+    let parsed: Value = serde_json::from_str(context).ok()?;
+    string_field(&parsed, "workflow_id")
+}
+
+fn first_action_diagnostic_message(
+    record: &AgentTaskLoopControllerRecord,
+    action_id: &str,
+) -> Option<String> {
+    record
+        .next_actions
+        .iter()
+        .find(|candidate| candidate.action_id == action_id)?
+        .diagnostics
+        .first()
+        .map(|diagnostic| diagnostic.message.clone())
+}
+
+#[derive(Default)]
+struct FailureContext {
+    diagnostic: Option<String>,
+    task_id: Option<String>,
+    provider: Option<String>,
+    failure_phase: Option<String>,
+}
+
+fn find_failure_context(value: &Value) -> Option<FailureContext> {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::Array(diagnostics)) = map.get("diagnostics") {
+                if let Some(diagnostic) = diagnostics.iter().find_map(Value::as_object) {
+                    let message = diagnostic
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    if message.is_some() {
+                        return Some(FailureContext {
+                            diagnostic: message,
+                            task_id: string_field(value, "task_id"),
+                            provider: diagnostic
+                                .get("provider")
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                                .or_else(|| nested_string_field(diagnostic, "data", "provider"))
+                                .or_else(|| nested_string_field(diagnostic, "data", "provider_id")),
+                            failure_phase: diagnostic
+                                .get("phase")
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                                .or_else(|| nested_string_field(diagnostic, "data", "phase"))
+                                .or_else(|| {
+                                    diagnostic
+                                        .get("class")
+                                        .and_then(Value::as_str)
+                                        .map(str::to_string)
+                                }),
+                        });
+                    }
+                }
+            }
+            map.values().find_map(find_failure_context)
+        }
+        Value::Array(items) => items.iter().find_map(find_failure_context),
+        _ => None,
+    }
+}
+
+fn string_field(value: &Value, field: &str) -> Option<String> {
+    value.get(field).and_then(Value::as_str).map(str::to_string)
+}
+
+fn nested_string_field(
+    map: &serde_json::Map<String, Value>,
+    parent: &str,
+    field: &str,
+) -> Option<String> {
+    map.get(parent)?.get(field)?.as_str().map(str::to_string)
+}
+
+fn find_string_field(value: &Value, field: &str) -> Option<String> {
+    match value {
+        Value::Object(map) => map
+            .get(field)
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| {
+                map.values()
+                    .find_map(|value| find_string_field(value, field))
+            }),
+        Value::Array(items) => items
+            .iter()
+            .find_map(|value| find_string_field(value, field)),
+        _ => None,
     }
 }
 

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -307,6 +307,7 @@ where
                 claimed: false,
                 action_id: None,
                 status: None,
+                failure_summary: None,
                 execution: None,
                 controller: record,
             },

--- a/src/core/agent_task_controller_service/reports.rs
+++ b/src/core/agent_task_controller_service/reports.rs
@@ -64,8 +64,31 @@ pub struct ControllerActionReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_summary: Option<ControllerActionFailureSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub execution: Option<Value>,
     pub controller: AgentTaskLoopControllerRecord,
+}
+
+/// Concise failed-action context for controller resume operators.
+#[derive(Debug, Clone, Serialize)]
+pub struct ControllerActionFailureSummary {
+    pub action_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dedupe_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_phase: Option<String>,
+    pub diagnostic: String,
 }
 
 /// Typed report returned by `resume`.

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -27,6 +27,9 @@ struct CapturingDispatchHook {
 }
 
 #[derive(Clone, Default)]
+struct FailingDispatchHook;
+
+#[derive(Clone, Default)]
 struct ArtifactDispatchHook {
     observed_requests: Arc<Mutex<Vec<Value>>>,
 }
@@ -55,6 +58,32 @@ impl ControllerDispatchHook for CapturingDispatchHook {
                 "run_id": format!("generic-run-{}", entity_id.replace([':', '/', '#', ' '], "_")),
             }),
             0,
+        ))
+    }
+}
+
+impl ControllerDispatchHook for FailingDispatchHook {
+    fn dispatch(&self, _request: &Value) -> Result<(Value, i32)> {
+        Ok((
+            json!({
+                "schema": "homeboy/test-generic-dispatch-result/v1",
+                "run_id": "generic-run-overlay",
+                "aggregate": {
+                    "outcomes": [{
+                        "task_id": "task-overlay-prepare",
+                        "status": "failed",
+                        "diagnostics": [{
+                            "class": "provider.runtime_overlay",
+                            "message": "Recipe runtime overlay preparation failed: download php-scoper timed out after 60004ms",
+                            "data": {
+                                "provider": "codebox",
+                                "phase": "runtime_overlay_preparation"
+                            }
+                        }]
+                    }]
+                }
+            }),
+            1,
         ))
     }
 }
@@ -1444,6 +1473,79 @@ fn resume_fails_required_workflow_artifact_handoff_before_downstream_action() {
                 && event.payload["diagnostics"][0]["code"]
                     == json!("required_workflow_artifacts_missing")
         }));
+    });
+}
+
+#[test]
+fn resume_failed_action_result_includes_top_level_failure_summary() {
+    with_isolated_home(|_| {
+        let mut record = init(ControllerInitRequest {
+            loop_id: "loop-service-failure-summary".to_string(),
+            phase: "prepare".to_string(),
+            config_version: "v1".to_string(),
+        })
+        .expect("controller initialized");
+        let workflow_context = json!({
+            "schema": "homeboy/repo-loop-workflow-context/v1",
+            "workflow_id": "scope-runtime",
+        });
+        record.record_action(
+            AgentTaskLoopPolicyAction::SpawnTask {
+                dedupe_key: "workflow:scope-runtime".to_string(),
+                entity_id: None,
+                request: json!({
+                    "mode": "dispatch",
+                    "dispatch": {
+                        "client_context": workflow_context.to_string()
+                    }
+                }),
+            },
+            "prepare runtime overlay",
+        );
+        controller::write_controller(&record).expect("controller written");
+
+        let result = resume(
+            "loop-service-failure-summary",
+            CapturingExecutor::default(),
+            &FailingDispatchHook,
+        )
+        .expect("controller resumed");
+
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.results.len(), 1);
+        let failed = &result.value.results[0];
+        assert_eq!(failed["status"], json!("failed"));
+        assert_eq!(failed["failure_summary"]["action_id"], failed["action_id"]);
+        assert_eq!(
+            failed["failure_summary"]["dedupe_key"],
+            json!("workflow:scope-runtime")
+        );
+        assert_eq!(
+            failed["failure_summary"]["workflow_id"],
+            json!("scope-runtime")
+        );
+        assert_eq!(
+            failed["failure_summary"]["run_id"],
+            json!("generic-run-overlay")
+        );
+        assert_eq!(
+            failed["failure_summary"]["task_id"],
+            json!("task-overlay-prepare")
+        );
+        assert_eq!(failed["failure_summary"]["phase"], json!("prepare"));
+        assert_eq!(failed["failure_summary"]["provider"], json!("codebox"));
+        assert_eq!(
+            failed["failure_summary"]["failure_phase"],
+            json!("runtime_overlay_preparation")
+        );
+        assert_eq!(
+            failed["failure_summary"]["diagnostic"],
+            json!("Recipe runtime overlay preparation failed: download php-scoper timed out after 60004ms")
+        );
+        assert_eq!(
+            failed["execution"]["result"]["aggregate"]["outcomes"][0]["diagnostics"][0]["message"],
+            failed["failure_summary"]["diagnostic"]
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
- Add a top-level failure_summary to failed controller action reports emitted during resume.
- Surface action/run/workflow/provider/phase context plus the primary diagnostic from nested execution payloads.
- Cover the generic dispatch failure shape with a focused controller service test.

## Verification
- homeboy test --runner homeboy-lab --skip-lint -- agent_task_controller_service::tests::resume_failed_action_result_includes_top_level_failure_summary
- homeboy lint --runner homeboy-lab

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Improving controller failure diagnostics for composable loop operators.