### PR TITLE
Refactor lab command portability descriptors

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -62,6 +62,33 @@ pub struct LabCommandContract {
     pub routing_policy: LabRoutingPolicy,
 }
 
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, PartialEq, Eq)]
+pub struct CommandPortabilityContract {
+    lab_command: Option<LabCommandContract>,
+}
+
+impl CommandPortabilityContract {
+    pub const fn none() -> Self {
+        Self { lab_command: None }
+    }
+
+    pub const fn lab(command: LabCommandContract) -> Self {
+        Self {
+            lab_command: Some(command),
+        }
+    }
+
+    pub const fn lab_optional(command: Option<LabCommandContract>) -> Self {
+        Self {
+            lab_command: command,
+        }
+    }
+
+    pub const fn lab_command(self) -> Option<LabCommandContract> {
+        self.lab_command
+    }
+}
+
 #[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
 pub enum LabCommandPortability {
     Portable,
@@ -246,8 +273,8 @@ impl LabLocalExecutionPolicy {
 }
 
 pub const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
-const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
-const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
+pub(crate) const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
+pub(crate) const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
 const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
 const AGENT_TASK_RUN_LAB_LABEL: &str = "agent-task cook/run-plan/retry --run";
@@ -264,12 +291,12 @@ pub(crate) const AUDIT_LAB_LABEL: &str = "audit";
 pub(crate) const REVIEW_LAB_LABEL: &str = "review";
 pub(crate) const BENCH_LAB_LABEL: &str = "bench";
 pub(crate) const FUZZ_LAB_LABEL: &str = "fuzz";
-const TRACE_LAB_LABEL: &str = "trace";
+pub(crate) const TRACE_LAB_LABEL: &str = "trace";
 const REFACTOR_LAB_LABEL: &str = "refactor";
-const RIG_CHECK_LAB_LABEL: &str = "rig check";
-const TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL: &str = "tunnel preview-consumer run";
-const TUNNEL_SERVICE_EXPOSE_LAB_LABEL: &str = "tunnel service expose";
-const TUNNEL_SERVICE_START_LAB_LABEL: &str = "tunnel service start";
+pub(crate) const RIG_CHECK_LAB_LABEL: &str = "rig check";
+pub(crate) const TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL: &str = "tunnel preview-consumer run";
+pub(crate) const TUNNEL_SERVICE_EXPOSE_LAB_LABEL: &str = "tunnel service expose";
+pub(crate) const TUNNEL_SERVICE_START_LAB_LABEL: &str = "tunnel service start";
 
 struct LabSupportedCommandSummary {
     contract_labels: &'static [&'static str],
@@ -444,7 +471,25 @@ fn human_join(labels: &[&str]) -> String {
 
 impl Commands {
     pub fn lab_contract(&self) -> Option<LabCommandContract> {
-        let mut contract = match self {
+        let mut contract = self.portability_contract().lab_command()?;
+
+        // Agent-task commands whose provider needs a real git checkout of the
+        // cwd workspace upgrade to the GitCheckoutRequired policy. This applies
+        // uniformly to every resolved agent-task contract; the predicate only
+        // returns true for the run/from-spec commands that own a portable or
+        // explicit-runner base, so the other arms (which set their own
+        // runner-resident policy) are left untouched.
+        if let Commands::AgentTask(args) = self {
+            if agent_task_provider_requires_cwd_git_checkout(&args.command) {
+                contract.workspace_mode_policy = LabWorkspaceModePolicy::GitCheckoutRequired;
+            }
+        }
+
+        Some(contract)
+    }
+
+    pub fn portability_contract(&self) -> CommandPortabilityContract {
+        let contract = match self {
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command: agent_task::AgentTaskCommand::Cook(args),
             }) if !args.gates.has_deterministic_gate() => LabCommandContract::local_only(
@@ -508,17 +553,19 @@ impl Commands {
                         command: agent_task::AgentTaskAuthCommand::Status(_),
                     }),
             }) => LabCommandContract::explicit_runner_simple(AGENT_TASK_AUTH_STATUS_LAB_LABEL),
-            Commands::Audit(args) => args.lab_contract()?,
-            Commands::Bench(args) => args.lab_contract()?,
-            Commands::Fuzz(args) => args.lab_contract()?,
+            Commands::Audit(args) => return CommandPortabilityContract::lab_optional(args.lab_contract()),
+            Commands::Bench(args) => return args.portability_contract(),
+            Commands::Fuzz(args) => return CommandPortabilityContract::lab_optional(args.lab_contract()),
             Commands::Extension(args) if args.is_update_command() => {
                 LabCommandContract::explicit_runner_simple("extension update")
             }
             Commands::Fleet(args) => {
-                crate::commands::fleet::adapter(CommandOutputFileMode::None).lab_contract(args)?
+                let contract = crate::commands::fleet::adapter(CommandOutputFileMode::None)
+                    .lab_contract(args);
+                return CommandPortabilityContract::lab_optional(contract);
             }
-            Commands::Lint(args) => args.lab_contract()?,
-            Commands::Review(args) => args.lab_contract(),
+            Commands::Lint(args) => return args.portability_contract(),
+            Commands::Review(args) => return CommandPortabilityContract::lab(args.lab_contract()),
             Commands::Refactor(args) if args.is_hot_resource_command() => {
                 LabCommandContract::portable(
                     "refactor",
@@ -528,55 +575,13 @@ impl Commands {
                     LAB_NO_EXTRA_TOOLS,
                 )
             }
-            Commands::Rig(args) if args.is_check_command() => {
-                LabCommandContract::portable_workload(
-                    RIG_CHECK_LAB_LABEL,
-                    None,
-                    false,
-                    LAB_NO_EXTRA_TOOLS,
-                )
-            }
-            Commands::Rig(args) if args.is_hot_resource_command() => {
-                LabCommandContract::local_only("rig up", RIG_UP_LAB_UNSUPPORTED_REASON)
-            }
-            Commands::Test(args) => args.lab_contract(),
-            Commands::Trace(args) => {
-                let mut contract = LabCommandContract::portable_workload(
-                    "trace",
-                    args.keep_overlay.then_some("--keep-overlay"),
-                    false,
-                    LAB_TRACE_EXTRA_TOOLS,
-                );
-                if args.is_compare_target_run() {
-                    contract.workspace_mode_policy = LabWorkspaceModePolicy::Git;
-                }
-                contract
-            }
-            Commands::Tunnel(args) if args.is_preview_consumer_run() => {
-                LabCommandContract::explicit_runner_simple(TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL)
-            }
-            Commands::Tunnel(args) if args.is_service_start() => {
-                LabCommandContract::runner_resident(TUNNEL_SERVICE_START_LAB_LABEL)
-            }
-            Commands::Tunnel(args) if args.is_service_expose() => {
-                LabCommandContract::runner_resident(TUNNEL_SERVICE_EXPOSE_LAB_LABEL)
-            }
-            _ => return None,
+            Commands::Rig(args) => return args.portability_contract(),
+            Commands::Test(args) => return CommandPortabilityContract::lab(args.lab_contract()),
+            Commands::Trace(args) => return args.portability_contract(),
+            Commands::Tunnel(args) => return args.portability_contract(),
+            _ => return CommandPortabilityContract::none(),
         };
-
-        // Agent-task commands whose provider needs a real git checkout of the
-        // cwd workspace upgrade to the GitCheckoutRequired policy. This applies
-        // uniformly to every resolved agent-task contract; the predicate only
-        // returns true for the run/from-spec commands that own a portable or
-        // explicit-runner base, so the other arms (which set their own
-        // runner-resident policy) are left untouched.
-        if let Commands::AgentTask(args) = self {
-            if agent_task_provider_requires_cwd_git_checkout(&args.command) {
-                contract.workspace_mode_policy = LabWorkspaceModePolicy::GitCheckoutRequired;
-            }
-        }
-
-        Some(contract)
+        CommandPortabilityContract::lab(contract)
     }
 }
 

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -1,7 +1,8 @@
 use serde_json::Value;
 
 use crate::command_contract::{
-    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
+    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, CommandPortabilityContract,
+    LabCommandContract,
 };
 
 use crate::cli_surface::Commands;
