### PR TITLE
Make runs readers canonical for benchmarks

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -238,11 +238,19 @@ homeboy runs list --kind bench --component <component> --rig <rig>
 
 Omit `--rig <rig>` from the list command for unpinned bench runs.
 
-`homeboy bench history <component>` lists persisted benchmark runs from the local observation store. `--scenario` filters to runs whose stored metadata includes the scenario, and `--rig` narrows to rig-pinned runs.
+`homeboy runs` is the canonical reader for persisted observation-store records. Use these commands for new automation:
 
-`homeboy bench distribution <component> --field <metadata.path>` summarizes repeated categorical values from persisted benchmark run metadata. It is generic over metadata shape: scalar string, number, and boolean values are counted directly, and arrays are flattened. Use `--scenario`, `--rig`, `--status`, and `--limit` to narrow the persisted run window before aggregation.
+```bash
+homeboy runs list --kind bench --component <component> [--scenario <id>] [--rig <id>] [--limit 20]
+homeboy runs distribution --kind bench --component <component> --field <metadata.path> [--scenario <id>] [--rig <id>] [--status <status>] [--limit 20]
+homeboy runs bench-compare --from-run <baseline-run-id> --to-run <candidate-run-id> [--metric <name>]
+```
 
-`homeboy bench compare --from-run <baseline-run-id> --to-run <candidate-run-id>` compares numeric metrics recorded in two persisted benchmark runs. It is the first useful baseline-vs-candidate comparison slice: it captures both run IDs, component state, shared bench context, selected metric deltas, and a Markdown table under `reports.markdown` in the JSON payload.
+The legacy `homeboy bench history <component>` reader is a compatibility wrapper over `runs list` and returns the same `runs.list` payload. `--scenario` filters to runs whose stored metadata includes the scenario, and `--rig` narrows to rig-pinned runs.
+
+The legacy `homeboy bench distribution <component> --field <metadata.path>` reader delegates to `runs distribution` and returns the same `runs.distribution` payload. It is generic over metadata shape: scalar string, number, and boolean values are counted directly, and arrays are flattened. Use `--scenario`, `--rig`, `--status`, and `--limit` to narrow the persisted run window before aggregation.
+
+The legacy `homeboy bench compare --from-run <baseline-run-id> --to-run <candidate-run-id>` reader delegates to `runs bench-compare` and returns the same `runs.bench-compare` payload. It compares numeric metrics recorded in two persisted benchmark runs, captures both run IDs, component state, shared bench context, selected metric deltas, and includes a Markdown table under `reports.markdown` in the JSON payload.
 
 Bench runners may attach generic tracker provenance to the top-level results
 envelope or to individual scenarios/workloads. Homeboy persists that metadata in

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -5,10 +5,11 @@ Inspect and maintain persisted observation-store runs and artifacts.
 ## Synopsis
 
 ```bash
-homeboy runs list [--runner <runner-id>] [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--limit 20] [--include-active-runner-jobs]
+homeboy runs list [--runner <runner-id>] [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--scenario <id>] [--status <status>] [--limit 20] [--include-active-runner-jobs]
 homeboy runs distribution --field <metadata.path> [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--status <status>] [--limit 20]
 homeboy runs latest-run [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>]
 homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
+homeboy runs bench-compare --from-run <run-id> --to-run <run-id> [--metric <name>]
 homeboy runs show <run-id> [--json]
 homeboy runs resume-plan <run-id>
 homeboy runs evidence <run-id>
@@ -34,7 +35,7 @@ homeboy runs loop-sync <archive-root> [--component <id>] [--rig <id>] [--label <
 
 `homeboy runs` is the inspection and maintenance surface for Homeboy's local observation store. Producers such as `bench`, `rig`, and `trace` write run and artifact records; this command lets humans and agents inspect that evidence without opening SQLite directly, export/import portable bundles, and run explicit cleanup or reconciliation tasks.
 
-`homeboy runs list` reads only the local observation store by default. Pass `--include-active-runner-jobs` to also append active jobs from connected runner daemons, which may inspect runner sessions. `homeboy runs list --runner <runner-id>` queries a connected runner daemon instead of the local observation store, preserving the normal `runs.list` JSON payload while returning evidence from the runner machine.
+`homeboy runs list` reads only the local observation store by default. Pass `--include-active-runner-jobs` to also append active jobs from connected runner daemons, which may inspect runner sessions. `homeboy runs list --runner <runner-id>` queries a connected runner daemon instead of the local observation store, preserving the normal `runs.list` JSON payload while returning evidence from the runner machine. For benchmark records, `--scenario <id>` filters to runs whose stored metadata includes that scenario.
 
 The JSON output includes stable run fields: run id, kind, status, timestamps, component id, rig id, git SHA, command, cwd, metadata, and artifact records where relevant.
 
@@ -99,6 +100,8 @@ homeboy runs compare --kind bench --component studio --metric total_elapsed_ms -
 
 Metric lookup supports top-level run metadata such as `results.total_elapsed_ms`, direct dotted paths, and benchmark scenario metrics recorded under `scenario_metrics[].metrics` or `metric_groups`.
 
+`homeboy runs bench-compare --from-run <baseline-run-id> --to-run <candidate-run-id>` compares numeric metrics recorded in two exact benchmark runs. It captures both run IDs, component state, shared benchmark context, selected metric deltas, and a Markdown table under `reports.markdown` in the JSON payload.
+
 ## Related Readers
 
 ```bash
