### PR TITLE
feat(extension): add explicit refresh/setup mode for CI to call core instead of hardcoding (#2917)

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -138,6 +138,27 @@ enum ComponentCommand {
         #[arg(long)]
         path: Option<String>,
     },
+    /// Prepare a component for build/test: install its declared extensions and
+    /// install its dependencies through detected providers.
+    ///
+    /// Core-owned replacement for hardcoded CI install/refresh + composer/npm/
+    /// pnpm/yarn dependency setup. The package manager is chosen by detection
+    /// and manifest config, never by shell literals. CI calls this instead of
+    /// orchestrating the sequence itself.
+    Setup {
+        /// Component ID (optional when --path is provided)
+        id: Option<String>,
+        /// Discover component from a directory's homeboy.json
+        #[arg(long)]
+        path: Option<String>,
+        /// Source (git URL or local path) to install the component's configured
+        /// extensions from. Omit to skip extension install (deps only).
+        #[arg(long)]
+        source: Option<String>,
+        /// Skip the dependency install step (extensions only).
+        #[arg(long)]
+        skip_dependencies: bool,
+    },
     /// Add a version target to a component
     AddVersionTarget {
         /// Component ID
@@ -342,6 +363,17 @@ pub fn run(
         ComponentCommand::Projects { id } => projects(&id),
         ComponentCommand::Shared { id } => shared(id.as_deref()),
         ComponentCommand::Env { id, path } => env::env(id.as_deref(), path.as_deref()),
+        ComponentCommand::Setup {
+            id,
+            path,
+            source,
+            skip_dependencies,
+        } => setup_component(
+            id.as_deref(),
+            path.as_deref(),
+            source.as_deref(),
+            skip_dependencies,
+        ),
         ComponentCommand::AddVersionTarget { id, file, pattern } => {
             add_version_target(&id, &file, &pattern)
         }
@@ -387,6 +419,43 @@ fn artifacts(id: Option<&str>, path: Option<&str>, apply: bool) -> CmdResult<Com
             })?),
             hint,
             updated_fields,
