### PR TITLE
Sync Lab runtime components from providers

### DIFF
--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -781,7 +781,7 @@ impl AgentTaskProviderCatalog {
             let refreshed = discover_provider_catalog();
             let catalog = PROVIDER_CATALOG.get_or_init(|| RwLock::new(refreshed.clone()));
             *catalog.write().expect("provider catalog lock") = refreshed.clone();
-            return refreshed;
+            refreshed
         }
         #[cfg(test)]
         {

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -96,6 +96,8 @@ pub struct AgentTaskExecutorProvider {
     pub runner_sources: Vec<AgentTaskProviderRunnerSource>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependency_failure_patterns: Vec<AgentTaskProviderDependencyFailurePattern>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lab_runtime_components: Vec<String>,
     #[serde(
         default,
         skip_serializing_if = "AgentTaskProviderTimeoutArtifactDiscovery::is_empty"
@@ -861,6 +863,10 @@ impl ExtensionProviderAgentTaskExecutor {
     pub fn required_extension_ids_for_plan(&self, plan: &AgentTaskPlan) -> Vec<String> {
         required_extension_ids_for_plan_with_providers(plan, &self.providers)
     }
+
+    pub fn lab_runtime_component_ids_for_plan(&self, plan: &AgentTaskPlan) -> Vec<String> {
+        lab_runtime_component_ids_for_plan_with_providers(plan, &self.providers)
+    }
 }
 
 pub fn default_backend() -> crate::core::Result<Option<String>> {
@@ -978,6 +984,10 @@ fn validate_provider_runner_readiness_for_backend_with_providers(
 
 pub fn required_extension_ids_for_plan(plan: &AgentTaskPlan) -> Vec<String> {
     ExtensionProviderAgentTaskExecutor::discover().required_extension_ids_for_plan(plan)
+}
+
+pub fn lab_runtime_component_ids_for_plan(plan: &AgentTaskPlan) -> Vec<String> {
+    ExtensionProviderAgentTaskExecutor::discover().lab_runtime_component_ids_for_plan(plan)
 }
 
 pub fn provider_requires_cwd_git_checkout(backend: &str, selector: Option<&str>) -> bool {
@@ -1914,6 +1924,24 @@ fn required_extension_ids_for_plan_with_providers(
         }
     }
     extension_ids.into_iter().collect()
+}
+
+fn lab_runtime_component_ids_for_plan_with_providers(
+    plan: &AgentTaskPlan,
+    providers: &[AgentTaskExecutorProvider],
+) -> Vec<String> {
+    let mut component_ids = BTreeSet::new();
+    for request in &plan.tasks {
+        if let Some(provider) = select_provider(providers, request) {
+            for component_id in &provider.lab_runtime_components {
+                let component_id = component_id.trim();
+                if !component_id.is_empty() {
+                    component_ids.insert(component_id.to_string());
+                }
+            }
+        }
+    }
+    component_ids.into_iter().collect()
 }
 
 /// Maximum number of attempts (1 initial + retries) for a transient provider
@@ -3642,6 +3670,7 @@ mod tests {
             runner_readiness: Vec::new(),
             runner_sources: Vec::new(),
             dependency_failure_patterns: Vec::new(),
+            lab_runtime_components: Vec::new(),
             timeout_artifact_discovery: AgentTaskProviderTimeoutArtifactDiscovery::default(),
             role_aliases: AgentTaskProviderRoleAliases::default(),
             runtime_contract: AgentTaskRuntimeContract::default(),
@@ -3755,6 +3784,31 @@ mod tests {
         ));
 
         assert_eq!(extension_ids, vec!["extension-a", "extension-b"]);
+    }
+
+    #[test]
+    fn lab_runtime_component_ids_follow_selected_agent_task_providers() {
+        let (request_a, mut provider_a) = request("task-a", "node provider-a.js".to_string());
+        provider_a.id = "provider-a".to_string();
+        provider_a.lab_runtime_components =
+            vec!["agents-api".to_string(), "data-machine".to_string()];
+        let (mut request_b, mut provider_b) = request("task-b", "node provider-b.js".to_string());
+        request_b.executor.selector = Some("provider-b".to_string());
+        provider_b.id = "provider-b".to_string();
+        provider_b.lab_runtime_components =
+            vec!["data-machine".to_string(), "php-ai-client".to_string()];
+        let executor =
+            ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
+
+        let component_ids = executor.lab_runtime_component_ids_for_plan(&AgentTaskPlan::new(
+            "plan-a",
+            vec![request_a, request_b],
+        ));
+
+        assert_eq!(
+            component_ids,
+            vec!["agents-api", "data-machine", "php-ai-client"]
+        );
     }
 
     #[test]
@@ -4056,7 +4110,8 @@ process.stdout.write(JSON.stringify({
                 "path_contains": "prepared-dependencies/",
                 "error_contains_any": ["enoent", "no such file or directory"],
                 "remediation": "Refresh prepared dependencies."
-            }]
+            }],
+            "lab_runtime_components": ["agents-api", "data-machine"]
         }))
         .expect("provider manifest");
 
