### PR TITLE
Fix runner-aware queued Lab agent-task handoff

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -84,7 +84,7 @@ const AGENT_TASK_RUN_LAB_LABEL: &str = "agent-task dispatch/cook/loop/run-plan/r
 const AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL: &str =
     "agent-task controller from-spec --resume/materialize";
 const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task controller resume";
-const AGENT_TASK_STATUS_LAB_LABEL: &str = "agent-task status/logs/artifacts/review";
+const AGENT_TASK_STATUS_LAB_LABEL: &str = "agent-task run/run-next/status/logs/artifacts/review";
 const AGENT_TASK_PROVIDERS_LAB_LABEL: &str = "agent-task providers";
 const AGENT_TASK_AUTH_STATUS_LAB_LABEL: &str = "agent-task auth status";
 pub(crate) const LINT_LAB_LABEL: &str = "lint";
@@ -140,8 +140,8 @@ const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
     LabSupportedCommandSummary {
         #[cfg(test)]
         contract_labels: &[AGENT_TASK_STATUS_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL],
-        message_label: "agent-task status/logs/artifacts/review/providers",
-        hint_label: "agent-task status/logs/artifacts/review/providers",
+        message_label: "agent-task run/run-next/status/logs/artifacts/review/providers",
+        hint_label: "agent-task run/run-next/status/logs/artifacts/review/providers",
     },
     LabSupportedCommandSummary {
         #[cfg(test)]
@@ -317,6 +317,8 @@ impl Commands {
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Status(_)
+                    | agent_task::AgentTaskCommand::Run(_)
+                    | agent_task::AgentTaskCommand::RunNext
                     | agent_task::AgentTaskCommand::Logs(_)
                     | agent_task::AgentTaskCommand::Artifacts(_)
                     | agent_task::AgentTaskCommand::Review(_),

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -241,6 +241,8 @@ fn command_json_value<T: Serialize>(value: T) -> Result<Value> {
 
 fn cook_handoff(value: &Value, to_worktree: Option<&str>) -> Value {
     let run_id = value["run_id"].as_str().unwrap_or("<run-id>");
+    let run_command = agent_task_run_command(value, run_id);
+    let run_next_command = agent_task_run_next_command(value);
     let aggregate_path = value["aggregate_path"].as_str().unwrap_or(run_id);
     let aggregate_review = value
         .get("aggregate")
@@ -269,7 +271,7 @@ fn cook_handoff(value: &Value, to_worktree: Option<&str>) -> Value {
         ));
     } else if value["queued"].as_bool().unwrap_or(false) {
         next_actions.push(format!(
-            "queued only; run `homeboy agent-task run {run_id}` or let a daemon claim it with `homeboy agent-task run-next`"
+            "queued only; run `{run_command}` or let a daemon claim it with `{run_next_command}`"
         ));
     } else {
         next_actions.push("no patch artifact was produced; inspect `aggregate` candidates before retrying or reporting".to_string());
@@ -295,6 +297,28 @@ fn cook_handoff(value: &Value, to_worktree: Option<&str>) -> Value {
         ),
         "next_actions": next_actions
     })
+}
+
+fn agent_task_run_command(value: &Value, run_id: &str) -> String {
+    match value
+        .pointer("/record/metadata/runner_id")
+        .and_then(Value::as_str)
+        .filter(|runner_id| !runner_id.trim().is_empty())
+    {
+        Some(runner_id) => format!("homeboy --runner {runner_id} agent-task run {run_id}"),
+        None => format!("homeboy agent-task run {run_id}"),
+    }
+}
+
+fn agent_task_run_next_command(value: &Value) -> String {
+    match value
+        .pointer("/record/metadata/runner_id")
+        .and_then(Value::as_str)
+        .filter(|runner_id| !runner_id.trim().is_empty())
+    {
+        Some(runner_id) => format!("homeboy --runner {runner_id} agent-task run-next"),
+        None => "homeboy agent-task run-next".to_string(),
+    }
 }
 
 fn cook_promotion_commands(
@@ -325,4 +349,31 @@ fn cook_promotion_commands(
             })
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queued_cook_handoff_uses_recorded_runner_context() {
+        let handoff = cook_handoff(
+            &serde_json::json!({
+                "run_id": "agent-task-queued",
+                "queued": true,
+                "record": {
+                    "metadata": {
+                        "runner_id": "homeboy-lab"
+                    }
+                }
+            }),
+            None,
+        );
+
+        let next_action = handoff["next_actions"][0].as_str().expect("next action");
+        assert!(
+            next_action.contains("homeboy --runner homeboy-lab agent-task run agent-task-queued")
+        );
+        assert!(next_action.contains("homeboy --runner homeboy-lab agent-task run-next"));
+    }
 }

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -185,6 +185,19 @@ pub fn submit_plan(
         .unwrap_or_else(default_run_id);
     let plan_path = store::write_plan(&run_id, plan)?;
 
+    let mut metadata = json!({
+        "task_count": plan.tasks.len(),
+        "max_concurrency": plan.options.max_concurrency,
+        "provider_run_ids": [],
+        "lifecycle_schema": RUN_LIFECYCLE_RECORD_SCHEMA,
+        "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
+    });
+    if let Ok(runner_id) = std::env::var(crate::core::runner::RUNNER_ID_ENV) {
+        if !runner_id.trim().is_empty() {
+            metadata["runner_id"] = json!(runner_id);
+        }
+    }
+
     let record = AgentTaskRunRecord {
         schema: schemas::RUN.to_string(),
         run_id,
@@ -199,13 +212,7 @@ pub fn submit_plan(
         artifact_refs: Vec::new(),
         provider_handles: Vec::new(),
         lifecycle: lifecycle_for_submitted_plan(plan),
-        metadata: json!({
-            "task_count": plan.tasks.len(),
-            "max_concurrency": plan.options.max_concurrency,
-            "provider_run_ids": [],
-            "lifecycle_schema": RUN_LIFECYCLE_RECORD_SCHEMA,
-            "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
-        }),
+        metadata,
     };
     store::write_record(&record)?;
     Ok(record)

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -37,6 +37,7 @@ use super::{normalize_runner_command_env, resolve_runner_secret_env};
 const DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS: u64 = 20 * 60;
 pub(crate) const RUNNER_EXEC_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS";
 pub(crate) const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
+pub(crate) const RUNNER_ID_ENV: &str = "HOMEBOY_RUNNER_ID";
 
 mod extension_parity;
 mod policy;
@@ -1310,6 +1311,7 @@ pub(crate) fn prepare_runner_process(
     env.extend(request.env);
     if runner.kind != RunnerKind::Local {
         env.insert(RUNNER_HOSTED_EXEC_ENV.to_string(), "1".to_string());
+        env.insert(RUNNER_ID_ENV.to_string(), runner.id.clone());
     }
     if runner.kind == RunnerKind::Local {
         env.extend(resolve_runner_secret_env_for_command(
@@ -2764,6 +2766,7 @@ mod tests {
                 plan.env.get(RUNNER_HOSTED_EXEC_ENV).map(String::as_str),
                 Some("1")
             );
+            assert_eq!(plan.env.get(RUNNER_ID_ENV).map(String::as_str), Some("lab"));
         });
     }
 
@@ -2795,6 +2798,7 @@ mod tests {
             .expect("prepare local runner process");
 
             assert!(!plan.env.contains_key(RUNNER_HOSTED_EXEC_ENV));
+            assert!(!plan.env.contains_key(RUNNER_ID_ENV));
         });
     }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -74,7 +74,7 @@ pub use evidence::{
 };
 pub(crate) use execution::{
     daemon_api_get, execute_runner_process_until_cancelled, prepare_daemon_local_process,
-    RunnerProcessRequest, RUNNER_HOSTED_EXEC_ENV,
+    RunnerProcessRequest, RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV,
 };
 pub use execution::{
     daemon_api_post, exec, runner_exec_failure_error, runner_job_cancel, RunnerExecDiagnostics,

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -21,7 +21,7 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
             "agent-task dispatch/cook/loop/run-plan",
             "agent-task controller from-spec --resume/materialize/resume",
             "agent-task retry --run",
-            "agent-task status/logs/artifacts/review/providers",
+            "agent-task run/run-next/status/logs/artifacts/review/providers",
             "agent-task auth status",
             "lint",
             "test",
@@ -39,11 +39,11 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
     );
     assert_eq!(
         lab_runner_unsupported_message(),
-        "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, review, bench, fuzz, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start"
+        "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task run/run-next/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, review, bench, fuzz, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start"
     );
     assert_eq!(
         lab_runner_unsupported_hint(),
-        "Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, review, bench run, fuzz run, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start."
+        "Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task run/run-next/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, review, bench run, fuzz run, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start."
     );
 }
 