+            ..Default::default()
+        },
+        0,
+    ))
+}
+
+fn setup_component(
+    id: Option<&str>,
+    path: Option<&str>,
+    source: Option<&str>,
+    skip_dependencies: bool,
+) -> CmdResult<ComponentOutput> {
+    let result = homeboy::core::setup::component_setup(
+        id,
+        path,
+        &homeboy::core::setup::ComponentSetupOptions {
+            extension_source: source,
+            skip_dependencies,
+        },
+    )
+    .map_err(|e| e.with_contextual_hint())?;
+
+    let component_id = result.component_id.clone();
+    let entity = serde_json::to_value(&result).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "component.setup",
+            "Failed to serialize component setup result",
+            Some(error.to_string()),
+            None,
+        )
+    })?;
+
+    Ok((
+        ComponentOutput {
+            command: "component.setup".to_string(),
+            id: Some(component_id),
+            entity: Some(entity),
             ..Default::default()
         },
         0,

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -1,8 +1,8 @@
 use clap::{Args, Subcommand};
 
 use homeboy::core::deps::{
-    self, DependencyStackApplyResult, DependencyStackPlan, DependencyStackStatus, DependencyStatus,
-    DependencyUpdateOptions, DependencyUpdateResult,
+    self, DependencyInstallResult, DependencyStackApplyResult, DependencyStackPlan,
+    DependencyStackStatus, DependencyStatus, DependencyUpdateOptions, DependencyUpdateResult,
 };
 
 use super::CmdResult;
@@ -23,6 +23,19 @@ enum DepsCommand {
         /// Limit output to one package.
         #[arg(long, value_name = "PACKAGE")]
         package: Option<String>,
+
+        /// Workspace path to operate on directly.
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+    /// Install a component's dependencies through its detected providers
+    ///
+    /// Package manager (composer/npm/component script/extension) is chosen by
+    /// workspace detection and manifest config — not hardcoded. CI uses this
+    /// (or `component setup`) instead of shell-level composer/npm/pnpm/yarn.
+    Install {
+        /// Component ID. When omitted, auto-detected from CWD.
+        component: Option<String>,
 
         /// Workspace path to operate on directly.
         #[arg(long, value_name = "PATH")]
@@ -105,6 +118,19 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
                     homeboy::core::Error::internal_json(
                         e.to_string(),
                         Some("serialize deps status".to_string()),
+                    )
+                })?,
+                0,
+            ))
+        }
+        DepsCommand::Install { component, path } => {
+            let output: DependencyInstallResult =
+                deps::install(component.as_deref(), path.as_deref())?;
+            Ok((
+                serde_json::to_value(output).map_err(|e| {
+                    homeboy::core::Error::internal_json(
+                        e.to_string(),
+                        Some("serialize deps install".to_string()),
                     )
                 })?,
                 0,

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -77,6 +77,20 @@ enum ExtensionCommand {
         #[arg(long)]
         replace: bool,
     },
+    /// Refresh an extension: uninstall any existing install, then reinstall
+    ///
+    /// Idempotent core-owned replacement for CI's hardcoded uninstall/install
+    /// sequence. Safe to re-run; a missing prior install is not an error.
+    Refresh {
+        /// Git URL or local path to extension directory
+        source: String,
+        /// Override extension id
+        #[arg(long)]
+        id: Option<String>,
+        /// Git ref to check out for URL installs (branch, tag, or commit)
+        #[arg(long = "ref")]
+        revision: Option<String>,
+    },
     /// Relink an installed symlinked extension to a new local source path
     Relink {
         /// Extension ID
@@ -181,6 +195,11 @@ pub fn run(
             revision,
             replace,
         } => install_extension(&source, id, revision, replace),
+        ExtensionCommand::Refresh {
+            source,
+            id,
+            revision,
+        } => refresh_extension(&source, id.as_deref(), revision.as_deref()),
         ExtensionCommand::Relink {
             extension_id,
             source,
@@ -248,6 +267,17 @@ pub enum ExtensionOutput {
         path: String,
         manifest_path: String,
         linked: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source_revision: Option<String>,
+    },
+    #[serde(rename = "extension.refresh")]
+    Refresh {
+        extension_id: String,
+        source: String,
+        path: String,
+        manifest_path: String,
+        linked: bool,
+        uninstalled_previous: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         source_revision: Option<String>,
     },
@@ -576,6 +606,28 @@ fn install_extension(
             path: result.path.to_string_lossy().to_string(),
             manifest_path: result.manifest_path.to_string_lossy().to_string(),
             linked,
+            source_revision: result.source_revision,
+        },
+        0,
+    ))
+}
+
+fn refresh_extension(
+    source: &str,
+    id: Option<&str>,
+    revision: Option<&str>,
+) -> CmdResult<ExtensionOutput> {
+    let result = homeboy::core::extension::refresh(source, id, revision)?;
+    let linked = is_extension_linked(&result.extension_id);
+
+    Ok((
+        ExtensionOutput::Refresh {
+            extension_id: result.extension_id,
+            source: result.url,
+            path: result.path.to_string_lossy().to_string(),
+            manifest_path: result.manifest_path.to_string_lossy().to_string(),
+            linked,
+            uninstalled_previous: result.uninstalled_previous,
             source_revision: result.source_revision,
         },
         0,

--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -65,6 +65,16 @@ pub struct DependencyCommandResult {
     pub stderr: String,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyInstallResult {
+    pub component_id: String,
+    pub component_path: String,
+    pub package_manager: String,
+    /// One entry per dependency provider that ran an install. Providers that
+    /// report nothing to install (e.g. no manifest detected) are omitted.
+    pub installs: Vec<DependencyCommandResult>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DependencyUpdateOptions {
     pub install: bool,
@@ -128,6 +138,74 @@ pub fn update(
         Some(package.to_string()),
         None,
     ))
+}
+
+/// Install a component's dependencies through its resolved dependency providers.
+///
+/// This is the detection/config-driven replacement for hardcoded
+/// "composer install / npm install / pnpm install / yarn install" CI policy:
+/// the package manager(s) are chosen by [`provider::resolve_dependency_providers`]
+/// based on the files present in the workspace (composer.json, package.json,
+/// lockfiles) and the component/extension manifest — not by shell literals in
+/// the calling environment. CI (or any caller) runs `homeboy component setup`
+/// or `homeboy deps install` and lets core own the policy.
+pub fn install(
+    component_id: Option<&str>,
+    path_override: Option<&str>,
+) -> Result<DependencyInstallResult> {
+    let (component, path) = resolve_component_path(component_id, path_override)?;
+    // Reuse the command-facing resolver so a dependency-less component returns
+    // the same actionable "no provider" error as `deps status`/`deps update`.
+    provider::resolve_dependency_providers(&component, &path)?;
+    Ok(
+        install_for_resolved(&component, &path)?.unwrap_or_else(|| DependencyInstallResult {
+            component_id: component.id.clone(),
+            component_path: path.display().to_string(),
+            package_manager: String::new(),
+            installs: Vec::new(),
+        }),
+    )
+}
+
+/// Run dependency installs for an already-resolved component/workspace pair.
+///
+/// Shared by [`install`] and the higher-level `component setup` orchestrator so
+/// the provider-resolution and best-effort install policy lives in exactly one
+/// place.
+///
+/// Returns `None` when the workspace exposes no dependency provider (nothing to
+/// install) so callers can treat a dependency-less component as a no-op.
+pub fn install_for_resolved(
+    component: &Component,
+    path: &Path,
+) -> Result<Option<DependencyInstallResult>> {
+    let providers = provider::resolve_dependency_providers_optional(component, path)?;
+    if providers.is_empty() {
+        return Ok(None);
+    }
+
+    let mut installs = Vec::new();
+    let mut package_managers = Vec::new();
+    for provider in providers {
+        let status = provider.status(component, path, None)?;
+        if let Some(result) = provider.install(component, path)? {
+            package_managers.push(status.package_manager);
+            installs.push(result);
+        }
+    }
+
+    let package_manager = match package_managers.as_slice() {
+        [] => String::new(),
+        [only] => only.clone(),
+        many => many.join(","),
+    };
+
+    Ok(Some(DependencyInstallResult {
+        component_id: component.id.clone(),
+        component_path: path.display().to_string(),
+        package_manager,
+        installs,
+    }))
 }
 
 fn rebuild_component(component: &Component, path: &Path) -> Result<DependencyCommandResult> {

--- a/src/core/extension/lifecycle/mod.rs
+++ b/src/core/extension/lifecycle/mod.rs
@@ -134,6 +134,53 @@ pub fn install_for_component(
     })
 }
 
+#[derive(Debug, Clone)]
+pub struct RefreshResult {
+    pub extension_id: String,
+    pub url: String,
+    pub path: PathBuf,
+    pub manifest_path: PathBuf,
+    pub source_revision: Option<String>,
+    /// Whether a previous install was removed before reinstalling. False on a
+    /// first-time install (nothing to uninstall).
+    pub uninstalled_previous: bool,
+}
+
+/// Refresh a single extension from a source: uninstall any existing install,
+/// then reinstall from the given source/revision.
+///
+/// This is the core-owned replacement for CI's hardcoded
+/// "uninstall (if present) then install" shell sequence. It is idempotent and
+/// safe to re-run: a missing prior install is not an error.
+pub fn refresh(
+    source: &str,
+    id_override: Option<&str>,
+    revision: Option<&str>,
+) -> Result<RefreshResult> {
+    let extension_id = match id_override {
+        Some(id) => slugify_id(id)?,
+        None => derive_id_from_url(source)?,
+    };
+
+    let uninstalled_previous = if load_extension(&extension_id).is_ok() {
+        uninstall(&extension_id)?;
+        true
+    } else {
+        false
+    };
+
+    let installed = install_with_revision(source, Some(&extension_id), revision)?;
+
+    Ok(RefreshResult {
+        extension_id: installed.extension_id,
+        url: installed.url,
+        path: installed.path,
+        manifest_path: installed.manifest_path,
+        source_revision: installed.source_revision,
+        uninstalled_previous,
+    })
+}
+
 mod install_sources;
 use install_sources::{install_configured_extension, install_from_path, install_from_url};
 pub(crate) use install_sources::{
@@ -176,7 +223,7 @@ pub fn uninstall(extension_id: &str) -> Result<PathBuf> {
 mod tests {
     use super::{
         install, install_for_component, install_with_revision, is_extension_update_workdir_clean,
-        load_extension, read_source_revision, source_metadata, update,
+        load_extension, read_source_revision, refresh, source_metadata, update,
     };
     use crate::core::component;
     use crate::core::extension::update_all;
@@ -506,6 +553,51 @@ exec '{}' "$@"
 
             assert_eq!(result.component_id, "multi-extension-component");
             assert_eq!(result.installed.len(), 2);
+        });
+    }
+
+    #[test]
+    fn refresh_installs_first_time_without_uninstalling() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source");
+            write_extension_fixture(&source, "alpha");
+
+            let result = refresh(&source.join("alpha").to_string_lossy(), Some("alpha"), None)
+                .expect("first-time refresh should install");
+
+            assert_eq!(result.extension_id, "alpha");
+            assert!(
+                !result.uninstalled_previous,
+                "first-time refresh has nothing to uninstall"
+            );
+            assert!(load_extension("alpha").is_ok());
+        });
+    }
+
+    #[test]
+    fn refresh_is_idempotent_and_reinstalls_existing() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source");
+            write_extension_fixture_with_version(&source, "alpha", "1.0.0");
+
+            install(&source.join("alpha").to_string_lossy(), Some("alpha")).expect("pre-install");
+
+            // Update the source, then refresh — the reinstall should pick it up
+            // without erroring on the pre-existing install.
+            write_extension_fixture_with_version(&source, "alpha", "2.0.0");
+            let result = refresh(&source.join("alpha").to_string_lossy(), Some("alpha"), None)
+                .expect("refresh over existing install should succeed");
+
+            assert!(
+                result.uninstalled_previous,
+                "refresh should remove the prior install before reinstalling"
+            );
+            assert_eq!(
+                load_extension("alpha").expect("reinstalled").version,
+                "2.0.0"
+            );
         });
     }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -60,8 +60,8 @@ pub(crate) use lifecycle::source_metadata::resolve_source_url;
 pub use lifecycle::source_metadata::SourceMetadataRepair;
 pub use lifecycle::{
     check_update_available, derive_id_from_url, install, install_for_component,
-    install_with_revision, is_git_url, read_source_revision, slugify_id, uninstall, update,
-    InstallForComponentResult, InstallResult, UpdateAvailable, UpdateResult,
+    install_with_revision, is_git_url, read_source_revision, refresh, slugify_id, uninstall,
+    update, InstallForComponentResult, InstallResult, RefreshResult, UpdateAvailable, UpdateResult,
 };
 pub use maintenance::{exec_tool, update_all};
 pub use manifest::{

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -108,6 +108,7 @@ pub mod scope;
 pub mod secret_env_plan;
 pub mod self_status;
 pub mod server;
+pub mod setup;
 pub mod source_snapshot;
 pub mod stack;
 pub mod stream_capture;

--- a/src/core/setup.rs
+++ b/src/core/setup.rs
@@ -1,0 +1,232 @@
+//! Component setup orchestration.
+//!
+//! Core-owned entry point that CI (and humans) call instead of hardcoding the
+//! extension install/refresh + dependency install sequence in shell. The
+//! sequence — install every extension a component declares, then install the
+//! component's dependencies through its detected providers — is policy that
+//! belongs in core, not in GitHub Action scripts.
+//!
+//! All package-manager selection stays agnostic: dependency installs are
+//! resolved through [`crate::core::deps`] providers (composer/npm/component
+//! script/extension), chosen by workspace detection and manifest config rather
+//! than literals here.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use crate::core::component;
+use crate::core::deps::{self, DependencyInstallResult};
+use crate::core::extension::{self, is_extension_linked};
+use crate::core::{Error, Result};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ComponentSetupResult {
+    pub component_id: String,
+    pub component_path: String,
+    /// Extensions installed for the component. `None` when no `--source` was
+    /// provided (extension install is skipped; dependency install still runs).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<ExtensionSetupSummary>,
+    /// Dependency install results, when the component has any resolvable
+    /// dependency provider. `None` when no provider is detected (nothing to do).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependencies: Option<DependencyInstallResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtensionSetupSummary {
+    pub source: String,
+    pub installed: Vec<InstalledExtensionSummary>,
+    pub skipped: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InstalledExtensionSummary {
+    pub extension_id: String,
+    pub path: String,
+    pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ComponentSetupOptions<'a> {
+    /// Source (git URL or local path) to install the component's configured
+    /// extensions from. When `None`, extension install is skipped — useful when
+    /// extensions are already installed and only dependency setup is needed.
+    pub extension_source: Option<&'a str>,
+    /// Skip the dependency install step entirely.
+    pub skip_dependencies: bool,
+}
+
+/// Run setup for a component: install its declared extensions (optional) and
+/// install its dependencies through resolved providers.
+///
+/// This replaces the action-side `install-extension.sh` +
+/// `auto-setup-environment.sh` (composer/npm/pnpm/yarn) policy with a single
+/// core call. The package manager is chosen by detection/config, never by
+/// hardcoded literals.
+pub fn component_setup(
+    component_id: Option<&str>,
+    path_override: Option<&str>,
+    options: &ComponentSetupOptions<'_>,
+) -> Result<ComponentSetupResult> {
+    let component = component::resolve_effective(component_id, path_override, None)?;
+    let path = PathBuf::from(shellexpand::tilde(&component.local_path).as_ref());
+
+    if !path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "component_path",
+            format!(
+                "Component '{}' path does not exist: {}",
+                component.id,
+                path.display()
+            ),
+            Some(component.id.clone()),
+            None,
+        ));
+    }
+
+    let extensions = match options.extension_source {
+        Some(source) => {
+            let result = extension::install_for_component(&component, source)?;
+            Some(ExtensionSetupSummary {
+                source: result.source,
+                installed: result
+                    .installed
+                    .into_iter()
+                    .map(|entry| InstalledExtensionSummary {
+                        linked: is_extension_linked(&entry.extension_id),
+                        extension_id: entry.extension_id,
+                        path: entry.path.to_string_lossy().to_string(),
+                        source_revision: entry.source_revision,
+                    })
+                    .collect(),
+                skipped: result.skipped,
+            })
+        }
+        None => None,
+    };
+
+    // Dependency install is best-effort: a component without a resolvable
+    // provider (no composer.json/package.json/deps script) is a no-op, not an
+    // error — `install_for_resolved` returns `None` in that case.
+    let dependencies = if options.skip_dependencies {
+        None
+    } else {
+        deps::install_for_resolved(&component, &path)?
+    };
+
+    Ok(ComponentSetupResult {
+        component_id: component.id.clone(),
+        component_path: path.display().to_string(),
+        extensions,
+        dependencies,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_isolated_home;
+    use std::fs;
+
+    fn write_extension_fixture(root: &std::path::Path, id: &str) {
+        let dir = root.join(id);
+        fs::create_dir_all(&dir).expect("extension dir");
+        fs::write(
+            dir.join(format!("{}.json", id)),
+            format!(r#"{{"name":"{} extension","version":"1.0.0"}}"#, id),
+        )
+        .expect("extension manifest");
+    }
+
+    fn write_component_fixture(root: &std::path::Path, extensions: &[&str]) {
+        let extension_json = extensions
+            .iter()
+            .map(|id| format!(r#"    "{}": {{}}"#, id))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        fs::write(
+            root.join("homeboy.json"),
+            format!(
+                r#"{{
+  "id": "setup-component",
+  "local_path": "{}",
+  "extensions": {{
+{}
+  }}
+}}"#,
+                root.display(),
+                extension_json
+            ),
+        )
+        .expect("component config");
+    }
+
+    #[test]
+    fn setup_installs_configured_extensions_from_source() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source");
+            write_extension_fixture(&source, "alpha");
+            write_extension_fixture(&source, "beta");
+
+            let component_dir = home.join("component");
+            fs::create_dir_all(&component_dir).expect("component dir");
+            write_component_fixture(&component_dir, &["alpha", "beta"]);
+
+            let result = component_setup(
+                None,
+                Some(&component_dir.to_string_lossy()),
+                &ComponentSetupOptions {
+                    extension_source: Some(&source.to_string_lossy()),
+                    skip_dependencies: true,
+                },
+            )
+            .expect("setup should succeed");
+
+            let extensions = result.extensions.expect("extensions installed");
+            let installed_ids: Vec<&str> = extensions
+                .installed
+                .iter()
+                .map(|entry| entry.extension_id.as_str())
+                .collect();
+            assert_eq!(installed_ids, vec!["alpha", "beta"]);
+            assert!(result.dependencies.is_none(), "deps were skipped");
+        });
+    }
+
+    #[test]
+    fn setup_dependency_step_is_noop_without_providers() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let component_dir = home.join("component");
+            fs::create_dir_all(&component_dir).expect("component dir");
+            // Component with no extensions, composer.json, package.json, or deps
+            // script — there is nothing to install.
+            fs::write(
+                component_dir.join("homeboy.json"),
+                format!(
+                    r#"{{"id":"setup-component","local_path":"{}"}}"#,
+                    component_dir.display()
+                ),
+            )
+            .expect("component config");
+
+            let result = component_setup(
+                None,
+                Some(&component_dir.to_string_lossy()),
+                &ComponentSetupOptions::default(),
+            )
+            .expect("setup should succeed even with nothing to install");
+
+            assert!(result.extensions.is_none());
+            assert!(
+                result.dependencies.is_none(),
+                "no dependency provider should be a no-op, not an error"
+            );
+        });
+    }
+}

