### PR TITLE
Fix file edit dry-run contract

### DIFF
--- a/src/commands/file/mod.rs
+++ b/src/commands/file/mod.rs
@@ -445,12 +445,13 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
     let EditArgs {
         project_id,
         file_path,
-        dry_run: _,
-        force: _,
+        dry_run,
+        force,
         line_ops,
         pattern_ops,
         file_mods,
     } = args;
+    let edit_options = files::EditOptions { dry_run, force };
 
     let result = if let Some(line_num) = line_ops.replace_line {
         let content = line_ops.replace_line_content.ok_or_else(|| {
@@ -461,7 +462,13 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
                 None,
             )
         })?;
-        files::edit_replace_line(&project_id, &file_path, line_num, &content)?
+        files::edit_replace_line_with_options(
+            &project_id,
+            &file_path,
+            line_num,
+            &content,
+            edit_options,
+        )?
     } else if let Some(line_num) = line_ops.insert_after {
         let content = line_ops.insert_after_content.ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
@@ -471,7 +478,13 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
                 None,
             )
         })?;
-        files::edit_insert_after_line(&project_id, &file_path, line_num, &content)?
+        files::edit_insert_after_line_with_options(
+            &project_id,
+            &file_path,
+            line_num,
+            &content,
+            edit_options,
+        )?
     } else if let Some(line_num) = line_ops.insert_before {
         let content = line_ops.insert_before_content.ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
@@ -481,9 +494,15 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
                 None,
             )
         })?;
-        files::edit_insert_before_line(&project_id, &file_path, line_num, &content)?
+        files::edit_insert_before_line_with_options(
+            &project_id,
+            &file_path,
+            line_num,
+            &content,
+            edit_options,
+        )?
     } else if let Some(line_num) = line_ops.delete_line {
-        files::edit_delete_line(&project_id, &file_path, line_num)?
+        files::edit_delete_line_with_options(&project_id, &file_path, line_num, edit_options)?
     } else if let Some(lines) = line_ops.delete_lines {
         if lines.len() != 2 {
             return Err(homeboy::core::Error::validation_invalid_argument(
@@ -493,7 +512,13 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
                 None,
             ));
         }
-        files::edit_delete_lines(&project_id, &file_path, lines[0], lines[1])?
+        files::edit_delete_lines_with_options(
+            &project_id,
+            &file_path,
+            lines[0],
+            lines[1],
+            edit_options,
+        )?
     } else if let Some(pattern) = pattern_ops.replace_pattern {
         let replacement = pattern_ops.replace_pattern_content.ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
@@ -503,7 +528,14 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
                 None,
             )
         })?;
-        files::edit_replace_pattern(&project_id, &file_path, &pattern, &replacement, false)?
+        files::edit_replace_pattern_with_options(
+            &project_id,
+            &file_path,
+            &pattern,
+            &replacement,
+            false,
+            edit_options,
+        )?
     } else if let Some(pattern) = pattern_ops.replace_all_pattern {
         let replacement = pattern_ops.replace_all_content.ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
@@ -513,13 +545,20 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
                 None,
             )
         })?;
