### PR TITLE
fix(test): resolve failing test (#5650)

### DIFF
--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -27,6 +27,7 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
             "test",
             "audit",
             "bench",
+            "fuzz",
             "trace",
             "refactor source runs",
             "rig check",
@@ -37,11 +38,11 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
     );
     assert_eq!(
         lab_runner_unsupported_message(),
-        "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start"
+        "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, fuzz, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start"
     );
     assert_eq!(
         lab_runner_unsupported_hint(),
-        "Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, full lint, full test, audit, bench run, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start."
+        "Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, full lint, full test, audit, bench run, fuzz run, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start."
     );
 }
 


### PR DESCRIPTION
## Summary
- Fixes the failing test `command_contract::lab::tests::test_lab_runner_supported_labels_are_contract_owned` (#5650).
- Root cause: the `feat/rig-fuzz-workloads` merge (#5655) added a `fuzz` entry to `LAB_SUPPORTED_COMMAND_SUMMARIES` in `src/command_contract/lab.rs` (between `bench` and `trace`, with `message_label: "fuzz"` / `hint_label: "fuzz run"`) but did not update the hardcoded contract expectations in `tests/command_contract/lab_test.rs`.
- Updated the three assertions in the contract test to include `fuzz`/`fuzz run` in the supported-labels list, the unsupported message, and the hint — matching the source ordering.

## Verification
- `cargo test --lib command_contract::lab::tests::test_lab_runner_supported_labels_are_contract_owned` → passes.