### PR TITLE
Refactor agent-task cook dispatch semantics

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -13,7 +13,7 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 - **Lifecycle:** durable run submission, execution, inspection, cancellation, and retry.
 - **Cook/review:** workspace task conveniences that compose lifecycle runs with promotion, gates, and PR finalization.
 - **Provider:** executor discovery, machine-readable contracts, and redacted auth readiness.
-- **Prompt store:** Homeboy-owned markdown prompts for reusable dispatch/cook input.
+- **Prompt store:** Homeboy-owned markdown prompts for reusable cook/controller input.
 - **Loop/controller:** durable multi-agent loop state with on/off, revolutions, handoffs, continuation policy, and resume/stop controls.
 
 ## Subcommands
@@ -22,7 +22,6 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 
 | Subcommand | Purpose |
 |---|---|
-| `dispatch` | Build and queue common workspace agent tasks without hand-authored provider JSON. |
 | `run-plan` | Run an `AgentTaskPlan` through extension-declared executor providers. |
 | `run <run-id>` | Execute a previously submitted durable run. |
 | `run-next` | Claim and execute the oldest queued durable run. |
@@ -72,7 +71,7 @@ ordering and output bindings belong in the existing single-run `fanout submit` /
 | `review <run-id>` | Build a durable aggregate review envelope from run state, logs, artifacts, and promotion hints. |
 | `promote <source>` | Promote a completed generic patch artifact into a managed worktree. |
 | `finalize-pr` | Finalize a green cook run into a review-ready pull request. |
-| `gate-feedback` | Convert deterministic gate results into a cook-loop retry or stop decision. |
+| `gate-feedback` | Convert deterministic gate results into a cook retry or stop decision. |
 
 ## Lab Guardrails
 
@@ -104,7 +103,7 @@ processes start. Compact `agent-task status` includes `execution_location` as
 
 `agent-task prompts` stores markdown prompt files under Homeboy's data directory,
 not under the current repo/worktree. Save prompt content with inline text,
-`@file`, or `-` for stdin, then reference it from `dispatch` or `cook`
+`@file`, or `-` for stdin, then reference it from `cook` or controller specs
 with `prompt:<id>` anywhere a prompt string is accepted.
 
 ```bash
@@ -310,17 +309,21 @@ the controller and immediately run pending handoffs. `loop resume` refuses to
 run off loops and stops once the persisted or supplied revolution limit is
 reached.
 
-## Dispatch
+## Cook
 
-`agent-task dispatch` builds a durable task plan from common workspace inputs
-without requiring hand-authored provider JSON:
+`agent-task cook` is the one-shot end-to-end PR workflow. It dispatches an agent,
+promotes the selected patch into the target worktree, runs deterministic gates,
+retries red gates within the configured budget, then commits, pushes, and opens or
+updates a PR.
 
 ```bash
-homeboy agent-task dispatch \
+homeboy agent-task cook \
   --repo sample-plugin \
   --cwd /path/to/worktree \
+  --to-worktree sample-plugin@fix-issue \
   --provider-config @provider-config.json \
   --client-context @client-context.json \
+  --verify "npm test" \
   --prompt @task.txt
 ```
 
@@ -329,7 +332,7 @@ adapters may include whatever correlation data they need to reconcile their own
 notifications or UI state, but Homeboy does not interpret transport-specific
 identifiers in core lifecycle state. Provider-specific execution settings belong
 in `--provider-config`; durable lifecycle commands remain headless and can be
-claimed later with `agent-task run` or `agent-task run-next`.
+inspected later with `agent-task status`, `agent-task logs`, or `agent-task review`.
 
 `--backend` selects the generic executor backend, `--dispatch-provider-id` (also
 accepted as `--selector`) selects a specific provider id for that backend, and
@@ -399,18 +402,16 @@ depending on transport-local state.
 ```bash
 run_id="homeboy-3357-$(date +%s)"
 
-homeboy agent-task dispatch \
+homeboy agent-task cook \
   --repo homeboy \
   --cwd /path/to/homeboy@fix-issue \
+  --to-worktree homeboy@fix-issue-3357-agent-task-non-chat-flow \
   --task-url https://github.com/Extra-Chill/homeboy/issues/3357 \
   --concurrency 4 \
   --attempts 2 \
+  --verify "homeboy test homeboy" \
   --run-id "$run_id" \
-  --queue-only \
   --prompt @task.txt
-
-# A daemon or later terminal process can claim work without chat history.
-homeboy agent-task run-next
 
 # One review envelope contains lifecycle state, logs, artifacts, aggregate
 # reconciliation, promotion candidates, and next actions.
@@ -547,7 +548,7 @@ a visible deterministic gate in the promoted worktree. Promotion reports gate
 results as `deterministic_gates[]` using
 `homeboy/agent-task-gate-report/v1`. Failed visible gates set promotion
 `status: "gate_failed"`, exit nonzero, and include
-`failure_evidence.agent_feedback` plus stdout/stderr tails so the next cook-loop
+`failure_evidence.agent_feedback` plus stdout/stderr tails so the next cook
 agent task can receive exact failure context instead of a generic shell error.
 
 Use `--private-verify <command>` for orchestrator-only completion gates that
@@ -560,7 +561,7 @@ policies are `summary-only` (default), `redacted`, `no-detail`, and
 evidence to the agent.
 
 `agent-task gate-feedback` converts a promotion report and the original
-`AgentTaskRequest` into a provider-neutral cook-loop decision:
+`AgentTaskRequest` into a provider-neutral cook feedback decision:
 
 ```bash
 homeboy agent-task gate-feedback \
@@ -572,7 +573,7 @@ homeboy agent-task gate-feedback \
   --current-diff @current.diff
 ```
 
-The command returns `homeboy/agent-task-cook-loop-report/v1`. Red gates with
+The command returns `homeboy/agent-task-cook-feedback-report/v1`. Red gates with
 remaining budget produce `status: "retry_requested"` and a complete
 `follow_up_request` containing the failed command, exit status, log tails,
 changed files, patch artifact ref, current diff context, and source run/task
@@ -618,7 +619,7 @@ plugin paths, workspace roots, and path-valued settings. Lab offload evidence
 records the original and remapped paths in `workspace_mapping.workspaces` using
 the `component_contract` role.
 
-When the intended checkout already exists on a Lab runner, dispatch from that
+When the intended checkout already exists on a Lab runner, cook from that
 runner-side checkout through `runner exec` instead of forcing a controller-local
 hot run:
 
@@ -628,23 +629,27 @@ homeboy runner exec homeboy-lab \
   -- homeboy agent-task cook \
     --repo homeboy \
     --cwd /srv/homeboy/checkouts/homeboy \
+    --to-worktree homeboy@remote-cook \
+    --verify "homeboy test homeboy" \
     --prompt @task.txt
 ```
 
 `runner exec` marks non-local jobs as runner-hosted, so nested `agent-task cook`
 commands pass the non-interactive resource preflight without `--force-hot`.
 
-## Dispatch Workspaces
+## Cook Workspaces
 
-`agent-task dispatch` accepts generic Homeboy workspace inputs and does not
+`agent-task cook` accepts generic Homeboy workspace inputs and does not
 resolve product-specific workspace handles itself.
 
 Use `--cwd <PATH>` when the caller already knows the checkout or worktree path:
 
 ```bash
-homeboy agent-task dispatch \
+homeboy agent-task cook \
   --repo homeboy \
   --cwd /path/to/homeboy@fix-issue \
+  --to-worktree homeboy@fix-issue \
+  --verify "homeboy test homeboy" \
   --prompt @task.txt
 ```
 
@@ -653,15 +658,17 @@ existing workspace path:
 
 ```bash
 homeboy worktree create homeboy --branch fix/issue-123
-homeboy agent-task dispatch \
+homeboy agent-task cook \
   --workspace homeboy@fix-issue-123 \
