### PR TITLE
fix(audit): remove dead code in phase_timing (#5863)

### DIFF
--- a/src/core/phase_timing.rs
+++ b/src/core/phase_timing.rs
@@ -91,8 +91,9 @@ impl PhaseTimingReport {
 ///
 /// The timer is the generic primitive every hot command can reuse. It records
 /// durations the moment a phase completes, so partial data survives an early
-/// return or a hard failure mid-workflow — call `record_failed` (or use a
-/// [`PhaseGuard`]) so timing is still finalized on the error path.
+/// return or a hard failure mid-workflow — call `record_failed` so timing is
+/// still finalized on the error path, or use a [`PhaseGuard`] to finalize an
+/// `ok` span automatically on scope exit.
 #[derive(Debug, Clone, Default)]
 pub struct PhaseTimer {
     spans: Vec<PhaseSpan>,
@@ -150,14 +151,13 @@ impl PhaseTimer {
 
     /// Start a scoped phase guard. The guard records the phase on drop, so an
     /// early return or panic between `start` and the end of the scope still
-    /// finalizes timing. The phase is recorded as `ok` unless explicitly marked
-    /// failed (see [`PhaseGuard::mark_failed`]).
+    /// finalizes timing. The phase is recorded as `ok`, or dropped without
+    /// recording via [`PhaseGuard::disarm`].
     pub fn start(&mut self, id: impl Into<String>) -> PhaseGuard<'_> {
         PhaseGuard {
             timer: self,
             id: id.into(),
             started: Instant::now(),
-            status: PhaseStatus::Ok,
             disarmed: false,
         }
     }
@@ -187,27 +187,18 @@ impl PhaseTimer {
 /// RAII scope that records a phase span when dropped.
 ///
 /// Guarantees timing is finalized even on an early return or a panic — the key
-/// requirement for the error path. Defaults to `ok`; call [`mark_failed`] to
-/// record the phase as failed instead, or [`disarm`] to drop without recording.
+/// requirement for the error path. Records the phase as `ok` on drop, or
+/// drops without recording via [`disarm`].
 ///
-/// [`mark_failed`]: PhaseGuard::mark_failed
 /// [`disarm`]: PhaseGuard::disarm
 pub struct PhaseGuard<'a> {
     timer: &'a mut PhaseTimer,
     id: String,
     started: Instant,
-    status: PhaseStatus,
     disarmed: bool,
 }
 
 impl PhaseGuard<'_> {
-    /// Mark the in-flight phase as failed; it will be recorded as `failed`
-    /// (with its duration) when the guard is dropped.
-    #[allow(dead_code)] // Error-path counterpart to the guard's `ok` default; part of the PhaseGuard RAII API and covered by tests.
-    pub fn mark_failed(&mut self) {
-        self.status = PhaseStatus::Failed;
-    }
-
     /// Drop the guard without recording a span (e.g. the phase was skipped
     /// after the guard was created).
     pub fn disarm(mut self) {
@@ -222,11 +213,8 @@ impl Drop for PhaseGuard<'_> {
         }
         let elapsed = self.started.elapsed();
         let id = std::mem::take(&mut self.id);
-        match self.status {
-            PhaseStatus::Failed => self.timer.record_failed(id, elapsed),
-            // Skipped never carries a duration; a guard always timed work.
-            _ => self.timer.record_ok(id, elapsed),
-        }
+        // A guard always timed work, so it records an `ok` span on drop.
+        self.timer.record_ok(id, elapsed);
     }
 }
 
@@ -302,17 +290,6 @@ mod tests {
         let full = full_timer.into_report();
         let ids: Vec<&str> = full.spans.iter().map(|s| s.id.as_str()).collect();
         assert_eq!(ids, vec!["prepare", "execute"]);
-    }
-
-    #[test]
-    fn guard_can_be_marked_failed() {
-        let mut timer = PhaseTimer::new();
-        {
-            let mut guard = timer.start("execute");
-            guard.mark_failed();
-        }
-        let report = timer.into_report();
-        assert_eq!(report.spans[0].status, PhaseStatus::Failed);
     }
 
     #[test]


### PR DESCRIPTION
Closes #5863. Removes unreferenced `mark_failed`.

`PhaseGuard::mark_failed` was flagged dead (allow_dead_code marker + unreferenced_export). It was only referenced by its own test and doc comments — no production caller. Deleted the function and its `#[allow(dead_code)]` marker.

Since `mark_failed` was the only writer of the guard `status` field, the guard could only ever record `ok`. Simplified accordingly:
- Removed the `status` field from `PhaseGuard`.
- `Drop` now always records an `ok` span (unless disarmed).
- Removed the `guard_can_be_marked_failed` test and updated doc comments.

`record_failed` / `PhaseStatus::Failed` remain in use via `PhaseTimer::time()`.

Verified with `cargo build --lib` (clean, no new warnings) and `cargo fmt`.