### PR TITLE
Add PR CI readiness triage summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,12 @@ gathers attention reports across components, projects, fleets, rigs, or the
 whole workspace. Snapshot report mode is read-only; watch mode only mutates
 GitHub when `--auto-merge` is explicitly passed.
 
+PR items include a `ci_readiness` JSON summary when GitHub exposes check rollup
+data. The summary groups queued, pending, running, failed, skipped, and passed
+checks by required, optional, or unknown requirement status, includes failure
+URLs, reports the oldest pending check duration when timestamps are available,
+and emits next steps for the merge path.
+
 ```bash
 homeboy deps status my-project
 homeboy deps update vendor/package my-project --to '^1.2'

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -215,6 +215,8 @@ pub struct TriagePrItem {
     pub draft: bool,
     #[serde(flatten)]
     pub signals: TriagePullRequestSignals,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_readiness: Option<TriageCiReadiness>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub check_failures: Vec<TriageCheckFailure>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -227,6 +229,36 @@ pub struct TriagePrItem {
     pub updated_at: Option<String>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stale: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TriageCiReadiness {
+    pub checks: TriageCiReadinessBuckets,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_pending_started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_pending_duration_seconds: Option<i64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub failure_urls: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub next_steps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct TriageCiReadinessBuckets {
+    pub required: TriageCiCheckStateCounts,
+    pub optional: TriageCiCheckStateCounts,
+    pub unknown_requirement: TriageCiCheckStateCounts,
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct TriageCiCheckStateCounts {
+    pub queued: usize,
+    pub pending: usize,
+    pub running: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub passed: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -869,6 +901,7 @@ fn parse_prs(
                     last_review_at: latest_review_at(&item.reviews),
                     ..TriagePullRequestSignals::default()
                 },
+                ci_readiness: summarize_ci_readiness(&item.status_check_rollup, Utc::now()),
                 check_failures: if include_drilldown {
                     summarize_check_failures(&item.status_check_rollup)
                 } else {
@@ -912,6 +945,13 @@ fn derive_pr_next_action(pr: &TriagePrItem) -> Option<String> {
     }
     if checks == Some("FAILURE") {
         return Some("checks_failed".to_string());
+    }
+    if pr
+        .ci_readiness
+        .as_ref()
+        .is_some_and(TriageCiReadiness::has_pending_required_checks)
+    {
+        return Some("required_checks_pending".to_string());
     }
     if review == Some("APPROVED") && is_dirty_merge_state(merge) {
         return Some("approved_but_dirty".to_string());
@@ -1001,6 +1041,164 @@ fn summarize_check_failures(checks: &[Value]) -> Vec<TriageCheckFailure> {
         .collect()
 }
 
+fn summarize_ci_readiness(checks: &[Value], now: DateTime<Utc>) -> Option<TriageCiReadiness> {
+    if checks.is_empty() {
+        return None;
+    }
+
+    let mut buckets = TriageCiReadinessBuckets::default();
+    let mut failure_urls = Vec::new();
+    let mut oldest_pending_started_at: Option<DateTime<Utc>> = None;
+
+    for check in checks {
+        let state = classify_check_state(check);
+        let counts = match bool_field(check, &["required", "isRequired"]) {
+            Some(true) => &mut buckets.required,
+            Some(false) => &mut buckets.optional,
+            None => &mut buckets.unknown_requirement,
+        };
+        counts.increment(state);
+
+        if state == TriageCiCheckState::Failed {
+            if let Some(url) = string_field(check, &["detailsUrl", "targetUrl", "url"]) {
+                failure_urls.push(url);
+            }
+        }
+
+        if matches!(
+            state,
+            TriageCiCheckState::Queued | TriageCiCheckState::Pending | TriageCiCheckState::Running
+        ) {
+            if let Some(started_at) = check_started_at(check) {
+                oldest_pending_started_at = Some(match oldest_pending_started_at {
+                    Some(existing) => existing.min(started_at),
+                    None => started_at,
+                });
+            }
+        }
+    }
+
+    failure_urls.sort();
+    failure_urls.dedup();
+
+    let oldest_pending_duration_seconds = oldest_pending_started_at
+        .map(|started_at| now.signed_duration_since(started_at).num_seconds().max(0));
+    let oldest_pending_started_at = oldest_pending_started_at.map(|dt| dt.to_rfc3339());
+    let next_steps = ci_readiness_next_steps(&buckets, oldest_pending_duration_seconds);
+
+    Some(TriageCiReadiness {
+        checks: buckets,
+        oldest_pending_started_at,
+        oldest_pending_duration_seconds,
+        failure_urls,
+        next_steps,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TriageCiCheckState {
+    Queued,
+    Pending,
+    Running,
+    Failed,
+    Skipped,
+    Passed,
+}
+
+impl TriageCiCheckStateCounts {
+    fn increment(&mut self, state: TriageCiCheckState) {
+        match state {
+            TriageCiCheckState::Queued => self.queued += 1,
+            TriageCiCheckState::Pending => self.pending += 1,
+            TriageCiCheckState::Running => self.running += 1,
+            TriageCiCheckState::Failed => self.failed += 1,
+            TriageCiCheckState::Skipped => self.skipped += 1,
+            TriageCiCheckState::Passed => self.passed += 1,
+        }
+    }
+
+    fn active(&self) -> usize {
+        self.queued + self.pending + self.running
+    }
+}
+
+impl TriageCiReadiness {
+    fn has_pending_required_checks(&self) -> bool {
+        self.checks.required.active() > 0
+    }
+}
+
+fn classify_check_state(check: &Value) -> TriageCiCheckState {
+    let conclusion = check.get("conclusion").and_then(Value::as_str);
+    if matches!(
+        conclusion,
+        Some("FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED")
+    ) {
+        return TriageCiCheckState::Failed;
+    }
+    if matches!(conclusion, Some("SKIPPED" | "NEUTRAL")) {
+        return TriageCiCheckState::Skipped;
+    }
+    if matches!(conclusion, Some("SUCCESS")) {
+        return TriageCiCheckState::Passed;
+    }
+
+    match check.get("status").and_then(Value::as_str) {
+        Some("QUEUED" | "REQUESTED" | "WAITING") => TriageCiCheckState::Queued,
+        Some("IN_PROGRESS") => TriageCiCheckState::Running,
+        Some("COMPLETED") => TriageCiCheckState::Passed,
+        _ => TriageCiCheckState::Pending,
+    }
+}
+
+fn check_started_at(check: &Value) -> Option<DateTime<Utc>> {
+    string_field(check, &["startedAt", "createdAt", "updatedAt"])
+        .and_then(|raw| DateTime::parse_from_rfc3339(&raw).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn ci_readiness_next_steps(
+    buckets: &TriageCiReadinessBuckets,
+    oldest_pending_duration_seconds: Option<i64>,
+) -> Vec<String> {
+    let mut steps = Vec::new();
+    if buckets.required.failed > 0 {
+        steps.push("Fix or rerun failing required checks before merge.".to_string());
+    }
+    if buckets.optional.failed > 0 || buckets.unknown_requirement.failed > 0 {
+        steps.push(
+            "Review failing optional/unknown checks and decide whether they block this PR."
+                .to_string(),
+        );
+    }
+    if buckets.required.active() > 0 {
+        let label = oldest_pending_duration_seconds
+            .map(format_duration)
+            .map(|duration| format!("Wait for required checks to finish; oldest pending check has been active for {duration}."))
+            .unwrap_or_else(|| "Wait for required checks to finish.".to_string());
+        steps.push(label);
+    } else if buckets.optional.active() > 0 || buckets.unknown_requirement.active() > 0 {
+        steps.push(
+            "Required checks are not pending; monitor optional/unknown checks for signal."
+                .to_string(),
+        );
+    }
+    if buckets.required.failed == 0 && buckets.required.active() == 0 {
+        steps.push("Required checks are not blocking merge.".to_string());
+    }
+    steps
+}
+
+fn format_duration(seconds: i64) -> String {
+    if seconds >= 3600 {
+        format!("{}h", seconds / 3600)
+    } else if seconds >= 60 {
+        format!("{}m", seconds / 60)
+    } else {
+        format!("{}s", seconds)
+    }
+}
+
 fn string_field(value: &Value, keys: &[&str]) -> Option<String> {
     keys.iter().find_map(|key| {
         value
@@ -1010,6 +1208,11 @@ fn string_field(value: &Value, keys: &[&str]) -> Option<String> {
             .filter(|v| !v.is_empty())
             .map(str::to_string)
     })
+}
+
+fn bool_field(value: &Value, keys: &[&str]) -> Option<bool> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_bool))
 }
 
 fn is_stale(updated_at: Option<&str>, stale_cutoff: Option<DateTime<Utc>>) -> bool {
@@ -1123,6 +1326,7 @@ const PR_ACTION_PRIORITY: &[&str] = &[
     "approved_but_dirty",
     "needs_rebase",
     "review_required",
+    "required_checks_pending",
     "clean_but_checks_not_reported",
     "approved_but_pending_checks",
     "clean_and_ready",
@@ -1134,6 +1338,7 @@ fn pr_action_severity(kind: &str) -> &'static str {
         "draft_with_failing_checks" | "checks_failed" | "approved_but_dirty" => "high",
         "needs_rebase"
         | "review_required"
+        | "required_checks_pending"
         | "clean_but_checks_not_reported"
         | "approved_but_pending_checks"
         | "clean_and_ready" => "medium",
@@ -1152,6 +1357,11 @@ fn pr_action_label(kind: &str, count: usize) -> String {
         "approved_but_dirty" => pluralize(count, "approved PR is dirty", "approved PRs are dirty"),
         "needs_rebase" => pluralize(count, "PR needs rebase", "PRs need rebase"),
         "review_required" => pluralize(count, "PR needs review", "PRs need review"),
+        "required_checks_pending" => pluralize(
+            count,
+            "PR is waiting on required checks",
+            "PRs are waiting on required checks",
+        ),
         "clean_but_checks_not_reported" => pluralize(
             count,
             "PR is CLEAN but checks have not reported yet",

--- a/src/core/triage/tests.rs
+++ b/src/core/triage/tests.rs
@@ -381,6 +381,103 @@ mod pull_requests {
     }
 
     #[test]
+    fn summarize_ci_readiness_groups_requirement_states_and_actions() {
+        let checks: Vec<Value> = serde_json::from_str(
+            r#"[
+                {
+                  "name": "required queued",
+                  "required": true,
+                  "status": "QUEUED",
+                  "conclusion": null,
+                  "startedAt": "2026-04-26T10:00:00Z"
+                },
+                {
+                  "name": "required running",
+                  "isRequired": true,
+                  "status": "IN_PROGRESS",
+                  "conclusion": null,
+                  "startedAt": "2026-04-26T10:10:00Z"
+                },
+                {
+                  "name": "required passed",
+                  "required": true,
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS"
+                },
+                {
+                  "name": "optional failed",
+                  "required": false,
+                  "status": "COMPLETED",
+                  "conclusion": "FAILURE",
+                  "detailsUrl": "https://github.com/o/r/actions/runs/1/job/2"
+                },
+                {
+                  "name": "unknown skipped",
+                  "status": "COMPLETED",
+                  "conclusion": "SKIPPED"
+                }
+            ]"#,
+        )
+        .unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-04-26T10:45:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let readiness = summarize_ci_readiness(&checks, now).unwrap();
+
+        assert_eq!(readiness.checks.required.queued, 1);
+        assert_eq!(readiness.checks.required.running, 1);
+        assert_eq!(readiness.checks.required.passed, 1);
+        assert_eq!(readiness.checks.optional.failed, 1);
+        assert_eq!(readiness.checks.unknown_requirement.skipped, 1);
+        assert_eq!(
+            readiness.oldest_pending_started_at.as_deref(),
+            Some("2026-04-26T10:00:00+00:00")
+        );
+        assert_eq!(readiness.oldest_pending_duration_seconds, Some(2700));
+        assert_eq!(
+            readiness.failure_urls,
+            vec!["https://github.com/o/r/actions/runs/1/job/2"]
+        );
+        assert!(readiness.next_steps.iter().any(|step| step.contains(
+            "Wait for required checks to finish; oldest pending check has been active for 45m."
+        )));
+    }
+
+    #[test]
+    fn parse_prs_marks_pending_required_checks_as_next_action() {
+        let raw = r#"[
+            {
+              "number": 11,
+              "title": "Waiting on required CI",
+              "url": "https://github.com/o/r/pull/11",
+              "state": "OPEN",
+              "isDraft": false,
+              "reviewDecision": "APPROVED",
+              "mergeStateStatus": "CLEAN",
+              "statusCheckRollup": [
+                {"name":"required", "required": true, "status":"IN_PROGRESS", "conclusion":null},
+                {"name":"optional", "required": false, "status":"COMPLETED", "conclusion":"SUCCESS"}
+              ],
+              "labels": [],
+              "assignees": [],
+              "author": {"login":"example-org"},
+              "updatedAt": "2026-04-26T00:00:00Z"
+            }
+        ]"#;
+
+        let items = parse_prs(raw, None, false).unwrap();
+
+        assert_eq!(
+            items[0].signals.next_action.as_deref(),
+            Some("required_checks_pending")
+        );
+        let readiness = items[0].ci_readiness.as_ref().unwrap();
+        assert_eq!(readiness.checks.required.running, 1);
+        assert_eq!(readiness.checks.optional.passed, 1);
+    }
+
+    #[test]
     fn parse_prs_derives_next_action_labels() {
         let raw = r#"[
             {
@@ -768,6 +865,7 @@ mod priority_and_summary {
                         next_action: Some("checks_failed".to_string()),
                         ..TriagePullRequestSignals::default()
                     },
+                    ci_readiness: None,
                     check_failures: Vec::new(),
                     labels: vec![],
                     assignees: vec![],
@@ -867,6 +965,7 @@ fn triage_pr_with_action(action: &str) -> TriagePrItem {
             next_action: Some(action.to_string()),
             ..TriagePullRequestSignals::default()
         },
+        ci_readiness: None,
         check_failures: Vec::new(),
         labels: vec![],
         assignees: vec![],


### PR DESCRIPTION
## Summary
- Adds a structured `ci_readiness` summary to triage PR items from GitHub status check rollups.
- Groups check counts by required, optional, and unknown requirement status across queued, pending, running, failed, skipped, and passed states.
- Includes failure URLs, oldest pending duration when timestamps are available, and actionable next steps.

Fixes #5804

## Verification
- `rustfmt src/core/triage.rs src/core/triage/tests.rs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the triage readiness summary, docs, and focused parser tests.