### PR TITLE
refactor(core): de-hardcode ecosystem terms in dead_code detector (#5876)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -493,17 +493,12 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-06-20T15:43:14Z",
-      "item_count": 381,
+      "item_count": 376,
       "known_fingerprints": [
         "compiler::src/core/deploy/planning.rs::CompilerWarning",
         "compiler::src/core/extension/test/run.rs::CompilerWarning",
         "core_boundary_leak:core-agnostic-source::src/core/code_audit/codebase_map.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `WooCommerce` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/code_audit/codebase_map.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `default_source_extensions`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::src/core/code_audit/dead_code.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `analyze_dead_code_with_config`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::src/core/code_audit/dead_code.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `is_framework_entry_point`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::src/core/code_audit/dead_code.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `analyze_dead_code_with_config`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::src/core/code_audit/dead_code.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `classify_unused_param`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::src/core/code_audit/dead_code.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `is_framework_entry_point`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/code_audit/detectors/upstream_workaround.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/code_audit/detectors/upstream_workaround.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `wordpress` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/code_audit/docs_audit/claims.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `extract_claims`::CoreBoundaryLeak",

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -188,6 +188,40 @@ impl Language {
     pub fn builtin_trivial_method_prefixes() -> &'static [&'static str] {
         &["get_", "is_", "has_"]
     }
+
+    /// Whether this language's only declaration visibility is "public" — i.e. it
+    /// has no narrower-than-public visibility modifier (no `pub(crate)` / module
+    /// scoping). For such languages a top-level/public symbol called from
+    /// anywhere in its own file IS genuinely referenced, so the dead-code
+    /// detector must not suggest narrowing its visibility. Languages that *do*
+    /// support visibility narrowing (e.g. module-scoped `pub(...)`) return
+    /// `false`, because a self-only public symbol there is actionable dead code.
+    ///
+    /// Keeping this classification in the agnostic conventions home lets the
+    /// dead-code detector under `code_audit` stay free of hardcoded ecosystem
+    /// names.
+    pub fn lacks_visibility_narrowing(&self) -> bool {
+        matches!(
+            self,
+            Language::Php | Language::JavaScript | Language::TypeScript
+        )
+    }
+
+    /// Whether this language dispatches methods through the type system (trait /
+    /// interface implementations invoked by the compiler rather than by explicit
+    /// call sites). Detectors treat such methods as entry points because they
+    /// are reachable even with no direct caller in source.
+    pub fn has_typesystem_trait_dispatch(&self) -> bool {
+        matches!(self, Language::Rust)
+    }
+
+    /// Whether this language's runtime commonly dispatches lifecycle / magic /
+    /// hook callbacks by convention (methods the framework invokes by name
+    /// rather than by an explicit call site). Detectors treat such methods as
+    /// entry points so convention-invoked callbacks are not flagged as dead.
+    pub fn has_framework_lifecycle_dispatch(&self) -> bool {
+        matches!(self, Language::Php)
+    }
 }
 
 /// Builtin tracker-reference regex defaults shipped with Homeboy. These match

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -111,19 +111,15 @@ pub(crate) fn analyze_dead_code_with_config(
         // Skip test files — test methods are invoked by the test runner via
         // reflection/convention, not by direct calls from other source files.
         if !is_test_path(&fp.relative_path) {
-            // For languages without finer-grained visibility than "public" (PHP
-            // top-level functions, for example), a public function called from
+            // For languages without finer-grained visibility than "public" (no
+            // module-scoped visibility narrowing), a public function called from
             // anywhere in its own file IS referenced — the "make it private"
-            // suggestion doesn't apply, because PHP top-level functions are
-            // always globally accessible. Rust, by contrast, supports
-            // `pub(crate)` / `pub(super)` narrowing, so a self-only public
-            // function IS actionably dead code.
-            let language_allows_self_reference = matches!(
-                fp.language,
-                super::conventions::Language::Php
-                    | super::conventions::Language::JavaScript
-                    | super::conventions::Language::TypeScript
-            );
+            // suggestion doesn't apply, because such top-level functions are
+            // always globally accessible. Languages that support visibility
+            // narrowing, by contrast, can scope a self-only public function, so
+            // it IS actionably dead code. The classification is owned by the
+            // agnostic conventions layer.
+            let language_allows_self_reference = fp.language.lacks_visibility_narrowing();
 
             for export in &fp.public_api {
                 // Skip if this function is registered as a hook/callback target
@@ -281,10 +277,11 @@ fn is_framework_entry_point(name: &str, fp: &FileFingerprint, audit_config: &Aud
         return true;
     }
 
-    // Rust-specific: trait implementations are called by the type system
-    if matches!(fp.language, super::conventions::Language::Rust) {
+    // Type-system-dispatched languages: trait/interface implementations are
+    // invoked by the compiler rather than by explicit call sites.
+    if fp.language.has_typesystem_trait_dispatch() {
         // Methods inside impl blocks for standard traits
-        let rust_trait_methods = [
+        let trait_dispatch_methods = [
             "serialize",
             "deserialize",
             "from_str",
@@ -307,18 +304,19 @@ fn is_framework_entry_point(name: &str, fp: &FileFingerprint, audit_config: &Aud
             "command",
             "value_variants",
         ];
-        if rust_trait_methods.contains(&name) {
+        if trait_dispatch_methods.contains(&name) {
             return true;
         }
     }
 
-    // PHP/framework-specific: hook callbacks, lifecycle methods
-    if matches!(fp.language, super::conventions::Language::Php) {
+    // Framework-lifecycle-dispatched languages: hook callbacks and lifecycle /
+    // magic methods are invoked by the runtime by convention.
+    if fp.language.has_framework_lifecycle_dispatch() {
         if is_runtime_entrypoint_file(fp, audit_config) {
             return true;
         }
 
-        let php_entry_points = [
+        let lifecycle_entry_points = [
             "__construct",
             "__destruct",
             "__get",
@@ -340,7 +338,7 @@ fn is_framework_entry_point(name: &str, fp: &FileFingerprint, audit_config: &Aud
             "handle",
             "process",
         ];
-        if php_entry_points.contains(&name) {
+        if lifecycle_entry_points.contains(&name) {
             return true;
         }
     }
@@ -416,7 +414,7 @@ fn classify_unused_param(
         None => {
             // No call site data for this function — fall back to legacy behavior.
             // This happens when: the function is never called, or call_sites
-            // aren't available yet (e.g., Rust grammar doesn't emit them).
+            // aren't available yet (e.g., the language grammar doesn't emit them).
             (
                 AuditFinding::UnusedParameter,
                 format!(


### PR DESCRIPTION
Closes #5876.

Relocates the `php`/`rust` ecosystem literals out of `src/core/code_audit/dead_code.rs` into the agnostic conventions home (`src/core/code_audit/conventions.rs`, which is excluded from the `core-agnostic-source` scan), so homeboy core stays free of language/ecosystem literals in behavioral code.

## What changed
- **`conventions.rs`**: added three semantic predicate methods on `Language` that capture the *behavioral intent* the dead-code detector needs:
  - `lacks_visibility_narrowing()` — languages whose only visibility is "public" (PHP/JS/TS).
  - `has_typesystem_trait_dispatch()` — languages where trait/interface impls are invoked by the compiler (Rust).
  - `has_framework_lifecycle_dispatch()` — languages whose runtime dispatches lifecycle/magic/hook callbacks by convention (PHP).
- **`dead_code.rs`**: replaced the inline `matches!(fp.language, Language::Php | ...)` checks and the `rust_trait_methods` / `php_entry_points` variable names with the new predicates / neutral names, and reworded comments that named "PHP"/"Rust". Behavior is unchanged.
- **`homeboy.json`**: removed the 5 now-resolved `dead_code.rs` `php`/`rust` baseline fingerprints and decremented `item_count` 381 -> 376.

## Verification
- `cargo build --lib` — clean.
- `cargo clippy --lib` — no new findings in the touched files.
- `cargo fmt` — applied.
- `homeboy audit --only core_boundary_leak` — the 5 dead_code.rs `php`/`rust` fingerprints now appear under `resolved_fingerprints` with **0 new fingerprints**.

(Heavy `cargo test` / `cargo build --tests` intentionally left to CI per VPS resource policy.)