### PR TITLE
fix(agent-task): carry dispatch component contracts

### DIFF
--- a/src/commands/agent_task/tests/controller_run.rs
+++ b/src/commands/agent_task/tests/controller_run.rs
@@ -1,6 +1,7 @@
 //! Agent-task command controller run/run-next execution tests.
 
 use super::support::*;
+use crate::core::agent_task::AgentTaskTypedArtifact;
 
 #[test]
 fn controller_run_next_executes_spawn_task_plan_and_records_dedupe_lineage() {
@@ -73,6 +74,132 @@ fn controller_run_next_executes_spawn_task_plan_and_records_dedupe_lineage() {
             json!("/tmp/homeboy-lab-artifacts/controller-run-next")
         );
     });
+}
+
+#[test]
+fn controller_dispatch_runtime_component_contracts_reach_spawned_agent_task_request() {
+    with_temp_home(|| {
+        let observed_request = Arc::new(Mutex::new(None));
+        let mut controller = agent_task_loop_controller::create_controller(
+            "loop-controller-runtime-components",
+            "repair",
+            "v1",
+        )
+        .expect("controller created");
+        controller.record_action(
+            AgentTaskLoopPolicyAction::SpawnTask {
+                dedupe_key: "workflow:generation".to_string(),
+                entity_id: None,
+                request: json!({
+                    "mode": "dispatch",
+                    "dispatch": {
+                        "prompt": "Run the generic workflow.",
+                        "backend": "fixture",
+                        "client_context": json!({
+                            "schema": "homeboy/repo-loop-workflow-context/v1",
+                            "workflow_id": "generation",
+                            "inputs": {
+                                "runtime_component_contracts": [{
+                                    "slug": "agents-api",
+                                    "path": "runtime/agents-api",
+                                    "loadAs": "plugin",
+                                    "activate": true,
+                                    "opaque": { "source": "workflow-input" }
+                                }]
+                            }
+                        }).to_string()
+                    }
+                }),
+            },
+            "repo loop spec workflow",
+        );
+        agent_task_loop_controller::write_controller(&controller).expect("controller written");
+
+        let (value, exit_code) = controller_run_next_with_executor(
+            "loop-controller-runtime-components".to_string(),
+            ArtifactCapturingExecutor {
+                observed_request: Arc::clone(&observed_request),
+            },
+        )
+        .expect("controller action executed");
+
+        let observed = observed_request
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .expect("provider saw request");
+
+        assert_eq!(exit_code, 0, "{value:#}");
+        assert_eq!(observed.component_contracts.len(), 1);
+        assert_eq!(
+            observed.component_contracts[0].slug.as_deref(),
+            Some("agents-api")
+        );
+        assert_eq!(
+            observed.component_contracts[0].path.as_deref(),
+            Some("runtime/agents-api")
+        );
+        assert_eq!(
+            observed.component_contracts[0].load_as.as_deref(),
+            Some("plugin")
+        );
+        assert_eq!(observed.component_contracts[0].activate, Some(true));
+        assert_eq!(
+            observed.component_contracts[0].extra["opaque"]["source"],
+            "workflow-input"
+        );
+    });
+}
+
+#[derive(Clone, Default)]
+struct ArtifactCapturingExecutor {
+    observed_request: Arc<Mutex<Option<AgentTaskRequest>>>,
+}
+
+impl AgentTaskExecutorAdapter for ArtifactCapturingExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        *self
+            .observed_request
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(request.clone());
+
+        AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: request.task_id,
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: Some("ok".to_string()),
+            failure_classification: None,
+            artifacts: Vec::new(),
+            typed_artifacts: vec![
+                AgentTaskTypedArtifact {
+                    name: "patch".to_string(),
+                    artifact_type: Some("diff".to_string()),
+                    artifact_schema: None,
+                    payload: json!({ "content": "diff --git a/README.md b/README.md" }),
+                    artifact: None,
+                    metadata: Value::Null,
+                },
+                AgentTaskTypedArtifact {
+                    name: "transcript".to_string(),
+                    artifact_type: Some("text".to_string()),
+                    artifact_schema: None,
+                    payload: json!({ "content": "ok" }),
+                    artifact: None,
+                    metadata: Value::Null,
+                },
+            ],
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        }
+    }
 }
 
 #[test]

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -9,8 +9,9 @@
 use serde_json::Value;
 
 use crate::core::agent_task::{
-    AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef,
-    AgentTaskWorkspace, AgentTaskWorkspaceMode, AGENT_TASK_REQUEST_SCHEMA,
+    AgentTaskComponentContract, AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy,
+    AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkspace, AgentTaskWorkspaceMode,
+    AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
 use crate::core::agent_task_prompts;
@@ -79,8 +80,10 @@ pub fn build_dispatch_plan_with_provider_requirements(
     )?);
 
     let client_context = dispatch_client_context(request)?;
-    let provider_config =
+    let mut provider_config =
         dispatch_provider_config(request, &repo, workspace_target.as_ref(), &client_context)?;
+    let component_contracts = dispatch_component_contracts(&provider_config, &client_context)?;
+    promote_component_contracts_to_provider_config(&mut provider_config, &component_contracts);
     let secret_env = dispatch_secret_env(request, &provider_config);
     let mut tasks = Vec::new();
     for (index, prompt_spec) in prompt_specs.iter().enumerate() {
@@ -140,7 +143,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
                     &repo,
                 ),
             },
