### PR TITLE
Fix Lab extension sync capability preflight

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -295,7 +295,7 @@ fn sync_lab_extension(
             capability_preflight: Some(homeboy::core::runners::RunnerCapabilityPreflight {
                 command: "homeboy lab extension-sync".to_string(),
                 required_tools: vec![RunnerRequiredTool::Homeboy],
-                required_commands: vec!["extension".to_string()],
+                required_commands: Vec::new(),
                 required_components: Vec::new(),
                 required_env: Vec::new(),
             }),


### PR DESCRIPTION
## Summary
- stop requiring runner command parity for the local-only Lab extension sync wrapper
- keep the preflight scoped to the remote Homeboy tool, which is what executes the extension install

## Testing
- 
- Not run: local Cargo tests, per site rule against local Rust-heavy verification

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** diagnosing the Lab extension-sync capability blocker and drafting the focused fix