@@ -110,6 +110,20 @@ fn test_supports_lab_runner() {
         !parsed_command(&["homeboy", "agent-task", "retry", "agent-task-123"])
             .supports_lab_runner()
     );
+    assert!(
+        parsed_command(&["homeboy", "agent-task", "run", "agent-task-123"]).supports_lab_runner()
+    );
+    assert!(parsed_command(&["homeboy", "agent-task", "run-next"]).supports_lab_runner());
+    let cli = parsed_cli(&[
+        "homeboy",
+        "agent-task",
+        "run",
+        "--runner",
+        "homeboy-lab",
+        "agent-task-123",
+    ]);
+    assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+    assert!(cli.command.supports_lab_runner());
     assert!(
         parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"])
             .supports_lab_runner()
@@ -408,6 +422,8 @@ fn test_lab_command_contracts_cover_hot_commands() {
     );
 
     for args in [
+        ["homeboy", "agent-task", "run", "agent-task-123"].as_slice(),
+        ["homeboy", "agent-task", "run-next"].as_slice(),
         ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
         ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
         ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),


### PR DESCRIPTION
## Summary
- Support `agent-task run` and `agent-task run-next` through the existing runner-resident Lab contract.
- Propagate the Lab runner id into runner-side agent-task run metadata.
- Render queued cook handoff commands with `--runner <runner>` when the run is runner-backed.

Fixes #5675.
Fixes #5676.

## Verification
- `rustfmt src/core/runner/execution.rs src/core/runner/mod.rs src/core/agent_task_lifecycle.rs src/core/agent_task_dispatch_service.rs src/command_contract/lab.rs tests/command_contract/lab_test.rs`
- `git diff --check`
- Not run: local `cargo`/Rust test suite, per repo/site rule prohibiting local Cargo on this machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implemented the runner-aware queued Lab handoff fix, updated contract/tests, and prepared this PR.
