### PR TITLE
docs: document generic WordPress fuzzer workflow

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -23,6 +23,7 @@
 - [extension](extension.md)
 - [file](file.md) — remote file operations, downloads, uploads, copies, and syncs
 - [fleet](fleet.md)
+- [fuzz](fuzz.md) — generic fuzz workload discovery, execution, and evidence
 - [git](git.md)
 - [http](http.md) — generic proxied authenticated HTTP requests
 - [issues](issues.md) — reconcile findings against issue trackers

--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -1,6 +1,6 @@
 # Fuzz Command
 
-Resolve generic fuzz workload contracts for a Homeboy component.
+List and run generic fuzz workloads for a Homeboy component or rig.
 
 ## Synopsis
 
@@ -12,16 +12,53 @@ homeboy fuzz list [<component>] [--rig <id>]
 
 ## Description
 
-`fuzz` is the generic contract surface for future fuzz runners. Core owns the
-command shape, manifest schema, JSON envelope, and Lab portability metadata.
-Concrete fuzz engines remain extension-owned.
-
-The initial `run` implementation returns a structured `planned` contract. It
-does not execute a fuzzer yet.
+`fuzz` is the generic contract surface for fuzz runners. Core owns the command
+shape, manifest schema, JSON envelope, persisted run/artifact evidence, and Lab
+portability metadata. Concrete fuzz engines remain extension-owned.
 
 With `--rig <id>`, `fuzz` resolves the rig component path and extension config,
 uses `fuzz.default_component` when no component is passed, and includes
 rig-owned `fuzz_workloads` for the selected extension.
+
+## Operator Workflow
+
+Start by listing the workloads declared by the rig and the selected extension:
+
+```bash
+homeboy fuzz list --rig <rig-id>
+```
+
+Run one workload through the fuzz command surface:
+
+```bash
+homeboy fuzz run --rig <rig-id> --workload <workload-id>
+```
+
+The run output should include a persisted run id. Inspect the recorded evidence
+through `homeboy runs` instead of opening temporary runner paths directly:
+
+```bash
+homeboy runs show <run-id>
+homeboy runs artifact get <run-id> <artifact-id> --output <path>
+```
+
+`homeboy runs show` renders the compact summary, coverage metadata when the
+runner provides it, and fetch commands for recorded artifacts such as failing
+cases, repro cases, and coverage reports. Use `homeboy runs artifact get` for
+artifact bytes that are stored locally or mirrored from a runner.
+
+Fuzz workloads do not have a benchmark fallback. If `homeboy fuzz run` cannot
+execute the selected workload, fix the fuzz runner, rig declaration, or Lab
+routing and re-run `homeboy fuzz run`; do not substitute `homeboy bench` as fuzz
+proof. Benchmark runs measure performance and baseline deltas, while fuzz runs
+exercise generated or discovered cases and preserve fuzz-specific case evidence.
+
+Heavy fuzz campaigns should run through Homeboy's offloaded Lab path. Use the
+normal `homeboy fuzz run --rig ... --workload ...` command and let Lab routing
+select the runner, or pass a runner explicitly with the global `--runner <id>`
+flag when required. The reviewer-facing proof is the persisted run plus artifact
+refs surfaced by `homeboy runs show` and `homeboy runs artifact get`, not a
+controller-local hot run or a benchmark surrogate.
 
 ## Manifest Shape
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ repository.
 - Rig spec JSON schema: [rig-spec](commands/rig-spec.md)
 - Combined-fixes branch specs: [stack](commands/stack.md)
 - Performance benchmarks with baseline ratchet: [bench](commands/bench.md)
+- Generic fuzz workload execution and evidence: [fuzz](commands/fuzz.md)
 - API authentication scoped per project: [auth](commands/auth.md)
 - JSON output envelope: [JSON output contract](architecture/output-system.md)
 - CI artifact payload for PR review agents: [CI result JSON contract](architecture/ci-results-contract.md)


### PR DESCRIPTION
## Summary
- Document the generic fuzz operator command path: `homeboy fuzz list --rig ...`, `homeboy fuzz run --rig ... --workload ...`, `homeboy runs show ...`, and `homeboy runs artifact get ...`.
- State that fuzz workloads have no benchmark fallback and that failed fuzz execution should be fixed in the fuzz runner, rig declaration, or Lab routing.
- Add the fuzz command to the embedded docs indexes and note offloaded Lab proof for heavy fuzz campaigns.

## Dependencies
- This is a Homeboy docs-only PR. No `homeboy-rigs` changes are required for the generic workflow docs.
- Runtime proof depends on the relevant fuzz runner/rig execution PRs producing persisted run ids and artifacts through the normal Homeboy observation store.

## Testing
- Not run: docs-only change; local Rust/cargo validation is avoided on this machine per operator rules.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and applying the docs update, inspecting repository docs structure, and preparing this PR description.