### PR TITLE
fix(runs): surface related lab fuzz result artifacts

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -22,18 +22,20 @@ mod public_variants;
 pub use lab::{
     lab_runner_support_summary, lab_runner_supported_contract_labels, lab_runner_supported_labels,
     lab_runner_supports_contract_label, lab_runner_unsupported_hint,
-    lab_runner_unsupported_message, LabCommandContract, LabCommandPortability,
-    LabCommandRequiredTool, LabCommandRouteContract, LabLocalExecutionPolicy, LabLocalHotPolicy,
-    LabRoutingPolicy, LabRunnerSupportSummary, LabSelectedRunnerFallbackPolicy, LabSourcePathMode,
-    LabWorkspaceModePolicy, RunnerWorkload, RunnerWorkloadArtifactRef, RunnerWorkloadAssignment,
-    RunnerWorkloadCapability, RunnerWorkloadCommandFamily, RunnerWorkloadKind,
-    RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
-    RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS,
-    RUNNER_WORKLOAD_SCHEMA,
+    lab_runner_unsupported_message, CommandPortabilityContract, LabCommandContract,
+    LabCommandPortability, LabCommandRequiredTool, LabCommandRouteContract,
+    LabLocalExecutionPolicy, LabLocalHotPolicy, LabRoutingPolicy, LabRunnerSupportSummary,
+    LabSelectedRunnerFallbackPolicy, LabSourcePathMode, LabWorkspaceModePolicy, RunnerWorkload,
+    RunnerWorkloadArtifactRef, RunnerWorkloadAssignment, RunnerWorkloadCapability,
+    RunnerWorkloadCommandFamily, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
+    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
+    RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS, RUNNER_WORKLOAD_SCHEMA,
 };
 pub(crate) use lab::{
-    AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REVIEW_LAB_LABEL,
-    TEST_LAB_LABEL,
+    AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LAB_NO_EXTRA_TOOLS, LINT_LAB_LABEL,
+    REVIEW_LAB_LABEL, RIG_CHECK_LAB_LABEL, RIG_UP_LAB_UNSUPPORTED_REASON, TEST_LAB_LABEL,
+    TRACE_LAB_LABEL, TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL, TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
+    TUNNEL_SERVICE_START_LAB_LABEL,
 };
 pub use output::{
     registered_command, registered_command_dispatch_family, registered_command_json_family,

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -38,6 +38,7 @@ use homeboy::core::{api_jobs, runners as runner};
 use homeboy::core::artifact_links::ArtifactViewerDescriptor;
 
 use super::{CmdResult, GlobalArgs};
+pub(crate) use bench::bench_compare_from_args;
 pub use bench::{bench_compare, BenchCompareOutput, RunsBenchCompareArgs};
 pub(super) use bench::{bench_numeric_metrics, run_contains_scenario};
 use bundle::{

--- a/src/commands/runs/evidence.rs
+++ b/src/commands/runs/evidence.rs
@@ -11,7 +11,7 @@ pub type RunsEvidenceOutput = RunEvidenceReport<RunSummary>;
 pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     let run = require_run(&store, run_id)?;
-    let artifacts = runs_service::enrich_artifact_links(store.list_artifacts(run_id)?);
+    let artifacts = runs_service::list_artifacts_for_run(&store, run_id)?;
     let artifact_root = homeboy::core::artifacts::root()?;
     let disk_budget = disk::disk_budget(
         &artifact_root,
@@ -324,6 +324,84 @@ mod tests {
             assert_eq!(output.run.status, "running");
             assert_eq!(output.failure.status, "running");
             assert!(!output.failure.failed);
+        });
+    }
+
+    #[test]
+    fn evidence_includes_related_lab_fuzz_results_for_runner_failure() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let artifact_root = home.path().join("agent-readable-artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let store = ObservationStore::open_initialized().expect("store");
+            let remote_job_id = "remote-job-5997";
+            let runner_run = store
+                .start_run(sample_run(
+                    "runner-exec",
+                    "homeboy",
+                    "studio",
+                    serde_json::json!({
+                        "exit_code": 1,
+                        "lab": {
+                            "runner": { "id": "lab-runner" },
+                            "remote_job_id": remote_job_id
+                        }
+                    }),
+                ))
+                .expect("runner run");
+            store
+                .finish_run(&runner_run.id, RunStatus::Fail, None)
+                .expect("finish runner run");
+            let fuzz_run = store
+                .start_run(sample_run(
+                    "fuzz",
+                    "homeboy",
+                    "studio",
+                    serde_json::json!({
+                        "exit_code": 1,
+                        "lab": { "remote_job_id": remote_job_id }
+                    }),
+                ))
+                .expect("fuzz run");
+            store
+                .finish_run(&fuzz_run.id, RunStatus::Fail, None)
+                .expect("finish fuzz run");
+            let results_path = home.path().join("fuzz-results.json");
+            std::fs::write(
+                &results_path,
+                br#"{"schema":"homeboy/fuzz-result-envelope/v1","campaign":{"id":"raw"}}"#,
+            )
+            .expect("write fuzz results");
+            store
+                .record_artifact(&fuzz_run.id, "fuzz_results", &results_path)
+                .expect("record fuzz results");
+
+            let (output, _) = evidence(&runner_run.id).expect("evidence");
+            let RunsOutput::Evidence(output) = output else {
+                panic!("expected evidence output");
+            };
+
+            let raw_results = output
+                .artifact_index
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.kind == "fuzz_results")
+                .expect("raw fuzz results artifact is discoverable");
+            assert_eq!(raw_results.artifact_type, "file");
+            assert_eq!(
+                raw_results.address.kind,
+                ArtifactAddressKind::LocalOperatorPath
+            );
+            let expected_fetch_command = format!(
+                "homeboy runs artifact get {} {} -o <path>",
+                fuzz_run.id, raw_results.id
+            );
+            assert_eq!(
+                raw_results.fetch_command.as_deref(),
+                Some(expected_fetch_command.as_str())
+            );
+            assert!(raw_results.exists);
+            homeboy::core::set_artifact_root_override(None);
         });
     }
 }

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -4350,6 +4350,7 @@ mod tests {
                 false,
                 None,
                 Vec::new(),
+                None,
                 false,
             )
             .expect("reverse broker exec");
