### PR TITLE
Mirror reverse runner artifact content

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -1775,6 +1775,7 @@ mod tests {
                         mime: Some("application/json".to_string()),
                         size_bytes: Some(42),
                         sha256: Some("abc123".to_string()),
+                        content_base64: None,
                         metadata: Some(json!({ "kind": "test_report" })),
                     }],
                     artifact_refs: Vec::new(),

--- a/src/core/api_jobs/remote_runner.rs
+++ b/src/core/api_jobs/remote_runner.rs
@@ -28,6 +28,8 @@ pub struct JobArtifactMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_base64: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
 }
 
@@ -289,7 +291,14 @@ impl JobStore {
                 .jobs
                 .get_mut(&job_id)
                 .ok_or_else(|| job_not_found(job_id))?;
-            stored.job.artifacts = result.artifacts;
+            stored.job.artifacts = result
+                .artifacts
+                .into_iter()
+                .map(|mut artifact| {
+                    artifact.content_base64 = None;
+                    artifact
+                })
+                .collect();
         }
         self.persist()?;
 

--- a/src/core/daemon/remote_runner.rs
+++ b/src/core/daemon/remote_runner.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use super::{daemon_endpoint_response, error_response, HttpResponse};
 use crate::core::api_jobs::{
-    JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerJobResult,
+    JobArtifactMetadata, JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerJobResult,
 };
 use crate::core::error::{Error, Result};
 use crate::core::paths;
