### PR TITLE
fix(lab): remap absolute file argv before dispatch

### DIFF
--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -118,12 +118,33 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
         if arg.starts_with("--output=") || arg.starts_with("--artifact-root=") {
             continue;
         }
-        stripped.push(arg.clone());
+        stripped.push(remap_lab_offload_arg(arg, &ordered));
     }
     if !has_force_hot {
         stripped.insert(1, "--force-hot".to_string());
     }
     stripped
+}
+
+fn remap_lab_offload_arg(arg: &str, mappings: &[&LabPathRemap]) -> String {
+    if let Some(raw_path) = arg.strip_prefix('@') {
+        return remap_local_path(raw_path, mappings)
+            .map(|remapped| format!("@{remapped}"))
+            .unwrap_or_else(|| arg.to_string());
+    }
+
+    if let Some((prefix, value)) = arg.split_once('=') {
+        if let Some(raw_path) = value.strip_prefix('@') {
+            return remap_local_path(raw_path, mappings)
+                .map(|remapped| format!("{prefix}=@{remapped}"))
+                .unwrap_or_else(|| arg.to_string());
+        }
+        return remap_local_path(value, mappings)
+            .map(|remapped| format!("{prefix}={remapped}"))
+            .unwrap_or_else(|| arg.to_string());
+    }
+
+    remap_local_path(arg, mappings).unwrap_or_else(|| arg.to_string())
 }
 
 pub(in crate::core::runner) fn rewrite_runner_resident_lab_offload_args(

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1044,6 +1044,64 @@ fn lab_args_rewrite_path_prefers_more_specific_duplicate_local_mapping() {
 }
 
 #[test]
+fn lab_args_rewrite_remaps_absolute_at_file_args() {
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "controller".to_string(),
+        "materialize".to_string(),
+        "@/Users/user/Developer/wp-site-generator/.github/homeboy/controllers/static-site-generation-loop.controller.json".to_string(),
+        "--inputs=@/Users/user/Developer/wp-site-generator/.ci/site-generation-loop.controller-run-inputs.json".to_string(),
+        "--policy-result".to_string(),
+        "@/Users/user/Developer/wp-site-generator/.ci/site-generation-loop.complexity-policy-result.json".to_string(),
+    ];
+    let mappings = vec![LabPathRemap {
+        local: "/Users/user/Developer/wp-site-generator".to_string(),
+        remote: "/home/user/_lab_workspaces/wp-site-generator".to_string(),
+    }];
+
+    assert_eq!(
+        rewrite_lab_offload_args(&args, "/home/user/_lab_workspaces/wp-site-generator", &mappings),
+        vec![
+            "homeboy".to_string(),
+            "--force-hot".to_string(),
+            "agent-task".to_string(),
+            "controller".to_string(),
+            "materialize".to_string(),
+            "@/home/user/_lab_workspaces/wp-site-generator/.github/homeboy/controllers/static-site-generation-loop.controller.json".to_string(),
+            "--inputs=@/home/user/_lab_workspaces/wp-site-generator/.ci/site-generation-loop.controller-run-inputs.json".to_string(),
+            "--policy-result".to_string(),
+            "@/home/user/_lab_workspaces/wp-site-generator/.ci/site-generation-loop.complexity-policy-result.json".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn lab_args_rewrite_remaps_standalone_absolute_file_args() {
+    let args = vec![
+        "homeboy".to_string(),
+        "report".to_string(),
+        "/Users/user/Developer/project/.ci/report.json".to_string(),
+        "--config=/Users/user/Developer/project/.ci/config.json".to_string(),
+    ];
+    let mappings = vec![LabPathRemap {
+        local: "/Users/user/Developer/project".to_string(),
+        remote: "/home/user/_lab_workspaces/project".to_string(),
+    }];
+
+    assert_eq!(
+        rewrite_lab_offload_args(&args, "/home/user/_lab_workspaces/project", &mappings),
+        vec![
+            "homeboy".to_string(),
+            "--force-hot".to_string(),
+            "report".to_string(),
+            "/home/user/_lab_workspaces/project/.ci/report.json".to_string(),
+            "--config=/home/user/_lab_workspaces/project/.ci/config.json".to_string(),
+        ]
+    );
+}
+
+#[test]
 fn lab_args_materializes_relative_at_file_specs_under_remote_workspace() {
     let dir = tempfile::tempdir().expect("temp dir");
     std::fs::create_dir_all(dir.path().join(".ci")).expect("create .ci");


### PR DESCRIPTION
## Summary
- remap generic Lab offload argv entries through the controller-to-runner workspace path mapping
- handle absolute `@file` args, `--flag=@file`, standalone absolute file args, and `--flag=/absolute/file` values before remote dispatch
- add focused regression coverage for the WPSG controller materialize shape and normal absolute file args

## Testing
- `rustfmt src/core/runner/lab_args/offload.rs src/core/runner/lab_args/tests.rs`
- `git diff --check`
- Not run: Rust unit tests / `cargo test`, because this host's site rule says not to run local `cargo` commands; relying on GitHub Actions for Rust test execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Root-cause analysis, code changes, targeted test drafting, formatting/check orchestration, and PR preparation.
