### PR TITLE
Add agent task prompt store

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -13,6 +13,7 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 - **Lifecycle:** durable run submission, execution, inspection, cancellation, and retry.
 - **Cook/review:** workspace task conveniences that compose lifecycle runs with promotion, gates, and PR finalization.
 - **Provider:** executor discovery, machine-readable contracts, and redacted auth readiness.
+- **Prompt store:** Homeboy-owned markdown prompts for reusable dispatch/cook/loop input.
 - **Controller:** durable multi-agent loop state that can create or observe lifecycle runs over time.
 
 ## Subcommands
@@ -36,6 +37,7 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `resume <run-id>` | Resume a queued or stale-running durable run. |
 | `retry <run-id>` | Submit a fresh durable run from an existing run's plan. |
 | `fanout plan\|submit\|run-plan` | Compile, persist, or run generic provider-neutral fanout inputs. |
+| `prompts save\|list\|show\|remove` | Manage markdown prompts in Homeboy-owned storage. |
 
 ### Cook/Review
 
@@ -73,6 +75,23 @@ processes start. Compact `agent-task status` includes `execution_location` as
 | `providers` | List extension-declared executor providers and optional secret/backend readiness. |
 | `contract` | Export Homeboy's machine-readable agent-task core contract metadata. |
 | `auth` | Configure and inspect provider authentication secrets. |
+
+### Prompt Store
+
+`agent-task prompts` stores markdown prompt files under Homeboy's data directory,
+not under the current repo/worktree. Save prompt content with inline text,
+`@file`, or `-` for stdin, then reference it from `dispatch`, `cook`, or `loop`
+with `prompt:<id>` anywhere a prompt string is accepted.
+
+```bash
+homeboy agent-task prompts save issue-123 --input @prompt.md
+homeboy agent-task prompts list
+homeboy agent-task cook --repo homeboy --prompt prompt:issue-123
+```
+
+Existing prompt inputs remain compatible: `--prompt @file`, `--prompt -`, inline
+prompt text, repeated `--task`, and `--tasks @tasks.json` still use the existing
+resolution behavior unless the prompt string starts with `prompt:`.
 
 ### Controller
 

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -16,6 +16,7 @@ pub mod controller;
 pub mod doctor;
 pub mod fanout;
 pub mod loop_definition;
+pub mod prompts;
 pub mod review;
 pub mod run;
 pub mod status;
@@ -70,6 +71,7 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::FinalizePr(finalize_args) => review::finalize_pull_request(finalize_args),
         AgentTaskCommand::GateFeedback(feedback_args) => review::gate_feedback(feedback_args),
         AgentTaskCommand::Providers(providers_args) => review::providers(providers_args),
+        AgentTaskCommand::Prompts(prompts_args) => prompts::prompts(prompts_args),
         AgentTaskCommand::Contract(contract_args) => contract::contract(contract_args),
         AgentTaskCommand::CompileLoop(compile_args) => loop_definition::compile_loop(compile_args),
         AgentTaskCommand::Auth(auth_args) => auth::auth(auth_args),

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -12,6 +12,7 @@ use clap::{Args, Subcommand, ValueEnum};
 use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
 
 use super::super::agent_task_dispatch::DispatchArgs;
+use super::prompts::AgentTaskPromptsArgs;
 use super::review;
 use super::tool::AgentTaskToolArgs;
 
