### PR TITLE
fix: centralize artifact viewer descriptors

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -261,6 +261,13 @@ Use `labels` for non-public or freeform context that should stay as text, such
 as `source: zendesk`, `scenario: shortcode checkout place-order latency`, or
 `privacy: internal`. Use `links` for reviewer-clickable references.
 
+Bench artifacts can attach a `viewer` descriptor when a file artifact has a
+browser-based reviewer view. Homeboy keeps link generation generic: descriptors
+name the viewer kind, base URL, and query parameter whose value is the public
+artifact URL. Built-in viewer descriptors live in `core::artifact_links` so new
+viewer families, such as Codebox artifact viewers, can be added without
+duplicating URL construction at call sites.
+
 The command is read-only and exits successfully for a valid comparison even when the numbers regress. Repeat `--metric <name>` to keep the comparison focused; omit it to compare all shared numeric scenario metrics.
 
 Homeboy rejects comparisons when the stored shared benchmark context differs for settings, selected scenarios, workload fingerprints, iteration count, run count, or concurrency. This keeps manually-created baseline/candidate runs from being compared when they were not actually measuring the same scenario contract.

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -856,15 +856,7 @@ mod tests {
             size_bytes: None,
             mime: Some("application/json".to_string()),
             metadata_json: serde_json::json!({
-                "viewer": {
-                    "kind": "wordpress-playground-blueprint",
-                    "base": "https://playground.wordpress.net/",
-                    "query": {
-                        "parameter": "blueprint-url",
-                        "value": { "source": "public-artifact-url" },
-                        "encoding": "url"
-                    }
-                },
+                "viewer": homeboy::core::artifact_links::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None),
                 "public_url_validation": {
                     "url": "https://artifacts.example.test/homeboy/runs/run-1/artifacts/artifact-1",
                     "reachable": false,
@@ -975,15 +967,10 @@ mod tests {
                     kind: Some("json".to_string()),
                     label: Some("Transcript".to_string()),
                     observation_artifact_id: None,
-                    viewer: Some(serde_json::json!({
-                        "kind": "wordpress-playground-blueprint",
-                        "base": "https://playground.wordpress.net/",
-                        "query": {
-                            "parameter": "blueprint-url",
-                            "value": { "source": "public-artifact-url" },
-                            "encoding": "url"
-                        }
-                    })),
+                    viewer: Some(
+                        homeboy::core::artifact_links::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER
+                            .to_metadata(None),
+                    ),
                     ..BenchArtifact::default()
                 },
             );

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1369,21 +1369,10 @@ mod tests {
                             "algorithm": "sha256",
                             "value": "abc123"
                         },
-                        "viewer": {
-                            "kind": "wordpress-playground-blueprint",
-                            "base": "https://playground.wordpress.net/",
-                            "query": {
-                                "parameter": "blueprint-url",
-                                "value": {
-                                    "source": "public-artifact-url"
-                                },
-                                "encoding": "url"
-                            },
-                            "replay": {
+                        "viewer": homeboy::core::artifact_links::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(Some(serde_json::json!({
                                 "status": "partial",
                                 "limitations": ["fixture limitation"]
-                            }
-                        }
+                        })))
                     }]
                 })
                 .to_string(),
@@ -1466,15 +1455,7 @@ mod tests {
                     "bench_artifact",
                     &artifact_path,
                     serde_json::json!({
-                        "viewer": {
-                            "kind": "wordpress-playground-blueprint",
-                            "base": "https://playground.wordpress.net/",
-                            "query": {
-                                "parameter": "blueprint-url",
-                                "value": { "source": "public-artifact-url" },
-                                "encoding": "url"
-                            }
-                        }
+                        "viewer": homeboy::core::artifact_links::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None)
                     }),
                 )
                 .expect("record artifact");

--- a/src/core/artifact_links.rs
+++ b/src/core/artifact_links.rs
@@ -6,7 +6,50 @@ use crate::core::execution_contract::encode_uri_component;
 use crate::core::observation::{ArtifactRecord, ArtifactViewerLink};
 
 pub const PUBLIC_ARTIFACT_BASE_URL_ENV: &str = "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL";
+pub const WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER: ArtifactViewerDescriptor =
+    ArtifactViewerDescriptor::new(
+        "wordpress-playground-blueprint",
+        "https://playground.wordpress.net/",
+        "blueprint-url",
+    );
 const PUBLIC_ARTIFACT_URL_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtifactViewerDescriptor {
+    pub kind: &'static str,
+    pub base: &'static str,
+    pub public_artifact_url_parameter: &'static str,
+}
+
+impl ArtifactViewerDescriptor {
+    pub const fn new(
+        kind: &'static str,
+        base: &'static str,
+        public_artifact_url_parameter: &'static str,
+    ) -> Self {
+        Self {
+            kind,
+            base,
+            public_artifact_url_parameter,
+        }
+    }
+
+    pub fn to_metadata(self, replay: Option<Value>) -> Value {
+        let mut viewer = serde_json::json!({
+            "kind": self.kind,
+            "base": self.base,
+            "query": {
+                "parameter": self.public_artifact_url_parameter,
+                "value": { "source": "public-artifact-url" },
+                "encoding": "url"
+            }
+        });
+        if let Some(replay) = replay {
+            viewer["replay"] = replay;
+        }
+        viewer
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublicArtifactUrlValidation {
@@ -249,6 +292,16 @@ mod tests {
             links[0].url,
             "https://viewer.example.test/?artifact-url=https%3A%2F%2Fartifacts.example.test%2Fa%20b.json"
         );
+    }
+
+    #[test]
+    fn playground_descriptor_produces_public_artifact_viewer_metadata() {
+        let viewer = WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None);
+
+        assert_eq!(viewer["kind"], "wordpress-playground-blueprint");
+        assert_eq!(viewer["base"], "https://playground.wordpress.net/");
+        assert_eq!(viewer["query"]["parameter"], "blueprint-url");
+        assert_eq!(viewer["query"]["value"]["source"], "public-artifact-url");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add an ArtifactViewerDescriptor seam for public-artifact-url viewer metadata.
- Centralize the WordPress Playground blueprint viewer as a reusable descriptor constant.
- Document the generic descriptor boundary for future viewer families such as Codebox.

## Verification
- Ran: rustfmt src/core/artifact_links.rs src/commands/bench/observation.rs src/commands/runs.rs
- Ran: git diff --check
- Not run: cargo test / cargo check / cargo fmt, per site rule prohibiting local cargo commands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing the descriptor seam, updating call sites/tests/docs, and preparing the PR.