### PR TITLE
Clean up command surface docs

### DIFF
--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -12,9 +12,15 @@ homeboy build <project_id> --all --changed-since origin/main
 
 ## Description
 
-Resolves a build command from the component's linked extension and runs it in the component's `local_path`.
+Runs the component's local build quality gate by resolving a build command from
+the component's linked extension and executing it in the component's `local_path`.
 
-Builds are extension-owned. A component links to one build-capable extension, and Homeboy asks that extension for the command to run. One-off shell commands that do not belong in a reusable extension should live in a rig `command` step instead.
+Builds are extension-owned and currently local-only. A component links to one
+build-capable extension, and Homeboy asks that extension for the command to run.
+Use runner or Lab-backed commands such as `test`, `lint`, `audit`, `review`,
+`bench run`, `fuzz run`, and `trace` for portable offload. One-off shell commands
+that do not belong in a reusable extension should live in a rig `command` step
+instead.
 
 ## Path Override
 

--- a/docs/commands/cargo.md
+++ b/docs/commands/cargo.md
@@ -17,7 +17,9 @@ Rust-aware command execution and you want Homeboy to route the Cargo invocation
 through the project/extension layer.
 
 If `homeboy cargo ...` is unavailable, install or link the extension that
-provides the Cargo CLI tool, then confirm it appears in `homeboy docs list`.
+provides the Cargo CLI tool. Static core docs describe the extension contract;
+availability in a specific installation depends on installed extension metadata
+and can be confirmed with `homeboy --help` or `homeboy docs list`.
 
 ## Related
 

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -6,8 +6,8 @@
 - [audit-baseline](audit-baseline.md) — deterministic audit baseline refresh workflow
 - [auth](auth.md)
 - [bench](bench.md) — performance benchmarks + p95 regression ratchet
-- [build](build.md)
-- [cargo](cargo.md) — run Cargo commands via Rust extension routing
+- [build](build.md) — local build quality gate
+- [cargo](cargo.md) — extension-provided Cargo routing when installed
 - [changelog](changelog.md)
 - [changes](changes.md)
 - [ci](ci.md) — CI reproduction profiles and shallow CI surface discovery
@@ -38,7 +38,7 @@
 - [review](review.md) — scoped audit + lint + test umbrella for PR-style changes
 - [rig](rig.md) — reproducible local dev environments ([spec](rig-spec.md))
 - [runner](runner.md) — local and SSH execution runner registry
-- [runtime](runtime.md) — core-owned runner runtime helper lookup
+- [runtime](runtime.md) — narrow lookup for bundled core runtime helpers
 - [runs](runs.md) — persisted observation runs and artifacts
 - [server](server.md)
 - [self](self.md) — active binary and install-signal inspection
@@ -53,11 +53,15 @@
 - [upgrade](upgrade.md)
 - [version](version.md)
 - [worktree](worktree.md) — component-backed task worktree lifecycle
-- [wp](wp.md) — run WP-CLI commands via WordPress extension routing
+- [wp](wp.md) — extension-provided WP-CLI routing when installed
 
-This list covers the top-level CLI commands currently surfaced by `homeboy --help` in this checkout.
+This list covers the top-level core CLI commands currently surfaced by `homeboy
+--help` in this checkout. Hidden compatibility aliases such as `lab` are
+documented but omitted from this index.
 
-Note: some extensions also expose additional top-level CLI commands at runtime (loaded from installed extensions).
+Note: some extensions also expose additional top-level CLI commands at runtime
+when installed. Extension command docs, including `cargo` and `wp`, describe
+possible runtime-provided commands rather than guaranteed core subcommands.
 
 Related:
 

--- a/docs/commands/docs.md
+++ b/docs/commands/docs.md
@@ -10,14 +10,18 @@ homeboy docs map [OPTIONS] <component-id>
 
 ## Description
 
-This command renders embedded documentation topics and provides a codebase-map helper for AI-assisted documentation work.
+This command has two modes: topic rendering and codebase-map generation for
+AI-assisted documentation work.
 
