### PR TITLE
Add fuzz inventory artifact contract

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -5,11 +5,12 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 ## Synopsis
 
 ```bash
-homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--max-duration <duration>] [-- <runner-args>]
-homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--max-duration <duration>] [-- <runner-args>]
+homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--max-duration <duration>] [-- <runner-args>]
+homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--max-duration <duration>] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
+homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>]
 homeboy fuzz validate <results-file>
-homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--output-envelope <path>]
+homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--inventory <path>] [--output-envelope <path>]
 homeboy fuzz replay [<case>] [--run-id <id>] [-- <runner-args>]
 ```
 
@@ -59,6 +60,16 @@ Runner scripts receive `HOMEBOY_FUZZ_RESULTS_FILE` pointing at
 `homeboy/fuzz-campaign/v1` campaign object there, `homeboy fuzz run` parses it
 and returns it as `results` in the JSON envelope. Malformed JSON fails the run
 instead of being treated as proof.
+
+`homeboy fuzz plan --inventory <path>`, `homeboy fuzz run --inventory <path>`,
+and `homeboy fuzz report --inventory <path>`
+accept a `homeboy/fuzz-target-inventory/v1` JSON file with discovered
+`surfaces`, `targets`, `workloads`, and `seeds`. Homeboy validates the inventory,
+merges it with the generated target inventory and declared workload metadata,
+embeds it in generated result envelope metadata when reporting, and exposes the
+path to runners as `HOMEBOY_FUZZ_INVENTORY_FILE`. The inventory contract is
+product-neutral; product-specific details belong in `metadata` or flattened extra
+fields on the inventory items.
 
 Campaigns can include a product-neutral coverage summary:
 

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -9,9 +9,10 @@ use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner};
 use homeboy::core::fuzz::{
     default_fuzz_gates, default_fuzz_required_artifacts, fuzz_core_contract,
-    parse_fuzz_results_file, FuzzCampaign, FuzzExecutionRequest, FuzzGate, FuzzProvenance,
-    FuzzRequiredArtifact, FuzzResultEnvelope, FuzzTargetInventory, FUZZ_CONTRACT_VERSION,
-    FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_RESULT_ENVELOPE_SCHEMA, FUZZ_TARGET_INVENTORY_SCHEMA,
+    merge_fuzz_target_inventory, parse_fuzz_results_file, parse_fuzz_target_inventory_file,
+    FuzzCampaign, FuzzExecutionRequest, FuzzGate, FuzzProvenance, FuzzRequiredArtifact,
+    FuzzResultEnvelope, FuzzTargetInventory, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
+    FUZZ_RESULT_ENVELOPE_SCHEMA, FUZZ_TARGET_INVENTORY_SCHEMA,
 };
 use homeboy::core::observation::{ObservationStore, RunRecord, RunStatus};
 use homeboy::core::rig::{self, RigSpec};
