### PR TITLE
Materialize Lab @file inputs

### DIFF
--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -28,6 +28,7 @@ use crate::command_contract::{
 use crate::core::agent_task_lifecycle;
 use crate::core::engine::shell;
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
+use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, ErrorCode, Result};
 
@@ -39,9 +40,10 @@ use super::super::execution::{
 use super::super::lab_apply::apply_lab_offload_patch;
 use super::super::lab_args::{
     inject_agent_task_default_provider_config_in_args, inline_agent_task_prompt_files_in_args,
-    lab_offload_source_path, remap_agent_task_plan_in_args, remap_path_settings_in_args,
-    remap_provider_config_in_args, rewrite_lab_offload_args,
-    rewrite_runner_resident_lab_offload_args, LabPathRemap,
+    lab_at_file_specs, lab_offload_source_path, remap_agent_task_plan_in_args,
+    remap_lab_at_file_args, remap_path_settings_in_args, remap_provider_config_in_args,
+    rewrite_lab_offload_args, rewrite_runner_resident_lab_offload_args, LabAtFileSpec,
+    LabPathRemap,
 };
 use super::super::lab_capabilities::lab_runner_capability_contract;
 use super::super::lab_command::lab_offload_command_prefix;
@@ -831,6 +833,31 @@ fn prepare_lab_offload_workspace_stage(
             .build(),
     );
 
+    let at_file_specs =
+        lab_at_file_specs(&offload_args, Path::new(&synced.local_path), &remote_cwd)?;
+    materialize_lab_at_files_on_runner(runner_id, &at_file_specs)?;
+    if !at_file_specs.is_empty() {
+        plan = with_step(
+            plan,
+            PlanStep::ready("lab.materialize_at_files", "lab.materialize_at_files")
+                .inputs(
+                    PlanValues::new().json("count", at_file_specs.len()).json(
+                        "files",
+                        &at_file_specs
+                            .iter()
+                            .map(|spec| {
+                                serde_json::json!({
+                                    "local_path": spec.local_path.display().to_string(),
+                                    "remote_path": spec.remote_path.as_str(),
+                                })
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                )
+                .build(),
+        );
+    }
+
     let synced_extra_workspaces = sync_extra_lab_workspaces(
         runner_id,
         &synced.local_path,
@@ -944,6 +971,7 @@ fn prepare_lab_offload_workspace_stage(
     let remapped_args =
         inline_agent_task_prompt_files_in_args(&remapped_args, Path::new(&synced.local_path))?;
     let remapped_args = remap_path_settings_in_args(&remapped_args, &path_remaps);
+    let remapped_args = remap_lab_at_file_args(&remapped_args, &at_file_specs);
     let (remapped_args, synced_remapped_tasks) =
         materialize_inline_agent_task_tasks_arg(runner_id, &remapped_args)?;
     plan = record_synced_remapped_workspace_entry(
@@ -993,6 +1021,77 @@ fn prepare_lab_offload_workspace_stage(
         synced_rigs,
         rig_component_path_overrides,
     })
+}
+
+fn materialize_lab_at_files_on_runner(runner_id: &str, specs: &[LabAtFileSpec]) -> Result<()> {
+    if specs.is_empty() {
+        return Ok(());
+    }
+
+    let client = ssh_client_for_lab_runner(runner_id)?;
+    for spec in specs {
+        let parent = spec
+            .remote_path
+            .rsplit_once('/')
+            .map(|(parent, _)| if parent.is_empty() { "/" } else { parent })
+            .unwrap_or(".");
+        let mkdir = client.execute(&format!("mkdir -p {}", shell::quote_arg(parent)));
+        if !mkdir.success {
+            return Err(lab_at_file_materialization_error(
+                runner_id,
+                spec,
+                format!("failed to create remote parent directory: {}", mkdir.stderr),
+            ));
+        }
+        let upload = client.upload_file(&spec.local_path.display().to_string(), &spec.remote_path);
+        if !upload.success {
+            return Err(lab_at_file_materialization_error(
+                runner_id,
+                spec,
+                format!("failed to upload file: {}", upload.stderr),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn ssh_client_for_lab_runner(runner_id: &str) -> Result<SshClient> {
+    let runner = load(runner_id)?;
+    let server_id = runner.server_id.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runner",
+            "Lab offload @file materialization requires an SSH runner with server_id",
+            Some(runner_id.to_string()),
+            Some(vec![
+                "Register a direct SSH runner or configure a reverse-connected runner before Lab offload.".to_string(),
+            ]),
+        )
+    })?;
+    let server = server::load(server_id)?;
+    let mut client = SshClient::from_server(&server, server_id)?;
+    client.env.extend(runner.env);
+    Ok(client)
+}
+
+fn lab_at_file_materialization_error(
+    runner_id: &str,
+    spec: &LabAtFileSpec,
+    reason: String,
+) -> Error {
+    Error::validation_invalid_argument(
+        "at_file",
+        format!(
+            "Lab offload cannot materialize @file argument `{}` on runner `{}`: {}",
+            spec.original_spec, runner_id, reason
+        ),
+        Some(spec.local_path.display().to_string()),
+        Some(vec![
+            format!("Controller-side file: {}", spec.local_path.display()),
+            format!("Runner-side file: {}", spec.remote_path),
+            "Ensure the selected runner is reachable and its workspace root is writable, then retry Lab offload.".to_string(),
+        ]),
+    )
 }
 
 fn run_lab_offload_inner(

--- a/src/core/runner/lab_args/at_files.rs
+++ b/src/core/runner/lab_args/at_files.rs
@@ -1,0 +1,207 @@
+//! Generic `@file` argument support for Lab offload.
+//!
+//! Homeboy commands commonly accept `@relative/path` as a local file spec. Git
+//! Lab workspaces are clean checkouts, so generated ignored/untracked files must
+//! be materialized explicitly before the runner command executes.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::core::{Error, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::core::runner) struct LabAtFileSpec {
+    pub(in crate::core::runner) original_spec: String,
+    pub(in crate::core::runner) local_path: PathBuf,
+    pub(in crate::core::runner) remote_spec: String,
+    pub(in crate::core::runner) remote_path: String,
+}
+
+pub(in crate::core::runner) fn lab_at_file_specs(
+    args: &[String],
+    source_path: &Path,
+    remote_cwd: &str,
+) -> Result<Vec<LabAtFileSpec>> {
+    let mut specs = Vec::new();
+    let mut seen = BTreeSet::new();
+    let cwd = std::env::current_dir()
+        .map_err(|err| Error::internal_io(err.to_string(), Some("read cwd".to_string())))?;
+
+    for spec in at_file_tokens(args) {
+        let resolved = resolve_at_file_spec(&spec, &cwd, source_path, remote_cwd)?;
+        let key = (
+            resolved.original_spec.clone(),
+            resolved.local_path.display().to_string(),
+            resolved.remote_path.clone(),
+        );
+        if seen.insert(key) {
+            specs.push(resolved);
+        }
+    }
+
+    Ok(specs)
+}
+
+pub(in crate::core::runner) fn remap_lab_at_file_args(
+    args: &[String],
+    specs: &[LabAtFileSpec],
+) -> Vec<String> {
+    if specs.is_empty() {
+        return args.to_vec();
+    }
+
+    args.iter()
+        .map(|arg| {
+            for spec in specs {
+                if arg == &spec.original_spec {
+                    return spec.remote_spec.clone();
+                }
+                if let Some((prefix, value)) = arg.split_once('=') {
+                    if value == spec.original_spec {
+                        return format!("{prefix}={}", spec.remote_spec);
+                    }
+                }
+            }
+            arg.clone()
+        })
+        .collect()
+}
+
+fn at_file_tokens(args: &[String]) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut passthrough = false;
+
+    for arg in args {
+        if passthrough {
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            continue;
+        }
+        if arg.starts_with('@') {
+            tokens.push(arg.clone());
+            continue;
+        }
+        if let Some((_, value)) = arg.split_once('=') {
+            if value.starts_with('@') {
+                tokens.push(value.to_string());
+            }
+        }
+    }
+
+    tokens
+}
+
+fn resolve_at_file_spec(
+    spec: &str,
+    cwd: &Path,
+    source_path: &Path,
+    remote_cwd: &str,
+) -> Result<LabAtFileSpec> {
+    let Some(raw_path) = spec.strip_prefix('@') else {
+        return Err(Error::validation_invalid_argument(
+            "at_file",
+            "Lab offload can only materialize @file arguments",
+            Some(spec.to_string()),
+            None,
+        ));
+    };
+    if raw_path.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "at_file",
+            "Lab offload cannot materialize empty @file argument '@'",
+            Some(spec.to_string()),
+            Some(vec![
+                "Pass @path/to/file for file-backed command arguments.".to_string(),
+            ]),
+        ));
+    }
+    if raw_path.contains("://") {
+        return Err(Error::validation_invalid_argument(
+            "at_file",
+            "Lab offload only supports local filesystem @file arguments",
+            Some(spec.to_string()),
+            Some(vec![
+                "Generate or download the file locally before offloading to Lab.".to_string(),
+                "Pass inline command input if the target command supports it.".to_string(),
+            ]),
+        ));
+    }
+
+    let expanded = PathBuf::from(shellexpand::tilde(raw_path).to_string());
+    let mut candidates = Vec::new();
+    if expanded.is_absolute() || raw_path.starts_with("~/") {
+        candidates.push(expanded.clone());
+    } else {
+        candidates.push(cwd.join(&expanded));
+        let source_relative = source_path.join(&expanded);
+        if !candidates
+            .iter()
+            .any(|candidate| candidate == &source_relative)
+        {
+            candidates.push(source_relative);
+        }
+    }
+
+    let mut tried = Vec::new();
+    for candidate in candidates {
+        tried.push(candidate.display().to_string());
+        if !candidate.is_file() {
+            continue;
+        }
+        let local_path = candidate.canonicalize().map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("canonicalize Lab @file {}", candidate.display())),
+            )
+        })?;
+        let remote_path = remote_path_for_at_file(&local_path, raw_path, remote_cwd);
+        return Ok(LabAtFileSpec {
+            original_spec: spec.to_string(),
+            local_path,
+            remote_spec: format!("@{remote_path}"),
+            remote_path,
+        });
+    }
+
+    Err(Error::validation_invalid_argument(
+        "at_file",
+        "Lab offload cannot materialize @file argument because the controller-side file does not exist",
+        Some(spec.to_string()),
+        Some(tried),
+    ))
+}
+
+fn remote_path_for_at_file(local_path: &Path, raw_path: &str, remote_cwd: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(local_path.display().to_string().as_bytes());
+    digest.update(b"\0");
+    digest.update(raw_path.as_bytes());
+    let digest = format!("{:x}", digest.finalize());
+    let filename = local_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("input");
+    format!(
+        "{}/.homeboy/lab-at-files/{}-{}",
+        remote_cwd.trim_end_matches('/'),
+        &digest[..16],
+        sanitize_remote_filename(filename)
+    )
+}
+
+fn sanitize_remote_filename(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}

