### PR TITLE
Refactor agent-task fanout into batch cook

### DIFF
--- a/docs/architecture/provider-fanout-boundary.md
+++ b/docs/architecture/provider-fanout-boundary.md
@@ -1,7 +1,7 @@
 # Provider fanout boundary
 
 Homeboy core owns durable orchestration and provider-neutral evidence. Runtime
-providers own backend-specific fanout execution. The seam is the
+providers own backend-specific execution details. The seam is the
 `AgentTaskRequest`/`AgentTaskOutcome` adapter boundary.
 
 ## Ownership map
@@ -20,18 +20,17 @@ Homeboy submits provider-neutral `AgentTaskRequest` tasks to an executor provide
 The provider may translate the task into any backend-specific single-task or
 fanout request, but Homeboy core does not depend on provider runtime field names.
 
-Homeboy's first-class fanout primitive is `AgentTaskFanoutPlan`, which wraps
-generic `AgentTaskRequest` tasks with a Homeboy-owned fanout id and one of two
-provider-neutral planes:
+The public operator meaning of `agent-task fanout` is batch cook: many
+independent cooks, each with its own worktree/branch and its own PR
+finalization. Generic provider-neutral fanout scheduling remains an internal
+implementation seam for adapters and schedulers that need it; it is not the
+public CLI contract.
 
-- `isolated_tasks` for many isolated execution units scheduled under one fanout
-  id.
-- `workflow` for dependent task steps inside one logical execution unit.
-
-The fanout scheduler lowers both planes into `AgentTaskPlan`, reuses the generic
-agent-task scheduler for concurrency, retry, timeout, dependency, and
-backpressure behavior, then emits `AgentTaskFanoutAggregate` with the normalized
-schedule aggregate plus the generic reconciliation report.
+Public batch-cook fanout lowers each cook into the normal cook-loop path, so
+Homeboy owns dispatch, promotion, deterministic gates, commit/push, and PR
+finalization per cook. Provider adapters still receive one normalized
+`AgentTaskRequest` at a time and return one normalized `AgentTaskOutcome` at a
+time.
 
 The provider returns a normalized `AgentTaskOutcome`:
 

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -36,7 +36,6 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `cancel <run-id>` | Mark a queued or stale-running durable run as cancelled. |
 | `resume <run-id>` | Resume a queued or stale-running durable run. |
 | `retry <run-id>` | Submit a fresh durable run from an existing run's plan. |
-| `fanout plan\|submit\|run-plan` | Batch many independent cooks through provider-neutral fanout inputs. |
 | `prompts save\|list\|show\|remove` | Manage markdown prompts in Homeboy-owned storage. |
 
 `agent-task list`, `agent-task active`, and `agent-task latest` accept `--limit <n>` to cap discovery output. `agent-task active --reconcile` cancels stale, suspect, or unreconciled active records through the durable lifecycle path; add `--dry-run` to report candidates without mutating records.
@@ -46,6 +45,7 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | Subcommand | Purpose |
 |---|---|
 | `cook` | Run one workspace task through the patch-artifact handoff workflow. |
+| `fanout plan\|submit\|run-plan` | Normalize, inspect, or run a batch of independent cooks, each with its own worktree/branch/PR. |
 | `review <run-id>` | Build a durable aggregate review envelope from run state, logs, artifacts, and promotion hints. |
 | `promote <source>` | Promote a completed generic patch artifact into a managed worktree. |
 | `finalize-pr` | Finalize a green cook run into a review-ready pull request. |
@@ -291,45 +291,56 @@ accepted as `--selector`) selects a specific provider id for that backend, and
 
 ## Fanout/Reconcile
 
-`agent-task fanout` is the public provider-neutral seam for batch cooking: many
-independent tasks, each with its own durable cook lifecycle and review handoff,
-without calling Homeboy Extensions internal scripts.
+`agent-task fanout` means batch cook: many independent one-shot cooks launched
+from one plan. Each cook declares its own target worktree and optional head
+branch, runs through the same cook-loop path as a single PR cook, and finalizes
+its own pull request when deterministic gates pass.
 
-It accepts these generic input shapes:
+The public input shape is `homeboy/agent-task-batch-cook-fanout-plan/v1`:
 
-- `homeboy/agent-task-plan/v1`: an existing durable task plan, stamped with fanout lineage metadata when needed.
-- `homeboy/agent-task-fanout-plan/v1`: Homeboy's explicit fanout plan wrapper.
-- A JSON array of task packets, or an object with `tasks`/`packets`.
-- A single task packet object with `task_id`/`key` and `instructions`/`prompt`/`title`.
+```json
+{
+  "schema": "homeboy/agent-task-batch-cook-fanout-plan/v1",
+  "fanout_id": "audit-batch-2026-06-21",
+  "cooks": [
+    {
+      "cook_id": "finding-a",
+      "prompt": "Fix finding A",
+      "repo": "homeboy",
+      "to_worktree": "homeboy@fix-finding-a",
+      "head": "fix/finding-a",
+      "verify": ["homeboy test homeboy"]
+    }
+  ]
+}
+```
 
-Packet inputs can carry full `AgentTaskRequest` fields including `executor`,
-`workspace`, `policy`, `source_refs`, `inputs`, `expected_artifacts`, and
-`metadata`. When a packet omits `executor`, pass `--backend` and optionally
-`--selector`/`--model`, or configure a default agent-task backend.
+Generic task fanout is not a public operator contract. Existing
+`homeboy/agent-task-plan/v1`, `homeboy/agent-task-fanout-plan/v1`, packet arrays,
+and `tasks`/`packets` objects are rejected by `agent-task fanout`; internal
+schedulers may still use provider-neutral fanout machinery behind a clearer
+batch-cook surface.
+
+Cook entries accept dispatch fields such as `prompt`, `tasks`, `repo`, `cwd`,
+`workspace`, `task_url`, `backend`, `selector`, `model`, `secret_env`,
+`provider_config`, and `client_context`. Review fields include `to_worktree`,
+`provider_command`, `verify`, `private_verify`, `max_attempts`, `base`, `head`,
+`title`, `commit_message`, `protected_branches`, `ai_tool`, and `ai_used_for`.
+Each cook must declare at least one deterministic `verify` or `private_verify`
+gate so PR finalization is reviewer-ready.
 
 ```bash
 homeboy agent-task fanout submit \
-  --input @findings.json \
+  --input @batch-cooks.json \
   --fanout-id audit-batch-2026-06-21 \
   --backend codex \
   --selector openai-codex
 ```
 
