### PR TITLE
Add runner workload dispatch contract

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -25,10 +25,11 @@ pub use lab::{
     lab_runner_unsupported_message, LabCommandContract, LabCommandPortability,
     LabCommandRequiredTool, LabCommandRouteContract, LabLocalExecutionPolicy, LabLocalHotPolicy,
     LabRoutingPolicy, LabRunnerSupportSummary, LabSelectedRunnerFallbackPolicy, LabSourcePathMode,
-    LabWorkspaceModePolicy, RunnerWorkload, RunnerWorkloadAssignment, RunnerWorkloadCapability,
-    RunnerWorkloadCommandFamily, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
-    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
-    RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS, RUNNER_WORKLOAD_SCHEMA,
+    LabWorkspaceModePolicy, RunnerWorkload, RunnerWorkloadArtifactRef, RunnerWorkloadAssignment,
+    RunnerWorkloadCapability, RunnerWorkloadCommandFamily, RunnerWorkloadKind,
+    RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
+    RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS,
+    RUNNER_WORKLOAD_SCHEMA,
 };
 pub(crate) use lab::{
     AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REVIEW_LAB_LABEL,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -162,6 +162,23 @@ pub struct RunnerWorkloadResultRefs {
     pub plan_id: String,
     pub proof_id: Option<String>,
     pub workspace_mapping_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mirror_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<RunnerWorkloadArtifactRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadArtifactRef {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -300,6 +300,7 @@ fn run_rig_source_management_on_runner(
             capability_preflight,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            runner_workload: None,
             detach_after_handoff: false,
         },
     )?;

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -1697,6 +1697,7 @@ fn exec(
             }),
             required_extensions: Vec::new(),
             require_paths,
+            runner_workload: None,
             detach_after_handoff: false,
         },
     )

--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -2072,6 +2072,7 @@ mod tests {
                 Some("/srv"),
             )),
             require_paths: Vec::new(),
+            runner_workload: None,
             metadata: Some(json!({ "submitted_by": "controller" })),
         }
     }

--- a/src/core/api_jobs/remote_runner.rs
+++ b/src/core/api_jobs/remote_runner.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use super::{
     job_not_found, timestamp_ms, Job, JobEvent, JobEventKind, JobStatus, JobStore, StoredJob,
 };
+use crate::command_contract::RunnerWorkload;
 use crate::core::engine::command::CommandCaptureMetadata;
 use crate::core::error::{Error, Result};
 use crate::core::runner::{RunnerMutationArtifacts, RunnerResourceMetrics};
@@ -52,7 +53,18 @@ pub struct RemoteRunnerJobRequest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub require_paths: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_workload: Option<RunnerWorkload>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
+}
+
+impl RemoteRunnerJobRequest {
+    pub(crate) fn required_extensions(&self) -> Vec<String> {
+        self.runner_workload
+            .as_ref()
+            .map(|workload| workload.required_extensions.clone())
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -109,6 +121,14 @@ impl JobStore {
                 None,
             ));
         }
+        crate::core::runner::workload::validate_runner_workload_dispatch(
+            request.runner_workload.as_ref(),
+            &request.runner_id,
+            request.cwd.as_deref(),
+            &request.command,
+            &request.secret_env_names,
+            request.capture_patch,
+        )?;
 
         let now = timestamp_ms();
         let job = Job {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -7,6 +7,7 @@ use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use crate::command_contract::RunnerWorkload;
 use crate::core::api_jobs::{JobStatus, JobStore};
 use crate::core::build_identity;
 use crate::core::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
@@ -95,6 +96,8 @@ struct ExecRequest {
     source_snapshot: Option<SourceSnapshot>,
     #[serde(default)]
     require_paths: Vec<String>,
+    #[serde(default)]
+    runner_workload: Option<RunnerWorkload>,
 }
 
 pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
@@ -378,6 +381,14 @@ fn enqueue_exec_job(
                 None,
             )
         })?;
