### PR TITLE
Fail project deploy readiness on missing component paths

### DIFF
--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -38,6 +38,7 @@ use crate::core::project;
 /// and SSH context resolution, keeping those details encapsulated.
 pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestrationResult> {
     let project = project::load(project_id)?;
+    project::validate_component_local_paths(&project)?;
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)?;
     orchestration::deploy_components(config, &project, &ctx, &base_path)
 }
@@ -260,4 +261,57 @@ pub fn resolve_shared_targets(component_ids: &[String]) -> Result<Vec<String>> {
     }
 
     Ok(project_ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::project::{Project, ProjectComponentAttachment};
+    use crate::test_support::with_isolated_home;
+
+    fn deploy_config() -> DeployConfig {
+        DeployConfig {
+            component_ids: vec!["plugin".to_string()],
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: true,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            expected_version: None,
+            no_pull: false,
+            head: false,
+            tagged: false,
+        }
+    }
+
+    #[test]
+    fn deploy_planning_fails_closed_when_project_component_local_path_is_missing() {
+        with_isolated_home(|_| {
+            project::save(&Project {
+                id: "site".to_string(),
+                server_id: None,
+                base_path: Some("/srv/site".to_string()),
+                components: vec![ProjectComponentAttachment {
+                    id: "plugin".to_string(),
+                    local_path: "/tmp/homeboy-missing-component-path".to_string(),
+                    remote_path: Some("wp-content/plugins/plugin".to_string()),
+                }],
+                ..Project::default()
+            })
+            .expect("save project");
+
+            let err = run("site", &deploy_config()).expect_err("missing local_path should block");
+
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("component local_path blockers"));
+            assert!(err.hints.iter().any(|hint| {
+                hint.message.contains(
+                    "Component 'plugin' local_path '/tmp/homeboy-missing-component-path' does not exist",
+                )
+            }));
+        });
+    }
 }

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -24,6 +24,7 @@ pub fn resolve_project_component_with_standalone_snapshot(
             .iter()
             .find(|component| component.id == component_id)
     {
+        super::super::validate_component_local_path(project, component_id)?;
         (
             discover_attached_component(Path::new(&attachment.local_path)).ok_or_else(|| {
                 Error::validation_invalid_argument(
@@ -332,5 +333,23 @@ mod tests {
                 Some("custom-extract {{artifact}}")
             );
         });
+    }
+
+    #[test]
+    fn status_resolution_reports_missing_component_local_path() {
+        let project = project_with_attachment(
+            Some("wp-content/plugins/fixture"),
+            "/tmp/homeboy-missing-component-path".to_string(),
+        );
+
+        let err = resolve_project_component(&project, "fixture").expect_err("missing local_path");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("missing local_path"));
+        assert!(err.hints.iter().any(|hint| {
+            hint.message.contains(
+                "Component 'fixture' local_path '/tmp/homeboy-missing-component-path' does not exist",
+            )
+        }));
     }
 }

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -34,7 +34,9 @@ pub use pins::{
     add_pin, list_pins, remove_pin, rename_pin, update_pin, PinUpdateOptions, ProjectPinChange,
     ProjectPinListItem, ProjectPinOutput,
 };
-pub use readiness::calculate_deploy_readiness;
+pub use readiness::{
+    calculate_deploy_readiness, validate_component_local_path, validate_component_local_paths,
+};
 pub use report::{
     build_components_output, build_create_output, build_delete_output, build_init_output,
     build_list_output, build_path_resolution_output, build_pin_output, build_remove_output,

--- a/src/core/project/readiness.rs
+++ b/src/core/project/readiness.rs
@@ -1,4 +1,5 @@
 use crate::core::component;
+use crate::core::error::{Error, Result};
 
 use super::Project;
 
@@ -40,6 +41,8 @@ pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
             project.id
         ));
     } else {
+        blockers.extend(component_local_path_blockers(project));
+
         let standalone_snapshot = super::StandaloneComponentConfigSnapshot::load();
         let has_deployable = project.components.iter().any(|attachment| {
             if let Ok(comp) = super::resolve_project_component_with_standalone_snapshot(
@@ -64,4 +67,120 @@ pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
     }
 
     (blockers.is_empty(), blockers)
+}
+
+pub fn validate_component_local_paths(project: &Project) -> Result<()> {
+    let blockers = component_local_path_blockers(project);
+    if blockers.is_empty() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "components.local_path",
+        "Project has component local_path blockers",
+        Some(project.id.clone()),
+        Some(blockers),
+    ))
+}
+
+pub fn validate_component_local_path(project: &Project, component_id: &str) -> Result<()> {
+    let blockers = project
+        .components
+        .iter()
+        .filter(|attachment| attachment.id == component_id)
+        .filter_map(|attachment| {
+            component_local_path_blocker(project, &attachment.id, &attachment.local_path)
+        })
+        .collect::<Vec<_>>();
+
+    if blockers.is_empty() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "components.local_path",
+        "Project component has a missing local_path",
+        Some(project.id.clone()),
+        Some(blockers),
+    ))
+}
+
+fn component_local_path_blockers(project: &Project) -> Vec<String> {
+    project
+        .components
+        .iter()
+        .filter_map(|attachment| {
+            component_local_path_blocker(project, &attachment.id, &attachment.local_path)
+        })
+        .collect()
+}
+
+fn component_local_path_blocker(
+    project: &Project,
+    component_id: &str,
+    local_path: &str,
+) -> Option<String> {
+    let trimmed = local_path.trim();
+    if trimmed.is_empty() {
+        return Some(format!(
+            "Component '{}' is missing local_path - attach a checkout with: homeboy project components attach-path {} <local-path>",
+            component_id, project.id
+        ));
+    }
+
+    let expanded = shellexpand::tilde(trimmed);
+    let path = std::path::Path::new(expanded.as_ref());
+    if path.exists() {
+        return None;
+    }
+
+    Some(format!(
+        "Component '{}' local_path '{}' does not exist - update it with: homeboy project components attach-path {} <local-path>",
+        component_id, trimmed, project.id
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::project::ProjectComponentAttachment;
+
+    fn project_with_component(local_path: String) -> Project {
+        Project {
+            id: "site".to_string(),
+            server_id: Some("server".to_string()),
+            base_path: Some("/srv/site".to_string()),
+            components: vec![ProjectComponentAttachment {
+                id: "plugin".to_string(),
+                local_path,
+                remote_path: Some("wp-content/plugins/plugin".to_string()),
+            }],
+            ..Project::default()
+        }
+    }
+
+    #[test]
+    fn project_show_readiness_blocks_missing_component_local_path() {
+        let project = project_with_component("/tmp/homeboy-missing-component-path".to_string());
+
+        let (ready, blockers) = calculate_deploy_readiness(&project);
+
+        assert!(!ready);
+        assert!(blockers.iter().any(|blocker| {
+            blocker.contains("Component 'plugin' local_path '/tmp/homeboy-missing-component-path' does not exist")
+        }));
+    }
+
+    #[test]
+    fn deploy_readiness_validation_fails_closed_on_missing_component_local_path() {
+        let project = project_with_component("/tmp/homeboy-missing-component-path".to_string());
+
+        let err = validate_component_local_paths(&project).expect_err("missing path should block");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("component local_path blockers"));
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("local_path '/tmp/homeboy-missing-component-path' does not exist")));
+    }
 }

