### PR TITLE
Highlight key artifacts in run summaries

### DIFF
--- a/src/commands/bench_summary.rs
+++ b/src/commands/bench_summary.rs
@@ -81,6 +81,10 @@ fn render_single_summary(output: &Value) -> String {
     lines.extend(bench_hotspot_lines(output));
     lines.extend(bench_coverage_lines(output));
     lines.extend(gate_failure_lines(output));
+    lines.extend(key_artifact_lines(
+        output,
+        persisted_run_id(output).as_deref(),
+    ));
     lines.extend(artifact_lines(output));
     lines.extend(failure_lines(output));
     lines.extend(hint_lines(output));
@@ -253,23 +257,18 @@ fn artifact_lines(output: &Value) -> Vec<String> {
     lines
 }
 
+fn key_artifact_lines(output: &Value, run_id: Option<&str>) -> Vec<String> {
+    value_at(output, &["artifacts"])
+        .and_then(Value::as_array)
+        .map(|artifacts| super::key_artifacts::key_artifact_lines(artifacts, run_id, false))
+        .unwrap_or_default()
+}
+
 /// Best on-disk / network locator for an artifact ref, in preference order.
 /// Paths come first because shared-state and bundle artifacts are local
 /// files the operator wants to open directly.
 fn artifact_locator(artifact: &Value) -> Option<String> {
-    for key in [
-        "path",
-        "local_url",
-        "viewer_url",
-        "preview_url",
-        "public_url",
-        "url",
-    ] {
-        if let Some(value) = string_value(artifact, &[key]) {
-            return Some(value.to_string());
-        }
-    }
-    None
+    super::key_artifacts::artifact_locator(artifact).map(str::to_string)
 }
 
 fn failure_lines(output: &Value) -> Vec<String> {
@@ -497,6 +496,43 @@ mod tests {
         assert!(summary.contains("Failure: scenario rtc-smoke exceeded budget\n"));
         // No persisted run id: suggest --json for full output.
         assert!(summary.contains("Full output: re-run with --json\n"));
+    }
+
+    #[test]
+    fn single_summary_surfaces_key_artifacts_before_full_artifact_list() {
+        let payload = single_payload(json!({
+            "passed": true,
+            "status": "passed",
+            "component": "homeboy",
+            "iterations": 1,
+            "artifacts": [
+                {
+                    "scenario_id": "scenario-a",
+                    "name": "route_inventory",
+                    "observation_artifact_id": "artifact-route-inventory",
+                    "path": "/tmp/route-inventory.json"
+                },
+                {
+                    "scenario_id": "scenario-a",
+                    "name": "transcript",
+                    "path": "/tmp/transcript.txt"
+                }
+            ],
+            "persisted_run": {
+                "run_id": "bench-run-42"
+            }
+        }));
+
+        let summary = render_bench_summary(&payload).expect("summary");
+        let key_index = summary.find("Key artifacts:\n").expect("key artifacts");
+        let artifact_index = summary.find("Artifacts (2):\n").expect("artifacts");
+
+        assert!(key_index < artifact_index);
+        assert!(summary.contains("  scenario-a/route_inventory: /tmp/route-inventory.json\n"));
+        assert!(summary.contains(
+            "    get: homeboy runs artifact get bench-run-42 artifact-route-inventory -o <path>\n"
+        ));
+        assert!(!summary.contains("Key artifacts:\n  scenario-a/transcript"));
     }
 
     #[test]

--- a/src/commands/key_artifacts.rs
+++ b/src/commands/key_artifacts.rs
@@ -1,0 +1,136 @@
+use serde_json::Value;
+
+use super::summary_json::string_value;
+
+const KEY_ARTIFACT_MARKERS: &[&str] = &[
+    "admin_page_coverage",
+    "route_inventory",
+    "coverage",
+    "raw_result",
+];
+
+pub(crate) fn key_artifact_lines(
+    artifacts: &[Value],
+    run_id: Option<&str>,
+    include_type_guard: bool,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    for artifact in artifacts
+        .iter()
+        .filter(|artifact| is_key_artifact(artifact))
+    {
+        let scenario = string_value(artifact, &["scenario_id"]).unwrap_or("global");
+        let name = artifact_name(artifact);
+        let mut line = format!("  {scenario}/{name}");
+        if let Some(locator) = artifact_locator(artifact) {
+            line.push_str(": ");
+            line.push_str(locator);
+        }
+        lines.push(line);
+        if let (Some(run_id), Some(artifact_id)) = (run_id, artifact_get_id(artifact)) {
+            if !include_type_guard || string_value(artifact, &["type"]) == Some("file") {
+                lines.push(format!(
+                    "    get: homeboy runs artifact get {run_id} {artifact_id} -o <path>"
+                ));
+            }
+        }
+    }
+    if !lines.is_empty() {
+        lines.insert(0, "Key artifacts:".to_string());
+    }
+    lines
+}
+
+pub(crate) fn artifact_locator(artifact: &Value) -> Option<&str> {
+    for key in [
+        "path",
+        "local_url",
+        "viewer_url",
+        "preview_url",
+        "public_url",
+        "url",
+    ] {
+        if let Some(value) = string_value(artifact, &[key]) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn is_key_artifact(artifact: &Value) -> bool {
+    [
+        string_value(artifact, &["name"]),
+        string_value(artifact, &["kind"]),
+        string_value(artifact, &["id"]),
+        string_value(artifact, &["artifact_id"]),
+        string_value(artifact, &["observation_artifact_id"]),
+    ]
+    .into_iter()
+    .flatten()
+    .any(|value| {
+        let normalized = value.to_ascii_lowercase().replace('-', "_");
+        KEY_ARTIFACT_MARKERS.contains(&normalized.as_str())
+    })
+}
+
+fn artifact_name(artifact: &Value) -> &str {
+    string_value(artifact, &["name"])
+        .or_else(|| string_value(artifact, &["id"]))
+        .or_else(|| string_value(artifact, &["artifact_id"]))
+        .or_else(|| string_value(artifact, &["kind"]))
+        .unwrap_or("artifact")
+}
+
+fn artifact_get_id(artifact: &Value) -> Option<&str> {
+    string_value(artifact, &["observation_artifact_id"])
+        .or_else(|| string_value(artifact, &["id"]))
+        .or_else(|| string_value(artifact, &["artifact_id"]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn highlights_generic_key_artifacts_with_get_commands() {
+        let artifacts = vec![
+            json!({
+                "scenario_id": "admin",
+                "name": "coverage",
+                "observation_artifact_id": "artifact-1",
+                "path": "/tmp/coverage.json"
+            }),
+            json!({
+                "scenario_id": "routes",
+                "name": "route-inventory",
+                "id": "artifact-2",
+                "viewer_url": "https://example.test/routes"
+            }),
+            json!({ "scenario_id": "other", "name": "transcript", "path": "/tmp/log.txt" }),
+        ];
+
+        let lines = key_artifact_lines(&artifacts, Some("run-1"), false).join("\n");
+
+        assert!(lines.starts_with("Key artifacts:\n"));
+        assert!(lines.contains("  admin/coverage: /tmp/coverage.json\n"));
+        assert!(lines.contains("    get: homeboy runs artifact get run-1 artifact-1 -o <path>\n"));
+        assert!(lines.contains("  routes/route-inventory: https://example.test/routes\n"));
+        assert!(lines.contains("    get: homeboy runs artifact get run-1 artifact-2 -o <path>"));
+        assert!(!lines.contains("transcript"));
+    }
+
+    #[test]
+    fn can_require_file_type_for_runs_artifacts() {
+        let artifacts = vec![
+            json!({ "id": "coverage", "type": "url", "url": "https://example.test" }),
+            json!({ "id": "raw_result", "type": "file", "path": "/tmp/raw.json" }),
+        ];
+
+        let lines = key_artifact_lines(&artifacts, Some("run-1"), true).join("\n");
+
+        assert!(lines.contains("  global/coverage: https://example.test\n"));
+        assert!(!lines.contains("homeboy runs artifact get run-1 coverage"));
+        assert!(lines.contains("homeboy runs artifact get run-1 raw_result -o <path>"));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,8 @@ use serde_json::{Map, Value};
 
 pub type CmdResult<T> = homeboy::core::Result<(T, i32)>;
 
+mod key_artifacts;
+
 pub(crate) fn escape_markdown_table_cell(value: &str) -> String {
     value.replace('|', "\\|")
 }

--- a/src/commands/runs_summary.rs
+++ b/src/commands/runs_summary.rs
@@ -56,6 +56,7 @@ fn render_run_detail(run: &Value) -> String {
         lines.extend(super::bench_summary::bench_hotspot_lines(run));
         lines.extend(super::bench_summary::bench_coverage_lines(run));
     }
+    lines.extend(key_artifact_lines(run, run_id));
     lines.extend(artifact_lines(run, run_id));
     lines.push(format!("Full output: homeboy runs show {run_id} --json"));
 
@@ -96,18 +97,15 @@ fn artifact_lines(run: &Value, run_id: &str) -> Vec<String> {
     lines
 }
 
+fn key_artifact_lines(run: &Value, run_id: &str) -> Vec<String> {
+    value_at(run, &["artifacts"])
+        .and_then(Value::as_array)
+        .map(|artifacts| super::key_artifacts::key_artifact_lines(artifacts, Some(run_id), true))
+        .unwrap_or_default()
+}
+
 fn artifact_locator(artifact: &Value) -> Option<String> {
-    if string_value(artifact, &["type"]) == Some("file") {
-        if let Some(path) = string_value(artifact, &["path"]) {
-            return Some(path.to_string());
-        }
-    }
-    for key in ["viewer_url", "public_url", "url", "path"] {
-        if let Some(value) = string_value(artifact, &[key]) {
-            return Some(value.to_string());
-        }
-    }
-    None
+    super::key_artifacts::artifact_locator(artifact).map(str::to_string)
 }
 
 fn finish(lines: Vec<String>) -> String {
@@ -320,6 +318,50 @@ mod tests {
         assert!(summary.contains("  Coverage gaps: 3\n"));
         assert!(summary.contains("    api: 2\n"));
         assert!(summary.contains("    cli: 1\n"));
+    }
+
+    #[test]
+    fn show_summary_surfaces_key_artifacts_before_full_artifact_list() {
+        let payload = json!({
+            "variant": "show",
+            "payload": {
+                "command": "runs.show",
+                "run": {
+                    "id": "run-1",
+                    "kind": "test",
+                    "status": "pass",
+                    "metadata": {},
+                    "artifacts": [
+                        {
+                            "id": "artifact-coverage",
+                            "run_id": "run-1",
+                            "scenario_id": "scenario-a",
+                            "kind": "coverage",
+                            "type": "file",
+                            "path": "/tmp/coverage.json"
+                        },
+                        {
+                            "id": "artifact-log",
+                            "run_id": "run-1",
+                            "scenario_id": "scenario-a",
+                            "kind": "log",
+                            "type": "file",
+                            "path": "/tmp/log.txt"
+                        }
+                    ]
+                }
+            }
+        });
+
+        let summary = render_runs_show_summary(&payload).expect("summary");
+        let key_index = summary.find("Key artifacts:\n").expect("key artifacts");
+        let artifact_index = summary.find("Artifacts (2):\n").expect("artifacts");
+
+        assert!(key_index < artifact_index);
+        assert!(summary.contains("  scenario-a/artifact-coverage: /tmp/coverage.json\n"));
+        assert!(summary
+            .contains("    get: homeboy runs artifact get run-1 artifact-coverage -o <path>\n"));
+        assert!(!summary.contains("Key artifacts:\n  scenario-a/artifact-log"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a generic key-artifact summary section for coverage-oriented artifacts in `homeboy runs show` and bench compact summaries.
- Match key artifacts by generic `name`, `kind`, or artifact id markers such as `admin_page_coverage`, `route_inventory`, `coverage`, and `raw_result`.
- Include scenario/name labels and `homeboy runs artifact get ...` commands when a retrievable artifact id is available.

## Verification
- `homeboy test --runner homeboy-lab --skip-lint --allow-dirty-lab-workspace -- key_artifacts` — 4 passed, 0 failed.
- `homeboy lint --runner homeboy-lab --allow-dirty-lab-workspace --summary` — passed with no findings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the summary rendering change, adding focused tests, and preparing the PR.