### PR TITLE
Fix runner active job imports

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -9,11 +9,12 @@ use serde_json::Value;
 
 use homeboy::core::api_jobs::{Job, JobEvent, JobStatus};
 use homeboy::core::redaction::RedactionPolicy;
+use homeboy::core::runner::{RunnerActiveJobSource, RunnerActiveJobState};
 use homeboy::core::runners::{
     self as runner, runner_job_log_snapshot, ReverseRunnerConnectOptions,
-    ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner, RunnerActiveJobSource,
-    RunnerActiveJobState, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput,
-    RunnerKind, RunnerSession, RunnerStatusReport, RunnerTunnelMode,
+    ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner, RunnerConnectReport,
+    RunnerDisconnectReport, RunnerExecOutput, RunnerKind, RunnerSession, RunnerStatusReport,
+    RunnerTunnelMode,
 };
 use homeboy::core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 use homeboy::core::stream_capture::StreamCaptureMetadata;


### PR DESCRIPTION
## Summary
- import runner active job types from the canonical `core::runner` module
- restore Homeboy source builds after runner module refactoring

Fixes the source-upgrade compile blocker found while trying to release Studio Native 0.12.0.

## Verification
- `rustfmt src/commands/runner.rs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** diagnosing the Homeboy build blocker and drafting the minimal import fix.