### PR TITLE
feat(ci): add GitHub Actions scope resolver in core (#2915)

### DIFF
--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -4,6 +4,9 @@ use std::path::PathBuf;
 
 use homeboy::core::ci_plan::{self, CiEventContext, CiPlan};
 use homeboy::core::ci_profile::{self, CiInventory, CiRunOutput, CiRunSelection};
+use homeboy::core::ci_scope::{
+    self, GithubActionsContext, MergeBaseResolver, ResolvedScope, ScopeRequest,
+};
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::refactor::auto::transaction::{
     self, CiContext, TransactionOutcome, TransactionRequest, AUTOFIX_COMMIT_PREFIX,
@@ -38,6 +41,48 @@ pub enum CiCommand {
     /// re-implementing branch/commit/push orchestration in shell. It assumes
     /// the working tree already contains the autofix changes to commit.
     Autofix(CiAutofixArgs),
+    /// Resolve a CI event context into the Homeboy scope (changed vs full)
+    /// and the per-command `--changed-since` flags.
+    ///
+    /// This is the core-owned translation the action calls instead of
+    /// deriving event-context → scope in shell (`scripts/scope/*.sh`). With
+    /// `--github-actions` the context is read from the standard GitHub
+    /// Actions environment; explicit flags override individual fields.
+    Scope(CiScopeArgs),
+}
+
+#[derive(Args)]
+pub struct CiScopeArgs {
+    /// Read the event context from the GitHub Actions environment
+    /// (`GITHUB_EVENT_NAME`, `BASE_SHA`, `PR_HEAD_REPO`, `GITHUB_REPOSITORY`).
+    #[arg(long)]
+    pub github_actions: bool,
+
+    /// Override the event name (e.g. `pull_request`, `push`, `schedule`).
+    #[arg(long)]
+    pub event_name: Option<String>,
+
+    /// Override the PR base SHA used for changed-file diffs.
+    #[arg(long)]
+    pub base_sha: Option<String>,
+
+    /// Override the PR head repository (`owner/repo`) for fork detection.
+    #[arg(long)]
+    pub head_repo: Option<String>,
+
+    /// Override the base repository (`owner/repo`).
+    #[arg(long)]
+    pub base_repo: Option<String>,
+
+    /// Checkout to resolve the merge base against (deepens shallow clones).
+    /// When omitted, the supplied base ref is trusted verbatim.
+    #[arg(long)]
+    pub repo_path: Option<String>,
+
+    /// Emit `--changed-since` flags for this command in addition to the
+    /// resolved scope. May be repeated.
+    #[arg(long = "for")]
+    pub for_commands: Vec<String>,
 }
 
 #[derive(Args)]
@@ -134,6 +179,18 @@ pub enum CiOutput {
     Plan(CiPlanCommandOutput),
     Run(CiRunCommandOutput),
     Autofix(CiAutofixCommandOutput),
+    Scope(CiScopeCommandOutput),
+}
+
+#[derive(Debug, Serialize)]
+pub struct CiScopeCommandOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub scope: ResolvedScope,
+    /// `--changed-since` flags keyed by the requested base command (only
+    /// present when `--for` was supplied).
+    #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub command_flags: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -168,6 +225,7 @@ pub fn run(args: CiArgs, global: &GlobalArgs) -> CmdResult<CiOutput> {
         CiCommand::Plan(args) => run_plan(args, global),
         CiCommand::Run(args) => run_ci(args, global),
         CiCommand::Autofix(args) => run_autofix(args, global),
+        CiCommand::Scope(args) => run_scope(args, global),
     }
 }
 
