### PR TITLE
Make runner active-job status explicit

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -11,9 +11,9 @@ use homeboy::core::api_jobs::{Job, JobEvent, JobStatus};
 use homeboy::core::redaction::RedactionPolicy;
 use homeboy::core::runners::{
     self as runner, runner_job_log_snapshot, ReverseRunnerConnectOptions,
-    ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner, RunnerConnectReport,
-    RunnerDisconnectReport, RunnerExecOutput, RunnerKind, RunnerSession, RunnerStatusReport,
-    RunnerTunnelMode,
+    ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner, RunnerActiveJobSource,
+    RunnerActiveJobState, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput,
+    RunnerKind, RunnerSession, RunnerStatusReport, RunnerTunnelMode,
 };
 use homeboy::core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 use homeboy::core::stream_capture::StreamCaptureMetadata;
@@ -1269,6 +1269,17 @@ fn runner_status_operator_hints(report: &RunnerStatusReport) -> Vec<String> {
         return Vec::new();
     };
     let mut hints = Vec::new();
+    if report.active_job_state == RunnerActiveJobState::Unavailable {
+        let reason = report
+            .active_job_error
+            .as_ref()
+            .map(|err| err.message.as_str())
+            .unwrap_or("active-job status endpoint was unavailable");
+        hints.push(format!(
+            "Active-job status for `{}` is unavailable: {reason}. Treat active_job_count=0 as unknown, not idle.",
+            report.runner_id
+        ));
+    }
     match session.mode {
         RunnerTunnelMode::DirectSsh => {
             if report.active_job_count > 0 {
@@ -1978,6 +1989,9 @@ mod tests {
                 artifact_refs: Vec::new(),
             }],
             active_job_count: 1,
+            active_job_state: RunnerActiveJobState::Available,
+            active_job_source: Some(RunnerActiveJobSource::ReverseBroker),
+            active_job_error: None,
             session_path: "/tmp/session.json".to_string(),
         };
 

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -16,7 +16,8 @@ use crate::core::server::{self, Server, ServerAuthMode, SshClient};
 
 use super::broker_http;
 use super::session::{
-    ReverseRunnerConnectOptions, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource,
+    RunnerActiveJobState, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
     RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
     RunnerStatusReport, RunnerTunnelMode,
 };
@@ -259,16 +260,24 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     let state = session_state(session.as_ref());
     let connected = state == RunnerSessionState::Connected;
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected);
-    // Active-job enrichment is best-effort: a status read must not hard-fail
-    // when the runner daemon or reverse broker is momentarily unreachable.
-    // Degrade to an empty job list so callers still receive session state.
-    let active_jobs = if connected {
+    let active_job_source = session.as_ref().and_then(active_runner_job_source);
+    let (active_jobs, active_job_state, active_job_error) = if connected {
         match session.as_ref() {
-            Some(session) => active_runner_jobs(runner_id, session).unwrap_or_default(),
-            None => Vec::new(),
+            Some(session) => match active_runner_jobs(runner_id, session) {
+                Ok(jobs) => (jobs, RunnerActiveJobState::Available, None),
+                Err(err) => (
+                    Vec::new(),
+                    RunnerActiveJobState::Unavailable,
+                    Some(RunnerActiveJobError {
+                        code: err.code.as_str().to_string(),
+                        message: err.message,
+                    }),
+                ),
+            },
+            None => (Vec::new(), RunnerActiveJobState::NotQueried, None),
         }
     } else {
-        Vec::new()
+        (Vec::new(), RunnerActiveJobState::NotQueried, None)
     };
     let active_job_count = active_jobs.len();
     let active_runner_jobs = active_jobs.iter().map(Into::into).collect();
@@ -281,8 +290,21 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
         active_jobs,
         active_runner_jobs,
         active_job_count,
+        active_job_state,
+        active_job_source,
+        active_job_error,
         session_path: session_path.display().to_string(),
     })
