### PR TITLE
fix(release): fail closed on off-branch release tags

### DIFF
--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -327,6 +327,27 @@ pub fn get_latest_tag_with_prefix(path: &str, tag_prefix: Option<&str>) -> Resul
         .map(|(tag, _)| tag))
 }
 
+/// Get the latest exact release tag regardless of whether it is reachable from HEAD.
+pub fn get_latest_tag_any_with_prefix(
+    path: &str,
+    tag_prefix: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(tags) = command::run_in_optional(path, "git", &["tag", "--sort=-v:refname", "--list"])
+    else {
+        return Ok(None);
+    };
+
+    Ok(tags
+        .lines()
+        .filter_map(|tag| {
+            let tag = tag.trim();
+            exact_release_version_from_tag(tag, tag_prefix)
+                .map(|version| (tag.to_string(), version))
+        })
+        .max_by(|(_, a), (_, b)| a.cmp(b))
+        .map(|(tag, _)| tag))
+}
+
 /// Get the previous release tag reachable from `current_tag`.
 ///
 /// In monorepos, `tag_prefix` scopes the search to the component tag namespace.
@@ -350,6 +371,45 @@ pub fn get_previous_tag_before_with_prefix(
             "--list",
         ],
     ) else {
+        return Ok(None);
+    };
+
+    Ok(tags
+        .lines()
+        .filter_map(|tag| {
+            let tag = tag.trim();
+            if tag == current_tag {
+                return None;
+            }
+            let version = exact_release_version_from_tag(tag, tag_prefix)?;
+            if version < current_version {
+                Some((tag.to_string(), version))
+            } else {
+                None
+            }
+        })
+        .max_by(|(_, a), (_, b)| a.cmp(b))
+        .map(|(tag, _)| tag))
+}
+
+/// Get the highest release tag lower than `current_tag` regardless of ancestry.
+///
+/// This is deliberately broader than [`get_previous_tag_before_with_prefix`],
+/// which only returns tags merged into `current_tag`. Release-note planning uses
+/// this to fail closed when a prior published tag exists on a side branch and
+/// would otherwise be skipped, causing generated notes to duplicate an older
+/// release range.
+pub fn get_previous_tag_before_any_with_prefix(
+    path: &str,
+    current_tag: &str,
+    tag_prefix: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(current_version) = exact_release_version_from_tag(current_tag, tag_prefix) else {
+        return Ok(None);
+    };
+
+    let Some(tags) = command::run_in_optional(path, "git", &["tag", "--sort=-v:refname", "--list"])
+    else {
         return Ok(None);
     };
 

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -27,9 +27,11 @@ pub use changes::{
 pub(crate) use commits::extract_version_from_tag;
 pub use commits::{
     categorize_commits, find_version_commit, find_version_release_commit, get_commits_since_tag,
-    get_commits_since_tag_for_path, get_last_n_commits, get_latest_tag, get_latest_tag_with_prefix,
-    get_previous_tag_before_with_prefix, recommended_bump_from_commits, strip_conventional_prefix,
-    CommitCategory, CommitCounts, CommitInfo, MonorepoContext, SemverBump,
+    get_commits_since_tag_for_path, get_last_n_commits, get_latest_tag,
+    get_latest_tag_any_with_prefix, get_latest_tag_with_prefix,
+    get_previous_tag_before_any_with_prefix, get_previous_tag_before_with_prefix,
+    recommended_bump_from_commits, strip_conventional_prefix, CommitCategory, CommitCounts,
+    CommitInfo, MonorepoContext, SemverBump,
 };
 pub use gh_client::{github_cli_env, GhClient};
 pub use github::{

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -509,7 +509,33 @@ fn github_generated_notes_start_tag(component: &Component, tag: &str) -> Result<
         Some(ctx) => (ctx.git_root.as_str(), Some(ctx.tag_prefix.as_str())),
         None => (component.local_path.as_str(), None),
     };
-    crate::core::git::get_previous_tag_before_with_prefix(git_root, tag, tag_prefix)
+    let previous =
+        crate::core::git::get_previous_tag_before_any_with_prefix(git_root, tag, tag_prefix)?;
+
+    if let Some(previous_tag) = previous.as_deref() {
+        if !crate::core::git::is_ancestor(git_root, previous_tag, tag)? {
+            return Err(Error::validation_invalid_argument(
+                "release-notes-range",
+                format!(
+                    "Previous release tag {} is not reachable from release tag {}. Refusing to generate GitHub release notes because using an older reachable tag would duplicate prior release ranges.",
+                    previous_tag, tag
+                ),
+                Some(format!("Repository: {}", git_root)),
+                Some(vec![
+                    format!(
+                        "Merge or recover the {} release commit onto the selected release base/default branch, then rerun the release.",
+                        previous_tag
+                    ),
+                    format!(
+                        "Inspect the boundary: git merge-base --is-ancestor {} {}",
+                        previous_tag, tag
+                    ),
+                ]),
+            ));
+        }
+    }
+
+    Ok(previous)
 }
 
 /// Build the release body used when GitHub-generated notes are unavailable.
@@ -1015,14 +1041,15 @@ pub(super) fn github_cli_env(github: &GitHubRepo, config: &GithubConfig) -> Vec<
 mod tests {
     use std::collections::HashMap;
 
+    use crate::core::component::Component;
     use crate::core::component::{GithubConfig, GithubHostConfig};
     use crate::core::deploy::release_download::GitHubRepo;
     use crate::core::release::types::{ReleaseState, ReleaseStepStatus};
 
     use super::{
         create_failed_result, fallback_release_notes, github_cli_env,
-        github_release_repair_commands, not_created_result, upload_failed_result,
-        GitHubReleaseBody,
+        github_generated_notes_start_tag, github_release_repair_commands, not_created_result,
+        upload_failed_result, GitHubReleaseBody,
     };
 
     fn test_repo() -> GitHubRepo {
@@ -1050,6 +1077,45 @@ mod tests {
                 .to_string(),
             generated_notes_ok: true,
             changelog_url: Some("https://example/CHANGELOG.md".to_string()),
+        }
+    }
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: stdout={} stderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn commit_file(dir: &std::path::Path, name: &str, content: &str, message: &str) {
+        std::fs::write(dir.join(name), content).expect("write fixture file");
+        run_git(dir, &["add", name]);
+        run_git(dir, &["commit", "-q", "-m", message]);
+    }
+
+    fn git_repo() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_git(dir, &["init", "-q", "-b", "main"]);
+        run_git(dir, &["config", "user.email", "homeboy@example.com"]);
+        run_git(dir, &["config", "user.name", "Homeboy Test"]);
+        run_git(dir, &["config", "commit.gpgsign", "false"]);
+        temp
+    }
+
+    fn component_for_repo(dir: &std::path::Path) -> Component {
+        Component {
+            id: "test-component".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
         }
     }
 
@@ -1398,5 +1464,78 @@ mod tests {
             "HTTPS_PROXY".to_string(),
             "socks5://127.0.0.1:9999".to_string()
         )));
