### PR TITLE
Fail release packages missing frontend assets

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -663,6 +663,29 @@ mod tests {
     }
 
     #[test]
+    fn package_success_output_fails_when_frontend_assets_are_missing() {
+        let response = serde_json::json!({
+            "success": true,
+            "exitCode": 0,
+            "stdout": "[{\"path\":\"build/studio-native.zip\",\"type\":\"archive\"}]",
+            "stderr": concat!(
+                "[SUCCESS] All nested packages built successfully\n",
+                "[WARNING] Build completed with frontend warnings\n",
+                "[WARNING] Frontend assets were NOT included.\n",
+                "[WARNING] Fix the frontend build to include JS/CSS.\n"
+            ),
+        });
+        let mut state = crate::core::release::types::ReleaseState::default();
+
+        let err = store_artifacts_from_output(&mut state, &response)
+            .expect_err("missing required frontend assets should fail package validation");
+
+        assert!(err.message.contains("required frontend assets"));
+        assert!(err.message.contains("Frontend assets were NOT included"));
+        assert!(state.artifacts.is_empty());
+    }
+
+    #[test]
     fn package_success_with_valid_json_still_works() {
         // Regression guard: the new success-first check must not break the
         // happy path.

--- a/src/core/release/executor/package.rs
+++ b/src/core/release/executor/package.rs
@@ -342,6 +342,10 @@ pub(super) fn store_artifacts_from_output(
         ));
     }
 
+    if package_output_reports_missing_frontend_assets(stdout, stderr) {
+        return Err(package_missing_frontend_assets_error(stdout, stderr));
+    }
+
     let raw_artifacts: serde_json::Value = serde_json::from_str(stdout).map_err(|e| {
         Error::internal_json(
             e.to_string(),
@@ -382,6 +386,28 @@ fn package_command_failure_error(exit_code: i64, stdout: &str, stderr: &str) -> 
     // actual error to stderr; the operator needs both to see what happened
     // before the crash.
     if has_stderr && has_stdout {
+        detail.push_str("\n\n--- stdout ---\n");
+        detail.push_str(stdout_trimmed);
+    }
+
+    Error::internal_unexpected(detail)
+}
+
+fn package_output_reports_missing_frontend_assets(stdout: &str, stderr: &str) -> bool {
+    let output = format!("{}\n{}", stdout, stderr).to_ascii_lowercase();
+    output.contains("frontend assets were not included")
+}
+
+fn package_missing_frontend_assets_error(stdout: &str, stderr: &str) -> Error {
+    let mut detail = "Package command completed without required frontend assets".to_string();
+
+    let stderr_trimmed = stderr.trim();
+    let stdout_trimmed = stdout.trim();
+    if !stderr_trimmed.is_empty() {
+        detail.push_str(": ");
+        detail.push_str(stderr_trimmed);
+    }
+    if !stdout_trimmed.is_empty() {
         detail.push_str("\n\n--- stdout ---\n");
         detail.push_str(stdout_trimmed);
     }


### PR DESCRIPTION
## Summary
- fail release package validation when package output reports missing frontend assets
- surface captured stdout/stderr in the package error
- add regression coverage for the Studio Native missing-assets failure shape

## Verification
- rustfmt --check on touched Rust files
- git diff --check

Cargo tests were not run locally per workstation rules; CI should run release executor package tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode, delegated coding subagent
- **Used for:** implementation, regression coverage, and verification planning