### PR TITLE
fix(audit): resolve dead-code in phase_timing (#5844)

### DIFF
--- a/src/core/phase_timing.rs
+++ b/src/core/phase_timing.rs
@@ -203,6 +203,7 @@ pub struct PhaseGuard<'a> {
 impl PhaseGuard<'_> {
     /// Mark the in-flight phase as failed; it will be recorded as `failed`
     /// (with its duration) when the guard is dropped.
+    #[allow(dead_code)] // Error-path counterpart to the guard's `ok` default; part of the PhaseGuard RAII API and covered by tests.
     pub fn mark_failed(&mut self) {
         self.status = PhaseStatus::Failed;
     }


### PR DESCRIPTION
## Summary
Resolves the `phase_timing.rs` dead-code finding from #5844.

`PhaseGuard::mark_failed` is the intentional error-path counterpart to the guard's default `ok` status — part of the `PhaseGuard` RAII API and covered by the `guard_can_be_marked_failed` unit test, but it has no production caller yet. Added `#[allow(dead_code)]` with a documented reason (matching the existing codebase convention, e.g. `code_audit/impact.rs`) so the audit recognizes it as an intentional suppression rather than removing a tested public API.

The other two findings (`agent_task_deterministic_loop.rs::agent_task_loop_spec`, `deterministic_loop.rs::validate_deterministic_loop_result`) are part of Fleet's active deterministic-loop work and were intentionally left untouched.

## Verification
- `homeboy audit homeboy` — `phase_timing.rs` now reports as a `DeadCodeMarker` (intentional suppression) instead of an `UnreferencedExport` finding
- `cargo build --lib` clean
- `cargo fmt` applied

Closes #5844 (partial — phase_timing only).