-The submit response includes the durable run record plus stable follow-up
-commands:
-
-```bash
-homeboy agent-task status <run-id>
-homeboy agent-task logs <run-id>
-homeboy agent-task artifacts <run-id>
-homeboy agent-task review <run-id>
-homeboy agent-task retry <run-id> --run
-```
-
-Use `fanout plan` when a downstream repository needs a reviewable plan artifact
-before queueing it, and `fanout run-plan --record-run-id <run-id>` when an
-operator wants to execute immediately while preserving durable lineage and
-aggregate outcomes.
+`fanout submit` prints the exact per-cook commands for runner or operator
+execution. `fanout run-plan` executes each cook through the cook-loop service and
+returns a batch summary with each child cook result; successful child cooks open
+or update their own PRs.
 
 ## Headless Fleet-Cooking Review
 

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -29,10 +29,11 @@ pub use args::{
     AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerMaterializeArgs,
     AgentTaskControllerRunArgs, AgentTaskControllerRunNextArgs, AgentTaskControllerStatusArgs,
     AgentTaskDoctorArgs, AgentTaskFanoutArgs, AgentTaskFanoutCommand, AgentTaskFanoutInputArgs,
-    AgentTaskFanoutSubmitArgs, AgentTaskLoopArgs, AgentTaskLoopCommand, AgentTaskLoopDefineArgs,
-    AgentTaskLoopResumeArgs, AgentTaskLoopStatusArgs, CancelArgs, CompileLoopArgs, ContractArgs,
-    ContractFormat, FinalizePrArgs, GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs,
-    ProvidersArgs, RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    AgentTaskFanoutPlanArgs, AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs,
+    AgentTaskLoopArgs, AgentTaskLoopCommand, AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs,
+    AgentTaskLoopStatusArgs, CancelArgs, CompileLoopArgs, ContractArgs, ContractFormat,
+    FinalizePrArgs, GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs, ProvidersArgs, RetryArgs,
+    ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -34,33 +34,29 @@ pub struct AgentTaskFanoutArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum AgentTaskFanoutCommand {
-    /// Compile generic task/finding packets or an existing plan into an AgentTaskPlan.
+    /// Normalize a batch-cook fanout plan with independent cooks, worktrees, and PR targets.
     Plan(AgentTaskFanoutPlanArgs),
-    /// Persist a compiled fanout plan and return durable status/log/artifact commands.
+    /// Return the independent cook commands for a batch-cook fanout plan.
     Submit(AgentTaskFanoutSubmitArgs),
-    /// Run a fanout plan immediately through extension-declared executor providers.
+    /// Run each independent cook and let each cook open/update its own PR.
     RunPlan(AgentTaskFanoutRunPlanArgs),
 }
 
 #[derive(Args, Debug, Clone)]
 pub struct AgentTaskFanoutInputArgs {
-    /// Fanout spec JSON file, @file, inline JSON, or - for stdin.
+    /// Batch-cook fanout spec JSON file, @file, inline JSON, or - for stdin.
     #[arg(long = "input", value_name = "SPEC")]
     pub input: String,
 
-    /// Fanout id to use when the input is a packet list. Defaults to a generated id.
+    /// Batch fanout id. Overrides the spec fanout_id when supplied.
     #[arg(long = "fanout-id", value_name = "ID")]
     pub fanout_id: Option<String>,
 
-    /// Fanout plane for packet inputs.
-    #[arg(long = "plane", default_value = "isolated-tasks", value_enum)]
-    pub plane: AgentTaskFanoutPlaneArg,
-
-    /// Default executor backend for packet inputs without an executor object.
+    /// Default executor backend for cooks without a backend.
     #[arg(long = "backend", value_name = "BACKEND")]
     pub backend: Option<String>,
 
-    /// Default executor provider selector for packet inputs without one.
+    /// Default executor provider selector for cooks without one.
     #[arg(
         long = "selector",
         visible_alias = "provider-id",
@@ -68,7 +64,7 @@ pub struct AgentTaskFanoutInputArgs {
     )]
     pub selector: Option<String>,
 
-    /// Default model override for packet inputs without one.
+    /// Default model override for cooks without one.
     #[arg(long = "model", value_name = "MODEL")]
     pub model: Option<String>,
 }