--- a/src/core/runner/lab_args/mod.rs
+++ b/src/core/runner/lab_args/mod.rs
@@ -12,6 +12,7 @@
 //! the surface the rest of the `runner` module consumes.
 
 mod agent_task_specs;
+mod at_files;
 mod envelope;
 mod offload;
 mod path_remap;
@@ -27,6 +28,7 @@ pub(super) const EXPLICIT_PASSTHROUGH_SENTINEL: &str = "__homeboy_explicit_passt
 pub(super) use agent_task_specs::{
     inline_agent_task_prompt_files_in_args, remap_agent_task_plan_in_args,
 };
+pub(super) use at_files::{lab_at_file_specs, remap_lab_at_file_args, LabAtFileSpec};
 pub(super) use offload::{
     lab_offload_source_path, rewrite_lab_offload_args, rewrite_runner_resident_lab_offload_args,
 };

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1042,3 +1042,53 @@ fn lab_args_rewrite_path_prefers_more_specific_duplicate_local_mapping() {
         ]
     );
 }
+
+#[test]
+fn lab_args_materializes_relative_at_file_specs_under_remote_workspace() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::create_dir_all(dir.path().join(".ci")).expect("create .ci");
+    std::fs::write(dir.path().join(".ci/spec.json"), "{}").expect("write spec");
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "controller".to_string(),
+        "from-spec".to_string(),
+        "@.ci/spec.json".to_string(),
+        "--config=@.ci/spec.json".to_string(),
+    ];
+
+    let specs = lab_at_file_specs(&args, dir.path(), "/runner/workspace").expect("specs");
+
+    assert_eq!(specs.len(), 1);
+    assert!(specs[0]
+        .remote_spec
+        .starts_with("@/runner/workspace/.homeboy/lab-at-files/"));
+    assert!(specs[0].remote_spec.ends_with("-spec.json"));
+    assert_eq!(
+        remap_lab_at_file_args(&args, &specs),
+        vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "controller".to_string(),
+            "from-spec".to_string(),
+            specs[0].remote_spec.clone(),
+            format!("--config={}", specs[0].remote_spec),
+        ]
+    );
+}
+
+#[test]
+fn lab_args_at_file_preflight_reports_missing_controller_file() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let args = vec![
+        "homeboy".to_string(),
+        "cmd".to_string(),
+        "@.ci/missing.json".to_string(),
+    ];
+
+    let err = lab_at_file_specs(&args, dir.path(), "/runner/workspace").expect_err("missing");
+
+    assert!(err
+        .to_string()
+        .contains("controller-side file does not exist"));
+}


