### PR TITLE
fix(agent-task): guard lab-only fanout handoff

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -48,6 +48,24 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `finalize-pr` | Finalize a green cook run into a review-ready pull request. |
 | `gate-feedback` | Convert deterministic gate results into a cook-loop retry or stop decision. |
 
+## Lab Guardrails
+
+Use global `--lab-only` (alias `--no-local-execution`) with long-running or
+patch-producing `agent-task cook` / `agent-task loop` waves that must not execute
+provider processes on the controller. If Lab routing cannot select or prepare a
+runner, Homeboy fails before local execution instead of falling back.
+
+Use global `--detach-after-handoff` with `--runner <runner-id>` when the Lab job is
+expected to outlive the local shell. Homeboy returns after the runner daemon
+accepts the job and prints follow/cancel commands instead of waiting for remote
+provider completion.
+
+`--force-hot --allow-local-hot` is safe only when local execution on this
+controller is intentional. For agent-task waves with concurrency greater than 1
+or multiple tasks, Homeboy prints `HOMEBOY_LOCAL_FANOUT_WARNING` before provider
+processes start. Compact `agent-task status` includes `execution_location` as
+`local` or `runner:<id>`.
+
 ### Provider
 
 | Subcommand | Purpose |

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -32,6 +32,14 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub allow_local_hot: bool,
 
+    /// Require Lab routing and fail instead of executing locally.
+    #[arg(long, visible_alias = "no-local-execution", global = true)]
+    pub lab_only: bool,
+
+    /// Return after a runner daemon accepts the job instead of waiting for remote completion.
+    #[arg(long, global = true)]
+    pub detach_after_handoff: bool,
+
     /// Directory where persisted run artifacts are copied.
     /// Overrides HOMEBOY_ARTIFACT_ROOT and global config /artifact_root.
     #[arg(long, global = true, value_name = "DIR")]

--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -288,6 +288,7 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
         "refs": refs,
         "refs_omitted": refs_omitted,
         "risk_flags": risk_flags,
+        "execution_location": execution_location(record),
         "queue_visibility": queue_visibility(record),
         "full_command": format!("homeboy agent-task status {run_id} --full"),
     });
@@ -319,6 +320,18 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
         }
     }
     summary