+  --to-worktree homeboy@fix-issue-123 \
+  --verify "homeboy test homeboy" \
   --prompt @task.txt
 ```
 
 External workspace managers should resolve their own handles to local paths and
-call dispatch with `--cwd <resolved-path>`.
+call cook with `--cwd <resolved-path>`.
 
-When `agent-task cook` or `agent-task dispatch` is Lab-offloaded with a
+When `agent-task cook` is Lab-offloaded with a
 patch-producing provider, `--cwd` must point at a clean git checkout with
 `remote.origin.url` configured. Homeboy uses that contract to materialize a real
 runner-side git checkout/worktree before provider dispatch so generated files can

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -445,9 +445,9 @@ defaults them to the current core contract ids.
 Use `homeboy agent-task providers --backend <backend> --validate-readiness` to
 fail fast when the selected backend is registered but its declared runner
 readiness is not usable in the current environment. Lab offload runs this check
-on the selected runner before dispatching `agent-task cook` or `agent-task
-dispatch`, so a missing provider executable/config blocks the run before a
-multi-cell task wave is queued.
+on the selected runner before `agent-task cook` dispatches work internally, so a
+missing provider executable/config blocks the run before a multi-cell task wave
+is queued.
 
 ## Repo-Local Gate Tasks
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -71,7 +71,7 @@ Lab offload support is intentionally command-specific:
 
 | Command | Auto offload | Explicit `--runner` | Decision |
 |---|---:|---:|---|
-| `agent-task dispatch` / `agent-task cook` / `agent-task loop` / `agent-task run-plan` | Yes | Yes | Portable agent-task execution when the command has deterministic gates where required. |
+| `agent-task cook` / `agent-task run-plan` | Yes | Yes | Portable agent-task execution when the command has deterministic gates where required. |
 | `agent-task controller from-spec --resume` / `agent-task controller materialize` / `agent-task controller resume` | No | Yes | Runner-hosted controller lifecycle work. |
 | `agent-task retry --run` | Yes | Yes | Retry plus execution follows the portable agent-task run path. |
 | `agent-task run` / `run-next` / `status` / `logs` / `artifacts` / `review` / `providers` | No | Yes | Runner-resident inspection and queue interaction. |

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -248,7 +248,9 @@ impl LabLocalExecutionPolicy {
 pub const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
 const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
 const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
-const AGENT_TASK_RUN_LAB_LABEL: &str = "agent-task dispatch/cook/run-plan/retry --run";
+const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
+    "agent-task cook requires at least one deterministic --verify or --private-verify gate";
+const AGENT_TASK_RUN_LAB_LABEL: &str = "agent-task cook/run-plan/retry --run";
 const AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL: &str =
     "agent-task controller from-spec --resume/materialize";
 const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task controller resume";
@@ -285,8 +287,8 @@ pub struct LabRunnerSupportSummary {
 const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
     LabSupportedCommandSummary {
         contract_labels: &[AGENT_TASK_RUN_LAB_LABEL],
-        message_label: "agent-task dispatch/cook/run-plan",
-        hint_label: "agent-task dispatch/cook/run-plan",
+        message_label: "agent-task cook/run-plan",
+        hint_label: "agent-task cook/run-plan",
     },
     LabSupportedCommandSummary {
         contract_labels: &[
@@ -444,9 +446,14 @@ impl Commands {
     pub fn lab_contract(&self) -> Option<LabCommandContract> {
         let mut contract = match self {
             Commands::AgentTask(agent_task::AgentTaskArgs {
+                command: agent_task::AgentTaskCommand::Cook(args),
+            }) if !args.gates.has_deterministic_gate() => LabCommandContract::local_only(
+                AGENT_TASK_RUN_LAB_LABEL,
+                AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON,
+            ),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Cook(_)
-                    | agent_task::AgentTaskCommand::Dispatch(_)
                     | agent_task::AgentTaskCommand::RunPlan(_)
                     | agent_task::AgentTaskCommand::Retry(agent_task::RetryArgs { run: true, .. }),
             }) => LabCommandContract::portable(
@@ -587,7 +594,10 @@ fn agent_task_provider_requires_cwd_git_checkout_with(
     provider_requires_cwd_git_checkout: impl Fn(&str, Option<&str>) -> bool,
 ) -> bool {
     match command {
-        agent_task::AgentTaskCommand::Cook(args) | agent_task::AgentTaskCommand::Dispatch(args) => {
+        agent_task::AgentTaskCommand::Cook(agent_task::AgentTaskCookArgs {
+            dispatch: args,
+            ..
+        }) => {
             let has_workspace = args.cwd.as_ref().is_some_and(|cwd| !cwd.trim().is_empty())
                 || args
                     .workspace

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -27,7 +27,7 @@ pub use args::{
     AgentTaskControllerFromSpecArgs, AgentTaskControllerInitArgs,
     AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerMaterializeArgs,
     AgentTaskControllerRunArgs, AgentTaskControllerRunFromSpecArgs, AgentTaskControllerRunNextArgs,
-    AgentTaskControllerStatusArgs, AgentTaskDoctorArgs, AgentTaskFanoutArgs,
+    AgentTaskControllerStatusArgs, AgentTaskCookArgs, AgentTaskDoctorArgs, AgentTaskFanoutArgs,
     AgentTaskFanoutBatchStatusArgs, AgentTaskFanoutCommand, AgentTaskFanoutInputArgs,
     AgentTaskFanoutPlanArgs, AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs,
     AgentTaskFanoutSubmitBatchArgs, AgentTaskLoopArgs, AgentTaskLoopCommand,
@@ -38,16 +38,11 @@ pub use args::{
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
-pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
+pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::Doctor(doctor_args) => doctor::doctor(doctor_args),
-        AgentTaskCommand::Cook(dispatch_args) => {
-            super::agent_task_dispatch::cook(dispatch_args, global)
-        }
+        AgentTaskCommand::Cook(cook_args) => run::run_cook(cook_args),
         AgentTaskCommand::Loop(loop_args) => controller::loop_command(loop_args),
-        AgentTaskCommand::Dispatch(dispatch_args) => {
-            super::agent_task_dispatch::run(dispatch_args, global)
-        }
         AgentTaskCommand::RunPlan(run_args) => run::run_plan(run_args),
         AgentTaskCommand::Run(status_args) => run::run_submitted(status_args),
         AgentTaskCommand::RunNext => run::run_next(),

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -4,7 +4,7 @@
 //! sibling module lets the `agent_task` root stay a thin dispatcher over the
 //! handler modules (`auth`, `controller`, `run`, `status`, `review`). The
 //! command tree is grouped by boundary: lifecycle commands own durable run
-//! records, cook-loop commands compose lifecycle primitives into reviewer
+//! records, cook commands compose lifecycle primitives into reviewer
 //! workflows, provider commands expose executor contracts/auth, and controller
 //! commands own long-running loop state.
 
@@ -135,12 +135,10 @@ pub struct AgentTaskArgs {
 pub enum AgentTaskCommand {
     /// Readiness: run the one-command cook readiness repair chain and return a single ready/blocked verdict.
     Doctor(AgentTaskDoctorArgs),
-    /// Cook: run one workspace task through the patch handoff workflow.
-    Cook(DispatchArgs),
+    /// Cook: dispatch, promote, verify, retry red gates, and finalize a one-shot PR task.
+    Cook(AgentTaskCookArgs),
     /// Loop: operate a durable multi-agent loop with on/off and resume controls.
     Loop(AgentTaskLoopArgs),
-    /// Lifecycle: build and queue agent tasks without hand-authored provider JSON.
-    Dispatch(DispatchArgs),
     /// Lifecycle: run an agent-task plan through extension-declared executor providers.
     RunPlan(RunPlanArgs),
     /// Lifecycle: execute a previously submitted durable agent-task run.
@@ -175,7 +173,7 @@ pub enum AgentTaskCommand {
     Promote(PromoteArgs),
     /// Review: finalize a green cook run into a review-ready pull request.
     FinalizePr(FinalizePrArgs),
-    /// Review: convert deterministic gate results into a cook-loop retry or stop decision.
+    /// Review: convert deterministic gate results into a cook retry or stop decision.
     GateFeedback(GateFeedbackArgs),
     /// Provider: list extension-declared agent-task executor providers and optional secret readiness.
     Providers(ProvidersArgs),
@@ -376,6 +374,67 @@ pub struct CompileLoopArgs {
     /// AgentTaskLoopDefinition JSON file, @file, inline JSON, or - for stdin.
     #[arg(long, value_name = "SPEC")]
     pub definition: String,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskCookArgs {
+    #[command(flatten)]
+    pub dispatch: DispatchArgs,
+
+    /// Repo-cooking goal. Alias for the dispatch prompt when --prompt is omitted.
+    #[arg(long, value_name = "TEXT")]
+    pub goal: Option<String>,
+
+    /// Target managed worktree handle where candidate patches are promoted.
+    #[arg(long, value_name = "HANDLE")]
+    pub to_worktree: String,
+
+    /// External workspace provider command. When omitted, HOMEBOY_AGENT_TASK_PROMOTION_COMMAND is used.
+    #[arg(long, value_name = "COMMAND")]
+    pub provider_command: Option<String>,
+
+    #[command(flatten)]
+    pub gates: VerifyGateArgs,
+
+    /// Maximum cook gate attempts, including the first candidate.
+    #[arg(long = "max-attempts", default_value_t = 3, value_name = "N")]
+    pub max_attempts: u32,
+
+    /// Stop after the first green promotion without committing, pushing, or opening/updating a PR.
+    #[arg(long = "no-finalize")]
+    pub no_finalize: bool,
+
+    /// PR base branch used by finalization.
+    #[arg(long, default_value = "main", value_name = "BRANCH")]
+    pub base: String,
+
+    /// PR head branch. Defaults to the current branch in the promoted worktree.
+    #[arg(long, value_name = "BRANCH")]
+    pub head: Option<String>,
+
+    /// PR title. Defaults to a title derived from --repo or --task-url.
+    #[arg(long, value_name = "TEXT")]
+    pub title: Option<String>,
+
+    /// Commit message for the verified candidate changes.
+    #[arg(long, value_name = "TEXT")]
+    pub commit_message: Option<String>,
+
+    /// Protected branch that may not be finalized directly. Repeatable.
+    #[arg(long = "protected-branch", default_values_t = review::default_protected_branches(), value_name = "BRANCH")]
+    pub protected_branches: Vec<String>,
+
+    /// AI tool disclosure line for the PR body.
+    #[arg(long, default_value = "OpenCode (GPT-5.5)", value_name = "TEXT")]
+    pub ai_tool: String,
+
+    /// AI assistance scope for the PR body.
+    #[arg(
+        long,
+        default_value = "Drafted implementation and tests; Chris reviews and owns the change.",
+        value_name = "TEXT"
+    )]
+    pub ai_used_for: String,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -316,7 +316,8 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
                 "agent-task providers --validate-readiness requires --backend",
                 None,
                 Some(vec![
-                    "Pass the same --backend value that the agent-task dispatch/cook command will use.".to_string(),
+                    "Pass the same --backend value that the agent-task cook command will use."
+                        .to_string(),
                 ]),
             )
         })?;

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -1,4 +1,5 @@
-//! Durable run lifecycle handlers: run-plan, run, run-next, submit, resume, and retry.
+//! Durable run lifecycle handlers: cook, run-plan, run, run-next, submit,
+//! resume, and retry.
 
 use serde_json::Value;
 
@@ -9,7 +10,7 @@ use homeboy::core::agent_tasks::scheduler::{
 use homeboy::core::agent_tasks::service as agent_task_service;
 
 use super::super::CmdResult;
-use super::args::{RetryArgs, RunPlanArgs, StatusArgs, SubmitArgs};
+use super::args::{AgentTaskCookArgs, RetryArgs, RunPlanArgs, StatusArgs, SubmitArgs};
 
 /// Serialize a completed run aggregate and, when the run did not fully succeed,
 /// surface a prominent top-level `failure_reasons` summary so the operator sees
@@ -25,6 +26,99 @@ fn aggregate_value_with_failure_reasons(aggregate: &AgentTaskAggregate) -> Value
         }
     }
     value
+}
+
+pub(super) fn run_cook(args: AgentTaskCookArgs) -> CmdResult<Value> {
+    run_cook_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
+}
+
+pub(super) fn run_cook_with_executor<E>(args: AgentTaskCookArgs, executor: E) -> CmdResult<Value>
+where
+    E: AgentTaskExecutorAdapter + Clone,
+{
+    if !args.gates.has_deterministic_gate() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "verify",
+            "agent-task cook requires at least one deterministic --verify or --private-verify gate",
+            None,
+            None,
+        ));
+    }
+
+    let mut dispatch_args = args.dispatch.clone();
+    if dispatch_args.prompt.is_none() {
+        dispatch_args.prompt = args.goal.clone();
+    }
+    dispatch_args.core.queue_only = false;
+    let (dispatch_value, _dispatch_exit) =
+        dispatch_service::run_dispatch_command(dispatch_args.into(), executor.clone())?;
+    let run_id = dispatch_value["run_id"]
+        .as_str()
+        .ok_or_else(|| {
+            homeboy::core::Error::internal_unexpected(
+                "agent-task cook dispatch step did not return a run_id".to_string(),
+            )
+        })?
+        .to_string();
+    let cook_id = run_id.clone();
+    let title = args
+        .title
+        .clone()
+        .unwrap_or_else(|| default_loop_title(&args));
+    let commit_message = args
+        .commit_message
+        .clone()
+        .unwrap_or_else(|| default_loop_commit_message(&args));
+    let result = agent_task_service::run_cook(
+        agent_task_service::AgentTaskCookServiceOptions {
+            cook_id,
+            initial_run_id: run_id,
+            to_worktree: args.to_worktree,
+            provider_command: args.provider_command,
+            gates: args.gates.into(),
+            max_attempts: args.max_attempts,
+            no_finalize: args.no_finalize,
+            base: args.base,
+            head: args.head,
+            title,
+            commit_message,
+            source_refs: args.dispatch.task_url.into_iter().collect(),
+            protected_branches: args.protected_branches,
+            ai_tool: args.ai_tool.clone(),
+            ai_model: args
+                .dispatch
+                .model
+                .or_else(|| ai_model_from_tool(&args.ai_tool)),
+            ai_used_for: args.ai_used_for,
+        },
+        executor,
+    )?;
+    Ok((
+        serde_json::to_value(result.value).unwrap_or(Value::Null),
+        result.exit_code,
+    ))
+}
+
+fn ai_model_from_tool(ai_tool: &str) -> Option<String> {
+    let start = ai_tool.find('(')?;
+    let end = ai_tool[start + 1..].find(')')? + start + 1;
+    let model = ai_tool[start + 1..end].trim();
+    (!model.is_empty()).then(|| model.to_string())
+}
+
+fn default_loop_title(args: &AgentTaskCookArgs) -> String {
+    let target = args
+        .dispatch
+        .repo
+        .as_deref()
+        .or(args.dispatch.task_url.as_deref())
+        .unwrap_or("agent task");
+    format!("Cook {target}")
+}
+
+fn default_loop_commit_message(args: &AgentTaskCookArgs) -> String {
+    let target = args.dispatch.repo.as_deref().unwrap_or("agent task");
+    format!("fix: cook {target}")
 }
 
 pub(super) fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -3,6 +3,7 @@
 
 use serde_json::Value;
 
+use homeboy::core::agent_tasks::dispatch_service;
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_tasks::scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan,

--- a/src/commands/agent_task/tests/dispatch.rs
+++ b/src/commands/agent_task/tests/dispatch.rs
@@ -298,11 +298,15 @@ fn controller_dispatch_args_preserve_top_level_workspace_context_in_plan() {
 }
 
 #[test]
-fn dispatch_provider_id_alias_maps_to_selector() {
+fn cook_dispatch_provider_id_alias_maps_to_selector() {
     let cli = Cli::try_parse_from([
         "homeboy",
         "agent-task",
-        "dispatch",
+        "cook",
+        "--to-worktree",
+        "homeboy@cook-provider-id",
+        "--verify",
+        "true",
         "--backend",
         "sample-backend",
         "--dispatch-provider-id",
@@ -315,12 +319,12 @@ fn dispatch_provider_id_alias_maps_to_selector() {
     let Commands::AgentTask(agent_task) = cli.command else {
         panic!("expected agent-task command");
     };
-    let AgentTaskCommand::Dispatch(args) = agent_task.command else {
-        panic!("expected dispatch command");
+    let AgentTaskCommand::Cook(args) = agent_task.command else {
+        panic!("expected cook command");
     };
 
-    assert_eq!(args.selector.as_deref(), Some("sample-provider"));
-    assert_eq!(args.model, None);
+    assert_eq!(args.dispatch.selector.as_deref(), Some("sample-provider"));
+    assert_eq!(args.dispatch.model, None);
 }
 
 #[test]

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -110,3 +110,66 @@ fn review_reports_completed_aggregate_and_promotion_hints() {
             .contains("promotion_candidates"));
     });
 }
+
+#[test]
+fn cook_returns_durable_id_when_promotion_provider_is_missing() {
+    with_temp_home(|| {
+        let (value, exit_code) = run_cook_with_executor(
+            AgentTaskCookArgs {
+                dispatch: DispatchArgs {
+                    prompt: None,
+                    tasks: Vec::new(),
+                    cwd: None,
+                    workspace: None,
+                    repo: Some("homeboy".to_string()),
+                    task_url: Some(
+                        "https://github.com/Extra-Chill/homeboy/issues/3675".to_string(),
+                    ),
+                    backend: Some("fixture".to_string()),
+                    selector: None,
+                    model: None,
+                    required_capabilities: Vec::new(),
+                    secret_env: Vec::new(),
+                    concurrency: 1,
+                    run_id: Some("cook-missing-provider".to_string()),
+                    core: DispatchCoreArgs {
+                        tasks_json: None,
+                        provider_config: None,
+                        client_context: None,
+                        attempts: 1,
+                        queue_only: false,
+                    },
+                },
+                goal: Some("cook fixture".to_string()),
+                to_worktree: "homeboy@fix-agent-task-runner-cook".to_string(),
+                provider_command: None,
+                gates: VerifyGateArgs {
+                    verify: vec!["cargo test --lib".to_string()],
+                    private_verify: Vec::new(),
+                    private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,
+                },
+                max_attempts: 2,
+                no_finalize: false,
+                base: "main".to_string(),
+                head: None,
+                title: None,
+                commit_message: None,
+                protected_branches: review::default_protected_branches(),
+                ai_tool: "OpenCode (GPT-5.5)".to_string(),
+                ai_used_for: "test".to_string(),
+            },
+            ExtensionProviderAgentTaskExecutor::default(),
+        )
+        .expect("cook reported controlled failure");
+
+        assert_eq!(exit_code, 1);
+        assert_eq!(value["schema"], "homeboy/agent-task-cook/v1");
+        assert_eq!(value["cook_id"], "cook-missing-provider");
+        assert_eq!(value["status"], "policy_failure");
+        assert_eq!(value["attempts"][0]["run_id"], "cook-missing-provider");
+        assert!(value["stop_reason"]
+            .as_str()
+            .expect("stop reason")
+            .contains("workspace provider command"));
+    });
+}

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -18,7 +18,8 @@ pub(in crate::commands::agent_task) use super::super::controller::{
     controller_run_next_with_executor,
 };
 pub(in crate::commands::agent_task) use super::super::run::{
-    retry, run_loaded_plan, run_next_with_executor, run_resume_with_executor, run_submitted, submit,
+    retry, run_cook_with_executor, run_loaded_plan, run_next_with_executor,
+    run_resume_with_executor, run_submitted, submit,
 };
 pub(in crate::commands::agent_task) use super::super::status::{cancel, logs, status};
 pub(in crate::commands::agent_task) use super::super::{

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -5,12 +5,15 @@
 
 pub(crate) use std::process::Command;
 
+pub(in crate::commands::agent_task) use super::super::super::agent_task_dispatch::{
+    DispatchArgs, DispatchCoreArgs,
+};
 pub(in crate::commands::agent_task) use super::super::args::{
     AgentTaskControllerApplyEventArgs, AgentTaskControllerFromSpecArgs,
     AgentTaskControllerMaterializeArgs, AgentTaskControllerRunFromSpecArgs,
 };
 pub(in crate::commands::agent_task) use super::super::args::{
-    CompileLoopArgs, ReviewArgs, StatusArgs, SubmitArgs,
+    AgentTaskCookArgs, CompileLoopArgs, ReviewArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(in crate::commands::agent_task) use super::super::controller::{
     apply_controller_event, controller_from_spec, controller_materialize,
@@ -32,8 +35,10 @@ pub(crate) use homeboy::core::agent_tasks::controller_service::{
 pub(crate) use homeboy::core::agent_tasks::controller_service::{
     AgentTaskRepoLoopSpec, ControllerFromSpecRequest,
 };
+pub(crate) use homeboy::core::agent_tasks::gate::AgentTaskGateRevealPolicy;
 pub(crate) use homeboy::core::agent_tasks::provider::{
-    AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA, AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
+    ExtensionProviderAgentTaskExecutor, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+    AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
 };
 pub(crate) use homeboy::core::agent_tasks::scheduler::{AgentTaskExecutorAdapter, AgentTaskPlan};
 

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -1,28 +1,6 @@
 use clap::Args;
-use serde_json::Value;
 
-use homeboy::core::agent_task_dispatch_service::render_backend_selection_summary;
-use homeboy::core::agent_tasks::dispatch_service::{
-    self, AgentTaskDispatchCommand, DispatchCoreInputs,
-};
-use homeboy::core::agent_tasks::provider::{
-    AgentTaskProviderCatalog, ExtensionProviderAgentTaskExecutor,
-};
-
-use super::{CmdResult, GlobalArgs};
-
-/// Print the effective backend selection (and any override warning) to stderr
-/// before dispatch so operators can see which backend will run and where the
-/// selection came from. Resolution happens here without consuming `command`;
-/// dispatch re-resolves identically. Errors are intentionally swallowed — the
-/// summary is best-effort and the dispatch path surfaces the real error (#5685).
-fn print_backend_selection_summary(command: &AgentTaskDispatchCommand) {
-    if let Ok(request) = dispatch_service::resolve_dispatch_request(command.clone()) {
-        if let Some(selection) = request.backend_selection.as_ref() {
-            eprintln!("{}", render_backend_selection_summary(selection));
-        }
-    }
-}
+use homeboy::core::agent_tasks::dispatch_service::{AgentTaskDispatchCommand, DispatchCoreInputs};
 
 /// CLI surface for the dispatch inputs shared across dispatch carriers. Flattened
 /// into [`DispatchArgs`] so the `--tasks/--provider-config/--client-context/