+    crate::core::runner::workload::validate_runner_workload_dispatch(
+        request.runner_workload.as_ref(),
+        &request.runner_id,
+        request.cwd.as_deref(),
+        &request.command,
+        &request.secret_env_names,
+        request.capture_patch,
+    )?;
     let plan = prepare_daemon_local_process(RunnerProcessRequest {
         runner_id: request.runner_id,
         runner: request.runner,

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -6,6 +6,7 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use crate::command_contract::RunnerWorkload;
 use crate::core::agent_tasks::{
     provider_secret_sources_for_discovered_providers, secrets as agent_task_secrets,
 };
@@ -61,6 +62,7 @@ pub struct RunnerExecOptions {
     pub capability_preflight: Option<RunnerCapabilityPreflight>,
     pub required_extensions: Vec<String>,
     pub require_paths: Vec<String>,
+    pub runner_workload: Option<RunnerWorkload>,
     pub detach_after_handoff: bool,
 }
 
@@ -223,8 +225,21 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
     let runner = plan.runner.clone();
     let cwd = plan.cwd.clone();
     let request_env = plan.env.clone();
-    let required_extensions =
-        required_extensions_for_command(&options.command, &options.required_extensions);
+    super::workload::validate_runner_workload_dispatch(
+        options.runner_workload.as_ref(),
+        runner_id,
+        Some(&cwd),
+        &options.command,
+        &secret_env_names,
+        options.capture_patch,
+    )?;
+    let required_extensions = required_extensions_for_command(
+        &options.command,
+        &super::workload::merge_runner_workload_required_extensions(
+            options.required_extensions.clone(),
+            options.runner_workload.as_ref(),
+        ),
+    );
 
     validate_runner_extension_parity(runner_id, &runner, &cwd, &required_extensions)?;
 
@@ -232,8 +247,10 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
     // top-level executable when the caller did not supply an explicit one, so
     // remote dispatch always validates that the runner can satisfy the command
     // before starting execution instead of failing mid-run (#5093, #5422).
-    let capability_preflight =
-        remote_execution_preflight(&options.command, options.capability_preflight.as_ref());
+    let capability_preflight = super::workload::merge_runner_workload_capability_preflight(
+        remote_execution_preflight(&options.command, options.capability_preflight.as_ref()),
+        options.runner_workload.as_ref(),
+    )?;
     let run_capability_preflight = |runner: &Runner| -> Result<()> {
         preflight_runner_capability_plan(runner, capability_preflight.as_ref(), &request_env)
     };
@@ -282,6 +299,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 options.capture_patch,
                 Some(plan.source_snapshot),
                 options.require_paths,
+                options.runner_workload,
                 options.detach_after_handoff,
             )
         }
@@ -298,6 +316,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 options.capture_patch,
                 Some(plan.source_snapshot),
                 options.require_paths,
+                options.runner_workload,
                 options.detach_after_handoff,
             )
         }
@@ -359,6 +378,22 @@ fn exec_worker_local_with_process_output(
         require_paths: options.require_paths.clone(),
         validate_require_paths_on_host: true,
     })?;
+    super::workload::validate_runner_workload_dispatch(
+        options.runner_workload.as_ref(),
+        runner_id,
+        Some(&plan.cwd),
+        &options.command,
+        &options.secret_env_names,
+        options.capture_patch,
+    )?;
+    let required_extensions = required_extensions_for_command(
+        &options.command,
+        &super::workload::merge_runner_workload_required_extensions(
+            options.required_extensions.clone(),
+            options.runner_workload.as_ref(),
+        ),
+    );
+    validate_runner_extension_parity(runner_id, &plan.runner, &plan.cwd, &required_extensions)?;
     validate_runner_policy(
         &plan.runner,
         &plan.cwd,
@@ -369,11 +404,11 @@ fn exec_worker_local_with_process_output(
             raw_exec: options.raw_exec,
         },
     )?;
