### PR TITLE
Prune duplicate CLI surfaces

### DIFF
--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -208,7 +208,7 @@ This is useful for:
 
 ```json
 {
-  "command": "component.create|component.show|component.set|component.delete|component.rename|component.list|component.projects|component.shared|component.env|component.add-version-target|component.reconcile|component.artifacts",
+  "command": "component.create|component.show|component.set|component.delete|component.rename|component.list|component.projects|component.shared|component.env|component.reconcile|component.artifacts",
   "component_id": "<id>|null",
   "success": true,
   "updated_fields": ["local_path", "remote_path"],

--- a/docs/commands/file.md
+++ b/docs/commands/file.md
@@ -85,10 +85,10 @@ homeboy file grep mysite /var/www "error" -i
 homeboy file grep mysite /var/www "add_action" --name "*.php" --max-depth 3
 ```
 
-### `upload`, `copy`, and `sync`
+### `copy` and `sync`
 
 ```sh
-homeboy file upload prod ./report.json /tmp/report.json --dry-run
+homeboy file copy ./report.json prod:/tmp/report.json --dry-run
 homeboy file copy ./dump.sql prod:/tmp/dump.sql --compress --dry-run
 homeboy file copy prod:/tmp/dump.sql ./dump.sql --dry-run
 homeboy file copy old:/var/www/uploads new:/var/www/uploads --recursive --exclude cache --dry-run
@@ -97,8 +97,8 @@ homeboy file sync ./uploads prod:/var/www/uploads --exclude cache --dry-run
 
 Notes:
 
-- `upload` is the ergonomic mirror of `download` for local-to-server uploads.
 - `copy` preserves the old local↔remote and remote↔remote transfer target syntax.
+- `file upload` is deprecated; use `file copy <local> <server>:<path>` for local-to-server uploads.
 - `sync` is directory-oriented and recursive, but does not delete files from the destination.
 
 ### `edit`

--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -11,16 +11,14 @@ managed follow-up work.
 
 ```bash
 homeboy lab status
