### PR TITLE
Refactor observation output runtime

### DIFF
--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -12,7 +12,9 @@
 //! returned from [`Commands::descriptor`].
 
 use crate::cli_surface::Commands;
-use crate::commands::{changelog, file, fleet, logs, report, review, runtime, trace, version};
+use crate::commands::{
+    changelog, file, fleet, logs, observe, report, review, runtime, trace, version,
+};
 
 use super::lab::apply_lab_contract_to_descriptor;
 
@@ -329,7 +331,8 @@ impl Commands {
             Commands::Fuzz(args) => args.output_descriptor(output_file_mode),
             Commands::Lint(args) => args.output_descriptor(output_file_mode),
             Commands::Audit(args) => args.output_descriptor(output_file_mode),
-            Commands::Observe(_) | Commands::AuditBaseline(_) | Commands::Refactor(_) => {
+            Commands::Observe(_) => observe::adapter(output_file_mode).output_descriptor(),
+            Commands::AuditBaseline(_) | Commands::Refactor(_) => {
                 registered_json_envelope_descriptor(self, output_file_mode)
             }
             Commands::Refs(_) => workspace_descriptor(

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -6,7 +6,7 @@ use crate::command_contract::{
 
 use crate::cli_surface::Commands;
 
-use super::{fleet, version, GlobalArgs};
+use super::{fleet, observe, version, GlobalArgs};
 
 pub(crate) type JsonCommandRun = (homeboy::core::Result<Value>, i32);
 pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonCommandRun;
@@ -122,6 +122,12 @@ pub(crate) fn command_adapter(
                 .expect("version adapter supports JSON execution");
             Ok(BoundCommandAdapter::bind(args, executor))
         }
+        Commands::Observe(args) => {
+            let executor = observe::adapter(output_file_mode)
+                .execute_json
+                .expect("observe adapter supports JSON execution");
+            Ok(BoundCommandAdapter::bind(args, executor))
+        }
         command => Err(command),
     }
 }
@@ -166,6 +172,11 @@ mod tests {
     fn command_adapter_recognizes_migrated_json_commands() {
         assert!(command_adapter(
             parsed_command(&["homeboy", "version", "show"]),
+            CommandOutputFileMode::None,
+        )
+        .is_ok());
+        assert!(command_adapter(
+            parsed_command(&["homeboy", "observe", "demo", "--watch-process", "sleep"]),
             CommandOutputFileMode::None,
         )
         .is_ok());

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -10,17 +10,19 @@ use clap::Args;
 use regex::Regex;
 use serde::Serialize;
 
+use crate::command_contract::{CommandJsonFamily, CommandOutputFileMode};
+
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::engine::run_dir::{self, RunDir};
 use homeboy::core::extension::trace::{
     ActiveTraceProbes, TraceArtifact, TraceEvent, TraceProbeConfig, TraceResults, TraceStatus,
 };
 use homeboy::core::git::short_head_revision_at;
-use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+use homeboy::core::observation::{ActiveObservation, NewRunRecord, RunStatus};
 use homeboy::core::Error;
 
 use super::utils::args::PositionalComponentArgs;
-use super::{CmdResult, GlobalArgs};
+use super::{adapter, CmdResult, GlobalArgs};
 
 const DEFAULT_DURATION: &str = "30s";
 const DEFAULT_PROCESS_WATCH_INTERVAL: &str = "1s";
@@ -74,6 +76,16 @@ pub struct ObserveOutput {
     pub hints: Vec<String>,
 }
 
+pub(crate) fn adapter(
+    output_file_mode: CommandOutputFileMode,
+) -> adapter::TypedCommandAdapter<ObserveArgs> {
+    adapter::TypedCommandAdapter::json_only(CommandJsonFamily::Quality, output_file_mode, run_json)
+}
+
+fn run_json(args: ObserveArgs, global: &GlobalArgs) -> adapter::JsonCommandRun {
+    crate::commands::utils::response::map_cmd_result_to_json(run(args, global))
+}
+
 struct TailLogState {
     path: PathBuf,
     offset: u64,
@@ -110,7 +122,6 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
     let component_path = ctx.source_path.clone();
     let run_dir = RunDir::create()?;
     let trace_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
-    let store = ObservationStore::open_initialized()?;
     let command = observe_command(&args);
     let initial_metadata = serde_json::json!({
         "duration_ms": duration_millis(args.duration),
@@ -122,7 +133,7 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
         "run_dir": run_dir.path(),
     });
 
-    let run = store.start_run(
+    let observation = ActiveObservation::start(
         NewRunRecord::builder("observe")
             .component_id(component_id.clone())
             .command(command)
@@ -177,11 +188,14 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
     };
 
     write_trace_results(&trace_path, &results)?;
-    let artifact = store.record_artifact(&run.id, "trace-results", &trace_path)?;
+    let artifact =
+        observation
+            .store()
+            .record_artifact(observation.run_id(), "trace-results", &trace_path)?;
     let artifact_id = artifact.id.clone();
     let artifact_path = artifact.path.clone();
-    let finished = store.finish_run(
-        &run.id,
+    let finished = observation.store().finish_run(
+        observation.run_id(),
         status,
         Some(serde_json::json!({
             "duration_ms": duration_millis(args.duration),
@@ -196,7 +210,7 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
     Ok((
         ObserveOutput {
             command: "observe",
-            run_id: finished.id.clone(),
+            run_id: observation.run_id().to_string(),
             component_id,
             status: finished.status,
             duration_ms: duration_millis(args.duration),

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -14,7 +14,7 @@ use homeboy::core::extension::trace::{
     TraceSpanDefinition,
 };
 use homeboy::core::extension::ExtensionCapability;
-use homeboy::core::observation::{ActiveObservation, NewRunRecord};
+use homeboy::core::observation::{ActiveObservation, NewRunRecord, ObservationStore};
 use homeboy::core::rig::{self, RigSpec};
 
 use super::utils::args::{BaselineArgs, PositionalComponentArgs, SettingArgs};
@@ -614,7 +614,7 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
                 }
             }));
         if let Ok(cwd) = std::env::current_dir() {
-            builder = builder.cwd_path(cwd);
+            builder = builder.cwd_path(&cwd);
         }
         builder.build()
     })

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -14,7 +14,7 @@ use homeboy::core::extension::trace::{
     TraceSpanDefinition,
 };
 use homeboy::core::extension::ExtensionCapability;
-use homeboy::core::observation::{NewRunRecord, ObservationStore};
+use homeboy::core::observation::{ActiveObservation, NewRunRecord};
 use homeboy::core::rig::{self, RigSpec};
 
 use super::utils::args::{BaselineArgs, PositionalComponentArgs, SettingArgs};
@@ -585,51 +585,44 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
     let component_path_for_observation = path_override
         .clone()
         .unwrap_or_else(|| ctx.component.local_path.clone());
-    let observation = ObservationStore::open_initialized().ok().and_then(|store| {
-        let cwd = std::env::current_dir().ok();
-        store
-            .start_run(
-                NewRunRecord::builder("trace")
-                    .component_id(ctx.component_id.clone())
-                    .command(std::env::args().collect::<Vec<_>>().join(" "))
-                    .optional_cwd_path(cwd.as_deref())
-                    .current_homeboy_version()
-                    .git_sha(homeboy::core::git::short_head_revision_at(Path::new(
-                        &component_path_for_observation,
-                    )))
-                    .optional_rig_id(rig_id.clone())
-                    .metadata(serde_json::json!({
-                        "scenario_id": scenario_id,
-                        "component_path": component_path_for_observation,
-                        "requested_overlays": requested_overlays,
-                        "requested_variants": requested_variants,
-                        "span_definitions": span_definitions.clone(),
-                        "phase_preset": args.phase_preset.clone(),
-                        "secret_env": trace_secret_env_status.clone(),
-                        "phase_milestones": args.phases.clone().into_iter().map(|phase| {
-                            serde_json::json!({ "label": phase.label, "key": phase.key })
-                        }).collect::<Vec<_>>(),
-                        "baseline": {
-                            "baseline": args.baseline_args.baseline,
-                            "ignore_baseline": args.baseline_args.ignore_baseline,
-                            "ratchet": args.baseline_args.ratchet,
-                            "regression_threshold_percent": args.regression_threshold,
-                            "regression_min_delta_ms": args.regression_min_delta_ms
-                        }
-                    }))
-                    .build(),
-            )
-            .ok()
-            .map(|run| {
-                std::env::set_var(homeboy::core::observation::ACTIVE_RUN_ID_ENV, &run.id);
-                ActiveTraceObservation {
-                    store,
-                    run_id: run.id,
-                    component_id: ctx.component_id.clone(),
-                    rig_id: rig_id.clone(),
-                    scenario_id: scenario_id.clone(),
+    let observation = ActiveObservation::start_best_effort({
+        let mut builder = NewRunRecord::builder("trace")
+            .component_id(ctx.component_id.clone())
+            .command(std::env::args().collect::<Vec<_>>().join(" "))
+            .current_homeboy_version()
+            .git_sha(homeboy::core::git::short_head_revision_at(Path::new(
+                &component_path_for_observation,
+            )))
+            .optional_rig_id(rig_id.clone())
+            .metadata(serde_json::json!({
+                "scenario_id": scenario_id,
+                "component_path": component_path_for_observation,
+                "requested_overlays": requested_overlays,
+                "requested_variants": requested_variants,
+                "span_definitions": span_definitions.clone(),
+                "phase_preset": args.phase_preset.clone(),
+                "secret_env": trace_secret_env_status.clone(),
+                "phase_milestones": args.phases.clone().into_iter().map(|phase| {
+                    serde_json::json!({ "label": phase.label, "key": phase.key })
+                }).collect::<Vec<_>>(),
+                "baseline": {
+                    "baseline": args.baseline_args.baseline,
+                    "ignore_baseline": args.baseline_args.ignore_baseline,
+                    "ratchet": args.baseline_args.ratchet,
+                    "regression_threshold_percent": args.regression_threshold,
+                    "regression_min_delta_ms": args.regression_min_delta_ms
                 }
-            })
+            }));
+        if let Ok(cwd) = std::env::current_dir() {
+            builder = builder.cwd_path(cwd);
+        }
+        builder.build()
+    })
+    .map(|observation| ActiveTraceObservation {
+        active: observation,
+        component_id: ctx.component_id.clone(),
+        rig_id: rig_id.clone(),
+        scenario_id: scenario_id.clone(),
     });
     let (extra_workloads, trace_dependencies, runner_capabilities, invocation_requirements) =
         trace_workload_inputs(rig_context.as_ref(), ctx.extension_id.as_deref());
@@ -714,7 +707,7 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
 
     let run_id = observation
         .as_ref()
-        .map(|observation| observation.run_id.clone());
+        .map(|observation| observation.active.run_id().to_string());
 
     Ok(TraceRunExecution {
         workflow,

--- a/src/commands/trace/observation_lifecycle.rs
+++ b/src/commands/trace/observation_lifecycle.rs
@@ -13,7 +13,8 @@ use std::path::Path;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::trace as extension_trace;
 use homeboy::core::observation::{
-    NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, ObservationStore, RunStatus,
+    ActiveObservation, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, ObservationStore,
+    RunStatus,
 };
 use homeboy::core::rig;
 
@@ -24,8 +25,7 @@ use super::{
 };
 
 pub(super) struct ActiveTraceObservation {
-    pub(super) store: ObservationStore,
-    pub(super) run_id: String,
+    pub(super) active: ActiveObservation,
     pub(super) component_id: String,
     pub(super) rig_id: Option<String>,
     pub(super) scenario_id: String,
@@ -164,9 +164,9 @@ pub(super) fn persist_trace_workflow_result(
     let trace_scenario_id = results
         .map(|results| results.scenario_id.clone())
         .unwrap_or_else(|| observation.scenario_id.clone());
-    let _ = observation.store.record_trace_run(
+    let _ = observation.active.store().record_trace_run(
         NewTraceRunRecord::builder(
-            &observation.run_id,
+            observation.active.run_id(),
             &observation.component_id,
             trace_scenario_id,
             run_status.as_str(),
@@ -192,9 +192,9 @@ pub(super) fn persist_trace_workflow_result(
 
     if let Some(results) = results {
         for span in &results.span_results {
-            let _ = observation.store.record_trace_span(
+            let _ = observation.active.store().record_trace_span(
                 NewTraceSpanRecord::builder(
-                    &observation.run_id,
+                    observation.active.run_id(),
                     &span.id,
                     format!("{:?}", span.status).to_ascii_lowercase(),
                 )
@@ -212,16 +212,20 @@ pub(super) fn persist_trace_workflow_result(
         }
     }
 
-    let artifact_observation =
-        record_trace_artifacts(&observation.store, &observation.run_id, run_dir, results);
+    let artifact_observation = record_trace_artifacts(
+        observation.active.store(),
+        observation.active.run_id(),
+        run_dir,
+        results,
+    );
     let finish_status =
         if run_status == RunStatus::Pass && artifact_observation.has_declared_artifact_failures() {
             RunStatus::Fail
         } else {
             run_status
         };
-    let _ = observation.store.finish_run(
-        &observation.run_id,
+    let _ = observation.active.store().finish_run(
+        observation.active.run_id(),
         finish_status,
         Some(trace_run_finish_metadata(
             workflow,
@@ -242,9 +246,9 @@ pub(super) fn persist_trace_workflow_error(
             "details": &error.details,
         }
     });
-    let _ = observation.store.record_trace_run(
+    let _ = observation.active.store().record_trace_run(
         NewTraceRunRecord::builder(
-            &observation.run_id,
+            observation.active.run_id(),
             &observation.component_id,
             &observation.scenario_id,
             RunStatus::Error.as_str(),
@@ -253,10 +257,14 @@ pub(super) fn persist_trace_workflow_error(
         .metadata(error_metadata.clone())
         .build(),
     );
-    let artifact_observation =
-        record_trace_artifacts(&observation.store, &observation.run_id, run_dir, None);
-    let _ = observation.store.finish_run(
-        &observation.run_id,
+    let artifact_observation = record_trace_artifacts(
+        observation.active.store(),
+        observation.active.run_id(),
+        run_dir,
+        None,
+    );
+    let _ = observation.active.store().finish_run(
+        observation.active.run_id(),
         RunStatus::Error,
         Some(merge_trace_artifact_metadata(
             error_metadata,


### PR DESCRIPTION
## Summary
- Route trace active run startup through ActiveObservation instead of manually opening the store and setting active run state.
- Route observe startup through ActiveObservation while preserving artifact persistence and finish error behavior.
- Migrate observe into the typed command adapter contract/dispatch path.

## Checks
- rustfmt src/commands/observe.rs src/commands/trace.rs src/commands/trace/observation_lifecycle.rs src/commands/adapter.rs src/command_contract/output.rs
- git diff --check
- Full Rust verification left to CI per local cargo constraint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general task agent
- **Used for:** Observation/output runtime simplification, lifecycle helper cleanup, tests/docs updates.