@@ -147,40 +125,19 @@ impl From<DispatchArgs> for AgentTaskDispatchCommand {
     }
 }
 
-pub fn run(args: DispatchArgs, _global: &GlobalArgs) -> CmdResult<Value> {
-    let catalog = AgentTaskProviderCatalog::discover();
-    let command: AgentTaskDispatchCommand = args.into();
-    print_backend_selection_summary(&command);
-    dispatch_service::run_dispatch_command_with_provider_catalog(
-        command,
-        ExtensionProviderAgentTaskExecutor::from_catalog(catalog.clone()),
-        &catalog,
-    )
-}
-
-pub(crate) fn cook(args: DispatchArgs, _global: &GlobalArgs) -> CmdResult<Value> {
-    let catalog = AgentTaskProviderCatalog::discover();
-    let command: AgentTaskDispatchCommand = args.into();
-    print_backend_selection_summary(&command);
-    dispatch_service::run_cook_command_with_provider_catalog(
-        command,
-        ExtensionProviderAgentTaskExecutor::from_catalog(catalog.clone()),
-        &catalog,
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_support::with_isolated_home;
     use homeboy::core::agent_task::AgentTaskRequest;
+    use homeboy::core::agent_tasks::dispatch_service;
     use homeboy::core::agent_tasks::scheduler::{
         AgentTaskExecutionContext, AgentTaskExecutorAdapter,
     };
     use homeboy::core::agent_tasks::{
-        AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
-        AGENT_TASK_OUTCOME_SCHEMA,
+        AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_OUTCOME_SCHEMA,
     };
+    use serde_json::Value;
 
     #[test]
     fn dispatch_adapter_preserves_queue_only_envelope_shape() {
@@ -212,92 +169,6 @@ mod tests {
                 .as_str()
                 .expect("plan path")
                 .ends_with("plan.json"));
-        });
-    }
-
-    #[test]
-    fn cook_output_marks_patch_artifact_handoff_boundary() {
-        with_isolated_home(|_| {
-            let workspace = tempfile::tempdir()
-                .expect("workspace")
-                .keep()
-                .display()
-                .to_string();
-            let patch_path = std::path::Path::new(&workspace).join("changes.patch");
-            std::fs::write(&patch_path, "diff --git a/file b/file\n").expect("patch fixture");
-            let transcript_path = std::path::Path::new(&workspace).join("transcript.log");
-            std::fs::write(&transcript_path, "cook transcript\n").expect("transcript fixture");
-            let (value, exit_code) = dispatch_service::run_cook_command(
-                dispatch_args(DispatchArgOverrides {
-                    prompt: Some("Cook a patch.".to_string()),
-                    workspace: Some(workspace.clone()),
-                    run_id: Some("cook-handoff".to_string()),
-                    ..DispatchArgOverrides::default()
-                })
-                .into(),
-                PatchExecutor {
-                    patch_path,
-                    transcript_path,
-                },
-            )
-            .expect("cook run");
-
-            assert_eq!(exit_code, 0);
-            assert_eq!(value["handoff"]["states"]["patch_artifact_produced"], true);
-            assert_eq!(value["handoff"]["states"]["patch_promoted"], false);
-            assert_eq!(value["handoff"]["states"]["pr_opened"], false);
-            assert_eq!(value["handoff"]["boundary"], "patch_artifact_only");
-            assert_eq!(
-                value["handoff"]["promote_commands"][0],
-                serde_json::json!([
-                    "homeboy",
-                    "agent-task",
-                    "promote",
-                    value["aggregate_path"].as_str().expect("aggregate path"),
-                    "--task-id",
-                    "cook-task",
-                    "--artifact-id",
-                    "patch-1",
-                    "--to-worktree",
-                    workspace
-                ])
-            );
-            assert!(value["handoff"]["finalize_command"]
-                .as_str()
-                .expect("finalize command")
-                .contains("homeboy agent-task finalize-pr --run-id cook-handoff"));
-        });
-    }
-
-    #[test]
-    fn queued_cook_handoff_surfaces_run_command_without_patch_claims() {
-        with_isolated_home(|_| {
-            let (value, exit_code) = dispatch_service::run_cook_command(
-                dispatch_args(DispatchArgOverrides {
-                    prompt: Some("Queue this cook.".to_string()),
-                    run_id: Some("cook-queued".to_string()),
-                    core: DispatchCoreInputs {
-                        queue_only: true,
-                        ..DispatchCoreInputs::default()
-                    },
-                    ..DispatchArgOverrides::default()
-                })
-                .into(),
-                PatchExecutor {
-                    patch_path: std::path::PathBuf::new(),
-                    transcript_path: std::path::PathBuf::new(),
-                },
-            )
-            .expect("queued cook");
-
-            assert_eq!(exit_code, 0);
-            assert_eq!(value["handoff"]["states"]["patch_artifact_produced"], false);
-            assert_eq!(value["handoff"]["states"]["patch_promoted"], false);
-            assert_eq!(value["handoff"]["states"]["pr_opened"], false);
-            assert!(value["handoff"]["next_actions"][0]
-                .as_str()
-                .expect("next action")
-                .contains("homeboy agent-task run cook-queued"));
         });
     }
 
