### PR TITLE
Protect remote runner secret env

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -795,10 +795,12 @@ fn reconcile_stale_jobs(durable: &mut DurableJobStore, event_retention_limit: us
             continue;
         }
         // Remote-runner jobs that are still Queued are waiting for a runner to
-        // claim them; a daemon restart does not invalidate that work, so leave
-        // them enqueued for re-claim.
+        // claim them; a daemon restart does not invalidate that work unless the
+        // non-serialized execution request carried secret env values.
         if stored.remote_runner.is_some() && stored.job.status == JobStatus::Queued {
-            continue;
+            if !remote_runner_job_has_unrecoverable_execution_env(stored) {
+                continue;
+            }
         }
 
         // Recover the real terminal status when the underlying command already
@@ -834,7 +836,11 @@ fn reconcile_stale_jobs(durable: &mut DurableJobStore, event_retention_limit: us
             continue;
         }
 
-        let reason = "daemon restarted before the job reached a terminal status".to_string();
+        let reason = if remote_runner_job_has_unrecoverable_execution_env(stored) {
+            "daemon restarted before the remote runner claimed secret execution env".to_string()
+        } else {
+            "daemon restarted before the job reached a terminal status".to_string()
+        };
         stored.job.status = JobStatus::Failed;
         stored.job.updated_at_ms = now;
         stored.job.finished_at_ms = Some(now);
@@ -866,6 +872,22 @@ fn reconcile_stale_jobs(durable: &mut DurableJobStore, event_retention_limit: us
     }
 
     next_sequence
+}
+
+fn remote_runner_job_has_unrecoverable_execution_env(stored: &StoredJob) -> bool {
+    let Some(remote_runner) = stored.remote_runner.as_ref() else {
+        return false;
+    };
+    if remote_runner.execution_request.is_some() {
+        return false;
+    }
+    remote_runner.request.secret_env_names.iter().any(|name| {
+        remote_runner
+            .request
+            .env
+            .get(name)
+            .is_some_and(|value| value == "<redacted>")
+    })
 }
 
 /// Recover a terminal job status from a recorded `Result` event when a job was
@@ -1571,6 +1593,71 @@ mod tests {
         let events = store.events(job.id).expect("events are readable");
         assert_eq!(events[0].kind, JobEventKind::Status);
         assert_eq!(events[0].data, Some(json!({ "status": "queued" })));
+    }
+
+    #[test]
+    fn remote_runner_job_secret_env_is_execution_only_not_public_or_persisted() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("durable store opens");
+        let sentinel = "homeboy-secret-sentinel-do-not-persist";
+        let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+        request
+            .env
+            .insert("RUNNER_SECRET_TOKEN".to_string(), sentinel.to_string());
+        request
+            .env
+            .insert("PUBLIC_FLAG".to_string(), "1".to_string());
+        request.secret_env_names = vec!["RUNNER_SECRET_TOKEN".to_string()];
+
+        let job = store
+            .submit_remote_runner_job(request)
+            .expect("remote runner job queues");
+
+        {
+            let inner = store.inner.lock().expect("job store mutex poisoned");
+            let stored = inner.jobs.get(&job.id).expect("job stored");
+            let remote_runner = stored.remote_runner.as_ref().expect("remote runner job");
+            assert_eq!(
+                remote_runner.request.env.get("RUNNER_SECRET_TOKEN"),
+                Some(&"<redacted>".to_string())
+            );
+            assert_eq!(
+                remote_runner
+                    .execution_request
+                    .as_ref()
+                    .expect("execution request")
+                    .env
+                    .get("RUNNER_SECRET_TOKEN"),
+                Some(&sentinel.to_string())
+            );
+        }
+
+        let persisted = fs::read_to_string(&path).expect("read durable store");
+        assert!(
+            !persisted.contains(sentinel),
+            "persisted store leaked secret"
+        );
+        assert!(persisted.contains("<redacted>"));
+
+        let reopened = JobStore::open(&path).expect("durable store reopens");
+        assert_eq!(
+            reopened.get(job.id).expect("reopened job").status,
+            JobStatus::Failed
+        );
+        assert!(reopened
+            .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
+            .expect("claim request succeeds")
+            .is_none());
+
+        let claim = store
+            .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
+            .expect("claim succeeds")
+            .expect("job is claimed");
+        assert_eq!(
+            claim.request.env.get("RUNNER_SECRET_TOKEN"),
+            Some(&sentinel.to_string())
+        );
     }
 
     #[test]

--- a/src/core/api_jobs/remote_runner.rs
+++ b/src/core/api_jobs/remote_runner.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -55,6 +55,23 @@ pub struct RemoteRunnerJobRequest {
     pub metadata: Option<Value>,
 }
 
