### PR TITLE
fix(agent-task): record pre-execution failures after claim

### DIFF
--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 use crate::core::agent_task::{
-    AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskExecutionHandle,
+    AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskExecutionHandle,
     AgentTaskExecutionHandleKind, AgentTaskExecutor, AgentTaskFailureClassification,
     AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest,
     AgentTaskSourceRef, AgentTaskWorkflowEvidence, AgentTaskWorkspace, AgentTaskWorkspaceMode,
@@ -409,6 +409,109 @@ pub fn record_run_aggregate(
 ) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
     record_aggregate(&mut record, plan, aggregate)
+}
+
+pub fn record_pre_execution_failure(
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    phase: &str,
+    error: &Error,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let mut record = store::read_record(&run_id)?;
+    let task_count = plan.tasks.len();
+    let failed = task_count;
+    let diagnostic = AgentTaskDiagnostic {
+        class: "pre_execution_failure".to_string(),
+        message: error.message.clone(),
+        data: json!({
+            "phase": phase,
+            "error_code": error.code.as_str(),
+            "details": error.details.clone(),
+            "hints": error.hints.iter().map(|hint| hint.message.as_str()).collect::<Vec<_>>(),
+        }),
+    };
+    let outcomes = plan
+        .tasks
+        .iter()
+        .map(|task| AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: task.task_id.clone(),
+            status: AgentTaskOutcomeStatus::Failed,
+            summary: Some(format!(
+                "agent-task pre-execution {phase} failed: {}",
+                error.message
+            )),
+            failure_classification: Some(AgentTaskFailureClassification::InvalidInput),
+            artifacts: Vec::new(),
+            typed_artifacts: Vec::new(),
+            evidence_refs: vec![AgentTaskEvidenceRef {
+                kind: "agent-task-pre-execution-failure".to_string(),
+                uri: format!("homeboy://agent-task/run/{run_id}/status"),
+                label: Some("Agent-task pre-execution failure".to_string()),
+            }],
+            diagnostics: vec![diagnostic.clone()],
+            outputs: json!({
+                "schema": "homeboy/agent-task-pre-execution-failure/v1",
+                "phase": phase,
+                "error_code": error.code.as_str(),
+                "message": error.message,
+                "details": error.details.clone(),
+                "hints": error.hints.iter().map(|hint| hint.message.as_str()).collect::<Vec<_>>(),
+            }),
+            workflow: None,
+            follow_up: None,
+            metadata: json!({
+                "kind": "pre_execution_failure",
+                "phase": phase,
+                "error_code": error.code.as_str(),
+            }),
+        })
+        .collect();
+    let aggregate = AgentTaskAggregate {
+        schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+        plan_id: plan.plan_id.clone(),
+        status: AgentTaskAggregateStatus::Failed,
+        totals: AgentTaskAggregateTotals {
+            failed,
+            ..AgentTaskAggregateTotals::default()
+        },
+        outcomes,
+        events: plan
+            .tasks
+            .iter()
+            .map(|task| AgentTaskProgressEvent {
+                task_id: task.task_id.clone(),
+                state: AgentTaskState::Failed,
+                attempt: 1,
+                message: Some(format!(
+                    "agent-task pre-execution {phase} failed: {}",
+                    error.message
+                )),
+            })
+            .collect(),
+        artifact_lineage: Vec::new(),
+        child_runs: Vec::new(),
+        artifact_bindings: Vec::new(),
+        queue: AgentTaskQueueStatus {
+            max_concurrency: plan.options.max_concurrency,
+            completed: failed,
+            ..AgentTaskQueueStatus::default()
+        },
+    };
+    let mut failed_record = record_aggregate(&mut record, plan, &aggregate)?;
+    let metadata = failed_record.ensure_metadata_object();
+    metadata.insert(
+        "pre_execution_failure".to_string(),
+        json!({
+            "phase": phase,
+            "error_code": error.code.as_str(),
+            "message": error.message,
+            "hints": error.hints.iter().map(|hint| hint.message.as_str()).collect::<Vec<_>>(),
+        }),
+    );
+    store::write_record(&failed_record)?;
+    Ok(failed_record)
 }
 
 /// Shared `(run_id, runner_id)` identity borrowed by the Lab offload dispatch

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -986,7 +986,15 @@ where
     E: AgentTaskExecutorAdapter,
 {
     let mut plan = agent_task_lifecycle::load_plan(&run_id)?;
-    prepare_plan_for_execution(&mut plan, Some(&run_id))?;
+    if let Err(error) = prepare_plan_for_execution(&mut plan, Some(&run_id)) {
+        agent_task_lifecycle::record_pre_execution_failure(
+            &run_id,
+            &plan,
+            "prepare_plan_for_execution",
+            &error,
+        )?;
+        return Err(error);
+    }
     run_prepared_claimed(run_id, plan, executor)
 }
 
@@ -1339,6 +1347,7 @@ mod tests {
     };
     use crate::core::agent_task_lifecycle::{status as lifecycle_status, AgentTaskRunState};
     use crate::core::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskState};
+    use crate::core::run_lifecycle_record::RunExecutionState;
     use crate::test_support::with_isolated_home;
     use std::path::Path;
     use std::sync::{Arc, Mutex};
@@ -1442,6 +1451,34 @@ mod tests {
                 Some("fixture@fix-service-task")
             );
             assert!(Path::new(&record.worktree_path).is_dir());
+        });
+    }
+
+    #[test]
+    fn run_next_records_failed_lifecycle_when_prepare_after_claim_fails() {
+        with_isolated_home(|_| {
+            let mut plan = test_plan();
+            plan.tasks[0]
+                .executor
+                .secret_env
+                .push("__HOMEBOY_TEST_MISSING_SECRET_ENV_RUN_NEXT__".to_string());
+            std::env::remove_var("__HOMEBOY_TEST_MISSING_SECRET_ENV_RUN_NEXT__");
+            agent_task_lifecycle::submit_plan(&plan, Some("run-next-preexecution-fails"))
+                .expect("submitted");
+
+            let error = run_next(SucceedingExecutor).expect_err("prepare failure returned");
+            let record = lifecycle_status("run-next-preexecution-fails").expect("status persisted");
+
+            assert_eq!(error.code.as_str(), "validation.invalid_argument");
+            assert_eq!(record.state, AgentTaskRunState::Failed);
+            assert_eq!(record.tasks[0].state, AgentTaskState::Failed);
+            assert_eq!(record.lifecycle.execution.state, RunExecutionState::Failed);
+            assert!(record.lifecycle.execution.finished_at.is_some());
+            assert_eq!(
+                record.metadata["pre_execution_failure"]["phase"],
+                "prepare_plan_for_execution"
+            );
+            assert!(record.aggregate_path.is_some());
         });
     }
 


### PR DESCRIPTION
## Summary
- Record a failed lifecycle state and aggregate when run_next claims a plan but prepare_plan_for_execution fails.
- Add a regression test covering missing secret env validation after claim.

## Tests
- git diff --check
- rustfmt --edition 2021 --check src/core/agent_task_lifecycle.rs src/core/agent_task_service.rs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the cooked worktree, verifying formatting/whitespace checks, committing, pushing, and opening this PR.