### PR TITLE
Remove Codebox-flavored provider leakage from core

### DIFF
--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -93,7 +93,7 @@ fn failed_run_status_logs_and_review_include_outcome_diagnostic_summary() {
         for value in [&status_value, &logs_value, &review_value] {
             assert_eq!(
                 value["diagnostic_summary"]["message"],
-                "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+                "Requested provider \"example-oauth\" is not registered. Registered provider plugins: []"
             );
             assert_eq!(value["diagnostic_summary"]["class"], "provider_discovery");
             assert_eq!(value["diagnostic_summary"]["task_id"], "task-a");

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -161,7 +161,7 @@ impl AgentTaskExecutorAdapter for DiagnosticFailureExecutor {
                 evidence_refs: Vec::new(),
                 diagnostics: vec![AgentTaskDiagnostic {
                     class: "provider_discovery".to_string(),
-                    message: "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+                    message: "Requested provider \"example-oauth\" is not registered. Registered provider plugins: []"
                         .to_string(),
                     data: json!({ "registered_provider_plugins": [] }),
                 }],

--- a/src/commands/agent_task_summary/mod.rs
+++ b/src/commands/agent_task_summary/mod.rs
@@ -780,7 +780,7 @@ mod tests {
                     "status": "provider_error",
                     "diagnostics": [{
                         "class": "provider_discovery",
-                        "message": "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+                        "message": "Requested provider \"example-oauth\" is not registered. Registered provider plugins: []"
                     }]
                 }]
             }
@@ -789,7 +789,7 @@ mod tests {
         let summary = render_agent_task_summary(AgentTaskSummaryKind::Review, &payload).unwrap();
 
         assert!(summary.contains(
-            "Diagnostic: Requested provider \"codex\" is not registered. Registered provider plugins: []\n"
+            "Diagnostic: Requested provider \"example-oauth\" is not registered. Registered provider plugins: []\n"
         ));
     }
 
@@ -898,14 +898,14 @@ mod tests {
             "diagnostic_summary": {
                 "task_id": "agent-task-d1622a44",
                 "class": "provider_discovery",
-                "message": "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+                "message": "Requested provider \"example-oauth\" is not registered. Registered provider plugins: []"
             }
         });
 
         let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
 
         assert!(summary.contains(
-            "Diagnostic: Requested provider \"codex\" is not registered. Registered provider plugins: []\n"
+            "Diagnostic: Requested provider \"example-oauth\" is not registered. Registered provider plugins: []\n"
         ));
     }
 
@@ -922,7 +922,7 @@ mod tests {
             "diagnostic_summary": {
                 "task_id": "agent-task-d1622a44",
                 "class": "provider_discovery",
-                "message": "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+                "message": "Requested provider \"example-oauth\" is not registered. Registered provider plugins: []"
             }
         });
 
