### PR TITLE
fix(lab): route agent-task fanout batches

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -257,6 +257,8 @@ const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task controller resu
 const AGENT_TASK_STATUS_LAB_LABEL: &str =
     "agent-task run/run-next/status/logs/artifacts/review/list/active/latest";
 const AGENT_TASK_PROVIDERS_LAB_LABEL: &str = "agent-task providers";
+const AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL: &str = "agent-task fanout submit-batch";
+const AGENT_TASK_FANOUT_STATUS_LAB_LABEL: &str = "agent-task fanout status/artifacts";
 const AGENT_TASK_AUTH_STATUS_LAB_LABEL: &str = "agent-task auth status";
 pub(crate) const LINT_LAB_LABEL: &str = "lint";
 pub(crate) const TEST_LAB_LABEL: &str = "test";
@@ -309,6 +311,14 @@ const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
             "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
         hint_label:
             "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
+    },
+    LabSupportedCommandSummary {
+        contract_labels: &[
+            AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
+            AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
+        ],
+        message_label: "agent-task fanout submit-batch/status/artifacts",
+        hint_label: "agent-task fanout submit-batch/status/artifacts",
     },
     LabSupportedCommandSummary {
         contract_labels: &[AGENT_TASK_AUTH_STATUS_LAB_LABEL],
@@ -465,6 +475,22 @@ impl Commands {
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command: agent_task::AgentTaskCommand::Providers(_),
             }) => LabCommandContract::explicit_runner_simple(AGENT_TASK_PROVIDERS_LAB_LABEL),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command:
