### PR TITLE
Preserve raw fuzz results on parse failure

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -61,13 +61,20 @@ pub(super) fn run_run(args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput
         &run_dir,
     )?;
     let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
-    let results = if results_path.exists() {
-        Some(parse_fuzz_results_file(&results_path)?)
+    let (results, results_error) = if results_path.exists() {
+        match parse_fuzz_results_file(&results_path) {
+            Ok(results) => (Some(results), None),
+            Err(error) => (None, Some(error.to_string())),
+        }
     } else {
-        None
+        (None, None)
     };
-    let exit_code = runner_output.exit_code;
-    let success = runner_output.success;
+    let exit_code = if runner_output.exit_code == 0 && results_error.is_some() {
+        1
+    } else {
+        runner_output.exit_code
+    };
+    let success = runner_output.success && results_error.is_none();
     let status = if success { "passed" } else { "failed" }.to_string();
     let rig_id = rig_context.map(|context| context.spec.id);
     let workload_id = selected_workload
@@ -86,8 +93,13 @@ pub(super) fn run_run(args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput
         args: &args,
         results_path: &results_path,
         results: results.as_ref(),
+        results_error: results_error.as_deref(),
     })?;
-    let evidence_followups = fuzz_evidence_followups(args.run_id.as_deref());
+    let evidence_followups = fuzz_evidence_followups(
+        args.run_id.as_deref(),
+        results_error.as_deref(),
+        &results_path,
+    );
     let campaign_contract = fuzz_campaign_contract(fuzz_config.as_ref(), args.seed.as_deref());
 
     Ok((
@@ -190,6 +202,7 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) args: &'a FuzzRunArgs,
     pub(super) results_path: &'a Path,
     pub(super) results: Option<&'a FuzzCampaign>,
+    pub(super) results_error: Option<&'a str>,
 }
 
 pub(super) fn persist_fuzz_run_evidence(
@@ -211,6 +224,7 @@ pub(super) fn persist_fuzz_run_evidence(
         "success": input.success,
         "status": input.status,
         "campaign_id": input.results.map(|campaign| campaign.id.as_str()),
+        "results_error": input.results_error,
         "coverage_completeness": input.results.map(fuzz_coverage_completeness),
         "gates": input.results.map(evaluate_fuzz_gates),
     });
@@ -280,8 +294,12 @@ fn fuzz_run_command(
     parts.join(" ")
 }
 