@@ -11,6 +12,7 @@ use super::{fleet, observe, version, GlobalArgs};
 pub(crate) type JsonCommandRun = (homeboy::core::Result<Value>, i32);
 pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonCommandRun;
 pub(crate) type LabContractResolver<Args> = fn(&Args) -> Option<LabCommandContract>;
+pub(crate) type PortabilityContractResolver<Args> = fn(&Args) -> CommandPortabilityContract;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CommandLabRunnerPolicy {
@@ -53,6 +55,7 @@ pub(crate) struct TypedCommandAdapter<Args> {
     pub contract: CommandAdapterContract,
     pub execute_json: Option<JsonCommandExecutor<Args>>,
     pub lab_contract: Option<LabContractResolver<Args>>,
+    pub portability_contract: Option<PortabilityContractResolver<Args>>,
 }
 
 pub(crate) struct BoundCommandAdapter {
@@ -92,6 +95,7 @@ impl<Args> TypedCommandAdapter<Args> {
             },
             execute_json: Some(execute_json),
             lab_contract: None,
+            portability_contract: None,
         }
     }
 
@@ -100,8 +104,25 @@ impl<Args> TypedCommandAdapter<Args> {
         self
     }
 
+    pub fn with_portability_contract(
+        mut self,
+        portability_contract: PortabilityContractResolver<Args>,
+    ) -> Self {
+        self.portability_contract = Some(portability_contract);
+        self
+    }
+
+    pub fn portability_contract(&self, args: &Args) -> CommandPortabilityContract {
+        if let Some(resolver) = self.portability_contract {
+            return resolver(args);
+        }
+        CommandPortabilityContract::lab_optional(
+            self.lab_contract.and_then(|resolver| resolver(args)),
+        )
+    }
+
     pub fn lab_contract(&self, args: &Args) -> Option<LabCommandContract> {
-        self.lab_contract.and_then(|resolver| resolver(args))
+        self.portability_contract(args).lab_command()
     }
 }
 