+}
+
+fn execution_location(record: &Value) -> Value {
+    let runner_id = record
+        .get("metadata")
+        .and_then(|metadata| metadata.get("runner_id"))
+        .and_then(Value::as_str)
+        .filter(|runner_id| !runner_id.trim().is_empty());
+    match runner_id {
+        Some(runner_id) => json!(format!("runner:{runner_id}")),
+        None => json!("local"),
+    }
 }
 
 fn queue_visibility(record: &Value) -> Value {
@@ -599,5 +612,17 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("concurrency"));
+        assert_eq!(summary["execution_location"], "local");
+
+        let remote = compact_status_summary(
+            &json!({
+                "run_id": "agent-task-run-2",
+                "state": "running",
+                "tasks": [],
+                "metadata": { "runner_id": "homeboy-lab" }
+            }),
+            "agent-task-run-2",
+        );
+        assert_eq!(remote["execution_location"], "runner:homeboy-lab");
     }
 }

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -333,6 +333,7 @@ fn sync_lab_extension(
             }),
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            detach_after_handoff: false,
         },
     )?;
 

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -82,19 +82,26 @@ pub fn route_after_parse(
             local_policy: runners::LabLocalExecutionPolicy {
                 allow_local_hot: cli.allow_local_hot,
                 allow_local_fallback: cli.allow_local_fallback,
+                deny_local_execution: cli.lab_only,
             },
             allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
             capture_patch: mutation_flag.is_some(),
             mutation_flag,
             timeout: None,
             active_run_id: active_run_id.as_deref(),
+            detach_after_handoff: cli.detach_after_handoff,
         },
         trace_runner_id.as_deref(),
         observer,
     )?;
 
     match outcome {
-        LabRouteOutcome::RunLocal => Ok(None),
+        LabRouteOutcome::RunLocal => {
+            if let Some(warning) = agent_task_local_fanout_warning(&cli.command) {
+                eprintln!("{warning}");
+            }
+            Ok(None)
+        }
         LabRouteOutcome::Offloaded(output) => {
             if !output.stderr.is_empty() {
                 eprint!("{}", output.stderr);
@@ -106,6 +113,38 @@ pub fn route_after_parse(
             Ok(Some(output.exit_code))
         }
     }
+}
+
+fn agent_task_local_fanout_warning(command: &Commands) -> Option<String> {
+    let (label, concurrency, task_count) = match command {
+        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+            command:
+                crate::commands::agent_task::AgentTaskCommand::Cook(args)
+                | crate::commands::agent_task::AgentTaskCommand::Dispatch(args),
+        }) => (
+            "agent-task local fanout",
+            args.concurrency,
+            args.tasks.len()
+                + usize::from(args.prompt.is_some())
+                + usize::from(args.core.tasks_json.is_some()),
+        ),
+        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+            command: crate::commands::agent_task::AgentTaskCommand::Loop(args),
+        }) => (
+            "agent-task loop local fanout",
+            args.dispatch.concurrency,
+            args.dispatch.tasks.len()
+                + usize::from(args.dispatch.prompt.is_some())
+                + usize::from(args.dispatch.core.tasks_json.is_some()),
+        ),
+        _ => return None,
+    };
+
+    (concurrency > 1 || task_count > 1).then(|| {
+        format!(
+            "HOMEBOY_LOCAL_FANOUT_WARNING: {label} will execute on this controller with concurrency={concurrency}, tasks={task_count}, execution_location=local. Use --runner <runner-id> or --lab-only to prevent local provider fanout."
+        )
+    })
 }
 
 fn inject_lab_changed_files(
@@ -272,6 +311,7 @@ fn run_rig_source_management_on_runner(
             capability_preflight,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            detach_after_handoff: false,
         },
     )?;
 

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -36,6 +36,7 @@ pub struct LabRoutingRequest<'a> {
     pub mutation_flag: Option<&'a str>,
     pub timeout: Option<Duration>,
     pub active_run_id: Option<&'a str>,
+    pub detach_after_handoff: bool,
 }
 
 pub(crate) fn route_lab_offload(
@@ -54,6 +55,7 @@ pub(crate) fn route_lab_offload(
         allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
         capture_patch: request.capture_patch,
         mutation_flag: request.mutation_flag,
+        detach_after_handoff: request.detach_after_handoff,
     })
 }
 
@@ -396,6 +398,7 @@ fn execute_lab_offload_with_timeout(
     let capture_patch = request.capture_patch;
     let active_run_id = request.active_run_id.map(str::to_string);
     let mutation_flag = request.mutation_flag.map(str::to_string);
+    let detach_after_handoff = request.detach_after_handoff;
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let result = runners::execute_lab_offload(runners::LabOffloadRequest {
@@ -407,6 +410,7 @@ fn execute_lab_offload_with_timeout(
             allow_dirty_lab_workspace,
             capture_patch,
             mutation_flag: mutation_flag.as_deref(),
+            detach_after_handoff,
         });
         let _ = tx.send(result);
     });
@@ -566,6 +570,7 @@ mod tests {
             mutation_flag: None,
             timeout: None,
             active_run_id: None,
+            detach_after_handoff: false,
         })
         .unwrap();
 
@@ -733,6 +738,7 @@ mod tests {
                 mutation_flag: None,
                 timeout: None,
                 active_run_id: None,
+                detach_after_handoff: false,
             },
             None,
             observer,

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -57,6 +57,7 @@ pub struct RunnerExecOptions {
     pub capability_preflight: Option<RunnerCapabilityPreflight>,
     pub required_extensions: Vec<String>,
     pub require_paths: Vec<String>,
+    pub detach_after_handoff: bool,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -237,6 +238,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 options.capture_patch,
                 Some(plan.source_snapshot),
                 options.require_paths,
+                options.detach_after_handoff,
             )
         }
         RunnerTransport::ReverseBroker(handle) => {
@@ -252,6 +254,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 options.capture_patch,
                 Some(plan.source_snapshot),
                 options.require_paths,
+                options.detach_after_handoff,
             )
         }
         RunnerTransport::Local => exec_local(plan),
