### PR TITLE
Guard scoped checks from self-check fallback

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -122,6 +122,24 @@ impl LintArgs {
             && self.glob.is_none()
     }
 
+    pub(crate) fn should_use_self_check_dispatch(&self) -> bool {
+        !self.fix
+            && self.ci_job.is_none()
+            && !self.summary
+            && self.is_full_workspace_run()
+            && !self.sniff_filters.errors_only
+            && self.sniff_filters.sniffs.is_none()
+            && self.sniff_filters.exclude_sniffs.is_none()
+            && self.category.is_none()
+            && self.setting_args.setting.is_empty()
+            && self.setting_args.setting_json.is_empty()
+            && !self.baseline_args.baseline
+            && !self.baseline_args.ignore_baseline
+            && !self.baseline_args.ratchet
+            && self.precomputed_changed_files.is_none()
+            && self.lab_changed_files_json.is_none()
+    }
+
     /// Positional component id targeted by this run, if any (the
     /// `homeboy lint <component>` form). Returns `None` when the component is
     /// auto-detected from the working directory.
@@ -145,8 +163,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         None,
     )?;
 
-    if !args.fix
-        && args.ci_job.is_none()
+    if args.should_use_self_check_dispatch()
         && source_ctx.component.has_script(ExtensionCapability::Lint)
     {
         let runner =
@@ -516,6 +533,35 @@ mod tests {
             .expect("lint should parse --ci-job");
 
         assert_eq!(cli.lint.ci_job.as_deref(), Some("lint-typecheck"));
+    }
+
+    #[test]
+    fn self_check_dispatch_only_allows_unscoped_default_lint() {
+        let default = TestCli::try_parse_from(["lint", "homeboy"])
+            .expect("default lint should parse")
+            .lint;
+        assert!(default.should_use_self_check_dispatch());
+
+        for argv in [
+            vec!["lint", "homeboy", "--changed-since", "origin/main"],
+            vec!["lint", "homeboy", "--changed-only"],
+            vec!["lint", "homeboy", "--file", "src/lib.rs"],
+            vec!["lint", "homeboy", "--glob", "src/**/*.rs"],
+            vec!["lint", "homeboy", "--errors-only"],
+            vec!["lint", "homeboy", "--sniffs", "WordPress.Security"],
+            vec!["lint", "homeboy", "--category", "security"],
+            vec!["lint", "homeboy", "--summary"],
+            vec!["lint", "homeboy", "--setting", "mode=strict"],
+            vec!["lint", "homeboy", "--baseline"],
+        ] {
+            let args = TestCli::try_parse_from(argv.clone())
+                .unwrap_or_else(|error| panic!("lint args should parse for {argv:?}: {error}"))
+                .lint;
+            assert!(
+                !args.should_use_self_check_dispatch(),
+                "scoped or behavior-changing args must use main lint workflow: {argv:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -992,6 +992,47 @@ mod tests {
         assert_eq!(build_audit_args(&args, &review_context).profile, "full");
     }
 
+    #[test]
+    fn scoped_review_lint_args_do_not_use_self_check_dispatch() {
+        let mut args = review_args_fixture();
+        args.changed_since = Some("origin/main".to_string());
+        let review_context = ReviewExecutionContext {
+            scope: "changed-since".to_string(),
+            changed_file_count: Some(1),
+            precomputed_changed_files: Some(vec!["src/lib.rs".to_string()]),
+        };
+
+        let lint_args = build_lint_args(&args, &review_context);
+
+        assert_eq!(lint_args.changed_since.as_deref(), Some("origin/main"));
+        assert_eq!(
+            lint_args.precomputed_changed_files.as_deref(),
+            Some(&["src/lib.rs".to_string()][..])
+        );
+        assert!(
+            !lint_args.should_use_self_check_dispatch(),
+            "review-scoped lint must run the main lint workflow, not full self-check scripts"
+        );
+    }
+
+    #[test]
+    fn review_test_args_do_not_use_self_check_dispatch() {
+        let args = review_args_fixture();
+        let review_context = ReviewExecutionContext {
+            scope: "full".to_string(),
+            changed_file_count: None,
+            precomputed_changed_files: None,
+        };
+
+        let test_args = build_test_args(&args, &review_context);
+
+        assert!(test_args.skip_lint);
+        assert!(
+            !test_args.should_use_self_check_dispatch(&[]),
+            "review test substep carries behavior flags and must not fall back to full self-check scripts"
+        );
+    }
+
     fn review_args_fixture() -> ReviewArgs {
         ReviewArgs {
             comp: PositionalComponentArgs {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -105,6 +105,25 @@ impl TestArgs {
         LabCommandContract::portable(TEST_LAB_LABEL, self.write.then_some("--write"), true, &[])
             .release_gate()
     }
+
+    pub(crate) fn should_use_self_check_dispatch(&self, cli_passthrough_args: &[String]) -> bool {
+        !self.skip_lint
+            && !self.coverage
+            && self.coverage_min.is_none()
+            && !self.analyze
+            && !self.drift
+            && !self.write
+            && self.changed_since.is_none()
+            && self.precomputed_changed_files.is_none()
+            && self.lab_changed_files_json.is_none()
+            && self.ci_job.is_none()
+            && cli_passthrough_args.is_empty()
+            && self.setting_args.setting.is_empty()
+            && self.setting_args.setting_json.is_empty()
+            && !self.baseline_args.baseline
+            && !self.baseline_args.ignore_baseline
+            && !self.baseline_args.ratchet
+    }
 }
 
 /// Filter out homeboy-owned flags from trailing args before passing to extension scripts.
@@ -130,9 +149,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
     )?;
     let cli_passthrough_args = filter_homeboy_flags(&args.args);
 
-    if !args.drift
-        && args.ci_job.is_none()
-        && cli_passthrough_args.is_empty()
+    if args.should_use_self_check_dispatch(&cli_passthrough_args)
         && source_ctx.component.has_script(ExtensionCapability::Test)
     {
         let runner =
@@ -542,6 +559,33 @@ mod tests {
             .expect("test should parse --ci-job");
 
         assert_eq!(cli.test.ci_job.as_deref(), Some("unit"));
+    }
+
+    #[test]
+    fn self_check_dispatch_only_allows_unscoped_default_test() {
+        let default = TestCli::try_parse_from(["test", "homeboy"])
+            .expect("default test should parse")
+            .test;
+        assert!(default.should_use_self_check_dispatch(&filter_homeboy_flags(&default.args)));
+
+        for argv in [
+            vec!["test", "homeboy", "--skip-lint"],
+            vec!["test", "homeboy", "--coverage"],
+            vec!["test", "homeboy", "--coverage-min", "80"],
+            vec!["test", "homeboy", "--analyze"],
+            vec!["test", "homeboy", "--changed-since", "origin/main"],
+            vec!["test", "homeboy", "--setting", "runner=ci"],
+            vec!["test", "homeboy", "--baseline"],
+            vec!["test", "homeboy", "--", "--filter=SmokeTest"],
+        ] {
+            let args = TestCli::try_parse_from(argv.clone())
+                .unwrap_or_else(|error| panic!("test args should parse for {argv:?}: {error}"))
+                .test;
+            assert!(
+                !args.should_use_self_check_dispatch(&filter_homeboy_flags(&args.args)),
+                "scoped or behavior-changing args must use main test workflow: {argv:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Gate lint and test self-check dispatch behind explicit default-invocation predicates.
- Route scoped and behavior-changing flags such as changed-since, changed-only, file/glob, skip-lint, coverage, settings, baseline, summary, and passthrough args through the main workflows.
- Add regression tests for direct lint/test dispatch and review-generated lint/test args.

## Verification
- `rustfmt --check src/commands/lint.rs src/commands/test.rs src/commands/review/mod.rs` passed.
- `git diff --check` passed.
- `homeboy test homeboy --runner homeboy-lab --changed-since=origin/main --skip-lint --json-summary` did not run tests: Homeboy rejected changed-since test Lab offload as local-only.
- `homeboy test homeboy --runner homeboy-lab --skip-lint --json-summary -- self_check_dispatch` reached the Lab runner but failed before tests ran because current main does not compile in unrelated runner code: `RunnerExecOutput` initializers in `src/core/runner/execution.rs`, `src/core/runner/lab/offload.rs`, and `src/core/runner/worker.rs` are missing newly required fields.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, implementation, regression test additions, and verification.