### PR TITLE
fix(audit): resolve compiler/dead-code findings (#5707)

### DIFF
--- a/src/core/artifact_contract.rs
+++ b/src/core/artifact_contract.rs
@@ -82,22 +82,6 @@ impl ArtifactContract {
             .or(self.path.as_deref())
     }
 
-    pub(crate) fn into_evidence_contract(self) -> Option<EvidenceContract> {
-        let target = self.target()?.to_string();
-        let label = self.label.clone().unwrap_or_else(|| self.kind.clone());
-        Some(EvidenceContract {
-            schema: EVIDENCE_CONTRACT_SCHEMA.to_string(),
-            kind: self.kind.clone(),
-            target,
-            label,
-            role: self.role.clone(),
-            semantic_key: self.semantic_key.clone(),
-            artifact: Some(self),
-            metadata: Value::Null,
-            extra: BTreeMap::new(),
-        })
-    }
-
     pub fn to_artifact_ref(&self, id: impl Into<String>, run_id: impl Into<String>) -> ArtifactRef {
         ArtifactRef {
             schema: crate::core::artifact_ref::ARTIFACT_REF_SCHEMA.to_string(),
@@ -287,30 +271,6 @@ mod tests {
         .expect_err("target error");
 
         assert!(err.contains("path, url, or public_url"));
-    }
-
-    #[test]
-    fn artifact_contract_can_become_evidence_contract() {
-        let evidence = ArtifactContract::from_value(json!({
-            "kind": "summary",
-            "role": "summary",
-            "semantic_key": "controller.summary",
-            "public_url": "https://artifacts.example.test/summary.json"
-        }))
-        .expect("artifact contract")
-        .into_evidence_contract()
-        .expect("evidence contract");
-
-        assert_eq!(evidence.schema, EVIDENCE_CONTRACT_SCHEMA);
-        assert_eq!(evidence.kind, "summary");
-        assert_eq!(
-            evidence.target,
-            "https://artifacts.example.test/summary.json"
-        );
-        assert_eq!(evidence.label, "summary");
-        assert_eq!(evidence.role.as_deref(), Some("summary"));
-        assert_eq!(evidence.semantic_key.as_deref(), Some("controller.summary"));
-        assert!(evidence.artifact.is_some());
     }
 
     #[test]

--- a/src/core/artifact_manifest.rs
+++ b/src/core/artifact_manifest.rs
@@ -120,23 +120,6 @@ impl ArtifactManifest {
         }
     }
 
-    pub(crate) fn artifact_contracts(
-        &self,
-    ) -> Result<Vec<crate::core::artifact_contract::ArtifactContract>> {
-        if self.schema != ARTIFACT_MANIFEST_SCHEMA {
-            return Err(Error::validation_invalid_argument(
-                "schema",
-                format!("expected {ARTIFACT_MANIFEST_SCHEMA}"),
-                Some(self.schema.clone()),
-                None,
-            ));
-        }
-        self.artifacts
-            .iter()
-            .map(ArtifactManifestEntry::to_artifact_contract)
-            .collect()
-    }
-
     pub fn read(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
         let raw = fs::read_to_string(path).map_err(|e| {
@@ -733,7 +716,7 @@ mod tests {
 
     #[test]
     fn validates_descriptor_fields_and_projects_artifact_contracts() {
-        let manifest = ArtifactManifest::new(vec![ArtifactManifestEntry {
+        let entry = ArtifactManifestEntry {
             id: Some("artifact-1".to_string()),
             path: "reports/summary.json".to_string(),
             kind: "summary".to_string(),
@@ -768,36 +751,35 @@ mod tests {
             ),
             redaction: Some(ArtifactRedactionState::Raw),
             metadata: json!({ "format": "homeboy-proof" }),
-        }]);
+        };
 
-        let contracts = manifest.artifact_contracts().expect("contracts");
+        let contract = entry.to_artifact_contract().expect("contract");
 
-        assert_eq!(contracts.len(), 1);
         assert_eq!(
-            contracts[0].schema,
+            contract.schema,
             crate::core::artifact_contract::ARTIFACT_CONTRACT_SCHEMA
         );
-        assert_eq!(contracts[0].kind, "summary");
-        assert_eq!(contracts[0].path.as_deref(), Some("reports/summary.json"));
+        assert_eq!(contract.kind, "summary");
+        assert_eq!(contract.path.as_deref(), Some("reports/summary.json"));
         assert_eq!(
-            contracts[0].public_url.as_deref(),
+            contract.public_url.as_deref(),
             Some("https://artifacts.example.test/reports/summary.json")
         );
-        assert_eq!(contracts[0].label.as_deref(), Some("Summary"));
-        assert_eq!(contracts[0].role.as_deref(), Some("summary"));
-        assert_eq!(contracts[0].semantic_key.as_deref(), Some("run.summary"));
-        assert_eq!(contracts[0].size_bytes, Some(17));
-        assert_eq!(contracts[0].metadata, json!({ "format": "homeboy-proof" }));
-        assert_eq!(contracts[0].extra["id"], "artifact-1");
+        assert_eq!(contract.label.as_deref(), Some("Summary"));
+        assert_eq!(contract.role.as_deref(), Some("summary"));
+        assert_eq!(contract.semantic_key.as_deref(), Some("run.summary"));
+        assert_eq!(contract.size_bytes, Some(17));
+        assert_eq!(contract.metadata, json!({ "format": "homeboy-proof" }));
+        assert_eq!(contract.extra["id"], "artifact-1");
         assert_eq!(
-            contracts[0].extra["provenance"]["producer"],
+            contract.extra["provenance"]["producer"],
             "homeboy-extension"
         );
         assert_eq!(
-            contracts[0].extra["viewer"]["links"][0]["kind"],
+            contract.extra["viewer"]["links"][0]["kind"],
             "report-viewer"
         );
-        assert_eq!(contracts[0].extra["public_url_state"]["reachable"], true);
+        assert_eq!(contract.extra["public_url_state"]["reachable"], true);
     }
 
     #[test]

--- a/src/core/artifact_ref.rs
+++ b/src/core/artifact_ref.rs
@@ -129,13 +129,6 @@ impl ArtifactRef {
             semantic_key: None,
         }
     }
-
-    pub(crate) fn public_target(&self) -> Option<String> {
-        self.public_url
-            .clone()
-            .or_else(|| self.url.clone())
-            .or_else(|| (self.artifact_type == "url").then(|| self.path.clone()))
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -167,19 +160,6 @@ impl EvidenceRef {
             semantic_key: None,
             artifact: None,
         }
-    }
-
-    pub(crate) fn from_artifact(artifact: ArtifactRef) -> Option<Self> {
-        let target = artifact.public_target()?;
-        Some(Self {
-            schema: EVIDENCE_REF_SCHEMA.to_string(),
-            kind: artifact.kind.clone(),
-            target,
-            label: artifact.kind.clone(),
-            role: artifact.role.clone(),
-            semantic_key: artifact.semantic_key.clone(),
-            artifact: Some(artifact),
-        })
     }
 }
 
@@ -256,32 +236,6 @@ mod tests {
                 "role": "summary",
                 "semantic_key": "run.summary"
             })
-        );
-    }
-
-    #[test]
-    fn evidence_ref_can_wrap_public_artifact_ref() {
-        let artifact = ArtifactRef {
-            schema: ARTIFACT_REF_SCHEMA.to_string(),
-            id: "artifact-1".to_string(),
-            run_id: "run-1".to_string(),
-            kind: "review".to_string(),
-            artifact_type: "url".to_string(),
-            path: "https://example.test/review".to_string(),
-            url: None,
-            public_url: None,
-            role: Some("review".to_string()),
-            semantic_key: Some("run.review".to_string()),
-        };
-
-        let evidence = EvidenceRef::from_artifact(artifact).expect("evidence ref");
-        assert_eq!(evidence.schema, EVIDENCE_REF_SCHEMA);
-        assert_eq!(evidence.target, "https://example.test/review");
-        assert_eq!(evidence.role.as_deref(), Some("review"));
-        assert_eq!(evidence.semantic_key.as_deref(), Some("run.review"));
-        assert_eq!(
-            evidence.artifact.expect("artifact").schema,
-            ARTIFACT_REF_SCHEMA
         );
     }
 }

