### PR TITLE
Surface rig bench_prepare failure details

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -14,7 +14,7 @@ use homeboy::core::extension::bench::{
 };
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::rig::lease::ActiveRigRunLease;
-use homeboy::core::rig::{self, BenchSpec, RigSpec, RigStateSnapshot};
+use homeboy::core::rig::{self, BenchPrepareReport, BenchSpec, RigSpec, RigStateSnapshot};
 
 use super::observation::{self, BenchObservationStart};
 use super::{BenchRunArgs, CmdResult};
@@ -41,7 +41,7 @@ fn prepare_rig_bench_context(
             return Err(homeboy::core::Error::rig_pipeline_failed(
                 &spec.id,
                 "bench_prepare",
-                "rig bench preparation failed; refusing to run bench workload",
+                bench_prepare_failure_message(&prepare),
             ));
         }
     }
@@ -55,6 +55,30 @@ fn prepare_rig_bench_context(
         snapshot,
         _lease: lease,
     })
+}
+
+fn bench_prepare_failure_message(prepare: &BenchPrepareReport) -> String {
+    let failed_steps = prepare
+        .pipeline
+        .steps
+        .iter()
+        .filter(|step| step.status == "fail")
+        .map(|step| match step.error.as_deref() {
+            Some(error) if !error.is_empty() => {
+                format!("{} `{}` failed: {}", step.kind, step.label, error)
+            }
+            _ => format!("{} `{}` failed", step.kind, step.label),
+        })
+        .collect::<Vec<_>>();
+
+    if failed_steps.is_empty() {
+        "rig bench preparation failed; refusing to run bench workload".to_string()
+    } else {
+        format!(
+            "rig bench preparation failed; refusing to run bench workload. Failed bench_prepare steps: {}",
+            failed_steps.join("; ")
+        )
+    }
 }
 
 fn bench_prepare_settings(args: &BenchRunArgs) -> Vec<(String, String)> {

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -768,7 +768,18 @@ fn run_requirement_step(
             cwd.as_deref(),
             env,
             settings,
-        )?;
+        )
+        .map_err(|error| {
+            requirement_failed(
+                rig,
+                format!(
+                    "{}; prepare command failed: {}",
+                    missing_before_prepare.join("; "),
+                    error
+                ),
+                remediation.as_deref(),
+            )
+        })?;
     }
 
     let missing = path_specs

--- a/tests/core/rig/bench_prepare_pipeline_test.rs
+++ b/tests/core/rig/bench_prepare_pipeline_test.rs
@@ -171,7 +171,71 @@ fn failing_bench_prepare_aborts_before_check_and_workload() {
         };
 
         assert!(error.to_string().contains("bench_prepare"));
+        assert!(error.to_string().contains("bench prep"));
+        assert!(error.to_string().contains("exit 7"));
         assert_eq!(log_lines(&log_path), vec!["prepare"]);
+    });
+}
+
+#[test]
+fn failing_bench_prepare_requirement_reports_context() {
+    with_isolated_home(|home| {
+        let component = tempfile::TempDir::new().expect("component");
+        let log_dir = tempfile::TempDir::new().expect("log dir");
+        let log_path = log_dir.path().join("order.log");
+        let missing_marker = component.path().join("ready.marker");
+        write_logging_bench_extension(home, &log_path);
+
+        let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+        fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+        let spec = serde_json::json!({
+            "components": {
+                "studio": {
+                    "path": component.path(),
+                    "extensions": { "fixture-bench": {} }
+                }
+            },
+            "bench": { "default_component": "studio" },
+            "pipeline": {
+                "bench_prepare": [{
+                    "kind": "requirement",
+                    "label": "prepare fixture marker",
+                    "file": missing_marker,
+                    "prepare_command": "printf 'prepare-command\\n'; exit 9",
+                    "prepare_phases": ["bench_prepare"],
+                    "remediation": "create the fixture marker before benchmarking"
+                }]
+            }
+        });
+        fs::write(
+            rig_dir.join("failing-requirement-rig.json"),
+            serde_json::to_string(&spec).expect("serialize rig"),
+        )
+        .expect("write rig");
+
+        let error = match run(
+            run_args(
+                None,
+                vec!["failing-requirement-rig".to_string()],
+                Vec::new(),
+            ),
+            &GlobalArgs {},
+        ) {
+            Ok(_) => panic!("bench should fail before workload"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(error.contains("prepare fixture marker"), "error: {error}");
+        assert!(
+            error.contains(missing_marker.to_str().unwrap()),
+            "error: {error}"
+        );
+        assert!(error.contains("printf 'prepare-command"), "error: {error}");
+        assert!(
+            error.contains("create the fixture marker before benchmarking"),
+            "error: {error}"
+        );
+        assert_eq!(log_lines(&log_path), Vec::<String>::new());
     });
 }
 


### PR DESCRIPTION
## Summary
- Include failed bench_prepare step kind, label, and error details in the bench refusal error.
- Preserve requirement context when a requirement prepare_command fails, including the missing requirement detail and remediation.
- Add focused bench_prepare tests covering command failures and requirement failure diagnostics.

## Verification
- homeboy test --runner homeboy-lab --skip-lint --allow-dirty-lab-workspace -- bench_prepare_pipeline_test
- homeboy lint --runner homeboy-lab --allow-dirty-lab-workspace

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the rig bench_prepare failure path, implementing the diagnostic surfacing change, adding focused tests, and preparing this PR.