@@ -150,7 +150,7 @@ pub(in crate::core::daemon) fn route(
 }
 
 fn lookup(path: &str, job_store: &JobStore) -> HttpResponse {
-    let Some((job_id, artifact_id)) = job_artifact_path(path) else {
+    let Some((job_id, artifact_id, content)) = job_artifact_path(path) else {
         return error_response(
             404,
             Error::validation_invalid_argument(
@@ -164,7 +164,12 @@ fn lookup(path: &str, job_store: &JobStore) -> HttpResponse {
         );
     };
 
-    match lookup_artifact(job_id, &artifact_id, job_store) {
+    let result = if content {
+        lookup_artifact_content(job_id, &artifact_id, job_store)
+    } else {
+        lookup_artifact(job_id, &artifact_id, job_store)
+    };
+    match result {
         Ok(body) => daemon_endpoint_response("runner.jobs.artifacts.lookup", body),
         Err(err) => error_response(404, err),
     }
@@ -172,6 +177,11 @@ fn lookup(path: &str, job_store: &JobStore) -> HttpResponse {
 
 fn lookup_artifact(job_id: Uuid, artifact_id: &str, job_store: &JobStore) -> Result<Value> {
     let job = job_store.get(job_id)?;
+    let encoded_artifact_id = crate::core::execution_contract::encode_uri_component(artifact_id);
+    let content_path = format!("/runner/jobs/{job_id}/artifacts/{encoded_artifact_id}/content");
+    let content_available = mirrored_artifact_content(job_id, artifact_id, job_store)?
+        .and_then(|artifact| artifact.content_base64)
+        .is_some();
     let artifact = job
         .artifacts
         .iter()
@@ -183,7 +193,7 @@ fn lookup_artifact(job_id: Uuid, artifact_id: &str, job_store: &JobStore) -> Res
                 format!("remote runner artifact record not found: {artifact_id}"),
                 Some(artifact_id.to_string()),
                 Some(vec![
-                    "Reverse broker artifact lookup exposes metadata posted with the finished job; artifact bytes are not stored by the broker yet.".to_string(),
+                    "Reverse broker artifact lookup exposes metadata posted with the finished job and a content path when worker-mirrored bytes are present.".to_string(),
                 ]),
             )
         })?;
@@ -194,15 +204,86 @@ fn lookup_artifact(job_id: Uuid, artifact_id: &str, job_store: &JobStore) -> Res
         "artifact_id": artifact_id,
         "artifact": artifact,
         "retrieval": {
-            "mode": "metadata_only",
-            "content_available": false,
-            "content_url": null,
-            "fetch_command": null,
-            "metadata_path": format!("/runner/jobs/{job_id}/artifacts/{artifact_id}"),
-            "future_content_path": format!("/runner/jobs/{job_id}/artifacts/{artifact_id}/content"),
-            "hint": "Reverse broker artifacts currently retain metadata only. Use runner-side artifact commands for bytes until broker content proxying lands."
+            "mode": "broker_content_path",
+            "content_available": content_available,
+            "content_url": if content_available { json!(content_path.clone()) } else { Value::Null },
+            "fetch_command": if content_available { json!(format!("curl -fsS {content_path}")) } else { Value::Null },
+            "metadata_path": format!("/runner/jobs/{job_id}/artifacts/{encoded_artifact_id}"),
+            "content_path": content_path,
+            "hint": "Reverse broker artifacts are mirrored from the worker finish payload and can be fetched through the broker content path."
         }
     }))
+}
+
+fn lookup_artifact_content(job_id: Uuid, artifact_id: &str, job_store: &JobStore) -> Result<Value> {
+    let artifact = mirrored_artifact_content(job_id, artifact_id, job_store)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact_id",
+            format!("remote runner artifact content not found: {artifact_id}"),
+            Some(artifact_id.to_string()),
+            Some(vec![
+                "Only artifacts mirrored by the reverse worker finish payload can be fetched from the broker content path.".to_string(),
+            ]),
+        )
+    })?;
+    let content_base64 = artifact.content_base64.clone().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact_id",
+            format!("remote runner artifact content not mirrored: {artifact_id}"),
+            Some(artifact_id.to_string()),
+            None,
+        )
+    })?;
+    Ok(json!({
+        "command": "api.runner.jobs.artifacts.content",
+        "job_id": job_id.to_string(),
+        "artifact_id": artifact.id,
+        "content_available": true,
+        "retrieval": inline_content_retrieval(),
+        "filename": artifact.name.unwrap_or_else(|| artifact_id.to_string()),
+        "mime": artifact.mime,
+        "size_bytes": artifact.size_bytes,
+        "sha256": artifact.sha256,
+        "content_base64": content_base64,
+    }))
+}
+
+fn mirrored_artifact_content(
+    job_id: Uuid,
+    artifact_id: &str,
+    job_store: &JobStore,
+) -> Result<Option<JobArtifactMetadata>> {
+    for event in job_store.events(job_id)?.into_iter().rev() {
+        if event.kind != JobEventKind::Result {
+            continue;
+        }
+        let Some(data) = event.data else {
+            continue;
+        };
+        let result: RemoteRunnerJobResult = serde_json::from_value(data).map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("parse remote runner result event".to_string()),
+            )
+        })?;
+        if let Some(artifact) = result
+            .artifacts
+            .into_iter()
+            .find(|artifact| artifact.id == artifact_id)
+        {
+            return Ok(Some(artifact));
+        }
+    }
+    Ok(None)
+}
+
+fn inline_content_retrieval() -> Value {
+    json!({
+        "mode": "inline_base64",
+        "content_available": true,
+        "content_field": "content_base64",
+        "encoding": "base64",
+    })
 }
 
 fn reconcile(job_store: &JobStore) -> Result<Value> {
@@ -365,10 +446,15 @@ fn job_path(path: &str) -> Option<(Uuid, &str)> {
     Some((job_id, operation))
 }
 
-fn job_artifact_path(path: &str) -> Option<(Uuid, String)> {
+fn job_artifact_path(path: &str) -> Option<(Uuid, String, bool)> {
     let tail = path.strip_prefix("/runner/jobs/")?;
     let (job_id, tail) = tail.split_once('/')?;
     let artifact_id = tail.strip_prefix("artifacts/")?;
+    let (artifact_id, content) = if let Some(artifact_id) = artifact_id.strip_suffix("/content") {
+        (artifact_id, true)
+    } else {
+        (artifact_id, false)
+    };
     if artifact_id.is_empty() || artifact_id.contains('/') {
         return None;
     }
@@ -376,6 +462,7 @@ fn job_artifact_path(path: &str) -> Option<(Uuid, String)> {
     Some((
         job_id,
         crate::core::execution_contract::decode_uri_component(artifact_id),
+        content,
     ))
 }
 
@@ -635,6 +722,103 @@ mod auth_tests {
         );
         assert_eq!(finish.status_code, 200, "finish body: {}", finish.body);
         assert_eq!(finish.body["body"]["job"]["status"], "succeeded");
+    }
+
+    #[test]
+    fn broker_artifact_content_path_returns_worker_mirrored_bytes() {
+        let _home = HomeGuard::new();
+        let store = JobStore::default();
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(submit_body()),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(submit.status_code, 200, "submit body: {}", submit.body);
+        let job_id = submit.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id")
+            .to_string();
+        let claim = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(json!({ "runner_id": "homeboy-lab", "lease_ms": 30000 })),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(claim.status_code, 200, "claim body: {}", claim.body);
+        let claim_id = claim.body["body"]["claim"]["job"]["claim_id"]
+            .as_str()
+            .expect("claim id")
+            .to_string();
+
+        let finish = route(
+            "POST",
+            &format!("/runner/jobs/{job_id}/finish"),
+            Some(json!({
+                "runner_id": "homeboy-lab",
+                "claim_id": claim_id,
+                "result": {
+                    "exit_code": 0,
+                    "artifacts": [{
+                        "id": "report.txt",
+                        "name": "report.txt",
+                        "path": "/worker/report.txt",
+                        "mime": "text/plain",
+                        "size_bytes": 21,
+                        "content_base64": "d29ya2VyIGFydGlmYWN0IGJ5dGVz"
+                    }]
+                }
+            })),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(finish.status_code, 200, "finish body: {}", finish.body);
+        assert!(finish.body["body"]["job"]["artifacts"][0]
+            .get("content_base64")
+            .is_none());
+
+        let metadata = route(
+            "GET",
+            &format!("/runner/jobs/{job_id}/artifacts/report.txt"),
+            None,
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(
+            metadata.status_code, 200,
+            "metadata body: {}",
+            metadata.body
+        );
+        assert_eq!(
+            metadata.body["body"]["retrieval"]["content_available"],
+            json!(true)
+        );
+        assert_eq!(
+            metadata.body["body"]["retrieval"]["content_path"],
+            json!(format!(
+                "/runner/jobs/{job_id}/artifacts/report.txt/content"
+            ))
+        );
+
+        let content = route(
+            "GET",
+            &format!("/runner/jobs/{job_id}/artifacts/report.txt/content"),
+            None,
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(content.status_code, 200, "content body: {}", content.body);
+        assert_eq!(content.body["body"]["content_available"], json!(true));
+        assert_eq!(
+            content.body["body"]["retrieval"]["mode"],
+            json!("inline_base64")
+        );
+        assert_eq!(
+            content.body["body"]["content_base64"],
+            json!("d29ya2VyIGFydGlmYWN0IGJ5dGVz")
+        );
     }
 
     #[test]

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -1417,6 +1417,7 @@ mod tests {
                 mime: None,
                 size_bytes: None,
                 sha256: None,
+                content_base64: None,
                 metadata: None,
             }],
         };
@@ -1551,6 +1552,7 @@ mod tests {
                 mime: None,
                 size_bytes: None,
                 sha256: None,
+                content_base64: None,
                 metadata: None,
             }],
         };

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -6,6 +6,7 @@ use std::sync::{
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+use base64::Engine;
 use reqwest::blocking::Client;
 use serde::Serialize;
 use serde_json::json;
@@ -460,6 +461,7 @@ fn remote_runner_result_from_exec_output(
     if let Some(mirror_run_id) = exec_output.mirror_run_id.clone() {
         data["mirror_run_id"] = json!(mirror_run_id);
     }
+    let artifacts = mirror_file_artifact_content(exec_output.artifacts, &exec_output.remote_cwd);
     RemoteRunnerJobResult {
         exit_code,
         stdout: Some(exec_output.stdout),
@@ -468,7 +470,7 @@ fn remote_runner_result_from_exec_output(
         mutation_artifacts,
         data: Some(data),
         observation_run_ids: exec_output.mirror_run_id.into_iter().collect(),
-        artifacts: exec_output.artifacts,
+        artifacts,
         artifact_refs: exec_output
             .runner_result
             .map(|result| {
@@ -483,6 +485,7 @@ fn remote_runner_result_from_exec_output(
                         mime: artifact.mime,
                         size_bytes: artifact.size_bytes,
                         sha256: artifact.sha256,
+                        content_base64: None,
                         metadata: None,
                     })
                     .collect()
@@ -491,6 +494,38 @@ fn remote_runner_result_from_exec_output(
         metrics: exec_output.metrics,
         capture: exec_output.capture,
     }
+}
+
+fn mirror_file_artifact_content(
+    artifacts: Vec<JobArtifactMetadata>,
+    remote_cwd: &str,
+) -> Vec<JobArtifactMetadata> {
+    artifacts
+        .into_iter()
+        .map(|mut artifact| {
+            if artifact.content_base64.is_none() {
+                if let Some(path) = artifact.path.as_deref().map(|path| {
+                    let path = std::path::PathBuf::from(path);
+                    if path.is_absolute() {
+                        path
+                    } else {
+                        std::path::Path::new(remote_cwd).join(path)
+                    }
+                }) {
+                    if path.is_file() {
+                        if let Ok(content) = std::fs::read(&path) {
+                            artifact.size_bytes = artifact
+                                .size_bytes
+                                .or_else(|| u64::try_from(content.len()).ok());
+                            artifact.content_base64 =
+                                Some(base64::engine::general_purpose::STANDARD.encode(content));
+                        }
+                    }
+                }
+            }
+            artifact
+        })
+        .collect()
 }
 
 fn cancelled_output(
@@ -876,6 +911,7 @@ mod tests {
                     mime: Some("text/x-diff".to_string()),
                     size_bytes: Some(42),
                     sha256: Some("abc123".to_string()),
+                    content_base64: None,
                     metadata: Some(json!({ "kind": "lab_fix_patch" })),
                 }],
                 metrics: None,
@@ -904,6 +940,58 @@ mod tests {
                 .and_then(|artifacts| artifacts.patch_ref.as_ref())
                 .map(|artifact| artifact.artifact_id.as_str()),
             Some("patch.diff")
+        );
+    }
+
+    #[test]
+    fn reverse_worker_result_mirrors_file_artifact_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let artifact_path = dir.path().join("report.txt");
+        std::fs::write(&artifact_path, b"worker artifact bytes").expect("write artifact");
+
+        let result = remote_runner_result_from_exec_output(
+            super::super::execution::RunnerExecOutput {
+                variant: "exec",
+                command: "runner.exec",
+                runner_id: "lab".to_string(),
+                dry_run: false,
+                mode: RunnerExecMode::Local,
+                argv: vec!["sh".to_string(), "-c".to_string(), "true".to_string()],
+                remote_cwd: dir.path().display().to_string(),
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+                source_snapshot: None,
+                job: None,
+                runner_job: None,
+                job_id: None,
+                job_events: None,
+                mirror_run_id: None,
+                patch: None,
+                mutation_artifacts: None,
+                artifacts: vec![JobArtifactMetadata {
+                    id: "report".to_string(),
+                    name: Some("report.txt".to_string()),
+                    path: Some("report.txt".to_string()),
+                    url: None,
+                    mime: Some("text/plain".to_string()),
+                    size_bytes: Some(21),
+                    sha256: None,
+                    content_base64: None,
+                    metadata: None,
+                }],
+                metrics: None,
+                capture: None,
+                runner_result: None,
+                handoff: None,
+                diagnostics: None,
+            },
+            0,
+        );
+
+        assert_eq!(
+            result.artifacts[0].content_base64.as_deref(),
+            Some("d29ya2VyIGFydGlmYWN0IGJ5dGVz")
         );
     }
 


### PR DESCRIPTION
## Summary
- Mirror file-backed reverse runner artifacts into the worker finish payload as base64 content.
- Keep persisted job artifact metadata content-free while preserving mirrored bytes in result events.
- Expose broker artifact content lookup paths when mirrored bytes are available.

## Verification
- git diff --check
- git diff --cached --check
- rustfmt --check src/core/api_jobs.rs src/core/api_jobs/remote_runner.rs src/core/daemon/remote_runner.rs src/core/runner/evidence.rs src/core/runner/worker.rs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the cooked worktree, reviewing the diff, committing, pushing, and drafting this PR description.