### PR TITLE
feat(agent-task): explicit backend selection summary (#5685)

### DIFF
--- a/src/commands/agent_task/tests/dispatch.rs
+++ b/src/commands/agent_task/tests/dispatch.rs
@@ -278,6 +278,7 @@ fn controller_dispatch_args_preserve_top_level_workspace_context_in_plan() {
         concurrency: args.concurrency,
         run_id: args.run_id,
         core: args.core.into(),
+        backend_selection: None,
     };
     let plan = homeboy::core::agent_tasks::dispatch_service::build_dispatch_plan_with_provider_requirements(
             &dispatch_request,

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use serde_json::Value;
 
+use homeboy::core::agent_task_dispatch_service::render_backend_selection_summary;
 use homeboy::core::agent_tasks::dispatch_service::{
     self, AgentTaskDispatchCommand, DispatchCoreInputs,
 };
@@ -9,6 +10,19 @@ use homeboy::core::agent_tasks::provider::{
 };
 
 use super::{CmdResult, GlobalArgs};
+
+/// Print the effective backend selection (and any override warning) to stderr
+/// before dispatch so operators can see which backend will run and where the
+/// selection came from. Resolution happens here without consuming `command`;
+/// dispatch re-resolves identically. Errors are intentionally swallowed — the
+/// summary is best-effort and the dispatch path surfaces the real error (#5685).
+fn print_backend_selection_summary(command: &AgentTaskDispatchCommand) {
+    if let Ok(request) = dispatch_service::resolve_dispatch_request(command.clone()) {
+        if let Some(selection) = request.backend_selection.as_ref() {
+            eprintln!("{}", render_backend_selection_summary(selection));
+        }
+    }
+}
 
 /// CLI surface for the dispatch inputs shared across dispatch carriers. Flattened
 /// into [`DispatchArgs`] so the `--tasks/--provider-config/--client-context/
@@ -135,8 +149,10 @@ impl From<DispatchArgs> for AgentTaskDispatchCommand {
 
 pub fn run(args: DispatchArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     let catalog = AgentTaskProviderCatalog::discover();
+    let command: AgentTaskDispatchCommand = args.into();
+    print_backend_selection_summary(&command);
     dispatch_service::run_dispatch_command_with_provider_catalog(
-        args.into(),
+        command,
         ExtensionProviderAgentTaskExecutor::from_catalog(catalog.clone()),
         &catalog,
     )
@@ -144,8 +160,10 @@ pub fn run(args: DispatchArgs, _global: &GlobalArgs) -> CmdResult<Value> {
 
 pub(crate) fn cook(args: DispatchArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     let catalog = AgentTaskProviderCatalog::discover();
+    let command: AgentTaskDispatchCommand = args.into();
+    print_backend_selection_summary(&command);
     dispatch_service::run_cook_command_with_provider_catalog(
-        args.into(),
+        command,
         ExtensionProviderAgentTaskExecutor::from_catalog(catalog.clone()),
         &catalog,
     )

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -1265,6 +1265,7 @@ mod tests {
                 },
                 queue_only: overrides.core.queue_only,
             },
+            backend_selection: None,
         }
     }
 

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -25,6 +25,48 @@ use crate::core::{Error, Result};
 
 pub const DISPATCH_RESULT_SCHEMA: &str = "homeboy/agent-task-dispatch/v1";
 
+/// Where the effective agent-task backend selection came from. Surfaced before
+/// dispatch so operators can see whether the backend was an explicit override or
+/// resolved from the configured default policy (#5685).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BackendSelectionSource {
+    /// Explicit `--backend` flag on the command line.
+    Cli,
+    /// Resolved from a component- or extension-scoped `agent_task.default_backend`
+    /// policy (higher priority than the Homeboy config default).
+    Policy,
+    /// Resolved from the Homeboy config `agent_task.default_backend`.
+    Config,
+}
+
+impl BackendSelectionSource {
+    /// Short human label for summary/warning rendering.
+    pub fn label(self) -> &'static str {
+        match self {
+            BackendSelectionSource::Cli => "cli (--backend)",
+            BackendSelectionSource::Policy => "config (component/extension default)",
+            BackendSelectionSource::Config => "config (homeboy default)",
+        }
+    }
+}
+
+/// The effective backend plus where it came from and whether it overrides the
+/// configured default. Attached to the dispatch report and rendered as a
+/// pre-dispatch summary by the command adapter (#5685).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BackendSelection {
+    /// The backend that will actually be dispatched.
+    pub backend: String,
+    /// Where the selection came from.
+    pub source: BackendSelectionSource,
+    /// The configured default backend, when any policy declares one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_backend: Option<String>,
+    /// True when an explicit `--backend` differs from the configured default.
+    pub overrides_default: bool,
+}
+
 /// Dispatch inputs shared verbatim across the dispatch arg, command, and request
 /// carriers (and their test override fixtures). Factored into one struct so the
 /// `[attempts, client_context, provider_config, queue_only, tasks_json]` group