@@ -427,6 +430,7 @@ fn exec_via_reverse_broker(
     capture_patch: bool,
     source_snapshot_override: Option<SourceSnapshot>,
     require_paths: Vec<String>,
+    detach_after_handoff: bool,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
         .timeout(Duration::from_secs(10))
@@ -474,6 +478,17 @@ fn exec_via_reverse_broker(
         )
     })?;
     persist_lab_offload_handoff_run(runner, &cwd, &command, &job);
+    if detach_after_handoff {
+        return Ok(detached_handoff_output(
+            runner,
+            RunnerExecMode::ReverseBroker,
+            cwd,
+            command,
+            source_snapshot,
+            job,
+            require_paths,
+        ));
+    }
 
     let deadline = Instant::now() + runner_exec_wait_timeout();
     while !matches!(
@@ -572,6 +587,7 @@ fn exec_via_daemon(
     capture_patch: bool,
     source_snapshot_override: Option<SourceSnapshot>,
     require_paths: Vec<String>,
+    detach_after_handoff: bool,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
         .timeout(Duration::from_secs(10))
@@ -622,6 +638,17 @@ fn exec_via_daemon(
         Error::internal_json(err.to_string(), Some("parse daemon exec job".to_string()))
     })?;
     persist_lab_offload_handoff_run(runner, &cwd, &command, &job);
+    if detach_after_handoff {
+        return Ok(detached_handoff_output(
+            runner,
+            RunnerExecMode::Daemon,
+            cwd,
+            command,
+            source_snapshot,
+            job,
+            require_paths,
+        ));
+    }
 
     let deadline = Instant::now() + runner_exec_wait_timeout();
     while !matches!(
@@ -722,6 +749,63 @@ fn fetch_daemon_job(client: &Client, local_url: &str, job_id: &str) -> Result<Jo
     let body = canonical_daemon_body(&data, "daemon job response")?;
     serde_json::from_value(body["job"].clone())
         .map_err(|err| Error::internal_json(err.to_string(), Some("parse daemon job".to_string())))
+}
+
+fn detached_handoff_output(
+    runner: &Runner,
+    mode: RunnerExecMode,
+    cwd: String,
+    command: Vec<String>,
+    source_snapshot: SourceSnapshot,
+    job: Job,
+    require_paths: Vec<String>,
+) -> (RunnerExecOutput, i32) {
+    let job_id = job.id.to_string();
+    print_lab_offload_handoff(
+        &runner.id,
+        Some(&cwd),
+        &job_id,
+        None,
+        DaemonJobHandoffState::InFlight,
+    );
+    let stdout = serde_json::to_string_pretty(&json!({
+        "schema": "homeboy/runner-exec-handoff/v1",
+        "status": "handoff_complete",
+        "execution_location": format!("runner:{}", runner.id),
+        "runner_id": runner.id.clone(),
+        "job_id": job_id,
+        "remote_cwd": cwd.clone(),
+        "follow_commands": {
+            "job_logs": format!("homeboy runner job logs {} {} --follow", runner.id, job.id),
+            "job_cancel": format!("homeboy runner job cancel {} {}", runner.id, job.id),
+        }
+    }))
+    .unwrap_or_else(|_| "{}".to_string());
+
+    (
+        RunnerExecOutput {
+            variant: "exec",
+            command: "runner.exec",
+            runner_id: runner.id.clone(),
+            dry_run: false,
+            mode,
+            argv: command,
+            remote_cwd: cwd,
+            exit_code: 0,
+            stdout,
+            stderr: String::new(),
+            source_snapshot: Some(source_snapshot.clone()),
+            job: Some(job.clone()),
+            job_id: Some(job.id.to_string()),
+            job_events: None,
+            mirror_run_id: None,
+            patch: None,
+            metrics: None,
+            capture: None,
+            diagnostics: runner_exec_diagnostics(runner, Some(&source_snapshot), &require_paths),
+        },
+        0,
+    )
 }
 
 /// Grace window during which a transient daemon polling failure (connection
@@ -3081,6 +3165,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: Vec::new(),
+                    detach_after_handoff: false,
                 },
             )
             .expect("exec local runner");
