### PR TITLE
Centralize runner workload construction

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -655,8 +655,8 @@ pub(super) fn apply_lab_contract_to_descriptor(
             LabCommandPortability::Portable => None,
             LabCommandPortability::LocalOnly(reason) => Some(reason),
         });
-    descriptor.lab_offload_captures_mutation_patch = contract
-        .is_some_and(|contract| contract.capture_mutation_patch);
+    descriptor.lab_offload_captures_mutation_patch =
+        contract.is_some_and(|contract| contract.capture_mutation_patch);
     descriptor.lab_offload_mutation_flag = contract.and_then(|contract| contract.mutation_flag);
 }
 

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -95,21 +95,11 @@ pub struct RunnerWorkload {
     pub workspace_mappings: RunnerWorkloadWorkspaceMappings,
     pub required_capabilities: Vec<RunnerWorkloadCapability>,
     pub required_secrets: RunnerWorkloadSecrets,
+    pub required_extensions: Vec<String>,
     pub mutation_policy: RunnerWorkloadMutationPolicy,
     pub assignment: RunnerWorkloadAssignment,
     pub state: RunnerWorkloadState,
     pub result_refs: RunnerWorkloadResultRefs,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RunnerWorkloadInput {
-    pub workload_id: String,
-    pub plan_id: String,
-    pub assignment: RunnerWorkloadAssignment,
-    pub state: RunnerWorkloadState,
-    pub mutation_policy: RunnerWorkloadMutationPolicy,
-    pub workspace_mapping_ref: Option<String>,
-    pub proof_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -683,60 +673,6 @@ impl LabCommandContract {
             command: self,
             required_extensions,
             requires_playwright,
-        }
-    }
-
-    pub fn runner_workload(&self, input: RunnerWorkloadInput) -> RunnerWorkload {
-        RunnerWorkload {
-            schema: RUNNER_WORKLOAD_SCHEMA.to_string(),
-            workload_id: input.workload_id,
-            kind: RunnerWorkloadKind {
-                command_label: self.hot_label.to_string(),
-                command_family: RunnerWorkloadCommandFamily::from_command_label(self.hot_label),
-            },
-            workspace_mappings: RunnerWorkloadWorkspaceMappings {
-                source_path_mode: self.source_path_mode.label().to_string(),
-                workspace_mode_policy: self.workspace_mode_policy.label().to_string(),
-                mapping_ref: input.workspace_mapping_ref.clone(),
-            },
-            required_capabilities: self.required_capabilities(),
-            required_secrets: RunnerWorkloadSecrets {
-                categories: self.required_secret_categories(),
-            },
-            mutation_policy: input.mutation_policy,
-            assignment: input.assignment,
-            state: input.state,
-            result_refs: RunnerWorkloadResultRefs {
-                plan_id: input.plan_id,
-                proof_id: input.proof_id,
-                workspace_mapping_ref: input.workspace_mapping_ref,
-            },
-        }
-    }
-
-    fn required_capabilities(&self) -> Vec<RunnerWorkloadCapability> {
-        let mut capabilities = Vec::new();
-        if self.routing_policy.requires_extension_parity {
-            capabilities.push(RunnerWorkloadCapability {
-                name: "extension_parity".to_string(),
-                required: true,
-            });
-        }
-        for tool in self.extra_required_tools {
-            capabilities.push(RunnerWorkloadCapability {
-                name: tool.label().to_string(),
-                required: true,
-            });
-        }
-        capabilities
-    }
-
-    fn required_secret_categories(&self) -> Vec<String> {
-        match self.hot_label {
-            label if label.starts_with("agent-task") => vec!["agent_task".to_string()],
-            TRACE_LAB_LABEL => vec!["trace".to_string()],
-            label if label.starts_with("tunnel") => vec!["tunnel".to_string()],
-            _ => Vec::new(),
         }
     }
 

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -790,34 +790,6 @@ impl LabCommandContract {
     }
 }
 
