### PR TITLE
Make command registry authoritative

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -189,18 +189,6 @@ impl CliRuntime {
 
         run_startup_update_checks(&cli.command);
 
-        // Show help for changelog when neither subcommand nor --self is provided.
-        if let Commands::Changelog(ref args) = cli.command {
-            if args.command.is_none() && !args.show_self {
-                let cmd = self.build_augmented_command();
-                if let Some(mut changelog_cmd) = cmd.find_subcommand("changelog").cloned() {
-                    changelog_cmd.print_help().expect("Failed to print help");
-                    println!();
-                    return std::process::ExitCode::SUCCESS;
-                }
-            }
-        }
-
         let exit_code = commands::response::run(cli.command, &global, output_file.as_deref());
         std::process::ExitCode::from(exit_code_to_u8(exit_code))
     }

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -684,11 +684,7 @@ fn docs_path(path: &[String], dynamic_commands: &[DynamicCommandDescriptor]) -> 
         }
     }
 
-    registered_command(command).and_then(|entry| {
-        entry
-            .docs_slug
-            .map(|slug| format!("docs/commands/{slug}.md"))
-    })
+    registered_command(command).and_then(|entry| entry.docs_path())
 }
 
 fn visible_subcommands(command: &Command, remaining_depth: usize) -> Vec<CommandSurfaceEntry> {
@@ -713,11 +709,18 @@ fn visible_subcommands(command: &Command, remaining_depth: usize) -> Vec<Command
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     fn command_doc(command: &str) -> String {
         let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         std::fs::read_to_string(root.join("docs/commands").join(format!("{command}.md")))
             .unwrap_or_else(|error| panic!("failed to read docs for {command}: {error}"))
+    }
+
+    fn commands_index() -> String {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        std::fs::read_to_string(root.join("docs/commands/commands-index.md"))
+            .unwrap_or_else(|error| panic!("failed to read docs command index: {error}"))
     }
 
     fn root_command(command: &str) -> clap::Command {
@@ -929,6 +932,107 @@ mod tests {
         assert!(bench.lab.supported);
         assert!(bench.lab.notes.contains("portable Lab offload"));
         assert_eq!(bench.docs.path.as_deref(), Some("docs/commands/bench.md"));
+    }
+
+    #[test]
+    fn command_registry_docs_paths_exist_and_are_indexed() {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let index = commands_index();
+
+        for entry in crate::command_contract::COMMAND_REGISTRY {
+            let Some(path) = entry.docs_path() else {
+                continue;
+            };
+            let Some(slug) = entry.docs_slug else {
+                continue;
+            };
+
+            assert!(
+                root.join(&path).is_file(),
+                "registered command `{}` points at missing docs path {path}",
+                entry.name
+            );
+            assert!(
+                index.contains(&format!("[{slug}]({slug}.md)")),
+                "docs/commands/commands-index.md is missing registered command `{}`",
+                entry.name
+            );
+        }
+    }
+
+    #[test]
+    fn command_registry_manifest_and_docs_metadata_align() {
+        let parser_names = Cli::command()
+            .get_subcommands()
+            .filter(|subcommand| !subcommand.is_hide_set())
+            .map(|subcommand| subcommand.get_name().to_string())
+            .collect::<BTreeSet<_>>();
+        let registry_names = crate::command_contract::COMMAND_REGISTRY
+            .iter()
+            .map(|entry| entry.name.to_string())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(registry_names, parser_names);
+
+        let manifest = current_command_safety_manifest();
+        for entry in crate::command_contract::COMMAND_REGISTRY {
+            let manifest_entry = manifest
+                .find_path(&[entry.name])
+                .unwrap_or_else(|| panic!("manifest missing registered command `{}`", entry.name));
+            let output_notes_overridden_for_safety = matches!(entry.name, "release" | "upgrade");
+
+            assert_eq!(
+                manifest_entry.docs.path,
+                entry.docs_path(),
+                "manifest docs path drifted from registry for `{}`",
+                entry.name
+            );
+            if !output_notes_overridden_for_safety {
+                assert_eq!(
+                    manifest_entry.output.notes, entry.output_notes,
+                    "manifest output notes drifted from registry for `{}`",
+                    entry.name
+                );
+            }
+            assert_eq!(
+                manifest_entry.lab.supported, entry.lab_supported,
+                "manifest Lab support drifted from registry for `{}`",
+                entry.name
+            );
+            assert_eq!(
+                manifest_entry.lab.notes, entry.lab_notes,
+                "manifest Lab notes drifted from registry for `{}`",
+                entry.name
+            );
+        }
+    }
+
+    #[test]
+    fn core_command_docs_do_not_drift_from_registry() {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let registered_docs = crate::command_contract::COMMAND_REGISTRY
+            .iter()
+            .filter_map(|entry| entry.docs_slug)
+            .collect::<BTreeSet<_>>();
+        let extension_or_support_docs =
+            BTreeSet::from(["audit-rules", "cargo", "commands-index", "rig-spec", "wp"]);
+
+        for doc in
+            std::fs::read_dir(root.join("docs/commands")).expect("failed to read docs/commands")
+        {
+            let doc = doc.expect("failed to read docs/commands entry");
+            let path = doc.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("md") {
+                continue;
+            }
+            let slug = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .expect("command docs filename should be valid UTF-8");
+            assert!(
+                registered_docs.contains(slug) || extension_or_support_docs.contains(slug),
+                "docs/commands/{slug}.md is not registered as a core command doc or known extension/support doc"
+            );
+        }
     }
 
     #[test]

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -96,6 +96,13 @@ pub struct CommandRegistryEntry {
     pub lab_notes: &'static str,
 }
 
+impl CommandRegistryEntry {
+    pub fn docs_path(&self) -> Option<String> {
+        self.docs_slug
+            .map(|slug| format!("docs/commands/{slug}.md"))
+    }
+}
+
 const fn command_registry_entry(
     name: &'static str,
     json_family: CommandJsonFamily,
@@ -486,6 +493,10 @@ mod tests {
         assert_eq!(
             parsed_command(&["homeboy", "manifest"]).response_mode(false),
             CommandResponseMode::Json
+        );
+        assert_eq!(
+            parsed_command(&["homeboy", "changelog"]).response_mode(false),
+            CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
         );
     }
 


### PR DESCRIPTION
## Summary
- Route command docs paths through the command registry entry helper.
- Remove bespoke changelog help handling so response mode owns changelog output behavior.
- Add drift tests covering registry docs paths, docs index entries, parser command names, manifest metadata, and unregistered command docs.

## Verification
- `git diff --check origin/main..HEAD`
- `rustfmt --check src/cli_runtime.rs src/cli_surface.rs src/command_contract/output.rs`
- Cargo tests were not run per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the cooked worktree, verification, commit, push, and PR drafting.