-            component_contracts: Vec::new(),
+            component_contracts: component_contracts.clone(),
             policy: AgentTaskPolicy {
                 read: "workspace".to_string(),
                 write: "patch".to_string(),
@@ -498,6 +501,56 @@ fn dispatch_provider_config(
         .or_insert_with(|| serde_json::json!(request.task_url));
 
     Ok(config)
+}
+
+fn dispatch_component_contracts(
+    provider_config: &Value,
+    client_context: &Value,
+) -> Result<Vec<AgentTaskComponentContract>> {
+    let mut contracts = Vec::new();
+    collect_component_contracts_from_value(provider_config, "provider-config", &mut contracts)?;
+    collect_component_contracts_from_value(client_context, "client-context", &mut contracts)?;
+    if let Some(inputs) = client_context.get("inputs") {
+        collect_component_contracts_from_value(inputs, "client-context.inputs", &mut contracts)?;
+    }
+    Ok(contracts)
+}
+
+fn collect_component_contracts_from_value(
+    value: &Value,
+    label: &str,
+    contracts: &mut Vec<AgentTaskComponentContract>,
+) -> Result<()> {
+    for key in ["component_contracts", "runtime_component_contracts"] {
+        let Some(raw) = value.get(key) else {
+            continue;
+        };
+        let mut parsed: Vec<AgentTaskComponentContract> = serde_json::from_value(raw.clone())
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    format!("{label}.{key}"),
+                    format!("agent-task dispatch {label}.{key} must be an array of component contracts: {error}"),
+                    Some(raw.to_string()),
+                    None,
+                )
+            })?;
+        contracts.append(&mut parsed);
+    }
+    Ok(())
+}
+
+fn promote_component_contracts_to_provider_config(
+    provider_config: &mut Value,
+    component_contracts: &[AgentTaskComponentContract],
+) {
+    if component_contracts.is_empty() {
+        return;
+    }
+    let Some(map) = provider_config.as_object_mut() else {
+        return;
+    };
+    map.entry("component_contracts".to_string())
+        .or_insert_with(|| serde_json::to_value(component_contracts).unwrap_or(Value::Null));
 }
 
 fn dispatch_secret_env(request: &AgentTaskDispatchRequest, provider_config: &Value) -> Vec<String> {
@@ -1069,6 +1122,76 @@ mod tests {
 
         assert_eq!(err.details["field"], "workspace");
         assert!(err.message.contains("dispatch workspace"));
+    }
+
+    #[test]
+    fn dispatch_plan_promotes_runtime_component_contracts_from_client_context_inputs() {
+        let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+            prompt: Some("Cook with runtime components.".to_string()),
+            core: DispatchCoreInputs {
+                client_context: Some(
+                    serde_json::json!({
+                        "schema": "homeboy/repo-loop-workflow-context/v1",
+                        "inputs": {
+                            "runtime_component_contracts": [{
+                                "slug": "agents-api",
+                                "path": "components/agents-api",
+                                "loadAs": "plugin",
+                                "activate": true,
+                                "opaque": { "preserve": "yes" }
+                            }]
+                        }
+                    })
+                    .to_string(),
+                ),
+                ..DispatchCoreInputs::default()
+            },
+            ..DispatchRequestOverrides::default()
+        }))
+        .expect("dispatch plan");
+
+        let contracts = &plan.tasks[0].component_contracts;
+        assert_eq!(contracts.len(), 1);
+        assert_eq!(contracts[0].slug.as_deref(), Some("agents-api"));
+        assert_eq!(contracts[0].path.as_deref(), Some("components/agents-api"));
+        assert_eq!(contracts[0].load_as.as_deref(), Some("plugin"));
+        assert_eq!(contracts[0].activate, Some(true));
+        assert_eq!(contracts[0].extra["opaque"]["preserve"], "yes");
+        assert_eq!(
+            plan.tasks[0].executor.config["component_contracts"][0]["path"],
+            "components/agents-api"
+        );
+    }
+
+    #[test]
+    fn dispatch_plan_accepts_component_contracts_from_provider_config() {
+        let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+            prompt: Some("Cook with provider runtime components.".to_string()),
+            core: DispatchCoreInputs {
+                provider_config: Some(
+                    serde_json::json!({
+                        "component_contracts": [{
+                            "slug": "runtime-helper",
+                            "path": "/opt/runtime-helper",
+                            "loadAs": "mu-plugin",
+                            "activate": false,
+                            "opaque_provider_hint": { "preserved": true }
+                        }]
+                    })
+                    .to_string(),
+                ),
+                ..DispatchCoreInputs::default()
+            },
+            ..DispatchRequestOverrides::default()
+        }))
+        .expect("dispatch plan");
+
+        let contract = &plan.tasks[0].component_contracts[0];
+        assert_eq!(contract.slug.as_deref(), Some("runtime-helper"));
+        assert_eq!(contract.path.as_deref(), Some("/opt/runtime-helper"));
+        assert_eq!(contract.load_as.as_deref(), Some("mu-plugin"));
+        assert_eq!(contract.activate, Some(false));
+        assert_eq!(contract.extra["opaque_provider_hint"]["preserved"], true);
     }
 
     struct NoopExecutor;


### PR DESCRIPTION
## Summary
- Extract generic component contracts from dispatch provider config, client context, and nested client_context.inputs.
- Attach parsed contracts to spawned AgentTaskRequest.component_contracts and promote them into provider config as component_contracts when absent.
- Cover direct dispatch and controller dispatch paths, preserving path/loadAs/activate plus opaque fields.

## Tests
- homeboy test --lab-only --skip-lint -- controller_dispatch_runtime_component_contracts_reach_spawned_agent_task_request dispatch_plan_promotes_runtime_component_contracts_from_client_context_inputs dispatch_plan_accepts_component_contracts_from_provider_config
- Remote lab run: runner-exec-homeboy-lab-3f82a30d-8cad-4767-b231-ddf06f881449

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the generic dispatch contract propagation, adding focused tests, running verification, and drafting this PR description.