@@ -3135,6 +3220,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: Vec::new(),
+                    detach_after_handoff: false,
                 },
             )
             .expect("exec local runner");
@@ -3172,6 +3258,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: Vec::new(),
+                    detach_after_handoff: false,
                 },
             )
             .expect("exec local runner");
@@ -3214,6 +3301,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: vec![missing.display().to_string()],
+                    detach_after_handoff: false,
                 },
             )
             .expect_err("missing required path rejects before command");
@@ -3255,6 +3343,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: vec![required_path.display().to_string()],
+                    detach_after_handoff: false,
                 },
             )
             .expect("exec with required path");
@@ -3307,6 +3396,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: Vec::new(),
+                    detach_after_handoff: false,
                 },
             )
             .expect_err("disconnected ssh runner needs daemon or diagnostic fallback");
@@ -3343,6 +3433,7 @@ mod tests {
             capability_preflight: None,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            detach_after_handoff: false,
         };
 
         assert!(should_force_diagnostic_ssh(&ssh_runner(), &options));
@@ -3386,6 +3477,7 @@ mod tests {
             capability_preflight: None,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            detach_after_handoff: false,
         };
 
         let err = validate_runner_policy(&runner, "/srv/homeboy/project", policy_request(&options))
@@ -3420,6 +3512,7 @@ mod tests {
             capability_preflight: None,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            detach_after_handoff: false,
         };
         validate_runner_policy(
             &runner,

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -94,6 +94,8 @@ pub struct LabLocalExecutionPolicy {
     /// Permit a selected Lab runner to fall back to local execution after
     /// offload preflight fails.
     pub allow_local_fallback: bool,
+    /// Fail instead of returning a local execution outcome.
+    pub deny_local_execution: bool,
 }
 
 pub struct LabOffloadRequest<'a> {
@@ -108,6 +110,7 @@ pub struct LabOffloadRequest<'a> {
     /// source-tree mutation. Used to render actionable diagnostics when the
     /// remote runner finishes cleanly but returns no patch to apply.
     pub mutation_flag: Option<&'a str>,
+    pub detach_after_handoff: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -193,6 +196,26 @@ fn skipped_automatic_run_local(plan: HomeboyPlan, reason: &str) -> LabOffloadOut
     }
 }
 
+fn local_execution_denied_error(reason: &str, runner_id: Option<&str>) -> Error {
+    let mut hints = vec![
+        "Use --runner <runner-id> to offload to Lab.".to_string(),
+        "Remove --lab-only only when local execution on this controller is intentional."
+            .to_string(),
+    ];
+    if let Some(runner_id) = runner_id {
+        hints.insert(
+            0,
+            format!("Reconnect or repair runner `{runner_id}` before retrying."),
+        );
+    }
+    Error::validation_invalid_argument(
+        "lab_only",
+        format!("Lab-only execution refused local execution: {reason}"),
+        runner_id.map(str::to_string),
+        Some(hints),
+    )
+}
+
 pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadOutcome> {
     let unsupported_runner_error = |runner_id: &str, message: String| {
         Error::validation_invalid_argument(
@@ -214,6 +237,12 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
                 lab_runner_support_summary().unsupported_message,
             ));
         }