@@ -179,6 +237,54 @@ fn run_plan(args: CiPlanArgs, _global: &GlobalArgs) -> CmdResult<CiOutput> {
         CiOutput::Plan(CiPlanCommandOutput {
             command: "ci.plan",
             plan,
+        }),
+        0,
+    ))
+}
+
+fn run_scope(args: CiScopeArgs, _global: &GlobalArgs) -> CmdResult<CiOutput> {
+    // Build the GitHub Actions context: start from the environment when
+    // `--github-actions` is set, then apply any explicit overrides.
+    let mut ctx = if args.github_actions {
+        GithubActionsContext::from_env()
+    } else {
+        GithubActionsContext::default()
+    };
+    if args.event_name.is_some() {
+        ctx.event_name = args.event_name.clone();
+    }
+    if args.base_sha.is_some() {
+        ctx.base_sha = args.base_sha.clone();
+    }
+    if args.head_repo.is_some() {
+        ctx.head_repo = args.head_repo.clone();
+    }
+    if args.base_repo.is_some() {
+        ctx.base_repo = args.base_repo.clone();
+    }
+
+    let request: ScopeRequest = ctx.to_request();
+    let resolver = match args.repo_path.as_deref() {
+        Some(path) => MergeBaseResolver::Git { path },
+        None => MergeBaseResolver::TrustBaseRef,
+    };
+    let scope = ci_scope::resolve_scope(&request, resolver)?;
+
+    let mut command_flags = std::collections::BTreeMap::new();
+    for command in &args.for_commands {
+        let base_cmd = command
+            .split_whitespace()
+            .next()
+            .unwrap_or(command)
+            .to_string();
+        command_flags.insert(base_cmd, scope.command_flags(command));
+    }
+
+    Ok((
+        CiOutput::Scope(CiScopeCommandOutput {
+            command: "ci.scope",
+            scope,
+            command_flags,
         }),
         0,
     ))
@@ -394,6 +500,60 @@ mod tests {
 
         assert_eq!(args.commands, "audit,lint,test");
         assert_eq!(args.context, "pr");
+    }
+
+    #[test]
+    fn parses_ci_scope_github_actions_and_for() {
+        let cli = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "ci",
+            "scope",
+            "--github-actions",
+            "--event-name",
+            "pull_request",
+            "--base-sha",
+            "abc123",
+            "--for",
+            "lint",
+            "--for",
+            "test",
+        ])
+        .expect("parse cli");
+
+        let crate::cli_surface::Commands::Ci(args) = cli.command else {
+            panic!("expected ci command");
+        };
+        let CiCommand::Scope(args) = args.command else {
+            panic!("expected ci scope");
+        };
+
+        assert!(args.github_actions);
+        assert_eq!(args.event_name.as_deref(), Some("pull_request"));
+        assert_eq!(args.base_sha.as_deref(), Some("abc123"));
+        assert_eq!(args.for_commands, vec!["lint", "test"]);
+    }
+
+    #[test]
+    fn ci_scope_pr_override_resolves_changed_flags() {
+        let args = CiScopeArgs {
+            github_actions: false,
+            event_name: Some("pull_request".to_string()),
+            base_sha: Some("base123".to_string()),
+            head_repo: None,
+            base_repo: None,
+            repo_path: None,
+            for_commands: vec!["lint".to_string()],
+        };
+
+        let (output, exit) = run_scope(args, &GlobalArgs {}).expect("scope resolves");
+        assert_eq!(exit, 0);
+        let CiOutput::Scope(scope) = output else {
+            panic!("expected scope output");
+        };
+        assert_eq!(
+            scope.command_flags.get("lint"),
+            Some(&vec!["--changed-since".to_string(), "base123".to_string()])
+        );
     }
 
     #[test]

