### PR TITLE
feat(agent-task): add core deterministic loop primitive

### DIFF
--- a/src/core/agent_task_deterministic_loop.rs
+++ b/src/core/agent_task_deterministic_loop.rs
@@ -1,0 +1,310 @@
+use crate::core::agent_task_scheduler::{
+    AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskExecutorAdapter, AgentTaskPlan,
+    AgentTaskScheduler,
+};
+use crate::core::deterministic_loop::{
+    DeterministicEvidenceRef, DeterministicLoopHooks, DeterministicLoopReconcileResult,
+    DeterministicLoopState, DeterministicLoopStatus,
+};
+use crate::core::{Error, Result};
+
+use super::agent_task_loop_definition::{compile_loop_definition, AgentTaskLoopDefinition};
+
+pub struct AgentTaskDeterministicLoop<E> {
+    definition: AgentTaskLoopDefinition,
+    scheduler: AgentTaskScheduler<E>,
+}
+
+impl<E> AgentTaskDeterministicLoop<E>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    pub fn new(definition: AgentTaskLoopDefinition, executor: E) -> Self {
+        Self {
+            definition,
+            scheduler: AgentTaskScheduler::new(executor),
+        }
+    }
+}
+
+impl<E> DeterministicLoopHooks for AgentTaskDeterministicLoop<E>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    type IterationPlan = AgentTaskPlan;
+    type IterationOutput = AgentTaskAggregate;
+
+    fn materialize_iteration(
+        &mut self,
+        state: &DeterministicLoopState,
+    ) -> Result<Self::IterationPlan> {
+        let mut plan = compile_loop_definition(self.definition.clone())?;
+        plan.plan_id = format!("{}-iteration-{}", plan.plan_id, state.iteration);
+        plan.metadata = merge_agent_task_loop_metadata(
+            plan.metadata,
+            serde_json::json!({
+                "deterministic_loop": {
+                    "loop_id": state.identity.loop_id,
+                    "run_id": state.identity.run_id,
+                    "iteration": state.iteration,
+                }
+            }),
+        );
+        plan.rebuild_homeboy_plan();
+        Ok(plan)
+    }
+
+    fn execute_iteration(
+        &mut self,
+        _state: &DeterministicLoopState,
+        plan: Self::IterationPlan,
+    ) -> Result<Self::IterationOutput> {
+        Ok(self.scheduler.run(plan))
+    }
+
+    fn reconcile_iteration(
+        &mut self,
+        _state: &DeterministicLoopState,
+        output: Self::IterationOutput,
+    ) -> Result<DeterministicLoopReconcileResult> {
+        let status = match output.status {
+            AgentTaskAggregateStatus::Succeeded => DeterministicLoopStatus::Succeeded,
+            AgentTaskAggregateStatus::PartialFailure | AgentTaskAggregateStatus::Failed => {
+                DeterministicLoopStatus::Failed
+            }
+            AgentTaskAggregateStatus::Cancelled => DeterministicLoopStatus::Canceled,
+        };
+        let mut result = DeterministicLoopReconcileResult::new(status);
+        result.artifact_refs = output
+            .artifact_lineage
+            .iter()
+            .filter_map(|artifact| {
+                artifact.url.as_ref().or(artifact.path.as_ref()).map(|uri| {
+                    DeterministicEvidenceRef {
+                        uri: uri.clone(),
+                        kind: Some(artifact.kind.clone()),
+                        label: Some(artifact.name.clone()),
+                    }
+                })
+            })
+            .collect();
+        for outcome in &output.outcomes {
+            result
+                .artifact_refs
+                .extend(outcome.artifacts.iter().filter_map(|artifact| {
+                    artifact.url.as_ref().or(artifact.path.as_ref()).map(|uri| {
+                        DeterministicEvidenceRef {
+                            uri: uri.clone(),
+                            kind: Some(artifact.kind.clone()),
+                            label: artifact.name.clone(),
+                        }
+                    })
+                }));
+            result
+                .artifact_refs
+                .extend(
+                    outcome
+                        .evidence_refs
+                        .iter()
+                        .map(|evidence| DeterministicEvidenceRef {
+                            uri: evidence.uri.clone(),
+                            kind: Some(evidence.kind.clone()),
+                            label: evidence.label.clone(),
+                        }),
+                );
+        }
+        result.metadata = serde_json::json!({
+            "agent_task": {
+                "plan_id": output.plan_id,
+                "status": output.status,
+                "totals": output.totals,
+                "events": output.events,
+            }
+        });
+        Ok(result)
+    }
+}
+
+fn merge_agent_task_loop_metadata(
+    current: serde_json::Value,
+    next: serde_json::Value,
+) -> serde_json::Value {
+    match (current, next) {
+        (serde_json::Value::Object(mut current), serde_json::Value::Object(next)) => {
+            current.extend(next);
+            serde_json::Value::Object(current)
+        }
+        (serde_json::Value::Null, next) => next,
+        (current, next) => serde_json::json!({
+            "definition_metadata": current,
+            "agent_task_loop": next,
+        }),
+    }
+}
+
+pub fn agent_task_loop_spec(
+    definition: &AgentTaskLoopDefinition,
+    max_iterations: u32,
+) -> Result<crate::core::deterministic_loop::DeterministicLoopSpec> {
+    if max_iterations == 0 {
+        return Err(Error::validation_invalid_argument(
+            "max_iterations",
+            "agent-task deterministic loops require max_iterations greater than zero",
+            Some(definition.loop_id.clone()),
+            None,
+        ));
+    }
+    Ok(crate::core::deterministic_loop::DeterministicLoopSpec {
+        loop_id: definition.loop_id.clone(),
+        max_iterations,
+        metadata: serde_json::json!({
+            "source_schema": definition.schema,
+            "loop_id": definition.loop_id,
+            "plan_id": definition.plan_id,
+        }),
+        ..crate::core::deterministic_loop::DeterministicLoopSpec::default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use serde_json::{json, Value};
+
+    use super::*;
+    use crate::core::agent_task::{
+        AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskFailureClassification, AgentTaskLimits,
+        AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest,
+        AgentTaskWorkspace, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+    use crate::core::agent_task_loop_definition::AGENT_TASK_LOOP_DEFINITION_SCHEMA;
+    use crate::core::agent_task_schedule::AgentTaskExecutionContext;
+    use crate::core::deterministic_loop::{run_deterministic_loop, DeterministicLoopRunIdentity};
+
+    #[derive(Clone)]
+    struct RecordingExecutor {
+        calls: Arc<AtomicUsize>,
+        status: AgentTaskOutcomeStatus,
+    }
+
+    impl AgentTaskExecutorAdapter for RecordingExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let mut artifacts = Vec::new();
+            if self.status == AgentTaskOutcomeStatus::Succeeded {
+                artifacts.push(AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: format!("{}-artifact", request.task_id),
+                    kind: "agent_result".to_string(),
+                    name: Some("agent_result".to_string()),
+                    label: None,
+                    role: None,
+                    semantic_key: None,
+                    path: Some(format!("artifact://{}", request.task_id)),
+                    url: None,
+                    mime: None,
+                    size_bytes: None,
+                    sha256: None,
+                    metadata: Value::Null,
+                });
+            }
+            AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: request.task_id,
+                status: self.status,
+                summary: None,
+                failure_classification: (self.status == AgentTaskOutcomeStatus::Failed)
+                    .then_some(AgentTaskFailureClassification::ExecutionFailed),
+                artifacts,
+                typed_artifacts: Vec::new(),
+                evidence_refs: vec![AgentTaskEvidenceRef {
+                    kind: "log".to_string(),
+                    uri: "artifact://log".to_string(),
+                    label: Some("log".to_string()),
+                }],
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }
+        }
+    }
+
+    #[test]
+    fn agent_task_loop_runs_through_core_deterministic_primitive() {
+        let definition = loop_definition();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let executor = RecordingExecutor {
+            calls: Arc::clone(&calls),
+            status: AgentTaskOutcomeStatus::Succeeded,
+        };
+        let spec = agent_task_loop_spec(&definition, 2).expect("spec materializes");
+        let identity = DeterministicLoopRunIdentity::new("example/loop", "run-a");
+        let mut hooks = AgentTaskDeterministicLoop::new(definition, executor);
+
+        let state = run_deterministic_loop(spec, identity, &mut hooks).expect("loop runs");
+
+        assert_eq!(state.status, DeterministicLoopStatus::Succeeded);
+        assert_eq!(state.iteration, 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(state
+            .artifact_lineage
+            .iter()
+            .any(|artifact| artifact.uri == "artifact://design"));
+    }
+
+    #[test]
+    fn agent_task_loop_reconciles_failed_aggregate_to_failed_loop() {
+        let definition = loop_definition();
+        let executor = RecordingExecutor {
+            calls: Arc::new(AtomicUsize::new(0)),
+            status: AgentTaskOutcomeStatus::Failed,
+        };
+        let spec = agent_task_loop_spec(&definition, 2).expect("spec materializes");
+        let identity = DeterministicLoopRunIdentity::new("example/loop", "run-a");
+        let mut hooks = AgentTaskDeterministicLoop::new(definition, executor);
+
+        let state = run_deterministic_loop(spec, identity, &mut hooks).expect("loop runs");
+
+        assert_eq!(state.status, DeterministicLoopStatus::Failed);
+        assert_eq!(state.iteration, 1);
+        assert_eq!(
+            state.metadata["agent_task"]["status"],
+            json!(AgentTaskAggregateStatus::Failed)
+        );
+    }
+
+    fn loop_definition() -> AgentTaskLoopDefinition {
+        serde_json::from_value(json!({
+            "schema": AGENT_TASK_LOOP_DEFINITION_SCHEMA,
+            "loop_id": "example/loop",
+            "plan_id": "example-plan",
+            "tasks": [
+                { "task_id": "design", "request": request("design") },
+                { "task_id": "verify", "request": request("verify"), "depends_on": ["design"] }
+            ]
+        }))
+        .expect("definition parses")
+    }
+
+    fn request(task_id: &str) -> Value {
+        json!({
+            "schema": AGENT_TASK_REQUEST_SCHEMA,
+            "task_id": task_id,
+            "executor": { "backend": "in-memory", "config": {} },
+            "instructions": format!("Run {task_id}"),
+            "workspace": AgentTaskWorkspace::default(),
+            "policy": AgentTaskPolicy::default(),
+            "limits": AgentTaskLimits::default(),
+            "inputs": null
+        })
+    }
+}