@@ -930,7 +930,7 @@ mod tests {
 
         assert!(summary.starts_with("Agent task logs\nRun: agent-task-d1622a44\nEvents: 1\n"));
         assert!(summary.contains(
-            "Diagnostic: Requested provider \"codex\" is not registered. Registered provider plugins: []\n"
+            "Diagnostic: Requested provider \"example-oauth\" is not registered. Registered provider plugins: []\n"
         ));
     }
 

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -723,7 +723,7 @@ mod tests {
         assert_eq!(
             materialization_plan.env_passthrough,
             vec![
-                "AI_PROVIDER_OPENAI_CODEX_API_KEY".to_string(),
+                "EXAMPLE_PROVIDER_API_KEY".to_string(),
                 "SAMPLE_RUNTIME_BIN".to_string(),
                 "SAMPLE_RUNTIME_HOME".to_string()
             ]

--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -1198,7 +1198,7 @@ mod tests {
                 "runtime_id": "runtime-a",
                 "backend": "runtime-backend",
                 "selector": "runtime-selector",
-                "provider": "codex",
+                "provider": "example-oauth",
                 "model": "gpt-5.5",
                 "substrate_ref": "sample-runtime://sandbox/123"
             }
@@ -1211,7 +1211,7 @@ mod tests {
         assert_eq!(executor.runtime_id(), Some("runtime-a"));
         assert_eq!(executor.executor_backend(), "runtime-backend");
         assert_eq!(executor.executor_provider_id(), Some("runtime-selector"));
-        assert_eq!(executor.provider(), Some("codex"));
+        assert_eq!(executor.provider(), Some("example-oauth"));
         assert_eq!(executor.model(), Some("gpt-5.5"));
         assert_eq!(
             executor.substrate_ref(),

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -4465,7 +4465,7 @@ process.stdout.write(JSON.stringify({
     fn provider_default_secret_sources_resolve_required_env_without_duplicate_mapping() {
         crate::test_support::with_isolated_home(|_| {
             let temp = tempfile::tempdir().expect("tempdir");
-            let auth_path = temp.path().join("codex-auth.json");
+            let auth_path = temp.path().join("provider-auth.json");
             fs::write(
                 &auth_path,
                 json!({
@@ -4478,22 +4478,22 @@ process.stdout.write(JSON.stringify({
             )
             .expect("write auth");
             let (mut request, mut provider) = request("task-a", "node provider-a.js".to_string());
-            request.executor.config = json!({ "provider": "codex" });
+            request.executor.config = json!({ "provider": "example-oauth" });
             request.executor.secret_env = vec![
-                "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
-                "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN".to_string(),
+                "EXAMPLE_PROVIDER_ACCESS_TOKEN".to_string(),
+                "EXAMPLE_PROVIDER_REFRESH_TOKEN".to_string(),
             ];
             provider.provider_defaults.insert(
-                "codex".to_string(),
+                "example-oauth".to_string(),
                 json!({
                     "secret_env": request.executor.secret_env,
                     "secret_env_sources": {
-                        "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN": {
+                        "EXAMPLE_PROVIDER_ACCESS_TOKEN": {
                             "source": "json-file",
                             "path": auth_path,
                             "field": "tokens.access_token"
                         },
-                        "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN": {
+                        "EXAMPLE_PROVIDER_REFRESH_TOKEN": {
                             "source": "json-file",
                             "path": auth_path,
                             "field": "tokens.refresh_token"
@@ -4505,7 +4505,7 @@ process.stdout.write(JSON.stringify({
             let env = provider_command_env(&request, &provider).expect("provider env resolves");
 
             assert!(env.contains(&(
-                "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
+                "EXAMPLE_PROVIDER_ACCESS_TOKEN".to_string(),
                 "provider-owned-access-token".to_string()
             )));
             let rendered =
@@ -4519,13 +4519,13 @@ process.stdout.write(JSON.stringify({
     fn provider_secret_sources_for_providers_include_default_json_sources() {
         let (_request, mut provider) = request("task-a", "node provider-a.js".to_string());
         provider.provider_defaults.insert(
-            "codex".to_string(),
+            "example-oauth".to_string(),
             json!({
-                "secret_env": ["AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN"],
+                "secret_env": ["EXAMPLE_PROVIDER_ACCESS_TOKEN"],
                 "secret_env_sources": {
-                    "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN": {
+                    "EXAMPLE_PROVIDER_ACCESS_TOKEN": {
                         "source": "json-file",
-                        "path": "~/.codex/auth.json",
+                        "path": "~/.example-provider/auth.json",
                         "field": "tokens.access_token"
                     }
                 }
@@ -4535,10 +4535,10 @@ process.stdout.write(JSON.stringify({
         let sources = provider_secret_sources_for_providers(&[provider]);
 
         let source = sources
-            .get("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN")
+            .get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
             .expect("provider default source discovered");
         assert_eq!(source.source, "json-file");
-        assert_eq!(source.path.as_deref(), Some("~/.codex/auth.json"));
+        assert_eq!(source.path.as_deref(), Some("~/.example-provider/auth.json"));
         assert_eq!(source.field.as_deref(), Some("tokens.access_token"));
     }
 
@@ -4612,7 +4612,7 @@ process.stdout.write(JSON.stringify({
     fn provider_default_secret_sources_feed_secret_readiness_status() {
         crate::test_support::with_isolated_home(|_| {
             let temp = tempfile::tempdir().expect("tempdir");
-            let auth_path = temp.path().join("codex-auth.json");
+            let auth_path = temp.path().join("provider-auth.json");
             fs::write(
                 &auth_path,
                 json!({
@@ -4625,10 +4625,10 @@ process.stdout.write(JSON.stringify({
             .expect("write auth");
             let (_request, mut provider) = request("task-a", "node provider-a.js".to_string());
             provider.provider_defaults.insert(
-                "codex".to_string(),
+                "example-oauth".to_string(),
                 json!({
                     "secret_env_sources": {
-                        "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN": {
+                        "EXAMPLE_PROVIDER_ACCESS_TOKEN": {
                             "source": "json-file",
                             "path": auth_path,
                             "field": "tokens.access_token"
@@ -4639,7 +4639,7 @@ process.stdout.write(JSON.stringify({
             let fallback_sources = provider_secret_sources_for_providers(&[provider]);
 
             let status = crate::core::agent_task_secrets::secret_env_status_with_fallbacks(
-                &["AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string()],
+                &["EXAMPLE_PROVIDER_ACCESS_TOKEN".to_string()],
                 &fallback_sources,
             );
 

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -777,7 +777,7 @@ mod tests {
         let mut cache = HashMap::new();
 
         assert_eq!(
-            source.resolve("AI_PROVIDER_OPENAI_CODEX_FEDRAMP", &mut cache),
+            source.resolve("EXAMPLE_PROVIDER_FEDRAMP", &mut cache),
             Some("false".to_string())
         );
     }
@@ -813,7 +813,7 @@ mod tests {
         let mut cache = HashMap::new();
 
         assert_eq!(
-            source.resolve("AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT", &mut cache),
+            source.resolve("EXAMPLE_PROVIDER_EXPIRES_AT", &mut cache),
             Some("4102444800".to_string())
         );
     }

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -1696,18 +1696,9 @@ fn lab_materialization_proof_metadata(
         "source_snapshot": source_snapshot,
         "source_checkout": source_checkout,
         "runner_homeboy": runner_homeboy,
-        "wp_codebox_version": passive_wp_codebox_version(),
         "workspace_mapping": workspace_mapping,
         "rigs": synced_rigs,
     })
-}
-
-fn passive_wp_codebox_version() -> Option<String> {
-    ["HOMEBOY_WP_CODEBOX_VERSION", "WP_CODEBOX_VERSION"]
-        .into_iter()
-        .find_map(|name| std::env::var(name).ok())
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
 }
 
 fn source_checkout_ref_display(metadata: &serde_json::Value) -> String {
@@ -2726,7 +2717,6 @@ mod tests {
             proof["runner_homeboy"]["active_daemon_version"],
             "homeboy 0.1.0"
         );
-        assert!(proof["wp_codebox_version"].is_null());
     }
 
     #[test]

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -862,7 +862,7 @@ mod tests {
 
     #[test]
     fn declared_agent_task_cook_provider_defaults_include_controller_sources() {
-        let provider = fixture_provider_with_codex_defaults();
+        let provider = fixture_provider_with_example_defaults();
         let args = vec![
             "homeboy".to_string(),
             "agent-task".to_string(),
@@ -870,7 +870,7 @@ mod tests {
             "--backend".to_string(),
             "sample-runtime".to_string(),
             "--provider-config".to_string(),
-            serde_json::json!({ "provider": "codex" }).to_string(),
+            serde_json::json!({ "provider": "example-oauth" }).to_string(),
         ];
 
         let names = declared_agent_task_controller_secret_env_with_providers(
@@ -883,24 +883,24 @@ mod tests {
             std::slice::from_ref(&provider),
         );
 
-        assert!(names.contains(&"AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string()));
+        assert!(names.contains(&"EXAMPLE_PROVIDER_ACCESS_TOKEN".to_string()));
         let source = sources
-            .get("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN")
-            .expect("codex provider default source discovered for cook");
+            .get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
+            .expect("example provider default source discovered for cook");
         assert_eq!(source.source, "json-file");
-        assert_eq!(source.path.as_deref(), Some("~/.codex/auth.json"));
+        assert_eq!(source.path.as_deref(), Some("~/.example-provider/auth.json"));
         assert_eq!(source.field.as_deref(), Some("tokens.access_token"));
     }
 
     #[test]
     fn declared_agent_task_providers_still_include_provider_default_sources() {
-        let provider = fixture_provider_with_codex_defaults();
+        let provider = fixture_provider_with_example_defaults();
         let args = vec![
             "homeboy".to_string(),
             "agent-task".to_string(),
             "providers".to_string(),
             "--secret-env".to_string(),
-            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
+            "EXAMPLE_PROVIDER_ACCESS_TOKEN".to_string(),
         ];
 
         let sources = declared_agent_task_controller_secret_sources_with_providers(
@@ -909,7 +909,7 @@ mod tests {
             std::slice::from_ref(&provider),
         );
 
-        assert!(sources.contains_key("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN"));
+        assert!(sources.contains_key("EXAMPLE_PROVIDER_ACCESS_TOKEN"));
     }
 
     #[test]
@@ -1058,10 +1058,10 @@ mod tests {
 
     #[test]
     fn hydrate_agent_task_secret_env_resolves_provider_default_run_plan_secrets_on_controller() {
-        let _access_token_env = RemovedEnvVar::new("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN");
+        let _access_token_env = RemovedEnvVar::new("EXAMPLE_PROVIDER_ACCESS_TOKEN");
         crate::test_support::with_isolated_home(|_| {
             let temp = tempfile::tempdir().expect("tempdir");
-            let auth_path = temp.path().join("codex-auth.json");
+            let auth_path = temp.path().join("provider-auth.json");
             std::fs::write(
                 &auth_path,
                 serde_json::json!({
@@ -1081,14 +1081,14 @@ mod tests {
                     "tasks": [
                         {
                             "schema": "homeboy/agent-task-request/v1",
-                            "task_id": "codex-task",
+                            "task_id": "provider-task",
                             "executor": {
                                 "backend": "sample-runtime",
                                 "config": {
-                                    "provider": "codex"
+                                    "provider": "example-oauth"
                                 }
                             },
-                            "instructions": "Use Codex credentials."
+                            "instructions": "Use provider credentials."
                         }
                     ]
                 })
@@ -1096,7 +1096,7 @@ mod tests {
             )
             .expect("write plan");
             let provider =
-                fixture_provider_with_codex_defaults_at(&auth_path.display().to_string());
+                fixture_provider_with_example_defaults_at(&auth_path.display().to_string());
             let mut env = HashMap::new();
 
             let diagnostics = hydrate_agent_task_secret_env_with_providers(
@@ -1107,7 +1107,7 @@ mod tests {
             .expect("provider default source should resolve on controller");
 
             assert!(matches!(
-                env.get("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN")
+                env.get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
                     .map(String::as_str),
                 Some("controller-access-token")
             ));
@@ -1119,7 +1119,7 @@ mod tests {
                 diagnostics["secret_env"],
                 serde_json::json!([
                     {
-                        "name": "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+                        "name": "EXAMPLE_PROVIDER_ACCESS_TOKEN",
                         "configured": true,
                         "source": "json-file"
                     }
@@ -1399,18 +1399,18 @@ HOMEBOY_SHARED_MISSING_SECRET_TEST, HOMEBOY_OTHER_MISSING_SECRET_TEST"
         }
     }
 
-    fn fixture_provider_with_codex_defaults() -> AgentTaskExecutorProvider {
-        fixture_provider_with_codex_defaults_at("~/.codex/auth.json")
+    fn fixture_provider_with_example_defaults() -> AgentTaskExecutorProvider {
+        fixture_provider_with_example_defaults_at("~/.example-provider/auth.json")
     }
 
-    fn fixture_provider_with_codex_defaults_at(path: &str) -> AgentTaskExecutorProvider {
+    fn fixture_provider_with_example_defaults_at(path: &str) -> AgentTaskExecutorProvider {
         let mut provider_defaults = std::collections::BTreeMap::new();
         provider_defaults.insert(
-            "codex".to_string(),
+            "example-oauth".to_string(),
             serde_json::json!({
-                "secret_env": ["AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN"],
+                "secret_env": ["EXAMPLE_PROVIDER_ACCESS_TOKEN"],
                 "secret_env_sources": {
-                    "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN": {
+                    "EXAMPLE_PROVIDER_ACCESS_TOKEN": {
                         "source": "json-file",
                         "path": path,
                         "field": "tokens.access_token"
@@ -1421,7 +1421,7 @@ HOMEBOY_SHARED_MISSING_SECRET_TEST, HOMEBOY_OTHER_MISSING_SECRET_TEST"
 
         AgentTaskExecutorProvider {
             schema: "homeboy/agent-task-executor-provider/v1".to_string(),
-            id: "sample-runtime.codex".to_string(),
+            id: "sample-runtime.example-oauth".to_string(),
             label: None,
             backend: "sample-runtime".to_string(),
             default_backend: true,

--- a/src/core/runner/lab_args/envelope.rs
+++ b/src/core/runner/lab_args/envelope.rs
@@ -182,7 +182,7 @@ mod tests {
             "cook".to_string(),
             "--provider-config".to_string(),
             "@config.json".to_string(),
-            "--provider-config={\"provider\":\"codex\"}".to_string(),
+            "--provider-config={\"provider\":\"example-oauth\"}".to_string(),
             "--provider-config=-".to_string(),
             "--".to_string(),
             "--provider-config".to_string(),
@@ -202,7 +202,7 @@ mod tests {
         );
         assert_eq!(
             envelope.inputs.provider_configs[1].value,
-            ArgValue::InlineText("{\"provider\":\"codex\"}".to_string())
+            ArgValue::InlineText("{\"provider\":\"example-oauth\"}".to_string())
         );
         assert_eq!(envelope.inputs.provider_configs[2].value, ArgValue::Stdin);
     }

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -152,8 +152,8 @@ fn spec_has_provider_plugin_paths(spec: &str) -> bool {
 ///
 /// Lab offload only syncs (and records local->remote mappings for) the
 /// directories a cook actually references, so an absolute provider-plugin path
-/// inherited from stale/global controller or runner settings (e.g. a Codex
-/// provider plugin path that is not part of this run's workspace) survives
+/// inherited from stale/global controller or runner settings (e.g. a provider
+/// plugin path that is not part of this run's workspace) survives
 /// remapping unchanged. Forwarding it would make the provider runtime declare
 /// an extra plugin/workspace entry pointing at a directory that does not exist
 /// on the runner, failing runtime validation with a `missing-path` error before the

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -236,10 +236,10 @@ fn remap_prunes_stale_unresolved_provider_plugin_path() {
         remote: "/home/user/_lab_workspaces/sample-plugin@cook-abc".to_string(),
     }];
     let config = serde_json::json!({
-        "provider": "codex",
+        "provider": "example-oauth",
         "provider_plugin_paths": [
             "/Users/user/Developer/sample-plugin@cook/vendor/provider",
-            "/Users/user/Developer/ai-provider-for-openai-codex-oauth-provider"
+            "/Users/user/Developer/example-oauth-provider"
         ]
     })
     .to_string();
@@ -276,9 +276,9 @@ fn remap_prunes_all_provider_plugin_paths_when_no_mappings() {
     // unresolvable on the runner and must be pruned so recipe validation never
     // sees a missing extra-plugin path. The array stays present but empty.
     let config = serde_json::json!({
-        "provider": "codex",
+        "provider": "example-oauth",
         "provider_plugin_paths": [
-            "/home/chubes/Developer/ai-provider-for-openai-codex-oauth-provider"
+            "/home/chubes/Developer/example-oauth-provider"
         ]
     })
     .to_string();
@@ -302,7 +302,7 @@ fn remap_prunes_all_provider_plugin_paths_when_no_mappings() {
         0
     );
     // Unrelated config is preserved.
-    assert_eq!(remapped["provider"], "codex");
+    assert_eq!(remapped["provider"], "example-oauth");
 }
 
 #[test]
@@ -342,10 +342,10 @@ fn injects_default_provider_config_for_agent_task_cook() {
     crate::test_support::with_isolated_home(|_| {
         defaults::save_config(&defaults::HomeboyConfig {
             settings: HashMap::from([
-                ("provider".to_string(), serde_json::json!("codex")),
+                ("provider".to_string(), serde_json::json!("example-oauth")),
                 (
                     "provider_plugin_paths".to_string(),
-                    serde_json::json!(["/Users/user/Developer/ai-provider-for-openai@codex"]),
+                    serde_json::json!(["/Users/user/Developer/example-provider@oauth"]),
                 ),
             ]),
             ..defaults::HomeboyConfig::default()
@@ -368,10 +368,10 @@ fn injects_default_provider_config_for_agent_task_cook() {
             + 1;
         let config: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("config");
 
-        assert_eq!(config["provider"], "codex");
+        assert_eq!(config["provider"], "example-oauth");
         assert_eq!(
             config["provider_plugin_paths"][0],
-            "/Users/user/Developer/ai-provider-for-openai@codex"
+            "/Users/user/Developer/example-provider@oauth"
         );
         assert!(out.iter().any(|arg| arg == "--prompt"));
     });
@@ -383,7 +383,7 @@ fn injected_default_provider_config_is_remappable() {
         defaults::save_config(&defaults::HomeboyConfig {
             settings: HashMap::from([(
                 "provider_plugin_paths".to_string(),
-                serde_json::json!(["/Users/user/Developer/ai-provider-for-openai@codex"]),
+                serde_json::json!(["/Users/user/Developer/example-provider@oauth"]),
             )]),
             ..defaults::HomeboyConfig::default()
         })
@@ -400,8 +400,8 @@ fn injected_default_provider_config_is_remappable() {
         let remapped = remap_provider_config_in_args(
             &injected,
             &[LabPathRemap {
-                local: "/Users/user/Developer/ai-provider-for-openai@codex".to_string(),
-                remote: "/home/user/Developer/_lab_workspaces/ai-provider-for-openai@codex"
+                local: "/Users/user/Developer/example-provider@oauth".to_string(),
+                remote: "/home/user/Developer/_lab_workspaces/example-provider@oauth"
                     .to_string(),
             }],
         );
@@ -414,7 +414,7 @@ fn injected_default_provider_config_is_remappable() {
 
         assert_eq!(
             config["provider_plugin_paths"][0],
-            "/home/user/Developer/_lab_workspaces/ai-provider-for-openai@codex"
+            "/home/user/Developer/_lab_workspaces/example-provider@oauth"
         );
     });
 }
@@ -425,7 +425,7 @@ fn explicit_provider_config_prevents_default_injection() {
         defaults::save_config(&defaults::HomeboyConfig {
             settings: HashMap::from([(
                 "provider_plugin_paths".to_string(),
-                serde_json::json!(["/Users/user/Developer/ai-provider-for-openai@codex"]),
+                serde_json::json!(["/Users/user/Developer/example-provider@oauth"]),
             )]),
             ..defaults::HomeboyConfig::default()
         })

--- a/src/core/secret_env_plan.rs
+++ b/src/core/secret_env_plan.rs
@@ -489,15 +489,15 @@ mod tests {
     fn secret_env_plan_redacts_secret_values_without_storing_them() {
         let mut provider_credentials = BTreeMap::new();
         provider_credentials.insert(
-            "codex".to_string(),
+            "example-oauth".to_string(),
             SecretEnvProviderCredentialMapping {
-                secret_env: vec!["CODEX_REFRESH_TOKEN".to_string()],
+                secret_env: vec!["EXAMPLE_PROVIDER_REFRESH_TOKEN".to_string()],
                 sources: BTreeMap::from([(
-                    "CODEX_REFRESH_TOKEN".to_string(),
+                    "EXAMPLE_PROVIDER_REFRESH_TOKEN".to_string(),
                     SecretEnvCredentialSource {
                         source: "keychain-bundle".to_string(),
                         scope: Some("agent-task".to_string()),
-                        name: Some("codex-oauth".to_string()),
+                        name: Some("example-oauth".to_string()),
                         field: Some("refresh_token".to_string()),
                         env_var: None,
                     },
@@ -522,7 +522,7 @@ mod tests {
             Some(&"https://example.test/?token=[REDACTED]&ok=1".to_string())
         );
         assert_eq!(
-            redacted.get("CODEX_REFRESH_TOKEN"),
+            redacted.get("EXAMPLE_PROVIDER_REFRESH_TOKEN"),
             Some(&"[REDACTED]".to_string())
         );
     }

--- a/tests/fixtures/sample_runtime_materialization_manifest.json
+++ b/tests/fixtures/sample_runtime_materialization_manifest.json
@@ -34,7 +34,7 @@
       {
         "id": "sample-runtime.ready",
         "label": "Sample Runtime available",
-        "secret_env": ["AI_PROVIDER_OPENAI_CODEX_API_KEY"],
+        "secret_env": ["EXAMPLE_PROVIDER_API_KEY"],
         "env_path": {
           "env": ["SAMPLE_RUNTIME_HOME"],
           "revision": true,
@@ -50,7 +50,7 @@
     "env_passthrough": [
       "SAMPLE_RUNTIME_HOME",
       "SAMPLE_RUNTIME_BIN",
-      "AI_PROVIDER_OPENAI_CODEX_API_KEY"
+      "EXAMPLE_PROVIDER_API_KEY"
     ],
     "workspace": {
       "cwd": "git_checkout",


### PR DESCRIPTION
## Summary
- remove the WP Codebox version probe from lab materialization proof metadata
- replace Codebox/Codex-flavored provider fixture data with neutral example provider values
- keep provider preflight/secret/default mechanics generic and fixture-driven

## Verification
- `git diff --check`
- searched `src/` and `tests/` for `codebox`, `WP_CODEBOX`, `wp_codebox`, `codex`, and `AI_PROVIDER_OPENAI_CODEX`

## Tests not run
- Rust test suite not run locally because this environment forbids local `cargo` commands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via opencode
- **Used for:** Implementing the code/test fixture cleanup, inspecting diffs, and drafting this PR description.