### PR TITLE
fix(audit): resolve thin-adapter and field-pattern findings (#5647, #5642)

### DIFF
--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -45,26 +45,22 @@ pub(crate) struct TypedCommandAdapter<Args> {
 }
 
 pub(crate) struct BoundCommandAdapter {
-    execution: BoundCommandExecution,
-}
-
-enum BoundCommandExecution {
-    Fleet {
-        args: fleet::FleetArgs,
-        execute_json: JsonCommandExecutor<fleet::FleetArgs>,
-    },
-    Version {
-        args: version::VersionArgs,
-        execute_json: JsonCommandExecutor<version::VersionArgs>,
-    },
+    run: Box<dyn FnOnce(&GlobalArgs) -> JsonCommandRun>,
 }
 
 impl BoundCommandAdapter {
-    pub fn execute_json(self, global: &GlobalArgs) -> JsonCommandRun {
-        match self.execution {
-            BoundCommandExecution::Fleet { args, execute_json } => execute_json(args, global),
-            BoundCommandExecution::Version { args, execute_json } => execute_json(args, global),
+    /// Bind already-parsed arguments to their typed executor, capturing both in a
+    /// single delegation closure. This keeps the adapter thin: every command's
+    /// real work lives behind its own `execute_json` executor, and binding adds
+    /// no per-command dispatch arms here — only argument-to-executor pairing.
+    fn bind<Args: 'static>(args: Args, executor: JsonCommandExecutor<Args>) -> Self {
+        Self {
+            run: Box::new(move |global| executor(args, global)),
         }
+    }
+
+    pub fn run(self, global: &GlobalArgs) -> JsonCommandRun {
+        (self.run)(global)
     }
 }
 
@@ -94,26 +90,16 @@ pub(crate) fn command_adapter(
 ) -> Result<BoundCommandAdapter, Commands> {
     match command {
         Commands::Fleet(args) => {
-            let adapter = fleet::adapter(output_file_mode);
-            Ok(BoundCommandAdapter {
-                execution: BoundCommandExecution::Fleet {
-                    args,
-                    execute_json: adapter
-                        .execute_json
-                        .expect("fleet adapter supports JSON execution"),
-                },
-            })
+            let executor = fleet::adapter(output_file_mode)
+                .execute_json
+                .expect("fleet adapter supports JSON execution");
+            Ok(BoundCommandAdapter::bind(args, executor))
         }
         Commands::Version(args) => {
-            let adapter = version::adapter(output_file_mode);
-            Ok(BoundCommandAdapter {
-                execution: BoundCommandExecution::Version {
-                    args,
-                    execute_json: adapter
-                        .execute_json
-                        .expect("version adapter supports JSON execution"),
-                },
-            })
+            let executor = version::adapter(output_file_mode)
+                .execute_json
+                .expect("version adapter supports JSON execution");
+            Ok(BoundCommandAdapter::bind(args, executor))
         }
         command => Err(command),
     }

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -824,20 +824,12 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
     Ok((BenchOutput::List(output), 0))
 }
 
-struct ListRigContext {
-    spec: RigSpec,
-    package_root: Option<PathBuf>,
-}
+type ListRigContext = rig::RigSourceContext;
 
 fn load_list_rig(args: &BenchListArgs) -> homeboy::core::Result<Option<ListRigContext>> {
     match args.rig.as_slice() {
         [] => Ok(None),
-        [rig_id] => {
-            let spec = rig::load(rig_id)?;
-            let package_root = rig::read_source_metadata(&spec.id)
-                .map(|metadata| PathBuf::from(metadata.package_path));
-            Ok(Some(ListRigContext { spec, package_root }))
-        }
+        [rig_id] => Ok(Some(rig::RigSourceContext::load(rig_id)?)),
         _ => Err(homeboy::core::Error::validation_invalid_argument(
             "--rig",
             "bench list accepts exactly one rig id",

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -21,10 +21,19 @@ use super::{BenchRunArgs, CmdResult};
 
 struct RigBenchContext {
     id: String,
-    spec: RigSpec,
-    package_root: Option<PathBuf>,
+    source: rig::RigSourceContext,
     snapshot: RigStateSnapshot,
     _lease: Option<ActiveRigRunLease>,
+}
+
+impl RigBenchContext {
+    fn spec(&self) -> &RigSpec {
+        &self.source.spec
+    }
+
+    fn package_root(&self) -> Option<&std::path::Path> {
+        self.source.package_root.as_deref()
+    }
 }
 
 fn prepare_rig_bench_context(
@@ -46,12 +55,10 @@ fn prepare_rig_bench_context(
         }
     }
     let snapshot = rig::snapshot_state(&declared_spec);
-    let package_root =
-        rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
+    let id = spec.id.clone();
     Ok(RigBenchContext {
-        id: spec.id.clone(),
-        spec,
-        package_root,
+        id,
+        source: rig::RigSourceContext::from_spec(spec),
         snapshot,
         _lease: lease,
     })
@@ -425,7 +432,7 @@ pub(super) fn run_single_rig(
     let matrix_components = if let Some(explicit) = args.comp.id() {
         vec![explicit.to_string()]
     } else {
-        rig_bench_components(&context.spec)
+        rig_bench_components(context.spec())
     };
 
     if matrix_components.len() <= 1 {
@@ -537,7 +544,7 @@ fn run_component_with_rig_context(
     component_override: Option<String>,
     shared_state_override: Option<PathBuf>,
 ) -> CmdResult<BenchCommandOutput> {
-    let rig_spec = rig_context.map(|context| &context.spec);
+    let rig_spec = rig_context.map(|context| context.spec());
     let rig_id = rig_context.map(|context| context.id.clone());
     let mut rig_snapshot = rig_context.map(|context| context.snapshot.clone());
     let default_component_id = rig_spec.and_then(|spec| {
@@ -720,7 +727,7 @@ fn rig_workload_runtime_inputs(
         return (Vec::new(), InvocationRequirements::default());
     };
 
-    let package_root = rig_context.and_then(|context| context.package_root.as_deref());
+    let package_root = rig_context.and_then(|context| context.package_root());
     (
         rig::workloads_for_extension(
             spec,

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use homeboy::core::component::{Component, ScopedExtensionConfig};
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
@@ -328,19 +328,13 @@ fn push_opt_env(env: &mut Vec<(String, String)>, key: &str, value: Option<&Strin
     }
 }
 
-struct FuzzRigContext {
-    spec: RigSpec,
-    package_root: Option<PathBuf>,
-}
+type FuzzRigContext = rig::RigSourceContext;
 
 fn load_rig(rig_id: Option<&str>) -> homeboy::core::Result<Option<FuzzRigContext>> {
     let Some(rig_id) = rig_id else {
         return Ok(None);
     };
-    let spec = rig::load(rig_id)?;
-    let package_root =
-        rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
-    Ok(Some(FuzzRigContext { spec, package_root }))
+    Ok(Some(rig::RigSourceContext::load(rig_id)?))
 }
 
 fn resolve_component_id(
@@ -660,7 +654,7 @@ mod tests {
         let component = rig_component_for_fuzz(&spec, "package").expect("rig component");
         let context = FuzzRigContext {
             spec,
-            package_root: Some(PathBuf::from("/tmp/homeboy-rigs/package")),
+            package_root: Some(std::path::PathBuf::from("/tmp/homeboy-rigs/package")),
         };
 
         let workloads = fuzz_workloads(&component, Some(&context), Some("generic"));

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -126,7 +126,7 @@ fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Va
         command,
         crate::command_contract::CommandOutputFileMode::None,
     ) {
-        Ok(adapter) => return adapter.execute_json(global),
+        Ok(adapter) => return adapter.run(global),
         Err(command) => command,
     };
 

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -69,7 +69,7 @@ pub use spec::{
     ComponentSpec, DiscoverSpec, ExecutableRequirementSpec, FilesystemAssertionKind,
     FilesystemAssertionSpec, NewerThanSpec, PatchOp, PipelineStep, RigRequirementsSpec,
     RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp,
-    SymlinkSpec, TimeSource, TraceDependencySpec, TraceExperimentArtifactSpec,
+    SymlinkSpec, TimeSource, TraceConfig, TraceDependencySpec, TraceExperimentArtifactSpec,
     TraceExperimentCommandSpec, TraceExperimentSpec, TraceGuardrailSpec,
     TraceNativePublicPreviewSpec, TracePhaseTemplateSpec, TracePreviewAssetFanoutSpec,
     TraceProfileSpec, TracePublicPreviewMode, TracePublicPreviewSpec, TraceVariantSpec,
@@ -208,6 +208,34 @@ fn stale_source_error(id: &str, config_path: &Path) -> Option<Error> {
 /// Load a rig spec by ID from `~/.config/homeboy/rigs/{id}.json`.
 pub fn load(id: &str) -> Result<RigSpec> {
     read_config(id).map(|(spec, _)| spec)
+}
+
+/// A loaded rig spec paired with the resolved on-disk package root of its
+/// installed source, when one is recorded.
+///
+/// Command modules repeatedly need both the parsed [`RigSpec`] and the
+/// `package_root` derived from the rig's source metadata, so this bundles the
+/// pair (and its resolution) in one place instead of re-deriving the same
+/// `{ spec, package_root }` field group in every command context.
+#[derive(Debug, Clone)]
+pub struct RigSourceContext {
+    pub spec: RigSpec,
+    pub package_root: Option<std::path::PathBuf>,
+}
+
+impl RigSourceContext {
+    /// Build a source context from an already-loaded spec, resolving the
+    /// package root from the rig's recorded source metadata.
+    pub fn from_spec(spec: RigSpec) -> Self {
+        let package_root = read_source_metadata(&spec.id)
+            .map(|metadata| std::path::PathBuf::from(metadata.package_path));
+        Self { spec, package_root }
+    }
+
+    /// Load a rig spec by ID and resolve its package root.
+    pub fn load(id: &str) -> Result<Self> {
+        Ok(Self::from_spec(load(id)?))
+    }
 }
 
 /// Return the JSON-declared rig ID when it differs from the installed ID.

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -452,6 +452,24 @@ impl BenchMetricGateCondition {
     }
 }
 
+/// Shared trace phase-preset configuration.
+///
+/// The `{ trace_phase_presets, trace_span_metadata, trace_default_phase_preset }`
+/// group is declared once here and flattened into every spec that carries it
+/// (`WorkloadSpec`, `WorkloadDefaultsSpec`, `TracePhaseTemplateSpec`), so the
+/// on-disk JSON keys stay flat while the field group lives in a single type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TraceConfig {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub trace_phase_presets: HashMap<String, Vec<String>>,
+
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub trace_span_metadata: HashMap<String, TraceSpanMetadata>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_default_phase_preset: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkloadSpec {
     pub path: String,
@@ -471,14 +489,8 @@ pub struct WorkloadSpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub named_leases: Vec<String>,
 
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub trace_phase_presets: HashMap<String, Vec<String>>,
-
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub trace_span_metadata: HashMap<String, TraceSpanMetadata>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trace_default_phase_preset: Option<String>,
+    #[serde(flatten)]
+    pub trace: TraceConfig,
 
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub trace_variants: HashMap<String, TraceVariantSpec>,
@@ -513,14 +525,8 @@ pub struct WorkloadDefaultsSpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub named_leases: Vec<String>,
 
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub trace_phase_presets: HashMap<String, Vec<String>>,
-
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub trace_span_metadata: HashMap<String, TraceSpanMetadata>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trace_default_phase_preset: Option<String>,
+    #[serde(flatten)]
+    pub trace: TraceConfig,
 
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub trace_variants: HashMap<String, TraceVariantSpec>,
@@ -540,14 +546,8 @@ pub struct WorkloadDefaultsSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct TracePhaseTemplateSpec {
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub trace_phase_presets: HashMap<String, Vec<String>>,
-
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub trace_span_metadata: HashMap<String, TraceSpanMetadata>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trace_default_phase_preset: Option<String>,
+    #[serde(flatten)]
+    pub trace: TraceConfig,
 }
 
 impl WorkloadSpec {
@@ -564,8 +564,9 @@ impl WorkloadSpec {
         if self.port_range_size.is_none() {
             self.port_range_size = defaults.port_range_size;
         }
-        if self.trace_default_phase_preset.is_none() {
-            self.trace_default_phase_preset = defaults.trace_default_phase_preset.clone();
+        if self.trace.trace_default_phase_preset.is_none() {
+            self.trace.trace_default_phase_preset =
+                defaults.trace.trace_default_phase_preset.clone();
         }
 
         prepend_missing(&mut self.named_leases, &defaults.named_leases);
@@ -573,17 +574,30 @@ impl WorkloadSpec {
         prepend_missing(&mut self.trace_probes, &defaults.trace_probes);
         prepend_missing(&mut self.dependencies, &defaults.dependencies);
         prepend_missing(&mut self.runner_capabilities, &defaults.runner_capabilities);
-        merge_defaults_map(&mut self.trace_phase_presets, &defaults.trace_phase_presets);
-        merge_defaults_map(&mut self.trace_span_metadata, &defaults.trace_span_metadata);
+        merge_defaults_map(
+            &mut self.trace.trace_phase_presets,
+            &defaults.trace.trace_phase_presets,
+        );
+        merge_defaults_map(
+            &mut self.trace.trace_span_metadata,
+            &defaults.trace.trace_span_metadata,
+        );
         merge_defaults_map(&mut self.trace_variants, &defaults.trace_variants);
     }
 
     pub fn apply_phase_template(&mut self, template: &TracePhaseTemplateSpec) {
-        if self.trace_default_phase_preset.is_none() {
-            self.trace_default_phase_preset = template.trace_default_phase_preset.clone();
+        if self.trace.trace_default_phase_preset.is_none() {
+            self.trace.trace_default_phase_preset =
+                template.trace.trace_default_phase_preset.clone();
         }
-        merge_defaults_map(&mut self.trace_phase_presets, &template.trace_phase_presets);
-        merge_defaults_map(&mut self.trace_span_metadata, &template.trace_span_metadata);
+        merge_defaults_map(
+            &mut self.trace.trace_phase_presets,
+            &template.trace.trace_phase_presets,
+        );
+        merge_defaults_map(
+            &mut self.trace.trace_span_metadata,
+            &template.trace.trace_span_metadata,
+        );
     }
 }
 
@@ -899,12 +913,14 @@ mod tests {
             check_groups: None,
             port_range_size: None,
             named_leases: Vec::new(),
-            trace_phase_presets: HashMap::from([(
-                "startup".to_string(),
-                vec!["launch".to_string(), "ready".to_string()],
-            )]),
-            trace_span_metadata: HashMap::new(),
-            trace_default_phase_preset: None,
+            trace: TraceConfig {
+                trace_phase_presets: HashMap::from([(
+                    "startup".to_string(),
+                    vec!["launch".to_string(), "ready".to_string()],
+                )]),
+                trace_span_metadata: HashMap::new(),
+                trace_default_phase_preset: None,
+            },
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
             trace_probes: Vec::new(),
@@ -1068,9 +1084,11 @@ mod tests {
             check_groups: None,
             port_range_size: None,
             named_leases: Vec::new(),
-            trace_phase_presets: HashMap::new(),
-            trace_span_metadata: HashMap::new(),
-            trace_default_phase_preset: Some("startup".to_string()),
+            trace: TraceConfig {
+                trace_phase_presets: HashMap::new(),
+                trace_span_metadata: HashMap::new(),
+                trace_default_phase_preset: Some("startup".to_string()),
+            },
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
             trace_probes: Vec::new(),
@@ -1093,9 +1111,11 @@ mod tests {
             check_groups: None,
             port_range_size: Some(8),
             named_leases: Vec::new(),
-            trace_phase_presets: HashMap::new(),
-            trace_span_metadata: HashMap::new(),
-            trace_default_phase_preset: None,
+            trace: TraceConfig {
+                trace_phase_presets: HashMap::new(),
+                trace_span_metadata: HashMap::new(),
+                trace_default_phase_preset: None,
+            },
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
             trace_probes: Vec::new(),
@@ -1118,9 +1138,11 @@ mod tests {
             check_groups: None,
             port_range_size: None,
             named_leases: vec!["browser-profile".to_string()],
-            trace_phase_presets: HashMap::new(),
-            trace_span_metadata: HashMap::new(),
-            trace_default_phase_preset: None,
+            trace: TraceConfig {
+                trace_phase_presets: HashMap::new(),
+                trace_span_metadata: HashMap::new(),
+                trace_default_phase_preset: None,
+            },
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
             trace_probes: Vec::new(),

--- a/src/core/rig/spec/workload.rs
+++ b/src/core/rig/spec/workload.rs
@@ -28,17 +28,18 @@ impl WorkloadSpec {
     }
 
     pub fn trace_phase_preset(&self, name: &str) -> Option<&[String]> {
-        self.trace_phase_presets
+        self.trace
+            .trace_phase_presets
             .get(name)
             .map(|phases| phases.as_slice())
     }
 
     pub fn trace_span_metadata(&self) -> &HashMap<String, TraceSpanMetadata> {
-        &self.trace_span_metadata
+        &self.trace.trace_span_metadata
     }
 
     pub fn trace_default_phase_preset(&self) -> Option<&str> {
-        self.trace_default_phase_preset.as_deref()
+        self.trace.trace_default_phase_preset.as_deref()
     }
 
     pub fn trace_variants(&self) -> &HashMap<String, TraceVariantSpec> {

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -3,7 +3,8 @@
 
 use crate::core::rig::{
     FilesystemAssertionKind, PipelineStep, RigRequirementsSpec, RigResourcesSpec, RigSpec,
-    ServiceKind, ServiceSpec, SharedPathSpec, SymlinkSpec, TraceVariantSpec, WorkloadSpec,
+    ServiceKind, ServiceSpec, SharedPathSpec, SymlinkSpec, TraceConfig, TraceVariantSpec,
+    WorkloadSpec,
 };
 
 /// Canonical fixture matching the studio-playground-dev shape used as the
@@ -485,12 +486,14 @@ fn workload_with_trace_metadata() -> WorkloadSpec {
         check_groups: Some(vec!["desktop-app".to_string()]),
         port_range_size: None,
         named_leases: Vec::new(),
-        trace_phase_presets: std::collections::HashMap::from([(
-            "startup".to_string(),
-            vec!["boot:runner.boot".to_string()],
-        )]),
-        trace_span_metadata: std::collections::HashMap::new(),
-        trace_default_phase_preset: Some("startup".to_string()),
+        trace: TraceConfig {
+            trace_phase_presets: std::collections::HashMap::from([(
+                "startup".to_string(),
+                vec!["boot:runner.boot".to_string()],
+            )]),
+            trace_span_metadata: std::collections::HashMap::new(),
+            trace_default_phase_preset: Some("startup".to_string()),
+        },
         trace_variants: std::collections::HashMap::from([(
             "fresh-install-mode".to_string(),
             TraceVariantSpec {


### PR DESCRIPTION
## Summary
Resolves two audit findings without changing behavior.

### #5647 — thin command adapter (`src/commands/adapter.rs`)
The `thin_command_adapter` detector flagged `adapter.rs` for "runner execution orchestration": the per-command `BoundCommandExecution` enum forced a manual `match` arm (and an `execute_json(args, global)` call) for every migrated command — exactly the dispatch accumulation the detector watches for. Replaced the growing enum with a single boxed delegation closure (`BoundCommandAdapter::bind`), so binding pairs already-parsed args to their typed executor with no per-command dispatch arms. The caller now invokes `adapter.run(global)`. Pure restructure; dispatch semantics unchanged.

### #5642 — repeated field patterns (3 findings)
- **`[package_root, spec]`** repeated across `ListRigContext` (bench.rs), `RigBenchContext` (bench/matrix.rs), and `FuzzRigContext` (fuzz.rs): extracted into a shared `rig::RigSourceContext { spec, package_root }` in the core rig module, which also centralizes the duplicated `rig::load` + `rig::read_source_metadata` resolution. `ListRigContext`/`FuzzRigContext` are now type aliases; `RigBenchContext` composes it as a single `source` field with `spec()`/`package_root()` accessors.
- **`[trace_default_phase_preset, trace_phase_presets, trace_span_metadata]`** repeated across `WorkloadSpec`, `WorkloadDefaultsSpec`, and `TracePhaseTemplateSpec` (`src/core/rig/spec.rs`): extracted into a shared `TraceConfig` embedded via `#[serde(flatten)]`, preserving the flat on-disk JSON wire format. Merge logic and accessors updated to read through the nested field.

## Verification
- `homeboy audit homeboy`: both the `adapter.rs` thin-adapter finding and all three `[package_root, spec]` / trace-group field-pattern findings are in `resolved_fingerprints`; no new findings reference any touched file.
- `cargo build --lib` clean, `cargo clippy --lib` clean (no unused imports), `cargo fmt` applied.
- Core stays ecosystem-agnostic.

Closes #5647
Closes #5642