--- a/src/core/deterministic_loop.rs
+++ b/src/core/deterministic_loop.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::core::{Error, Result};
+
 pub const DETERMINISTIC_LOOP_PLAN_SCHEMA: &str = "homeboy/deterministic-loop-plan/v1";
 pub const DETERMINISTIC_LOOP_RUN_IDENTITY_SCHEMA: &str =
     "homeboy/deterministic-loop-run-identity/v1";
@@ -8,6 +10,9 @@ pub const DETERMINISTIC_FANOUT_PLAN_SCHEMA: &str = "homeboy/deterministic-fanout
 pub const DETERMINISTIC_FANOUT_RESULT_SCHEMA: &str = "homeboy/deterministic-fanout-result/v1";
 pub const DETERMINISTIC_EVIDENCE_SNAPSHOT_SCHEMA: &str =
     "homeboy/deterministic-evidence-snapshot/v1";
+pub const DETERMINISTIC_LOOP_SPEC_SCHEMA: &str = "homeboy/deterministic-loop-spec/v1";
+pub const DETERMINISTIC_LOOP_STATE_SCHEMA: &str = "homeboy/deterministic-loop-state/v1";
+pub const DETERMINISTIC_LOOP_EVENT_SCHEMA: &str = "homeboy/deterministic-loop-event/v1";
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -112,6 +117,89 @@ pub struct DeterministicEvidenceRef {
     pub label: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DeterministicLoopSpec {
+    #[serde(default = "loop_spec_schema")]
+    pub schema: String,
+    pub loop_id: String,
+    #[serde(default = "default_max_iterations")]
+    pub max_iterations: u32,
+    #[serde(default)]
+    pub stop: DeterministicLoopStopCriteria,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeterministicLoopStopCriteria {
+    #[serde(
+        default = "default_stop_statuses",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub statuses: Vec<DeterministicLoopStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DeterministicLoopState {
+    #[serde(default = "loop_state_schema")]
+    pub schema: String,
+    pub identity: DeterministicLoopRunIdentity,
+    pub status: DeterministicLoopStatus,
+    #[serde(default)]
+    pub iteration: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<DeterministicLoopEvent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_lineage: Vec<DeterministicEvidenceRef>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DeterministicLoopEvent {
+    #[serde(default = "loop_event_schema")]
+    pub schema: String,
+    pub sequence: u32,
+    pub iteration: u32,
+    pub event_type: String,
+    pub status: DeterministicLoopStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<DeterministicEvidenceRef>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DeterministicLoopReconcileResult {
+    pub status: DeterministicLoopStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<DeterministicEvidenceRef>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+pub trait DeterministicLoopHooks {
+    type IterationPlan;
+    type IterationOutput;
+
+    fn materialize_iteration(
+        &mut self,
+        state: &DeterministicLoopState,
+    ) -> Result<Self::IterationPlan>;
+
+    fn execute_iteration(
+        &mut self,
+        state: &DeterministicLoopState,
+        plan: Self::IterationPlan,
+    ) -> Result<Self::IterationOutput>;
+
+    fn reconcile_iteration(
+        &mut self,
+        state: &DeterministicLoopState,
+        output: Self::IterationOutput,
+    ) -> Result<DeterministicLoopReconcileResult>;
+}
+
 impl DeterministicLoopRunIdentity {
     pub fn new(loop_id: impl Into<String>, run_id: impl Into<String>) -> Self {
         Self {
@@ -185,6 +273,185 @@ impl DeterministicEvidenceSnapshot {
     }
 }
 
+impl Default for DeterministicLoopSpec {
+    fn default() -> Self {
+        Self {
+            schema: DETERMINISTIC_LOOP_SPEC_SCHEMA.to_string(),
+            loop_id: String::new(),
+            max_iterations: default_max_iterations(),
+            stop: DeterministicLoopStopCriteria::default(),
+            metadata: Value::Null,
+        }
+    }
+}
+
+impl Default for DeterministicLoopStopCriteria {
+    fn default() -> Self {
+        Self {
+            statuses: default_stop_statuses(),
+        }
+    }
+}
+
+impl DeterministicLoopState {
+    pub fn new(identity: DeterministicLoopRunIdentity) -> Self {
+        Self {
+            schema: DETERMINISTIC_LOOP_STATE_SCHEMA.to_string(),
+            identity,
+            status: DeterministicLoopStatus::Planned,
+            iteration: 0,
+            events: Vec::new(),
+            artifact_lineage: Vec::new(),
+            metadata: Value::Null,
+        }
+    }
+
+    pub fn push_event(
+        &mut self,
+        event_type: impl Into<String>,
+        status: DeterministicLoopStatus,
+        artifact_refs: Vec<DeterministicEvidenceRef>,
+        payload: Value,
+    ) {
+        self.events.push(DeterministicLoopEvent {
+            schema: DETERMINISTIC_LOOP_EVENT_SCHEMA.to_string(),
+            sequence: self.events.len() as u32 + 1,
+            iteration: self.iteration,
+            event_type: event_type.into(),
+            status,
+            artifact_refs,
+            payload,
+        });
+    }
+}
+
+impl DeterministicLoopReconcileResult {
+    pub fn new(status: DeterministicLoopStatus) -> Self {
+        Self {
+            status,
+            artifact_refs: Vec::new(),
+            metadata: Value::Null,
+        }
+    }
+}
+
+pub fn run_deterministic_loop<H>(
+    spec: DeterministicLoopSpec,
+    identity: DeterministicLoopRunIdentity,
+    hooks: &mut H,
+) -> Result<DeterministicLoopState>
+where
+    H: DeterministicLoopHooks,
+{
+    validate_loop_spec(&spec)?;
+    if identity.loop_id != spec.loop_id {
+        return Err(Error::validation_invalid_argument(
+            "identity.loop_id",
+            "deterministic loop identity must match spec loop_id",
+            Some(identity.loop_id),
+            Some(vec![spec.loop_id]),
+        ));
+    }
+
+    let mut state = DeterministicLoopState::new(identity);
+    state.metadata = spec.metadata.clone();
+    state.status = DeterministicLoopStatus::Running;
+    state.push_event(
+        "loop.started",
+        state.status,
+        Vec::new(),
+        serde_json::json!({ "max_iterations": spec.max_iterations }),
+    );
+
+    while state.iteration < spec.max_iterations {
+        state.iteration += 1;
+        let plan = hooks.materialize_iteration(&state)?;
+        state.push_event(
+            "iteration.materialized",
+            DeterministicLoopStatus::Running,
+            Vec::new(),
+            Value::Null,
+        );
+        let output = hooks.execute_iteration(&state, plan)?;
+        state.push_event(
+            "iteration.executed",
+            DeterministicLoopStatus::Running,
+            Vec::new(),
+            Value::Null,
+        );
+        let reconciliation = hooks.reconcile_iteration(&state, output)?;
+        state.status = reconciliation.status;
+        state
+            .artifact_lineage
+            .extend(reconciliation.artifact_refs.clone());
+        if !reconciliation.metadata.is_null() {
+            state.metadata = merge_metadata(state.metadata, reconciliation.metadata);
+        }
+        state.push_event(
+            "iteration.reconciled",
+            state.status,
+            reconciliation.artifact_refs,
+            Value::Null,
+        );
+        if spec.stop.statuses.contains(&state.status) {
+            break;
+        }
+    }
+
+    if state.iteration >= spec.max_iterations && !spec.stop.statuses.contains(&state.status) {
+        state.status = DeterministicLoopStatus::Blocked;
+        state.push_event(
+            "loop.max_iterations_reached",
+            state.status,
+            Vec::new(),
+            serde_json::json!({ "max_iterations": spec.max_iterations }),
+        );
+    }
+    state.push_event("loop.finished", state.status, Vec::new(), Value::Null);
+    Ok(state)
+}
+
+fn validate_loop_spec(spec: &DeterministicLoopSpec) -> Result<()> {
+    if spec.schema != DETERMINISTIC_LOOP_SPEC_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "schema",
+            format!(
+                "expected {DETERMINISTIC_LOOP_SPEC_SCHEMA}, got {}",
+                spec.schema
+            ),
+            Some(spec.loop_id.clone()),
+            None,
+        ));
+    }
+    if spec.loop_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "loop_id",
+            "deterministic loop spec requires a non-empty loop_id",
+            None,
+            None,
+        ));
+    }
+    if spec.max_iterations == 0 {
+        return Err(Error::validation_invalid_argument(
+            "max_iterations",
+            "deterministic loop spec requires max_iterations greater than zero",
+            Some(spec.loop_id.clone()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn merge_metadata(current: Value, next: Value) -> Value {
+    match (current, next) {
+        (Value::Object(mut current), Value::Object(next)) => {
+            current.extend(next);
+            Value::Object(current)
+        }
+        (_, next) => next,
+    }
+}
+
 fn loop_plan_schema() -> String {
     DETERMINISTIC_LOOP_PLAN_SCHEMA.to_string()
 }
@@ -203,6 +470,31 @@ fn fanout_result_schema() -> String {
 
 fn evidence_snapshot_schema() -> String {
     DETERMINISTIC_EVIDENCE_SNAPSHOT_SCHEMA.to_string()
+}
+
+fn loop_spec_schema() -> String {
+    DETERMINISTIC_LOOP_SPEC_SCHEMA.to_string()
+}
+
+fn loop_state_schema() -> String {
+    DETERMINISTIC_LOOP_STATE_SCHEMA.to_string()
+}
+
+fn loop_event_schema() -> String {
+    DETERMINISTIC_LOOP_EVENT_SCHEMA.to_string()
+}
+
+fn default_max_iterations() -> u32 {
+    1
+}
+
+fn default_stop_statuses() -> Vec<DeterministicLoopStatus> {
+    vec![
+        DeterministicLoopStatus::Succeeded,
+        DeterministicLoopStatus::Failed,
+        DeterministicLoopStatus::Canceled,
+        DeterministicLoopStatus::Blocked,
+    ]
 }
 
 #[cfg(test)]
@@ -247,5 +539,96 @@ mod tests {
             DETERMINISTIC_EVIDENCE_SNAPSHOT_SCHEMA
         );
         assert_eq!(snapshot_value["status"], "succeeded");
+    }
+
+    #[derive(Default)]
+    struct CountingHooks {
+        statuses: Vec<DeterministicLoopStatus>,
+    }
+
+    impl DeterministicLoopHooks for CountingHooks {
+        type IterationPlan = u32;
+        type IterationOutput = DeterministicLoopStatus;
+
+        fn materialize_iteration(
+            &mut self,
+            state: &DeterministicLoopState,
+        ) -> Result<Self::IterationPlan> {
+            Ok(state.iteration)
+        }
+
+        fn execute_iteration(
+            &mut self,
+            _state: &DeterministicLoopState,
+            plan: Self::IterationPlan,
+        ) -> Result<Self::IterationOutput> {
+            Ok(self
+                .statuses
+                .get(plan as usize - 1)
+                .copied()
+                .unwrap_or(DeterministicLoopStatus::Running))
+        }
+
+        fn reconcile_iteration(
+            &mut self,
+            _state: &DeterministicLoopState,
+            output: Self::IterationOutput,
+        ) -> Result<DeterministicLoopReconcileResult> {
+            let mut result = DeterministicLoopReconcileResult::new(output);
+            result.artifact_refs.push(DeterministicEvidenceRef {
+                uri: "artifact://iteration".to_string(),
+                kind: Some("test".to_string()),
+                label: None,
+            });
+            Ok(result)
+        }
+    }
+
+    #[test]
+    fn deterministic_loop_runs_hooks_until_stop_status() {
+        let spec = DeterministicLoopSpec {
+            loop_id: "loop-a".to_string(),
+            max_iterations: 3,
+            ..DeterministicLoopSpec::default()
+        };
+        let identity = DeterministicLoopRunIdentity::new("loop-a", "run-a");
+        let mut hooks = CountingHooks {
+            statuses: vec![
+                DeterministicLoopStatus::Running,
+                DeterministicLoopStatus::Succeeded,
+            ],
+        };
+
+        let state = run_deterministic_loop(spec, identity, &mut hooks).expect("loop runs");
+
+        assert_eq!(state.status, DeterministicLoopStatus::Succeeded);
+        assert_eq!(state.iteration, 2);
+        assert_eq!(state.artifact_lineage.len(), 2);
+        assert_eq!(state.events.last().unwrap().event_type, "loop.finished");
+    }
+
+    #[test]
+    fn deterministic_loop_blocks_when_max_iterations_are_exhausted() {
+        let spec = DeterministicLoopSpec {
+            loop_id: "loop-a".to_string(),
+            max_iterations: 2,
+            ..DeterministicLoopSpec::default()
+        };
+        let identity = DeterministicLoopRunIdentity::new("loop-a", "run-a");
+        let mut hooks = CountingHooks {
+            statuses: vec![
+                DeterministicLoopStatus::Running,
+                DeterministicLoopStatus::Running,
+            ],
+        };
+
+        let state = run_deterministic_loop(spec, identity, &mut hooks).expect("loop runs");
+
+        assert_eq!(state.status, DeterministicLoopStatus::Blocked);
+        assert_eq!(state.iteration, 2);
+        assert!(state
+            .events
+            .iter()
+            .any(|event| event.event_type == "loop.max_iterations_reached"));
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod agent_task_config_materialization;
 pub mod agent_task_contract;
 pub mod agent_task_controller_service;
 pub mod agent_task_cook_loop;
+pub mod agent_task_deterministic_loop;
 pub mod agent_task_dispatch_plan;
 pub mod agent_task_dispatch_service;
 pub mod agent_task_fanout;


### PR DESCRIPTION
## Summary
- Add a core deterministic loop spec/state/event primitive with materialization, execution, reconcile hooks, stop statuses, max iteration enforcement, durable event history, and artifact lineage.
- Add a thin agent-task adapter that compiles `AgentTaskLoopDefinition` into `AgentTaskPlan`, runs through the existing scheduler, and reconciles aggregate outcomes back into deterministic loop state.
- Add focused core tests proving the primitive runs without Homeboy Extensions or provider-specific dependencies.

Closes #5394.

## Tests
- `cargo test core::deterministic_loop`
- `cargo test core::agent_task_deterministic_loop`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 / OpenCode
- **Used for:** Implementing the core deterministic loop primitive, agent-task adapter, tests, and PR preparation.