+    }
+
+    #[test]
+    fn generated_notes_start_tag_fails_closed_when_prior_release_tag_is_off_branch() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "v0.1.0"]);
+        commit_file(
+            dir,
+            "feature.txt",
+            "first release work",
+            "feat: first release work",
+        );
+        run_git(dir, &["branch", "release-v0.2.0"]);
+        run_git(dir, &["checkout", "release-v0.2.0"]);
+        commit_file(dir, "VERSION", "0.2.0", "release: v0.2.0");
+        run_git(dir, &["tag", "v0.2.0"]);
+        run_git(dir, &["checkout", "main"]);
+        commit_file(
+            dir,
+            "fix.txt",
+            "second release work",
+            "fix: second release work",
+        );
+        run_git(dir, &["tag", "v0.2.1"]);
+
+        assert_eq!(
+            crate::core::git::get_previous_tag_before_with_prefix(
+                &dir.to_string_lossy(),
+                "v0.2.1",
+                None,
+            )
+            .expect("reachable previous tag lookup"),
+            Some("v0.1.0".to_string()),
+            "the old reachable-only lookup skips the off-branch v0.2.0 boundary"
+        );
+
+        let err = github_generated_notes_start_tag(&component_for_repo(dir), "v0.2.1")
+            .expect_err("off-branch prior release tag should fail closed");
+        assert!(err.message.contains("Previous release tag v0.2.0"));
+        assert!(err
+            .message
+            .contains("not reachable from release tag v0.2.1"));
+        assert!(err.message.contains("duplicate prior release ranges"));
+    }
+
+    #[test]
+    fn generated_notes_start_tag_uses_prior_release_tag_when_reachable() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "v0.1.0"]);
+        commit_file(
+            dir,
+            "feature.txt",
+            "first release work",
+            "feat: first release work",
+        );
+        commit_file(dir, "VERSION", "0.2.0", "release: v0.2.0");
+        run_git(dir, &["tag", "v0.2.0"]);
+        commit_file(
+            dir,
+            "fix.txt",
+            "second release work",
+            "fix: second release work",
+        );
+        run_git(dir, &["tag", "v0.2.1"]);
+
+        let start_tag = github_generated_notes_start_tag(&component_for_repo(dir), "v0.2.1")
+            .expect("reachable previous tag should resolve");
+
+        assert_eq!(start_tag.as_deref(), Some("v0.2.0"));
     }
 }