@@ -59,6 +101,8 @@ pub struct AgentTaskDispatchRequest {
     pub concurrency: usize,
     pub run_id: Option<String>,
     pub core: DispatchCoreInputs,
+    /// Effective backend selection metadata, surfaced before dispatch (#5685).
+    pub backend_selection: Option<BackendSelection>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -72,6 +116,10 @@ pub struct AgentTaskDispatchReport {
     pub aggregate_path: Option<String>,
     pub task_count: usize,
     pub queued: bool,
+    /// Effective backend selection + source, mirrored into the report so logs and
+    /// status metadata record the override decision (#5685).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend_selection: Option<BackendSelection>,
     pub record: AgentTaskRunRecord,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AgentTaskAggregate>,
@@ -96,6 +144,7 @@ pub fn dispatch_with_provider_catalog<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
+    let backend_selection = request.backend_selection.clone();
     let mut plan =
         build_dispatch_plan_with_provider_requirements(&request, |backend, selector| {
             catalog.provider_requires_cwd_git_checkout(backend, selector)
@@ -107,7 +156,7 @@ where
 
     if request.core.queue_only {
         return Ok(AgentTaskRunResult {
-            value: dispatch_report(submitted, None, true),
+            value: dispatch_report(submitted, None, true, backend_selection),
             exit_code: 0,
         });
     }
@@ -118,7 +167,7 @@ where
     let exit_code = aggregate_exit_code(&aggregate);
 
     Ok(AgentTaskRunResult {
-        value: dispatch_report(record, Some(aggregate), false),
+        value: dispatch_report(record, Some(aggregate), false, backend_selection),
         exit_code,
     })
 }
@@ -131,6 +180,7 @@ pub fn dispatch_with_provider_requirements<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
+    let backend_selection = request.backend_selection.clone();
     let mut plan = build_dispatch_plan_with_provider_requirements(
         &request,
         provider_requires_cwd_git_checkout,
@@ -142,7 +192,7 @@ where
 
     if request.core.queue_only {
         return Ok(AgentTaskRunResult {
-            value: dispatch_report(submitted, None, true),
+            value: dispatch_report(submitted, None, true, backend_selection),
             exit_code: 0,
         });
     }
@@ -153,7 +203,7 @@ where
     let exit_code = aggregate_exit_code(&aggregate);
 
     Ok(AgentTaskRunResult {
-        value: dispatch_report(record, Some(aggregate), false),
+        value: dispatch_report(record, Some(aggregate), false, backend_selection),
         exit_code,
     })
 }
@@ -162,6 +212,7 @@ fn dispatch_report(
     record: AgentTaskRunRecord,
     aggregate: Option<AgentTaskAggregate>,
     queued: bool,
+    backend_selection: Option<BackendSelection>,
 ) -> AgentTaskDispatchReport {
     AgentTaskDispatchReport {
         schema: DISPATCH_RESULT_SCHEMA,
@@ -172,6 +223,7 @@ fn dispatch_report(
         aggregate_path: record.aggregate_path.clone(),
         task_count: record.tasks.len(),
         queued,
+        backend_selection,
         record,
         aggregate,
     }
@@ -213,19 +265,69 @@ pub fn resolve_dispatch_request_with_default(
     command: AgentTaskDispatchCommand,
     default_backend: impl FnOnce(Option<&str>) -> Result<Option<String>>,
 ) -> Result<AgentTaskDispatchRequest> {
-    let backend = match command.backend {
-        Some(backend) => backend,
-        None => default_backend(command.repo.as_deref())?.ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "backend",
-                "agent-task dispatch requires --backend because no default backend policy is configured",
-                None,
-                Some(vec![
-                    "Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.".to_string(),
-                ]),
-            )
-        })?,
+    resolve_dispatch_request_with_default_and_config(
+        command,
+        default_backend,
+        config_default_backend,
+    )
+}
+
+/// The configured Homeboy-config `agent_task.default_backend`, when set. Read via
+/// the public `defaults` surface so the dispatch service can name the selection
+/// source without touching fleet-owned provider policy code (#5685).
+fn config_default_backend() -> Option<String> {
+    crate::core::defaults::load_config()
+        .agent_task
+        .default_backend
+        .filter(|backend| !backend.trim().is_empty())
+}
+
+/// Resolution core that also takes the Homeboy-config default resolver so tests
+/// can drive deterministic source classification (#5685).
+pub fn resolve_dispatch_request_with_default_and_config(
+    command: AgentTaskDispatchCommand,
+    default_backend: impl FnOnce(Option<&str>) -> Result<Option<String>>,
+    config_default: impl FnOnce() -> Option<String>,
+) -> Result<AgentTaskDispatchRequest> {
+    let config_default = config_default();
+    let (backend, source) = match command.backend {
+        Some(backend) => (backend, BackendSelectionSource::Cli),
+        None => {
+            let resolved = default_backend(command.repo.as_deref())?.ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "backend",
+                    "agent-task dispatch requires --backend because no default backend policy is configured",
+                    None,
+                    Some(vec![
+                        "Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.".to_string(),
+                    ]),
+                )
+            })?;
+            // The policy resolver prefers component/extension defaults over the
+            // Homeboy config default; if the resolved value matches the config
+            // default we attribute it to config, otherwise to higher-priority
+            // component/extension policy.
+            let source = if config_default.as_deref() == Some(resolved.as_str()) {
+                BackendSelectionSource::Config
+            } else {
+                BackendSelectionSource::Policy
+            };
+            (resolved, source)
+        }
     };
+
+    let overrides_default = source == BackendSelectionSource::Cli
+        && config_default
+            .as_deref()
+            .map(|default| default != backend.as_str())
+            .unwrap_or(false);
+
+    let backend_selection = Some(BackendSelection {
+        backend: backend.clone(),
+        source,
+        default_backend: config_default,
+        overrides_default,
+    });
 
     Ok(AgentTaskDispatchRequest {
         prompt: command.prompt,
@@ -242,7 +344,32 @@ pub fn resolve_dispatch_request_with_default(
         concurrency: command.concurrency,
         run_id: command.run_id,
         core: command.core,
+        backend_selection,
     })
+}
+
+/// Render a human-readable, single-line-per-field backend selection summary for
+/// the command adapter to print to stderr before dispatch (#5685). Kept in the
+/// service so the wording stays consistent across cook and dispatch surfaces.
+pub fn render_backend_selection_summary(selection: &BackendSelection) -> String {
+    let mut lines = vec![
+        "agent-task backend selection:".to_string(),
+        format!("  backend: {}", selection.backend),
+        format!("  source:  {}", selection.source.label()),
+    ];
+    match selection.default_backend.as_deref() {
+        Some(default) => lines.push(format!("  default: {default}")),
+        None => lines.push("  default: <none configured>".to_string()),
+    }
+    if selection.overrides_default {
+        if let Some(default) = selection.default_backend.as_deref() {
+            lines.push(format!(
+                "  warning: --backend '{}' overrides the configured default '{}'",
+                selection.backend, default
+            ));
+        }
+    }
+    lines.join("\n")
 }
 
 /// Run a dispatch invocation end to end: resolve the request, dispatch it through
@@ -415,6 +542,99 @@ fn cook_promotion_commands(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn command_with_backend(backend: Option<&str>) -> AgentTaskDispatchCommand {
+        AgentTaskDispatchCommand {
+            prompt: Some("task".to_string()),
+            backend: backend.map(str::to_string),
+            ..AgentTaskDispatchCommand::default()
+        }
+    }
+
+    #[test]
+    fn explicit_backend_is_attributed_to_cli_source() {
+        let request = resolve_dispatch_request_with_default_and_config(
+            command_with_backend(Some("claude-code")),
+            |_| Ok(Some("opencode".to_string())),
+            || Some("opencode".to_string()),
+        )
+        .expect("request");
+
+        let selection = request.backend_selection.expect("selection");
+        assert_eq!(selection.backend, "claude-code");
+        assert_eq!(selection.source, BackendSelectionSource::Cli);
+        assert_eq!(selection.default_backend.as_deref(), Some("opencode"));
+        assert!(selection.overrides_default);
+    }
+
+    #[test]
+    fn explicit_backend_matching_default_does_not_warn() {
+        let request = resolve_dispatch_request_with_default_and_config(
+            command_with_backend(Some("opencode")),
+            |_| Ok(Some("opencode".to_string())),
+            || Some("opencode".to_string()),
+        )
+        .expect("request");
+
+        let selection = request.backend_selection.expect("selection");
+        assert_eq!(selection.source, BackendSelectionSource::Cli);
+        assert!(!selection.overrides_default);
+    }
+
+    #[test]
+    fn config_default_backend_is_attributed_to_config_source() {
+        let request = resolve_dispatch_request_with_default_and_config(
+            command_with_backend(None),
+            |_| Ok(Some("opencode".to_string())),
+            || Some("opencode".to_string()),
+        )
+        .expect("request");
+
+        let selection = request.backend_selection.expect("selection");
+        assert_eq!(selection.backend, "opencode");
+        assert_eq!(selection.source, BackendSelectionSource::Config);
+        assert!(!selection.overrides_default);
+    }
+
+    #[test]
+    fn component_or_extension_default_is_attributed_to_policy_source() {
+        let request = resolve_dispatch_request_with_default_and_config(
+            command_with_backend(None),
+            |_| Ok(Some("component-backend".to_string())),
+            || Some("opencode".to_string()),
+        )
+        .expect("request");
+
+        let selection = request.backend_selection.expect("selection");
+        assert_eq!(selection.backend, "component-backend");
+        assert_eq!(selection.source, BackendSelectionSource::Policy);
+        // Default-policy selections never count as an explicit override.
+        assert!(!selection.overrides_default);
+    }
+
+    #[test]
+    fn summary_includes_override_warning_only_for_cli_override() {
+        let override_selection = BackendSelection {
+            backend: "claude-code".to_string(),
+            source: BackendSelectionSource::Cli,
+            default_backend: Some("opencode".to_string()),
+            overrides_default: true,
+        };
+        let summary = render_backend_selection_summary(&override_selection);
+        assert!(summary.contains("backend: claude-code"));
+        assert!(summary.contains("cli (--backend)"));
+        assert!(summary.contains("warning:"));
+        assert!(summary.contains("overrides the configured default 'opencode'"));
+
+        let default_selection = BackendSelection {
+            backend: "opencode".to_string(),
+            source: BackendSelectionSource::Config,
+            default_backend: Some("opencode".to_string()),
+            overrides_default: false,
+        };
+        let summary = render_backend_selection_summary(&default_selection);
+        assert!(!summary.contains("warning:"));
+    }
 
     #[test]
     fn queued_cook_handoff_uses_recorded_runner_context() {


### PR DESCRIPTION
Closes #5685.

## Summary
`agent-task cook` (and `dispatch`) now make the effective backend selection explicit **before dispatch**:

- A backend selection **summary** is printed to stderr before dispatch: selected `backend`, the selection `source` (CLI / config-component-or-extension-default / config-homeboy-default), and the configured `default`.
- When an explicit `--backend` differs from the configured `agent_task.default_backend`, a short **override warning** is printed (only for explicit CLI overrides — default-policy selections never warn).
- The selection is mirrored into the dispatch report JSON as `backend_selection { backend, source, default_backend, overrides_default }`, so logs/status metadata record the override decision.

## Implementation
- `src/core/agent_task_dispatch_service.rs`: new `BackendSelectionSource` enum + `BackendSelection` struct; source-aware resolution (`resolve_dispatch_request_with_default_and_config`) that classifies the source by comparing the resolved default against the Homeboy-config default (read via the public `defaults` surface); `render_backend_selection_summary`; threaded `backend_selection` into `AgentTaskDispatchRequest` and `AgentTaskDispatchReport`. Added unit tests for CLI/Config/Policy classification, override warning behavior, and summary rendering.
- `src/commands/agent_task_dispatch.rs`: `run`/`cook` print the summary to stderr before dispatch (best-effort; stdout JSON contract untouched).

## Source classification
The default-backend policy resolves component → extension → Homeboy config. Without modifying the fleet-owned `agent_task_provider.rs`, the service distinguishes **Cli** (explicit `--backend`), **Config** (matches the Homeboy-config default), and **Policy** (a higher-priority component/extension default) by comparing the resolved value to the public config default. There is no env-var backend source in the codebase, so it is not modeled.

## Scope / limitations
Stayed fully out of fleet-owned and contract files (`agent_task.rs`, `agent_tasks.rs`, `agent_task_provider.rs`, `agent_task_contract.rs`, `agent_task_lifecycle.rs`, `args/mod.rs`, `review.rs`, `tests/contract.rs`, all `command_contract/*`, `runner/*`). Provider/config data was read via existing public functions only.

**Deferred:** `agent-task providers` highlighting the default backend was NOT implemented — that command lives in the fleet-owned `src/commands/agent_task/review.rs` (`review::providers`), which is off-limits this round to avoid collisions. The default backend is already discoverable via the new cook/dispatch summary and the `backend_selection` report field; a follow-up can surface it in `providers` once that file is free.

## Verification
- `cargo build --lib` — clean (pre-existing warnings only)
- `cargo clippy --lib` — no findings in changed files (remaining warnings are pre-existing, in `runner/*`)
- `cargo fmt --check` — clean
- Did not run `cargo test` / `cargo build --tests` per VPS OOM policy; added unit tests will run in CI.