### PR TITLE
Expose extension command manifests

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -2,13 +2,20 @@ use clap::{ArgMatches, Command, CommandFactory, FromArgMatches};
 use std::io::IsTerminal;
 use std::sync::OnceLock;
 
-use crate::cli_surface::{Cli, Commands, DynamicCommandDescriptor};
+use crate::cli_surface::{
+    command_safety_manifest_from_dynamic, command_surface_from, Cli, CommandSafetyManifest,
+    Commands, DynamicCommandDescriptor, ExtensionCommandArgContract, ExtensionCommandArgsContract,
+    ExtensionCommandHealth, ExtensionCommandManifest,
+};
 use crate::commands;
 use crate::commands::cli;
 use crate::commands::output_runtime;
 use crate::commands::utils::{args, entity_suggest, resource_policy, response as output};
 use crate::commands::GlobalArgs;
-use crate::core::extension::{list_summaries, load_all_extensions};
+use crate::core::extension::{
+    list_summaries, load_all_extensions, CliConfig,
+    ExtensionManifest as InstalledExtensionManifest, ExtensionSummary,
+};
 use crate::core::upgrade;
 
 pub struct CliRuntime {
@@ -57,6 +64,20 @@ pub fn run_startup_fast_path(args: &[String]) -> Option<std::process::ExitCode> 
     }
 
     Some(std::process::ExitCode::SUCCESS)