@@ -4072,6 +4127,10 @@ process.stdout.write(JSON.stringify({
         assert_eq!(
             provider.dependency_failure_patterns[0].path_contains,
             "prepared-dependencies/"
+        );
+        assert_eq!(
+            provider.lab_runtime_components,
+            vec!["agents-api", "data-machine"]
         );
     }
 

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -71,11 +71,9 @@ use super::super::{
     lab_offload_metadata_with_workspace_mapping, load, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since, prepare_lab_runner_capability, rig_materialization,
     status, sync_workspace, LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions,
-    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
+    RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
-#[cfg(test)]
-use super::super::{RunnerActiveJobSource, RunnerActiveJobState};
 
 use super::agent_task_bridge::{
     agent_task_dispatch_run_isolation_token, ensure_agent_task_dispatch_run_id_with,

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -58,11 +58,12 @@ use super::super::lab_selection::{
     LabRunnerSelectionSource,
 };
 use super::super::lab_workspaces::{
-    agent_task_plan_extra_workspaces, lab_extra_workspaces, lab_workspace_mapping_metadata,
-    path_setting_extra_workspaces, preflight_provider_config_source_cli_dependencies,
-    provider_config_extra_workspaces, rig_component_path_env_extra_workspaces,
-    sync_extra_lab_workspaces, workspace_mapping_entries_for_git_dependency,
-    workspace_mapping_entry, LabWorkspaceMappingEntry,
+    agent_task_plan_extra_workspaces, agent_task_provider_runtime_component_extra_workspaces,
+    lab_extra_workspaces, lab_workspace_mapping_metadata, path_setting_extra_workspaces,
+    preflight_provider_config_source_cli_dependencies, provider_config_extra_workspaces,
+    rig_component_path_env_extra_workspaces, sync_extra_lab_workspaces,
+    workspace_mapping_entries_for_git_dependency, workspace_mapping_entry,
+    LabWorkspaceMappingEntry,
 };
 use super::super::offload_changed_since::LabOffloadChangedSincePreflight;
 use super::super::{
@@ -766,6 +767,10 @@ fn prepare_lab_offload_workspace_stage(
         source_path,
     )?);
     extra_workspaces.extend(agent_task_plan_extra_workspaces(
+        &offload_args,
+        source_path,
+    )?);
+    extra_workspaces.extend(agent_task_provider_runtime_component_extra_workspaces(
         &offload_args,
         source_path,
     )?);

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -833,7 +833,7 @@ fn prepare_lab_offload_workspace_stage(
                 .inputs(
                     PlanValues::new().json("count", at_file_specs.len()).json(
                         "files",
-                        &at_file_specs
+                        at_file_specs
                             .iter()
                             .map(|spec| {
                                 serde_json::json!({
@@ -1824,6 +1824,7 @@ fn lab_materialization_proof_metadata(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn runner_workload_metadata(
     plan: &HomeboyPlan,
     contract: &LabOffloadCommand,
@@ -1924,14 +1925,6 @@ impl LabOffloadWorkspaceModePolicy {
             Self::RunnerResident => "runner_resident",
         }
     }
-}
-
-fn passive_wp_codebox_version() -> Option<String> {
-    ["HOMEBOY_WP_CODEBOX_VERSION", "WP_CODEBOX_VERSION"]
-        .into_iter()
-        .find_map(|name| std::env::var(name).ok())
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
 }
 
 fn source_checkout_ref_display(metadata: &serde_json::Value) -> String {

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::core::{Error, Result};
+use crate::core::agent_task_scheduler::AgentTaskPlan;
+use crate::core::{agent_task_provider, component, Error, Result};
 
 use super::lab_workspaces_deps::{
     accepted_extra_lab_workspaces, add_candidate_extra_workspace, bare_module_imports,
@@ -298,6 +299,59 @@ pub(super) fn agent_task_plan_extra_workspaces(
         )?;
     }
 
+    Ok(workspaces)
+}
+
+/// Resolve runtime components declared by the selected agent-task provider and
+/// add their controller-local checkouts to the Lab workspace handoff.
+pub(super) fn agent_task_provider_runtime_component_extra_workspaces(
+    args: &[String],
+    source_path: &Path,
+) -> Result<Vec<ExtraLabWorkspace>> {
+    let Some(spec) = agent_task_plan_spec(args) else {
+        return Ok(Vec::new());
+    };
+    let raw = read_agent_task_plan_spec_to_string(&spec, source_path)?;
+    let plan: AgentTaskPlan = serde_json::from_str(&raw).map_err(|error| {
+        Error::validation_invalid_argument(
+            "plan",
+            format!("invalid agent-task run-plan --plan payload: {error}"),
+            Some(spec.clone()),
+            Some(vec![
+                "Pass a valid AgentTaskPlan JSON payload or @file to `agent-task run-plan --plan`."
+                    .to_string(),
+            ]),
+        )
+    })?;
+
+    let source_canon = source_path
+        .canonicalize()
+        .unwrap_or_else(|_| source_path.to_path_buf());
+    let mut seen = BTreeSet::new();
+    let mut workspaces = Vec::new();
+    for component_id in agent_task_provider::lab_runtime_component_ids_for_plan(&plan) {
+        let resolved = component::resolve_effective(Some(&component_id), None, None).map_err(|error| {
+            Error::validation_invalid_argument(
+                "lab_runtime_components",
+                format!(
+                    "agent-task provider requires Lab runtime component `{component_id}`, but Homeboy could not resolve it: {}",
+                    error.message()
+                ),
+                Some(component_id.clone()),
+                Some(vec![
+                    format!("Register component `{component_id}` on the controller or provide a component with that id before Lab offload."),
+                    "Run `homeboy component list` to inspect configured components.".to_string(),
+                ]),
+            )
+        })?;
+        add_candidate_extra_workspace(
+            &resolved.local_path,
+            "agent_task_runtime_component",
+            &source_canon,
+            &mut seen,
+            &mut workspaces,
+        )?;
+    }
     Ok(workspaces)
 }
 

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -335,7 +335,7 @@ pub(super) fn agent_task_provider_runtime_component_extra_workspaces(
                 "lab_runtime_components",
                 format!(
                     "agent-task provider requires Lab runtime component `{component_id}`, but Homeboy could not resolve it: {}",
-                    error.message()
+                    error
                 ),
                 Some(component_id.clone()),
                 Some(vec![


### PR DESCRIPTION
## Summary
- Add provider-declared `lab_runtime_components` to agent-task executor manifests.
- Derive required runtime component ids from the selected providers in an `AgentTaskPlan`.
- Resolve those components on the controller and sync them into Lab as extra workspaces before remapping/handoff.

## Testing
- `rustfmt src/core/agent_task_provider.rs src/core/runner/lab/offload.rs src/core/runner/lab_workspaces.rs`
- `homeboy component show data-machine`
- `homeboy component show agents-api`
- `git diff --check`

Not run: local Cargo tests/builds, per environment rule.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Lab runtime substrate handoff gap and drafting the provider-declared runtime component sync implementation.