### PR TITLE
Make changed-since Lab offload use precomputed scope

### DIFF
--- a/src/commands/agent_task/prompts.rs
+++ b/src/commands/agent_task/prompts.rs
@@ -85,39 +85,51 @@ pub fn prompts(args: AgentTaskPromptsArgs) -> CmdResult<Value> {
 fn save(args: AgentTaskPromptSaveArgs) -> CmdResult<Value> {
     let content = agent_task_prompts::read_prompt_input(&args.input)?;
     let record = agent_task_prompts::save_prompt(&args.name, &content)?;
-    command_json_value(PromptSaveReport {
-        schema: "homeboy/agent-task-prompt/v1",
-        id: record.id.clone(),
-        path: record.path,
-        reference: format!("{}{}", agent_task_prompts::PROMPT_REF_PREFIX, record.id),
-        size_bytes: record.size_bytes,
-    })
+    Ok((
+        command_json_value(PromptSaveReport {
+            schema: "homeboy/agent-task-prompt/v1",
+            id: record.id.clone(),
+            path: record.path,
+            reference: format!("{}{}", agent_task_prompts::PROMPT_REF_PREFIX, record.id),
+            size_bytes: record.size_bytes,
+        })?,
+        0,
+    ))
 }
 
 fn list() -> CmdResult<Value> {
-    command_json_value(PromptListReport {
-        schema: "homeboy/agent-task-prompts/v1",
-        prompt_dir: agent_task_prompts::prompts_dir()?.display().to_string(),
-        prompts: agent_task_prompts::list_prompts()?,
-    })
+    Ok((
+        command_json_value(PromptListReport {
+            schema: "homeboy/agent-task-prompts/v1",
+            prompt_dir: agent_task_prompts::prompts_dir()?.display().to_string(),
+            prompts: agent_task_prompts::list_prompts()?,
+        })?,
+        0,
+    ))
 }
 
 fn show(args: AgentTaskPromptNameArgs) -> CmdResult<Value> {
     let record = agent_task_prompts::prompt_path(&args.name)?;
-    command_json_value(PromptShowReport {
-        schema: "homeboy/agent-task-prompt-content/v1",
-        id: agent_task_prompts::prompt_id(&args.name)?,
-        path: record.display().to_string(),
-        content: agent_task_prompts::read_prompt(&args.name)?,
-    })
+    Ok((
+        command_json_value(PromptShowReport {
+            schema: "homeboy/agent-task-prompt-content/v1",
+            id: agent_task_prompts::prompt_id(&args.name)?,
+            path: record.display().to_string(),
+            content: agent_task_prompts::read_prompt(&args.name)?,
+        })?,
+        0,
+    ))
 }
 
 fn remove(args: AgentTaskPromptNameArgs) -> CmdResult<Value> {
     let record = agent_task_prompts::remove_prompt(&args.name)?;
-    command_json_value(PromptRemoveReport {
-        schema: "homeboy/agent-task-prompt-remove/v1",
-        removed: true,
-        id: record.id,
-        path: record.path,
-    })
+    Ok((
+        command_json_value(PromptRemoveReport {
+            schema: "homeboy/agent-task-prompt-remove/v1",
+            removed: true,
+            id: record.id,
+            path: record.path,
+        })?,
+        0,
+    ))
 }

--- a/src/core/runner/offload_changed_since.rs
+++ b/src/core/runner/offload_changed_since.rs
@@ -77,6 +77,10 @@ pub fn prepare_git_lab_offload_changed_since(
 }
 
 pub fn lab_offload_changed_since_ref(args: &[String]) -> Option<String> {
+    if lab_offload_has_precomputed_changed_files(args) {
+        return None;
+    }
+
     let mut iter = args.iter().skip(1);
     while let Some(arg) = iter.next() {
         if arg == "--" {
@@ -90,6 +94,22 @@ pub fn lab_offload_changed_since_ref(args: &[String]) -> Option<String> {
         }
     }
     None
+}
+
+fn lab_offload_has_precomputed_changed_files(args: &[String]) -> bool {
+    let mut iter = args.iter().skip(1);
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--lab-changed-files-json" {
+            return iter.next().is_some();
+        }
+        if arg.starts_with("--lab-changed-files-json=") {
+            return true;
+        }
+    }
+    false
 }
 
 fn rewrite_changed_since_ref(args: &[String], resolved_base: &str) -> Vec<String> {
@@ -243,6 +263,48 @@ mod tests {
         assert!(err.message.contains("cannot honor --changed-since"));
         assert!(err.message.contains("snapshot workspaces"));
         assert_eq!(err.details["id"], "origin/main");
+    }
+
+    #[test]
+    fn precomputed_changed_files_make_changed_since_snapshot_portable() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--path".to_string(),
+            "/Users/user/Developer/project".to_string(),
+            "--changed-since".to_string(),
+            "origin/main".to_string(),
+            "--lab-changed-files-json".to_string(),
+            "[\"src/lib.rs\"]".to_string(),
+        ];
+
+        assert_eq!(lab_offload_changed_since_ref(&args), None);
+
+        let preflight =
+            preflight_lab_offload_changed_since(&args, RunnerWorkspaceSyncMode::Snapshot)
+                .expect("precomputed changed-file scope should be snapshot portable");
+        assert_eq!(preflight.args, args);
+        assert_eq!(preflight.requested_ref, None);
+        assert_eq!(preflight.resolved_base, None);
+        assert!(preflight.git_fetch_refs.is_empty());
+    }
+
+    #[test]
+    fn precomputed_changed_files_ignore_passthrough_payloads() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--changed-since".to_string(),
+            "origin/main".to_string(),
+            "--".to_string(),
+            "--lab-changed-files-json".to_string(),
+            "[\"fixture\"]".to_string(),
+        ];
+
+        assert_eq!(
+            lab_offload_changed_since_ref(&args),
+            Some("origin/main".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat Lab-injected `--lab-changed-files-json` as the portable changed-file scope for offload preflight, so `--changed-since` lint/test can use snapshot workspaces without requiring runner git refs.
- Add focused tests covering snapshot portability with precomputed changed files and passthrough safety.
- Fix the agent-task prompt adapter return shape that blocked Rust test compilation on `origin/main`.

## Verification
- `rustfmt src/core/runner/offload_changed_since.rs src/commands/agent_task/prompts.rs`
- `git diff --check`
- `homeboy runner workspace sync homeboy-lab --path /Users/chubes/Developer/homeboy@cook-5785-lab-changed-since-portable --mode snapshot`
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-cook-5785-lab-changed-since-portable-337c5cab4d8f-d9de9d89-4b29-4067-a860-16ed1977e5e6-1782092658403034000 -- cargo test offload_changed_since --lib` (7 passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, focused tests, verification, and PR preparation.