### PR TITLE
Add baseline-red differential CI gate

### DIFF
--- a/docs/commands/ci.md
+++ b/docs/commands/ci.md
@@ -52,6 +52,26 @@ homeboy ci autofix --path /path/to/repo \
 
 `--dry-run` classifies the changes and resolves the push target without committing or pushing. The JSON output uses command `ci.autofix` and includes `push_target`, the `route` (`direct-drift` or `autofix-branch`), `changed_files`, `committed`, and a machine-readable `status` (`pushed`, `no-changes`, `push-failed`, or `dry-run`).
 
+## Differential Gate Classification
+
+```sh
+homeboy ci differential-gate \
+  --baseline-command 'cargo fmt --check' --baseline-exit-code 1 \
+  --baseline-evidence 'FMT SUMMARY: 7 files need formatting' \
+  --head-command 'homeboy test homeboy --changed-since origin/main' --head-exit-code 0
+```
+
+`ci differential-gate` lets CI wrappers classify baseline-vs-PR outcomes without
+collapsing a red baseline into a PR-head failure. When the baseline command exits
+non-zero, the command reports `status: "baseline_red"`, `passed: true`, and exits
+0 so branch protection can treat the result as inconclusive instead of a
+candidate regression. When the baseline passes and the head command fails, it
+reports `status: "failed"` and exits non-zero, preserving true PR regressions.
+
+Pass the exact baseline/head commands and any available log excerpts or artifact
+refs through `--baseline-evidence` / `--head-evidence` so failure comments can
+show the baseline command and supporting evidence.
+
 ## Manifest Shape
 
 Extensions can declare CI profiles with a `ci` block:
@@ -86,6 +106,11 @@ Supported fidelity values are `local-equivalent`, `local-partial`, `remote-only`
 The JSON output uses command `ci.list` and includes an `inventory` object with `profiles`, `jobs`, and `discovered_jobs`.
 
 `ci run` uses command `ci.run` and includes the selected job/profile, per-job command output, per-job `ci_context`, per-job exit codes, and an aggregate `success` / `exit_code`.
+
+`ci differential-gate` uses command `ci.differential-gate` and includes the
+machine-readable `status` (`passed`, `failed`, or `baseline_red`), `passed`, a
+human conclusion, and baseline/head command, exit-code, pass/fail, and evidence
+fields.
 
 Command-native CI reproduction also includes `ci_context` when a CI selector is used. `homeboy lint --ci-job <ID>`, `homeboy test --ci-job <ID>`, and `homeboy bench --ci-profile <ID>` preserve the normal command output shape and add the selected job's mapping metadata:
 

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -2,6 +2,9 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use std::path::PathBuf;
 
+use homeboy::core::ci_gate::{
+    self, DifferentialGateDecision, DifferentialGateInput, DifferentialGateSide,
+};
 use homeboy::core::ci_plan::{self, CiEventContext, CiPlan};
 use homeboy::core::ci_profile::{self, CiInventory, CiRunOutput, CiRunSelection};
 use homeboy::core::ci_scope::{
@@ -49,6 +52,35 @@ pub enum CiCommand {
     /// `--github-actions` the context is read from the standard GitHub
     /// Actions environment; explicit flags override individual fields.
     Scope(CiScopeArgs),
+    /// Classify differential CI results without blaming a PR for a red baseline.
+    DifferentialGate(CiDifferentialGateArgs),
+}
+
+#[derive(Args)]
+pub struct CiDifferentialGateArgs {
+    /// Exact command run against the baseline checkout.
+    #[arg(long)]
+    pub baseline_command: String,
+
+    /// Exit code from the baseline command.
+    #[arg(long)]
+    pub baseline_exit_code: i32,
+
+    /// Evidence for baseline failures, such as log excerpts or artifact refs.
+    #[arg(long = "baseline-evidence")]
+    pub baseline_evidence: Vec<String>,
+
+    /// Exact command run against the candidate/PR-head checkout.
+    #[arg(long)]
+    pub head_command: String,
+
+    /// Exit code from the candidate/PR-head command.
+    #[arg(long)]
+    pub head_exit_code: i32,
+
+    /// Evidence for candidate failures, such as log excerpts or artifact refs.
+    #[arg(long = "head-evidence")]
+    pub head_evidence: Vec<String>,
 }
 
 #[derive(Args)]
@@ -180,6 +212,14 @@ pub enum CiOutput {
     Run(CiRunCommandOutput),
     Autofix(CiAutofixCommandOutput),
     Scope(CiScopeCommandOutput),
+    DifferentialGate(CiDifferentialGateCommandOutput),
+}
+
+#[derive(Debug, Serialize)]
+pub struct CiDifferentialGateCommandOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub decision: DifferentialGateDecision,
 }
 
 #[derive(Debug, Serialize)]
