### PR TITLE
feat(agent-task): expose public fanout primitive

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -35,6 +35,7 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `cancel <run-id>` | Mark a queued or stale-running durable run as cancelled. |
 | `resume <run-id>` | Resume a queued or stale-running durable run. |
 | `retry <run-id>` | Submit a fresh durable run from an existing run's plan. |
+| `fanout plan\|submit\|run-plan` | Compile, persist, or run generic provider-neutral fanout inputs. |
 
 ### Cook/Review
 
@@ -225,6 +226,48 @@ claimed later with `agent-task run` or `agent-task run-next`.
 accepted as `--selector`) selects a specific provider id for that backend, and
 `--model` is only a provider-owned model override. Provider ids come from
 `homeboy agent-task providers`; they are not model names or provider families.
+
+## Fanout/Reconcile
+
+`agent-task fanout` is the public provider-neutral seam for downstream loops that
+need to submit many related agent tasks and reconcile aggregate outcomes without
+calling Homeboy Extensions internal scripts.
+
+It accepts these generic input shapes:
+
+- `homeboy/agent-task-plan/v1`: an existing durable task plan, stamped with fanout lineage metadata when needed.
+- `homeboy/agent-task-fanout-plan/v1`: Homeboy's explicit fanout plan wrapper.
+- A JSON array of task packets, or an object with `tasks`/`packets`.
+- A single task packet object with `task_id`/`key` and `instructions`/`prompt`/`title`.
+
+Packet inputs can carry full `AgentTaskRequest` fields including `executor`,
+`workspace`, `policy`, `source_refs`, `inputs`, `expected_artifacts`, and
+`metadata`. When a packet omits `executor`, pass `--backend` and optionally
+`--selector`/`--model`, or configure a default agent-task backend.
+
+```bash
+homeboy agent-task fanout submit \
+  --input @findings.json \
+  --fanout-id audit-batch-2026-06-21 \
+  --backend codex \
+  --selector openai-codex
+```
+
+The submit response includes the durable run record plus stable follow-up
+commands:
+
+```bash
+homeboy agent-task status <run-id>
+homeboy agent-task logs <run-id>
+homeboy agent-task artifacts <run-id>
+homeboy agent-task review <run-id>
+homeboy agent-task retry <run-id> --run
+```
+
+Use `fanout plan` when a downstream repository needs a reviewable plan artifact
+before queueing it, and `fanout run-plan --record-run-id <run-id>` when an
+operator wants to execute immediately while preserving durable lineage and
+aggregate outcomes.
 
 ## Headless Fleet-Cooking Review
 

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -14,6 +14,7 @@ pub mod auth;
 pub mod contract;
 pub mod controller;
 pub mod doctor;
+pub mod fanout;
 pub mod loop_definition;
 pub mod review;
 pub mod run;
