### PR TITLE
Add PR landing triage dashboard

### DIFF
--- a/src/commands/triage.rs
+++ b/src/commands/triage.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use homeboy::core::triage::{
-    self, TriageCommandOutput, TriageOptions, TriageTarget, TriageWatchOptions,
+    self, TriageCommandOutput, TriageLandingOptions, TriageOptions, TriageTarget,
+    TriageWatchOptions,
 };
 use homeboy::core::Error;
 use std::path::PathBuf;
@@ -113,6 +114,43 @@ enum TriageCommand {
     Rig { rig_id: String },
     /// Triage every configured project, rig, and registered component once per repo.
     Workspace,
+    /// Summarize mergeability and check blockers for a PR landing fleet.
+    Landing {
+        /// PR numbers, owner/repo#number refs, or GitHub PR URLs.
+        pr_refs: Vec<String>,
+
+        /// Resolve bare PR numbers against this GitHub repo (`owner/name` or URL).
+        #[arg(long, value_name = "REPO")]
+        repo: Option<String>,
+
+        /// Include open PRs whose source branch matches this pattern. Repeatable.
+        #[arg(long, value_name = "PATTERN")]
+        branch: Vec<String>,
+
+        /// Include PRs linked to this issue number in each resolved repo. Repeatable.
+        #[arg(long, value_name = "NUMBER")]
+        source_issue: Vec<u64>,
+
+        /// Landing scope: project id.
+        #[arg(long, conflicts_with_all = ["fleet", "component", "path", "workspace"])]
+        project: Option<String>,
+
+        /// Landing scope: fleet id.
+        #[arg(long, conflicts_with_all = ["project", "component", "path", "workspace"])]
+        fleet: Option<String>,
+
+        /// Landing scope: registered component id.
+        #[arg(long, conflicts_with_all = ["project", "fleet", "path", "workspace"])]
+        component: Option<String>,
+
+        /// Landing scope: checkout path, bypassing the registry.
+        #[arg(long, conflicts_with_all = ["project", "fleet", "component", "workspace"])]
+        path: Option<String>,
+
+        /// Landing scope: all configured workspace repos. This is the default when no scope is supplied.
+        #[arg(long, conflicts_with_all = ["project", "fleet", "component", "path"])]
+        workspace: bool,
+    },
 }
 
 pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageCommandOutput> {
@@ -143,7 +181,33 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageCom
     issue_numbers.sort_unstable();
     issue_numbers.dedup();
 
-    let target = match args.command.unwrap_or(TriageCommand::Workspace) {
+    let command = args.command.unwrap_or(TriageCommand::Workspace);
+    if let TriageCommand::Landing {
+        pr_refs,
+        repo,
+        branch,
+        source_issue,
+        project,
+        fleet,
+        component,
+        path,
+        workspace: _,
+    } = command
+    {
+        let target = resolve_landing_target(project, fleet, component, path)?;
+        let output = triage::landing(TriageLandingOptions {
+            target,
+            repo,
+            pr_refs,
+            branch_patterns: branch,
+            source_issues: source_issue,
+            drilldown: args.drilldown,
+            limit: args.limit,
+        })?;
+        return Ok((TriageCommandOutput::Landing(output), 0));
+    }
+
+    let target = match command {
         TriageCommand::Component { component_id, path } => {
             resolve_component_target(component_id, path)?
         }
@@ -151,6 +215,7 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageCom
         TriageCommand::Fleet { fleet_id } => TriageTarget::Fleet(fleet_id),
         TriageCommand::Rig { rig_id } => TriageTarget::Rig(rig_id),
         TriageCommand::Workspace => TriageTarget::Workspace,
+        TriageCommand::Landing { .. } => unreachable!("landing handled above"),
     };
 
     let include_issues = args.issues || !args.prs || !issue_numbers.is_empty();
@@ -177,6 +242,30 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageCom
         TriageCommandOutput::Report(triage::run(target, options)?),
         0,
     ))