-    preflight_worker_local_capability_plan(
-        &plan.runner,
-        options.capability_preflight.as_ref(),
-        &plan.env,
+    let capability_preflight = super::workload::merge_runner_workload_capability_preflight(
+        options.capability_preflight.clone(),
+        options.runner_workload.as_ref(),
     )?;
+    preflight_worker_local_capability_plan(&plan.runner, capability_preflight.as_ref(), &plan.env)?;
     let output = execute(&plan)?;
     Ok(exec_output(
         &plan.runner,
@@ -572,6 +607,7 @@ fn exec_via_reverse_broker(
     capture_patch: bool,
     source_snapshot_override: Option<SourceSnapshot>,
     require_paths: Vec<String>,
+    runner_workload: Option<RunnerWorkload>,
     detach_after_handoff: bool,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
@@ -593,6 +629,7 @@ fn exec_via_reverse_broker(
         secret_env_names,
         capture_patch,
         source_snapshot: Some(source_snapshot.clone()),
+        runner_workload: runner_workload.clone(),
         metadata: Some(json!({
             "transport": "reverse_broker",
         })),
@@ -754,6 +791,7 @@ fn exec_via_daemon(
     capture_patch: bool,
     source_snapshot_override: Option<SourceSnapshot>,
     require_paths: Vec<String>,
+    runner_workload: Option<RunnerWorkload>,
     detach_after_handoff: bool,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
@@ -776,6 +814,7 @@ fn exec_via_daemon(
             "capture_patch": capture_patch,
             "source_snapshot": source_snapshot.clone(),
             "require_paths": require_paths.clone(),
+            "runner_workload": runner_workload,
         }))
         .send()
         .map_err(|err| daemon_exec_transport_error(&runner.id, err))?;
@@ -3556,6 +3595,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     detach_after_handoff: false,
                 },
             )
@@ -3611,6 +3651,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     detach_after_handoff: false,
                 },
             )
@@ -3649,6 +3690,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     detach_after_handoff: false,
                 },
             )
@@ -3692,6 +3734,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: vec![missing.display().to_string()],
+                    runner_workload: None,
                     detach_after_handoff: false,
                 },
             )
@@ -3734,6 +3777,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: vec![required_path.display().to_string()],
+                    runner_workload: None,
                     detach_after_handoff: false,
                 },
             )
@@ -3787,6 +3831,7 @@ mod tests {
                     capability_preflight: None,
                     required_extensions: Vec::new(),
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     detach_after_handoff: false,
                 },
             )
@@ -3824,6 +3869,7 @@ mod tests {
             capability_preflight: None,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            runner_workload: None,
             detach_after_handoff: false,
         };
 
@@ -3868,6 +3914,7 @@ mod tests {
             capability_preflight: None,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            runner_workload: None,
             detach_after_handoff: false,
         };
 
@@ -3903,6 +3950,7 @@ mod tests {
             capability_preflight: None,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            runner_workload: None,
             detach_after_handoff: false,
         };
         validate_runner_policy(

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -635,6 +635,7 @@ fn run_runner_resident_lab_offload(
             capability_preflight: None,
             required_extensions: contract.required_extensions.clone(),
             require_paths: Vec::new(),
+            runner_workload: None,
             detach_after_handoff: false,
         },
     )?;
@@ -1390,26 +1391,26 @@ fn run_lab_offload_inner(
         None,
         Some(&workspace_mapping_metadata),
     );
+    let runner_workload = build_runner_workload(RunnerWorkloadBuildInput {
+        plan: &plan,
+        command: &contract,
+        capture_patch: request.capture_patch,
+        mutation_flag: request.mutation_flag,
+        allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+        runner_id,
+        runner_mode: status_tunnel_mode(&runner_status).metadata_value(),
+        assignment_source: selection.source.metadata_value(),
+        status: "offloaded",
+        remote_workspace: Some(&remote_cwd),
+        fallback_reason: None,
+        workspace_mapping_ref: Some("workspace_mapping"),
+        proof_id: lab_metadata
+            .get("proof")
+            .and_then(|proof| proof.get("id"))
+            .and_then(|id| id.as_str()),
+    });
     lab_metadata["runner_workload"] =
