### PR TITLE
Fix controller reconciliation import

### DIFF
--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -74,7 +74,7 @@ use spec_compile::{
     compile_loop_spec_policy, compile_loop_spec_workflows, controller_spec_homeboy_plan,
     merge_policy_into_event_payload, reconcile_repo_loop_spec_actions, repo_loop_spec_fingerprint,
     repo_loop_spec_fingerprint_from_metadata, set_repo_loop_spec_metadata,
-    REPO_LOOP_SPEC_ACTION_REASON, REPO_LOOP_SPEC_WORKFLOW_REASON,
+    RepoLoopSpecReconciliation, REPO_LOOP_SPEC_ACTION_REASON, REPO_LOOP_SPEC_WORKFLOW_REASON,
 };
 
 /// Create a new durable controller record.


### PR DESCRIPTION
## Summary
- Import RepoLoopSpecReconciliation where init_from_spec uses it.
- Fixes the release build failure from run https://github.com/Extra-Chill/homeboy/actions/runs/27927697339/job/82633488829.

## Tests
- git diff --check
- Did not run local Cargo because this environment prohibits local Cargo commands; CI release/build verifies the Rust compile path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the release build failure and applying the minimal import fix.
