### PR TITLE
Add controller dispatch provider config override

### DIFF
--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -75,6 +75,10 @@ pub struct AgentTaskControllerFromSpecArgs {
     /// Model override to use for controller-spawned dispatch actions when the action omits one.
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
+
+    /// Provider config JSON, @file, or - to use for controller-spawned dispatch actions when the action omits one.
+    #[arg(long = "dispatch-provider-config", value_name = "JSON")]
+    pub dispatch_provider_config: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -158,6 +162,10 @@ pub struct AgentTaskControllerRunNextArgs {
     /// Model override to use for controller-spawned dispatch actions when the action omits one.
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
+
+    /// Provider config JSON, @file, or - to use for controller-spawned dispatch actions when the action omits one.
+    #[arg(long = "dispatch-provider-config", value_name = "JSON")]
+    pub dispatch_provider_config: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -184,6 +192,10 @@ pub struct AgentTaskControllerRunArgs {
     /// Model override to use for controller-spawned dispatch actions when the action omits one.
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
+
+    /// Provider config JSON, @file, or - to use for controller-spawned dispatch actions when the action omits one.
+    #[arg(long = "dispatch-provider-config", value_name = "JSON")]
+    pub dispatch_provider_config: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -444,6 +444,7 @@ struct ControllerDispatchDefaults {
     backend: Option<String>,
     selector: Option<String>,
     model: Option<String>,
+    provider_config: Option<String>,
 }
 
 impl ControllerDispatchDefaults {
@@ -452,6 +453,7 @@ impl ControllerDispatchDefaults {
             backend: args.dispatch_backend.clone(),
             selector: args.dispatch_selector.clone(),
             model: args.dispatch_model.clone(),
+            provider_config: args.dispatch_provider_config.clone(),
         }
     }
 
@@ -460,6 +462,7 @@ impl ControllerDispatchDefaults {
             backend: args.dispatch_backend.clone(),
             selector: args.dispatch_selector.clone(),
             model: args.dispatch_model.clone(),
+            provider_config: args.dispatch_provider_config.clone(),
         }
     }
 
@@ -468,6 +471,7 @@ impl ControllerDispatchDefaults {
             backend: args.dispatch_backend.clone(),
             selector: args.dispatch_selector.clone(),
             model: args.dispatch_model.clone(),
+            provider_config: args.dispatch_provider_config.clone(),
         }
     }
 
@@ -480,6 +484,9 @@ impl ControllerDispatchDefaults {
         }
         if args.model.is_none() {
             args.model = self.model.clone();
+        }
+        if args.core.provider_config.is_none() {
+            args.core.provider_config = self.provider_config.clone();
         }
     }
 }
@@ -670,4 +677,61 @@ where
     };
     let result = agent_task_controller_service::resume(&loop_id, executor, &dispatch)?;
     Ok((command_json_value(result.value)?, result.exit_code))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn controller_dispatch_defaults_apply_provider_config_when_missing() {
+        let mut args = dispatch_args_from_controller_request(&serde_json::json!({
+            "dispatch": {
+                "prompt": "Cook",
+                "tasks": ["Do the work"],
+                "backend": "codebox"
+            }
+        }))
+        .expect("dispatch args");
+
+        ControllerDispatchDefaults {
+            backend: Some("ignored-backend".to_string()),
+            selector: None,
+            model: Some("gpt-5.5".to_string()),
+            provider_config: Some(r#"{"runtime_wordpress_version":"7.0"}"#.to_string()),
+        }
+        .apply(&mut args);
+
+        assert_eq!(args.backend.as_deref(), Some("codebox"));
+        assert_eq!(args.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(
+            args.core.provider_config.as_deref(),
+            Some(r#"{"runtime_wordpress_version":"7.0"}"#)
+        );
+    }
+
+    #[test]
+    fn controller_dispatch_defaults_preserve_existing_provider_config() {
+        let mut args = dispatch_args_from_controller_request(&serde_json::json!({
+            "dispatch": {
+                "prompt": "Cook",
+                "tasks": ["Do the work"],
+                "provider_config": "{\"runtime_wordpress_version\":\"nightly\"}"
+            }
+        }))
+        .expect("dispatch args");
+
+        ControllerDispatchDefaults {
+            backend: None,
+            selector: None,
+            model: None,
+            provider_config: Some(r#"{"runtime_wordpress_version":"7.0"}"#.to_string()),
+        }
+        .apply(&mut args);
+
+        assert_eq!(
+            args.core.provider_config.as_deref(),
+            Some(r#"{"runtime_wordpress_version":"nightly"}"#)
+        );
+    }
 }

--- a/src/commands/agent_task/tests/loop_compile.rs
+++ b/src/commands/agent_task/tests/loop_compile.rs
@@ -364,6 +364,7 @@ fn controller_from_spec_doctor_reports_missing_provider_before_resume() {
         dispatch_backend: Some("missing-provider".to_string()),
         dispatch_selector: None,
         dispatch_model: None,
+        dispatch_provider_config: None,
     })
     .expect("doctor report");
 
@@ -403,6 +404,7 @@ fn controller_from_spec_doctor_accepts_fixture_provider() {
         dispatch_backend: Some("fixture".to_string()),
         dispatch_selector: None,
         dispatch_model: None,
+        dispatch_provider_config: None,
     })
     .expect("doctor report");
 


### PR DESCRIPTION
## Summary
- add `--dispatch-provider-config` to controller `from-spec`, `resume`, `run-next`, and `run`
- apply the override only when a controller-spawned dispatch omits provider config
- keep repo-authored controller specs backend-neutral while allowing operator/runtime-specific provider config at execution time

## Verification
- Lab: `cargo test controller_dispatch_defaults -- --nocapture` via `runner-exec-homeboy-lab-a496e553-015b-462d-b533-656861a811b6`
- Lab: `cargo test controller_from_spec_doctor -- --nocapture` via `runner-exec-homeboy-lab-1505d1be-6103-49a9-afdd-4aaeb8d91ade`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the generic controller provider-config override and running focused Lab verification.