### PR TITLE
refactor(core): de-hardcode ecosystem literals (#5897)

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -856,7 +856,7 @@ mod tests {
             size_bytes: None,
             mime: Some("application/json".to_string()),
             metadata_json: serde_json::json!({
-                "viewer": homeboy::core::artifact_links::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None),
+                "viewer": crate::commands::runs::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None),
                 "public_url_validation": {
                     "url": "https://artifacts.example.test/homeboy/runs/run-1/artifacts/artifact-1",
                     "reachable": false,
@@ -968,7 +968,7 @@ mod tests {
                     label: Some("Transcript".to_string()),
                     observation_artifact_id: None,
                     viewer: Some(
-                        homeboy::core::artifact_links::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER
+                        crate::commands::runs::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER
                             .to_metadata(None),
                     ),
                     ..BenchArtifact::default()

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -141,10 +141,10 @@ enum ComponentCommand {
     /// Prepare a component for build/test: install its declared extensions and
     /// install its dependencies through detected providers.
     ///
-    /// Core-owned replacement for hardcoded CI install/refresh + composer/npm/
-    /// pnpm/yarn dependency setup. The package manager is chosen by detection
-    /// and manifest config, never by shell literals. CI calls this instead of
-    /// orchestrating the sequence itself.
+    /// Core-owned replacement for hardcoded CI install/refresh + per-ecosystem
+    /// dependency setup. The package manager is chosen by detection and manifest
+    /// config, never by shell literals. CI calls this instead of orchestrating
+    /// the sequence itself.
     Setup {
         /// Component ID (optional when --path is provided)
         id: Option<String>,

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -35,6 +35,8 @@ use homeboy::core::validation_progress::{ValidationCommandSummary, ValidationPro
 use homeboy::core::Error;
 use homeboy::core::{api_jobs, runners as runner};
 
+use homeboy::core::artifact_links::ArtifactViewerDescriptor;
+
 use super::{CmdResult, GlobalArgs};
 pub use bench::{bench_compare, bench_history, BenchCompareOutput, BenchHistoryOutput};
 pub(super) use bench::{bench_numeric_metrics, run_contains_scenario};
@@ -71,6 +73,18 @@ pub(crate) use refs::{
 };
 
 const DEFAULT_LIMIT: i64 = 20;
+
+/// Command-layer artifact viewer for WordPress Playground blueprint artifacts.
+///
+/// The viewer is an ecosystem-specific presentation concern, so it lives in the
+/// command layer (which composes ecosystem integrations) rather than in core,
+/// which stays agnostic and only owns the generic [`ArtifactViewerDescriptor`].
+pub const WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER: ArtifactViewerDescriptor =
+    ArtifactViewerDescriptor::new(
+        "wordpress-playground-blueprint",
+        "https://playground.wordpress.net/",
+        "blueprint-url",
+    );
 
 #[derive(Args, Clone)]
 pub struct RunsArgs {
@@ -1338,7 +1352,7 @@ mod tests {
                             "algorithm": "sha256",
                             "value": "abc123"
                         },
-                        "viewer": homeboy::core::artifact_links::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(Some(serde_json::json!({
+                        "viewer": WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(Some(serde_json::json!({
                                 "status": "partial",
                                 "limitations": ["fixture limitation"]
                         })))
@@ -1424,7 +1438,7 @@ mod tests {
                     "bench_artifact",
                     &artifact_path,
                     serde_json::json!({
-                        "viewer": homeboy::core::artifact_links::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None)
+                        "viewer": WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None)
                     }),
                 )
                 .expect("record artifact");

--- a/src/core/artifact_links.rs
+++ b/src/core/artifact_links.rs
@@ -289,12 +289,17 @@ mod tests {
     }
 
     #[test]
-    fn playground_descriptor_produces_public_artifact_viewer_metadata() {
-        let viewer = WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None);
+    fn descriptor_produces_public_artifact_viewer_metadata() {
+        let viewer = ArtifactViewerDescriptor::new(
+            "example-viewer-kind",
+            "https://viewer.example.test/",
+            "artifact-url",
+        )
+        .to_metadata(None);
 
-        assert_eq!(viewer["kind"], "wordpress-playground-blueprint");
-        assert_eq!(viewer["base"], "https://playground.wordpress.net/");
-        assert_eq!(viewer["query"]["parameter"], "blueprint-url");
+        assert_eq!(viewer["kind"], "example-viewer-kind");
+        assert_eq!(viewer["base"], "https://viewer.example.test/");
+        assert_eq!(viewer["query"]["parameter"], "artifact-url");
         assert_eq!(viewer["query"]["value"]["source"], "public-artifact-url");
     }
 

--- a/src/core/artifact_links.rs
+++ b/src/core/artifact_links.rs
@@ -6,12 +6,6 @@ use crate::core::execution_contract::encode_uri_component;
 use crate::core::observation::{ArtifactRecord, ArtifactViewerLink};
 
 pub const PUBLIC_ARTIFACT_BASE_URL_ENV: &str = "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL";
-pub const WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER: ArtifactViewerDescriptor =
-    ArtifactViewerDescriptor::new(
-        "wordpress-playground-blueprint",
-        "https://playground.wordpress.net/",
-        "blueprint-url",
-    );
 const PUBLIC_ARTIFACT_URL_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/core/code_audit/test_quality.rs
+++ b/src/core/code_audit/test_quality.rs
@@ -85,7 +85,7 @@ fn detect_vacuous_tests(file: &str, content: &str) -> Vec<Finding> {
             severity: Severity::Info,
             file: file_path.clone(),
             description: format!(
-                "Unreachable test `{}` is nested inside another item near line {}; Rust's test harness will not discover it",
+                "Unreachable test `{}` is nested inside another item near line {}; the test harness will not discover it",
                 test.name, test.line
             ),
             suggestion: format!(

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -249,7 +249,7 @@ pub(super) fn deploy_components(
     // Post-deploy front-end smoke check (opt-in, project-scoped). Runs only when
     // something actually deployed — a runtime-fataling release that returns 500
     // to fresh visitors should fail the deploy here so it gets rolled back
-    // instead of sitting live. Catches runtime errors that `php -l`/syntax-only
+    // instead of sitting live. Catches runtime errors that a syntax-only
     // preflight structurally cannot. See homeboy#5471.
     if succeeded > 0 {
         if let Some(smoke) = run_post_deploy_smoke(&project, &mut results) {

--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -143,12 +143,12 @@ pub fn update(
 /// Install a component's dependencies through its resolved dependency providers.
 ///
 /// This is the detection/config-driven replacement for hardcoded
-/// "composer install / npm install / pnpm install / yarn install" CI policy:
-/// the package manager(s) are chosen by [`provider::resolve_dependency_providers`]
-/// based on the files present in the workspace (composer.json, package.json,
-/// lockfiles) and the component/extension manifest — not by shell literals in
-/// the calling environment. CI (or any caller) runs `homeboy component setup`
-/// or `homeboy deps install` and lets core own the policy.
+/// per-ecosystem install CI policy: the package manager(s) are chosen by
+/// [`provider::resolve_dependency_providers`] based on the manifest and lock
+/// files present in the workspace and the component/extension manifest — not
+/// by shell literals in the calling environment. CI (or any caller) runs
+/// `homeboy component setup` or `homeboy deps install` and lets core own the
+/// policy.
 pub fn install(
     component_id: Option<&str>,
     path_override: Option<&str>,

--- a/src/core/refactor/auto/transaction.rs
+++ b/src/core/refactor/auto/transaction.rs
@@ -17,8 +17,8 @@
 //! - Drift-file classification: [`crate::core::component::drift`].
 //! - Git primitives: [`crate::core::git`] (`stage_all`, `commit_*`, `run_git`).
 //!
-//! The transaction is intentionally agnostic: it knows nothing about Rust, PHP,
-//! JS, or any particular ecosystem. It operates purely on git state, the
+//! The transaction is intentionally agnostic: it knows nothing about any
+//! particular language or ecosystem. It operates purely on git state, the
 //! component's declared drift files, and the supplied CI context.
 //!
 //! [Extra-Chill/homeboy-action]: https://github.com/Extra-Chill/homeboy-action


### PR DESCRIPTION
Part of #5897. Relocates ecosystem term literals out of core behavioral code into conventions/config.

## Findings cleared (13/13)
- **src/core/deps.rs** (5): reworded the `install` doc-comment that enumerated `composer install / npm install`, `composer.json`, `package.json` into ecosystem-agnostic prose (the package manager is already detection/config-driven via `resolve_dependency_providers`).
- **src/core/artifact_links.rs** (2): moved the WordPress-Playground-specific `WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER` const out of core into the command layer (`src/commands/runs.rs`). Core keeps the generic, agnostic `ArtifactViewerDescriptor` type; the ecosystem-specific instance now lives where it is consumed. Updated call sites in `runs.rs` and `bench/observation.rs`.
- **src/core/refactor/auto/transaction.rs** (2): generalized the module doc that listed `Rust, PHP, JS`.
- **src/core/deploy/orchestration.rs** (1): generalized a comment referencing `php -l` to "syntax-only preflight".
- **src/core/code_audit/test_quality.rs** (1): generalized a user-facing finding string.
- **src/commands/component.rs** (2): reworded the `Setup` doc-comment enumerating package managers (command layer, cleaned for consistency).

## Verification
- `cargo build --lib` — clean (only pre-existing warnings)
- `cargo clippy --lib` — 0 errors, no new warnings in touched files
- `cargo fmt` — applied
- No `cargo test`/`--tests` (VPS OOM policy)