### PR TITLE
Centralize GitHub CLI client handling

### DIFF
--- a/src/commands/runs/gh_actions.rs
+++ b/src/commands/runs/gh_actions.rs
@@ -24,13 +24,13 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{Cursor, Read};
 use std::path::PathBuf;
-use std::process::Command;
 
 use clap::Args;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use homeboy::core::git::GhClient;
 use homeboy::core::observation::{ObservationStore, RunRecord};
 use homeboy::core::Error;
 
@@ -115,25 +115,20 @@ pub enum GhActionsImportedArtifactStatus {
 }
 
 pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput> {
-    if !args.repo.contains('/') {
-        return Err(Error::validation_invalid_argument(
-            "repo",
-            "expected owner/repo form (e.g. Extra-Chill/homeboy)",
-            Some(args.repo.clone()),
-            None,
-        ));
-    }
+    let gh = GhClient::from_repo_arg(&args.repo)?;
+    gh.ensure_ready()?;
+    let repo = gh.repo_path()?.to_string();
 
     let store = ObservationStore::open_initialized()?;
     let pattern = compile_glob(&args.artifact_glob)?;
 
     let (runs, etag_cache_hit) = if let Some(run_id) = args.run_id {
-        (vec![get_workflow_run(&args.repo, run_id)?], false)
+        (vec![get_workflow_run(&gh, run_id)?], false)
     } else {
         let workflow = args.workflow.as_deref().ok_or_else(|| {
             Error::validation_missing_argument(vec!["--workflow or --run-id".to_string()])
         })?;
-        list_workflow_runs(&args.repo, workflow, &args.since)?
+        list_workflow_runs(&gh, workflow, &args.since)?
     };
     let runs_inspected = runs.len().min(args.limit);
     let runs_to_process: Vec<&GhWorkflowRun> = runs.iter().take(args.limit).collect();
@@ -146,11 +141,10 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
     let mut artifact_rows = Vec::new();
 
     for gh_run in runs_to_process {
-        let homeboy_run_id = deterministic_run_id(&args.repo, gh_run.id);
+        let homeboy_run_id = deterministic_run_id(&repo, gh_run.id);
         let existed = store.get_run(&homeboy_run_id)?.is_some();
         if !existed {
-            let run_record =
-                build_run_record(&homeboy_run_id, &args.component_id, &args.repo, gh_run);
+            let run_record = build_run_record(&homeboy_run_id, &args.component_id, &repo, gh_run);
             store.import_run(&run_record)?;
             runs_imported += 1;
         } else {
@@ -161,7 +155,7 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
         // artifacts can land late (e.g. retried jobs) and we still want them
         // ingested. Existing artifact rows are detected via deterministic
         // (run_id, gh_artifact_id, file_name) IDs.
-        let artifacts = list_run_artifacts(&args.repo, gh_run.id)?;
+        let artifacts = list_run_artifacts(&gh, gh_run.id)?;
         let existing_artifacts: HashMap<String, homeboy::core::observation::ArtifactRecord> = store
             .list_artifacts(&homeboy_run_id)?
             .into_iter()
@@ -177,7 +171,7 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
                 // bytes — skip silently. Future re-imports won't recover.
                 continue;
             }
-            let zip_bytes = match download_artifact_zip(&args.repo, artifact.id) {
+            let zip_bytes = match download_artifact_zip(&gh, artifact.id) {
                 Ok(bytes) => bytes,
                 Err(_) => continue,
             };
@@ -250,7 +244,7 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
         RunsOutput::ImportFromGhActions(GhActionsImportOutput {
             command: "runs.import.gh-actions",
             component_id: args.component_id,
-            repo: args.repo,
+            repo,
             workflow: args.workflow,
             run_id: args.run_id,
             artifact_glob: args.artifact_glob,
@@ -338,23 +332,10 @@ fn map_gh_conclusion_to_status(gh_run: &GhWorkflowRun) -> String {
 
 // ── GitHub API listing (via `gh` CLI) ───────────────────────────────────────
 
-fn get_workflow_run(repo: &str, run_id: u64) -> homeboy::core::Result<GhWorkflowRun> {
-    let api_path = format!("repos/{repo}/actions/runs/{run_id}");
-    let output = Command::new("gh")
-        .args(["api", &api_path])
-        .output()
-        .map_err(|e| Error::internal_io(format!("Failed to invoke gh: {e}"), Some("gh".into())))?;
-    if !output.status.success() {
-        return Err(Error::internal_io(
-            format!(
-                "gh api workflow run failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ),
-            Some(format!("gh api {api_path}")),
-        ));
-    }
-
-    parse_run_payload(&output.stdout)
+fn get_workflow_run(gh: &GhClient, run_id: u64) -> homeboy::core::Result<GhWorkflowRun> {
+    let api_path = format!("repos/{}/actions/runs/{run_id}", gh.repo_path()?);
+    gh.api_json::<GhWorkflowRunRaw>(&api_path)
+        .map(GhWorkflowRun::from)
 }
 
 /// One GitHub Actions workflow run, projected to the fields we persist.
@@ -427,10 +408,11 @@ impl From<GhWorkflowRunRaw> for GhWorkflowRun {
 /// List workflow runs via `gh api`, with ETag caching to keep us off
 /// GitHub's primary rate limit on re-runs of the ingestor.
 fn list_workflow_runs(
-    repo: &str,
+    gh: &GhClient,
     workflow: &str,
     since: &str,
 ) -> homeboy::core::Result<(Vec<GhWorkflowRun>, bool)> {
+    let repo = gh.repo_path()?;
     let cache_key = list_runs_cache_key(repo, workflow);
     let etag_path = list_runs_cache_path(&cache_key, "etag")?;
     let body_path = list_runs_cache_path(&cache_key, "json")?;
@@ -458,10 +440,8 @@ fn list_workflow_runs(
         args.push(format!("If-None-Match: {etag}"));
     }
 
-    let output = Command::new("gh")
-        .args(&args)
-        .output()
-        .map_err(|e| Error::internal_io(format!("Failed to invoke gh: {e}"), Some("gh".into())))?;
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let output = gh.output(&arg_refs)?;
 
     if !output.status.success() {
         // 304 from gh api -i comes back with a non-zero status because
@@ -651,13 +631,13 @@ struct GhArtifact {
     archive_download_url: Option<String>,
 }
 
-fn list_run_artifacts(repo: &str, gh_run_id: u64) -> homeboy::core::Result<Vec<GhArtifact>> {
-    let api_path = format!("repos/{repo}/actions/runs/{gh_run_id}/artifacts?per_page=100");
+fn list_run_artifacts(gh: &GhClient, gh_run_id: u64) -> homeboy::core::Result<Vec<GhArtifact>> {
+    let api_path = format!(
+        "repos/{}/actions/runs/{gh_run_id}/artifacts?per_page=100",
+        gh.repo_path()?
+    );
     let args = vec!["api".to_string(), "--paginate".into(), api_path.clone()];
-    let output = Command::new("gh")
-        .args(&args)
-        .output()
-        .map_err(|e| Error::internal_io(format!("Failed to invoke gh: {e}"), Some("gh".into())))?;
+    let output = gh.output(&args.iter().map(String::as_str).collect::<Vec<_>>())?;
     if !output.status.success() {
         return Err(Error::internal_io(
             format!(
@@ -697,24 +677,14 @@ fn list_run_artifacts(repo: &str, gh_run_id: u64) -> homeboy::core::Result<Vec<G
     Ok(out)
 }
 
-fn download_artifact_zip(repo: &str, artifact_id: u64) -> homeboy::core::Result<Vec<u8>> {
+fn download_artifact_zip(gh: &GhClient, artifact_id: u64) -> homeboy::core::Result<Vec<u8>> {
     // `gh api repos/.../actions/artifacts/{id}/zip` follows the redirect to
     // the artifact storage URL automatically.
-    let api_path = format!("repos/{repo}/actions/artifacts/{artifact_id}/zip");
-    let output = Command::new("gh")
-        .args(["api", &api_path])
-        .output()
-        .map_err(|e| Error::internal_io(format!("Failed to invoke gh: {e}"), Some("gh".into())))?;
-    if !output.status.success() {
-        return Err(Error::internal_io(
-            format!(
-                "gh api artifact download failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ),
-            Some(format!("gh api {api_path}")),
-        ));
-    }
-    Ok(output.stdout)
+    let api_path = format!(
+        "repos/{}/actions/artifacts/{artifact_id}/zip",
+        gh.repo_path()?
+    );
+    gh.api_bytes(&api_path)
 }
 
 /// Walk a downloaded artifact zip in memory and yield `(file_name, bytes)`

--- a/src/core/git/gh_client.rs
+++ b/src/core/git/gh_client.rs
@@ -1,0 +1,233 @@
+//! Shared GitHub CLI client helpers.
+
+use std::process::{Command, Output, Stdio};
+
+use serde::de::DeserializeOwned;
+
+use crate::core::component::GithubConfig;
+use crate::core::deploy::release_download::GitHubRepo;
+use crate::core::error::{Error, Result};
+
+#[derive(Debug, Clone)]
+pub struct GhClient {
+    host: String,
+    repo: Option<String>,
+    env: Vec<(String, String)>,
+}
+
+impl GhClient {
+    pub fn for_repo(repo: &GitHubRepo) -> Self {
+        Self::for_repo_with_config(repo, &GithubConfig::default())
+    }
+
+    pub fn for_repo_with_config(repo: &GitHubRepo, config: &GithubConfig) -> Self {
+        Self {
+            host: repo.host.clone(),
+            repo: Some(format!("{}/{}", repo.owner, repo.repo)),
+            env: github_cli_env(&repo.host, config),
+        }
+    }
+
+    pub fn for_host(host: impl Into<String>) -> Self {
+        let host = host.into();
+        Self {
+            env: github_cli_env(&host, &GithubConfig::default()),
+            host,
+            repo: None,
+        }
+    }
+
+    pub fn from_repo_arg(repo: &str) -> Result<Self> {
+        let repo = repo.trim();
+        let parts: Vec<&str> = repo.split('/').collect();
+        let (host, repo_slug) = match parts.as_slice() {
+            [owner, name] if !owner.is_empty() && !name.is_empty() => {
+                let host = std::env::var("GH_HOST")
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or_else(|| "github.com".to_string());
+                (host, format!("{owner}/{name}"))
+            }
+            [host, owner, name] if !host.is_empty() && !owner.is_empty() && !name.is_empty() => {
+                ((*host).to_string(), format!("{owner}/{name}"))
+            }
+            _ => {
+                return Err(Error::validation_invalid_argument(
+                    "repo",
+                    "expected owner/repo or host/owner/repo form",
+                    Some(repo.to_string()),
+                    None,
+                ));
+            }
+        };
+
+        Ok(Self {
+            env: github_cli_env(&host, &GithubConfig::default()),
+            host,
+            repo: Some(repo_slug),
+        })
+    }
+
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    pub fn repo(&self) -> Option<&str> {
+        self.repo.as_deref()
+    }
+
+    pub fn repo_path(&self) -> Result<&str> {
+        self.repo.as_deref().ok_or_else(|| {
+            Error::validation_missing_argument(vec!["GitHub repository".to_string()])
+        })
+    }
+
+    pub fn ensure_ready(&self) -> Result<()> {
+        if !self.probe(&["--version"]) {
+            return Err(Error::internal_io(
+                "`gh` CLI not found on PATH".to_string(),
+                Some("gh".to_string()),
+            )
+            .with_hint("Install the GitHub CLI: https://cli.github.com"));
+        }
+
+        if !self.probe(&["auth", "status", "--hostname", &self.host]) {
+            return Err(Error::internal_io(
+                format!("`gh` is not authenticated for {}", self.host),
+                Some(format!("gh auth status --hostname {}", self.host)),
+            )
+            .with_hint("Authenticate with: gh auth login"));
+        }
+
+        Ok(())
+    }
+
+    pub fn probe(&self, args: &[&str]) -> bool {
+        self.command(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    pub fn run(&self, args: &[String]) -> Result<String> {
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        let output = self.output(&arg_refs)?;
+        if !output.status.success() {
+            let action = format!("gh {}", args.first().map(String::as_str).unwrap_or(""));
+            return Err(self.command_failed(&action, output));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
+    pub fn output(&self, args: &[&str]) -> Result<Output> {
+        self.command(args)
+            .output()
+            .map_err(|e| Error::internal_io(format!("Failed to invoke gh: {e}"), Some("gh".into())))
+    }
+
+    pub fn api_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let args = ["api", path];
+        let output = self.output(&args)?;
+        if !output.status.success() {
+            return Err(self.command_failed(&format!("gh api {path}"), output));
+        }
+
+        serde_json::from_slice(&output.stdout)
+            .map_err(|e| Error::internal_json(e.to_string(), Some(format!("parse gh api {path}"))))
+    }
+
+    pub fn api_bytes(&self, path: &str) -> Result<Vec<u8>> {
+        let args = ["api", path];
+        let output = self.output(&args)?;
+        if !output.status.success() {
+            return Err(self.command_failed(&format!("gh api {path}"), output));
+        }
+        Ok(output.stdout)
+    }
+
+    fn command(&self, args: &[&str]) -> Command {
+        let mut command = Command::new("gh");
+        command.args(args);
+        for (key, value) in &self.env {
+            command.env(key, value);
+        }
+        command
+    }
+
+    fn command_failed(&self, action: &str, output: Output) -> Error {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let combined = if stderr.is_empty() { stdout } else { stderr };
+        Error::git_command_failed(format!("{action} failed: {combined}"))
+    }
+}
+
+pub fn github_cli_env(host: &str, config: &GithubConfig) -> Vec<(String, String)> {
+    let mut env = Vec::new();
+    if host != "github.com" {
+        env.push(("GH_HOST".to_string(), host.to_string()));
+    }
+
+    let Some(host_config) = config.hosts.get(host) else {
+        return env;
+    };
+
+    if let Some(proxy) = host_config
+        .proxy
+        .as_deref()
+        .filter(|proxy| !proxy.is_empty())
+    {
+        env.push(("HTTPS_PROXY".to_string(), proxy.to_string()));
+    }
+
+    for (key, value) in &host_config.env {
+        if !key.is_empty() && key != "GH_HOST" {
+            env.retain(|(existing, _)| existing != key);
+            env.push((key.clone(), value.clone()));
+        }
+    }
+
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::core::component::{GithubConfig, GithubHostConfig};
+
+    use super::{github_cli_env, GhClient};
+
+    #[test]
+    fn repo_arg_accepts_host_qualified_repo() {
+        let client = GhClient::from_repo_arg("github.example.com/acme/widgets").unwrap();
+
+        assert_eq!(client.host(), "github.example.com");
+        assert_eq!(client.repo(), Some("acme/widgets"));
+    }
+
+    #[test]
+    fn github_cli_env_sets_enterprise_host_and_configured_proxy() {
+        let mut hosts = HashMap::new();
+        hosts.insert(
+            "github.example.com".to_string(),
+            GithubHostConfig {
+                proxy: Some("socks5://127.0.0.1:8080".to_string()),
+                env: HashMap::new(),
+            },
+        );
+        let config = GithubConfig { hosts };
+
+        let env = github_cli_env("github.example.com", &config);
+
+        assert!(env.contains(&("GH_HOST".to_string(), "github.example.com".to_string())));
+        assert!(env.contains(&(
+            "HTTPS_PROXY".to_string(),
+            "socks5://127.0.0.1:8080".to_string()
+        )));
+    }
+}

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -26,6 +26,7 @@ use crate::core::component;
 use crate::core::deploy::release_download::{detect_remote_url, parse_github_url, GitHubRepo};
 use crate::core::error::{Error, Result};
 
+use super::gh_client::GhClient;
 pub use super::github_types::{
     GithubFindItem, GithubFindOutput, GithubIssueOutput, GithubPrOutput, GithubPrView,
     IssueCloseOptions, IssueCloseReason, IssueCommentOptions, IssueCreateOptions, IssueEditOptions,
@@ -744,47 +745,23 @@ fn gh_auth_token() -> Option<String> {
 /// (which soft-fails because the tag is already pushed), primitive operations
 /// have no already-committed side effect to preserve — fail loudly.
 pub(super) fn ensure_gh_ready() -> Result<()> {
-    if !gh_probe_succeeds(&["--version"]) {
-        return Err(Error::internal_io(
-            "`gh` CLI not found on PATH".to_string(),
-            Some("gh".to_string()),
-        )
-        .with_hint("Install the GitHub CLI: https://cli.github.com"));
-    }
-
-    if !gh_probe_succeeds(&["auth", "status", "--hostname", "github.com"]) {
-        return Err(Error::internal_io(
-            "`gh` is not authenticated for github.com".to_string(),
-            Some("gh auth status".to_string()),
-        )
-        .with_hint("Authenticate with: gh auth login"));
-    }
-
-    Ok(())
+    let host = std::env::var("GH_HOST")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "github.com".to_string());
+    GhClient::for_host(host).ensure_ready()
 }
 
 /// Run `gh <args>` and return stdout on success, or a structured error on
 /// failure (with stderr captured in the error message).
 pub(super) fn run_gh(args: &[String]) -> Result<String> {
-    let output = Command::new("gh")
-        .args(args.iter().map(|s| s.as_str()))
-        .output()
-        .map_err(|e| {
-            Error::internal_io(format!("Failed to invoke gh: {}", e), Some("gh".into()))
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let combined = if stderr.is_empty() { stdout } else { stderr };
-        return Err(Error::git_command_failed(format!(
-            "gh {} failed: {}",
-            args.first().map(|s| s.as_str()).unwrap_or(""),
-            combined
-        )));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    let host = std::env::var("GH_HOST")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "github.com".to_string());
+    GhClient::for_host(host).run(args)
 }
 
 fn parse_issue_number_from_url(url: &str) -> Option<u64> {

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -1,5 +1,6 @@
 mod changes;
 mod commits;
+mod gh_client;
 mod github;
 mod github_comment_sections;
 mod github_pr_comments;
@@ -28,6 +29,7 @@ pub use commits::{
     get_previous_tag_before_with_prefix, recommended_bump_from_commits, strip_conventional_prefix,
     CommitCategory, CommitCounts, CommitInfo, MonorepoContext, SemverBump,
 };
+pub use gh_client::{github_cli_env, GhClient};
 pub use github::{
     gh_probe_succeeds, github_token_from_env_or_gh, issue_close, issue_comment, issue_create,
     issue_edit, issue_find, pr_create, pr_edit, pr_files, pr_find, pr_find_by_commit, pr_merge,


### PR DESCRIPTION
## Summary
- Add a shared `GhClient` helper for GitHub CLI host/repo resolution, auth probing, command execution, API JSON/byte reads, and host-scoped environment construction.
- Move `runs import --from-gh-actions` GitHub API calls onto the shared client.
- Route existing core git `ensure_gh_ready` / `run_gh` helpers through `GhClient` so they honor `GH_HOST` instead of always probing `github.com`.
- Add focused unit coverage for host-qualified repo parsing and Enterprise proxy env construction.

## Verification
- `git diff --check`
- `rustfmt --check src/core/git/gh_client.rs src/core/git/mod.rs src/core/git/github.rs src/commands/runs/gh_actions.rs`
- `homeboy lint --changed-only --summary` was attempted, but Homeboy refused because the machine was warm and changed-scope lint is currently local-only under resource policy. I did not force a hot local run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the shared GitHub CLI helper, moving the GitHub Actions importer call sites, formatting, and drafting the PR description.