@@ -108,7 +111,7 @@ homeboy bench compare --from-run <run-id> --to-run <run-id>
 homeboy rig runs <id> [--limit 20]
 ```
 
-These commands are thin read-only wrappers over the same observation-store records.
+These commands are thin read-only compatibility wrappers over the same observation-store records. Prefer `runs` readers for new automation: `bench history` returns the `runs.list` payload, `bench distribution` returns `runs.distribution`, and `bench compare` returns `runs.bench-compare`.
 
 ## Portable Bundles
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -466,11 +466,18 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
             }
             BenchCommand::List(list_args) => run_list(list_args),
             BenchCommand::History(history_args) => {
-                let (output, exit_code) = runs::bench_history(
-                    &history_args.component,
-                    history_args.scenario_id.as_deref(),
-                    history_args.rig.as_deref(),
-                    history_args.limit,
+                let (output, exit_code) = runs::list_runs(
+                    runs::RunsListArgs {
+                        runner: None,
+                        kind: Some("bench".to_string()),
+                        component_id: Some(history_args.component.clone()),
+                        rig: history_args.rig.clone(),
+                        scenario_id: history_args.scenario_id.clone(),
+                        status: None,
+                        limit: history_args.limit,
+                        include_active_runner_jobs: false,
+                    },
+                    "runs.list",
                 )?;
                 Ok((BenchOutput::Observation(output), exit_code))
             }
@@ -485,16 +492,17 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
                         fields: distribution_args.fields.clone(),
                         limit: distribution_args.limit,
                     },
-                    "bench.distribution",
+                    "runs.distribution",
                 )?;
                 Ok((BenchOutput::Observation(output), exit_code))
             }
             BenchCommand::Compare(compare_args) => {
-                let (output, exit_code) = runs::bench_compare(
-                    &compare_args.from_run,
-                    &compare_args.to_run,
-                    &compare_args.metrics,
-                )?;
+                let (output, exit_code) =
+                    runs::bench_compare_from_args(runs::RunsBenchCompareArgs {
+                        from_run: compare_args.from_run.clone(),
+                        to_run: compare_args.to_run.clone(),
+                        metrics: compare_args.metrics.clone(),
+                    })?;
                 Ok((BenchOutput::Observation(output), exit_code))
             }
         };

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -38,7 +38,7 @@ use homeboy::core::{api_jobs, runners as runner};
 use homeboy::core::artifact_links::ArtifactViewerDescriptor;
 
 use super::{CmdResult, GlobalArgs};
-pub use bench::{bench_compare, bench_history, BenchCompareOutput, BenchHistoryOutput};
+pub use bench::{bench_compare, BenchCompareOutput, RunsBenchCompareArgs};
 pub(super) use bench::{bench_numeric_metrics, run_contains_scenario};
 use bundle::{
     export_runs, import_runs, RunsExportArgs, RunsExportOutput, RunsImportArgs, RunsImportOutput,
@@ -110,6 +110,8 @@ enum RunsCommand {
     LatestRun(RunsLatestRunArgs),
     /// Compare selected metrics across persisted run history
     Compare(RunsCompareArgs),
+    /// Compare two persisted benchmark runs by exact run id
+    BenchCompare(RunsBenchCompareArgs),
     /// Mark orphaned running observation records stale
     Reconcile(RunsReconcileArgs),
     /// Show one persisted observation run
@@ -165,6 +167,9 @@ pub struct RunsListArgs {
     /// Rig ID
     #[arg(long)]
     pub rig: Option<String>,
+    /// Benchmark scenario ID. Only applies to bench metadata.
+    #[arg(long = "scenario")]
+    pub scenario_id: Option<String>,
     /// Run status
     #[arg(long)]
     pub status: Option<String>,
@@ -193,7 +198,6 @@ pub enum RunsOutput {
     Findings(RunsFindingsOutput),
     Finding(RunsFindingOutput),
     LatestFinding(RunsLatestFindingOutput),
-    BenchHistory(BenchHistoryOutput),
     BenchCompare(BenchCompareOutput),
     Reconcile(RunsReconcileOutput),
     Export(RunsExportOutput),
@@ -369,6 +373,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         }
         RunsCommand::LatestRun(args) => latest::latest_run(args),
         RunsCommand::Compare(args) => compare_runs(args),
+        RunsCommand::BenchCompare(args) => bench::bench_compare_from_args(args),
         RunsCommand::Reconcile(args) => reconcile_runs(args),
         RunsCommand::Show { run_id, json: _ } => show_run(&run_id),
         RunsCommand::ResumePlan { run_id } => resume_plan(&run_id),
@@ -501,6 +506,14 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
         rig_id: args.rig,
         limit: Some(args.limit),
     })?;
+    let run_records = run_records
+        .into_iter()
+        .filter(|run| {
+            args.scenario_id
+                .as_deref()
+                .is_none_or(|scenario| run_contains_scenario(run, scenario))
+        })
+        .collect::<Vec<_>>();
     let mut runs = run_summaries_with_artifact_indexes(&store, run_records)?;
 
     if args.include_active_runner_jobs {
@@ -833,6 +846,7 @@ mod tests {
                     kind: Some("bench".to_string()),
                     component_id: Some("homeboy".to_string()),
                     rig: Some("studio".to_string()),
+                    scenario_id: None,
                     status: Some("pass".to_string()),
                     limit: 20,
                     include_active_runner_jobs: false,
@@ -864,6 +878,7 @@ mod tests {
                     kind: Some("bench".to_string()),
                     component_id: Some("homeboy".to_string()),
                     rig: Some("studio".to_string()),
+                    scenario_id: None,
                     status: None,
                     limit: 20,
                     include_active_runner_jobs: false,
@@ -1646,14 +1661,26 @@ mod tests {
                 .finish_run(&new.id, RunStatus::Pass, None)
                 .expect("finish new");
 
-            let (output, _) =
-                bench_history("homeboy", Some("cold"), Some("studio"), 20).expect("history");
-            let RunsOutput::BenchHistory(output) = output else {
+            let (output, _) = list_runs(
+                RunsListArgs {
+                    runner: None,
+                    kind: Some("bench".to_string()),
+                    component_id: Some("homeboy".to_string()),
+                    rig: Some("studio".to_string()),
+                    scenario_id: Some("cold".to_string()),
+                    status: None,
+                    limit: 20,
+                    include_active_runner_jobs: false,
+                },
+                "runs.list",
+            )
+            .expect("history");
+            let RunsOutput::List(output) = output else {
                 panic!("expected history output");
             };
             assert_eq!(output.runs.len(), 2);
-            assert_eq!(output.runs[0].summary.id, new.id);
-            assert_eq!(output.runs[1].summary.id, old.id);
+            assert_eq!(output.runs[0].id, new.id);
+            assert_eq!(output.runs[1].id, old.id);
         });
     }
 

--- a/src/commands/runs/artifact_index_tests.rs
+++ b/src/commands/runs/artifact_index_tests.rs
@@ -75,6 +75,7 @@ fn rig_runs_list_surfaces_compact_artifact_index() {
                 kind: None,
                 component_id: None,
                 rig: Some("proof-rig".to_string()),
+                scenario_id: None,
                 status: None,
                 limit: 20,
                 include_active_runner_jobs: false,

--- a/src/commands/runs/bench/mod.rs
+++ b/src/commands/runs/bench/mod.rs
@@ -1,47 +1,18 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use homeboy::core::observation::{ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::observation::{ObservationStore, RunRecord};
 use homeboy::core::Error;
 use serde_json::Value;
 
 use crate::commands::escape_markdown_table_cell;
 
-use super::{require_run, run_detail, run_summary, CmdResult, RunDetail, RunSummary, RunsOutput};
+use super::{require_run, run_summary, CmdResult, RunSummary, RunsOutput};
 
 mod types;
 pub use types::*;
 
-pub fn bench_history(
-    component_id: &str,
-    scenario_id: Option<&str>,
-    rig_id: Option<&str>,
-    limit: i64,
-) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let runs = store
-        .list_runs(RunListFilter {
-            kind: Some("bench".to_string()),
-            component_id: Some(component_id.to_string()),
-            rig_id: rig_id.map(str::to_string),
-            limit: Some(limit.clamp(1, 1000)),
-            ..RunListFilter::default()
-        })?
-        .into_iter()
-        .filter(|run| scenario_id.is_none_or(|scenario| run_contains_scenario(run, scenario)))
-        .take(limit.max(1) as usize)
-        .map(|run| run_detail(&store, run))
-        .collect::<homeboy::core::Result<Vec<_>>>()?;
-
-    Ok((
-        RunsOutput::BenchHistory(BenchHistoryOutput {
-            command: "bench.history",
-            component_id: component_id.to_string(),
-            scenario_id: scenario_id.map(str::to_string),
-            rig_id: rig_id.map(str::to_string),
-            runs,
-        }),
-        0,
-    ))
+pub fn bench_compare_from_args(args: RunsBenchCompareArgs) -> CmdResult<RunsOutput> {
+    bench_compare(&args.from_run, &args.to_run, &args.metrics)
 }
 
 pub fn bench_compare(
@@ -118,7 +89,7 @@ pub fn bench_compare(
 
     Ok((
         RunsOutput::BenchCompare(BenchCompareOutput {
-            command: "bench.compare",
+            command: "runs.bench-compare",
             baseline,
             candidate,
             shared,

--- a/src/commands/runs/bench/types.rs
+++ b/src/commands/runs/bench/types.rs
@@ -1,19 +1,22 @@
 use std::collections::BTreeMap;
 
+use clap::Args;
 use serde::Serialize;
 use serde_json::Value;
 
-use super::{RunDetail, RunSummary};
+use super::RunSummary;
 
-#[derive(Serialize)]
-pub struct BenchHistoryOutput {
-    pub command: &'static str,
-    pub component_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scenario_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rig_id: Option<String>,
-    pub runs: Vec<RunDetail>,
+#[derive(Args, Clone)]
+pub struct RunsBenchCompareArgs {
+    /// Earlier benchmark run ID
+    #[arg(long = "from-run")]
+    pub from_run: String,
+    /// Later benchmark run ID
+    #[arg(long = "to-run")]
+    pub to_run: String,
+    /// Metric to include. Repeat to compare multiple metrics. Defaults to all shared numeric metrics.
+    #[arg(long = "metric")]
+    pub metrics: Vec<String>,
 }
 
 #[derive(Serialize)]

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -207,13 +207,9 @@ fn runs_rig_and_bench_output_variants_have_unambiguous_contracts() {
                 json!({ "command": "runs.latest-finding", "run": {}, "finding": {} }),
             ),
             variant_contract(
-                "bench_history",
-                json!({ "command": "bench.history", "component_id": "homeboy", "runs": [] }),
-            ),
-            variant_contract(
                 "bench_compare",
                 json!({
-                    "command": "bench.compare",
+                    "command": "runs.bench-compare",
                     "from_run": {},
                     "to_run": {},
                     "comparisons": [],


### PR DESCRIPTION
## Summary
- Make `homeboy runs` the canonical reader surface for benchmark history/distribution/compare outputs.
- Add `runs bench-compare` and `runs list --scenario` support.
- Keep legacy `homeboy bench` readers as compatibility wrappers returning canonical `runs.*` payloads.

## Verification
- `git diff --check origin/main..HEAD`
- `rustfmt --check src/commands/bench.rs src/commands/runs.rs src/commands/runs/artifact_index_tests.rs src/commands/runs/bench/mod.rs src/commands/runs/bench/types.rs tests/output_contracts_test.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the cooked worktree, verifying the diff, rebasing onto `main`, committing, and drafting the PR.