### PR TITLE
feat(runner): secure reverse runner broker authentication and pairing (#2990)

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -212,6 +212,39 @@ The broker exposes `POST /runner/jobs`, `POST /runner/jobs/claim`,
 controllers can queue work and reverse runners can claim, stream progress, and
 return results without inbound access to the lab machine.
 
+#### Broker authentication and pairing
+
+Every `/runner/*` broker route requires an authenticated, scoped bearer token
+(#2990). The trust model is:
+
+- **Pairing.** On the broker host, mint a credential with
+  `homeboy runner broker pair <id> --runner-id <runner-id> [--work] [--submit]`.
+  Pairing prints a one-time bearer token and stores only its SHA-256 hash in
+  `~/.config/homeboy/broker_auth.json` (`0600`). The plaintext token is shown
+  once and never re-displayed or logged.
+- **Scopes.** `--work` authorizes worker routes (register, claim, events,
+  finish, heartbeat); `--submit` authorizes controller job submission and
+  cancellation (`POST /runner/jobs`, `POST /runner/jobs/<id>/cancel`). A
+  credential may carry both. When neither flag is given, `--work` is assumed.
+- **Runner-id binding.** Worker routes carry a `runner_id`; the presented token
+  must belong to a credential paired to that exact `runner_id`, so a paired
+  runner can never claim, progress, or finish another runner's jobs.
+- **Revocation.** `homeboy runner broker revoke <id>` disables a credential.
+  `homeboy runner broker list` shows non-secret credential metadata (never
+  tokens or hashes).
+- **Secure by default.** With no credentials configured, the broker rejects all
+  `/runner/*` traffic with a structured `broker.auth_denied` (`401`) error. To
+  keep an existing loopback-only smoke setup working without auth, set
+  `"allow_unauthenticated_loopback": true` in `broker_auth.json`; this is only
+  honored when the broker is bound to loopback.
+
+Workers send the token via `--broker-token <token>` or the
+`HOMEBOY_BROKER_TOKEN` environment variable; controllers read their submit token
+from `HOMEBOY_BROKER_TOKEN`. Tokens travel as both `X-Homeboy-Broker-Token` and
+`Authorization: Bearer <token>` so they survive proxies that strip one form.
+Unauthenticated, mismatched-runner, or wrong-scope requests are rejected with a
+structured `broker.auth_denied` error and never expose the stored secret.
+
 Daemon and broker HTTP responses use one canonical envelope. The outer response
 reports transport success and the endpoint payload always lives under
 `data.body`; runner clients require that shape and do not parse legacy direct
@@ -240,10 +273,14 @@ broker exposure.
 ### `work`
 
 ```sh
-homeboy runner work <runner-id> --broker-url <url>
+homeboy runner work <runner-id> --broker-url <url> --broker-token <token>
 homeboy runner work <runner-id> --broker-url <url> --project <project-id> --lease-ms 30000
-homeboy runner work <runner-id> --broker-url <url> --loop
+HOMEBOY_BROKER_TOKEN=<token> homeboy runner work <runner-id> --broker-url <url> --loop
 ```
+
+Pass the paired token with `--broker-token` or the `HOMEBOY_BROKER_TOKEN`
+environment variable. The token is required whenever the broker enforces auth;
+omit it only for a loopback-open smoke broker.
 
 Claims one brokered reverse-runner job for the runner, executes it on the runner
 machine under the runner's local policy, streams a progress event, and finishes
@@ -264,6 +301,22 @@ queues use exponential backoff controlled by `--idle-backoff-ms` and
 Transient broker failures sleep for `--broker-failure-backoff-ms` and exit
 non-zero after `--broker-retry-limit` consecutive failures. `SIGINT` and
 `SIGTERM` request graceful shutdown after the current claim attempt or job.
+
+### `broker`
+
+```sh
+homeboy runner broker pair lab-1 --runner-id homeboy-lab --work
+homeboy runner broker pair ctrl-1 --runner-id homeboy-lab --submit
+homeboy runner broker revoke lab-1
+homeboy runner broker list
+```
+
+Manage reverse runner broker authentication and pairing on the broker host.
+`pair` mints a one-time scoped bearer token (printed once; only its SHA-256 hash
+is stored under `~/.config/homeboy/broker_auth.json`). `revoke` disables a
+credential by id, and `list` reports non-secret credential metadata. See
+[Broker authentication and pairing](#broker-authentication-and-pairing) for the
+full trust model.
 
 ### `job`
 
@@ -294,6 +347,7 @@ Wants=network-online.target
 Type=simple
 User=deploy
 WorkingDirectory=/home/user
+Environment=HOMEBOY_BROKER_TOKEN=<paired-token>
 ExecStart=/usr/local/bin/homeboy runner work homeboy-lab --broker-url https://controller.example.com --loop --idle-backoff-ms 1000 --max-idle-backoff-ms 30000 --broker-retry-limit 12
 Restart=on-failure
 RestartSec=10
@@ -303,9 +357,12 @@ KillSignal=SIGTERM
 WantedBy=multi-user.target
 ```
 
-The unit intentionally leaves authentication out until the broker auth contract
-lands; configure the broker URL and any future auth material using the production
-mechanism for issue #2990 rather than embedding secrets in the unit file.
+The worker authenticates with the broker using the paired bearer token. Prefer
+delivering it through `HOMEBOY_BROKER_TOKEN` — via a systemd
+`EnvironmentFile=/etc/homeboy/broker.env` with `0600` permissions rather than an
+inline `Environment=` line — so the secret never lands in `systemctl show`
+output. Pair the credential on the broker host with `homeboy runner broker pair`
+(see [Broker authentication and pairing](#broker-authentication-and-pairing)).
 
 ### `status`
 

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -84,6 +84,39 @@ pub enum RunnerCommandOutput {
     Job(RunnerJobOutput),
     Worker(ReverseRunnerWorkerOutput),
     Workspace(workspace::RunnerWorkspaceOutput),
+    Broker(RunnerBrokerOutput),
+}
+
+/// Result of a broker auth/pairing management command. The plaintext `token` is
+/// present only on a successful `pair` and is the single time it is ever shown.
+#[derive(Debug, Serialize)]
+pub struct RunnerBrokerOutput {
+    pub command: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+    /// One-time plaintext bearer token (only on `pair`). Never re-displayed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked: Option<bool>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub credentials: Vec<RunnerBrokerCredentialSummary>,
+    pub store_path: String,
+}
+
+/// Non-secret summary of a stored broker credential. Token hashes are never
+/// surfaced.
+#[derive(Debug, Serialize)]
+pub struct RunnerBrokerCredentialSummary {
+    pub id: String,
+    pub runner_id: String,
+    pub scopes: Vec<String>,
+    pub revoked: bool,
+    pub created_at: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -398,6 +431,12 @@ enum RunnerCommand {
         #[arg(long)]
         broker_url: String,
 
+        /// Paired broker bearer token. Falls back to the HOMEBOY_BROKER_TOKEN
+        /// environment variable when omitted. Required when the broker enforces
+        /// auth; omit only for loopback-open smoke setups.
+        #[arg(long)]
+        broker_token: Option<String>,
+
         /// Optional project filter for claimed jobs
         #[arg(long)]
         project: Option<String>,
@@ -431,6 +470,39 @@ enum RunnerCommand {
         #[command(subcommand)]
         command: workspace::RunnerWorkspaceCommand,
     },
+    /// Manage reverse runner broker authentication and pairing
+    Broker {
+        #[command(subcommand)]
+        command: RunnerBrokerCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum RunnerBrokerCommand {
+    /// Pair a runner with the broker, minting a one-time scoped bearer token
+    Pair {
+        /// Stable credential id used for later revocation
+        id: String,
+
+        /// Runner id this credential authorizes (worker routes must match it)
+        #[arg(long)]
+        runner_id: String,
+
+        /// Grant the controller submit scope (POST /runner/jobs)
+        #[arg(long)]
+        submit: bool,
+
+        /// Grant the worker scope (register/claim/event/finish/heartbeat)
+        #[arg(long)]
+        work: bool,
+    },
+    /// Revoke a paired credential by id
+    Revoke {
+        /// Credential id to revoke
+        id: String,
+    },
+    /// List paired broker credentials (never prints tokens)
+    List,
 }
 
 #[derive(Subcommand)]
@@ -636,6 +708,7 @@ pub fn run(
         RunnerCommand::Work {
             runner_id,
             broker_url,
+            broker_token,
             project,
             lease_ms,
             r#loop,
@@ -647,9 +720,11 @@ pub fn run(
             let concurrency_limit = runner::load(&runner_id)
                 .ok()
                 .and_then(|runner| runner.settings.concurrency_limit);
+            let broker_token = broker_token.or_else(runner::broker_token_from_env);
             map_worker(runner::run_reverse_worker(ReverseRunnerWorkerOptions {
                 runner_id,
                 broker_url,
+                broker_token,
                 project_id: project,
                 lease_ms,
                 concurrency_limit,
@@ -662,7 +737,104 @@ pub fn run(
         }
         RunnerCommand::Workspace { command } => workspace::run(command)
             .map(|(output, exit_code)| (RunnerCommandOutput::Workspace(output), exit_code)),
+        RunnerCommand::Broker { command } => {
+            run_broker(command).map(|output| (RunnerCommandOutput::Broker(output), 0))
+        }
     }
+}
+
+fn run_broker(command: RunnerBrokerCommand) -> Result<RunnerBrokerOutput, homeboy::core::Error> {
+    use std::collections::BTreeSet;
+
+    let mut store = runner::BrokerAuthStore::load()?;
+    match command {
+        RunnerBrokerCommand::Pair {
+            id,
+            runner_id,
+            submit,
+            work,
+        } => {
+            let mut scopes: BTreeSet<runner::BrokerScope> = BTreeSet::new();
+            if submit {
+                scopes.insert(runner::BrokerScope::Submit);
+            }
+            if work {
+                scopes.insert(runner::BrokerScope::Work);
+            }
+            if scopes.is_empty() {
+                // Default to a worker credential, the most common pairing.
+                scopes.insert(runner::BrokerScope::Work);
+            }
+            let minted = store.pair(id, runner_id, scopes)?;
+            let store_path = store.save()?;
+            let scope_labels = scope_labels(&store, &minted.id);
+            Ok(RunnerBrokerOutput {
+                command: "runner.broker.pair",
+                credential_id: Some(minted.id),
+                runner_id: Some(minted.runner_id),
+                scopes: scope_labels,
+                token: Some(minted.token),
+                revoked: None,
+                credentials: Vec::new(),
+                store_path: store_path.display().to_string(),
+            })
+        }
+        RunnerBrokerCommand::Revoke { id } => {
+            let revoked = store.revoke(&id);
+            let store_path = store.save()?;
+            Ok(RunnerBrokerOutput {
+                command: "runner.broker.revoke",
+                credential_id: Some(id),
+                runner_id: None,
+                scopes: Vec::new(),
+                token: None,
+                revoked: Some(revoked),
+                credentials: Vec::new(),
+                store_path: store_path.display().to_string(),
+            })
+        }
+        RunnerBrokerCommand::List => {
+            let credentials = store
+                .credentials
+                .iter()
+                .map(|cred| RunnerBrokerCredentialSummary {
+                    id: cred.id.clone(),
+                    runner_id: cred.runner_id.clone(),
+                    scopes: cred.scopes.iter().map(scope_label).collect(),
+                    revoked: cred.revoked_at.is_some(),
+                    created_at: cred.created_at.clone(),
+                })
+                .collect();
+            // Listing does not mutate; resolve the path without rewriting.
+            let path = runner::broker_auth_store_path()?;
+            Ok(RunnerBrokerOutput {
+                command: "runner.broker.list",
+                credential_id: None,
+                runner_id: None,
+                scopes: Vec::new(),
+                token: None,
+                revoked: None,
+                credentials,
+                store_path: path.display().to_string(),
+            })
+        }
+    }
+}
+
+fn scope_label(scope: &runner::BrokerScope) -> String {
+    match scope {
+        runner::BrokerScope::Submit => "submit".to_string(),
+        runner::BrokerScope::Work => "work".to_string(),
+    }
+}
+
+fn scope_labels(store: &runner::BrokerAuthStore, id: &str) -> Vec<String> {
+    store
+        .credentials
+        .iter()
+        .find(|cred| cred.id == id)
+        .map(|cred| cred.scopes.iter().map(scope_label).collect())
+        .unwrap_or_default()
 }
 
 pub fn run_command_output(args: RunnerArgs, _global: &super::GlobalArgs) -> JsonCommandRun {

--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -141,6 +141,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
 
         ErrorCode::RigPipelineFailed
         | ErrorCode::RunnerPolicyDenied
+        | ErrorCode::BrokerAuthDenied
         | ErrorCode::RigServiceFailed
         | ErrorCode::RigResourceConflict
         | ErrorCode::StackApplyConflict => 20,

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -204,11 +204,13 @@ where
     })?;
     let state = write_state(local_addr)?;
     let job_store = JobStore::open(paths::daemon_jobs_file()?)?;
+    let loopback_bind = local_addr.ip().is_loopback();
 
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
-                let _ = handle_connection(stream, &job_store, analysis_runner.clone());
+                let _ =
+                    handle_connection(stream, &job_store, analysis_runner.clone(), loopback_bind);
             }
             Err(err) => {
                 return Err(Error::internal_io(
@@ -251,6 +253,30 @@ fn route_with_job_store_and_body_and_runner<R>(
     body: Option<serde_json::Value>,
     job_store: &JobStore,
     analysis_runner: R,
+) -> HttpResponse
+where
+    R: AnalysisJobRunner,
+{
+    // In-process dispatch (CLI internals, tests) is already inside the trust
+    // boundary; only the network entry point (`handle_connection`) authenticates
+    // broker traffic against the on-disk auth store.
+    route_with_job_store_and_body_and_runner_and_auth(
+        method,
+        path,
+        body,
+        job_store,
+        analysis_runner,
+        remote_runner::BrokerAuthContext::trusted_local(),
+    )
+}
+
+fn route_with_job_store_and_body_and_runner_and_auth<R>(
+    method: &str,
+    path: &str,
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+    analysis_runner: R,
+    broker_auth: remote_runner::BrokerAuthContext,
 ) -> HttpResponse
 where
     R: AnalysisJobRunner,
@@ -298,16 +324,18 @@ where
         ("POST", "/runner/sessions")
         | ("POST", "/runner/jobs")
         | ("POST", "/runner/jobs/reconcile")
-        | ("POST", "/runner/jobs/claim") => remote_runner::route(method, path, body, job_store),
+        | ("POST", "/runner/jobs/claim") => {
+            remote_runner::route(method, path, body, job_store, &broker_auth)
+        }
         ("GET", "/runner/sessions")
         | ("GET", "/runner/jobs")
         | ("GET", "/runner/jobs/reconcile")
         | ("GET", "/runner/jobs/claim") => method_not_allowed(),
         ("GET", path) if path.starts_with("/runner/jobs/") => {
-            remote_runner::route(method, path, body, job_store)
+            remote_runner::route(method, path, body, job_store, &broker_auth)
         }
         ("POST", path) if path.starts_with("/runner/jobs/") => {
-            remote_runner::route(method, path, body, job_store)
+            remote_runner::route(method, path, body, job_store, &broker_auth)
         }
         _ => route_read_only_api(method, path, body, job_store, analysis_runner),
     }
@@ -587,6 +615,7 @@ fn handle_connection<R>(
     mut stream: TcpStream,
     job_store: &JobStore,
     analysis_runner: R,
+    loopback_bind: bool,
 ) -> std::io::Result<()>
 where
     R: AnalysisJobRunner,
@@ -597,6 +626,7 @@ where
     let mut headers_and_body = request.splitn(2, "\r\n\r\n");
     let headers = headers_and_body.next().unwrap_or_default();
     let body = headers_and_body.next().unwrap_or_default();
+    let broker_token = crate::core::runner::extract_bearer_token(headers);
     let mut parts = headers
         .lines()
         .next()
@@ -623,12 +653,18 @@ where
             }
         }
     };
-    let response = route_with_job_store_and_body_and_runner(
+    let broker_auth = remote_runner::BrokerAuthContext {
+        token: broker_token,
+        loopback_bind,
+        trusted_local: false,
+    };
+    let response = route_with_job_store_and_body_and_runner_and_auth(
         method,
         path,
         parsed_body,
         job_store,
         analysis_runner,
+        broker_auth,
     );
     write_http_response(stream, response)
 }
@@ -651,6 +687,8 @@ fn write_http_response(mut stream: TcpStream, response: HttpResponse) -> std::io
     let status_text = match response.status_code {
         200 => "OK",
         400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
         404 => "Not Found",
         405 => "Method Not Allowed",
         _ => "Internal Server Error",

--- a/src/core/daemon/broker_config.rs
+++ b/src/core/daemon/broker_config.rs
@@ -77,8 +77,8 @@ pub fn render_broker_config(options: BrokerConfigOptions) -> Result<BrokerConfig
         safe_exposure: BrokerExposure {
             loopback_only: true,
             private_tunnel_safe: true,
-            public_reverse_proxy_blocked_by: "https://github.com/Extra-Chill/homeboy/issues/2990".to_string(),
-            reason: "Current broker routes do not enforce production auth/pairing, so keep the service on loopback and reach it through a private tunnel until #2990 lands.".to_string(),
+            public_reverse_proxy_blocked_by: "broker auth pairing (homeboy runner broker pair)".to_string(),
+            reason: "Broker /runner/* routes now require scoped bearer tokens (#2990). Pair every runner with `homeboy runner broker pair` before exposing the broker via a reverse proxy; keep it loopback-only until credentials are configured. Private tunnels remain the simplest hardening.".to_string(),
         },
         systemd_unit: render_systemd_unit(&options, &listen),
         private_tunnel_examples: vec![
@@ -89,7 +89,7 @@ pub fn render_broker_config(options: BrokerConfigOptions) -> Result<BrokerConfig
                 "cloudflared tunnel --url http://{listen} # protect with Zero Trust before use"
             ),
             format!(
-                "tailscale funnel is not recommended until #2990; use tailnet-only access to http://{listen}"
+                "tailscale funnel exposes the broker publicly; only use it once every runner is paired (homeboy runner broker pair), otherwise keep tailnet-only access to http://{listen}"
             ),
         ],
         nginx_site: domain.as_ref().map(|domain| render_nginx_site(domain, &listen)),
@@ -163,8 +163,9 @@ WantedBy=multi-user.target
 
 fn render_nginx_site(domain: &str, listen_addr: &str) -> String {
     format!(
-        r#"# Blocked for public Internet use until Homeboy broker auth/pairing lands in #2990.
-# Use only behind private network controls or keep this site disabled.
+        r#"# Only expose publicly after pairing every runner with `homeboy runner broker pair` (#2990).
+# Until credentials are configured the broker rejects /runner/* with broker.auth_denied;
+# keep this site disabled or behind private network controls otherwise.
 server {{
     listen 443 ssl http2;
     server_name {domain};
@@ -183,8 +184,9 @@ server {{
 
 fn render_caddy_site(domain: &str, listen_addr: &str) -> String {
     format!(
-        r#"# Blocked for public Internet use until Homeboy broker auth/pairing lands in #2990.
-# Use only behind private network controls or keep this site disabled.
+        r#"# Only expose publicly after pairing every runner with `homeboy runner broker pair` (#2990).
+# Until credentials are configured the broker rejects /runner/* with broker.auth_denied;
+# keep this site disabled or behind private network controls otherwise.
 {domain} {{
     reverse_proxy http://{listen_addr}
 }}
@@ -213,7 +215,7 @@ mod tests {
         assert!(config
             .safe_exposure
             .public_reverse_proxy_blocked_by
-            .ends_with("/2990"));
+            .contains("broker auth"));
         assert!(config.nginx_site.is_none());
     }
 
@@ -231,8 +233,10 @@ mod tests {
         assert!(nginx.contains("broker.example.com"));
         assert!(nginx.contains("proxy_pass http://127.0.0.1:7421"));
         assert!(nginx.contains("#2990"));
+        assert!(nginx.contains("homeboy runner broker pair"));
         assert!(caddy.contains("reverse_proxy http://127.0.0.1:7421"));
         assert!(caddy.contains("#2990"));
+        assert!(caddy.contains("homeboy runner broker pair"));
     }
 
     #[test]

--- a/src/core/daemon/remote_runner.rs
+++ b/src/core/daemon/remote_runner.rs
@@ -8,7 +8,49 @@ use crate::core::api_jobs::{
 };
 use crate::core::error::{Error, Result};
 use crate::core::paths;
-use crate::core::runner::{self, RunnerSession, RunnerSessionRole, RunnerTunnelMode};
+use crate::core::runner::{
+    self, BrokerAuthStore, BrokerScope, RunnerSession, RunnerSessionRole, RunnerTunnelMode,
+};
+
+/// Per-request broker authentication context extracted from the network layer.
+///
+/// `handle_connection` (the only network entry point) builds the real context
+/// from request headers and the bind address. In-process callers (CLI dispatch,
+/// tests) use [`BrokerAuthContext::trusted_local`], which is already inside the
+/// trust boundary and bypasses bearer enforcement.
+#[derive(Debug, Clone, Default)]
+pub(in crate::core::daemon) struct BrokerAuthContext {
+    pub token: Option<String>,
+    pub loopback_bind: bool,
+    pub trusted_local: bool,
+}
+
+impl BrokerAuthContext {
+    /// Context for in-process dispatch already inside the trust boundary.
+    pub(in crate::core::daemon) fn trusted_local() -> Self {
+        Self {
+            token: None,
+            loopback_bind: true,
+            trusted_local: true,
+        }
+    }
+
+    /// Authorize this request against the on-disk broker auth store for the
+    /// given scope and (optionally) the runner id carried in the request body.
+    fn authorize(&self, required: BrokerScope, runner_id: Option<&str>) -> Result<()> {
+        if self.trusted_local {
+            return Ok(());
+        }
+        let store = BrokerAuthStore::load()?;
+        store.authorize(
+            self.loopback_bind,
+            self.token.as_deref(),
+            required,
+            runner_id,
+        )?;
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone, Deserialize)]
 struct ClaimRequest {
@@ -65,31 +107,32 @@ struct SessionRequest {
     last_seen_at: Option<String>,
 }
 
-pub(super) fn route(
+pub(in crate::core::daemon) fn route(
     method: &str,
     path: &str,
     body: Option<Value>,
     job_store: &JobStore,
+    auth: &BrokerAuthContext,
 ) -> HttpResponse {
     match (method, path) {
-        ("POST", "/runner/sessions") => match register_session(body) {
+        ("POST", "/runner/sessions") => match register_session(body, auth) {
             Ok(body) => daemon_endpoint_response("runner.sessions.register", body),
-            Err(err) => error_response(400, err),
+            Err(err) => auth_or_bad_request(err),
         },
-        ("POST", "/runner/jobs") => match enqueue(body, job_store) {
+        ("POST", "/runner/jobs") => match enqueue(body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.submit", body),
-            Err(err) => error_response(400, err),
+            Err(err) => auth_or_bad_request(err),
         },
         ("POST", "/runner/jobs/reconcile") => match reconcile(job_store) {
             Ok(body) => daemon_endpoint_response("runner.jobs.reconcile", body),
             Err(err) => error_response(400, err),
         },
-        ("POST", "/runner/jobs/claim") => match claim(body, job_store) {
+        ("POST", "/runner/jobs/claim") => match claim(body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.claim", body),
-            Err(err) => error_response(400, err),
+            Err(err) => auth_or_bad_request(err),
         },
         ("GET", path) if path.starts_with("/runner/jobs/") => lookup(path, job_store),
-        ("POST", path) if path.starts_with("/runner/jobs/") => update(path, body, job_store),
+        ("POST", path) if path.starts_with("/runner/jobs/") => update(path, body, job_store, auth),
         _ => error_response(
             404,
             Error::validation_invalid_argument(
@@ -176,7 +219,7 @@ fn reconcile(job_store: &JobStore) -> Result<Value> {
     }))
 }
 
-fn register_session(body: Option<Value>) -> Result<Value> {
+fn register_session(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
     let request: SessionRequest = parse_body(body, "remote runner session request")?;
     if request.runner_id.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -186,6 +229,7 @@ fn register_session(body: Option<Value>) -> Result<Value> {
             None,
         ));
     }
+    auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     if request.controller_id.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "controller_id",
@@ -227,7 +271,8 @@ fn register_session(body: Option<Value>) -> Result<Value> {
     }))
 }
 
-fn enqueue(body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
     let request: RemoteRunnerJobRequest = parse_body(body, "remote runner job request")?;
     let job = job_store.submit_remote_runner_job(request.clone())?;
     Ok(json!({
@@ -241,8 +286,9 @@ fn enqueue(body: Option<Value>, job_store: &JobStore) -> Result<Value> {
     }))
 }
 
-fn claim(body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+fn claim(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
     let request: ClaimRequest = parse_body(body, "remote runner claim request")?;
+    auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     touch_reverse_session(&request.runner_id)?;
     let concurrency_limit = request.concurrency_limit.or_else(|| {
         runner::load(&request.runner_id)
@@ -261,7 +307,12 @@ fn claim(body: Option<Value>, job_store: &JobStore) -> Result<Value> {
     }))
 }
 
-fn update(path: &str, body: Option<Value>, job_store: &JobStore) -> HttpResponse {
+fn update(
+    path: &str,
+    body: Option<Value>,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> HttpResponse {
     let Some((job_id, operation)) = job_path(path) else {
         return error_response(
             404,
@@ -277,21 +328,21 @@ fn update(path: &str, body: Option<Value>, job_store: &JobStore) -> HttpResponse
     };
 
     match operation {
-        "events" => match append_event(job_id, body, job_store) {
+        "events" => match append_event(job_id, body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.events.append", body),
-            Err(err) => error_response(400, err),
+            Err(err) => auth_or_bad_request(err),
         },
-        "finish" => match finish(job_id, body, job_store) {
+        "finish" => match finish(job_id, body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.finish", body),
-            Err(err) => error_response(400, err),
+            Err(err) => auth_or_bad_request(err),
         },
-        "heartbeat" => match heartbeat(job_id, body, job_store) {
+        "heartbeat" => match heartbeat(job_id, body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.heartbeat", body),
-            Err(err) => error_response(400, err),
+            Err(err) => auth_or_bad_request(err),
         },
-        "cancel" => match cancel(job_id, job_store) {
+        "cancel" => match cancel(job_id, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.cancel", body),
-            Err(err) => error_response(400, err),
+            Err(err) => auth_or_bad_request(err),
         },
         _ => error_response(
             404,
@@ -328,8 +379,14 @@ fn job_artifact_path(path: &str) -> Option<(Uuid, String)> {
     ))
 }
 
-fn append_event(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+fn append_event(
+    job_id: Uuid,
+    body: Option<Value>,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
     let request: EventRequest = parse_body(body, "remote runner event request")?;
+    auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     touch_reverse_session(&request.runner_id)?;
     let event = job_store.append_remote_runner_event(
         job_id,
@@ -345,8 +402,14 @@ fn append_event(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Resu
     }))
 }
 
-fn finish(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+fn finish(
+    job_id: Uuid,
+    body: Option<Value>,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
     let request: FinishRequest = parse_body(body, "remote runner finish request")?;
+    auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     touch_reverse_session(&request.runner_id)?;
     let job = job_store.finish_remote_runner_job(
         job_id,
@@ -360,8 +423,14 @@ fn finish(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Result<Val
     }))
 }
 
-fn heartbeat(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+fn heartbeat(
+    job_id: Uuid,
+    body: Option<Value>,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
     let request: HeartbeatRequest = parse_body(body, "remote runner heartbeat request")?;
+    auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     touch_reverse_session(&request.runner_id)?;
     let job = job_store.renew_remote_runner_claim(
         job_id,
@@ -375,7 +444,8 @@ fn heartbeat(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Result<
     }))
 }
 
-fn cancel(job_id: Uuid, job_store: &JobStore) -> Result<Value> {
+fn cancel(job_id: Uuid, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
     let job = job_store.cancel_remote_runner_job(job_id, "cancel requested via broker API")?;
     let events = job_store.events(job_id)?;
     Ok(json!({
@@ -383,6 +453,17 @@ fn cancel(job_id: Uuid, job_store: &JobStore) -> Result<Value> {
         "job": job,
         "events": events,
     }))
+}
+
+/// Map a handler error to an HTTP response. Broker auth rejections become
+/// `401 Unauthorized` (so unauthenticated callers see a distinct status), all
+/// other errors keep the existing `400 Bad Request` contract.
+fn auth_or_bad_request(err: Error) -> HttpResponse {
+    if err.code == crate::core::error::ErrorCode::BrokerAuthDenied {
+        error_response(401, err)
+    } else {
+        error_response(400, err)
+    }
 }
 
 fn parse_body<T: for<'de> Deserialize<'de>>(body: Option<Value>, label: &str) -> Result<T> {
@@ -428,4 +509,219 @@ fn write_session(session: &RunnerSession) -> Result<std::path::PathBuf> {
         Error::internal_io(err.to_string(), Some(format!("write {}", path.display())))
     })?;
     Ok(path)
+}
+
+#[cfg(test)]
+mod auth_tests {
+    use super::*;
+    use crate::core::runner::BrokerScope;
+    use crate::test_support::HomeGuard;
+    use std::collections::BTreeSet;
+
+    /// Build a network-style (enforcing, non-loopback) auth context carrying
+    /// `token`. `trusted_local` is false so the auth store is consulted.
+    fn enforcing_auth(token: Option<&str>) -> BrokerAuthContext {
+        BrokerAuthContext {
+            token: token.map(str::to_string),
+            loopback_bind: false,
+            trusted_local: false,
+        }
+    }
+
+    /// Pair a runner credential with `scope`, returning the one-time token.
+    fn pair(runner_id: &str, scope: BrokerScope) -> String {
+        pair_extra("cred-1", runner_id, scope)
+    }
+
+    /// Pair an additional credential under an explicit `id`.
+    fn pair_extra(id: &str, runner_id: &str, scope: BrokerScope) -> String {
+        let mut store = BrokerAuthStore::load().expect("load store");
+        let scopes: BTreeSet<BrokerScope> = std::iter::once(scope).collect();
+        let minted = store.pair(id, runner_id, scopes).expect("pair");
+        store.save().expect("save store");
+        minted.token
+    }
+
+    fn submit_body() -> Value {
+        json!({
+            "runner_id": "homeboy-lab",
+            "project_id": "extrachill",
+            "command": ["homeboy", "test", "sample"],
+            "cwd": "/tmp/sample"
+        })
+    }
+
+    #[test]
+    fn unauthenticated_broker_route_is_rejected() {
+        let _home = HomeGuard::new();
+        // Configure at least one credential so the broker is in enforcing mode.
+        pair("homeboy-lab", BrokerScope::Work);
+        let store = JobStore::default();
+
+        let response = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(json!({ "runner_id": "homeboy-lab", "lease_ms": 30000 })),
+            &store,
+            &enforcing_auth(None),
+        );
+        assert_eq!(response.status_code, 401);
+        assert_eq!(response.body["error"], "broker.auth_denied");
+    }
+
+    #[test]
+    fn paired_runner_can_register_claim_progress_and_finish() {
+        let _home = HomeGuard::new();
+        let submit_token = pair("homeboy-lab", BrokerScope::Submit);
+        // Add a work-scoped credential for the worker side.
+        let work_token = pair_extra("worker-cred", "homeboy-lab", BrokerScope::Work);
+
+        let store = JobStore::default();
+
+        // Controller submits (submit scope).
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(submit_body()),
+            &store,
+            &enforcing_auth(Some(&submit_token)),
+        );
+        assert_eq!(submit.status_code, 200, "submit body: {}", submit.body);
+        let job_id = submit.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id")
+            .to_string();
+
+        // Worker claims (work scope, runner-bound).
+        let claim = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(json!({ "runner_id": "homeboy-lab", "lease_ms": 30000 })),
+            &store,
+            &enforcing_auth(Some(&work_token)),
+        );
+        assert_eq!(claim.status_code, 200, "claim body: {}", claim.body);
+        let claim_id = claim.body["body"]["claim"]["job"]["claim_id"]
+            .as_str()
+            .expect("claim id")
+            .to_string();
+
+        // Worker streams progress.
+        let event = route(
+            "POST",
+            &format!("/runner/jobs/{job_id}/events"),
+            Some(json!({
+                "runner_id": "homeboy-lab",
+                "claim_id": claim_id,
+                "kind": "progress",
+                "message": "started"
+            })),
+            &store,
+            &enforcing_auth(Some(&work_token)),
+        );
+        assert_eq!(event.status_code, 200, "event body: {}", event.body);
+
+        // Worker finishes.
+        let finish = route(
+            "POST",
+            &format!("/runner/jobs/{job_id}/finish"),
+            Some(json!({
+                "runner_id": "homeboy-lab",
+                "claim_id": claim_id,
+                "result": { "exit_code": 0 }
+            })),
+            &store,
+            &enforcing_auth(Some(&work_token)),
+        );
+        assert_eq!(finish.status_code, 200, "finish body: {}", finish.body);
+        assert_eq!(finish.body["body"]["job"]["status"], "succeeded");
+    }
+
+    #[test]
+    fn wrong_runner_id_cannot_claim_anothers_jobs() {
+        let _home = HomeGuard::new();
+        // Token paired to runner-a only.
+        let token = pair("runner-a", BrokerScope::Work);
+        let store = JobStore::default();
+
+        // Attempt to claim as runner-b with runner-a's token.
+        let claim = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(json!({ "runner_id": "runner-b", "lease_ms": 30000 })),
+            &store,
+            &enforcing_auth(Some(&token)),
+        );
+        assert_eq!(claim.status_code, 401);
+        assert_eq!(claim.body["error"], "broker.auth_denied");
+    }
+
+    #[test]
+    fn wrong_runner_id_cannot_finish_anothers_job() {
+        let _home = HomeGuard::new();
+        // Submit + claim legitimately as runner-a.
+        let submit_token = pair("runner-a", BrokerScope::Submit);
+        let work_token = pair_extra("work-a", "runner-a", BrokerScope::Work);
+        // A second runner with its own (work) token.
+        let other_token = pair_extra("work-b", "runner-b", BrokerScope::Work);
+
+        let store = JobStore::default();
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(json!({
+                "runner_id": "runner-a",
+                "command": ["homeboy", "test"],
+                "cwd": "/tmp/x"
+            })),
+            &store,
+            &enforcing_auth(Some(&submit_token)),
+        );
+        let job_id = submit.body["body"]["job"]["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let claim = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(json!({ "runner_id": "runner-a", "lease_ms": 30000 })),
+            &store,
+            &enforcing_auth(Some(&work_token)),
+        );
+        let claim_id = claim.body["body"]["claim"]["job"]["claim_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // runner-b tries to finish runner-a's job with its own valid token.
+        let finish = route(
+            "POST",
+            &format!("/runner/jobs/{job_id}/finish"),
+            Some(json!({
+                "runner_id": "runner-b",
+                "claim_id": claim_id,
+                "result": { "exit_code": 0 }
+            })),
+            &store,
+            &enforcing_auth(Some(&other_token)),
+        );
+        assert_eq!(finish.status_code, 401);
+        assert_eq!(finish.body["error"], "broker.auth_denied");
+    }
+
+    #[test]
+    fn work_token_cannot_submit_jobs() {
+        let _home = HomeGuard::new();
+        let work_token = pair("homeboy-lab", BrokerScope::Work);
+        let store = JobStore::default();
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(submit_body()),
+            &store,
+            &enforcing_auth(Some(&work_token)),
+        );
+        assert_eq!(submit.status_code, 401);
+        assert_eq!(submit.body["error"], "broker.auth_denied");
+    }
 }

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -33,6 +33,7 @@ pub enum ErrorCode {
     RigNotFound,
     RunnerNotFound,
     RunnerPolicyDenied,
+    BrokerAuthDenied,
     ServiceTunnelNotFound,
     RigPipelineFailed,
     RigServiceFailed,
@@ -84,6 +85,7 @@ impl ErrorCode {
             ErrorCode::RigNotFound => "rig.not_found",
             ErrorCode::RunnerNotFound => "runner.not_found",
             ErrorCode::RunnerPolicyDenied => "runner.policy_denied",
+            ErrorCode::BrokerAuthDenied => "broker.auth_denied",
             ErrorCode::ServiceTunnelNotFound => "service_tunnel.not_found",
             ErrorCode::RigPipelineFailed => "rig.pipeline_failed",
             ErrorCode::RigServiceFailed => "rig.service_failed",
@@ -445,6 +447,32 @@ impl Error {
 
     pub fn runner_not_found(id: impl Into<String>, suggestions: Vec<String>) -> Self {
         Self::entity_not_found(ErrorCode::RunnerNotFound, "Runner", id, suggestions)
+    }
+
+    /// Reverse runner broker authentication/authorization rejection.
+    ///
+    /// Secrets (tokens) are never embedded in the message or details; only the
+    /// non-sensitive reason and any matched runner id are surfaced so the broker
+    /// can return a structured `broker.auth_denied` error.
+    pub fn broker_auth_denied(
+        reason: impl Into<String>,
+        runner_id: Option<String>,
+        hints: Vec<String>,
+    ) -> Self {
+        let reason_str = reason.into();
+        let details = serde_json::json!({
+            "reason": reason_str,
+            "runner_id": runner_id,
+        });
+        let mut error = Self::new(
+            ErrorCode::BrokerAuthDenied,
+            format!("Reverse runner broker rejected request: {reason_str}"),
+            details,
+        );
+        for hint in hints {
+            error = error.with_hint(hint);
+        }
+        error
     }
 
     pub fn service_tunnel_not_found(id: impl Into<String>, suggestions: Vec<String>) -> Self {

--- a/src/core/runner/broker_auth.rs
+++ b/src/core/runner/broker_auth.rs
@@ -1,0 +1,564 @@
+//! Trust model for the reverse runner broker (`/runner/*` routes).
+//!
+//! The reverse runner broker lets a Homeboy controller submit jobs and remote
+//! Lab workers claim/execute/finish them over HTTP. On loopback or private
+//! tunnels that is acceptable, but a VPS-hosted broker is reachable beyond the
+//! trust boundary and therefore must authenticate every caller (#2990).
+//!
+//! ## Trust model
+//!
+//! * **Pairing.** An operator pairs a worker by minting a *runner credential*
+//!   on the broker host (`broker_auth_pair`). Pairing generates a random bearer
+//!   token, stores only its SHA-256 hash, and binds it to a single `runner_id`
+//!   with a set of [`BrokerScope`]s. The plaintext token is returned exactly
+//!   once so it can be handed to the worker; it is never persisted or logged.
+//! * **Controller submit.** Job submission (`POST /runner/jobs`) is authorized
+//!   by a credential carrying the [`BrokerScope::Submit`] scope. Worker claims
+//!   are authorized by [`BrokerScope::Work`]. A credential may hold both.
+//! * **Runner-id binding.** Worker routes carry a `runner_id` in their body.
+//!   The presented token must belong to a credential whose `runner_id` matches,
+//!   so a paired runner can never claim, progress, or finish jobs on behalf of a
+//!   different runner id.
+//! * **Revocation.** Credentials are revocable by id; revoked credentials are
+//!   retained (so their ids stay reserved) but reject every request.
+//! * **Secure by default.** If no auth store exists the broker refuses all
+//!   `/runner/*` traffic. An operator must explicitly opt a credential-less
+//!   broker into loopback-only smoke mode, which is gated to loopback binds.
+//!
+//! Tokens live in `~/.config/homeboy/broker_auth.json` with `0600` perms on
+//! Unix and are never emitted in normal command output — only the one-time mint
+//! response carries the plaintext.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::core::error::{Error, Result};
+use crate::core::paths;
+
+/// Header carrying the broker bearer token. `Authorization: Bearer <token>` is
+/// also accepted; this header is the canonical, proxy-friendly form.
+pub const BROKER_TOKEN_HEADER: &str = "x-homeboy-broker-token";
+
+/// Environment variable a controller reads its broker submit token from. Kept
+/// in the environment (not config) so the secret never lands in serialized,
+/// printed config.
+pub const BROKER_TOKEN_ENV: &str = "HOMEBOY_BROKER_TOKEN";
+
+/// Resolve the controller-side broker token from the environment, if set.
+pub fn broker_token_from_env() -> Option<String> {
+    std::env::var(BROKER_TOKEN_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Authorization scopes a broker credential may grant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BrokerScope {
+    /// Controller-side job submission (`POST /runner/jobs`).
+    Submit,
+    /// Worker-side register/claim/event/finish/heartbeat/cancel.
+    Work,
+}
+
+impl BrokerScope {
+    fn as_str(self) -> &'static str {
+        match self {
+            BrokerScope::Submit => "submit",
+            BrokerScope::Work => "work",
+        }
+    }
+}
+
+/// A single paired credential. Only the token *hash* is persisted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrokerCredential {
+    /// Stable credential id (operator-facing label for revocation).
+    pub id: String,
+    /// Runner id this credential is bound to. Worker routes must match it.
+    pub runner_id: String,
+    /// Lowercase hex SHA-256 of the bearer token. Never the plaintext.
+    pub token_sha256: String,
+    /// Granted scopes.
+    #[serde(default)]
+    pub scopes: BTreeSet<BrokerScope>,
+    /// When set, the credential is disabled and rejects every request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<String>,
+    /// Creation timestamp (RFC3339).
+    pub created_at: String,
+}
+
+impl BrokerCredential {
+    fn is_active(&self) -> bool {
+        self.revoked_at.is_none()
+    }
+}
+
+/// On-disk broker auth store.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BrokerAuthStore {
+    #[serde(default)]
+    pub credentials: Vec<BrokerCredential>,
+    /// Explicit opt-in to run without any credentials. Only honored for
+    /// loopback binds; keeps existing local/tunnel smoke setups working without
+    /// silently disabling auth on an exposed broker.
+    #[serde(default)]
+    pub allow_unauthenticated_loopback: bool,
+}
+
+/// Result of a successful authorization: the matched credential and the scope
+/// the request was checked against.
+#[derive(Debug, Clone)]
+pub struct BrokerAuthGrant {
+    pub credential_id: String,
+    pub runner_id: String,
+}
+
+impl BrokerAuthStore {
+    /// Load the store, returning an empty (unconfigured) store if absent.
+    pub fn load() -> Result<Self> {
+        let path = store_path()?;
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let raw = std::fs::read_to_string(&path).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
+        })?;
+        if raw.trim().is_empty() {
+            return Ok(Self::default());
+        }
+        serde_json::from_str(&raw)
+            .map_err(|err| Error::config_invalid_json(path.display().to_string(), err))
+    }
+
+    /// Persist the store with restrictive permissions.
+    pub fn save(&self) -> Result<PathBuf> {
+        let path = store_path()?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some(format!("create {}", parent.display())),
+                )
+            })?;
+        }
+        let serialized = serde_json::to_string_pretty(self).map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("serialize broker auth store".to_string()),
+            )
+        })?;
+        std::fs::write(&path, serialized).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("write {}", path.display())))
+        })?;
+        restrict_permissions(&path)?;
+        Ok(path)
+    }
+
+    fn configured(&self) -> bool {
+        self.credentials.iter().any(BrokerCredential::is_active)
+    }
+
+    /// Authorize a request for `required` scope, optionally bound to
+    /// `runner_id`. `presented` is the bearer token extracted from the request
+    /// headers (already trimmed of any `Bearer ` prefix), if any.
+    pub fn authorize(
+        &self,
+        loopback_bind: bool,
+        presented: Option<&str>,
+        required: BrokerScope,
+        runner_id: Option<&str>,
+    ) -> Result<BrokerAuthGrant> {
+        if !self.configured() {
+            if self.allow_unauthenticated_loopback && loopback_bind {
+                return Ok(BrokerAuthGrant {
+                    credential_id: "loopback-open".to_string(),
+                    runner_id: runner_id.unwrap_or_default().to_string(),
+                });
+            }
+            return Err(Error::broker_auth_denied(
+                "broker has no paired runner credentials configured",
+                runner_id.map(str::to_string),
+                vec![
+                    "Pair a runner with `homeboy runner broker pair` to mint a scoped token."
+                        .to_string(),
+                    "For loopback-only smoke runs, set allow_unauthenticated_loopback in broker_auth.json."
+                        .to_string(),
+                ],
+            ));
+        }
+
+        let Some(token) = presented.map(str::trim).filter(|t| !t.is_empty()) else {
+            return Err(Error::broker_auth_denied(
+                "missing broker bearer token",
+                runner_id.map(str::to_string),
+                vec![format!(
+                    "Send the paired token via `{BROKER_TOKEN_HEADER}` or `Authorization: Bearer <token>`."
+                )],
+            ));
+        };
+
+        let presented_hash = sha256_hex(token);
+        let Some(credential) = self
+            .credentials
+            .iter()
+            .filter(|cred| cred.is_active())
+            .find(|cred| constant_time_eq(&cred.token_sha256, &presented_hash))
+        else {
+            return Err(Error::broker_auth_denied(
+                "broker token is not recognized or has been revoked",
+                runner_id.map(str::to_string),
+                vec!["Re-pair the runner to mint a fresh token.".to_string()],
+            ));
+        };
+
+        if !credential.scopes.contains(&required) {
+            return Err(Error::broker_auth_denied(
+                format!(
+                    "broker credential lacks required `{}` scope",
+                    required.as_str()
+                ),
+                Some(credential.runner_id.clone()),
+                vec![format!(
+                    "Re-pair `{}` with the `{}` scope.",
+                    credential.runner_id,
+                    required.as_str()
+                )],
+            ));
+        }
+
+        if let Some(requested_runner) = runner_id {
+            if credential.runner_id != requested_runner {
+                return Err(Error::broker_auth_denied(
+                    "broker token is bound to a different runner id",
+                    Some(requested_runner.to_string()),
+                    vec![
+                        "A paired runner may only act on its own runner id; claims cannot be stolen."
+                            .to_string(),
+                    ],
+                ));
+            }
+        }
+
+        Ok(BrokerAuthGrant {
+            credential_id: credential.id.clone(),
+            runner_id: credential.runner_id.clone(),
+        })
+    }
+
+    /// Mint and store a new credential, returning the one-time plaintext token.
+    pub fn pair(
+        &mut self,
+        id: impl Into<String>,
+        runner_id: impl Into<String>,
+        scopes: BTreeSet<BrokerScope>,
+    ) -> Result<MintedCredential> {
+        let id = id.into();
+        let runner_id = runner_id.into();
+        if id.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "id",
+                "broker credential id must not be empty",
+                None,
+                None,
+            ));
+        }
+        if runner_id.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "runner_id",
+                "broker credential requires a runner id",
+                None,
+                None,
+            ));
+        }
+        if scopes.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "scopes",
+                "broker credential requires at least one scope",
+                None,
+                Some(vec!["Grant `submit`, `work`, or both.".to_string()]),
+            ));
+        }
+        if self
+            .credentials
+            .iter()
+            .any(|cred| cred.id == id && cred.is_active())
+        {
+            return Err(Error::validation_invalid_argument(
+                "id",
+                format!("an active broker credential `{id}` already exists"),
+                Some(id.clone()),
+                Some(vec!["Revoke it first or choose a different id.".to_string()]),
+            ));
+        }
+
+        let token = generate_token();
+        let credential = BrokerCredential {
+            id: id.clone(),
+            runner_id: runner_id.clone(),
+            token_sha256: sha256_hex(&token),
+            scopes,
+            revoked_at: None,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+        self.credentials.push(credential);
+        Ok(MintedCredential {
+            id,
+            runner_id,
+            token,
+        })
+    }
+
+    /// Revoke an active credential by id. Returns true when a credential was
+    /// transitioned to revoked.
+    pub fn revoke(&mut self, id: &str) -> bool {
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut revoked = false;
+        for cred in self.credentials.iter_mut() {
+            if cred.id == id && cred.is_active() {
+                cred.revoked_at = Some(now.clone());
+                revoked = true;
+            }
+        }
+        revoked
+    }
+}
+
+/// The one-time result of minting a credential. The plaintext `token` must be
+/// delivered to the worker immediately; it cannot be recovered later.
+#[derive(Debug, Clone)]
+pub struct MintedCredential {
+    pub id: String,
+    pub runner_id: String,
+    pub token: String,
+}
+
+/// Extract a bearer token from request header lines, supporting both the
+/// canonical `x-homeboy-broker-token` header and `Authorization: Bearer ...`.
+pub fn extract_bearer_token(header_lines: &str) -> Option<String> {
+    for line in header_lines.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let name = name.trim().to_ascii_lowercase();
+        let value = value.trim();
+        if name == BROKER_TOKEN_HEADER {
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        } else if name == "authorization" {
+            if let Some(token) = value
+                .strip_prefix("Bearer ")
+                .or_else(|| value.strip_prefix("bearer "))
+            {
+                let token = token.trim();
+                if !token.is_empty() {
+                    return Some(token.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Path to the broker auth store on disk.
+pub fn store_path() -> Result<PathBuf> {
+    Ok(paths::homeboy()?.join("broker_auth.json"))
+}
+
+fn sha256_hex(token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    format!("{digest:x}")
+}
+
+/// Length-independent constant-time string compare for hashes to avoid leaking
+/// match progress via timing.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Generate a 256-bit-equivalent random token from two UUIDv4 values. Avoids a
+/// new RNG dependency while staying high-entropy and url-safe.
+fn generate_token() -> String {
+    format!(
+        "hbk_{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    )
+}
+
+#[cfg(unix)]
+fn restrict_permissions(path: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o600);
+    std::fs::set_permissions(path, perms).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("set permissions {}", path.display())),
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_path: &std::path::Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scopes(values: &[BrokerScope]) -> BTreeSet<BrokerScope> {
+        values.iter().copied().collect()
+    }
+
+    fn store_with(runner_id: &str, scope: BrokerScope) -> (BrokerAuthStore, String) {
+        let mut store = BrokerAuthStore::default();
+        let minted = store
+            .pair("cred-1", runner_id, scopes(&[scope]))
+            .expect("pair");
+        (store, minted.token)
+    }
+
+    #[test]
+    fn unconfigured_store_rejects_by_default() {
+        let store = BrokerAuthStore::default();
+        let err = store
+            .authorize(true, None, BrokerScope::Work, Some("runner-a"))
+            .expect_err("secure by default");
+        assert_eq!(err.code.as_str(), "broker.auth_denied");
+    }
+
+    #[test]
+    fn loopback_open_opt_in_allows_unauthenticated_loopback_only() {
+        let store = BrokerAuthStore {
+            allow_unauthenticated_loopback: true,
+            ..Default::default()
+        };
+        // Loopback bind: permitted.
+        store
+            .authorize(true, None, BrokerScope::Work, Some("runner-a"))
+            .expect("loopback open");
+        // Non-loopback bind: still rejected even with opt-in.
+        let err = store
+            .authorize(false, None, BrokerScope::Work, Some("runner-a"))
+            .expect_err("non-loopback rejected");
+        assert_eq!(err.code.as_str(), "broker.auth_denied");
+    }
+
+    #[test]
+    fn missing_token_is_rejected_when_configured() {
+        let (store, _token) = store_with("runner-a", BrokerScope::Work);
+        let err = store
+            .authorize(false, None, BrokerScope::Work, Some("runner-a"))
+            .expect_err("missing token");
+        assert!(err.message.contains("missing broker bearer token"));
+    }
+
+    #[test]
+    fn paired_runner_can_authorize_its_own_runner_id() {
+        let (store, token) = store_with("runner-a", BrokerScope::Work);
+        let grant = store
+            .authorize(false, Some(&token), BrokerScope::Work, Some("runner-a"))
+            .expect("authorized");
+        assert_eq!(grant.runner_id, "runner-a");
+    }
+
+    #[test]
+    fn wrong_runner_id_cannot_claim() {
+        let (store, token) = store_with("runner-a", BrokerScope::Work);
+        let err = store
+            .authorize(false, Some(&token), BrokerScope::Work, Some("runner-b"))
+            .expect_err("cross-runner claim rejected");
+        assert!(err.message.contains("different runner id"));
+    }
+
+    #[test]
+    fn wrong_token_is_rejected() {
+        let (store, _token) = store_with("runner-a", BrokerScope::Work);
+        let err = store
+            .authorize(
+                false,
+                Some("hbk_bogus"),
+                BrokerScope::Work,
+                Some("runner-a"),
+            )
+            .expect_err("bad token");
+        assert!(err.message.contains("not recognized"));
+    }
+
+    #[test]
+    fn scope_is_enforced() {
+        let (store, token) = store_with("runner-a", BrokerScope::Work);
+        let err = store
+            .authorize(false, Some(&token), BrokerScope::Submit, None)
+            .expect_err("submit needs submit scope");
+        assert!(err.message.contains("scope"));
+    }
+
+    #[test]
+    fn revoked_credential_is_rejected() {
+        let (mut store, token) = store_with("runner-a", BrokerScope::Work);
+        assert!(store.revoke("cred-1"));
+        let err = store
+            .authorize(false, Some(&token), BrokerScope::Work, Some("runner-a"))
+            .expect_err("revoked");
+        assert!(
+            err.message.contains("no paired runner credentials") || err.message.contains("revoked")
+        );
+    }
+
+    #[test]
+    fn submit_scope_authorizes_controller_submit_without_runner_binding() {
+        let (store, token) = store_with("runner-a", BrokerScope::Submit);
+        store
+            .authorize(false, Some(&token), BrokerScope::Submit, None)
+            .expect("submit authorized");
+    }
+
+    #[test]
+    fn extract_bearer_supports_both_header_forms() {
+        let token = extract_bearer_token("Authorization: Bearer abc123\r\nHost: x").expect("auth");
+        assert_eq!(token, "abc123");
+        let token =
+            extract_bearer_token("X-Homeboy-Broker-Token: tok-xyz\r\nHost: x").expect("custom");
+        assert_eq!(token, "tok-xyz");
+        assert!(extract_bearer_token("Host: x").is_none());
+    }
+
+    #[test]
+    fn minted_token_is_high_entropy_and_hashed_not_stored_plain() {
+        let (store, token) = store_with("runner-a", BrokerScope::Work);
+        assert!(token.starts_with("hbk_"));
+        assert!(token.len() > 32);
+        // Plaintext never appears in the persisted credential.
+        assert!(store
+            .credentials
+            .iter()
+            .all(|cred| cred.token_sha256 != token));
+        assert_eq!(store.credentials[0].token_sha256, sha256_hex(&token));
+    }
+
+    #[test]
+    fn duplicate_active_credential_id_is_rejected() {
+        let (mut store, _token) = store_with("runner-a", BrokerScope::Work);
+        let err = store
+            .pair("cred-1", "runner-a", scopes(&[BrokerScope::Work]))
+            .expect_err("duplicate id");
+        assert!(err.message.contains("already exists"));
+    }
+}

--- a/src/core/runner/broker_http.rs
+++ b/src/core/runner/broker_http.rs
@@ -1,7 +1,8 @@
-use reqwest::blocking::Client;
+use reqwest::blocking::{Client, RequestBuilder};
 use serde::Deserialize;
 use serde_json::Value;
 
+use super::broker_auth::BROKER_TOKEN_HEADER;
 use crate::core::error::{Error, Result};
 
 #[derive(Debug, Deserialize)]
@@ -11,18 +12,34 @@ struct BrokerEnvelope {
     error: Option<Value>,
 }
 
+/// Attach the paired broker bearer token, when present, to an outgoing broker
+/// request. Sent via both the canonical header and `Authorization: Bearer` so
+/// the request works through proxies that strip one or the other.
+fn with_broker_token(builder: RequestBuilder, token: Option<&str>) -> RequestBuilder {
+    match token {
+        Some(token) if !token.trim().is_empty() => builder
+            .header(BROKER_TOKEN_HEADER, token)
+            .bearer_auth(token),
+        _ => builder,
+    }
+}
+
 pub(crate) fn post_json(
     client: &Client,
     base_url: &str,
     path: &str,
     body: Value,
     action: &str,
+    token: Option<&str>,
 ) -> Result<Value> {
-    let response = client
-        .post(format!("{}{}", base_url.trim_end_matches('/'), path))
-        .json(&body)
-        .send()
-        .map_err(|err| Error::internal_unexpected(format!("{action}: {err}")))?;
+    let response = with_broker_token(
+        client
+            .post(format!("{}{}", base_url.trim_end_matches('/'), path))
+            .json(&body),
+        token,
+    )
+    .send()
+    .map_err(|err| Error::internal_unexpected(format!("{action}: {err}")))?;
     let status_code = response.status().as_u16();
     let envelope: BrokerEnvelope = response.json().map_err(|err| {
         Error::internal_json(err.to_string(), Some("parse broker response".to_string()))
@@ -39,11 +56,19 @@ pub(crate) fn post_json(
     canonical_broker_body(&data)
 }
 
-pub(crate) fn get_json(client: &Client, base_url: &str, path: &str, action: &str) -> Result<Value> {
-    let response = client
-        .get(format!("{}{}", base_url.trim_end_matches('/'), path))
-        .send()
-        .map_err(|err| Error::internal_unexpected(format!("{action}: {err}")))?;
+pub(crate) fn get_json(
+    client: &Client,
+    base_url: &str,
+    path: &str,
+    action: &str,
+    token: Option<&str>,
+) -> Result<Value> {
+    let response = with_broker_token(
+        client.get(format!("{}{}", base_url.trim_end_matches('/'), path)),
+        token,
+    )
+    .send()
+    .map_err(|err| Error::internal_unexpected(format!("{action}: {err}")))?;
     let status_code = response.status().as_u16();
     let envelope: BrokerEnvelope = response.json().map_err(|err| {
         Error::internal_json(err.to_string(), Some("parse broker response".to_string()))

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -305,6 +305,7 @@ fn active_runner_jobs(
             broker_url,
             "/jobs",
             "list reverse runner broker jobs",
+            None,
         )?
     } else {
         return Ok(Vec::new());

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -452,6 +452,7 @@ fn exec_via_reverse_broker(
         })),
         require_paths: require_paths.clone(),
     };
+    let broker_token = super::broker_auth::broker_token_from_env();
     let data = broker_http::post_json(
         &client,
         broker_url,
@@ -463,6 +464,7 @@ fn exec_via_reverse_broker(
             )
         })?,
         "submit reverse runner job",
+        broker_token.as_deref(),
     )?;
     let job_value = data
         .get("job")
@@ -958,6 +960,7 @@ pub fn runner_job_cancel(runner_id: &str, job_id: &str) -> Result<(Job, Vec<JobE
             &path,
             json!({}),
             "cancel reverse runner broker job",
+            super::broker_auth::broker_token_from_env().as_deref(),
         )?
     } else {
         return Err(runner_job_cancel_unsupported(
@@ -1078,16 +1081,22 @@ fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> Result<Value
                 ]),
             ));
         };
+        let broker_token = super::broker_auth::broker_token_from_env();
         return match method {
-            "GET" => {
-                broker_http::get_json(&client, broker_url, path, "query reverse runner broker")
-            }
+            "GET" => broker_http::get_json(
+                &client,
+                broker_url,
+                path,
+                "query reverse runner broker",
+                broker_token.as_deref(),
+            ),
             "POST" => broker_http::post_json(
                 &client,
                 broker_url,
                 path,
                 json!({}),
                 "query reverse runner broker",
+                broker_token.as_deref(),
             ),
             _ => Err(Error::internal_unexpected(format!(
                 "unsupported daemon API method {method}"

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -11,7 +11,13 @@ use crate::core::output::{BatchResult, CreateOutput, CreateResult, MergeOutput, 
 use crate::core::server::{self, RunnerPolicy, RunnerSecretEnvRef, RunnerSettings, ServerRunner};
 
 mod apply;
+mod broker_auth;
 mod broker_http;
+pub use broker_auth::{
+    broker_token_from_env, extract_bearer_token, store_path as broker_auth_store_path,
+    BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential,
+    BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+};
 mod capabilities;
 mod command_path;
 mod connection;

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -23,6 +23,9 @@ const BROKER_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(250);
 pub struct ReverseRunnerWorkerOptions {
     pub runner_id: String,
     pub broker_url: String,
+    /// Paired broker bearer token. Required when the broker enforces auth;
+    /// omitted for loopback-open smoke setups.
+    pub broker_token: Option<String>,
     pub project_id: Option<String>,
     pub lease_ms: u64,
     pub concurrency_limit: Option<usize>,
@@ -275,7 +278,12 @@ fn run_once_output(
         ));
     };
 
-    if let Some(job) = cancelled_job_snapshot(&client, &options.broker_url, &claim.job)? {
+    if let Some(job) = cancelled_job_snapshot(
+        &client,
+        &options.broker_url,
+        options.broker_token.as_deref(),
+        &claim.job,
+    )? {
         return Ok(cancelled_output(
             options,
             iterations,
@@ -286,7 +294,13 @@ fn run_once_output(
         ));
     }
 
-    append_progress(&client, &options.broker_url, &options.runner_id, &claim.job)?;
+    append_progress(
+        &client,
+        &options.broker_url,
+        options.broker_token.as_deref(),
+        &options.runner_id,
+        &claim.job,
+    )?;
     // Remote capability-parity preflight: validate that this runner can satisfy
     // the claimed job's top-level command (and any required paths) before
     // starting execution, so a missing tool fails before remote dispatch instead
@@ -299,6 +313,7 @@ fn run_once_output(
         finish_job(
             &client,
             &options.broker_url,
+            options.broker_token.as_deref(),
             &options.runner_id,
             &claim.job,
             result,
@@ -327,16 +342,26 @@ fn run_once_output(
                 return cancel_seen;
             }
             last_cancel_poll = Instant::now();
-            cancel_seen = cancelled_job_snapshot(&client, &options.broker_url, &claim.job)
-                .map(|job| job.is_some())
-                .unwrap_or(false);
+            cancel_seen = cancelled_job_snapshot(
+                &client,
+                &options.broker_url,
+                options.broker_token.as_deref(),
+                &claim.job,
+            )
+            .map(|job| job.is_some())
+            .unwrap_or(false);
             cancel_seen
         },
     );
     let (exec_output, exit_code) = match exec_result {
         Ok(result) => result,
         Err(err) => {
-            if let Some(job) = cancelled_job_snapshot(&client, &options.broker_url, &claim.job)? {
+            if let Some(job) = cancelled_job_snapshot(
+                &client,
+                &options.broker_url,
+                options.broker_token.as_deref(),
+                &claim.job,
+            )? {
                 return Ok(cancelled_output(
                     options,
                     iterations,
@@ -372,7 +397,12 @@ fn run_once_output(
             ));
         }
     };
-    if let Some(job) = cancelled_job_snapshot(&client, &options.broker_url, &claim.job)? {
+    if let Some(job) = cancelled_job_snapshot(
+        &client,
+        &options.broker_url,
+        options.broker_token.as_deref(),
+        &claim.job,
+    )? {
         return Ok(cancelled_output(
             options,
             iterations,
@@ -522,6 +552,7 @@ fn claim_job(
             "concurrency_limit": options.concurrency_limit,
         }),
         "claim reverse runner job",
+        options.broker_token.as_deref(),
     )?;
     let claim = data["claim"].clone();
     if claim.is_null() {
@@ -535,7 +566,13 @@ fn claim_job(
     })
 }
 
-fn append_progress(client: &Client, broker_url: &str, runner_id: &str, job: &Job) -> Result<()> {
+fn append_progress(
+    client: &Client,
+    broker_url: &str,
+    token: Option<&str>,
+    runner_id: &str,
+    job: &Job,
+) -> Result<()> {
     let claim_id = remote_runner_claim_id(job)?;
     broker_http::post_json(
         client,
@@ -548,6 +585,7 @@ fn append_progress(client: &Client, broker_url: &str, runner_id: &str, job: &Job
             "message": "reverse runner worker started execution",
         }),
         "append reverse runner progress event",
+        token,
     )?;
     Ok(())
 }
@@ -555,6 +593,7 @@ fn append_progress(client: &Client, broker_url: &str, runner_id: &str, job: &Job
 fn finish_job(
     client: &Client,
     broker_url: &str,
+    token: Option<&str>,
     runner_id: &str,
     job: &Job,
     result: RemoteRunnerJobResult,
@@ -570,6 +609,7 @@ fn finish_job(
             "result": result,
         }),
         "finish reverse runner job",
+        token,
     )?;
     serde_json::from_value(data["job"].clone()).map_err(|err| {
         Error::internal_json(
@@ -579,12 +619,18 @@ fn finish_job(
     })
 }
 
-fn cancelled_job_snapshot(client: &Client, broker_url: &str, job: &Job) -> Result<Option<Job>> {
+fn cancelled_job_snapshot(
+    client: &Client,
+    broker_url: &str,
+    token: Option<&str>,
+    job: &Job,
+) -> Result<Option<Job>> {
     let data = broker_http::get_json(
         client,
         broker_url,
         &format!("/jobs/{}", job.id),
         "inspect reverse runner job cancellation state",
+        token,
     )?;
     let snapshot: Job = serde_json::from_value(data["job"].clone()).map_err(|err| {
         Error::internal_json(
@@ -624,6 +670,7 @@ mod tests {
         ReverseRunnerWorkerOptions {
             runner_id: "lab".to_string(),
             broker_url,
+            broker_token: None,
             project_id: None,
             lease_ms: 30_000,
             concurrency_limit: None,

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -25,7 +25,11 @@
 // ----------------------------------------------------------------------------
 
 pub use super::runner::{
-    apply_change_artifact, apply_workspace_patch, capture_lab_offload_subprocess_metadata, connect,
+    apply_change_artifact, apply_workspace_patch, broker_auth_store_path, broker_token_from_env,
+    capture_lab_offload_subprocess_metadata, connect, BrokerAuthGrant, BrokerAuthStore,
+    BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+};
+pub use super::runner::{
     connect_reverse, disconnect, download_remote_artifact,
     evaluate_lab_runner_capabilities_for_runner, exec, execute_lab_offload,
     is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,


### PR DESCRIPTION
## Summary

Adds a production trust model for the reverse runner broker `/runner/*` routes (#2990). The broker worked end-to-end but authenticated nothing, so it was only safe on loopback / private tunnels. This PR makes it **secure by default**: every `/runner/*` route requires a scoped, revocable bearer token bound to a runner id.

## Trust model

- **Pairing.** `homeboy runner broker pair <id> --runner-id <runner> [--work] [--submit]` mints a one-time random bearer token, stores only its SHA-256 hash in `~/.config/homeboy/broker_auth.json` (`0600`), and binds it to a single runner id. The plaintext is shown once and never logged or re-displayed.
- **Scopes.** `--submit` authorizes controller job submission/cancel; `--work` authorizes worker register/claim/event/finish/heartbeat. A credential may hold both.
- **Runner-id binding.** Worker routes carry a `runner_id`; the token must belong to a credential paired to that exact runner id, so a paired runner can never claim, progress, or finish another runner's jobs.
- **Revocation.** `homeboy runner broker revoke <id>`; `homeboy runner broker list` shows non-secret metadata only.
- **Secure by default.** With no credentials configured the broker rejects all `/runner/*` traffic with a structured `broker.auth_denied` (`401`). Existing loopback smoke setups can opt in via `allow_unauthenticated_loopback`, honored only for loopback binds.

## Implementation

- New `core::runner::broker_auth` module: `BrokerAuthStore`, `BrokerCredential`, `BrokerScope`, constant-time hash compare, `0600` persistence, env/header token plumbing (`X-Homeboy-Broker-Token` + `Authorization: Bearer`).
- `daemon` network entry point extracts the bearer token and bind context; `remote_runner::route` enforces per-route scope + runner-id binding. In-process/CLI dispatch uses a `trusted_local` context (already inside the trust boundary) so existing mechanics tests are unaffected.
- New `broker.auth_denied` structured error (maps to HTTP 401).
- Client side: worker `--broker-token` flag + `HOMEBOY_BROKER_TOKEN` env; controller submit/cancel read the token from env. Tokens never appear in normal output.
- `daemon broker_config` exposure guidance updated: an authenticated broker may be reverse-proxied once every runner is paired.

## Tests

- Auth store unit tests: secure-by-default rejection, loopback opt-in (loopback-only), missing/wrong/revoked token, scope enforcement, wrong-runner-id rejection, hashed-not-plaintext storage.
- Route-level tests: unauthenticated `/runner/*` rejected; paired runner can register/claim/progress/finish; wrong runner id/token cannot claim or finish another runner's job; work token cannot submit.

## Docs

- `docs/commands/runner.md`: broker authentication & pairing section, `broker` subcommand, updated `work` and systemd guidance.

## Notes

- Scoped to the reverse-runner broker; no changes to lab offload.
- `cargo build --lib`, `cargo check --lib --tests`, and `cargo clippy --lib --tests` are clean for this change. `main` currently has an unrelated pre-existing compile break in `src/commands/agent_task/fanout.rs` (`provider::default_backend` signature) that is not touched here.