-impl LabSourcePathMode {
-    fn label(self) -> &'static str {
-        match self {
-            Self::CwdOrPathFlag => "cwd_or_path_flag",
-            Self::RunnerResident => "runner_resident",
-        }
-    }
-}
-
-impl LabWorkspaceModePolicy {
-    fn label(self) -> &'static str {
-        match self {
-            Self::ChangedSinceGitElseSnapshot => "changed_since_git_else_snapshot",
-            Self::Git => "git",
-            Self::GitCheckoutRequired => "git_checkout_required",
-            Self::RunnerResident => "runner_resident",
-        }
-    }
-}
-
-impl LabCommandRequiredTool {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Playwright => "playwright",
-        }
-    }
-}
-
 impl RunnerWorkloadCommandFamily {
     pub(crate) fn from_command_label(label: &str) -> Self {
         match label {

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -19,12 +19,6 @@
 use std::path::Path;
 
 use crate::command_contract::lab_runner_support_summary;
-use crate::command_contract::{
-    RunnerWorkload, RunnerWorkloadAssignment, RunnerWorkloadCapability,
-    RunnerWorkloadCommandFamily, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
-    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
-    RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
-};
 use crate::core::agent_task_lifecycle;
 use crate::core::engine::shell;
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
@@ -75,6 +69,7 @@ use super::super::{
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
+use super::super::workload::{build_runner_workload, RunnerWorkloadBuildInput};
 use super::agent_task_bridge::{
     agent_task_dispatch_run_isolation_token, ensure_agent_task_dispatch_run_id_with,
     lab_pre_dispatch_failure_message, materialize_inline_agent_task_plan_arg,
@@ -1399,17 +1394,26 @@ fn run_lab_offload_inner(
         None,
         Some(&workspace_mapping_metadata),
     );
-    lab_metadata["runner_workload"] = serde_json::to_value(runner_workload_metadata(
-        &plan,
-        &contract,
-        &request,
-        runner_id,
-        status_tunnel_mode(&runner_status).metadata_value(),
-        selection.source.metadata_value(),
-        &remote_cwd,
-        &lab_metadata,
-    ))
-    .unwrap_or(serde_json::json!(null));
+    lab_metadata["runner_workload"] =
+        serde_json::to_value(build_runner_workload(RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &contract,
+            capture_patch: request.capture_patch,
+            mutation_flag: request.mutation_flag,
+            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+            runner_id,
+            runner_mode: status_tunnel_mode(&runner_status).metadata_value(),
+            assignment_source: selection.source.metadata_value(),
+            status: "offloaded",
+            remote_workspace: Some(&remote_cwd),
+            fallback_reason: None,
+            workspace_mapping_ref: Some("workspace_mapping"),
+            proof_id: lab_metadata
+                .get("proof")
+                .and_then(|proof| proof.get("id"))
+                .and_then(|id| id.as_str()),
+        }))
+        .unwrap_or(serde_json::json!(null));
     lab_metadata["source_snapshot"] =
         serde_json::to_value(&source_snapshot).unwrap_or(serde_json::json!(null));
     lab_metadata["materialization_proof"] = lab_materialization_proof_metadata(
@@ -1822,109 +1826,6 @@ fn lab_materialization_proof_metadata(
         "workspace_mapping": workspace_mapping,
         "rigs": synced_rigs,
     })
-}
-
-#[allow(clippy::too_many_arguments)]
-fn runner_workload_metadata(
-    plan: &HomeboyPlan,
-    contract: &LabOffloadCommand,
-    request: &LabOffloadRequest<'_>,
-    runner_id: &str,
-    runner_mode: &str,
-    assignment_source: &str,
-    remote_workspace: &str,
-    lab_metadata: &serde_json::Value,
-) -> RunnerWorkload {
-    RunnerWorkload {
-        schema: RUNNER_WORKLOAD_SCHEMA.to_string(),
-        workload_id: format!("{}.runner_workload", plan.id),
-        kind: RunnerWorkloadKind {
-            command_label: contract.hot_label.to_string(),
-            command_family: RunnerWorkloadCommandFamily::from_command_label(contract.hot_label),
-        },
-        workspace_mappings: RunnerWorkloadWorkspaceMappings {
-            source_path_mode: contract.source_path_mode.label().to_string(),
-            workspace_mode_policy: contract.workspace_mode_policy.label().to_string(),
-            mapping_ref: Some("workspace_mapping".to_string()),
-        },
-        required_capabilities: runner_workload_required_capabilities(contract),
-        required_secrets: RunnerWorkloadSecrets {
-            categories: runner_workload_required_secret_categories(contract.hot_label),
-        },
-        mutation_policy: RunnerWorkloadMutationPolicy {
-            capture_patch: request.capture_patch,
-            mutation_flag: request.mutation_flag.map(str::to_string),
-            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
-        },
-        assignment: RunnerWorkloadAssignment {
-            runner_id: Some(runner_id.to_string()),
-            runner_mode: Some(runner_mode.to_string()),
-            source: Some(assignment_source.to_string()),
-        },
-        state: RunnerWorkloadState {
-            status: "offloaded".to_string(),
-            remote_workspace: Some(remote_workspace.to_string()),
-            fallback_reason: None,
-        },
-        result_refs: RunnerWorkloadResultRefs {
-            plan_id: plan.id.clone(),
-            proof_id: lab_metadata
-                .get("proof")
-                .and_then(|proof| proof.get("id"))
-                .and_then(|id| id.as_str())
-                .map(str::to_string),
-            workspace_mapping_ref: Some("workspace_mapping".to_string()),
-        },
-    }
-}
-
-fn runner_workload_required_capabilities(
-    contract: &LabOffloadCommand,
-) -> Vec<RunnerWorkloadCapability> {
-    let mut capabilities = Vec::new();
-    if contract.routing_policy.requires_extension_parity || !contract.required_extensions.is_empty()
-    {
-        capabilities.push(RunnerWorkloadCapability {
-            name: "extension_parity".to_string(),
-            required: true,
-        });
-    }
-    if contract.requires_playwright {
-        capabilities.push(RunnerWorkloadCapability {
-            name: "playwright".to_string(),
-            required: true,
-        });
-    }
-    capabilities
-}
-
-fn runner_workload_required_secret_categories(hot_label: &str) -> Vec<String> {
-    match hot_label {
-        label if label.starts_with("agent-task") => vec!["agent_task".to_string()],
-        "trace" => vec!["trace".to_string()],
-        label if label.starts_with("tunnel") => vec!["tunnel".to_string()],
-        _ => Vec::new(),
-    }
-}
-
-impl LabOffloadSourcePathMode {
-    fn label(self) -> &'static str {
-        match self {
-            Self::CwdOrPathFlag => "cwd_or_path_flag",
-            Self::RunnerResident => "runner_resident",
-        }
-    }
-}
-
-impl LabOffloadWorkspaceModePolicy {
-    fn label(self) -> &'static str {
-        match self {
-            Self::ChangedSinceGitElseSnapshot => "changed_since_git_else_snapshot",
-            Self::Git => "git",
-            Self::GitCheckoutRequired => "git_checkout_required",
-            Self::RunnerResident => "runner_resident",
-        }
-    }
 }
 
 fn source_checkout_ref_display(metadata: &serde_json::Value) -> String {

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -53,6 +53,7 @@ mod validation_dependencies;
 pub(crate) use validation_dependencies::validation_dependency_ids;
 pub use validation_dependencies::RunnerValidationDependencySyncOutput;
 mod worker;
+mod workload;
 mod workspace;
 pub(crate) use workspace::copy_snapshot_to_directory;
 

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -359,6 +359,7 @@ mod tests {
             required_secrets: RunnerWorkloadSecrets {
                 categories: Vec::new(),
             },
+            required_extensions: vec!["browser".to_string()],
             mutation_policy: RunnerWorkloadMutationPolicy {
                 capture_patch: false,
                 mutation_flag: None,
@@ -405,6 +406,10 @@ mod tests {
         assert_eq!(
             metadata["runner_workload"]["assignment"]["runner_id"],
             "lab"
+        );
+        assert_eq!(
+            metadata["runner_workload"]["required_extensions"][0],
+            "browser"
         );
     }
 

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -1,0 +1,190 @@
+use crate::command_contract::{
+    RunnerWorkload, RunnerWorkloadAssignment, RunnerWorkloadCapability,
+    RunnerWorkloadCommandFamily, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
+    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
+    RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
+};
+use crate::core::plan::HomeboyPlan;
+
+use super::{LabOffloadCommand, LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy};
+
+pub(crate) struct RunnerWorkloadBuildInput<'a> {
+    pub plan: &'a HomeboyPlan,
+    pub command: &'a LabOffloadCommand,
+    pub capture_patch: bool,
+    pub mutation_flag: Option<&'a str>,
+    pub allow_dirty_lab_workspace: bool,
+    pub runner_id: &'a str,
+    pub runner_mode: &'a str,
+    pub assignment_source: &'a str,
+    pub status: &'a str,
+    pub remote_workspace: Option<&'a str>,
+    pub fallback_reason: Option<&'a str>,
+    pub workspace_mapping_ref: Option<&'a str>,
+    pub proof_id: Option<&'a str>,
+}
+
+pub(crate) fn build_runner_workload(input: RunnerWorkloadBuildInput<'_>) -> RunnerWorkload {
+    let workspace_mapping_ref = input.workspace_mapping_ref.map(str::to_string);
+    RunnerWorkload {
+        schema: RUNNER_WORKLOAD_SCHEMA.to_string(),
+        workload_id: format!("{}.runner_workload", input.plan.id),
+        kind: RunnerWorkloadKind {
+            command_label: input.command.hot_label.to_string(),
+            command_family: RunnerWorkloadCommandFamily::from_command_label(
+                input.command.hot_label,
+            ),
+        },
+        workspace_mappings: RunnerWorkloadWorkspaceMappings {
+            source_path_mode: source_path_mode_label(input.command.source_path_mode).to_string(),
+            workspace_mode_policy: workspace_mode_policy_label(input.command.workspace_mode_policy)
+                .to_string(),
+            mapping_ref: workspace_mapping_ref.clone(),
+        },
+        required_capabilities: required_capabilities(input.command),
+        required_secrets: RunnerWorkloadSecrets {
+            categories: required_secret_categories(input.command.hot_label),
+        },
+        required_extensions: input.command.required_extensions.clone(),
+        mutation_policy: RunnerWorkloadMutationPolicy {
+            capture_patch: input.capture_patch,
+            mutation_flag: input.mutation_flag.map(str::to_string),
+            allow_dirty_lab_workspace: input.allow_dirty_lab_workspace,
+        },
+        assignment: RunnerWorkloadAssignment {
+            runner_id: Some(input.runner_id.to_string()),
+            runner_mode: Some(input.runner_mode.to_string()),
+            source: Some(input.assignment_source.to_string()),
+        },
+        state: RunnerWorkloadState {
+            status: input.status.to_string(),
+            remote_workspace: input.remote_workspace.map(str::to_string),
+            fallback_reason: input.fallback_reason.map(str::to_string),
+        },
+        result_refs: RunnerWorkloadResultRefs {
+            plan_id: input.plan.id.clone(),
+            proof_id: input.proof_id.map(str::to_string),
+            workspace_mapping_ref,
+        },
+    }
+}
+
+fn required_capabilities(command: &LabOffloadCommand) -> Vec<RunnerWorkloadCapability> {
+    let mut capabilities = Vec::new();
+    if command.routing_policy.requires_extension_parity || !command.required_extensions.is_empty() {
+        capabilities.push(RunnerWorkloadCapability {
+            name: "extension_parity".to_string(),
+            required: true,
+        });
+    }
+    if command.requires_playwright {
+        capabilities.push(RunnerWorkloadCapability {
+            name: "playwright".to_string(),
+            required: true,
+        });
+    }
+    capabilities
+}
+
+fn required_secret_categories(hot_label: &str) -> Vec<String> {
+    match hot_label {
+        label if label.starts_with("agent-task") => vec!["agent_task".to_string()],
+        "trace" => vec!["trace".to_string()],
+        label if label.starts_with("tunnel") => vec!["tunnel".to_string()],
+        _ => Vec::new(),
+    }
+}
+
+fn source_path_mode_label(mode: LabOffloadSourcePathMode) -> &'static str {
+    match mode {
+        LabOffloadSourcePathMode::CwdOrPathFlag => "cwd_or_path_flag",
+        LabOffloadSourcePathMode::RunnerResident => "runner_resident",
+    }
+}
+
+fn workspace_mode_policy_label(policy: LabOffloadWorkspaceModePolicy) -> &'static str {
+    match policy {
+        LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot => {
+            "changed_since_git_else_snapshot"
+        }
+        LabOffloadWorkspaceModePolicy::Git => "git",
+        LabOffloadWorkspaceModePolicy::GitCheckoutRequired => "git_checkout_required",
+        LabOffloadWorkspaceModePolicy::RunnerResident => "runner_resident",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command_contract::LabRoutingPolicy;
+    use crate::core::plan::{HomeboyPlan, PlanKind};
+
+    fn plan() -> HomeboyPlan {
+        HomeboyPlan::builder_for_description(PlanKind::LabOffload, "test").build()
+    }
+
+    fn command() -> LabOffloadCommand {
+        LabOffloadCommand {
+            hot_label: "trace",
+            portable: true,
+            unsupported_reason: None,
+            source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
+            workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+            required_extensions: vec!["browser".to_string()],
+            requires_playwright: true,
+            routing_policy: LabRoutingPolicy {
+                requires_extension_parity: true,
+                ..LabRoutingPolicy::default()
+            },
+        }
+    }
+
+    #[test]
+    fn runner_core_builds_complete_workload_payload() {
+        let plan = plan();
+        let command = command();
+        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &command,
+            capture_patch: true,
+            mutation_flag: Some("--keep-overlay"),
+            allow_dirty_lab_workspace: true,
+            runner_id: "lab-a",
+            runner_mode: "direct_ssh",
+            assignment_source: "explicit",
+            status: "offloaded",
+            remote_workspace: Some("/srv/homeboy/work"),
+            fallback_reason: None,
+            workspace_mapping_ref: Some("workspace_mapping"),
+            proof_id: Some("proof-1"),
+        });
+
+        assert_eq!(workload.schema, RUNNER_WORKLOAD_SCHEMA);
+        assert_eq!(workload.workload_id, "lab_offload.test.runner_workload");
+        assert_eq!(workload.kind.command_label, "trace");
+        assert_eq!(
+            workload.kind.command_family,
+            RunnerWorkloadCommandFamily::Quality
+        );
+        assert_eq!(
+            workload.workspace_mappings.mapping_ref.as_deref(),
+            Some("workspace_mapping")
+        );
+        assert_eq!(workload.required_capabilities.len(), 2);
+        assert_eq!(workload.required_capabilities[0].name, "extension_parity");
+        assert_eq!(workload.required_capabilities[1].name, "playwright");
+        assert_eq!(workload.required_secrets.categories, vec!["trace"]);
+        assert_eq!(workload.required_extensions, vec!["browser"]);
+        assert_eq!(
+            workload.mutation_policy.mutation_flag.as_deref(),
+            Some("--keep-overlay")
+        );
+        assert_eq!(workload.assignment.runner_id.as_deref(), Some("lab-a"));
+        assert_eq!(
+            workload.state.remote_workspace.as_deref(),
+            Some("/srv/homeboy/work")
+        );
+        assert_eq!(workload.result_refs.plan_id, "lab_offload.test");
+        assert_eq!(workload.result_refs.proof_id.as_deref(), Some("proof-1"));
+    }
+}

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -13,54 +13,6 @@ fn parsed_cli(args: &[&str]) -> Cli {
     Cli::try_parse_from(args).expect("CLI args should parse")
 }
 
