### PR TITLE
Add fuzz coverage skip summaries

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -86,10 +86,50 @@ Campaigns can include a product-neutral coverage summary:
     "declared_operations": 4,
     "executable_operations": 4,
     "proven_operations": 4,
+    "skipped_targets": [
+      { "id": "target-3", "reason": "auth_required" }
+    ],
+    "surface_summaries": [
+      {
+        "id": "surface-a",
+        "kind": "api",
+        "declared_targets": 2,
+        "executable_targets": 2,
+        "proven_targets": 2,
+        "declared_operations": 3,
+        "executable_operations": 3,
+        "proven_operations": 3
+      }
+    ],
+    "kind_summaries": [
+      {
+        "id": "read",
+        "kind": "operation_kind",
+        "declared_targets": 1,
+        "executable_targets": 1,
+        "proven_targets": 1,
+        "declared_operations": 2,
+        "executable_operations": 2,
+        "proven_operations": 2
+      }
+    ],
     "artifact_ids": ["coverage-report"]
   }
 }
 ```
+
+Coverage summaries can include selector breakdowns in `surface_summaries` and
+`kind_summaries`. Each selector row uses the same declared, executable, proven,
+and skipped-count shape as the aggregate summary, allowing gates and reports to
+show which surface or operation kind is incomplete without embedding any
+product-specific taxonomy.
+
+Use standardized skip reason codes when a declared target or operation is not
+executable in the current campaign: `unsafe`, `destructive`, `auth_required`,
+`unavailable`, `legacy`, `unsupported`, and `config_required`. The codes are
+reported in `coverage_completeness.skipped_reason_counts` for `fuzz validate`
+and `fuzz report`, including per-selector counts for `surface_summaries` and
+`kind_summaries`.
 
 `homeboy fuzz replay` resolves replay metadata from a product-neutral campaign
 or result envelope artifact. Pass a `homeboy/fuzz-campaign/v1` or

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use homeboy::core::component::{Component, ScopedExtensionConfig};
@@ -347,7 +347,28 @@ pub struct FuzzCoverageCompletenessOutput {
     pub operation_coverage_ratio: f64,
     pub skipped_targets: usize,
     pub skipped_operations: usize,
+    pub skipped_reason_counts: BTreeMap<String, usize>,
+    pub surface_summaries: Vec<FuzzCoverageSelectorSummaryOutput>,
+    pub kind_summaries: Vec<FuzzCoverageSelectorSummaryOutput>,
     pub artifact_ids: Vec<String>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct FuzzCoverageSelectorSummaryOutput {
+    pub id: String,
+    pub kind: String,
+    pub label: Option<String>,
+    pub declared_targets: u64,
+    pub executable_targets: u64,
+    pub proven_targets: u64,
+    pub target_coverage_ratio: f64,
+    pub declared_operations: u64,
+    pub executable_operations: u64,
+    pub proven_operations: u64,
+    pub operation_coverage_ratio: f64,
+    pub skipped_targets: usize,
+    pub skipped_operations: usize,
+    pub skipped_reason_counts: BTreeMap<String, usize>,
 }
 
 pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
@@ -1145,28 +1166,45 @@ fn coverage_ratio(
 
 fn fuzz_coverage_completeness(campaign: &FuzzCampaign) -> FuzzCoverageCompletenessOutput {
     match campaign.coverage_summary.as_ref() {
-        Some(summary) => FuzzCoverageCompletenessOutput {
-            has_summary: true,
-            declared_targets: summary.declared_targets,
-            executable_targets: summary.executable_targets,
-            proven_targets: summary.proven_targets,
-            target_coverage_ratio: coverage_ratio(
-                Some(summary),
-                |summary| summary.proven_targets,
-                |summary| summary.declared_targets,
-            ),
-            declared_operations: summary.declared_operations,
-            executable_operations: summary.executable_operations,
-            proven_operations: summary.proven_operations,
-            operation_coverage_ratio: coverage_ratio(
-                Some(summary),
-                |summary| summary.proven_operations,
-                |summary| summary.declared_operations,
-            ),
-            skipped_targets: summary.skipped_targets.len(),
-            skipped_operations: summary.skipped_operations.len(),
-            artifact_ids: summary.artifact_ids.clone(),
-        },
+        Some(summary) => {
+            let mut skipped_reason_counts = BTreeMap::new();
+            accumulate_skip_reason_counts(&mut skipped_reason_counts, &summary.skipped_targets);
+            accumulate_skip_reason_counts(&mut skipped_reason_counts, &summary.skipped_operations);
+
+            FuzzCoverageCompletenessOutput {
+                has_summary: true,
+                declared_targets: summary.declared_targets,
+                executable_targets: summary.executable_targets,
+                proven_targets: summary.proven_targets,
+                target_coverage_ratio: coverage_ratio(
+                    Some(summary),
+                    |summary| summary.proven_targets,
+                    |summary| summary.declared_targets,
+                ),
+                declared_operations: summary.declared_operations,
+                executable_operations: summary.executable_operations,
+                proven_operations: summary.proven_operations,
+                operation_coverage_ratio: coverage_ratio(
+                    Some(summary),
+                    |summary| summary.proven_operations,
+                    |summary| summary.declared_operations,
+                ),
+                skipped_targets: summary.skipped_targets.len(),
+                skipped_operations: summary.skipped_operations.len(),
+                skipped_reason_counts,
+                surface_summaries: summary
+                    .surface_summaries
+                    .iter()
+                    .map(fuzz_coverage_selector_summary)
+                    .collect(),
+                kind_summaries: summary
+                    .kind_summaries
+                    .iter()
+                    .map(fuzz_coverage_selector_summary)
+                    .collect(),
+                artifact_ids: summary.artifact_ids.clone(),
+            }
+        }
         None => FuzzCoverageCompletenessOutput {
             has_summary: false,
             declared_targets: 0,
@@ -1179,8 +1217,59 @@ fn fuzz_coverage_completeness(campaign: &FuzzCampaign) -> FuzzCoverageCompletene
             operation_coverage_ratio: 0.0,
             skipped_targets: 0,
             skipped_operations: 0,
+            skipped_reason_counts: BTreeMap::new(),
+            surface_summaries: Vec::new(),
+            kind_summaries: Vec::new(),
             artifact_ids: Vec::new(),
         },
+    }
+}
+
+fn fuzz_coverage_selector_summary(
+    summary: &homeboy::core::fuzz::FuzzCoverageGroupSummary,
+) -> FuzzCoverageSelectorSummaryOutput {
+    let mut skipped_reason_counts = BTreeMap::new();
+    accumulate_skip_reason_counts(&mut skipped_reason_counts, &summary.skipped_targets);
+    accumulate_skip_reason_counts(&mut skipped_reason_counts, &summary.skipped_operations);
+
+    FuzzCoverageSelectorSummaryOutput {
+        id: summary.id.clone(),
+        kind: summary.kind.clone(),
+        label: summary.label.clone(),
+        declared_targets: summary.declared_targets,
+        executable_targets: summary.executable_targets,
+        proven_targets: summary.proven_targets,
+        target_coverage_ratio: count_ratio(summary.proven_targets, summary.declared_targets),
+        declared_operations: summary.declared_operations,
+        executable_operations: summary.executable_operations,
+        proven_operations: summary.proven_operations,
+        operation_coverage_ratio: count_ratio(
+            summary.proven_operations,
+            summary.declared_operations,
+        ),
+        skipped_targets: summary.skipped_targets.len(),
+        skipped_operations: summary.skipped_operations.len(),
+        skipped_reason_counts,
+    }
+}
+
+fn count_ratio(covered: u64, total: u64) -> f64 {
+    if total == 0 {
+        1.0
+    } else {
+        covered as f64 / total as f64
+    }
+}
+
+fn accumulate_skip_reason_counts(
+    counts: &mut BTreeMap<String, usize>,
+    skips: &[homeboy::core::fuzz::FuzzCoverageSkip],
+) {
+    for skip in skips {
+        let reason = skip.reason.trim();
+        if !reason.is_empty() {
+            *counts.entry(reason.to_string()).or_default() += 1;
+        }
     }
 }
 
@@ -1725,6 +1814,8 @@ mod tests {
                 proven_operations: 4,
                 skipped_targets: Vec::new(),
                 skipped_operations: Vec::new(),
+                surface_summaries: Vec::new(),
+                kind_summaries: Vec::new(),
                 artifact_ids: vec!["coverage-report".to_string()],
                 metadata: serde_json::Value::Null,
                 extra: std::collections::BTreeMap::new(),
@@ -1786,10 +1877,52 @@ mod tests {
                 proven_operations: 0,
                 skipped_targets: vec![homeboy::core::fuzz::FuzzCoverageSkip {
                     id: "target-2".to_string(),
-                    reason: "not_executable".to_string(),
+                    reason: "auth_required".to_string(),
                     label: None,
                 }],
-                skipped_operations: Vec::new(),
+                skipped_operations: vec![homeboy::core::fuzz::FuzzCoverageSkip {
+                    id: "operation-2".to_string(),
+                    reason: "config_required".to_string(),
+                    label: None,
+                }],
+                surface_summaries: vec![homeboy::core::fuzz::FuzzCoverageGroupSummary {
+                    id: "surface-a".to_string(),
+                    kind: "api".to_string(),
+                    label: Some("Surface A".to_string()),
+                    declared_targets: 2,
+                    executable_targets: 1,
+                    proven_targets: 1,
+                    declared_operations: 2,
+                    executable_operations: 1,
+                    proven_operations: 1,
+                    skipped_targets: vec![homeboy::core::fuzz::FuzzCoverageSkip {
+                        id: "target-2".to_string(),
+                        reason: "auth_required".to_string(),
+                        label: None,
+                    }],
+                    skipped_operations: vec![homeboy::core::fuzz::FuzzCoverageSkip {
+                        id: "operation-2".to_string(),
+                        reason: "config_required".to_string(),
+                        label: None,
+                    }],
+                    metadata: serde_json::Value::Null,
+                    extra: std::collections::BTreeMap::new(),
+                }],
+                kind_summaries: vec![homeboy::core::fuzz::FuzzCoverageGroupSummary {
+                    id: "read".to_string(),
+                    kind: "operation_kind".to_string(),
+                    label: None,
+                    declared_targets: 1,
+                    executable_targets: 1,
+                    proven_targets: 1,
+                    declared_operations: 1,
+                    executable_operations: 1,
+                    proven_operations: 1,
+                    skipped_targets: Vec::new(),
+                    skipped_operations: Vec::new(),
+                    metadata: serde_json::Value::Null,
+                    extra: std::collections::BTreeMap::new(),
+                }],
                 artifact_ids: vec!["coverage-report".to_string()],
                 metadata: serde_json::Value::Null,
                 extra: std::collections::BTreeMap::new(),
@@ -1810,6 +1943,18 @@ mod tests {
         assert_eq!(summary.target_coverage_ratio, 0.5);
         assert_eq!(summary.operation_coverage_ratio, 1.0);
         assert_eq!(summary.skipped_targets, 1);
+        assert_eq!(summary.skipped_operations, 1);
+        assert_eq!(summary.skipped_reason_counts["auth_required"], 1);
+        assert_eq!(summary.skipped_reason_counts["config_required"], 1);
+        assert_eq!(summary.surface_summaries.len(), 1);
+        assert_eq!(summary.surface_summaries[0].id, "surface-a");
+        assert_eq!(summary.surface_summaries[0].target_coverage_ratio, 0.5);
+        assert_eq!(summary.surface_summaries[0].operation_coverage_ratio, 0.5);
+        assert_eq!(
+            summary.surface_summaries[0].skipped_reason_counts["auth_required"],
+            1
+        );
+        assert_eq!(summary.kind_summaries[0].id, "read");
         assert_eq!(summary.artifact_ids, vec!["coverage-report"]);
     }
 

--- a/src/core/fuzz.rs
+++ b/src/core/fuzz.rs
@@ -32,6 +32,13 @@ pub const FUZZ_EXECUTION_REQUEST_SCHEMA: &str = "homeboy/fuzz-execution-request/
 pub const FUZZ_RESULT_ENVELOPE_SCHEMA: &str = "homeboy/fuzz-result-envelope/v1";
 pub const FUZZ_REQUIRED_ARTIFACT_SCHEMA: &str = "homeboy/fuzz-required-artifact/v1";
 pub const FUZZ_GATE_SCHEMA: &str = "homeboy/fuzz-gate/v1";
+pub const FUZZ_SKIP_REASON_UNSAFE: &str = "unsafe";
+pub const FUZZ_SKIP_REASON_DESTRUCTIVE: &str = "destructive";
+pub const FUZZ_SKIP_REASON_AUTH_REQUIRED: &str = "auth_required";
+pub const FUZZ_SKIP_REASON_UNAVAILABLE: &str = "unavailable";
+pub const FUZZ_SKIP_REASON_LEGACY: &str = "legacy";
+pub const FUZZ_SKIP_REASON_UNSUPPORTED: &str = "unsupported";
+pub const FUZZ_SKIP_REASON_CONFIG_REQUIRED: &str = "config_required";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FuzzCoreContract {
@@ -42,6 +49,8 @@ pub struct FuzzCoreContract {
     pub schemas: FuzzContractSchemas,
     pub safety_classes: Vec<FuzzSafetyClass>,
     pub finding_statuses: Vec<FuzzFindingStatus>,
+    #[serde(default = "standardized_fuzz_skip_reason_codes")]
+    pub skip_reason_codes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -385,7 +394,33 @@ pub struct FuzzCoverageSummary {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skipped_operations: Vec<FuzzCoverageSkip>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub surface_summaries: Vec<FuzzCoverageGroupSummary>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub kind_summaries: Vec<FuzzCoverageGroupSummary>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FuzzCoverageGroupSummary {
+    pub id: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub declared_targets: u64,
+    pub executable_targets: u64,
+    pub proven_targets: u64,
+    pub declared_operations: u64,
+    pub executable_operations: u64,
+    pub proven_operations: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skipped_targets: Vec<FuzzCoverageSkip>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skipped_operations: Vec<FuzzCoverageSkip>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -398,6 +433,21 @@ pub struct FuzzCoverageSkip {
     pub reason: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+}
+
+pub fn standardized_fuzz_skip_reason_codes() -> Vec<String> {
+    [
+        FUZZ_SKIP_REASON_UNSAFE,
+        FUZZ_SKIP_REASON_DESTRUCTIVE,
+        FUZZ_SKIP_REASON_AUTH_REQUIRED,
+        FUZZ_SKIP_REASON_UNAVAILABLE,
+        FUZZ_SKIP_REASON_LEGACY,
+        FUZZ_SKIP_REASON_UNSUPPORTED,
+        FUZZ_SKIP_REASON_CONFIG_REQUIRED,
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -701,6 +751,7 @@ pub fn fuzz_core_contract() -> FuzzCoreContract {
             FuzzFindingStatus::Mitigated,
             FuzzFindingStatus::Suppressed,
         ],
+        skip_reason_codes: standardized_fuzz_skip_reason_codes(),
     }
 }
 
@@ -1054,6 +1105,9 @@ mod tests {
             .safety_classes
             .contains(&FuzzSafetyClass::IsolatedMutation));
         assert!(contract.finding_statuses.contains(&FuzzFindingStatus::Open));
+        assert!(contract
+            .skip_reason_codes
+            .contains(&FUZZ_SKIP_REASON_AUTH_REQUIRED.to_string()));
     }
 
     #[test]
@@ -1203,6 +1257,36 @@ mod tests {
                 proven_operations: 1,
                 skipped_targets: Vec::new(),
                 skipped_operations: Vec::new(),
+                surface_summaries: vec![FuzzCoverageGroupSummary {
+                    id: "surface-1".to_string(),
+                    kind: "api".to_string(),
+                    label: Some("API".to_string()),
+                    declared_targets: 1,
+                    executable_targets: 1,
+                    proven_targets: 1,
+                    declared_operations: 1,
+                    executable_operations: 1,
+                    proven_operations: 1,
+                    skipped_targets: Vec::new(),
+                    skipped_operations: Vec::new(),
+                    metadata: Value::Null,
+                    extra: BTreeMap::new(),
+                }],
+                kind_summaries: vec![FuzzCoverageGroupSummary {
+                    id: "read".to_string(),
+                    kind: "operation_kind".to_string(),
+                    label: None,
+                    declared_targets: 1,
+                    executable_targets: 1,
+                    proven_targets: 1,
+                    declared_operations: 1,
+                    executable_operations: 1,
+                    proven_operations: 1,
+                    skipped_targets: Vec::new(),
+                    skipped_operations: Vec::new(),
+                    metadata: Value::Null,
+                    extra: BTreeMap::new(),
+                }],
                 artifact_ids: vec!["artifact-1".to_string()],
                 metadata: Value::Null,
                 extra: BTreeMap::new(),
@@ -1282,6 +1366,11 @@ mod tests {
             value["coverage_summary"]["schema"],
             FUZZ_COVERAGE_SUMMARY_SCHEMA
         );
+        assert_eq!(
+            value["coverage_summary"]["surface_summaries"][0]["id"],
+            "surface-1"
+        );
+        assert_eq!(value["coverage_summary"]["kind_summaries"][0]["id"], "read");
         assert_eq!(value["findings"][0]["schema"], FUZZ_FINDING_SCHEMA);
         assert_eq!(value["artifacts"][0]["schema"], FUZZ_ARTIFACT_SCHEMA);
         assert_eq!(value["thresholds"][0]["schema"], FUZZ_THRESHOLD_SCHEMA);


### PR DESCRIPTION
## Summary
- Add standardized neutral skip reason codes for fuzz reporting.
- Add per-surface and per-kind coverage summary fields.
- Include skip reason counts in validation/report output and update docs.

## Testing
- rustfmt src/core/fuzz.rs src/commands/fuzz.rs
- git diff --check

Note: Cargo tests were not run locally because this environment is configured not to run cargo commands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing coverage summary fields, skip accounting, docs updates, formatting checks, and PR preparation.