### PR TITLE
Add dependent PR refresh helper

### DIFF
--- a/docs/commands/git.md
+++ b/docs/commands/git.md
@@ -169,6 +169,7 @@ homeboy git pr create <component_id> --base <base> --head <head> --title <title>
 homeboy git pr edit <component_id> --number <n> [--title <title>] [--body <body> | --body-file <path>]
 homeboy git pr find <component_id> [--base <base>] [--head <head>] [--state open|closed|merged|all] [--limit <n>]
 homeboy git pr comment <component_id> --number <n> [comment mode flags]
+homeboy git pr refresh <component_id> <number-or-url> [--strategy auto|rebase|merge|ff-only] [--check <cmd>...] [--push]
 ```
 
 Like issue commands, PR commands accept `--path` to discover component metadata from a portable checkout:
@@ -177,6 +178,25 @@ Like issue commands, PR commands accept `--path` to discover component metadata 
 homeboy git pr create homeboy --base main --head docs-refresh-git-command --title "docs: refresh git command workflows" --body-file /tmp/pr.md
 homeboy git pr find homeboy --head docs-refresh-git-command --state open
 ```
+
+### PR Refresh
+
+`homeboy git pr refresh` updates a PR branch from its current base and emits a structured summary for merge-train recovery after sibling PRs land.
+
+```sh
+homeboy git pr refresh homeboy 5806
+homeboy git pr refresh homeboy https://github.com/Extra-Chill/homeboy/pull/5806 --strategy rebase
+homeboy git pr refresh homeboy 5806 --check "git diff --check" --push
+```
+
+Safety behavior:
+
+1. Refuses to start when the worktree is already dirty.
+2. Checks out the PR through `gh pr checkout`, fetches the current base, then applies the selected strategy.
+3. `--strategy auto` honors `branch.<name>.rebase` or `pull.rebase`, falling back to `rebase`.
+4. Reports conflicted files from `git status --porcelain` and exits non-zero when blockers remain.
+5. Runs lightweight checks only after a clean refresh. When no `--check` is supplied, it runs `git diff --check`.
+6. Never pushes by default. `--push` publishes only a clean, check-passing branch and uses `git push --force-with-lease`; plain destructive force-push is not exposed.
 
 ### PR Comments
 

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -5,8 +5,8 @@ use homeboy::core::git::{
     self, CherryPickOptions, GitOutput, GithubFindOutput, GithubIssueOutput, GithubPrOutput,
     IssueCloseOptions, IssueCloseReason, IssueCommentOptions, IssueCreateOptions, IssueEditOptions,
     IssueFindOptions, IssueState, PrCommentMode, PrCommentOptions, PrCreateOptions, PrEditOptions,
-    PrFindOptions, PrPolicyDecision, PrPolicyMergeOptions, PrPolicyOpenOptions, PrState,
-    PushOptions, RebaseOptions,
+    PrFindOptions, PrPolicyDecision, PrPolicyMergeOptions, PrPolicyOpenOptions, PrRefreshOptions,
+    PrRefreshOutput, PrRefreshStrategy, PrState, PushOptions, RebaseOptions,
 };
 use homeboy::core::BulkResult;
 
@@ -565,6 +565,33 @@ enum PrCommand {
     },
     /// Evaluate PR open/merge policy.
     Policy(PrPolicyArgs),
+    /// Refresh a PR branch from its current base and report conflicts/checks.
+    Refresh {
+        /// Component ID
+        component_id: String,
+
+        /// PR number or GitHub pull request URL.
+        pr: String,
+
+        /// Update strategy. `auto` uses branch/pull rebase git config, falling
+        /// back to rebase.
+        #[arg(long, default_value = "auto", value_parser = ["auto", "rebase", "merge", "ff-only"])]
+        strategy: String,
+
+        /// Push the refreshed PR branch when the worktree is clean and checks pass.
+        /// Uses --force-with-lease for rebase safety; plain force is not exposed.
+        #[arg(long)]
+        push: bool,
+
+        /// Lightweight check command to run after a clean refresh. Repeatable.
+        /// Defaults to `git diff --check` when omitted.
+        #[arg(long = "check", value_name = "COMMAND")]
+        checks: Vec<String>,
+
+        /// Workspace path to discover the component from a portable homeboy.json.
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
 }
 
 #[derive(Args)]
