### PR TITLE
refactor(audit): make test coverage and vacuity detectors language-agnostic (#2841)

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -117,6 +117,77 @@ impl Language {
     pub fn builtin_test_file_suffixes() -> &'static [&'static str] {
         &["_test.rs", "_test.php", ".test.ts", ".test.js", ".test.tsx"]
     }
+
+    /// Method names that are universally idiomatic-shape across the ecosystems
+    /// Homeboy can classify — stdlib/trait methods, common conversions and
+    /// accessors, builder/serde hooks, and framework lifecycle/magic methods.
+    ///
+    /// These names are *expected* to carry boilerplate-shaped bodies across
+    /// unrelated types (e.g. every collection wrapper defines the same
+    /// `len`/`is_empty`), so coverage and duplication detectors treat them as
+    /// idiomatic rather than as gaps or smells. The concrete ecosystem literals
+    /// live here in the agnostic conventions home so detector implementations
+    /// under `code_audit::detectors` stay free of hardcoded language names;
+    /// components that opt into builtin defaults inherit this set and others
+    /// declare their own via `TestMappingConfig`.
+    pub fn builtin_trivial_method_names() -> &'static [&'static str] {
+        &[
+            // Core trait methods
+            "new",
+            "default",
+            "from",
+            "into",
+            "clone",
+            "fmt",
+            "display",
+            "eq",
+            "hash",
+            "drop",
+            // Common conversions
+            "as_str",
+            "as_ref",
+            "as_mut",
+            "to_string",
+            "to_str",
+            "to_owned",
+            // Common accessors
+            "is_empty",
+            "len",
+            "iter",
+            // Serialization hooks
+            "serialize",
+            "deserialize",
+            // Builder pattern
+            "build",
+            "builder",
+            // Magic / constructor methods
+            "__construct",
+            "__destruct",
+            "__toString",
+            "__clone",
+            "get_instance",
+            "getInstance",
+            // Test lifecycle methods (optional base-class overrides — not every
+            // test class needs to define them).
+            "set_up",
+            "tear_down",
+            "set_up_before_class",
+            "tear_down_after_class",
+            "setUp",
+            "tearDown",
+            "setUpBeforeClass",
+            "tearDownAfterClass",
+        ]
+    }
+
+    /// Method-name prefixes that mark a method as a simple getter / predicate
+    /// (e.g. `get_`, `is_`, `has_`). Like [`Self::builtin_trivial_method_names`],
+    /// these are kept in the agnostic conventions home so detectors do not bake
+    /// in language-shaped accessor conventions. Components that opt into builtin
+    /// defaults inherit this set; others declare their own.
+    pub fn builtin_trivial_method_prefixes() -> &'static [&'static str] {
+        &["get_", "is_", "has_"]
+    }
 }
 
 /// Builtin tracker-reference regex defaults shipped with Homeboy. These match