--- a/src/core/project/report.rs
+++ b/src/core/project/report.rs
@@ -343,3 +343,36 @@ pub fn build_init_output(project_id: &str, dir: &std::path::Path) -> ProjectRepo
         ..Default::default()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::project::ProjectComponentAttachment;
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn show_report_marks_project_not_deploy_ready_when_component_local_path_is_missing() {
+        with_isolated_home(|_| {
+            crate::core::project::save(&Project {
+                id: "site".to_string(),
+                base_path: Some("/srv/site".to_string()),
+                components: vec![ProjectComponentAttachment {
+                    id: "plugin".to_string(),
+                    local_path: "/tmp/homeboy-missing-component-path".to_string(),
+                    remote_path: Some("wp-content/plugins/plugin".to_string()),
+                }],
+                ..Project::default()
+            })
+            .expect("save project");
+
+            let report = show_report("site").expect("show report");
+
+            assert!(!report.deploy_ready);
+            assert!(report.deploy_blockers.iter().any(|blocker| {
+                blocker.contains(
+                    "Component 'plugin' local_path '/tmp/homeboy-missing-component-path' does not exist",
+                )
+            }));
+        });
+    }
+}


### PR DESCRIPTION
Closes #5742

## What changed
- Added project component `local_path` existence validation to deploy readiness so `project show` fails closed when an attached checkout path is missing.
- Reused the same validation before deploy resolves SSH/planning, producing a clear blocker instead of proceeding with stale project config.
- Made project component resolution surface the missing `local_path` blocker for status/readiness callers.
- Added focused regression coverage for project show readiness, status component resolution, and deploy planning fail-closed behavior.

## Verification
- `rustfmt --check src/core/project/report.rs src/core/project/readiness.rs src/core/project/component/resolution.rs src/core/deploy/mod.rs src/core/project/mod.rs`
- `git diff --check`
- Not run: `cargo test` or other cargo commands locally, per repo constraint to avoid local cargo/Rust-heavy verification.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the focused readiness guard, adding regression tests, formatting/checking, and drafting this PR body.