### PR TITLE
Clarify agent-task provider id selector UX

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -221,6 +221,11 @@ identifiers in core lifecycle state. Provider-specific execution settings belong
 in `--provider-config`; durable lifecycle commands remain headless and can be
 claimed later with `agent-task run` or `agent-task run-next`.
 
+`--backend` selects the generic executor backend, `--dispatch-provider-id` (also
+accepted as `--selector`) selects a specific provider id for that backend, and
+`--model` is only a provider-owned model override. Provider ids come from
+`homeboy agent-task providers`; they are not model names or provider families.
+
 ## Headless Fleet-Cooking Review
 
 The authoritative non-chat workflow is the durable `agent-task` lifecycle. Chat

--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -60,8 +60,12 @@ pub struct AgentTaskControllerFromSpecArgs {
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
 
-    /// Provider selector/id to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-selector", value_name = "SELECTOR")]
+    /// Provider id to use for controller-spawned dispatch actions when the action omits one.
+    #[arg(
+        long = "dispatch-selector",
+        visible_alias = "dispatch-provider-id",
+        value_name = "PROVIDER_ID"
+    )]
     pub dispatch_selector: Option<String>,
 
     /// Model override to use for controller-spawned dispatch actions when the action omits one.
@@ -139,8 +143,12 @@ pub struct AgentTaskControllerRunNextArgs {
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
 
-    /// Provider selector/id to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-selector", value_name = "SELECTOR")]
+    /// Provider id to use for controller-spawned dispatch actions when the action omits one.
+    #[arg(
+        long = "dispatch-selector",
+        visible_alias = "dispatch-provider-id",
+        value_name = "PROVIDER_ID"
+    )]
     pub dispatch_selector: Option<String>,
 
     /// Model override to use for controller-spawned dispatch actions when the action omits one.
@@ -161,8 +169,12 @@ pub struct AgentTaskControllerRunArgs {
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
 
-    /// Provider selector/id to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-selector", value_name = "SELECTOR")]
+    /// Provider id to use for controller-spawned dispatch actions when the action omits one.
+    #[arg(
+        long = "dispatch-selector",
+        visible_alias = "dispatch-provider-id",
+        value_name = "PROVIDER_ID"
+    )]
     pub dispatch_selector: Option<String>,
 
     /// Model override to use for controller-spawned dispatch actions when the action omits one.

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -163,8 +163,8 @@ pub struct AgentTaskDoctorArgs {
     #[arg(long, value_name = "BACKEND")]
     pub backend: Option<String>,
 
-    /// Provider selector/id to disambiguate when more than one backend provider exists.
-    #[arg(long, value_name = "SELECTOR")]
+    /// Provider id to disambiguate when more than one provider exists for the backend.
+    #[arg(long, visible_alias = "provider-id", value_name = "PROVIDER_ID")]
     pub selector: Option<String>,
 
     /// Component/workspace path used as the runner extension parity probe cwd.

--- a/src/commands/agent_task/doctor.rs
+++ b/src/commands/agent_task/doctor.rs
@@ -128,10 +128,10 @@ fn provider_stage(args: &AgentTaskDoctorArgs) -> ProviderStage {
                     "stage": "provider_contracts",
                     "code": "selector_unmatched",
                     "message": format!(
-                        "No provider for backend `{backend}` matched selector `{}`",
+                        "No provider for backend `{backend}` matched provider id `{}`",
                         args.selector.as_deref().unwrap_or("")
                     ),
-                    "remediation": "List providers with `homeboy agent-task providers` and pass a --selector that matches a declared provider id",
+                    "remediation": "List providers with `homeboy agent-task providers` and pass --provider-id/--selector with a declared provider id, not a model or provider family",
                 }));
                 mapping_value = json!({
                     "selected_backend": backend,

--- a/src/commands/agent_task/tests/dispatch.rs
+++ b/src/commands/agent_task/tests/dispatch.rs
@@ -1,6 +1,11 @@
 //! Agent-task command from-spec dispatch defaults and controller dispatch arg tests.
 
 use super::support::*;
+use clap::Parser;
+
+use crate::cli_surface::{Cli, Commands};
+
+use super::super::AgentTaskCommand;
 
 #[test]
 fn from_spec_dispatch_defaults_use_spec_git_checkout() {
@@ -292,6 +297,59 @@ fn controller_dispatch_args_preserve_top_level_workspace_context_in_plan() {
         plan.metadata["workspace_root"].as_str(),
         Some(repo_path.as_str())
     );
+}
+
+#[test]
+fn dispatch_provider_id_alias_maps_to_selector() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "agent-task",
+        "dispatch",
+        "--backend",
+        "sample-backend",
+        "--dispatch-provider-id",
+        "sample-provider",
+        "--prompt",
+        "cook",
+    ])
+    .expect("dispatch provider id alias parses");
+
+    let Commands::AgentTask(agent_task) = cli.command else {
+        panic!("expected agent-task command");
+    };
+    let AgentTaskCommand::Dispatch(args) = agent_task.command else {
+        panic!("expected dispatch command");
+    };
+
+    assert_eq!(args.selector.as_deref(), Some("sample-provider"));
+    assert_eq!(args.model, None);
+}
+
+#[test]
+fn controller_dispatch_provider_id_alias_maps_to_dispatch_selector() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "agent-task",
+        "controller",
+        "from-spec",
+        "@controller.json",
+        "--dispatch-provider-id",
+        "sample-provider",
+    ])
+    .expect("controller dispatch provider id alias parses");
+
+    let Commands::AgentTask(agent_task) = cli.command else {
+        panic!("expected agent-task command");
+    };
+    let AgentTaskCommand::Controller(controller) = agent_task.command else {
+        panic!("expected controller command");
+    };
+    let super::super::AgentTaskControllerCommand::FromSpec(args) = controller.command else {
+        panic!("expected controller from-spec command");
+    };
+
+    assert_eq!(args.dispatch_selector.as_deref(), Some("sample-provider"));
+    assert_eq!(args.dispatch_model, None);
 }
 
 #[test]

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -78,8 +78,12 @@ pub struct DispatchArgs {
     #[arg(long, value_name = "BACKEND")]
     pub backend: Option<String>,
 
-    /// Optional provider selector/id when more than one backend provider exists.
-    #[arg(long, value_name = "SELECTOR")]
+    /// Optional provider id when more than one provider exists for the backend.
+    #[arg(
+        long,
+        visible_alias = "dispatch-provider-id",
+        value_name = "PROVIDER_ID"
+    )]
     pub selector: Option<String>,
 
     /// Optional model override passed through to the provider.


### PR DESCRIPTION
## Summary
- Adds a visible generic --dispatch-provider-id alias for agent-task dispatch/controller provider selection while keeping --selector/--dispatch-selector working.
- Clarifies help/docs that provider selection expects a provider id for the selected backend, while --model remains provider-owned.
- Improves the doctor selector mismatch remediation to say provider id, not model or provider family.

## Verification
- homeboy runner workspace sync homeboy-lab --path /Users/chubes/Developer/homeboy@fix-agent-task-provider-id-ux --mode snapshot
- homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-agent-task-provider-id-ux-5da2a206c9f9-5549aec9-2c3a-4d75-b56d-12e1dc675b03-1782062798914531000 --raw -- cargo test --lib provider_id_alias

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the agent-task CLI selector surface, drafting the provider-id alias/docs/tests, and running focused verification.