### PR TITLE
Fail closed for coupled deploy component groups

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -47,6 +47,8 @@ Options:
 
 Real deploys with `--head` or `--force` require `--apply`. Preview and status commands (`--dry-run` or `--check`) do not require `--apply`.
 
+Components can declare `deploy_together` in their component config. When any selected component belongs to a deploy-together group, Homeboy requires the full group in the same deploy plan and fails before build/upload if only part of the group was selected. Use explicit component IDs for the whole group or `--all` for the project.
+
 Bulk JSON input uses `component_ids` (snake_case):
 
 ```json

--- a/docs/schemas/component-schema.md
+++ b/docs/schemas/component-schema.md
@@ -11,6 +11,7 @@ Component configuration defines buildable and deployable units stored in `compon
   "local_path": "string",
   "remote_path": "string",
   "build_artifact": "string",
+  "deploy_together": ["component-id"],
   "artifact_inputs": [
     {
       "component": "string",
@@ -81,6 +82,9 @@ Component configuration defines buildable and deployable units stored in `compon
   - **`target`** (string): Relative path where the producer artifact is placed inside the consumer artifact
   - **`sha256`** (string, optional): Expected producer artifact SHA-256; comparison is case-insensitive
   - The resolved input metadata is generic (`component`, resolved `artifact`, `target`, `sha256`). The current writer implementation supports ZIP consumer artifacts and writes each input at `target` inside the ZIP.
+- **`deploy_together`** (array): Component IDs that must be deployed in the same operation as this component
+  - Use this when separately tracked components form one runtime contract, such as a WordPress plugin and theme that must stay in sync.
+  - Deploy planning fails closed when a selection includes only part of a declared group. Select all coupled components explicitly or use `--all` for the project.
 - **`release`** (object): Component-scoped release configuration
   - **`enabled`** (boolean): Whether release pipeline is enabled
   - **`steps`** (array): Release step definitions

--- a/docs/schemas/portable-config.md
+++ b/docs/schemas/portable-config.md
@@ -9,6 +9,7 @@ A `homeboy.json` file in a repo root defines portable component configuration th
   "id": "string",
   "remote_path": "string",
   "build_artifact": "string",
+  "deploy_together": ["component-id"],
   "extract_command": "string",
   "version_targets": [
     {
@@ -73,6 +74,7 @@ homeboy component create --local-path /path/to/repo --changelog-target "CHANGELO
 | `id` | Required stable component identifier |
 | `remote_path` | Deploy target relative to project `base_path` |
 | `build_artifact` | Build output path relative to repo root |
+| `deploy_together` | Component IDs that must be deployed in the same operation as this component |
 | `extract_command` | Post-upload command (supports `{artifact}`, `{targetDir}`) |
 | `version_targets` | Version detection patterns (`file`, `pattern`, optional `artifact_path`) |
 | `changelog_target` | Path to changelog file |
@@ -80,6 +82,8 @@ homeboy component create --local-path /path/to/repo --changelog-target "CHANGELO
 | `extensions` | Extension configuration (e.g., `{"wordpress": {}}`) |
 
 Build, lint, test, bench, and trace behavior resolves from `scripts.<capability>` first, then linked extensions. Use `scripts.build` for component-owned shell builds; component-level `build_command` is not supported.
+
+Use `deploy_together` for coupled components that are versioned or built separately but must stay in sync at runtime. When a deploy selection includes one member of a declared group without the rest, Homeboy fails the plan before building or uploading.
 
 ## Precedence
 

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -319,6 +319,12 @@ pub struct Component {
     pub audit: Option<AuditConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependency_stack: Vec<DependencyStackEdge>,
+    /// Component IDs that must be deployed in the same operation as this component.
+    ///
+    /// Use this for separately tracked components that form one runtime contract,
+    /// such as a plugin and theme that must stay in sync on the target site.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deploy_together: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_inputs: Vec<ArtifactInput>,
     /// Override the CLI path used by extension deploy install steps.
@@ -412,6 +418,8 @@ struct RawComponent {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     dependency_stack: Vec<DependencyStackEdge>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    deploy_together: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     artifact_inputs: Vec<ArtifactInput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cli_path: Option<String>,
@@ -457,6 +465,7 @@ impl From<RawComponent> for Component {
             scripts: raw.scripts,
             audit: raw.audit,
             dependency_stack: raw.dependency_stack,
+            deploy_together: raw.deploy_together,
             artifact_inputs: raw.artifact_inputs,
             cli_path: raw.cli_path,
             extra_drift_files: raw.extra_drift_files,
@@ -499,6 +508,7 @@ impl From<Component> for RawComponent {
             scripts: c.scripts,
             audit: c.audit,
             dependency_stack: c.dependency_stack,
+            deploy_together: c.deploy_together,
             artifact_inputs: c.artifact_inputs,
             cli_path: c.cli_path,
             extra_drift_files: c.extra_drift_files,
@@ -584,6 +594,7 @@ impl Component {
             scripts: None,
             audit: None,
             dependency_stack: Vec::new(),
+            deploy_together: Vec::new(),
             artifact_inputs: Vec::new(),
             cli_path: None,
             extra_drift_files: Vec::new(),

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -278,6 +278,10 @@ fn validate_deploy_plan(config: &DeployConfig, plan: &DeployComponentPlan) -> Re
             ));
         }
 
+        if !config.check {
+            validate_deploy_together_selection(plan)?;
+        }
+
         return Ok(());
     }
 
@@ -297,6 +301,10 @@ fn validate_deploy_plan(config: &DeployConfig, plan: &DeployComponentPlan) -> Re
         ));
     }
 
+    if !config.check {
+        validate_deploy_together_selection(plan)?;
+    }
+
     if plan
         .plan
         .steps
@@ -309,6 +317,89 @@ fn validate_deploy_plan(config: &DeployConfig, plan: &DeployComponentPlan) -> Re
     }
 
     Ok(())
+}
+
+fn validate_deploy_together_selection(plan: &DeployComponentPlan) -> Result<()> {
+    let selected = plan
+        .ready_components()
+        .into_iter()
+        .map(|component| component.id)
+        .collect::<HashSet<_>>();
+    if selected.is_empty() {
+        return Ok(());
+    }
+
+    let mut graph = plan
+        .components
+        .keys()
+        .map(|id| (id.clone(), HashSet::<String>::new()))
+        .collect::<HashMap<_, _>>();
+
+    for component in plan.components.values() {
+        for companion in &component.deploy_together {
+            if companion == &component.id {
+                continue;
+            }
+            graph
+                .entry(component.id.clone())
+                .or_default()
+                .insert(companion.clone());
+            graph
+                .entry(companion.clone())
+                .or_default()
+                .insert(component.id.clone());
+        }
+    }
+
+    let mut visited = HashSet::new();
+    let mut violations = Vec::new();
+
+    for component_id in graph.keys() {
+        if visited.contains(component_id) {
+            continue;
+        }
+
+        let mut stack = vec![component_id.clone()];
+        let mut group = HashSet::new();
+        while let Some(id) = stack.pop() {
+            if !visited.insert(id.clone()) {
+                continue;
+            }
+            group.insert(id.clone());
+            if let Some(neighbors) = graph.get(&id) {
+                for neighbor in neighbors {
+                    if !visited.contains(neighbor) {
+                        stack.push(neighbor.clone());
+                    }
+                }
+            }
+        }
+
+        if group.len() <= 1 || group.is_disjoint(&selected) || group.is_subset(&selected) {
+            continue;
+        }
+
+        let mut selected_members = group.intersection(&selected).cloned().collect::<Vec<_>>();
+        let mut missing_members = group.difference(&selected).cloned().collect::<Vec<_>>();
+        selected_members.sort();
+        missing_members.sort();
+        violations.push(format!(
+            "Selected [{}] without deploy-together component(s) [{}]",
+            selected_members.join(", "),
+            missing_members.join(", ")
+        ));
+    }
+
+    if violations.is_empty() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "deploy_together",
+        "Deploy selection omits coupled components",
+        None,
+        Some(violations),
+    ))
 }
 
 fn deploy_plan(mode: &str, config: &DeployConfig, steps: Vec<PlanStep>) -> HomeboyPlan {
@@ -844,6 +935,15 @@ mod tests {
         )
     }
 
+    fn coupled_component(id: &str, path: &Path, deploy_together: &[&str]) -> Component {
+        let mut component = component(id, path);
+        component.deploy_together = deploy_together
+            .iter()
+            .map(|component_id| (*component_id).to_string())
+            .collect();
+        component
+    }
+
     fn versioned_component(id: &str, path: &Path, version: &str) -> Component {
         std::fs::write(path.join("VERSION"), format!("{}\n", version)).expect("version file");
         let mut component = component(id, path);
@@ -929,6 +1029,54 @@ mod tests {
         assert_eq!(plan.plan.kind, PlanKind::Deploy);
         assert_eq!(step(&plan, "selected").status, PlanStepStatus::Ready);
         assert_eq!(plan.ready_components()[0].id, "selected");
+    }
+
+    #[test]
+    fn validate_deploy_plan_rejects_partial_deploy_together_selection() {
+        let temp = TempDir::new().expect("temp dir");
+        let plugin = coupled_component("studio-plugin", temp.path(), &["studio-theme"]);
+        let theme = component("studio-theme", temp.path());
+        let config = DeployConfig {
+            component_ids: vec!["studio-plugin".to_string()],
+            ..deploy_config()
+        };
+
+        let plan = plan_component_deploys(
+            &config,
+            &[plugin, theme],
+            &[],
+            &project(),
+            "/var/www/example",
+            &ssh_client(),
+        );
+
+        let err = validate_deploy_plan(&config, &plan).expect_err("partial group should fail");
+        assert!(err
+            .message
+            .contains("Deploy selection omits coupled components"));
+        assert!(err.details.to_string().contains("studio-theme"));
+    }
+
+    #[test]
+    fn validate_deploy_plan_accepts_complete_deploy_together_selection() {
+        let temp = TempDir::new().expect("temp dir");
+        let plugin = coupled_component("studio-plugin", temp.path(), &["studio-theme"]);
+        let theme = component("studio-theme", temp.path());
+        let config = DeployConfig {
+            component_ids: vec!["studio-plugin".to_string(), "studio-theme".to_string()],
+            ..deploy_config()
+        };
+
+        let plan = plan_component_deploys(
+            &config,
+            &[plugin, theme],
+            &[],
+            &project(),
+            "/var/www/example",
+            &ssh_client(),
+        );
+
+        validate_deploy_plan(&config, &plan).expect("complete group should pass");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add component-level `deploy_together` metadata for coupled deploy units.
- Fail deploy planning before build/upload when a selection includes only part of a declared deploy-together group.
- Document the new component config field in deploy and schema docs.

Fixes #5968

## Verification
- `rustfmt --check src/core/component/mod.rs src/core/deploy/planning.rs`
- `git diff --check`
- Local Cargo tests not run per environment guidance; relying on GitHub CI.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagent
- **Used for:** Implementation and PR drafting.