@@ -26,7 +27,9 @@ pub use args::{
     AgentTaskControllerFromSpecArgs, AgentTaskControllerInitArgs,
     AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerMaterializeArgs,
     AgentTaskControllerRunArgs, AgentTaskControllerRunNextArgs, AgentTaskControllerStatusArgs,
-    AgentTaskDoctorArgs, AgentTaskLoopArgs, CancelArgs, CompileLoopArgs, ContractArgs,
+    AgentTaskDoctorArgs, AgentTaskFanoutArgs, AgentTaskFanoutCommand, AgentTaskFanoutInputArgs,
+    AgentTaskFanoutPlanArgs, AgentTaskFanoutPlaneArg, AgentTaskFanoutRunPlanArgs,
+    AgentTaskFanoutSubmitArgs, AgentTaskLoopArgs, CancelArgs, CompileLoopArgs, ContractArgs,
     ContractFormat, FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs, RetryArgs,
     ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
@@ -61,6 +64,7 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::Cancel(cancel_args) => status::cancel(cancel_args),
         AgentTaskCommand::Resume(status_args) => run::resume(status_args),
         AgentTaskCommand::Retry(retry_args) => run::retry(retry_args),
+        AgentTaskCommand::Fanout(fanout_args) => fanout::fanout(fanout_args),
         AgentTaskCommand::Review(review_args) => review::review(review_args),
         AgentTaskCommand::Promote(promote_args) => review::promote_artifact(promote_args),
         AgentTaskCommand::FinalizePr(finalize_args) => review::finalize_pull_request(finalize_args),

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -23,6 +23,85 @@ pub use auth::{
     AgentTaskAuthRemoveArgs, AgentTaskAuthSetConfigArgs, AgentTaskAuthSetKeychainArgs,
     AgentTaskAuthSetKeychainBundleArgs, AgentTaskAuthStatusArgs,
 };
+
+#[derive(Args, Debug)]
+pub struct AgentTaskFanoutArgs {
+    #[command(subcommand)]
+    pub command: AgentTaskFanoutCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AgentTaskFanoutCommand {
+    /// Compile generic task/finding packets or an existing plan into an AgentTaskPlan.
+    Plan(AgentTaskFanoutPlanArgs),
+    /// Persist a compiled fanout plan and return durable status/log/artifact commands.
+    Submit(AgentTaskFanoutSubmitArgs),
+    /// Run a fanout plan immediately through extension-declared executor providers.
+    RunPlan(AgentTaskFanoutRunPlanArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct AgentTaskFanoutInputArgs {
+    /// Fanout spec JSON file, @file, inline JSON, or - for stdin.
+    #[arg(long = "input", value_name = "SPEC")]
+    pub input: String,
+
+    /// Fanout id to use when the input is a packet list. Defaults to a generated id.
+    #[arg(long = "fanout-id", value_name = "ID")]
+    pub fanout_id: Option<String>,
+
+    /// Fanout plane for packet inputs.
+    #[arg(long = "plane", default_value = "isolated-tasks", value_enum)]
+    pub plane: AgentTaskFanoutPlaneArg,
+
+    /// Default executor backend for packet inputs without an executor object.
+    #[arg(long = "backend", value_name = "BACKEND")]
+    pub backend: Option<String>,
+
+    /// Default executor provider selector for packet inputs without one.
+    #[arg(
+        long = "selector",
+        visible_alias = "provider-id",
+        value_name = "PROVIDER_ID"
+    )]
+    pub selector: Option<String>,
+
+    /// Default model override for packet inputs without one.
+    #[arg(long = "model", value_name = "MODEL")]
+    pub model: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskFanoutPlanArgs {
+    #[command(flatten)]
+    pub input: AgentTaskFanoutInputArgs,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskFanoutSubmitArgs {
+    #[command(flatten)]
+    pub input: AgentTaskFanoutInputArgs,
+
+    /// Optional durable run id. Generated when omitted.
+    #[arg(long = "run-id", value_name = "ID")]
+    pub run_id: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskFanoutRunPlanArgs {
+    #[command(flatten)]
+    pub input: AgentTaskFanoutInputArgs,
+
+    /// Also persist the completed run lifecycle record under this id.
+    #[arg(long = "record-run-id", value_name = "ID")]
+    pub record_run_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum AgentTaskFanoutPlaneArg {
+    IsolatedTasks,
+    Workflow,
+}
 pub use controller::{
     AgentTaskControllerApplyEventArgs, AgentTaskControllerCommand, AgentTaskControllerFromSpecArgs,
     AgentTaskControllerInitArgs, AgentTaskControllerMarkHumanReadyArgs,
@@ -73,6 +152,8 @@ pub enum AgentTaskCommand {
     Resume(StatusArgs),
     /// Lifecycle: submit a fresh durable run from an existing run's plan.
     Retry(RetryArgs),
+    /// Lifecycle: compile, submit, or run generic provider-neutral fanout inputs.
+    Fanout(AgentTaskFanoutArgs),
     /// Review: build a durable aggregate envelope from run state, logs, artifacts, and promotion hints.
     Review(ReviewArgs),
     /// Review: promote a completed generic patch artifact into a managed worktree.

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -1,0 +1,425 @@
+//! Public provider-neutral fanout/reconcile command handlers.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use homeboy::core::agent_task::{
+    AgentTaskArtifactDeclaration, AgentTaskComponentContract, AgentTaskLimits,
+};
+use homeboy::core::agent_tasks::lifecycle;
+use homeboy::core::agent_tasks::provider;
+use homeboy::core::agent_tasks::scheduler::{AgentTaskPlan, AgentTaskScheduleOptions};
+use homeboy::core::agent_tasks::{
+    AgentTaskExecutor, AgentTaskFanoutPlan, AgentTaskFanoutPlane, AgentTaskPolicy,
+    AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkspace, AGENT_TASK_FANOUT_PLAN_SCHEMA,
+    AGENT_TASK_PLAN_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+};
+use homeboy::core::{config, Error, Result};
+
+use super::super::CmdResult;
+use super::args::{
+    AgentTaskFanoutArgs, AgentTaskFanoutCommand, AgentTaskFanoutInputArgs, AgentTaskFanoutPlaneArg,
+    AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs,
+};
+use super::command_json_value;
+use super::run;
+
+pub(super) fn fanout(args: AgentTaskFanoutArgs) -> CmdResult<Value> {
+    match args.command {
+        AgentTaskFanoutCommand::Plan(plan_args) => {
+            let plan = load_fanout_agent_task_plan(&plan_args.input)?;
+            Ok((command_json_value(plan)?, 0))
+        }
+        AgentTaskFanoutCommand::Submit(submit_args) => submit_fanout(submit_args),
+        AgentTaskFanoutCommand::RunPlan(run_args) => run_fanout_plan(run_args),
+    }
+}
+
+fn submit_fanout(args: AgentTaskFanoutSubmitArgs) -> CmdResult<Value> {
+    let plan = load_fanout_agent_task_plan(&args.input)?;
+    let record = lifecycle::submit_plan(&plan, args.run_id.as_deref())?;
+    Ok((
+        serde_json::json!({
+            "schema": "homeboy/agent-task-fanout-submit-result/v1",
+            "run": record,
+            "commands": durable_commands(&record.run_id),
+        }),
+        0,
+    ))
+}
+
+fn run_fanout_plan(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
+    let plan = load_fanout_agent_task_plan(&args.input)?;
+    run::run_loaded_plan(
+        plan,
+        args.record_run_id.as_deref(),
+        provider::ExtensionProviderAgentTaskExecutor::discover(),
+    )
+}
+
+fn load_fanout_agent_task_plan(args: &AgentTaskFanoutInputArgs) -> Result<AgentTaskPlan> {
+    let raw = config::read_json_spec_to_string(&args.input)?;
+    let value: Value = serde_json::from_str(&raw).map_err(|error| {
+        Error::validation_invalid_json(
+            error,
+            Some("agent-task fanout input".to_string()),
+            Some(raw.clone()),
+        )
+    })?;
+    fanout_value_to_plan(value, args)
+}
+
+fn fanout_value_to_plan(value: Value, args: &AgentTaskFanoutInputArgs) -> Result<AgentTaskPlan> {
+    if value.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_PLAN_SCHEMA) {
+        let mut plan: AgentTaskPlan = serde_json::from_value(value).map_err(|error| {
+            Error::validation_invalid_argument(
+                "input",
+                error.to_string(),
+                None,
+                Some(vec![
+                    "Expected a valid homeboy/agent-task-plan/v1 payload.".to_string()
+                ]),
+            )
+        })?;
+        stamp_plan_fanout_metadata(&mut plan, args.fanout_id.clone());
+        return Ok(plan);
+    }
+
+    if value.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_FANOUT_PLAN_SCHEMA) {
+        let fanout_plan: AgentTaskFanoutPlan = serde_json::from_value(value).map_err(|error| {
+            Error::validation_invalid_argument(
+                "input",
+                error.to_string(),
+                None,
+                Some(vec![
+                    "Expected a valid homeboy/agent-task-fanout-plan/v1 payload.".to_string(),
+                ]),
+            )
+        })?;
+        return Ok(fanout_plan.to_agent_task_plan());
+    }
+
+    let spec = FanoutPacketSpec::from_value(value)?;
+    let fanout_id = spec
+        .fanout_id
+        .or_else(|| args.fanout_id.clone())
+        .unwrap_or_else(|| format!("agent-task-fanout-{}", uuid::Uuid::new_v4()));
+    let plane = spec.plane.unwrap_or_else(|| plane_from_arg(args.plane));
+    let tasks = spec
+        .packets
+        .into_iter()
+        .enumerate()
+        .map(|(index, packet)| packet.into_request(index, args))
+        .collect::<Result<Vec<_>>>()?;
+    if tasks.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "input",
+            "agent-task fanout requires at least one task or packet",
+            None,
+            None,
+        ));
+    }
+
+    let mut fanout_plan = AgentTaskFanoutPlan::new(fanout_id, plane, tasks);
+    fanout_plan.group_key = spec.group_key;
+    fanout_plan.options = spec.options.unwrap_or_default();
+    fanout_plan.metadata = spec.metadata.unwrap_or(Value::Null);
+    Ok(fanout_plan.to_agent_task_plan())
+}
+
+#[derive(Debug, Deserialize)]
+struct FanoutPacketSpec {
+    #[serde(default)]
+    fanout_id: Option<String>,
+    #[serde(default)]
+    plane: Option<AgentTaskFanoutPlane>,
+    #[serde(default)]
+    group_key: Option<String>,
+    #[serde(default)]
+    options: Option<AgentTaskScheduleOptions>,
+    #[serde(default)]
+    metadata: Option<Value>,
+    #[serde(default)]
+    packets: Vec<FanoutTaskPacket>,
+}
+
+impl FanoutPacketSpec {
+    fn from_value(value: Value) -> Result<Self> {
+        match value {
+            Value::Array(packets) => Ok(Self {
+                packets: parse_packet_array(packets)?,
+                fanout_id: None,
+                plane: None,
+                group_key: None,
+                options: None,
+                metadata: None,
+            }),
+            Value::Object(mut object) => {
+                if !object.contains_key("packets") {
+                    if let Some(tasks) = object.remove("tasks") {
+                        object.insert("packets".to_string(), tasks);
+                    } else if object.contains_key("task_id")
+                        || object.contains_key("key")
+                        || object.contains_key("instructions")
+                        || object.contains_key("prompt")
+                        || object.contains_key("title")
+                    {
+                        return Ok(Self {
+                            packets: vec![serde_json::from_value(Value::Object(object)).map_err(
+                                packet_parse_error,
+                            )?],
+                            fanout_id: None,
+                            plane: None,
+                            group_key: None,
+                            options: None,
+                            metadata: None,
+                        });
+                    }
+                }
+                serde_json::from_value(Value::Object(object)).map_err(|error| {
+                    Error::validation_invalid_argument("input", error.to_string(), None, None)
+                })
+            }
+            _ => Err(Error::validation_invalid_argument(
+                "input",
+                "agent-task fanout input must be an AgentTaskPlan, AgentTaskFanoutPlan, packet object, or packet array",
+                None,
+                None,
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct FanoutTaskPacket {
+    #[serde(default = "request_schema")]
+    schema: String,
+    #[serde(default)]
+    task_id: Option<String>,
+    #[serde(default)]
+    group_key: Option<String>,
+    #[serde(default)]
+    parent_plan_id: Option<String>,
+    #[serde(default)]
+    key: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    instructions: Option<String>,
+    #[serde(default)]
+    prompt: Option<String>,
+    #[serde(default)]
+    executor: Option<AgentTaskExecutor>,
+    #[serde(default)]
+    inputs: Value,
+    #[serde(default)]
+    source_refs: Vec<AgentTaskSourceRef>,
+    #[serde(default)]
+    workspace: AgentTaskWorkspace,
+    #[serde(default)]
+    component_contracts: Vec<AgentTaskComponentContract>,
+    #[serde(default)]
+    policy: AgentTaskPolicy,
+    #[serde(default)]
+    limits: AgentTaskLimits,
+    #[serde(default)]
+    expected_artifacts: Vec<String>,
+    #[serde(default, alias = "artifactDeclarations")]
+    artifact_declarations: Vec<AgentTaskArtifactDeclaration>,
+    #[serde(default)]
+    metadata: Value,
+}
+
+impl FanoutTaskPacket {
+    fn into_request(
+        self,
+        index: usize,
+        args: &AgentTaskFanoutInputArgs,
+    ) -> Result<AgentTaskRequest> {
+        if let Ok(request) = serde_json::from_value::<AgentTaskRequest>(
+            serde_json::to_value(&self).unwrap_or(Value::Null),
+        ) {
+            return Ok(request);
+        }
+
+        let task_id = self
+            .task_id
+            .or(self.key)
+            .unwrap_or_else(|| format!("task-{}", index + 1));
+        let instructions = self
+            .instructions
+            .or(self.prompt)
+            .or(self.title)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "instructions",
+                    format!(
+                        "fanout packet '{}' is missing instructions/prompt/title",
+                        task_id
+                    ),
+                    Some(task_id.clone()),
+                    None,
+                )
+            })?;
+        let executor = match self.executor {
+            Some(executor) => executor,
+            None => default_executor(args)?,
+        };
+
+        Ok(AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id,
+            group_key: self.group_key,
+            parent_plan_id: self.parent_plan_id,
+            executor,
+            instructions,
+            inputs: self.inputs,
+            source_refs: self.source_refs,
+            workspace: self.workspace,
+            component_contracts: self.component_contracts,
+            policy: self.policy,
+            limits: self.limits,
+            expected_artifacts: self.expected_artifacts,
+            artifact_declarations: self.artifact_declarations,
+            metadata: self.metadata,
+        })
+    }
+}
+
+fn request_schema() -> String {
+    AGENT_TASK_REQUEST_SCHEMA.to_string()
+}
+
+fn parse_packet_array(packets: Vec<Value>) -> Result<Vec<FanoutTaskPacket>> {
+    packets
+        .into_iter()
+        .map(|packet| serde_json::from_value(packet).map_err(packet_parse_error))
+        .collect()
+}
+
+fn packet_parse_error(error: serde_json::Error) -> Error {
+    Error::validation_invalid_argument("packet", error.to_string(), None, None)
+}
+
+fn default_executor(args: &AgentTaskFanoutInputArgs) -> Result<AgentTaskExecutor> {
+    let backend = args
+        .backend
+        .clone()
+        .map(Ok)
+        .unwrap_or_else(provider::default_backend)?
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "backend",
+                "fanout packets without executor objects require --backend or a configured default agent-task backend",
+                None,
+                None,
+            )
+        })?;
+    Ok(AgentTaskExecutor {
+        backend,
+        selector: args.selector.clone(),
+        runtime_selection: None,
+        required_capabilities: Vec::new(),
+        secret_env: Vec::new(),
+        model: args.model.clone(),
+        config: Value::Null,
+    })
+}
+
+fn plane_from_arg(plane: AgentTaskFanoutPlaneArg) -> AgentTaskFanoutPlane {
+    match plane {
+        AgentTaskFanoutPlaneArg::IsolatedTasks => AgentTaskFanoutPlane::IsolatedTasks,
+        AgentTaskFanoutPlaneArg::Workflow => AgentTaskFanoutPlane::Workflow,
+    }
+}
+
+fn stamp_plan_fanout_metadata(plan: &mut AgentTaskPlan, requested_fanout_id: Option<String>) {
+    let fanout_id = requested_fanout_id.unwrap_or_else(|| plan.plan_id.clone());
+    let mut metadata = plan.metadata.take();
+    if !metadata.is_object() {
+        metadata = serde_json::json!({ "base": metadata });
+    }
+    if let Some(object) = metadata.as_object_mut() {
+        object.entry("fanout".to_string()).or_insert_with(|| {
+            serde_json::json!({
+                "id": fanout_id,
+                "plane": "existing_plan",
+                "lineage": "compiled_from_agent_task_plan"
+            })
+        });
+    }
+    plan.metadata = metadata;
+}
+
+fn durable_commands(run_id: &str) -> Value {
+    serde_json::json!({
+        "status": format!("homeboy agent-task status {run_id}"),
+        "logs": format!("homeboy agent-task logs {run_id}"),
+        "artifacts": format!("homeboy agent-task artifacts {run_id}"),
+        "review": format!("homeboy agent-task review {run_id}"),
+        "run": format!("homeboy agent-task run {run_id}"),
+        "retry": format!("homeboy agent-task retry {run_id} --run")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn packet_array_compiles_to_public_agent_task_plan_with_lineage() {
+        let args = AgentTaskFanoutInputArgs {
+            input: "inline".to_string(),
+            fanout_id: Some("fanout/audit".to_string()),
+            plane: AgentTaskFanoutPlaneArg::IsolatedTasks,
+            backend: Some("test".to_string()),
+            selector: None,
+            model: None,
+        };
+
+        let plan = fanout_value_to_plan(
+            json!([
+                { "task_id": "finding-a", "instructions": "inspect a" },
+                { "task_id": "finding-b", "prompt": "inspect b" }
+            ]),
+            &args,
+        )
+        .expect("fanout plan");
+
+        assert_eq!(plan.plan_id, "fanout/audit");
+        assert_eq!(plan.tasks.len(), 2);
+        assert_eq!(
+            plan.tasks[0].parent_plan_id.as_deref(),
+            Some("fanout/audit")
+        );
+        assert_eq!(plan.tasks[0].executor.backend, "test");
+        assert_eq!(plan.tasks[1].instructions, "inspect b");
+        assert_eq!(plan.metadata["fanout"]["id"], json!("fanout/audit"));
+    }
+
+    #[test]
+    fn existing_agent_task_plan_is_accepted_and_stamped() {
+        let args = AgentTaskFanoutInputArgs {
+            input: "inline".to_string(),
+            fanout_id: None,
+            plane: AgentTaskFanoutPlaneArg::Workflow,
+            backend: None,
+            selector: None,
+            model: None,
+        };
+        let value = json!({
+            "schema": AGENT_TASK_PLAN_SCHEMA,
+            "plan_id": "existing-plan",
+            "tasks": [],
+            "options": {},
+            "metadata": {}
+        });
+
+        let plan = fanout_value_to_plan(value, &args).expect("agent task plan");
+
+        assert_eq!(plan.plan_id, "existing-plan");
+        assert_eq!(plan.metadata["fanout"]["id"], json!("existing-plan"));
+        assert_eq!(plan.metadata["fanout"]["plane"], json!("existing_plan"));
+    }
+}

--- a/src/core/agent_task_fanout.rs
+++ b/src/core/agent_task_fanout.rs
@@ -72,7 +72,11 @@ impl AgentTaskFanoutPlan {
         }
     }
 
-    pub(crate) fn to_schedule_plan(&self) -> AgentTaskPlan {
+    pub fn to_agent_task_plan(&self) -> AgentTaskPlan {
+        self.to_schedule_plan()
+    }
+
+    fn to_schedule_plan(&self) -> AgentTaskPlan {
         let mut plan = AgentTaskPlan::new(
             self.fanout_id.clone(),
             self.tasks


### PR DESCRIPTION
## Summary
- Adds `homeboy agent-task fanout plan|submit|run-plan` as a public provider-neutral fanout/reconcile surface.
- Accepts existing `AgentTaskPlan`, `AgentTaskFanoutPlan`, packet arrays, `tasks`/`packets` objects, or single task packets and compiles them into durable agent-task lifecycle plans.
- Returns stable status/log/artifact/review/retry commands from `fanout submit` and documents downstream usage without internal Homeboy Extensions adapters.

Closes #3212.

## Tests
- `rustfmt src/commands/agent_task.rs src/commands/agent_task/args/mod.rs src/commands/agent_task/fanout.rs src/core/agent_task_fanout.rs`
- `git diff --check`
- Not run: local `cargo` tests/checks, per environment rule prohibiting local cargo commands on this machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Drafted implementation, documentation, and focused unit coverage; Chris reviews and owns the change.