### PR TITLE
fix(agent-task): reject empty required typed artifacts

### DIFF
--- a/src/core/agent_task_scheduler/outcome.rs
+++ b/src/core/agent_task_scheduler/outcome.rs
@@ -9,6 +9,7 @@
 //! can reach them without widening the crate-public surface.
 
 use std::collections::HashMap;
+use std::fs;
 
 use serde_json::{Map, Value};
 
@@ -30,6 +31,120 @@ pub(super) fn missing_required_typed_artifacts(
                 .any(|artifact| artifact.name == *name)
         })
         .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct InvalidRequiredTypedArtifact {
+    pub(super) task_id: String,
+    pub(super) name: String,
+    pub(super) artifact_type: Option<String>,
+    pub(super) artifact_id: Option<String>,
+    pub(super) path: Option<String>,
+    pub(super) url: Option<String>,
+    pub(super) size_bytes: Option<u64>,
+    pub(super) reason: String,
+}
+
+pub(super) fn invalid_required_typed_artifacts(
+    outcome: &AgentTaskOutcome,
+    request: &AgentTaskRequest,
+) -> Vec<InvalidRequiredTypedArtifact> {
+    request
+        .canonical_artifact_declarations()
+        .into_iter()
+        .filter(|declaration| declaration.required)
+        .filter_map(|declaration| {
+            let artifact = outcome
+                .typed_artifacts
+                .iter()
+                .find(|artifact| artifact.name == declaration.name)?;
+            invalid_required_typed_artifact(outcome, artifact)
+        })
+        .collect()
+}
+
+fn invalid_required_typed_artifact(
+    outcome: &AgentTaskOutcome,
+    typed_artifact: &AgentTaskTypedArtifact,
+) -> Option<InvalidRequiredTypedArtifact> {
+    let artifact_id = typed_artifact
+        .artifact
+        .as_ref()
+        .map(|artifact| artifact.id.clone());
+    let path = typed_artifact
+        .artifact
+        .as_ref()
+        .and_then(|artifact| artifact.path.clone())
+        .or_else(|| string_field(&typed_artifact.payload, "path"));
+    let url = typed_artifact
+        .artifact
+        .as_ref()
+        .and_then(|artifact| artifact.url.clone())
+        .or_else(|| string_field(&typed_artifact.payload, "url"));
+    let size_bytes = typed_artifact
+        .artifact
+        .as_ref()
+        .and_then(|artifact| artifact.size_bytes)
+        .or_else(|| {
+            typed_artifact
+                .payload
+                .get("size_bytes")
+                .and_then(Value::as_u64)
+        });
+    let reason = invalid_typed_artifact_reason(typed_artifact, path.as_deref(), size_bytes)?;
+
+    Some(InvalidRequiredTypedArtifact {
+        task_id: outcome.task_id.clone(),
+        name: typed_artifact.name.clone(),
+        artifact_type: typed_artifact.artifact_type.clone(),
+        artifact_id,
+        path,
+        url,
+        size_bytes,
+        reason,
+    })
+}
+
+fn invalid_typed_artifact_reason(
+    typed_artifact: &AgentTaskTypedArtifact,
+    path: Option<&str>,
+    size_bytes: Option<u64>,
+) -> Option<String> {
+    if size_bytes == Some(0) {
+        return Some("declared artifact size is zero bytes".to_string());
+    }
+
+    if let Some(path) = path.filter(|path| !path.trim().is_empty()) {
+        if let Ok(metadata) = fs::metadata(path) {
+            if metadata.is_file() && metadata.len() == 0 {
+                return Some("referenced artifact file is zero bytes".to_string());
+            }
+        }
+    }
+
+    if typed_artifact.artifact.is_none() && value_is_empty(&typed_artifact.payload) {
+        return Some("typed artifact payload is empty and has no artifact reference".to_string());
+    }
+
+    None
+}
+
+fn string_field(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn value_is_empty(value: &Value) -> bool {
+    match value {
+        Value::Null => true,
+        Value::String(value) => value.trim().is_empty(),
+        Value::Array(values) => values.is_empty(),
+        Value::Object(object) => object.is_empty() || object.values().all(Value::is_null),
+        Value::Bool(_) | Value::Number(_) => false,
+    }
 }
 
 pub(super) fn missing_typed_artifacts_failure(outcome: &AgentTaskOutcome) -> bool {

--- a/src/core/agent_task_scheduler/scheduling.rs
+++ b/src/core/agent_task_scheduler/scheduling.rs
@@ -15,7 +15,8 @@ use serde_json::Value;
 
 use super::outcome::{
     artifact_matches_required_artifact, event, evidence_matches_required_artifact,
-    mark_generated_from_outputs, missing_required_typed_artifacts, missing_typed_artifacts_failure,
+    invalid_required_typed_artifacts, mark_generated_from_outputs,
+    missing_required_typed_artifacts, missing_typed_artifacts_failure,
     nested_failed_executor_status, provider_run_result_is_empty_incomplete, render_template_string,
     render_template_value, runtime_result_is_materializable, typed_artifact_from_artifact,
     typed_artifact_from_evidence, typed_artifact_from_outcome,
@@ -477,6 +478,7 @@ impl AgentTaskScheduleSupport {
             Self::normalize_required_typed_artifacts(&mut outcome, &running.request);
             Self::recover_missing_typed_artifacts_wrapper_failure(&mut outcome, &running.request);
             Self::classify_missing_required_typed_artifacts(&mut outcome, &running.request);
+            Self::classify_invalid_required_typed_artifacts(&mut outcome, &running.request);
         }
 
         Self::classify_failed_nested_executor_status(&mut outcome);
@@ -621,6 +623,54 @@ impl AgentTaskScheduleSupport {
             class: "agent_task.required_typed_artifacts_missing".to_string(),
             message,
             data: serde_json::json!({ "missing": missing }),
+        });
+    }
+
+    pub(super) fn classify_invalid_required_typed_artifacts(
+        outcome: &mut AgentTaskOutcome,
+        request: &AgentTaskRequest,
+    ) {
+        if outcome.status != AgentTaskOutcomeStatus::Succeeded {
+            return;
+        }
+
+        let invalid = invalid_required_typed_artifacts(outcome, request);
+        if invalid.is_empty() {
+            return;
+        }
+
+        let labels = invalid
+            .iter()
+            .map(|artifact| {
+                let location = artifact
+                    .path
+                    .as_deref()
+                    .or(artifact.url.as_deref())
+                    .or(artifact.artifact_id.as_deref())
+                    .unwrap_or("unknown location");
+                format!("{} ({location}: {})", artifact.name, artifact.reason)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let message = format!("agent task produced invalid required typed artifacts: {labels}.");
+        outcome.status = AgentTaskOutcomeStatus::Failed;
+        outcome.failure_classification = Some(AgentTaskFailureClassification::ExecutionFailed);
+        outcome.summary = Some(message.clone());
+        outcome.diagnostics.push(AgentTaskDiagnostic {
+            class: "agent_task.required_typed_artifacts_invalid".to_string(),
+            message,
+            data: serde_json::json!({
+                "invalid": invalid.iter().map(|artifact| serde_json::json!({
+                    "task_id": artifact.task_id,
+                    "name": artifact.name,
+                    "type": artifact.artifact_type,
+                    "artifact_id": artifact.artifact_id,
+                    "path": artifact.path,
+                    "url": artifact.url,
+                    "size_bytes": artifact.size_bytes,
+                    "reason": artifact.reason,
+                })).collect::<Vec<_>>()
+            }),
         });
     }
 

--- a/src/core/agent_task_scheduler/tests/fixtures.rs
+++ b/src/core/agent_task_scheduler/tests/fixtures.rs
@@ -31,6 +31,10 @@ pub(super) struct NestedAgentResultFailedExecutor;
 
 pub(super) struct SuccessMissingRequiredArtifactsExecutor;
 
+pub(super) struct SuccessEmptyRequiredTypedArtifactExecutor {
+    pub(super) artifact_path: std::path::PathBuf,
+}
+
 impl AgentTaskExecutorAdapter for RetryOnceExecutor {
     fn execute(
         &self,
@@ -233,6 +237,45 @@ impl AgentTaskExecutorAdapter for SuccessMissingRequiredArtifactsExecutor {
         _context: AgentTaskExecutionContext,
     ) -> AgentTaskOutcome {
         outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded)
+    }
+}
+
+impl AgentTaskExecutorAdapter for SuccessEmptyRequiredTypedArtifactExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        let mut outcome = outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded);
+        let artifact = AgentTaskArtifact {
+            schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "empty-patch".to_string(),
+            kind: "patch".to_string(),
+            name: Some("patch.diff".to_string()),
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: Some(self.artifact_path.display().to_string()),
+            url: None,
+            mime: Some("text/x-patch".to_string()),
+            size_bytes: Some(0),
+            sha256: None,
+            metadata: json!({ "role": "patch" }),
+        };
+        outcome.typed_artifacts.push(AgentTaskTypedArtifact {
+            name: "patch".to_string(),
+            artifact_type: Some("file".to_string()),
+            artifact_schema: None,
+            payload: json!({
+                "artifact_id": artifact.id.clone(),
+                "kind": artifact.kind.clone(),
+                "path": artifact.path.clone(),
+                "size_bytes": artifact.size_bytes,
+            }),
+            artifact: Some(artifact),
+            metadata: Value::Null,
+        });
+        outcome
     }
 }
 

