### PR TITLE
Fix controller proof spec validation

### DIFF
--- a/src/commands/agent_task/tests/loop_compile.rs
+++ b/src/commands/agent_task/tests/loop_compile.rs
@@ -142,6 +142,38 @@ fn compile_loop_command_rejects_controller_only_sections() {
 }
 
 #[test]
+fn compile_loop_command_rejects_controller_workflow_gates_and_metrics() {
+    let error = loop_definition::compile_loop(CompileLoopArgs {
+        definition: serde_json::to_string(&json!({
+            "loop_id": "repo-loop-with-controller-gates",
+            "gates": [{ "gate_id": "review" }],
+            "metrics": [{ "metric_id": "fallback_blocks" }],
+            "workflows": [
+                {
+                    "workflow_id": "publish",
+                    "prompt": "Publish the output.",
+                    "gates": ["review"],
+                    "metrics": ["fallback_blocks"]
+                }
+            ]
+        }))
+        .expect("definition json"),
+    })
+    .expect_err("controller workflow gates and metrics are rejected");
+
+    assert!(error.message.contains("controller-only sections"));
+    let diagnostics = error.details["tried"].as_array().expect("diagnostics");
+    assert!(diagnostics.iter().any(|diagnostic| diagnostic
+        .as_str()
+        .unwrap_or_default()
+        .contains("workflows[publish].gates")));
+    assert!(diagnostics.iter().any(|diagnostic| diagnostic
+        .as_str()
+        .unwrap_or_default()
+        .contains("workflows[publish].metrics")));
+}
+
+#[test]
 fn controller_materialize_merges_inputs_and_metadata_without_mutating_source() {
     let temp = tempfile::tempdir().expect("tempdir");
     let spec_path = temp.path().join("repo-loop.json");

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -69,7 +69,13 @@ use pr_ownership::*;
 pub use reports::*;
 pub use request::*;
 pub use spec::*;
-use spec_compile::*;
+pub(crate) use spec_compile::validate_loop_spec;
+use spec_compile::{
+    compile_loop_spec_policy, compile_loop_spec_workflows, controller_spec_homeboy_plan,
+    merge_policy_into_event_payload, reconcile_repo_loop_spec_actions, repo_loop_spec_fingerprint,
+    repo_loop_spec_fingerprint_from_metadata, set_repo_loop_spec_metadata,
+    REPO_LOOP_SPEC_ACTION_REASON, REPO_LOOP_SPEC_WORKFLOW_REASON,
+};
 
 /// Create a new durable controller record.
 pub fn init(request: ControllerInitRequest) -> Result<AgentTaskLoopControllerRecord> {

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -270,7 +270,7 @@ pub(super) fn is_repo_loop_spec_action(action: &AgentTaskLoopPolicyActionRecord)
     action.reason == REPO_LOOP_SPEC_WORKFLOW_REASON || action.reason == REPO_LOOP_SPEC_ACTION_REASON
 }
 
-pub(super) fn validate_loop_spec(spec: &AgentTaskRepoLoopSpec) -> Result<()> {
+pub(crate) fn validate_loop_spec(spec: &AgentTaskRepoLoopSpec) -> Result<()> {
     if spec.loop_id.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "loop_id",

--- a/src/core/proof.rs
+++ b/src/core/proof.rs
@@ -537,6 +537,8 @@ mod tests {
                 "loop_id": "example/join",
                 "config_version": "v1",
                 "artifacts": [{ "artifact_id": "page_blocks", "kind": "json" }],
+                "gates": [{ "gate_id": "review" }],
+                "metrics": [{ "metric_id": "fallback_blocks" }],
                 "workflows": [
                     {
                         "workflow_id": "build_page",
@@ -557,6 +559,28 @@ mod tests {
 
         assert!(report.valid, "{report:?}");
         assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn proof_validation_rejects_undeclared_materialized_controller_gate() {
+        let report = validate_proof_value(json!({
+            "schema": "homeboy/agent-task-loop-spec-materialization/v1",
+            "spec": {
+                "loop_id": "example/join",
+                "config_version": "v1",
+                "workflows": [{
+                    "workflow_id": "publish_site",
+                    "prompt": "publish site",
+                    "gates": ["review"]
+                }]
+            }
+        }));
+
+        assert!(!report.valid);
+        assert_eq!(report.diagnostics[0].code, "invalid_controller_loop_spec");
+        assert!(report.diagnostics[0]
+            .message
+            .contains("workflows[0].gates"));
     }
 
     #[test]

--- a/src/core/proof/validation.rs
+++ b/src/core/proof/validation.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::core::agent_task_controller_service::AgentTaskRepoLoopSpec;
+use crate::core::agent_task_controller_service::{validate_loop_spec, AgentTaskRepoLoopSpec};
 use crate::core::agent_task_repo_loop_compile::validate_repo_loop_artifact_references;
 use crate::core::artifact_address::validated_public_url;
 use crate::core::gate::{HomeboyGateResult, HomeboyGateStatus};
@@ -222,6 +222,13 @@ fn validate_materialized_loop_spec(
         ));
         return;
     };
+    if let Err(error) = validate_loop_spec(&spec) {
+        diagnostics.push(diagnostic(
+            "invalid_controller_loop_spec",
+            error.message,
+            path("/spec"),
+        ));
+    }
     if let Err(error) = validate_repo_loop_artifact_references(&spec) {
         diagnostics.push(diagnostic(
             "invalid_artifact_references",


### PR DESCRIPTION
## Summary
- Validate materialized controller specs with the controller spec validator instead of compile-loop-only checks.
- Keep compile-loop rejecting controller workflow gates/metrics for executable agent-task plans.
- Add proof coverage for declared controller workflow gates/metrics and undeclared gate rejection.

## Tests
- `git diff --check`
- Not run: Rust tests/local build. This repo only exposes Cargo-based local verification, and site rules prohibit local cargo commands on this machine.
- WPSG repro command run with installed `homeboy`; still fails with the original `unsupported_gate` diagnostics because the installed binary is not rebuilt from this branch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the controller proof validation path, implementing the generic validation fix, and drafting tests/PR text.