### PR TITLE
Add fuzz replay CLI skeleton

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -8,6 +8,7 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--max-duration <duration>] [-- <runner-args>]
 homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--max-duration <duration>] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
+homeboy fuzz replay [<case>] [--run-id <id>] [-- <runner-args>]
 ```
 
 ## Description
@@ -56,6 +57,11 @@ Runner scripts receive `HOMEBOY_FUZZ_RESULTS_FILE` pointing at
 `homeboy/fuzz-campaign/v1` campaign object there, `homeboy fuzz run` parses it
 and returns it as `results` in the JSON envelope. Malformed JSON fails the run
 instead of being treated as proof.
+
+`homeboy fuzz replay` is reserved for a future generic replay contract. Today it
+returns a product-agnostic `not_implemented` JSON response and does not execute
+local fuzz code. Use the originating fuzz runner's replay command until Homeboy
+owns that contract.
 
 Full-coverage claims need persisted proof artifacts. A neutral coverage summary
 can report declared, executable, and proven counts; operation totals; skipped
@@ -113,8 +119,8 @@ Rigs can add private fuzz workloads keyed by extension id:
 
 ## Output
 
-Both `list` and `run` return JSON envelopes with stable `variant` values:
-`list` and `run`.
+`list`, `run`, and `replay` return JSON envelopes with stable `variant` values:
+`list`, `run`, and `replay`.
 
 `run.execution.results_file` is the path advertised to the runner through
 `HOMEBOY_FUZZ_RESULTS_FILE`. `run.results` is present only when the runner wrote

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -54,6 +54,8 @@ enum FuzzCommand {
     List(FuzzListArgs),
     /// Resolve the selected fuzz workload contract without executing it
     Run(FuzzRunArgs),
+    /// Reserved replay surface for persisted fuzz cases
+    Replay(FuzzReplayArgs),
 }
 
 #[derive(Args, Clone)]
@@ -110,11 +112,27 @@ pub struct FuzzRunArgs {
     args: Vec<String>,
 }
 
+#[derive(Args, Clone)]
+struct FuzzReplayArgs {
+    /// Persisted fuzz case path or case identifier to replay in a future runner.
+    #[arg(value_name = "CASE")]
+    case: Option<String>,
+
+    /// Stable Homeboy run id associated with the persisted fuzz evidence.
+    #[arg(long = "run-id", value_name = "ID")]
+    run_id: Option<String>,
+
+    /// Additional runner arguments reserved for future fuzz replay support.
+    #[arg(last = true)]
+    args: Vec<String>,
+}
+
 #[derive(Serialize)]
 #[serde(tag = "variant", rename_all = "snake_case")]
 pub enum FuzzOutput {
     List(FuzzListOutput),
     Run(FuzzRunOutput),
+    Replay(FuzzReplayOutput),
 }
 
 #[derive(Serialize)]
@@ -144,6 +162,17 @@ pub struct FuzzRunOutput {
     pub results: Option<FuzzCampaign>,
     pub runner_contract: FuzzRunnerContract,
     pub evidence_followups: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct FuzzReplayOutput {
+    pub command: String,
+    pub status: String,
+    pub message: String,
+    pub case: Option<String>,
+    pub run_id: Option<String>,
+    pub passthrough_args: Vec<String>,
+    pub next_steps: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -181,10 +210,30 @@ pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
             let (output, exit) = run_run(run_args)?;
             Ok((FuzzOutput::Run(output), exit))
         }
+        Some(FuzzCommand::Replay(replay_args)) => {
+            Ok((FuzzOutput::Replay(run_replay(replay_args)), 0))
+        }
         None => {
             let (output, exit) = run_run(args.run)?;
             Ok((FuzzOutput::Run(output), exit))
         }
+    }
+}
+
+fn run_replay(args: FuzzReplayArgs) -> FuzzReplayOutput {
+    FuzzReplayOutput {
+        command: "fuzz.replay".to_string(),
+        status: "not_implemented".to_string(),
+        message: "Generic fuzz replay is reserved but not implemented yet; use the originating fuzz runner's replay command for now."
+            .to_string(),
+        case: args.case,
+        run_id: args.run_id,
+        passthrough_args: args.args,
+        next_steps: vec![
+            "Use `homeboy fuzz list <component>` to inspect configured fuzz workloads.".to_string(),
+            "Use `homeboy runs artifacts <run-id>` to locate persisted fuzz evidence when a runner records it."
+                .to_string(),
+        ],
     }
 }
 


### PR DESCRIPTION
## Summary
- adds a reserved `homeboy fuzz replay` subcommand that returns a product-agnostic `not_implemented` JSON response
- keeps replay self-contained without adding core fuzz/capability contracts
- documents the replay stub alongside existing fuzz list/run docs

## Verification
- `git diff --check`
- Did not run Cargo, benchmarks, deploys, or destructive commands per request.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing the CLI stub, updating docs, and preparing the PR.