@@ -217,5 +238,33 @@ mod tests {
         assert!(fleet::adapter(CommandOutputFileMode::None)
             .lab_contract(&args)
             .is_none());
+    }
+
+    #[test]
+    fn adapter_can_expose_generic_portability_contract() {
+        let adapter = TypedCommandAdapter::<()>::json_only(
+            CommandJsonFamily::Quality,
+            CommandOutputFileMode::None,
+            |_, _| (Ok(Value::Null), 0),
+        )
+        .with_portability_contract(|_| {
+            CommandPortabilityContract::lab(LabCommandContract::portable(
+                "adapter-owned",
+                None,
+                false,
+                &[],
+            ))
+        });
+
+        let contract = adapter
+            .portability_contract(&())
+            .lab_command()
+            .expect("adapter should expose Lab portability");
+
+        assert_eq!(contract.hot_label, "adapter-owned");
+        assert!(matches!(
+            contract.portability,
+            LabCommandPortability::Portable
+        ));
     }
 }

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -21,8 +21,8 @@ use super::utils::args::{
 };
 use super::{runs, CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
-    BENCH_LAB_LABEL,
+    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, CommandPortabilityContract,
+    LabCommandContract, BENCH_LAB_LABEL,
 };
 
 mod default_baseline;
@@ -85,6 +85,10 @@ impl BenchArgs {
                 &[],
             )
         })
+    }
+
+    pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
+        CommandPortabilityContract::lab_optional(self.lab_contract())
     }
 
     pub fn is_lab_offload_command(&self) -> bool {

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -23,8 +23,8 @@ use super::utils::args::{
 use super::utils::observed_workflow::{ObservedWorkflowRunner, WorkflowObservationAdapter};
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
-    LINT_LAB_LABEL,
+    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, CommandPortabilityContract,
+    LabCommandContract, LINT_LAB_LABEL,
 };
 
 #[derive(Args)]
@@ -113,6 +113,10 @@ impl LintArgs {
         }
 
         None
+    }
+
+    pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
+        CommandPortabilityContract::lab_optional(self.lab_contract())
     }
 
     pub fn is_full_workspace_run(&self) -> bool {

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -15,6 +15,10 @@ use self::output::{
     RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput, RigUpdateOutput,
 };
 use super::CmdResult;
+use crate::command_contract::{
+    CommandPortabilityContract, LabCommandContract, LAB_NO_EXTRA_TOOLS, RIG_CHECK_LAB_LABEL,
+    RIG_UP_LAB_UNSUPPORTED_REASON,
+};
 
 #[derive(Args)]
 pub struct RigArgs {
@@ -39,6 +43,24 @@ impl RigArgs {
             self.command,
             RigCommand::Install { .. } | RigCommand::Sources { .. }
         )
+    }
+
+    pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
+        if self.is_check_command() {
+            return CommandPortabilityContract::lab(LabCommandContract::portable_workload(
+                RIG_CHECK_LAB_LABEL,
+                None,
+                false,
+                LAB_NO_EXTRA_TOOLS,
+            ));
+        }
+        if self.is_hot_resource_command() {
+            return CommandPortabilityContract::lab(LabCommandContract::local_only(
+                "rig up",
+                RIG_UP_LAB_UNSUPPORTED_REASON,
+            ));
+        }
+        CommandPortabilityContract::none()
     }
 }
 

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -19,6 +19,10 @@ use homeboy::core::rig::{self, RigSpec};
 
 use super::utils::args::{BaselineArgs, PositionalComponentArgs, SettingArgs};
 use super::{CmdResult, GlobalArgs};
