### PR TITLE
Type agent-task discovery command args

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -28,9 +28,9 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `run-next` | Claim and execute the oldest queued durable run. |
 | `submit` | Persist an agent-task plan and return a durable run id without executing it. |
 | `status <run-id>` | Read durable run status. |
-| `list` | List durable runs, newest first. |
-| `active` | List queued and running durable runs, newest first. |
-| `latest` | Show the latest durable run. |
+| `list [--limit <n>]` | List durable runs, newest first. |
+| `active [--limit <n>] [--reconcile [--dry-run]]` | List queued and running durable runs, newest first, or reconcile stale active records. |
+| `latest [--limit <n>]` | Show the latest durable run. |
 | `logs <run-id>` | Read durable run scheduler events. |
 | `artifacts <run-id>` | List artifacts and evidence refs recorded for a completed run. |
 | `cancel <run-id>` | Mark a queued or stale-running durable run as cancelled. |
@@ -38,6 +38,8 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `retry <run-id>` | Submit a fresh durable run from an existing run's plan. |
 | `fanout plan\|submit\|run-plan` | Compile, persist, or run generic provider-neutral fanout inputs. |
 | `prompts save\|list\|show\|remove` | Manage markdown prompts in Homeboy-owned storage. |
+
+`agent-task list`, `agent-task active`, and `agent-task latest` accept `--limit <n>` to cap discovery output. `agent-task active --reconcile` cancels stale, suspect, or unreconciled active records through the durable lifecycle path; add `--dry-run` to report candidates without mutating records.
 
 ### Cook/Review
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -628,6 +628,12 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.output_notes =
                 "applies a selected patch artifact into a managed worktree unless --dry-run is passed";
         }
