### PR TITLE
Fail closed on deploy release asset misses

### DIFF
--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -498,6 +498,7 @@ fn component_deploy_result(id: &str) -> ComponentDeployResult {
         warnings: Vec::new(),
         error: None,
         artifact_path: Some("target/dist/homeboy.tar.gz".to_string()),
+        artifact_source: None,
         artifact_inputs: Vec::new(),
         remote_path: Some("/srv/homeboy".to_string()),
         build_exit_code: None,

--- a/src/core/deploy/execution/prepare.rs
+++ b/src/core/deploy/execution/prepare.rs
@@ -8,7 +8,7 @@ use crate::core::project::Project;
 use super::super::generated_artifacts::GeneratedBuildArtifactCleanupGuard;
 use super::super::path_roots::{component_remote_path, resolve_effective_remote_path};
 use super::super::policy::{owner_hint_for_path, protected_path_suffixes, validate_deploy_target};
-use super::super::types::{ComponentDeployResult, DeployConfig};
+use super::super::types::{ComponentDeployResult, DeployArtifactSource, DeployConfig};
 use super::super::version_overrides::is_self_deploy;
 use super::preflight::{resolve_preflight_artifact_path, validate_preflight_file_artifact};
 use super::release_plan::{
@@ -24,6 +24,7 @@ pub(crate) struct PreparedComponentDeploy {
     pub remote_version: Option<String>,
     pub build_exit_code: Option<i32>,
     pub artifact_path: Option<PathBuf>,
+    pub artifact_source: Option<DeployArtifactSource>,
     pub cleanup_local_artifact: bool,
 }
 
@@ -54,7 +55,8 @@ pub(crate) fn prepare_component_deploy(
                             remote_version,
                             None,
                             error,
-                        ));
+                        )
+                        .with_artifact_source(DeployArtifactSource::ReleaseAsset));
                     }
                 }
             }
@@ -70,6 +72,13 @@ pub(crate) fn prepare_component_deploy(
                 None
             }
         };
+    let artifact_source = if is_git_deploy || is_file_deploy {
+        None
+    } else if release_artifact.is_some() {
+        Some(DeployArtifactSource::ReleaseAsset)
+    } else {
+        Some(DeployArtifactSource::LocalBuild)
+    };
 
     let cleanup_generated_artifacts = !is_git_deploy
         && !is_file_deploy
@@ -191,6 +200,7 @@ pub(crate) fn prepare_component_deploy(
         remote_version,
         build_exit_code,
         artifact_path,
+        artifact_source,
         cleanup_local_artifact,
     })
 }

--- a/src/core/deploy/execution/release_plan.rs
+++ b/src/core/deploy/execution/release_plan.rs
@@ -75,9 +75,9 @@ pub(super) fn should_try_download_release_artifact(
 
 /// Try to download a release artifact from GitHub for the selected deploy tag.
 ///
-/// Returns `Ok(Some(path))` if successful and `Ok(None)` for normal download misses
-/// that should fall back to local build. Validation failures are returned as deploy
-/// errors so invalid artifacts never reach remote install.
+/// Returns `Ok(Some(path))` only when the planned release asset was downloaded.
+/// Once deploy has selected the release asset path, any download miss fails closed
+/// instead of silently rebuilding from the local checkout.
 pub(super) fn try_download_release_artifact(
     component: &Component,
     tag: &str,
@@ -99,22 +99,21 @@ pub(super) fn try_download_release_artifact(
         tag
     );
 
-    match release_download::download_release_artifact(&github, tag, &artifact_name) {
-        Ok(path) => Ok(Some(path)),
-        Err(e) => {
-            if e.code == crate::core::error::ErrorCode::ValidationInvalidArgument {
-                return Err(e.to_string());
-            }
+    release_download::download_release_artifact(&github, tag, &artifact_name)
+        .map(Some)
+        .map_err(|error| release_asset_download_error(component, tag, &artifact_name, error))
+}
 
-            log_status!(
-                "deploy",
-                "Release download failed for '{}': {} — falling back to local build",
-                component.id,
-                e
-            );
-            Ok(None)
-        }
-    }
+fn release_asset_download_error(
+    component: &Component,
+    tag: &str,
+    artifact_name: &str,
+    error: crate::core::error::Error,
+) -> String {
+    format!(
+        "artifact source release_asset failed for '{}' tag {} artifact '{}': {}. Refusing to fall back to local_build; use --tagged to request an explicit local tag build.",
+        component.id, tag, artifact_name, error
+    )
 }
 
 fn deploy_release_tag(component: &Component, config: &DeployConfig) -> Option<String> {
@@ -123,4 +122,33 @@ fn deploy_release_tag(component: &Component, config: &DeployConfig) -> Option<St
     }
 
     git::get_latest_tag(&component.local_path).ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::release_asset_download_error;
+    use crate::core::component::Component;
+    use crate::core::error::Error;
+
+    #[test]
+    fn release_asset_download_error_fails_closed_without_local_build_fallback() {
+        let component = Component {
+            id: "example".to_string(),
+            ..Component::default()
+        };
+
+        let message = release_asset_download_error(
+            &component,
+            "v1.2.3",
+            "example.zip",
+            Error::internal_io(
+                "HTTP 404".to_string(),
+                Some("download release artifact".to_string()),
+            ),
+        );
+
+        assert!(message.contains("artifact source release_asset failed"));
+        assert!(message.contains("Refusing to fall back to local_build"));
+        assert!(message.contains("use --tagged"));
+    }
 }