+        if request.local_policy.deny_local_execution {
+            return Err(local_execution_denied_error(
+                "command has no Lab contract",
+                None,
+            ));
+        }
         return Ok(LabOffloadOutcome::RunLocal {
             plan: disabled_select_runner_plan(plan, "command has no Lab contract"),
             metadata: None,
@@ -232,11 +261,20 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         let reason = contract
             .unsupported_reason
             .unwrap_or("command is local-only");
+        if request.local_policy.deny_local_execution {
+            return Err(local_execution_denied_error(reason, None));
+        }
         plan = disabled_select_runner_plan(plan, reason);
         return Ok(skipped_automatic_run_local(plan, reason));
     }
 
     if request.explicit_runner.is_none() && !contract.routing_policy.default_lab_offload {
+        if request.local_policy.deny_local_execution {
+            return Err(local_execution_denied_error(
+                "automatic Lab offload disabled",
+                None,
+            ));
+        }
         return Ok(LabOffloadOutcome::RunLocal {
             plan: disabled_select_runner_plan(plan, "automatic Lab offload disabled"),
             metadata: None,
@@ -273,6 +311,9 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             .skip_reason(reason)
             .build(),
         );
+        if request.local_policy.deny_local_execution {
+            return Err(local_execution_denied_error(reason, None));
+        }
         return Ok(skipped_automatic_run_local(plan, reason));
     };
 
@@ -341,6 +382,12 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
                         contract.hot_label, selection.runner_id, reason
                     ),
                     "release_gate",
+                ));
+            }
+            if request.local_policy.deny_local_execution {
+                return Err(local_execution_denied_error(
+                    &reason,
+                    Some(&selection.runner_id),
                 ));
             }
             if !request.local_policy.allow_local_fallback {
@@ -590,6 +637,7 @@ fn run_runner_resident_lab_offload(
             capability_preflight: None,
             required_extensions: contract.required_extensions,
             require_paths: Vec::new(),
+            detach_after_handoff: false,
         },
     )?;
     plan = with_step(
@@ -1132,6 +1180,9 @@ fn run_lab_offload_inner(
                     .skip_reason(reason.clone())
                     .build(),
                 );
+                if request.local_policy.deny_local_execution {
+                    return Err(local_execution_denied_error(&reason, Some(runner_id)));
+                }
                 return Ok(automatic_capability_fallback(
                     plan,
                     runner_id,
@@ -1177,6 +1228,7 @@ fn run_lab_offload_inner(
                         reason,
                         remediation,
                         request.local_policy.allow_local_fallback,
+                        request.local_policy.deny_local_execution,
                     );
                 }
                 LabRunnerSelectionSource::Explicit => {
@@ -1337,6 +1389,7 @@ fn run_lab_offload_inner(
             capability_preflight,
             required_extensions: contract.required_extensions,
             require_paths: Vec::new(),
+            detach_after_handoff: request.detach_after_handoff,
         },
     );
     let (exec_output, exit_code) = match exec_result {
@@ -1362,7 +1415,9 @@ fn run_lab_offload_inner(
                 }
                 return match selection.source {
                     LabRunnerSelectionSource::Default => {
-                        if !request.local_policy.allow_local_fallback {
+                        if request.local_policy.deny_local_execution {
+                            Err(local_execution_denied_error(&reason, Some(runner_id)))
+                        } else if !request.local_policy.allow_local_fallback {
                             Err(selected_runner_fallback_error(
                                 &selection,
                                 "Lab offload selected a runner but its daemon did not respond",
@@ -1913,7 +1968,14 @@ fn automatic_capability_fallback_or_error(
     reason: String,
     remediation: Vec<String>,
     allow_local_fallback: bool,
+    deny_local_execution: bool,
 ) -> Result<LabOffloadOutcome> {
+    if deny_local_execution {
+        return Err(local_execution_denied_error(
+            &reason,
+            Some(&selection.runner_id),
+        ));
+    }
     if !allow_local_fallback {
         return Err(selected_runner_fallback_error(
             selection,
@@ -3317,6 +3379,7 @@ mod tests {
                 .to_string(),
             vec!["Install Playwright and browser binaries on the runner.".to_string()],
             false,
+            false,
         );
 
         let Err(err) = result else {
@@ -3350,6 +3413,7 @@ mod tests {
                 .to_string(),
             Vec::new(),
             true,
+            false,
         )
         .expect("explicit fallback opt-in should allow local run");
 
@@ -3373,10 +3437,12 @@ mod tests {
             local_policy: LabLocalExecutionPolicy {
                 allow_local_hot: true,
                 allow_local_fallback: false,
+                deny_local_execution: false,
             },
             allow_dirty_lab_workspace: false,
             capture_patch: false,
             mutation_flag: None,
+            detach_after_handoff: false,
         })
         .expect("outcome");
 
@@ -3387,6 +3453,31 @@ mod tests {
         assert_eq!(plan.steps[0].id, "lab.select_runner");
         assert_eq!(plan.steps[0].status, PlanStepStatus::Skipped);
         assert_eq!(metadata.expect("metadata")["status"], "skipped");
+    }
+
+    #[test]
+    fn lab_only_refuses_local_execution_without_lab_contract() {
+        let outcome = execute_lab_offload(LabOffloadRequest {
+            command: None,
+            normalized_args: &["homeboy".to_string(), "status".to_string()],
+            explicit_runner: None,
+            force_hot: false,
+            local_policy: LabLocalExecutionPolicy {
+                allow_local_hot: false,
+                allow_local_fallback: false,
+                deny_local_execution: true,
+            },
+            allow_dirty_lab_workspace: false,
+            capture_patch: false,
+            mutation_flag: None,
+            detach_after_handoff: false,
+        });
+
+        let Err(err) = outcome else {
+            panic!("lab-only should refuse local execution");
+        };
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("Lab-only execution refused"));
     }
 
     #[test]
@@ -3406,6 +3497,7 @@ mod tests {
             allow_dirty_lab_workspace: false,
             capture_patch: false,
             mutation_flag: None,
+            detach_after_handoff: false,
         });
 
         let Err(err) = outcome else {

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -261,6 +261,7 @@ fn probe_agent_task_providers_on_runner(
             capability_preflight,
             required_extensions,
             require_paths: Vec::new(),
+            detach_after_handoff: false,
         },
     )?;
 

--- a/src/core/runner/lab_workspaces_deps.rs
+++ b/src/core/runner/lab_workspaces_deps.rs
@@ -455,6 +455,7 @@ pub(super) fn bootstrap_source_cli_node_dependencies(
             capability_preflight: Some(source_cli_bootstrap_capability_preflight()),
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            detach_after_handoff: false,
         },
     )?;
     if exit_code == 0 {

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -230,6 +230,7 @@ pub(super) fn sync_lab_offload_rigs(
                 capability_preflight: Some(rig_install_capability_preflight()),
                 required_extensions: Vec::new(),
                 require_paths: Vec::new(),
+                detach_after_handoff: false,
             },
         )?;
 

--- a/src/core/runner/rig_materialization/rig_source_install.rs
+++ b/src/core/runner/rig_materialization/rig_source_install.rs
@@ -78,6 +78,7 @@ fn exec_runner_rig_sources_command(
             capability_preflight: None,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            detach_after_handoff: false,
         },
     )
 }

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -321,6 +321,7 @@ fn run_once_output(
             capability_preflight,
             required_extensions: Vec::new(),
             require_paths: claim.request.require_paths.clone(),
+            detach_after_handoff: false,
         },
         || {
             if cancel_seen || last_cancel_poll.elapsed() < BROKER_CANCEL_POLL_INTERVAL {

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -1621,6 +1621,7 @@ fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecOptio
         capability_preflight: Some(runner_upgrade_capability_plan()),
         required_extensions: Vec::new(),
         require_paths: Vec::new(),
+        detach_after_handoff: false,
     }
 }
 


### PR DESCRIPTION
## Summary
- add global `--lab-only` / `--no-local-execution` to fail before local Lab fallback
- add `--detach-after-handoff` to return after runner daemon/broker job acceptance
- surface local fanout warnings and compact `agent-task status` execution locality
- document safe `--force-hot --allow-local-hot` usage for agent-task waves

Fixes #5678.
Fixes #5679.

## Verification
- `rustfmt src/cli_surface.rs src/commands/agent_task/status.rs src/commands/lab.rs src/commands/route.rs src/core/lab_routing.rs src/core/runner/execution.rs src/core/runner/lab/offload.rs src/core/runner/lab/provider_preflight.rs src/core/runner/lab_workspaces_deps.rs src/core/runner/rig_materialization/mod.rs src/core/runner/rig_materialization/rig_source_install.rs src/core/runner/worker.rs src/core/upgrade/runners.rs`
- `git diff --check`
- Local Cargo intentionally not run per task instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementation, docs, and targeted test updates.