### PR TITLE
fix(lab): keep artifact roots runner-local

### DIFF
--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -3317,12 +3317,6 @@ mod tests {
             .is_some_and(|hint| hint.contains("--runner <runner-id>"))));
     }
 
-    fn release_gate_lab_command(label: &'static str) -> LabOffloadCommand {
-        let mut command = portable_lab_command(label);
-        command.routing_policy.release_gate = true;
-        command
-    }
-
     #[test]
     fn release_gate_force_hot_allow_local_hot_fails_closed_with_default_runner() {
         // #4605: --force-hot --allow-local-hot must not silently bypass Lab

--- a/src/core/runner/lab_arg_tests.rs
+++ b/src/core/runner/lab_arg_tests.rs
@@ -1,5 +1,6 @@
 use super::super::lab_args::{
-    lab_offload_source_path, rewrite_lab_offload_args, EXPLICIT_PASSTHROUGH_SENTINEL,
+    lab_offload_source_path, rewrite_lab_offload_args, rewrite_runner_resident_lab_offload_args,
+    EXPLICIT_PASSTHROUGH_SENTINEL,
 };
 
 fn args(items: &[&str]) -> Vec<String> {
@@ -30,6 +31,60 @@ fn rewrites_lab_offload_path_and_strips_runner_and_output_flags() {
             "--path",
             "/home/user/Developer/project",
             "--json-summary",
+        ])
+    );
+}
+
+#[test]
+fn strips_controller_artifact_root_from_lab_offload_command() {
+    let input = args(&[
+        "homeboy",
+        "fuzz",
+        "run",
+        "--path",
+        "/Users/user/Developer/project",
+        "--artifact-root",
+        "/var/folders/local-homeboy-artifacts",
+        "--workload",
+        "smoke",
+        "--artifact-root=/tmp/also-local",
+    ]);
+
+    assert_eq!(
+        rewrite_lab_offload_args(&input, "/home/user/Developer/project", &[]),
+        args(&[
+            "homeboy",
+            "--force-hot",
+            "fuzz",
+            "run",
+            "--path",
+            "/home/user/Developer/project",
+            "--workload",
+            "smoke",
+        ])
+    );
+}
+
+#[test]
+fn strips_controller_artifact_root_from_runner_resident_command() {
+    let input = args(&[
+        "homeboy",
+        "agent-task",
+        "status",
+        "agent-task-123",
+        "--artifact-root",
+        "/var/folders/local-homeboy-artifacts",
+        "--artifact-root=/tmp/also-local",
+    ]);
+
+    assert_eq!(
+        rewrite_runner_resident_lab_offload_args(&input),
+        args(&[
+            "homeboy",
+            "--force-hot",
+            "agent-task",
+            "status",
+            "agent-task-123",
         ])
     );
 }

--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -111,11 +111,11 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
         if arg.starts_with("--runner=") {
             continue;
         }
-        if arg == "--output" {
+        if arg == "--output" || arg == "--artifact-root" {
             let _ = iter.next();
             continue;
         }
-        if arg.starts_with("--output=") {
+        if arg.starts_with("--output=") || arg.starts_with("--artifact-root=") {
             continue;
         }
         stripped.push(arg.clone());
@@ -159,11 +159,11 @@ pub(in crate::core::runner) fn rewrite_runner_resident_lab_offload_args(
         if arg.starts_with("--runner=") {
             continue;
         }
-        if arg == "--output" {
+        if arg == "--output" || arg == "--artifact-root" {
             let _ = iter.next();
             continue;
         }
-        if arg.starts_with("--output=") {
+        if arg.starts_with("--output=") || arg.starts_with("--artifact-root=") {
             continue;
         }
         if is_service_expose && arg == "--server" {


### PR DESCRIPTION
## Summary
- Strip controller-side `--artifact-root` flags before Lab offload command execution.
- Cover both standard workspace offload and runner-resident command rewrites.
- Remove a duplicate test helper that prevented the branch from compiling.

## Testing
- `homeboy test --lab-only --skip-lint -- strips_controller_artifact_root` passed: 2 tests executed, 2 passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Lab offload artifact-root forwarding bug, implementing the Rust fix, adding regression tests, and preparing this PR.