-        serde_json::to_value(build_runner_workload(RunnerWorkloadBuildInput {
-            plan: &plan,
-            command: &contract,
-            capture_patch: request.capture_patch,
-            mutation_flag: request.mutation_flag,
-            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
-            runner_id,
-            runner_mode: status_tunnel_mode(&runner_status).metadata_value(),
-            assignment_source: selection.source.metadata_value(),
-            status: "offloaded",
-            remote_workspace: Some(&remote_cwd),
-            fallback_reason: None,
-            workspace_mapping_ref: Some("workspace_mapping"),
-            proof_id: lab_metadata
-                .get("proof")
-                .and_then(|proof| proof.get("id"))
-                .and_then(|id| id.as_str()),
-        }))
-        .unwrap_or(serde_json::json!(null));
+        serde_json::to_value(&runner_workload).unwrap_or(serde_json::json!(null));
     lab_metadata["source_snapshot"] =
         serde_json::to_value(&source_snapshot).unwrap_or(serde_json::json!(null));
     lab_metadata["materialization_proof"] = lab_materialization_proof_metadata(
@@ -1497,6 +1498,7 @@ fn run_lab_offload_inner(
             capability_preflight,
             required_extensions: contract.required_extensions.clone(),
             require_paths: Vec::new(),
+            runner_workload: Some(runner_workload),
             detach_after_handoff: request.detach_after_handoff,
         },
     );

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -270,6 +270,7 @@ fn probe_agent_task_providers_on_runner(
             capability_preflight,
             required_extensions,
             require_paths: Vec::new(),
+            runner_workload: None,
             detach_after_handoff: false,
         },
     )?;

--- a/src/core/runner/lab_workspaces_deps.rs
+++ b/src/core/runner/lab_workspaces_deps.rs
@@ -455,6 +455,7 @@ pub(super) fn bootstrap_source_cli_node_dependencies(
             capability_preflight: Some(source_cli_bootstrap_capability_preflight()),
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            runner_workload: None,
             detach_after_handoff: false,
         },
     )?;

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -53,7 +53,7 @@ mod validation_dependencies;
 pub(crate) use validation_dependencies::validation_dependency_ids;
 pub use validation_dependencies::RunnerValidationDependencySyncOutput;
 mod worker;
-mod workload;
+pub(crate) mod workload;
 mod workspace;
 pub(crate) use workspace::copy_snapshot_to_directory;
 

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -379,6 +379,9 @@ mod tests {
                 plan_id: plan.id.clone(),
                 proof_id: None,
                 workspace_mapping_ref: Some("workspace_mapping".to_string()),
+                job_id: None,
+                mirror_run_id: None,
+                artifacts: Vec::new(),
             },
         };
 

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -230,6 +230,7 @@ pub(super) fn sync_lab_offload_rigs(
                 capability_preflight: Some(rig_install_capability_preflight()),
                 required_extensions: Vec::new(),
                 require_paths: Vec::new(),
+                runner_workload: None,
                 detach_after_handoff: false,
             },
         )?;