--- a/src/extensions/deps_provider.rs
+++ b/src/extensions/deps_provider.rs
@@ -34,7 +34,10 @@ pub(crate) struct DependencyProviderSnapshot {
 pub(crate) enum DependencyProvider {
     Composer(ComposerDependencyProvider),
     Npm(NpmDependencyProvider),
-    Extension(ExtensionDependencyProvider),
+    // Boxed: `ExtensionDependencyProvider` carries a full execution context and
+    // is far larger than the other (zero-sized) variants, so storing it inline
+    // would bloat every `DependencyProvider` value (clippy::large_enum_variant).
+    Extension(Box<ExtensionDependencyProvider>),
     ComponentScript(ComponentScriptDependencyProvider),
 }
 
@@ -158,11 +161,9 @@ pub(crate) fn resolve_dependency_providers_optional(
         .unwrap_or(false)
     {
         match extension::resolve_execution_context(component, ExtensionCapability::Deps) {
-            Ok(context) => {
-                providers.push(DependencyProvider::Extension(ExtensionDependencyProvider {
-                    context,
-                }))
-            }
+            Ok(context) => providers.push(DependencyProvider::Extension(Box::new(
+                ExtensionDependencyProvider { context },
+            ))),
             Err(err) if providers.is_empty() => return Err(err),
             Err(_) => {}
         }

--- a/src/extensions/deps_provider.rs
+++ b/src/extensions/deps_provider.rs
@@ -107,6 +107,34 @@ pub(crate) fn resolve_dependency_providers(
     component: &Component,
     path: &Path,
 ) -> Result<Vec<DependencyProvider>> {
+    let providers = resolve_dependency_providers_optional(component, path)?;
+
+    if providers.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "dependency_provider",
+            format!("No dependency provider found for {}", path.display()),
+            None,
+            Some(vec![
+                "Link an extension with deps support, or use a component with a supported dependency provider".to_string(),
+                "Package managers are resolved through dependency providers, not core command orchestration".to_string(),
+            ]),
+        ));
+    }
+
+    Ok(providers)
+}
+
+/// Resolve the dependency providers a component/workspace exposes, returning an
+/// empty vector when none are detected instead of erroring.
+///
+/// Setup orchestration treats "no provider" as a no-op (a component with no
+/// composer.json/package.json/deps script simply has nothing to install), so it
+/// needs the empty case without the actionable error that the command-facing
+/// [`resolve_dependency_providers`] raises.
+pub(crate) fn resolve_dependency_providers_optional(
+    component: &Component,
+    path: &Path,
+) -> Result<Vec<DependencyProvider>> {
     let mut providers = Vec::new();
 
     if ComposerDependencyProvider::supports(path) {
@@ -138,18 +166,6 @@ pub(crate) fn resolve_dependency_providers(
             Err(err) if providers.is_empty() => return Err(err),
             Err(_) => {}
         }
-    }
-
-    if providers.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "dependency_provider",
-            format!("No dependency provider found for {}", path.display()),
-            None,
-            Some(vec![
-                "Link an extension with deps support, or use a component with a supported dependency provider".to_string(),
-                "Package managers are resolved through dependency providers, not core command orchestration".to_string(),
-            ]),
-        ));
     }
 
     Ok(providers)