@@ -672,6 +699,7 @@ pub enum GitCommandOutput {
     Bulk(BulkResult<GitOutput>),
     Issue(GithubIssueOutput),
     Pr(GithubPrOutput),
+    PrRefresh(PrRefreshOutput),
     Find(GithubFindOutput),
     Policy(PrPolicyDecision),
 }
@@ -686,6 +714,7 @@ impl Serialize for GitCommandOutput {
             GitCommandOutput::Bulk(output) => ("bulk", serde_json::to_value(output)),
             GitCommandOutput::Issue(output) => ("issue", serde_json::to_value(output)),
             GitCommandOutput::Pr(output) => ("pr", serde_json::to_value(output)),
+            GitCommandOutput::PrRefresh(output) => ("pr_refresh", serde_json::to_value(output)),
             GitCommandOutput::Find(output) => ("find", serde_json::to_value(output)),
             GitCommandOutput::Policy(output) => ("policy", serde_json::to_value(output)),
         };
@@ -1181,6 +1210,43 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             Ok((GitCommandOutput::Pr(output), 0))
         }
         PrCommand::Policy(args) => run_pr_policy(args),
+        PrCommand::Refresh {
+            component_id,
+            pr,
+            strategy,
+            push,
+            checks,
+            path,
+        } => {
+            let strategy = parse_pr_refresh_strategy(&strategy)?;
+            let output = git::pr_refresh(
+                Some(&component_id),
+                PrRefreshOptions {
+                    pr,
+                    strategy,
+                    push,
+                    checks,
+                    path,
+                },
+            )?;
+            let exit = if output.success { 0 } else { 1 };
+            Ok((GitCommandOutput::PrRefresh(output), exit))
+        }
+    }
+}
+
+fn parse_pr_refresh_strategy(value: &str) -> homeboy::core::Result<PrRefreshStrategy> {
+    match value {
+        "auto" => Ok(PrRefreshStrategy::Auto),
+        "rebase" => Ok(PrRefreshStrategy::Rebase),
+        "merge" => Ok(PrRefreshStrategy::Merge),
+        "ff-only" => Ok(PrRefreshStrategy::FfOnly),
+        _ => Err(homeboy::core::Error::validation_invalid_argument(
+            "strategy",
+            "strategy must be one of auto, rebase, merge, or ff-only",
+            Some(value.to_string()),
+            None,
+        )),
     }
 }
 

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -7,8 +7,8 @@ use homeboy::core::git::{
     IssueEditOptions, IssueFindOptions, IssueState, PrCommentMode, PrCommentOptions,
     PrCreateOptions, PrEditOptions, PrFindOptions, PrFleetOptions, PrLandOptions, PrLandOutput,
     PrLandRefreshHelper, PrMergeabilityReconcileOptions, PrMergeabilityReconcileOutput,
-    PrPolicyDecision, PrPolicyMergeOptions, PrPolicyOpenOptions, PrRefreshOptions,
-    PrRefreshOutput, PrRefreshStrategy, PrState, PushOptions, RebaseOptions,
+    PrPolicyDecision, PrPolicyMergeOptions, PrPolicyOpenOptions, PrRefreshOptions, PrRefreshOutput,
+    PrRefreshStrategy, PrState, PushOptions, RebaseOptions,
 };
 use homeboy::core::BulkResult;
 

--- a/src/commands/report/failure_digest.rs
+++ b/src/commands/report/failure_digest.rs
@@ -250,8 +250,8 @@ fn render_formatting_findings(out: &mut String, data: &Map<String, Value>) {
     }
 
     let files = string_array(&formatting, "files");
-    let command = string_value(&formatting, "suggested_command")
-        .unwrap_or_else(|| "cargo fmt".to_string());
+    let command =
+        string_value(&formatting, "suggested_command").unwrap_or_else(|| "cargo fmt".to_string());
     let summary = string_value(&formatting, "summary");
 
     out.push_str("- Formatting findings:");
@@ -746,8 +746,8 @@ fn has_any_lint_detail(data: &Map<String, Value>, error: &Map<String, Value>) ->
         "phpstan_summary",
         "build_failed",
     ]
-        .iter()
-        .any(|key| string_value(data, key).is_some())
+    .iter()
+    .any(|key| string_value(data, key).is_some())
         || !object_value(data, "formatting_findings").is_empty()
         || ["code", "message"]
             .iter()

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -12,6 +12,7 @@ mod operations_commit;
 mod operations_push;
 mod operations_tags;
 mod pr_policy;
+mod pr_refresh;
 mod primitives;
 mod primitives_query;
 