@@ -4454,6 +4455,7 @@ mod tests {
             false,
             None,
             Vec::new(),
+            None,
             false,
         )
         .expect_err("daemon exec failure");
@@ -4539,6 +4541,7 @@ mod tests {
             false,
             None,
             Vec::new(),
+            None,
             false,
         )
         .expect_err("daemon exec failure");

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -934,6 +934,7 @@ mod tests {
                 diagnostics: None,
             },
             0,
+            None,
         );
 
         assert_eq!(result.exit_code, 0);
@@ -1000,6 +1001,7 @@ mod tests {
                 diagnostics: None,
             },
             0,
+            None,
         );
 
         assert_eq!(

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -429,6 +429,7 @@ mod tests {
                 mime: None,
                 size_bytes: Some(42),
                 sha256: None,
+                content_base64: None,
                 metadata: None,
             }],
         );

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1066,6 +1066,7 @@ fn runner_exec_rejects_requests_that_violate_runner_policy_before_daemon_dispatc
             capability_preflight: None,
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
+            runner_workload: None,
             detach_after_handoff: false,
         },
     )

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -311,6 +311,7 @@ fn runs_list_includes_active_runner_jobs() {
                 capture_patch: false,
                 source_snapshot: None,
                 require_paths: Vec::new(),
+                runner_workload: None,
                 metadata: Some(serde_json::json!({
                     "source": "lab",
                     "kind": "agent-task-cook",


### PR DESCRIPTION
## Summary
- routes runs evidence through the canonical run artifact listing service so runner-exec evidence includes same-Lab downstream artifacts
- adds regression coverage for remote fuzz failure evidence exposing raw fuzz_results with a fetch command
- restores missing command contract re-exports needed for the current branch to compile

## Verification
- cargo test evidence_includes_related_lab_fuzz_results_for_runner_failure

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Fixing Homeboy issue #5997, tests, and verification.