-**Topic display** renders documentation from:
+**Topic display** is the default mode. `homeboy docs <topic>` renders
+documentation from:
 
 1. Embedded core docs in the CLI binary
 2. Installed extension docs under `<config dir>/homeboy/extensions/<extension_id>/docs/`
 
-**Map** generates machine-optimized codebase maps for AI documentation.
+**Map** is the `homeboy docs map <component-id>` subcommand. It generates
+machine-optimized codebase maps for AI documentation and does not render an
+embedded topic.
 
 ## Subcommands
 

--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -1,11 +1,16 @@
 # Lab Command
 
-Compatibility shortcut for Lab routing helpers. Keep using `homeboy lab ...`
-when you already know the shortcut; use [`homeboy runner`](runner.md) for the
-discoverable runner and Lab offload surface.
+Hidden compatibility shortcut for Lab routing helpers. Keep using `homeboy lab
+...` when you already know the shortcut; use [`homeboy runner`](runner.md) for
+the discoverable runner and Lab offload surface.
 
-Inspect and use configured Lab runners for remote benchmark execution and
-managed follow-up work.
+`lab` is intentionally hidden from top-level help. It remains available so older
+automation and operator notes keep working while discoverable guidance lives in
+`runner` docs.
+
+Treat `homeboy lab` as a routing helper, not a benchmark executor. Benchmark
+workloads should start at `homeboy bench`; Lab routing then selects a runner when
+the command and configuration support offload.
 
 ## Synopsis
 

--- a/docs/commands/observe.md
+++ b/docs/commands/observe.md
@@ -15,7 +15,14 @@ homeboy observe <component> --duration 60s --probe '{"type":"http.egress","host"
 
 ## V1 Scope
 
-`observe` is a passive producer. It does not drive a scenario, attach to privileged OS probes, or own target lifecycle.
+`observe` is a passive producer. It samples or tails a system that is already
+running and persists timeline evidence. It does not drive a scenario, assert
+behavior, attach to privileged OS probes, or own target lifecycle.
+
+Use `trace` when Homeboy should execute a declared scenario, collect
+runner-owned artifacts, and evaluate assertions. Use `observe` when the target is
+already live and the goal is to capture supporting evidence before or during a
+manual investigation.
 
 V1 supports:
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -51,7 +51,7 @@ homeboy runner connect <runner-id>
 
 After this, `<runner-id>` is both the server ID and the runner ID.
 
-Commands that are both resource-policy hot and portable for Lab offload (`audit`, full `lint`, `test`, `bench run`, and `trace`) auto-select a default runner when `--runner` is omitted. Selection is conservative:
+Commands that are both resource-policy hot and portable for Lab offload (`audit`, full `lint`, `test`, `bench run`, `fuzz run`, and `trace`) auto-select a default runner when `--runner` is omitted. Selection is conservative:
 
 - `--runner <id>` always wins.
 - `--force-hot` only suppresses the resource-policy warning. If a default Lab runner is available for a portable hot command, Homeboy refuses to use `--force-hot` as an implicit local bypass.
@@ -71,14 +71,26 @@ Lab offload support is intentionally command-specific:
 
 | Command | Auto offload | Explicit `--runner` | Decision |
 |---|---:|---:|---|
+| `agent-task dispatch` / `agent-task cook` / `agent-task loop` / `agent-task run-plan` | Yes | Yes | Portable agent-task execution when the command has deterministic gates where required. |
+| `agent-task controller from-spec --resume` / `agent-task controller materialize` / `agent-task controller resume` | No | Yes | Runner-hosted controller lifecycle work. |
+| `agent-task retry --run` | Yes | Yes | Retry plus execution follows the portable agent-task run path. |
+| `agent-task run` / `run-next` / `status` / `logs` / `artifacts` / `review` / `providers` | No | Yes | Runner-resident inspection and queue interaction. |
+| `agent-task auth status` | No | Yes | Runner-resident auth diagnostics. |
 | `audit` full workspace | Yes | Yes | Safe single-workspace replay after snapshot sync. |
 | `audit --changed-since` | No | No | Runs locally for now because changed-since audit depends on git base refs that Lab sync may not have fetched. The Lab plan records the skipped local-only decision. |
 | `bench run` / default bench run | Yes | Yes | Safe single-workspace replay; local baseline/ratchet writes are treated as mutation flags. |
