### PR TITLE
feat(agent-task): summarize controller runs

### DIFF
--- a/src/commands/agent_task_summary.rs
+++ b/src/commands/agent_task_summary.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use super::agent_task::{AgentTaskArgs, AgentTaskCommand};
+use super::agent_task::{AgentTaskArgs, AgentTaskCommand, AgentTaskControllerCommand};
 use super::summary_json::{array_len, string_value, u64_value, usize_value, value_at};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -9,14 +9,25 @@ pub(crate) enum AgentTaskSummaryKind {
     Status,
     Logs,
     Review,
+    Controller,
 }
 
 pub(crate) fn agent_task_summary_kind(args: &AgentTaskArgs) -> Option<AgentTaskSummaryKind> {
-    match args.command {
+    match &args.command {
         AgentTaskCommand::Cook(_) => Some(AgentTaskSummaryKind::Cook),
         AgentTaskCommand::Status(_) => Some(AgentTaskSummaryKind::Status),
         AgentTaskCommand::Logs(_) => Some(AgentTaskSummaryKind::Logs),
         AgentTaskCommand::Review(_) => Some(AgentTaskSummaryKind::Review),
+        AgentTaskCommand::Controller(controller_args) => match &controller_args.command {
+            AgentTaskControllerCommand::Status(_)
+            | AgentTaskControllerCommand::RunNext(_)
+            | AgentTaskControllerCommand::Run(_)
+            | AgentTaskControllerCommand::Resume(_) => Some(AgentTaskSummaryKind::Controller),
+            AgentTaskControllerCommand::FromSpec(args) if args.resume => {
+                Some(AgentTaskSummaryKind::Controller)
+            }
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -30,6 +41,7 @@ pub(crate) fn render_agent_task_summary(
         AgentTaskSummaryKind::Status => render_status_summary(payload),
         AgentTaskSummaryKind::Logs => render_logs_summary(payload),
         AgentTaskSummaryKind::Review => render_review_summary(payload),
+        AgentTaskSummaryKind::Controller => render_controller_summary(payload),
     }
 }
 
@@ -185,6 +197,242 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Next: {next}"));
     }
     Some(finish(lines))
+}
+
+fn render_controller_summary(payload: &Value) -> Option<String> {
+    let controller = controller_payload(payload)?;
+    let loop_id =
+        string_value(controller, &["loop_id"]).or_else(|| string_value(payload, &["loop_id"]))?;
+    let state = string_value(controller, &["state"]).unwrap_or("unknown");
+    let phase = string_value(controller, &["phase"]).unwrap_or("unknown");
+    let current_step = controller_current_step(controller).unwrap_or("none");
+    let totals = controller_totals(controller);
+
+    let mut lines = vec![
+        "Agent task controller".to_string(),
+        format!("Loop: {loop_id}"),
+        format!("State: {state}"),
+        format!("Current step: {phase} / {current_step}"),
+        format!(
+            "Actions: {} pending / {} running / {} completed / {} failed / {} total",
+            totals.pending, totals.running, totals.completed, totals.failed, totals.total
+        ),
+        format!(
+            "Entities: {} total / {} human-ready",
+            totals.entities, totals.human_ready
+        ),
+        format!("Runs: {}", totals.runs),
+        format!("Artifacts: {}", totals.artifacts),
+    ];
+
+    if let Some(failure) = controller_last_failure(payload, controller) {
+        lines.push(format!("Last failure: {failure}"));
+    }
+    for artifact in controller_key_artifacts(controller).into_iter().take(3) {
+        lines.push(format!("Artifact: {artifact}"));
+    }
+    if let Some(recovery) = first_controller_recovery_command(payload) {
+        lines.push(format!("Next: {recovery}"));
+    } else if totals.pending > 0 {
+        lines.push(format!(
+            "Next: homeboy agent-task controller resume {loop_id}"
+        ));
+    } else {
+        lines.push(format!(
+            "Next: homeboy agent-task controller status {loop_id}"
+        ));
+    }
+
+    Some(finish(lines))
+}
+
+fn controller_payload<'a>(payload: &'a Value) -> Option<&'a Value> {
+    value_at(payload, &["controller"])
+        .or_else(|| value_at(payload, &["resume", "controller"]))
+        .or_else(|| value_at(payload, &["from_spec", "controller"]))
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct ControllerTotals {
+    total: usize,
+    pending: usize,
+    running: usize,
+    completed: usize,
+    failed: usize,
+    entities: usize,
+    human_ready: usize,
+    runs: usize,
+    artifacts: usize,
+}
+
+fn controller_totals(controller: &Value) -> ControllerTotals {
+    let mut totals = ControllerTotals {
+        entities: value_at(controller, &["entities"])
+            .and_then(Value::as_object)
+            .map(|entities| entities.len())
+            .unwrap_or(0),
+        runs: array_len(controller, &["task_lineage"]).unwrap_or(0),
+        artifacts: controller_artifact_count(controller),
+        ..ControllerTotals::default()
+    };
+
+    if let Some(entities) = value_at(controller, &["entities"]).and_then(Value::as_object) {
+        totals.human_ready = entities
+            .values()
+            .filter(|entity| {
+                value_at(entity, &["human_ready"])
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            })
+            .count();
+    }
+
+    if let Some(actions) = value_at(controller, &["next_actions"]).and_then(Value::as_array) {
+        totals.total = actions.len();
+        for action in actions {
+            match string_value(action, &["status"]).unwrap_or("unknown") {
+                "pending" => totals.pending += 1,
+                "running" => totals.running += 1,
+                "completed" | "already_satisfied" => totals.completed += 1,
+                "failed"
+                | "blocked_runner_unavailable"
+                | "blocked_remote_materialization"
+                | "blocked_local_fallback_denied" => totals.failed += 1,
+                _ => {}
+            }
+        }
+    }
+
+    totals
+}
+
+fn controller_current_step(controller: &Value) -> Option<&str> {
+    let actions = value_at(controller, &["next_actions"]).and_then(Value::as_array)?;
+    actions
+        .iter()
+        .find(|action| string_value(action, &["status"]) == Some("running"))
+        .or_else(|| {
+            actions
+                .iter()
+                .find(|action| string_value(action, &["status"]) == Some("pending"))
+        })
+        .or_else(|| actions.last())
+        .and_then(controller_action_label)
+}
+
+fn controller_action_label(action: &Value) -> Option<&str> {
+    string_value(action, &["action_id"]).or_else(|| string_value(action, &["action", "action"]))
+}
+
+fn controller_last_failure<'a>(payload: &'a Value, controller: &'a Value) -> Option<String> {
+    if let Some(summary) = value_at(payload, &["failure_summary"])
+        .or_else(|| last_failure_summary(payload, &["results"]))
+        .or_else(|| last_failure_summary(payload, &["resume", "results"]))
+    {
+        let diagnostic = string_value(summary, &["diagnostic"])?;
+        let action_id = string_value(summary, &["action_id"]);
+        return Some(match action_id {
+            Some(action_id) => format!("{action_id}: {diagnostic}"),
+            None => diagnostic.to_string(),
+        });
+    }
+
+    value_at(controller, &["next_actions"])
+        .and_then(Value::as_array)?
+        .iter()
+        .rev()
+        .filter(|action| {
+            matches!(
+                string_value(action, &["status"]),
+                Some(
+                    "failed"
+                        | "blocked_runner_unavailable"
+                        | "blocked_remote_materialization"
+                        | "blocked_local_fallback_denied"
+                )
+            )
+        })
+        .find_map(|action| {
+            let diagnostic = value_at(action, &["diagnostics"])?
+                .as_array()?
+                .first()
+                .and_then(|diagnostic| string_value(diagnostic, &["message"]))?;
+            Some(match string_value(action, &["action_id"]) {
+                Some(action_id) => format!("{action_id}: {diagnostic}"),
+                None => diagnostic.to_string(),
+            })
+        })
+}
+
+fn last_failure_summary<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    value_at(payload, path)?
+        .as_array()?
+        .iter()
+        .rev()
+        .find_map(|result| value_at(result, &["failure_summary"]))
+}
+
+fn controller_artifact_count(controller: &Value) -> usize {
+    let entity_artifacts = value_at(controller, &["entities"])
+        .and_then(Value::as_object)
+        .map(|entities| {
+            entities
+                .values()
+                .map(|entity| array_len(entity, &["artifact_refs"]).unwrap_or(0))
+                .sum::<usize>()
+        })
+        .unwrap_or(0);
+    let lineage_artifacts = value_at(controller, &["task_lineage"])
+        .and_then(Value::as_array)
+        .map(|lineage| {
+            lineage
+                .iter()
+                .map(|item| array_len(item, &["artifact_refs"]).unwrap_or(0))
+                .sum::<usize>()
+        })
+        .unwrap_or(0);
+    entity_artifacts + lineage_artifacts
+}
+
+fn controller_key_artifacts(controller: &Value) -> Vec<String> {
+    let mut artifacts = Vec::new();
+    if let Some(entities) = value_at(controller, &["entities"]).and_then(Value::as_object) {
+        for entity in entities.values() {
+            collect_controller_artifact_lines(entity, &["artifact_refs"], &mut artifacts);
+        }
+    }
+    if let Some(lineage) = value_at(controller, &["task_lineage"]).and_then(Value::as_array) {
+        for item in lineage {
+            collect_controller_artifact_lines(item, &["artifact_refs"], &mut artifacts);
+        }
+    }
+    artifacts
+}
+
+fn collect_controller_artifact_lines(value: &Value, path: &[&str], artifacts: &mut Vec<String>) {
+    let Some(refs) = value_at(value, path).and_then(Value::as_array) else {
+        return;
+    };
+    for artifact in refs {
+        let Some(uri) = string_value(artifact, &["uri"]) else {
+            continue;
+        };
+        let label = string_value(artifact, &["label"])
+            .or_else(|| string_value(artifact, &["kind"]))
+            .unwrap_or("artifact");
+        artifacts.push(format!("{label}: {uri}"));
+    }
+}
+
+fn first_controller_recovery_command(payload: &Value) -> Option<&str> {
+    value_at(payload, &["diagnostics", "pending_actions"])
+        .and_then(Value::as_array)
+        .or_else(|| {
+            value_at(payload, &["resume", "diagnostics", "pending_actions"])
+                .and_then(Value::as_array)
+        })?
+        .iter()
+        .find_map(|action| first_string(action, &["recovery_commands"]))
 }
 
 fn first_actionable_diagnostic(payload: &Value) -> Option<&str> {
@@ -918,6 +1166,104 @@ mod tests {
         assert!(summary.contains(
             "Diagnostic: Requested provider \"codex\" is not registered. Registered provider plugins: []\n"
         ));
+    }
+
+    #[test]
+    fn controller_status_summary_surfaces_operator_resume_context() {
+        let payload = json!({
+            "schema": "homeboy/agent-task-loop-controller-status/v1",
+            "controller": {
+                "loop_id": "loop-123",
+                "phase": "triage",
+                "state": "running",
+                "entities": {
+                    "entity-1": {
+                        "human_ready": true,
+                        "run_refs": [{ "run_id": "agent-task-1" }],
+                        "artifact_refs": [{
+                            "uri": "artifact://agent-task-1/report.json",
+                            "kind": "report",
+                            "label": "summary report"
+                        }]
+                    },
+                    "entity-2": { "human_ready": false }
+                },
+                "task_lineage": [{
+                    "run_id": "agent-task-1",
+                    "artifact_refs": [{ "uri": "artifact://agent-task-1/log.txt", "kind": "log" }]
+                }],
+                "next_actions": [
+                    { "action_id": "action-1", "action": { "action": "spawn_task" }, "status": "completed" },
+                    { "action_id": "action-2", "action": { "action": "spawn_task" }, "status": "pending" }
+                ]
+            },
+            "diagnostics": {
+                "pending_actions": [{
+                    "action_id": "action-2",
+                    "recovery_commands": ["homeboy agent-task controller run loop-123 --action-id action-2"]
+                }]
+            }
+        });
+
+        let summary =
+            render_agent_task_summary(AgentTaskSummaryKind::Controller, &payload).unwrap();
+
+        assert!(summary.starts_with(
+            "Agent task controller\nLoop: loop-123\nState: running\nCurrent step: triage / action-2\n"
+        ));
+        assert!(
+            summary.contains("Actions: 1 pending / 0 running / 1 completed / 0 failed / 2 total\n")
+        );
+        assert!(summary.contains("Entities: 2 total / 1 human-ready\n"));
+        assert!(summary.contains("Runs: 1\n"));
+        assert!(summary.contains("Artifacts: 2\n"));
+        assert!(summary.contains("Artifact: summary report: artifact://agent-task-1/report.json\n"));
+        assert!(summary
+            .contains("Next: homeboy agent-task controller run loop-123 --action-id action-2\n"));
+        assert!(!summary.contains("schema"));
+    }
+
+    #[test]
+    fn controller_resume_summary_surfaces_last_failure_and_generic_resume_command() {
+        let payload = json!({
+            "schema": "homeboy/agent-task-loop-controller-resume-result/v1",
+            "loop_id": "loop-456",
+            "claimed": true,
+            "results": [
+                { "action_id": "action-1", "status": "completed" },
+                {
+                    "action_id": "action-2",
+                    "status": "failed",
+                    "failure_summary": {
+                        "action_id": "action-2",
+                        "run_id": "agent-task-2",
+                        "diagnostic": "executor returned exit code 1"
+                    }
+                }
+            ],
+            "controller": {
+                "loop_id": "loop-456",
+                "phase": "verify",
+                "state": "running",
+                "entities": {},
+                "task_lineage": [],
+                "next_actions": [
+                    { "action_id": "action-1", "action": { "action": "spawn_task" }, "status": "completed" },
+                    { "action_id": "action-2", "action": { "action": "spawn_task" }, "status": "failed" },
+                    { "action_id": "action-3", "action": { "action": "wait" }, "status": "pending" }
+                ]
+            }
+        });
+
+        let summary =
+            render_agent_task_summary(AgentTaskSummaryKind::Controller, &payload).unwrap();
+
+        assert!(summary.contains("Current step: verify / action-3\n"));
+        assert!(
+            summary.contains("Actions: 1 pending / 0 running / 1 completed / 1 failed / 3 total\n")
+        );
+        assert!(summary.contains("Last failure: action-2: executor returned exit code 1\n"));
+        assert!(summary.contains("Next: homeboy agent-task controller resume loop-456\n"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add compact human presentation for `agent-task controller status`, `run`, `run-next`, `resume`, and `from-spec --resume` outputs.
- Summarize generic controller metadata: current step, action/entity/run/artifact totals, last failure, key artifact refs, and next resume/status command.
- Keep the structured JSON payload unchanged and avoid runtime-specific artifact names or WordPress/Codebox behavior.

## Verification
- `rustfmt src/commands/agent_task_summary.rs`
- Lab: `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-feat-controller-run-summary-028bdd9a2b3f-5cfd4183-4acf-4b32-b061-a7bd01f69f5b-1782062717206998000 --raw -- cargo test --lib agent_task_summary -- --nocapture`
- Evidence: `homeboy runs evidence runner-exec-homeboy-lab-f4b04c0c-09a5-417f-8fe0-176d78aec312`

## Residual risk
- Broader `homeboy test --runner homeboy-lab --allow-dirty-lab-workspace -- controller_ -- --nocapture` failed before running focused tests because existing `tests/self_checks_test.rs` constructs `LintArgs` with removed fields (`errors_only`, `sniffs`, `exclude_sniffs`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Investigation, implementation, tests, formatting, offloaded verification, and PR drafting.