-homeboy lab bench <component> [options] [-- <runner-args>]
 homeboy lab extension-sync --runner <runner-id> --source <url-or-path> --id <extension-id> --ref <ref>
 ```
 
 ## Description
 
-The `lab` command remains a compatibility shortcut for Lab runner availability,
-benchmark routing, and the Homeboy-managed follow-up commands to use when a Lab
-run needs diagnosis or replay. For normal benchmark runs, prefer
-`homeboy bench <component>`: Homeboy
+The `lab` command remains a compatibility shortcut for Lab runner availability
+and the Homeboy-managed follow-up commands to use when a Lab run needs diagnosis
+or replay. For normal benchmark runs, use `homeboy bench <component>`: Homeboy
 automatically selects a Lab runner when the component declares
 `lab.preferred_runner` or when exactly one Lab runner is configured.
 
@@ -79,11 +77,6 @@ runner Homeboy command before remote execution starts. Legacy
 `lab.self_command_prefix` values in `homeboy.json` are ignored and are not
 preserved by portable config rewrites.
 
-`homeboy lab bench` is a routing helper, not a benchmark executor. It prints the
-equivalent `homeboy bench ...` command plus the same managed follow-up hints so
-the operator can run the benchmark through the normal benchmark pipeline and keep
-failed follow-up work inside the Homeboy workflow.
-
 `homeboy lab extension-sync` updates a Lab runner's installed extension through
 the runner API. Use it to pin a runner-side runtime dependency, such as the
 installed Homeboy Extensions `wordpress` extension, to a specific source ref
@@ -106,8 +99,6 @@ debugging.
 ## Commands
 
 - `status`: Show configured Lab runners and benchmark routing guidance.
-- `bench`: Print the standard `homeboy bench ...` command for the provided
-  arguments with Lab routing guidance and managed follow-up commands.
 - `extension-sync`: Install or replace a Lab runner extension from a source and
   ref. Successful output returns the runner id, runner `homeboy_path`, install
   command, and remote execution output; failures surface the runner-side root

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -160,6 +160,7 @@ enum ComponentCommand {
         skip_dependencies: bool,
     },
     /// Add a version target to a component
+    #[command(hide = true)]
     AddVersionTarget {
         /// Component ID
         id: String,
@@ -374,9 +375,17 @@ pub fn run(
             source.as_deref(),
             skip_dependencies,
         ),
-        ComponentCommand::AddVersionTarget { id, file, pattern } => {
-            add_version_target(&id, &file, &pattern)
-        }
+        ComponentCommand::AddVersionTarget { id, file, pattern } => Err(
+            homeboy::core::Error::validation_invalid_argument(
+                "component.add-version-target",
+                "`homeboy component add-version-target` is deprecated; use `homeboy component set --version-target`",
+                None,
+                Some(vec![format!(
+                    "Use: homeboy component set {} --version-target '{}::{}'",
+                    id, file, pattern
+                )]),
+            ),
+        ),
         ComponentCommand::Reconcile { id, apply } => reconcile(&id, apply),
         ComponentCommand::Artifacts { id, path, apply } => {
             artifacts(id.as_deref(), path.as_deref(), apply)
@@ -714,60 +723,6 @@ fn set(
                 exit_code,
             ))
         }
-    }
-}
-
-fn add_version_target(id: &str, file: &str, pattern: &str) -> CmdResult<ComponentOutput> {
-    // Validate pattern is a valid regex with capture group
-    component::validate_version_pattern(pattern)?;
-
-    // Load component to check existing targets
-    let comp = component::load(id).map_err(|e| e.with_contextual_hint())?;
-
-    // Validate no conflicting target exists
-    if let Some(ref existing) = comp.version_targets {
-        component::validate_version_target_conflict(existing, file, pattern, id)?;
-    }
-
-    let version_target = serde_json::json!({
-        "version_targets": [{
-            "file": file,
-            "pattern": pattern
-        }]
-    });
-
-    let json_string = homeboy::core::config::to_json_string(&version_target)?;
-
-    match component::merge(Some(id), &json_string, &[])? {
-        homeboy::core::MergeOutput::Single(result) => {
-            let comp = component::load(&result.id)?;
-            Ok((
-                ComponentOutput {
-                    command: "component.add-version-target".to_string(),
-                    id: Some(result.id),
-                    updated_fields: result.updated_fields,
-                    entity: Some({
-                        let mut value = serde_json::to_value(&comp).map_err(|error| {
-                            homeboy::core::Error::validation_invalid_argument(
-                                "component",
-                                "Failed to serialize component",
-                                Some(error.to_string()),
-                                None,
-                            )
-                        })?;
-                        if let Value::Object(ref mut map) = value {
-                            map.insert("id".to_string(), Value::String(comp.id.clone()));
-                        }
-                        value
-                    }),
-                    ..Default::default()
-                },
-                0,
-            ))
-        }
-        homeboy::core::MergeOutput::Bulk(_) => Err(homeboy::core::Error::internal_unexpected(
-            "Unexpected bulk result for single component".to_string(),
-        )),
     }
 }
 

--- a/src/commands/file/args.rs
+++ b/src/commands/file/args.rs
@@ -122,6 +122,7 @@ pub(crate) enum FileCommand {
         recursive: bool,
     },
     /// Upload a local file or directory to a remote server
+    #[command(hide = true)]
     Upload {
         /// Server ID
         server: String,

--- a/src/commands/file/mod.rs
+++ b/src/commands/file/mod.rs
@@ -163,16 +163,16 @@ pub fn run(args: FileArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<F
             server,
             local_path,
             remote_path,
-            compress,
-            dry_run,
-        } => transfer_command(TransferConfig {
-            source: local_path,
-            destination: format!("{}:{}", server, remote_path),
-            recursive: false,
-            compress,
-            dry_run,
-            exclude: Vec::new(),
-        }),
+            ..
+        } => Err(homeboy::core::Error::validation_invalid_argument(
+            "file.upload",
+            "`homeboy file upload` is deprecated; use `homeboy file copy` for local-to-remote transfers",
+            None,
+            Some(vec![format!(
+                "Use: homeboy file copy {} {}:{}",
+                local_path, server, remote_path
+            )]),
+        )),
         FileCommand::Copy(args) => transfer_command(args.into_config()),
         FileCommand::Sync(args) => transfer_command(args.into_config()),
         FileCommand::Edit(args) => {

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -28,12 +28,6 @@ enum LabCommand {
         #[arg(long)]
         runner: Option<String>,
     },
-    /// Print the runner-backed benchmark command for the provided bench args
-    Bench {
-        /// Arguments to pass after `homeboy bench`
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
     /// Sync an extension install on a Lab runner by source and git ref
     ExtensionSync {
         /// Runner ID. Defaults to lab.preferred_runner or the only configured SSH Lab runner.
@@ -166,32 +160,6 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
                         "Use `homeboy config set /lab/preferred_runner '\"<runner-id>\"'` to set the default Lab runner.".to_string(),
                         "Use `homeboy config set /bench/local_execution '\"denied\"'` to make local benchmark execution fail closed.".to_string(),
                         "Use `--runner <runner-id>` only when multiple Lab runners are available and no default should be inferred.".to_string(),
-                    ],
-                })),
-                0,
-            ))
-        }
-        LabCommand::Bench { args } => {
-            let managed_followups =
-                lab_followups(preferred_runner.as_deref(), current_workspace.as_deref());
-            let mut bench_command = "homeboy bench".to_string();
-            if !args.is_empty() {
-                bench_command.push(' ');
-                bench_command.push_str(&args.join(" "));
-            }
-            Ok((
-                LabCommandOutput::Status(Box::new(LabOutput {
-                    command: "lab.bench",
-                    preferred_runner,
-                    selected_runner: None,
-                    config_key: "/lab/preferred_runner",
-                    config_path,
-                    current_workspace,
-                    managed_followups,
-                    guidance: vec![
-                        bench_command,
-                        "Homeboy auto-routes portable benchmarks to `lab.preferred_runner`, or to the only configured SSH Lab runner when there is exactly one.".to_string(),
-                        "Use `--runner <runner-id>` only to override an ambiguous or non-default Lab selection.".to_string(),
                     ],
                 })),
                 0,

--- a/src/core/release/version/default_pattern_for_file.rs
+++ b/src/core/release/version/default_pattern_for_file.rs
@@ -231,7 +231,7 @@ pub(crate) fn build_init_warnings(component: &Component) -> Vec<String> {
     let unconfigured = detect_unconfigured_patterns(component);
     for pattern in &unconfigured {
         warnings.push(format!(
-            "Unconfigured version pattern in '{}': {} found in {} (v{}). Add with: homeboy component add-version-target {} '{}' '{}'",
+            "Unconfigured version pattern in '{}': {} found in {} (v{}). Add with: homeboy component set {} --version-target '{}::{}'",
             component.id,
             pattern.description,
             pattern.file,

--- a/src/core/server/transfer.rs
+++ b/src/core/server/transfer.rs
@@ -166,7 +166,7 @@ pub fn transfer(config: &TransferConfig) -> crate::core::Result<(TransferOutput,
                 "Both source and destination are local paths. At least one must be a remote server",
                 None,
                 Some(vec![
-                    "Upload to server: homeboy file upload server ./file /path/to/file".to_string(),
+                    "Upload to server: homeboy file copy ./file server:/path/to/file".to_string(),
                     "Copy from server: homeboy file copy server:/path/to/file ./local-copy"
                         .to_string(),
                 ]),


### PR DESCRIPTION
## Summary
- Remove the ceremonial `homeboy lab bench` subcommand so benchmark routing stays on `homeboy bench`.
- Hide/deprecate `homeboy file upload` with explicit `homeboy file copy <local> <server>:<path>` guidance.
- Hide/deprecate `homeboy component add-version-target` with explicit `component set --version-target` guidance, and update docs/diagnostics accordingly.

## Verification
- `git diff --check`
- `rustfmt --check src/commands/lab.rs src/commands/file/args.rs src/commands/file/mod.rs src/commands/component.rs src/core/server/transfer.rs src/core/release/version/default_pattern_for_file.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting duplicate CLI surfaces, editing Rust/docs, and preparing this PR.