### PR TITLE
Add ordered PR landing rebase plans

### DIFF
--- a/src/commands/triage.rs
+++ b/src/commands/triage.rs
@@ -131,6 +131,10 @@ enum TriageCommand {
         #[arg(long, value_name = "NUMBER")]
         source_issue: Vec<u64>,
 
+        /// Preserve supplied PR order and emit dependent-branch rebase plans.
+        #[arg(long)]
+        ordered: bool,
+
         /// Landing scope: project id.
         #[arg(long, conflicts_with_all = ["fleet", "component", "path", "workspace"])]
         project: Option<String>,
@@ -187,6 +191,7 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageCom
         repo,
         branch,
         source_issue,
+        ordered,
         project,
         fleet,
         component,
@@ -201,6 +206,7 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageCom
             pr_refs,
             branch_patterns: branch,
             source_issues: source_issue,
+            ordered,
             drilldown: args.drilldown,
             limit: args.limit,
         })?;
@@ -404,6 +410,24 @@ mod tests {
         assert_eq!(cli.args.timeout, "5m");
         assert_eq!(cli.args.poll_interval, "30s");
         assert!(cli.args.command.is_none());
+    }
+
+    #[test]
+    fn landing_ordered_flag_parses() {
+        let cli = TestCli::parse_from([
+            "triage",
+            "landing",
+            "42",
+            "43",
+            "--repo",
+            "Extra-Chill/homeboy",
+            "--ordered",
+        ]);
+
+        match cli.args.command {
+            Some(TriageCommand::Landing { ordered, .. }) => assert!(ordered),
+            other => panic!("expected Landing subcommand, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -9,7 +9,7 @@
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -58,6 +58,7 @@ pub struct TriageLandingOptions {
     pub pr_refs: Vec<String>,
     pub branch_patterns: Vec<String>,
     pub source_issues: Vec<u64>,
+    pub ordered: bool,
     pub drilldown: bool,
     pub limit: usize,
 }
@@ -107,15 +108,30 @@ pub struct TriageLandingPr {
     pub url: String,
     pub state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub head_branch: Option<String>,
     pub mergeability_state: TriageLandingMergeabilityState,
     pub check_state: TriageLandingCheckState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_repo: Option<String>,
     pub classification: TriageLandingClassification,
     pub suggested_next_command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependent_rebase: Option<TriageLandingRebasePlan>,
     #[serde(flatten)]
     pub signals: TriagePullRequestSignals,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub check_failures: Vec<TriageCheckFailure>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TriageLandingRebasePlan {
+    pub after_pr: u64,
+    pub safe_to_update: bool,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -464,8 +480,13 @@ pub fn landing(options: TriageLandingOptions) -> Result<TriageLandingOutput> {
         }
     }
 
-    pull_requests.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.number.cmp(&b.number)));
-    pull_requests.dedup_by(|a, b| a.repo == b.repo && a.number == b.number);
+    if options.ordered {
+        dedupe_landing_prs_preserving_order(&mut pull_requests);
+        annotate_ordered_dependent_rebases(&mut pull_requests);
+    } else {
+        pull_requests.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.number.cmp(&b.number)));
+        pull_requests.dedup_by(|a, b| a.repo == b.repo && a.number == b.number);
+    }
     let summary = summarize_landing(&pull_requests);
 
     Ok(TriageLandingOutput {
@@ -1014,7 +1035,7 @@ fn fetch_landing_pr(
 }
 
 fn landing_pr_json_fields() -> &'static str {
-    "number,title,url,state,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,headRefName,comments,reviews,updatedAt,mergedAt"
+    "number,title,url,state,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,baseRefName,headRefName,headRepository,headRepositoryOwner,comments,reviews,updatedAt,mergedAt"
 }
 
 fn effective_landing_limit(options: &TriageLandingOptions) -> usize {
@@ -1207,8 +1228,14 @@ struct RawPr {
     merge_state_status: Option<String>,
     #[serde(default, rename = "statusCheckRollup")]
     status_check_rollup: Vec<Value>,
+    #[serde(default, rename = "baseRefName")]
+    base_ref_name: Option<String>,
     #[serde(default, rename = "headRefName")]
     head_ref_name: Option<String>,
+    #[serde(default, rename = "headRepository")]
+    head_repository: Option<RawPrHeadRepository>,
+    #[serde(default, rename = "headRepositoryOwner")]
+    head_repository_owner: Option<RawNamedNode>,
     #[serde(default, rename = "mergedAt")]
     merged_at: Option<String>,
     #[serde(default)]
@@ -1223,6 +1250,14 @@ struct RawPr {
     reviews: Vec<RawReview>,
     #[serde(default, rename = "updatedAt")]
     updated_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPrHeadRepository {
+    #[serde(default, rename = "nameWithOwner")]
+    name_with_owner: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
 }
 
 fn parse_landing_prs(
@@ -1274,11 +1309,14 @@ fn raw_pr_to_landing_pr(item: RawPr, repo: &GitHubRepo, drilldown: bool) -> Tria
         title: item.title,
         url: item.url,
         state: item.state,
+        base_branch: non_empty(item.base_ref_name),
         head_branch: non_empty(item.head_ref_name),
         mergeability_state: landing_mergeability_state(signals.merge_state.as_deref()),
         check_state: landing_check_state(signals.checks.as_deref()),
+        head_repo: raw_head_repo_name_with_owner(item.head_repository, item.head_repository_owner),
         classification,
         suggested_next_command: landing_next_command(classification, repo, item.number),
+        dependent_rebase: None,
         signals,
         check_failures,
     }
@@ -1303,6 +1341,69 @@ fn landing_check_state(checks: Option<&str>) -> TriageLandingCheckState {
         Some("FAILURE") => TriageLandingCheckState::Failed,
         None => TriageLandingCheckState::Unknown,
         Some(_) => TriageLandingCheckState::Other,
+    }
+}
+
+fn raw_head_repo_name_with_owner(
+    repo: Option<RawPrHeadRepository>,
+    owner: Option<RawNamedNode>,
+) -> Option<String> {
+    let repo = repo?;
+    if let Some(name_with_owner) = non_empty(repo.name_with_owner) {
+        return Some(name_with_owner);
+    }
+    let owner = owner.and_then(|owner| owner.login)?;
+    let name = non_empty(repo.name)?;
+    Some(format!("{owner}/{name}"))
+}
+
+fn dedupe_landing_prs_preserving_order(items: &mut Vec<TriageLandingPr>) {
+    let mut seen = BTreeSet::new();
+    items.retain(|item| seen.insert((item.repo.clone(), item.number)));
+}
+
+fn annotate_ordered_dependent_rebases(items: &mut [TriageLandingPr]) {
+    for index in 1..items.len() {
+        let previous = items[index - 1].number;
+        let plan = dependent_rebase_plan(&items[index], previous);
+        items[index].dependent_rebase = Some(plan);
+    }
+}
+
+fn dependent_rebase_plan(item: &TriageLandingPr, after_pr: u64) -> TriageLandingRebasePlan {
+    let Some(head_branch) = item.head_branch.as_deref() else {
+        return TriageLandingRebasePlan {
+            after_pr,
+            safe_to_update: false,
+            reason: "missing_head_branch".to_string(),
+            command: None,
+        };
+    };
+    let Some(base_branch) = item.base_branch.as_deref() else {
+        return TriageLandingRebasePlan {
+            after_pr,
+            safe_to_update: false,
+            reason: "missing_base_branch".to_string(),
+            command: None,
+        };
+    };
+    if item.head_repo.as_deref() != Some(item.repo.as_str()) {
+        return TriageLandingRebasePlan {
+            after_pr,
+            safe_to_update: false,
+            reason: "head_branch_not_in_base_repo".to_string(),
+            command: None,
+        };
+    }
+
+    TriageLandingRebasePlan {
+        after_pr,
+        safe_to_update: true,
+        reason: "same_repo_head_branch".to_string(),
+        command: Some(format!(
+            "gh pr checkout {} -R {} && git fetch origin {} && git rebase origin/{} && git push --force-with-lease origin HEAD:{}",
+            item.number, item.repo, base_branch, base_branch, head_branch
+        )),
     }
 }
 

--- a/src/core/triage/tests.rs
+++ b/src/core/triage/tests.rs
@@ -637,7 +637,10 @@ mod pull_requests {
           "reviewDecision": "APPROVED",
           "mergeStateStatus": "CLEAN",
           "statusCheckRollup": [{"status":"COMPLETED","conclusion":"SUCCESS"}],
+          "baseRefName": "main",
           "headRefName": "cook/ready",
+          "headRepository": {"name":"homeboy"},
+          "headRepositoryOwner": {"login":"Extra-Chill"},
           "mergedAt": null,
           "comments": [],
           "reviews": [],
@@ -656,10 +659,96 @@ mod pull_requests {
         );
         assert_eq!(item.check_state, TriageLandingCheckState::Clean);
         assert_eq!(item.head_branch.as_deref(), Some("cook/ready"));
+        assert_eq!(item.base_branch.as_deref(), Some("main"));
+        assert_eq!(item.head_repo.as_deref(), Some("Extra-Chill/homeboy"));
         assert_eq!(
             item.suggested_next_command,
             "homeboy triage --watch Extra-Chill/homeboy#42 --until green-mergeable"
         );
+        assert!(item.dependent_rebase.is_none());
+    }
+
+    #[test]
+    fn ordered_landing_preserves_input_order_and_dedupes() {
+        let mut items = vec![
+            landing_pr(
+                2,
+                "Extra-Chill/homeboy",
+                "main",
+                "feature/two",
+                "Extra-Chill/homeboy",
+            ),
+            landing_pr(
+                1,
+                "Extra-Chill/homeboy",
+                "main",
+                "feature/one",
+                "Extra-Chill/homeboy",
+            ),
+            landing_pr(
+                2,
+                "Extra-Chill/homeboy",
+                "main",
+                "feature/two",
+                "Extra-Chill/homeboy",
+            ),
+        ];
+
+        dedupe_landing_prs_preserving_order(&mut items);
+
+        assert_eq!(
+            items.iter().map(|item| item.number).collect::<Vec<_>>(),
+            vec![2, 1]
+        );
+    }
+
+    #[test]
+    fn ordered_landing_generates_same_repo_dependent_rebase_command() {
+        let mut items = vec![
+            landing_pr(
+                10,
+                "Extra-Chill/homeboy",
+                "main",
+                "feature/base",
+                "Extra-Chill/homeboy",
+            ),
+            landing_pr(
+                11,
+                "Extra-Chill/homeboy",
+                "main",
+                "feature/dependent",
+                "Extra-Chill/homeboy",
+            ),
+        ];
+
+        annotate_ordered_dependent_rebases(&mut items);
+
+        assert!(items[0].dependent_rebase.is_none());
+        let plan = items[1].dependent_rebase.as_ref().unwrap();
+        assert_eq!(plan.after_pr, 10);
+        assert!(plan.safe_to_update);
+        assert_eq!(plan.reason, "same_repo_head_branch");
+        assert_eq!(
+            plan.command.as_deref(),
+            Some("gh pr checkout 11 -R Extra-Chill/homeboy && git fetch origin main && git rebase origin/main && git push --force-with-lease origin HEAD:feature/dependent")
+        );
+    }
+
+    #[test]
+    fn ordered_landing_marks_forked_heads_manual() {
+        let item = landing_pr(
+            11,
+            "Extra-Chill/homeboy",
+            "main",
+            "feature/dependent",
+            "someone/homeboy",
+        );
+
+        let plan = dependent_rebase_plan(&item, 10);
+
+        assert!(!plan.safe_to_update);
+        assert_eq!(plan.reason, "head_branch_not_in_base_repo");
+        assert!(plan.command.is_none());
     }
 
     #[test]
@@ -838,6 +927,32 @@ mod pull_requests {
         assert_eq!(actions[0].label, "2 PRs have failed checks");
         assert_eq!(actions[1].kind, "review_required");
         assert_eq!(actions[2].kind, "clean_and_ready");
+    }
+
+    fn landing_pr(
+        number: u64,
+        repo: &str,
+        base_branch: &str,
+        head_branch: &str,
+        head_repo: &str,
+    ) -> TriageLandingPr {
+        TriageLandingPr {
+            repo: repo.to_string(),
+            number,
+            title: format!("PR {number}"),
+            url: format!("https://github.com/{repo}/pull/{number}"),
+            state: "OPEN".to_string(),
+            base_branch: Some(base_branch.to_string()),
+            head_branch: Some(head_branch.to_string()),
+            head_repo: Some(head_repo.to_string()),
+            classification: TriageLandingClassification::CleanMergeable,
+            suggested_next_command: format!(
+                "homeboy triage --watch {repo}#{number} --until green-mergeable"
+            ),
+            dependent_rebase: None,
+            signals: TriagePullRequestSignals::default(),
+            check_failures: Vec::new(),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `homeboy triage landing --ordered` to preserve supplied PR order for dependency-aware landing reports.
- Includes PR base/head repository metadata in landing output.
- Emits dependent rebase plans only when the dependent branch is clearly owned by the base repo; forked or ambiguous heads are marked manual with a reason.

Fixes #5818

## Tests/checks
- `rustfmt src/commands/triage.rs src/core/triage.rs src/core/triage/tests.rs`
- `git diff --check`
- `gh pr list -R Extra-Chill/homeboy --limit 1 --json number,headRepository,headRepositoryOwner,baseRefName,headRefName`

Skipped: local `cargo` checks/tests per operator rule not to run cargo locally on this machine.

## Follow-up
- This PR intentionally implements the planning/reporting/rebase-command generation primitive, not automatic PR merge/rebase execution.
- A later PR can add an explicit apply mode that executes these plans, captures conflict files, and stops on unsafe rebases.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, formatting, PR preparation.