### PR TITLE
refactor(audit): thin command adapters (#5902)

### DIFF
--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -1,12 +1,7 @@
 //! `agent-task controller` handlers: durable multi-agent loop controller
 //! lifecycle, spec defaults, and the CLI dispatch bridge.
 
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
-use serde::Deserialize;
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use homeboy::core::agent_task_loop_definition::{
     materialize_repo_loop_spec, AgentTaskLoopPolicyResultMaterialization,
@@ -26,9 +21,6 @@ use homeboy::core::proof::validate_proof_value;
 use homeboy::core::agent_tasks::dispatch_service;
 use homeboy::core::agent_tasks::loop_controller::AgentTaskLoopPolicyAction;
 
-const CONTROLLER_SPEC_GENERATOR_SCHEMA: &str = "homeboy/agent-task-loop-spec-generator/v1";
-
-use super::super::agent_task_dispatch::{DispatchArgs, DispatchCoreArgs};
 use super::super::CmdResult;
 use super::args::{
     AgentTaskControllerApplyEventArgs, AgentTaskControllerArgs, AgentTaskControllerCommand,
@@ -99,7 +91,7 @@ fn controller_validate_proof(args: AgentTaskControllerValidateProofArgs) -> CmdR
 }
 
 pub(super) fn controller_materialize(args: AgentTaskControllerMaterializeArgs) -> CmdResult<Value> {
-    let source = load_materialize_spec_source(&args.spec)?;
+    let source = agent_task_controller_service::load_materialize_spec_source(&args.spec)?;
     let mut spec = source.spec;
     agent_task_controller_service::apply_spec_dispatch_defaults(&mut spec, &args.spec);
     let run_inputs = match args.inputs {
@@ -132,198 +124,6 @@ pub(super) fn controller_materialize(args: AgentTaskControllerMaterializeArgs) -
         }
     }
     Ok((value, 0))
-}
-
-struct ControllerMaterializeSpecSource {
-    spec: AgentTaskRepoLoopSpec,
-    generator_evidence: Option<Value>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ControllerSpecGeneratorManifest {
-    schema: String,
-    command: Vec<String>,
-    output_path: String,
-    #[serde(default)]
-    inputs: Value,
-}
-
-fn load_materialize_spec_source(
-    source: &str,
-) -> homeboy::core::Result<ControllerMaterializeSpecSource> {
-    let raw = config::read_json_spec_to_string(source)?;
-    match serde_json::from_str::<AgentTaskRepoLoopSpec>(&raw) {
-        Ok(spec) => {
-            return Ok(ControllerMaterializeSpecSource {
-                spec,
-                generator_evidence: None,
-            })
-        }
-        Err(spec_error) => {
-            let manifest: ControllerSpecGeneratorManifest =
-                serde_json::from_str(&raw).map_err(|_| {
-                    homeboy::core::Error::validation_invalid_argument(
-                        "spec",
-                        spec_error.to_string(),
-                        Some(source.to_string()),
-                        None,
-                    )
-                })?;
-            load_generated_materialize_spec(source, manifest)
-        }
-    }
-}
-
-fn load_generated_materialize_spec(
-    source: &str,
-    manifest: ControllerSpecGeneratorManifest,
-) -> homeboy::core::Result<ControllerMaterializeSpecSource> {
-    validate_generator_manifest(source, &manifest)?;
-    let manifest_dir = manifest_base_dir(source);
-    let output_path = resolve_manifest_path(manifest_dir.as_deref(), &manifest.output_path);
-    let command_status = run_spec_generator_command(&manifest, manifest_dir.as_deref())?;
-    let generated_raw = std::fs::read_to_string(&output_path).map_err(|error| {
-        homeboy::core::Error::validation_invalid_argument(
-            "spec.output_path",
-            format!(
-                "generator command completed but generated spec was not found at {}; rerun the manifest command or update output_path: {error}",
-                output_path.display()
-            ),
-            Some(source.to_string()),
-            Some(vec![format!(
-                "{} must write {}",
-                manifest.command.join(" "),
-                manifest.output_path
-            )]),
-        )
-    })?;
-    let spec: AgentTaskRepoLoopSpec = serde_json::from_str(&generated_raw).map_err(|error| {
-        homeboy::core::Error::validation_invalid_argument(
-            "spec.output_path",
-            format!("generated spec JSON is invalid: {error}"),
-            Some(output_path.display().to_string()),
-            None,
-        )
-    })?;
-    let materialized = materialize_repo_loop_spec(AgentTaskLoopSpecMaterializationRequest {
-        spec: &spec,
-        run_inputs: &Value::Null,
-        policy_results: &[],
-    })?;
-    let validation_result = validate_proof_value(command_json_value(materialized)?);
-    let spec_hash = format!("{:x}", Sha256::digest(generated_raw.as_bytes()));
-
-    Ok(ControllerMaterializeSpecSource {
-        spec,
-        generator_evidence: Some(serde_json::json!({
-            "schema": "homeboy/agent-task-loop-spec-generator-evidence/v1",
-            "manifest": source,
-            "command": manifest.command,
-            "inputs": manifest.inputs,
-            "output_path": output_path.display().to_string(),
-            "spec_hash": spec_hash,
-            "validation_result": validation_result,
-            "status": command_status,
-        })),
-    })
-}
-
-fn validate_generator_manifest(
-    source: &str,
-    manifest: &ControllerSpecGeneratorManifest,
-) -> homeboy::core::Result<()> {
-    if manifest.schema != CONTROLLER_SPEC_GENERATOR_SCHEMA {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "spec.schema",
-            format!(
-                "controller materialize generator manifests must use schema {CONTROLLER_SPEC_GENERATOR_SCHEMA}"
-            ),
-            Some(source.to_string()),
-            None,
-        ));
-    }
-    if manifest.command.is_empty() || manifest.command.iter().any(|part| part.trim().is_empty()) {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "spec.command",
-            "generator command must be a non-empty array of program and arguments",
-            Some(source.to_string()),
-            None,
-        ));
-    }
-    if manifest.output_path.trim().is_empty() {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "spec.output_path",
-            "generator manifest must declare the spec file path written by the command",
-            Some(source.to_string()),
-            None,
-        ));
-    }
-    if !manifest.inputs.is_null() && !manifest.inputs.is_object() {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "spec.inputs",
-            "generator manifest inputs must be a JSON object when present",
-            Some(source.to_string()),
-            None,
-        ));
-    }
-    Ok(())
-}
-
-fn manifest_base_dir(source: &str) -> Option<PathBuf> {
-    let file = source.strip_prefix('@')?;
-    if file == "-" {
-        return None;
-    }
-    Path::new(file).parent().map(Path::to_path_buf)
-}
-
-fn resolve_manifest_path(base_dir: Option<&Path>, path: &str) -> PathBuf {
-    let path = PathBuf::from(path);
-    if path.is_absolute() {
-        path
-    } else if let Some(base_dir) = base_dir {
-        base_dir.join(path)
-    } else {
-        path
-    }
-}
-
-fn run_spec_generator_command(
-    manifest: &ControllerSpecGeneratorManifest,
-    manifest_dir: Option<&Path>,
-) -> homeboy::core::Result<Value> {
-    let mut command = Command::new(&manifest.command[0]);
-    command.args(&manifest.command[1..]);
-    if let Some(manifest_dir) = manifest_dir {
-        command.current_dir(manifest_dir);
-    }
-    let output = command.output().map_err(|error| {
-        homeboy::core::Error::validation_invalid_argument(
-            "spec.command",
-            format!("failed to execute generator command: {error}"),
-            Some(manifest.command.join(" ")),
-            None,
-        )
-    })?;
-    let code = output.status.code();
-    if !output.status.success() {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "spec.command",
-            format!(
-                "generator command exited with status {}; stderr: {}",
-                code.map(|value| value.to_string())
-                    .unwrap_or_else(|| "terminated by signal".to_string()),
-                String::from_utf8_lossy(&output.stderr).trim()
-            ),
-            Some(manifest.command.join(" ")),
-            None,
-        ));
-    }
-    Ok(serde_json::json!({
-        "exit_code": code,
-        "stdout": String::from_utf8_lossy(&output.stdout).trim(),
-        "stderr": String::from_utf8_lossy(&output.stderr).trim(),
-    }))
 }
 
 fn parse_policy_result(
@@ -466,8 +266,11 @@ fn doctor_dispatch_request_checks(
         return checks;
     }
 
-    let mut dispatch_args = match dispatch_args_from_controller_request(request) {
-        Ok(args) => args,
+    let command = match agent_task_controller_service::controller_request_dispatch_command(
+        request,
+        &defaults.to_overrides(),
+    ) {
+        Ok(command) => command,
         Err(error) => {
             checks.push(doctor_check(
                 format!("controller.action.{action_id}.dispatch.parse"),
@@ -479,9 +282,7 @@ fn doctor_dispatch_request_checks(
             return checks;
         }
     };
-    defaults.apply(&mut dispatch_args);
 
-    let command: dispatch_service::AgentTaskDispatchCommand = dispatch_args.into();
     let dispatch_request = match dispatch_service::resolve_dispatch_request(command) {
         Ok(request) => request,
         Err(error) => {
@@ -673,18 +474,12 @@ impl ControllerDispatchDefaults {
         }
     }
 
-    fn apply(&self, args: &mut DispatchArgs) {
-        if args.backend.is_none() {
-            args.backend = self.backend.clone();
-        }
-        if args.selector.is_none() {
-            args.selector = self.selector.clone();
-        }
-        if args.model.is_none() {
-            args.model = self.model.clone();
-        }
-        if args.core.provider_config.is_none() {
-            args.core.provider_config = self.provider_config.clone();
+    fn to_overrides(&self) -> agent_task_controller_service::ControllerDispatchOverrides {
+        agent_task_controller_service::ControllerDispatchOverrides {
+            backend: self.backend.clone(),
+            selector: self.selector.clone(),
+            model: self.model.clone(),
+            provider_config: self.provider_config.clone(),
         }
     }
 }
@@ -694,44 +489,12 @@ where
     E: AgentTaskExecutorAdapter + Clone,
 {
     fn dispatch(&self, request: &Value) -> homeboy::core::Result<(Value, i32)> {
-        let mut dispatch_args = dispatch_args_from_controller_request(request)?;
-        self.defaults.apply(&mut dispatch_args);
-        dispatch_service::run_dispatch_command(dispatch_args.into(), self.executor.clone())
+        let command = agent_task_controller_service::controller_request_dispatch_command(
+            request,
+            &self.defaults.to_overrides(),
+        )?;
+        dispatch_service::run_dispatch_command(command, self.executor.clone())
     }
-}
-
-pub(super) fn dispatch_args_from_controller_request(
-    request: &Value,
-) -> homeboy::core::Result<DispatchArgs> {
-    use agent_task_controller_service::{
-        optional_bool, optional_string, optional_string_array, optional_u32, optional_usize,
-    };
-    let dispatch = request.get("dispatch").unwrap_or(request);
-    Ok(DispatchArgs {
-        prompt: optional_string(dispatch, "prompt"),
-        tasks: optional_string_array(dispatch, "tasks")?,
-        cwd: optional_string(dispatch, "cwd")
-            .or_else(|| optional_string(request, "cwd"))
-            .or_else(|| optional_string(request, "workspace_root")),
-        workspace: optional_string(dispatch, "workspace")
-            .or_else(|| optional_string(request, "workspace")),
-        repo: optional_string(dispatch, "repo").or_else(|| optional_string(request, "repo")),
-        task_url: optional_string(dispatch, "task_url"),
-        backend: optional_string(dispatch, "backend"),
-        selector: optional_string(dispatch, "selector"),
-        model: optional_string(dispatch, "model"),
-        required_capabilities: optional_string_array(dispatch, "required_capabilities")?,
-        secret_env: optional_string_array(dispatch, "secret_env")?,
-        concurrency: optional_usize(dispatch, "concurrency")?.unwrap_or(1),
-        run_id: optional_string(dispatch, "run_id"),
-        core: DispatchCoreArgs {
-            tasks_json: optional_string(dispatch, "tasks_json"),
-            provider_config: optional_string(dispatch, "provider_config"),
-            client_context: optional_string(dispatch, "client_context"),
-            attempts: optional_u32(dispatch, "attempts")?.unwrap_or(1),
-            queue_only: optional_bool(dispatch, "queue_only").unwrap_or(false),
-        },
-    })
 }
 
 pub(super) fn apply_controller_event(args: AgentTaskControllerApplyEventArgs) -> CmdResult<Value> {
@@ -883,52 +646,56 @@ mod tests {
 
     #[test]
     fn controller_dispatch_defaults_apply_provider_config_when_missing() {
-        let mut args = dispatch_args_from_controller_request(&serde_json::json!({
-            "dispatch": {
-                "prompt": "Cook",
-                "tasks": ["Do the work"],
-                "backend": "synthetic-runtime"
-            }
-        }))
-        .expect("dispatch args");
-
-        ControllerDispatchDefaults {
+        let command = ControllerDispatchDefaults {
             backend: Some("ignored-backend".to_string()),
             selector: None,
             model: Some("gpt-5.5".to_string()),
             provider_config: Some(r#"{"runtime_wordpress_version":"7.0"}"#.to_string()),
         }
-        .apply(&mut args);
+        .to_overrides();
+        let command = agent_task_controller_service::controller_request_dispatch_command(
+            &serde_json::json!({
+                "dispatch": {
+                    "prompt": "Cook",
+                    "tasks": ["Do the work"],
+                    "backend": "synthetic-runtime"
+                }
+            }),
+            &command,
+        )
+        .expect("dispatch command");
 
-        assert_eq!(args.backend.as_deref(), Some("synthetic-runtime"));
-        assert_eq!(args.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(command.backend.as_deref(), Some("synthetic-runtime"));
+        assert_eq!(command.model.as_deref(), Some("gpt-5.5"));
         assert_eq!(
-            args.core.provider_config.as_deref(),
+            command.core.provider_config.as_deref(),
             Some(r#"{"runtime_wordpress_version":"7.0"}"#)
         );
     }
 
     #[test]
     fn controller_dispatch_defaults_preserve_existing_provider_config() {
-        let mut args = dispatch_args_from_controller_request(&serde_json::json!({
-            "dispatch": {
-                "prompt": "Cook",
-                "tasks": ["Do the work"],
-                "provider_config": "{\"runtime_wordpress_version\":\"nightly\"}"
-            }
-        }))
-        .expect("dispatch args");
-
-        ControllerDispatchDefaults {
+        let overrides = ControllerDispatchDefaults {
             backend: None,
             selector: None,
             model: None,
             provider_config: Some(r#"{"runtime_wordpress_version":"7.0"}"#.to_string()),
         }
-        .apply(&mut args);
+        .to_overrides();
+        let command = agent_task_controller_service::controller_request_dispatch_command(
+            &serde_json::json!({
+                "dispatch": {
+                    "prompt": "Cook",
+                    "tasks": ["Do the work"],
+                    "provider_config": "{\"runtime_wordpress_version\":\"nightly\"}"
+                }
+            }),
+            &overrides,
+        )
+        .expect("dispatch command");
 
         assert_eq!(
-            args.core.provider_config.as_deref(),
+            command.core.provider_config.as_deref(),
             Some(r#"{"runtime_wordpress_version":"nightly"}"#)
         );
     }

--- a/src/commands/agent_task/tests/dispatch.rs
+++ b/src/commands/agent_task/tests/dispatch.rs
@@ -262,24 +262,15 @@ fn controller_dispatch_args_preserve_top_level_workspace_context_in_plan() {
         }
     });
 
-    let args = dispatch_args_from_controller_request(&request).expect("dispatch args");
-    let dispatch_request = homeboy::core::agent_tasks::dispatch_service::AgentTaskDispatchRequest {
-        prompt: args.prompt,
-        tasks: args.tasks,
-        cwd: args.cwd,
-        workspace: args.workspace,
-        repo: args.repo,
-        task_url: args.task_url,
-        backend: args.backend.expect("backend"),
-        selector: args.selector,
-        model: args.model,
-        required_capabilities: args.required_capabilities,
-        secret_env: args.secret_env,
-        concurrency: args.concurrency,
-        run_id: args.run_id,
-        core: args.core.into(),
-        backend_selection: None,
-    };
+    let command =
+        homeboy::core::agent_tasks::controller_service::controller_request_dispatch_command(
+            &request,
+            &homeboy::core::agent_tasks::controller_service::ControllerDispatchOverrides::default(),
+        )
+        .expect("dispatch command");
+    let dispatch_request =
+        homeboy::core::agent_tasks::dispatch_service::resolve_dispatch_request(command)
+            .expect("dispatch request");
     let plan = homeboy::core::agent_tasks::dispatch_service::build_dispatch_plan_with_provider_requirements(
             &dispatch_request,
             |_backend, _selector| false,

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -18,7 +18,6 @@ pub(in crate::commands::agent_task) use super::super::args::{
 pub(in crate::commands::agent_task) use super::super::controller::{
     apply_controller_event, controller_from_spec, controller_materialize,
     controller_run_action_with_executor, controller_run_next_with_executor,
-    dispatch_args_from_controller_request,
 };
 pub(in crate::commands::agent_task) use super::super::run::{
     retry, run_loaded_plan, run_loop_with_executor, run_next_with_executor,

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -1,9 +1,6 @@
 use clap::{Args, Parser, Subcommand};
 use serde::Serialize;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
 
 use homeboy::core::daemon::{
     self, BrokerConfig, BrokerConfigOptions, DaemonStartResult, DaemonStatus, DaemonStopResult,
@@ -99,7 +96,9 @@ pub struct DaemonArtifactGetOutput {
 
 pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<DaemonOutput> {
     match args.command {
-        DaemonCommand::Start { addr } => start(&addr),
+        DaemonCommand::Start { addr } => {
+            Ok((DaemonOutput::Start(daemon::start_background(&addr)?), 0))
+        }
         DaemonCommand::Serve { addr } => serve(&addr),
         DaemonCommand::Stop => Ok((DaemonOutput::Stop(daemon::stop()?), 0)),
         DaemonCommand::Status => Ok((DaemonOutput::Status(daemon::read_status()?), 0)),
@@ -126,118 +125,27 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
 }
 
 fn artifact_get(args: DaemonArtifactGetArgs) -> CmdResult<DaemonOutput> {
-    let daemon_url = resolve_daemon_url(args.daemon_url)?;
-    let content_url = artifact_content_url(&daemon_url, &args.run_id, &args.artifact_id)?;
-    let output_path = args
-        .output
-        .unwrap_or_else(|| default_artifact_output_path(&args.artifact_id));
-    let response = reqwest::blocking::get(&content_url).map_err(reqwest_error)?;
-    let status = response.status();
-    let headers = response.headers().clone();
-    if !status.is_success() {
-        let body = response.text().unwrap_or_default();
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "artifact_id",
-            format!(
-                "daemon artifact fetch failed with HTTP {}: {}",
-                status.as_u16(),
-                body
-            ),
-            Some(args.artifact_id),
-            None,
-        ));
-    }
-
-    let bytes = response.bytes().map_err(reqwest_error)?;
-    if let Some(parent) = output_path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-    {
-        std::fs::create_dir_all(parent).map_err(|e| {
-            homeboy::core::Error::internal_io(
-                e.to_string(),
-                Some(format!("create {}", parent.display())),
-            )
-        })?;
-    }
-    std::fs::write(&output_path, &bytes).map_err(|e| {
-        homeboy::core::Error::internal_io(
-            e.to_string(),
-            Some(format!("write {}", output_path.display())),
-        )
-    })?;
+    let outcome = daemon::fetch_artifact_to_path(
+        &args.run_id,
+        &args.artifact_id,
+        args.daemon_url,
+        args.output,
+    )?;
 
     Ok((
         DaemonOutput::ArtifactGet(DaemonArtifactGetOutput {
             command: "daemon.artifact.get",
             run_id: args.run_id,
             artifact_id: args.artifact_id,
-            daemon_url,
-            content_url,
-            output_path: output_path.display().to_string(),
-            content_type: header_value(&headers, reqwest::header::CONTENT_TYPE.as_str()),
-            size_bytes: Some(bytes.len() as u64),
-            sha256: header_value(&headers, "x-homeboy-artifact-sha256"),
+            daemon_url: outcome.daemon_url,
+            content_url: outcome.content_url,
+            output_path: outcome.output_path.display().to_string(),
+            content_type: outcome.content_type,
+            size_bytes: Some(outcome.size_bytes),
+            sha256: outcome.sha256,
         }),
         0,
     ))
-}
-
-fn resolve_daemon_url(daemon_url: Option<String>) -> homeboy::core::Result<String> {
-    if let Some(url) = daemon_url.filter(|url| !url.trim().is_empty()) {
-        return Ok(url);
-    }
-    let status = daemon::read_status()?;
-    let Some(state) = status.state.filter(|_| status.running) else {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "daemon-url",
-            "daemon is not running; pass --daemon-url or start it with `homeboy daemon start`",
-            None,
-            None,
-        ));
-    };
-    Ok(format!("http://{}", state.address))
-}
-
-fn artifact_content_url(
-    daemon_url: &str,
-    run_id: &str,
-    artifact_id: &str,
-) -> homeboy::core::Result<String> {
-    let mut base = reqwest::Url::parse(daemon_url).map_err(|e| {
-        homeboy::core::Error::validation_invalid_argument(
-            "daemon-url",
-            e.to_string(),
-            Some(daemon_url.to_string()),
-            None,
-        )
-    })?;
-    base.set_path(&format!(
-        "/runs/{}/artifacts/{}/content",
-        homeboy::core::execution_contract::encode_uri_component(run_id),
-        homeboy::core::execution_contract::encode_uri_component(artifact_id)
-    ));
-    base.set_query(None);
-    Ok(base.to_string())
-}
-
-fn default_artifact_output_path(artifact_id: &str) -> PathBuf {
-    artifact_id
-        .rsplit('/')
-        .find(|segment| !segment.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("artifact.bin"))
-}
-
-fn header_value(headers: &reqwest::header::HeaderMap, name: &str) -> Option<String> {
-    headers
-        .get(name)
-        .and_then(|value| value.to_str().ok())
-        .map(str::to_string)
-}
-
-fn reqwest_error(error: reqwest::Error) -> homeboy::core::Error {
-    homeboy::core::Error::internal_io(error.to_string(), Some("fetch daemon artifact".to_string()))
 }
 
 fn serve(addr: &str) -> CmdResult<DaemonOutput> {
@@ -251,53 +159,6 @@ fn serve(addr: &str) -> CmdResult<DaemonOutput> {
         }),
         0,
     ))
-}
-
-fn start(addr: &str) -> CmdResult<DaemonOutput> {
-    daemon::parse_bind_addr(addr)?;
-
-    let exe = std::env::current_exe().map_err(|e| {
-        homeboy::core::Error::internal_io(
-            e.to_string(),
-            Some("resolve current executable".to_string()),
-        )
-    })?;
-    let child = Command::new(exe)
-        .args(["daemon", "serve", "--addr", addr])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|e| {
-            homeboy::core::Error::internal_io(e.to_string(), Some("spawn daemon".to_string()))
-        })?;
-    let pid = child.id();
-
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        let status = daemon::read_status()?;
-        if let Some(state) = status.state {
-            if state.pid == pid {
-                return Ok((
-                    DaemonOutput::Start(DaemonStartResult {
-                        pid,
-                        address: state.address,
-                        state_path: state.state_path,
-                    }),
-                    0,
-                ));
-            }
-        }
-
-        if Instant::now() >= deadline {
-            return Err(homeboy::core::Error::internal_unexpected(format!(
-                "daemon process {} did not publish state before timeout",
-                pid
-            )));
-        }
-
-        thread::sleep(Duration::from_millis(50));
-    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -332,21 +193,6 @@ mod tests {
     use homeboy::test_support::with_isolated_home;
 
     use super::*;
-
-    #[test]
-    fn artifact_content_url_builds_encoded_daemon_byte_alias() {
-        let url = artifact_content_url(
-            "http://127.0.0.1:7421/base?ignored=true",
-            "run 1",
-            "report/summary.json",
-        )
-        .expect("url");
-
-        assert_eq!(
-            url,
-            "http://127.0.0.1:7421/runs/run%201/artifacts/report%2Fsummary.json/content"
-        );
-    }
 
     #[test]
     fn artifact_get_downloads_daemon_byte_alias() {

--- a/src/commands/report/browser_evidence_compare.rs
+++ b/src/commands/report/browser_evidence_compare.rs
@@ -4,7 +4,6 @@ use serde_json::{Map, Value};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use crate::commands::escape_markdown_table_cell;
 use homeboy::core::extension::trace::{
@@ -1475,73 +1474,18 @@ mod implementation {
         baseline_label: &str,
         candidate_label: &str,
     ) -> homeboy::core::Result<VisualCompareResult> {
-        std::fs::create_dir_all(artifacts_dir).map_err(|err| {
-            homeboy::core::Error::internal_io(
-                format!(
-                    "Failed to create visual compare artifact directory {}: {}",
-                    artifacts_dir.display(),
-                    err
-                ),
-                Some("report.browser_evidence_compare.visual_artifacts".to_string()),
-            )
-        })?;
-        let input_path = artifacts_dir.join("homeboy-visual-compare-input.json");
-        let mut input = serde_json::json!({
-            "schema": "homeboy/visual-compare-request/v1",
-            "source_screenshot": source_screenshot,
-            "candidate_screenshot": candidate_screenshot,
-            "source_label": baseline_label,
-            "candidate_label": candidate_label,
-            "artifacts_directory": artifacts_dir,
-        });
-        if let Some(threshold) = options.threshold {
-            input["threshold"] = serde_json::json!(threshold);
-        }
-        std::fs::write(
-            &input_path,
-            serde_json::to_string_pretty(&input).map_err(|err| {
-                homeboy::core::Error::internal_json(
-                    err.to_string(),
-                    Some("report.browser_evidence_compare.visual_input".to_string()),
-                )
-            })?,
-        )
-        .map_err(|err| {
-            homeboy::core::Error::internal_io(
-                format!(
-                    "Failed to write visual compare input {}: {}",
-                    input_path.display(),
-                    err
-                ),
-                Some("report.browser_evidence_compare.visual_input".to_string()),
-            )
-        })?;
-
-        let output = Command::new(&options.provider_command)
-            .args(&options.provider_args)
-            .arg(&input_path)
-            .output()
-            .map_err(|err| {
-                homeboy::core::Error::internal_unexpected(format!(
-                    "Failed to invoke visual compare provider `{}`: {}",
-                    options.provider_command, err
-                ))
-            })?;
-        if !output.status.success() {
-            return Err(homeboy::core::Error::internal_unexpected(format!(
-                "Visual compare provider `{}` failed with status {:?}: {}{}",
-                options.provider_command,
-                output.status.code(),
-                String::from_utf8_lossy(&output.stderr),
-                String::from_utf8_lossy(&output.stdout)
-            )));
-        }
-        let value = serde_json::from_slice::<Value>(&output.stdout).map_err(|err| {
-            homeboy::core::Error::internal_json(
-                format!("Failed to parse visual compare provider output: {}", err),
-                Some("report.browser_evidence_compare.visual_output".to_string()),
-            )
-        })?;
+        let value = homeboy::core::browser_visual_compare::run_visual_compare_provider(
+            &homeboy::core::browser_visual_compare::VisualCompareProviderRequest {
+                artifacts_dir,
+                source_screenshot,
+                candidate_screenshot,
+                baseline_label,
+                candidate_label,
+                threshold: options.threshold,
+                provider_command: &options.provider_command,
+                provider_args: &options.provider_args,
+            },
+        )?;
         Ok(visual_compare_result_from_value(&value, artifacts_dir))
     }
 

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -60,6 +60,7 @@ mod reports;
 mod request;
 mod spec;
 mod spec_compile;
+mod spec_source;
 
 use action_state::*;
 use actions::*;
@@ -76,6 +77,7 @@ use spec_compile::{
     repo_loop_spec_fingerprint_from_metadata, set_repo_loop_spec_metadata,
     RepoLoopSpecReconciliation, REPO_LOOP_SPEC_ACTION_REASON, REPO_LOOP_SPEC_WORKFLOW_REASON,
 };
+pub use spec_source::{load_materialize_spec_source, MaterializeSpecSource};
 
 /// Create a new durable controller record.
 pub fn init(request: ControllerInitRequest) -> Result<AgentTaskLoopControllerRecord> {

--- a/src/core/agent_task_controller_service/request.rs
+++ b/src/core/agent_task_controller_service/request.rs
@@ -2,6 +2,73 @@
 #![allow(unused_imports)]
 use super::*;
 
+use crate::core::agent_task_dispatch_service::{AgentTaskDispatchCommand, DispatchCoreInputs};
+
+/// Optional dispatch overrides applied to a controller request when the request
+/// itself does not declare a backend/selector/model/provider config. The CLI
+/// supplies these from `--dispatch-*` flags; core owns how they merge so the
+/// command module stays a thin adapter.
+#[derive(Debug, Clone, Default)]
+pub struct ControllerDispatchOverrides {
+    pub backend: Option<String>,
+    pub selector: Option<String>,
+    pub model: Option<String>,
+    pub provider_config: Option<String>,
+}
+
+/// Build a typed dispatch command from a controller action request, applying the
+/// supplied overrides when the corresponding request fields are absent.
+///
+/// The request may nest dispatch inputs under a `"dispatch"` key or supply them
+/// at the top level. Owns the JSON-to-command adaptation so the CLI controller
+/// adapter only constructs overrides and renders the result.
+pub fn controller_request_dispatch_command(
+    request: &Value,
+    overrides: &ControllerDispatchOverrides,
+) -> Result<AgentTaskDispatchCommand> {
+    let dispatch = request.get("dispatch").unwrap_or(request);
+    let mut command = AgentTaskDispatchCommand {
+        prompt: optional_string(dispatch, "prompt"),
+        tasks: optional_string_array(dispatch, "tasks")?,
+        cwd: optional_string(dispatch, "cwd")
+            .or_else(|| optional_string(request, "cwd"))
+            .or_else(|| optional_string(request, "workspace_root")),
+        workspace: optional_string(dispatch, "workspace")
+            .or_else(|| optional_string(request, "workspace")),
+        repo: optional_string(dispatch, "repo").or_else(|| optional_string(request, "repo")),
+        task_url: optional_string(dispatch, "task_url"),
+        backend: optional_string(dispatch, "backend"),
+        selector: optional_string(dispatch, "selector"),
+        model: optional_string(dispatch, "model"),
+        required_capabilities: optional_string_array(dispatch, "required_capabilities")?,
+        secret_env: optional_string_array(dispatch, "secret_env")?,
+        concurrency: optional_usize(dispatch, "concurrency")?.unwrap_or(1),
+        run_id: optional_string(dispatch, "run_id"),
+        core: DispatchCoreInputs {
+            tasks_json: optional_string(dispatch, "tasks_json"),
+            provider_config: optional_string(dispatch, "provider_config"),
+            client_context: optional_string(dispatch, "client_context"),
+            attempts: optional_u32(dispatch, "attempts")?.unwrap_or(1),
+            queue_only: optional_bool(dispatch, "queue_only").unwrap_or(false),
+        },
+    };
+
+    if command.backend.is_none() {
+        command.backend = overrides.backend.clone();
+    }
+    if command.selector.is_none() {
+        command.selector = overrides.selector.clone();
+    }
+    if command.model.is_none() {
+        command.model = overrides.model.clone();
+    }
+    if command.core.provider_config.is_none() {
+        command.core.provider_config = overrides.provider_config.clone();
+    }
+
+    Ok(command)
+}
+
 /// Parse an `AgentTaskPlan` out of a controller spawn-task request.
 ///
 /// The request may either wrap the plan under a `"plan"` field or be the plan

--- a/src/core/agent_task_controller_service/spec_source.rs
+++ b/src/core/agent_task_controller_service/spec_source.rs
@@ -1,0 +1,223 @@
+//! Controller materialize spec-source resolution.
+//!
+//! Resolves the `materialize` command's `--spec` input into a concrete repo
+//! loop spec. The input may be a literal spec or a generator manifest that
+//! declares a command to run; in the latter case this module executes the
+//! generator (process execution), reads the generated spec from disk, validates
+//! it, and assembles generator evidence. This orchestration belongs in core so
+//! the CLI adapter stays thin.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::core::agent_task_loop_definition::{
+    materialize_repo_loop_spec, AgentTaskLoopSpecMaterializationRequest,
+};
+use crate::core::config;
+use crate::core::proof::validate_proof_value;
+use crate::core::{Error, Result};
+
+use super::AgentTaskRepoLoopSpec;
+
+const CONTROLLER_SPEC_GENERATOR_SCHEMA: &str = "homeboy/agent-task-loop-spec-generator/v1";
+
+/// Resolved controller materialize spec plus optional generator evidence.
+pub struct MaterializeSpecSource {
+    pub spec: AgentTaskRepoLoopSpec,
+    pub generator_evidence: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ControllerSpecGeneratorManifest {
+    schema: String,
+    command: Vec<String>,
+    output_path: String,
+    #[serde(default)]
+    inputs: Value,
+}
+
+/// Load the materialize spec source, executing a generator manifest if the
+/// input declares one rather than an inline spec.
+pub fn load_materialize_spec_source(source: &str) -> Result<MaterializeSpecSource> {
+    let raw = config::read_json_spec_to_string(source)?;
+    match serde_json::from_str::<AgentTaskRepoLoopSpec>(&raw) {
+        Ok(spec) => Ok(MaterializeSpecSource {
+            spec,
+            generator_evidence: None,
+        }),
+        Err(spec_error) => {
+            let manifest: ControllerSpecGeneratorManifest =
+                serde_json::from_str(&raw).map_err(|_| {
+                    Error::validation_invalid_argument(
+                        "spec",
+                        spec_error.to_string(),
+                        Some(source.to_string()),
+                        None,
+                    )
+                })?;
+            load_generated_materialize_spec(source, manifest)
+        }
+    }
+}
+
+fn load_generated_materialize_spec(
+    source: &str,
+    manifest: ControllerSpecGeneratorManifest,
+) -> Result<MaterializeSpecSource> {
+    validate_generator_manifest(source, &manifest)?;
+    let manifest_dir = manifest_base_dir(source);
+    let output_path = resolve_manifest_path(manifest_dir.as_deref(), &manifest.output_path);
+    let command_status = run_spec_generator_command(&manifest, manifest_dir.as_deref())?;
+    let generated_raw = std::fs::read_to_string(&output_path).map_err(|error| {
+        Error::validation_invalid_argument(
+            "spec.output_path",
+            format!(
+                "generator command completed but generated spec was not found at {}; rerun the manifest command or update output_path: {error}",
+                output_path.display()
+            ),
+            Some(source.to_string()),
+            Some(vec![format!(
+                "{} must write {}",
+                manifest.command.join(" "),
+                manifest.output_path
+            )]),
+        )
+    })?;
+    let spec: AgentTaskRepoLoopSpec = serde_json::from_str(&generated_raw).map_err(|error| {
+        Error::validation_invalid_argument(
+            "spec.output_path",
+            format!("generated spec JSON is invalid: {error}"),
+            Some(output_path.display().to_string()),
+            None,
+        )
+    })?;
+    let materialized = materialize_repo_loop_spec(AgentTaskLoopSpecMaterializationRequest {
+        spec: &spec,
+        run_inputs: &Value::Null,
+        policy_results: &[],
+    })?;
+    let validation_result =
+        validate_proof_value(serde_json::to_value(materialized).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("controller.materialize.generator.serialize".to_string()),
+            )
+        })?);
+    let spec_hash = format!("{:x}", Sha256::digest(generated_raw.as_bytes()));
+
+    Ok(MaterializeSpecSource {
+        spec,
+        generator_evidence: Some(serde_json::json!({
+            "schema": "homeboy/agent-task-loop-spec-generator-evidence/v1",
+            "manifest": source,
+            "command": manifest.command,
+            "inputs": manifest.inputs,
+            "output_path": output_path.display().to_string(),
+            "spec_hash": spec_hash,
+            "validation_result": validation_result,
+            "status": command_status,
+        })),
+    })
+}
+
+fn validate_generator_manifest(
+    source: &str,
+    manifest: &ControllerSpecGeneratorManifest,
+) -> Result<()> {
+    if manifest.schema != CONTROLLER_SPEC_GENERATOR_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "spec.schema",
+            format!(
+                "controller materialize generator manifests must use schema {CONTROLLER_SPEC_GENERATOR_SCHEMA}"
+            ),
+            Some(source.to_string()),
+            None,
+        ));
+    }
+    if manifest.command.is_empty() || manifest.command.iter().any(|part| part.trim().is_empty()) {
+        return Err(Error::validation_invalid_argument(
+            "spec.command",
+            "generator command must be a non-empty array of program and arguments",
+            Some(source.to_string()),
+            None,
+        ));
+    }
+    if manifest.output_path.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "spec.output_path",
+            "generator manifest must declare the spec file path written by the command",
+            Some(source.to_string()),
+            None,
+        ));
+    }
+    if !manifest.inputs.is_null() && !manifest.inputs.is_object() {
+        return Err(Error::validation_invalid_argument(
+            "spec.inputs",
+            "generator manifest inputs must be a JSON object when present",
+            Some(source.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn manifest_base_dir(source: &str) -> Option<PathBuf> {
+    let file = source.strip_prefix('@')?;
+    if file == "-" {
+        return None;
+    }
+    Path::new(file).parent().map(Path::to_path_buf)
+}
+
+fn resolve_manifest_path(base_dir: Option<&Path>, path: &str) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        path
+    } else if let Some(base_dir) = base_dir {
+        base_dir.join(path)
+    } else {
+        path
+    }
+}
+
+fn run_spec_generator_command(
+    manifest: &ControllerSpecGeneratorManifest,
+    manifest_dir: Option<&Path>,
+) -> Result<Value> {
+    let mut command = Command::new(&manifest.command[0]);
+    command.args(&manifest.command[1..]);
+    if let Some(manifest_dir) = manifest_dir {
+        command.current_dir(manifest_dir);
+    }
+    let output = command.output().map_err(|error| {
+        Error::validation_invalid_argument(
+            "spec.command",
+            format!("failed to execute generator command: {error}"),
+            Some(manifest.command.join(" ")),
+            None,
+        )
+    })?;
+    let code = output.status.code();
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "spec.command",
+            format!(
+                "generator command exited with status {}; stderr: {}",
+                code.map(|value| value.to_string())
+                    .unwrap_or_else(|| "terminated by signal".to_string()),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+            Some(manifest.command.join(" ")),
+            None,
+        ));
+    }
+    Ok(serde_json::json!({
+        "exit_code": code,
+        "stdout": String::from_utf8_lossy(&output.stdout).trim(),
+        "stderr": String::from_utf8_lossy(&output.stderr).trim(),
+    }))
+}

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -139,20 +139,21 @@ pub use super::agent_task_provider::{
 /// Durable controller execution service entry points and report contracts.
 pub mod controller_service {
     pub use super::super::agent_task_controller_service::{
-        apply_event, apply_spec_dispatch_defaults, apply_spec_dispatch_defaults_with_cwd, init,
-        init_from_spec, list, mark_human_ready, optional_bool, optional_string,
+        apply_event, apply_spec_dispatch_defaults, apply_spec_dispatch_defaults_with_cwd,
+        controller_request_dispatch_command, init, init_from_spec, list,
+        load_materialize_spec_source, mark_human_ready, optional_bool, optional_string,
         optional_string_array, optional_u32, optional_usize, plan_from_controller_request,
         plan_from_spec, resume, run_action, run_next, status, AgentTaskRepoLoopSpec,
         AgentTaskRepoLoopSpecAbility, AgentTaskRepoLoopSpecAgent, AgentTaskRepoLoopSpecArtifact,
         AgentTaskRepoLoopSpecDependency, AgentTaskRepoLoopSpecEntity, AgentTaskRepoLoopSpecEvent,
         AgentTaskRepoLoopSpecGate, AgentTaskRepoLoopSpecMetric, AgentTaskRepoLoopSpecPhase,
         AgentTaskRepoLoopSpecTool, AgentTaskRepoLoopSpecWorkflow, ControllerActionReport,
-        ControllerApplyEventRequest, ControllerDispatchHook, ControllerEventReport,
-        ControllerFromSpecReport, ControllerFromSpecRequest, ControllerInitRequest,
-        ControllerListReport, ControllerMarkHumanReadyRequest, ControllerPlanReport,
-        ControllerPlanRequest, ControllerResumeReport, NoopDispatchHook, ACTION_RESULT_SCHEMA,
-        APPLY_EVENT_RESULT_SCHEMA, FROM_SPEC_RESULT_SCHEMA, LIST_RESULT_SCHEMA, PLAN_RESULT_SCHEMA,
-        RESUME_RESULT_SCHEMA,
+        ControllerApplyEventRequest, ControllerDispatchHook, ControllerDispatchOverrides,
+        ControllerEventReport, ControllerFromSpecReport, ControllerFromSpecRequest,
+        ControllerInitRequest, ControllerListReport, ControllerMarkHumanReadyRequest,
+        ControllerPlanReport, ControllerPlanRequest, ControllerResumeReport, MaterializeSpecSource,
+        NoopDispatchHook, ACTION_RESULT_SCHEMA, APPLY_EVENT_RESULT_SCHEMA, FROM_SPEC_RESULT_SCHEMA,
+        LIST_RESULT_SCHEMA, PLAN_RESULT_SCHEMA, RESUME_RESULT_SCHEMA,
     };
 }
 

--- a/src/core/browser_visual_compare.rs
+++ b/src/core/browser_visual_compare.rs
@@ -1,0 +1,100 @@
+//! Visual-compare provider orchestration.
+//!
+//! Owns the side-effecting parts of the browser-evidence visual compare flow:
+//! creating the artifacts directory, writing the provider request file, invoking
+//! the external visual-compare provider process, and parsing its JSON response.
+//! The report command layer stays a thin adapter that maps the parsed value into
+//! its presentation types.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+use crate::core::{Error, Result};
+
+/// Inputs required to run the external visual-compare provider for one variant.
+pub struct VisualCompareProviderRequest<'a> {
+    pub artifacts_dir: &'a Path,
+    pub source_screenshot: &'a str,
+    pub candidate_screenshot: &'a str,
+    pub baseline_label: &'a str,
+    pub candidate_label: &'a str,
+    pub threshold: Option<f64>,
+    pub provider_command: &'a str,
+    pub provider_args: &'a [String],
+}
+
+/// Create the artifacts directory, write the request file, run the provider
+/// process, and return the parsed JSON response value.
+pub fn run_visual_compare_provider(request: &VisualCompareProviderRequest<'_>) -> Result<Value> {
+    std::fs::create_dir_all(request.artifacts_dir).map_err(|err| {
+        Error::internal_io(
+            format!(
+                "Failed to create visual compare artifact directory {}: {}",
+                request.artifacts_dir.display(),
+                err
+            ),
+            Some("report.browser_evidence_compare.visual_artifacts".to_string()),
+        )
+    })?;
+    let input_path = request
+        .artifacts_dir
+        .join("homeboy-visual-compare-input.json");
+    let mut input = serde_json::json!({
+        "schema": "homeboy/visual-compare-request/v1",
+        "source_screenshot": request.source_screenshot,
+        "candidate_screenshot": request.candidate_screenshot,
+        "source_label": request.baseline_label,
+        "candidate_label": request.candidate_label,
+        "artifacts_directory": request.artifacts_dir,
+    });
+    if let Some(threshold) = request.threshold {
+        input["threshold"] = serde_json::json!(threshold);
+    }
+    std::fs::write(
+        &input_path,
+        serde_json::to_string_pretty(&input).map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("report.browser_evidence_compare.visual_input".to_string()),
+            )
+        })?,
+    )
+    .map_err(|err| {
+        Error::internal_io(
+            format!(
+                "Failed to write visual compare input {}: {}",
+                input_path.display(),
+                err
+            ),
+            Some("report.browser_evidence_compare.visual_input".to_string()),
+        )
+    })?;
+
+    let output = Command::new(request.provider_command)
+        .args(request.provider_args)
+        .arg(&input_path)
+        .output()
+        .map_err(|err| {
+            Error::internal_unexpected(format!(
+                "Failed to invoke visual compare provider `{}`: {}",
+                request.provider_command, err
+            ))
+        })?;
+    if !output.status.success() {
+        return Err(Error::internal_unexpected(format!(
+            "Visual compare provider `{}` failed with status {:?}: {}{}",
+            request.provider_command,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+            String::from_utf8_lossy(&output.stdout)
+        )));
+    }
+    serde_json::from_slice::<Value>(&output.stdout).map_err(|err| {
+        Error::internal_json(
+            format!("Failed to parse visual compare provider output: {}", err),
+            Some("report.browser_evidence_compare.visual_output".to_string()),
+        )
+    })
+}

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -22,10 +22,14 @@ use crate::core::upgrade::VERSION;
 
 mod artifact_download;
 mod broker_config;
+mod control;
 mod patch_capture;
 mod remote_runner;
 pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
+pub use control::{
+    artifact_content_url, fetch_artifact_to_path, start_background, ArtifactFetchOutcome,
+};
 use patch_capture::{capture_baseline, capture_patch_report};
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -1,0 +1,188 @@
+//! Local daemon lifecycle and artifact-fetch orchestration owned by core.
+//!
+//! The command layer (`src/commands/daemon.rs`) stays a thin adapter: it parses
+//! arguments and renders output. The process spawning, status polling, HTTP
+//! artifact fetch, and filesystem persistence live here so the orchestration is
+//! testable and reusable outside the CLI.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::core::error::{Error, Result};
+use crate::core::execution_contract::encode_uri_component;
+
+use super::{parse_bind_addr, read_status, DaemonStartResult};
+
+/// Outcome of a daemon byte-endpoint artifact download.
+#[derive(Debug, Clone)]
+pub struct ArtifactFetchOutcome {
+    pub daemon_url: String,
+    pub content_url: String,
+    pub output_path: PathBuf,
+    pub content_type: Option<String>,
+    pub size_bytes: u64,
+    pub sha256: Option<String>,
+}
+
+/// Spawn the daemon in the background, then poll the state file until the new
+/// process publishes its address (or a timeout elapses).
+pub fn start_background(addr: &str) -> Result<DaemonStartResult> {
+    parse_bind_addr(addr)?;
+
+    let exe = std::env::current_exe().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("resolve current executable".to_string()),
+        )
+    })?;
+    let child = Command::new(exe)
+        .args(["daemon", "serve", "--addr", addr])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| Error::internal_io(e.to_string(), Some("spawn daemon".to_string())))?;
+    let pid = child.id();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let status = read_status()?;
+        if let Some(state) = status.state {
+            if state.pid == pid {
+                return Ok(DaemonStartResult {
+                    pid,
+                    address: state.address,
+                    state_path: state.state_path,
+                });
+            }
+        }
+
+        if Instant::now() >= deadline {
+            return Err(Error::internal_unexpected(format!(
+                "daemon process {} did not publish state before timeout",
+                pid
+            )));
+        }
+
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Resolve the daemon base URL, falling back to the running daemon's address.
+pub fn resolve_daemon_url(daemon_url: Option<String>) -> Result<String> {
+    if let Some(url) = daemon_url.filter(|url| !url.trim().is_empty()) {
+        return Ok(url);
+    }
+    let status = read_status()?;
+    let Some(state) = status.state.filter(|_| status.running) else {
+        return Err(Error::validation_invalid_argument(
+            "daemon-url",
+            "daemon is not running; pass --daemon-url or start it with `homeboy daemon start`",
+            None,
+            None,
+        ));
+    };
+    Ok(format!("http://{}", state.address))
+}
+
+/// Build the encoded daemon byte-endpoint URL for a given run/artifact pair.
+pub fn artifact_content_url(daemon_url: &str, run_id: &str, artifact_id: &str) -> Result<String> {
+    let mut base = reqwest::Url::parse(daemon_url).map_err(|e| {
+        Error::validation_invalid_argument(
+            "daemon-url",
+            e.to_string(),
+            Some(daemon_url.to_string()),
+            None,
+        )
+    })?;
+    base.set_path(&format!(
+        "/runs/{}/artifacts/{}/content",
+        encode_uri_component(run_id),
+        encode_uri_component(artifact_id)
+    ));
+    base.set_query(None);
+    Ok(base.to_string())
+}
+
+/// Fetch artifact bytes through the local daemon byte endpoint and persist them.
+///
+/// Resolves the daemon URL, downloads the content, ensures the parent directory
+/// exists, and writes the bytes to `output`. Returns metadata describing the
+/// download for the caller to render.
+pub fn fetch_artifact_to_path(
+    run_id: &str,
+    artifact_id: &str,
+    daemon_url: Option<String>,
+    output: Option<PathBuf>,
+) -> Result<ArtifactFetchOutcome> {
+    let daemon_url = resolve_daemon_url(daemon_url)?;
+    let content_url = artifact_content_url(&daemon_url, run_id, artifact_id)?;
+    let output_path = output.unwrap_or_else(|| default_artifact_output_path(artifact_id));
+
+    let response = reqwest::blocking::get(&content_url).map_err(reqwest_error)?;
+    let status = response.status();
+    let headers = response.headers().clone();
+    if !status.is_success() {
+        let body = response.text().unwrap_or_default();
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "daemon artifact fetch failed with HTTP {}: {}",
+                status.as_u16(),
+                body
+            ),
+            Some(artifact_id.to_string()),
+            None,
+        ));
+    }
+
+    let bytes = response.bytes().map_err(reqwest_error)?;
+    if let Some(parent) = output_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("create {}", parent.display())))
+        })?;
+    }
+    std::fs::write(&output_path, &bytes).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("write {}", output_path.display())),
+        )
+    })?;
+
+    Ok(ArtifactFetchOutcome {
+        daemon_url,
+        content_url,
+        output_path,
+        content_type: header_value(&headers, reqwest::header::CONTENT_TYPE.as_str()),
+        size_bytes: bytes.len() as u64,
+        sha256: header_value(&headers, "x-homeboy-artifact-sha256"),
+    })
+}
+
+fn default_artifact_output_path(artifact_id: &str) -> PathBuf {
+    artifact_id
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("artifact.bin"))
+}
+
+fn header_value(headers: &reqwest::header::HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+}
+
+fn reqwest_error(error: reqwest::Error) -> Error {
+    Error::internal_io(error.to_string(), Some("fetch daemon artifact".to_string()))
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/daemon/control_test.rs"]
+mod control_test;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -50,6 +50,7 @@ pub(crate) mod artifact_metadata;
 pub mod artifact_origin;
 pub mod artifact_ref;
 pub mod browser_evidence;
+pub mod browser_visual_compare;
 pub mod build_identity;
 pub mod change_artifact;
 pub mod ci_failure_log_triage;

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -1,0 +1,56 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+
+use super::{artifact_content_url, fetch_artifact_to_path};
+use crate::test_support::with_isolated_home;
+
+#[test]
+fn artifact_content_url_builds_encoded_daemon_byte_alias() {
+    let url = artifact_content_url(
+        "http://127.0.0.1:7421/base?ignored=true",
+        "run 1",
+        "report/summary.json",
+    )
+    .expect("url");
+
+    assert_eq!(
+        url,
+        "http://127.0.0.1:7421/runs/run%201/artifacts/report%2Fsummary.json/content"
+    );
+}
+
+#[test]
+fn fetch_artifact_to_path_downloads_daemon_byte_alias() {
+    with_isolated_home(|home| {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let addr = listener.local_addr().expect("addr");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = [0; 1024];
+            let bytes = stream.read(&mut request).expect("request");
+            let request = String::from_utf8_lossy(&request[..bytes]);
+            assert!(request
+                .starts_with("GET /runs/run-1/artifacts/report%2Fsummary.json/content HTTP/1.1"));
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nX-Homeboy-Artifact-Sha256: abc123\r\nConnection: close\r\n\r\n{\"ok\":true}",
+                )
+                .expect("response");
+        });
+        let output = home.path().join("summary.json");
+
+        let outcome = fetch_artifact_to_path(
+            "run-1",
+            "report/summary.json",
+            Some(format!("http://{addr}")),
+            Some(output.clone()),
+        )
+        .expect("artifact get");
+
+        server.join().expect("server");
+        assert_eq!(outcome.content_type.as_deref(), Some("application/json"));
+        assert_eq!(outcome.size_bytes, 11);
+        assert_eq!(outcome.sha256.as_deref(), Some("abc123"));
+        assert_eq!(std::fs::read(&output).expect("output"), br#"{"ok":true}"#);
+    });
+}