@@ -226,7 +266,35 @@ pub fn run(args: CiArgs, global: &GlobalArgs) -> CmdResult<CiOutput> {
         CiCommand::Run(args) => run_ci(args, global),
         CiCommand::Autofix(args) => run_autofix(args, global),
         CiCommand::Scope(args) => run_scope(args, global),
+        CiCommand::DifferentialGate(args) => run_differential_gate(args, global),
     }
+}
+
+fn run_differential_gate(
+    args: CiDifferentialGateArgs,
+    _global: &GlobalArgs,
+) -> CmdResult<CiOutput> {
+    let decision = ci_gate::classify(DifferentialGateInput {
+        baseline: DifferentialGateSide {
+            command: args.baseline_command,
+            exit_code: args.baseline_exit_code,
+            evidence: args.baseline_evidence,
+        },
+        head: DifferentialGateSide {
+            command: args.head_command,
+            exit_code: args.head_exit_code,
+            evidence: args.head_evidence,
+        },
+    });
+    let exit_code = decision.exit_code();
+
+    Ok((
+        CiOutput::DifferentialGate(CiDifferentialGateCommandOutput {
+            command: "ci.differential-gate",
+            decision,
+        }),
+        exit_code,
+    ))
 }
 
 fn run_plan(args: CiPlanArgs, _global: &GlobalArgs) -> CmdResult<CiOutput> {
@@ -531,6 +599,85 @@ mod tests {
         assert_eq!(args.event_name.as_deref(), Some("pull_request"));
         assert_eq!(args.base_sha.as_deref(), Some("abc123"));
         assert_eq!(args.for_commands, vec!["lint", "test"]);
+    }
+
+    #[test]
+    fn parses_ci_differential_gate_evidence() {
+        let cli = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "ci",
+            "differential-gate",
+            "--baseline-command",
+            "cargo fmt --check",
+            "--baseline-exit-code",
+            "1",
+            "--baseline-evidence",
+            "FMT SUMMARY: 7 files need formatting",
+            "--head-command",
+            "homeboy test homeboy",
+            "--head-exit-code",
+            "0",
+        ])
+        .expect("parse cli");
+
+        let crate::cli_surface::Commands::Ci(args) = cli.command else {
+            panic!("expected ci command");
+        };
+        let CiCommand::DifferentialGate(args) = args.command else {
+            panic!("expected ci differential-gate");
+        };
+
+        assert_eq!(args.baseline_command, "cargo fmt --check");
+        assert_eq!(args.baseline_exit_code, 1);
+        assert_eq!(
+            args.baseline_evidence,
+            vec!["FMT SUMMARY: 7 files need formatting"]
+        );
+        assert_eq!(args.head_command, "homeboy test homeboy");
+        assert_eq!(args.head_exit_code, 0);
+    }
+
+    #[test]
+    fn ci_differential_gate_baseline_red_exits_zero() {
+        let args = CiDifferentialGateArgs {
+            baseline_command: "cargo fmt --check".to_string(),
+            baseline_exit_code: 1,
+            baseline_evidence: vec!["FMT SUMMARY: 7 files need formatting".to_string()],
+            head_command: "homeboy test homeboy".to_string(),
+            head_exit_code: 0,
+            head_evidence: Vec::new(),
+        };
+
+        let (output, exit) = run_differential_gate(args, &GlobalArgs {}).expect("gate classifies");
+
+        assert_eq!(exit, 0);
+        let CiOutput::DifferentialGate(output) = output else {
+            panic!("expected ci differential gate output");
+        };
+        assert_eq!(output.command, "ci.differential-gate");
+        assert_eq!(output.decision.status, "baseline_red");
+        assert!(output.decision.passed);
+    }
+
+    #[test]
+    fn ci_differential_gate_candidate_failure_exits_nonzero() {
+        let args = CiDifferentialGateArgs {
+            baseline_command: "cargo fmt --check".to_string(),
+            baseline_exit_code: 0,
+            baseline_evidence: Vec::new(),
+            head_command: "homeboy test homeboy".to_string(),
+            head_exit_code: 1,
+            head_evidence: vec!["homeboy-ci-results/test.log".to_string()],
+        };
+
+        let (output, exit) = run_differential_gate(args, &GlobalArgs {}).expect("gate classifies");
+
+        assert_eq!(exit, 1);
+        let CiOutput::DifferentialGate(output) = output else {
+            panic!("expected ci differential gate output");
+        };
+        assert_eq!(output.decision.status, "failed");
+        assert!(!output.decision.passed);
     }
 
     #[test]

