### PR TITLE
fix(agent-task): preflight loop verify gates

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -80,6 +80,8 @@ pub enum LabCommandRequiredTool {
 pub const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
 const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
 const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
+const AGENT_TASK_LOOP_MISSING_VERIFY_GATE_REASON: &str =
+    "agent-task loop requires at least one deterministic --verify or --private-verify gate";
 const AGENT_TASK_RUN_LAB_LABEL: &str = "agent-task dispatch/cook/loop/run-plan/retry --run";
 const AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL: &str =
     "agent-task controller from-spec --resume/materialize";
@@ -282,9 +284,22 @@ impl Commands {
                 command:
                     agent_task::AgentTaskCommand::Cook(_)
                     | agent_task::AgentTaskCommand::Dispatch(_)
-                    | agent_task::AgentTaskCommand::Loop(_)
                     | agent_task::AgentTaskCommand::RunPlan(_)
                     | agent_task::AgentTaskCommand::Retry(agent_task::RetryArgs { run: true, .. }),
+            }) => LabCommandContract::portable(
+                AGENT_TASK_RUN_LAB_LABEL,
+                None,
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command: agent_task::AgentTaskCommand::Loop(args),
+            }) if !args.gates.has_deterministic_gate() => LabCommandContract::local_only(
+                AGENT_TASK_RUN_LAB_LABEL,
+                AGENT_TASK_LOOP_MISSING_VERIFY_GATE_REASON,
+            ),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command: agent_task::AgentTaskCommand::Loop(_),
             }) => LabCommandContract::portable(
                 AGENT_TASK_RUN_LAB_LABEL,
                 None,

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -199,6 +199,12 @@ pub struct VerifyGateArgs {
     pub private_gate_reveal: AgentTaskGateRevealPolicy,
 }
 
+impl VerifyGateArgs {
+    pub fn has_deterministic_gate(&self) -> bool {
+        !self.verify.is_empty() || !self.private_verify.is_empty()
+    }
+}
+
 impl From<VerifyGateArgs> for VerifyGateOptions {
     fn from(args: VerifyGateArgs) -> Self {
         VerifyGateOptions {

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -37,7 +37,7 @@ pub(super) fn run_loop_with_executor<E>(args: AgentTaskLoopArgs, executor: E) ->
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
-    if args.gates.verify.is_empty() && args.gates.private_verify.is_empty() {
+    if !args.gates.has_deterministic_gate() {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "verify",
             "agent-task loop requires at least one deterministic --verify or --private-verify gate",

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -174,6 +174,22 @@ fn test_supports_lab_runner() {
         "cook"
     ])
     .supports_lab_runner());
+    let invalid_loop = parsed_command(&[
+        "homeboy",
+        "agent-task",
+        "loop",
+        "--to-worktree",
+        "homeboy@smoke",
+        "--prompt",
+        "cook",
+    ]);
+    assert!(!invalid_loop.supports_lab_runner());
+    assert_eq!(
+        invalid_loop.lab_runner_unsupported_reason(),
+        Some(
+            "agent-task loop requires at least one deterministic --verify or --private-verify gate"
+        )
+    );
     assert!(
         !parsed_command(&["homeboy", "refactor", "rename", "--from", "old", "--to", "new",])
             .supports_lab_runner()


### PR DESCRIPTION
## Summary
- Treat `agent-task loop` without `--verify` or `--private-verify` as Lab-local-invalid during command contract resolution.
- Reuse a shared deterministic gate predicate between the direct loop handler and Lab portability contract.
- Add focused command-contract coverage proving invalid loop args do not support Lab runner offload and surface the verify-gate reason.

Fixes #5700

## Tests
- `git diff --check`
- Not run: local cargo tests, per environment rule prohibiting local cargo commands. CI should exercise the added Rust test.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation, focused test, and PR description; Chris reviews and owns the change.