-        files::edit_replace_pattern(&project_id, &file_path, &pattern, &replacement, true)?
+        files::edit_replace_pattern_with_options(
+            &project_id,
+            &file_path,
+            &pattern,
+            &replacement,
+            true,
+            edit_options,
+        )?
     } else if let Some(pattern) = pattern_ops.delete_pattern {
-        files::edit_delete_pattern(&project_id, &file_path, &pattern)?
+        files::edit_delete_pattern_with_options(&project_id, &file_path, &pattern, edit_options)?
     } else if let Some(content) = file_mods.append {
-        files::edit_append(&project_id, &file_path, &content)?
+        files::edit_append_with_options(&project_id, &file_path, &content, edit_options)?
     } else if let Some(content) = file_mods.prepend {
-        files::edit_prepend(&project_id, &file_path, &content)?
+        files::edit_prepend_with_options(&project_id, &file_path, &content, edit_options)?
     } else {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "operation",
@@ -537,6 +576,7 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
             project_id: project_id.to_string(),
             base_path: result.base_path,
             path: result.path,
+            dry_run,
             changes_made: result.changes_made,
             change_count,
             success: result.success,

--- a/src/commands/file/output.rs
+++ b/src/commands/file/output.rs
@@ -58,6 +58,8 @@ pub struct FileEditOutput {
     pub(crate) project_id: String,
     pub(crate) base_path: Option<String>,
     pub(crate) path: String,
+    #[serde(skip_serializing_if = "is_false")]
+    pub(crate) dry_run: bool,
     pub(crate) changes_made: Vec<LineChange>,
     pub(crate) change_count: usize,
     pub(crate) success: bool,

--- a/src/core/project/files.rs
+++ b/src/core/project/files.rs
@@ -23,9 +23,12 @@ mod edit;
 const STDIN_CONTENT_LIMIT_BYTES: u64 = 1024 * 1024;
 
 pub use edit::{
-    edit_append, edit_delete_line, edit_delete_lines, edit_delete_pattern, edit_insert_after_line,
-    edit_insert_before_line, edit_prepend, edit_replace_line, edit_replace_pattern, EditResult,
-    LineChange,
+    edit_append, edit_append_with_options, edit_delete_line, edit_delete_line_with_options,
+    edit_delete_lines, edit_delete_lines_with_options, edit_delete_pattern,
+    edit_delete_pattern_with_options, edit_insert_after_line, edit_insert_after_line_with_options,
+    edit_insert_before_line, edit_insert_before_line_with_options, edit_prepend,
+    edit_prepend_with_options, edit_replace_line, edit_replace_line_with_options,
+    edit_replace_pattern, edit_replace_pattern_with_options, EditOptions, EditResult, LineChange,
 };
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/core/project/files/edit.rs
+++ b/src/core/project/files/edit.rs
@@ -8,6 +8,25 @@ use crate::core::project;
 
 use super::{read, write};
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EditOptions {
+    pub dry_run: bool,
+    pub force: bool,
+}
+
+fn write_modified_content(
+    project_id: &str,
+    path: &str,
+    content: &str,
+    options: EditOptions,
+) -> Result<()> {
+    if options.dry_run {
+        return Ok(());
+    }
+
+    write(project_id, path, content).map(|_| ())
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct EditResult {
     pub base_path: Option<String>,
@@ -32,6 +51,16 @@ pub fn edit_replace_line(
     path: &str,
     line_num: usize,
     content: &str,
+) -> Result<EditResult> {
+    edit_replace_line_with_options(project_id, path, line_num, content, EditOptions::default())
+}
+
+pub fn edit_replace_line_with_options(
+    project_id: &str,
+    path: &str,
+    line_num: usize,
+    content: &str,
+    options: EditOptions,
 ) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
@@ -60,7 +89,7 @@ pub fn edit_replace_line(
     modified_lines[line_index] = content.to_string();
 
     let modified_content = modified_lines.join("\n");
-    write(project_id, path, &modified_content)?;
+    write_modified_content(project_id, path, &modified_content, options)?;
 
     let changes = vec![LineChange {
         line_number: line_num,
@@ -85,6 +114,16 @@ pub fn edit_insert_after_line(
     path: &str,
     line_num: usize,
     content: &str,
+) -> Result<EditResult> {
+    edit_insert_after_line_with_options(project_id, path, line_num, content, EditOptions::default())
+}
+
+pub fn edit_insert_after_line_with_options(
+    project_id: &str,
+    path: &str,
+    line_num: usize,
+    content: &str,
+    options: EditOptions,
 ) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
@@ -111,7 +150,7 @@ pub fn edit_insert_after_line(
     modified_lines.insert(line_num, content.to_string());
 
     let modified_content = modified_lines.join("\n");
-    write(project_id, path, &modified_content)?;
+    write_modified_content(project_id, path, &modified_content, options)?;
 
     let changes = vec![LineChange {
         line_number: line_num + 1,
@@ -136,6 +175,22 @@ pub fn edit_insert_before_line(
     path: &str,
     line_num: usize,
     content: &str,
+) -> Result<EditResult> {
+    edit_insert_before_line_with_options(
+        project_id,
+        path,
+        line_num,
+        content,
+        EditOptions::default(),
+    )
+}
+
+pub fn edit_insert_before_line_with_options(
+    project_id: &str,
+    path: &str,
+    line_num: usize,
+    content: &str,
+    options: EditOptions,
 ) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
@@ -162,7 +217,7 @@ pub fn edit_insert_before_line(
     modified_lines.insert(line_num - 1, content.to_string());
 
     let modified_content = modified_lines.join("\n");
-    write(project_id, path, &modified_content)?;
+    write_modified_content(project_id, path, &modified_content, options)?;
 
     let changes = vec![LineChange {
         line_number: line_num,
@@ -183,6 +238,15 @@ pub fn edit_insert_before_line(
 }
 
 pub fn edit_delete_line(project_id: &str, path: &str, line_num: usize) -> Result<EditResult> {
+    edit_delete_line_with_options(project_id, path, line_num, EditOptions::default())
+}
+
+pub fn edit_delete_line_with_options(
+    project_id: &str,
+    path: &str,
+    line_num: usize,
+    options: EditOptions,
+) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
     let full_path =
@@ -208,7 +272,7 @@ pub fn edit_delete_line(project_id: &str, path: &str, line_num: usize) -> Result
     let removed_content = modified_lines.remove(line_num - 1);
 
     let modified_content = modified_lines.join("\n");
-    write(project_id, path, &modified_content)?;
+    write_modified_content(project_id, path, &modified_content, options)?;
 
     let changes = vec![LineChange {
         line_number: line_num,
@@ -233,6 +297,22 @@ pub fn edit_delete_lines(
     path: &str,
     start_line: usize,
     end_line: usize,
+) -> Result<EditResult> {
+    edit_delete_lines_with_options(
+        project_id,
+        path,
+        start_line,
+        end_line,
+        EditOptions::default(),
+    )
+}
+
+pub fn edit_delete_lines_with_options(
+    project_id: &str,
+    path: &str,
+    start_line: usize,
+    end_line: usize,
+    options: EditOptions,
 ) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
@@ -267,7 +347,7 @@ pub fn edit_delete_lines(
     let removed_lines: Vec<String> = modified_lines.drain(start_index..end_index).collect();
 
     let modified_content = modified_lines.join("\n");
-    write(project_id, path, &modified_content)?;
+    write_modified_content(project_id, path, &modified_content, options)?;
 
     let changes: Vec<LineChange> = removed_lines
         .iter()
@@ -298,6 +378,24 @@ pub fn edit_replace_pattern(
     replacement: &str,
     all: bool,
 ) -> Result<EditResult> {
+    edit_replace_pattern_with_options(
+        project_id,
+        path,
+        pattern,
+        replacement,
+        all,
+        EditOptions::default(),
+    )
+}
+
+pub fn edit_replace_pattern_with_options(
+    project_id: &str,
+    path: &str,
+    pattern: &str,
+    replacement: &str,
+    all: bool,
+    options: EditOptions,
+) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
     let full_path =
@@ -306,13 +404,26 @@ pub fn edit_replace_pattern(
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();
 
+    let match_count = read_result.content.matches(pattern).count();
+    if !all && match_count > 1 && !options.force {
+        return Err(Error::validation_invalid_argument(
+            "replace_pattern",
+            format!(
+                "Pattern matches {} times; use --replace-all-pattern or --force to replace only the first match",
+                match_count
+            ),
+            None,
+            None,
+        ));
+    }
+
     let modified_content = if all {
         read_result.content.replace(pattern, replacement)
     } else {
         read_result.content.replacen(pattern, replacement, 1)
     };
 
-    write(project_id, path, &modified_content)?;
+    write_modified_content(project_id, path, &modified_content, options)?;
 
     let modified_lines: Vec<String> = modified_content.lines().map(String::from).collect();
 
@@ -346,6 +457,15 @@ pub fn edit_replace_pattern(
 }
 
 pub fn edit_delete_pattern(project_id: &str, path: &str, pattern: &str) -> Result<EditResult> {
+    edit_delete_pattern_with_options(project_id, path, pattern, EditOptions::default())
+}
+
+pub fn edit_delete_pattern_with_options(
+    project_id: &str,
+    path: &str,
+    pattern: &str,
+    options: EditOptions,
+) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
     let full_path =
@@ -361,7 +481,7 @@ pub fn edit_delete_pattern(project_id: &str, path: &str, pattern: &str) -> Resul
         .collect();
 
     let modified_content = modified_lines.join("\n");
-    write(project_id, path, &modified_content)?;
+    write_modified_content(project_id, path, &modified_content, options)?;
 
     let changes: Vec<LineChange> = original_lines
         .iter()
@@ -387,6 +507,15 @@ pub fn edit_delete_pattern(project_id: &str, path: &str, pattern: &str) -> Resul
 }
 
 pub fn edit_append(project_id: &str, path: &str, content: &str) -> Result<EditResult> {
+    edit_append_with_options(project_id, path, content, EditOptions::default())
+}
+
+pub fn edit_append_with_options(
+    project_id: &str,
+    path: &str,
+    content: &str,
+    options: EditOptions,
+) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
     let full_path =
@@ -401,8 +530,10 @@ pub fn edit_append(project_id: &str, path: &str, content: &str) -> Result<EditRe
         shell::quote_path(&full_path)
     );
 
-    let output = execute_for_project(&project, &command)?;
-    command::require_success(output.success, &output.stderr, "EDIT")?;
+    if !options.dry_run {
+        let output = execute_for_project(&project, &command)?;
+        command::require_success(output.success, &output.stderr, "EDIT")?;
+    }
 
     let mut modified_lines = original_lines.clone();
     modified_lines.push(content.to_string());
@@ -426,6 +557,15 @@ pub fn edit_append(project_id: &str, path: &str, content: &str) -> Result<EditRe
 }
 
 pub fn edit_prepend(project_id: &str, path: &str, content: &str) -> Result<EditResult> {
+    edit_prepend_with_options(project_id, path, content, EditOptions::default())
+}
+
+pub fn edit_prepend_with_options(
+    project_id: &str,
+    path: &str,
+    content: &str,
+    options: EditOptions,
+) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
     let full_path =
@@ -441,8 +581,10 @@ pub fn edit_prepend(project_id: &str, path: &str, content: &str) -> Result<EditR
         shell::quote_path(&full_path)
     );
 
-    let output = execute_for_project(&project, &command)?;
-    command::require_success(output.success, &output.stderr, "EDIT")?;
+    if !options.dry_run {
+        let output = execute_for_project(&project, &command)?;
+        command::require_success(output.success, &output.stderr, "EDIT")?;
+    }
 
     let mut modified_lines = original_lines.clone();
     modified_lines.insert(0, content.to_string());

--- a/tests/commands/file_test.rs
+++ b/tests/commands/file_test.rs
@@ -1,6 +1,25 @@
+use super::args::{EditArgs, FileModifications, LineOperations, PatternOperations};
 use super::{run, FileArgs, FileCommand, FileCommandOutput};
 use crate::commands::GlobalArgs;
 use crate::test_support::with_isolated_home;
+use std::path::Path;
+
+fn write_project_config(home: &Path, project_id: &str, project_root: &Path) {
+    let project_dir = home
+        .join(".config")
+        .join("homeboy")
+        .join("projects")
+        .join(project_id);
+    std::fs::create_dir_all(&project_dir).expect("create project config dir");
+    let config = serde_json::json!({
+        "base_path": project_root.to_string_lossy(),
+    });
+    std::fs::write(
+        project_dir.join(format!("{project_id}.json")),
+        serde_json::to_vec(&config).expect("serialize project config"),
+    )
+    .expect("write project config");
+}
 
 #[test]
 fn file_read_json_includes_size_metadata() {
@@ -11,21 +30,7 @@ fn file_read_json_includes_size_metadata() {
     std::fs::write(project_root.path().join("sample.txt"), content).expect("write sample file");
 
     let result = with_isolated_home(|home| {
-        let project_dir = home
-            .path()
-            .join(".config")
-            .join("homeboy")
-            .join("projects")
-            .join(project_id);
-        std::fs::create_dir_all(&project_dir).expect("create project config dir");
-        let config = serde_json::json!({
-            "base_path": project_root.path().to_string_lossy(),
-        });
-        std::fs::write(
-            project_dir.join(format!("{project_id}.json")),
-            serde_json::to_vec(&config).expect("serialize project config"),
-        )
-        .expect("write project config");
+        write_project_config(home.path(), project_id, project_root.path());
 
         run(
             FileArgs {
@@ -64,21 +69,7 @@ fn file_delete_without_apply_returns_plan_and_preserves_file() {
     std::fs::write(&file_path, "keep me").expect("write sample file");
 
     let result = with_isolated_home(|home| {
-        let project_dir = home
-            .path()
-            .join(".config")
-            .join("homeboy")
-            .join("projects")
-            .join(project_id);
-        std::fs::create_dir_all(&project_dir).expect("create project config dir");
-        let config = serde_json::json!({
-            "base_path": project_root.path().to_string_lossy(),
-        });
-        std::fs::write(
-            project_dir.join(format!("{project_id}.json")),
-            serde_json::to_vec(&config).expect("serialize project config"),
-        )
-        .expect("write project config");
+        write_project_config(home.path(), project_id, project_root.path());
 
         run(
             FileArgs {
@@ -106,4 +97,135 @@ fn file_delete_without_apply_returns_plan_and_preserves_file() {
         Some("Re-run with --apply to delete the remote path.")
     );
     assert!(file_path.exists());
+}
+
+#[test]
+fn file_edit_dry_run_returns_preview_and_preserves_file() {
+    let project_root = tempfile::tempdir().expect("project tempdir");
+    let project_id = "local-file-edit-dry-run";
+    let file_path = project_root.path().join("sample.txt");
+    std::fs::write(&file_path, "one\ntwo\nthree").expect("write sample file");
+
+    let result = with_isolated_home(|home| {
+        write_project_config(home.path(), project_id, project_root.path());
+
+        run(
+            FileArgs {
+                command: FileCommand::Edit(EditArgs {
+                    project_id: project_id.to_string(),
+                    file_path: "sample.txt".to_string(),
+                    dry_run: true,
+                    force: false,
+                    line_ops: LineOperations {
+                        replace_line: Some(2),
+                        replace_line_content: Some("TWO".to_string()),
+                        ..Default::default()
+                    },
+                    pattern_ops: PatternOperations::default(),
+                    file_mods: FileModifications::default(),
+                }),
+            },
+            &GlobalArgs {},
+        )
+    });
+
+    let (output, code) = result.expect("run homeboy file edit dry-run");
+    let FileCommandOutput::Edit(payload) = output else {
+        panic!("expected edit file output");
+    };
+
+    assert_eq!(code, 0);
+    assert_eq!(payload.command, "file.edit");
+    assert!(payload.dry_run);
+    assert_eq!(payload.change_count, 1);
+    assert_eq!(payload.changes_made[0].line_number, 2);
+    assert_eq!(payload.changes_made[0].original, "two");
+    assert_eq!(payload.changes_made[0].modified, "TWO");
+    assert_eq!(
+        std::fs::read_to_string(&file_path).expect("read sample file"),
+        "one\ntwo\nthree"
+    );
+}
+
+#[test]
+fn file_edit_without_dry_run_writes_file() {
+    let project_root = tempfile::tempdir().expect("project tempdir");
+    let project_id = "local-file-edit-write";
+    let file_path = project_root.path().join("sample.txt");
+    std::fs::write(&file_path, "one\ntwo\nthree").expect("write sample file");
+
+    let result = with_isolated_home(|home| {
+        write_project_config(home.path(), project_id, project_root.path());
+
+        run(
+            FileArgs {
+                command: FileCommand::Edit(EditArgs {
+                    project_id: project_id.to_string(),
+                    file_path: "sample.txt".to_string(),
+                    dry_run: false,
+                    force: false,
+                    line_ops: LineOperations {
+                        replace_line: Some(2),
+                        replace_line_content: Some("TWO".to_string()),
+                        ..Default::default()
+                    },
+                    pattern_ops: PatternOperations::default(),
+                    file_mods: FileModifications::default(),
+                }),
+            },
+            &GlobalArgs {},
+        )
+    });
+
+    let (output, code) = result.expect("run homeboy file edit");
+    let FileCommandOutput::Edit(payload) = output else {
+        panic!("expected edit file output");
+    };
+
+    assert_eq!(code, 0);
+    assert!(!payload.dry_run);
+    assert_eq!(payload.change_count, 1);
+    assert_eq!(
+        std::fs::read_to_string(&file_path).expect("read sample file"),
+        "one\nTWO\nthree"
+    );
+}
+
+#[test]
+fn file_edit_force_allows_first_replacement_when_pattern_has_multiple_matches() {
+    let project_root = tempfile::tempdir().expect("project tempdir");
+    let project_id = "local-file-edit-force";
+    let file_path = project_root.path().join("sample.txt");
+    std::fs::write(&file_path, "needle\nneedle").expect("write sample file");
+
+    let result = with_isolated_home(|home| {
+        write_project_config(home.path(), project_id, project_root.path());
+
+        run(
+            FileArgs {
+                command: FileCommand::Edit(EditArgs {
+                    project_id: project_id.to_string(),
+                    file_path: "sample.txt".to_string(),
+                    dry_run: false,
+                    force: true,
+                    line_ops: LineOperations::default(),
+                    pattern_ops: PatternOperations {
+                        replace_pattern: Some("needle".to_string()),
+                        replace_pattern_content: Some("thread".to_string()),
+                        ..Default::default()
+                    },
+                    file_mods: FileModifications::default(),
+                }),
+            },
+            &GlobalArgs {},
+        )
+    });
+
+    let (_output, code) = result.expect("run forced homeboy file edit");
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        std::fs::read_to_string(&file_path).expect("read sample file"),
+        "thread\nneedle"
+    );
 }


### PR DESCRIPTION
## Summary
- Wire `file edit --dry-run` into core edit operations so previews return changes without writing files.
- Add edit options for the command path while preserving existing write-default core wrappers.
- Make `--force` bypass the multiple-match safety for single `--replace-pattern` edits by intentionally replacing only the first match.
- Add command-level tests for dry-run preservation, normal writes, and forced first-match pattern replacement.

## Verification
- `git diff --check` passed.
- `rustfmt --check src/core/project/files.rs src/core/project/files/edit.rs src/commands/file/mod.rs src/commands/file/output.rs tests/commands/file_test.rs` passed.
- `homeboy test --changed-since origin/main --skip-lint` blocked by Homeboy resource policy because `test --changed-since` is currently local-only and the machine was warm; I did not rerun with `--force-hot`.

## Residual risks
- Targeted tests were added but not executed locally due to the resource-policy blocker above; CI should run them.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation and tests for the file edit dry-run/force contract.