@@ -382,70 +253,6 @@ mod tests {
                 summary: Some("ok".to_string()),
                 failure_classification: None,
                 artifacts: Vec::new(),
-                typed_artifacts: Vec::new(),
-                evidence_refs: Vec::new(),
-                diagnostics: Vec::new(),
-                outputs: Value::Null,
-                workflow: None,
-                follow_up: None,
-                metadata: Value::Null,
-            }
-        }
-    }
-
-    struct PatchExecutor {
-        patch_path: std::path::PathBuf,
-        transcript_path: std::path::PathBuf,
-    }
-
-    impl AgentTaskExecutorAdapter for PatchExecutor {
-        fn execute(
-            &self,
-            _request: AgentTaskRequest,
-            _context: AgentTaskExecutionContext,
-        ) -> AgentTaskOutcome {
-            AgentTaskOutcome {
-                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-                task_id: "cook-task".to_string(),
-                status: AgentTaskOutcomeStatus::Succeeded,
-                summary: Some("patch ready".to_string()),
-                failure_classification: None,
-                artifacts: vec![
-                    AgentTaskArtifact {
-                        schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                        id: "patch-1".to_string(),
-                        kind: "patch".to_string(),
-                        name: Some("changes.patch".to_string()),
-                        label: None,
-                        role: None,
-                        semantic_key: None,
-                        path: Some(self.patch_path.display().to_string()),
-                        url: None,
-                        mime: None,
-                        size_bytes: std::fs::metadata(&self.patch_path)
-                            .ok()
-                            .map(|metadata| metadata.len()),
-                        sha256: None,
-                        metadata: Value::Null,
-                    },
-                    AgentTaskArtifact {
-                        schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                        id: "transcript-1".to_string(),
-                        kind: "transcript".to_string(),
-                        name: Some("transcript.log".to_string()),
-                        label: None,
-                        role: None,
-                        semantic_key: None,
-                        path: Some(self.transcript_path.display().to_string()),
-                        url: None,
-                        mime: None,
-                        size_bytes: std::fs::metadata(&self.transcript_path)
-                            .ok()
-                            .map(|metadata| metadata.len()),
-                        sha256: None,
-                        metadata: Value::Null,
-                    },
-                ],
                 typed_artifacts: Vec::new(),
                 evidence_refs: Vec::new(),
                 diagnostics: Vec::new(),

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -119,15 +119,13 @@ pub fn route_after_parse(
 fn agent_task_local_fanout_warning(command: &Commands) -> Option<String> {
     let (label, concurrency, task_count) = match command {
         Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-            command:
-                crate::commands::agent_task::AgentTaskCommand::Cook(args)
-                | crate::commands::agent_task::AgentTaskCommand::Dispatch(args),
+            command: crate::commands::agent_task::AgentTaskCommand::Cook(args),
         }) => (
-            "agent-task local fanout",
-            args.concurrency,
-            args.tasks.len()
-                + usize::from(args.prompt.is_some())
-                + usize::from(args.core.tasks_json.is_some()),
+            "agent-task cook local fanout",
+            args.dispatch.concurrency,
+            args.dispatch.tasks.len()
+                + usize::from(args.dispatch.prompt.is_some())
+                + usize::from(args.dispatch.core.tasks_json.is_some()),
         ),
         _ => return None,
     };

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -597,7 +597,7 @@ mod tests {
         let _lock = env_lock();
         let _guard = EnvVarGuard::set(crate::core::runner::RUNNER_HOSTED_EXEC_ENV, "1");
         let warning = evaluate(
-            lab_supported_hot("agent-task dispatch/cook/run-plan"),
+            lab_supported_hot("agent-task cook/run-plan"),
             &resources(ResourceRecommendation::Hot),
         )
         .expect("hot machines warn");

--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -8,7 +8,7 @@ use crate::core::agent_task::{
     AGENT_TOOL_RESULT_SCHEMA,
 };
 use crate::core::agent_task_aggregate::AGENT_TASK_AGGREGATE_SCHEMA;
-use crate::core::agent_task_cook_loop::AGENT_TASK_COOK_LOOP_REPORT_SCHEMA;
+use crate::core::agent_task_cook_loop::AGENT_TASK_COOK_FEEDBACK_REPORT_SCHEMA;
 use crate::core::agent_task_gate::AGENT_TASK_GATE_REPORT_SCHEMA;
 use crate::core::agent_task_lifecycle::AgentTaskRunState;
 use crate::core::agent_task_loop_controller::{
@@ -69,7 +69,7 @@ pub struct AgentTaskCoreContractSchemas {
     pub tool_dispatch_evidence: String,
     pub gate_report: String,
     pub promotion_report: String,
-    pub cook_loop_report: String,
+    pub cook_feedback_report: String,
     pub loop_controller: String,
     pub loop_controller_status: String,
     pub loop_definition: String,
@@ -145,7 +145,7 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
             tool_dispatch_evidence: AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA.to_string(),
             gate_report: AGENT_TASK_GATE_REPORT_SCHEMA.to_string(),
             promotion_report: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
-            cook_loop_report: AGENT_TASK_COOK_LOOP_REPORT_SCHEMA.to_string(),
+            cook_feedback_report: AGENT_TASK_COOK_FEEDBACK_REPORT_SCHEMA.to_string(),
             loop_controller: AGENT_TASK_LOOP_CONTROLLER_SCHEMA.to_string(),
             loop_controller_status: AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA.to_string(),
             loop_definition: AGENT_TASK_LOOP_DEFINITION_SCHEMA.to_string(),

--- a/src/core/agent_task_controller_service/reports.rs
+++ b/src/core/agent_task_controller_service/reports.rs
@@ -110,9 +110,9 @@ pub struct ControllerListReport {
 
 /// Optional dispatch hook used when a `spawn_task` request asks for `"mode": "dispatch"`.
 ///
-/// The CLI adapter implements this to bridge controller-driven dispatch into the
-/// existing `agent-task dispatch` command. Callers that do not need dispatch
-/// mode can pass [`NoopDispatchHook`].
+/// The CLI adapter implements this to bridge controller-driven work into the
+/// internal dispatch service. Callers that do not need dispatch mode can pass
+/// [`NoopDispatchHook`].
 pub trait ControllerDispatchHook {
     /// Run a dispatch request and return its JSON envelope and process exit code.
     fn dispatch(&self, request: &Value) -> Result<(Value, i32)>;

--- a/src/core/agent_task_cook_loop.rs
+++ b/src/core/agent_task_cook_loop.rs
@@ -11,7 +11,8 @@ use crate::core::agent_task_gate::{
 use crate::core::agent_task_promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
 use crate::core::gate::{HomeboyGateResult, HomeboyGateStatus};
 
-pub const AGENT_TASK_COOK_LOOP_REPORT_SCHEMA: &str = "homeboy/agent-task-cook-loop-report/v1";
+pub const AGENT_TASK_COOK_FEEDBACK_REPORT_SCHEMA: &str =
+    "homeboy/agent-task-cook-feedback-report/v1";
 const RISKY_CHANGED_FILE_THRESHOLD: usize = 20;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -30,7 +31,7 @@ pub struct AgentTaskCookLoopOptions {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskCookLoopReport {
-    #[serde(default = "cook_loop_report_schema")]
+    #[serde(default = "cook_feedback_report_schema")]
     pub schema: String,
     pub status: AgentTaskCookLoopStatus,
     pub attempt: u32,
@@ -123,7 +124,7 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
     };
 
     AgentTaskCookLoopReport {
-        schema: AGENT_TASK_COOK_LOOP_REPORT_SCHEMA.to_string(),
+        schema: AGENT_TASK_COOK_FEEDBACK_REPORT_SCHEMA.to_string(),
         status,
         attempt: options.attempt,
         max_attempts: options.max_attempts,
@@ -433,8 +434,8 @@ fn worktree_root_hint(report: &AgentTaskPromotionReport) -> Option<String> {
         .map(str::to_string)
 }
 
-fn cook_loop_report_schema() -> String {
-    AGENT_TASK_COOK_LOOP_REPORT_SCHEMA.to_string()
+fn cook_feedback_report_schema() -> String {
+    AGENT_TASK_COOK_FEEDBACK_REPORT_SCHEMA.to_string()
 }
 
 #[cfg(test)]

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -33,11 +33,11 @@ pub fn build_dispatch_plan_with_provider_requirements(
     if request.prompt.is_none() && request.tasks.is_empty() && request.core.tasks_json.is_none() {
         return Err(Error::validation_invalid_argument(
             "prompt",
-            "agent-task dispatch requires --prompt, --prompt @file, --prompt -, repeated --task inputs, or --tasks @tasks.json",
+            "agent-task cook requires --prompt, --prompt @file, --prompt -, repeated --task inputs, or --tasks @tasks.json",
             None,
             Some(vec![
-                "Example: homeboy agent-task dispatch --repo sample-plugin --cwd /path/to/worktree --prompt @task.txt".to_string(),
-                "Wave input: homeboy agent-task dispatch --tasks @tasks.json --concurrency 8".to_string(),
+                "Example: homeboy agent-task cook --repo sample-plugin --cwd /path/to/worktree --to-worktree sample-plugin@fix-issue --verify 'npm test' --prompt @task.txt".to_string(),
+                "Wave input: homeboy agent-task cook --tasks @tasks.json --concurrency 8 --to-worktree sample-plugin@fix-issue --verify 'npm test'".to_string(),
             ]),
         ));
     }
@@ -163,7 +163,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 "workspace": workspace_target.as_ref().map(|target| target.metadata.clone()),
                 "task_url": request.task_url,
                 "prompt_source": prompt_spec,
-                "dispatch": "agent-task dispatch",
+                "dispatch": "agent-task cook",
                 "required_capabilities": request.required_capabilities,
             }),
         });
@@ -281,7 +281,7 @@ fn resolve_dispatch_workspace(
             return Err(Error::validation_invalid_argument(
                 "cwd",
                 format!(
-                    "agent-task dispatch workspace '{}' is not a directory",
+                    "agent-task cook workspace '{}' is not a directory",
                     path.display()
                 ),
                 Some(cwd.clone()),
@@ -304,7 +304,7 @@ fn resolve_dispatch_workspace(
         Error::validation_invalid_argument(
             "workspace",
             format!(
-                "agent-task dispatch workspace '{}' is neither an existing directory nor a Homeboy worktree record",
+                "agent-task cook workspace '{}' is neither an existing directory nor a Homeboy worktree record",
                 workspace
             ),
             Some(workspace.clone()),
@@ -409,7 +409,7 @@ fn dispatch_client_context(request: &AgentTaskDispatchRequest) -> Result<Value> 
     let context = serde_json::from_str::<Value>(&raw).map_err(|error| {
         Error::validation_invalid_json(
             error,
-            Some("agent-task dispatch client context".to_string()),
+            Some("agent-task cook client context".to_string()),
             Some(raw),
         )
     })?;
@@ -417,7 +417,7 @@ fn dispatch_client_context(request: &AgentTaskDispatchRequest) -> Result<Value> 
     if !context.is_object() {
         return Err(Error::validation_invalid_argument(
             "client-context",
-            "agent-task dispatch --client-context must resolve to a JSON object",
+            "agent-task cook --client-context must resolve to a JSON object",
             None,
             None,
         ));
@@ -432,7 +432,7 @@ fn dispatch_client_context(request: &AgentTaskDispatchRequest) -> Result<Value> 
 fn provider_config_must_be_object_error() -> Error {
     Error::validation_invalid_argument(
         "provider-config",
-        "agent-task dispatch --provider-config must resolve to a JSON object",
+        "agent-task cook --provider-config must resolve to a JSON object",
         None,
         None,
     )
@@ -450,7 +450,7 @@ fn dispatch_provider_config(
         let explicit = serde_json::from_str::<Value>(&raw).map_err(|error| {
             Error::validation_invalid_json(
                 error,
-                Some("agent-task dispatch provider config".to_string()),
+                Some("agent-task cook provider config".to_string()),
                 Some(raw),
             )
         })?;
@@ -476,7 +476,7 @@ fn dispatch_provider_config(
     if !config.is_object() {
         return Err(Error::validation_invalid_argument(
             "provider-config",
-            "agent-task dispatch --provider-config root must remain a JSON object after materializing configured refs",
+            "agent-task cook --provider-config root must remain a JSON object after materializing configured refs",
             None,
             None,
         ));
@@ -529,7 +529,7 @@ fn collect_component_contracts_from_value(
             .map_err(|error| {
                 Error::validation_invalid_argument(
                     format!("{label}.{key}"),
-                    format!("agent-task dispatch {label}.{key} must be an array of component contracts: {error}"),
+                    format!("agent-task cook {label}.{key} must be an array of component contracts: {error}"),
                     Some(raw.to_string()),
                     None,
                 )
@@ -592,7 +592,7 @@ fn read_text_spec(spec: &str, label: &str) -> Result<String> {
 
     config::read_json_spec_to_string(spec).map_err(|error| {
         Error::internal_unexpected(format!(
-            "failed to read agent-task dispatch {label} input: {error}"
+            "failed to read agent-task cook {label} input: {error}"
         ))
     })
 }
@@ -606,7 +606,7 @@ fn read_dispatch_tasks_json(spec: Option<&str>) -> Result<Vec<String>> {
     let value: Value = serde_json::from_str(&raw).map_err(|error| {
         Error::validation_invalid_json(
             error,
-            Some("agent-task dispatch tasks".to_string()),
+            Some("agent-task cook tasks".to_string()),
             Some(raw.clone()),
         )
     })?;
@@ -632,7 +632,7 @@ fn task_prompts_from_json_items(items: Vec<Value>) -> Result<Vec<String>> {
 fn invalid_tasks_json_error() -> Error {
     Error::validation_invalid_argument(
         "tasks",
-        "agent-task dispatch --tasks expects a JSON array or object with a tasks array",
+        "agent-task cook --tasks expects a JSON array or object with a tasks array",
         None,
         None,
     )
@@ -649,7 +649,7 @@ fn task_prompt_from_json_item(item: Value, index: usize) -> Result<String> {
                 Error::validation_invalid_argument(
                     "tasks",
                     format!(
-                        "agent-task dispatch task item {} must include a string prompt or instructions field",
+                        "agent-task cook task item {} must include a string prompt or instructions field",
                         index + 1
                     ),
                     None,
@@ -659,7 +659,7 @@ fn task_prompt_from_json_item(item: Value, index: usize) -> Result<String> {
         _ => Err(Error::validation_invalid_argument(
             "tasks",
             format!(
-                "agent-task dispatch task item {} must be a string or object",
+                "agent-task cook task item {} must be a string or object",
                 index + 1
             ),
             None,

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -7,7 +7,6 @@
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::core::agent_task_aggregate::AgentTaskAggregateReport;
 use crate::core::agent_task_dispatch_plan::{
     build_dispatch_plan_with_provider_requirements, preflight_dispatch_provider_secrets,
 };
@@ -38,17 +37,6 @@ pub enum BackendSelectionSource {
     Policy,
     /// Resolved from the Homeboy config `agent_task.default_backend`.
     Config,
-}
-
-impl BackendSelectionSource {
-    /// Short human label for summary/warning rendering.
-    pub fn label(self) -> &'static str {
-        match self {
-            BackendSelectionSource::Cli => "cli (--backend)",
-            BackendSelectionSource::Policy => "config (component/extension default)",
-            BackendSelectionSource::Config => "config (homeboy default)",
-        }
-    }
 }
 
 /// The effective backend plus where it came from and whether it overrides the
@@ -296,7 +284,7 @@ pub fn resolve_dispatch_request_with_default_and_config(
             let resolved = default_backend(command.repo.as_deref())?.ok_or_else(|| {
                 Error::validation_invalid_argument(
                     "backend",
-                    "agent-task dispatch requires --backend because no default backend policy is configured",
+                    "agent-task cook requires --backend because no default backend policy is configured",
                     None,
                     Some(vec![
                         "Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.".to_string(),
@@ -348,30 +336,6 @@ pub fn resolve_dispatch_request_with_default_and_config(
     })
 }
 
-/// Render a human-readable, single-line-per-field backend selection summary for
-/// the command adapter to print to stderr before dispatch (#5685). Kept in the
-/// service so the wording stays consistent across cook and dispatch surfaces.
-pub fn render_backend_selection_summary(selection: &BackendSelection) -> String {
-    let mut lines = vec![
-        "agent-task backend selection:".to_string(),
-        format!("  backend: {}", selection.backend),
-        format!("  source:  {}", selection.source.label()),
-    ];
-    match selection.default_backend.as_deref() {
-        Some(default) => lines.push(format!("  default: {default}")),
-        None => lines.push("  default: <none configured>".to_string()),
-    }
-    if selection.overrides_default {
-        if let Some(default) = selection.default_backend.as_deref() {
-            lines.push(format!(
-                "  warning: --backend '{}' overrides the configured default '{}'",
-                selection.backend, default
-            ));
-        }
-    }
-    lines.join("\n")
-}
-
 /// Run a dispatch invocation end to end: resolve the request, dispatch it through
 /// the scheduler, and adapt the report into a JSON value plus process exit code.
 pub fn run_dispatch_command<E>(
@@ -398,145 +362,8 @@ where
     Ok((command_json_value(result.value)?, result.exit_code))
 }
 
-/// Run a cook invocation: dispatch the request and attach the cook handoff
-/// envelope describing the patch-artifact boundary and promotion next actions.
-pub fn run_cook_command<E>(command: AgentTaskDispatchCommand, executor: E) -> Result<(Value, i32)>
-where
-    E: AgentTaskExecutorAdapter,
-{
-    let catalog = AgentTaskProviderCatalog::discover();
-    run_cook_command_with_provider_catalog(command, executor, &catalog)
-}
-
-pub fn run_cook_command_with_provider_catalog<E>(
-    command: AgentTaskDispatchCommand,
-    executor: E,
-    catalog: &AgentTaskProviderCatalog,
-) -> Result<(Value, i32)>
-where
-    E: AgentTaskExecutorAdapter,
-{
-    let target_worktree = command.workspace.clone();
-    let (mut value, exit_code) =
-        run_dispatch_command_with_provider_catalog(command, executor, catalog)?;
-    value["handoff"] = cook_handoff(&value, target_worktree.as_deref());
-    Ok((value, exit_code))
-}
-
 fn command_json_value<T: Serialize>(value: T) -> Result<Value> {
     serde_json::to_value(value).map_err(|error| Error::internal_json(error.to_string(), None))
-}
-
-fn cook_handoff(value: &Value, to_worktree: Option<&str>) -> Value {
-    let run_id = value["run_id"].as_str().unwrap_or("<run-id>");
-    let run_command = agent_task_run_command(value, run_id);
-    let run_next_command = agent_task_run_next_command(value);
-    let aggregate_path = value["aggregate_path"].as_str().unwrap_or(run_id);
-    let aggregate_review = value
-        .get("aggregate")
-        .and_then(|aggregate| serde_json::from_value::<AgentTaskAggregate>(aggregate.clone()).ok())
-        .map(|aggregate| AgentTaskAggregateReport::from(aggregate.outcomes))
-        .unwrap_or_else(|| AgentTaskAggregateReport::from(Vec::new()));
-    let promotion_commands =
-        cook_promotion_commands(aggregate_path, to_worktree, &aggregate_review);
-    let patch_artifact_produced = !promotion_commands.is_empty();
-    let mut next_actions = Vec::new();
-
-    if patch_artifact_produced {
-        next_actions.push("patch artifact produced; promote one candidate before claiming worktree changes or PR completion".to_string());
-        if to_worktree.is_some() {
-            next_actions.push(
-                "run one `promote_commands` entry to apply the patch into the target worktree"
-                    .to_string(),
-            );
-        } else {
-            next_actions.push(format!(
-                "run `homeboy agent-task review {run_id} --to-worktree <handle>` to generate exact promote commands"
-            ));
-        }
-        next_actions.push(format!(
-            "after promotion and verification, run `homeboy agent-task finalize-pr --run-id {run_id} --path <promoted-worktree-path> --title <title> --commit-message <message>`"
-        ));
-    } else if value["queued"].as_bool().unwrap_or(false) {
-        next_actions.push(format!(
-            "queued only; run `{run_command}` or let a daemon claim it with `{run_next_command}`"
-        ));
-    } else {
-        next_actions.push("no patch artifact was produced; inspect `aggregate` candidates before retrying or reporting".to_string());
-    }
-
-    serde_json::json!({
-        "schema": "homeboy/agent-task-cook-handoff/v1",
-        "states": {
-            "patch_artifact_produced": patch_artifact_produced,
-            "patch_promoted": false,
-            "pr_opened": false
-        },
-        "boundary": if value["queued"].as_bool().unwrap_or(false) {
-            "queued"
-        } else if patch_artifact_produced {
-            "patch_artifact_only"
-        } else {
-            "no_patch_artifact"
-        },
-        "promote_commands": promotion_commands,
-        "finalize_command": format!(
-            "homeboy agent-task finalize-pr --run-id {run_id} --path <promoted-worktree-path> --title <title> --commit-message <message>"
-        ),
-        "next_actions": next_actions
-    })
-}
-
-fn agent_task_run_command(value: &Value, run_id: &str) -> String {
-    match value
-        .pointer("/record/metadata/runner_id")
-        .and_then(Value::as_str)
-        .filter(|runner_id| !runner_id.trim().is_empty())
-    {
-        Some(runner_id) => format!("homeboy --runner {runner_id} agent-task run {run_id}"),
-        None => format!("homeboy agent-task run {run_id}"),
-    }
-}
-
-fn agent_task_run_next_command(value: &Value) -> String {
-    match value
-        .pointer("/record/metadata/runner_id")
-        .and_then(Value::as_str)
-        .filter(|runner_id| !runner_id.trim().is_empty())
-    {
-        Some(runner_id) => format!("homeboy --runner {runner_id} agent-task run-next"),
-        None => "homeboy agent-task run-next".to_string(),
-    }
-}
-
-fn cook_promotion_commands(
-    source: &str,
-    to_worktree: Option<&str>,
-    review: &AgentTaskAggregateReport,
-) -> Vec<Vec<String>> {
-    review
-        .apply_candidates
-        .iter()
-        .flat_map(|candidate| {
-            candidate.artifact_ids.iter().map(move |artifact_id| {
-                let mut command = vec![
-                    "homeboy".to_string(),
-                    "agent-task".to_string(),
-                    "promote".to_string(),
-                    source.to_string(),
-                    "--task-id".to_string(),
-                    candidate.task_id.clone(),
-                    "--artifact-id".to_string(),
-                    artifact_id.clone(),
-                ];
-                if let Some(to_worktree) = to_worktree {
-                    command.push("--to-worktree".to_string());
-                    command.push(to_worktree.to_string());
-                }
-                command
-            })
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -610,51 +437,5 @@ mod tests {
         assert_eq!(selection.source, BackendSelectionSource::Policy);
         // Default-policy selections never count as an explicit override.
         assert!(!selection.overrides_default);
-    }
-
-    #[test]
-    fn summary_includes_override_warning_only_for_cli_override() {
-        let override_selection = BackendSelection {
-            backend: "claude-code".to_string(),
-            source: BackendSelectionSource::Cli,
-            default_backend: Some("opencode".to_string()),
-            overrides_default: true,
-        };
-        let summary = render_backend_selection_summary(&override_selection);
-        assert!(summary.contains("backend: claude-code"));
-        assert!(summary.contains("cli (--backend)"));
-        assert!(summary.contains("warning:"));
-        assert!(summary.contains("overrides the configured default 'opencode'"));
-
-        let default_selection = BackendSelection {
-            backend: "opencode".to_string(),
-            source: BackendSelectionSource::Config,
-            default_backend: Some("opencode".to_string()),
-            overrides_default: false,
-        };
-        let summary = render_backend_selection_summary(&default_selection);
-        assert!(!summary.contains("warning:"));
-    }
-
-    #[test]
-    fn queued_cook_handoff_uses_recorded_runner_context() {
-        let handoff = cook_handoff(
-            &serde_json::json!({
-                "run_id": "agent-task-queued",
-                "queued": true,
-                "record": {
-                    "metadata": {
-                        "runner_id": "homeboy-lab"
-                    }
-                }
-            }),
-            None,
-        );
-
-        let next_action = handoff["next_actions"][0].as_str().expect("next action");
-        assert!(
-            next_action.contains("homeboy --runner homeboy-lab agent-task run agent-task-queued")
-        );
-        assert!(next_action.contains("homeboy --runner homeboy-lab agent-task run-next"));
     }
 }

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -768,7 +768,7 @@ where
                         0,
                     ));
                 }
-                let finalization = finalize_loop_pr(&options, &cook_id, &promotion)?;
+                let finalization = finalize_cook_pr(&options, &cook_id, &promotion)?;
                 let final_status = finalization["status"]
                     .as_str()
                     .unwrap_or("unknown")
@@ -1081,7 +1081,7 @@ fn promote_attempt(
     })
 }
 
-fn finalize_loop_pr(
+fn finalize_cook_pr(
     options: &AgentTaskCookServiceOptions,
     cook_id: &str,
     promotion: &AgentTaskPromotionReport,

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -170,7 +170,7 @@ pub mod controller_service {
 pub mod cook_loop {
     pub use super::super::agent_task_cook_loop::{
         evaluate_cook_loop, AgentTaskCookLoopGateFailure, AgentTaskCookLoopOptions,
-        AgentTaskCookLoopReport, AgentTaskCookLoopStatus, AGENT_TASK_COOK_LOOP_REPORT_SCHEMA,
+        AgentTaskCookLoopReport, AgentTaskCookLoopStatus, AGENT_TASK_COOK_FEEDBACK_REPORT_SCHEMA,
     };
 }
 
@@ -193,8 +193,7 @@ pub mod dispatch_service {
     };
     pub use super::super::agent_task_dispatch_service::{
         dispatch, dispatch_with_provider_requirements, resolve_dispatch_request,
-        resolve_dispatch_request_with_default, run_cook_command,
-        run_cook_command_with_provider_catalog, run_dispatch_command,
+        resolve_dispatch_request_with_default, run_dispatch_command,
         run_dispatch_command_with_provider_catalog, AgentTaskDispatchCommand,
         AgentTaskDispatchReport, AgentTaskDispatchRequest, DispatchCoreInputs,
         DISPATCH_RESULT_SCHEMA,

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -537,7 +537,7 @@ fn agent_task_run_plan_recording_args(args: &[String]) -> Option<(String, String
 
 pub(super) fn agent_task_dispatch_requested_run_id(args: &[String]) -> Option<String> {
     let invocation = CommandInvocation::for_subcommand(args, "agent-task")?;
-    let action_index = invocation.child_index_matching(&["dispatch", "cook"])?;
+    let action_index = invocation.child_index_matching(&["cook"])?;
     invocation
         .option_value_after(action_index, "--run-id")
         .map(str::to_string)
@@ -556,7 +556,7 @@ pub(super) fn ensure_agent_task_dispatch_run_id_with(
     preferred: Option<&str>,
 ) -> Option<(Vec<String>, String)> {
     let invocation = CommandInvocation::for_subcommand(args, "agent-task")?;
-    let action_index = invocation.child_index_matching(&["dispatch", "cook"])?;
+    let action_index = invocation.child_index_matching(&["cook"])?;
 
     if let Some(run_id) = agent_task_dispatch_requested_run_id(args) {
         return Some((args.to_vec(), run_id));
@@ -572,10 +572,10 @@ pub(super) fn ensure_agent_task_dispatch_run_id_with(
     Some((out, run_id))
 }
 
-/// Resolves the stable per-run isolation token for an agent-task `dispatch`/`cook`
-/// offload: the explicit `--run-id` when provided, otherwise a freshly generated
-/// run id. Returns `None` for non-dispatch/cook invocations (which already use
-/// unique snapshot workspaces and need no extra isolation).
+/// Resolves the stable per-run isolation token for an agent-task cook offload:
+/// the explicit `--run-id` when provided, otherwise a freshly generated run id.
+/// Returns `None` for other invocations, which already use unique snapshot
+/// workspaces and need no extra isolation.
 pub(super) fn agent_task_dispatch_run_isolation_token(args: &[String]) -> Option<String> {
     if let Some(run_id) = agent_task_dispatch_requested_run_id(args) {
         return Some(run_id);

--- a/src/core/runner/lab/args_util.rs
+++ b/src/core/runner/lab/args_util.rs
@@ -104,32 +104,27 @@ mod tests {
     fn command_invocation_reads_flag_value_forms() {
         let cases = [
             (
-                args(&["homeboy", "agent-task", "dispatch", "--run-id", "abc"]),
+                args(&["homeboy", "agent-task", "cook", "--run-id", "abc"]),
                 Some("abc"),
             ),
             (
-                args(&["homeboy", "agent-task", "dispatch", "--run-id=abc"]),
+                args(&["homeboy", "agent-task", "cook", "--run-id=abc"]),
                 Some("abc"),
             ),
+            (args(&["homeboy", "agent-task", "cook", "--run-id"]), None),
             (
-                args(&["homeboy", "agent-task", "dispatch", "--run-id"]),
+                args(&["homeboy", "agent-task", "cook", "--run-id", "--other"]),
                 None,
             ),
             (
-                args(&["homeboy", "agent-task", "dispatch", "--run-id", "--other"]),
-                None,
-            ),
-            (
-                args(&["homeboy", "agent-task", "dispatch", "--", "--run-id", "abc"]),
+                args(&["homeboy", "agent-task", "cook", "--", "--run-id", "abc"]),
                 None,
             ),
         ];
 
         for (input, expected) in cases {
             let invocation = CommandInvocation::for_subcommand(&input, "agent-task").unwrap();
-            let action_index = invocation
-                .child_index_matching(&["dispatch", "cook"])
-                .unwrap();
+            let action_index = invocation.child_index_matching(&["cook"]).unwrap();
             assert_eq!(
                 invocation.option_value_after(action_index, "--run-id"),
                 expected
@@ -139,11 +134,9 @@ mod tests {
 
     #[test]
     fn arg_editor_inserts_after_subcommand_child() {
-        let input = args(&["homeboy", "agent-task", "dispatch", "--repo", "homeboy"]);
+        let input = args(&["homeboy", "agent-task", "cook", "--repo", "homeboy"]);
         let invocation = CommandInvocation::for_subcommand(&input, "agent-task").unwrap();
-        let action_index = invocation
-            .child_index_matching(&["dispatch", "cook"])
-            .unwrap();
+        let action_index = invocation.child_index_matching(&["cook"]).unwrap();
 
         let edited = ArgEditor::new(&input)
             .insert_after(
@@ -157,7 +150,7 @@ mod tests {
             args(&[
                 "homeboy",
                 "agent-task",
-                "dispatch",
+                "cook",
                 "--run-id",
                 "generated",
                 "--repo",
@@ -168,7 +161,7 @@ mod tests {
 
     #[test]
     fn command_invocation_detects_subcommand_before_passthrough_only() {
-        let input = args(&["homeboy", "lab", "exec", "--", "agent-task", "dispatch"]);
+        let input = args(&["homeboy", "lab", "exec", "--", "agent-task", "cook"]);
 
         assert_eq!(
             CommandInvocation::for_subcommand(&input, "lab")

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -3357,7 +3357,7 @@ mod tests {
     fn non_release_gate_command_keeps_allow_local_hot_bypass() {
         // Non-gate portable commands (e.g. agent-task) keep the existing
         // --force-hot --allow-local-hot bypass behavior.
-        let command = portable_lab_command("agent-task dispatch/cook/run-plan");
+        let command = portable_lab_command("agent-task cook/run-plan");
 
         assert!(resolve_lab_runner_selection_from_default(
             &command,

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -1,6 +1,6 @@
 //! AgentTask provider preflight for Lab offload.
 //!
-//! Before dispatching an `agent-task dispatch`/`cook`/`loop` command to a Lab
+//! Before dispatching an `agent-task cook` command to a Lab
 //! runner, Homeboy verifies that the requested executor backend/selector is
 //! actually selectable *on that runner* — not just locally. This module owns
 //! that command-specific bridge end to end:

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -54,16 +54,12 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
             "refactor",
         ),
         (
-            parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"]),
-            "agent-task dispatch/cook/run-plan",
-        ),
-        (
             parsed_command(&["homeboy", "agent-task", "cook", "--prompt", "cook"]),
-            "agent-task dispatch/cook/run-plan",
+            "agent-task cook/run-plan",
         ),
         (
             parsed_command(&["homeboy", "agent-task", "run-plan", "--plan", "@plan.json"]),
-            "agent-task dispatch/cook/run-plan",
+            "agent-task cook/run-plan",
         ),
         (
             parsed_command(&["homeboy", "agent-task", "retry", "agent-task-123", "--run"]),
@@ -219,7 +215,7 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
     assert_eq!(
         lab_runner_supported_labels().as_slice(),
         &[
-            "agent-task dispatch/cook/run-plan",
+            "agent-task cook/run-plan",
             "agent-task controller from-spec --resume/materialize/resume",
             "agent-task retry --run",
             "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
@@ -316,7 +312,6 @@ fn test_supports_lab_runner() {
     ]);
     assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
     assert!(cli.command.supports_lab_runner());
-
     let cli = parsed_cli(&["homeboy", "lint", "--runner", "lab-a"]);
     assert_eq!(cli.runner.as_deref(), Some("lab-a"));
     assert!(cli.command.supports_lab_runner());
@@ -425,11 +420,21 @@ fn test_lab_command_contracts_cover_hot_commands() {
             .release_gate
     );
     assert!(
-        !parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"])
-            .lab_contract()
-            .expect("agent-task contract")
-            .routing_policy
-            .release_gate
+        !parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--to-worktree",
+            "homeboy@smoke",
+            "--verify",
+            "true",
+            "--prompt",
+            "cook",
+        ])
+        .lab_contract()
+        .expect("agent-task contract")
+        .routing_policy
+        .release_gate
     );
 
     for args in [
@@ -643,7 +648,17 @@ fn agent_task_git_checkout_policy_uses_default_backend_when_backend_is_omitted()
 
 #[test]
 fn agent_task_git_checkout_policy_keeps_non_cwd_dispatch_snapshot_eligible() {
-    let command = parsed_command(&["homeboy", "agent-task", "cook", "--prompt", "cook"]);
+    let command = parsed_command(&[
+        "homeboy",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "homeboy@smoke",
+        "--verify",
+        "true",
+        "--prompt",
+        "cook",
+    ]);
     let Commands::AgentTask(args) = command else {
         panic!("expected agent-task command");
     };
@@ -660,7 +675,11 @@ fn agent_task_git_checkout_policy_treats_workspace_like_cwd() {
     let command = parsed_command(&[
         "homeboy",
         "agent-task",
-        "dispatch",
+        "cook",
+        "--to-worktree",
+        "homeboy@smoke",
+        "--verify",
+        "true",
         "--workspace",
         "/work/repo",
         "--prompt",
@@ -693,6 +712,59 @@ fn agent_task_loop_status_is_durable_controller_surface_not_cook_dispatch() {
         parsed_command(&["homeboy", "agent-task", "loop", "status", "site-loop"])
             .lab_contract()
             .is_none()
+    );
+}
+
+#[test]
+fn agent_task_git_checkout_policy_covers_cook_dispatch_workspace() {
+    let command = parsed_command(&[
+        "homeboy",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "homeboy@smoke",
+        "--verify",
+        "true",
+        "--cwd",
+        "/work/repo",
+        "--backend",
+        "generic-patch-provider",
+        "--selector",
+        "selected",
+        "--prompt",
+        "cook",
+    ]);
+    let Commands::AgentTask(ref args) = command else {
+        panic!("expected agent-task command");
+    };
+
+    assert!(!agent_task_provider_requires_cwd_git_checkout_with(
+        &args.command,
+        || Some("default-patch-provider".to_string()),
+        |backend, _| backend == "default-patch-provider",
+    ));
+    assert_eq!(
+        parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--to-worktree",
+            "homeboy@smoke",
+            "--verify",
+            "true",
+            "--cwd",
+            "/work/repo",
+            "--backend",
+            "generic-patch-provider",
+            "--selector",
+            "selected",
+            "--prompt",
+            "cook",
+        ])
+        .lab_contract()
+            .expect("agent-task cook contract")
+            .workspace_mode_policy,
+        LabWorkspaceModePolicy::GitCheckoutRequired
     );
 }
 

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -580,15 +580,26 @@ fn test_lab_command_contracts_cover_hot_commands() {
 
     for args in [
         ["homeboy", "audit", "--changed-since", "origin/main"].as_slice(),
-        ["homeboy", "lint", "--changed-since", "origin/main"].as_slice(),
-        ["homeboy", "lint", "--changed-only"].as_slice(),
-        ["homeboy", "test", "--changed-since", "origin/main"].as_slice(),
         ["homeboy", "review", "--changed-since", "origin/main"].as_slice(),
         ["homeboy", "review", "--changed-only"].as_slice(),
     ] {
         parsed_command(args)
             .lab_contract()
             .expect("scoped hot command should have a Lab plan contract");
+    }
+
+    for args in [
+        ["homeboy", "lint", "--changed-since", "origin/main"].as_slice(),
+        ["homeboy", "lint", "--changed-only"].as_slice(),
+        ["homeboy", "test", "--changed-since", "origin/main"].as_slice(),
+    ] {
+        let contract = parsed_command(args)
+            .lab_contract()
+            .expect("scoped hot command should have a Lab plan contract");
+        assert!(matches!(
+            contract.portability,
+            LabCommandPortability::Portable
+        ));
     }
 
     assert!(parsed_command(&["homeboy", "status"])

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -762,8 +762,8 @@ fn agent_task_git_checkout_policy_covers_cook_dispatch_workspace() {
             "cook",
         ])
         .lab_contract()
-            .expect("agent-task cook contract")
-            .workspace_mode_policy,
+        .expect("agent-task cook contract")
+        .workspace_mode_policy,
         LabWorkspaceModePolicy::GitCheckoutRequired
     );
 }

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -64,8 +64,7 @@ fn agent_task_dispatch_is_not_public_cli_surface() {
     let surface = current_command_surface();
 
     assert!(!surface.contains_path(&["agent-task", "dispatch"]));
-    assert!(Cli::try_parse_from(["homeboy", "agent-task", "dispatch", "--prompt", "x"])
-        .is_err());
+    assert!(Cli::try_parse_from(["homeboy", "agent-task", "dispatch", "--prompt", "x"]).is_err());
 }
 
 #[test]

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -51,6 +51,8 @@ fn agent_task_prompt_store_commands_parse() {
         "cook",
         "--repo",
         "homeboy",
+        "--to-worktree",
+        "homeboy@prompt-ref-test",
         "--prompt",
         "prompt:issue-123",
         "--verify",

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -48,11 +48,24 @@ fn agent_task_prompt_store_commands_parse() {
     Cli::try_parse_from([
         "homeboy",
         "agent-task",
-        "dispatch",
+        "cook",
+        "--repo",
+        "homeboy",
         "--prompt",
         "prompt:issue-123",
+        "--verify",
+        "homeboy test homeboy",
     ])
-    .expect("stored prompt refs should parse as prompt values");
+    .expect("stored prompt refs should parse as cook prompt values");
+}
+
+#[test]
+fn agent_task_dispatch_is_not_public_cli_surface() {
+    let surface = current_command_surface();
+
+    assert!(!surface.contains_path(&["agent-task", "dispatch"]));
+    assert!(Cli::try_parse_from(["homeboy", "agent-task", "dispatch", "--prompt", "x"])
+        .is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Make `agent-task cook` the visible one-shot workflow that dispatches, promotes, gates, retries, and finalizes PRs.
- Remove public `agent-task dispatch` and old one-shot `agent-task loop` command variants, plus the legacy lightweight cook handoff path.
- Rename the one-shot cook report/contract output to `homeboy/agent-task-cook/v1` with `cook_id`, and move gate feedback schema wording away from cook-loop terminology.
- Update Lab command contracts, local fanout warnings, tests, and docs to teach cook as the public workflow while keeping controller loop terminology for durable loop controllers.

Closes #5929

## Verification
- `rustfmt` on touched Rust files
- `git diff --check`
- Source searches confirm no public `AgentTaskCommand::Dispatch` / `AgentTaskCommand::Loop` variants or `agent-task dispatch` / one-shot `agent-task loop` docs/tests remain, excluding historical changelog entries.

Local Rust build/tests were not run because this environment is configured to avoid local cargo/Rust-heavy verification.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Drafted implementation, tests, docs, and verification notes.