### PR TITLE
fix(core): remove playground/codebox ecosystem leaks from core

### DIFF
--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -907,18 +907,17 @@ pub(crate) fn self_check_output_is_harness_failure(
     }
 
     let combined = format!("{}\n{}", stdout, stderr).to_lowercase();
+    // Core matches only ecosystem-agnostic markers: generic shell/harness
+    // wiring failures plus the shared neutral infra markers. Ecosystem-specific
+    // failure signatures (interpreter crashes, bootstrap script paths, etc.)
+    // must be detected by the extension that owns that ecosystem, not here.
     [
         "runner-steps.sh",
         "no such file or directory",
         "command not found",
-        "playground bootstrap helper not found",
-        "playground php crash",
-        "bootstrap failure:",
-        "test harness infrastructure failure",
-        "lint runner infrastructure failure",
-        "failed opening required '/homeboy-extension/scripts/lib/playground-bootstrap.php'",
     ]
     .iter()
+    .chain(extension::GENERIC_INFRASTRUCTURE_FAILURE_MARKERS.iter())
     .any(|needle| combined.contains(needle))
 }
 
@@ -1620,10 +1619,12 @@ mod tests {
     }
 
     #[test]
-    fn self_check_output_is_harness_failure_detects_playground_bootstrap_fatal() {
+    fn self_check_output_is_harness_failure_detects_generic_infra_marker() {
+        // Core only recognizes ecosystem-agnostic infra markers at exit 1.
+        // Ecosystem-specific signatures are detected by the owning extension.
         assert!(self_check_output_is_harness_failure(
             1,
-            "Fatal error: Failed opening required '/homeboy-extension/scripts/lib/playground-bootstrap.php'",
+            "lint runner infrastructure failure",
             ""
         ));
     }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -97,7 +97,7 @@ pub use runner::{ExtensionRunner, RunnerOutput};
 pub use runner_contract::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, ExtensionPhaseTiming,
     PhaseFailure, PhaseFailureCategory, PhaseReport, PhaseStatus, RunnerStepFilter,
-    VerificationPhase,
+    VerificationPhase, GENERIC_INFRASTRUCTURE_FAILURE_MARKERS,
 };
 pub use runtime_helper::{
     helper_path, BASH_PREFLIGHT_ENV, COMMAND_CAPTURE_ENV, RUNNER_PRELUDE_ENV, RUNNER_STEPS_ENV,

--- a/src/core/extension/runner_contract.rs
+++ b/src/core/extension/runner_contract.rs
@@ -2,6 +2,21 @@ use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
+/// Generic, ecosystem-agnostic markers that indicate a runner failed because of
+/// its own infrastructure (missing harness wrapper, bootstrap aborted, etc.)
+/// rather than because the component under test had findings.
+///
+/// Core only knows these vocabulary-neutral phrases. Any ecosystem- or
+/// product-specific failure signatures (e.g. a particular interpreter crash or
+/// a bootstrap script path) are the responsibility of the extension that owns
+/// that ecosystem — core must not branch on them. Detection of those belongs
+/// in the extension's own runner output, not in this list.
+pub const GENERIC_INFRASTRUCTURE_FAILURE_MARKERS: &[&str] = &[
+    "bootstrap failure:",
+    "test harness infrastructure failure",
+    "lint runner infrastructure failure",
+];
+
 /// Shared verification phase vocabulary for isolated commands and composed runners.
 ///
 /// `homeboy lint`, `homeboy audit`, and `homeboy test` stay independent. A

--- a/src/core/release/planning_quality.rs
+++ b/src/core/release/planning_quality.rs
@@ -254,16 +254,12 @@ fn is_runner_infrastructure_failure(output: &extension::RunnerOutput) -> bool {
     }
 
     let combined = format!("{}\n{}", output.stdout, output.stderr).to_lowercase();
-    [
-        "playground bootstrap helper not found",
-        "playground php crash",
-        "bootstrap failure:",
-        "test harness infrastructure failure",
-        "lint runner infrastructure failure",
-        "failed opening required '/homeboy-extension/scripts/lib/playground-bootstrap.php'",
-    ]
-    .iter()
-    .any(|needle| combined.contains(needle))
+    // Core only matches ecosystem-agnostic infra markers. Ecosystem-specific
+    // failure signatures must be detected by the extension that owns that
+    // ecosystem, not hardcoded here.
+    extension::GENERIC_INFRASTRUCTURE_FAILURE_MARKERS
+        .iter()
+        .any(|needle| combined.contains(needle))
 }
 
 #[cfg(test)]
@@ -496,12 +492,10 @@ mod tests {
     }
 
     #[test]
-    fn code_quality_failure_message_detects_pre_runner_playground_fatal_output() {
-        let output = runner_output(
-            1,
-            "Fatal error: Uncaught Error: Failed opening required '/homeboy-extension/scripts/lib/playground-bootstrap.php'",
-            "",
-        );
+    fn code_quality_failure_message_detects_generic_infra_marker_at_exit_one() {
+        // Core only recognizes ecosystem-agnostic infra markers. Ecosystem-specific
+        // failure signatures are detected by the owning extension, not here.
+        let output = runner_output(1, "test harness infrastructure failure", "");
 
         assert!(is_runner_infrastructure_failure(&output));
         assert_eq!(


### PR DESCRIPTION
Core must stay ecosystem-agnostic. Removes hardcoded Playground/PHP-specific failure-detection literals from `is_runner_infrastructure_failure` (`release/planning_quality.rs`) and the matching list in `extension/lint/run.rs`.

## Approach (route b, with a small shared-constant refactor)
- Added `GENERIC_INFRASTRUCTURE_FAILURE_MARKERS` to `extension/runner_contract.rs` — a single, vocabulary-neutral list of infra-failure needles (`bootstrap failure:`, `test harness infrastructure failure`, `lint runner infrastructure failure`), re-exported from `extension`.
- Both detection sites now match only generic markers. `extension/lint/run.rs` keeps its generic shell/harness needles (`runner-steps.sh`, `no such file or directory`, `command not found`) and chains the shared list.
- Dropped the ecosystem-specific literals (`playground bootstrap helper not found`, `playground php crash`, `failed opening required '/homeboy-extension/scripts/lib/playground-bootstrap.php'`).
- Updated the two test fixtures that asserted playground-string detection to assert generic infra-marker detection at exit code 1 instead.

Infrastructure-failure detection for a specific ecosystem should be extension-driven (the extension that owns that ecosystem supplies its own failure signatures), not core-hardcoded. The doc comment on the new constant notes this. A future extension contract can carry extension-declared infra markers; this PR removes the core leak without that larger plumbing.

## Verification
- `cargo build --lib` PASS
- `cargo clippy --lib --all-targets 2>&1 | grep ^error` -> empty
- `cargo fmt` clean
- `grep -rn 'playground\|codebox' src/core/release/planning_quality.rs src/core/extension/lint/run.rs` -> no matches