+        ["agent-task", "active"] => {
+            metadata.mutates = true;
+            metadata.dry_run_flag = Some("--dry-run");
+            metadata.output_notes =
+                "reads active runs by default; --reconcile cancels stale active records unless --dry-run is passed";
+        }
         ["db", "delete-row"] | ["db", "drop-table"] => {
             metadata.mutates = true;
             metadata.operator = true;

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -100,6 +100,17 @@ pub struct RunnerWorkload {
     pub result_refs: RunnerWorkloadResultRefs,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerWorkloadInput {
+    pub workload_id: String,
+    pub plan_id: String,
+    pub assignment: RunnerWorkloadAssignment,
+    pub state: RunnerWorkloadState,
+    pub mutation_policy: RunnerWorkloadMutationPolicy,
+    pub workspace_mapping_ref: Option<String>,
+    pub proof_id: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RunnerWorkloadKind {
     pub command_label: String,
@@ -672,19 +683,10 @@ impl LabCommandContract {
         }
     }
 
-    pub fn runner_workload(
-        &self,
-        workload_id: impl Into<String>,
-        plan_id: impl Into<String>,
-        assignment: RunnerWorkloadAssignment,
-        state: RunnerWorkloadState,
-        mutation_policy: RunnerWorkloadMutationPolicy,
-        workspace_mapping_ref: Option<String>,
-        proof_id: Option<String>,
-    ) -> RunnerWorkload {
+    pub fn runner_workload(&self, input: RunnerWorkloadInput) -> RunnerWorkload {
         RunnerWorkload {
             schema: RUNNER_WORKLOAD_SCHEMA.to_string(),
-            workload_id: workload_id.into(),
+            workload_id: input.workload_id,
             kind: RunnerWorkloadKind {
                 command_label: self.hot_label.to_string(),
                 command_family: RunnerWorkloadCommandFamily::from_command_label(self.hot_label),
@@ -692,19 +694,19 @@ impl LabCommandContract {
             workspace_mappings: RunnerWorkloadWorkspaceMappings {
                 source_path_mode: self.source_path_mode.label().to_string(),
                 workspace_mode_policy: self.workspace_mode_policy.label().to_string(),
-                mapping_ref: workspace_mapping_ref.clone(),
+                mapping_ref: input.workspace_mapping_ref.clone(),
             },
             required_capabilities: self.required_capabilities(),
             required_secrets: RunnerWorkloadSecrets {
                 categories: self.required_secret_categories(),
             },
-            mutation_policy,
-            assignment,
-            state,
+            mutation_policy: input.mutation_policy,
+            assignment: input.assignment,
+            state: input.state,
             result_refs: RunnerWorkloadResultRefs {
-                plan_id: plan_id.into(),
-                proof_id,
-                workspace_mapping_ref,
+                plan_id: input.plan_id,
+                proof_id: input.proof_id,
+                workspace_mapping_ref: input.workspace_mapping_ref,
             },
         }
     }

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -505,9 +505,9 @@ impl Commands {
                     // lives on the runner, so `--runner <id> agent-task
                     // list/active/latest` must resolve against that runner to
                     // make discovery consistent with status/logs/etc (#5681).
-                    | agent_task::AgentTaskCommand::List
-                    | agent_task::AgentTaskCommand::Active
-                    | agent_task::AgentTaskCommand::Latest,
+                    | agent_task::AgentTaskCommand::List(_)
+                    | agent_task::AgentTaskCommand::Active(_)
+                    | agent_task::AgentTaskCommand::Latest(_),
             }) => LabCommandContract::runner_resident(AGENT_TASK_STATUS_LAB_LABEL),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -23,7 +23,7 @@ pub mod status;
 pub mod tool;
 
 pub use args::{
-    AgentTaskArgs, AgentTaskAuthArgs, AgentTaskAuthCommand, AgentTaskCommand,
+    ActiveArgs, AgentTaskArgs, AgentTaskAuthArgs, AgentTaskAuthCommand, AgentTaskCommand,
     AgentTaskControllerApplyEventArgs, AgentTaskControllerArgs, AgentTaskControllerCommand,
     AgentTaskControllerFromSpecArgs, AgentTaskControllerInitArgs,
     AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerMaterializeArgs,
@@ -31,8 +31,8 @@ pub use args::{
     AgentTaskDoctorArgs, AgentTaskFanoutArgs, AgentTaskFanoutCommand, AgentTaskFanoutInputArgs,
     AgentTaskFanoutPlanArgs, AgentTaskFanoutPlaneArg, AgentTaskFanoutRunPlanArgs,
     AgentTaskFanoutSubmitArgs, AgentTaskLoopArgs, CancelArgs, CompileLoopArgs, ContractArgs,
-    ContractFormat, FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs, RetryArgs,
-    ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    ContractFormat, FinalizePrArgs, GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs,
+    ProvidersArgs, RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
@@ -51,28 +51,20 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::RunNext => run::run_next(),
         AgentTaskCommand::Submit(submit_args) => run::submit(submit_args),
         AgentTaskCommand::Status(status_args) => status::status(status_args),
-        AgentTaskCommand::List => status::list_runs(
+        AgentTaskCommand::List(list_args) => status::list_runs(
             agent_task_service::AgentTaskDiscoveryFilter::All,
-            discovery_options_from_raw_args(),
+            list_args.into(),
         ),
-        AgentTaskCommand::Active => {
-            // `Active` is a unit clap variant whose flag surface lives in the
-            // fleet-owned args module; until a typed `--reconcile`/`--dry-run`/
-            // `--limit` flag can be added there, detect them from the raw
-            // process args so the safe stale-run reconcile path and the shared
-            // `--limit` pagination cap are reachable today (#5682, #5681).
-            let raw: Vec<String> = std::env::args().collect();
-            let reconcile = raw.iter().any(|arg| arg == "--reconcile");
-            let dry_run = raw.iter().any(|arg| arg == "--dry-run");
-            if reconcile {
-                status::reconcile_active(dry_run)
+        AgentTaskCommand::Active(active_args) => {
+            if active_args.reconcile {
+                status::reconcile_active(active_args.dry_run)
             } else {
-                status::list_active(discovery_options_from_raw_args())
+                status::list_active(active_args.into())
             }
         }
-        AgentTaskCommand::Latest => status::list_runs(
+        AgentTaskCommand::Latest(latest_args) => status::list_runs(
             agent_task_service::AgentTaskDiscoveryFilter::Latest,
-            discovery_options_from_raw_args(),
+            latest_args.into(),
         ),
         AgentTaskCommand::Logs(status_args) => status::logs(status_args),
         AgentTaskCommand::Artifacts(status_args) => status::artifacts(status_args),
@@ -103,33 +95,7 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
     }
 }
 
-use homeboy::core::agent_task_service as agent_task_service_direct;
 use homeboy::core::agent_tasks::service as agent_task_service;
-
-/// Parse shared discovery options (`--limit`) from the raw process args for the
-/// `list`/`active`/`latest` unit clap variants. Their typed flag surface lives
-/// in the fleet-owned args module; mirroring the existing #5682
-/// `--reconcile`/`--dry-run` raw-arg detection, this lets the `--limit`
-/// pagination cap ship without editing that module. Accepts both `--limit N`
-/// and `--limit=N`; a missing/invalid value leaves the limit unset so the full
-/// list is returned (#5681).
-fn discovery_options_from_raw_args() -> agent_task_service_direct::AgentTaskDiscoveryOptions {
-    let raw: Vec<String> = std::env::args().collect();
-    let mut limit = None;
-    let mut iter = raw.iter();
-    while let Some(arg) = iter.next() {
-        if let Some(value) = arg.strip_prefix("--limit=") {
-            if let Ok(parsed) = value.parse::<usize>() {
-                limit = Some(parsed);
-            }
-        } else if arg == "--limit" {
-            if let Some(parsed) = iter.next().and_then(|value| value.parse::<usize>().ok()) {
-                limit = Some(parsed);
-            }
-        }
-    }
-    agent_task_service_direct::AgentTaskDiscoveryOptions { limit }
-}
 
 pub(crate) fn command_json_value<T: Serialize>(value: T) -> homeboy::core::Result<Value> {
     serde_json::to_value(value)

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -9,6 +9,7 @@
 //! commands own long-running loop state.
 
 use clap::{Args, Subcommand, ValueEnum};
+use homeboy::core::agent_task_service::AgentTaskDiscoveryOptions;
 use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
 
 use super::super::agent_task_dispatch::DispatchArgs;
@@ -138,11 +139,11 @@ pub enum AgentTaskCommand {
     /// Lifecycle: read durable agent-task run status.
     Status(StatusArgs),
     /// Lifecycle: list durable agent-task runs, newest first.
-    List,
+    List(ListArgs),
     /// Lifecycle: list queued and running durable agent-task runs, newest first.
-    Active,
+    Active(ActiveArgs),
     /// Lifecycle: show the latest durable agent-task run.
-    Latest,
+    Latest(LatestArgs),
     /// Lifecycle: read durable agent-task run scheduler events.
     Logs(StatusArgs),
     /// Lifecycle: list artifacts and evidence refs recorded for a completed run.
@@ -178,6 +179,53 @@ pub enum AgentTaskCommand {
     /// Internal bridge for provider-runtime agent tool requests.
     #[command(hide = true)]
     Tool(AgentTaskToolArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ListArgs {
+    /// Maximum number of durable runs to return.
+    #[arg(long = "limit", value_name = "N")]
+    pub limit: Option<usize>,
+}
+
+#[derive(Args, Debug)]
+pub struct ActiveArgs {
+    /// Maximum number of active durable runs to return.
+    #[arg(long = "limit", value_name = "N")]
+    pub limit: Option<usize>,
+
+    /// Cancel stale/suspect/unreconciled active runs through the lifecycle path.
+    #[arg(long = "reconcile")]
+    pub reconcile: bool,
+
+    /// Report reconcile candidates without cancelling durable run records.
+    #[arg(long = "dry-run", requires = "reconcile")]
+    pub dry_run: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct LatestArgs {
+    /// Maximum number of latest durable runs to return.
+    #[arg(long = "limit", value_name = "N")]
+    pub limit: Option<usize>,
+}
+
+impl From<ListArgs> for AgentTaskDiscoveryOptions {
+    fn from(args: ListArgs) -> Self {
+        AgentTaskDiscoveryOptions { limit: args.limit }
+    }
+}
+
+impl From<ActiveArgs> for AgentTaskDiscoveryOptions {
+    fn from(args: ActiveArgs) -> Self {
+        AgentTaskDiscoveryOptions { limit: args.limit }
+    }
+}
+
+impl From<LatestArgs> for AgentTaskDiscoveryOptions {
+    fn from(args: LatestArgs) -> Self {
+        AgentTaskDiscoveryOptions { limit: args.limit }
+    }
 }
 
 /// Shared deterministic verification gate flags. Flattened into every

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -18,27 +18,27 @@ fn runner_workload_contract_serializes_versioned_shape() {
     let contract = parsed_command(&["homeboy", "trace"])
         .lab_contract()
         .expect("trace should declare a Lab contract");
-    let workload = contract.runner_workload(
-        "workload-1",
-        "plan-1",
-        RunnerWorkloadAssignment {
+    let workload = contract.runner_workload(RunnerWorkloadInput {
+        workload_id: "workload-1".to_string(),
+        plan_id: "plan-1".to_string(),
+        assignment: RunnerWorkloadAssignment {
             runner_id: Some("lab-a".to_string()),
             runner_mode: Some("direct_ssh".to_string()),
             source: Some("explicit".to_string()),
         },
-        RunnerWorkloadState {
+        state: RunnerWorkloadState {
             status: "offloaded".to_string(),
             remote_workspace: Some("/srv/homeboy/work".to_string()),
             fallback_reason: None,
         },
-        RunnerWorkloadMutationPolicy {
+        mutation_policy: RunnerWorkloadMutationPolicy {
             capture_patch: false,
             mutation_flag: Some("--keep-overlay".to_string()),
             allow_dirty_lab_workspace: false,
         },
-        Some("workspace_mapping".to_string()),
-        Some("proof-1".to_string()),
-    );
+        workspace_mapping_ref: Some("workspace_mapping".to_string()),
+        proof_id: Some("proof-1".to_string()),
+    });
 
     let serialized = serde_json::to_value(workload).expect("workload should serialize");
     assert_eq!(serialized["schema"], RUNNER_WORKLOAD_SCHEMA);

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -220,6 +220,23 @@ fn test_supports_lab_runner() {
         parsed_command(&["homeboy", "agent-task", "review", "agent-task-123"])
             .supports_lab_runner()
     );
+    assert!(
+        parsed_command(&["homeboy", "agent-task", "list", "--limit", "5"]).supports_lab_runner()
+    );
+    assert!(
+        parsed_command(&["homeboy", "agent-task", "active", "--limit", "5"]).supports_lab_runner()
+    );
+    assert!(parsed_command(&[
+        "homeboy",
+        "agent-task",
+        "active",
+        "--reconcile",
+        "--dry-run"
+    ])
+    .supports_lab_runner());
+    assert!(
+        parsed_command(&["homeboy", "agent-task", "latest", "--limit", "1"]).supports_lab_runner()
+    );
     assert!(parsed_command(&["homeboy", "agent-task", "providers"]).supports_lab_runner());
     assert!(parsed_command(&[
         "homeboy",

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -54,6 +54,88 @@ fn agent_task_prompt_store_commands_parse() {
 }
 
 #[test]
+fn agent_task_discovery_commands_use_typed_args() {
+    let list = Cli::try_parse_from(["homeboy", "agent-task", "list", "--limit", "5"])
+        .expect("agent-task list --limit should parse");
+    let active = Cli::try_parse_from([
+        "homeboy",
+        "agent-task",
+        "active",
+        "--limit=7",
+        "--reconcile",
+        "--dry-run",
+    ])
+    .expect("agent-task active typed flags should parse");
+    let latest = Cli::try_parse_from(["homeboy", "agent-task", "latest", "--limit", "1"])
+        .expect("agent-task latest --limit should parse");
+
+    match list.command {
+        Commands::AgentTask(args) => match args.command {
+            homeboy::commands::agent_task::AgentTaskCommand::List(args) => {
+                assert_eq!(args.limit, Some(5));
+            }
+            other => panic!("expected agent-task list, got {other:?}"),
+        },
+        other => panic!("expected agent-task command, got {other:?}"),
+    }
+
+    match active.command {
+        Commands::AgentTask(args) => match args.command {
+            homeboy::commands::agent_task::AgentTaskCommand::Active(args) => {
+                assert_eq!(args.limit, Some(7));
+                assert!(args.reconcile);
+                assert!(args.dry_run);
+            }
+            other => panic!("expected agent-task active, got {other:?}"),
+        },
+        other => panic!("expected agent-task command, got {other:?}"),
+    }
+
+    match latest.command {
+        Commands::AgentTask(args) => match args.command {
+            homeboy::commands::agent_task::AgentTaskCommand::Latest(args) => {
+                assert_eq!(args.limit, Some(1));
+            }
+            other => panic!("expected agent-task latest, got {other:?}"),
+        },
+        other => panic!("expected agent-task command, got {other:?}"),
+    }
+
+    assert!(Cli::try_parse_from(["homeboy", "agent-task", "active", "--dry-run"]).is_err());
+}
+
+#[test]
+fn agent_task_discovery_help_documents_typed_flags() {
+    let mut root = Cli::command();
+    let agent_task = root
+        .find_subcommand_mut("agent-task")
+        .expect("agent-task command");
+
+    let list_help = agent_task
+        .find_subcommand_mut("list")
+        .expect("agent-task list command")
+        .render_long_help()
+        .to_string();
+    assert!(list_help.contains("--limit <N>"));
+
+    let active_help = agent_task
+        .find_subcommand_mut("active")
+        .expect("agent-task active command")
+        .render_long_help()
+        .to_string();
+    assert!(active_help.contains("--limit <N>"));
+    assert!(active_help.contains("--reconcile"));
+    assert!(active_help.contains("--dry-run"));
+
+    let latest_help = agent_task
+        .find_subcommand_mut("latest")
+        .expect("agent-task latest command")
+        .render_long_help()
+        .to_string();
+    assert!(latest_help.contains("--limit <N>"));
+}
+
+#[test]
 fn agent_task_tool_bridge_stays_hidden_but_parseable() {
     let surface = current_command_surface();
 

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -76,7 +76,7 @@ fn agent_task_discovery_commands_use_typed_args() {
             }
             other => panic!("expected agent-task list, got {other:?}"),
         },
-        other => panic!("expected agent-task command, got {other:?}"),
+        _ => panic!("expected agent-task command"),
     }
 
     match active.command {
@@ -88,7 +88,7 @@ fn agent_task_discovery_commands_use_typed_args() {
             }
             other => panic!("expected agent-task active, got {other:?}"),
         },
-        other => panic!("expected agent-task command, got {other:?}"),
+        _ => panic!("expected agent-task command"),
     }
 
     match latest.command {
@@ -98,7 +98,7 @@ fn agent_task_discovery_commands_use_typed_args() {
             }
             other => panic!("expected agent-task latest, got {other:?}"),
         },
-        other => panic!("expected agent-task command, got {other:?}"),
+        _ => panic!("expected agent-task command"),
     }
 
     assert!(Cli::try_parse_from(["homeboy", "agent-task", "active", "--dry-run"]).is_err());


### PR DESCRIPTION
## Summary
- Replace raw process-arg parsing for `agent-task list`, `active`, and `latest` with typed clap arg structs.
- Add typed `--limit` support to list/active/latest and typed `--reconcile` / `--dry-run` support to active.
- Update docs, help/parse tests, Lab contract matching, and active command safety metadata.

## Verification
- `rustfmt src/commands/agent_task.rs src/commands/agent_task/args/mod.rs src/command_contract/lab.rs src/cli_surface.rs tests/command_surface_test.rs tests/command_contract/lab_test.rs`
- `git diff --check`
- `homeboy lint --lab-only --changed-since origin/main` passed on runner `homeboy-lab`.
- `homeboy test --lab-only --changed-since origin/main` reached runner `homeboy-lab` but failed before running selected tests because an existing lib-test initializer in `src/core/runner/lab/secrets.rs` is missing `lab_runtime_components` on `AgentTaskExecutorProvider`.
- `homeboy test --lab-only --changed-since origin/main -- --test command_surface_test --test command_contract` hit the same unrelated lib-test compile blocker before selected tests ran.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, docs, and verification orchestration.