### PR TITLE
fix(fuzz): ingest runner results file

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -51,6 +51,12 @@ runner provides it, and fetch commands for recorded artifacts such as failing
 cases, repro cases, and coverage reports. Use `homeboy runs artifact get` for
 artifact bytes that are stored locally or mirrored from a runner.
 
+Runner scripts receive `HOMEBOY_FUZZ_RESULTS_FILE` pointing at
+`fuzz-results.json` in the command run directory. When a runner writes a
+`homeboy/fuzz-campaign/v1` campaign object there, `homeboy fuzz run` parses it
+and returns it as `results` in the JSON envelope. Malformed JSON fails the run
+instead of being treated as proof.
+
 Full-coverage claims need persisted proof artifacts. A neutral coverage summary
 can report declared, executable, and proven counts; operation totals; skipped
 reason codes; and case/manifest artifacts. Treat missing `proven` counts or
@@ -109,3 +115,7 @@ Rigs can add private fuzz workloads keyed by extension id:
 
 Both `list` and `run` return JSON envelopes with stable `variant` values:
 `list` and `run`.
+
+`run.execution.results_file` is the path advertised to the runner through
+`HOMEBOY_FUZZ_RESULTS_FILE`. `run.results` is present only when the runner wrote
+a valid campaign result file.

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -7,6 +7,7 @@ use homeboy::core::component::{Component, ScopedExtensionConfig};
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner};
+use homeboy::core::fuzz::{parse_fuzz_results_file, FuzzCampaign};
 use homeboy::core::rig::{self, RigSpec};
 
 use super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
@@ -140,6 +141,7 @@ pub struct FuzzRunOutput {
     pub max_duration: Option<String>,
     pub passthrough_args: Vec<String>,
     pub execution: Option<FuzzExecutionOutput>,
+    pub results: Option<FuzzCampaign>,
     pub runner_contract: FuzzRunnerContract,
     pub evidence_followups: Vec<String>,
 }
@@ -151,6 +153,7 @@ pub struct FuzzExecutionOutput {
     pub exit_code: i32,
     pub success: bool,
     pub run_dir: String,
+    pub results_file: String,
     pub stdout: String,
     pub stderr: String,
 }
@@ -237,6 +240,12 @@ fn run_run(args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput, i32)> {
     let selected_workload = select_workload(&workloads, args.workload_id.as_deref())?;
     let run_dir = RunDir::create()?;
     let runner_output = run_fuzz_extension_script(&ctx, &args, selected_workload, &run_dir)?;
+    let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
+    let results = if results_path.exists() {
+        Some(parse_fuzz_results_file(&results_path)?)
+    } else {
+        None
+    };
     let exit_code = runner_output.exit_code;
     let success = runner_output.success;
     let evidence_followups = fuzz_evidence_followups(args.run_id.as_deref());
@@ -262,13 +271,16 @@ fn run_run(args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput, i32)> {
                 exit_code,
                 success,
                 run_dir: run_dir.path().to_string_lossy().to_string(),
+                results_file: results_path.to_string_lossy().to_string(),
                 stdout: runner_output.stdout,
                 stderr: runner_output.stderr,
             }),
