### PR TITLE
Add fuzz coverage completeness gates

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -8,6 +8,8 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--max-duration <duration>] [-- <runner-args>]
 homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--max-duration <duration>] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
+homeboy fuzz validate <results-file>
+homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--output-envelope <path>]
 homeboy fuzz replay [<case>] [--run-id <id>] [-- <runner-args>]
 ```
 
@@ -58,6 +60,26 @@ Runner scripts receive `HOMEBOY_FUZZ_RESULTS_FILE` pointing at
 and returns it as `results` in the JSON envelope. Malformed JSON fails the run
 instead of being treated as proof.
 
+Campaigns can include a product-neutral coverage summary:
+
+```json
+{
+  "schema": "homeboy/fuzz-campaign/v1",
+  "id": "campaign-1",
+  "safety_class": "read_only",
+  "coverage_summary": {
+    "schema": "homeboy/fuzz-coverage-summary/v1",
+    "declared_targets": 2,
+    "executable_targets": 2,
+    "proven_targets": 2,
+    "declared_operations": 4,
+    "executable_operations": 4,
+    "proven_operations": 4,
+    "artifact_ids": ["coverage-report"]
+  }
+}
+```
+
 `homeboy fuzz replay` is reserved for a future generic replay contract. Today it
 returns a product-agnostic `not_implemented` JSON response and does not execute
 local fuzz code. Use the originating fuzz runner's replay command until Homeboy
@@ -67,6 +89,11 @@ Full-coverage claims need persisted proof artifacts. A neutral coverage summary
 can report declared, executable, and proven counts; operation totals; skipped
 reason codes; and case/manifest artifacts. Treat missing `proven` counts or
 missing coverage/case artifacts as incomplete evidence, not as full coverage.
+`homeboy fuzz validate` and `homeboy fuzz report` evaluate coverage completeness
+gates from `coverage_summary`: `target-coverage-complete` and
+`operation-coverage-complete` pass only when every declared target/operation is
+proven, or when the summary explicitly declares zero targets/operations. Missing
+`coverage_summary` fails those completeness gates.
 
 Fuzz workloads do not have a benchmark fallback. If `homeboy fuzz run` cannot
 execute the selected workload, fix the fuzz runner, rig declaration, or Lab
@@ -122,8 +149,8 @@ Rigs can add private fuzz workloads keyed by extension id:
 
 ## Output
 
-`list`, `run`, and `replay` return JSON envelopes with stable `variant` values:
-`list`, `run`, and `replay`.
+`contract`, `list`, `plan`, `run`, `validate`, `report`, and `replay` return
+JSON envelopes with stable `variant` values.
 
 `run.execution.results_file` is the path advertised to the runner through
 `HOMEBOY_FUZZ_RESULTS_FILE`. `run.results` is present only when the runner wrote

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -242,6 +242,7 @@ pub struct FuzzValidateOutput {
     pub campaign_id: String,
     pub open_findings: usize,
     pub artifacts: usize,
+    pub coverage_completeness: FuzzCoverageCompletenessOutput,
     pub gates: Vec<FuzzGateEvaluation>,
 }
 
@@ -252,6 +253,7 @@ pub struct FuzzReportOutput {
     pub results_file: String,
     pub envelope_file: Option<String>,
     pub envelope: FuzzResultEnvelope,
+    pub coverage_completeness: FuzzCoverageCompletenessOutput,
     pub gates: Vec<FuzzGateEvaluation>,
 }
 
@@ -301,6 +303,22 @@ pub struct FuzzGateEvaluation {
     pub metric: String,
     pub observed: f64,
     pub expected: f64,
+}
+
+#[derive(Serialize, Clone)]
+pub struct FuzzCoverageCompletenessOutput {
+    pub has_summary: bool,
+    pub declared_targets: u64,
+    pub executable_targets: u64,
+    pub proven_targets: u64,
+    pub target_coverage_ratio: f64,
+    pub declared_operations: u64,
+    pub executable_operations: u64,
+    pub proven_operations: u64,
+    pub operation_coverage_ratio: f64,
+    pub skipped_targets: usize,
+    pub skipped_operations: usize,
+    pub artifact_ids: Vec<String>,
 }
 
 pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
@@ -458,6 +476,7 @@ fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutput> {
 fn run_validate(args: FuzzValidateArgs) -> homeboy::core::Result<FuzzValidateOutput> {
     let campaign = parse_fuzz_results_file(&args.results_file)?;
     let gates = evaluate_fuzz_gates(&campaign);
+    let coverage_completeness = fuzz_coverage_completeness(&campaign);
 
     Ok(FuzzValidateOutput {
         command: "fuzz.validate".to_string(),
@@ -466,6 +485,7 @@ fn run_validate(args: FuzzValidateArgs) -> homeboy::core::Result<FuzzValidateOut
         campaign_id: campaign.id.clone(),
         open_findings: open_finding_count(&campaign),
         artifacts: campaign.artifacts.len(),
+        coverage_completeness,
         gates,
     })
 }
@@ -473,6 +493,7 @@ fn run_validate(args: FuzzValidateArgs) -> homeboy::core::Result<FuzzValidateOut
 fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzReportOutput> {
     let campaign = parse_fuzz_results_file(&args.results_file)?;
     let gates = evaluate_fuzz_gates(&campaign);
+    let coverage_completeness = fuzz_coverage_completeness(&campaign);
     let status = gate_status(&gates);
     let run_id = args.run.run_id.clone();
     let component = args.run.comp.id().unwrap_or("unknown").to_string();
@@ -536,6 +557,7 @@ fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzReportOutput> {
             .output_envelope
             .map(|path| path.to_string_lossy().to_string()),
         envelope,
+        coverage_completeness,
         gates,
     })
 }
@@ -659,6 +681,16 @@ fn evaluate_fuzz_gates(campaign: &FuzzCampaign) -> Vec<FuzzGateEvaluation> {
                     .iter()
                     .filter(|artifact| artifact.kind == "case_log")
                     .count() as f64,
+                "target_coverage_ratio" => coverage_ratio(
+                    campaign.coverage_summary.as_ref(),
+                    |summary| summary.proven_targets,
+                    |summary| summary.declared_targets,
+                ),
+                "operation_coverage_ratio" => coverage_ratio(
+                    campaign.coverage_summary.as_ref(),
+                    |summary| summary.proven_operations,
+                    |summary| summary.declared_operations,
+                ),
                 _ => 0.0,
             };
             let passed = threshold_passes(observed, gate.operator, gate.value);
@@ -671,6 +703,63 @@ fn evaluate_fuzz_gates(campaign: &FuzzCampaign) -> Vec<FuzzGateEvaluation> {
             }
         })
         .collect()
+}
+
+fn coverage_ratio(
+    summary: Option<&homeboy::core::fuzz::FuzzCoverageSummary>,
+    covered: impl Fn(&homeboy::core::fuzz::FuzzCoverageSummary) -> u64,
+    total: impl Fn(&homeboy::core::fuzz::FuzzCoverageSummary) -> u64,
+) -> f64 {
+    let Some(summary) = summary else {
+        return 0.0;
+    };
+    let total = total(summary);
+    if total == 0 {
+        1.0
+    } else {
+        covered(summary) as f64 / total as f64
+    }
+}
+
+fn fuzz_coverage_completeness(campaign: &FuzzCampaign) -> FuzzCoverageCompletenessOutput {
+    match campaign.coverage_summary.as_ref() {
+        Some(summary) => FuzzCoverageCompletenessOutput {
+            has_summary: true,
+            declared_targets: summary.declared_targets,
+            executable_targets: summary.executable_targets,
+            proven_targets: summary.proven_targets,
+            target_coverage_ratio: coverage_ratio(
+                Some(summary),
+                |summary| summary.proven_targets,
+                |summary| summary.declared_targets,
+            ),
+            declared_operations: summary.declared_operations,
+            executable_operations: summary.executable_operations,
+            proven_operations: summary.proven_operations,
+            operation_coverage_ratio: coverage_ratio(
+                Some(summary),
+                |summary| summary.proven_operations,
+                |summary| summary.declared_operations,
+            ),
+            skipped_targets: summary.skipped_targets.len(),
+            skipped_operations: summary.skipped_operations.len(),
+            artifact_ids: summary.artifact_ids.clone(),
+        },
+        None => FuzzCoverageCompletenessOutput {
+            has_summary: false,
+            declared_targets: 0,
+            executable_targets: 0,
+            proven_targets: 0,
+            target_coverage_ratio: 0.0,
+            declared_operations: 0,
+            executable_operations: 0,
+            proven_operations: 0,
+            operation_coverage_ratio: 0.0,
+            skipped_targets: 0,
+            skipped_operations: 0,
+            artifact_ids: Vec::new(),
+        },
+    }
 }
 
 fn open_finding_count(campaign: &FuzzCampaign) -> usize {
@@ -1128,6 +1217,7 @@ mod tests {
             cases: Vec::new(),
             seeds: Vec::new(),
             coverage: Vec::new(),
+            coverage_summary: None,
             findings: Vec::new(),
             artifacts: Vec::new(),
             thresholds: Vec::new(),
@@ -1143,6 +1233,123 @@ mod tests {
         assert!(gates.iter().any(|gate| {
             gate.gate_id == "has-case-evidence" && gate.status == "failed" && gate.observed == 0.0
         }));
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "target-coverage-complete"
+                && gate.status == "failed"
+                && gate.observed == 0.0
+        }));
+    }
+
+    #[test]
+    fn fuzz_gate_evaluation_requires_complete_target_and_operation_coverage() {
+        let mut campaign = FuzzCampaign {
+            schema: homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA.to_string(),
+            version: homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+            id: "campaign-1".to_string(),
+            title: None,
+            safety_class: homeboy::core::fuzz::FuzzSafetyClass::ReadOnly,
+            surfaces: Vec::new(),
+            targets: Vec::new(),
+            workloads: Vec::new(),
+            cases: Vec::new(),
+            seeds: Vec::new(),
+            coverage: Vec::new(),
+            coverage_summary: Some(homeboy::core::fuzz::FuzzCoverageSummary {
+                schema: homeboy::core::fuzz::FUZZ_COVERAGE_SUMMARY_SCHEMA.to_string(),
+                declared_targets: 2,
+                executable_targets: 2,
+                proven_targets: 1,
+                declared_operations: 4,
+                executable_operations: 4,
+                proven_operations: 4,
+                skipped_targets: Vec::new(),
+                skipped_operations: Vec::new(),
+                artifact_ids: vec!["coverage-report".to_string()],
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            }),
+            findings: Vec::new(),
+            artifacts: vec![homeboy::core::fuzz::FuzzArtifact {
+                schema: homeboy::core::fuzz::FUZZ_ARTIFACT_SCHEMA.to_string(),
+                id: "case-log".to_string(),
+                kind: "case_log".to_string(),
+                artifact: None,
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            }],
+            thresholds: Vec::new(),
+            provenance: None,
+            replay: None,
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        };
+
+        let gates = evaluate_fuzz_gates(&campaign);
+
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "target-coverage-complete"
+                && gate.status == "failed"
+                && gate.observed == 0.5
+        }));
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "operation-coverage-complete"
+                && gate.status == "passed"
+                && gate.observed == 1.0
+        }));
+
+        campaign.coverage_summary.as_mut().unwrap().proven_targets = 2;
+        assert_eq!(gate_status(&evaluate_fuzz_gates(&campaign)), "passed");
+    }
+
+    #[test]
+    fn fuzz_coverage_completeness_reports_summary_counts() {
+        let campaign = FuzzCampaign {
+            schema: homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA.to_string(),
+            version: homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+            id: "campaign-1".to_string(),
+            title: None,
+            safety_class: homeboy::core::fuzz::FuzzSafetyClass::ReadOnly,
+            surfaces: Vec::new(),
+            targets: Vec::new(),
+            workloads: Vec::new(),
+            cases: Vec::new(),
+            seeds: Vec::new(),
+            coverage: Vec::new(),
+            coverage_summary: Some(homeboy::core::fuzz::FuzzCoverageSummary {
+                schema: homeboy::core::fuzz::FUZZ_COVERAGE_SUMMARY_SCHEMA.to_string(),
+                declared_targets: 2,
+                executable_targets: 1,
+                proven_targets: 1,
+                declared_operations: 0,
+                executable_operations: 0,
+                proven_operations: 0,
+                skipped_targets: vec![homeboy::core::fuzz::FuzzCoverageSkip {
+                    id: "target-2".to_string(),
+                    reason: "not_executable".to_string(),
+                    label: None,
+                }],
+                skipped_operations: Vec::new(),
+                artifact_ids: vec!["coverage-report".to_string()],
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            }),
+            findings: Vec::new(),
+            artifacts: Vec::new(),
+            thresholds: Vec::new(),
+            provenance: None,
+            replay: None,
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        };
+
+        let summary = fuzz_coverage_completeness(&campaign);
+
+        assert!(summary.has_summary);
+        assert_eq!(summary.declared_targets, 2);
+        assert_eq!(summary.target_coverage_ratio, 0.5);
+        assert_eq!(summary.operation_coverage_ratio, 1.0);
+        assert_eq!(summary.skipped_targets, 1);
+        assert_eq!(summary.artifact_ids, vec!["coverage-report"]);
     }
 
     #[test]
@@ -1265,6 +1472,7 @@ mod tests {
             cases: Vec::new(),
             seeds: Vec::new(),
             coverage: Vec::new(),
+            coverage_summary: None,
             findings: Vec::new(),
             artifacts: Vec::new(),
             thresholds: Vec::new(),

--- a/src/core/fuzz.rs
+++ b/src/core/fuzz.rs
@@ -26,6 +26,7 @@ pub const FUZZ_ARTIFACT_SCHEMA: &str = "homeboy/fuzz-artifact/v1";
 pub const FUZZ_THRESHOLD_SCHEMA: &str = "homeboy/fuzz-threshold/v1";
 pub const FUZZ_PROVENANCE_SCHEMA: &str = "homeboy/fuzz-provenance/v1";
 pub const FUZZ_REPLAY_SCHEMA: &str = "homeboy/fuzz-replay/v1";
+pub const FUZZ_COVERAGE_SUMMARY_SCHEMA: &str = "homeboy/fuzz-coverage-summary/v1";
 pub const FUZZ_TARGET_INVENTORY_SCHEMA: &str = "homeboy/fuzz-target-inventory/v1";
 pub const FUZZ_EXECUTION_REQUEST_SCHEMA: &str = "homeboy/fuzz-execution-request/v1";
 pub const FUZZ_RESULT_ENVELOPE_SCHEMA: &str = "homeboy/fuzz-result-envelope/v1";
@@ -57,6 +58,7 @@ pub struct FuzzContractSchemas {
     pub threshold: String,
     pub provenance: String,
     pub replay: String,
+    pub coverage_summary: String,
     pub target_inventory: String,
     pub execution_request: String,
     pub result_envelope: String,
@@ -229,6 +231,8 @@ pub struct FuzzCampaign {
     pub seeds: Vec<FuzzSeed>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub coverage: Vec<FuzzCoverage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage_summary: Option<FuzzCoverageSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub findings: Vec<FuzzFinding>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -323,6 +327,36 @@ pub struct FuzzCoverageGap {
     pub operation: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub operation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FuzzCoverageSummary {
+    #[serde(default = "fuzz_coverage_summary_schema")]
+    pub schema: String,
+    pub declared_targets: u64,
+    pub executable_targets: u64,
+    pub proven_targets: u64,
+    pub declared_operations: u64,
+    pub executable_operations: u64,
+    pub proven_operations: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skipped_targets: Vec<FuzzCoverageSkip>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skipped_operations: Vec<FuzzCoverageSkip>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FuzzCoverageSkip {
+    pub id: String,
+    pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -571,6 +605,7 @@ pub fn fuzz_core_contract() -> FuzzCoreContract {
             threshold: FUZZ_THRESHOLD_SCHEMA.to_string(),
             provenance: FUZZ_PROVENANCE_SCHEMA.to_string(),
             replay: FUZZ_REPLAY_SCHEMA.to_string(),
+            coverage_summary: FUZZ_COVERAGE_SUMMARY_SCHEMA.to_string(),
             target_inventory: FUZZ_TARGET_INVENTORY_SCHEMA.to_string(),
             execution_request: FUZZ_EXECUTION_REQUEST_SCHEMA.to_string(),
             result_envelope: FUZZ_RESULT_ENVELOPE_SCHEMA.to_string(),
@@ -648,6 +683,17 @@ pub fn default_fuzz_required_artifacts() -> Vec<FuzzRequiredArtifact> {
             ),
             acceptable_artifact_kinds: vec!["json".to_string(), "artifact".to_string()],
         },
+        FuzzRequiredArtifact {
+            schema: FUZZ_REQUIRED_ARTIFACT_SCHEMA.to_string(),
+            id: "coverage-summary".to_string(),
+            kind: "coverage_summary".to_string(),
+            required: true,
+            description: Some(
+                "Target and operation coverage summary with declared, executable, and proven counts"
+                    .to_string(),
+            ),
+            acceptable_artifact_kinds: vec!["json".to_string()],
+        },
     ]
 }
 
@@ -673,6 +719,32 @@ pub fn default_fuzz_gates() -> Vec<FuzzGate> {
             unit: Some("count".to_string()),
             description: Some(
                 "Result envelope links at least one case-level proof artifact".to_string(),
+            ),
+        },
+        FuzzGate {
+            schema: FUZZ_GATE_SCHEMA.to_string(),
+            id: "target-coverage-complete".to_string(),
+            kind: "coverage_completeness".to_string(),
+            metric: "target_coverage_ratio".to_string(),
+            operator: FuzzThresholdOperator::GreaterThanOrEqual,
+            value: 1.0,
+            unit: Some("ratio".to_string()),
+            description: Some(
+                "Coverage summary proves every declared target, or explicitly declares zero targets"
+                    .to_string(),
+            ),
+        },
+        FuzzGate {
+            schema: FUZZ_GATE_SCHEMA.to_string(),
+            id: "operation-coverage-complete".to_string(),
+            kind: "coverage_completeness".to_string(),
+            metric: "operation_coverage_ratio".to_string(),
+            operator: FuzzThresholdOperator::GreaterThanOrEqual,
+            value: 1.0,
+            unit: Some("ratio".to_string()),
+            description: Some(
+                "Coverage summary proves every declared operation, or explicitly declares zero operations"
+                    .to_string(),
             ),
         },
     ]
@@ -732,6 +804,10 @@ fn fuzz_provenance_schema() -> String {
 
 fn fuzz_replay_schema() -> String {
     FUZZ_REPLAY_SCHEMA.to_string()
+}
+
+fn fuzz_coverage_summary_schema() -> String {
+    FUZZ_COVERAGE_SUMMARY_SCHEMA.to_string()
 }
 
 fn fuzz_target_inventory_schema() -> String {
@@ -815,6 +891,10 @@ mod tests {
         assert_eq!(contract.schemas.case, FUZZ_CASE_SCHEMA);
         assert_eq!(contract.schemas.replay, FUZZ_REPLAY_SCHEMA);
         assert_eq!(
+            contract.schemas.coverage_summary,
+            FUZZ_COVERAGE_SUMMARY_SCHEMA
+        );
+        assert_eq!(
             contract.schemas.target_inventory,
             FUZZ_TARGET_INVENTORY_SCHEMA
         );
@@ -846,10 +926,19 @@ mod tests {
             artifact.schema == FUZZ_REQUIRED_ARTIFACT_SCHEMA && artifact.id == "result-envelope"
         }));
         assert!(artifacts.iter().any(|artifact| artifact.id == "case-log"));
+        assert!(artifacts
+            .iter()
+            .any(|artifact| artifact.id == "coverage-summary"));
         assert!(gates
             .iter()
             .any(|gate| gate.schema == FUZZ_GATE_SCHEMA && gate.id == "no-open-findings"));
         assert!(gates.iter().any(|gate| gate.id == "has-case-evidence"));
+        assert!(gates
+            .iter()
+            .any(|gate| gate.id == "target-coverage-complete"));
+        assert!(gates
+            .iter()
+            .any(|gate| gate.id == "operation-coverage-complete"));
     }
 
     #[test]
@@ -965,6 +1054,20 @@ mod tests {
                 metadata: Value::Null,
                 extra: BTreeMap::new(),
             }],
+            coverage_summary: Some(FuzzCoverageSummary {
+                schema: FUZZ_COVERAGE_SUMMARY_SCHEMA.to_string(),
+                declared_targets: 1,
+                executable_targets: 1,
+                proven_targets: 1,
+                declared_operations: 1,
+                executable_operations: 1,
+                proven_operations: 1,
+                skipped_targets: Vec::new(),
+                skipped_operations: Vec::new(),
+                artifact_ids: vec!["artifact-1".to_string()],
+                metadata: Value::Null,
+                extra: BTreeMap::new(),
+            }),
             findings: vec![FuzzFinding {
                 schema: FUZZ_FINDING_SCHEMA.to_string(),
                 id: "finding-1".to_string(),
@@ -1036,6 +1139,10 @@ mod tests {
         assert_eq!(value["cases"][0]["schema"], FUZZ_CASE_SCHEMA);
         assert_eq!(value["seeds"][0]["schema"], FUZZ_SEED_SCHEMA);
         assert_eq!(value["coverage"][0]["schema"], FUZZ_COVERAGE_SCHEMA);
+        assert_eq!(
+            value["coverage_summary"]["schema"],
+            FUZZ_COVERAGE_SUMMARY_SCHEMA
+        );
         assert_eq!(value["findings"][0]["schema"], FUZZ_FINDING_SCHEMA);
         assert_eq!(value["artifacts"][0]["schema"], FUZZ_ARTIFACT_SCHEMA);
         assert_eq!(value["thresholds"][0]["schema"], FUZZ_THRESHOLD_SCHEMA);


### PR DESCRIPTION
## Summary
- add a product-neutral `homeboy/fuzz-coverage-summary/v1` contract to fuzz campaigns
- add required coverage-summary artifact metadata plus target/operation completeness gates
- surface coverage completeness in `homeboy fuzz validate` and `homeboy fuzz report`
- document the coverage summary shape and validate/report gate behavior

## Verification
- `rustfmt src/core/fuzz.rs src/commands/fuzz.rs`
- `git diff --check`
- Not run: Cargo tests/builds, per local site rule to avoid Cargo-heavy commands on this machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fuzz coverage summary contract, validate/report gates, tests, docs, and PR preparation.