### PR DESCRIPTION
Part of #5902. Moves orchestration out of command adapters into core services.

## Findings addressed (3 of 4)
- `src/commands/daemon.rs` — moved daemon background-spawn (process exec) + artifact-fetch HTTP/fs-write orchestration into new `core::daemon::control` (`start_background`, `fetch_artifact_to_path`, `artifact_content_url`).
- `src/commands/agent_task/controller.rs` — moved the spec-generator manifest execution (process exec + fs read) into `core::agent_task_controller_service::spec_source`, and moved controller-request → dispatch-command conversion into `core::agent_task_controller_service::controller_request_dispatch_command` (with `ControllerDispatchOverrides`). Adapter is now marker-free.
- `src/commands/report/browser_evidence_compare.rs` — moved the visual-compare provider orchestration (artifacts dir creation, request write, provider process exec, output parse) into new `core::browser_visual_compare`.

## Not addressed (noted)
- `src/commands/trace/compare_targets.rs` — too entangled for a safe surgical move: the module owns `TemporaryGitWorktree` (with a `Drop`-based cleanup), target resolution holding worktree leases, the proof-matrix execution loop, observation lifecycle, and artifact persistence all interwoven. Extracting it cleanly is a larger refactor that warrants its own PR. Left untouched to keep this change low-risk.

## Verification
- `cargo build --lib` clean
- `cargo clippy --lib` — no new warnings (3 pre-existing unused-import warnings are in untouched files: runner.rs, trace.rs, offload.rs)
- `cargo fmt` applied
- Each fixed command file now has 0 orchestration markers outside `#[cfg(test)]`