### PR TITLE
feat(agent-task): consistent Lab discovery and list pagination (#5681)

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -164,7 +164,8 @@ const AGENT_TASK_RUN_LAB_LABEL: &str = "agent-task dispatch/cook/loop/run-plan/r
 const AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL: &str =
     "agent-task controller from-spec --resume/materialize";
 const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task controller resume";
-const AGENT_TASK_STATUS_LAB_LABEL: &str = "agent-task run/run-next/status/logs/artifacts/review";
+const AGENT_TASK_STATUS_LAB_LABEL: &str =
+    "agent-task run/run-next/status/logs/artifacts/review/list/active/latest";
 const AGENT_TASK_PROVIDERS_LAB_LABEL: &str = "agent-task providers";
 const AGENT_TASK_AUTH_STATUS_LAB_LABEL: &str = "agent-task auth status";
 pub(crate) const LINT_LAB_LABEL: &str = "lint";
@@ -214,8 +215,10 @@ const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
     },
     LabSupportedCommandSummary {
         contract_labels: &[AGENT_TASK_STATUS_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL],
-        message_label: "agent-task run/run-next/status/logs/artifacts/review/providers",
-        hint_label: "agent-task run/run-next/status/logs/artifacts/review/providers",
+        message_label:
+            "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
+        hint_label:
+            "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
     },
     LabSupportedCommandSummary {
         contract_labels: &[AGENT_TASK_AUTH_STATUS_LAB_LABEL],
@@ -408,7 +411,15 @@ impl Commands {
                     | agent_task::AgentTaskCommand::RunNext
                     | agent_task::AgentTaskCommand::Logs(_)
                     | agent_task::AgentTaskCommand::Artifacts(_)
-                    | agent_task::AgentTaskCommand::Review(_),
+                    | agent_task::AgentTaskCommand::Review(_)
+                    // Discovery commands (list/active/latest) are runner-resident
+                    // reads too: a freshly-offloaded Lab run's durable record
+                    // lives on the runner, so `--runner <id> agent-task
+                    // list/active/latest` must resolve against that runner to
+                    // make discovery consistent with status/logs/etc (#5681).
+                    | agent_task::AgentTaskCommand::List
+                    | agent_task::AgentTaskCommand::Active
+                    | agent_task::AgentTaskCommand::Latest,
             }) => LabCommandContract::runner_resident(AGENT_TASK_STATUS_LAB_LABEL),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -51,26 +51,29 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::RunNext => run::run_next(),
         AgentTaskCommand::Submit(submit_args) => run::submit(submit_args),
         AgentTaskCommand::Status(status_args) => status::status(status_args),
-        AgentTaskCommand::List => {
-            status::list_runs(agent_task_service::AgentTaskDiscoveryFilter::All)
-        }
+        AgentTaskCommand::List => status::list_runs(
+            agent_task_service::AgentTaskDiscoveryFilter::All,
+            discovery_options_from_raw_args(),
+        ),
         AgentTaskCommand::Active => {
             // `Active` is a unit clap variant whose flag surface lives in the
-            // fleet-owned args module; until a typed `--reconcile`/`--dry-run`
-            // flag can be added there, detect them from the raw process args so
-            // the safe stale-run reconcile path is reachable today (#5682).
+            // fleet-owned args module; until a typed `--reconcile`/`--dry-run`/
+            // `--limit` flag can be added there, detect them from the raw
+            // process args so the safe stale-run reconcile path and the shared
+            // `--limit` pagination cap are reachable today (#5682, #5681).
             let raw: Vec<String> = std::env::args().collect();
             let reconcile = raw.iter().any(|arg| arg == "--reconcile");
             let dry_run = raw.iter().any(|arg| arg == "--dry-run");
             if reconcile {
                 status::reconcile_active(dry_run)
             } else {
-                status::list_active()
+                status::list_active(discovery_options_from_raw_args())
             }
         }
