### PR TITLE
Neutralize product-specific core fixtures

### DIFF
--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -689,7 +689,7 @@ mod tests {
             "dispatch": {
                 "prompt": "Cook",
                 "tasks": ["Do the work"],
-                "backend": "codebox"
+                "backend": "synthetic-runtime"
             }
         }))
         .expect("dispatch args");
@@ -702,7 +702,7 @@ mod tests {
         }
         .apply(&mut args);
 
-        assert_eq!(args.backend.as_deref(), Some("codebox"));
+        assert_eq!(args.backend.as_deref(), Some("synthetic-runtime"));
         assert_eq!(args.model.as_deref(), Some("gpt-5.5"));
         assert_eq!(
             args.core.provider_config.as_deref(),

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -283,11 +283,11 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
     };
     let mut plan = test_plan();
     plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
-    plan.tasks[0].workspace.component_id = Some("wp-coding-agents".to_string());
-    plan.tasks[0].workspace.branch = Some("fix/179-runtime-guidance".to_string());
+    plan.tasks[0].workspace.component_id = Some("sample-agent-runtime".to_string());
+    plan.tasks[0].workspace.branch = Some("fix/runtime-guidance".to_string());
     plan.tasks[0].workspace.base_ref = Some("origin/main".to_string());
     plan.tasks[0].workspace.task_url =
