### PR TITLE
Refresh stale runner daemon before Lab dispatch

### DIFF
--- a/src/core/runner/lab/preparation_tests.rs
+++ b/src/core/runner/lab/preparation_tests.rs
@@ -109,7 +109,7 @@ fn lab_runner_preparation_uses_already_connected_runner() {
 }
 
 #[test]
-fn lab_runner_preparation_falls_back_for_stale_default_daemon_version() {
+fn lab_runner_preparation_refreshes_stale_default_daemon_version() {
     let selection = LabRunnerSelection {
         runner_id: "lab".to_string(),
         source: LabRunnerSelectionSource::Default,
@@ -139,20 +139,15 @@ fn lab_runner_preparation_falls_back_for_stale_default_daemon_version() {
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
-        |_| panic!("stale connected daemon should not dispatch or reconnect automatically"),
+        |runner_id| Ok((successful_connect_report(runner_id), 0)),
     )
     .expect("prepared");
 
-    assert_eq!(
-        prepared,
-        LabRunnerPreparation::FallBackLocal {
-            reason: "connected runner `lab` daemon is stale: connected daemon reports homeboy 0.218.0, but the configured runner executable reports homeboy 0.219.0; stale runner runtimes can return malformed or misleading provider output; restart the active daemon with `homeboy runner disconnect lab && homeboy runner connect lab`".to_string()
-        }
-    );
+    assert_eq!(prepared, LabRunnerPreparation::Ready);
 }
 
 #[test]
-fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
+fn lab_runner_preparation_errors_when_explicit_stale_daemon_refresh_fails() {
     let selection = LabRunnerSelection {
         runner_id: "lab".to_string(),
         source: LabRunnerSelectionSource::Explicit,
@@ -182,11 +177,16 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
                 session_path: "/tmp/lab.json".to_string(),
             })
         },
-        |_| panic!("explicit stale connected daemon should fail before reconnect"),
+        |runner_id| Ok((failed_connect_report(runner_id, "daemon restart failed"), 1)),
     )
-    .expect_err("explicit stale daemon should error");
+    .expect_err("explicit stale daemon refresh failure should error");
 
-    assert!(err.message.contains("connected but is not ready"));
+    assert!(err
+        .message
+        .contains("stale daemon and automatic refresh failed"));
+    assert!(err
+        .message
+        .contains("automatic refresh failed: daemon restart failed"));
     assert!(err.message.contains("daemon is stale"));
     assert!(err.message.contains("homeboy 0.218.0"));
     assert!(err.message.contains("homeboy 0.219.0"));
@@ -204,7 +204,46 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
         .flatten()
         .any(|suggestion| suggestion
             .as_str()
-            .is_some_and(|value| value.contains("homeboy runner connect lab"))));
+            .is_some_and(|value| value
+                .contains("homeboy runner disconnect lab && homeboy runner connect lab"))));
+}
+
+#[test]
+fn lab_runner_preparation_refreshes_stale_explicit_daemon_version() {
+    let selection = LabRunnerSelection {
+        runner_id: "lab".to_string(),
+        source: LabRunnerSelectionSource::Explicit,
+        mode: RunnerTunnelMode::DirectSsh,
+    };
+
+    let prepared = prepare_lab_runner_for_offload_with(
+        &selection,
+        |runner_id| {
+            Ok(RunnerStatusReport {
+                runner_id: runner_id.to_string(),
+                connected: true,
+                state: super::super::RunnerSessionState::Connected,
+                session: Some(connected_direct_session(
+                    runner_id,
+                    Some("http://127.0.0.1:1234"),
+                )),
+                stale_daemon: Some(stale_daemon_warning(runner_id)),
+                active_jobs: Vec::new(),
+                active_runner_jobs: Vec::new(),
+                active_job_count: 0,
+                stale_runner_jobs: Vec::new(),
+                stale_runner_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
+                session_path: "/tmp/lab.json".to_string(),
+            })
+        },
+        |runner_id| Ok((successful_connect_report(runner_id), 0)),
+    )
+    .expect("prepared");
+
+    assert_eq!(prepared, LabRunnerPreparation::Ready);
 }
 
 #[test]