--- a/src/core/release/planning_semver.rs
+++ b/src/core/release/planning_semver.rs
@@ -173,6 +173,11 @@ pub(super) fn resolve_tag_and_commits(
     match monorepo {
         Some(ctx) => {
             let latest_tag = git::get_latest_tag_with_prefix(&ctx.git_root, Some(&ctx.tag_prefix))?;
+            validate_latest_release_tag_reachable(
+                &ctx.git_root,
+                latest_tag.as_deref(),
+                Some(&ctx.tag_prefix),
+            )?;
             let commits = git::get_commits_since_tag_for_path(
                 &ctx.git_root,
                 latest_tag.as_deref(),
@@ -182,10 +187,49 @@ pub(super) fn resolve_tag_and_commits(
         }
         None => {
             let latest_tag = git::get_latest_tag(local_path)?;
+            validate_latest_release_tag_reachable(local_path, latest_tag.as_deref(), None)?;
             let commits = git::get_commits_since_tag(local_path, latest_tag.as_deref())?;
             Ok((latest_tag, commits))
         }
     }
+}
+
+fn validate_latest_release_tag_reachable(
+    git_root: &str,
+    latest_reachable_tag: Option<&str>,
+    tag_prefix: Option<&str>,
+) -> Result<()> {
+    let Some(latest_any_tag) = git::get_latest_tag_any_with_prefix(git_root, tag_prefix)? else {
+        return Ok(());
+    };
+
+    if latest_reachable_tag == Some(latest_any_tag.as_str()) {
+        return Ok(());
+    }
+
+    if git::is_ancestor(git_root, &latest_any_tag, "HEAD")? {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "release-range",
+        format!(
+            "Latest release tag {} is not reachable from HEAD. Refusing to plan changelog entries from {} because that would duplicate a prior release range.",
+            latest_any_tag,
+            latest_reachable_tag.unwrap_or("the initial commit")
+        ),
+        Some(format!("Repository: {}", git_root)),
+        Some(vec![
+            format!(
+                "Merge or recover the {} release commit onto the selected release base/default branch, then rerun the release.",
+                latest_any_tag
+            ),
+            format!(
+                "Inspect the boundary: git merge-base --is-ancestor {} HEAD",
+                latest_any_tag
+            ),
+        ]),
+    ))
 }
 
 fn commit_rows(commits: &[git::CommitInfo]) -> Vec<ReleaseSemverCommit> {
@@ -378,6 +422,39 @@ mod tests {
         assert_eq!(latest_tag.as_deref(), Some("v1.0.0"));
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].subject, "fix: patch bug");
+    }
+
+    #[test]
+    fn resolve_tag_and_commits_fails_closed_when_latest_release_tag_is_off_branch() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["branch", "-M", "main"]);
+        run_git(dir, &["tag", "v0.1.0"]);
+        commit_file(
+            dir,
+            "feature.txt",
+            "first release work",
+            "feat: first release work",
+        );
+        run_git(dir, &["branch", "release-v0.2.0"]);
+        run_git(dir, &["checkout", "release-v0.2.0"]);
+        commit_file(dir, "VERSION", "0.2.0", "release: v0.2.0");
+        run_git(dir, &["tag", "v0.2.0"]);
+        run_git(dir, &["checkout", "main"]);
+        commit_file(
+            dir,
+            "fix.txt",
+            "second release work",
+            "fix: second release work",
+        );
+
+        let err = resolve_tag_and_commits(&dir.to_string_lossy(), None)
+            .expect_err("off-branch latest release tag should fail closed");
+
+        assert!(err.message.contains("Latest release tag v0.2.0"));
+        assert!(err.message.contains("not reachable from HEAD"));
+        assert!(err.message.contains("duplicate a prior release range"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Detect the newest published release tag across all tags before changelog/semver planning and fail closed when it is not reachable from the selected release base (`HEAD`).
- Use the newest prior published tag for GitHub generated release notes, and fail closed when that prior tag is not reachable from the new release tag.
- Add focused git-fixture coverage for consecutive releases where the first release tag exists on a side branch but its release commit never reached default.

Closes #5908.

## Behavior
- Changelog/semver planning now refuses to plan from an older reachable tag when a newer release tag exists off-branch, because that would duplicate the prior release range.
- GitHub generated notes now pass the real prior published tag as the boundary when reachable.
- If the real prior published tag is not an ancestor of the new release tag, GitHub release creation stops before generating notes with an older boundary.
- Error remediation tells the operator to merge or recover the off-branch release commit onto the selected release base/default branch and includes the relevant `git merge-base --is-ancestor` inspection command.

## Tests
- `rustfmt src/core/git/commits.rs src/core/git/mod.rs src/core/release/planning_semver.rs src/core/release/executor/github_release.rs`
- `git diff --check`
- Not run locally: `cargo test` / Rust test suite, because local cargo commands are disallowed on this machine. GitHub Actions must verify the new Rust unit tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating release range selection, implementing the fail-closed boundary checks, and drafting focused regression tests.
