### PR TITLE
Use shared target source path resolution

### DIFF
--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -1,4 +1,5 @@
 use homeboy::cli_surface::{Cli, Commands};
+use homeboy::core::component::{self, TargetSpec};
 use homeboy::core::git;
 use homeboy::core::lab_routing::{
     self, LabDispatchObserver, LabRouteOutcome, LabRoutingRequest, NoopLabDispatchObserver,
@@ -68,10 +69,8 @@ pub fn route_after_parse(
     let scoped_args = inject_lab_changed_files(&cli.command, normalized_args)?;
     let normalized_args = scoped_args.as_deref().unwrap_or(normalized_args);
 
-    let rewritten_args = capture_mutation_patch
-        .then(|| rewrite_component_target_to_path(&cli.command, normalized_args))
-        .flatten()
-        .or_else(|| rewrite_ad_hoc_lab_workspace_to_path(&cli.command, normalized_args));
+    let rewritten_args =
+        lab_route_source_path_args(&cli.command, normalized_args, capture_mutation_patch);
     let routed_args = rewritten_args.as_deref().unwrap_or(normalized_args);
 
     let outcome = lab_routing::dispatch_lab_offload(
@@ -214,14 +213,11 @@ fn resolve_changed_scope_source_path(
     component_id: Option<&String>,
     path_override: Option<&String>,
 ) -> homeboy::core::Result<String> {
-    use homeboy::core::engine::execution_context::{self, ResolveOptions};
-
-    let ctx = execution_context::resolve(&ResolveOptions {
-        component_id: component_id.cloned(),
-        path_override: path_override.cloned(),
-        ..ResolveOptions::default()
-    })?;
-    Ok(ctx.source_path.to_string_lossy().to_string())
+    let target = component::resolve_target(TargetSpec::new(
+        component_id.map(String::as_str),
+        path_override.map(String::as_str),
+    ))?;
+    Ok(target.source_path.to_string_lossy().to_string())
 }
 
 /// Build the Lab dispatch observer for the parsed command. Only `trace`
@@ -377,6 +373,20 @@ fn lab_offload_command(
     )))
 }
 
+fn lab_route_source_path_args(
+    command: &Commands,
+    normalized_args: &[String],
+    capture_mutation_patch: bool,
+) -> Option<Vec<String>> {
+    if capture_mutation_patch {
+        if let Some(rewritten) = rewrite_component_target_to_path(command, normalized_args) {
+            return Some(rewritten);
+        }
+    }
+
+    rewrite_ad_hoc_lab_workspace_to_path(command, normalized_args)
+}
+
 /// When a `lint --fix` / `refactor --write` command targets a component by id
 /// (positionally or via `--component`/`--components`), resolve that component to
 /// its on-disk source path and rewrite the offload args to `--path <source>`.
@@ -426,14 +436,8 @@ fn rewrite_component_target_to_path(
 /// when resolution fails so the caller can fall back to the original args and
 /// let the normal offload path surface any downstream error.
 fn resolve_component_source_path(component_id: &str) -> Option<String> {
-    use homeboy::core::engine::execution_context::{self, ResolveOptions};
-
-    let ctx = execution_context::resolve(&ResolveOptions {
-        component_id: Some(component_id.to_string()),
-        ..ResolveOptions::default()
-    })
-    .ok()?;
-    Some(ctx.source_path.to_string_lossy().to_string())
+    let target = component::resolve_target(TargetSpec::new(Some(component_id), None)).ok()?;
+    Some(target.source_path.to_string_lossy().to_string())
 }
 
 /// Lab sync already materializes the controller CWD when no explicit source path
@@ -1242,6 +1246,29 @@ mod tests {
         ];
 
         assert!(rewrite_component_target_to_path(&cli.command, &normalized).is_none());
+    }
+
+    #[test]
+    fn changed_scope_source_path_uses_shared_target_resolution() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+
+        let source_path = resolve_changed_scope_source_path(None, Some(&path))
+            .expect("path override should resolve through TargetSpec");
+
+        assert_eq!(source_path, path);
+    }
+
+    #[test]
+    fn lab_route_source_path_args_keeps_component_id_without_patch_capture() {
+        let cli = Cli::parse_from(["homeboy", "lint", "sample-component"]);
+        let normalized = vec![
+            "homeboy".to_string(),
+            "lint".to_string(),
+            "sample-component".to_string(),
+        ];
+
+        assert!(lab_route_source_path_args(&cli.command, &normalized, false).is_none());
     }
 
     #[test]

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -7,7 +7,6 @@
 //! See: https://github.com/Extra-Chill/homeboy/issues/436
 
 use clap::{Arg, ArgAction, Args, Command, CommandFactory};
-use std::path::PathBuf;
 
 use crate::cli_surface::Cli;
 use homeboy::core::component::{self, Component};
@@ -168,43 +167,6 @@ fn arg_takes_value(arg: &Arg) -> bool {
 /// Apply all argument normalizations in sequence.
 pub fn normalize(args: Vec<String>) -> Vec<String> {
     mark_explicit_passthrough(args)
-}
-
-// ============================================================================
-// ComponentArgs: --component + --path + resolve()
-// ============================================================================
-
-#[derive(Args, Debug, Clone, Default)]
-pub struct ComponentArgs {
-    #[arg(short, long)]
-    pub component: Option<String>,
-
-    /// Override the component checkout path for this invocation
-    #[arg(long)]
-    pub path: Option<String>,
-}
-
-#[allow(dead_code)]
-impl ComponentArgs {
-    pub fn resolve(&self) -> homeboy::core::Result<Component> {
-        component::resolve_effective(self.component.as_deref(), self.path.as_deref(), None)
-    }
-
-    pub fn resolve_root(&self) -> homeboy::core::Result<PathBuf> {
-        if let Some(ref p) = self.path {
-            Ok(PathBuf::from(p))
-        } else {
-            let comp = component::resolve(self.component.as_deref())?;
-            component::validate_local_path(&comp)
-        }
-    }
-
-    pub fn load(&self) -> homeboy::core::Result<Component> {
-        let id = self.component.as_deref().ok_or_else(|| {
-            homeboy::core::Error::validation_missing_argument(vec!["component".to_string()])
-        })?;
-        component::resolve_effective(Some(id), self.path.as_deref(), None)
-    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Route changed-scope and mutation-patch source path resolution through the shared target resolver.
- Keep component IDs intact for Lab routing when mutation patch capture is not active.
- Remove the unused legacy ComponentArgs helper.

## Verification
- git diff --check origin/main...HEAD
- rustfmt --check src/commands/route.rs src/commands/utils/args.rs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the cooked worktree, checking the diff, committing, pushing, and drafting this PR description.