@@ -61,6 +62,9 @@ pub use operations_tags::{
 pub use pr_policy::{
     evaluate_merge_policy, evaluate_open_policy, PrPolicyContext, PrPolicyDecision, PrPolicyFile,
     PrPolicyMergeOptions, PrPolicyMode, PrPolicyOpenOptions, PrPolicyRules,
+};
+pub use pr_refresh::{
+    pr_refresh, PrRefreshCheck, PrRefreshOptions, PrRefreshOutput, PrRefreshStrategy,
 };
 pub use primitives::{
     clone_repo, clone_repo_at_ref, commit_staged_with_author, get_component_path_prefix,

--- a/src/core/git/pr_refresh.rs
+++ b/src/core/git/pr_refresh.rs
@@ -1,0 +1,433 @@
+use serde::Serialize;
+use std::path::Path;
+use std::process::Command;
+
+use crate::core::error::{Error, Result};
+
+use super::resolve_target;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrRefreshStrategy {
+    Auto,
+    Rebase,
+    Merge,
+    FfOnly,
+}
+
+impl PrRefreshStrategy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PrRefreshStrategy::Auto => "auto",
+            PrRefreshStrategy::Rebase => "rebase",
+            PrRefreshStrategy::Merge => "merge",
+            PrRefreshStrategy::FfOnly => "ff-only",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrRefreshOptions {
+    pub pr: String,
+    pub strategy: PrRefreshStrategy,
+    pub push: bool,
+    pub checks: Vec<String>,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PrRefreshOutput {
+    pub component_id: String,
+    pub path: String,
+    pub action: String,
+    pub success: bool,
+    pub number: u64,
+    pub url: String,
+    pub base: String,
+    pub head: String,
+    pub strategy: String,
+    pub pushed: bool,
+    pub clean: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge_state: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub conflict_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub checks: Vec<PrRefreshCheck>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub blockers: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PrRefreshCheck {
+    pub command: String,
+    pub success: bool,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhPrView {
+    number: u64,
+    url: String,
+    state: String,
+    base_ref_name: String,
+    head_ref_name: String,
+    merge_state_status: Option<String>,
+}
+
+pub fn pr_refresh(
+    component_id: Option<&str>,
+    options: PrRefreshOptions,
+) -> Result<PrRefreshOutput> {
+    let (id, path) = resolve_target(component_id, options.path.as_deref())?;
+    let root = Path::new(&path);
+
+    if !status_porcelain(root)?.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "worktree",
+            "refusing to refresh a dirty worktree before making any changes",
+            None,
+            Some(vec![
+                "Commit, stash, or discard local changes before running pr refresh".to_string(),
+                "This helper never runs destructive cleanup operations for you".to_string(),
+            ]),
+        ));
+    }
+
+    let pr = view_pr(root, &options.pr)?;
+    if pr.state != "OPEN" {
+        return Err(Error::validation_invalid_argument(
+            "pr",
+            format!("PR #{} is not open", pr.number),
+            Some(pr.state),
+            None,
+        ));
+    }
+
+    checkout_pr_branch(root, pr.number)?;
+    let branch = git_stdout(root, &["rev-parse", "--abbrev-ref", "HEAD"], "git branch")?;
+    if branch == pr.base_ref_name {
+        return Err(Error::validation_invalid_argument(
+            "branch",
+            "refusing to refresh the PR base branch",
+            Some(branch),
+            Some(vec![
+                "Run this helper from the PR head branch or let gh check it out".to_string(),
+                "Primary/default branch checkouts are not valid refresh targets".to_string(),
+            ]),
+        ));
+    }
+
+    git_checked(
+        root,
+        &["fetch", "origin", &pr.base_ref_name],
+        "git fetch base",
+    )?;
+
+    let strategy = resolve_strategy(root, options.strategy, &branch)?;
+    let update = match strategy {
+        PrRefreshStrategy::Rebase => {
+            git_output(root, &["rebase", &format!("origin/{}", pr.base_ref_name)])
+        }
+        PrRefreshStrategy::Merge => git_output(
+            root,
+            &[
+                "merge",
+                "--no-edit",
+                &format!("origin/{}", pr.base_ref_name),
+            ],
+        ),
+        PrRefreshStrategy::FfOnly => git_output(
+            root,
+            &[
+                "merge",
+                "--ff-only",
+                &format!("origin/{}", pr.base_ref_name),
+            ],
+        ),
+        PrRefreshStrategy::Auto => unreachable!("auto strategy resolved before update"),
+    }?;
+
+    let mut blockers = Vec::new();
+    if !update.status.success() {
+        blockers.push(format!(
+            "{} failed with exit code {}",
+            strategy.as_str(),
+            update.status.code().unwrap_or(1)
+        ));
+    }
+
+    let conflict_files = conflict_files(root)?;
+    if !conflict_files.is_empty() {
+        blockers.push(format!(
+            "{} conflicted file(s) require manual resolution",
+            conflict_files.len()
+        ));
+    }
+
+    let mut check_results = Vec::new();
+    if blockers.is_empty() {
+        for check in effective_checks(&options.checks) {
+            let result = run_check(root, &check)?;
+            if !result.success {
+                blockers.push(format!("check failed: {}", result.command));
+            }
+            check_results.push(result);
+        }
+    }
+
+    let clean = status_porcelain(root)?.is_empty();
+    if !clean && blockers.is_empty() {
+        blockers.push("worktree is not clean after refresh".to_string());
+    }
+
+    let mut pushed = false;
+    if options.push {
+        if blockers.is_empty() && clean {
+            let refspec = format!("HEAD:{}", pr.head_ref_name);
+            git_checked(
+                root,
+                &["push", "--force-with-lease", "origin", &refspec],
+                "git push --force-with-lease",
+            )?;
+            pushed = true;
+        } else {
+            blockers.push("push requested but refresh is not clean".to_string());
+        }
+    }
+
+    Ok(PrRefreshOutput {
+        component_id: id,
+        path,
+        action: "pr.refresh".to_string(),
+        success: blockers.is_empty(),
+        number: pr.number,
+        url: pr.url,
+        base: pr.base_ref_name,
+        head: pr.head_ref_name,
+        strategy: strategy.as_str().to_string(),
+        pushed,
+        clean,
+        merge_state: pr.merge_state_status,
+        conflict_files,
+        checks: check_results,
+        blockers,
+        warnings: if options.push {
+            Vec::new()
+        } else {
+            vec!["branch was not pushed; pass --push to publish a clean refresh".to_string()]
+        },
+    })
+}
+
+fn effective_checks(checks: &[String]) -> Vec<String> {
+    if checks.is_empty() {
+        vec!["git diff --check".to_string()]
+    } else {
+        checks.to_vec()
+    }
+}
+
+fn view_pr(root: &Path, pr: &str) -> Result<GhPrView> {
+    let pr_ref = normalize_pr_ref(pr)?;
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr_ref,
+            "--json",
+            "number,url,state,baseRefName,headRefName,mergeStateStatus",
+        ])
+        .current_dir(root)
+        .output()
+        .map_err(|e| Error::git_command_failed(format!("gh pr view failed: {e}")))?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(format!(
+            "gh pr view failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    serde_json::from_slice(&output.stdout).map_err(|e| {
+        Error::validation_invalid_argument(
+            "pr",
+            format!("failed to parse gh pr view output: {e}"),
+            None,
+            None,
+        )
+    })
+}
+
+fn checkout_pr_branch(root: &Path, number: u64) -> Result<()> {
+    git_checked(root, &["status", "--porcelain=v1"], "git status")?;
+    let output = Command::new("gh")
+        .args(["pr", "checkout", &number.to_string()])
+        .current_dir(root)
+        .output()
+        .map_err(|e| Error::git_command_failed(format!("gh pr checkout failed: {e}")))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(Error::git_command_failed(format!(
+            "gh pr checkout failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )))
+    }
+}
+
+fn resolve_strategy(
+    root: &Path,
+    requested: PrRefreshStrategy,
+    branch: &str,
+) -> Result<PrRefreshStrategy> {
+    if requested != PrRefreshStrategy::Auto {
+        return Ok(requested);
+    }
+
+    let branch_key = format!("branch.{branch}.rebase");
+    for key in [branch_key.as_str(), "pull.rebase"] {
+        if let Some(value) = git_stdout_optional(root, &["config", "--get", key])? {
+            return Ok(match value.as_str() {
+                "true" | "merges" | "interactive" => PrRefreshStrategy::Rebase,
+                "false" => PrRefreshStrategy::Merge,
+                _ => PrRefreshStrategy::Rebase,
+            });
+        }
+    }
+
+    Ok(PrRefreshStrategy::Rebase)
+}
+
+fn conflict_files(root: &Path) -> Result<Vec<String>> {
+    let status = status_porcelain(root)?;
+    Ok(conflict_files_from_porcelain(&status))
+}
+
+fn conflict_files_from_porcelain(status: &str) -> Vec<String> {
+    let mut files = Vec::new();
+    for line in status.lines() {
+        let Some(code) = line.get(0..2) else { continue };
+        let conflicted = matches!(code, "DD" | "AU" | "UD" | "UA" | "DU" | "AA" | "UU");
+        if conflicted {
+            if let Some(path) = line.get(3..) {
+                files.push(path.to_string());
+            }
+        }
+    }
+    files
+}
+
+fn run_check(root: &Path, command: &str) -> Result<PrRefreshCheck> {
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(root)
+        .output()
+        .map_err(|e| Error::git_command_failed(format!("check failed to start: {e}")))?;
+    Ok(PrRefreshCheck {
+        command: command.to_string(),
+        success: output.status.success(),
+        exit_code: output.status.code().unwrap_or(1),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn normalize_pr_ref(pr: &str) -> Result<String> {
+    let trimmed = pr.trim();
+    if trimmed.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "pr",
+            "PR number or URL is required",
+            None,
+            None,
+        ));
+    }
+    if trimmed.chars().all(|c| c.is_ascii_digit()) {
+        return Ok(trimmed.to_string());
+    }
+    if let Some((_, number)) = trimmed.rsplit_once("/pull/") {
+        let digits = number
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect::<String>();
+        if !digits.is_empty() {
+            return Ok(digits);
+        }
+    }
+    Ok(trimmed.to_string())
+}
+
+fn status_porcelain(root: &Path) -> Result<String> {
+    git_stdout(
+        root,
+        &["status", "--porcelain=v1"],
+        "git status --porcelain",
+    )
+}
+
+fn git_stdout_optional(root: &Path, args: &[&str]) -> Result<Option<String>> {
+    let output = git_output(root, args)?;
+    if output.status.success() {
+        Ok(Some(
+            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
+fn git_stdout(root: &Path, args: &[&str], label: &str) -> Result<String> {
+    let output = git_checked(root, args, label)?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn git_checked(root: &Path, args: &[&str], label: &str) -> Result<std::process::Output> {
+    let output = git_output(root, args)?;
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(Error::git_command_failed(format!(
+            "{label} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )))
+    }
+}
+
+fn git_output(root: &Path, args: &[&str]) -> Result<std::process::Output> {
+    Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .map_err(|e| Error::git_command_failed(format!("git failed: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_pr_numbers_and_urls() {
+        assert_eq!(normalize_pr_ref("123").unwrap(), "123");
+        assert_eq!(
+            normalize_pr_ref("https://github.com/Extra-Chill/homeboy/pull/5806").unwrap(),
+            "5806"
+        );
+    }
+
+    #[test]
+    fn detects_conflict_files_from_porcelain() {
+        let files = conflict_files_from_porcelain("UU src/lib.rs\n M README.md\nAA docs/a.md\n");
+        assert_eq!(files, vec!["src/lib.rs", "docs/a.md"]);
+    }
+
+    #[test]
+    fn default_check_is_git_diff_check() {
+        assert_eq!(effective_checks(&[]), vec!["git diff --check"]);
+    }
+}

--- a/src/core/proof.rs
+++ b/src/core/proof.rs
@@ -578,9 +578,7 @@ mod tests {
 
         assert!(!report.valid);
         assert_eq!(report.diagnostics[0].code, "invalid_controller_loop_spec");
-        assert!(report.diagnostics[0]
-            .message
-            .contains("workflows[0].gates"));
+        assert!(report.diagnostics[0].message.contains("workflows[0].gates"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #5806

## Summary
- Adds `homeboy git pr refresh <component> <number-or-url>` for safe dependent PR branch refreshes.
- Resolves PR metadata with `gh`, refuses pre-existing dirty worktrees/base-branch refreshes, fetches the current base, applies repo-preferred `auto` strategy (`branch.<name>.rebase` / `pull.rebase`, fallback rebase), and reports conflict files/blockers.
- Runs lightweight checks after clean refreshes (`git diff --check` by default, repeatable `--check`) and only pushes with explicit `--push` using `--force-with-lease`.
- Documents the workflow and adds unit coverage for PR ref parsing, conflict-file extraction, and default checks.

## Verification
- `rustfmt --edition 2021 src/core/git/mod.rs src/core/git/pr_refresh.rs src/commands/git.rs --check`
- `git diff --check origin/main...HEAD`

Not run: local Cargo tests/builds, per no-cargo-local rule for this environment.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the CLI helper, docs, and tests.