-        AgentTaskCommand::Latest => {
-            status::list_runs(agent_task_service::AgentTaskDiscoveryFilter::Latest)
-        }
+        AgentTaskCommand::Latest => status::list_runs(
+            agent_task_service::AgentTaskDiscoveryFilter::Latest,
+            discovery_options_from_raw_args(),
+        ),
         AgentTaskCommand::Logs(status_args) => status::logs(status_args),
         AgentTaskCommand::Artifacts(status_args) => status::artifacts(status_args),
         AgentTaskCommand::Cancel(cancel_args) => status::cancel(cancel_args),
@@ -100,7 +103,33 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
     }
 }
 
+use homeboy::core::agent_task_service as agent_task_service_direct;
 use homeboy::core::agent_tasks::service as agent_task_service;
+
+/// Parse shared discovery options (`--limit`) from the raw process args for the
+/// `list`/`active`/`latest` unit clap variants. Their typed flag surface lives
+/// in the fleet-owned args module; mirroring the existing #5682
+/// `--reconcile`/`--dry-run` raw-arg detection, this lets the `--limit`
+/// pagination cap ship without editing that module. Accepts both `--limit N`
+/// and `--limit=N`; a missing/invalid value leaves the limit unset so the full
+/// list is returned (#5681).
+fn discovery_options_from_raw_args() -> agent_task_service_direct::AgentTaskDiscoveryOptions {
+    let raw: Vec<String> = std::env::args().collect();
+    let mut limit = None;
+    let mut iter = raw.iter();
+    while let Some(arg) = iter.next() {
+        if let Some(value) = arg.strip_prefix("--limit=") {
+            if let Ok(parsed) = value.parse::<usize>() {
+                limit = Some(parsed);
+            }
+        } else if arg == "--limit" {
+            if let Some(parsed) = iter.next().and_then(|value| value.parse::<usize>().ok()) {
+                limit = Some(parsed);
+            }
+        }
+    }
+    agent_task_service_direct::AgentTaskDiscoveryOptions { limit }
+}
 
 pub(crate) fn command_json_value<T: Serialize>(value: T) -> homeboy::core::Result<Value> {
     serde_json::to_value(value)

--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -32,8 +32,11 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     Ok((summary, 0))
 }
 