--- a/src/core/runner/rig_materialization/rig_source_install.rs
+++ b/src/core/runner/rig_materialization/rig_source_install.rs
@@ -78,6 +78,7 @@ fn exec_runner_rig_sources_command(
             capability_preflight: None,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            runner_workload: None,
             detach_after_handoff: false,
         },
     )

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -338,8 +338,9 @@ fn run_once_output(
             raw_exec: false,
             source_snapshot: claim.request.source_snapshot.clone(),
             capability_preflight,
-            required_extensions: Vec::new(),
+            required_extensions: claim.request.required_extensions(),
             require_paths: claim.request.require_paths.clone(),
+            runner_workload: claim.request.runner_workload.clone(),
             detach_after_handoff: false,
         },
         || {
@@ -424,6 +425,7 @@ fn run_once_output(
     let job = finish(remote_runner_result_from_exec_output(
         exec_output,
         exit_code,
+        claim.request.runner_workload.clone(),
     ))?;
 
     Ok((
@@ -443,6 +445,7 @@ fn run_once_output(
 fn remote_runner_result_from_exec_output(
     exec_output: super::execution::RunnerExecOutput,
     exit_code: i32,
+    runner_workload: Option<crate::command_contract::RunnerWorkload>,
 ) -> RemoteRunnerJobResult {
     let patch = exec_output.patch.clone();
     let mutation_artifacts = exec_output.mutation_artifacts.clone();
@@ -459,6 +462,16 @@ fn remote_runner_result_from_exec_output(
     }
     if let Some(mirror_run_id) = exec_output.mirror_run_id.clone() {
         data["mirror_run_id"] = json!(mirror_run_id);
+    }
+    if let Some(runner_workload) = runner_workload {
+        data["runner_workload"] =
+            serde_json::to_value(super::workload::runner_workload_with_result_refs(
+                runner_workload,
+                exec_output.job_id.as_deref(),
+                exec_output.mirror_run_id.as_deref(),
+                &exec_output.artifacts,
+            ))
+            .unwrap_or(serde_json::Value::Null);
     }
     RemoteRunnerJobResult {
         exit_code,
@@ -946,6 +959,7 @@ mod tests {
                     capture_patch: false,
                     source_snapshot: None,
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     metadata: None,
                 })
                 .expect("submit job");
@@ -1051,6 +1065,7 @@ mod tests {
                     capture_patch: false,
                     source_snapshot: None,
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     metadata: None,
                 })
                 .expect("submit job");
@@ -1090,6 +1105,7 @@ mod tests {
                     capture_patch: false,
                     source_snapshot: None,
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     metadata: None,
                 })
                 .expect("submit job");
@@ -1160,6 +1176,7 @@ mod tests {
                     capture_patch: false,
                     source_snapshot: None,
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     metadata: None,
                 })
                 .expect("submit job");
@@ -1220,6 +1237,7 @@ mod tests {
                     capture_patch: false,
                     source_snapshot: None,
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     metadata: None,
                 })
                 .expect("submit job");
@@ -1292,6 +1310,7 @@ mod tests {
                     capture_patch: false,
                     source_snapshot: None,
                     require_paths: Vec::new(),
+                    runner_workload: None,
                     metadata: None,
                 })
                 .expect("submit job");

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -4,9 +4,13 @@ use crate::command_contract::{
     RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
     RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
 };
+use crate::core::error::{Error, Result};
 use crate::core::plan::HomeboyPlan;
 
-use super::{LabOffloadCommand, LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy};
+use super::{
+    LabOffloadCommand, LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy,
+    RunnerCapabilityPreflight, RunnerRequiredTool,
+};
 
 pub(crate) struct RunnerWorkloadBuildInput<'a> {
     pub plan: &'a HomeboyPlan,
@@ -65,8 +69,143 @@ pub(crate) fn build_runner_workload(input: RunnerWorkloadBuildInput<'_>) -> Runn
             plan_id: input.plan.id.clone(),
             proof_id: input.proof_id.map(str::to_string),
             workspace_mapping_ref,
+            job_id: None,
+            mirror_run_id: None,
+            artifacts: Vec::new(),
         },
     }