+use crate::command_contract::{
+    CommandPortabilityContract, LabCommandContract, LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
+    TRACE_LAB_LABEL,
+};
 
 mod aggregate;
 #[cfg(test)]
@@ -261,6 +265,19 @@ impl TraceArgs {
     pub fn is_compare_target_run(&self) -> bool {
         self.comp.component.as_deref() == Some("compare")
             && (self.baseline_target.is_some() || self.candidate.is_some())
+    }
+
+    pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
+        let mut contract = LabCommandContract::portable_workload(
+            TRACE_LAB_LABEL,
+            self.keep_overlay.then_some("--keep-overlay"),
+            false,
+            LAB_TRACE_EXTRA_TOOLS,
+        );
+        if self.is_compare_target_run() {
+            contract.workspace_mode_policy = LabWorkspaceModePolicy::Git;
+        }
+        CommandPortabilityContract::lab(contract)
     }
 }
 

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -23,6 +23,10 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use super::{CmdResult, DynamicSetArgs};
+use crate::command_contract::{
+    CommandPortabilityContract, LabCommandContract, TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
+    TUNNEL_SERVICE_EXPOSE_LAB_LABEL, TUNNEL_SERVICE_START_LAB_LABEL,
+};
 
 mod service;
 use service::TunnelServiceCommand;
@@ -114,6 +118,25 @@ impl TunnelArgs {
                 command: TunnelServiceCommand::Expose { .. }
             }
         )
+    }
+
+    pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
+        if self.is_preview_consumer_run() {
+            return CommandPortabilityContract::lab(LabCommandContract::explicit_runner_simple(
+                TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
+            ));
+        }
+        if self.is_service_start() {
+            return CommandPortabilityContract::lab(LabCommandContract::runner_resident(
+                TUNNEL_SERVICE_START_LAB_LABEL,
+            ));
+        }
+        if self.is_service_expose() {
+            return CommandPortabilityContract::lab(LabCommandContract::runner_resident(
+                TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
+            ));
+        }
+        CommandPortabilityContract::none()
     }
 }
 

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -636,6 +636,39 @@ fn test_lab_command_contracts_cover_hot_commands() {
 }
 
 #[test]
+fn command_portability_contract_exposes_delegated_lab_descriptors() {
+    for args in [
+        ["homeboy", "bench"].as_slice(),
+        ["homeboy", "lint"].as_slice(),
+        ["homeboy", "trace"].as_slice(),
+        ["homeboy", "rig", "check", "studio"].as_slice(),
+        [
+            "homeboy",
+            "tunnel",
+            "preview-consumer",
+            "run",
+            "--config",
+            "preview-consumer.json",
+            "--preview-public-url",
+            "https://preview.example.test/",
+        ]
+        .as_slice(),
+    ] {
+        let command = parsed_command(args);
+        assert_eq!(
+            command.portability_contract().lab_command(),
+            command.lab_contract(),
+            "portability descriptor diverged for {args:?}"
+        );
+    }
+
+    assert!(parsed_command(&["homeboy", "bench", "list"])
+        .portability_contract()
+        .lab_command()
+        .is_none());
+}
+
+#[test]
 fn agent_task_git_checkout_policy_uses_default_backend_when_backend_is_omitted() {
     let command = parsed_command(&[
         "homeboy",


### PR DESCRIPTION
## Summary
- Add a generic command portability contract wrapper around Lab command descriptors.
- Delegate lab portability descriptors to command-owned implementations for bench, lint, rig, trace, and tunnel commands.
- Add coverage proving delegated portability descriptors stay aligned with existing lab contracts.

## Verification
- git diff --check origin/main...HEAD
- rustfmt --check src/command_contract/lab.rs src/commands/adapter.rs src/commands/bench.rs src/commands/lint.rs src/commands/rig/mod.rs src/commands/trace.rs src/commands/tunnel.rs tests/command_contract/lab_test.rs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the prepared worktree, reviewing the diff, running non-cargo verification, committing, pushing, and drafting this PR description.

No cargo commands or benchmarks were run.