-#[test]
-fn runner_workload_contract_serializes_versioned_shape() {
-    let contract = parsed_command(&["homeboy", "trace"])
-        .lab_contract()
-        .expect("trace should declare a Lab contract");
-    let workload = contract.runner_workload(RunnerWorkloadInput {
-        workload_id: "workload-1".to_string(),
-        plan_id: "plan-1".to_string(),
-        assignment: RunnerWorkloadAssignment {
-            runner_id: Some("lab-a".to_string()),
-            runner_mode: Some("direct_ssh".to_string()),
-            source: Some("explicit".to_string()),
-        },
-        state: RunnerWorkloadState {
-            status: "offloaded".to_string(),
-            remote_workspace: Some("/srv/homeboy/work".to_string()),
-            fallback_reason: None,
-        },
-        mutation_policy: RunnerWorkloadMutationPolicy {
-            capture_patch: false,
-            mutation_flag: Some("--keep-overlay".to_string()),
-            allow_dirty_lab_workspace: false,
-        },
-        workspace_mapping_ref: Some("workspace_mapping".to_string()),
-        proof_id: Some("proof-1".to_string()),
-    });
-
-    let serialized = serde_json::to_value(workload).expect("workload should serialize");
-    assert_eq!(serialized["schema"], RUNNER_WORKLOAD_SCHEMA);
-    assert_eq!(serialized["workload_id"], "workload-1");
-    assert_eq!(serialized["kind"]["command_label"], "trace");
-    assert_eq!(serialized["kind"]["command_family"], "quality");
-    assert_eq!(
-        serialized["workspace_mappings"]["mapping_ref"],
-        "workspace_mapping"
-    );
-    assert_eq!(serialized["required_capabilities"][0]["name"], "playwright");
-    assert_eq!(serialized["required_secrets"]["categories"][0], "trace");
-    assert_eq!(
-        serialized["mutation_policy"]["mutation_flag"],
-        "--keep-overlay"
-    );
-    assert_eq!(serialized["assignment"]["runner_id"], "lab-a");
-    assert_eq!(serialized["state"]["remote_workspace"], "/srv/homeboy/work");
-    assert_eq!(serialized["result_refs"]["proof_id"], "proof-1");
-}
-
-#[test]
 fn test_lab_runner_supported_labels_are_contract_owned() {
     assert_eq!(
         lab_runner_supported_labels().as_slice(),


### PR DESCRIPTION
## Summary
- Move RunnerWorkload assembly into runner core via a single builder.
- Remove the command-contract workload builder and the duplicate Lab offload builder path.
- Add required_extensions to the RunnerWorkload payload and focused builder/metadata coverage.

## Verification
- rustfmt --check src/command_contract/lab.rs src/core/runner/workload.rs src/core/runner/mod.rs src/core/runner/lab/offload.rs src/core/runner/offload_metadata.rs tests/command_contract/lab_test.rs
- git diff --check
- Local cargo/tests not run per task constraint to avoid local cargo.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Implementing the runner workload construction refactor, focused tests, formatting/verification, and PR preparation.