+                    agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
+                        command: agent_task::AgentTaskFanoutCommand::SubmitBatch(_),
+                    }),
+            }) => LabCommandContract::explicit_runner_simple(
+                AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
+            ),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command:
+                    agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
+                        command:
+                            agent_task::AgentTaskFanoutCommand::Status(_)
+                            | agent_task::AgentTaskFanoutCommand::Artifacts(_),
+                    }),
+            }) => LabCommandContract::runner_resident(AGENT_TASK_FANOUT_STATUS_LAB_LABEL),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Controller(agent_task::AgentTaskControllerArgs {

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -1009,6 +1009,78 @@ mod tests {
     }
 
     #[test]
+    fn agent_task_fanout_submit_batch_requires_explicit_runner_under_lab_only() {
+        let normalized = vec![
+            "homeboy".to_string(),
+            "--lab-only".to_string(),
+            "agent-task".to_string(),
+            "fanout".to_string(),
+            "submit-batch".to_string(),
+            "--input".to_string(),
+            "fanout.json".to_string(),
+        ];
+        let cli = Cli::parse_from(&normalized);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+        assert_eq!(command.hot_label, "agent-task fanout submit-batch");
+        assert!(!command.routing_policy.default_lab_offload);
+        assert!(!command.routing_policy.infer_source_path_tools);
+
+        let err = route_after_parse(&cli, &normalized, None)
+            .expect_err("fanout submit-batch must not run locally under --lab-only");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err
+            .message
+            .contains("Lab-only execution refused local execution"));
+        assert!(err.message.contains("automatic Lab offload disabled"));
+    }
+
+    #[test]
+    fn agent_task_fanout_state_reads_are_runner_resident() {
+        for args in [
+            [
+                "homeboy",
+                "--runner",
+                "homeboy-lab",
+                "agent-task",
+                "fanout",
+                "status",
+                "fanout-batch-123",
+            ],
+            [
+                "homeboy",
+                "--runner",
+                "homeboy-lab",
+                "agent-task",
+                "fanout",
+                "artifacts",
+                "fanout-batch-123",
+            ],
+        ] {
+            let cli = Cli::parse_from(args);
+
+            let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+            assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+            assert_eq!(command.hot_label, "agent-task fanout status/artifacts");
+            assert!(command.portable);
+            assert!(!command.routing_policy.default_lab_offload);
+            assert_eq!(
+                command.source_path_mode,
+                runners::LabOffloadSourcePathMode::RunnerResident
+            );
+            assert_eq!(
+                command.workspace_mode_policy,
+                runners::LabOffloadWorkspaceModePolicy::RunnerResident
+            );
+            assert!(command.required_extensions.is_empty());
+            assert!(!command.routing_policy.requires_extension_parity);
+            assert!(!command.routing_policy.infer_source_path_tools);
+        }
+    }
+
+    #[test]
     fn tunnel_service_start_supports_explicit_runner_discovery() {
         let cli = Cli::parse_from([
             "homeboy",

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -109,6 +109,37 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
             parsed_command(&[
                 "homeboy",
                 "agent-task",
+                "fanout",
+                "submit-batch",
+                "--input",
+                "fanout.json",
+            ]),
+            "agent-task fanout submit-batch/status/artifacts",
+        ),
+        (
+            parsed_command(&[
+                "homeboy",
+                "agent-task",
+                "fanout",
+                "status",
+                "fanout-batch-123",
+            ]),
+            "agent-task fanout submit-batch/status/artifacts",
+        ),
+        (
+            parsed_command(&[
+                "homeboy",
+                "agent-task",
+                "fanout",
+                "artifacts",
+                "fanout-batch-123",
+            ]),
+            "agent-task fanout submit-batch/status/artifacts",
+        ),
+        (
+            parsed_command(&[
+                "homeboy",
+                "agent-task",
                 "controller",
                 "from-spec",
                 "loop.json",
@@ -219,6 +250,7 @@ fn test_lab_runner_supported_labels_are_contract_owned() {
             "agent-task controller from-spec --resume/materialize/resume",
             "agent-task retry --run",
             "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
+            "agent-task fanout submit-batch/status/artifacts",
             "agent-task auth status",
             "lint",
             "test",
@@ -444,6 +476,22 @@ fn test_lab_command_contracts_cover_hot_commands() {
         ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
         ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
         ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
+        [
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "status",
+            "fanout-batch-123",
+        ]
+        .as_slice(),
+        [
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "artifacts",
+            "fanout-batch-123",
+        ]
+        .as_slice(),
         ["homeboy", "agent-task", "controller", "resume", "loop-123"].as_slice(),
     ] {
         let contract = parsed_command(args)
@@ -456,6 +504,32 @@ fn test_lab_command_contracts_cover_hot_commands() {
         );
         assert!(!contract.routing_policy.default_lab_offload);
     }
+
+    let fanout_submit_batch = parsed_command(&[
+        "homeboy",
+        "agent-task",
+        "fanout",
+        "submit-batch",
+        "--input",
+        "fanout.json",
+    ])
+    .lab_contract()
+    .expect("fanout submit-batch contract");
+    assert_eq!(
+        fanout_submit_batch.hot_label,
+        "agent-task fanout submit-batch"
+    );
+    assert_eq!(
+        fanout_submit_batch.source_path_mode,
+        LabSourcePathMode::CwdOrPathFlag
+    );
+    assert_eq!(
+        fanout_submit_batch.workspace_mode_policy,
+        LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot
+    );
+    assert!(!fanout_submit_batch.routing_policy.default_lab_offload);
+    assert!(!fanout_submit_batch.routing_policy.requires_extension_parity);
+    assert!(!fanout_submit_batch.routing_policy.infer_source_path_tools);
 
     assert!(
         parsed_command(&[


### PR DESCRIPTION
## Summary
- Add Lab command contracts for agent-task fanout submit-batch/status/artifacts.
- Keep submit-batch explicit-runner only so durable parent/child fanout state is created on the selected runner.
- Mark fanout status/artifacts as runner-resident reads and cover --lab-only refusing local execution when no runner is selected.

## Verification
- rustfmt src/command_contract/lab.rs tests/command_contract/lab_test.rs src/commands/route.rs
- rustfmt --check src/command_contract/lab.rs tests/command_contract/lab_test.rs src/commands/route.rs
- git diff --check

Not run: local cargo commands, per task instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the lab command-contract routing changes, adding tests, formatting, and PR preparation.