-pub(super) fn list_runs(filter: agent_task_service::AgentTaskDiscoveryFilter) -> CmdResult<Value> {
-    let report = agent_task_service::discover_runs(filter)?;
+pub(super) fn list_runs(
+    filter: agent_task_service::AgentTaskDiscoveryFilter,
+    options: agent_task_service_direct::AgentTaskDiscoveryOptions,
+) -> CmdResult<Value> {
+    let report = agent_task_service_direct::discover_runs_with_options(filter, options)?;
     Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
 }
 
@@ -45,9 +48,13 @@ pub(super) fn list_runs(filter: agent_task_service::AgentTaskDiscoveryFilter) ->
 /// The base discovery report (with per-run liveness, source, last-update age,
 /// and a per-run safe reconcile command) is preserved under `report`, and a
 /// `buckets` view groups run ids by classification for an at-a-glance triage.
-pub(super) fn list_active() -> CmdResult<Value> {
-    let report =
-        agent_task_service::discover_runs(agent_task_service::AgentTaskDiscoveryFilter::Active)?;
+pub(super) fn list_active(
+    options: agent_task_service_direct::AgentTaskDiscoveryOptions,
+) -> CmdResult<Value> {
+    let report = agent_task_service_direct::discover_runs_with_options(
+        agent_task_service::AgentTaskDiscoveryFilter::Active,
+        options,
+    )?;
     let mut value = serde_json::to_value(&report).unwrap_or(Value::Null);
 
     let buckets = active_liveness_buckets(&report);

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -39,6 +39,18 @@ pub enum AgentTaskDiscoveryFilter {
     Latest,
 }
 
+/// Discovery options layered on top of an [`AgentTaskDiscoveryFilter`]. Today
+/// this carries the operator-facing `--limit` cap shared by the `list`/`active`
+/// list surfaces so a large run history stays scannable, matching the
+/// pagination affordance other list commands expose (#5681).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AgentTaskDiscoveryOptions {
+    /// Maximum number of runs to return, applied after filtering/sorting.
+    /// `None` returns every matching run. Ignored for the `latest` filter,
+    /// which is always a single run.
+    pub limit: Option<usize>,
+}
+
 /// Number of minutes a `Running` record may go without an `updated_at`
 /// heartbeat before `agent-task active` treats it as suspect even when its
 /// owner process/runner-job liveness cannot be disproven. Lab/offloaded runs
@@ -51,12 +63,54 @@ pub struct AgentTaskDiscoveryReport {
     pub schema: &'static str,
     pub filter: &'static str,
     pub count: usize,
+    /// Total matching runs before any `--limit` cap was applied. Equals `count`
+    /// when no limit truncated the list; larger when results were capped so an
+    /// operator knows more runs exist (#5681).
+    pub total: usize,
+    /// The applied `--limit`, echoed back so consumers can tell a capped list
+    /// from a complete one. `None` when every matching run was returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    /// `true` when `total > count` because the `--limit` cap truncated results.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
     pub runs: Vec<AgentTaskDiscoveryRun>,
     /// Liveness buckets for the `active` filter so operators can separate
     /// genuinely-active runs from stale/suspect/unreconciled records at a
     /// glance. Only populated for the `active` filter; `None` elsewhere.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub liveness_summary: Option<AgentTaskLivenessSummary>,
+    /// Operator guidance explaining how to find Lab/offloaded runs that this
+    /// local discovery pass may not see. A freshly offloaded Lab cook's durable
+    /// record lives on the runner, so a local `agent-task list/active/latest`
+    /// can miss it; this note documents the correct runner-scoped command and
+    /// the `homeboy runs list` fallback (#5681).
+    pub lab_discovery: AgentTaskLabDiscoveryHint,
+}
+
+/// Guidance describing where Lab/offloaded agent-task runs are discoverable.
+/// Local discovery (`agent-task list/active/latest` without `--runner`) only
+/// sees runs whose durable records live on this controller; a run offloaded to
+/// a Lab runner is recorded on that runner until it reports back. This hint
+/// gives operators the exact runner-scoped command plus the cross-location
+/// fallback so a freshly-offloaded run is never "lost" (#5681).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentTaskLabDiscoveryHint {
+    pub note: &'static str,
+    pub runner_scoped_command: &'static str,
+    pub fallback_command: &'static str,
+}
+
+impl Default for AgentTaskLabDiscoveryHint {
+    fn default() -> Self {
+        Self {
+            note: "This list covers runs whose durable records live on this controller. A run offloaded to a Lab runner is recorded on that runner until it reports back, so a freshly-offloaded run may not appear here yet.",
+            runner_scoped_command:
+                "homeboy --runner <runner-id> agent-task list   # discover runs resident on a specific Lab runner",
+            fallback_command:
+                "homeboy runs list   # cross-location fallback that includes offloaded runs",
+        }
+    }
 }
 
 /// Coarse liveness classification for an active (queued/running) run. The
@@ -237,6 +291,17 @@ pub fn read_plan(spec: &str) -> Result<AgentTaskPlan> {
 }
 
 pub fn discover_runs(filter: AgentTaskDiscoveryFilter) -> Result<AgentTaskDiscoveryReport> {
+    discover_runs_with_options(filter, AgentTaskDiscoveryOptions::default())
+}
+
+/// Discovery with operator options (currently `--limit`). The `latest` filter
+/// is inherently a single run, so a limit is a no-op there; `all`/`active`
+/// truncate to the requested cap after filtering and sorting, and report the
+/// pre-cap `total` so consumers know more runs exist (#5681).
+pub fn discover_runs_with_options(
+    filter: AgentTaskDiscoveryFilter,
+    options: AgentTaskDiscoveryOptions,
+) -> Result<AgentTaskDiscoveryReport> {
     let mut records = agent_task_lifecycle::list_records()?;
     let is_active = filter == AgentTaskDiscoveryFilter::Active;
     if is_active {
@@ -252,6 +317,17 @@ pub fn discover_runs(filter: AgentTaskDiscoveryFilter) -> Result<AgentTaskDiscov
         records.truncate(1);
     }
 
+    let total = records.len();
+
+    // `latest` is always a single run; only `all`/`active` honor a limit cap.
+    let effective_limit = match filter {
+        AgentTaskDiscoveryFilter::Latest => None,
+        _ => options.limit,
+    };
+    if let Some(limit) = effective_limit {
+        records.truncate(limit);
+    }
+
     let now = chrono::Utc::now();
     let runs: Vec<_> = records
         .into_iter()
@@ -259,6 +335,7 @@ pub fn discover_runs(filter: AgentTaskDiscoveryFilter) -> Result<AgentTaskDiscov
         .collect();
 
     let liveness_summary = is_active.then(|| liveness_summary(&runs));
+    let truncated = runs.len() < total;
 
     Ok(AgentTaskDiscoveryReport {
         schema: "homeboy/agent-task-discovery/v1",
@@ -268,8 +345,12 @@ pub fn discover_runs(filter: AgentTaskDiscoveryFilter) -> Result<AgentTaskDiscov
             AgentTaskDiscoveryFilter::Latest => "latest",
         },
         count: runs.len(),
+        total,
+        limit: effective_limit,
+        truncated,
         runs,
         liveness_summary,
+        lab_discovery: AgentTaskLabDiscoveryHint::default(),
     })
 }
 