+}
+
+pub fn current_augmented_command_safety_manifest() -> CommandSafetyManifest {
+    let discovery = collect_extension_cli_info();
+    let dynamic_descriptors = discovery
+        .info
+        .iter()
+        .map(|info| info.descriptor.clone())
+        .collect::<Vec<_>>();
+
+    command_safety_manifest_from_dynamic(
+        command_surface_from(build_augmented_command(&discovery.info, &discovery.health)),
+        &dynamic_descriptors,
+    )
 }
 
 impl CliRuntime {
@@ -276,18 +297,32 @@ fn collect_extension_cli_info() -> ExtensionCliDiscovery {
     let info = extensions
         .into_iter()
         .filter_map(|m| {
-            m.cli.map(|cli| {
-                let help = cli.help.unwrap_or_default();
+            let cli = m.cli.clone()?;
+            Some({
+                let help = cli.help.clone().unwrap_or_default();
+                let project_id_help = help.project_id_help.clone();
+                let args_help = help.args_help.clone();
+                let examples = help.examples.clone();
                 let about = format!("Run {} commands via {}", cli.display_name, m.name);
+                let extension_manifest = extension_command_manifest(
+                    &m,
+                    &cli,
+                    project_id_help.clone(),
+                    args_help.clone(),
+                    examples.clone(),
+                    &summaries,
+                );
                 ExtensionCliInfo {
-                    descriptor: DynamicCommandDescriptor::extension_command(
+                    descriptor: DynamicCommandDescriptor::installed_extension_command(
                         cli.tool.clone(),
                         about,
+                        extension_command_docs_path(&m, &cli.tool),
+                        extension_manifest,
                     ),
                     tool: cli.tool,
-                    project_id_help: help.project_id_help,
-                    args_help: help.args_help,
-                    examples: help.examples,
+                    project_id_help,
+                    args_help,
+                    examples,
                 }
             })
         })
@@ -300,6 +335,92 @@ fn collect_extension_cli_info() -> ExtensionCliDiscovery {
             broken_link_ids,
         },
     }
+}
+
+fn extension_command_manifest(
+    extension: &InstalledExtensionManifest,
+    cli: &CliConfig,
+    project_id_help: Option<String>,
+    args_help: Option<String>,
+    examples: Vec<String>,
+    summaries: &[ExtensionSummary],
+) -> ExtensionCommandManifest {
+    let project_id_help = project_id_help.unwrap_or_else(|| "Project ID".to_string());
+    let args_help = args_help.unwrap_or_else(|| "Command arguments".to_string());
+    let summary = summaries.iter().find(|summary| summary.id == extension.id);
+    let health = summary
+        .map(extension_command_health_from_summary)
+        .unwrap_or_else(|| ExtensionCommandHealth {
+            status: "unknown".to_string(),
+            ready: false,
+            compatible: false,
+            linked: false,
+            reason: Some("summary_missing".to_string()),
+            detail: Some("Extension loaded, but no extension summary was available".to_string()),
+        });
+
+    ExtensionCommandManifest {
+        extension_id: extension.id.clone(),
+        extension_name: extension.name.clone(),
+        extension_version: extension.version.clone(),
+        tool_name: cli.tool.clone(),
+        display_name: cli.display_name.clone(),
+        args_contract: ExtensionCommandArgsContract {
+            project_id: ExtensionCommandArgContract {
+                name: "project_id".to_string(),
+                help: project_id_help,
+                required: true,
+                multiple: false,
+            },
+            args: ExtensionCommandArgContract {
+                name: "args".to_string(),
+                help: args_help,
+                required: false,
+                multiple: true,
+            },
+            trailing_var_arg: true,
+            allow_hyphen_values: true,
+            examples,
+        },
+        health,
+    }
+}
+
+fn extension_command_health_from_summary(summary: &ExtensionSummary) -> ExtensionCommandHealth {
+    let status = if summary.error.is_some() {
+        "error"
+    } else if summary.ready && summary.compatible {
+        "ready"
+    } else if !summary.compatible {
+        "incompatible"
+    } else {
+        "not_ready"
+    };
+
+    ExtensionCommandHealth {
+        status: status.to_string(),
+        ready: summary.ready,
+        compatible: summary.compatible,
+        linked: summary.linked,
+        reason: summary
+            .error
+            .clone()
+            .or_else(|| summary.ready_reason.clone()),
+        detail: summary.ready_detail.clone(),
+    }
+}
+
+fn extension_command_docs_path(
+    extension: &InstalledExtensionManifest,
+    tool: &str,
+) -> Option<String> {
+    let docs_path = format!("docs/commands/{tool}.md");
+    let extension_path = extension.extension_path.as_ref()?;
+
+    std::path::Path::new(extension_path)
+        .join(&docs_path)
+        .exists()
+        .then_some(docs_path)
 }
 
 fn build_augmented_command(
@@ -715,6 +836,16 @@ mod tests {
         .expect("extension manifest");
     }
 
+    fn write_extension_command_docs(home: &std::path::Path, id: &str, tool: &str) {
+        let docs_dir = home
+            .join(".config/homeboy/extensions")
+            .join(id)
+            .join("docs/commands");
+        std::fs::create_dir_all(&docs_dir).expect("extension docs dir");
+        std::fs::write(docs_dir.join(format!("{tool}.md")), "# Extension command")
+            .expect("extension command docs");
+    }
+
     #[test]
     fn output_format_names_are_rejected_as_global_output_paths() {
         let err = output_runtime::validate_output_file_path("json")
@@ -824,6 +955,39 @@ mod tests {
             assert_eq!(discovery.info.len(), 1);
             assert_eq!(discovery.info[0].tool, "wp");
             assert_eq!(discovery.health.broken_link_ids, vec!["nodejs"]);
+        });
+    }
+
+    #[test]
+    fn augmented_manifest_includes_extension_command_contract_and_health() {
+        crate::test_support::with_isolated_home(|home| {
+            write_cli_extension(home.path(), "wordpress", "wp");
+            write_extension_command_docs(home.path(), "wordpress", "wp");
+
+            let manifest = current_augmented_command_safety_manifest();
+            let wp = manifest.find_path(&["wp"]).expect("wp command manifest");
+
+            assert!(wp.mutates);
+            assert!(wp.operator);
+            assert_eq!(wp.docs.path.as_deref(), Some("docs/commands/wp.md"));
+            assert!(wp.dangerous_flags.contains(&"passthrough args".to_string()));
+            assert!(wp
+                .output
+                .notes
+                .contains("extension-provided CLI passthrough"));
+
+            let extension = wp.extension.as_ref().expect("extension metadata");
+            assert_eq!(extension.extension_id, "wordpress");
+            assert_eq!(extension.tool_name, "wp");
+            assert_eq!(extension.args_contract.project_id.name, "project_id");
+            assert!(extension.args_contract.project_id.required);
+            assert_eq!(extension.args_contract.args.name, "args");
+            assert!(extension.args_contract.args.multiple);
+            assert!(extension.args_contract.trailing_var_arg);
+            assert!(extension.args_contract.allow_hyphen_values);
+            assert_eq!(extension.health.status, "ready");
+            assert!(extension.health.ready);
+            assert!(extension.health.compatible);
         });
     }
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -237,6 +237,8 @@ pub struct CommandSafetyEntry {
     pub output: CommandOutputMetadata,
     pub lab: CommandLabMetadata,
     pub docs: CommandDocsMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension: Option<ExtensionCommandManifest>,
     pub dangerous_flags: Vec<String>,
     pub subcommands: Vec<CommandSafetyEntry>,
 }
@@ -275,6 +277,46 @@ pub struct CommandLabMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandDocsMetadata {
     pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ExtensionCommandManifest {
+    pub extension_id: String,
+    pub extension_name: String,
+    pub extension_version: String,
+    pub tool_name: String,
+    pub display_name: String,
+    pub args_contract: ExtensionCommandArgsContract,
+    pub health: ExtensionCommandHealth,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ExtensionCommandArgsContract {
+    pub project_id: ExtensionCommandArgContract,
+    pub args: ExtensionCommandArgContract,
+    pub trailing_var_arg: bool,
+    pub allow_hyphen_values: bool,
+    pub examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ExtensionCommandArgContract {
+    pub name: String,
+    pub help: String,
+    pub required: bool,
+    pub multiple: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ExtensionCommandHealth {
+    pub status: String,
+    pub ready: bool,
+    pub compatible: bool,
+    pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 impl CommandSurfaceEntry {
@@ -359,6 +401,8 @@ pub struct DynamicCommandDescriptor {
     pub name: String,
     pub about: String,
     pub docs_path: Option<String>,
+    pub extension: Option<ExtensionCommandManifest>,
+    pub safety: Option<DynamicCommandSafety>,
 }
 
 impl DynamicCommandDescriptor {
@@ -367,6 +411,44 @@ impl DynamicCommandDescriptor {
             docs_path: Some(format!("docs/commands/{name}.md")),
             name,
             about,
+            extension: None,
+            safety: None,
+        }
+    }
+
+    pub fn installed_extension_command(
+        name: String,
+        about: String,
+        docs_path: Option<String>,
+        extension: ExtensionCommandManifest,
+    ) -> Self {
+        Self {
+            name,
+            about,
+            docs_path,
+            extension: Some(extension),
+            safety: Some(DynamicCommandSafety::extension_cli_passthrough()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DynamicCommandSafety {
+    pub mutates: bool,
+    pub operator: bool,
+    pub output_notes: &'static str,
+    pub lab_notes: &'static str,
+    pub dangerous_flags: Vec<&'static str>,
+}
+
+impl DynamicCommandSafety {
+    fn extension_cli_passthrough() -> Self {
+        Self {
+            mutates: true,
+            operator: true,
+            output_notes: "extension-provided CLI passthrough; forwarded arguments may mutate the target system",
+            lab_notes: "not declared as Lab-routable in the safety manifest",
+            dangerous_flags: vec!["passthrough args"],
         }
     }
 }
@@ -413,7 +495,16 @@ fn command_safety_entry(
 ) -> CommandSafetyEntry {
     let mut path = parent_path.to_vec();
     path.push(entry.name.clone());
-    let safety = command_safety_metadata(&path);
+    let mut safety = command_safety_metadata(&path);
+    let dynamic_command = dynamic_command_for_path(&path, dynamic_commands);
+
+    if let Some(dynamic_safety) = dynamic_command.and_then(|command| command.safety.as_ref()) {
+        safety.mutates = dynamic_safety.mutates;
+        safety.operator = dynamic_safety.operator;
+        safety.output_notes = dynamic_safety.output_notes;
+        safety.lab_notes = dynamic_safety.lab_notes;
+        safety.dangerous_flags = dynamic_safety.dangerous_flags.clone();
+    }
 
     CommandSafetyEntry {
         name: entry.name.clone(),
@@ -437,6 +528,7 @@ fn command_safety_entry(
         docs: CommandDocsMetadata {
             path: docs_path(&path, dynamic_commands),
         },
+        extension: dynamic_command.and_then(|command| command.extension.clone()),
         dangerous_flags: safety
             .dangerous_flags
             .into_iter()
@@ -676,19 +768,30 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
 }
 
 fn docs_path(path: &[String], dynamic_commands: &[DynamicCommandDescriptor]) -> Option<String> {
-    let command = path.first()?;
-
-    if path.len() == 1 {
-        if let Some(dynamic) = dynamic_commands.iter().find(|entry| entry.name == *command) {
-            return dynamic.docs_path.clone();
-        }
+    if let Some(dynamic) = dynamic_command_for_path(path, dynamic_commands) {
+        return dynamic.docs_path.clone();
     }
+
+    let command = path.first()?;
 
     registered_command(command).and_then(|entry| {
         entry
             .docs_slug
             .map(|slug| format!("docs/commands/{slug}.md"))
     })
+}
+
+fn dynamic_command_for_path<'a>(
+    path: &[String],
+    dynamic_commands: &'a [DynamicCommandDescriptor],
+) -> Option<&'a DynamicCommandDescriptor> {
+    let command = path.first()?;
+
+    if path.len() == 1 {
+        dynamic_commands.iter().find(|entry| entry.name == *command)
+    } else {
+        None
+    }
 }
 
 fn visible_subcommands(command: &Command, remaining_depth: usize) -> Vec<CommandSurfaceEntry> {

--- a/src/commands/manifest.rs
+++ b/src/commands/manifest.rs
@@ -1,7 +1,8 @@
 use clap::Args;
 use serde::Serialize;
 
-use crate::cli_surface::{current_command_safety_manifest, CommandSafetyManifest};
+use crate::cli_runtime::current_augmented_command_safety_manifest;
+use crate::cli_surface::CommandSafetyManifest;
 
 use super::{CmdResult, GlobalArgs};
 
@@ -19,7 +20,7 @@ pub fn run(_args: ManifestArgs, _global: &GlobalArgs) -> CmdResult<ManifestOutpu
     Ok((
         ManifestOutput {
             command: "manifest".to_string(),
-            manifest: current_command_safety_manifest(),
+            manifest: current_augmented_command_safety_manifest(),
         },
         0,
     ))


### PR DESCRIPTION
## Summary
- Include installed extension CLI command contracts, health, docs path, and safety metadata in command manifests.
- Generate the manifest command from the augmented runtime command surface so dynamic extension commands are represented.
- Add coverage for extension command metadata in the augmented manifest.

## Verification
- \
- \
- \
- No cargo commands or benchmarks run, per request.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the cooked worktree, verifying the diff, committing, pushing, and preparing this PR description.