+}
+
+pub(crate) fn validate_runner_workload_dispatch(
+    workload: Option<&RunnerWorkload>,
+    runner_id: &str,
+    cwd: Option<&str>,
+    command: &[String],
+    _secret_env_names: &[String],
+    capture_patch: bool,
+) -> Result<()> {
+    let Some(workload) = workload else {
+        return Ok(());
+    };
+    if workload.schema != RUNNER_WORKLOAD_SCHEMA {
+        return Err(workload_error(
+            "runner_workload.schema",
+            format!("runner workload schema must be `{RUNNER_WORKLOAD_SCHEMA}`"),
+        ));
+    }
+    if workload.assignment.runner_id.as_deref() != Some(runner_id) {
+        return Err(workload_error(
+            "runner_workload.assignment.runner_id",
+            "runner workload assignment does not match dispatch runner_id".to_string(),
+        ));
+    }
+    if let (Some(expected), Some(actual)) = (workload.state.remote_workspace.as_deref(), cwd) {
+        if expected != actual {
+            return Err(workload_error(
+                "runner_workload.state.remote_workspace",
+                "runner workload remote workspace does not match dispatch cwd".to_string(),
+            ));
+        }
+    }
+    if workload.mutation_policy.capture_patch != capture_patch {
+        return Err(workload_error(
+            "runner_workload.mutation_policy.capture_patch",
+            "runner workload mutation policy does not match dispatch capture_patch".to_string(),
+        ));
+    }
+    for category in &workload.required_secrets.categories {
+        if !matches!(category.as_str(), "agent_task" | "trace" | "tunnel") {
+            return Err(workload_error(
+                "runner_workload.required_secrets",
+                format!("runner workload declares unsupported secret category `{category}`"),
+            ));
+        }
+    }
+    for capability in &workload.required_capabilities {
+        match capability.name.as_str() {
+            "extension_parity" | "playwright" => {}
+            name if !capability.required => {}
+            name => {
+                return Err(workload_error(
+                    "runner_workload.required_capabilities",
+                    format!("runner workload requires unsupported capability `{name}`"),
+                ));
+            }
+        }
+    }
+    if command.is_empty() {
+        return Err(workload_error(
+            "runner_workload.command",
+            "runner workload dispatch requires a command".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn merge_runner_workload_capability_preflight(
+    mut preflight: Option<RunnerCapabilityPreflight>,
+    workload: Option<&RunnerWorkload>,
+) -> Result<Option<RunnerCapabilityPreflight>> {
+    let Some(workload) = workload else {
+        return Ok(preflight);
+    };
+    for capability in &workload.required_capabilities {
+        if capability.name == "playwright" && capability.required {
+            let preflight = preflight.get_or_insert_with(|| RunnerCapabilityPreflight {
+                command: workload.kind.command_label.clone(),
+                ..Default::default()
+            });
+            if !preflight
+                .required_tools
+                .contains(&RunnerRequiredTool::Playwright)
+            {
+                preflight
+                    .required_tools
+                    .push(RunnerRequiredTool::Playwright);
+            }
+        }
+    }
+    Ok(preflight)
+}
+
+pub(crate) fn merge_runner_workload_required_extensions(
+    mut required_extensions: Vec<String>,
+    workload: Option<&RunnerWorkload>,
+) -> Vec<String> {
+    if let Some(workload) = workload {
+        for extension in &workload.required_extensions {
+            if !required_extensions.contains(extension) {
+                required_extensions.push(extension.clone());
+            }
+        }
+    }
+    required_extensions
+}
+
+fn workload_error(field: &str, message: String) -> Error {
+    Error::validation_invalid_argument(field, message, None, None)
+}
+
+pub(crate) fn runner_workload_with_result_refs(
+    mut workload: RunnerWorkload,
+    job_id: Option<&str>,
+    mirror_run_id: Option<&str>,
+    artifacts: &[crate::core::api_jobs::JobArtifactMetadata],
+) -> RunnerWorkload {
+    workload.result_refs.job_id = job_id.map(str::to_string);
+    workload.result_refs.mirror_run_id = mirror_run_id.map(str::to_string);
+    workload.result_refs.artifacts = artifacts
+        .iter()
+        .map(
+            |artifact| crate::command_contract::RunnerWorkloadArtifactRef {
+                id: artifact.id.clone(),
+                name: artifact.name.clone(),
+                path: artifact.path.clone(),
+                url: artifact.url.clone(),
+            },
+        )
+        .collect();
+    workload
 }
 
 fn required_capabilities(command: &LabOffloadCommand) -> Vec<RunnerWorkloadCapability> {
@@ -117,6 +256,7 @@ fn workspace_mode_policy_label(policy: LabOffloadWorkspaceModePolicy) -> &'stati
 mod tests {
     use super::*;
     use crate::command_contract::LabRoutingPolicy;
+    use crate::core::api_jobs::JobArtifactMetadata;
     use crate::core::plan::{HomeboyPlan, PlanKind};
 
     fn plan() -> HomeboyPlan {
@@ -186,5 +326,122 @@ mod tests {
         );
         assert_eq!(workload.result_refs.plan_id, "lab_offload.test");
         assert_eq!(workload.result_refs.proof_id.as_deref(), Some("proof-1"));
+    }
+
+    #[test]
+    fn runner_workload_validation_rejects_dispatch_drift() {
+        let plan = plan();
+        let command = command();
+        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &command,
+            capture_patch: true,
+            mutation_flag: None,
+            allow_dirty_lab_workspace: false,
+            runner_id: "lab-a",
+            runner_mode: "direct_ssh",
+            assignment_source: "explicit",
+            status: "offloaded",
+            remote_workspace: Some("/srv/homeboy/work"),
+            fallback_reason: None,
+            workspace_mapping_ref: Some("workspace_mapping"),
+            proof_id: None,
+        });
+
+        validate_runner_workload_dispatch(
+            Some(&workload),
+            "lab-a",
+            Some("/srv/homeboy/work"),
+            &["homeboy".to_string(), "trace".to_string()],
+            &[],
+            true,
+        )
+        .expect("matching dispatch is valid");
+
+        let err = validate_runner_workload_dispatch(
+            Some(&workload),
+            "other-runner",
+            Some("/srv/homeboy/work"),
+            &["homeboy".to_string(), "trace".to_string()],
+            &[],
+            true,
+        )
+        .expect_err("drifted runner id must fail");
+        assert_eq!(err.details["field"], "runner_workload.assignment.runner_id");
+    }
+
+    #[test]
+    fn runner_workload_capabilities_merge_into_preflight() {
+        let plan = plan();
+        let command = command();
+        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &command,
+            capture_patch: false,
+            mutation_flag: None,
+            allow_dirty_lab_workspace: false,
+            runner_id: "lab-a",
+            runner_mode: "direct_ssh",
+            assignment_source: "explicit",
+            status: "offloaded",
+            remote_workspace: Some("/srv/homeboy/work"),
+            fallback_reason: None,
+            workspace_mapping_ref: None,
+            proof_id: None,
+        });
+
+        let preflight = merge_runner_workload_capability_preflight(None, Some(&workload))
+            .expect("merge workload capabilities")
+            .expect("playwright preflight");
+        assert!(preflight
+            .required_tools
+            .contains(&RunnerRequiredTool::Playwright));
+    }
+
+    #[test]
+    fn runner_workload_result_refs_use_actual_artifacts() {
+        let plan = plan();
+        let command = command();
+        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &command,
+            capture_patch: false,
+            mutation_flag: None,
+            allow_dirty_lab_workspace: false,
+            runner_id: "lab-a",
+            runner_mode: "direct_ssh",
+            assignment_source: "explicit",
+            status: "offloaded",
+            remote_workspace: Some("/srv/homeboy/work"),
+            fallback_reason: None,
+            workspace_mapping_ref: None,
+            proof_id: None,
+        });
+        let workload = runner_workload_with_result_refs(
+            workload,
+            Some("job-1"),
+            Some("mirror-1"),
+            &[JobArtifactMetadata {
+                id: "artifact-1".to_string(),
+                name: Some("trace.zip".to_string()),
+                path: Some("/tmp/trace.zip".to_string()),
+                url: None,
+                mime: None,
+                size_bytes: Some(42),
+                sha256: None,
+                metadata: None,
+            }],
+        );
+
+        assert_eq!(workload.result_refs.job_id.as_deref(), Some("job-1"));
+        assert_eq!(
+            workload.result_refs.mirror_run_id.as_deref(),
+            Some("mirror-1")
+        );
+        assert_eq!(workload.result_refs.artifacts[0].id, "artifact-1");
+        assert_eq!(
+            workload.result_refs.artifacts[0].name.as_deref(),
+            Some("trace.zip")
+        );
     }
 }

