### PR TITLE
ci: cheapen homeboy quality gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ on:
 
 env:
   RELEASE_BLOCKING_COMMANDS: ${{ inputs.release_blocking_commands || 'lint,test' }}
+  HOMEBOY_NO_UPDATE_CHECK: '1'
 
 # Only one release pipeline at a time. If a push arrives while a release
 # is already running, it queues (never cancels). The queued run starts
@@ -232,7 +233,7 @@ jobs:
           binary-path: .homeboy-bin/homeboy
           commands: audit
           expected-commands: audit,lint,test
-          args: ${{ github.event.before && format('--changed-since {0}', github.event.before) || '' }}
+          args: ${{ github.event.before && format('--profile=pr --changed-since {0}', github.event.before) || '--profile=pr' }}
           autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -8,6 +8,7 @@ pub(crate) struct HomeGuard {
     prior_artifact_root: Option<String>,
     prior_runtime_tmpdir: Option<String>,
     prior_invocation_runtime: Option<String>,
+    prior_no_update_check: Option<String>,
     dir: TempDir,
     _runtime_dir: TempDir,
     /// Held alongside `dir` so the short invocation runtime tempdir is
@@ -61,10 +62,12 @@ impl HomeGuard {
         let prior_runtime_tmpdir = std::env::var("HOMEBOY_RUNTIME_TMPDIR").ok();
         let prior_invocation_runtime =
             std::env::var(crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+        let prior_no_update_check = std::env::var("HOMEBOY_NO_UPDATE_CHECK").ok();
         let dir = TempDir::new().expect("home tempdir");
         std::env::set_var("HOME", dir.path());
         std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
+        std::env::set_var("HOMEBOY_NO_UPDATE_CHECK", "1");
         let runtime_dir = TempDir::new().expect("runtime tempdir");
         std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", runtime_dir.path());
         crate::core::set_artifact_root_override(None);
@@ -84,6 +87,7 @@ impl HomeGuard {
             prior_artifact_root,
             prior_runtime_tmpdir,
             prior_invocation_runtime,
+            prior_no_update_check,
             dir,
             _runtime_dir: runtime_dir,
             _inv_dir: Some(inv_dir),
@@ -138,6 +142,10 @@ impl Drop for HomeGuard {
             None => std::env::remove_var(
                 crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
             ),
+        }
+        match &self.prior_no_update_check {
+            Some(value) => std::env::set_var("HOMEBOY_NO_UPDATE_CHECK", value),
+            None => std::env::remove_var("HOMEBOY_NO_UPDATE_CHECK"),
         }
         crate::core::defaults::reset_config_cache_for_test();
         crate::commands::utils::entity_suggest::reset_entity_suggestion_cache_for_test();

--- a/tests/agent_tool_dispatch.rs
+++ b/tests/agent_tool_dispatch.rs
@@ -138,6 +138,7 @@ fn agent_tool_dispatch_outputs_raw_control_plane_validation_result() {
 fn run_tool_dispatch(policy: Value, request: Value) -> std::process::Output {
     let mut child = Command::new(homeboy_bin())
         .args(["agent-task", "tool", "dispatch"])
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
         .env("HOMEBOY_AGENT_TOOL_POLICY_JSON", policy.to_string())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -1,10 +1,11 @@
 use clap::{CommandFactory, Parser};
 use homeboy::cli_surface::{
     command_surface_from_with_depth, current_command_safety_manifest, current_command_surface, Cli,
-    CommandSafetyEntry, Commands,
+    CommandSafetyEntry, CommandSafetyManifest, Commands,
 };
 use std::collections::BTreeSet;
 use std::fs;
+use std::sync::OnceLock;
 
 #[test]
 fn command_surface_tracks_representative_live_and_removed_paths() {
@@ -119,8 +120,8 @@ fn hidden_list_json_flag_exposes_recursive_safety_manifest() {
         .expect("hidden list --json should parse");
     assert!(matches!(cli.command, Commands::List { json: true }));
 
-    let value = serde_json::to_value(current_command_safety_manifest())
-        .expect("safety manifest should serialize");
+    let value =
+        serde_json::to_value(command_safety_manifest()).expect("safety manifest should serialize");
     assert_eq!(value["commands"][0]["path"].as_array().unwrap().len(), 1);
     assert!(value["commands"]
         .as_array()
@@ -140,7 +141,7 @@ fn hidden_list_json_flag_exposes_recursive_safety_manifest() {
 
 #[test]
 fn command_index_matches_top_level_command_surface() {
-    let manifest = current_command_safety_manifest();
+    let manifest = command_safety_manifest();
     let documented = documented_command_index_entries();
 
     let extension_commands = BTreeSet::from(["cargo".to_string(), "wp".to_string()]);
@@ -174,7 +175,7 @@ fn command_index_matches_top_level_command_surface() {
 
 #[test]
 fn command_safety_manifest_docs_paths_match_command_docs() {
-    let manifest = current_command_safety_manifest();
+    let manifest = command_safety_manifest();
     let hidden_top_level_commands = BTreeSet::from(["lab", "list"]);
 
     for entry in &manifest.commands {
@@ -211,7 +212,7 @@ fn command_safety_manifest_docs_paths_match_command_docs() {
 
 #[test]
 fn visible_safety_manifest_entries_advertise_live_command_docs() {
-    let manifest = current_command_safety_manifest();
+    let manifest = command_safety_manifest();
 
     for entry in all_safety_entries(&manifest.commands) {
         if entry.hidden {
@@ -239,7 +240,7 @@ fn visible_safety_manifest_entries_advertise_live_command_docs() {
 
 #[test]
 fn mutating_safety_manifest_entries_advertise_apply_or_are_allowlisted() {
-    let manifest = current_command_safety_manifest();
+    let manifest = command_safety_manifest();
     let explicit_no_apply_surface = BTreeSet::from([
         "file mkdir".to_string(),
         "file rename".to_string(),
@@ -298,7 +299,7 @@ fn command_docs_files_match_command_index_snapshot() {
     // top-level command exposed by the safety manifest must be both indexed and
     // backed by a docs file. This anchors the assertion to real product
     // behavior rather than to fixture-only set arithmetic.
-    let manifest = current_command_safety_manifest();
+    let manifest = command_safety_manifest();
     let live_top_level: BTreeSet<String> = manifest
         .commands
         .iter()
@@ -580,6 +581,11 @@ fn documented_command_index_entries() -> BTreeSet<String> {
         .filter_map(|rest| rest.split(']').next())
         .map(str::to_string)
         .collect()
+}
+
+fn command_safety_manifest() -> &'static CommandSafetyManifest {
+    static MANIFEST: OnceLock<CommandSafetyManifest> = OnceLock::new();
+    MANIFEST.get_or_init(current_command_safety_manifest)
 }
 
 fn documented_command_doc_files() -> BTreeSet<String> {

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -510,6 +510,7 @@ fn deps_orchestration_stays_package_manager_agnostic() {
 }
 
 #[test]
+#[ignore = "integration test mutates real composer manifests/locks and shells out to composer"]
 fn update_with_constraint_changes_manifest_and_lock_for_local_path_package() {
     if std::process::Command::new("composer")
         .arg("--version")

--- a/tests/deps_npm_provider_test.rs
+++ b/tests/deps_npm_provider_test.rs
@@ -159,6 +159,7 @@ fn core_deps_orchestration_stays_package_manager_agnostic() {
 }
 
 #[test]
+#[ignore = "integration test mutates real npm manifests/locks and shells out to npm"]
 fn npm_update_with_constraint_changes_manifest_and_lock_for_local_path_package() {
     if std::process::Command::new("npm")
         .arg("--version")

--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -33,7 +33,7 @@ fn validation_error_writes_json_output_file() {
     let output_path = dir.path().join("runner-unsupported.json");
     register_local_runner(dir.path());
 
-    let output = Command::new(homeboy_bin())
+    let output = homeboy_command()
         .args(["--output"])
         .arg(&output_path)
         .args([
@@ -75,7 +75,7 @@ fn bare_json_output_format_is_rejected_as_footgun() {
     ] {
         let dir = tempfile::tempdir().expect("tempdir");
 
-        let output = Command::new(homeboy_bin())
+        let output = homeboy_command()
             .args(args)
             .current_dir(dir.path())
             .env("HOME", dir.path())
@@ -102,7 +102,7 @@ fn bare_json_output_format_is_rejected_as_footgun() {
 fn command_owned_output_path_is_not_rejected_as_global_format() {
     let dir = tempfile::tempdir().expect("tempdir");
 
-    let output = Command::new(homeboy_bin())
+    let output = homeboy_command()
         .args([
             "runs",
             "artifact",
@@ -132,7 +132,7 @@ fn lab_status_accepts_command_owned_runner_selector() {
     let dir = tempfile::tempdir().expect("tempdir");
     register_local_runner(dir.path());
 
-    let output = Command::new(homeboy_bin())
+    let output = homeboy_command()
         .args(["lab", "status", "--runner", "lab-local"])
         .current_dir(dir.path())
         .env("HOME", dir.path())
@@ -176,7 +176,7 @@ fn explicit_json_path_is_allowed() {
     let dir = tempfile::tempdir().expect("tempdir");
     register_local_runner(dir.path());
 
-    let output = Command::new(homeboy_bin())
+    let output = homeboy_command()
         .args([
             "--output",
             "./json",
@@ -212,8 +212,14 @@ fn homeboy_bin() -> PathBuf {
     PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
 }
 
+fn homeboy_command() -> Command {
+    let mut command = Command::new(homeboy_bin());
+    command.env("HOMEBOY_NO_UPDATE_CHECK", "1");
+    command
+}
+
 fn register_local_runner(home: &std::path::Path) {
-    let output = Command::new(homeboy_bin())
+    let output = homeboy_command()
         .args([
             "runner",
             "add",

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -65,6 +65,12 @@ fn release_audit_is_advisory_without_losing_raw_failure_outcome() {
     assert!(gate_audit.contains("audit-result: ${{ steps.audit.outcome }}"));
     assert!(gate_audit.contains("id: audit"));
     assert!(gate_audit.contains("continue-on-error: true"));
+    assert!(gate_audit.contains("--profile=pr"));
+}
+
+#[test]
+fn release_ci_disables_homeboy_update_checks() {
+    assert!(release_workflow().contains("HOMEBOY_NO_UPDATE_CHECK: '1'"));
 }
 
 #[test]

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -153,7 +153,7 @@ fn json_self_check_failure_reports_bounded_large_output_metadata() {
     write_script(
         dir.path(),
         "large-fail.sh",
-        "perl -e 'print \"stdout-line\\n\" x 20000'\nperl -e 'print STDERR \"stderr-line\\n\" x 20000'\nexit 7\n",
+        "perl -e 'print \"stdout-line-\" . (\"x\" x 80) . \"\\n\" for 1..800'\nperl -e 'print STDERR \"stderr-line-\" . (\"x\" x 80) . \"\\n\" for 1..800'\nexit 7\n",
     );
 
     let (output, exit_code) = run_test(json_test_args(dir.path()), &GlobalArgs {})


### PR DESCRIPTION
## Summary
- run the release advisory audit with the PR audit profile while preserving changed-since scoping
- disable Homeboy startup update checks in the release workflow and binary-spawning test helpers
- move real npm/composer manifest mutation checks behind ignored integration tests
- reduce large-output self-check fixture volume while preserving truncation coverage
- cache the integration command safety manifest with OnceLock inside command surface tests

## Tests/checks
- git diff --check
- No local cargo, package-manager tests, or benchmarks run per task constraints; CI is expected to cover Rust compile/test/lint/audit.

## Follow-ups
- PR CI audit profile scoping needs a homeboy-action input/change for command-specific args; the current reusable workflow passes shared args to every command and canonicalizes audit args away.
- Release planning still runs once for dry-run decision and once for prepare/apply; removing that safely needs a small release-plan reuse contract rather than a caller-only workflow tweak.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general task agent
- **Used for:** Implementing conservative CI/test/lint/audit speed cleanup changes and drafting this PR description.