### PR TITLE
chore(audit): guard against playground/codebox leaks in core

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -184,7 +184,9 @@
           "src/core/cleanup.rs",
           "src/core/cleanup/self_artifacts.rs",
           "src/core/runner/lab_args/tests.rs",
-          "src/core/release/executor/lockfile_guard.rs"
+          "src/core/release/executor/lockfile_guard.rs",
+          "src/core/triage/tests.rs",
+          "src/core/extension/bench/baseline.rs"
         ],
         "id": "core-agnostic-source",
         "ignore_after_line_equals": [
@@ -286,6 +288,20 @@
           {
             "match_mode": "literal",
             "value": "Action Scheduler"
+          },
+          {
+            "value": "playground"
+          },
+          {
+            "value": "codebox"
+          },
+          {
+            "match_mode": "literal",
+            "value": "wp-codebox"
+          },
+          {
+            "match_mode": "literal",
+            "value": "wpcom-codebox"
           }
         ],
         "type": "forbidden_terms"


### PR DESCRIPTION
Adds `playground`, `codebox`, `wp-codebox`, `wpcom-codebox` to the core-agnostic-source detector's forbidden-terms list so the audit gate catches any future ecosystem-specific product leaks into homeboy core.

Regression guard for the leaks removed in #5947 (hardcoded Playground/PHP failure-detection strings). Test fixtures in triage/tests.rs and bench/baseline.rs are excluded; generated_artifacts.rs fixtures are already ignored via the #[cfg(test)] gate.