+}
+
+fn resolve_landing_target(
+    project: Option<String>,
+    fleet: Option<String>,
+    component: Option<String>,
+    path: Option<String>,
+) -> Result<TriageTarget, Error> {
+    if let Some(project) = project {
+        return Ok(TriageTarget::Project(project));
+    }
+    if let Some(fleet) = fleet {
+        return Ok(TriageTarget::Fleet(fleet));
+    }
+    if let Some(component) = component {
+        return Ok(TriageTarget::Component(component));
+    }
+    if let Some(path) = path {
+        return Ok(TriageTarget::Path {
+            path,
+            component_id: None,
+        });
+    }
+    Ok(TriageTarget::Workspace)
 }
 
 fn parse_watch_duration(name: &str, raw: &str) -> Result<std::time::Duration, Error> {

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -51,11 +51,74 @@ pub struct TriageOptions {
     pub limit: usize,
 }
 
+#[derive(Debug, Clone)]
+pub struct TriageLandingOptions {
+    pub target: TriageTarget,
+    pub repo: Option<String>,
+    pub pr_refs: Vec<String>,
+    pub branch_patterns: Vec<String>,
+    pub source_issues: Vec<u64>,
+    pub drilldown: bool,
+    pub limit: usize,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum TriageCommandOutput {
     Report(TriageOutput),
     Watch(TriageWatchOutput),
+    Landing(TriageLandingOutput),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TriageLandingOutput {
+    pub command: &'static str,
+    pub target: ScopeOutput,
+    pub summary: TriageLandingSummary,
+    pub pull_requests: Vec<TriageLandingPr>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unresolved: Vec<TriageUnresolved>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TriageLandingSummary {
+    pub total: usize,
+    pub merged: usize,
+    pub clean_mergeable: usize,
+    pub conflict_repair_needed: usize,
+    pub checks_pending: usize,
+    pub baseline_red_inconclusive: usize,
+    pub candidate_red: usize,
+    pub unknown: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TriageLandingPr {
+    pub repo: String,
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_branch: Option<String>,
+    pub classification: TriageLandingClassification,
+    pub suggested_next_command: String,
+    #[serde(flatten)]
+    pub signals: TriagePullRequestSignals,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub check_failures: Vec<TriageCheckFailure>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TriageLandingClassification {
+    Merged,
+    CleanMergeable,
+    ConflictRepairNeeded,
+    ChecksPending,
+    BaselineRedInconclusive,
+    CandidateRed,
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -308,6 +371,49 @@ pub fn run(target: TriageTarget, options: TriageOptions) -> Result<TriageOutput>
     }
 
     Ok(output)
+}
+
+pub fn landing(options: TriageLandingOptions) -> Result<TriageLandingOutput> {
+    let target = options.target.clone();
+    let repos = resolve_landing_repos(&options)?;
+    if repos.len() > 1 && options.pr_refs.iter().any(|raw| is_bare_pr_number(raw)) {
+        return Err(Error::validation_invalid_argument(
+            "pr_refs",
+            "bare PR numbers require --repo or a landing scope that resolves to one repo",
+            None,
+            Some(vec![
+                "Use owner/repo#number or a GitHub PR URL for fleet-wide landing dashboards"
+                    .to_string(),
+            ]),
+        ));
+    }
+    let mut pull_requests = Vec::new();
+    let mut unresolved = Vec::new();
+
+    for repo in repos {
+        let repo_slug = format!("{}/{}", repo.owner, repo.repo);
+        match fetch_landing_prs_for_repo(&repo, &options) {
+            Ok(mut prs) => pull_requests.append(&mut prs),
+            Err(reason) => unresolved.push(TriageUnresolved {
+                component_id: repo_slug,
+                local_path: String::new(),
+                reason,
+                sources: vec!["triage.landing".to_string()],
+            }),
+        }
+    }
+
+    pull_requests.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.number.cmp(&b.number)));
+    pull_requests.dedup_by(|a, b| a.repo == b.repo && a.number == b.number);
+    let summary = summarize_landing(&pull_requests);
+
+    Ok(TriageLandingOutput {
+        command: "triage.landing",
+        target: ScopeOutput::from(&target),
+        summary,
+        pull_requests,
+        unresolved,
+    })
 }
 
 fn triage_component_has_items(component: &TriageComponentReport) -> bool {
@@ -666,6 +772,217 @@ fn fetch_prs(
     Ok(items)
 }
 
+fn resolve_landing_repos(options: &TriageLandingOptions) -> Result<Vec<GitHubRepo>> {
+    if let Some(repo) = &options.repo {
+        return parse_landing_repo(repo).map(|repo| vec![repo]);
+    }
+
+    let refs = resolve_target_components(&options.target)?;
+    let mut repos = Vec::new();
+    let mut unresolved = Vec::new();
+    for component_ref in refs {
+        match resolve_repo(&component_ref) {
+            Ok(resolved) => repos.push(resolved.repo),
+            Err(reason) => unresolved.push(reason),
+        }
+    }
+    repos.sort_by(|a, b| a.owner.cmp(&b.owner).then(a.repo.cmp(&b.repo)));
+    repos.dedup_by(|a, b| a.owner == b.owner && a.repo == b.repo);
+    if repos.is_empty() {
+        return Err(Error::internal_unexpected(format!(
+            "No GitHub repos resolved for landing target: {}",
+            unresolved.join("; ")
+        )));
+    }
+    Ok(repos)
+}
+
+fn parse_landing_repo(raw: &str) -> Result<GitHubRepo> {
+    parse_github_url(raw)
+        .or_else(|| {
+            let (owner, repo) = raw.split_once('/')?;
+            Some(GitHubRepo {
+                host: "github.com".to_string(),
+                owner: owner.trim().to_string(),
+                repo: repo.trim_end_matches(".git").trim().to_string(),
+            })
+        })
+        .filter(|repo| !repo.owner.is_empty() && !repo.repo.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "repo",
+                "expected GitHub repo as owner/name or GitHub URL",
+                Some(raw.to_string()),
+                None,
+            )
+        })
+}
+
+fn fetch_landing_prs_for_repo(
+    repo: &GitHubRepo,
+    options: &TriageLandingOptions,
+) -> std::result::Result<Vec<TriageLandingPr>, String> {
+    ensure_gh_ready()?;
+    let mut items = Vec::new();
+    let mut explicit_numbers = Vec::new();
+    for raw in &options.pr_refs {
+        if let Some(reference) = parse_landing_pr_ref(raw, repo)? {
+            if reference.owner == repo.owner && reference.repo == repo.repo {
+                explicit_numbers.push(reference.number);
+            }
+        }
+    }
+
+    for number in explicit_numbers {
+        items.push(fetch_landing_pr(repo, number, options.drilldown)?);
+    }
+
+    if !options.branch_patterns.is_empty()
+        || (options.pr_refs.is_empty() && options.source_issues.is_empty())
+    {
+        let mut listed = fetch_landing_open_prs(repo, options)?;
+        if !options.branch_patterns.is_empty() {
+            listed.retain(|item| {
+                item.head_branch.as_deref().is_some_and(|branch| {
+                    options
+                        .branch_patterns
+                        .iter()
+                        .any(|pattern| branch_matches(pattern, branch))
+                })
+            });
+        }
+        items.append(&mut listed);
+    }
+
+    for issue_number in &options.source_issues {
+        for linked in fetch_linked_prs(repo, *issue_number)? {
+            items.push(fetch_landing_pr(repo, linked.number, options.drilldown)?);
+        }
+    }
+
+    Ok(items)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LandingPrRef {
+    owner: String,
+    repo: String,
+    number: u64,
+}
+
+fn parse_landing_pr_ref(
+    raw: &str,
+    default_repo: &GitHubRepo,
+) -> std::result::Result<Option<LandingPrRef>, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if let Ok(number) = trimmed.trim_start_matches('#').parse::<u64>() {
+        return Ok(Some(LandingPrRef {
+            owner: default_repo.owner.clone(),
+            repo: default_repo.repo.clone(),
+            number,
+        }));
+    }
+    let (repo_raw, number_raw) = trimmed
+        .rsplit_once('#')
+        .or_else(|| trimmed.rsplit_once("/pull/"))
+        .ok_or_else(|| format!("PR ref must be a number, owner/repo#number, or PR URL: {raw}"))?;
+    let number = number_raw
+        .parse::<u64>()
+        .map_err(|_| format!("PR ref number must be a positive integer: {raw}"))?;
+    let repo = parse_github_url(repo_raw)
+        .or_else(|| {
+            let (owner, repo) = repo_raw.split_once('/')?;
+            Some(GitHubRepo {
+                host: "github.com".to_string(),
+                owner: owner.to_string(),
+                repo: repo.trim_end_matches(".git").to_string(),
+            })
+        })
+        .ok_or_else(|| format!("PR ref repo must be owner/name or GitHub URL: {raw}"))?;
+    Ok(Some(LandingPrRef {
+        owner: repo.owner,
+        repo: repo.repo,
+        number,
+    }))
+}
+
+fn is_bare_pr_number(raw: &str) -> bool {
+    let trimmed = raw.trim().trim_start_matches('#');
+    !trimmed.is_empty() && trimmed.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn fetch_landing_open_prs(
+    repo: &GitHubRepo,
+    options: &TriageLandingOptions,
+) -> std::result::Result<Vec<TriageLandingPr>, String> {
+    let args = vec![
+        "pr".to_string(),
+        "list".to_string(),
+        "-R".to_string(),
+        format!("{}/{}", repo.owner, repo.repo),
+        "--state".to_string(),
+        "open".to_string(),
+        "--limit".to_string(),
+        effective_landing_limit(options).to_string(),
+        "--json".to_string(),
+        landing_pr_json_fields().to_string(),
+    ];
+    let raw = run_gh(&args)?;
+    parse_landing_prs(&raw, repo, options.drilldown)
+}
+
+fn fetch_landing_pr(
+    repo: &GitHubRepo,
+    number: u64,
+    drilldown: bool,
+) -> std::result::Result<TriageLandingPr, String> {
+    let args = vec![
+        "pr".to_string(),
+        "view".to_string(),
+        number.to_string(),
+        "-R".to_string(),
+        format!("{}/{}", repo.owner, repo.repo),
+        "--json".to_string(),
+        landing_pr_json_fields().to_string(),
+    ];
+    let raw = run_gh(&args)?;
+    parse_landing_pr(&raw, repo, drilldown)
+}
+
+fn landing_pr_json_fields() -> &'static str {
+    "number,title,url,state,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,headRefName,comments,reviews,updatedAt,mergedAt"
+}
+
+fn effective_landing_limit(options: &TriageLandingOptions) -> usize {
+    if options.limit == 0 {
+        30
+    } else {
+        options.limit
+    }
+}
+
+fn branch_matches(pattern: &str, branch: &str) -> bool {
+    if pattern == "*" || pattern == branch {
+        return true;
+    }
+    if let Some(contains) = pattern
+        .strip_prefix('*')
+        .and_then(|value| value.strip_suffix('*'))
+    {
+        return branch.contains(contains);
+    }
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        return branch.starts_with(prefix);
+    }
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        return branch.ends_with(suffix);
+    }
+    branch.contains(pattern)
+}
+
 fn effective_limit(options: &TriageOptions) -> usize {
     if options.limit == 0 {
         30
@@ -829,6 +1146,10 @@ struct RawPr {
     merge_state_status: Option<String>,
     #[serde(default, rename = "statusCheckRollup")]
     status_check_rollup: Vec<Value>,
+    #[serde(default, rename = "headRefName")]
+    head_ref_name: Option<String>,
+    #[serde(default, rename = "mergedAt")]
+    merged_at: Option<String>,
     #[serde(default)]
     labels: Vec<RawNamedNode>,
     #[serde(default)]
@@ -841,6 +1162,153 @@ struct RawPr {
     reviews: Vec<RawReview>,
     #[serde(default, rename = "updatedAt")]
     updated_at: Option<String>,
+}
+
+fn parse_landing_prs(
+    raw: &str,
+    repo: &GitHubRepo,
+    drilldown: bool,
+) -> std::result::Result<Vec<TriageLandingPr>, String> {
+    let parsed: Vec<RawPr> = serde_json::from_str(raw.trim()).map_err(|e| e.to_string())?;
+    Ok(parsed
+        .into_iter()
+        .map(|item| raw_pr_to_landing_pr(item, repo, drilldown))
+        .collect())
+}
+
+fn parse_landing_pr(
+    raw: &str,
+    repo: &GitHubRepo,
+    drilldown: bool,
+) -> std::result::Result<TriageLandingPr, String> {
+    let parsed: RawPr = serde_json::from_str(raw.trim()).map_err(|e| e.to_string())?;
+    Ok(raw_pr_to_landing_pr(parsed, repo, drilldown))
+}
+
+fn raw_pr_to_landing_pr(item: RawPr, repo: &GitHubRepo, drilldown: bool) -> TriageLandingPr {
+    let signals = TriagePullRequestSignals {
+        checks: summarize_checks(&item.status_check_rollup),
+        review_decision: non_empty(item.review_decision),
+        merge_state: non_empty(item.merge_state_status),
+        comments_count: usize_to_i64(item.comments.len()),
+        reviews_count: usize_to_i64(item.reviews.len()),
+        last_comment_at: latest_comment_at(&item.comments),
+        last_review_at: latest_review_at(&item.reviews),
+        ..TriagePullRequestSignals::default()
+    };
+    let check_failures = if drilldown {
+        summarize_check_failures(&item.status_check_rollup)
+    } else {
+        Vec::new()
+    };
+    let classification = classify_landing_pr(
+        &item.state,
+        item.merged_at.as_deref(),
+        signals.checks.as_deref(),
+        signals.merge_state.as_deref(),
+    );
+    TriageLandingPr {
+        repo: format!("{}/{}", repo.owner, repo.repo),
+        number: item.number,
+        title: item.title,
+        url: item.url,
+        state: item.state,
+        head_branch: non_empty(item.head_ref_name),
+        classification,
+        suggested_next_command: landing_next_command(classification, repo, item.number),
+        signals,
+        check_failures,
+    }
+}
+
+pub(crate) fn classify_landing_pr(
+    state: &str,
+    merged_at: Option<&str>,
+    checks: Option<&str>,
+    merge_state: Option<&str>,
+) -> TriageLandingClassification {
+    if state == "MERGED" || merged_at.is_some() {
+        return TriageLandingClassification::Merged;
+    }
+    if matches!(
+        merge_state,
+        Some("DIRTY" | "BEHIND" | "BLOCKED" | "HAS_HOOKS")
+    ) {
+        return TriageLandingClassification::ConflictRepairNeeded;
+    }
+    if matches!(checks, Some("PENDING")) || (merge_state == Some("CLEAN") && checks.is_none()) {
+        return TriageLandingClassification::ChecksPending;
+    }
+    if checks == Some("FAILURE") {
+        return TriageLandingClassification::CandidateRed;
+    }
+    if merge_state == Some("CLEAN") && checks == Some("SUCCESS") {
+        return TriageLandingClassification::CleanMergeable;
+    }
+    if checks.is_none() || matches!(merge_state, None | Some("UNKNOWN" | "UNSTABLE")) {
+        return TriageLandingClassification::BaselineRedInconclusive;
+    }
+    TriageLandingClassification::Unknown
+}
+
+fn landing_next_command(
+    classification: TriageLandingClassification,
+    repo: &GitHubRepo,
+    number: u64,
+) -> String {
+    let reference = format!("{}/{}#{}", repo.owner, repo.repo, number);
+    match classification {
+        TriageLandingClassification::Merged => {
+            format!("homeboy triage --watch {reference} --until merged")
+        }
+        TriageLandingClassification::CleanMergeable => {
+            format!("homeboy triage --watch {reference} --until green-mergeable")
+        }
+        TriageLandingClassification::ConflictRepairNeeded => {
+            format!(
+                "gh pr checkout {number} -R {}/{} && git rebase origin/main",
+                repo.owner, repo.repo
+            )
+        }
+        TriageLandingClassification::ChecksPending => {
+            format!("homeboy triage --watch {reference} --until green")
+        }
+        TriageLandingClassification::BaselineRedInconclusive => {
+            format!("gh pr checks {number} -R {}/{}", repo.owner, repo.repo)
+        }
+        TriageLandingClassification::CandidateRed => {
+            format!(
+                "gh pr checks {number} -R {}/{} --fail-fast",
+                repo.owner, repo.repo
+            )
+        }
+        TriageLandingClassification::Unknown => {
+            format!("gh pr view {number} -R {}/{} --web", repo.owner, repo.repo)
+        }
+    }
+}
+
+fn summarize_landing(items: &[TriageLandingPr]) -> TriageLandingSummary {
+    let mut summary = TriageLandingSummary {
+        total: items.len(),
+        ..Default::default()
+    };
+    for item in items {
+        match item.classification {
+            TriageLandingClassification::Merged => summary.merged += 1,
+            TriageLandingClassification::CleanMergeable => summary.clean_mergeable += 1,
+            TriageLandingClassification::ConflictRepairNeeded => {
+                summary.conflict_repair_needed += 1
+            }
+            TriageLandingClassification::ChecksPending => summary.checks_pending += 1,
+            TriageLandingClassification::BaselineRedInconclusive => {
+                summary.baseline_red_inconclusive += 1
+            }
+            TriageLandingClassification::CandidateRed => summary.candidate_red += 1,
+            TriageLandingClassification::Unknown => summary.unknown += 1,
+        }
+    }
+    summary
 }
 
 fn parse_prs(

--- a/src/core/triage/tests.rs
+++ b/src/core/triage/tests.rs
@@ -473,6 +473,121 @@ mod pull_requests {
     }
 
     #[test]
+    fn landing_classifier_covers_ready_and_blocked_states() {
+        assert_eq!(
+            classify_landing_pr("MERGED", Some("2026-06-01T00:00:00Z"), None, None),
+            TriageLandingClassification::Merged
+        );
+        assert_eq!(
+            classify_landing_pr("OPEN", None, Some("SUCCESS"), Some("CLEAN")),
+            TriageLandingClassification::CleanMergeable
+        );
+        assert_eq!(
+            classify_landing_pr("OPEN", None, Some("SUCCESS"), Some("DIRTY")),
+            TriageLandingClassification::ConflictRepairNeeded
+        );
+        assert_eq!(
+            classify_landing_pr("OPEN", None, Some("PENDING"), Some("CLEAN")),
+            TriageLandingClassification::ChecksPending
+        );
+        assert_eq!(
+            classify_landing_pr("OPEN", None, Some("FAILURE"), Some("CLEAN")),
+            TriageLandingClassification::CandidateRed
+        );
+        assert_eq!(
+            classify_landing_pr("OPEN", None, None, Some("UNKNOWN")),
+            TriageLandingClassification::BaselineRedInconclusive
+        );
+    }
+
+    #[test]
+    fn parse_landing_pr_adds_classification_and_command() {
+        let repo = GitHubRepo {
+            host: "github.com".to_string(),
+            owner: "Extra-Chill".to_string(),
+            repo: "homeboy".to_string(),
+        };
+        let raw = r#"{
+          "number": 42,
+          "title": "Ready",
+          "url": "https://github.com/Extra-Chill/homeboy/pull/42",
+          "state": "OPEN",
+          "isDraft": false,
+          "reviewDecision": "APPROVED",
+          "mergeStateStatus": "CLEAN",
+          "statusCheckRollup": [{"status":"COMPLETED","conclusion":"SUCCESS"}],
+          "headRefName": "cook/ready",
+          "mergedAt": null,
+          "comments": [],
+          "reviews": [],
+          "updatedAt": "2026-06-01T00:00:00Z"
+        }"#;
+
+        let item = parse_landing_pr(raw, &repo, false).unwrap();
+
+        assert_eq!(
+            item.classification,
+            TriageLandingClassification::CleanMergeable
+        );
+        assert_eq!(item.head_branch.as_deref(), Some("cook/ready"));
+        assert_eq!(
+            item.suggested_next_command,
+            "homeboy triage --watch Extra-Chill/homeboy#42 --until green-mergeable"
+        );
+    }
+
+    #[test]
+    fn landing_pr_ref_accepts_number_repo_ref_and_url() {
+        let repo = GitHubRepo {
+            host: "github.com".to_string(),
+            owner: "Extra-Chill".to_string(),
+            repo: "homeboy".to_string(),
+        };
+
+        assert_eq!(
+            parse_landing_pr_ref("42", &repo).unwrap().unwrap(),
+            LandingPrRef {
+                owner: "Extra-Chill".to_string(),
+                repo: "homeboy".to_string(),
+                number: 42,
+            }
+        );
+        assert_eq!(
+            parse_landing_pr_ref("Extra-Chill/homeboy#43", &repo)
+                .unwrap()
+                .unwrap()
+                .number,
+            43
+        );
+        assert_eq!(
+            parse_landing_pr_ref("https://github.com/Extra-Chill/homeboy/pull/44", &repo)
+                .unwrap()
+                .unwrap()
+                .number,
+            44
+        );
+    }
+
+    #[test]
+    fn bare_pr_number_detection_only_matches_numbers() {
+        assert!(is_bare_pr_number("42"));
+        assert!(is_bare_pr_number("#42"));
+        assert!(!is_bare_pr_number("Extra-Chill/homeboy#42"));
+        assert!(!is_bare_pr_number(
+            "https://github.com/Extra-Chill/homeboy/pull/42"
+        ));
+    }
+
+    #[test]
+    fn branch_matcher_supports_simple_globs_and_contains() {
+        assert!(branch_matches("cook/*", "cook/landing"));
+        assert!(branch_matches("*landing", "cook/landing"));
+        assert!(branch_matches("*land*", "cook/landing"));
+        assert!(branch_matches("land", "cook/landing"));
+        assert!(!branch_matches("fix/*", "cook/landing"));
+    }
+
+    #[test]
     fn parse_prs_flags_clean_with_zero_checks_as_not_reported() {
         // Reproduces the #4872 force-push window: GitHub reports mergeStateStatus
         // CLEAN with an empty statusCheckRollup before CI registers on the new head.


### PR DESCRIPTION
## Summary
- Add `homeboy triage landing` for read-only PR landing dashboards across a repo, component, project, fleet, path, or workspace scope.
- Support explicit PR refs, branch-pattern filtering, and linked source issue PR discovery.
- Classify PRs as merged, clean-mergeable, conflict-repair-needed, checks-pending, baseline-red-inconclusive, candidate-red, or unknown, with a suggested next command per PR.
- Add focused unit coverage for landing classification, PR ref parsing, and branch matching.

## Verification
- `rustfmt src/core/triage.rs src/core/triage/tests.rs src/commands/triage.rs`
- `rustfmt --check src/core/triage.rs src/core/triage/tests.rs src/commands/triage.rs`
- `git diff --check`

Local Cargo-based tests were not run because this Studio machine is configured to avoid direct local `cargo` execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the triage landing dashboard, classification helper, CLI wiring, and focused tests.