### PR TITLE
Apply Enterprise proxy to release gh calls

### DIFF
--- a/src/core/git/gh_client.rs
+++ b/src/core/git/gh_client.rs
@@ -172,17 +172,18 @@ pub fn github_cli_env(host: &str, config: &GithubConfig) -> Vec<(String, String)
         env.push(("GH_HOST".to_string(), host.to_string()));
     }
 
-    let Some(host_config) = config.hosts.get(host) else {
-        return env;
-    };
-
+    let host_config = config.hosts.get(host);
     if let Some(proxy) = host_config
-        .proxy
-        .as_deref()
+        .and_then(|host_config| host_config.proxy.clone())
+        .or_else(|| inherited_enterprise_https_proxy(host))
         .filter(|proxy| !proxy.is_empty())
     {
-        env.push(("HTTPS_PROXY".to_string(), proxy.to_string()));
+        env.push(("HTTPS_PROXY".to_string(), proxy));
     }
+
+    let Some(host_config) = host_config else {
+        return env;
+    };
 
     for (key, value) in &host_config.env {
         if !key.is_empty() && key != "GH_HOST" {
@@ -192,6 +193,18 @@ pub fn github_cli_env(host: &str, config: &GithubConfig) -> Vec<(String, String)
     }
 
     env
+}
+
+fn inherited_enterprise_https_proxy(host: &str) -> Option<String> {
+    if host == "github.com" {
+        return None;
+    }
+
+    std::env::var("HTTPS_PROXY")
+        .or_else(|_| std::env::var("https_proxy"))
+        .ok()
+        .map(|proxy| proxy.trim().to_string())
+        .filter(|proxy| !proxy.is_empty())
 }
 
 #[cfg(test)]
@@ -216,7 +229,7 @@ mod tests {
         hosts.insert(
             "github.example.com".to_string(),
             GithubHostConfig {
-                proxy: Some("socks5://127.0.0.1:8080".to_string()),
+                proxy: Some("https://proxy.example.test:8443".to_string()),
                 env: HashMap::new(),
             },
         );
@@ -227,7 +240,37 @@ mod tests {
         assert!(env.contains(&("GH_HOST".to_string(), "github.example.com".to_string())));
         assert!(env.contains(&(
             "HTTPS_PROXY".to_string(),
-            "socks5://127.0.0.1:8080".to_string()
+            "https://proxy.example.test:8443".to_string()
+        )));
+    }
+
+    #[test]
+    fn github_cli_env_sets_enterprise_host_without_implicit_proxy() {
+        let env = github_cli_env("github.enterprise.test", &GithubConfig::default());
+
+        assert_eq!(
+            env,
+            vec![("GH_HOST".to_string(), "github.enterprise.test".to_string())]
+        );
+    }
+
+    #[test]
+    fn github_cli_env_uses_configured_enterprise_proxy() {
+        let mut hosts = HashMap::new();
+        hosts.insert(
+            "github.enterprise.test".to_string(),
+            GithubHostConfig {
+                proxy: Some("https://proxy.example.test:9443".to_string()),
+                env: HashMap::new(),
+            },
+        );
+        let config = GithubConfig { hosts };
+
+        let env = github_cli_env("github.enterprise.test", &config);
+
+        assert!(env.contains(&(
+            "HTTPS_PROXY".to_string(),
+            "https://proxy.example.test:9443".to_string()
         )));
     }
 }

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -1000,31 +1000,7 @@ fn gh_command(github: &GitHubRepo, config: &GithubConfig, args: &[&str]) -> std:
 }
 
 pub(super) fn github_cli_env(github: &GitHubRepo, config: &GithubConfig) -> Vec<(String, String)> {
-    let mut env = Vec::new();
-    if github.host != "github.com" {
-        env.push(("GH_HOST".to_string(), github.host.clone()));
-    }
-
-    let Some(host_config) = config.hosts.get(&github.host) else {
-        return env;
-    };
-
-    if let Some(proxy) = host_config
-        .proxy
-        .as_deref()
-        .filter(|proxy| !proxy.is_empty())
-    {
-        env.push(("HTTPS_PROXY".to_string(), proxy.to_string()));
-    }
-
-    for (key, value) in &host_config.env {
-        if !key.is_empty() && key != "GH_HOST" {
-            env.retain(|(existing, _)| existing != key);
-            env.push((key.clone(), value.clone()));
-        }
-    }
-
-    env
+    crate::core::git::github_cli_env(&github.host, config)
 }
 
 #[cfg(test)]
@@ -1341,6 +1317,46 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn repair_commands_include_configured_enterprise_proxy() {
+        let github = GitHubRepo {
+            host: "github.enterprise.test".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        };
+        let config = GithubConfig {
+            hosts: HashMap::from([(
+                "github.enterprise.test".to_string(),
+                GithubHostConfig {
+                    proxy: Some("https://proxy.example.test:8443".to_string()),
+                    env: HashMap::new(),
+                },
+            )]),
+        };
+
+        let repair = github_release_repair_commands(
+            "v1.2.3",
+            &github,
+            &config,
+            &[],
+            None,
+            Some("build/v1.2.3-release-notes.md"),
+        );
+
+        assert!(repair.create_command.starts_with(
+            "GH_HOST=github.enterprise.test HTTPS_PROXY=https://proxy.example.test:8443 gh release create v1.2.3"
+        ));
+        assert_eq!(
+            repair.view_command,
+            "GH_HOST=github.enterprise.test HTTPS_PROXY=https://proxy.example.test:8443 gh release view v1.2.3 -R owner/repo"
+        );
+        assert!(repair
+            .env_hint
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Configured HTTPS_PROXY is included"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- centralize GitHub CLI release environment handling
- apply only locally configured Enterprise proxy environment for release operations
- include configured proxy env in generated repair commands without hardcoding any host-specific proxy defaults

## Verification
- rustfmt on touched Rust files
- git diff --check
- grep confirmed no hardcoded Automattic host/proxy defaults in the changed files

Cargo tests were not run locally per workstation rules; CI should run GitHub CLI env/release repair command tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode, delegated coding subagent
- **Used for:** implementation, regression coverage, correction of generic host/proxy behavior, and verification planning