@@ -164,6 +165,8 @@ pub enum AgentTaskCommand {
     GateFeedback(GateFeedbackArgs),
     /// Provider: list extension-declared agent-task executor providers and optional secret readiness.
     Providers(ProvidersArgs),
+    /// Prompt store: save, list, show, and remove markdown prompts in Homeboy-owned storage.
+    Prompts(AgentTaskPromptsArgs),
     /// Provider: export Homeboy's machine-readable agent-task core contract metadata.
     Contract(ContractArgs),
     /// Controller: compile a declarative loop definition into an agent-task plan.

--- a/src/commands/agent_task/prompts.rs
+++ b/src/commands/agent_task/prompts.rs
@@ -1,0 +1,123 @@
+use clap::{Args, Subcommand};
+use serde::Serialize;
+use serde_json::Value;
+
+use homeboy::core::agent_task_prompts;
+
+use super::super::CmdResult;
+use super::command_json_value;
+
+#[derive(Args, Debug)]
+pub struct AgentTaskPromptsArgs {
+    #[command(subcommand)]
+    pub command: AgentTaskPromptsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AgentTaskPromptsCommand {
+    /// Save a markdown prompt in Homeboy's agent-task prompt store.
+    Save(AgentTaskPromptSaveArgs),
+    /// List stored agent-task prompts.
+    List,
+    /// Show a stored agent-task prompt.
+    Show(AgentTaskPromptNameArgs),
+    /// Remove a stored agent-task prompt.
+    Remove(AgentTaskPromptNameArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskPromptSaveArgs {
+    /// Stable prompt name. Unsafe path characters are normalized for storage.
+    pub name: String,
+
+    /// Prompt markdown content, @file, or - for stdin.
+    #[arg(long, value_name = "PROMPT")]
+    pub input: String,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskPromptNameArgs {
+    /// Stored prompt name or id.
+    pub name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptSaveReport {
+    schema: &'static str,
+    id: String,
+    path: String,
+    reference: String,
+    size_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptListReport {
+    schema: &'static str,
+    prompt_dir: String,
+    prompts: Vec<homeboy::core::agent_task_prompts::AgentTaskPromptRecord>,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptShowReport {
+    schema: &'static str,
+    id: String,
+    path: String,
+    content: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptRemoveReport {
+    schema: &'static str,
+    removed: bool,
+    id: String,
+    path: String,
+}
+
+pub fn prompts(args: AgentTaskPromptsArgs) -> CmdResult<Value> {
+    match args.command {
+        AgentTaskPromptsCommand::Save(args) => save(args),
+        AgentTaskPromptsCommand::List => list(),
+        AgentTaskPromptsCommand::Show(args) => show(args),
+        AgentTaskPromptsCommand::Remove(args) => remove(args),
+    }
+}
+
+fn save(args: AgentTaskPromptSaveArgs) -> CmdResult<Value> {
+    let content = agent_task_prompts::read_prompt_input(&args.input)?;
+    let record = agent_task_prompts::save_prompt(&args.name, &content)?;
+    command_json_value(PromptSaveReport {
+        schema: "homeboy/agent-task-prompt/v1",
+        id: record.id.clone(),
+        path: record.path,
+        reference: format!("{}{}", agent_task_prompts::PROMPT_REF_PREFIX, record.id),
+        size_bytes: record.size_bytes,
+    })
+}
+
+fn list() -> CmdResult<Value> {
+    command_json_value(PromptListReport {
+        schema: "homeboy/agent-task-prompts/v1",
+        prompt_dir: agent_task_prompts::prompts_dir()?.display().to_string(),
+        prompts: agent_task_prompts::list_prompts()?,
+    })
+}
+
+fn show(args: AgentTaskPromptNameArgs) -> CmdResult<Value> {
+    let record = agent_task_prompts::prompt_path(&args.name)?;
+    command_json_value(PromptShowReport {
+        schema: "homeboy/agent-task-prompt-content/v1",
+        id: agent_task_prompts::prompt_id(&args.name)?,
+        path: record.display().to_string(),
+        content: agent_task_prompts::read_prompt(&args.name)?,
+    })
+}
+
+fn remove(args: AgentTaskPromptNameArgs) -> CmdResult<Value> {
+    let record = agent_task_prompts::remove_prompt(&args.name)?;
+    command_json_value(PromptRemoveReport {
+        schema: "homeboy/agent-task-prompt-remove/v1",
+        removed: true,
+        id: record.id,
+        path: record.path,
+    })
+}

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -13,6 +13,7 @@ use crate::core::agent_task::{
     AgentTaskWorkspace, AgentTaskWorkspaceMode, AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
+use crate::core::agent_task_prompts;
 use crate::core::agent_task_provider::provider_requires_cwd_git_checkout;
 use crate::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskRetryPolicy};
 use crate::core::agent_task_secrets::validate_secret_env;
@@ -532,6 +533,10 @@ fn provider_config_secret_env(provider_config: &Value) -> Vec<String> {
 }
 
 fn read_text_spec(spec: &str, label: &str) -> Result<String> {
+    if let Some(prompt) = agent_task_prompts::resolve_stored_prompt_ref(spec)? {
+        return Ok(prompt);
+    }
+
     config::read_json_spec_to_string(spec).map_err(|error| {
         Error::internal_unexpected(format!(
             "failed to read agent-task dispatch {label} input: {error}"
@@ -701,6 +706,30 @@ mod tests {
         assert!(!serialized.contains("kimaki"));
         assert!(!serialized.contains("channel"));
         assert!(!serialized.contains("thread"));
+    }
+
+    #[test]
+    fn builds_dispatch_plan_from_stored_prompt_ref() {
+        with_isolated_home(|_| {
+            crate::core::agent_task_prompts::save_prompt(
+                "review-fix",
+                "# Review fix\nCook from stored markdown.\n",
+            )
+            .expect("save prompt");
+
+            let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+                prompt: Some("prompt:review-fix".to_string()),
+                repo: Some("homeboy".to_string()),
+                ..DispatchRequestOverrides::default()
+            }))
+            .expect("dispatch plan");
+
+            assert_eq!(plan.tasks.len(), 1);
+            assert_eq!(
+                plan.tasks[0].instructions,
+                "# Review fix\nCook from stored markdown.\n"
+            );
+        });
     }
 
     #[test]

--- a/src/core/agent_task_prompts.rs
+++ b/src/core/agent_task_prompts.rs
@@ -1,0 +1,220 @@
+use serde::Serialize;
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::UNIX_EPOCH;
+
+use crate::core::{paths, Error, Result};
+
+pub const PROMPT_REF_PREFIX: &str = "prompt:";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskPromptRecord {
+    pub id: String,
+    pub path: String,
+    pub size_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modified_unix: Option<u64>,
+}
+
+pub fn prompts_dir() -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?.join("agent-task").join("prompts"))
+}
+
+pub fn prompt_id(name: &str) -> Result<String> {
+    let trimmed = name.trim().trim_end_matches(".md");
+    if trimmed.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "name",
+            "prompt name cannot be empty",
+            None,
+            None,
+        ));
+    }
+
+    let id = paths::sanitize_path_segment(trimmed)
+        .trim_matches('_')
+        .to_string();
+    if id.is_empty() || id == "." || id == ".." {
+        return Err(Error::validation_invalid_argument(
+            "name",
+            "prompt name must include at least one safe path character",
+            Some(name.to_string()),
+            None,
+        ));
+    }
+
+    Ok(id)
+}
+
+pub fn prompt_path(name: &str) -> Result<PathBuf> {
+    Ok(prompts_dir()?.join(format!("{}.md", prompt_id(name)?)))
+}
+
+pub fn save_prompt(name: &str, content: &str) -> Result<AgentTaskPromptRecord> {
+    let path = prompt_path(name)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+        })?;
+    }
+    fs::write(&path, content)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    prompt_record_for_path(prompt_id(name)?, path)
+}
+
+pub fn read_prompt(name: &str) -> Result<String> {
+    let path = prompt_path(name)?;
+    fs::read_to_string(&path).map_err(|error| prompt_io_error("prompt", name, &path, error))
+}
+
+pub fn remove_prompt(name: &str) -> Result<AgentTaskPromptRecord> {
+    let id = prompt_id(name)?;
+    let path = prompt_path(&id)?;
+    let record = prompt_record_for_path(id, path.clone())?;
+    fs::remove_file(&path).map_err(|error| prompt_io_error("prompt", name, &path, error))?;
+    Ok(record)
+}
+
+pub fn list_prompts() -> Result<Vec<AgentTaskPromptRecord>> {
+    let dir = prompts_dir()?;
+    let entries = match fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(dir.display().to_string()),
+            ))
+        }
+    };
+
+    let mut records = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(error.to_string(), Some(dir.display().to_string()))
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        records.push(prompt_record_for_path(stem.to_string(), path)?);
+    }
+    records.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(records)
+}
+
+pub fn resolve_stored_prompt_ref(spec: &str) -> Result<Option<String>> {
+    let Some(name) = spec.strip_prefix(PROMPT_REF_PREFIX) else {
+        return Ok(None);
+    };
+    Ok(Some(read_prompt(name)?))
+}
+
+pub fn read_prompt_input(spec: &str) -> Result<String> {
+    if spec.trim() == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map_err(|error| {
+            Error::internal_io(error.to_string(), Some("read stdin".to_string()))
+        })?;
+        return Ok(buf);
+    }
+
+    if let Some(path) = spec.strip_prefix('@') {
+        if path.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "input",
+                "Invalid prompt input '@' (missing file path)",
+                None,
+                None,
+            ));
+        }
+        return fs::read_to_string(path)
+            .map_err(|error| Error::internal_io(error.to_string(), Some(path.to_string())));
+    }
+
+    Ok(spec.to_string())
+}
+
+fn prompt_record_for_path(id: String, path: PathBuf) -> Result<AgentTaskPromptRecord> {
+    let metadata = fs::metadata(&path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    let modified_unix = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_secs());
+    Ok(AgentTaskPromptRecord {
+        id,
+        path: path.display().to_string(),
+        size_bytes: metadata.len(),
+        modified_unix,
+    })
+}
+
+fn prompt_io_error(
+    field: &str,
+    name: &str,
+    path: &std::path::Path,
+    error: std::io::Error,
+) -> Error {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        return Error::validation_invalid_argument(
+            field,
+            format!("stored agent-task prompt '{}' was not found", name),
+            Some(name.to_string()),
+            Some(vec![
+                "Run `homeboy agent-task prompts list` to see stored prompts".to_string(),
+            ]),
+        );
+    }
+    Error::internal_io(error.to_string(), Some(path.display().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn stores_markdown_prompts_under_homeboy_data() {
+        with_isolated_home(|home| {
+            let record =
+                save_prompt("Cook: PR 123.md", "# Cook\nDo the thing.\n").expect("saved prompt");
+
+            assert_eq!(record.id, "Cook__PR_123");
+            assert!(record.path.ends_with("agent-task/prompts/Cook__PR_123.md"));
+            assert!(record.path.starts_with(&home.path().display().to_string()));
+            assert_eq!(
+                read_prompt("Cook__PR_123").expect("read prompt"),
+                "# Cook\nDo the thing.\n"
+            );
+        });
+    }
+
+    #[test]
+    fn lists_and_resolves_prompt_refs() {
+        with_isolated_home(|_| {
+            save_prompt("beta", "second").expect("save beta");
+            save_prompt("alpha", "first").expect("save alpha");
+
+            let ids: Vec<String> = list_prompts()
+                .expect("list prompts")
+                .into_iter()
+                .map(|record| record.id)
+                .collect();
+            assert_eq!(ids, vec!["alpha".to_string(), "beta".to_string()]);
+            assert_eq!(
+                resolve_stored_prompt_ref("prompt:alpha").expect("resolve ref"),
+                Some("first".to_string())
+            );
+            assert_eq!(
+                resolve_stored_prompt_ref("plain prompt").expect("plain prompt"),
+                None
+            );
+        });
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -30,6 +30,7 @@ pub mod agent_task_loop_definition;
 pub mod agent_task_loop_runner_policy;
 mod agent_task_pr_body;
 pub mod agent_task_promotion;
+pub mod agent_task_prompts;
 pub mod agent_task_provider;
 pub mod agent_task_repo_loop_compile;
 pub mod agent_task_schedule;

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -18,6 +18,7 @@ fn command_surface_tracks_representative_live_and_removed_paths() {
     assert!(surface.contains_path(&["runner", "job"]));
     assert!(surface.contains_path(&["agent-task", "controller", "run-next"]));
     assert!(surface.contains_path(&["agent-task", "auth", "status"]));
+    assert!(surface.contains_path(&["agent-task", "prompts", "save"]));
     assert!(surface.contains_path(&["runner", "job", "logs"]));
     assert!(!surface.contains_path(&["init"]));
     assert!(!surface.contains_path(&["version", "bump"]));
@@ -25,6 +26,30 @@ fn command_surface_tracks_representative_live_and_removed_paths() {
     assert!(!surface.contains_path(&["stacks", "inspect"]));
     assert!(!surface.contains_path(&["audit", "code"]));
     assert!(!surface.contains_path(&["runner", "job", "logs", "extra"]));
+}
+
+#[test]
+fn agent_task_prompt_store_commands_parse() {
+    Cli::try_parse_from([
+        "homeboy",
+        "agent-task",
+        "prompts",
+        "save",
+        "issue-123",
+        "--input",
+        "@prompt.md",
+    ])
+    .expect("agent-task prompts save should parse");
+    Cli::try_parse_from(["homeboy", "agent-task", "prompts", "list"])
+        .expect("agent-task prompts list should parse");
+    Cli::try_parse_from([
+        "homeboy",
+        "agent-task",
+        "dispatch",
+        "--prompt",
+        "prompt:issue-123",
+    ])
+    .expect("stored prompt refs should parse as prompt values");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a Homeboy-owned agent-task prompt store under the Homeboy data directory.
- Add `homeboy agent-task prompts save|list|show|remove` for markdown prompt files.
- Allow dispatch/cook/loop prompt inputs to reference stored prompts with `prompt:<id>` while preserving existing inline, `@file`, and stdin behavior.
- Document the prompt store and add focused command-surface and prompt-resolution tests.

## Verification
- `rustfmt src/core/agent_task_prompts.rs src/core/agent_task_dispatch_plan.rs src/core/mod.rs src/commands/agent_task.rs src/commands/agent_task/args/mod.rs src/commands/agent_task/prompts.rs tests/command_surface_test.rs`
- `git diff --check`
- `git diff --cached --check`

Full local test/lint was not run because this repo's Homeboy test/lint configuration is Cargo-backed and the task forbids running local `cargo` on this Studio machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation, tests, docs, and PR description.