@@ -481,6 +562,18 @@ fn discovery_run(
     let source = run_source(&record);
     let liveness = classify.then(|| classify_liveness(&record, last_update_age_minutes));
 
+    // A runner-backed run's durable record (status/logs/artifacts/review) lives
+    // on the runner, so the emitted recovery commands must be runner-scoped to
+    // resolve against the run's actual location. Local runs use the bare
+    // command. This keeps "commands emitted in run metadata valid for the run
+    // location" (#5681).
+    let runner_id = metadata_string(&record.metadata, "runner_id")
+        .filter(|runner_id| !runner_id.trim().is_empty());
+    let command_prefix = match runner_id.as_deref() {
+        Some(runner_id) => format!("homeboy --runner {runner_id} agent-task"),
+        None => "homeboy agent-task".to_string(),
+    };
+
     AgentTaskDiscoveryRun {
         run_id: run_id.clone(),
         state: record.state,
@@ -502,19 +595,19 @@ fn discovery_run(
         last_update,
         last_update_age_minutes,
         commands: AgentTaskDiscoveryCommands {
-            status: format!("homeboy agent-task status {run_id}"),
-            logs: format!("homeboy agent-task logs {run_id}"),
-            artifacts: format!("homeboy agent-task artifacts {run_id}"),
-            review: format!("homeboy agent-task review {run_id}"),
-            retry: format!("homeboy agent-task retry {run_id} --run"),
+            status: format!("{command_prefix} status {run_id}"),
+            logs: format!("{command_prefix} logs {run_id}"),
+            artifacts: format!("{command_prefix} artifacts {run_id}"),
+            review: format!("{command_prefix} review {run_id}"),
+            retry: format!("{command_prefix} retry {run_id} --run"),
             run_plan: format!(
                 "homeboy --runner <runner-id> agent-task run-plan --plan @{} --record-run-id <new-run-id>",
                 record.plan_path
             ),
             promote: aggregate_path
                 .map(|path| format!("homeboy agent-task promote {path} --to-worktree <handle>"))
-                .unwrap_or_else(|| format!("homeboy agent-task review {run_id}")),
-            reconcile: format!("homeboy agent-task cancel {run_id} --reason stale-running"),
+                .unwrap_or_else(|| format!("{command_prefix} review {run_id}")),
+            reconcile: format!("{command_prefix} cancel {run_id} --reason stale-running"),
         },
     }
 }
@@ -1366,6 +1459,14 @@ mod tests {
             assert_eq!(report.schema, "homeboy/agent-task-discovery/v1");
             assert_eq!(report.filter, "all");
             assert_eq!(report.count, 1);
+            assert_eq!(report.total, 1);
+            assert!(!report.truncated);
+            assert!(report.limit.is_none());
+            assert!(report
+                .lab_discovery
+                .runner_scoped_command
+                .contains("--runner"));
+            assert!(report.lab_discovery.fallback_command.contains("runs list"));
             assert_eq!(run.run_id, "run-discovery-list");
             assert_eq!(run.state, AgentTaskRunState::Queued);
             assert_eq!(run.repo.as_deref(), Some("homeboy"));
@@ -1584,6 +1685,90 @@ mod tests {
             assert_eq!(report.filter, "latest");
             assert_eq!(report.count, 1);
             assert_eq!(report.runs[0].run_id, "run-latest-z");
+        });
+    }
+
+    #[test]
+    fn discovery_limit_caps_list_and_reports_total() {
+        with_isolated_home(|_| {
+            for run_id in ["run-cap-a", "run-cap-b", "run-cap-c"] {
+                agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id))
+                    .expect("submitted");
+            }
+
+            let report = discover_runs_with_options(
+                AgentTaskDiscoveryFilter::All,
+                AgentTaskDiscoveryOptions { limit: Some(2) },
+            )
+            .expect("listed with limit");
+
+            assert_eq!(report.count, 2);
+            assert_eq!(report.total, 3);
+            assert_eq!(report.limit, Some(2));
+            assert!(report.truncated);
+            assert_eq!(report.runs.len(), 2);
+        });
+    }
+
+    #[test]
+    fn discovery_latest_ignores_limit() {
+        with_isolated_home(|_| {
+            agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-latest-limit-a"))
+                .expect("submitted");
+            agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-latest-limit-z"))
+                .expect("submitted");
+
+            let report = discover_runs_with_options(
+                AgentTaskDiscoveryFilter::Latest,
+                AgentTaskDiscoveryOptions { limit: Some(5) },
+            )
+            .expect("latest listed");
+
+            // `latest` is always a single run; a limit is a no-op and not echoed.
+            assert_eq!(report.count, 1);
+            assert!(report.limit.is_none());
+            assert!(!report.truncated);
+        });
+    }
+
+    #[test]
+    fn discovery_runner_backed_run_emits_runner_scoped_commands() {
+        with_isolated_home(|_| {
+            agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-runner-commands"))
+                .expect("submitted");
+            agent_task_lifecycle::rewrite_record_for_test("run-runner-commands", |record| {
+                record.state = AgentTaskRunState::Running;
+                record.tasks[0].state = AgentTaskState::Running;
+                record.metadata = serde_json::json!({
+                    "runner_id": "homeboy-lab",
+                });
+            })
+            .expect("runner-backed record stored");
+
+            let report = discover_runs(AgentTaskDiscoveryFilter::All).expect("listed");
+            let run = report
+                .runs
+                .iter()
+                .find(|run| run.run_id == "run-runner-commands")
+                .expect("runner-backed run listed");
+
+            // Commands must be valid for the run's location: runner-scoped.
+            assert_eq!(
+                run.commands.status,
+                "homeboy --runner homeboy-lab agent-task status run-runner-commands"
+            );
+            assert_eq!(
+                run.commands.logs,
+                "homeboy --runner homeboy-lab agent-task logs run-runner-commands"
+            );
+            assert_eq!(
+                run.commands.review,
+                "homeboy --runner homeboy-lab agent-task review run-runner-commands"
+            );
+            assert_eq!(
+                run.commands.reconcile,
+                "homeboy --runner homeboy-lab agent-task cancel run-runner-commands --reason stale-running"
+            );
         });
     }
 

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -68,7 +68,7 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
             "agent-task dispatch/cook/loop/run-plan",
             "agent-task controller from-spec --resume/materialize/resume",
             "agent-task retry --run",