--- a/src/core/ci_gate.rs
+++ b/src/core/ci_gate.rs
@@ -1,0 +1,137 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DifferentialGateInput {
+    pub baseline: DifferentialGateSide,
+    pub head: DifferentialGateSide,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DifferentialGateSide {
+    pub command: String,
+    pub exit_code: i32,
+    pub evidence: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DifferentialGateDecision {
+    pub status: String,
+    pub passed: bool,
+    pub conclusion: String,
+    pub baseline: DifferentialGateSideOutput,
+    pub head: DifferentialGateSideOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DifferentialGateSideOutput {
+    pub command: String,
+    pub exit_code: i32,
+    pub passed: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub evidence: Vec<String>,
+}
+
+impl DifferentialGateDecision {
+    pub fn exit_code(&self) -> i32 {
+        if self.passed {
+            0
+        } else if self.head.exit_code != 0 {
+            self.head.exit_code
+        } else {
+            1
+        }
+    }
+}
+
+pub fn classify(input: DifferentialGateInput) -> DifferentialGateDecision {
+    let baseline = side_output(input.baseline);
+    let head = side_output(input.head);
+
+    let (status, passed, conclusion) = if !baseline.passed {
+        (
+            "baseline_red",
+            true,
+            "baseline failed before differential comparison; treat this gate as inconclusive instead of a PR-head regression",
+        )
+    } else if !head.passed {
+        (
+            "failed",
+            false,
+            "candidate failed while baseline passed; treat this as a PR-head regression",
+        )
+    } else {
+        (
+            "passed",
+            true,
+            "baseline and candidate passed; no differential regression detected",
+        )
+    };
+
+    DifferentialGateDecision {
+        status: status.to_string(),
+        passed,
+        conclusion: conclusion.to_string(),
+        baseline,
+        head,
+    }
+}
+
+fn side_output(side: DifferentialGateSide) -> DifferentialGateSideOutput {
+    DifferentialGateSideOutput {
+        passed: side.exit_code == 0,
+        command: side.command,
+        exit_code: side.exit_code,
+        evidence: side.evidence,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_failure_is_inconclusive_success() {
+        let decision = classify(input(1, 0));
+
+        assert_eq!(decision.status, "baseline_red");
+        assert!(decision.passed);
+        assert_eq!(decision.exit_code(), 0);
+        assert!(!decision.baseline.passed);
+        assert!(decision.head.passed);
+    }
+
+    #[test]
+    fn candidate_failure_after_green_baseline_is_regression() {
+        let decision = classify(input(0, 1));
+
+        assert_eq!(decision.status, "failed");
+        assert!(!decision.passed);
+        assert_eq!(decision.exit_code(), 1);
+        assert!(decision.baseline.passed);
+        assert!(!decision.head.passed);
+    }
+
+    #[test]
+    fn green_baseline_and_head_pass() {
+        let decision = classify(input(0, 0));
+
+        assert_eq!(decision.status, "passed");
+        assert!(decision.passed);
+        assert_eq!(decision.exit_code(), 0);
+    }
+
+    fn input(baseline_exit_code: i32, head_exit_code: i32) -> DifferentialGateInput {
+        DifferentialGateInput {
+            baseline: DifferentialGateSide {
+                command: "cargo fmt --check".to_string(),
+                exit_code: baseline_exit_code,
+                evidence: vec!["FMT SUMMARY: 7 files need formatting".to_string()],
+            },
+            head: DifferentialGateSide {
+                command: "homeboy test homeboy".to_string(),
+                exit_code: head_exit_code,
+                evidence: vec!["homeboy-ci-results/test.log".to_string()],
+            },
+        }
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -52,6 +52,7 @@ pub mod artifact_ref;
 pub mod browser_evidence;
 pub mod build_identity;
 pub mod change_artifact;
+pub mod ci_gate;
 pub mod ci_plan;
 pub mod ci_profile;
 pub mod ci_scope;


### PR DESCRIPTION
## Summary
- Add a core-owned `homeboy ci differential-gate` classifier for baseline-vs-PR CI outcomes.
- Report baseline-side failures as `status: "baseline_red"`, `passed: true`, and exit 0 so differential CI can stay inconclusive instead of blaming PR head.
- Preserve true PR regressions: a green baseline plus failing head reports `status: "failed"` and exits non-zero.
- Document command/evidence fields for baseline command excerpts and artifact refs.

## Context
Fixes #5788.

Observed context from the issue and cited PRs:
- #5730 and #5731 had Homeboy Audit green while Lint/Test failed under the differential CI workflow.
- Issue #5788 records baseline `cargo fmt --check` failing before tests ran with `FMT SUMMARY: 7 files need formatting`.

## Testing
- `rustfmt src/core/ci_gate.rs src/core/mod.rs src/commands/ci.rs`
- `git diff --check`
- `git diff --cached --check`

Not run:
- `cargo` commands, per local constraints.
- Benchmarks, per local constraints.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the CI/differential gate context, implementing the classifier/CLI/docs/tests, and drafting this PR description.
