### PR TITLE
refactor(lab): declare mutation patch capture

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -55,6 +55,7 @@ pub struct LabCommandContract {
     pub portability: LabCommandPortability,
     pub source_path_mode: LabSourcePathMode,
     pub workspace_mode_policy: LabWorkspaceModePolicy,
+    pub capture_mutation_patch: bool,
     pub mutation_flag: Option<&'static str>,
     pub extra_required_tools: &'static [LabCommandRequiredTool],
     /// Routing-policy flags shared across the Lab command layers.
@@ -653,6 +654,8 @@ pub(super) fn apply_lab_contract_to_descriptor(
             LabCommandPortability::Portable => None,
             LabCommandPortability::LocalOnly(reason) => Some(reason),
         });
+    descriptor.lab_offload_captures_mutation_patch = contract
+        .is_some_and(|contract| contract.capture_mutation_patch);
     descriptor.lab_offload_mutation_flag = contract.and_then(|contract| contract.mutation_flag);
 }
 
@@ -746,6 +749,7 @@ impl LabCommandContract {
             portability: LabCommandPortability::Portable,
             source_path_mode: LabSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+            capture_mutation_patch: mutation_flag.is_some(),
             mutation_flag,
             extra_required_tools,
             routing_policy: LabRoutingPolicy {
@@ -827,6 +831,7 @@ impl LabCommandContract {
             portability: LabCommandPortability::LocalOnly(reason),
             source_path_mode: LabSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+            capture_mutation_patch: false,
             mutation_flag: None,
             extra_required_tools: LAB_NO_EXTRA_TOOLS,
             routing_policy: LabRoutingPolicy {
@@ -913,6 +918,11 @@ impl Commands {
     pub fn lab_offload_mutation_flag(&self) -> Option<&'static str> {
         self.lab_contract()
             .and_then(|contract| contract.mutation_flag)
+    }
+
+    pub fn lab_offload_captures_mutation_patch(&self) -> bool {
+        self.lab_contract()
+            .is_some_and(|contract| contract.capture_mutation_patch)
     }
 
     pub fn lab_required_extensions(&self) -> crate::core::Result<Vec<String>> {

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -207,6 +207,7 @@ pub struct CommandDescriptor {
     pub output: CommandOutputDescriptor,
     pub supports_lab_runner: bool,
     pub lab_runner_unsupported_reason: Option<&'static str>,
+    pub lab_offload_captures_mutation_patch: bool,
     pub lab_offload_mutation_flag: Option<&'static str>,
 }
 
@@ -231,6 +232,7 @@ impl CommandOutputDescriptor {
             output: self,
             supports_lab_runner: false,
             lab_runner_unsupported_reason: None,
+            lab_offload_captures_mutation_patch: false,
             lab_offload_mutation_flag: None,
         };
         apply_lab_contract_to_descriptor(&mut descriptor, contract);

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -54,6 +54,7 @@ pub fn route_after_parse(
     let observer = lab_dispatch_observer(cli, normalized_args, trace_runner_id.as_deref());
     let active_run_id = observer.run_id().map(str::to_string);
 
+    let capture_mutation_patch = cli.command.lab_offload_captures_mutation_patch();
     let mutation_flag = cli.command.lab_offload_mutation_flag();
 
     // For component-targeted write/fix commands (`homeboy lint --fix <component>`,
@@ -67,7 +68,7 @@ pub fn route_after_parse(
     let scoped_args = inject_lab_changed_files(&cli.command, normalized_args)?;
     let normalized_args = scoped_args.as_deref().unwrap_or(normalized_args);
 
-    let rewritten_args = (mutation_flag.is_some())
+    let rewritten_args = capture_mutation_patch
         .then(|| rewrite_component_target_to_path(&cli.command, normalized_args))
         .flatten()
         .or_else(|| rewrite_ad_hoc_lab_workspace_to_path(&cli.command, normalized_args));
@@ -85,7 +86,7 @@ pub fn route_after_parse(
                 cli.lab_only,
             ),
             allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
-            capture_patch: mutation_flag.is_some(),
+            capture_patch: capture_mutation_patch,
             mutation_flag,
             timeout: None,
             active_run_id: active_run_id.as_deref(),

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -496,6 +496,7 @@ mod tests {
             portability: LabCommandPortability::Portable,
             source_path_mode: LabSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabWorkspaceModePolicy::GitCheckoutRequired,
+            capture_mutation_patch: true,
             mutation_flag: Some("--keep-overlay"),
             extra_required_tools: LAB_TRACE_EXTRA_TOOLS,
             routing_policy: LabRoutingPolicy {

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -959,3 +959,18 @@ fn test_lab_offload_mutation_flag() {
         Some("--baseline/--ratchet")
     );
 }
+
+#[test]
+fn lab_mutation_patch_capture_is_descriptor_owned() {
+    let mutating_lint = parsed_command(&["homeboy", "lint", "--fix"]);
+    let mutating_descriptor = mutating_lint.descriptor(false);
+    assert!(mutating_lint.lab_offload_captures_mutation_patch());
+    assert!(mutating_descriptor.lab_offload_captures_mutation_patch);
+    assert_eq!(mutating_descriptor.lab_offload_mutation_flag, Some("--fix"));
+
+    let read_only_lint = parsed_command(&["homeboy", "lint"]);
+    let read_only_descriptor = read_only_lint.descriptor(false);
+    assert!(!read_only_lint.lab_offload_captures_mutation_patch());
+    assert!(!read_only_descriptor.lab_offload_captures_mutation_patch);
+    assert_eq!(read_only_descriptor.lab_offload_mutation_flag, None);
+}


### PR DESCRIPTION
## Summary
- Add explicit lab contract/descriptor state for mutation patch capture.
- Route patch capture and component-target rewriting from the declared contract field instead of re-deriving from the mutation flag at route time.
- Add descriptor-driven coverage for mutating and read-only lab commands.

## Verification
- `git diff --check`
- Local cargo verification not run per instruction to avoid local cargo.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the lab descriptor refactor, adding tests, and preparing this PR.