-            "agent-task run/run-next/status/logs/artifacts/review/providers",
+            "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
             "agent-task auth status",
             "lint",
             "test",
@@ -86,11 +86,11 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
     );
     assert_eq!(
         lab_runner_unsupported_message(),
-        "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task run/run-next/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, review, bench, fuzz, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start"
+        "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers, agent-task auth status, lint, test, audit, review, bench, fuzz, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start"
     );
     assert_eq!(
         lab_runner_unsupported_hint(),
-        "Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task run/run-next/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, review, bench run, fuzz run, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start."
+        "Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task controller from-spec --resume/materialize/resume, agent-task retry --run, agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers, agent-task auth status, lint, test, audit, review, bench run, fuzz run, trace, refactor source runs, rig check, tunnel preview-consumer run, tunnel service expose, and tunnel service start."
     );
 }
 


### PR DESCRIPTION
Closes #5681. Makes `active`/`list`/`latest` consistent for Lab/offloaded runs, adds `--limit` to the list surfaces, makes emitted recovery commands valid for each run's location, and aligns runner-support help/error text with the accepted subcommands.

## Changes

### Consistent Lab/offloaded discovery
- `list`/`active`/`latest` are now runner-resident Lab commands (`command_contract/lab.rs`), so `homeboy --runner <id> agent-task list/active/latest` resolves against the runner where a freshly-offloaded run's durable record actually lives — matching how `status`/`logs`/`artifacts`/`review` already work. Previously these had no Lab contract, so `--runner` against them was rejected and operators had to fall back to `homeboy runs list`.
- Every discovery report now carries a `lab_discovery` hint documenting the runner-scoped command and the `homeboy runs list` cross-location fallback, so a locally-invisible offloaded run is never "lost".
- Per-run `commands` (status/logs/artifacts/review/retry/promote/reconcile) are now emitted with a `--runner <id>` prefix for runner-backed runs, so the commands in run metadata are valid for the run's location.