### PR DESCRIPTION
## Summary

Closes #2917. Core already owned extension install/uninstall and dependency-provider resolution, but `homeboy-action` still hardcoded the refresh/uninstall/install sequence plus generic Composer/npm/pnpm/yarn dependency-install policy in shell. This adds explicit, core-owned refresh/setup entry points so CI calls core instead of orchestrating the sequence itself.

## What's added

- **`homeboy extension refresh <source> [--id] [--ref]`** — idempotent uninstall-if-present-then-reinstall for a single extension (`core::extension::refresh`). Replaces CI's hardcoded uninstall/install loop; a missing prior install is not an error.
- **`homeboy deps install [component] [--path]`** — installs a component's dependencies through its *detected* providers (`core::deps::install`). Package manager is chosen by workspace detection + manifest config (composer.json / package.json / lockfiles / deps script / extension), never by shell literals.
- **`homeboy component setup [id] [--path] [--source] [--skip-dependencies]`** — single orchestrator (`core::setup::component_setup`) that installs a component's declared extensions (existing `install_for_component`) and then runs the dependency install. This is the one call CI makes to replace `install-extension.sh` + `auto-setup-environment.sh`.

## Agnostic by construction

Dependency setup stays manifest/detection-driven: `resolve_dependency_providers_optional` picks providers from files present and manifest config. A component with no provider is a no-op, not an error. No package-manager literals were added to core.

## Action migration (follow-up, separate repo)

`homeboy-action` can now drop the generic dependency-install logic and uninstall/install loops in favor of `homeboy component setup` / `homeboy extension refresh` / `homeboy deps install`.

## Tests

- `extension::lifecycle::refresh_*` — first-time install (no uninstall) and idempotent reinstall over an existing install.
- `core::setup::*` — installs configured extensions from source; dependency step is a no-op when no provider is detected.
- Existing `command_surface_test` / `output_contracts_test` pass (new mutating commands satisfy the safety manifest contract).

`cargo build --lib`, `cargo build --bin homeboy`, and the targeted tests above pass locally; full build/test left to CI.