### PR TITLE
fix(upgrade): actually replace active binary on --method source and fail loudly if swap fails (#5772)

### DIFF
--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -147,7 +147,57 @@ pub(crate) fn execute_upgrade(
     let new_version = active_binary.as_ref().and_then(|info| info.version.clone());
     let new_build_identity = active_binary.and_then(|info| info.build_identity);
 
+    // A source upgrade's command is responsible for swapping the freshly built
+    // artifact into the active binary on disk. When that command exits 0 but the
+    // read-back proves the active binary is unchanged, the swap silently
+    // no-op'd (e.g. the artifact was built but never installed over the active
+    // path, or `command -v` resolved a different binary than the one running).
+    // Reporting a soft `upgraded: false` "completed" here lets operators
+    // believe the roll-forward succeeded. Fail loudly with an actionable reason
+    // so urgent source fixes are not silently dropped (#5772).
+    if let Some(error) = source_swap_failure(
+        method,
+        success,
+        new_version.as_deref(),
+        new_build_identity.as_deref(),
+    ) {
+        return Err(error);
+    }
+
     Ok((success, new_version, new_build_identity))
+}
+
+/// Detect a source upgrade whose command exited successfully but left the
+/// active binary unchanged (the swap silently no-op'd), and surface it as a
+/// loud, actionable failure instead of a soft `upgraded: false` "completed".
+///
+/// Returns `None` for every other case (verified swap, or a non-source method
+/// where a soft unverified result is reported by the caller).
+fn source_swap_failure(
+    method: InstallMethod,
+    success: bool,
+    new_version: Option<&str>,
+    new_build_identity: Option<&str>,
+) -> Option<Error> {
+    if method != InstallMethod::Source || success {
+        return None;
+    }
+
+    let observed = new_build_identity
+        .or(new_version)
+        .unwrap_or("an unverifiable version");
+
+    Some(
+        Error::internal_unexpected(format!(
+            "source upgrade command exited successfully but the active binary was not replaced (still {observed})"
+        ))
+        .with_hint(
+            "The build succeeded but the swap into the active binary path did not take effect.",
+        )
+        .with_hint(
+            "Verify the active binary is writable and on PATH, then re-run: homeboy upgrade --method source --force",
+        ),
+    )
 }
 
 /// Read back the active binary version after a successful swap, retrying while
@@ -838,6 +888,61 @@ mod tests {
         assert_eq!(
             active.and_then(|info| info.version).as_deref(),
             Some("0.158.0")
+        );
+    }
+
+    #[test]
+    fn source_swap_failure_errors_when_active_binary_unchanged() {
+        // Issue #5772: the source upgrade command exited 0 but the read-back
+        // proves the active binary was not replaced — fail loudly instead of a
+        // soft `upgraded: false` "completed".
+        let err = source_swap_failure(
+            InstallMethod::Source,
+            false,
+            Some("0.247.5"),
+            Some("homeboy 0.247.5+old"),
+        )
+        .expect("unverified source swap must surface an error");
+
+        assert!(err.message.contains("active binary was not replaced"));
+        assert!(err.message.contains("homeboy 0.247.5+old"));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("--method source")));
+    }
+
+    #[test]
+    fn source_swap_failure_reports_version_when_no_build_identity() {
+        let err = source_swap_failure(InstallMethod::Source, false, Some("0.247.5"), None)
+            .expect("unverified source swap must surface an error");
+
+        assert!(err.message.contains("0.247.5"));
+    }
+
+    #[test]
+    fn source_swap_failure_reports_placeholder_when_version_unverifiable() {
+        let err = source_swap_failure(InstallMethod::Source, false, None, None)
+            .expect("unverified source swap must surface an error");
+
+        assert!(err.message.contains("an unverifiable version"));
+    }
+
+    #[test]
+    fn source_swap_failure_silent_on_verified_swap() {
+        assert!(
+            source_swap_failure(InstallMethod::Source, true, Some("0.249.0"), None).is_none(),
+            "a verified source swap is not a failure"
+        );
+    }
+
+    #[test]
+    fn source_swap_failure_ignores_non_source_methods() {
+        // Non-source methods keep their soft unverified reporting; only source
+        // (where the swap is part of the command's contract) fails loudly here.
+        assert!(source_swap_failure(InstallMethod::Binary, false, Some("0.247.5"), None).is_none());
+        assert!(
+            source_swap_failure(InstallMethod::Secondary, false, Some("0.247.5"), None).is_none()
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes #5772 — `homeboy upgrade --method source` reported a soft "completed" result (`upgraded: false`, exit 0) even when the freshly built binary failed to replace the active binary, so operators believed an urgent roll-forward had succeeded when it had silently no-op'd.

## Root cause
`execute_upgrade` (`src/core/upgrade/execution.rs`) for the `Source` method runs the configured, agnostic source `upgrade_command` (build + swap the artifact over the active binary), then reads the active binary back via `verify_upgrade_with_retry`. When the shell command exits 0 but the read-back proves the active binary is unchanged (e.g. the artifact built but never installed over the active path, or `command -v homeboy` resolved a different binary than the one running), `verify_upgrade_with_retry` returns `success = false`. That `Ok((false, ...))` flowed up to `run_upgrade_with_method`, which still ran extension/runner sync and returned a soft `UpgradeResult { upgraded: false, message: "Upgrade command completed but active binary is still <old>" }` with a success exit — masking a genuine swap failure.

## Fix
For the `Source` method, when the upgrade command exits successfully but the active-binary read-back proves it was not replaced, return a loud, actionable `Err` (new `source_swap_failure` helper) instead of a soft `upgraded: false` completion. The swap is part of the source upgrade command's contract: an exit-0 that leaves the active binary unchanged is unambiguously a failure (this path is only reached when an update is available or `--force` is set, so an identical-version no-op cannot be a false positive). The error explains the build succeeded but the swap didn't take effect and points at re-running with `--force` after verifying the binary is writable/on PATH. Stays config-driven and agnostic — no swap logic hardcoded in core.

## Tests
- `source_swap_failure_errors_when_active_binary_unchanged`
- `source_swap_failure_reports_version_when_no_build_identity`
- `source_swap_failure_reports_placeholder_when_version_unverifiable`
- `source_swap_failure_silent_on_verified_swap`
- `source_swap_failure_ignores_non_source_methods`

`cargo build --lib` and `cargo clippy --lib` clean; `cargo fmt` applied.