### PR TITLE
Support manifest-only fuzz capability

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -88,13 +88,16 @@ Extensions declare fuzz support with a product-agnostic capability block:
 ```json
 {
   "fuzz": {
-    "extension_script": "scripts/fuzz.sh",
     "workloads": [
       { "id": "parser", "label": "Parser fuzz" }
     ]
   }
 }
 ```
+
+The `fuzz` block is valid manifest support with only workload metadata. Add
+`"extension_script": "scripts/fuzz.sh"` when the extension is ready to execute
+workloads through `homeboy fuzz run`.
 
 Rigs can add private fuzz workloads keyed by extension id:
 

--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -44,6 +44,7 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
 - **`executable`** (object): Standalone tool runtime, inputs, output schema
 - **`platform`** (object): Platform behavior definitions (database, deployment, version patterns)
 - **`structured_sidecars`** (object): Declares public machine-readable run-directory sidecar contracts
+- **`fuzz`** (object): Declares fuzz workload metadata and, optionally, a runner script
 - **`commands`** (object): Additional CLI commands provided by extension
 - **`actions`** (array): Action definitions for `homeboy extension action`; release actions are normal actions whose IDs start with `release.`
 - **`hooks`** (object): Lifecycle hooks (pre/post version bump, deploy, release)
@@ -208,6 +209,32 @@ Known sidecar names default to these run-directory paths when `path` is omitted:
 ### Inspection Behavior
 
 Core exposes declared sidecars through manifest inspection, including `homeboy extension show <id>` JSON output. Consumers that need machine-readable output should require the matching declaration before relying on a sidecar.
+
+## Fuzz Capability
+
+Extensions declare fuzz workload metadata with a top-level `fuzz` capability block. The block is first-class manifest support even when it only declares workloads. Execution remains opt-in: `extension_script` must be present before Homeboy can run a fuzz workload through an extension runner.
+
+```json
+{
+  "fuzz": {
+    "workloads": [
+      {
+        "id": "parser",
+        "label": "Parser fuzz",
+        "description": "Parser corpus and generated input workload"
+      }
+    ]
+  }
+}
+```
+
+### Fuzz Fields
+
+- **`fuzz.extension_script`** (string): Optional script path, relative to the extension directory, that executes a selected fuzz workload. Omit this for manifest-only workload discovery.
+- **`fuzz.workloads`** (array): Declarative workload entries surfaced by `homeboy fuzz list` and downstream rig/workload tooling.
+- **`fuzz.workloads[].id`** (string): Stable workload identifier.
+- **`fuzz.workloads[].label`** (string): Optional human-readable workload label.
+- **`fuzz.workloads[].description`** (string): Optional workload description.
 
 ## Audit Configuration
 

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -316,6 +316,20 @@ fn run_fuzz_extension_script(
 ) -> homeboy::core::Result<homeboy::core::extension::RunnerOutput> {
     let execution_context =
         extension::resolve_execution_context(&ctx.component, ExtensionCapability::Fuzz)?;
+    if execution_context.script_path.trim().is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "fuzz.extension_script",
+            format!(
+                "Extension '{}' declares fuzz manifest support but no fuzz runner script",
+                execution_context.extension_id
+            ),
+            Some(execution_context.extension_id),
+            None,
+        )
+        .with_hint(
+            "Add fuzz.extension_script to execute workloads, or use `homeboy fuzz list` for manifest-only discovery",
+        ));
+    }
     let mut runner = ExtensionRunner::for_context(execution_context)
         .component(ctx.component.clone())
         .settings(&args.setting_args.setting)

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -92,7 +92,9 @@ impl ExtensionCapability {
     }
 
     pub(crate) fn requires_script(self) -> bool {
-        self != ExtensionCapability::Build
+        // Fuzz supports manifest-only workload discovery; `fuzz run` validates
+        // its runner script before execution.
+        !matches!(self, ExtensionCapability::Build | ExtensionCapability::Fuzz)
     }
 }
 

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -685,10 +685,7 @@ impl ExtensionManifest {
     }
 
     pub fn has_fuzz(&self) -> bool {
-        self.fuzz
-            .as_ref()
-            .and_then(|c| c.extension_script.as_ref())
-            .is_some()
+        self.fuzz.is_some()
     }
 
     pub fn has_trace(&self) -> bool {

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -69,7 +69,7 @@ fn extension_capability_owns_labels_and_scripts() {
         (ExtensionCapability::Test, "test", "test.sh", true),
         (ExtensionCapability::Build, "build", "build.sh", false),
         (ExtensionCapability::Bench, "bench", "bench.sh", true),
-        (ExtensionCapability::Fuzz, "fuzz", "fuzz.sh", true),
+        (ExtensionCapability::Fuzz, "fuzz", "fuzz.sh", false),
         (ExtensionCapability::Trace, "trace", "trace.sh", true),
         (ExtensionCapability::Deps, "deps", "deps.sh", true),
     ] {
@@ -79,6 +79,23 @@ fn extension_capability_owns_labels_and_scripts() {
         assert_eq!(capability.requires_script(), requires_script);
     }
 
+    assert_eq!(manifest.fuzz_workloads()[0].id, "parser");
+}
+
+#[test]
+fn fuzz_manifest_support_does_not_require_execution_script() {
+    let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+        "name": "Example",
+        "version": "0.0.0",
+        "fuzz": {
+            "workloads": [{ "id": "parser", "label": "Parser fuzz" }]
+        }
+    }))
+    .unwrap();
+
+    assert!(ExtensionCapability::Fuzz.has_manifest_support(&manifest));
+    assert_eq!(ExtensionCapability::Fuzz.script_path(&manifest), None);
+    assert!(!ExtensionCapability::Fuzz.requires_script());
     assert_eq!(manifest.fuzz_workloads()[0].id, "parser");
 }
 


### PR DESCRIPTION
## Summary
- Treat a top-level `fuzz` extension manifest block as first-class fuzz capability support, even when it only declares workloads.
- Keep execution gated by `fuzz.extension_script` so manifest-only fuzz declarations can be discovered without adding a runnable fallback.
- Document the manifest-only fuzz shape in command and extension-manifest docs.

## Verification
- `git diff --check`
- Not run: `cargo`/Rust tests, per local instruction not to run cargo on this machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the scoped code/docs changes, adding the manifest accessor test case, and drafting this PR description.
