### PR TITLE
fix(runner): redact command displays

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::core::error::{Error, Result};
+use crate::core::redaction::redact_argv_display;
 use crate::core::source_snapshot::SourceSnapshot;
 
 mod remote_runner;
@@ -610,7 +611,7 @@ fn active_runner_job_summary(
             .unwrap_or_else(|| "runner-daemon".to_string()),
         kind: request_metadata_string(request, "kind").unwrap_or_else(|| job.operation.clone()),
         status: job.status,
-        command: request.command.join(" "),
+        command: redact_argv_display(&request.command),
         cwd: request.cwd.clone(),
         started_at_ms,
         updated_at_ms: job.updated_at_ms,

--- a/src/core/redaction.rs
+++ b/src/core/redaction.rs
@@ -21,6 +21,7 @@ impl Default for RedactionPolicy {
                 "bearer",
                 "client_secret",
                 "cookie",
+                "credential",
                 "key",
                 "nonce",
                 "passwd",
@@ -127,6 +128,10 @@ impl RedactionPolicy {
         self.redact_json_with_key(None, value)
     }
 
+    pub fn redact_argv(&self, argv: &[String]) -> Vec<String> {
+        redact_argv_with_policy(argv, self)
+    }
+
     fn redact_json_with_key(&self, key: Option<&str>, value: &Value) -> Value {
         if key.is_some_and(|key| self.is_sensitive_key(key) || self.is_sensitive_header(key)) {
             return Value::String(self.replacement.clone());
@@ -179,6 +184,104 @@ pub fn redact_url(value: &str) -> String {
 
 pub fn redact_json(value: &Value) -> Value {
     RedactionPolicy::default().redact_json(value)
+}
+
+pub fn redact_argv(argv: &[String]) -> Vec<String> {
+    RedactionPolicy::default().redact_argv(argv)
+}
+
+pub fn redact_argv_display(argv: &[String]) -> String {
+    redact_argv(argv).join(" ")
+}
+
+fn redact_argv_with_policy(argv: &[String], policy: &RedactionPolicy) -> Vec<String> {
+    let mut redacted = Vec::with_capacity(argv.len());
+    let mut redact_next_for: Option<String> = None;
+
+    for arg in argv {
+        if let Some(flag) = redact_next_for.take() {
+            redacted.push(redact_split_flag_value(&flag, arg, policy));
+            continue;
+        }
+
+        if sensitive_whole_value_flag(arg) || sensitive_pair_value_flag(arg) {
+            redacted.push(arg.clone());
+            redact_next_for = Some(arg.clone());
+            continue;
+        }
+
+        if let Some((flag, value)) = arg.split_once('=') {
+            if sensitive_whole_value_flag(flag) {
+                redacted.push(format!("{flag}={}", policy.replacement()));
+                continue;
+            }
+            if sensitive_pair_value_flag(flag) {
+                redacted.push(format!("{flag}={}", redact_key_value_arg(value, policy)));
+                continue;
+            }
+        }
+
+        redacted.push(redact_sensitive_inline_arg(arg, policy));
+    }
+
+    redacted
+}
+
+fn redact_split_flag_value(flag: &str, value: &str, policy: &RedactionPolicy) -> String {
+    if sensitive_whole_value_flag(flag) {
+        policy.replacement().to_string()
+    } else {
+        redact_key_value_arg(value, policy)
+    }
+}
+
+fn sensitive_whole_value_flag(flag: &str) -> bool {
+    matches!(
+        normalize_flag(flag).as_str(),
+        "secret_env"
+            | "provider_auth"
+            | "provider_auth_json"
+            | "provider_auth_token"
+            | "provider_access_token"
+            | "provider_refresh_token"
+            | "access_token"
+            | "refresh_token"
+            | "api_key"
+            | "password"
+            | "token"
+    )
+}
+
+fn sensitive_pair_value_flag(flag: &str) -> bool {
+    matches!(normalize_flag(flag).as_str(), "setting" | "setting_json")
+}
+
+fn normalize_flag(flag: &str) -> String {
+    normalize_key(flag.trim_start_matches('-'))
+}
+
+fn redact_key_value_arg(value: &str, policy: &RedactionPolicy) -> String {
+    let Some((key, raw_value)) = value.split_once('=') else {
+        if let Ok(json) = serde_json::from_str::<Value>(value) {
+            return policy.redact_json(&json).to_string();
+        }
+        return redact_sensitive_inline_arg(value, policy);
+    };
+    if policy.is_sensitive_key(key) || policy.is_sensitive_header(key) {
+        return format!("{key}={}", policy.replacement());
+    }
+    if let Ok(json) = serde_json::from_str::<Value>(raw_value) {
+        return format!("{key}={}", policy.redact_json(&json));
+    }
+    format!("{key}={}", redact_sensitive_inline_arg(raw_value, policy))
+}
+
+fn redact_sensitive_inline_arg(value: &str, policy: &RedactionPolicy) -> String {
+    if looks_like_url(value) {
+        policy.redact_url(value)
+    } else {
+        policy.redact_string(value)
+    }
 }
 
 fn normalize_key(key: &str) -> String {
@@ -302,6 +405,52 @@ mod tests {
         assert_eq!(
             policy.redact_json(&json!({ "x-private": "secret" })),
             json!({ "x-private": "***" })
+        );
+    }
+
+    #[test]
+    fn redacts_sensitive_argv_split_and_equals_forms() {
+        let argv = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--setting".to_string(),
+            "api_token=abc123".to_string(),
+            "--setting=password=hunter2".to_string(),
+            "--setting-json".to_string(),
+            r#"provider={"access_token":"token-value","safe":"ok"}"#.to_string(),
+            "--setting-json".to_string(),
+            r#"{"client_secret":"client-secret","safe":"ok"}"#.to_string(),
+            r#"--setting-json={"refresh_token":"refresh-value","safe":"ok"}"#.to_string(),
+            "--secret-env".to_string(),
+            "OPENAI_API_KEY=sk-test".to_string(),
+            "--secret-env=ANTHROPIC_API_KEY=sk-ant".to_string(),
+            "--provider-auth-token".to_string(),
+            "provider-token".to_string(),
+            "--url=https://example.test/?token=query-token&ok=1".to_string(),
+        ];
+
+        assert_eq!(
+            redact_argv(&argv),
+            vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--setting".to_string(),
+                "api_token=[REDACTED]".to_string(),
+                "--setting=password=[REDACTED]".to_string(),
+                "--setting-json".to_string(),
+                r#"provider={"access_token":"[REDACTED]","safe":"ok"}"#.to_string(),
+                "--setting-json".to_string(),
+                r#"{"client_secret":"[REDACTED]","safe":"ok"}"#.to_string(),
+                r#"--setting-json={"refresh_token":"[REDACTED]","safe":"ok"}"#.to_string(),
+                "--secret-env".to_string(),
+                "[REDACTED]".to_string(),
+                "--secret-env=[REDACTED]".to_string(),
+                "--provider-auth-token".to_string(),
+                "[REDACTED]".to_string(),
+                "--url=https://example.test/?token=[REDACTED]&ok=1".to_string(),
+            ]
         );
     }
 }

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -13,6 +13,7 @@ use crate::core::execution_contract::{
 };
 use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::core::paths;
+use crate::core::redaction::redact_argv_display;
 
 use super::execution::{canonical_daemon_body, daemon_api_get, result_event_data};
 use super::{load, status, Runner, RunnerArtifactRef, RunnerTunnelMode};
@@ -553,7 +554,7 @@ fn mirror_job_run(
         started_at: ms_to_rfc3339(job.started_at_ms.unwrap_or(job.created_at_ms)),
         finished_at: job.finished_at_ms.map(ms_to_rfc3339),
         status: job_status_as_run_status(job.status).to_string(),
-        command: Some(command.join(" ")),
+        command: Some(redact_argv_display(command)),
         cwd: Some(cwd.to_string()),
         homeboy_version: None,
         git_sha: None,

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -15,7 +15,7 @@ use crate::core::api_jobs::{
 use crate::core::engine::command::CommandCaptureMetadata;
 use crate::core::engine::shell;
 use crate::core::error::{Error, ErrorCode, Result};
-use crate::core::redaction::RedactionPolicy;
+use crate::core::redaction::{redact_argv, redact_argv_display, RedactionPolicy};
 use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
 
@@ -430,12 +430,13 @@ pub fn runner_exec_failure_error(output: &RunnerExecOutput) -> Option<Error> {
         .unwrap_or("runner command exited non-zero")
         .to_string();
     let execution = serde_json::to_value(output).unwrap_or(Value::Null);
-    let command = output.argv.join(" ");
+    let command = redact_argv_display(&output.argv);
+    let redacted_argv = redact_argv(&output.argv);
     let mut details = json!({
         "runner_id": output.runner_id,
         "job_id": output.job_id,
         "remote_cwd": output.remote_cwd,
-        "command": output.argv,
+        "command": redacted_argv,
         "exit_code": output.exit_code,
         "execution": execution,
     });
@@ -718,7 +719,7 @@ fn exec_via_reverse_broker(
             runner_id: runner.id.clone(),
             dry_run: false,
             mode: RunnerExecMode::ReverseBroker,
-            argv: command,
+            argv: redact_argv(&command),
             remote_cwd: cwd,
             exit_code,
             stdout,
@@ -894,7 +895,7 @@ fn exec_via_daemon(
             runner_id: runner.id.clone(),
             dry_run: false,
             mode: RunnerExecMode::Daemon,
-            argv: command,
+            argv: redact_argv(&command),
             remote_cwd: cwd,
             exit_code,
             stdout,
@@ -981,7 +982,7 @@ fn detached_handoff_output(
             runner_id: runner.id.clone(),
             dry_run: false,
             mode,
-            argv: command,
+            argv: redact_argv(&command),
             remote_cwd: cwd,
             exit_code: 0,
             stdout,
@@ -1086,7 +1087,7 @@ fn daemon_job_wait_timeout(
     error.details["runner_id"] = Value::String(runner.id.clone());
     error.details["job_id"] = Value::String(job_id.clone());
     error.details["remote_cwd"] = Value::String(cwd.to_string());
-    error.details["command"] = json!(command);
+    error.details["command"] = json!(redact_argv(command));
     match mirrored {
         Ok(run) => {
             error.details["active_run_id"] = Value::String(run.id.clone());
@@ -2219,7 +2220,7 @@ fn exec_output(
             runner_id: runner.id.clone(),
             dry_run: false,
             mode,
-            argv: command,
+            argv: redact_argv(&command),
             remote_cwd: cwd,
             exit_code,
             stdout,
@@ -2511,7 +2512,7 @@ fn runner_exec_failure_context_hint(output: &RunnerExecOutput) -> String {
         .unwrap_or("unknown persisted run");
     format!(
         "Canonical failed command: `{}`; runner job: `{job}`; persisted run: `{run}`; contract field: `{field}`; reason: {}.",
-        context.command.join(" "),
+        redact_argv_display(&context.command),
         context.reason
     )
 }

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -22,6 +22,7 @@ use crate::command_contract::lab_runner_support_summary;
 use crate::core::agent_task_lifecycle;
 use crate::core::engine::shell;
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
+use crate::core::redaction::{redact_argv, redact_argv_display};
 use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, ErrorCode, Result};
@@ -576,7 +577,7 @@ fn run_runner_resident_lab_offload(
     plan = with_step(
         plan,
         PlanStep::ready("lab.rewrite_args", "lab.rewrite_args")
-            .inputs(PlanValues::new().json("argv", &command))
+            .inputs(PlanValues::new().json("argv", &redact_argv(&command)))
             .build(),
     );
 
@@ -595,7 +596,7 @@ fn run_runner_resident_lab_offload(
 
     eprintln!(
         "Lab offload: running runner-resident `{}` on runner `{}` in `{}`.",
-        command.join(" "),
+        redact_argv_display(&command),
         runner_id,
         runner_workspace_root
     );
@@ -983,7 +984,7 @@ fn prepare_lab_offload_workspace_stage(
     plan = with_step(
         plan,
         PlanStep::ready("lab.rewrite_args", "lab.rewrite_args")
-            .inputs(PlanValues::new().json("argv", &command))
+            .inputs(PlanValues::new().json("argv", &redact_argv(&command)))
             .build(),
     );
 
@@ -1247,7 +1248,7 @@ fn run_lab_offload_inner(
         "Lab offload preflight: source checkout `{}` at {}; active Homeboy command `{}` from runner `{}`.",
         source_path.display(),
         source_checkout_ref_display(&source_checkout),
-        command_prefix.argv.join(" "),
+        redact_argv_display(&command_prefix.argv),
         runner_id,
     );
     let capability_contract =
@@ -1367,7 +1368,7 @@ fn run_lab_offload_inner(
 
     eprintln!(
         "Lab offload: running `{}` on runner `{}` in `{}`.",
-        command.join(" "),
+        redact_argv_display(&command),
         runner_id,
         remote_cwd
     );
@@ -1632,8 +1633,8 @@ fn run_lab_offload_inner(
                 if let Some(record) = agent_task_lifecycle::record_remote_dispatch_failure(
                     agent_task_lifecycle::AgentTaskRemoteDispatchFailure {
                         identity: agent_task_lifecycle::RunDispatchIdentity { run_id, runner_id },
-                        local_command: request.normalized_args.to_vec(),
-                        remote_command: remote_command.clone(),
+                        local_command: redact_argv(request.normalized_args),
+                        remote_command: redact_argv(&remote_command),
                         remote_workspace: &remote_cwd,
                         stdout: &exec_output.stdout,
                         stderr: &exec_output.stderr,
@@ -1660,8 +1661,8 @@ fn run_lab_offload_inner(
             let record = agent_task_lifecycle::record_pre_dispatch_failure(
                 agent_task_lifecycle::AgentTaskPreDispatchFailure {
                     identity: agent_task_lifecycle::RunDispatchIdentity { run_id, runner_id },
-                    local_command: request.normalized_args.to_vec(),
-                    remote_command: remote_command.clone(),
+                    local_command: redact_argv(request.normalized_args),
+                    remote_command: redact_argv(&remote_command),
                     remote_workspace: &remote_cwd,
                     failure_message: &failure_message,
                     stdout: &exec_output.stdout,
@@ -2128,8 +2129,8 @@ fn missing_mutation_patch_error(
     exec_output: &super::super::RunnerExecOutput,
 ) -> Error {
     let flag_label = mutation_flag.unwrap_or("write");
-    let original_command = normalized_args.join(" ");
-    let remote_command = exec_output.argv.join(" ");
+    let original_command = redact_argv_display(normalized_args);
+    let remote_command = redact_argv_display(&exec_output.argv);
     let patch_artifact_id = exec_output
         .patch
         .as_ref()
@@ -2203,7 +2204,7 @@ fn append_runner_failure_context_summary(
         .unwrap_or("unknown contract field");
     stderr.push_str(&format!(
         "Lab offload failure context: command `{}` failed on runner `{}`; runner job `{job}`; persisted run `{run}`; contract field `{field}`; reason: {}.\n",
-        context.command.join(" "),
+        redact_argv_display(&context.command),
         context.runner_id,
         context.reason
     ));

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -27,6 +27,7 @@ use crate::core::agent_tasks::provider::{
     default_backend_for_component, AgentTaskExecutorProvider, ExtensionProviderAgentTaskExecutor,
 };
 use crate::core::engine::shell;
+use crate::core::redaction::redact_argv_display;
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
 
@@ -425,7 +426,7 @@ fn agent_task_provider_selection_preflight_error(
                 .as_str()
                 .unwrap_or("homeboy upgrade --force --upgrade-runner <runner>")
         ),
-        format!("Preflight command: `{}`.", command.join(" ")),
+        format!("Preflight command: `{}`.", redact_argv_display(command)),
     ];
     hints.retain(|hint| !hint.is_empty());
 

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::core::redaction::RedactionPolicy;
 use crate::core::{Error, Result};
 
 use super::execution::RUNNER_EXEC_WAIT_TIMEOUT_ENV;
@@ -255,23 +256,8 @@ fn parse_setting_pair(source: &'static str, raw: &str) -> Option<ParsedSettingAr
 }
 
 fn should_redact_setting(key: &str, value: &str) -> bool {
-    let lower_key = key.to_ascii_lowercase();
-    let lower_value = value.to_ascii_lowercase();
-    [
-        "secret",
-        "token",
-        "password",
-        "passwd",
-        "credential",
-        "authorization",
-        "auth",
-        "cookie",
-        "api_key",
-        "apikey",
-        "private_key",
-    ]
-    .iter()
-    .any(|needle| lower_key.contains(needle) || lower_value.contains(needle))
+    let policy = RedactionPolicy::default();
+    policy.is_sensitive_key(key) || policy.redact_string(value) != value
 }
 
 fn redacted_value_preview(value: &str, redacted: bool) -> String {

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::core::redaction::redact_argv_display;
+
 use crate::core::api_jobs::{ActiveRunnerJobSummary, Job, JobArtifactMetadata, JobStatus};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -259,7 +261,7 @@ impl RunnerJob {
             job_id: job.id.to_string(),
             operation: job.operation.clone(),
             status: job.status,
-            command: command.join(" "),
+            command: redact_argv_display(command),
             cwd,
             source: source.to_string(),
             lifecycle_owner: if source == "broker" {


### PR DESCRIPTION
## Summary
- redact sensitive argv values before rendering runner and lab command displays
- reuse redaction policy for lab setting previews
- add argv redaction coverage for split flags, equals flags, JSON settings, secret env, provider auth, and URL query tokens

## Verification
- `git diff --check`
- `rustfmt --check src/core/api_jobs.rs src/core/redaction.rs src/core/runner/evidence.rs src/core/runner/execution.rs src/core/runner/lab/offload.rs src/core/runner/lab/provider_preflight.rs src/core/runner/lab_env.rs src/core/runner/session.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing, verifying, committing, and preparing this PR description.