### PR TITLE
Refactor CLI: hide lab shortcut from advertised surface

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -27,7 +27,6 @@
 - [git](git.md)
 - [http](http.md) — generic proxied authenticated HTTP requests
 - [issues](issues.md) — reconcile findings against issue trackers
-- [lab](lab.md) — remote Lab runner status and benchmark routing helpers
 - [lint](lint.md)
 - [logs](logs.md)
 - [observe](observe.md) — passive live observation into trace timeline evidence

--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -1,5 +1,9 @@
 # Lab Command
 
+Compatibility shortcut for Lab routing helpers. Keep using `homeboy lab ...`
+when you already know the shortcut; use [`homeboy runner`](runner.md) for the
+discoverable runner and Lab offload surface.
+
 Inspect and use configured Lab runners for remote benchmark execution and
 managed follow-up work.
 
@@ -13,9 +17,10 @@ homeboy lab extension-sync --runner <runner-id> --source <url-or-path> --id <ext
 
 ## Description
 
-The `lab` command surfaces Lab runner availability, benchmark routing, and the
-Homeboy-managed follow-up commands to use when a Lab run needs diagnosis or
-replay. For normal benchmark runs, prefer `homeboy bench <component>`: Homeboy
+The `lab` command remains a compatibility shortcut for Lab runner availability,
+benchmark routing, and the Homeboy-managed follow-up commands to use when a Lab
+run needs diagnosis or replay. For normal benchmark runs, prefer
+`homeboy bench <component>`: Homeboy
 automatically selects a Lab runner when the component declares
 `lab.preferred_runner` or when exactly one Lab runner is configured.
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -142,7 +142,8 @@ pub enum Commands {
     Rig(rig::RigArgs),
     /// Manage local and SSH execution runners
     Runner(runner::RunnerArgs),
-    /// Discover Lab routing and benchmark offload commands
+    /// Compatibility shortcut for Lab routing helpers; use `runner` for discovery.
+    #[command(hide = true)]
     Lab(lab::LabArgs),
     /// Inspect core-owned runtime helper assets
     Runtime(runtime::RuntimeArgs),
@@ -525,6 +526,7 @@ fn docs_path(path: &[String]) -> Option<String> {
 fn visible_subcommands(command: &Command, remaining_depth: usize) -> Vec<CommandSurfaceEntry> {
     command
         .get_subcommands()
+        .filter(|subcommand| !subcommand.is_hide_set())
         .map(|subcommand| CommandSurfaceEntry {
             name: subcommand.get_name().to_string(),
             visible_aliases: subcommand
@@ -650,12 +652,18 @@ mod tests {
     fn command_safety_manifest_records_clap_visibility_metadata() {
         let manifest = current_command_safety_manifest();
 
-        let hidden_list = manifest.find_path(&["list"]).unwrap();
-        assert!(hidden_list.hidden);
+        assert!(manifest.find_path(&["list"]).is_none());
+        assert!(manifest.find_path(&["lab"]).is_none());
 
         let visible_status = manifest.find_path(&["status"]).unwrap();
         assert!(!visible_status.hidden);
         assert!(visible_status.aliases.is_empty());
+    }
+
+    #[test]
+    fn hidden_lab_shortcut_still_parses() {
+        Cli::try_parse_from(["homeboy", "lab", "status"])
+            .expect("hidden Lab compatibility shortcut should keep parsing");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Hide the top-level `homeboy lab` shortcut from the advertised CLI surface while preserving parsing for existing users.
- Make the command surface manifest omit hidden commands instead of carrying hidden compatibility entries.
- Point `lab` docs at `runner` as the discoverable runner/Lab offload surface and remove `lab` from the command index.

## Tests
- `git diff --check`
- Not run: local `cargo` commands are prohibited in this environment.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted and applied the focused CLI/docs/test change, source review, PR preparation.