### PR TITLE
fix(agent-task): restore main CI after loop fanout

### DIFF
--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -302,19 +302,18 @@ fn packet_parse_error(error: serde_json::Error) -> Error {
 }
 
 fn default_executor(args: &AgentTaskFanoutInputArgs) -> Result<AgentTaskExecutor> {
-    let backend = args
-        .backend
-        .clone()
-        .map(Ok)
-        .unwrap_or_else(provider::default_backend)?
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "backend",
-                "fanout packets without executor objects require --backend or a configured default agent-task backend",
-                None,
-                None,
-            )
-        })?;
+    let backend = match &args.backend {
+        Some(backend) => Some(backend.clone()),
+        None => provider::default_backend()?,
+    }
+    .ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "backend",
+            "fanout packets without executor objects require --backend or a configured default agent-task backend",
+            None,
+            None,
+        )
+    })?;
     Ok(AgentTaskExecutor {
         backend,
         selector: args.selector.clone(),

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -155,7 +155,7 @@ pub struct FuzzExecutionOutput {
     pub stderr: String,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct FuzzWorkloadOutput {
     pub id: String,
     pub label: Option<String>,

--- a/src/core/self_status.rs
+++ b/src/core/self_status.rs
@@ -435,7 +435,7 @@ pub fn build_runtime_view(
         version: Some(controller.version.clone()),
         build_identity: Some(controller.build_identity.display.clone()),
         binary_path: controller.binary_path.clone(),
-        install_method: Some(controller.install_method.clone()),
+        install_method: Some(controller.install_method),
         source_checkout: controller.source_checkout.clone(),
         connected: true,
         relation_to_controller: VersionRelation::Current,


### PR DESCRIPTION
## Summary
- fix fanout default backend fallback now that provider defaults return an optional backend
- derive Debug for fuzz workload output used by Result::expect_err in tests
- remove a clone_on_copy install method clone in runtime status assembly

## Verification
- Inspected failed GitHub Actions logs for PRs #5691 and #5692.
- Local cargo verification not run per instruction; relying on GitHub Actions for Rust verification.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** CI log inspection, minimal code fix, PR preparation
