### PR TITLE
fix(runner): populate detached exec handoff fields

### DIFF
--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -915,6 +915,8 @@ fn detached_handoff_output(
         }
     }))
     .unwrap_or_else(|_| "{}".to_string());
+    let runner_job = RunnerJob::from_job(&runner.id, "daemon", &command, Some(cwd.clone()), &job);
+    let handoff = runner_handoff(runner, "daemon", Some(runner_job.clone()), None);
 
     (
         RunnerExecOutput {
@@ -930,6 +932,7 @@ fn detached_handoff_output(
             stderr: String::new(),
             source_snapshot: Some(source_snapshot.clone()),
             job: Some(job.clone()),
+            runner_job: Some(runner_job),
             job_id: Some(job.id.to_string()),
             job_events: None,
             mirror_run_id: None,
@@ -937,6 +940,8 @@ fn detached_handoff_output(
             artifacts: Vec::new(),
             metrics: None,
             capture: None,
+            runner_result: None,
+            handoff: Some(handoff),
             diagnostics: runner_exec_diagnostics(runner, Some(&source_snapshot), &require_paths),
         },
         0,


### PR DESCRIPTION
## Summary
- populate detached runner exec output with runner job and handoff fields
- leave runner_result empty until the detached job reaches a terminal result

## Verification
- rustfmt --check src/core/runner/execution.rs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** debugging the runner build failure and drafting the minimal fix.