--- a/src/core/agent_task_scheduler/tests/outcome_tests.rs
+++ b/src/core/agent_task_scheduler/tests/outcome_tests.rs
@@ -6,6 +6,7 @@ use super::super::outcome::{
 use super::super::*;
 use super::fixtures::*;
 use serde_json::json;
+use std::fs;
 use std::sync::atomic::Ordering;
 
 #[test]
@@ -108,6 +109,46 @@ fn missing_required_typed_artifacts_fails_succeeded_outcome() {
     assert_eq!(
         aggregate.outcomes[0].diagnostics[0].data["missing"],
         json!(["import_validation_result", "visual_parity_artifact"])
+    );
+}
+
+#[test]
+fn empty_required_typed_artifact_fails_with_operator_pointer() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let patch_path = temp.path().join("patch.diff");
+    fs::write(&patch_path, "").expect("empty patch");
+    let scheduler = AgentTaskScheduler::new(SuccessEmptyRequiredTypedArtifactExecutor {
+        artifact_path: patch_path.clone(),
+    });
+
+    let aggregate = scheduler.run(plan_with_required_artifacts(&["patch"]));
+
+    assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+    assert_eq!(aggregate.totals.failed, 1);
+    assert_eq!(aggregate.outcomes[0].status, AgentTaskOutcomeStatus::Failed);
+    assert_eq!(
+        aggregate.outcomes[0].failure_classification,
+        Some(AgentTaskFailureClassification::ExecutionFailed)
+    );
+    let diagnostic = aggregate.outcomes[0]
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.class == "agent_task.required_typed_artifacts_invalid")
+        .expect("invalid required typed artifact diagnostic");
+    assert_eq!(diagnostic.data["invalid"][0]["task_id"], json!("task-1"));
+    assert_eq!(diagnostic.data["invalid"][0]["name"], json!("patch"));
+    assert_eq!(
+        diagnostic.data["invalid"][0]["artifact_id"],
+        json!("empty-patch")
+    );
+    assert_eq!(
+        diagnostic.data["invalid"][0]["path"],
+        json!(patch_path.display().to_string())
+    );
+    assert_eq!(diagnostic.data["invalid"][0]["size_bytes"], json!(0));
+    assert_eq!(
+        diagnostic.data["invalid"][0]["reason"],
+        json!("declared artifact size is zero bytes")
     );
 }
 


### PR DESCRIPTION
## Summary
- Fail successful agent-task outcomes when required typed artifacts are present but empty or zero-byte.
- Add generic diagnostic details for the offending task, typed artifact name/type, artifact id, path/url, size, and reason.
- Cover zero-byte required typed artifact handling with a focused scheduler test.

## Verification
- Passed: `homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-required-typed-artifact-diagnostics --runner homeboy-lab --skip-lint --json-summary -- empty_required_typed_artifact_fails_with_operator_pointer missing_required_typed_artifacts_fails_succeeded_outcome runtime_bundle_artifacts_materialize_required_typed_artifacts`
- Evidence run: `runner-exec-homeboy-lab-a45db855-235e-4402-90fd-043b95ab75e1`
- Full offloaded test attempted: `homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-required-typed-artifact-diagnostics --runner homeboy-lab --skip-lint --json-summary`; failed with 15 unrelated existing lab/runner/artifact-portability failures outside this change area.
- Not run locally: `cargo` commands are disallowed on this machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the required typed-artifact validation/diagnostic and focused tests.