-        Some("https://github.com/Extra-Chill/wp-coding-agents/issues/179".to_string());
+        Some("https://github.com/example/sample-agent-runtime/issues/179".to_string());
     plan.tasks[0].workspace.cleanup = Some("preserve".to_string());
     plan.tasks[0].workspace.materialization = json!({
         "root": "/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance"
@@ -309,7 +309,7 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
         observed.workspace.root.as_deref(),
         Some("/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance")
     );
-    assert_eq!(observed.workspace.slug.as_deref(), Some("wp-coding-agents"));
+    assert_eq!(observed.workspace.slug.as_deref(), Some("sample-agent-runtime"));
     assert!(observed.workspace.kind.is_none());
     assert!(observed.workspace.component_id.is_none());
     assert!(observed.workspace.branch.is_none());
@@ -323,7 +323,7 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
 fn run_plan_rejects_component_worktree_without_branch() {
     let mut plan = test_plan();
     plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
-    plan.tasks[0].workspace.component_id = Some("wp-coding-agents".to_string());
+    plan.tasks[0].workspace.component_id = Some("sample-agent-runtime".to_string());
 
     let error = run_loaded_plan(plan, None, CapturingExecutor::default())
         .expect_err("component worktree without branch rejected");

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -844,7 +844,7 @@ Installing declared dependencies...
     fn lab_extension_sync_accepts_named_refs_resolved_by_install() {
         assert!(revision_matches("main", "941bf8c"));
         assert!(revision_matches(
-            "fix/provider-bundled-agents-api",
+            "fix/provider-bundled-shared-runtime",
             "9d17a58a"
         ));
         assert!(!revision_matches("main", ""));

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -76,7 +76,7 @@ impl ControllerDispatchHook for FailingDispatchHook {
                             "class": "provider.runtime_overlay",
                             "message": "Recipe runtime overlay preparation failed: download php-scoper timed out after 60004ms",
                             "data": {
-                                "provider": "codebox",
+                                "provider": "synthetic-runtime",
                                 "phase": "runtime_overlay_preparation"
                             }
                         }]
@@ -1536,7 +1536,7 @@ fn resume_failed_action_result_includes_top_level_failure_summary() {
             json!("task-overlay-prepare")
         );
         assert_eq!(failed["failure_summary"]["phase"], json!("prepare"));
-        assert_eq!(failed["failure_summary"]["provider"], json!("codebox"));
+        assert_eq!(failed["failure_summary"]["provider"], json!("synthetic-runtime"));
         assert_eq!(
             failed["failure_summary"]["failure_phase"],
             json!("runtime_overlay_preparation")

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -2285,7 +2285,7 @@ fn is_failure_status(status: AgentTaskOutcomeStatus) -> bool {
 /// Surface actionable provider run-result evidence into the outcome on failure
 /// (#4105).
 ///
-/// Provider executors (e.g. the WP Codebox agent-task executor) emit a
+/// Provider executors emit a
 /// structured run-result under `outputs.provider_run_result` following the
 /// `*/agent-task-run-result/*` shape: `{status, failure_classification,
 /// diagnostics[], artifacts[], metadata{provider_error,run_id,run_status,
@@ -3631,16 +3631,16 @@ mod tests {
     #[test]
     fn provider_selection_reports_exact_backend_selector_mismatch() {
         let (_, mut provider) = request("task-a", "node provider.js".to_string());
-        provider.id = "wordpress.codebox-agent-task-executor".to_string();
-        provider.backend = "codebox".to_string();
+        provider.id = "example.synthetic-agent-task-executor".to_string();
+        provider.backend = "synthetic-runtime".to_string();
 
         let providers = [provider];
-        let resolution = resolve_provider_for_backend(&providers, "codebox", Some("openai"));
+        let resolution = resolve_provider_for_backend(&providers, "synthetic-runtime", Some("fast"));
 
         assert_eq!(
             resolution,
             ProviderResolution::SelectorMismatch {
-                available_ids: vec!["wordpress.codebox-agent-task-executor".to_string()],
+                available_ids: vec!["example.synthetic-agent-task-executor".to_string()],
             }
         );
     }
@@ -4304,7 +4304,7 @@ process.stdout.write(JSON.stringify({
             schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
             task_id: "cook-conductor".to_string(),
             status: AgentTaskOutcomeStatus::Failed,
-            summary: Some("WP Codebox agent task failed.".to_string()),
+            summary: Some("Provider agent task failed.".to_string()),
             failure_classification: Some(AgentTaskFailureClassification::ExecutionFailed),
             artifacts: Vec::new(),
             typed_artifacts: Vec::new(),
@@ -4321,7 +4321,7 @@ process.stdout.write(JSON.stringify({
     fn empty_failed_run_result_surfaces_explanatory_diagnostic() {
         // Mirrors the #4105 repro: a failed run-result that is an empty shell.
         let mut outcome = failed_outcome_with_run_result(json!({
-            "schema": "wp-codebox/agent-task-run-result/v1",
+            "schema": "example-provider/agent-task-run-result/v1",
             "status": "failed",
             "failure_classification": "runtime",
             "artifacts": [],
@@ -4359,10 +4359,10 @@ process.stdout.write(JSON.stringify({
     #[test]
     fn populated_failed_run_result_surfaces_error_identity_and_refs() {
         let mut outcome = failed_outcome_with_run_result(json!({
-            "schema": "wp-codebox/agent-task-run-result/v1",
+            "schema": "example-provider/agent-task-run-result/v1",
             "status": "failed",
             "diagnostics": [
-                { "class": "codebox.api_error", "message": "runtime provisioning rejected" }
+                { "class": "provider.api_error", "message": "runtime provisioning rejected" }
             ],
             "metadata": {
                 "provider_error": { "code": "E_RUNTIME", "message": "quota exceeded" },
@@ -4372,8 +4372,8 @@ process.stdout.write(JSON.stringify({
                 "runtime_status": "failed"
             },
             "refs": {
-                "logs": ["https://codebox.example/logs/run-123"],
-                "transcripts": [{ "uri": "https://codebox.example/transcripts/rt-456" }],
+                "logs": ["https://provider.example/logs/run-123"],
+                "transcripts": [{ "uri": "https://provider.example/transcripts/rt-456" }],
                 "artifact_bundles": []
             }
         }));
@@ -4384,7 +4384,7 @@ process.stdout.write(JSON.stringify({
         assert!(outcome
             .diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.class == "codebox.api_error"));
+            .any(|diagnostic| diagnostic.class == "provider.api_error"));
         // The structured identity becomes an actionable diagnostic.
         let identity = outcome
             .diagnostics
@@ -4404,12 +4404,12 @@ process.stdout.write(JSON.stringify({
             .evidence_refs
             .iter()
             .any(|reference| reference.kind == "provider-log"
-                && reference.uri == "https://codebox.example/logs/run-123"));
+                && reference.uri == "https://provider.example/logs/run-123"));
         assert!(outcome
             .evidence_refs
             .iter()
             .any(|reference| reference.kind == "provider-transcript"
-                && reference.uri == "https://codebox.example/transcripts/rt-456"));
+                && reference.uri == "https://provider.example/transcripts/rt-456"));
         // The empty-shell guard must NOT fire when real evidence exists.
         assert!(outcome
             .diagnostics
@@ -4840,10 +4840,10 @@ process.stdout.write(JSON.stringify({
     #[test]
     fn scheduler_reports_provider_selector_mismatch() {
         let (mut request, mut provider) = request("task-selector-mismatch", "unused".to_string());
-        request.executor.backend = "codebox".to_string();
-        request.executor.selector = Some("openai".to_string());
-        provider.id = "wordpress.codebox-agent-task-executor".to_string();
-        provider.backend = "codebox".to_string();
+        request.executor.backend = "synthetic-runtime".to_string();
+        request.executor.selector = Some("fast".to_string());
+        provider.id = "example.synthetic-agent-task-executor".to_string();
+        provider.backend = "synthetic-runtime".to_string();
         let scheduler =
             AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
                 provider,
@@ -4858,7 +4858,7 @@ process.stdout.write(JSON.stringify({
         );
         assert_eq!(
             aggregate.outcomes[0].diagnostics[0].data["available_provider_ids"],
-            json!(["wordpress.codebox-agent-task-executor"])
+            json!(["example.synthetic-agent-task-executor"])
         );
     }
 

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -852,9 +852,9 @@ mod tests {
     #[test]
     fn component_lifecycle_bundled_roundtrips_and_suppresses() {
         let component: Component = serde_json::from_value(serde_json::json!({
-            "id": "agents-api",
+            "id": "shared-runtime",
             "lifecycle": "bundled",
-            "bundled_into": "data-machine"
+            "bundled_into": "host-app"
         }))
         .unwrap();
 
@@ -862,18 +862,18 @@ mod tests {
         assert!(!component.is_active_lifecycle());
         assert_eq!(
             component.bundled_into.as_deref(),
-            Some("data-machine"),
+            Some("host-app"),
             "bundled_into host should be preserved"
         );
         assert_eq!(
             component.lifecycle_suppression_reason().as_deref(),
-            Some("Component is bundled into 'data-machine'")
+            Some("Component is bundled into 'host-app'")
         );
 
         // Roundtrip must preserve the lifecycle marker so config is stable.
         let json = serde_json::to_value(&component).unwrap();
         assert_eq!(json["lifecycle"], serde_json::json!("bundled"));
-        assert_eq!(json["bundled_into"], serde_json::json!("data-machine"));
+        assert_eq!(json["bundled_into"], serde_json::json!("host-app"));
         let reparsed: Component = serde_json::from_value(json).unwrap();
         assert_eq!(reparsed.lifecycle, ComponentLifecycle::Bundled);
     }

--- a/src/core/component/mutations.rs
+++ b/src/core/component/mutations.rs
@@ -183,25 +183,25 @@ mod tests {
     #[test]
     fn merge_local_path_updates_standalone_registration() {
         crate::test_support::with_isolated_home(|home| {
-            let old_repo = home.path().join("agents-api");
-            let new_repo = home.path().join("agents-api-current");
+            let old_repo = home.path().join("sample-plugin");
+            let new_repo = home.path().join("sample-plugin-current");
             fs::create_dir_all(&old_repo).expect("old repo dir");
             fs::create_dir_all(&new_repo).expect("new repo dir");
             fs::write(
                 old_repo.join("homeboy.json"),
-                r#"{"id":"agents-api","remote_path":"wp-content/plugins/agents-api"}"#,
+                r#"{"id":"sample-plugin","remote_path":"wp-content/plugins/sample-plugin"}"#,
             )
             .expect("old homeboy.json");
             fs::write(
                 new_repo.join("homeboy.json"),
-                r#"{"id":"agents-api","remote_path":"wp-content/plugins/agents-api"}"#,
+                r#"{"id":"sample-plugin","remote_path":"wp-content/plugins/sample-plugin"}"#,
             )
             .expect("new homeboy.json");
 
             let component = Component::new(
-                "agents-api".to_string(),
+                "sample-plugin".to_string(),
                 old_repo.to_string_lossy().to_string(),
-                "wp-content/plugins/agents-api".to_string(),
+                "wp-content/plugins/sample-plugin".to_string(),
                 None,
             );
             inventory::write_standalone_registration(&component)
@@ -211,18 +211,18 @@ mod tests {
                 "local_path": new_repo.to_string_lossy()
             })
             .to_string();
-            let result = merge(Some("agents-api"), &patch, &[]).expect("component merge");
+            let result = merge(Some("sample-plugin"), &patch, &[]).expect("component merge");
             let MergeOutput::Single(result) = result else {
                 panic!("expected single merge result");
             };
             assert_eq!(result.updated_fields, vec!["local_path".to_string()]);
 
-            let loaded = crate::core::component::load("agents-api").expect("load component");
+            let loaded = crate::core::component::load("sample-plugin").expect("load component");
             assert_eq!(loaded.local_path, new_repo.to_string_lossy());
 
             let registration_path = home
                 .path()
-                .join(".config/homeboy/components/agents-api.json");
+                .join(".config/homeboy/components/sample-plugin.json");
             let registration: serde_json::Value = serde_json::from_str(
                 &fs::read_to_string(registration_path).expect("read registration"),
             )

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -1232,7 +1232,7 @@ mod tests {
             assert_eq!(deployable_ids, vec!["active"]);
 
             // Bundled/retired components are suppressed (not a hard error, not
-            // deployable) — exactly the agents-api scenario from #3489.
+            // deployable), matching the generic bundled dependency scenario.
             assert!(loaded.skipped.contains(&"bundled".to_string()));
             assert!(loaded.skipped.contains(&"retired".to_string()));
         });

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -154,9 +154,9 @@ fn spec_has_provider_plugin_paths(spec: &str) -> bool {
 /// directories a cook actually references, so an absolute provider-plugin path
 /// inherited from stale/global controller or runner settings (e.g. a Codex
 /// provider plugin path that is not part of this run's workspace) survives
-/// remapping unchanged. Forwarding it would make the WP Codebox recipe declare
-/// an `extra_plugins[..]` entry pointing at a directory that does not exist on
-/// the runner, failing recipe validation with a `missing-path` error before the
+/// remapping unchanged. Forwarding it would make the provider runtime declare
+/// an extra plugin/workspace entry pointing at a directory that does not exist
+/// on the runner, failing runtime validation with a `missing-path` error before the
 /// task runs (homeboy #4829). Such entries are not materialized on the selected
 /// runner, so we omit them; explicit, materializable refs and entries that did
 /// remap into a synced remote location are preserved.

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -228,8 +228,8 @@ fn remap_prunes_stale_unresolved_provider_plugin_path() {
     // #4829: a `provider_plugin_paths` entry inherited from stale/global
     // settings points at a controller-local absolute directory that is not part
     // of this run's synced workspace, so no local->remote mapping is recorded
-    // for it. Forwarding it verbatim makes the WP Codebox recipe declare an
-    // `extra_plugins` entry for a directory that does not exist on the runner,
+    // for it. Forwarding it verbatim makes the provider runtime declare an
+    // extra plugin/workspace entry for a directory that does not exist on the runner,
     // failing recipe validation. Such entries must be pruned before offload.
     let mappings = vec![LabPathRemap {
         local: "/Users/user/Developer/sample-plugin@cook".to_string(),

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -580,7 +580,7 @@ mod provider_config_candidate_paths_tests {
             "runtime_overlays": [
                 { "kind": "bundled-library", "library": "portable-ai-client", "source": "/local/portable-ai-client@custom-provider-auth", "target": "/runtime/includes/portable-ai-client" }
             ],
-            "agents_api": "/local/agents-api",
+            "provider_support": "/local/provider-support",
             "source_cli": "/local/provider/packages/cli/dist/index.js",
             "model": "claude-opus-4-8"
         });
@@ -593,7 +593,7 @@ mod provider_config_candidate_paths_tests {
             "/local/sample-plugin-code",
             "/local/ai-provider-for-claude-code",
             "/local/portable-ai-client@custom-provider-auth",
-            "/local/agents-api",
+            "/local/provider-support",
             "/local/provider/packages/cli/dist/index.js",
         ] {
             assert!(

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -459,19 +459,19 @@ mod tests {
     fn sync_workspace_materializes_validation_dependency_siblings() {
         crate::test_support::with_isolated_home(|_| {
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
-            let source = workspace_parent.path().join("studio-web");
-            let dependency = workspace_parent.path().join("agents-api");
+            let source = workspace_parent.path().join("host-app");
+            let dependency = workspace_parent.path().join("shared-runtime");
             let runner_root = tempfile::tempdir().expect("runner root tempdir");
             fs::create_dir_all(source.join("src")).expect("source dir");
             fs::create_dir_all(dependency.join("lib")).expect("dependency dir");
             fs::write(
                 source.join("homeboy.json"),
                 serde_json::json!({
-                    "id": "studio-web",
+                    "id": "host-app",
                     "extensions": {
                         "wordpress": {
                             "settings": {
-                                "validation_dependencies": ["agents-api"]
+                                "validation_dependencies": ["shared-runtime"]
                             }
                         }
                     }
@@ -482,10 +482,10 @@ mod tests {
             fs::write(source.join("src/main.php"), "<?php\n").expect("source file");
             fs::write(
                 dependency.join("homeboy.json"),
-                serde_json::json!({ "id": "agents-api" }).to_string(),
+                serde_json::json!({ "id": "shared-runtime" }).to_string(),
             )
             .expect("dependency manifest");
-            fs::write(dependency.join("lib/agents.php"), "<?php\n").expect("dependency file");
+            fs::write(dependency.join("lib/runtime.php"), "<?php\n").expect("dependency file");
             let _remote = init_checkout_with_upstream(&dependency);
 
             super::super::create(
@@ -514,7 +514,7 @@ mod tests {
 
             assert_eq!(exit_code, 0);
             assert_eq!(output.validation_dependencies.len(), 1);
-            assert_eq!(output.validation_dependencies[0].id, "agents-api");
+            assert_eq!(output.validation_dependencies[0].id, "shared-runtime");
             assert_eq!(
                 output.validation_dependencies[0].role,
                 "validation_dependency"
@@ -525,7 +525,7 @@ mod tests {
             );
             let remote_parent = parent_remote_path(&output.remote_path);
             assert!(Path::new(&output.remote_path).join("src/main.php").exists());
-            let remote_dependency = Path::new(&remote_parent).join("agents-api");
+            let remote_dependency = Path::new(&remote_parent).join("shared-runtime");
             assert_eq!(
                 output.validation_dependencies[0].remote_path,
                 remote_dependency.display().to_string()
@@ -537,7 +537,7 @@ mod tests {
                     .display()
                     .to_string()
             );
-            assert!(remote_dependency.join("lib/agents.php").exists());
+            assert!(remote_dependency.join("lib/runtime.php").exists());
             assert!(!remote_dependency.join(".git").exists());
             assert!(remote_dependency
                 .join(".homeboy/lab-source-evidence.json")
@@ -545,7 +545,7 @@ mod tests {
 
             crate::core::hygiene::require_checkout_hygiene_without_lifecycle(
                 vec![crate::core::hygiene::DependencyCheckout {
-                    id: "agents-api".to_string(),
+                    id: "shared-runtime".to_string(),
                     role: "validation_dependency".to_string(),
                     path: remote_dependency,
                 }],
@@ -559,19 +559,19 @@ mod tests {
     fn sync_workspace_runs_validation_dependency_lifecycle_before_materializing() {
         crate::test_support::with_isolated_home(|_| {
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
-            let source = workspace_parent.path().join("studio-web");
-            let dependency = workspace_parent.path().join("agents-api");
+            let source = workspace_parent.path().join("host-app");
+            let dependency = workspace_parent.path().join("shared-runtime");
             let runner_root = tempfile::tempdir().expect("runner root tempdir");
             fs::create_dir_all(&source).expect("source dir");
             fs::create_dir_all(&dependency).expect("dependency dir");
             fs::write(
                 source.join("homeboy.json"),
                 serde_json::json!({
-                    "id": "studio-web",
+                    "id": "host-app",
                     "extensions": {
                         "wordpress": {
                             "settings": {
-                                "validation_dependencies": ["agents-api"]
+                                "validation_dependencies": ["shared-runtime"]
                             }
                         }
                     }
@@ -582,7 +582,7 @@ mod tests {
             fs::write(
                 dependency.join("homeboy.json"),
                 serde_json::json!({
-                    "id": "agents-api",
+                    "id": "shared-runtime",
                     "scripts": {
                         "deps": ["sh -c 'printf install > deps-installed.txt'"],
                         "build": ["sh -c 'printf build > build-built.txt'"]
@@ -625,10 +625,10 @@ mod tests {
             assert_eq!(exit_code, 0);
             let remote_parent = parent_remote_path(&output.remote_path);
             assert!(Path::new(&remote_parent)
-                .join("agents-api/deps-installed.txt")
+                .join("shared-runtime/deps-installed.txt")
                 .exists());
             assert!(Path::new(&remote_parent)
-                .join("agents-api/build-built.txt")
+                .join("shared-runtime/build-built.txt")
                 .exists());
             assert!(!dependency.join("deps-installed.txt").exists());
             assert!(!dependency.join("build-built.txt").exists());
@@ -639,15 +639,15 @@ mod tests {
     fn sync_workspace_uses_manifest_id_for_absolute_validation_dependency() {
         crate::test_support::with_isolated_home(|_| {
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
-            let source = workspace_parent.path().join("studio-web");
-            let dependency = workspace_parent.path().join("agents-api");
+            let source = workspace_parent.path().join("host-app");
+            let dependency = workspace_parent.path().join("shared-runtime");
             let runner_root = tempfile::tempdir().expect("runner root tempdir");
             fs::create_dir_all(&source).expect("source dir");
             fs::create_dir_all(&dependency).expect("dependency dir");
             fs::write(
                 source.join("homeboy.json"),
                 serde_json::json!({
-                    "id": "studio-web",
+                    "id": "host-app",
                     "extensions": {
                         "wordpress": {
                             "settings": {
@@ -662,7 +662,7 @@ mod tests {
             fs::write(
                 dependency.join("homeboy.json"),
                 serde_json::json!({
-                    "id": "agents-api",
+                    "id": "shared-runtime",
                     "scripts": {
                         "build": ["sh -c 'printf \"$HOMEBOY_COMPONENT_ID\" > component-id.txt'"]
                     }
@@ -700,11 +700,11 @@ mod tests {
 
             assert_eq!(exit_code, 0);
             let remote_parent = parent_remote_path(&output.remote_path);
-            let remote_dependency = Path::new(&remote_parent).join("agents-api");
+            let remote_dependency = Path::new(&remote_parent).join("shared-runtime");
             assert!(remote_dependency.join("component-id.txt").exists());
             assert_eq!(
                 fs::read_to_string(remote_dependency.join("component-id.txt")).unwrap(),
-                "agents-api"
+                "shared-runtime"
             );
             assert!(!Path::new(&remote_parent).join("Users").exists());
         });
@@ -714,19 +714,19 @@ mod tests {
     fn sync_workspace_failed_validation_dependency_build_keeps_source_clean() {
         crate::test_support::with_isolated_home(|_| {
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
-            let source = workspace_parent.path().join("studio-web");
-            let dependency = workspace_parent.path().join("agents-api");
+            let source = workspace_parent.path().join("host-app");
+            let dependency = workspace_parent.path().join("shared-runtime");
             let runner_root = tempfile::tempdir().expect("runner root tempdir");
             fs::create_dir_all(&source).expect("source dir");
             fs::create_dir_all(&dependency).expect("dependency dir");
             fs::write(
                 source.join("homeboy.json"),
                 serde_json::json!({
-                    "id": "studio-web",
+                    "id": "host-app",
                     "extensions": {
                         "wordpress": {
                             "settings": {
-                                "validation_dependencies": ["agents-api"]
+                                "validation_dependencies": ["shared-runtime"]
                             }
                         }
                     }
@@ -737,7 +737,7 @@ mod tests {
             fs::write(
                 dependency.join("homeboy.json"),
                 serde_json::json!({
-                    "id": "agents-api",
+                    "id": "shared-runtime",
                     "scripts": {
                         "build": ["sh -c 'mkdir .homeboy-build && printf dirty > .homeboy-build/state && exit 7'"]
                     }
@@ -788,20 +788,20 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
             let remote_parent = tempfile::tempdir().expect("remote parent");
-            let source = workspace_parent.path().join("studio-web");
-            let seed = remote_parent.path().join("agents-api-seed");
-            let clone_target = workspace_parent.path().join("agents-api-clone");
+            let source = workspace_parent.path().join("host-app");
+            let seed = remote_parent.path().join("shared-runtime-seed");
+            let clone_target = workspace_parent.path().join("shared-runtime-clone");
             let runner_root = tempfile::tempdir().expect("runner root tempdir");
             fs::create_dir_all(&source).expect("source dir");
             fs::create_dir_all(seed.join("lib")).expect("seed dir");
             fs::write(
                 source.join("homeboy.json"),
                 serde_json::json!({
-                    "id": "studio-web",
+                    "id": "host-app",
                     "extensions": {
                         "wordpress": {
                             "settings": {
-                                "validation_dependencies": ["agents-api"]
+                                "validation_dependencies": ["shared-runtime"]
                             }
                         }
                     }
@@ -811,15 +811,15 @@ mod tests {
             .expect("source manifest");
             fs::write(
                 seed.join("homeboy.json"),
-                serde_json::json!({ "id": "agents-api" }).to_string(),
+                serde_json::json!({ "id": "shared-runtime" }).to_string(),
             )
             .expect("seed manifest");
-            fs::write(seed.join("lib/agents.php"), "<?php\n").expect("seed file");
+            fs::write(seed.join("lib/runtime.php"), "<?php\n").expect("seed file");
             let remote = init_checkout_with_upstream(&seed);
             let components_dir = crate::core::paths::components().expect("components dir");
             fs::create_dir_all(&components_dir).expect("components dir exists");
             fs::write(
-                components_dir.join("agents-api.json"),
+                components_dir.join("shared-runtime.json"),
                 serde_json::json!({
                     "local_path": clone_target,
                     "remote_url": remote.path()
@@ -853,10 +853,10 @@ mod tests {
             .expect("sync workspace");
 
             assert_eq!(exit_code, 0);
-            assert!(clone_target.join("lib/agents.php").exists());
+            assert!(clone_target.join("lib/runtime.php").exists());
             let remote_parent = parent_remote_path(&output.remote_path);
             assert!(Path::new(&remote_parent)
-                .join("agents-api/lib/agents.php")
+                .join("shared-runtime/lib/runtime.php")
                 .exists());
         });
     }
@@ -865,16 +865,16 @@ mod tests {
     fn validation_dependency_workspace_errors_when_sibling_missing() {
         crate::test_support::with_isolated_home(|_| {
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
-            let source = workspace_parent.path().join("studio-web");
+            let source = workspace_parent.path().join("host-app");
             fs::create_dir_all(&source).expect("source dir");
             fs::write(
                 source.join("homeboy.json"),
                 serde_json::json!({
-                    "id": "studio-web",
+                    "id": "host-app",
                     "extensions": {
                         "wordpress": {
                             "settings": {
-                                "validation_dependencies": ["agents-api"]
+                                "validation_dependencies": ["shared-runtime"]
                             }
                         }
                     }
@@ -887,7 +887,7 @@ mod tests {
                 validation_dependency_workspaces(&source, &[]).expect_err("missing dependency");
 
             assert_eq!(err.details["field"], "validation_dependencies");
-            assert!(err.message.contains("agents-api"));
+            assert!(err.message.contains("shared-runtime"));
         });
     }
 }


### PR DESCRIPTION
## Summary
- Replace product-specific fixture names in core tests and comments with neutral examples.
- Keep assertions and fixture behavior equivalent while removing Codebox/Agents API/Data Machine-specific naming from generic core coverage.

## Verification
- git diff --check
- git grep -n -E 'wp-coding-agents|agents-api|data-machine|codebox|Codebox|WP Codebox|provider-bundled-agents-api' -- <modified files>
- Did not run local Cargo commands per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Final worktree inspection, verification, commit, push, and PR preparation.