--- a/src/core/change_artifact.rs
+++ b/src/core/change_artifact.rs
@@ -9,10 +9,7 @@
 //! execution run.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
-use crate::core::execution::ChangeArtifactProvenance as ExecutionChangeArtifactProvenance;
-use crate::core::execution::{ApprovalScope, ChangeArtifact as ExecutionChangeArtifact};
 use crate::core::execution_contract::EXECUTION_CONTRACT;
 use crate::core::source_snapshot::SourceSnapshot;
 
@@ -114,64 +111,6 @@ impl ChangeArtifact {
             schema: self.schema.clone(),
             provenance: self.provenance.clone(),
             digest: self.digest.clone(),
-        }
-    }
-
-    /// Project this apply-wire artifact into the lifecycle artifact envelope.
-    ///
-    /// The projection is intentionally lossy: source snapshot, schema, and
-    /// digest remain in metadata while the lifecycle artifact carries the
-    /// review-facing id/type/files/diff/provenance fields.
-    pub(crate) fn to_execution_change_artifact(
-        &self,
-        fallback_id: impl Into<String>,
-        artifact_type: impl Into<String>,
-    ) -> ExecutionChangeArtifact {
-        let artifact_id = self
-            .provenance
-            .as_ref()
-            .and_then(|provenance| provenance.artifact_id.clone())
-            .unwrap_or_else(|| fallback_id.into());
-        let artifact_type = artifact_type.into();
-        let mut metadata = HashMap::new();
-        metadata.insert("schema".to_string(), serde_json::json!(self.schema.clone()));
-        metadata.insert(
-            "source_snapshot".to_string(),
-            serde_json::to_value(&self.source_snapshot).unwrap_or(serde_json::Value::Null),
-        );
-        if let Some(digest) = &self.digest {
-            metadata.insert(
-                "digest".to_string(),
-                serde_json::to_value(digest).unwrap_or(serde_json::Value::Null),
-            );
-        }
-
-        ExecutionChangeArtifact {
-            id: artifact_id.clone(),
-            artifact_type,
-            provenance: self.provenance.as_ref().map_or_else(
-                || ExecutionChangeArtifactProvenance {
-                    source: "apply_change_artifact".to_string(),
-                    run_id: None,
-                    step_id: None,
-                    command: None,
-                    captured_at: None,
-                },
-                |provenance| ExecutionChangeArtifactProvenance {
-                    source: provenance.producer.clone(),
-                    run_id: provenance.run_id.clone(),
-                    step_id: None,
-                    command: provenance.command.as_ref().map(|command| command.join(" ")),
-                    captured_at: None,
-                },
-            ),
-            title: None,
-            summary: None,
-            path: None,
-            files: self.files(),
-            diff: self.patch.as_ref().map(|patch| patch.content.clone()),
-            approval_scope: Some(ApprovalScope::Artifact { artifact_id }),
-            metadata,
         }
     }
 