+| `build` | No | No | Local quality gate; extension-owned build commands are not represented in the portable Lab contract yet. |
+| `fuzz run` / default fuzz run | Yes | Yes | Safe single-workspace replay with fuzz-specific case/result artifacts. |
 | `lint` full workspace | Yes | Yes | Safe single-workspace replay; `--fix` is treated as a mutation flag. |
 | `lint --changed-since` / `lint --changed-only` | No | No | Runs locally for now because changed-file scopes are not represented in the Lab portability contract yet. The Lab plan records the skipped local-only decision. |
+| `refactor --from audit` / `refactor --all` | No | Yes | Source refactor runs with command-owned mutation flags and runner-side workspace controls. |
+| `review` | Yes | Yes | Scoped audit/lint/test umbrella using the same portable quality gates. |
+| `rig check` | No | Yes | Runner-side rig validation without starting local services. |
 | `test` full workspace | Yes | Yes | Safe single-workspace replay with runner extension parity preflight. |
 | `test --changed-since` | No | No | Runs locally for now because changed-since test selection depends on git base refs that Lab sync may not have fetched. The Lab plan records the skipped local-only decision. |
 | `trace` | Yes | Yes | Safe single-workspace replay with Playwright/browser capability gate. |
+| `tunnel preview-consumer run` | No | Yes | Runner-hosted preview consumer execution. |
+| `tunnel service expose` / `tunnel service start` | No | Yes | Runner-hosted private service tunnel lifecycle. |
 | `rig up` | No | No | Stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace snapshot cannot safely mirror. |
 | `fleet exec` | No | No | Stays local because fleet execution depends on local fleet/project/server config before opening SSH sessions to each project; runner-side config parity is not guaranteed. |
 

