### PR TITLE
fix(agent-task): restore main CI — missing import + stale test fixtures

### DIFF
--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -74,7 +74,7 @@ use spec_compile::{
     compile_loop_spec_policy, compile_loop_spec_workflows, controller_spec_homeboy_plan,
     merge_policy_into_event_payload, reconcile_repo_loop_spec_actions, repo_loop_spec_fingerprint,
     repo_loop_spec_fingerprint_from_metadata, set_repo_loop_spec_metadata,
-    REPO_LOOP_SPEC_ACTION_REASON, REPO_LOOP_SPEC_WORKFLOW_REASON,
+    RepoLoopSpecReconciliation, REPO_LOOP_SPEC_ACTION_REASON, REPO_LOOP_SPEC_WORKFLOW_REASON,
 };
 
 /// Create a new durable controller record.

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -1833,7 +1833,10 @@ mod tests {
             owner: "Extra-Chill".into(),
             repo: "homeboy".into(),
             number: 42,
+            url: "https://github.com/Extra-Chill/homeboy/pull/42".into(),
+            title: None,
             state: "OPEN".into(),
+            draft: false,
             author: None,
             base: "main".into(),
             head: "feature".into(),
@@ -1844,6 +1847,7 @@ mod tests {
             merge_state: Some("CLEAN".into()),
             ci_state: "terminal_green".into(),
             ci_summary: "1 check(s): 1 terminal-green, 0 failed/unknown, 0 pending".into(),
+            ci_next_action: "merge_ready".into(),
         };
 
         let item = pr_fleet_item("42", &view, GithubPrCheckRollup::default());
@@ -1859,7 +1863,10 @@ mod tests {
             owner: "Extra-Chill".into(),
             repo: "homeboy".into(),
             number: 42,
+            url: "https://github.com/Extra-Chill/homeboy/pull/42".into(),
+            title: None,
             state: "OPEN".into(),
+            draft: false,
             author: None,
             base: "main".into(),
             head: "feature".into(),
@@ -1870,6 +1877,7 @@ mod tests {
             merge_state: Some("BEHIND".into()),
             ci_state: "terminal_green".into(),
             ci_summary: "1 check(s): 1 terminal-green, 0 failed/unknown, 0 pending".into(),
+            ci_next_action: "merge_ready".into(),
         };
 
         let item = pr_fleet_item("42", &view, GithubPrCheckRollup::default());

--- a/src/core/triage/tests.rs
+++ b/src/core/triage/tests.rs
@@ -944,6 +944,8 @@ mod pull_requests {
             state: "OPEN".to_string(),
             base_branch: Some(base_branch.to_string()),
             head_branch: Some(head_branch.to_string()),
+            mergeability_state: TriageLandingMergeabilityState::Clean,
+            check_state: TriageLandingCheckState::Clean,
             head_repo: Some(head_repo.to_string()),
             classification: TriageLandingClassification::CleanMergeable,
             suggested_next_command: format!(


### PR DESCRIPTION
## Summary
Main was RED with compile breaks blocking all CI. This restores a clean `cargo build --lib --tests`.

## Fixes
- **E0433** `src/core/agent_task_controller_service/mod.rs:104` — `RepoLoopSpecReconciliation` used but not imported. Added it to the existing `use spec_compile::{...}` block.
- **E0063 (x2)** `src/core/git/github.rs` — two `GithubPrView` test fixtures missing `url`, `title`, `draft`, `ci_next_action` fields. Filled them in.
- **E0063** `src/core/triage/tests.rs:939` — `TriageLandingPr` fixture missing `mergeability_state` and `check_state`. Added `Clean`/`Clean` to match the fixture's `CleanMergeable` classification.

## Verification
- `cargo build --lib --tests` compiles clean (no errors).
- `cargo fmt` applied (only to the three touched files).