### `--limit` pagination
- Added `AgentTaskDiscoveryOptions { limit }` and `discover_runs_with_options`. `list`/`active` honor `--limit` (both `--limit N` and `--limit=N`); `latest` ignores it (always one run).
- Reports now include `total`, `limit`, and `truncated` so a capped list is distinguishable from a complete one.
- `--limit` is parsed from raw process args in the dispatcher, mirroring the existing #5682 `--reconcile`/`--dry-run` pattern (the typed flag surface lives in the fleet-owned `args/mod.rs`, which this PR deliberately does not touch).

### Runner-support text
- The runner-support summary/message/hint labels now list `list/active/latest` alongside the other accepted agent-task subcommands.

## Scope / limitation
Per task scope, this stays out of the fleet-owned files (`core/agent_task.rs`, `agent_tasks.rs`, `agent_task_provider.rs`, `agent_task_contract.rs`, `agent_task_lifecycle.rs`, `commands/agent_task/args/mod.rs`, `review.rs`, `tests/contract.rs`, `runner/lab/offload.rs`). Because `--limit` and the typed help one-liner for `list` live in the fleet-owned `args/mod.rs`, the limit/filtering behavior is self-documented in the discovery report (`limit`/`truncated`/`lab_discovery` fields) rather than in `agent-task list --help`; a typed `--limit` flag + help text can be added to `args/mod.rs` in a follow-up.

## Files changed
- `src/core/agent_task_service.rs` — options/limit, `total`/`truncated`/`limit`, `lab_discovery` hint, location-aware commands, tests
- `src/commands/agent_task/status.rs` — pass options through to discovery
- `src/commands/agent_task.rs` — `--limit` raw-arg parsing + wiring
- `src/command_contract/lab.rs` — runner-resident contract for list/active/latest + label text
- `tests/command_contract/lab_test.rs` — updated label assertions

## Verification
- `cargo build --lib` — clean
- `cargo clippy --lib` — no new warnings in changed files
- `cargo fmt` — applied
- (Test suite / `cargo build --tests` not run locally per VPS OOM policy; CI gates them.)