@@ -99,11 +95,6 @@ pub struct AgentTaskFanoutRunPlanArgs {
     pub record_run_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum AgentTaskFanoutPlaneArg {
-    IsolatedTasks,
-    Workflow,
-}
 pub use controller::{
     AgentTaskControllerApplyEventArgs, AgentTaskControllerCommand, AgentTaskControllerFromSpecArgs,
     AgentTaskControllerInitArgs, AgentTaskControllerMarkHumanReadyArgs,
@@ -154,7 +145,7 @@ pub enum AgentTaskCommand {
     Resume(StatusArgs),
     /// Lifecycle: submit a fresh durable run from an existing run's plan.
     Retry(RetryArgs),
-    /// Lifecycle: compile, submit, or run generic provider-neutral fanout inputs.
+    /// Cook/review: run many independent cooks, each with its own worktree/branch/PR.
     Fanout(AgentTaskFanoutArgs),
     /// Review: build a durable aggregate envelope from run state, logs, artifacts, and promotion hints.
     Review(ReviewArgs),

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -1,25 +1,21 @@
-//! Public provider-neutral fanout/reconcile command handlers.
+//! Public batch-cook fanout command handlers.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use homeboy::core::agent_task::{
-    AgentTaskArtifactDeclaration, AgentTaskComponentContract, AgentTaskLimits,
-};
-use homeboy::core::agent_tasks::lifecycle;
+use homeboy::core::agent_tasks::gate::AgentTaskGateRevealPolicy;
 use homeboy::core::agent_tasks::provider;
-use homeboy::core::agent_tasks::scheduler::{AgentTaskPlan, AgentTaskScheduleOptions};
 use homeboy::core::agent_tasks::{
-    AgentTaskExecutor, AgentTaskFanoutPlan, AgentTaskFanoutPlane, AgentTaskPolicy,
-    AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkspace, AGENT_TASK_FANOUT_PLAN_SCHEMA,
-    AGENT_TASK_PLAN_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+    AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA, AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA,
+    AGENT_TASK_BATCH_COOK_FANOUT_SUBMIT_SCHEMA,
 };
 use homeboy::core::{config, Error, Result};
 
+use super::super::agent_task_dispatch::{DispatchArgs, DispatchCoreArgs};
 use super::super::CmdResult;
 use super::args::{
-    AgentTaskFanoutArgs, AgentTaskFanoutCommand, AgentTaskFanoutInputArgs, AgentTaskFanoutPlaneArg,
-    AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs,
+    AgentTaskFanoutArgs, AgentTaskFanoutCommand, AgentTaskFanoutInputArgs,
+    AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs, AgentTaskLoopArgs, VerifyGateArgs,
 };
 use super::command_json_value;
 use super::run;
@@ -27,338 +23,401 @@ use super::run;
 pub(super) fn fanout(args: AgentTaskFanoutArgs) -> CmdResult<Value> {
     match args.command {
         AgentTaskFanoutCommand::Plan(plan_args) => {
-            let plan = load_fanout_agent_task_plan(&plan_args.input)?;
+            let plan = load_batch_cook_fanout_plan(&plan_args.input)?;
             Ok((command_json_value(plan)?, 0))
         }
-        AgentTaskFanoutCommand::Submit(submit_args) => submit_fanout(submit_args),
-        AgentTaskFanoutCommand::RunPlan(run_args) => run_fanout_plan(run_args),
+        AgentTaskFanoutCommand::Submit(submit_args) => submit_batch_cook_fanout(submit_args),
+        AgentTaskFanoutCommand::RunPlan(run_args) => run_batch_cook_fanout(run_args),
     }
 }
 
-fn submit_fanout(args: AgentTaskFanoutSubmitArgs) -> CmdResult<Value> {
-    let plan = load_fanout_agent_task_plan(&args.input)?;
-    let record = lifecycle::submit_plan(&plan, args.run_id.as_deref())?;
+fn submit_batch_cook_fanout(args: AgentTaskFanoutSubmitArgs) -> CmdResult<Value> {
+    let mut plan = load_batch_cook_fanout_plan(&args.input)?;
+    if let Some(run_id) = args.run_id {
+        plan.fanout_id = run_id;
+    }
+
+    let cooks = plan
+        .cooks
+        .iter()
+        .map(|cook| {
+            serde_json::json!({
+                "cook_id": cook.cook_id,
+                "run_id": cook.run_id(),
+                "worktree": cook.to_worktree,
+                "head": cook.head,
+                "title": cook.title,
+                "command": cook_command(&plan, cook),
+            })
+        })
+        .collect::<Vec<_>>();
+
     Ok((
         serde_json::json!({
-            "schema": "homeboy/agent-task-fanout-submit-result/v1",
-            "run": record,
-            "commands": durable_commands(&record.run_id),
+            "schema": AGENT_TASK_BATCH_COOK_FANOUT_SUBMIT_SCHEMA,
+            "fanout_id": plan.fanout_id,
+            "state": "ready",
+            "cooks": cooks,
+            "next_actions": [
+                "run each cook command on its target worktree/branch, or use `agent-task fanout run-plan` to execute the batch cook from this machine"
+            ]
         }),
         0,
     ))
 }
 
-fn run_fanout_plan(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
-    let plan = load_fanout_agent_task_plan(&args.input)?;
-    run::run_loaded_plan(
-        plan,
-        args.record_run_id.as_deref(),
-        provider::ExtensionProviderAgentTaskExecutor::discover(),
-    )
+fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
+    let mut plan = load_batch_cook_fanout_plan(&args.input)?;
+    if let Some(record_run_id) = args.record_run_id {
+        plan.fanout_id = record_run_id;
+    }
+    let executor = provider::ExtensionProviderAgentTaskExecutor::discover();
+    let mut results = Vec::new();
+    let mut failed = 0usize;
+
+    for cook in &plan.cooks {
+        let (value, exit_code) =
+            run::run_loop_with_executor(cook.to_loop_args(&plan)?, executor.clone())?;
+        if exit_code != 0 {
+            failed += 1;
+        }
+        results.push(serde_json::json!({
+            "cook_id": cook.cook_id,
+            "run_id": cook.run_id(),
+            "worktree": cook.to_worktree,
+            "head": cook.head,
+            "exit_code": exit_code,
+            "result": value,
+        }));
+    }
+
+    Ok((
+        serde_json::json!({
+            "schema": AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA,
+            "fanout_id": plan.fanout_id,
+            "status": if failed == 0 { "succeeded" } else { "failed" },
+            "summary": {
+                "total": results.len(),
+                "succeeded": results.len() - failed,
+                "failed": failed,
+            },
+            "cooks": results,
+        }),
+        if failed == 0 { 0 } else { 1 },
+    ))
 }
 
-fn load_fanout_agent_task_plan(args: &AgentTaskFanoutInputArgs) -> Result<AgentTaskPlan> {
+fn load_batch_cook_fanout_plan(args: &AgentTaskFanoutInputArgs) -> Result<BatchCookFanoutPlan> {
     let raw = config::read_json_spec_to_string(&args.input)?;
     let value: Value = serde_json::from_str(&raw).map_err(|error| {
         Error::validation_invalid_json(
             error,
-            Some("agent-task fanout input".to_string()),
+            Some("agent-task fanout batch-cook input".to_string()),
             Some(raw.clone()),
         )
     })?;
-    fanout_value_to_plan(value, args)
+    BatchCookFanoutPlan::from_value(value, args)
 }
 
-fn fanout_value_to_plan(value: Value, args: &AgentTaskFanoutInputArgs) -> Result<AgentTaskPlan> {
-    if value.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_PLAN_SCHEMA) {
-        let mut plan: AgentTaskPlan = serde_json::from_value(value).map_err(|error| {
-            Error::validation_invalid_argument(
-                "input",
-                error.to_string(),
-                None,
-                Some(vec![
-                    "Expected a valid homeboy/agent-task-plan/v1 payload.".to_string()
-                ]),
-            )
-        })?;
-        stamp_plan_fanout_metadata(&mut plan, args.fanout_id.clone());
-        return Ok(plan);
-    }
-
-    if value.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_FANOUT_PLAN_SCHEMA) {
-        let fanout_plan: AgentTaskFanoutPlan = serde_json::from_value(value).map_err(|error| {
-            Error::validation_invalid_argument(
-                "input",
-                error.to_string(),
-                None,
-                Some(vec![
-                    "Expected a valid homeboy/agent-task-fanout-plan/v1 payload.".to_string(),
-                ]),
-            )
-        })?;
-        return Ok(fanout_plan.to_agent_task_plan());
-    }
-
-    let spec = FanoutPacketSpec::from_value(value)?;
-    let fanout_id = spec
-        .fanout_id
-        .or_else(|| args.fanout_id.clone())
-        .unwrap_or_else(|| format!("agent-task-fanout-{}", uuid::Uuid::new_v4()));
-    let plane = spec.plane.unwrap_or_else(|| plane_from_arg(args.plane));
-    let tasks = spec
-        .packets
-        .into_iter()
-        .enumerate()
-        .map(|(index, packet)| packet.into_request(index, args))
-        .collect::<Result<Vec<_>>>()?;
-    if tasks.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "input",
-            "agent-task fanout requires at least one task or packet",
-            None,
-            None,
-        ));
-    }
-
-    let mut fanout_plan = AgentTaskFanoutPlan::new(fanout_id, plane, tasks);
-    fanout_plan.group_key = spec.group_key;
-    fanout_plan.options = spec.options.unwrap_or_default();
-    fanout_plan.metadata = spec.metadata.unwrap_or(Value::Null);
-    Ok(fanout_plan.to_agent_task_plan())
-}
-
-#[derive(Debug, Deserialize)]
-struct FanoutPacketSpec {
-    #[serde(default)]
-    fanout_id: Option<String>,
-    #[serde(default)]
-    plane: Option<AgentTaskFanoutPlane>,
-    #[serde(default)]
-    group_key: Option<String>,
-    #[serde(default)]
-    options: Option<AgentTaskScheduleOptions>,
-    #[serde(default)]
-    metadata: Option<Value>,
-    #[serde(default)]
-    packets: Vec<FanoutTaskPacket>,
-}
-
-impl FanoutPacketSpec {
-    fn from_value(value: Value) -> Result<Self> {
-        match value {
-            Value::Array(packets) => Ok(Self {
-                packets: parse_packet_array(packets)?,
-                fanout_id: None,
-                plane: None,
-                group_key: None,
-                options: None,
-                metadata: None,
-            }),
-            Value::Object(mut object) => {
-                if !object.contains_key("packets") {
-                    if let Some(tasks) = object.remove("tasks") {
-                        object.insert("packets".to_string(), tasks);
-                    } else if object.contains_key("task_id")
-                        || object.contains_key("key")
-                        || object.contains_key("instructions")
-                        || object.contains_key("prompt")
-                        || object.contains_key("title")
-                    {
-                        return Ok(Self {
-                            packets: vec![serde_json::from_value(Value::Object(object)).map_err(
-                                packet_parse_error,
-                            )?],
-                            fanout_id: None,
-                            plane: None,
-                            group_key: None,
-                            options: None,
-                            metadata: None,
-                        });
-                    }
-                }
-                serde_json::from_value(Value::Object(object)).map_err(|error| {
-                    Error::validation_invalid_argument("input", error.to_string(), None, None)
-                })
-            }
-            _ => Err(Error::validation_invalid_argument(
-                "input",
-                "agent-task fanout input must be an AgentTaskPlan, AgentTaskFanoutPlan, packet object, or packet array",
-                None,
-                None,
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct FanoutTaskPacket {
-    #[serde(default = "request_schema")]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct BatchCookFanoutPlan {
+    #[serde(default = "batch_cook_fanout_plan_schema")]
     schema: String,
-    #[serde(default)]
-    task_id: Option<String>,
-    #[serde(default)]
-    group_key: Option<String>,
-    #[serde(default)]
-    parent_plan_id: Option<String>,
-    #[serde(default)]
-    key: Option<String>,
-    #[serde(default)]
-    title: Option<String>,
-    #[serde(default)]
-    instructions: Option<String>,
-    #[serde(default)]
-    prompt: Option<String>,
-    #[serde(default)]
-    executor: Option<AgentTaskExecutor>,
-    #[serde(default)]
-    inputs: Value,
-    #[serde(default)]
-    source_refs: Vec<AgentTaskSourceRef>,
-    #[serde(default)]
-    workspace: AgentTaskWorkspace,
-    #[serde(default)]
-    component_contracts: Vec<AgentTaskComponentContract>,
-    #[serde(default)]
-    policy: AgentTaskPolicy,
-    #[serde(default)]
-    limits: AgentTaskLimits,
-    #[serde(default)]
-    expected_artifacts: Vec<String>,
-    #[serde(default, alias = "artifactDeclarations")]
-    artifact_declarations: Vec<AgentTaskArtifactDeclaration>,
-    #[serde(default)]
+    fanout_id: String,
+    cooks: Vec<BatchCookSpec>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
     metadata: Value,
 }
 
-impl FanoutTaskPacket {
-    fn into_request(
-        self,
-        index: usize,
-        args: &AgentTaskFanoutInputArgs,
-    ) -> Result<AgentTaskRequest> {
-        if let Ok(request) = serde_json::from_value::<AgentTaskRequest>(
-            serde_json::to_value(&self).unwrap_or(Value::Null),
-        ) {
-            return Ok(request);
+impl BatchCookFanoutPlan {
+    fn from_value(value: Value, args: &AgentTaskFanoutInputArgs) -> Result<Self> {
+        reject_generic_fanout_inputs(&value)?;
+        let mut plan: BatchCookFanoutPlan = serde_json::from_value(value).map_err(|error| {
+            Error::validation_invalid_argument(
+                "input",
+                error.to_string(),
+                None,
+                Some(vec![
+                    "Expected homeboy/agent-task-batch-cook-fanout-plan/v1 with a non-empty cooks array.".to_string(),
+                ]),
+            )
+        })?;
+        if let Some(fanout_id) = &args.fanout_id {
+            plan.fanout_id = fanout_id.clone();
         }
+        if plan.schema != AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA {
+            return Err(invalid_fanout(
+                "agent-task fanout requires homeboy/agent-task-batch-cook-fanout-plan/v1",
+            ));
+        }
+        if plan.fanout_id.trim().is_empty() {
+            return Err(invalid_fanout(
+                "fanout_id is required for batch cook fanout",
+            ));
+        }
+        if plan.cooks.is_empty() {
+            return Err(invalid_fanout(
+                "batch cook fanout requires at least one cook",
+            ));
+        }
+        for cook in &mut plan.cooks {
+            cook.apply_defaults(args)?;
+        }
+        Ok(plan)
+    }
+}
 
-        let task_id = self
-            .task_id
-            .or(self.key)
-            .unwrap_or_else(|| format!("task-{}", index + 1));
-        let instructions = self
-            .instructions
-            .or(self.prompt)
-            .or(self.title)
-            .ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "instructions",
-                    format!(
-                        "fanout packet '{}' is missing instructions/prompt/title",
-                        task_id
-                    ),
-                    Some(task_id.clone()),
-                    None,
-                )
-            })?;
-        let executor = match self.executor {
-            Some(executor) => executor,
-            None => default_executor(args)?,
-        };
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct BatchCookSpec {
+    cook_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    prompt: Option<String>,
+    #[serde(default)]
+    tasks: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    workspace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    task_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    backend: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    selector: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(default)]
+    secret_env: Vec<String>,
+    #[serde(default = "one")]
+    attempts: u32,
+    #[serde(default = "one_usize")]
+    concurrency: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_config: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    client_context: Option<String>,
+    to_worktree: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_command: Option<String>,
+    #[serde(default)]
+    verify: Vec<String>,
+    #[serde(default)]
+    private_verify: Vec<String>,
+    #[serde(default = "default_private_gate_reveal")]
+    private_gate_reveal: AgentTaskGateRevealPolicy,
+    #[serde(default = "default_max_attempts")]
+    max_attempts: u32,
+    #[serde(default)]
+    no_finalize: bool,
+    #[serde(default = "default_base")]
+    base: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    head: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    commit_message: Option<String>,
+    #[serde(default)]
+    protected_branches: Vec<String>,
+    #[serde(default = "default_ai_tool")]
+    ai_tool: String,
+    #[serde(default = "default_ai_used_for")]
+    ai_used_for: String,
+}
 
-        Ok(AgentTaskRequest {
-            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
-            task_id,
-            group_key: self.group_key,
-            parent_plan_id: self.parent_plan_id,
-            executor,
-            instructions,
-            inputs: self.inputs,
-            source_refs: self.source_refs,
-            workspace: self.workspace,
-            component_contracts: self.component_contracts,
-            policy: self.policy,
-            limits: self.limits,
-            expected_artifacts: self.expected_artifacts,
-            artifact_declarations: self.artifact_declarations,
-            metadata: self.metadata,
+impl BatchCookSpec {
+    fn apply_defaults(&mut self, args: &AgentTaskFanoutInputArgs) -> Result<()> {
+        if self.cook_id.trim().is_empty() {
+            return Err(invalid_fanout("each cook requires a non-empty cook_id"));
+        }
+        if self.to_worktree.trim().is_empty() {
+            return Err(invalid_fanout("each cook requires to_worktree"));
+        }
+        if self.prompt.is_none() && self.tasks.is_empty() {
+            return Err(invalid_fanout("each cook requires prompt or tasks"));
+        }
+        if self.backend.is_none() {
+            self.backend = args.backend.clone();
+        }
+        if self.selector.is_none() {
+            self.selector = args.selector.clone();
+        }
+        if self.model.is_none() {
+            self.model = args.model.clone();
+        }
+        if self.protected_branches.is_empty() {
+            self.protected_branches = super::review::default_protected_branches();
+        }
+        Ok(())
+    }
+
+    fn run_id(&self) -> String {
+        format!("cook-{}", self.cook_id)
+    }
+
+    fn to_loop_args(&self, plan: &BatchCookFanoutPlan) -> Result<AgentTaskLoopArgs> {
+        if self.verify.is_empty() && self.private_verify.is_empty() {
+            return Err(invalid_fanout(
+                "each fanout cook requires verify or private_verify so PR finalization has deterministic gates",
+            ));
+        }
+        Ok(AgentTaskLoopArgs {
+            dispatch: DispatchArgs {
+                prompt: self.prompt.clone(),
+                tasks: self.tasks.clone(),
+                cwd: self.cwd.clone(),
+                workspace: self.workspace.clone(),
+                repo: self.repo.clone(),
+                task_url: self.task_url.clone(),
+                backend: self.backend.clone(),
+                selector: self.selector.clone(),
+                model: self.model.clone(),
+                required_capabilities: Vec::new(),
+                secret_env: self.secret_env.clone(),
+                concurrency: self.concurrency,
+                run_id: Some(self.run_id()),
+                core: DispatchCoreArgs {
+                    tasks_json: None,
+                    provider_config: self.provider_config.clone(),
+                    client_context: Some(merged_client_context(plan, self)),
+                    attempts: self.attempts,
+                    queue_only: false,
+                },
+            },
+            goal: self.prompt.clone(),
+            to_worktree: self.to_worktree.clone(),
+            provider_command: self.provider_command.clone(),
+            gates: VerifyGateArgs {
+                verify: self.verify.clone(),
+                private_verify: self.private_verify.clone(),
+                private_gate_reveal: self.private_gate_reveal,
+            },
+            max_attempts: self.max_attempts,
+            no_finalize: self.no_finalize,
+            base: self.base.clone(),
+            head: self.head.clone(),
+            title: self.title.clone(),
+            commit_message: self.commit_message.clone(),
+            protected_branches: self.protected_branches.clone(),
+            ai_tool: self.ai_tool.clone(),
+            ai_used_for: self.ai_used_for.clone(),
         })
     }
 }
 
-fn request_schema() -> String {
-    AGENT_TASK_REQUEST_SCHEMA.to_string()
-}
-
-fn parse_packet_array(packets: Vec<Value>) -> Result<Vec<FanoutTaskPacket>> {
-    packets
-        .into_iter()
-        .map(|packet| serde_json::from_value(packet).map_err(packet_parse_error))
-        .collect()
-}
-
-fn packet_parse_error(error: serde_json::Error) -> Error {
-    Error::validation_invalid_argument("packet", error.to_string(), None, None)
-}
-
-fn default_executor(args: &AgentTaskFanoutInputArgs) -> Result<AgentTaskExecutor> {
-    let backend = match &args.backend {
-        Some(backend) => Some(backend.clone()),
-        None => provider::default_backend()?,
-    }
-    .ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "backend",
-            "fanout packets without executor objects require --backend or a configured default agent-task backend",
-            None,
-            None,
-        )
-    })?;
-    Ok(AgentTaskExecutor {
-        backend,
-        selector: args.selector.clone(),
-        runtime_selection: None,
-        required_capabilities: Vec::new(),
-        secret_env: Vec::new(),
-        model: args.model.clone(),
-        config: Value::Null,
-    })
-}
-
-fn plane_from_arg(plane: AgentTaskFanoutPlaneArg) -> AgentTaskFanoutPlane {
-    match plane {
-        AgentTaskFanoutPlaneArg::IsolatedTasks => AgentTaskFanoutPlane::IsolatedTasks,
-        AgentTaskFanoutPlaneArg::Workflow => AgentTaskFanoutPlane::Workflow,
-    }
-}
-
-fn stamp_plan_fanout_metadata(plan: &mut AgentTaskPlan, requested_fanout_id: Option<String>) {
-    let fanout_id = requested_fanout_id.unwrap_or_else(|| plan.plan_id.clone());
-    let mut metadata = plan.metadata.take();
-    if !metadata.is_object() {
-        metadata = serde_json::json!({ "base": metadata });
-    }
-    if let Some(object) = metadata.as_object_mut() {
-        object.entry("fanout".to_string()).or_insert_with(|| {
-            serde_json::json!({
-                "id": fanout_id,
-                "plane": "existing_plan",
-                "lineage": "compiled_from_agent_task_plan"
-            })
-        });
-    }
-    plan.metadata = metadata;
-}
-
-fn durable_commands(run_id: &str) -> Value {
+fn client_context(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> String {
     serde_json::json!({
-        "status": format!("homeboy agent-task status {run_id}"),
-        "logs": format!("homeboy agent-task logs {run_id}"),
-        "artifacts": format!("homeboy agent-task artifacts {run_id}"),
-        "review": format!("homeboy agent-task review {run_id}"),
-        "run": format!("homeboy agent-task run {run_id}"),
-        "retry": format!("homeboy agent-task retry {run_id} --run")
+        "fanout": {
+            "id": plan.fanout_id,
+            "semantics": "batch_cook",
+            "cook_id": cook.cook_id,
+            "to_worktree": cook.to_worktree,
+            "head": cook.head,
+        }
     })
+    .to_string()
+}
+
+fn merged_client_context(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> String {
+    let mut context = serde_json::from_str::<Value>(cook.client_context.as_deref().unwrap_or("{}"))
+        .unwrap_or(Value::Null);
+    if !context.is_object() {
+        context = serde_json::json!({ "base": context });
+    }
+    if let Some(object) = context.as_object_mut() {
+        object.insert(
+            "fanout".to_string(),
+            serde_json::json!({
+                "id": plan.fanout_id,
+                "semantics": "batch_cook",
+                "cook_id": cook.cook_id,
+                "to_worktree": cook.to_worktree,
+                "head": cook.head,
+            }),
+        );
+    }
+    context.to_string()
+}
+
+fn cook_command(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> Vec<String> {
+    let mut command = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "loop".to_string(),
+        "--to-worktree".to_string(),
+        cook.to_worktree.clone(),
+        "--run-id".to_string(),
+        cook.run_id(),
+        "--client-context".to_string(),
+        client_context(plan, cook),
+    ];
+    if let Some(prompt) = &cook.prompt {
+        command.push("--prompt".to_string());
+        command.push(prompt.clone());
+    }
+    if let Some(head) = &cook.head {
+        command.push("--head".to_string());
+        command.push(head.clone());
+    }
+    for verify in &cook.verify {
+        command.push("--verify".to_string());
+        command.push(verify.clone());
+    }
+    command
+}
+
+fn reject_generic_fanout_inputs(value: &Value) -> Result<()> {
+    let schema = value.get("schema").and_then(Value::as_str);
+    if matches!(
+        schema,
+        Some("homeboy/agent-task-plan/v1" | "homeboy/agent-task-fanout-plan/v1")
+    ) || value.is_array()
+        || value.get("tasks").is_some()
+        || value.get("packets").is_some()
+    {
+        return Err(invalid_fanout(
+            "agent-task fanout now accepts only batch cook plans with independent cooks; generic task fanout belongs behind internal scheduler code",
+        ));
+    }
+    Ok(())
+}
+
+fn invalid_fanout(message: &str) -> Error {
+    Error::validation_invalid_argument("input", message.to_string(), None, None)
+}
+
+fn batch_cook_fanout_plan_schema() -> String {
+    AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA.to_string()
+}
+
+fn one() -> u32 {
+    1
+}
+
+fn one_usize() -> usize {
+    1
+}
+
+fn default_max_attempts() -> u32 {
+    3
+}
+
+fn default_base() -> String {
+    "main".to_string()
+}
+
+fn default_private_gate_reveal() -> AgentTaskGateRevealPolicy {
+    AgentTaskGateRevealPolicy::SummaryOnly
+}
+
+fn default_ai_tool() -> String {
+    "OpenCode (GPT-5.5)".to_string()
+}
+
+fn default_ai_used_for() -> String {
+    "Drafted implementation and tests; Chris reviews and owns the change.".to_string()
 }
 
 #[cfg(test)]
@@ -366,59 +425,78 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    #[test]
-    fn packet_array_compiles_to_public_agent_task_plan_with_lineage() {
-        let args = AgentTaskFanoutInputArgs {
+    fn args() -> AgentTaskFanoutInputArgs {
+        AgentTaskFanoutInputArgs {
             input: "inline".to_string(),
-            fanout_id: Some("fanout/audit".to_string()),
-            plane: AgentTaskFanoutPlaneArg::IsolatedTasks,
+            fanout_id: Some("fanout/refactor".to_string()),
             backend: Some("test".to_string()),
-            selector: None,
+            selector: Some("fixture".to_string()),
             model: None,
-        };
-
-        let plan = fanout_value_to_plan(
-            json!([
-                { "task_id": "finding-a", "instructions": "inspect a" },
-                { "task_id": "finding-b", "prompt": "inspect b" }
-            ]),
-            &args,
-        )
-        .expect("fanout plan");
-
-        assert_eq!(plan.plan_id, "fanout/audit");
-        assert_eq!(plan.tasks.len(), 2);
-        assert_eq!(
-            plan.tasks[0].parent_plan_id.as_deref(),
-            Some("fanout/audit")
-        );
-        assert_eq!(plan.tasks[0].executor.backend, "test");
-        assert_eq!(plan.tasks[1].instructions, "inspect b");
-        assert_eq!(plan.metadata["fanout"]["id"], json!("fanout/audit"));
+        }
     }
 
     #[test]
-    fn existing_agent_task_plan_is_accepted_and_stamped() {
-        let args = AgentTaskFanoutInputArgs {
-            input: "inline".to_string(),
-            fanout_id: None,
-            plane: AgentTaskFanoutPlaneArg::Workflow,
-            backend: None,
-            selector: None,
-            model: None,
-        };
-        let value = json!({
-            "schema": AGENT_TASK_PLAN_SCHEMA,
-            "plan_id": "existing-plan",
-            "tasks": [],
-            "options": {},
-            "metadata": {}
-        });
+    fn batch_cook_plan_requires_independent_cooks_with_worktrees() {
+        let plan = BatchCookFanoutPlan::from_value(
+            json!({
+                "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
+                "fanout_id": "fanout/original",
+                "cooks": [
+                    {
+                        "cook_id": "5929-docs",
+                        "prompt": "fix docs",
+                        "repo": "homeboy",
+                        "to_worktree": "homeboy@fix-5929-docs",
+                        "head": "fix/5929-docs",
+                        "verify": ["homeboy test homeboy"]
+                    },
+                    {
+                        "cook_id": "5929-cli",
+                        "prompt": "fix cli",
+                        "repo": "homeboy",
+                        "to_worktree": "homeboy@fix-5929-cli",
+                        "head": "fix/5929-cli",
+                        "verify": ["homeboy test homeboy"]
+                    }
+                ]
+            }),
+            &args(),
+        )
+        .expect("batch cook fanout plan");
 
-        let plan = fanout_value_to_plan(value, &args).expect("agent task plan");
+        assert_eq!(plan.fanout_id, "fanout/refactor");
+        assert_eq!(plan.cooks.len(), 2);
+        assert_eq!(plan.cooks[0].backend.as_deref(), Some("test"));
+        assert_eq!(plan.cooks[0].selector.as_deref(), Some("fixture"));
+        let loop_args = plan.cooks[0].to_loop_args(&plan).expect("loop args");
+        assert_eq!(loop_args.to_worktree, "homeboy@fix-5929-docs");
+        assert_eq!(loop_args.head.as_deref(), Some("fix/5929-docs"));
+        assert_eq!(loop_args.dispatch.run_id.as_deref(), Some("cook-5929-docs"));
+        assert_eq!(loop_args.gates.verify, vec!["homeboy test homeboy"]);
+        assert!(loop_args
+            .dispatch
+            .core
+            .client_context
+            .as_deref()
+            .expect("client context")
+            .contains("batch_cook"));
+    }
 
-        assert_eq!(plan.plan_id, "existing-plan");
-        assert_eq!(plan.metadata["fanout"]["id"], json!("existing-plan"));
-        assert_eq!(plan.metadata["fanout"]["plane"], json!("existing_plan"));
+    #[test]
+    fn generic_fanout_inputs_are_rejected_from_public_contract() {
+        let error = BatchCookFanoutPlan::from_value(
+            json!({
+                "schema": "homeboy/agent-task-fanout-plan/v1",
+                "fanout_id": "generic",
+                "plane": "workflow",
+                "tasks": []
+            }),
+            &args(),
+        )
+        .expect_err("generic fanout rejected");
+
+        assert!(error
+            .to_string()
+            .contains("accepts only batch cook plans with independent cooks"));
     }
 }

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -3,22 +3,22 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use homeboy::core::agent_tasks::gate::AgentTaskGateRevealPolicy;
+use homeboy::core::agent_tasks::dispatch_service::{self, AgentTaskDispatchCommand, DispatchCoreInputs};
+use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
 use homeboy::core::agent_tasks::provider;
+use homeboy::core::agent_tasks::service::{self as agent_task_service, AgentTaskCookServiceOptions};
 use homeboy::core::agent_tasks::{
     AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA, AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA,
     AGENT_TASK_BATCH_COOK_FANOUT_SUBMIT_SCHEMA,
 };
 use homeboy::core::{config, Error, Result};
 
-use super::super::agent_task_dispatch::{DispatchArgs, DispatchCoreArgs};
 use super::super::CmdResult;
 use super::args::{
     AgentTaskFanoutArgs, AgentTaskFanoutCommand, AgentTaskFanoutInputArgs,
-    AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs, AgentTaskLoopArgs, VerifyGateArgs,
+    AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs,
 };
 use super::command_json_value;
-use super::run;
 
 pub(super) fn fanout(args: AgentTaskFanoutArgs) -> CmdResult<Value> {
     match args.command {
@@ -76,8 +76,22 @@ fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
     let mut failed = 0usize;
 
     for cook in &plan.cooks {
-        let (value, exit_code) =
-            run::run_loop_with_executor(cook.to_loop_args(&plan)?, executor.clone())?;
+        let invocation = cook.to_cook_invocation(&plan)?;
+        let (dispatch_value, _dispatch_exit) =
+            dispatch_service::run_dispatch_command(invocation.dispatch, executor.clone())?;
+        let run_id = dispatch_value["run_id"]
+            .as_str()
+            .ok_or_else(|| {
+                Error::internal_unexpected(
+                    "agent-task dispatch did not return a run_id".to_string(),
+                )
+            })?
+            .to_string();
+        let mut options = invocation.options;
+        options.initial_run_id = run_id;
+        let result = agent_task_service::run_cook(options, executor.clone())?;
+        let value = serde_json::to_value(result.value).unwrap_or(Value::Null);
+        let exit_code = result.exit_code;
         if exit_code != 0 {
             failed += 1;
         }
@@ -227,6 +241,12 @@ struct BatchCookSpec {
     ai_used_for: String,
 }
 
+#[derive(Debug, Clone)]
+struct BatchCookInvocation {
+    dispatch: AgentTaskDispatchCommand,
+    options: AgentTaskCookServiceOptions,
+}
+
 impl BatchCookSpec {
     fn apply_defaults(&mut self, args: &AgentTaskFanoutInputArgs) -> Result<()> {
         if self.cook_id.trim().is_empty() {
@@ -257,54 +277,86 @@ impl BatchCookSpec {
         format!("cook-{}", self.cook_id)
     }
 
-    fn to_loop_args(&self, plan: &BatchCookFanoutPlan) -> Result<AgentTaskLoopArgs> {
+    fn to_cook_invocation(&self, plan: &BatchCookFanoutPlan) -> Result<BatchCookInvocation> {
         if self.verify.is_empty() && self.private_verify.is_empty() {
             return Err(invalid_fanout(
                 "each fanout cook requires verify or private_verify so PR finalization has deterministic gates",
             ));
         }
-        Ok(AgentTaskLoopArgs {
-            dispatch: DispatchArgs {
-                prompt: self.prompt.clone(),
-                tasks: self.tasks.clone(),
-                cwd: self.cwd.clone(),
-                workspace: self.workspace.clone(),
-                repo: self.repo.clone(),
-                task_url: self.task_url.clone(),
-                backend: self.backend.clone(),
-                selector: self.selector.clone(),
-                model: self.model.clone(),
-                required_capabilities: Vec::new(),
-                secret_env: self.secret_env.clone(),
-                concurrency: self.concurrency,
-                run_id: Some(self.run_id()),
-                core: DispatchCoreArgs {
-                    tasks_json: None,
-                    provider_config: self.provider_config.clone(),
-                    client_context: Some(merged_client_context(plan, self)),
-                    attempts: self.attempts,
-                    queue_only: false,
+        let dispatch = AgentTaskDispatchCommand {
+            prompt: self.prompt.clone(),
+            tasks: self.tasks.clone(),
+            cwd: self.cwd.clone(),
+            workspace: self.workspace.clone(),
+            repo: self.repo.clone(),
+            task_url: self.task_url.clone(),
+            backend: self.backend.clone(),
+            selector: self.selector.clone(),
+            model: self.model.clone(),
+            required_capabilities: Vec::new(),
+            secret_env: self.secret_env.clone(),
+            concurrency: self.concurrency,
+            run_id: Some(self.run_id()),
+            core: DispatchCoreInputs {
+                tasks_json: None,
+                provider_config: self.provider_config.clone(),
+                client_context: Some(merged_client_context(plan, self)),
+                attempts: self.attempts,
+                queue_only: false,
+            },
+        };
+        let title = self.title.clone().unwrap_or_else(|| default_cook_title(self));
+        let commit_message = self
+            .commit_message
+            .clone()
+            .unwrap_or_else(|| default_cook_commit_message(self));
+        Ok(BatchCookInvocation {
+            dispatch,
+            options: AgentTaskCookServiceOptions {
+                cook_id: self.cook_id.clone(),
+                initial_run_id: self.run_id(),
+                to_worktree: self.to_worktree.clone(),
+                provider_command: self.provider_command.clone(),
+                gates: VerifyGateOptions {
+                    verify: self.verify.clone(),
+                    private_verify: self.private_verify.clone(),
+                    private_gate_reveal: self.private_gate_reveal,
                 },
+                max_attempts: self.max_attempts,
+                no_finalize: self.no_finalize,
+                base: self.base.clone(),
+                head: self.head.clone(),
+                title,
+                commit_message,
+                source_refs: self.task_url.clone().into_iter().collect(),
+                protected_branches: self.protected_branches.clone(),
+                ai_tool: self.ai_tool.clone(),
+                ai_model: self.model.clone().or_else(|| ai_model_from_tool(&self.ai_tool)),
+                ai_used_for: self.ai_used_for.clone(),
             },
-            goal: self.prompt.clone(),
-            to_worktree: self.to_worktree.clone(),
-            provider_command: self.provider_command.clone(),
-            gates: VerifyGateArgs {
-                verify: self.verify.clone(),
-                private_verify: self.private_verify.clone(),
-                private_gate_reveal: self.private_gate_reveal,
-            },
-            max_attempts: self.max_attempts,
-            no_finalize: self.no_finalize,
-            base: self.base.clone(),
-            head: self.head.clone(),
-            title: self.title.clone(),
-            commit_message: self.commit_message.clone(),
-            protected_branches: self.protected_branches.clone(),
-            ai_tool: self.ai_tool.clone(),
-            ai_used_for: self.ai_used_for.clone(),
         })
     }
+}
+
+fn ai_model_from_tool(ai_tool: &str) -> Option<String> {
+    let start = ai_tool.find('(')?;
+    let end = ai_tool[start + 1..].find(')')? + start + 1;
+    let model = ai_tool[start + 1..end].trim();
+    (!model.is_empty()).then(|| model.to_string())
+}
+
+fn default_cook_title(cook: &BatchCookSpec) -> String {
+    let target = cook
+        .repo
+        .as_deref()
+        .or(cook.task_url.as_deref())
+        .unwrap_or("agent task");
+    format!("Cook {target}")
+}
+
+fn default_cook_commit_message(cook: &BatchCookSpec) -> String {
+    let target = cook.repo.as_deref().unwrap_or("agent task");
+    format!("fix: cook {target}")
 }
 
 fn client_context(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> String {
@@ -341,31 +393,17 @@ fn merged_client_context(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> St
     context.to_string()
 }
 
-fn cook_command(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> Vec<String> {
-    let mut command = vec![
+fn cook_command(plan: &BatchCookFanoutPlan, _cook: &BatchCookSpec) -> Vec<String> {
+    vec![
         "homeboy".to_string(),
         "agent-task".to_string(),
-        "loop".to_string(),
-        "--to-worktree".to_string(),
-        cook.to_worktree.clone(),
-        "--run-id".to_string(),
-        cook.run_id(),
-        "--client-context".to_string(),
-        client_context(plan, cook),
-    ];
-    if let Some(prompt) = &cook.prompt {
-        command.push("--prompt".to_string());
-        command.push(prompt.clone());
-    }
-    if let Some(head) = &cook.head {
-        command.push("--head".to_string());
-        command.push(head.clone());
-    }
-    for verify in &cook.verify {
-        command.push("--verify".to_string());
-        command.push(verify.clone());
-    }
-    command
+        "fanout".to_string(),
+        "run-plan".to_string(),
+        "--input".to_string(),
+        "<batch-cook-plan.json>".to_string(),
+        "--record-run-id".to_string(),
+        plan.fanout_id.clone(),
+    ]
 }
 
 fn reject_generic_fanout_inputs(value: &Value) -> Result<()> {
@@ -468,12 +506,14 @@ mod tests {
         assert_eq!(plan.cooks.len(), 2);
         assert_eq!(plan.cooks[0].backend.as_deref(), Some("test"));
         assert_eq!(plan.cooks[0].selector.as_deref(), Some("fixture"));
-        let loop_args = plan.cooks[0].to_loop_args(&plan).expect("loop args");
-        assert_eq!(loop_args.to_worktree, "homeboy@fix-5929-docs");
-        assert_eq!(loop_args.head.as_deref(), Some("fix/5929-docs"));
-        assert_eq!(loop_args.dispatch.run_id.as_deref(), Some("cook-5929-docs"));
-        assert_eq!(loop_args.gates.verify, vec!["homeboy test homeboy"]);
-        assert!(loop_args
+        let invocation = plan.cooks[0]
+            .to_cook_invocation(&plan)
+            .expect("cook invocation");
+        assert_eq!(invocation.options.to_worktree, "homeboy@fix-5929-docs");
+        assert_eq!(invocation.options.head.as_deref(), Some("fix/5929-docs"));
+        assert_eq!(invocation.dispatch.run_id.as_deref(), Some("cook-5929-docs"));
+        assert_eq!(invocation.options.gates.verify, vec!["homeboy test homeboy"]);
+        assert!(invocation
             .dispatch
             .core
             .client_context

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -3,10 +3,14 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use homeboy::core::agent_tasks::dispatch_service::{self, AgentTaskDispatchCommand, DispatchCoreInputs};
+use homeboy::core::agent_tasks::dispatch_service::{
+    self, AgentTaskDispatchCommand, DispatchCoreInputs,
+};
 use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
 use homeboy::core::agent_tasks::provider;
-use homeboy::core::agent_tasks::service::{self as agent_task_service, AgentTaskCookServiceOptions};
+use homeboy::core::agent_tasks::service::{
+    self as agent_task_service, AgentTaskCookServiceOptions,
+};
 use homeboy::core::agent_tasks::{
     AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA, AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA,
     AGENT_TASK_BATCH_COOK_FANOUT_SUBMIT_SCHEMA,
@@ -305,7 +309,10 @@ impl BatchCookSpec {
                 queue_only: false,
             },
         };
-        let title = self.title.clone().unwrap_or_else(|| default_cook_title(self));
+        let title = self
+            .title
+            .clone()
+            .unwrap_or_else(|| default_cook_title(self));
         let commit_message = self
             .commit_message
             .clone()
@@ -331,7 +338,10 @@ impl BatchCookSpec {
                 source_refs: self.task_url.clone().into_iter().collect(),
                 protected_branches: self.protected_branches.clone(),
                 ai_tool: self.ai_tool.clone(),
-                ai_model: self.model.clone().or_else(|| ai_model_from_tool(&self.ai_tool)),
+                ai_model: self
+                    .model
+                    .clone()
+                    .or_else(|| ai_model_from_tool(&self.ai_tool)),
                 ai_used_for: self.ai_used_for.clone(),
             },
         })
@@ -511,8 +521,14 @@ mod tests {
             .expect("cook invocation");
         assert_eq!(invocation.options.to_worktree, "homeboy@fix-5929-docs");
         assert_eq!(invocation.options.head.as_deref(), Some("fix/5929-docs"));
-        assert_eq!(invocation.dispatch.run_id.as_deref(), Some("cook-5929-docs"));
-        assert_eq!(invocation.options.gates.verify, vec!["homeboy test homeboy"]);
+        assert_eq!(
+            invocation.dispatch.run_id.as_deref(),
+            Some("cook-5929-docs")
+        );
+        assert_eq!(
+            invocation.options.gates.verify,
+            vec!["homeboy test homeboy"]
+        );
         assert!(invocation
             .dispatch
             .core

--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -33,6 +33,12 @@ pub const AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA: &str =
     "homeboy/agent-task-artifact-declaration/v1";
 pub const AGENT_TASK_EVIDENCE_REF_SCHEMA: &str = "homeboy/agent-task-evidence-ref/v1";
 pub const SECRET_ENV_REQUIREMENT_SCHEMA: &str = "homeboy/secret-env-requirement/v1";
+pub const AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA: &str =
+    "homeboy/agent-task-batch-cook-fanout-plan/v1";
+pub const AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA: &str =
+    "homeboy/agent-task-batch-cook-fanout-run/v1";
+pub const AGENT_TASK_BATCH_COOK_FANOUT_SUBMIT_SCHEMA: &str =
+    "homeboy/agent-task-batch-cook-fanout-submit/v1";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AgentTaskCoreContract {
@@ -70,6 +76,9 @@ pub struct AgentTaskCoreContractSchemas {
     pub secret_env_plan: String,
     pub secret_env_requirement: String,
     pub command_invocation: String,
+    pub batch_cook_fanout_plan: String,
+    pub batch_cook_fanout_run: String,
+    pub batch_cook_fanout_submit: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -143,6 +152,9 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
             secret_env_plan: SECRET_ENV_PLAN_SCHEMA.to_string(),
             secret_env_requirement: SECRET_ENV_REQUIREMENT_SCHEMA.to_string(),
             command_invocation: COMMAND_INVOCATION_SCHEMA.to_string(),
+            batch_cook_fanout_plan: AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA.to_string(),
+            batch_cook_fanout_run: AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA.to_string(),
+            batch_cook_fanout_submit: AGENT_TASK_BATCH_COOK_FANOUT_SUBMIT_SCHEMA.to_string(),
         },
         provider_capability: AgentTaskCoreProviderCapabilityContract {
             schema: provider_capability.schema,
@@ -386,6 +398,10 @@ mod tests {
         assert_eq!(
             contract.schemas.command_invocation,
             COMMAND_INVOCATION_SCHEMA
+        );
+        assert_eq!(
+            contract.schemas.batch_cook_fanout_plan,
+            AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA
         );
         assert_eq!(
             contract.provider_capability.request_required_fields,

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -60,7 +60,9 @@ pub use super::agent_task_aggregate::{
 pub use super::agent_task_contract::{
     agent_task_core_contract, AgentTaskCoreContract, AgentTaskCoreContractEnums,
     AgentTaskCoreContractSchemas, AgentTaskCoreProviderCapabilityContract,
-    AgentTaskCoreRedactionDefaults, AGENT_TASK_CORE_CONTRACT_SCHEMA,
+    AgentTaskCoreRedactionDefaults, AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
+    AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA, AGENT_TASK_BATCH_COOK_FANOUT_SUBMIT_SCHEMA,
+    AGENT_TASK_CORE_CONTRACT_SCHEMA,
 };
 
 pub use super::agent_task_fanout::{


### PR DESCRIPTION
## Summary
- Replaces the public agent-task fanout packet/plan adapter with a batch-cook fanout plan contract.
- Normalizes each fanout cook into the existing cook-loop path with its own worktree, head branch, gates, and PR finalization metadata.
- Rejects old generic AgentTaskPlan / AgentTaskFanoutPlan / packet fanout inputs from the public CLI and documents generic fanout as internal scheduler machinery.
- Exposes the batch-cook fanout schemas through the agent-task core contract.

Closes #5929

## Verification
- \
- \

Local Cargo tests were not run per task instruction to avoid local cargo.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafted implementation, documentation, contract updates, and tests.