--- a/docs/commands/runtime.md
+++ b/docs/commands/runtime.md
@@ -12,14 +12,18 @@ Provider commands can use `{{runtime_path}}`, and Homeboy injects `HOMEBOY_RUNTI
 
 ## Helper Paths
 
-Resolve the materialized path for a core runtime helper:
+Resolve the materialized path for a bundled core runtime helper:
 
 ```bash
 homeboy runtime helper path runner-prelude.sh
 homeboy runtime helper path HOMEBOY_RUNTIME_COMMAND_CAPTURE
 ```
 
-The command accepts either the helper filename or the injected `HOMEBOY_RUNTIME_*` environment variable name. Normal extension execution receives these paths automatically in the runner environment.
+The command accepts only known helper filenames or the corresponding injected
+`HOMEBOY_RUNTIME_*` environment variable names. It is not a general runtime
+package browser, extension asset resolver, or arbitrary config-path lookup.
+Normal extension execution receives these paths automatically in the runner
+environment.
 
 Use `--plain` when a shell wrapper needs a sourceable path without parsing JSON:
 

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -1,6 +1,11 @@
 # homeboy trace
 
-Capture black-box behavioral traces for a component. Trace runners write a JSON evidence envelope plus optional artifacts under the Homeboy run directory.
+Capture black-box behavioral traces for a component by executing declared
+scenarios. Trace runners write a JSON evidence envelope plus optional artifacts
+under the Homeboy run directory.
+
+Use `trace` when Homeboy owns scenario execution and assertions. Use `observe`
+for passive timeline capture against an already-running target.
 
 ## Usage
 

--- a/docs/commands/wp.md
+++ b/docs/commands/wp.md
@@ -12,8 +12,9 @@ For multisite projects, use `project:subtarget` as the project ID.
 
 `wp` is not a core subcommand compiled into Homeboy. It is registered at runtime
 by an installed extension with CLI tool metadata, typically the WordPress
-extension. Use `homeboy docs list` to confirm the command is available in the
-current installation.
+extension. Static core docs describe the extension contract; availability in a
+specific installation depends on installed extension metadata and can be
+confirmed with `homeboy --help` or `homeboy docs list`.
 
 ## Examples
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -77,7 +77,7 @@ pub enum Commands {
     Test(test::TestArgs),
     /// Run performance benchmarks for a component
     Bench(bench::BenchArgs),
-    /// Resolve generic fuzz workload contracts for a component
+    /// Run generic fuzz workloads for a component
     Fuzz(fuzz::FuzzArgs),
     /// Capture black-box behavioral traces for a component
     #[command(
@@ -128,7 +128,7 @@ pub enum Commands {
     Issues(issues::IssuesArgs),
     /// Version management for components
     Version(version::VersionArgs),
-    /// Build a component
+    /// Run a local build quality gate for a component
     Build(build::BuildArgs),
     /// Show changes since last version tag
     Changes(changes::ChangesArgs),

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -158,7 +158,7 @@ pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
     command_registry_entry("git", CommandJsonFamily::Ops),
     command_registry_entry("issues", CommandJsonFamily::Ops),
     command_registry_entry("version", CommandJsonFamily::Workspace),
-    command_registry_entry("build", CommandJsonFamily::Workspace),
+    command_registry_entry("build", CommandJsonFamily::Quality),
     command_registry_entry("changes", CommandJsonFamily::Workspace),
     command_registry_entry("release", CommandJsonFamily::Workspace),
     command_registry_entry("report", CommandJsonFamily::Workspace),

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -65,7 +65,7 @@ enum FuzzCommand {
     List(FuzzListArgs),
     /// Build a fuzz execution request without executing it
     Plan(FuzzPlanArgs),
-    /// Resolve the selected fuzz workload contract without executing it
+    /// Execute the selected fuzz workload and persist fuzz evidence
     Run(FuzzRunArgs),
     /// Validate a fuzz result campaign file
     Validate(FuzzValidateArgs),

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -175,7 +175,7 @@ fn command_index_matches_top_level_command_surface() {
 #[test]
 fn command_safety_manifest_docs_paths_match_command_docs() {
     let manifest = current_command_safety_manifest();
-    let hidden_top_level_commands = BTreeSet::from(["list"]);
+    let hidden_top_level_commands = BTreeSet::from(["lab", "list"]);
 
     for entry in &manifest.commands {
         if entry.hidden {
@@ -276,7 +276,7 @@ fn command_docs_files_match_command_index_snapshot() {
     ]);
     // Hidden top-level commands ship a docs file for runtimes but are
     // deliberately kept out of the human-facing command index.
-    let hidden_documented_commands = BTreeSet::from(["list".to_string()]);
+    let hidden_documented_commands = BTreeSet::from(["lab".to_string(), "list".to_string()]);
     let docs_files = documented_command_doc_files();
 
     // Guard against a vacuously-passing snapshot: the index and the docs


### PR DESCRIPTION
## Summary
- Hide the unimplemented `fuzz replay` placeholder from help while keeping compatibility, and correct `fuzz run` help text to describe execution.
- Classify `build` as a local quality gate and document that it is not Lab-routable yet.
- Clarify hidden `lab` compatibility docs, sync runner Lab-support guidance with the current contract, and tighten docs/runtime/observe/trace command boundaries.
- Clarify extension-provided `cargo` and `wp` docs so static docs do not present them as guaranteed core commands.

## Checks
- `git diff --check`
- Not run: local `cargo` tests/format, per environment constraint against local cargo; leaving Rust verification to CI.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general task agent
- **Used for:** Command-surface inspection, small Rust help/metadata edits, docs/test updates, and PR preparation.