--- a/src/core/upgrade/runners/commands.rs
+++ b/src/core/upgrade/runners/commands.rs
@@ -156,6 +156,7 @@ pub fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecO
         capability_preflight: Some(runner_upgrade_capability_plan()),
         required_extensions: Vec::new(),
         require_paths: Vec::new(),
+        runner_workload: None,
         detach_after_handoff: false,
     }
 }

--- a/src/core/upgrade/runners/source_checkout.rs
+++ b/src/core/upgrade/runners/source_checkout.rs
@@ -109,6 +109,7 @@ pub fn runner_source_checkout_prepare_options(
         }),
         required_extensions: Vec::new(),
         require_paths: Vec::new(),
+        runner_workload: None,
         detach_after_handoff: false,
     }
 }


### PR DESCRIPTION
## Summary
- Carry runner workload metadata through lab offload, daemon, broker, and worker dispatch paths.
- Validate runner workload dispatch invariants before execution.
- Attach job, mirror run, and artifact result refs to completed workload metadata.

## Verification
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `rustfmt --check src/command_contract.rs src/command_contract/lab.rs src/commands/route.rs src/commands/runner.rs src/core/api_jobs.rs src/core/api_jobs/remote_runner.rs src/core/daemon.rs src/core/runner/execution.rs src/core/runner/lab/offload.rs src/core/runner/lab/provider_preflight.rs src/core/runner/lab_workspaces_deps.rs src/core/runner/mod.rs src/core/runner/offload_metadata.rs src/core/runner/rig_materialization/mod.rs src/core/runner/rig_materialization/rig_source_install.rs src/core/runner/worker.rs src/core/runner/workload.rs src/core/upgrade/runners/commands.rs src/core/upgrade/runners/source_checkout.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the existing cooked worktree, verification, commit, push, and PR creation.