@@ -320,55 +259,6 @@ mod tests {
         );
         assert_eq!(UNIFIED_DIFF_PATCH_FORMAT, "unified_diff");
         assert_eq!(DIGEST_ALGORITHM_SHA256, "sha256");
-    }
-
-    #[test]
-    fn apply_artifact_projects_to_execution_lifecycle_artifact() {
-        let artifact = ChangeArtifact {
-            schema: CHANGE_ARTIFACT_SCHEMA.to_string(),
-            source_snapshot: source_snapshot(),
-            patch: None,
-            delta: Some(ChangeDelta {
-                files: vec![ChangeDeltaFile {
-                    path: "src/lib.rs".to_string(),
-                    content_base64: Some("Zm9vCg==".to_string()),
-                    delete: false,
-                }],
-            }),
-            provenance: Some(ChangeArtifactProvenance {
-                producer: "runner.capture_patch".to_string(),
-                run_id: Some("run-1".to_string()),
-                artifact_id: Some("patch.diff".to_string()),
-                command: Some(vec!["homeboy".to_string(), "lab".to_string()]),
-            }),
-            digest: Some(ChangeArtifactDigest {
-                algorithm: DIGEST_ALGORITHM_SHA256.to_string(),
-                value: "abc123".to_string(),
-            }),
-        };
-
-        let execution_artifact =
-            artifact.to_execution_change_artifact("fallback.patch", "runner.apply.change_artifact");
-
-        assert_eq!(execution_artifact.id, "patch.diff");
-        assert_eq!(
-            execution_artifact.artifact_type,
-            "runner.apply.change_artifact"
-        );
-        assert_eq!(execution_artifact.provenance.source, "runner.capture_patch");
-        assert_eq!(
-            execution_artifact.provenance.command.as_deref(),
-            Some("homeboy lab")
-        );
-        assert_eq!(execution_artifact.files, vec!["src/lib.rs"]);
-        assert_eq!(
-            execution_artifact.metadata["schema"],
-            serde_json::json!(CHANGE_ARTIFACT_SCHEMA)
-        );
-        assert_eq!(
-            execution_artifact.metadata["digest"]["algorithm"],
-            DIGEST_ALGORITHM_SHA256
-        );
     }
 
     fn source_snapshot() -> SourceSnapshot {

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -1,5 +1,5 @@
 use crate::core::error::{Error, Result};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 #[cfg(unix)]
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -33,29 +33,6 @@ impl ProcessStep {
     }
 }
 