--- a/src/core/code_audit/detectors/test_coverage.rs
+++ b/src/core/code_audit/detectors/test_coverage.rs
@@ -66,6 +66,13 @@ pub(crate) fn analyze_test_coverage(
         .and_then(|policy| policy.package_name.as_ref())
         .and_then(|source| resolve_package_name(root, source));
 
+    // Resolve the effective idiomatic-method sets once. These are
+    // config-declared (or the builtin agnostic fallback) so the detector does
+    // not embed any language/ecosystem literals when deciding which methods are
+    // exempt from coverage findings.
+    let trivial_names = config.effective_trivial_method_names();
+    let trivial_prefixes = config.effective_trivial_method_prefixes();
+
     // Check 1 & 2: For each source file, check for corresponding test file and methods
     for source_fp in &source_fps {
         // Skip files matching skip_test_patterns (e.g. CLI wrappers, pure type defs)
@@ -184,7 +191,7 @@ pub(crate) fn analyze_test_coverage(
 
             // Find source methods without tests (Check 2: MissingTestMethod)
             for method in &source_methods {
-                if is_trivial_method(method) {
+                if is_trivial_method(method, &trivial_names, &trivial_prefixes) {
                     continue;
                 }
                 if !is_testable_visibility(method, &source_fp.visibility) {
@@ -302,7 +309,7 @@ pub(crate) fn analyze_test_coverage(
                     .unwrap_or_else(|| "test file".to_string());
 
                 for method in &source_fp.methods {
-                    if is_trivial_method(method) {
+                    if is_trivial_method(method, &trivial_names, &trivial_prefixes) {
                         continue;
                     }
                     if !is_testable_visibility(method, &source_fp.visibility) {

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use super::conventions::AuditFinding;
+use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::idiomatic::is_trivial_method;
@@ -362,8 +362,15 @@ pub(crate) fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<F
         // and Clippy's `len_without_is_empty` lint actually *requires* you to
         // pair `len` with `is_empty`. Flagging these as duplication is a
         // false positive (#1517). Predicate is shared with `test_coverage`
-        // via `super::idiomatic::is_trivial_method`.
-        if is_trivial_method(method_name) {
+        // via `super::idiomatic::is_trivial_method`. The near-duplicate pass has
+        // no per-component test mapping config, so it uses the builtin agnostic
+        // idiomatic name/prefix sets from the conventions home rather than
+        // embedding any language literals here.
+        if is_trivial_method(
+            method_name,
+            Language::builtin_trivial_method_names().iter().copied(),
+            Language::builtin_trivial_method_prefixes().iter().copied(),
+        ) {
             continue;
         }
 

--- a/src/core/code_audit/idiomatic.rs
+++ b/src/core/code_audit/idiomatic.rs
@@ -1,6 +1,6 @@
-//! Shared predicates for recognizing idiomatic Rust / PHP shape — names that
-//! are expected to have boilerplate bodies and test names that describe
-//! behavior rather than literally repeat the production method name.
+//! Shared predicates for recognizing idiomatic code shape — names that are
+//! expected to have boilerplate bodies and test names that describe behavior
+//! rather than literally repeat the production method name.
 //!
 //! Two distinct concerns live here, both about "don't punish idiomatic code":
 //!
@@ -10,6 +10,14 @@
 //! `into`, `clone`, `fmt`, `as_str`, `to_string`, etc. — are **expected** to
 //! have boilerplate-shaped bodies across unrelated types. That's the language
 //! and stdlib doing what they're designed to do, not a code-smell.
+//!
+//! The concrete ecosystem literals are **not** hardcoded here: callers pass the
+//! effective name/prefix sets (extension-config-declared, or the builtin
+//! agnostic fallback resolved via
+//! [`crate::core::extension::TestMappingConfig`] /
+//! [`crate::core::code_audit::conventions::Language`]). This predicate only
+//! implements the generic membership/prefix test, keeping language names out of
+//! the audit detector layer.
 //!
 //! - **test_coverage**: don't expect a dedicated test for a method whose name
 //!   is universally idiomatic. `len`/`is_empty`/`fmt` get tested transitively.
@@ -33,69 +41,33 @@
 //!   method is exercised by a behavior-describing test, even when the test
 //!   name doesn't literally start with `test_<methodname>`.
 
-/// Method names that are universally idiomatic-shape across types.
+/// Whether `name` is a universally idiomatic-shape method name, given the
+/// effective idiomatic name and prefix sets.
 ///
 /// Returns true if the name is either:
-/// - in a curated list of stdlib-trait / common-accessor / lifecycle method
-///   names that are expected to look the same across unrelated types, or
-/// - prefixed with `get_`, `is_`, or `has_` (simple getters / predicates).
-pub(super) fn is_trivial_method(name: &str) -> bool {
-    let trivial = [
-        // Rust core trait methods
-        "new",
-        "default",
-        "from",
-        "into",
-        "clone",
-        "fmt",
-        "display",
-        "eq",
-        "hash",
-        "drop",
-        // Rust common conversions
-        "as_str",
-        "as_ref",
-        "as_mut",
-        "to_string",
-        "to_str",
-        "to_owned",
-        // Rust common accessors
-        "is_empty",
-        "len",
-        "iter",
-        // Serde
-        "serialize",
-        "deserialize",
-        // Builder pattern
-        "build",
-        "builder",
-        // PHP magic methods
-        "__construct",
-        "__destruct",
-        "__toString",
-        "__clone",
-        "get_instance",
-        "getInstance",
-        // Test lifecycle methods (PHPUnit / WP_UnitTestCase)
-        // These are optional overrides inherited from the base test class —
-        // not every test class needs to define them.
-        "set_up",
-        "tear_down",
-        "set_up_before_class",
-        "tear_down_after_class",
-        "setUp",
-        "tearDown",
-        "setUpBeforeClass",
-        "tearDownAfterClass",
-    ];
-    if trivial.contains(&name) {
+/// - an exact member of `trivial_names` (stdlib-trait / common-accessor /
+///   lifecycle method names that look the same across unrelated types), or
+/// - starts with any entry in `trivial_prefixes` (simple getters / predicates).
+///
+/// The `trivial_names`/`trivial_prefixes` sets are supplied by the caller —
+/// resolved from extension config or the builtin agnostic fallback — so the
+/// concrete ecosystem literals never live in this detector helper.
+pub(super) fn is_trivial_method<N, P>(name: &str, trivial_names: N, trivial_prefixes: P) -> bool
+where
+    N: IntoIterator,
+    N::Item: AsRef<str>,
+    P: IntoIterator,
+    P::Item: AsRef<str>,
+{
+    if trivial_names
+        .into_iter()
+        .any(|candidate| candidate.as_ref() == name)
+    {
         return true;
     }
-    // Prefix-based rules: simple getters/accessors/predicates
-    if name.starts_with("get_") || name.starts_with("is_") || name.starts_with("has_") {
-        return true;
-    }
-    false
+    trivial_prefixes
+        .into_iter()
+        .any(|prefix| name.starts_with(prefix.as_ref()))
 }
 
 /// Check if `test_name` covers `source_method` under the configured prefix.
@@ -162,6 +134,19 @@ fn is_word_byte(b: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::code_audit::conventions::Language;
+
+    fn names() -> &'static [&'static str] {
+        Language::builtin_trivial_method_names()
+    }
+
+    fn prefixes() -> &'static [&'static str] {
+        Language::builtin_trivial_method_prefixes()
+    }
+
+    fn trivial(name: &str) -> bool {
+        is_trivial_method(name, names().iter().copied(), prefixes().iter().copied())
+    }
 
     #[test]
     fn is_trivial_method_recognizes_collection_idioms() {
@@ -169,17 +154,17 @@ mod tests {
         // Every Vec/HashMap/String wrapper in the ecosystem looks the same
         // for these names, and Clippy's `len_without_is_empty` lint requires
         // them paired.
-        assert!(is_trivial_method("len"));
-        assert!(is_trivial_method("is_empty"));
-        assert!(is_trivial_method("iter"));
+        assert!(trivial("len"));
+        assert!(trivial("is_empty"));
+        assert!(trivial("iter"));
     }
 
     #[test]
     fn is_trivial_method_recognizes_prefix_rules() {
         // Simple getters / predicates / capability checks.
-        assert!(is_trivial_method("get_foo"));
-        assert!(is_trivial_method("is_bar"));
-        assert!(is_trivial_method("has_baz"));
+        assert!(trivial("get_foo"));
+        assert!(trivial("is_bar"));
+        assert!(trivial("has_baz"));
     }
 
     #[test]
@@ -187,26 +172,49 @@ mod tests {
         // Domain methods with substantive bodies should not be considered
         // trivial — they carry real logic that's worth testing and worth
         // flagging if duplicated.
-        assert!(!is_trivial_method("compute_fixability"));
-        assert!(!is_trivial_method("from_snapshot"));
+        assert!(!trivial("compute_fixability"));
+        assert!(!trivial("from_snapshot"));
     }
 
     #[test]
     fn is_trivial_method_recognizes_stdlib_trait_methods() {
         // Core trait methods on the curated list.
-        assert!(is_trivial_method("new"));
-        assert!(is_trivial_method("default"));
-        assert!(is_trivial_method("from"));
-        assert!(is_trivial_method("into"));
-        assert!(is_trivial_method("clone"));
-        assert!(is_trivial_method("fmt"));
+        assert!(trivial("new"));
+        assert!(trivial("default"));
+        assert!(trivial("from"));
+        assert!(trivial("into"));
+        assert!(trivial("clone"));
+        assert!(trivial("fmt"));
     }
 
     #[test]
     fn is_trivial_method_recognizes_php_magic_methods() {
-        assert!(is_trivial_method("__construct"));
-        assert!(is_trivial_method("__toString"));
-        assert!(is_trivial_method("getInstance"));
+        assert!(trivial("__construct"));
+        assert!(trivial("__toString"));
+        assert!(trivial("getInstance"));
+    }
+
+    #[test]
+    fn is_trivial_method_honors_caller_supplied_sets() {
+        // The predicate is driven entirely by the caller-supplied sets — no
+        // hardcoded ecosystem literals. A custom config can opt a name in or
+        // out independently of the builtin agnostic set.
+        assert!(is_trivial_method(
+            "custom_trivial",
+            ["custom_trivial"],
+            std::iter::empty::<&str>(),
+        ));
+        assert!(is_trivial_method(
+            "fetch_record",
+            std::iter::empty::<&str>(),
+            ["fetch_"],
+        ));
+        // Builtin trivial name is NOT trivial under an empty custom set.
+        assert!(!is_trivial_method(
+            "len",
+            std::iter::empty::<&str>(),
+            std::iter::empty::<&str>(),
+        ));
     }
 
     // ========================================================================

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -143,6 +143,51 @@ pub struct TestMappingConfig {
     /// language markers supplied here; when absent, vacuity detection is skipped.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vacuity: Option<TestVacuityPolicy>,
+    /// Method names that are universally idiomatic for this ecosystem (e.g.
+    /// stdlib/trait methods, common accessors, framework lifecycle/magic
+    /// methods). Methods whose name matches are not expected to carry a
+    /// dedicated test. When empty, core falls back to its builtin agnostic set.
+    /// Extension manifests own the concrete ecosystem literals so core stays
+    /// language-agnostic.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trivial_method_names: Vec<String>,
+    /// Method-name prefixes that mark a method as a simple getter / predicate
+    /// (e.g. `get_`, `is_`, `has_`). Methods whose name starts with one are
+    /// treated as idiomatic and not expected to carry a dedicated test. When
+    /// empty, core falls back to its builtin agnostic set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trivial_method_prefixes: Vec<String>,
+}
+
+impl TestMappingConfig {
+    /// Resolve the effective set of universally-idiomatic method names for this
+    /// config, falling back to the builtin agnostic set when the extension
+    /// declared none. Returned as owned `String`s so callers can blend config
+    /// and builtin defaults without core embedding the literals.
+    pub fn effective_trivial_method_names(&self) -> Vec<String> {
+        if self.trivial_method_names.is_empty() {
+            crate::core::code_audit::conventions::Language::builtin_trivial_method_names()
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        } else {
+            self.trivial_method_names.clone()
+        }
+    }
+
+    /// Resolve the effective set of idiomatic getter/predicate prefixes for this
+    /// config, falling back to the builtin agnostic set when the extension
+    /// declared none.
+    pub fn effective_trivial_method_prefixes(&self) -> Vec<String> {
+        if self.trivial_method_prefixes.is_empty() {
+            crate::core::code_audit::conventions::Language::builtin_trivial_method_prefixes()
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        } else {
+            self.trivial_method_prefixes.clone()
+        }
+    }
 }
 
 /// Name fragments that indicate a behavior/scenario-describing test name.
@@ -1047,4 +1092,44 @@ pub struct RuntimeRequirementsConfig {
 #[serde(deny_unknown_fields)]
 pub struct RuntimeRequirementConfig {
     pub version: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_trivial_method_names_falls_back_to_builtin_set() {
+        // No config-declared idiomatic names → core uses the builtin agnostic
+        // set so existing behavior is preserved without the detector embedding
+        // the literals.
+        let config = TestMappingConfig::default();
+        let names = config.effective_trivial_method_names();
+        assert!(names.iter().any(|n| n == "len"));
+        assert!(names.iter().any(|n| n == "__construct"));
+
+        let prefixes = config.effective_trivial_method_prefixes();
+        assert!(prefixes.iter().any(|p| p == "get_"));
+        assert!(prefixes.iter().any(|p| p == "is_"));
+    }
+
+    #[test]
+    fn effective_trivial_method_names_honors_configured_policy() {
+        // A project/extension-declared policy fully replaces the builtin set —
+        // language/ecosystem conventions live in config, not in core.
+        let config = TestMappingConfig {
+            trivial_method_names: vec!["only_this".to_string()],
+            trivial_method_prefixes: vec!["fetch_".to_string()],
+            ..Default::default()
+        };
+
+        let names = config.effective_trivial_method_names();
+        assert_eq!(names, vec!["only_this".to_string()]);
+        // Builtin literals are not silently merged in.
+        assert!(!names.iter().any(|n| n == "len"));
+
+        let prefixes = config.effective_trivial_method_prefixes();
+        assert_eq!(prefixes, vec!["fetch_".to_string()]);
+        assert!(!prefixes.iter().any(|p| p == "get_"));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #2841 (parent #2240). Removes the last language/ecosystem-shaped matching from the test-coverage detector layer so coverage/vacuity stay generic concepts, with concrete ecosystem literals living in config + the canonical agnostic home.

The detectors (`test_coverage.rs`, `test_vacuity.rs`) were already config-driven via `TestMappingConfig`/`TestVacuityPolicy`. The remaining offender was `code_audit::idiomatic::is_trivial_method`, which hardcoded a curated list of Rust/Serde/PHP-magic/PHPUnit method-name literals and `get_`/`is_`/`has_` prefixes inside the audit detector layer.

## Changes

- **`idiomatic.rs`** — `is_trivial_method` is now a generic membership/prefix predicate that takes the effective name/prefix sets from the caller. No ecosystem literals remain in the detector helper. This resolves the two pre-existing `core_boundary_leak` (term `php`) baseline findings in `idiomatic.rs`.
- **`conventions.rs`** (the canonical agnostic home) — adds `Language::builtin_trivial_method_names()` and `builtin_trivial_method_prefixes()` holding the literals, consistent with the existing `builtin_*` helpers.
- **`manifest.rs`** — `TestMappingConfig` gains optional `trivial_method_names` / `trivial_method_prefixes`, plus `effective_*` resolvers that fall back to the builtin agnostic set when a component declares none. Extensions/projects can now declare their own idiomatic conventions as config.
- **`test_coverage.rs`** — resolves the effective sets once from config and passes them to `is_trivial_method`.
- **`duplication.rs`** — the near-duplicate pass (no per-component config) uses the builtin agnostic sets from the conventions home instead of an embedded literal list.

## Behavior preserved

Findings are equivalent: when no config is declared the builtin set reproduces the previous hardcoded list exactly. Tests cover both the generic predicate (caller-supplied sets, including a custom non-Rust/PHP policy) and the config fallback/override resolution.

## Verification

- `cargo build --lib` compiles clean.
- `cargo fmt` applied.
- `homeboy audit homeboy --changed-since origin/main`: `new_items: []`, `drift_increased: false` — no new findings; the `idiomatic.rs` `php` boundary-leak findings move to `resolved_fingerprints`.

> Heavy `cargo test` / `cargo build --tests` intentionally not run locally (VPS OOM constraints) — CI is the test gate.