### PR TITLE
perf(audit): migrate whole-tree detectors onto shared snapshots (#3401)

### DIFF
--- a/src/core/code_audit/detectors/enum_dispatch_contracts.rs
+++ b/src/core/code_audit/detectors/enum_dispatch_contracts.rs
@@ -6,23 +6,29 @@
 //! otherwise requires updating scattered dispatch contracts.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::path::Path;
 
-use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::codebase_scan::CodebaseSnapshot;
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 
 const MIN_MATCHES: usize = 2;
 
-pub(in crate::core::code_audit) fn run(root: &Path) -> Vec<Finding> {
-    let config = ScanConfig {
-        extensions: ExtensionFilter::Only(vec!["rs".to_string()]),
-        ..Default::default()
-    };
+/// Run enum-dispatch contract detection over the shared audit source snapshot.
+///
+/// Consumes the in-memory `(path, content)` view built once during discovery
+/// instead of re-walking and re-reading the tree. Behavior is preserved: the
+/// snapshot is a superset of the `.rs` files this detector previously walked,
+/// so filtering to Rust source files here yields the identical input set in
+/// walk order.
+pub(in crate::core::code_audit) fn run(snapshot: &CodebaseSnapshot) -> Vec<Finding> {
+    let root = snapshot.root();
     let mut files = Vec::new();
 
-    for file_path in codebase_scan::walk_files(root, &config) {
+    for (file_path, content) in snapshot.iter() {
+        if file_path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
         let Ok(relative_path) = file_path.strip_prefix(root) else {
             continue;
         };
@@ -30,12 +36,9 @@ pub(in crate::core::code_audit) fn run(root: &Path) -> Vec<Finding> {
         if super::walker::is_test_path(&relative_path) {
             continue;
         }
-        let Ok(content) = std::fs::read_to_string(&file_path) else {
-            continue;
-        };
         files.push(SourceFile {
             relative_path,
-            content,
+            content: content.to_string(),
         });
     }
 
@@ -651,7 +654,15 @@ mod tests {
         )
         .expect("write fixture");
 
-        let findings = run(dir.path());
+        use crate::core::engine::codebase_scan::{ExtensionFilter, ScanConfig};
+        let snapshot = CodebaseSnapshot::build(
+            dir.path(),
+            &ScanConfig {
+                extensions: ExtensionFilter::Only(vec!["rs".to_string()]),
+                ..Default::default()
+            },
+        );
+        let findings = run(&snapshot);
 
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, AuditFinding::RepeatedEnumDispatchContract);

--- a/src/core/code_audit/detectors/enum_dispatch_contracts.rs
+++ b/src/core/code_audit/detectors/enum_dispatch_contracts.rs
@@ -18,9 +18,9 @@ const MIN_MATCHES: usize = 2;
 ///
 /// Consumes the in-memory `(path, content)` view built once during discovery
 /// instead of re-walking and re-reading the tree. Behavior is preserved: the
-/// snapshot is a superset of the `.rs` files this detector previously walked,
-/// so filtering to Rust source files here yields the identical input set in
-/// walk order.
+/// snapshot is a superset of the files this detector previously walked, so
+/// filtering to the same file-extension subset here yields the identical input
+/// set in walk order.
 pub(in crate::core::code_audit) fn run(snapshot: &CodebaseSnapshot) -> Vec<Finding> {
     let root = snapshot.root();
     let mut files = Vec::new();

--- a/src/core/code_audit/detectors/field_patterns.rs
+++ b/src/core/code_audit/detectors/field_patterns.rs
@@ -27,10 +27,9 @@ mod field_patterns_data_contracts {
 }
 
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
 
 use crate::core::component::DetectorProfileConfig;
-use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::codebase_scan::CodebaseSnapshot;
 
 use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
@@ -43,8 +42,25 @@ const MIN_OCCURRENCES: usize = 3;
 /// Minimum number of fields in a group to report.
 const MIN_GROUP_SIZE: usize = 2;
 
+/// Resolve the file-extension scan tokens this detector would walk for a given
+/// profile. Used by the audit pipeline to ensure the shared source snapshot is a
+/// superset of the detector's inputs, so filtering the snapshot here reproduces
+/// the detector's previous independent walk exactly.
+pub(in crate::core::code_audit) fn scan_token_extensions(
+    config: &DetectorProfileConfig,
+) -> Vec<String> {
+    ResolvedFieldScan::from_config(config).scan_tokens
+}
+
+/// Run repeated-field-pattern detection over the shared audit source snapshot.
+///
+/// Consumes the in-memory `(path, content)` view built once during discovery
+/// rather than re-walking and re-reading the tree. The shared snapshot is a
+/// superset of the extensions this detector scans, so filtering by the resolved
+/// scan tokens reproduces the previous per-file input set (in walk order),
+/// keeping findings identical.
 pub(in crate::core::code_audit) fn run(
-    root: &Path,
+    snapshot: &CodebaseSnapshot,
     config: &DetectorProfileConfig,
 ) -> Vec<Finding> {
     let settings = ResolvedFieldScan::from_config(config);
@@ -54,7 +70,7 @@ pub(in crate::core::code_audit) fn run(
         // detector stays inert until a component declares its languages.
         return Vec::new();
     }
-    detect_repeated_field_patterns(root, &settings)
+    detect_repeated_field_patterns(snapshot, &settings)
 }
 
 /// Resolved field-scan settings. Concrete language/extension tokens come from
@@ -172,16 +188,22 @@ enum FieldSyntax {
     TypeBeforeName,
 }
 
-fn detect_repeated_field_patterns(root: &Path, settings: &ResolvedFieldScan) -> Vec<Finding> {
-    let config = ScanConfig {
-        extensions: ExtensionFilter::Only(settings.scan_tokens.clone()),
-        ..Default::default()
-    };
-    let files = codebase_scan::walk_files(root, &config);
-
+fn detect_repeated_field_patterns(
+    snapshot: &CodebaseSnapshot,
+    settings: &ResolvedFieldScan,
+) -> Vec<Finding> {
+    let root = snapshot.root();
     let mut all_structs: Vec<StructDef> = Vec::new();
 
-    for file_path in &files {
+    for (file_path, content) in snapshot.iter() {
+        // Filter the shared snapshot to the detector's scan-token extensions,
+        // matching the `ExtensionFilter::Only(scan_tokens)` walk this detector
+        // previously performed.
+        let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if !settings.scan_tokens.iter().any(|token| token == ext) {
+            continue;
+        }
+
         let relative = match file_path.strip_prefix(root) {
             Ok(p) => p.to_string_lossy().replace('\\', "/"),
             Err(_) => continue,
@@ -192,14 +214,10 @@ fn detect_repeated_field_patterns(root: &Path, settings: &ResolvedFieldScan) -> 
             continue;
         }
 
-        let Ok(content) = std::fs::read_to_string(file_path) else {
-            continue;
-        };
-
         let scan_content = if settings.needs_inline_test_strip(&relative) {
-            strip_rust_cfg_test_modules(&content)
+            std::borrow::Cow::Owned(strip_rust_cfg_test_modules(content))
         } else {
-            content
+            std::borrow::Cow::Borrowed(content)
         };
 
         let syntax = settings.syntax_for_path(&relative);
@@ -823,11 +841,31 @@ mod tests {
         }
     }
 
+    /// Build a shared-style codebase snapshot over the multi-language source
+    /// extensions these tests use, mirroring how the audit pipeline now feeds
+    /// the detector an already-walked `(path, content)` view.
+    fn snapshot_of(root: &std::path::Path) -> CodebaseSnapshot {
+        use crate::core::engine::codebase_scan::{ExtensionFilter, ScanConfig};
+        CodebaseSnapshot::build(
+            root,
+            &ScanConfig {
+                extensions: ExtensionFilter::Only(vec![
+                    "rs".to_string(),
+                    "php".to_string(),
+                    "ts".to_string(),
+                    "js".to_string(),
+                    "go".to_string(),
+                ]),
+                ..Default::default()
+            },
+        )
+    }
+
     #[test]
     fn test_run() {
         let dir = tempfile::tempdir().unwrap();
         // Empty profile (no tokens, builtin defaults on) → still empty on empty dir.
-        assert!(run(dir.path(), &DetectorProfileConfig::default()).is_empty());
+        assert!(run(&snapshot_of(dir.path()), &DetectorProfileConfig::default()).is_empty());
     }
 
     #[test]
@@ -843,7 +881,7 @@ mod tests {
             ..Default::default()
         };
         assert!(
-            run(dir.path(), &config).is_empty(),
+            run(&snapshot_of(dir.path()), &config).is_empty(),
             "no scan tokens declared and builtin defaults off → inert"
         );
     }
@@ -979,7 +1017,7 @@ class {} {{
             .unwrap();
         }
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             findings.is_empty(),
             "presentation arrays and WP_CLI call sites are not extractable field groups: {:?}",
@@ -1059,7 +1097,7 @@ class {} {{
             .unwrap();
         }
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             findings.is_empty(),
             "PHP self::class registration arguments should not be reported as fields"
@@ -1096,7 +1134,7 @@ struct FindingRecord {
         )
         .unwrap();
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             findings.is_empty(),
             "small scalar coordinate overlaps across boundary records are not extractable: {:?}",
@@ -1152,7 +1190,7 @@ struct Foo {
         )
         .unwrap();
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             findings.is_empty(),
             "inline Rust test fixtures should not be scanned as production structs: {:?}",
@@ -1256,7 +1294,7 @@ struct Foo {
             .unwrap();
         }
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             !findings.is_empty(),
             "Should detect repeated [verbose, quiet] pattern"
@@ -1330,7 +1368,7 @@ struct ReviewArgs {
         )
         .unwrap();
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             findings.is_empty(),
             "boundary DTO overlap across command/workflow/refactor layers should not suggest extraction: {:?}",
@@ -1352,10 +1390,11 @@ struct ReviewArgs {
             .unwrap();
         }
 
-        let descriptions: Vec<String> = detect_repeated_field_patterns(dir.path(), &test_scan())
-            .into_iter()
-            .map(|finding| finding.description)
-            .collect();
+        let descriptions: Vec<String> =
+            detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan())
+                .into_iter()
+                .map(|finding| finding.description)
+                .collect();
         assert!(
             descriptions
                 .iter()
@@ -1420,7 +1459,7 @@ struct ReviewArgs {
             .unwrap();
         }
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             findings.is_empty(),
             "generic DTO field pairs across unrelated modules should not become extraction work: {:?}",
@@ -1469,7 +1508,7 @@ struct ReviewArgs {
             std::fs::write(file, format!("struct {name} {{\n    {fields}\n}}\n")).unwrap();
         }
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             findings.is_empty(),
             "boundary data contract field overlaps should not suggest extraction: {:?}",
@@ -1505,10 +1544,11 @@ struct ReviewArgs {
             .unwrap();
         }
 
-        let descriptions: Vec<String> = detect_repeated_field_patterns(dir.path(), &test_scan())
-            .into_iter()
-            .map(|finding| finding.description)
-            .collect();
+        let descriptions: Vec<String> =
+            detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan())
+                .into_iter()
+                .map(|finding| finding.description)
+                .collect();
 
         assert!(
             descriptions
@@ -1543,7 +1583,7 @@ struct ReviewArgs {
             .unwrap();
         }
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             !findings.is_empty(),
             "Should detect repeated [alpha, middle, zebra] pattern"
@@ -1581,7 +1621,7 @@ struct ReviewArgs {
             .unwrap();
         }
 
-        let findings = detect_repeated_field_patterns(dir.path(), &test_scan());
+        let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
         assert!(
             findings.is_empty(),
             "Two occurrences should be below threshold"

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -566,8 +566,7 @@ fn audit_internal(
     // Phase 1: Auto-discover file groups (always full codebase for convention detection)
     let discovery_started = std::time::Instant::now();
     let source_snapshot_started = std::time::Instant::now();
-    let source_snapshot =
-        walker::walk_shared_audit_files_snapshot(root, structural::source_extensions());
+    let source_snapshot = build_shared_source_snapshot(root, &audit_config);
     timing.push_ok("source_snapshot", source_snapshot_started.elapsed());
     if scoped_execution.is_scoped() {
         log_status!(
@@ -1016,7 +1015,7 @@ fn audit_internal(
         &mut timing,
         "detector.field_patterns",
         plan.run_field_patterns(),
-        || field_patterns::run(root, &audit_config.detector_profile),
+        || field_patterns::run(&source_snapshot, &audit_config.detector_profile),
         Vec::new,
     );
     if !field_pattern_findings.is_empty() {
@@ -1267,7 +1266,7 @@ fn audit_internal(
         &mut timing,
         "detector.enum_dispatch_contracts",
         plan.run_enum_dispatch_contracts(),
-        || enum_dispatch_contracts::run(root),
+        || enum_dispatch_contracts::run(&source_snapshot),
         Vec::new,
     );
     if !enum_dispatch_findings.is_empty() {
@@ -1517,6 +1516,31 @@ fn audit_internal(
     })
 }
 
+/// Build the shared audit source snapshot consumed by whole-tree detectors.
+///
+/// The snapshot is a single walk/read of the codebase whose extension set is a
+/// superset of every snapshot-backed detector's inputs (structural source
+/// extensions plus the field-pattern detector's resolved scan tokens). This
+/// lets those detectors filter the shared snapshot instead of each re-walking
+/// and re-reading the tree, while keeping their inputs — and therefore their
+/// findings — identical.
+fn build_shared_source_snapshot(
+    root: &Path,
+    audit_config: &AuditConfig,
+) -> crate::core::engine::codebase_scan::CodebaseSnapshot {
+    let mut additional: Vec<String> = structural::source_extensions()
+        .iter()
+        .map(|ext| (*ext).to_string())
+        .collect();
+    additional.extend(field_patterns::scan_token_extensions(
+        &audit_config.detector_profile,
+    ));
+    additional.sort();
+    additional.dedup();
+    let additional_refs: Vec<&str> = additional.iter().map(|s| s.as_str()).collect();
+    walker::walk_shared_audit_files_snapshot(root, &additional_refs)
+}
+
 fn audit_root_only(
     component_id: &str,
     source_path: &str,
@@ -1534,11 +1558,27 @@ fn audit_root_only(
         all_fingerprints: &[],
     };
 
+    // Build the shared source snapshot once for the root-only path so the
+    // whole-tree detectors below (structural, field patterns) consume a single
+    // walk/read instead of each re-walking and re-reading the tree. Built only
+    // when at least one snapshot-backed detector is enabled.
+    let source_snapshot = if plan.run_structural() || plan.run_field_patterns() {
+        let snapshot_started = std::time::Instant::now();
+        let snapshot = build_shared_source_snapshot(root, &audit_config);
+        timing.push_ok("source_snapshot", snapshot_started.elapsed());
+        Some(snapshot)
+    } else {
+        None
+    };
+
     let structural_findings = time_audit_detector(
         timing,
         "detector.structural",
         plan.run_structural(),
-        || structural::analyze_structure(root),
+        || match source_snapshot.as_ref() {
+            Some(snapshot) => structural::analyze_snapshot(root, snapshot),
+            None => structural::analyze_structure(root),
+        },
         Vec::new,
     );
     if !structural_findings.is_empty() {
@@ -1610,7 +1650,10 @@ fn audit_root_only(
         timing,
         "detector.field_patterns",
         plan.run_field_patterns(),
-        || field_patterns::run(root, &audit_config.detector_profile),
+        || match source_snapshot.as_ref() {
+            Some(snapshot) => field_patterns::run(snapshot, &audit_config.detector_profile),
+            None => Vec::new(),
+        },
         Vec::new,
     );
     if !field_pattern_findings.is_empty() {


### PR DESCRIPTION
## Summary

Migrates the remaining whole-tree audit detectors onto the shared in-memory source snapshot built once during discovery (#1492), instead of each detector re-walking and re-reading the tree. This is a perf refactor — findings are byte-for-byte preserved.

Closes #3401.

## Detectors migrated

- **`enum_dispatch_contracts`** — previously did its own `walk_files(Only(["rs"]))` + `read_to_string` per file. Now consumes the shared `CodebaseSnapshot`, filtering to `.rs` source files. Same test-path skip, same walk order.
- **`field_patterns`** — previously walked `Only(scan_tokens)` + re-read every file. Now filters the shared snapshot by the resolved scan-token extensions (with a `Cow` to avoid an extra allocation on the non-test-strip path). Same inline-test-strip and test-file skip logic.
- **`structural`** — was already snapshot-backed on the discovery path; the new `audit_root_only` (no-discovery `--only`) path now also feeds it the shared snapshot rather than building its own.

## Shared snapshot superset guarantee

Added `build_shared_source_snapshot()` which constructs the snapshot from `structural::source_extensions()` **plus** the field-pattern detector's resolved scan tokens (`field_patterns::scan_token_extensions`). This guarantees the shared snapshot is a superset of every snapshot-backed detector's inputs, so each detector's extension-filtered view reproduces its previous independent walk exactly. `walk_files` directory traversal order is identical regardless of the extension filter, and both migrated detectors sort their groups deterministically — so findings (and ordering) are unchanged.

The `audit_root_only` path builds the snapshot only when structural or field-pattern detection is enabled, preserving the cheap `--only` selections that don't need it.

## Verification

- `cargo build --lib` compiles clean (no new warnings).
- `cargo fmt` clean.
- Targeted lib tests pass: `field_patterns` (29), `enum_dispatch_contracts` (4), `structural` (11) — including the existing `snapshot_analysis_matches_root_analysis` equivalence test.
- Detector unit tests updated to feed a `CodebaseSnapshot` (via a `snapshot_of` test helper) instead of a root path, exercising the new shared-state input shape.