-fn fuzz_evidence_followups(run_id: Option<&str>) -> Vec<String> {
-    match run_id.filter(|run_id| !run_id.trim().is_empty()) {
+pub(super) fn fuzz_evidence_followups(
+    run_id: Option<&str>,
+    results_error: Option<&str>,
+    results_path: &Path,
+) -> Vec<String> {
+    let mut followups = match run_id.filter(|run_id| !run_id.trim().is_empty()) {
         Some(run_id) => vec![
             format!("homeboy runs show {run_id}"),
             format!("homeboy runs evidence {run_id}"),
@@ -291,7 +309,14 @@ fn fuzz_evidence_followups(run_id: Option<&str>) -> Vec<String> {
             "Use --run-id <stable-id> when the downstream runner records persisted Homeboy evidence.".to_string(),
             "Inspect persisted proof with `homeboy runs show <run-id>` and `homeboy runs evidence <run-id>`.".to_string(),
         ],
+    };
+    if let Some(error) = results_error {
+        followups.push(format!(
+            "Inspect raw fuzz results artifact at {} because normalization failed: {error}",
+            results_path.display()
+        ));
     }
+    followups
 }
 
 pub(super) fn default_runner_contract() -> FuzzRunnerContract {

--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -160,7 +160,8 @@ fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutput> {
 mod tests {
     use super::super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
     use super::execution::{
-        fuzz_campaign_contract, fuzz_runner_env, persist_fuzz_run_evidence, FuzzRunEvidenceInput,
+        fuzz_campaign_contract, fuzz_evidence_followups, fuzz_runner_env,
+        persist_fuzz_run_evidence, FuzzRunEvidenceInput,
     };
     use super::replay::run_replay;
     use super::report::{evaluate_fuzz_gates, fuzz_coverage_completeness, gate_status};
@@ -721,6 +722,7 @@ mod tests {
                 args: &args,
                 results_path: &results_path,
                 results: None,
+                results_error: None,
             })
             .expect("persist fuzz run")
             .expect("run record");
@@ -748,6 +750,97 @@ mod tests {
             assert_eq!(artifacts[0].artifact_type, "file");
             assert!(std::path::Path::new(&artifacts[0].path).is_file());
         });
+    }
+
+    #[test]
+    fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
+        with_isolated_home(|home| {
+            let args = FuzzRunArgs {
+                comp: PositionalComponentArgs {
+                    component: Some("component-a".to_string()),
+                    path: None,
+                },
+                rig: Some("package-fuzz".to_string()),
+                extension_override: ExtensionOverrideArgs { extensions: vec![] },
+                setting_args: SettingArgs {
+                    setting: vec![],
+                    setting_json: vec![],
+                },
+                workload_id: Some("parser".to_string()),
+                run_id: Some("proof-bad-results".to_string()),
+                seed: None,
+                inventory: None,
+                max_duration: None,
+                args: vec![],
+            };
+            let results_path = home.path().join("fuzz-results.json");
+            std::fs::write(
+                &results_path,
+                r#"{"schema":"unsupported/fuzz-result/v1","id":"raw-output"}"#,
+            )
+            .expect("results file");
+
+            let persisted = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
+                run_id: args.run_id.as_deref(),
+                component_id: "component-a",
+                rig_id: args.rig.as_deref(),
+                workload_id: args.workload_id.as_deref(),
+                workload_path: Some("/tmp/fuzz/parser.json"),
+                status: "failed",
+                exit_code: 1,
+                success: false,
+                args: &args,
+                results_path: &results_path,
+                results: None,
+                results_error: Some(
+                    "fuzz results schema must be homeboy/fuzz-campaign/v1, got unsupported/fuzz-result/v1",
+                ),
+            })
+            .expect("persist fuzz run")
+            .expect("run record");
+
+            assert_eq!(persisted.id, "proof-bad-results");
+            assert_eq!(persisted.status, "fail");
+            assert_eq!(
+                persisted.metadata_json["campaign_id"],
+                serde_json::Value::Null
+            );
+            assert!(persisted.metadata_json["results_error"]
+                .as_str()
+                .unwrap()
+                .contains("unsupported/fuzz-result/v1"));
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let artifacts = store
+                .list_artifacts("proof-bad-results")
+                .expect("artifacts");
+            assert_eq!(artifacts.len(), 1);
+            assert_eq!(artifacts[0].kind, "fuzz_results");
+            assert_eq!(artifacts[0].mime.as_deref(), Some("application/json"));
+            assert!(std::path::Path::new(&artifacts[0].path).is_file());
+            let raw = std::fs::read_to_string(&artifacts[0].path).expect("raw artifact");
+            assert!(raw.contains("unsupported/fuzz-result/v1"));
+        });
+    }
+
+    #[test]
+    fn fuzz_evidence_followups_point_to_raw_results_when_parse_fails() {
+        let results_path = Path::new("/tmp/homeboy-run/fuzz-results.json");
+
+        let followups = fuzz_evidence_followups(
+            Some("proof-bad-results"),
+            Some("Unsupported WordPress fuzz case status: error"),
+            results_path,
+        );
+
+        assert!(followups
+            .iter()
+            .any(|followup| followup == "homeboy runs artifacts proof-bad-results"));
+        assert!(followups.iter().any(|followup| {
+            followup.contains("/tmp/homeboy-run/fuzz-results.json")
+                && followup.contains("normalization failed")
+                && followup.contains("Unsupported WordPress fuzz case status: error")
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep fuzz run output/evidence generation alive when results parsing or schema validation fails
- mark the run failed, persist the raw fuzz results artifact, and record the normalization error in run metadata
- add coverage for malformed structured fuzz results and operator followup links

Fixes #5995

## Verification
- `rustfmt src/commands/fuzz/execution.rs src/commands/fuzz/mod.rs`
- `git diff --check`
- `cargo test commands::fuzz::tests::` (blocked by unrelated current main compile errors: missing command_contract re-exports and inaccessible runs::bench_compare_from_args)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Fixing Homeboy issue #5995, tests, and verification.