-/// Resolve a process step's working directory inside a containment root.
-///
-/// When a step omits a working directory, the normalized root becomes the
-/// effective working directory. This gives local commands, extensions, and rigs
-/// one reusable path policy without requiring filesystem canonicalization.
-pub(crate) fn prepare_contained_process_step(
-    root: impl AsRef<Path>,
-    step: ProcessStep,
-) -> Result<ProcessStep> {
-    let root = crate::core::paths::normalize_local_path(root);
-    let working_dir = match step.working_dir.as_deref() {
-        Some(working_dir) => {
-            crate::core::paths::resolve_contained_local_path(&root, working_dir, "working_dir")?
-        }
-        None => root,
-    };
-
-    Ok(ProcessStep {
-        working_dir: Some(working_dir),
-        ..step
-    })
-}
-
 pub fn pid_is_running(pid: u32) -> bool {
     if pid > i32::MAX as u32 {
         return false;
@@ -87,48 +64,6 @@ pub fn install_shutdown_handler(stop: Arc<AtomicBool>, context: &str) -> Result<
         stop.store(true, Ordering::SeqCst);
     })
     .map_err(|err| Error::internal_unexpected(format!("install {context} signal handler: {err}")))
-}
-
-#[cfg(test)]
-mod containment_tests {
-    use super::*;
-
-    #[test]
-    fn process_step_defaults_to_root_working_dir() {
-        let step = prepare_contained_process_step("/repo/./worktree", ProcessStep::new("cargo"))
-            .expect("prepared step");
-
-        assert_eq!(step.working_dir, Some(PathBuf::from("/repo/worktree")));
-    }
-
-    #[test]
-    fn process_step_accepts_relative_working_dir_inside_root() {
-        let step = prepare_contained_process_step(
-            "/repo/worktree",
-            ProcessStep::new("cargo")
-                .args(["test"])
-                .working_dir("crates/core/.."),
-        )
-        .expect("prepared step");
-
-        assert_eq!(step.program, "cargo");
-        assert_eq!(step.args, vec!["test".to_string()]);
-        assert_eq!(
-            step.working_dir,
-            Some(PathBuf::from("/repo/worktree/crates"))
-        );
-    }
-
-    #[test]
-    fn process_step_rejects_working_dir_escape() {
-        let err = prepare_contained_process_step(
-            "/repo/worktree",
-            ProcessStep::new("cargo").working_dir("../outside"),
-        )
-        .expect_err("cwd escape should fail");
-
-        assert!(err.to_string().contains("escapes root '/repo/worktree'"));
-    }
 }
 
 pub fn process_group_is_running(pgid: i32) -> bool {


### PR DESCRIPTION
## Summary
Resolves all 6 `compiler` audit findings in #5707 — `[dead_code]` methods/functions that became unreachable in non-test builds after PR #5416 narrowed their visibility from `pub` to `pub(crate)`. Each was only ever called from `#[cfg(test)]` code, so the compiler correctly flagged them as dead in `cargo build --lib`.

All flagged items had **zero production callers**; per the audit guidance to prefer removing truly dead code, each was removed along with its now-orphaned test, with surrounding test coverage preserved or rewired where it still exercised live code.

## Findings resolved
- `src/core/artifact_contract.rs` — removed `into_evidence_contract` + its sole test (`EvidenceContract` struct/`from_value` stay; still covered).
- `src/core/artifact_manifest.rs` — removed the `artifact_contracts` wrapper; rewired its test to call the still-live `ArtifactManifestEntry::to_artifact_contract` directly, preserving descriptor-field-projection coverage.
- `src/core/artifact_ref.rs` — removed `EvidenceRef::from_artifact` and its only helper `public_target` (both test-only) + the orphaned test. `EvidenceRef`/`EvidenceRef::new` remain (used by `observation/evidence_report.rs`).
- `src/core/change_artifact.rs` — removed `to_execution_change_artifact` + its test, and the imports it solely used (`HashMap`, `ApprovalScope`, the `ExecutionChangeArtifact*` aliases).
- `src/core/process.rs` — removed `prepare_contained_process_step` + its `containment_tests` module, and the now-unused `Path` import.

## Notes
- Touches **only** the 5 artifact/process files — no fleet-owned files (runner.rs, runs.rs, api_jobs*, agent_task*, cli_*, command_contract*, route.rs, runner/lab*, fuzz*).
- `cargo fmt` applied. `docs/changelog.md` untouched.
- CI will be RED until main's pre-existing fleet break in `runner.rs`/`fuzz.rs` (unrelated `RunnerExecOptions`/`?`-conversion compile errors on origin/main) is fixed. Those errors exist on a clean origin/main checkout independent of this PR; these dead-code fixes compile in isolation. Merge once main is green.