### PR TITLE
Refactor fleet metadata through command adapter

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -9,7 +9,7 @@
 //! `lab_runner_unsupported_reason`, `lab_offload_mutation_flag`).
 
 use crate::cli_surface::Commands;
-use crate::command_contract::CommandDescriptor;
+use crate::command_contract::{CommandDescriptor, CommandOutputFileMode};
 use crate::commands::agent_task;
 use crate::core::agent_tasks::provider::{default_backend, provider_requires_cwd_git_checkout};
 use crate::core::engine::execution_context::{self, ResolveOptions};
@@ -344,7 +344,9 @@ impl Commands {
             Commands::Extension(args) if args.is_update_command() => {
                 LabCommandContract::explicit_runner_simple("extension update")
             }
-            Commands::Fleet(args) => args.lab_contract()?,
+            Commands::Fleet(args) => {
+                crate::commands::fleet::adapter(CommandOutputFileMode::None).lab_contract(args)?
+            }
             Commands::Lint(args) => args.lab_contract()?,
             Commands::Review(args) => args.lab_contract(),
             Commands::Refactor(args) if args.is_hot_resource_command() => {

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
 
-use crate::command_contract::{CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode};
+use crate::command_contract::{
+    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
+};
 
 use crate::cli_surface::Commands;
 
@@ -8,6 +10,7 @@ use super::{fleet, version, GlobalArgs};
 
 pub(crate) type JsonCommandRun = (homeboy::core::Result<Value>, i32);
 pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonCommandRun;
+pub(crate) type LabContractResolver<Args> = fn(&Args) -> Option<LabCommandContract>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CommandLabRunnerPolicy {
@@ -39,9 +42,17 @@ impl CommandAdapterContract {
     }
 }
 
+/// Adapter-owned metadata for a parsed command family.
+///
+/// New command migrations should keep output contract, JSON dispatch, raw
+/// dispatch hooks, and Lab policy together in the command module's adapter. The
+/// top-level dispatch modules should only bind the parsed enum variant to that
+/// adapter, so follow-up PRs can migrate one family at a time without changing
+/// public CLI behavior.
 pub(crate) struct TypedCommandAdapter<Args> {
     pub contract: CommandAdapterContract,
     pub execute_json: Option<JsonCommandExecutor<Args>>,
+    pub lab_contract: Option<LabContractResolver<Args>>,
 }
 
 pub(crate) struct BoundCommandAdapter {
@@ -80,7 +91,17 @@ impl<Args> TypedCommandAdapter<Args> {
                 lab_runner: CommandLabRunnerPolicy::LOCAL,
             },
             execute_json: Some(execute_json),
+            lab_contract: None,
         }
+    }
+
+    pub fn with_lab_contract(mut self, lab_contract: LabContractResolver<Args>) -> Self {
+        self.lab_contract = Some(lab_contract);
+        self
+    }
+
+    pub fn lab_contract(&self, args: &Args) -> Option<LabCommandContract> {
+        self.lab_contract.and_then(|resolver| resolver(args))
     }
 }
 
@@ -108,7 +129,9 @@ pub(crate) fn command_adapter(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::command_contract::{CommandOutputContractKind, CommandResponseMode};
+    use crate::command_contract::{
+        CommandOutputContractKind, CommandResponseMode, LabCommandPortability,
+    };
     use clap::Parser;
 
     fn parsed_command(args: &[&str]) -> Commands {
@@ -150,5 +173,36 @@ mod tests {
         assert!(
             command_adapter(Commands::List { json: false }, CommandOutputFileMode::None).is_err()
         );
+    }
+
+    #[test]
+    fn fleet_adapter_owns_hot_exec_lab_contract() {
+        let Commands::Fleet(args) = parsed_command(&[
+            "homeboy", "fleet", "exec", "--apply", "growth", "wp", "plugin", "list",
+        ]) else {
+            panic!("expected parsed fleet command");
+        };
+
+        let contract = fleet::adapter(CommandOutputFileMode::None)
+            .lab_contract(&args)
+            .expect("hot fleet exec should declare a Lab contract");
+
+        assert_eq!(contract.hot_label, "fleet exec");
+        assert!(matches!(
+            contract.portability,
+            LabCommandPortability::LocalOnly(reason)
+                if reason.contains("runner-side config parity")
+        ));
+    }
+
+    #[test]
+    fn fleet_adapter_leaves_cold_commands_without_lab_contract() {
+        let Commands::Fleet(args) = parsed_command(&["homeboy", "fleet", "list"]) else {
+            panic!("expected parsed fleet command");
+        };
+
+        assert!(fleet::adapter(CommandOutputFileMode::None)
+            .lab_contract(&args)
+            .is_none());
     }
 }

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -19,12 +19,6 @@ pub struct FleetArgs {
 }
 
 impl FleetArgs {
-    pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
-        self.is_hot_resource_command().then(|| {
-            LabCommandContract::local_only("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON)
-        })
-    }
-
     pub fn is_hot_resource_command(&self) -> bool {
         matches!(
             self.command,
@@ -202,10 +196,16 @@ pub(crate) fn adapter(
     output_file_mode: CommandOutputFileMode,
 ) -> adapter::TypedCommandAdapter<FleetArgs> {
     adapter::TypedCommandAdapter::json_only(CommandJsonFamily::Ops, output_file_mode, run_json)
+        .with_lab_contract(lab_contract)
 }
 
 fn run_json(args: FleetArgs, global: &super::GlobalArgs) -> adapter::JsonCommandRun {
     crate::commands::utils::response::map_cmd_result_to_json(run(args, global))
+}
+
+fn lab_contract(args: &FleetArgs) -> Option<LabCommandContract> {
+    args.is_hot_resource_command()
+        .then(|| LabCommandContract::local_only("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON))
 }
 
 fn create(


### PR DESCRIPTION
## Summary
- add an optional Lab contract resolver to typed command adapters
- move fleet's hot `fleet exec --apply` Lab local-only policy into the fleet adapter
- document the adapter-owned metadata pattern and add focused adapter tests for fleet Lab policy

## Verification
- `rustfmt --check src/commands/adapter.rs src/commands/fleet.rs src/command_contract/lab.rs`
- `git diff --check`

Rust compile/tests were not run locally because this task explicitly prohibited local `cargo` commands on the Studio machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Refactoring the command adapter seam, adding focused tests, and preparing this PR.