+}
+
+fn active_runner_job_source(session: &RunnerSession) -> Option<RunnerActiveJobSource> {
+    if session.local_url.is_some() {
+        Some(RunnerActiveJobSource::DirectDaemon)
+    } else if session.mode == RunnerTunnelMode::Reverse && session.broker_url.is_some() {
+        Some(RunnerActiveJobSource::ReverseBroker)
+    } else {
+        None
+    }
 }
 
 fn active_runner_jobs(
@@ -300,7 +322,9 @@ fn active_runner_jobs(
             .ok_or_else(|| Error::internal_unexpected("daemon jobs response missing data.body"))?
     } else if session.mode == RunnerTunnelMode::Reverse {
         let Some(broker_url) = session.broker_url.as_deref() else {
-            return Ok(Vec::new());
+            return Err(Error::internal_unexpected(format!(
+                "reverse runner `{runner_id}` is connected but has no broker URL for active-job status"
+            )));
         };
         broker_http::get_json(
             &client,
@@ -310,7 +334,9 @@ fn active_runner_jobs(
             None,
         )?
     } else {
-        return Ok(Vec::new());
+        return Err(Error::internal_unexpected(format!(
+            "runner `{runner_id}` is connected but has no active-job status endpoint"
+        )));
     };
     let jobs: Vec<ActiveRunnerJobSummary> = serde_json::from_value(
         body.get("active_runner_jobs")
@@ -1233,8 +1259,62 @@ mod tests {
     }
 
     #[test]
+    fn status_marks_connected_reverse_active_jobs_unavailable_without_broker_url() {
+        test_support::with_isolated_home(|_| {
+            crate::core::runner::create(r#"{"id":"homeboy-lab","kind":"local"}"#, false)
+                .expect("create runner");
+            let mut session = reverse_controller_session();
+            session.broker_url = None;
+            write_session(&session).expect("write session");
+
+            let report = status("homeboy-lab").expect("status");
+
+            assert!(report.connected);
+            assert_eq!(report.active_job_count, 0);
+            assert_eq!(report.active_jobs, Vec::new());
+            assert_eq!(report.active_runner_jobs, Vec::new());
+            assert_eq!(report.active_job_state, RunnerActiveJobState::Unavailable);
+            assert_eq!(report.active_job_source, None);
+            let error = report.active_job_error.expect("active job error");
+            assert_eq!(error.code, "internal.unexpected");
+            assert!(error.message.contains("no broker URL"));
+        });
+    }
+
+    #[test]
+    fn active_runner_job_source_maps_direct_and_reverse_endpoints() {
+        let mut direct = reverse_controller_session();
+        direct.mode = RunnerTunnelMode::DirectSsh;
+        direct.role = RunnerSessionRole::Controller;
+        direct.local_url = Some("http://127.0.0.1:49153".to_string());
+        direct.broker_url = None;
+        assert_eq!(
+            active_runner_job_source(&direct),
+            Some(RunnerActiveJobSource::DirectDaemon)
+        );
+
+        let reverse = reverse_controller_session();
+        assert_eq!(
+            active_runner_job_source(&reverse),
+            Some(RunnerActiveJobSource::ReverseBroker)
+        );
+    }
+
+    #[test]
     fn reverse_controller_session_requires_fresh_heartbeat() {
-        let mut session = RunnerSession {
+        let mut session = reverse_controller_session();
+
+        assert_eq!(session_state(Some(&session)), RunnerSessionState::Connected);
+
+        session.last_seen_at = Some((Utc::now() - chrono::Duration::seconds(120)).to_rfc3339());
+        assert_eq!(session_state(Some(&session)), RunnerSessionState::Recorded);
+
+        session.last_seen_at = None;
+        assert_eq!(session_state(Some(&session)), RunnerSessionState::Recorded);
+    }
+
+    fn reverse_controller_session() -> RunnerSession {
+        RunnerSession {
             runner_id: "homeboy-lab".to_string(),
             mode: RunnerTunnelMode::Reverse,
             role: RunnerSessionRole::Controller,
@@ -1252,14 +1332,6 @@ mod tests {
             worker_identity: Some("worker-1".to_string()),
             worker_pid: Some(1234),
             last_seen_at: Some(Utc::now().to_rfc3339()),
-        };
-
-        assert_eq!(session_state(Some(&session)), RunnerSessionState::Connected);
-
-        session.last_seen_at = Some((Utc::now() - chrono::Duration::seconds(120)).to_rfc3339());
-        assert_eq!(session_state(Some(&session)), RunnerSessionState::Recorded);
-
-        session.last_seen_at = None;
-        assert_eq!(session_state(Some(&session)), RunnerSessionState::Recorded);
+        }
     }
 }

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -61,9 +61,10 @@ use super::super::{
     evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping, load, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since, prepare_lab_runner_capability, rig_materialization,
-    status, sync_workspace, LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions,
-    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    status, sync_workspace, LabRunnerGateDecision, RunnerActiveJobSource, RunnerActiveJobState,
+    RunnerCapabilityPreflight, RunnerExecOptions, RunnerStatusReport, RunnerTunnelMode,
+    RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    RunnerWorkspaceSyncOutput,
 };
 
 use super::agent_task_bridge::{
@@ -2531,6 +2532,9 @@ mod tests {
             active_jobs: Vec::new(),
             active_runner_jobs: Vec::new(),
             active_job_count: 0,
+            active_job_state: RunnerActiveJobState::Available,
+            active_job_source: Some(RunnerActiveJobSource::ReverseBroker),
+            active_job_error: None,
             session_path: "/tmp/lab.json".to_string(),
         }
     }

--- a/src/core/runner/lab/preparation_tests.rs
+++ b/src/core/runner/lab/preparation_tests.rs
@@ -2,7 +2,9 @@ use super::super::lab_selection::{
     prepare_lab_runner_for_offload_with, LabRunnerPreparation, LabRunnerSelection,
 };
 use super::*;
-use crate::core::runner::{RunnerConnectReport, RunnerStatusReport, RunnerTunnelMode};
+use crate::core::runner::{
+    RunnerActiveJobState, RunnerConnectReport, RunnerStatusReport, RunnerTunnelMode,
+};
 
 use super::super::session::RunnerStaleDaemonWarning;
 
@@ -26,6 +28,9 @@ fn lab_runner_preparation_falls_back_for_unreachable_default_runner() {
                 active_jobs: Vec::new(),
                 active_runner_jobs: Vec::new(),
                 active_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -86,6 +91,9 @@ fn lab_runner_preparation_uses_already_connected_runner() {
                 active_jobs: Vec::new(),
                 active_runner_jobs: Vec::new(),
                 active_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -119,6 +127,9 @@ fn lab_runner_preparation_falls_back_for_stale_default_daemon_version() {
                 active_jobs: Vec::new(),
                 active_runner_jobs: Vec::new(),
                 active_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -157,6 +168,9 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
                 active_jobs: Vec::new(),
                 active_runner_jobs: Vec::new(),
                 active_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -205,6 +219,9 @@ fn lab_runner_preparation_falls_back_for_stale_default_direct_session_without_da
                 active_jobs: Vec::new(),
                 active_runner_jobs: Vec::new(),
                 active_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -240,6 +257,9 @@ fn lab_runner_preparation_errors_for_explicit_direct_session_without_daemon_url(
                 active_jobs: Vec::new(),
                 active_runner_jobs: Vec::new(),
                 active_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -280,6 +300,9 @@ fn lab_runner_preparation_connects_disconnected_runner() {
                 active_jobs: Vec::new(),
                 active_runner_jobs: Vec::new(),
                 active_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
@@ -332,6 +355,9 @@ fn lab_runner_preparation_errors_for_unreachable_explicit_runner() {
                 active_jobs: Vec::new(),
                 active_runner_jobs: Vec::new(),
                 active_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
                 session_path: "/tmp/lab.json".to_string(),
             })
         },

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -32,8 +32,8 @@ use crate::core::{Error, Result};
 
 use super::super::command_path::preflight_remote_argv_path_translation;
 use super::super::{
-    connect, disconnect, exec, status, RunnerCapabilityPreflight, RunnerExecOptions,
-    RunnerStatusReport, RunnerTunnelMode,
+    connect, disconnect, exec, status, RunnerActiveJobState, RunnerCapabilityPreflight,
+    RunnerExecOptions, RunnerStatusReport, RunnerTunnelMode,
 };
 use super::offload::runner_homeboy_daemon_display;
 
@@ -282,7 +282,8 @@ fn probe_agent_task_providers_on_runner(
 }
 
 fn runner_provider_refresh_is_safe(status: &RunnerStatusReport) -> bool {
-    status.active_jobs.is_empty()
+    status.active_job_state == RunnerActiveJobState::Available
+        && status.active_jobs.is_empty()
         && status
             .session
             .as_ref()

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -105,10 +105,11 @@ pub use offload_metadata::{
 };
 pub use resource_metrics::RunnerResourceMetrics;
 pub use session::{
-    ReverseRunnerConnectOptions, RunnerArtifactRef, RunnerConnectReport, RunnerDisconnectReport,
-    RunnerFailureKind, RunnerHandoff, RunnerJob, RunnerLifecycleOwner, RunnerResult, RunnerSession,
-    RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
-    RunnerTunnelMode, RunnerWorkspaceLease,
+    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource,
+    RunnerActiveJobState, RunnerArtifactRef, RunnerConnectReport, RunnerDisconnectReport,
+    RunnerFailureKind, RunnerHandoff, RunnerJob, RunnerLifecycleOwner, RunnerResult,
+    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
+    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceLease,
 };
 pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerTransport};
@@ -326,6 +327,7 @@ pub fn resolve_default_lab_runner() -> Result<Option<String>> {
                 connected: status.connected,
                 stale_daemon: status.stale_daemon.is_some(),
                 active_jobs: status.active_jobs.len(),
+                active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
                 capabilities_ready: true,
             })
         }),
@@ -339,6 +341,7 @@ struct DefaultLabRunnerCandidate {
     connected: bool,
     stale_daemon: bool,
     active_jobs: usize,
+    active_jobs_available: bool,
     capabilities_ready: bool,
 }
 
@@ -370,6 +373,9 @@ impl DefaultLabRunnerCandidate {
         }
         if self.mode == RunnerTunnelMode::DirectSsh {
             score += 5;
+        }
+        if !self.active_jobs_available {
+            score -= 25;
         }
         score -= self.active_jobs.min(50) as i32;
 
@@ -742,6 +748,7 @@ mod tests {
             connected,
             stale_daemon: false,
             active_jobs: 0,
+            active_jobs_available: true,
             capabilities_ready: true,
         }
     }
@@ -1232,6 +1239,21 @@ mod tests {
             None,
             vec![
                 busy,
+                default_lab_candidate("lab-b", RunnerTunnelMode::DirectSsh, true),
+            ],
+        );
+
+        assert_eq!(selected.as_deref(), Some("lab-b"));
+    }
+
+    #[test]
+    fn default_lab_runner_prefers_known_active_job_state() {
+        let mut unknown = default_lab_candidate("lab-a", RunnerTunnelMode::DirectSsh, true);
+        unknown.active_jobs_available = false;
+        let selected = resolve_default_lab_runner_from_candidates(
+            None,
+            vec![
+                unknown,
                 default_lab_candidate("lab-b", RunnerTunnelMode::DirectSsh, true),
             ],
         );

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -70,6 +70,27 @@ pub enum RunnerSessionState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerActiveJobState {
+    Available,
+    Unavailable,
+    NotQueried,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerActiveJobSource {
+    DirectDaemon,
+    ReverseBroker,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerActiveJobError {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerSession {
     pub runner_id: String,
     #[serde(default = "default_tunnel_mode")]
@@ -346,6 +367,11 @@ pub struct RunnerStatusReport {
     pub active_runner_jobs: Vec<RunnerJob>,
     #[serde(default)]
     pub active_job_count: usize,
+    pub active_job_state: RunnerActiveJobState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_job_source: Option<RunnerActiveJobSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_job_error: Option<RunnerActiveJobError>,
     pub session_path: String,
 }
 

--- a/src/core/runner/transport.rs
+++ b/src/core/runner/transport.rs
@@ -69,7 +69,9 @@ pub(crate) fn select_runner_transport(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::runner::session::{RunnerSessionRole, RunnerSessionState};
+    use crate::core::runner::session::{
+        RunnerActiveJobState, RunnerSessionRole, RunnerSessionState,
+    };
 
     fn runner(kind: RunnerKind) -> Runner {
         Runner {
@@ -95,6 +97,9 @@ mod tests {
             active_jobs: Vec::new(),
             active_runner_jobs: Vec::new(),
             active_job_count: 0,
+            active_job_state: RunnerActiveJobState::NotQueried,
+            active_job_source: None,
+            active_job_error: None,
             session_path: "/tmp/session.json".to_string(),
         }
     }

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -1667,7 +1667,8 @@ fn runner_upgrade_summary(entry: &RunnerUpgradeEntry) -> String {
 mod tests {
     use super::*;
     use crate::core::runner::{
-        RunnerExecMode, RunnerExecOutput, RunnerSessionState, RunnerStaleDaemonWarning,
+        RunnerActiveJobState, RunnerExecMode, RunnerExecOutput, RunnerSessionState,
+        RunnerStaleDaemonWarning,
     };
     use crate::core::server::RunnerSettings;
     use std::cell::RefCell;
@@ -2904,6 +2905,9 @@ mod tests {
             active_jobs: Vec::new(),
             active_runner_jobs: Vec::new(),
             active_job_count: 0,
+            active_job_state: RunnerActiveJobState::NotQueried,
+            active_job_source: None,
+            active_job_error: None,
             session_path: "/tmp/homeboy-runner-session.json".to_string(),
         })
     }
@@ -2924,6 +2928,9 @@ mod tests {
             active_jobs: Vec::new(),
             active_runner_jobs: Vec::new(),
             active_job_count: 0,
+            active_job_state: RunnerActiveJobState::NotQueried,
+            active_job_source: None,
+            active_job_error: None,
             session_path: "/tmp/homeboy-runner-session.json".to_string(),
         })
     }


### PR DESCRIPTION
## Summary
- Add explicit active-job state/source/error fields to runner status output so zero jobs is distinguishable from unavailable job state.
- Surface daemon/broker active-job fetch failures in status hints without failing the whole status call.
- Treat unknown active-job state as non-idle for default runner scoring and provider refresh safety.
- Add targeted unit coverage for reverse-runner unavailable status mapping and runner selection behavior.

## Verification
-  passed.
- Rust tests were not run locally because this Studio machine is under a no-local-cargo constraint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, implementation, targeted tests, PR preparation.