### PR TITLE
Ignore generated release artifacts in deploy gate

### DIFF
--- a/src/core/cleanup.rs
+++ b/src/core/cleanup.rs
@@ -13,6 +13,7 @@ use self_artifacts::validate_homeboy_manifest_dir;
 use self_artifacts::{homeboy_source_checkout, self_temp_artifact_candidates};
 
 const BUILTIN_ARTIFACT_PATHS: &[(&str, &str)] = &[
+    ("build", "generated_build"),
     ("target", "build_target"),
     ("node_modules", "node_modules"),
     ("dist", "generated_dist"),
@@ -84,10 +85,10 @@ struct WorktreeInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ArtifactDeclaration {
-    relative_path: String,
-    kind: String,
-    declared_by: String,
+pub(crate) struct ArtifactDeclaration {
+    pub(crate) relative_path: String,
+    pub(crate) kind: String,
+    pub(crate) declared_by: String,
 }
 
 #[derive(Debug, Default)]
@@ -251,7 +252,7 @@ fn discover_worktrees(root: &Path) -> Result<Vec<WorktreeInfo>> {
     Ok(worktrees)
 }
 
-fn artifact_declarations(worktree: &Path) -> Result<Vec<ArtifactDeclaration>> {
+pub(crate) fn artifact_declarations(worktree: &Path) -> Result<Vec<ArtifactDeclaration>> {
     let mut declarations = Vec::new();
     for (relative_path, kind) in BUILTIN_ARTIFACT_PATHS {
         declarations.push(ArtifactDeclaration {
@@ -407,7 +408,7 @@ fn skip_row(
     }
 }
 
-fn is_safe_artifact_path(relative_path: &str) -> bool {
+pub(crate) fn is_safe_artifact_path(relative_path: &str) -> bool {
     let path = Path::new(relative_path);
     !relative_path.is_empty()
         && relative_path != "."

--- a/src/core/deploy/generated_artifacts.rs
+++ b/src/core/deploy/generated_artifacts.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::core::cleanup;
 use crate::core::component::Component;
 use crate::core::defaults::deploy_generated_build_dir;
 use crate::core::error::Result;
@@ -13,10 +14,25 @@ pub(super) fn is_generated_build_path(rel_path: &str) -> bool {
 pub(super) fn unexpected_uncommitted_files_excluding_generated_build(
     component: &Component,
 ) -> Result<Vec<String>> {
+    Ok(uncommitted_file_report_excluding_known_generated(component)?.unexpected)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct UncommittedFileReport {
+    pub(super) unexpected: Vec<String>,
+    pub(super) known_generated: Vec<String>,
+}
+
+pub(super) fn uncommitted_file_report_excluding_known_generated(
+    component: &Component,
+) -> Result<UncommittedFileReport> {
     let local_path = &component.local_path;
     let uncommitted = git::get_uncommitted_changes(local_path)?;
     if !uncommitted.has_changes {
-        return Ok(Vec::new());
+        return Ok(UncommittedFileReport {
+            unexpected: Vec::new(),
+            known_generated: Vec::new(),
+        });
     }
 
     let mut unexpected: Vec<String> = uncommitted
@@ -27,16 +43,65 @@ pub(super) fn unexpected_uncommitted_files_excluding_generated_build(
         .cloned()
         .collect();
 
+    let mut known_generated: Vec<String> = uncommitted
+        .untracked
+        .iter()
+        .filter(|path| is_known_generated_untracked_path(component, path))
+        .cloned()
+        .collect();
+
     unexpected.extend(
         uncommitted
             .untracked
             .iter()
-            .filter(|path| !is_generated_build_path(path))
-            .filter(|path| !is_deploy_target_debris_path(component, path))
+            .filter(|path| !known_generated.contains(path))
             .cloned(),
     );
 
-    Ok(unexpected)
+    known_generated.sort();
+    known_generated.dedup();
+
+    Ok(UncommittedFileReport {
+        unexpected,
+        known_generated,
+    })
+}
+
+fn is_known_generated_untracked_path(component: &Component, rel_path: &str) -> bool {
+    is_generated_build_path(rel_path)
+        || is_deploy_target_debris_path(component, rel_path)
+        || is_declared_artifact_path(component, rel_path)
+        || is_root_package_archive(rel_path)
+}
+
+fn is_declared_artifact_path(component: &Component, rel_path: &str) -> bool {
+    if component.cleanup_artifacts.iter().any(|artifact| {
+        artifact.path.as_deref().is_some_and(|path| {
+            cleanup::is_safe_artifact_path(path) && path_is_at_or_under(rel_path, path)
+        }) || artifact.glob.as_deref().is_some_and(|pattern| {
+            glob_match::glob_match(pattern, rel_path.trim_end_matches('/'))
+                || glob_match::glob_match(pattern, rel_path)
+        })
+    }) {
+        return true;
+    }
+
+    cleanup::artifact_declarations(Path::new(&component.local_path))
+        .map(|declarations| {
+            declarations.iter().any(|declaration| {
+                cleanup::is_safe_artifact_path(&declaration.relative_path)
+                    && path_is_at_or_under(rel_path, &declaration.relative_path)
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn path_is_at_or_under(path: &str, root: &str) -> bool {
+    path == root || path.starts_with(&format!("{}/", root.trim_end_matches('/')))
+}
+
+fn is_root_package_archive(rel_path: &str) -> bool {
+    !rel_path.contains('/') && (rel_path.ends_with(".tgz") || rel_path.ends_with(".zip"))
 }
 
 fn is_deploy_target_debris_path(component: &Component, rel_path: &str) -> bool {
@@ -125,9 +190,10 @@ impl Drop for GeneratedBuildArtifactCleanupGuard<'_> {
 mod tests {
     use super::{
         cleanup_generated_build_artifacts, is_deploy_target_debris_path, is_generated_build_path,
+        uncommitted_file_report_excluding_known_generated,
         unexpected_uncommitted_files_excluding_generated_build,
     };
-    use crate::core::component::Component;
+    use crate::core::component::{CleanupArtifactDeclaration, Component};
     use crate::core::defaults::deploy_generated_build_dir;
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
@@ -185,6 +251,70 @@ mod tests {
             unexpected_uncommitted_files_excluding_generated_build(&component).expect("status");
 
         assert_eq!(unexpected, vec!["src.rs"]);
+    }
+
+    #[test]
+    fn uncommitted_report_classifies_declared_cleanup_paths_and_archives() {
+        let temp = git_repo();
+        let dir = temp.path();
+        std::fs::create_dir_all(dir.join("plugins/agentic-ui-block/app/tools/common"))
+            .expect("tracked parent dir");
+        std::fs::write(
+            dir.join("plugins/agentic-ui-block/app/tools/common/.keep"),
+            "tracked\n",
+        )
+        .expect("tracked parent file");
+        std::fs::create_dir_all(dir.join("runtime")).expect("tracked runtime parent dir");
+        std::fs::write(dir.join("runtime/.keep"), "tracked\n")
+            .expect("tracked runtime parent file");
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "chore: tracked parent"]);
+        std::fs::write(
+            dir.join("homeboy.json"),
+            r#"{"artifact_cleanup_paths":["plugins/agentic-ui-block/app/tools/common/dist"]}"#,
+        )
+        .expect("homeboy config");
+        std::fs::create_dir_all(dir.join("build")).expect("build dir");
+        std::fs::write(dir.join("build/studio-native.zip"), "artifact").expect("build artifact");
+        std::fs::create_dir_all(dir.join("plugins/agentic-ui-block/app/tools/common/dist"))
+            .expect("dist dir");
+        std::fs::write(
+            dir.join("plugins/agentic-ui-block/app/tools/common/dist/index.js"),
+            "generated",
+        )
+        .expect("dist artifact");
+        std::fs::write(dir.join("wp-codebox-workspace-0.9.0.tgz"), "package")
+            .expect("package artifact");
+        std::fs::create_dir_all(dir.join("runtime/generated-fixture")).expect("runtime artifact");
+        std::fs::write(
+            dir.join("runtime/generated-fixture/output.json"),
+            "generated",
+        )
+        .expect("runtime artifact file");
+        std::fs::write(dir.join("src.rs"), "source\n").expect("source");
+
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            cleanup_artifacts: vec![CleanupArtifactDeclaration {
+                label: "runtime fixture".to_string(),
+                path: Some("runtime/generated-fixture".to_string()),
+                glob: None,
+            }],
+            ..Component::default()
+        };
+        let report = uncommitted_file_report_excluding_known_generated(&component).expect("status");
+
+        assert_eq!(report.unexpected, vec!["homeboy.json", "src.rs"]);
+        assert!(report.known_generated.contains(&"build/".to_string()));
+        assert!(report
+            .known_generated
+            .contains(&"plugins/agentic-ui-block/app/tools/common/dist/".to_string()));
+        assert!(report
+            .known_generated
+            .contains(&"wp-codebox-workspace-0.9.0.tgz".to_string()));
+        assert!(report
+            .known_generated
+            .contains(&"runtime/generated-fixture/".to_string()));
     }
 
     #[test]

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -10,7 +10,7 @@ use crate::core::release::version;
 use super::execution::{
     execute_preflighted_component_deploy, prepare_component_deploy, PreparedComponentDeploy,
 };
-use super::generated_artifacts::unexpected_uncommitted_files_excluding_generated_build;
+use super::generated_artifacts::uncommitted_file_report_excluding_known_generated;
 use super::orchestration_tag_checkout::{
     checkout_deploy_tags, deploy_tag_for_version, restore_branches, TagCheckout,
 };
@@ -641,7 +641,7 @@ fn check_uncommitted_changes(components: &[Component]) -> Result<()> {
     // nonexistent uncommitted-changes problem when the real issue is that
     // local_path doesn't point at a git checkout. (#1141)
     let mut non_git: Vec<&Component> = Vec::new();
-    let mut dirty: Vec<&str> = Vec::new();
+    let mut dirty: Vec<DirtyComponent> = Vec::new();
 
     for component in components {
         if component.is_file_component() {
@@ -651,9 +651,18 @@ fn check_uncommitted_changes(components: &[Component]) -> Result<()> {
             non_git.push(component);
             continue;
         }
-        match unexpected_uncommitted_files_excluding_generated_build(component) {
-            Ok(unexpected) if unexpected.is_empty() => {}
-            Ok(_) | Err(_) => dirty.push(component.id.as_str()),
+        match uncommitted_file_report_excluding_known_generated(component) {
+            Ok(report) if report.unexpected.is_empty() => {}
+            Ok(report) => dirty.push(DirtyComponent {
+                id: component.id.clone(),
+                unexpected_paths: report.unexpected,
+                known_generated_paths: report.known_generated,
+            }),
+            Err(_) => dirty.push(DirtyComponent {
+                id: component.id.clone(),
+                unexpected_paths: Vec::new(),
+                known_generated_paths: Vec::new(),
+            }),
         }
     }
 
@@ -689,18 +698,57 @@ fn check_uncommitted_changes(components: &[Component]) -> Result<()> {
     }
 
     if !dirty.is_empty() {
+        let dirty_ids: Vec<&str> = dirty.iter().map(|row| row.id.as_str()).collect();
         return Err(Error::validation_invalid_argument(
             "components",
-            format!("Components have uncommitted changes: {}", dirty.join(", ")),
+            format!(
+                "Components have uncommitted changes: {}. {}",
+                dirty_ids.join(", "),
+                dirty_worktree_path_summary(&dirty)
+            ),
             None,
             Some(vec![
                 "Commit your changes before deploying to ensure deployed code is tracked"
+                    .to_string(),
+                "Known generated artifacts are ignored by the deploy dirty gate; remove them with `homeboy cleanup --apply` if you want a clean worktree"
                     .to_string(),
                 "Use --force to deploy anyway".to_string(),
             ]),
         ));
     }
     Ok(())
+}
+
+struct DirtyComponent {
+    id: String,
+    unexpected_paths: Vec<String>,
+    known_generated_paths: Vec<String>,
+}
+
+fn dirty_worktree_path_summary(dirty: &[DirtyComponent]) -> String {
+    dirty
+        .iter()
+        .map(|row| {
+            let unexpected = if row.unexpected_paths.is_empty() {
+                "<unable to read git status>".to_string()
+            } else {
+                row.unexpected_paths.join(", ")
+            };
+            let known_generated = if row.known_generated_paths.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "; known generated artifacts ignored: {}",
+                    row.known_generated_paths.join(", ")
+                )
+            };
+            format!(
+                "{} unexpected paths: {}{}",
+                row.id, unexpected, known_generated
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 /// Fetch and pull latest changes for each component before deploying.
@@ -1304,6 +1352,9 @@ mod tests {
             .expect_err("source changes should still block deploy");
 
         assert!(err.message.contains("uncommitted changes"));
+        assert!(err.message.contains("src.rs"));
+        assert!(err.message.contains("known generated artifacts ignored"));
+        assert!(err.message.contains(".homeboy-build/"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- classify release/build leftovers as reconstructable generated artifacts
- keep deploy dirty gate focused on real source changes
- improve dirty-worktree diagnostics with exact path classification

## Verification
- rustfmt on touched Rust files
- git diff --check

Cargo tests were not run locally per workstation rules; CI should run cleanup/deploy generated artifact tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode, delegated coding subagent
- **Used for:** implementation, targeted test updates, and verification planning