### PR TITLE
Harden proof artifact semantics

### DIFF
--- a/src/core/proof.rs
+++ b/src/core/proof.rs
@@ -29,6 +29,12 @@ pub struct HomeboyProof {
     pub gates: Vec<HomeboyGateResult>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<HomeboyProofArtifactRef>,
+    #[serde(
+        default,
+        alias = "required_artifacts",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub artifact_requirements: Vec<HomeboyProofArtifactRequirement>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub environment: Vec<HomeboyProofEnvironmentVariable>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -68,11 +74,45 @@ pub enum HomeboyProofRunner {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HomeboyProofArtifactRef {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub uri: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_key: Option<String>,
+    #[serde(
+        default = "default_proof_artifact_purpose",
+        skip_serializing_if = "is_default_proof_artifact_purpose"
+    )]
+    pub purpose: HomeboyProofArtifactPurpose,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeboyProofArtifactRequirement {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_key: Option<String>,
+    #[serde(
+        default = "default_proof_artifact_purpose",
+        skip_serializing_if = "is_default_proof_artifact_purpose"
+    )]
+    pub purpose: HomeboyProofArtifactPurpose,
+    #[serde(default = "default_required_proof_artifact")]
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HomeboyProofArtifactPurpose {
+    Proof,
+    Diagnostic,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -99,8 +139,18 @@ pub struct HomeboyProofGap {
 pub struct HomeboyProofValidationReport {
     #[serde(default = "proof_validation_schema")]
     pub schema: String,
+    #[serde(default = "default_proof_validation_status")]
+    pub status: HomeboyProofValidationStatus,
     pub valid: bool,
     pub diagnostics: Vec<HomeboyProofValidationDiagnostic>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HomeboyProofValidationStatus {
+    Passed,
+    Incomplete,
+    Failed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -130,6 +180,7 @@ impl HomeboyProof {
             provenance,
             gates: Vec::new(),
             artifacts: Vec::new(),
+            artifact_requirements: Vec::new(),
             environment: Vec::new(),
             gaps: Vec::new(),
         }
@@ -153,6 +204,14 @@ impl HomeboyProof {
         artifacts: impl IntoIterator<Item = HomeboyProofArtifactRef>,
     ) -> Self {
         self.artifacts = artifacts.into_iter().collect();
+        self
+    }
+
+    pub fn artifact_requirements(
+        mut self,
+        artifact_requirements: impl IntoIterator<Item = HomeboyProofArtifactRequirement>,
+    ) -> Self {
+        self.artifact_requirements = artifact_requirements.into_iter().collect();
         self
     }
 
@@ -209,11 +268,30 @@ impl HomeboyProofProvenance {
 impl HomeboyProofArtifactRef {
     pub fn uri(uri: impl Into<String>) -> Self {
         Self {
+            id: None,
             uri: uri.into(),
             kind: None,
             label: None,
+            semantic_key: None,
+            purpose: HomeboyProofArtifactPurpose::Proof,
         }
     }
+}
+
+fn default_proof_artifact_purpose() -> HomeboyProofArtifactPurpose {
+    HomeboyProofArtifactPurpose::Proof
+}
+
+fn is_default_proof_artifact_purpose(purpose: &HomeboyProofArtifactPurpose) -> bool {
+    *purpose == HomeboyProofArtifactPurpose::Proof
+}
+
+fn default_required_proof_artifact() -> bool {
+    true
+}
+
+fn default_proof_validation_status() -> HomeboyProofValidationStatus {
+    HomeboyProofValidationStatus::Passed
 }
 
 #[cfg(test)]
@@ -294,6 +372,82 @@ mod tests {
         }));
 
         assert!(report.valid, "{report:?}");
+        assert_eq!(report.status, HomeboyProofValidationStatus::Passed);
+        assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn proof_validation_marks_missing_required_proof_artifact_incomplete() {
+        let report = validate_proof_value(json!({
+            "schema": HOMEBOY_PROOF_SCHEMA,
+            "id": "proof-1",
+            "scope": "targeted",
+            "provenance": { "runner": "homeboy", "run_id": "run-1" },
+            "gates": [{
+                "schema": "homeboy/gate-result/v1",
+                "id": "quality-check",
+                "name": "quality check",
+                "kind": "command",
+                "status": "passed"
+            }],
+            "artifact_requirements": [{
+                "id": "coverage-summary",
+                "kind": "coverage",
+                "purpose": "proof",
+                "required": true
+            }],
+            "artifacts": [{
+                "id": "coverage-debug-log",
+                "uri": "runner-artifact://lab/run-1/debug.log",
+                "kind": "log",
+                "purpose": "diagnostic"
+            }]
+        }));
+
+        assert!(!report.valid);
+        assert_eq!(report.status, HomeboyProofValidationStatus::Incomplete);
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(
+            report.diagnostics[0].code,
+            "required_proof_artifact_missing"
+        );
+    }
+
+    #[test]
+    fn proof_validation_accepts_missing_optional_diagnostic_artifact() {
+        let report = validate_proof_value(json!({
+            "schema": HOMEBOY_PROOF_SCHEMA,
+            "id": "proof-1",
+            "scope": "targeted",
+            "provenance": { "runner": "homeboy", "run_id": "run-1" },
+            "gates": [{
+                "schema": "homeboy/gate-result/v1",
+                "id": "quality-check",
+                "name": "quality check",
+                "kind": "command",
+                "status": "passed"
+            }],
+            "artifact_requirements": [{
+                "id": "coverage-summary",
+                "kind": "coverage",
+                "purpose": "proof",
+                "required": true
+            }, {
+                "id": "coverage-debug-log",
+                "kind": "log",
+                "purpose": "diagnostic",
+                "required": false
+            }],
+            "artifacts": [{
+                "id": "coverage-summary",
+                "uri": "runner-artifact://lab/run-1/coverage.json",
+                "kind": "coverage",
+                "purpose": "proof"
+            }]
+        }));
+
+        assert!(report.valid, "{report:?}");
+        assert_eq!(report.status, HomeboyProofValidationStatus::Passed);
         assert!(report.diagnostics.is_empty());
     }
 
@@ -318,6 +472,7 @@ mod tests {
         }));
 
         assert!(!report.valid);
+        assert_eq!(report.status, HomeboyProofValidationStatus::Failed);
         let codes: Vec<&str> = report
             .diagnostics
             .iter()

--- a/src/core/proof/validation.rs
+++ b/src/core/proof/validation.rs
@@ -7,6 +7,8 @@ use crate::core::gate::{HomeboyGateResult, HomeboyGateStatus};
 
 use super::*;
 
+const REQUIRED_PROOF_ARTIFACT_MISSING: &str = "required_proof_artifact_missing";
+
 pub fn validate_proof_value(value: Value) -> HomeboyProofValidationReport {
     let mut diagnostics = Vec::new();
     let value = match unwrap_command_envelope(value, &mut diagnostics) {
@@ -14,6 +16,7 @@ pub fn validate_proof_value(value: Value) -> HomeboyProofValidationReport {
         None => {
             return HomeboyProofValidationReport {
                 schema: HOMEBOY_PROOF_VALIDATION_SCHEMA.to_string(),
+                status: validation_status(&diagnostics),
                 valid: false,
                 diagnostics,
             };
@@ -47,11 +50,7 @@ pub fn validate_proof_value(value: Value) -> HomeboyProofValidationReport {
         )),
     }
 
-    HomeboyProofValidationReport {
-        schema: HOMEBOY_PROOF_VALIDATION_SCHEMA.to_string(),
-        valid: diagnostics.is_empty(),
-        diagnostics,
-    }
+    validation_report(diagnostics)
 }
 
 fn unwrap_command_envelope(
@@ -118,6 +117,7 @@ fn validate_homeboy_proof(
             diagnostics,
         );
     }
+    validate_required_proof_artifacts(proof, diagnostics);
     for (index, source_ref) in proof.provenance.source_refs.iter().enumerate() {
         validate_evidence_ref(
             source_ref,
@@ -151,6 +151,55 @@ fn validate_homeboy_proof(
             Some(format!("/gaps/{index}")),
         ));
     }
+}
+
+fn validate_required_proof_artifacts(
+    proof: &HomeboyProof,
+    diagnostics: &mut Vec<HomeboyProofValidationDiagnostic>,
+) {
+    for (index, requirement) in proof.artifact_requirements.iter().enumerate() {
+        if !requirement.required {
+            continue;
+        }
+        if proof
+            .artifacts
+            .iter()
+            .any(|artifact| artifact_satisfies_requirement(artifact, requirement))
+        {
+            continue;
+        }
+        diagnostics.push(diagnostic(
+            REQUIRED_PROOF_ARTIFACT_MISSING,
+            format!(
+                "required {:?} artifact '{}' was declared but not recorded in proof artifacts",
+                requirement.purpose, requirement.id
+            ),
+            Some(format!("/artifact_requirements/{index}")),
+        ));
+    }
+}
+
+fn artifact_satisfies_requirement(
+    artifact: &HomeboyProofArtifactRef,
+    requirement: &HomeboyProofArtifactRequirement,
+) -> bool {
+    artifact.purpose == requirement.purpose
+        && artifact.id.as_ref().is_some_and(|id| id == &requirement.id)
+        && requirement
+            .kind
+            .as_ref()
+            .map(|kind| artifact.kind.as_ref() == Some(kind))
+            .unwrap_or(true)
+        && requirement
+            .label
+            .as_ref()
+            .map(|label| artifact.label.as_ref() == Some(label))
+            .unwrap_or(true)
+        && requirement
+            .semantic_key
+            .as_ref()
+            .map(|semantic_key| artifact.semantic_key.as_ref() == Some(semantic_key))
+            .unwrap_or(true)
 }
 
 fn validate_materialized_loop_spec(
@@ -252,6 +301,33 @@ fn diagnostic(
 
 fn path(value: &str) -> Option<String> {
     Some(value.to_string())
+}
+
+fn validation_report(
+    diagnostics: Vec<HomeboyProofValidationDiagnostic>,
+) -> HomeboyProofValidationReport {
+    let status = validation_status(&diagnostics);
+    HomeboyProofValidationReport {
+        schema: HOMEBOY_PROOF_VALIDATION_SCHEMA.to_string(),
+        status,
+        valid: status == HomeboyProofValidationStatus::Passed,
+        diagnostics,
+    }
+}
+
+fn validation_status(
+    diagnostics: &[HomeboyProofValidationDiagnostic],
+) -> HomeboyProofValidationStatus {
+    if diagnostics.is_empty() {
+        return HomeboyProofValidationStatus::Passed;
+    }
+    if diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.code == REQUIRED_PROOF_ARTIFACT_MISSING)
+    {
+        return HomeboyProofValidationStatus::Incomplete;
+    }
+    HomeboyProofValidationStatus::Failed
 }
 
 pub(super) fn proof_validation_schema() -> String {


### PR DESCRIPTION
## Summary
- Add explicit proof artifact requirements with `proof` vs `diagnostic` artifact purpose semantics.
- Preserve older proof payloads by keeping existing `artifacts` valid and accepting `required_artifacts` as an alias.
- Report missing required proof artifacts as `status: incomplete` with `valid: false`, so controller proof validation exits non-zero instead of silently succeeding.

## Tests
- `rustfmt src/core/proof.rs src/core/proof/validation.rs`
- `git diff --check`
- Not run: `cargo test` / local benchmarks per local environment rules.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.5
- **Used for:** Schema hardening implementation, focused proof validation tests, and PR preparation.
