### PR TITLE
ci: skip redundant release quality work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           commands: release
           expected-commands: audit,lint,test
+          args: --skip-checks=audit,lint,test
           release-dry-run: 'true'
 
       - name: Validate existing release tag
@@ -321,7 +322,7 @@ jobs:
           binary-path: .homeboy-bin/homeboy
           commands: test
           expected-commands: audit,lint,test
-          args: ${{ github.event.before && format('--changed-since {0}', github.event.before) || '' }}
+          args: ${{ github.event.before && format('--skip-lint --changed-since {0}', github.event.before) || '--skip-lint' }}
           autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
@@ -474,6 +475,7 @@ jobs:
           source: '.'
           commands: release
           expected-commands: audit,lint,test
+          args: --skip-checks=audit,lint,test
           release-dry-run: ${{ inputs.dry-run || 'false' }}
           release-skip-publish: 'true'
           release-skip-github-release: 'true'

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -68,6 +68,26 @@ fn release_audit_is_advisory_without_losing_raw_failure_outcome() {
 }
 
 #[test]
+fn release_test_gate_does_not_repeat_separate_lint_gate() {
+    let gate_test = job_section(release_workflow(), "gate-test");
+
+    assert!(gate_test.contains("commands: test"));
+    assert!(gate_test.contains("--skip-lint"));
+    assert!(gate_test.contains("--changed-since {0}"));
+}
+
+#[test]
+fn release_planning_skips_quality_gates_already_owned_by_gate_jobs() {
+    let check = job_section(release_workflow(), "check");
+    let prepare = job_section(release_workflow(), "prepare");
+
+    for section in [check, prepare] {
+        assert!(section.contains("commands: release"));
+        assert!(section.contains("args: --skip-checks=audit,lint,test"));
+    }
+}
+
+#[test]
 fn release_prepare_waits_for_command_policy_not_raw_audit_or_refactor() {
     let gate_refactor = job_section(release_workflow(), "gate-refactor");
     let prepare = job_section(release_workflow(), "prepare");


### PR DESCRIPTION
## Summary
- Skip release command quality preflights in release decision/preparation because dedicated audit/lint/test gate jobs already own those checks.
- Pass `--skip-lint` to the release test gate so the separate lint gate is not repeated inside `homeboy test`.
- Add workflow contract tests that preserve the release quality split.

## Tests
- `git diff --check`
- Not run: local cargo tests, per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Identifying redundant release workflow quality checks, editing workflow/tests, and preparing this PR description.