+impl RemoteRunnerJobRequest {
+    pub(crate) fn public_metadata(&self) -> Self {
+        let mut public = self.clone();
+        let secret_env_names = self
+            .secret_env_names
+            .iter()
+            .map(String::as_str)
+            .collect::<HashSet<_>>();
+        for (name, value) in public.env.iter_mut() {
+            if secret_env_names.contains(name.as_str()) {
+                *value = "<redacted>".to_string();
+            }
+        }
+        public
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemoteRunnerJobClaim {
     pub job: Job,
@@ -88,6 +105,8 @@ pub struct RemoteRunnerJobResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct StoredRemoteRunnerJob {
+    #[serde(default, skip)]
+    pub(super) execution_request: Option<RemoteRunnerJobRequest>,
     pub(super) request: RemoteRunnerJobRequest,
 }
 
@@ -131,13 +150,17 @@ impl JobStore {
             artifacts: Vec::new(),
         };
 
+        let public_request = request.public_metadata();
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
         inner.jobs.insert(
             job.id,
             StoredJob {
                 job: job.clone(),
                 events: Vec::new(),
-                remote_runner: Some(StoredRemoteRunnerJob { request }),
+                remote_runner: Some(StoredRemoteRunnerJob {
+                    execution_request: Some(request),
+                    request: public_request,
+                }),
             },
         );
         drop(inner);
@@ -214,11 +237,14 @@ impl JobStore {
                 stored.job.claimed_by_runner_id = Some(runner_id.to_string());
                 stored.job.claimed_at_ms = Some(now);
                 stored.job.claim_expires_at_ms = Some(now.saturating_add(lease_ms));
-                let request = stored
+                let remote_runner = stored
                     .remote_runner
                     .as_ref()
-                    .expect("filtered remote runner job has request")
-                    .request
+                    .expect("filtered remote runner job has request");
+                let request = remote_runner
+                    .execution_request
+                    .as_ref()
+                    .unwrap_or(&remote_runner.request)
                     .clone();
                 claimed = Some((stored.job.id, request));
             }

--- a/src/core/daemon/remote_runner.rs
+++ b/src/core/daemon/remote_runner.rs
@@ -274,7 +274,8 @@ fn register_session(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Val
 fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
     auth.authorize(BrokerScope::Submit, None)?;
     let request: RemoteRunnerJobRequest = parse_body(body, "remote runner job request")?;
-    let job = job_store.submit_remote_runner_job(request.clone())?;
+    let public_request = request.public_metadata();
+    let job = job_store.submit_remote_runner_job(request)?;
     Ok(json!({
         "command": "api.runner.jobs.submit",
         "job": job,
@@ -282,7 +283,7 @@ fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) 
             "job": format!("/jobs/{}", job.id),
             "events": format!("/jobs/{}/events", job.id),
         },
-        "request": request,
+        "request": public_request,
     }))
 }
 

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -5,6 +5,12 @@ use crate::test_support::HomeGuard;
 
 const DAEMON_TEST_RESPONSE_LIMIT_BYTES: u64 = 64 * 1024;
 
+fn serialized_contains(value: &serde_json::Value, needle: &str) -> bool {
+    serde_json::to_string(value)
+        .expect("serialize test value")
+        .contains(needle)
+}
+
 #[test]
 fn parse_bind_addr_defaults_to_loopback_shape() {
     let addr = parse_bind_addr(DEFAULT_ADDR).expect("parse default");
@@ -454,6 +460,67 @@ fn routes_remote_runner_job_broker_lifecycle() {
     assert_eq!(finish.status_code, 200);
     assert_eq!(finish.body["endpoint"], "runner.jobs.finish");
     assert_eq!(finish.body["body"]["job"]["status"], "succeeded");
+}
+
+#[test]
+fn remote_runner_broker_redacts_secret_env_from_public_surfaces() {
+    let store = JobStore::default();
+    let sentinel = "homeboy-secret-sentinel-do-not-echo";
+    let submit = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "project_id": "extrachill",
+            "command": ["homeboy", "test", "sample-plugin"],
+            "cwd": "/home/user/Developer/sample-plugin",
+            "env": {
+                "PUBLIC_FLAG": "1",
+                "RUNNER_SECRET_TOKEN": sentinel
+            },
+            "secret_env_names": ["RUNNER_SECRET_TOKEN"]
+        })),
+        &store,
+    );
+
+    assert_eq!(submit.status_code, 200, "submit body: {}", submit.body);
+    assert!(!serialized_contains(&submit.body, sentinel));
+    assert_eq!(
+        submit.body["body"]["request"]["env"]["RUNNER_SECRET_TOKEN"],
+        "<redacted>"
+    );
+    let job_id = submit.body["body"]["job"]["id"]
+        .as_str()
+        .expect("job id")
+        .to_string();
+
+    let list = route_with_job_store("GET", "/jobs", &store);
+    assert_eq!(list.status_code, 200, "list body: {}", list.body);
+    assert!(!serialized_contains(&list.body, sentinel));
+
+    let show = route_with_job_store("GET", &format!("/jobs/{job_id}"), &store);
+    assert_eq!(show.status_code, 200, "show body: {}", show.body);
+    assert!(!serialized_contains(&show.body, sentinel));
+
+    let events = route_with_job_store("GET", &format!("/jobs/{job_id}/events"), &store);
+    assert_eq!(events.status_code, 200, "events body: {}", events.body);
+    assert!(!serialized_contains(&events.body, sentinel));
+
+    let claim = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs/claim",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "project_id": "extrachill",
+            "lease_ms": 30000
+        })),
+        &store,
+    );
+    assert_eq!(claim.status_code, 200, "claim body: {}", claim.body);
+    assert_eq!(
+        claim.body["body"]["claim"]["request"]["env"]["RUNNER_SECRET_TOKEN"],
+        sentinel
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Redact remote runner `secret_env_names` from public broker/job surfaces.
- Keep full secret env values only in execution-only in-memory job claims.
- Mark persisted queued remote-runner jobs with unrecoverable redacted execution env as failed after daemon restart.

## Tests
- `git diff --check`
- `rustfmt --check src/core/api_jobs.rs src/core/api_jobs/remote_runner.rs src/core/daemon/remote_runner.rs tests/core/daemon_test.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Finalizing the branch, lightweight verification, commit, push, and PR description drafting.