--- a/src/core/deploy/execution/strategies.rs
+++ b/src/core/deploy/execution/strategies.rs
@@ -239,7 +239,7 @@ pub(super) fn execute_artifact_deploy(
         prepared.cleanup_local_artifact,
     );
     let Some(artifact_path) = prepared.artifact_path.as_ref() else {
-        return ComponentDeployResult::failed(
+        let result = ComponentDeployResult::failed(
             component,
             base_path,
             prepared.local_version.clone(),
@@ -250,11 +250,12 @@ pub(super) fn execute_artifact_deploy(
             ),
         )
         .with_build_exit_code(prepared.build_exit_code);
+        return with_prepared_artifact_source(result, prepared);
     };
     let artifact_input_metadata = match artifact_inputs::resolve_metadata(component) {
         Ok(inputs) => inputs,
         Err(err) => {
-            return ComponentDeployResult::failed(
+            let result = ComponentDeployResult::failed(
                 component,
                 base_path,
                 prepared.local_version.clone(),
@@ -263,6 +264,7 @@ pub(super) fn execute_artifact_deploy(
             )
             .with_remote_path(install_dir.to_string())
             .with_build_exit_code(prepared.build_exit_code);
+            return with_prepared_artifact_source(result, prepared);
         }
     };
 
@@ -312,7 +314,7 @@ pub(super) fn execute_artifact_deploy(
             ) {
                 Ok(version) => version,
                 Err(error) => {
-                    return ComponentDeployResult::failed(
+                    let result = ComponentDeployResult::failed(
                         component,
                         base_path,
                         prepared.local_version.clone(),
@@ -323,6 +325,7 @@ pub(super) fn execute_artifact_deploy(
                     .with_artifact_inputs(artifact_input_metadata)
                     .with_build_exit_code(prepared.build_exit_code)
                     .with_deploy_exit_code(Some(exit_code));
+                    return with_prepared_artifact_source(result, prepared);
                 }
             };
 
@@ -342,39 +345,56 @@ pub(super) fn execute_artifact_deploy(
             }
             run_post_deploy_hooks(&ctx.client, component, install_dir, base_path);
 
-            ComponentDeployResult::new(component, base_path)
+            let result = ComponentDeployResult::new(component, base_path)
                 .with_status("deployed")
                 .with_versions(prepared.local_version.clone(), reported_remote_version)
                 .with_remote_path(install_dir.to_string())
                 .with_artifact_inputs(artifact_input_metadata)
                 .with_build_exit_code(prepared.build_exit_code)
-                .with_deploy_exit_code(Some(exit_code))
+                .with_deploy_exit_code(Some(exit_code));
+            with_prepared_artifact_source(result, prepared)
         }
         Ok(DeployResult {
             success: false,
             exit_code,
             error,
             ..
-        }) => ComponentDeployResult::failed(
-            component,
-            base_path,
-            prepared.local_version.clone(),
-            prepared.remote_version.clone(),
-            error.unwrap_or_default(),
-        )
-        .with_remote_path(install_dir.to_string())
-        .with_build_exit_code(prepared.build_exit_code)
-        .with_deploy_exit_code(Some(exit_code)),
-        Err(err) => ComponentDeployResult::failed(
-            component,
-            base_path,
-            prepared.local_version.clone(),
-            prepared.remote_version.clone(),
-            err.to_string(),
-        )
-        .with_remote_path(install_dir.to_string())
-        .with_build_exit_code(prepared.build_exit_code),
+        }) => {
+            let result = ComponentDeployResult::failed(
+                component,
+                base_path,
+                prepared.local_version.clone(),
+                prepared.remote_version.clone(),
+                error.unwrap_or_default(),
+            )
+            .with_remote_path(install_dir.to_string())
+            .with_build_exit_code(prepared.build_exit_code)
+            .with_deploy_exit_code(Some(exit_code));
+            with_prepared_artifact_source(result, prepared)
+        }
+        Err(err) => {
+            let result = ComponentDeployResult::failed(
+                component,
+                base_path,
+                prepared.local_version.clone(),
+                prepared.remote_version.clone(),
+                err.to_string(),
+            )
+            .with_remote_path(install_dir.to_string())
+            .with_build_exit_code(prepared.build_exit_code);
+            with_prepared_artifact_source(result, prepared)
+        }
     }
+}
+
+fn with_prepared_artifact_source(
+    mut result: ComponentDeployResult,
+    prepared: &PreparedComponentDeploy,
+) -> ComponentDeployResult {
+    if let Some(source) = prepared.artifact_source {
+        result = result.with_artifact_source(source);
+    }
+    result
 }
 
 /// Remove the local build artifact created for a deploy.

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -21,7 +21,8 @@ use super::planning::{
     plan_components, ExtensionSkippedComponent, GitProbeCache,
 };
 use super::types::{
-    ComponentDeployResult, ComponentStatus, DeployConfig, DeployOrchestrationResult, DeploySummary,
+    ComponentDeployResult, ComponentStatus, DeployArtifactSource, DeployConfig,
+    DeployOrchestrationResult, DeploySummary,
 };
 use super::version_overrides::fetch_remote_versions_for_project;
 
@@ -520,13 +521,15 @@ fn with_dry_run_artifact_plan(
             result.warnings.push(format!(
                 "artifact source: release asset for tag {tag}; build phase: skipped if asset is available; deploy phase: would upload downloaded asset"
             ));
-            result.with_artifact_path(Some(url))
+            result
+                .with_artifact_path(Some(url))
+                .with_artifact_source(DeployArtifactSource::ReleaseAsset)
         }
         ReleaseArtifactPlan::LocalBuild { reason } => {
             result.warnings.push(format!(
                 "artifact source: local rebuild; reason: {reason}; build phase: would run before deploy; deploy phase: would upload local build_artifact"
             ));
-            result
+            result.with_artifact_source(DeployArtifactSource::LocalBuild)
         }
     }
 }

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -79,6 +79,13 @@ pub struct DeployConfig {
     pub tagged: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeployArtifactSource {
+    ReleaseAsset,
+    LocalBuild,
+}
+
 /// Reason why a component was selected for deployment.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -210,6 +217,8 @@ pub struct ComponentDeployResult {
     pub warnings: Vec<String>,
     pub error: Option<String>,
     pub artifact_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_source: Option<DeployArtifactSource>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_inputs: Vec<ResolvedArtifactInput>,
     pub remote_path: Option<String>,
@@ -241,6 +250,7 @@ impl ComponentDeployResult {
             warnings: Vec::new(),
             error: None,
             artifact_path: component.build_artifact.clone(),
+            artifact_source: None,
             artifact_inputs: Vec::new(),
             remote_path: base_path::join_remote_path(Some(base_path), &component.remote_path).ok(),
             build_exit_code: None,
@@ -302,6 +312,11 @@ impl ComponentDeployResult {
 
     pub(super) fn with_artifact_path(mut self, path: Option<String>) -> Self {
         self.artifact_path = path;
+        self
+    }
+
+    pub(super) fn with_artifact_source(mut self, source: DeployArtifactSource) -> Self {
+        self.artifact_source = Some(source);
         self
     }
 


### PR DESCRIPTION
## Summary
- fail deploy preparation when a planned release asset cannot be downloaded instead of silently rebuilding locally
- add explicit artifact_source values for artifact deploy results and dry-run plans
- cover the fail-closed release asset error contract without network access

Fixes #5969

## Verification
- rustfmt src/commands/golden_contract_tests.rs src/core/deploy/types.rs src/core/deploy/execution/prepare.rs src/core/deploy/execution/strategies.rs src/core/deploy/execution/release_plan.rs src/core/deploy/orchestration.rs
- git diff --check
- Local cargo tests not run per task guidance; relying on PR CI for Rust verification.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagent
- **Used for:** Implementation and PR drafting.