### PR TITLE
Unify Lab secret env handoff

### DIFF
--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -83,10 +83,7 @@ use super::agent_task_bridge::{
 };
 use super::evidence::terminal_lab_run_evidence;
 use super::provider_preflight::preflight_agent_task_provider_on_runner;
-use super::secrets::{
-    hydrate_agent_task_secret_env, hydrate_trace_secret_env, hydrate_tunnel_secret_env,
-    preflight_agent_task_runner_secret_env,
-};
+use super::secrets::{build_lab_secret_env_handoff_plan, preflight_agent_task_runner_secret_env};
 use super::trace_fetch_refs::lab_offload_git_fetch_refs;
 use super::workspace_plan::{lab_workspace_sync_mode, preflight_required_git_checkout_workspace};
 #[cfg(test)]
@@ -623,11 +620,10 @@ fn run_runner_resident_lab_offload(
         "runner_cwd": runner_workspace_root,
         "command_paths": "runner_side",
     });
+    let secret_env_handoff = build_lab_secret_env_handoff_plan(&remapped_args, Default::default())?;
+    lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
     let mut env = build_lab_offload_env_with_passthroughs(&lab_metadata);
-    let tunnel_secret_env = hydrate_tunnel_secret_env(&remapped_args, &mut env)?;
-    lab_metadata["tunnel_secret_env"] = tunnel_secret_env;
-    env = build_lab_offload_env_with_passthroughs(&lab_metadata);
-    hydrate_tunnel_secret_env(&remapped_args, &mut env)?;
+    env.extend(secret_env_handoff.env_delta);
 
     let (exec_output, exit_code) = exec(
         runner_id,
@@ -637,7 +633,7 @@ fn run_runner_resident_lab_offload(
             allow_diagnostic_ssh: false,
             command,
             env,
-            secret_env_names: Vec::new(),
+            secret_env_names: secret_env_handoff.secret_env_names,
             capture_patch: request.capture_patch,
             raw_exec: false,
             source_snapshot: None,
@@ -1421,20 +1417,18 @@ fn run_lab_offload_inner(
         &workspace_mapping_metadata,
         &synced_rigs,
     );
-    let mut env = build_lab_offload_env_with_passthroughs(&lab_metadata);
-    let rig_component_path_env = forward_rig_component_path_env(&mut env, &workspace_mapping)?;
-    apply_rig_component_path_overrides(&mut env, &rig_component_path_overrides);
-    let agent_task_secret_env =
-        hydrate_agent_task_secret_env(&changed_since_preflight.args, &mut env)?;
-    let trace_secret_env = hydrate_trace_secret_env(&changed_since_preflight.args, &mut env)?;
-    let tunnel_secret_env = hydrate_tunnel_secret_env(&changed_since_preflight.args, &mut env)?;
-    lab_metadata["agent_task_secret_env"] = agent_task_secret_env;
-    lab_metadata["trace_secret_env"] = trace_secret_env;
-    lab_metadata["tunnel_secret_env"] = tunnel_secret_env;
+    let mut env_delta = std::collections::HashMap::new();
+    let rig_component_path_env =
+        forward_rig_component_path_env(&mut env_delta, &workspace_mapping)?;
+    apply_rig_component_path_overrides(&mut env_delta, &rig_component_path_overrides);
+    let secret_env_handoff =
+        build_lab_secret_env_handoff_plan(&changed_since_preflight.args, env_delta)?;
+    lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
     lab_metadata["rig_component_path_env"] = rig_component_path_env;
     lab_metadata["rig_component_path_overrides"] =
         rig_component_path_overrides_metadata(&rig_component_path_overrides);
-    lab_metadata["settings_env"] = settings_env_diagnostics(&remapped_args, &env);
+    lab_metadata["settings_env"] =
+        settings_env_diagnostics(&remapped_args, &secret_env_handoff.env_delta);
     lab_metadata["runner_homeboy"] = runner_homeboy.clone();
     lab_metadata["source_checkout"] = source_checkout.clone();
     lab_metadata["rig_sync"] = serde_json::json!({
@@ -1451,12 +1445,8 @@ fn run_lab_offload_inner(
         "status": synced.workspace_cleanliness,
         "allow_dirty_lab_workspace": request.allow_dirty_lab_workspace,
     });
-    env = build_lab_offload_env_with_passthroughs(&lab_metadata);
-    forward_rig_component_path_env(&mut env, &workspace_mapping)?;
-    apply_rig_component_path_overrides(&mut env, &rig_component_path_overrides);
-    hydrate_agent_task_secret_env(&changed_since_preflight.args, &mut env)?;
-    hydrate_trace_secret_env(&changed_since_preflight.args, &mut env)?;
-    hydrate_tunnel_secret_env(&changed_since_preflight.args, &mut env)?;
+    let mut env = build_lab_offload_env_with_passthroughs(&lab_metadata);
+    env.extend(secret_env_handoff.env_delta.clone());
     preflight_agent_task_runner_secret_env(
         runner_id,
         &runner,
@@ -1496,7 +1486,7 @@ fn run_lab_offload_inner(
             allow_diagnostic_ssh: false,
             command,
             env,
-            secret_env_names: Vec::new(),
+            secret_env_names: secret_env_handoff.secret_env_names,
             capture_patch: request.capture_patch,
             raw_exec: false,
             source_snapshot: Some(source_snapshot),

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -2,9 +2,9 @@
 //!
 //! Splits agent-task vs trace secret discovery from the offload orchestrator so
 //! that the secret env contract for each command family stays close to its
-//! parser. Both entry points (`hydrate_agent_task_secret_env`,
-//! `hydrate_trace_secret_env`) mutate the runner exec environment in place and
-//! return diagnostic metadata that is embedded into the Lab offload envelope.
+//! parser. `build_lab_secret_env_handoff_plan` is the single offload boundary:
+//! it resolves controller-owned secret values once, records runner-deferred
+//! requirements by name, and exposes only redacted diagnostics for metadata.
 
 use std::collections::HashMap;
 
@@ -26,6 +26,86 @@ use super::args_util::{non_empty_arg, subcommand_index};
 /// Provenance key used when a missing runner secret_env name is contributed by
 /// the plan's provider runner requirements rather than an individual task.
 const PLAN_PROVIDER_PROVENANCE: &str = "plan:provider";
+const LAB_SECRET_ENV_HANDOFF_SCHEMA: &str = "homeboy/lab-secret-env-handoff/v1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LabSecretEnvHandoffPlan {
+    pub(super) env_delta: HashMap<String, String>,
+    pub(super) diagnostics: serde_json::Value,
+    pub(super) secret_env_names: Vec<String>,
+    pub(super) runner_deferred_secret_env: Vec<String>,
+}
+
+pub(super) fn build_lab_secret_env_handoff_plan(
+    args: &[String],
+    mut env_delta: HashMap<String, String>,
+) -> Result<LabSecretEnvHandoffPlan> {
+    let agent_task_secret_env = hydrate_agent_task_secret_env(args, &mut env_delta)?;
+    let trace_secret_env = hydrate_trace_secret_env(args, &mut env_delta)?;
+    let tunnel_secret_env = hydrate_tunnel_secret_env(args, &mut env_delta)?;
+    let mut secret_env_names = declared_agent_task_secret_env(args);
+    secret_env_names.extend(declared_trace_secret_env(args));
+    secret_env_names.extend(declared_tunnel_secret_env(args));
+    secret_env_names.sort();
+    secret_env_names.dedup();
+
+    let mut runner_deferred_secret_env = Vec::new();
+    runner_deferred_secret_env.extend(runner_deferred_secret_env_names(&agent_task_secret_env));
+    runner_deferred_secret_env.extend(runner_deferred_secret_env_names(&tunnel_secret_env));
+    runner_deferred_secret_env.sort();
+    runner_deferred_secret_env.dedup();
+
+    let diagnostics = serde_json::json!({
+        "schema": LAB_SECRET_ENV_HANDOFF_SCHEMA,
+        "final_env_delta": redacted_env_delta_metadata(&env_delta),
+        "secret_env_names": secret_env_names.clone(),
+        "runner_deferred_secret_env": runner_deferred_secret_env
+            .iter()
+            .map(|name| serde_json::json!({
+                "name": name,
+                "source": "runner",
+                "required": true,
+            }))
+            .collect::<Vec<_>>(),
+        "agent_task_secret_env": agent_task_secret_env,
+        "trace_secret_env": trace_secret_env,
+        "tunnel_secret_env": tunnel_secret_env,
+    });
+
+    Ok(LabSecretEnvHandoffPlan {
+        env_delta,
+        diagnostics,
+        secret_env_names,
+        runner_deferred_secret_env,
+    })
+}
+
+fn redacted_env_delta_metadata(env_delta: &HashMap<String, String>) -> Vec<serde_json::Value> {
+    let mut names = env_delta.keys().cloned().collect::<Vec<_>>();
+    names.sort();
+    names
+        .into_iter()
+        .map(|name| {
+            serde_json::json!({
+                "name": name,
+                "forwarded_to_runner": true,
+                "value_preview": "<redacted>",
+                "redacted": true,
+            })
+        })
+        .collect()
+}
+
+fn runner_deferred_secret_env_names(metadata: &serde_json::Value) -> Vec<String> {
+    metadata
+        .get("runner_deferred_secret_env")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get("name").and_then(serde_json::Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
 
 pub(super) fn hydrate_agent_task_secret_env(
     args: &[String],
@@ -755,6 +835,79 @@ mod tests {
         assert!(!rendered.contains("sk_test_fake_not_real"));
 
         std::env::remove_var("HOMEBOY_TRACE_SECRET_TEST_KEY");
+    }
+
+    #[test]
+    fn lab_secret_env_handoff_plan_reports_redacted_env_delta_and_exact_names() {
+        let args = vec![
+            "homeboy".to_string(),
+            "trace".to_string(),
+            "compare".to_string(),
+            "woocommerce-gateway-stripe".to_string(),
+            "real-wallet".to_string(),
+            "--secret-env=HOMEBOY_TRACE_HANDOFF_SECRET_TEST".to_string(),
+        ];
+        let mut env_delta = HashMap::new();
+        env_delta.insert(
+            "HOMEBOY_PUBLIC_CONTEXT".to_string(),
+            "still-redacted-in-diagnostics".to_string(),
+        );
+        std::env::set_var("HOMEBOY_TRACE_HANDOFF_SECRET_TEST", "trace-secret-value");
+
+        let plan = build_lab_secret_env_handoff_plan(&args, env_delta).expect("handoff plan");
+
+        assert_eq!(
+            plan.env_delta
+                .get("HOMEBOY_TRACE_HANDOFF_SECRET_TEST")
+                .map(String::as_str),
+            Some("trace-secret-value")
+        );
+        assert_eq!(
+            plan.secret_env_names,
+            vec!["HOMEBOY_TRACE_HANDOFF_SECRET_TEST".to_string()]
+        );
+        assert!(plan.runner_deferred_secret_env.is_empty());
+        let rendered = plan.diagnostics.to_string();
+        assert!(rendered.contains("homeboy/lab-secret-env-handoff/v1"));
+        assert!(rendered.contains("HOMEBOY_TRACE_HANDOFF_SECRET_TEST"));
+        assert!(rendered.contains("HOMEBOY_PUBLIC_CONTEXT"));
+        assert!(!rendered.contains("trace-secret-value"));
+        assert!(!rendered.contains("still-redacted-in-diagnostics"));
+
+        std::env::remove_var("HOMEBOY_TRACE_HANDOFF_SECRET_TEST");
+    }
+
+    #[test]
+    fn lab_secret_env_handoff_plan_reports_runner_deferred_requirements() {
+        let args = vec![
+            "homeboy".to_string(),
+            "tunnel".to_string(),
+            "preview-client".to_string(),
+            "start".to_string(),
+            "--ingress".to_string(),
+            "https://preview-broker.example.test".to_string(),
+            "--token-env=HOMEBOY_RUNNER_PREVIEW_TOKEN".to_string(),
+        ];
+
+        let plan = build_lab_secret_env_handoff_plan(&args, HashMap::new()).expect("handoff plan");
+
+        assert!(plan.env_delta.is_empty());
+        assert_eq!(
+            plan.secret_env_names,
+            vec!["HOMEBOY_RUNNER_PREVIEW_TOKEN".to_string()]
+        );
+        assert_eq!(
+            plan.runner_deferred_secret_env,
+            vec!["HOMEBOY_RUNNER_PREVIEW_TOKEN".to_string()]
+        );
+        assert_eq!(
+            plan.diagnostics["runner_deferred_secret_env"][0]["name"],
+            "HOMEBOY_RUNNER_PREVIEW_TOKEN"
+        );
+        assert_eq!(
+            plan.diagnostics["runner_deferred_secret_env"][0]["required"],
+            true
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a single Lab secret/env handoff plan that resolves controller-side env deltas once.
- Emit redacted handoff diagnostics with final env delta names, exact secret env names, and runner-deferred requirements.
- Remove duplicate Lab offload hydration before runner exec and pass the handoff secret names into runner execution.

## Verification
- `rustfmt src/core/runner/lab/secrets.rs src/core/runner/lab/offload.rs`
- `git diff --check`
- Local cargo tests were not run per instruction to avoid local cargo.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the Lab secret/env handoff plan, removing duplicate hydration, and drafting focused tests.