### PR TITLE
fix(test): update self-check lint args

### DIFF
--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -1,7 +1,7 @@
 use homeboy::commands::lint::{run as run_lint, LintArgs};
 use homeboy::commands::test::{run as run_test, TestArgs};
 use homeboy::commands::utils::args::{
-    BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
+    BaselineArgs, ExtensionOverrideArgs, LintSniffArgs, PositionalComponentArgs, SettingArgs,
 };
 use homeboy::commands::GlobalArgs;
 use std::fs;
@@ -56,9 +56,7 @@ fn lint_args(root: &Path) -> LintArgs {
         changed_since: None,
         precomputed_changed_files: None,
         ci_job: None,
-        errors_only: false,
-        sniffs: None,
-        exclude_sniffs: None,
+        sniff_filters: LintSniffArgs::default(),
         category: None,
         fix: false,
         force: false,


### PR DESCRIPTION
## Summary
- Update the self-check lint test helper for the current LintArgs shape.
- Use LintSniffArgs::default() instead of removed individual sniff fields.

## Verification
- git diff --check
- Lab: runner-exec-homeboy-lab-abc0b742-ee04-4893-875f-a593c5599310
- Command: homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-self-checks-lint-args --runner homeboy-lab --allow-dirty-lab-workspace --skip-lint --output ./lab-self-checks-test.json -- --filter=self_checks

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the shared CI test compile blocker and updating the stale test fixture.