--- a/src/core/ci_scope.rs
+++ b/src/core/ci_scope.rs
@@ -1,0 +1,455 @@
+//! CI scope resolution.
+//!
+//! Translates a continuous-integration event into the Homeboy scope that
+//! gated commands (audit, lint, test, review, refactor) should operate on.
+//! Core already owns the `--changed-since` semantics; this module owns the
+//! *event-context → scope* translation so provider-specific automation (the
+//! GitHub Actions runner, for example) calls core instead of re-deriving the
+//! mapping in shell.
+//!
+//! The model is split into two layers:
+//!
+//! - A **generic, provider-agnostic** core: [`ScopeContext`], [`ScopeMode`],
+//!   [`ScopeRequest`], [`ResolvedScope`], and [`resolve_scope`]. These know
+//!   nothing about GitHub — they only describe "what kind of event is this and
+//!   what is its base ref".
+//! - A clearly-delineated **GitHub Actions adapter**
+//!   ([`GithubActionsContext`]) that reads GitHub event fields/environment and
+//!   produces a [`ScopeRequest`].
+//!
+//! Differential gating exceptions (which commands accept changed-since scope)
+//! are typed in [`SCOPED_COMMANDS`] rather than embedded in shell `case`
+//! statements.
+
+use serde::Serialize;
+
+use crate::core::error::Result;
+use crate::core::git;
+
+/// Commands that accept a `--changed-since` scope. Everything else always runs
+/// at full scope. Typed here instead of a shell `case` statement so the
+/// exception set is auditable and testable.
+pub const SCOPED_COMMANDS: &[&str] = &["audit", "lint", "test", "review", "refactor"];
+
+/// The kind of CI event that triggered the run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScopeContext {
+    /// A pull/merge request against a base branch.
+    PullRequest,
+    /// A push to a branch (not a PR).
+    Push,
+    /// A scheduled/cron run.
+    Cron,
+    /// A manual / unknown trigger.
+    Manual,
+}
+
+impl ScopeContext {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ScopeContext::PullRequest => "pr",
+            ScopeContext::Push => "push",
+            ScopeContext::Cron => "cron",
+            ScopeContext::Manual => "manual",
+        }
+    }
+}
+
+/// Whether the run should be scoped to changed files or run fully.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScopeMode {
+    /// Only the files changed relative to a base ref.
+    Changed,
+    /// The whole component.
+    Full,
+}
+
+impl ScopeMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ScopeMode::Changed => "changed",
+            ScopeMode::Full => "full",
+        }
+    }
+}
+
+/// Provider-agnostic description of a CI event, normalized from whatever the
+/// provider adapter produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopeRequest {
+    /// The normalized event context.
+    pub context: ScopeContext,
+    /// Base ref/SHA for changed-file diffs (PR base). `None` outside PRs or
+    /// when the provider could not supply one.
+    pub base_ref: Option<String>,
+    /// Whether the change set originates from a fork (informational; affects
+    /// downstream trust decisions, not the scope math itself).
+    pub is_fork: bool,
+}
+
+impl ScopeRequest {
+    pub fn new(context: ScopeContext) -> Self {
+        Self {
+            context,
+            base_ref: None,
+            is_fork: false,
+        }
+    }
+
+    pub fn with_base_ref(mut self, base_ref: Option<String>) -> Self {
+        self.base_ref = base_ref.filter(|r| !r.is_empty());
+        self
+    }
+
+    pub fn with_fork(mut self, is_fork: bool) -> Self {
+        self.is_fork = is_fork;
+        self
+    }
+}
+
+/// A fully resolved scope ready to be turned into command flags.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedScope {
+    /// Normalized event context.
+    pub context: ScopeContext,
+    /// Resolved scope mode (`changed` or `full`).
+    pub mode: ScopeMode,
+    /// The base ref to diff against when `mode == Changed`. Empty otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<String>,
+    /// Whether the change set originates from a fork.
+    pub is_fork: bool,
+    /// Human-readable note explaining a fallback to full scope, when one
+    /// occurred. Lets the caller surface a deterministic warning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
+}
+
+impl ResolvedScope {
+    /// A deterministic full-scope result for the given context.
+    fn full(context: ScopeContext, is_fork: bool, fallback_reason: Option<String>) -> Self {
+        Self {
+            context,
+            mode: ScopeMode::Full,
+            base_ref: None,
+            is_fork,
+            fallback_reason,
+        }
+    }
+
+    /// Produce the CLI flags a given base command should receive under this
+    /// scope. Returns an empty vec for full scope or for commands that are not
+    /// in [`SCOPED_COMMANDS`].
+    ///
+    /// `command` may be a compound invocation (e.g. `"refactor --from all"`);
+    /// only the leading base command is inspected.
+    pub fn command_flags(&self, command: &str) -> Vec<String> {
+        let base_cmd = command.split_whitespace().next().unwrap_or("");
+        match (&self.mode, &self.base_ref) {
+            (ScopeMode::Changed, Some(base_ref))
+                if SCOPED_COMMANDS.contains(&base_cmd) && !base_ref.is_empty() =>
+            {
+                vec!["--changed-since".to_string(), base_ref.clone()]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// How merge-base resolution should be performed during [`resolve_scope`].
+pub enum MergeBaseResolver<'a> {
+    /// Resolve the merge base against a real git checkout at `path`,
+    /// deepening shallow CI clones as needed.
+    Git { path: &'a str },
+    /// Skip git interaction; trust the request's base ref verbatim. Useful for
+    /// callers that have already verified ancestry or for tests.
+    TrustBaseRef,
+}
+
+/// Resolve a normalized [`ScopeRequest`] into a [`ResolvedScope`].
+///
+/// Rules:
+/// - Non-PR contexts (push/cron/manual) always resolve to full scope.
+/// - PR contexts with a usable base ref resolve to changed scope; the base
+///   ref's merge base with HEAD is verified (and shallow clones deepened) via
+///   the [`MergeBaseResolver`].
+/// - Any failure to establish a base ref or merge base falls back
+///   deterministically to full scope, with a `fallback_reason` recorded.
+pub fn resolve_scope(request: &ScopeRequest, resolver: MergeBaseResolver) -> Result<ResolvedScope> {
+    if request.context != ScopeContext::PullRequest {
+        return Ok(ResolvedScope::full(request.context, request.is_fork, None));
+    }
+
+    let Some(base_ref) = request.base_ref.as_ref().filter(|r| !r.is_empty()) else {
+        return Ok(ResolvedScope::full(
+            request.context,
+            request.is_fork,
+            Some("pull request event without a base ref — using full scope".to_string()),
+        ));
+    };
+
+    match resolver {
+        MergeBaseResolver::TrustBaseRef => Ok(ResolvedScope {
+            context: request.context,
+            mode: ScopeMode::Changed,
+            base_ref: Some(base_ref.clone()),
+            is_fork: request.is_fork,
+            fallback_reason: None,
+        }),
+        MergeBaseResolver::Git { path } => match git::resolve_merge_base(path, base_ref) {
+            Ok(_) => Ok(ResolvedScope {
+                context: request.context,
+                mode: ScopeMode::Changed,
+                base_ref: Some(base_ref.clone()),
+                is_fork: request.is_fork,
+                fallback_reason: None,
+            }),
+            Err(error) => Ok(ResolvedScope::full(
+                request.context,
+                request.is_fork,
+                Some(format!(
+                    "could not resolve merge base for {base_ref} — using full scope ({error})"
+                )),
+            )),
+        },
+    }
+}
+
+/// GitHub Actions adapter: maps GitHub event context to a [`ScopeRequest`].
+///
+/// This is the only GitHub-specific surface in the module. Fields mirror the
+/// values the GitHub Actions workflow already exposes; [`from_env`] reads them
+/// from the standard environment variables so the action can stop deriving the
+/// mapping in shell.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GithubActionsContext {
+    /// `GITHUB_EVENT_NAME` (e.g. `pull_request`, `push`, `schedule`).
+    pub event_name: Option<String>,
+    /// PR base commit SHA (`github.event.pull_request.base.sha`).
+    pub base_sha: Option<String>,
+    /// Full name of the PR head repository (`owner/repo`), for fork detection.
+    pub head_repo: Option<String>,
+    /// Full name of the base repository (`GITHUB_REPOSITORY`).
+    pub base_repo: Option<String>,
+}
+
+impl GithubActionsContext {
+    /// Read the context from the standard GitHub Actions environment.
+    pub fn from_env() -> Self {
+        let var = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
+        Self {
+            event_name: var("GITHUB_EVENT_NAME"),
+            base_sha: var("BASE_SHA"),
+            head_repo: var("PR_HEAD_REPO"),
+            base_repo: var("GITHUB_REPOSITORY"),
+        }
+    }
+
+    /// Map the GitHub event name to a normalized [`ScopeContext`]. Unknown
+    /// events fall back to [`ScopeContext::Manual`] deterministically.
+    pub fn context(&self) -> ScopeContext {
+        match self.event_name.as_deref() {
+            Some("pull_request") | Some("pull_request_target") => ScopeContext::PullRequest,
+            Some("push") => ScopeContext::Push,
+            Some("schedule") => ScopeContext::Cron,
+            // workflow_dispatch and anything else → manual.
+            _ => ScopeContext::Manual,
+        }
+    }
+
+    /// Detect whether the PR originates from a fork. Only meaningful for PR
+    /// events; non-PR events are never forks for scoping purposes.
+    pub fn is_fork(&self) -> bool {
+        if self.context() != ScopeContext::PullRequest {
+            return false;
+        }
+        match (self.head_repo.as_deref(), self.base_repo.as_deref()) {
+            (Some(head), Some(base)) => head != base,
+            _ => false,
+        }
+    }
+
+    /// Normalize this GitHub context into a provider-agnostic [`ScopeRequest`].
+    pub fn to_request(&self) -> ScopeRequest {
+        let context = self.context();
+        let base_ref = if context == ScopeContext::PullRequest {
+            self.base_sha.clone()
+        } else {
+            None
+        };
+        ScopeRequest::new(context)
+            .with_base_ref(base_ref)
+            .with_fork(self.is_fork())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_pr_events_resolve_to_full_scope() {
+        for context in [ScopeContext::Push, ScopeContext::Cron, ScopeContext::Manual] {
+            let request = ScopeRequest::new(context).with_base_ref(Some("abc123".to_string()));
+            let resolved =
+                resolve_scope(&request, MergeBaseResolver::TrustBaseRef).expect("resolve");
+            assert_eq!(resolved.mode, ScopeMode::Full);
+            assert_eq!(resolved.base_ref, None);
+            assert_eq!(resolved.context, context);
+        }
+    }
+
+    #[test]
+    fn pr_with_base_ref_resolves_to_changed_scope() {
+        let request =
+            ScopeRequest::new(ScopeContext::PullRequest).with_base_ref(Some("abc123".to_string()));
+        let resolved = resolve_scope(&request, MergeBaseResolver::TrustBaseRef).expect("resolve");
+        assert_eq!(resolved.mode, ScopeMode::Changed);
+        assert_eq!(resolved.base_ref.as_deref(), Some("abc123"));
+        assert!(resolved.fallback_reason.is_none());
+    }
+
+    #[test]
+    fn pr_without_base_ref_falls_back_to_full_scope() {
+        let request = ScopeRequest::new(ScopeContext::PullRequest);
+        let resolved = resolve_scope(&request, MergeBaseResolver::TrustBaseRef).expect("resolve");
+        assert_eq!(resolved.mode, ScopeMode::Full);
+        assert!(resolved.fallback_reason.is_some());
+    }
+
+    #[test]
+    fn empty_base_ref_is_treated_as_missing() {
+        let request =
+            ScopeRequest::new(ScopeContext::PullRequest).with_base_ref(Some(String::new()));
+        assert_eq!(request.base_ref, None);
+        let resolved = resolve_scope(&request, MergeBaseResolver::TrustBaseRef).expect("resolve");
+        assert_eq!(resolved.mode, ScopeMode::Full);
+    }
+
+    #[test]
+    fn changed_scope_emits_changed_since_flags_only_for_scoped_commands() {
+        let resolved = ResolvedScope {
+            context: ScopeContext::PullRequest,
+            mode: ScopeMode::Changed,
+            base_ref: Some("base123".to_string()),
+            is_fork: false,
+            fallback_reason: None,
+        };
+
+        for cmd in SCOPED_COMMANDS {
+            assert_eq!(
+                resolved.command_flags(cmd),
+                vec!["--changed-since".to_string(), "base123".to_string()],
+                "command {cmd} should be scoped"
+            );
+        }
+
+        // Compound invocations only inspect the base command.
+        assert_eq!(
+            resolved.command_flags("refactor --from all --write"),
+            vec!["--changed-since".to_string(), "base123".to_string()]
+        );
+
+        // Non-scoped commands get no flags.
+        for cmd in ["release", "deploy", "fleet"] {
+            assert!(
+                resolved.command_flags(cmd).is_empty(),
+                "command {cmd} must not be scoped"
+            );
+        }
+    }
+
+    #[test]
+    fn full_scope_emits_no_flags() {
+        let resolved = ResolvedScope::full(ScopeContext::Push, false, None);
+        for cmd in SCOPED_COMMANDS {
+            assert!(resolved.command_flags(cmd).is_empty());
+        }
+    }
+
+    #[test]
+    fn github_event_names_map_to_contexts() {
+        let cases = [
+            ("pull_request", ScopeContext::PullRequest),
+            ("pull_request_target", ScopeContext::PullRequest),
+            ("push", ScopeContext::Push),
+            ("schedule", ScopeContext::Cron),
+            ("workflow_dispatch", ScopeContext::Manual),
+            ("something_unknown", ScopeContext::Manual),
+        ];
+        for (event, expected) in cases {
+            let ctx = GithubActionsContext {
+                event_name: Some(event.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(ctx.context(), expected, "event {event}");
+        }
+    }
+
+    #[test]
+    fn missing_event_name_falls_back_to_manual() {
+        let ctx = GithubActionsContext::default();
+        assert_eq!(ctx.context(), ScopeContext::Manual);
+    }
+
+    #[test]
+    fn fork_detection_compares_head_and_base_repo() {
+        let same = GithubActionsContext {
+            event_name: Some("pull_request".to_string()),
+            head_repo: Some("Extra-Chill/homeboy".to_string()),
+            base_repo: Some("Extra-Chill/homeboy".to_string()),
+            ..Default::default()
+        };
+        assert!(!same.is_fork());
+
+        let fork = GithubActionsContext {
+            event_name: Some("pull_request".to_string()),
+            head_repo: Some("contributor/homeboy".to_string()),
+            base_repo: Some("Extra-Chill/homeboy".to_string()),
+            ..Default::default()
+        };
+        assert!(fork.is_fork());
+
+        // Fork detection is only meaningful for PR events.
+        let push = GithubActionsContext {
+            event_name: Some("push".to_string()),
+            head_repo: Some("contributor/homeboy".to_string()),
+            base_repo: Some("Extra-Chill/homeboy".to_string()),
+            ..Default::default()
+        };
+        assert!(!push.is_fork());
+    }
+
+    #[test]
+    fn github_pr_context_normalizes_to_changed_request() {
+        let ctx = GithubActionsContext {
+            event_name: Some("pull_request".to_string()),
+            base_sha: Some("deadbeef".to_string()),
+            head_repo: Some("contributor/homeboy".to_string()),
+            base_repo: Some("Extra-Chill/homeboy".to_string()),
+        };
+        let request = ctx.to_request();
+        assert_eq!(request.context, ScopeContext::PullRequest);
+        assert_eq!(request.base_ref.as_deref(), Some("deadbeef"));
+        assert!(request.is_fork);
+
+        let resolved = resolve_scope(&request, MergeBaseResolver::TrustBaseRef).expect("resolve");
+        assert_eq!(resolved.mode, ScopeMode::Changed);
+        assert_eq!(resolved.base_ref.as_deref(), Some("deadbeef"));
+        assert!(resolved.is_fork);
+    }
+
+    #[test]
+    fn github_push_context_ignores_base_sha() {
+        let ctx = GithubActionsContext {
+            event_name: Some("push".to_string()),
+            base_sha: Some("deadbeef".to_string()),
+            ..Default::default()
+        };
+        let request = ctx.to_request();
+        assert_eq!(request.context, ScopeContext::Push);
+        assert_eq!(request.base_ref, None);
+    }
+}

--- a/src/core/git/changes.rs
+++ b/src/core/git/changes.rs
@@ -290,6 +290,38 @@ fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
     }
 }
 
+/// Ensure a ref's merge base with HEAD is reachable, then return it.
+///
+/// Handles shallow CI clones by progressively deepening the repository
+/// (the same strategy as [`get_files_changed_since`]). Returns the resolved
+/// merge-base SHA on success, or an error if the ancestry cannot be made
+/// reachable. Callers that want a deterministic "fall back to full scope"
+/// behavior should treat the error as a signal to skip changed-since scoping
+/// rather than aborting.
+pub fn resolve_merge_base(path: &str, git_ref: &str) -> Result<String> {
+    ensure_ancestry_for_ref(path, git_ref)?;
+
+    let output = execute_git(path, &["merge-base", git_ref, "HEAD"])
+        .map_err(|e| Error::git_command_failed(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::git_command_failed(format!(
+            "git merge-base {git_ref} HEAD failed: {}",
+            stderr.trim()
+        )));
+    }
+
+    let merge_base = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if merge_base.is_empty() {
+        return Err(Error::git_command_failed(format!(
+            "git merge-base {git_ref} HEAD returned no commit"
+        )));
+    }
+
+    Ok(merge_base)
+}
+
 /// Get all dirty files in the working tree (modified, new, deleted).
 /// Returns repo-relative paths. Useful for detecting what changed between
 /// operations on the working tree.

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -19,7 +19,7 @@ mod operation_tests;
 
 pub use changes::{
     discard_worktree_changes, get_diff, get_dirty_files, get_files_changed_since, get_range_diff,
-    get_uncommitted_changes, UncommittedChanges,
+    get_uncommitted_changes, resolve_merge_base, UncommittedChanges,
 };
 pub(crate) use commits::extract_version_from_tag;
 pub use commits::{

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -53,6 +53,7 @@ pub mod build_identity;
 pub mod change_artifact;
 pub mod ci_plan;
 pub mod ci_profile;
+pub mod ci_scope;
 pub mod cleanup;
 pub mod code_audit;
 pub mod command_execution_plan;


### PR DESCRIPTION
## Summary

Closes #2915. Moves the GitHub-Actions-context → Homeboy-scope translation out of the action's shell scripts (`scripts/scope/resolve.sh`, `scripts/scope/flags.sh`) and into core, so `homeboy-action` calls core instead of re-deriving the mapping in bash.

## What's added

- **`src/core/ci_scope.rs`** — a new, mostly provider-agnostic scope resolver:
  - Generic core: `ScopeContext` (pr/push/cron/manual), `ScopeMode` (changed/full), `ScopeRequest`, `ResolvedScope`, and `resolve_scope()`.
  - `ResolvedScope::command_flags()` emits `--changed-since <ref>` only for the typed `SCOPED_COMMANDS` set (audit, lint, test, review, refactor) — differential gating exceptions are a typed constant, not a shell `case` statement.
  - A clearly-delineated **GitHub Actions adapter** (`GithubActionsContext`) that reads `GITHUB_EVENT_NAME`, `BASE_SHA`, `PR_HEAD_REPO`, `GITHUB_REPOSITORY` (via `from_env()`) and normalizes to a `ScopeRequest`, including fork detection.
  - Invalid/unknown event names fall back deterministically to `manual`; PRs without a usable base ref (or whose merge base can't be resolved) fall back deterministically to full scope with a recorded `fallback_reason`.
- **`git::resolve_merge_base()`** — exposes the existing shallow-clone-deepening merge-base resolution from `git/changes.rs` so the resolver reuses core's ancestry logic instead of duplicating the `git fetch --deepen`/`--unshallow` dance the shell did.
- **`homeboy ci scope`** CLI subcommand — wraps the resolver: `--github-actions` reads the env, explicit flags override individual fields, `--repo-path` enables real merge-base verification, and `--for <cmd>` emits the per-command `--changed-since` flags. Mirrors the existing `ci autofix` pattern (core-owned transaction the action calls instead of shelling).

## Acceptance criteria

- GitHub event context parsing is covered by tests (event→context mapping, fork detection, normalization).
- Invalid/unknown scope input falls back deterministically (unknown event → manual; PR w/o base ref → full scope).
- Differential gating exceptions are typed (`SCOPED_COMMANDS`), not embedded in shell `case` statements.
- The action can remove `scripts/scope/resolve.sh` and `scripts/scope/flags.sh` once it migrates to `homeboy ci scope`.

## Tests

11 unit tests in `ci_scope` plus 2 CLI tests in `commands/ci.rs`, all green via `cargo test --lib ci_scope::`. `cargo build --lib` / `cargo clippy --lib` / `cargo clippy --bin homeboy` clean for all touched files.

## Notes

- Complements the parallel `ci_plan` command-inference module — this resolver owns event-context → scope mode/base-ref (the changed-since translation), while `ci plan` owns command inference/ordering. Both `ci scope` and `ci plan` coexist.
- Did not touch `agent_task*`, `runner/lab*`, or `fuzz*` (parallel fleet territory). `main` currently has a pre-existing compile break in `src/commands/agent_task/fanout.rs` from the agent-task/fanout merge storm — unrelated to this PR; CI goes green once the fleet fixes main.