+            results,
             runner_contract: FuzzRunnerContract {
                 capability: "fuzz".to_string(),
                 extension_script_required: true,
                 env: vec![
+                    "HOMEBOY_FUZZ_RESULTS_FILE",
                     "HOMEBOY_FUZZ_WORKLOAD_ID",
                     "HOMEBOY_FUZZ_WORKLOAD_PATH",
                     "HOMEBOY_FUZZ_RUN_ID",
@@ -665,6 +677,7 @@ mod tests {
             max_duration: None,
             passthrough_args: Vec::new(),
             execution: None,
+            results: None,
             runner_contract: FuzzRunnerContract {
                 capability: "fuzz".to_string(),
                 extension_script_required: true,
@@ -768,6 +781,9 @@ mod tests {
 
         let env = fuzz_runner_env(&args, Some(&workload));
 
+        assert!(env
+            .iter()
+            .all(|(key, _)| key != "HOMEBOY_FUZZ_RESULTS_FILE"));
         assert!(env.contains(&("HOMEBOY_FUZZ_WORKLOAD_ID".to_string(), "parser".to_string())));
         assert!(env.contains(&(
             "HOMEBOY_FUZZ_WORKLOAD_PATH".to_string(),
@@ -776,6 +792,71 @@ mod tests {
         assert!(env.contains(&("HOMEBOY_FUZZ_RUN_ID".to_string(), "proof-1".to_string())));
         assert!(env.contains(&("HOMEBOY_FUZZ_SEED".to_string(), "1234".to_string())));
         assert!(env.contains(&("HOMEBOY_FUZZ_MAX_DURATION".to_string(), "60s".to_string())));
+    }
+
+    #[test]
+    fn fuzz_output_contract_includes_results_file_and_parsed_campaign() {
+        let results = FuzzCampaign {
+            schema: homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA.to_string(),
+            id: "campaign-1".to_string(),
+            title: None,
+            safety_class: homeboy::core::fuzz::FuzzSafetyClass::ReadOnly,
+            surfaces: Vec::new(),
+            workloads: Vec::new(),
+            seeds: Vec::new(),
+            coverage: Vec::new(),
+            findings: Vec::new(),
+            artifacts: Vec::new(),
+            thresholds: Vec::new(),
+            provenance: None,
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        };
+        let run = serde_json::to_value(FuzzOutput::Run(FuzzRunOutput {
+            kind: "fuzz".to_string(),
+            command: "fuzz.run".to_string(),
+            component: "component-a".to_string(),
+            rig_id: None,
+            status: "passed".to_string(),
+            workload_id: None,
+            workload_path: None,
+            run_id: None,
+            seed: None,
+            max_duration: None,
+            passthrough_args: Vec::new(),
+            execution: Some(FuzzExecutionOutput {
+                kind: "fuzz".to_string(),
+                extension_id: "generic".to_string(),
+                exit_code: 0,
+                success: true,
+                run_dir: "/tmp/homeboy-run".to_string(),
+                results_file: "/tmp/homeboy-run/fuzz-results.json".to_string(),
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            results: Some(results),
+            runner_contract: FuzzRunnerContract {
+                capability: "fuzz".to_string(),
+                extension_script_required: true,
+                env: vec!["HOMEBOY_FUZZ_RESULTS_FILE"],
+            },
+            evidence_followups: Vec::new(),
+        }))
+        .unwrap();
+
+        assert_eq!(
+            run["execution"]["results_file"],
+            "/tmp/homeboy-run/fuzz-results.json"
+        );
+        assert_eq!(
+            run["results"]["schema"],
+            homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA
+        );
+        assert_eq!(run["results"]["id"], "campaign-1");
+        assert_eq!(
+            run["runner_contract"]["env"][0],
+            "HOMEBOY_FUZZ_RESULTS_FILE"
+        );
     }
 
     #[test]

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -37,6 +37,7 @@ pub mod files {
     pub const FIX_RESULTS: &str = "fix-results.json";
     pub const BENCH_RESULTS: &str = "bench-results.json";
     pub const BENCH_RESPONSIVENESS: &str = "bench-responsiveness.jsonl";
+    pub const FUZZ_RESULTS: &str = "fuzz-results.json";
     pub const TRACE_RESULTS: &str = "trace.json";
     pub const RESOURCE_SUMMARY: &str = "resource-summary.json";
     pub const PHASE_TIMINGS: &str = "phase-timings.json";
@@ -159,6 +160,12 @@ impl RunDir {
                 crate::core::product_identity::PRODUCT_IDENTITY
                     .env_var("BENCH_RESPONSIVENESS_FILE"),
                 self.step_file(files::BENCH_RESPONSIVENESS)
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+            (
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("FUZZ_RESULTS_FILE"),
+                self.step_file(files::FUZZ_RESULTS)
                     .to_string_lossy()
                     .to_string(),
             ),

--- a/src/core/extension/manifest_sidecar.rs
+++ b/src/core/extension/manifest_sidecar.rs
@@ -70,6 +70,7 @@ fn default_structured_sidecar_path(name: &str) -> String {
         "test.failures" => run_dir::files::TEST_FAILURES,
         "test.coverage" => run_dir::files::COVERAGE,
         "bench.results" => run_dir::files::BENCH_RESULTS,
+        "fuzz.results" => run_dir::files::FUZZ_RESULTS,
         "trace.results" => run_dir::files::TRACE_RESULTS,
         "trace.artifacts" => "artifacts",
         "resource.summary" => run_dir::files::RESOURCE_SUMMARY,
@@ -90,6 +91,7 @@ fn default_structured_sidecar_producer(name: &str) -> Option<String> {
         "lint.findings" | "lint.producers" => Some("lint"),
         "test.results" | "test.failures" | "test.coverage" => Some("test"),
         "bench.results" => Some("bench"),
+        "fuzz.results" => Some("fuzz"),
         "trace.results" | "trace.artifacts" => Some("trace"),
         _ => None,
     }

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -131,6 +131,7 @@ fn manifest_parses_declared_structured_sidecars() {
             },
             "lint.findings": true,
             "lint.producers": true,
+            "fuzz.results": true,
             "trace.results": true,
             "trace.artifacts": true,
             "test.coverage": false
@@ -139,7 +140,7 @@ fn manifest_parses_declared_structured_sidecars() {
     .unwrap();
 
     let sidecars = manifest.structured_sidecars();
-    assert_eq!(sidecars.len(), 6);
+    assert_eq!(sidecars.len(), 7);
     assert_eq!(sidecars[0].name, "findings");
     assert_eq!(sidecars[0].path, "findings.json");
     assert_eq!(sidecars[0].schema_version.as_deref(), Some("1"));
@@ -154,12 +155,15 @@ fn manifest_parses_declared_structured_sidecars() {
     assert_eq!(sidecars[3].name, "producer.summary");
     assert_eq!(sidecars[3].path, "producer-summary.json");
     assert_eq!(sidecars[3].producer.as_deref(), Some("lint"));
-    assert_eq!(sidecars[4].name, "trace.artifacts");
-    assert_eq!(sidecars[4].path, "artifacts");
-    assert_eq!(sidecars[4].producer.as_deref(), Some("trace"));
-    assert_eq!(sidecars[5].name, "trace.results");
-    assert_eq!(sidecars[5].path, "trace.json");
+    assert_eq!(sidecars[4].name, "fuzz.results");
+    assert_eq!(sidecars[4].path, "fuzz-results.json");
+    assert_eq!(sidecars[4].producer.as_deref(), Some("fuzz"));
+    assert_eq!(sidecars[5].name, "trace.artifacts");
+    assert_eq!(sidecars[5].path, "artifacts");
     assert_eq!(sidecars[5].producer.as_deref(), Some("trace"));
+    assert_eq!(sidecars[6].name, "trace.results");
+    assert_eq!(sidecars[6].path, "trace.json");
+    assert_eq!(sidecars[6].producer.as_deref(), Some("trace"));
 }
 
 #[test]

--- a/src/core/fuzz.rs
+++ b/src/core/fuzz.rs
@@ -4,11 +4,13 @@
 //! runners can attach their own details through `metadata` or flattened extras.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::artifact_contract::ArtifactContract;
+use crate::core::{Error, Result};
 
 pub const FUZZ_CORE_CONTRACT_SCHEMA: &str = "homeboy/fuzz-core-contract/v1";
 pub const FUZZ_SURFACE_SCHEMA: &str = "homeboy/fuzz-surface/v1";
@@ -369,6 +371,30 @@ pub fn fuzz_core_contract() -> FuzzCoreContract {
     }
 }
 
+pub fn parse_fuzz_results_file(path: &Path) -> Result<FuzzCampaign> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+    let campaign: FuzzCampaign = serde_json::from_str(&contents).map_err(|err| {
+        Error::validation_invalid_json(
+            err,
+            Some(format!("parse fuzz results file {}", path.display())),
+            Some(contents),
+        )
+    })?;
+    if campaign.schema != FUZZ_CAMPAIGN_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "schema",
+            format!(
+                "fuzz results schema must be {FUZZ_CAMPAIGN_SCHEMA}, got {}",
+                campaign.schema
+            ),
+            Some(campaign.schema),
+            None,
+        ));
+    }
+    Ok(campaign)
+}
+
 fn fuzz_core_contract_schema() -> String {
     FUZZ_CORE_CONTRACT_SCHEMA.to_string()
 }
@@ -609,5 +635,26 @@ mod tests {
         assert_eq!(value["artifacts"][0]["schema"], FUZZ_ARTIFACT_SCHEMA);
         assert_eq!(value["thresholds"][0]["schema"], FUZZ_THRESHOLD_SCHEMA);
         assert_eq!(value["provenance"]["schema"], FUZZ_PROVENANCE_SCHEMA);
+    }
+
+    #[test]
+    fn parse_fuzz_results_file_reads_campaign_contract() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("fuzz-results.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "schema": FUZZ_CAMPAIGN_SCHEMA,
+                "id": "campaign-1",
+                "safety_class": "read_only"
+            })
+            .to_string(),
+        )
+        .expect("write fuzz results");
+
+        let parsed = parse_fuzz_results_file(&path).expect("parse fuzz results");
+
+        assert_eq!(parsed.id, "campaign-1");
+        assert_eq!(parsed.safety_class, FuzzSafetyClass::ReadOnly);
     }
 }

--- a/src/core/structured_sidecar.rs
+++ b/src/core/structured_sidecar.rs
@@ -55,6 +55,14 @@ pub const REGISTRY: &[StructuredSidecarSchema] = &[
         required_fields: &[],
     },
     StructuredSidecarSchema {
+        key: "fuzz.results",
+        schema_version: "v1",
+        path: run_dir::files::FUZZ_RESULTS,
+        producer: Some("fuzz"),
+        shape: StructuredSidecarShape::Object,
+        required_fields: &[],
+    },
+    StructuredSidecarSchema {
         key: "trace.results",
         schema_version: "v1",
         path: run_dir::files::TRACE_RESULTS,


### PR DESCRIPTION
## Summary
- Pass `HOMEBOY_FUZZ_RESULTS_FILE` through the run-dir env contract for fuzz runners.
- Parse runner-written `fuzz-results.json` campaign output into `homeboy fuzz run` JSON results.
- Register `fuzz.results` as a structured sidecar and document the runner contract.

## Verification
- `rustfmt src/commands/fuzz.rs src/core/engine/run_dir.rs src/core/extension/manifest_sidecar.rs src/core/extension/tests.rs src/core/fuzz.rs src/core/structured_sidecar.rs`
- `git diff --check`
- Cargo tests not run locally per no-local-cargo constraint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the merged fuzz primitive, implementing runner results-file ingestion, updating focused tests/docs, and preparing this PR.