### PR TITLE
Add runner workload contract metadata

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -24,7 +24,10 @@ pub use lab::{
     lab_runner_supports_contract_label, lab_runner_unsupported_hint,
     lab_runner_unsupported_message, LabCommandContract, LabCommandPortability,
     LabCommandRequiredTool, LabRoutingPolicy, LabRunnerSupportSummary, LabSourcePathMode,
-    LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
+    LabWorkspaceModePolicy, RunnerWorkload, RunnerWorkloadAssignment, RunnerWorkloadCapability,
+    RunnerWorkloadCommandFamily, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
+    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
+    RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS, RUNNER_WORKLOAD_SCHEMA,
 };
 pub(crate) use lab::{
     AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REVIEW_LAB_LABEL,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -16,6 +16,8 @@ use crate::core::engine::execution_context::{self, ResolveOptions};
 use crate::core::extension::ExtensionCapability;
 use std::collections::BTreeSet;
 
+pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
+
 /// Routing-policy flags shared by every Lab command representation
 /// (`LabCommandContract`, `LabRoutePlan`, `LabOffloadCommand`). These four
 /// booleans travel together as one cohesive policy as a command is resolved
@@ -75,6 +77,82 @@ pub enum LabWorkspaceModePolicy {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabCommandRequiredTool {
     Playwright,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkload {
+    pub schema: String,
+    pub workload_id: String,
+    pub kind: RunnerWorkloadKind,
+    pub workspace_mappings: RunnerWorkloadWorkspaceMappings,
+    pub required_capabilities: Vec<RunnerWorkloadCapability>,
+    pub required_secrets: RunnerWorkloadSecrets,
+    pub mutation_policy: RunnerWorkloadMutationPolicy,
+    pub assignment: RunnerWorkloadAssignment,
+    pub state: RunnerWorkloadState,
+    pub result_refs: RunnerWorkloadResultRefs,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadKind {
+    pub command_label: String,
+    pub command_family: RunnerWorkloadCommandFamily,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerWorkloadCommandFamily {
+    AgentTask,
+    Quality,
+    Workspace,
+    Service,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadWorkspaceMappings {
+    pub source_path_mode: String,
+    pub workspace_mode_policy: String,
+    pub mapping_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadCapability {
+    pub name: String,
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadSecrets {
+    pub categories: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadMutationPolicy {
+    pub capture_patch: bool,
+    pub mutation_flag: Option<String>,
+    pub allow_dirty_lab_workspace: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadAssignment {
+    pub runner_id: Option<String>,
+    pub runner_mode: Option<String>,
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadState {
+    pub status: String,
+    pub remote_workspace: Option<String>,
+    pub fallback_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadResultRefs {
+    pub plan_id: String,
+    pub proof_id: Option<String>,
+    pub workspace_mapping_ref: Option<String>,
 }
 
 pub const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
@@ -480,6 +558,69 @@ pub(super) fn apply_lab_contract_to_descriptor(
 }
 
 impl LabCommandContract {
+    pub fn runner_workload(
+        &self,
+        workload_id: impl Into<String>,
+        plan_id: impl Into<String>,
+        assignment: RunnerWorkloadAssignment,
+        state: RunnerWorkloadState,
+        mutation_policy: RunnerWorkloadMutationPolicy,
+        workspace_mapping_ref: Option<String>,
+        proof_id: Option<String>,
+    ) -> RunnerWorkload {
+        RunnerWorkload {
+            schema: RUNNER_WORKLOAD_SCHEMA.to_string(),
+            workload_id: workload_id.into(),
+            kind: RunnerWorkloadKind {
+                command_label: self.hot_label.to_string(),
+                command_family: RunnerWorkloadCommandFamily::from_command_label(self.hot_label),
+            },
+            workspace_mappings: RunnerWorkloadWorkspaceMappings {
+                source_path_mode: self.source_path_mode.label().to_string(),
+                workspace_mode_policy: self.workspace_mode_policy.label().to_string(),
+                mapping_ref: workspace_mapping_ref.clone(),
+            },
+            required_capabilities: self.required_capabilities(),
+            required_secrets: RunnerWorkloadSecrets {
+                categories: self.required_secret_categories(),
+            },
+            mutation_policy,
+            assignment,
+            state,
+            result_refs: RunnerWorkloadResultRefs {
+                plan_id: plan_id.into(),
+                proof_id,
+                workspace_mapping_ref,
+            },
+        }
+    }
+
+    fn required_capabilities(&self) -> Vec<RunnerWorkloadCapability> {
+        let mut capabilities = Vec::new();
+        if self.routing_policy.requires_extension_parity {
+            capabilities.push(RunnerWorkloadCapability {
+                name: "extension_parity".to_string(),
+                required: true,
+            });
+        }
+        for tool in self.extra_required_tools {
+            capabilities.push(RunnerWorkloadCapability {
+                name: tool.label().to_string(),
+                required: true,
+            });
+        }
+        capabilities
+    }
+
+    fn required_secret_categories(&self) -> Vec<String> {
+        match self.hot_label {
+            label if label.starts_with("agent-task") => vec!["agent_task".to_string()],
+            TRACE_LAB_LABEL => vec!["trace".to_string()],
+            label if label.starts_with("tunnel") => vec!["tunnel".to_string()],
+            _ => Vec::new(),
+        }
+    }
+
     pub(crate) fn portable(
         hot_label: &'static str,
         mutation_flag: Option<&'static str>,
@@ -589,6 +730,47 @@ impl LabCommandContract {
     pub(crate) const fn release_gate(mut self) -> Self {
         self.routing_policy.release_gate = true;
         self
+    }
+}
+
+impl LabSourcePathMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::CwdOrPathFlag => "cwd_or_path_flag",
+            Self::RunnerResident => "runner_resident",
+        }
+    }
+}
+
+impl LabWorkspaceModePolicy {
+    fn label(self) -> &'static str {
+        match self {
+            Self::ChangedSinceGitElseSnapshot => "changed_since_git_else_snapshot",
+            Self::Git => "git",
+            Self::GitCheckoutRequired => "git_checkout_required",
+            Self::RunnerResident => "runner_resident",
+        }
+    }
+}
+
+impl LabCommandRequiredTool {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Playwright => "playwright",
+        }
+    }
+}
+
+impl RunnerWorkloadCommandFamily {
+    pub(crate) fn from_command_label(label: &str) -> Self {
+        match label {
+            label if label.starts_with("agent-task") => Self::AgentTask,
+            LINT_LAB_LABEL | TEST_LAB_LABEL | AUDIT_LAB_LABEL | REVIEW_LAB_LABEL
+            | BENCH_LAB_LABEL | FUZZ_LAB_LABEL | TRACE_LAB_LABEL => Self::Quality,
+            REFACTOR_LAB_LABEL | RIG_CHECK_LAB_LABEL => Self::Workspace,
+            label if label.starts_with("tunnel") => Self::Service,
+            _ => Self::Unknown,
+        }
     }
 }
 

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -309,7 +309,10 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
         observed.workspace.root.as_deref(),
         Some("/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance")
     );
-    assert_eq!(observed.workspace.slug.as_deref(), Some("sample-agent-runtime"));
+    assert_eq!(
+        observed.workspace.slug.as_deref(),
+        Some("sample-agent-runtime")
+    );
     assert!(observed.workspace.kind.is_none());
     assert!(observed.workspace.component_id.is_none());
     assert!(observed.workspace.branch.is_none());

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -9,11 +9,12 @@ use serde_json::Value;
 
 use homeboy::core::api_jobs::{Job, JobEvent, JobStatus};
 use homeboy::core::redaction::RedactionPolicy;
+use homeboy::core::runner::{RunnerActiveJobSource, RunnerActiveJobState};
 use homeboy::core::runners::{
     self as runner, runner_job_log_snapshot, ReverseRunnerConnectOptions,
-    ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner, RunnerActiveJobSource,
-    RunnerActiveJobState, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput,
-    RunnerKind, RunnerSession, RunnerStatusReport, RunnerTunnelMode,
+    ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner, RunnerConnectReport,
+    RunnerDisconnectReport, RunnerExecOutput, RunnerKind, RunnerSession, RunnerStatusReport,
+    RunnerTunnelMode,
 };
 use homeboy::core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 use homeboy::core::stream_capture::StreamCaptureMetadata;

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -1536,7 +1536,10 @@ fn resume_failed_action_result_includes_top_level_failure_summary() {
             json!("task-overlay-prepare")
         );
         assert_eq!(failed["failure_summary"]["phase"], json!("prepare"));
-        assert_eq!(failed["failure_summary"]["provider"], json!("synthetic-runtime"));
+        assert_eq!(
+            failed["failure_summary"]["provider"],
+            json!("synthetic-runtime")
+        );
         assert_eq!(
             failed["failure_summary"]["failure_phase"],
             json!("runtime_overlay_preparation")

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -3709,7 +3709,8 @@ mod tests {
         provider.backend = "synthetic-runtime".to_string();
 
         let providers = [provider];
-        let resolution = resolve_provider_for_backend(&providers, "synthetic-runtime", Some("fast"));
+        let resolution =
+            resolve_provider_for_backend(&providers, "synthetic-runtime", Some("fast"));
 
         assert_eq!(
             resolution,
@@ -4612,7 +4613,10 @@ process.stdout.write(JSON.stringify({
             .get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
             .expect("provider default source discovered");
         assert_eq!(source.source, "json-file");
-        assert_eq!(source.path.as_deref(), Some("~/.example-provider/auth.json"));
+        assert_eq!(
+            source.path.as_deref(),
+            Some("~/.example-provider/auth.json")
+        );
         assert_eq!(source.field.as_deref(), Some("tokens.access_token"));
     }
 

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -518,11 +518,8 @@ fn planned_deploy_ref(component: &Component, config: &DeployConfig) -> Result<Op
     }
 
     let tag = latest_deploy_tag(component, config.expected_version.as_deref())?;
-    let tag_sha = crate::core::engine::command::run_in_optional(
-        path,
-        "git",
-        &["rev-parse", "--short", &tag],
-    );
+    let tag_sha =
+        crate::core::engine::command::run_in_optional(path, "git", &["rev-parse", "--short", &tag]);
     let head_ahead = crate::core::engine::command::run_in_optional(
         path,
         "git",

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -16,10 +16,10 @@ use crate::core::server::{self, Server, ServerAuthMode, SshClient};
 
 use super::broker_http;
 use super::session::{
-    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource,
-    RunnerActiveJobState, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
-    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
-    RunnerStatusReport, RunnerTunnelMode,
+    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
+    RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
+    RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
+    RunnerTunnelMode,
 };
 use super::{load, Runner, RunnerKind};
 

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -19,6 +19,12 @@
 use std::path::Path;
 
 use crate::command_contract::lab_runner_support_summary;
+use crate::command_contract::{
+    RunnerWorkload, RunnerWorkloadAssignment, RunnerWorkloadCapability,
+    RunnerWorkloadCommandFamily, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
+    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
+    RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
+};
 use crate::core::agent_task_lifecycle;
 use crate::core::engine::shell;
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
@@ -61,11 +67,12 @@ use super::super::{
     evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping, load, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since, prepare_lab_runner_capability, rig_materialization,
-    status, sync_workspace, LabRunnerGateDecision, RunnerActiveJobSource, RunnerActiveJobState,
-    RunnerCapabilityPreflight, RunnerExecOptions, RunnerStatusReport, RunnerTunnelMode,
-    RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
-    RunnerWorkspaceSyncOutput,
+    status, sync_workspace, LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions,
+    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
+#[cfg(test)]
+use super::super::{RunnerActiveJobSource, RunnerActiveJobState};
 
 use super::agent_task_bridge::{
     agent_task_dispatch_run_isolation_token, ensure_agent_task_dispatch_run_id_with,
@@ -1302,6 +1309,17 @@ fn run_lab_offload_inner(
         None,
         Some(&workspace_mapping_metadata),
     );
+    lab_metadata["runner_workload"] = serde_json::to_value(runner_workload_metadata(
+        &plan,
+        &contract,
+        &request,
+        runner_id,
+        status_tunnel_mode(&runner_status).metadata_value(),
+        selection.source.metadata_value(),
+        &remote_cwd,
+        &lab_metadata,
+    ))
+    .unwrap_or(serde_json::json!(null));
     lab_metadata["source_snapshot"] =
         serde_json::to_value(&source_snapshot).unwrap_or(serde_json::json!(null));
     lab_metadata["materialization_proof"] = lab_materialization_proof_metadata(
@@ -1706,6 +1724,116 @@ fn lab_materialization_proof_metadata(
         "workspace_mapping": workspace_mapping,
         "rigs": synced_rigs,
     })
+}
+
+fn runner_workload_metadata(
+    plan: &HomeboyPlan,
+    contract: &LabOffloadCommand,
+    request: &LabOffloadRequest<'_>,
+    runner_id: &str,
+    runner_mode: &str,
+    assignment_source: &str,
+    remote_workspace: &str,
+    lab_metadata: &serde_json::Value,
+) -> RunnerWorkload {
+    RunnerWorkload {
+        schema: RUNNER_WORKLOAD_SCHEMA.to_string(),
+        workload_id: format!("{}.runner_workload", plan.id),
+        kind: RunnerWorkloadKind {
+            command_label: contract.hot_label.to_string(),
+            command_family: RunnerWorkloadCommandFamily::from_command_label(contract.hot_label),
+        },
+        workspace_mappings: RunnerWorkloadWorkspaceMappings {
+            source_path_mode: contract.source_path_mode.label().to_string(),
+            workspace_mode_policy: contract.workspace_mode_policy.label().to_string(),
+            mapping_ref: Some("workspace_mapping".to_string()),
+        },
+        required_capabilities: runner_workload_required_capabilities(contract),
+        required_secrets: RunnerWorkloadSecrets {
+            categories: runner_workload_required_secret_categories(contract.hot_label),
+        },
+        mutation_policy: RunnerWorkloadMutationPolicy {
+            capture_patch: request.capture_patch,
+            mutation_flag: request.mutation_flag.map(str::to_string),
+            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+        },
+        assignment: RunnerWorkloadAssignment {
+            runner_id: Some(runner_id.to_string()),
+            runner_mode: Some(runner_mode.to_string()),
+            source: Some(assignment_source.to_string()),
+        },
+        state: RunnerWorkloadState {
+            status: "offloaded".to_string(),
+            remote_workspace: Some(remote_workspace.to_string()),
+            fallback_reason: None,
+        },
+        result_refs: RunnerWorkloadResultRefs {
+            plan_id: plan.id.clone(),
+            proof_id: lab_metadata
+                .get("proof")
+                .and_then(|proof| proof.get("id"))
+                .and_then(|id| id.as_str())
+                .map(str::to_string),
+            workspace_mapping_ref: Some("workspace_mapping".to_string()),
+        },
+    }
+}
+
+fn runner_workload_required_capabilities(
+    contract: &LabOffloadCommand,
+) -> Vec<RunnerWorkloadCapability> {
+    let mut capabilities = Vec::new();
+    if contract.routing_policy.requires_extension_parity || !contract.required_extensions.is_empty()
+    {
+        capabilities.push(RunnerWorkloadCapability {
+            name: "extension_parity".to_string(),
+            required: true,
+        });
+    }
+    if contract.requires_playwright {
+        capabilities.push(RunnerWorkloadCapability {
+            name: "playwright".to_string(),
+            required: true,
+        });
+    }
+    capabilities
+}
+
+fn runner_workload_required_secret_categories(hot_label: &str) -> Vec<String> {
+    match hot_label {
+        label if label.starts_with("agent-task") => vec!["agent_task".to_string()],
+        "trace" => vec!["trace".to_string()],
+        label if label.starts_with("tunnel") => vec!["tunnel".to_string()],
+        _ => Vec::new(),
+    }
+}
+
+impl LabOffloadSourcePathMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::CwdOrPathFlag => "cwd_or_path_flag",
+            Self::RunnerResident => "runner_resident",
+        }
+    }
+}
+
+impl LabOffloadWorkspaceModePolicy {
+    fn label(self) -> &'static str {
+        match self {
+            Self::ChangedSinceGitElseSnapshot => "changed_since_git_else_snapshot",
+            Self::Git => "git",
+            Self::GitCheckoutRequired => "git_checkout_required",
+            Self::RunnerResident => "runner_resident",
+        }
+    }
+}
+
+fn passive_wp_codebox_version() -> Option<String> {
+    ["HOMEBOY_WP_CODEBOX_VERSION", "WP_CODEBOX_VERSION"]
+        .into_iter()
+        .find_map(|name| std::env::var(name).ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn source_checkout_ref_display(metadata: &serde_json::Value) -> String {

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -888,7 +888,10 @@ mod tests {
             .get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
             .expect("example provider default source discovered for cook");
         assert_eq!(source.source, "json-file");
-        assert_eq!(source.path.as_deref(), Some("~/.example-provider/auth.json"));
+        assert_eq!(
+            source.path.as_deref(),
+            Some("~/.example-provider/auth.json")
+        );
         assert_eq!(source.field.as_deref(), Some("tokens.access_token"));
     }
 
@@ -1107,8 +1110,7 @@ mod tests {
             .expect("provider default source should resolve on controller");
 
             assert!(matches!(
-                env.get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
-                    .map(String::as_str),
+                env.get("EXAMPLE_PROVIDER_ACCESS_TOKEN").map(String::as_str),
                 Some("controller-access-token")
             ));
             assert_eq!(

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -401,8 +401,7 @@ fn injected_default_provider_config_is_remappable() {
             &injected,
             &[LabPathRemap {
                 local: "/Users/user/Developer/example-provider@oauth".to_string(),
-                remote: "/home/user/Developer/_lab_workspaces/example-provider@oauth"
-                    .to_string(),
+                remote: "/home/user/Developer/_lab_workspaces/example-provider@oauth".to_string(),
             }],
         );
         let cfg_idx = remapped

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -102,14 +102,15 @@ pub use offload_changed_since::{
 pub use offload_metadata::{
     capture_lab_offload_subprocess_metadata, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping,
+    lab_offload_metadata_with_workspace_mapping_and_runner_workload,
 };
 pub use resource_metrics::RunnerResourceMetrics;
 pub use session::{
-    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource,
-    RunnerActiveJobState, RunnerArtifactRef, RunnerConnectReport, RunnerDisconnectReport,
-    RunnerFailureKind, RunnerHandoff, RunnerJob, RunnerLifecycleOwner, RunnerResult,
-    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
-    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceLease,
+    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
+    RunnerArtifactRef, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+    RunnerHandoff, RunnerJob, RunnerLifecycleOwner, RunnerResult, RunnerSession, RunnerSessionRole,
+    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
+    RunnerWorkspaceLease,
 };
 pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerTransport};

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -1,3 +1,4 @@
+use crate::command_contract::RunnerWorkload;
 use crate::core::execution_contract::EXECUTION_CONTRACT;
 use crate::core::gate::{collect_plan_gate_results, HomeboyGateResult};
 use crate::core::plan::{HomeboyPlan, PlanStepStatus};
@@ -37,6 +38,31 @@ pub fn lab_offload_metadata_with_workspace_mapping(
     fallback_reason: Option<&str>,
     workspace_mapping: Option<&serde_json::Value>,
 ) -> serde_json::Value {
+    lab_offload_metadata_with_workspace_mapping_and_runner_workload(
+        plan,
+        source,
+        runner_id,
+        runner_mode,
+        status,
+        remote_workspace,
+        fallback_reason,
+        workspace_mapping,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn lab_offload_metadata_with_workspace_mapping_and_runner_workload(
+    plan: &HomeboyPlan,
+    source: &str,
+    runner_id: Option<&str>,
+    runner_mode: Option<&str>,
+    status: &str,
+    remote_workspace: Option<&str>,
+    fallback_reason: Option<&str>,
+    workspace_mapping: Option<&serde_json::Value>,
+    runner_workload: Option<&RunnerWorkload>,
+) -> serde_json::Value {
     let sync_mode = plan_step_input_string(plan, "lab.sync_workspace", "mode");
     let gate_results = collect_plan_gate_results(plan);
     let proof = plan.proof.clone().or_else(|| {
@@ -67,6 +93,7 @@ pub fn lab_offload_metadata_with_workspace_mapping(
         "proof": proof,
         "patch_captured": plan_has_step(plan, "lab.apply_patch"),
         "workspace_mapping": workspace_mapping,
+        "runner_workload": runner_workload,
     })
 }
 
@@ -156,7 +183,13 @@ pub fn capture_lab_offload_subprocess_metadata(metadata: serde_json::Value) {
 mod tests {
     use super::{
         lab_offload_metadata, lab_offload_metadata_with_workspace_mapping,
+        lab_offload_metadata_with_workspace_mapping_and_runner_workload,
         LAB_OFFLOAD_METADATA_SCHEMA,
+    };
+    use crate::command_contract::{
+        RunnerWorkload, RunnerWorkloadAssignment, RunnerWorkloadCommandFamily, RunnerWorkloadKind,
+        RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
+        RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
     };
     use crate::core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
     use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
@@ -305,6 +338,74 @@ mod tests {
         );
 
         assert_eq!(metadata["workspace_mapping"], mapping);
+    }
+
+    #[test]
+    fn lab_offload_metadata_records_runner_workload_when_supplied() {
+        let plan = lab_plan();
+        let workload = RunnerWorkload {
+            schema: RUNNER_WORKLOAD_SCHEMA.to_string(),
+            workload_id: "workload-1".to_string(),
+            kind: RunnerWorkloadKind {
+                command_label: "lint".to_string(),
+                command_family: RunnerWorkloadCommandFamily::Quality,
+            },
+            workspace_mappings: RunnerWorkloadWorkspaceMappings {
+                source_path_mode: "cwd_or_path_flag".to_string(),
+                workspace_mode_policy: "changed_since_git_else_snapshot".to_string(),
+                mapping_ref: Some("workspace_mapping".to_string()),
+            },
+            required_capabilities: Vec::new(),
+            required_secrets: RunnerWorkloadSecrets {
+                categories: Vec::new(),
+            },
+            mutation_policy: RunnerWorkloadMutationPolicy {
+                capture_patch: false,
+                mutation_flag: None,
+                allow_dirty_lab_workspace: false,
+            },
+            assignment: RunnerWorkloadAssignment {
+                runner_id: Some("lab".to_string()),
+                runner_mode: Some("direct_ssh".to_string()),
+                source: Some("explicit".to_string()),
+            },
+            state: RunnerWorkloadState {
+                status: "offloaded".to_string(),
+                remote_workspace: Some("/srv/homeboy/app".to_string()),
+                fallback_reason: None,
+            },
+            result_refs: RunnerWorkloadResultRefs {
+                plan_id: plan.id.clone(),
+                proof_id: None,
+                workspace_mapping_ref: Some("workspace_mapping".to_string()),
+            },
+        };
+
+        let metadata = lab_offload_metadata_with_workspace_mapping_and_runner_workload(
+            &plan,
+            "explicit",
+            Some("lab"),
+            Some("direct_ssh"),
+            "offloaded",
+            Some("/srv/homeboy/app"),
+            None,
+            None,
+            Some(&workload),
+        );
+
+        assert_eq!(
+            metadata["runner_workload"]["schema"],
+            RUNNER_WORKLOAD_SCHEMA
+        );
+        assert_eq!(metadata["runner_workload"]["workload_id"], "workload-1");
+        assert_eq!(
+            metadata["runner_workload"]["kind"]["command_family"],
+            "quality"
+        );
+        assert_eq!(
+            metadata["runner_workload"]["assignment"]["runner_id"],
+            "lab"
+        );
     }
 
     #[test]

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -14,6 +14,53 @@ fn parsed_cli(args: &[&str]) -> Cli {
 }
 
 #[test]
+fn runner_workload_contract_serializes_versioned_shape() {
+    let contract = parsed_command(&["homeboy", "trace"])
+        .lab_contract()
+        .expect("trace should declare a Lab contract");
+    let workload = contract.runner_workload(
+        "workload-1",
+        "plan-1",
+        RunnerWorkloadAssignment {
+            runner_id: Some("lab-a".to_string()),
+            runner_mode: Some("direct_ssh".to_string()),
+            source: Some("explicit".to_string()),
+        },
+        RunnerWorkloadState {
+            status: "offloaded".to_string(),
+            remote_workspace: Some("/srv/homeboy/work".to_string()),
+            fallback_reason: None,
+        },
+        RunnerWorkloadMutationPolicy {
+            capture_patch: false,
+            mutation_flag: Some("--keep-overlay".to_string()),
+            allow_dirty_lab_workspace: false,
+        },
+        Some("workspace_mapping".to_string()),
+        Some("proof-1".to_string()),
+    );
+
+    let serialized = serde_json::to_value(workload).expect("workload should serialize");
+    assert_eq!(serialized["schema"], RUNNER_WORKLOAD_SCHEMA);
+    assert_eq!(serialized["workload_id"], "workload-1");
+    assert_eq!(serialized["kind"]["command_label"], "trace");
+    assert_eq!(serialized["kind"]["command_family"], "quality");
+    assert_eq!(
+        serialized["workspace_mappings"]["mapping_ref"],
+        "workspace_mapping"
+    );
+    assert_eq!(serialized["required_capabilities"][0]["name"], "playwright");
+    assert_eq!(serialized["required_secrets"]["categories"][0], "trace");
+    assert_eq!(
+        serialized["mutation_policy"]["mutation_flag"],
+        "--keep-overlay"
+    );
+    assert_eq!(serialized["assignment"]["runner_id"], "lab-a");
+    assert_eq!(serialized["state"]["remote_workspace"], "/srv/homeboy/work");
+    assert_eq!(serialized["result_refs"]["proof_id"], "proof-1");
+}
+
+#[test]
 fn test_lab_runner_supported_labels_are_contract_owned() {
     assert_eq!(
         lab_runner_supported_labels().as_slice(),


### PR DESCRIPTION
## Summary
- Add a versioned `homeboy/runner-workload/v1` contract for Lab runner workloads.
- Populate `runner_workload` in Lab offload metadata after workspace sync, using existing command/workspace/capability/mutation/assignment/result context.
- Add serialization and metadata coverage for the new contract shape.
- Fill stale `RunnerExecOutput` handoff fields in affected constructors so runner/test output remains structurally complete.

## Verification
- `homeboy runner exec homeboy-lab --cwd <synced-runner-workspace> cargo check --lib` passed. Run id: `runner-exec-homeboy-lab-26d24b66-7dd0-4f10-aa4a-049e53bcae2b`.
- `homeboy runner exec homeboy-lab --cwd <synced-runner-workspace> cargo test runner_workload_contract_serializes_versioned_shape` passed. Run id: `runner-exec-homeboy-lab-2cf157c3-78fc-4b57-82af-077b5939a2de`.
- `homeboy runner exec homeboy-lab --cwd <synced-runner-workspace> cargo test lab_offload_metadata_records_runner_workload_when_supplied` passed. Run id: `runner-exec-homeboy-lab-3328e2ac-0aa2-470e-bd13-f25ac9644dd6`.
- `homeboy test --runner homeboy-lab --skip-lint` compiled and ran the suite, but failed on 8 pre-existing/environment-sensitive tests unrelated to this contract path. Observed summary: 5490 passed, 8 failed, 18 ignored. Run/job evidence: `homeboy runner job logs homeboy-lab b39577fd-6feb-41ef-bf0e-9f66724e9dd0`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the typed runner workload contract, wiring metadata, adding tests, and running verification.