### PR TITLE
Add review audit profile override

### DIFF
--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -67,6 +67,11 @@ pub struct ReviewArgs {
     #[arg(long, value_name = "ID")]
     pub ci_profile: Option<String>,
 
+    /// Audit detector profile for the audit stage. Defaults to `pr` for
+    /// changed-file review and `full` for full review.
+    #[arg(long, value_name = "PROFILE", value_parser = ["full", "pr", "architecture"])]
+    pub audit_profile: Option<String>,
+
     /// Output format. Default JSON envelope; `--report=pr-comment` emits a
     /// markdown PR-comment section instead, suitable for piping to
     /// `homeboy git pr comment --body-file`.
@@ -148,11 +153,9 @@ impl<Args, Output: Serialize + ReviewArtifactFindings> ReviewStageDescriptor<Arg
             component_label,
             scope_flag_suffix(review_args, self.include_changed_only_scope),
         );
-        if self.name == "audit"
-            && (review_args.changed_since.is_some()
-                || review_context.precomputed_changed_files().is_some())
-        {
-            hint.push_str(" --profile=pr");
+        if self.name == "audit" {
+            hint.push_str(" --profile=");
+            hint.push_str(&selected_audit_profile(review_args, review_context));
         }
 
         Ok((
@@ -509,13 +512,7 @@ fn build_audit_args(
         conventions: false,
         only: Vec::new(),
         exclude: Vec::new(),
-        profile: if args.changed_since.is_some()
-            || review_context.precomputed_changed_files().is_some()
-        {
-            "pr".to_string()
-        } else {
-            "full".to_string()
-        },
+        profile: selected_audit_profile(args, review_context),
         baseline_args: args.baseline_args.clone(),
         changed_since: args.changed_since.clone(),
         precomputed_changed_files: review_context
@@ -524,6 +521,16 @@ fn build_audit_args(
         json_summary: args.summary,
         fixability: false,
     }
+}
+
+fn selected_audit_profile(args: &ReviewArgs, review_context: &ReviewExecutionContext) -> String {
+    args.audit_profile.clone().unwrap_or_else(|| {
+        if args.changed_since.is_some() || review_context.precomputed_changed_files().is_some() {
+            "pr".to_string()
+        } else {
+            "full".to_string()
+        }
+    })
 }
 
 fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -> lint::LintArgs {
@@ -914,6 +921,7 @@ mod tests {
             changed_only: false,
             summary: false,
             ci_profile: None,
+            audit_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
@@ -935,6 +943,7 @@ mod tests {
             changed_only: true,
             summary: false,
             ci_profile: None,
+            audit_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
@@ -958,6 +967,7 @@ mod tests {
             changed_only: false,
             summary: false,
             ci_profile: None,
+            audit_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
@@ -1033,6 +1043,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn review_audit_profile_override_takes_precedence() {
+        let mut args = review_args_fixture();
+        args.changed_since = Some("origin/main".to_string());
+        args.audit_profile = Some("architecture".to_string());
+        let review_context = ReviewExecutionContext {
+            scope: "changed since origin/main".to_string(),
+            changed_file_count: Some(1),
+            precomputed_changed_files: None,
+        };
+
+        assert_eq!(
+            build_audit_args(&args, &review_context).profile,
+            "architecture"
+        );
+    }
+
     fn review_args_fixture() -> ReviewArgs {
         ReviewArgs {
             comp: PositionalComponentArgs {
@@ -1044,6 +1071,7 @@ mod tests {
             changed_only: false,
             summary: false,
             ci_profile: None,
+            audit_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),

--- a/src/commands/review/observation.rs
+++ b/src/commands/review/observation.rs
@@ -196,6 +196,7 @@ mod tests {
             changed_only: false,
             summary: true,
             ci_profile: None,
+            audit_profile: None,
             report: Some("pr-comment".to_string()),
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),


### PR DESCRIPTION
## Summary
- Adds `review --audit-profile <full|pr|architecture>` to make the audit stage profile explicit.
- Keeps the cheap `pr` audit profile as the default for changed-file review and `full` for full review.
- Updates review deep-dive hints and targeted tests to reflect selected audit profiles.

## Verification
- `git diff --check` passed.
- `rustfmt --edition 2021 src/commands/review/mod.rs src/commands/review/observation.rs` passed.
- `homeboy test --runner homeboy-lab --changed-since origin/main --skip-lint` could not run: Homeboy reports `test --changed-since` is local-only and unavailable for `--runner`.
- `homeboy test --runner homeboy-lab --skip-lint -- review_audit_profile_override_takes_precedence changed_since_review_uses_pr_audit_profile full_review_uses_full_audit_profile` offloaded to Lab, but failed before tests ran due to unrelated compile errors in `src/core/runner/...` `RunnerExecOutput` initializers. Persisted run: `runner-exec-homeboy-lab-c8c7cd08-1b97-4f2a-ba35-a95433ec2518`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing the review audit profile override, updating tests, and running verification.