### PR TITLE
fix(review): support Lab runner routing

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -26,7 +26,8 @@ pub use lab::{
     LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
 };
 pub(crate) use lab::{
-    AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, TEST_LAB_LABEL,
+    AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REVIEW_LAB_LABEL,
+    TEST_LAB_LABEL,
 };
 pub use output::{
     registered_command_dispatch_family, registered_command_json_family, CommandDescriptor,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -90,6 +90,7 @@ const AGENT_TASK_AUTH_STATUS_LAB_LABEL: &str = "agent-task auth status";
 pub(crate) const LINT_LAB_LABEL: &str = "lint";
 pub(crate) const TEST_LAB_LABEL: &str = "test";
 pub(crate) const AUDIT_LAB_LABEL: &str = "audit";
+pub(crate) const REVIEW_LAB_LABEL: &str = "review";
 pub(crate) const BENCH_LAB_LABEL: &str = "bench";
 pub(crate) const FUZZ_LAB_LABEL: &str = "fuzz";
 const TRACE_LAB_LABEL: &str = "trace";
@@ -165,6 +166,12 @@ const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
         contract_labels: &[AUDIT_LAB_LABEL],
         message_label: AUDIT_LAB_LABEL,
         hint_label: AUDIT_LAB_LABEL,
+    },
+    LabSupportedCommandSummary {
+        #[cfg(test)]
+        contract_labels: &[REVIEW_LAB_LABEL],
+        message_label: REVIEW_LAB_LABEL,
+        hint_label: "full review",
     },
     LabSupportedCommandSummary {
         #[cfg(test)]
@@ -328,6 +335,7 @@ impl Commands {
             }
             Commands::Fleet(args) => args.lab_contract()?,
             Commands::Lint(args) => args.lab_contract()?,
+            Commands::Review(args) => args.lab_contract(),
             Commands::Refactor(args) if args.is_hot_resource_command() => {
                 LabCommandContract::portable(
                     "refactor",
@@ -607,6 +615,10 @@ impl Commands {
             Commands::Lint(args) => {
                 extension_ids.extend(args.extension_override.extensions.clone())
             }
+            Commands::Review(args) => {
+                extension_ids.extend(args.extension_override.extensions.clone());
+                extension_ids.extend(review_lab_extension_ids(args)?);
+            }
             Commands::Test(args) => {
                 extension_ids.extend(args.extension_override.extensions.clone());
                 extension_ids.extend(test_lab_extension_ids(args)?);
@@ -662,6 +674,37 @@ fn test_lab_extension_ids(
         capability: Some(ExtensionCapability::Test),
         settings_overrides: args.setting_args.setting.clone(),
         settings_json_overrides: args.setting_args.setting_json.clone(),
+        extension_overrides: args.extension_override.extensions.clone(),
+    })?;
+
+    Ok(context.extension_id.into_iter().collect())
+}
+
+fn review_lab_extension_ids(
+    args: &crate::commands::review::ReviewArgs,
+) -> crate::core::Result<Vec<String>> {
+    let source_context = execution_context::resolve(&ResolveOptions {
+        component_id: args.comp.component.clone(),
+        path_override: args.comp.path.clone(),
+        capability: None,
+        settings_overrides: Vec::new(),
+        settings_json_overrides: Vec::new(),
+        extension_overrides: args.extension_override.extensions.clone(),
+    })?;
+
+    if source_context
+        .component
+        .has_script(ExtensionCapability::Test)
+    {
+        return Ok(Vec::new());
+    }
+
+    let context = execution_context::resolve(&ResolveOptions {
+        component_id: args.comp.component.clone(),
+        path_override: args.comp.path.clone(),
+        capability: Some(ExtensionCapability::Test),
+        settings_overrides: Vec::new(),
+        settings_json_overrides: Vec::new(),
         extension_overrides: args.extension_override.extensions.clone(),
     })?;
 

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -34,6 +34,7 @@ use super::parse_key_val;
 use super::utils::args::{BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs};
 use super::utils::output::{write_output_file_atomically, OutputWriteOptions};
 use super::{audit, lint, test, CmdResult, GlobalArgs};
+use crate::command_contract::{LabCommandContract, REVIEW_LAB_LABEL};
 
 mod observation;
 pub(super) mod raw_output;
@@ -79,6 +80,18 @@ pub struct ReviewArgs {
 
     #[command(flatten)]
     pub baseline_args: BaselineArgs,
+}
+
+const REVIEW_SCOPED_LAB_UNSUPPORTED_REASON: &str = "Scoped review runs stay local because their audit, lint, and test substeps use changed-file scopes that are not represented consistently in the current Lab portability contract yet.";
+
+impl ReviewArgs {
+    pub(crate) fn lab_contract(&self) -> LabCommandContract {
+        if self.changed_since.is_some() || self.changed_only {
+            LabCommandContract::local_only(REVIEW_LAB_LABEL, REVIEW_SCOPED_LAB_UNSUPPORTED_REASON)
+        } else {
+            LabCommandContract::portable(REVIEW_LAB_LABEL, None, true, &[]).release_gate()
+        }
+    }
 }
 
 /// True when the caller asked for a markdown PR-comment section instead of

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -380,6 +380,13 @@ fn unsupported_runner_hints(
 ) -> Vec<String> {
     let mut hints = vec![support_hint];
 
+    if let Some(commands) = review_lab_fallback_commands(runner_id, normalized_args) {
+        hints.push(format!(
+            "Scoped `homeboy review` cannot offload yet. Run these full-workspace Lab gates instead: {}; {}; {}.",
+            commands.audit, commands.lint, commands.test
+        ));
+    }
+
     if let Some(service_command) = tunnel_service_command(normalized_args) {
         hints.push(format!(
             "`tunnel service {service_command} --runner {runner_id}` is not routed directly; inspect runner-side tunnel state with `homeboy runner exec {runner_id} --ssh --raw -- homeboy tunnel service {service_command} ...` until service inspection supports native --runner routing."
@@ -387,6 +394,98 @@ fn unsupported_runner_hints(
     }
 
     hints
+}
+
+struct ReviewLabFallbackCommands {
+    audit: String,
+    lint: String,
+    test: String,
+}
+
+fn review_lab_fallback_commands(
+    runner_id: &str,
+    normalized_args: &[String],
+) -> Option<ReviewLabFallbackCommands> {
+    let review_index = normalized_args.iter().position(|arg| arg == "review")?;
+    let review_args = &normalized_args[review_index + 1..];
+    let mut component: Option<&str> = None;
+    let mut path: Option<&str> = None;
+    let mut extensions: Vec<&str> = Vec::new();
+    let mut scoped = false;
+    let mut i = 0;
+
+    while i < review_args.len() {
+        let arg = review_args[i].as_str();
+        if arg == "--changed-only" || arg.starts_with("--changed-since=") {
+            scoped = true;
+        } else if arg == "--changed-since" {
+            scoped = true;
+            i += 1;
+        } else if arg == "--path" {
+            if let Some(value) = review_args.get(i + 1) {
+                path = Some(value.as_str());
+            }
+            i += 1;
+        } else if let Some(value) = arg.strip_prefix("--path=") {
+            path = Some(value);
+        } else if arg == "--extension" {
+            if let Some(value) = review_args.get(i + 1) {
+                extensions.push(value.as_str());
+            }
+            i += 1;
+        } else if let Some(value) = arg.strip_prefix("--extension=") {
+            extensions.push(value);
+        } else if !arg.starts_with('-') && component.is_none() {
+            component = Some(arg);
+        }
+        i += 1;
+    }
+
+    if !scoped {
+        return None;
+    }
+
+    let mut common = vec!["--runner".to_string(), shell_arg(runner_id)];
+    if let Some(path) = path {
+        common.push("--path".to_string());
+        common.push(shell_arg(path));
+    }
+    for extension in extensions {
+        common.push("--extension".to_string());
+        common.push(shell_arg(extension));
+    }
+    if path.is_none() {
+        if let Some(component) = component {
+            common.push(shell_arg(component));
+        }
+    }
+
+    Some(ReviewLabFallbackCommands {
+        audit: fallback_command("audit", &common),
+        lint: fallback_command("lint", &common),
+        test: fallback_command("test", &common),
+    })
+}
+
+fn fallback_command(command: &str, args: &[String]) -> String {
+    let suffix = if args.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", args.join(" "))
+    };
+    format!("`homeboy {command}{suffix}`")
+}
+
+fn shell_arg(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '@'))
+    {
+        return value.to_string();
+    }
+
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn tunnel_service_command(normalized_args: &[String]) -> Option<&str> {
@@ -1989,6 +2088,34 @@ mod tests {
             requires_playwright: false,
             routing_policy: crate::command_contract::LabRoutingPolicy::default(),
         }
+    }
+
+    #[test]
+    fn scoped_review_runner_rejection_includes_full_gate_fallbacks() {
+        let args = vec![
+            "homeboy".to_string(),
+            "review".to_string(),
+            "homeboy".to_string(),
+            "--changed-since".to_string(),
+            "origin/main".to_string(),
+            "--extension".to_string(),
+            "rust".to_string(),
+        ];
+
+        let hints = unsupported_runner_hints("homeboy-lab", &args, "support".to_string());
+
+        assert!(hints.iter().any(|hint| hint.contains(
+            "`homeboy audit --runner homeboy-lab --extension rust homeboy`; `homeboy lint --runner homeboy-lab --extension rust homeboy`; `homeboy test --runner homeboy-lab --extension rust homeboy`"
+        )));
+    }
+
+    #[test]
+    fn unscoped_review_runner_rejection_does_not_include_fallbacks() {
+        let args = vec!["homeboy".to_string(), "review".to_string()];
+
+        let hints = unsupported_runner_hints("homeboy-lab", &args, "support".to_string());
+
+        assert_eq!(hints, vec!["support".to_string()]);
     }
 
     #[test]

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -26,6 +26,7 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
             "lint",
             "test",
             "audit",
+            "review",
             "bench",
             "fuzz",
             "trace",
@@ -38,11 +39,11 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
     );
     assert_eq!(
         lab_runner_unsupported_message(),
-        "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, fuzz, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start"
+        "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, review, bench, fuzz, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start"
     );
     assert_eq!(
         lab_runner_unsupported_hint(),
-        "Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, full lint, full test, audit, bench run, fuzz run, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start."
+        "Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, full lint, full test, audit, full review, bench run, fuzz run, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start."
     );
 }
 
@@ -66,6 +67,7 @@ fn test_supports_lab_runner() {
     assert!(parsed_command(&["homeboy", "lint"]).supports_lab_runner());
     assert!(parsed_command(&["homeboy", "test"]).supports_lab_runner());
     assert!(parsed_command(&["homeboy", "audit"]).supports_lab_runner());
+    assert!(parsed_command(&["homeboy", "review"]).supports_lab_runner());
     assert!(parsed_command(&["homeboy", "refactor", "--from", "audit"]).supports_lab_runner());
     assert!(parsed_command(&["homeboy", "refactor", "--all"]).supports_lab_runner());
     assert!(parsed_command(&["homeboy", "bench"]).supports_lab_runner());
@@ -178,6 +180,11 @@ fn test_supports_lab_runner() {
         !parsed_command(&["homeboy", "test", "--changed-since", "origin/main"])
             .supports_lab_runner()
     );
+    assert!(
+        !parsed_command(&["homeboy", "review", "--changed-since", "origin/main"])
+            .supports_lab_runner()
+    );
+    assert!(!parsed_command(&["homeboy", "review", "--changed-only"]).supports_lab_runner());
 
     let cli = parsed_cli(&["homeboy", "lint", "--runner", "lab-a"]);
     assert_eq!(cli.runner.as_deref(), Some("lab-a"));
@@ -205,6 +212,7 @@ fn test_lab_command_contracts_cover_hot_commands() {
         (parsed_command(&["homeboy", "lint"]), "lint"),
         (parsed_command(&["homeboy", "test"]), "test"),
         (parsed_command(&["homeboy", "audit"]), "audit"),
+        (parsed_command(&["homeboy", "review"]), "review"),
         (parsed_command(&["homeboy", "bench"]), "bench"),
         (
             parsed_command(&[
@@ -359,6 +367,11 @@ fn test_lab_command_contracts_cover_hot_commands() {
         .lab_contract()
         .expect("audit contract");
     assert!(audit_full.routing_policy.release_gate);
+
+    let review_full = parsed_command(&["homeboy", "review"])
+        .lab_contract()
+        .expect("review contract");
+    assert!(review_full.routing_policy.release_gate);
 
     // Changed-scope/local-only variants and non-gate commands are NOT
     // release gates.
@@ -535,6 +548,8 @@ fn test_lab_command_contracts_cover_hot_commands() {
         ["homeboy", "lint", "--changed-since", "origin/main"].as_slice(),
         ["homeboy", "lint", "--changed-only"].as_slice(),
         ["homeboy", "test", "--changed-since", "origin/main"].as_slice(),
+        ["homeboy", "review", "--changed-since", "origin/main"].as_slice(),
+        ["homeboy", "review", "--changed-only"].as_slice(),
     ] {
         let contract = parsed_command(args)
             .lab_contract()


### PR DESCRIPTION
## Summary
- Add a Lab portability contract for full-workspace `homeboy review`, so `--runner` can offload the review umbrella as a release gate.
- Keep scoped `review --changed-since/--changed-only` local-only because the underlying scoped audit/lint/test contracts are not Lab-portable yet.
- Add explicit scoped-review fallback hints with full-workspace Lab-compatible `audit`, `lint`, and `test` commands.

Fixes #5663.

## Verification
- `homeboy runner workspace sync homeboy-lab --path /Users/chubes/Developer/homeboy@fix-review-lab-runner --mode snapshot`
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-review-lab-runner-4c665951b1fa-32ea084e-b74c-4306-87bd-e3c68fd65942-1782077286865836000 --raw -- cargo test review` passed: 134 matching tests passed, 0 failed.
- Persisted run: `runner-exec-homeboy-lab-014b3873-0f7a-4712-9043-a91fe9d67bf9`.
- `git diff --check` passed locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Source inspection, implementation, tests, Lab/offloaded verification, and PR preparation.