@@ -117,6 +118,10 @@ pub struct FuzzRunArgs {
     #[arg(long, value_name = "SEED")]
     seed: Option<String>,
 
+    /// Product-neutral fuzz target inventory JSON discovered before execution.
+    #[arg(long = "inventory", value_name = "PATH")]
+    inventory: Option<PathBuf>,
+
     /// Maximum runtime budget forwarded by future fuzz runners, e.g. 60s or 5m.
     #[arg(long, value_name = "DURATION")]
     max_duration: Option<String>,
@@ -217,8 +222,10 @@ pub struct FuzzRunOutput {
     pub workload_path: Option<String>,
     pub run_id: Option<String>,
     pub seed: Option<String>,
+    pub inventory_file: Option<String>,
     pub max_duration: Option<String>,
     pub passthrough_args: Vec<String>,
+    pub target_inventory: Option<FuzzTargetInventory>,
     pub execution: Option<FuzzExecutionOutput>,
     pub results: Option<FuzzCampaign>,
     pub runner_contract: FuzzRunnerContract,
@@ -436,24 +443,18 @@ fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutput> {
         .unwrap_or_else(|| format!("{}-fuzz-request", ctx.component_id));
     let rig_id = rig_context.as_ref().map(|context| context.spec.id.clone());
 
+    let target_inventory = build_target_inventory(
+        &ctx.component_id,
+        &workloads,
+        args.run.run_id.clone(),
+        args.run.inventory.as_deref(),
+    )?;
+
     Ok(FuzzPlanOutput {
         command: "fuzz.plan".to_string(),
         component: ctx.component_id.clone(),
         rig_id: rig_id.clone(),
-        target_inventory: FuzzTargetInventory {
-            schema: FUZZ_TARGET_INVENTORY_SCHEMA.to_string(),
-            version: FUZZ_CONTRACT_VERSION,
-            id: format!("{}-inventory", ctx.component_id),
-            surfaces: Vec::new(),
-            targets: Vec::new(),
-            workloads: Vec::new(),
-            seeds: Vec::new(),
-            provenance: Some(fuzz_provenance(args.run.run_id.clone())),
-            metadata: serde_json::json!({
-                "declared_workloads": workloads,
-            }),
-            extra: std::collections::BTreeMap::new(),
-        },
+        target_inventory,
         request: FuzzExecutionRequest {
             schema: FUZZ_EXECUTION_REQUEST_SCHEMA.to_string(),
             version: FUZZ_CONTRACT_VERSION,
@@ -509,6 +510,7 @@ fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzReportOutput> {
         .clone()
         .or_else(|| args.run.run_id.clone())
         .unwrap_or_else(|| campaign.id.clone());
+    let metadata = fuzz_result_metadata(args.run.inventory.as_deref())?;
     let envelope = FuzzResultEnvelope {
         schema: FUZZ_RESULT_ENVELOPE_SCHEMA.to_string(),
         version: FUZZ_CONTRACT_VERSION,
@@ -535,7 +537,7 @@ fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzReportOutput> {
         required_artifacts: default_fuzz_required_artifacts(),
         gates: default_fuzz_gates(),
         provenance: Some(fuzz_provenance(run_id)),
-        metadata: serde_json::Value::Null,
+        metadata,
         extra: std::collections::BTreeMap::new(),
     };
 
@@ -583,6 +585,12 @@ fn run_run(args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput, i32)> {
         ctx.extension_id.as_deref(),
     );
     let selected_workload = select_workload(&workloads, args.workload_id.as_deref())?;
+    let target_inventory = build_target_inventory(
+        &ctx.component_id,
+        &workloads,
+        args.run_id.clone(),
+        args.inventory.as_deref(),
+    )?;
     let run_dir = RunDir::create()?;
     let runner_output = run_fuzz_extension_script(&ctx, &args, selected_workload, &run_dir)?;
     let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
@@ -625,8 +633,12 @@ fn run_run(args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput, i32)> {
             workload_path,
             run_id: args.run_id,
             seed: args.seed,
+            inventory_file: args
+                .inventory
+                .map(|path| path.to_string_lossy().to_string()),
             max_duration: args.max_duration,
             passthrough_args: args.args,
+            target_inventory: Some(target_inventory),
             execution: Some(FuzzExecutionOutput {
                 kind: "fuzz".to_string(),
                 extension_id: ctx.extension_id.unwrap_or_default(),
@@ -762,9 +774,52 @@ fn default_runner_contract() -> FuzzRunnerContract {
             "HOMEBOY_FUZZ_WORKLOAD_PATH",
             "HOMEBOY_FUZZ_RUN_ID",
             "HOMEBOY_FUZZ_SEED",
+            "HOMEBOY_FUZZ_INVENTORY_FILE",
             "HOMEBOY_FUZZ_MAX_DURATION",
         ],
     }
+}
+
+fn build_target_inventory(
+    component_id: &str,
+    workloads: &[FuzzWorkloadOutput],
+    run_id: Option<String>,
+    inventory_path: Option<&Path>,
+) -> homeboy::core::Result<FuzzTargetInventory> {
+    let mut inventory = FuzzTargetInventory {
+        schema: FUZZ_TARGET_INVENTORY_SCHEMA.to_string(),
+        version: FUZZ_CONTRACT_VERSION,
+        id: format!("{}-inventory", component_id),
+        surfaces: Vec::new(),
+        targets: Vec::new(),
+        workloads: Vec::new(),
+        seeds: Vec::new(),
+        provenance: Some(fuzz_provenance(run_id)),
+        metadata: serde_json::json!({
+            "declared_workloads": workloads,
+        }),
+        extra: std::collections::BTreeMap::new(),
+    };
+
+    if let Some(path) = inventory_path {
+        let discovered = parse_fuzz_target_inventory_file(path)?;
+        inventory.metadata["inventory_file"] =
+            serde_json::Value::String(path.to_string_lossy().to_string());
+        merge_fuzz_target_inventory(&mut inventory, discovered);
+    }
+
+    Ok(inventory)
+}
+
+fn fuzz_result_metadata(inventory_path: Option<&Path>) -> homeboy::core::Result<serde_json::Value> {
+    let Some(path) = inventory_path else {
+        return Ok(serde_json::Value::Null);
+    };
+    let inventory = parse_fuzz_target_inventory_file(path)?;
+    Ok(serde_json::json!({
+        "inventory_file": path.to_string_lossy(),
+        "target_inventory": inventory,
+    }))
 }
 
 fn fuzz_provenance(run_id: Option<String>) -> FuzzProvenance {
@@ -961,6 +1016,12 @@ fn fuzz_runner_env(
     }
     push_opt_env(&mut env, "HOMEBOY_FUZZ_RUN_ID", args.run_id.as_ref());
     push_opt_env(&mut env, "HOMEBOY_FUZZ_SEED", args.seed.as_ref());
+    if let Some(path) = args.inventory.as_ref() {
+        env.push((
+            "HOMEBOY_FUZZ_INVENTORY_FILE".to_string(),
+            path.to_string_lossy().to_string(),
+        ));
+    }
     push_opt_env(
         &mut env,
         "HOMEBOY_FUZZ_MAX_DURATION",
@@ -1247,6 +1308,8 @@ mod tests {
             "proof-1",
             "--seed",
             "1234",
+            "--inventory",
+            "/tmp/fuzz-inventory.json",
             "--max-duration",
             "60s",
             "--",
@@ -1261,6 +1324,10 @@ mod tests {
                 assert_eq!(run.workload_id.as_deref(), Some("parser"));
                 assert_eq!(run.run_id.as_deref(), Some("proof-1"));
                 assert_eq!(run.seed.as_deref(), Some("1234"));
+                assert_eq!(
+                    run.inventory.as_deref(),
+                    Some(Path::new("/tmp/fuzz-inventory.json"))
+                );
                 assert_eq!(run.max_duration.as_deref(), Some("60s"));
                 assert_eq!(run.args, vec!["--engine", "libfuzzer"]);
             }
@@ -1298,8 +1365,10 @@ mod tests {
             workload_path: None,
             run_id: None,
             seed: None,
+            inventory_file: None,
             max_duration: None,
             passthrough_args: Vec::new(),
+            target_inventory: None,
             execution: None,
             results: None,
             runner_contract: FuzzRunnerContract {
@@ -1541,6 +1610,7 @@ mod tests {
             workload_id: Some("parser".to_string()),
             run_id: Some("proof-1".to_string()),
             seed: Some("1234".to_string()),
+            inventory: Some(PathBuf::from("/tmp/fuzz-inventory.json")),
             max_duration: Some("60s".to_string()),
             args: vec![],
         };
@@ -1567,6 +1637,10 @@ mod tests {
         )));
         assert!(env.contains(&("HOMEBOY_FUZZ_RUN_ID".to_string(), "proof-1".to_string())));
         assert!(env.contains(&("HOMEBOY_FUZZ_SEED".to_string(), "1234".to_string())));
+        assert!(env.contains(&(
+            "HOMEBOY_FUZZ_INVENTORY_FILE".to_string(),
+            "/tmp/fuzz-inventory.json".to_string()
+        )));
         assert!(env.contains(&("HOMEBOY_FUZZ_MAX_DURATION".to_string(), "60s".to_string())));
     }
 
@@ -1667,8 +1741,10 @@ mod tests {
             workload_path: None,
             run_id: None,
             seed: None,
+            inventory_file: None,
             max_duration: None,
             passthrough_args: Vec::new(),
+            target_inventory: None,
             execution: Some(FuzzExecutionOutput {
                 kind: "fuzz".to_string(),
                 extension_id: "generic".to_string(),

--- a/src/core/fuzz.rs
+++ b/src/core/fuzz.rs
@@ -161,6 +161,21 @@ pub struct FuzzTarget {
     pub extra: BTreeMap<String, Value>,
 }
 
+impl FuzzTarget {
+    fn normalize(&mut self) -> std::result::Result<(), String> {
+        self.schema = trim_or_default(&self.schema, FUZZ_TARGET_SCHEMA);
+        require_schema(&self.schema, FUZZ_TARGET_SCHEMA, "fuzz target")?;
+        self.id = required_trimmed("target.id", &self.id)?;
+        self.kind = required_trimmed("target.kind", &self.kind)?;
+        self.label = normalize_optional_string(self.label.take());
+        self.locator = normalize_optional_string(self.locator.take());
+        for operation in &mut self.operations {
+            operation.normalize()?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FuzzInput {
     pub name: String,
@@ -207,6 +222,19 @@ pub struct FuzzWorkload {
     pub metadata: Value,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, Value>,
+}
+
+impl FuzzWorkload {
+    fn normalize(&mut self) -> std::result::Result<(), String> {
+        self.schema = trim_or_default(&self.schema, FUZZ_WORKLOAD_SCHEMA);
+        require_schema(&self.schema, FUZZ_WORKLOAD_SCHEMA, "fuzz workload")?;
+        self.id = required_trimmed("workload.id", &self.id)?;
+        self.label = normalize_optional_string(self.label.take());
+        self.surface_ids = normalize_string_vec(std::mem::take(&mut self.surface_ids));
+        self.operations = normalize_string_vec(std::mem::take(&mut self.operations));
+        self.seed_ids = normalize_string_vec(std::mem::take(&mut self.seed_ids));
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -294,6 +322,19 @@ pub struct FuzzSeed {
     pub metadata: Value,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, Value>,
+}
+
+impl FuzzSeed {
+    fn normalize(&mut self) -> std::result::Result<(), String> {
+        self.schema = trim_or_default(&self.schema, FUZZ_SEED_SCHEMA);
+        require_schema(&self.schema, FUZZ_SEED_SCHEMA, "fuzz seed")?;
+        self.id = required_trimmed("seed.id", &self.id)?;
+        self.kind = required_trimmed("seed.kind", &self.kind)?;
+        self.label = normalize_optional_string(self.label.take());
+        self.value = normalize_optional_string(self.value.take());
+        self.tags = normalize_string_vec(std::mem::take(&mut self.tags));
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -505,6 +546,42 @@ pub struct FuzzTargetInventory {
     pub extra: BTreeMap<String, Value>,
 }
 
+impl FuzzTargetInventory {
+    pub fn from_value(value: Value) -> std::result::Result<Self, String> {
+        let mut inventory: Self = serde_json::from_value(value).map_err(|err| err.to_string())?;
+        inventory.normalize()?;
+        Ok(inventory)
+    }
+
+    fn normalize(&mut self) -> std::result::Result<(), String> {
+        self.schema = trim_or_default(&self.schema, FUZZ_TARGET_INVENTORY_SCHEMA);
+        require_schema(
+            &self.schema,
+            FUZZ_TARGET_INVENTORY_SCHEMA,
+            "fuzz target inventory",
+        )?;
+        if self.version != FUZZ_CONTRACT_VERSION {
+            return Err(format!(
+                "fuzz target inventory version must be {FUZZ_CONTRACT_VERSION}"
+            ));
+        }
+        self.id = required_trimmed("inventory.id", &self.id)?;
+        for surface in &mut self.surfaces {
+            surface.normalize()?;
+        }
+        for target in &mut self.targets {
+            target.normalize()?;
+        }
+        for workload in &mut self.workloads {
+            workload.normalize()?;
+        }
+        for seed in &mut self.seeds {
+            seed.normalize()?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FuzzExecutionRequest {
     #[serde(default = "fuzz_execution_request_schema")]
@@ -649,6 +726,68 @@ pub fn parse_fuzz_results_file(path: &Path) -> Result<FuzzCampaign> {
         ));
     }
     Ok(campaign)
+}
+
+pub fn parse_fuzz_target_inventory_file(path: &Path) -> Result<FuzzTargetInventory> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+    let value: Value = serde_json::from_str(&contents).map_err(|err| {
+        Error::validation_invalid_json(
+            err,
+            Some(format!(
+                "parse fuzz target inventory file {}",
+                path.display()
+            )),
+            Some(contents.clone()),
+        )
+    })?;
+    FuzzTargetInventory::from_value(value).map_err(|message| {
+        Error::validation_invalid_argument(
+            "inventory",
+            message,
+            Some(path.display().to_string()),
+            None,
+        )
+    })
+}
+
+pub fn merge_fuzz_target_inventory(
+    base: &mut FuzzTargetInventory,
+    mut discovered: FuzzTargetInventory,
+) {
+    base.surfaces.append(&mut discovered.surfaces);
+    base.targets.append(&mut discovered.targets);
+    base.workloads.append(&mut discovered.workloads);
+    base.seeds.append(&mut discovered.seeds);
+    if base.provenance.is_none() {
+        base.provenance = discovered.provenance;
+    }
+    merge_metadata(&mut base.metadata, discovered.metadata);
+    base.extra.append(&mut discovered.extra);
+}
+
+fn merge_metadata(base: &mut Value, discovered: Value) {
+    if discovered.is_null() {
+        return;
+    }
+    if base.is_null() {
+        *base = discovered;
+        return;
+    }
+    match (base, discovered) {
+        (Value::Object(base_map), Value::Object(incoming_map)) => {
+            for (key, value) in incoming_map {
+                base_map.entry(key).or_insert(value);
+            }
+        }
+        (base, incoming) => {
+            let previous = std::mem::take(base);
+            *base = serde_json::json!({
+                "homeboy_metadata": previous,
+                "merged_inventory_metadata": incoming,
+            });
+        }
+    }
 }
 
 pub fn default_fuzz_required_artifacts() -> Vec<FuzzRequiredArtifact> {
@@ -1169,5 +1308,81 @@ mod tests {
 
         assert_eq!(parsed.id, "campaign-1");
         assert_eq!(parsed.safety_class, FuzzSafetyClass::ReadOnly);
+    }
+
+    #[test]
+    fn parse_fuzz_target_inventory_file_reads_and_normalizes_inventory_contract() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("fuzz-inventory.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "schema": FUZZ_TARGET_INVENTORY_SCHEMA,
+                "id": " discovered ",
+                "surfaces": [{
+                    "id": " api ",
+                    "kind": " rest ",
+                    "safety_class": "read_only"
+                }],
+                "targets": [{
+                    "id": " target-1 ",
+                    "kind": " endpoint "
+                }],
+                "workloads": [{
+                    "id": " workload-1 ",
+                    "safety_class": "read_only",
+                    "surface_ids": [" api ", " "]
+                }],
+                "seeds": [{
+                    "id": " seed-1 ",
+                    "kind": " literal ",
+                    "tags": [" stable ", " "]
+                }]
+            })
+            .to_string(),
+        )
+        .expect("write fuzz inventory");
+
+        let parsed = parse_fuzz_target_inventory_file(&path).expect("parse fuzz inventory");
+
+        assert_eq!(parsed.id, "discovered");
+        assert_eq!(parsed.surfaces[0].id, "api");
+        assert_eq!(parsed.targets[0].kind, "endpoint");
+        assert_eq!(parsed.workloads[0].surface_ids, vec!["api"]);
+        assert_eq!(parsed.seeds[0].tags, vec!["stable"]);
+    }
+
+    #[test]
+    fn merge_fuzz_target_inventory_appends_discovered_contract_sections() {
+        let mut base = FuzzTargetInventory {
+            schema: FUZZ_TARGET_INVENTORY_SCHEMA.to_string(),
+            version: FUZZ_CONTRACT_VERSION,
+            id: "base".to_string(),
+            surfaces: Vec::new(),
+            targets: Vec::new(),
+            workloads: Vec::new(),
+            seeds: Vec::new(),
+            provenance: None,
+            metadata: json!({ "declared_workloads": [] }),
+            extra: BTreeMap::new(),
+        };
+        let discovered = FuzzTargetInventory::from_value(json!({
+            "schema": FUZZ_TARGET_INVENTORY_SCHEMA,
+            "id": "discovered",
+            "surfaces": [{
+                "id": "api",
+                "kind": "rest",
+                "safety_class": "read_only"
+            }],
+            "metadata": { "producer": "runner" }
+        }))
+        .expect("inventory contract");
+
+        merge_fuzz_target_inventory(&mut base, discovered);
+
+        assert_eq!(base.id, "base");
+        assert_eq!(base.surfaces.len(), 1);
+        assert_eq!(base.metadata["declared_workloads"], json!([]));
+        assert_eq!(base.metadata["producer"], "runner");
     }
 }


### PR DESCRIPTION
## Summary
- Accept product-neutral fuzz target inventory artifacts for plan/run/report.
- Validate and merge discovered inventory data with generated target inventory metadata.
- Expose the inventory file path to fuzz runners.

## Verification
- `rustfmt --check src/commands/fuzz.rs src/core/fuzz.rs`
- `git diff --check`

## Intended cargo verification
- `cargo test fuzz`
- `cargo test core::fuzz`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and formatting the generic fuzz core changes described above.