### PR TITLE
Improve PR CI status next actions

### DIFF
--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -546,7 +546,12 @@ pub fn pr_view(
         .and_then(|v| v.as_array())
         .map(|v| v.as_slice())
         .unwrap_or(&[]);
-    let (ci_state, ci_summary) = classify_pr_ci(&state, merged_at.as_deref(), status_check_rollup);
+    let (ci_state, ci_summary, ci_next_action) = classify_pr_ci(
+        &state,
+        merged_at.as_deref(),
+        merge_state.as_deref(),
+        status_check_rollup,
+    );
 
     Ok(GithubPrView {
         component_id: id,
@@ -564,6 +569,7 @@ pub fn pr_view(
         merge_state,
         ci_state,
         ci_summary,
+        ci_next_action,
     })
 }
 
@@ -780,69 +786,226 @@ fn string_value(value: &serde_json::Value, key: &str) -> Option<String> {
 fn classify_pr_ci(
     pr_state: &str,
     merged_at: Option<&str>,
+    merge_state: Option<&str>,
     checks: &[serde_json::Value],
-) -> (String, String) {
+) -> (String, String, String) {
     if checks.is_empty() {
         return (
             "no_checks".to_string(),
-            "GitHub reported no status checks for this PR head.".to_string(),
+            "GitHub reported no status checks for this PR head; next action: merge-ready"
+                .to_string(),
+            "merge_ready".to_string(),
         );
     }
 
-    let mut pending = 0usize;
+    let mut passed = 0usize;
+    let mut skipped = 0usize;
     let mut failed = 0usize;
-    let mut green = 0usize;
+    let mut queued = 0usize;
+    let mut running = 0usize;
+    let mut pending = 0usize;
     let mut unknown = 0usize;
+    let mut rerunnable = 0usize;
+    let mut required = 0usize;
+    let mut optional = 0usize;
+    let mut failed_details = Vec::new();
+    let mut pending_details = Vec::new();
 
     for check in checks {
-        let status = check.get("status").and_then(serde_json::Value::as_str);
+        let name = check_name(check);
+        let workflow = string_field(check, &["workflowName", "workflow_name"]);
+        let status = check
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty());
         let conclusion = check
             .get("conclusion")
             .and_then(serde_json::Value::as_str)
             .map(str::trim)
             .filter(|v| !v.is_empty());
+        if let Some(is_required) = bool_field(check, &["isRequired", "required"]) {
+            if is_required {
+                required += 1;
+            } else {
+                optional += 1;
+            }
+        }
 
         match (status, conclusion) {
-            (
-                _,
-                Some("FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE"),
-            ) => {
+            (_, Some("FAILURE" | "ACTION_REQUIRED")) => {
                 failed += 1;
+                failed_details.push(check_detail(check, &name));
             }
-            (Some("COMPLETED"), Some("SUCCESS" | "SKIPPED" | "NEUTRAL")) => {
-                green += 1;
+            (_, Some("CANCELLED" | "TIMED_OUT" | "STARTUP_FAILURE")) => {
+                failed += 1;
+                rerunnable += 1;
+                failed_details.push(check_detail(check, &name));
+            }
+            (Some("COMPLETED"), Some("SUCCESS" | "NEUTRAL")) => {
+                passed += 1;
+            }
+            (Some("COMPLETED"), Some("SKIPPED")) => {
+                skipped += 1;
             }
             (Some("COMPLETED"), Some(_)) => {
                 unknown += 1;
+                failed_details.push(check_detail(check, &name));
             }
             (Some("COMPLETED"), None) => {
                 unknown += 1;
+                failed_details.push(check_detail(check, &name));
+            }
+            (Some("QUEUED" | "REQUESTED" | "WAITING"), _) => {
+                queued += 1;
+                pending_details.push(check_pending_detail(check, &name, workflow.as_deref()));
+            }
+            (Some("IN_PROGRESS"), _) => {
+                running += 1;
+                pending_details.push(check_pending_detail(check, &name, workflow.as_deref()));
             }
             _ => {
                 pending += 1;
+                pending_details.push(check_pending_detail(check, &name, workflow.as_deref()));
             }
         }
     }
 
+    let blocked = failed + unknown;
+    let waiting = queued + running + pending;
     let state = if failed > 0 || unknown > 0 {
         "terminal_failed"
-    } else if pending > 0 && (pr_state == "MERGED" || merged_at.is_some()) {
+    } else if waiting > 0 && (pr_state == "MERGED" || merged_at.is_some()) {
         "stale"
-    } else if pending > 0 {
+    } else if waiting > 0 {
         "pending"
     } else {
         "terminal_green"
     };
 
-    let summary = format!(
-        "{} check(s): {} terminal-green, {} failed/unknown, {} pending",
-        checks.len(),
-        green,
-        failed + unknown,
-        pending
-    );
+    let next_action = if blocked > 0 && failed == rerunnable && unknown == 0 {
+        "rerun"
+    } else if blocked > 0 {
+        "inspect_failed_logs"
+    } else if matches!(merge_state, Some("BEHIND")) {
+        "update_branch"
+    } else if waiting > 0 {
+        "wait"
+    } else {
+        "merge_ready"
+    };
 
-    (state.to_string(), summary)
+    let mut parts = vec![format!(
+        "{} reported check(s): {} passed, {} failed/unknown, {} queued, {} running, {} pending, {} skipped",
+        checks.len(), passed, blocked, queued, running, pending, skipped
+    )];
+    if required > 0 || optional > 0 {
+        parts.push(format!("{} required, {} optional", required, optional));
+    } else {
+        parts.push("required/optional split unavailable".to_string());
+    }
+    if let Some(oldest) = pending_details
+        .iter()
+        .filter_map(|detail| detail.started_at.as_deref())
+        .min()
+    {
+        parts.push(format!("oldest pending since {}", oldest));
+    }
+    if !pending_details.is_empty() {
+        parts.push(format!(
+            "waiting: {}",
+            pending_details
+                .iter()
+                .take(3)
+                .map(PendingCheckDetail::label)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !failed_details.is_empty() {
+        parts.push(format!(
+            "failed logs: {}",
+            failed_details
+                .iter()
+                .take(3)
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    let action_label = if next_action == "merge_ready" {
+        "merge-ready".to_string()
+    } else {
+        next_action.replace('_', " ")
+    };
+    parts.push(format!("next action: {}", action_label));
+
+    (state.to_string(), parts.join("; "), next_action.to_string())
+}
+
+struct PendingCheckDetail {
+    name: String,
+    workflow: Option<String>,
+    started_at: Option<String>,
+}
+
+impl PendingCheckDetail {
+    fn label(&self) -> String {
+        match (&self.workflow, &self.started_at) {
+            (Some(workflow), Some(started_at)) => {
+                format!("{} ({}, since {})", self.name, workflow, started_at)
+            }
+            (Some(workflow), None) => format!("{} ({})", self.name, workflow),
+            (None, Some(started_at)) => format!("{} (since {})", self.name, started_at),
+            (None, None) => self.name.clone(),
+        }
+    }
+}
+
+fn check_pending_detail(
+    check: &serde_json::Value,
+    name: &str,
+    workflow: Option<&str>,
+) -> PendingCheckDetail {
+    PendingCheckDetail {
+        name: name.to_string(),
+        workflow: workflow.map(str::to_string),
+        started_at: string_field(check, &["startedAt", "started_at", "queuedAt", "queued_at"]),
+    }
+}
+
+fn check_detail(check: &serde_json::Value, name: &str) -> String {
+    match string_field(
+        check,
+        &[
+            "detailsUrl",
+            "details_url",
+            "targetUrl",
+            "target_url",
+            "url",
+        ],
+    ) {
+        Some(url) => format!("{} ({})", name, url),
+        None => name.to_string(),
+    }
+}
+
+fn check_name(check: &serde_json::Value) -> String {
+    string_field(check, &["name", "context", "workflowName", "workflow_name"])
+        .unwrap_or_else(|| "unnamed check".to_string())
+}
+
+fn string_field(check: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| check.get(*key).and_then(serde_json::Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn bool_field(check: &serde_json::Value, keys: &[&str]) -> Option<bool> {
+    keys.iter()
+        .find_map(|key| check.get(*key).and_then(serde_json::Value::as_bool))
 }
 
 fn parse_issue_list_json(raw: &str, options: &IssueFindOptions) -> Result<Vec<GithubFindItem>> {
@@ -996,33 +1159,47 @@ mod tests {
             {"status":"COMPLETED","conclusion":"SUCCESS"},
             {"status":"COMPLETED","conclusion":"SKIPPED"}
         ]);
-        let (state, summary) = classify_pr_ci("OPEN", None, checks.as_array().unwrap());
+        let (state, summary, next_action) =
+            classify_pr_ci("OPEN", None, None, checks.as_array().unwrap());
 
         assert_eq!(state, "terminal_green");
-        assert!(summary.contains("2 terminal-green"));
+        assert!(summary.contains("1 passed"));
+        assert!(summary.contains("1 skipped"));
+        assert_eq!(next_action, "merge_ready");
     }
 
     #[test]
     fn classify_pr_ci_distinguishes_terminal_failed() {
         let checks = serde_json::json!([
             {"status":"COMPLETED","conclusion":"SUCCESS"},
-            {"status":"COMPLETED","conclusion":"FAILURE"}
+            {"status":"COMPLETED","conclusion":"FAILURE","name":"homeboy / Test","detailsUrl":"https://example.test/logs"}
         ]);
-        let (state, summary) = classify_pr_ci("OPEN", None, checks.as_array().unwrap());
+        let (state, summary, next_action) =
+            classify_pr_ci("OPEN", None, None, checks.as_array().unwrap());
 
         assert_eq!(state, "terminal_failed");
         assert!(summary.contains("1 failed/unknown"));
+        assert!(summary.contains("homeboy / Test (https://example.test/logs)"));
+        assert_eq!(next_action, "inspect_failed_logs");
     }
 
     #[test]
     fn classify_pr_ci_distinguishes_pending_open_pr() {
         let checks = serde_json::json!([
-            {"status":"IN_PROGRESS","conclusion":""}
+            {"status":"QUEUED","conclusion":"","name":"homeboy / Build","workflowName":"CI","startedAt":"2026-06-22T01:00:00Z"},
+            {"status":"IN_PROGRESS","conclusion":"","name":"homeboy / Test","workflowName":"CI","startedAt":"2026-06-22T01:01:00Z"},
+            {"status":"PENDING","conclusion":"","name":"required/context"}
         ]);
-        let (state, summary) = classify_pr_ci("OPEN", None, checks.as_array().unwrap());
+        let (state, summary, next_action) =
+            classify_pr_ci("OPEN", None, None, checks.as_array().unwrap());
 
         assert_eq!(state, "pending");
+        assert!(summary.contains("1 queued"));
+        assert!(summary.contains("1 running"));
         assert!(summary.contains("1 pending"));
+        assert!(summary.contains("oldest pending since 2026-06-22T01:00:00Z"));
+        assert!(summary.contains("homeboy / Build (CI, since 2026-06-22T01:00:00Z)"));
+        assert_eq!(next_action, "wait");
     }
 
     #[test]
@@ -1030,14 +1207,42 @@ mod tests {
         let checks = serde_json::json!([
             {"name":"homeboy / Test","status":"IN_PROGRESS","conclusion":""}
         ]);
-        let (state, summary) = classify_pr_ci(
+        let (state, summary, next_action) = classify_pr_ci(
             "MERGED",
             Some("2026-06-15T12:47:01Z"),
+            None,
             checks.as_array().unwrap(),
         );
 
         assert_eq!(state, "stale");
-        assert!(summary.contains("1 pending"));
+        assert!(summary.contains("1 running"));
+        assert_eq!(next_action, "wait");
+    }
+
+    #[test]
+    fn classify_pr_ci_recommends_update_branch_when_behind() {
+        let checks = serde_json::json!([
+            {"status":"COMPLETED","conclusion":"SUCCESS"}
+        ]);
+        let (state, summary, next_action) =
+            classify_pr_ci("OPEN", None, Some("BEHIND"), checks.as_array().unwrap());
+
+        assert_eq!(state, "terminal_green");
+        assert!(summary.contains("next action: update branch"));
+        assert_eq!(next_action, "update_branch");
+    }
+
+    #[test]
+    fn classify_pr_ci_recommends_rerun_for_cancelled_checks() {
+        let checks = serde_json::json!([
+            {"status":"COMPLETED","conclusion":"CANCELLED","name":"homeboy / Lint","detailsUrl":"https://example.test/lint"}
+        ]);
+        let (state, summary, next_action) =
+            classify_pr_ci("OPEN", None, None, checks.as_array().unwrap());
+
+        assert_eq!(state, "terminal_failed");
+        assert!(summary.contains("next action: rerun"));
+        assert_eq!(next_action, "rerun");
     }
 
     #[test]

--- a/src/core/git/github_types.rs
+++ b/src/core/git/github_types.rs
@@ -69,6 +69,7 @@ pub struct GithubPrView {
     pub merge_state: Option<String>,
     pub ci_state: String,
     pub ci_summary: String,
+    pub ci_next_action: String,
 }
 
 /// Result of a find-many operation (list of matches).

--- a/src/core/git/pr_policy.rs
+++ b/src/core/git/pr_policy.rs
@@ -78,6 +78,8 @@ pub struct PrPolicyDecision {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ci_summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_next_action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub merged: Option<bool>,
 }
 
@@ -218,7 +220,12 @@ pub fn evaluate_merge_policy(options: PrPolicyMergeOptions) -> Result<PrPolicyDe
             ..Default::default()
         },
     );
-    apply_ci_gate(&mut decision, &pr.ci_state, &pr.ci_summary);
+    apply_ci_gate(
+        &mut decision,
+        &pr.ci_state,
+        &pr.ci_summary,
+        &pr.ci_next_action,
+    );
 
     if options.merge && decision.allowed {
         pr_merge(
@@ -239,9 +246,15 @@ pub fn evaluate_merge_policy(options: PrPolicyMergeOptions) -> Result<PrPolicyDe
     Ok(decision)
 }
 
-fn apply_ci_gate(decision: &mut PrPolicyDecision, ci_state: &str, ci_summary: &str) {
+fn apply_ci_gate(
+    decision: &mut PrPolicyDecision,
+    ci_state: &str,
+    ci_summary: &str,
+    ci_next_action: &str,
+) {
     decision.ci_state = Some(ci_state.to_string());
     decision.ci_summary = Some(ci_summary.to_string());
+    decision.ci_next_action = Some(ci_next_action.to_string());
     decision.report = format!(
         "{}\n\nCI status: `{}` - {}.",
         decision.report, ci_state, ci_summary
@@ -410,6 +423,7 @@ fn evaluate_rules(rules: &PrPolicyRules, context: PrPolicyContext) -> PrPolicyDe
         files: context.files,
         ci_state: None,
         ci_summary: None,
+        ci_next_action: None,
         merged: None,
     }
 }
@@ -587,17 +601,20 @@ mod tests {
             files: Vec::new(),
             ci_state: None,
             ci_summary: None,
+            ci_next_action: None,
             merged: None,
         };
 
         apply_ci_gate(
             &mut decision,
             "terminal_green",
-            "1 check(s): 1 terminal-green, 0 failed/unknown, 0 pending",
+            "1 reported check(s): 1 passed, 0 failed/unknown, 0 queued, 0 running, 0 pending, 0 skipped",
+            "merge_ready",
         );
 
         assert!(decision.allowed);
         assert_eq!(decision.ci_state.as_deref(), Some("terminal_green"));
+        assert_eq!(decision.ci_next_action.as_deref(), Some("merge_ready"));
         assert!(decision.report.contains("CI status: `terminal_green`"));
     }
 
@@ -613,13 +630,15 @@ mod tests {
             files: Vec::new(),
             ci_state: None,
             ci_summary: None,
+            ci_next_action: None,
             merged: None,
         };
 
         apply_ci_gate(
             &mut decision,
             "stale",
-            "1 check(s): 0 terminal-green, 0 failed/unknown, 1 pending",
+            "1 reported check(s): 0 passed, 0 failed/unknown, 0 queued, 0 running, 1 pending, 0 skipped",
+            "wait",
         );
 
         assert!(!decision.allowed);


### PR DESCRIPTION
Fixes #5804.

## Summary
- Expand PR CI status classification into explicit passed, failed/unknown, queued, running, pending, and skipped counts.
- Add a machine-readable `ci_next_action` to PR CI metadata and PR policy output.
- Include concise human guidance for wait, inspect failed logs, rerun, update branch, and merge-ready states, with failed check log URLs and pending workflow/timestamp details when GitHub provides them.

## Tests
- `rustfmt --edition 2021 src/core/git/github.rs src/core/git/github_types.rs src/core/git/pr_policy.rs`
- `rustfmt --edition 2021 --check src/core/git/github.rs src/core/git/github_types.rs src/core/git/pr_policy.rs`
- `git diff --check`

## Skipped
- Cargo-based tests/checks were not run locally per repo instruction to avoid local Rust-heavy verification.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the CI status summary changes, tests, formatting, and PR preparation.