### PR TITLE
Format Rust sources

### DIFF
--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -309,7 +309,10 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
         observed.workspace.root.as_deref(),
         Some("/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance")
     );
-    assert_eq!(observed.workspace.slug.as_deref(), Some("sample-agent-runtime"));
+    assert_eq!(
+        observed.workspace.slug.as_deref(),
+        Some("sample-agent-runtime")
+    );
     assert!(observed.workspace.kind.is_none());
     assert!(observed.workspace.component_id.is_none());
     assert!(observed.workspace.branch.is_none());

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -1536,7 +1536,10 @@ fn resume_failed_action_result_includes_top_level_failure_summary() {
             json!("task-overlay-prepare")
         );
         assert_eq!(failed["failure_summary"]["phase"], json!("prepare"));
-        assert_eq!(failed["failure_summary"]["provider"], json!("synthetic-runtime"));
+        assert_eq!(
+            failed["failure_summary"]["provider"],
+            json!("synthetic-runtime")
+        );
         assert_eq!(
             failed["failure_summary"]["failure_phase"],
             json!("runtime_overlay_preparation")

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -3709,7 +3709,8 @@ mod tests {
         provider.backend = "synthetic-runtime".to_string();
 
         let providers = [provider];
-        let resolution = resolve_provider_for_backend(&providers, "synthetic-runtime", Some("fast"));
+        let resolution =
+            resolve_provider_for_backend(&providers, "synthetic-runtime", Some("fast"));
 
         assert_eq!(
             resolution,
@@ -4612,7 +4613,10 @@ process.stdout.write(JSON.stringify({
             .get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
             .expect("provider default source discovered");
         assert_eq!(source.source, "json-file");
-        assert_eq!(source.path.as_deref(), Some("~/.example-provider/auth.json"));
+        assert_eq!(
+            source.path.as_deref(),
+            Some("~/.example-provider/auth.json")
+        );
         assert_eq!(source.field.as_deref(), Some("tokens.access_token"));
     }
 

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -518,11 +518,8 @@ fn planned_deploy_ref(component: &Component, config: &DeployConfig) -> Result<Op
     }
 
     let tag = latest_deploy_tag(component, config.expected_version.as_deref())?;
-    let tag_sha = crate::core::engine::command::run_in_optional(
-        path,
-        "git",
-        &["rev-parse", "--short", &tag],
-    );
+    let tag_sha =
+        crate::core::engine::command::run_in_optional(path, "git", &["rev-parse", "--short", &tag]);
     let head_ahead = crate::core::engine::command::run_in_optional(
         path,
         "git",

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -16,10 +16,10 @@ use crate::core::server::{self, Server, ServerAuthMode, SshClient};
 
 use super::broker_http;
 use super::session::{
-    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource,
-    RunnerActiveJobState, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
-    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
-    RunnerStatusReport, RunnerTunnelMode,
+    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
+    RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
+    RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
+    RunnerTunnelMode,
 };
 use super::{load, Runner, RunnerKind};
 

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -888,7 +888,10 @@ mod tests {
             .get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
             .expect("example provider default source discovered for cook");
         assert_eq!(source.source, "json-file");
-        assert_eq!(source.path.as_deref(), Some("~/.example-provider/auth.json"));
+        assert_eq!(
+            source.path.as_deref(),
+            Some("~/.example-provider/auth.json")
+        );
         assert_eq!(source.field.as_deref(), Some("tokens.access_token"));
     }
 
@@ -1107,8 +1110,7 @@ mod tests {
             .expect("provider default source should resolve on controller");
 
             assert!(matches!(
-                env.get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
-                    .map(String::as_str),
+                env.get("EXAMPLE_PROVIDER_ACCESS_TOKEN").map(String::as_str),
                 Some("controller-access-token")
             ));
             assert_eq!(

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -401,8 +401,7 @@ fn injected_default_provider_config_is_remappable() {
             &injected,
             &[LabPathRemap {
                 local: "/Users/user/Developer/example-provider@oauth".to_string(),
-                remote: "/home/user/Developer/_lab_workspaces/example-provider@oauth"
-                    .to_string(),
+                remote: "/home/user/Developer/_lab_workspaces/example-provider@oauth".to_string(),
             }],
         );
         let cfg_idx = remapped

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -105,11 +105,11 @@ pub use offload_metadata::{
 };
 pub use resource_metrics::RunnerResourceMetrics;
 pub use session::{
-    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource,
-    RunnerActiveJobState, RunnerArtifactRef, RunnerConnectReport, RunnerDisconnectReport,
-    RunnerFailureKind, RunnerHandoff, RunnerJob, RunnerLifecycleOwner, RunnerResult,
-    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
-    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceLease,
+    ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
+    RunnerArtifactRef, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+    RunnerHandoff, RunnerJob, RunnerLifecycleOwner, RunnerResult, RunnerSession, RunnerSessionRole,
+    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
+    RunnerWorkspaceLease,
 };
 pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerTransport};


### PR DESCRIPTION
## Summary
- Apply rustfmt to the current main branch Rust sources so PR differential CI has a clean baseline.
- Keep this formatting-only to unblock the refactor fleet checks.

## Verification
- rustfmt --edition 2021 on tracked Rust files
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the shared CI baseline formatting blocker and preparing the formatting-only fix.