### PR DESCRIPTION
## Summary
- Detects generic Lab offload command arguments that reference controller-side files with `@path` or `--flag=@path`.
- Preflights missing, empty, and URL-style `@file` specs before remote execution.
- Uploads resolved files to the runner workspace under `.homeboy/lab-at-files/` and rewrites command args to runner-available `@/remote/path` specs.
- Records a `lab.materialize_at_files` plan step for evidence.

## Why
WPSG production loop validation hit a Homeboy Lab offload failure where `agent-task controller from-spec @.ci/site-generation-loop.controller-run-spec.json --resume` was offloaded to `homeboy-lab`, but the generated `.ci` file was not present in the runner workspace. The remote command failed with `File not found: .ci/site-generation-loop.controller-run-spec.json`.

Evidence: `runner-exec-homeboy-lab-95a4ae51-2434-47f3-9261-01518cabdbbe`.

## Testing
- rustfmt --check src/core/runner/lab/offload.rs src/core/runner/lab_args/mod.rs src/core/runner/lab_args/tests.rs src/core/runner/lab_args/at_files.rs
- git diff --check

Not run locally per site rule against local cargo execution:
- cargo test lab_args_at_file lab_args_materializes_relative_at_file_specs_under_remote_workspace

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, tests, and PR preparation.