@@ -428,6 +467,48 @@ fn connected_direct_session(
         worker_identity: None,
         worker_pid: None,
         last_seen_at: None,
+    }
+}
+
+fn successful_connect_report(runner_id: &str) -> RunnerConnectReport {
+    RunnerConnectReport {
+        runner_id: runner_id.to_string(),
+        mode: Some(RunnerTunnelMode::DirectSsh),
+        role: Some(super::super::RunnerSessionRole::Controller),
+        connected: true,
+        recorded: None,
+        local_url: Some("http://127.0.0.1:1234".to_string()),
+        broker_url: None,
+        controller_id: None,
+        remote_daemon_address: Some("127.0.0.1:5678".to_string()),
+        tunnel_pid: None,
+        remote_daemon_pid: Some(42),
+        homeboy_version: Some("homeboy 0.219.0".to_string()),
+        homeboy_build_identity: Some("homeboy 0.219.0+new".to_string()),
+        session_path: Some("/tmp/lab.json".to_string()),
+        failure_kind: None,
+        failure_message: None,
+    }
+}
+
+fn failed_connect_report(runner_id: &str, failure_message: &str) -> RunnerConnectReport {
+    RunnerConnectReport {
+        runner_id: runner_id.to_string(),
+        mode: None,
+        role: None,
+        connected: false,
+        recorded: None,
+        local_url: None,
+        broker_url: None,
+        controller_id: None,
+        remote_daemon_address: None,
+        tunnel_pid: None,
+        remote_daemon_pid: None,
+        homeboy_version: None,
+        homeboy_build_identity: None,
+        session_path: Some("/tmp/lab.json".to_string()),
+        failure_kind: Some(super::super::RunnerFailureKind::DaemonStartupFailure),
+        failure_message: Some(failure_message.to_string()),
     }
 }
 

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -193,6 +193,34 @@ pub(super) fn prepare_lab_runner_for_offload_with(
     let status = status_fn(&selection.runner_id)?;
     if status.connected {
         if let Some(reason) = connected_runner_not_ready_reason(&selection.runner_id, &status) {
+            if status.stale_daemon.is_some()
+                && status_tunnel_mode(&status) == RunnerTunnelMode::DirectSsh
+            {
+                eprintln!(
+                    "Lab offload: connected runner `{}` daemon is stale; attempting automatic refresh.",
+                    selection.runner_id
+                );
+                let (report, _) = connect_fn(&selection.runner_id)?;
+                if report.connected {
+                    eprintln!(
+                        "Lab offload: refreshed runner `{}` daemon session before dispatch.",
+                        selection.runner_id
+                    );
+                    return Ok(LabRunnerPreparation::Ready);
+                }
+                let refresh_reason = report.failure_message.unwrap_or_else(|| {
+                    "runner connect did not establish a fresh daemon session".to_string()
+                });
+                return automatic_fallback_or_explicit_error(
+                    selection,
+                    format!("{reason}; automatic refresh failed: {refresh_reason}"),
+                    format!(
+                        "Lab offload runner `{}` has a stale daemon and automatic refresh failed",
+                        selection.runner_id
+                    ),
+                    stale_daemon_repair_command(&selection.runner_id, &status),
+                );
+            }
             return automatic_fallback_or_explicit_error(
                 selection,
                 reason,
@@ -283,12 +311,7 @@ fn connected_runner_not_ready_reason(
     status: &RunnerStatusReport,
 ) -> Option<String> {
     if let Some(warning) = status.stale_daemon.as_ref() {
-        let restart = warning.recovery_commands.join(" && ");
-        let restart = if restart.is_empty() {
-            format!("homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}")
-        } else {
-            restart
-        };
+        let restart = stale_daemon_repair_command(runner_id, status);
         return Some(format!(
             "connected runner `{runner_id}` daemon is stale: connected daemon reports {}, but the configured runner executable reports {}; stale runner runtimes can return malformed or misleading provider output; restart the active daemon with `{restart}`",
             warning.session_homeboy_version, warning.current_homeboy_version
@@ -308,6 +331,19 @@ fn connected_runner_not_ready_reason(
             ))
         }
         _ => None,
+    }
+}
+
+fn stale_daemon_repair_command(runner_id: &str, status: &RunnerStatusReport) -> String {
+    let restart = status
+        .stale_daemon
+        .as_ref()
+        .map(|warning| warning.recovery_commands.join(" && "))
+        .unwrap_or_default();
+    if restart.is_empty() {
+        format!("homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}")
+    } else {
+        restart
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixes #6014.
- Refreshes a stale connected direct SSH runner daemon during Lab offload preparation before dispatch.
- Keeps the existing ordered disconnect/connect repair command in the explicit failure path when automatic refresh fails.
- Updates Lab preparation tests for default refresh, explicit refresh, and failed refresh diagnostics.

## Tests
- cargo test core::runner::lab::preparation_tests
- cargo test core::runner::connection::tests::stale_daemon_warning_includes_ordered_restart_recovery_commands
- cargo fmt --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Lab offload runner freshness path, implementing the Rust change, adding tests, and preparing this PR description.
