### PR TITLE
Fix PR merge cleanup in multi-worktree repos

### DIFF
--- a/src/core/git/gh_client.rs
+++ b/src/core/git/gh_client.rs
@@ -161,6 +161,26 @@ impl GhClient {
     }
 }
 
+pub(crate) fn pr_merge_api_args(repo: &str, number: u64, method: &str) -> Vec<String> {
+    vec![
+        "api".to_string(),
+        "-X".to_string(),
+        "PUT".to_string(),
+        format!("repos/{repo}/pulls/{number}/merge"),
+        "-f".to_string(),
+        format!("merge_method={method}"),
+    ]
+}
+
+pub(crate) fn delete_branch_ref_api_args(repo: &str, branch: &str) -> Vec<String> {
+    vec![
+        "api".to_string(),
+        "-X".to_string(),
+        "DELETE".to_string(),
+        format!("repos/{repo}/git/refs/heads/{branch}"),
+    ]
+}
+
 /// Run a prepared `gh`/CLI command swallowing stdout/stderr, returning whether
 /// it exited successfully.
 ///
@@ -224,7 +244,7 @@ mod tests {
 
     use crate::core::component::{GithubConfig, GithubHostConfig};
 
-    use super::{github_cli_env, GhClient};
+    use super::{delete_branch_ref_api_args, github_cli_env, pr_merge_api_args, GhClient};
 
     #[test]
     fn repo_arg_accepts_host_qualified_repo() {
@@ -283,5 +303,39 @@ mod tests {
             "HTTPS_PROXY".to_string(),
             "https://proxy.example.test:9443".to_string()
         )));
+    }
+
+    #[test]
+    fn pr_merge_api_args_do_not_use_checkout_merger() {
+        let args = pr_merge_api_args("Extra-Chill/homeboy", 6006, "merge");
+
+        assert_eq!(
+            args,
+            vec![
+                "api",
+                "-X",
+                "PUT",
+                "repos/Extra-Chill/homeboy/pulls/6006/merge",
+                "-f",
+                "merge_method=merge"
+            ]
+        );
+        assert!(!args.windows(2).any(|window| window == ["pr", "merge"]));
+    }
+
+    #[test]
+    fn delete_branch_ref_api_args_do_not_checkout_default_branch() {
+        let args = delete_branch_ref_api_args("Extra-Chill/homeboy", "fix/example");
+
+        assert_eq!(
+            args,
+            vec![
+                "api",
+                "-X",
+                "DELETE",
+                "repos/Extra-Chill/homeboy/git/refs/heads/fix/example"
+            ]
+        );
+        assert!(!args.windows(2).any(|window| window == ["pr", "merge"]));
     }
 }

--- a/src/core/git/github/fleet.rs
+++ b/src/core/git/github/fleet.rs
@@ -3,6 +3,7 @@
 
 use crate::core::error::Result;
 
+use super::super::gh_client::pr_merge_api_args;
 use super::super::github_types::{
     GithubPrCheckRollup, GithubPrFleetItem, GithubPrFleetOutput, GithubPrFleetSummary,
     GithubPrView, PrFleetOptions,
@@ -67,14 +68,7 @@ pub fn pr_fleet(
         item.updated = updated;
 
         if options.apply && item.mergeable {
-            let args: Vec<String> = vec![
-                "pr".into(),
-                "merge".into(),
-                parsed.to_string(),
-                "-R".into(),
-                repo_flag.clone(),
-                format!("--{}", merge_method),
-            ];
+            let args = pr_merge_api_args(&repo_flag, parsed, &merge_method);
             match run_gh(&args) {
                 Ok(_) => {
                     item.merged = true;

--- a/src/core/git/github/pulls.rs
+++ b/src/core/git/github/pulls.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 
 use crate::core::error::{Error, Result};
 
+use super::super::gh_client::{delete_branch_ref_api_args, pr_merge_api_args};
 use super::super::github_types::{
     GithubFindItem, GithubFindOutput, GithubPrOutput, GithubPrView, PrCreateOptions, PrEditOptions,
     PrFindOptions, PrMergeOptions,
@@ -341,18 +342,22 @@ pub fn pr_merge(component_id: Option<&str>, options: PrMergeOptions) -> Result<G
     let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
-    let mut args: Vec<String> = vec![
-        "pr".into(),
-        "merge".into(),
-        options.number.to_string(),
-        "-R".into(),
-        repo_flag,
-        format!("--{}", method),
-    ];
-    if options.delete_branch {
-        args.push("--delete-branch".into());
+    let branch_to_delete = if options.delete_branch {
+        let view = pr_view(Some(&id), options.number, options.path.clone())?;
+        (view.head_repository.as_deref() == Some(repo_flag.as_str()) && !view.head.is_empty())
+            .then_some(view.head)
+    } else {
+        None
+    };
+
+    run_gh(&pr_merge_api_args(&repo_flag, options.number, &method))?;
+
+    let mut warnings = Vec::new();
+    if let Some(branch) = branch_to_delete {
+        if let Err(error) = run_gh(&delete_branch_ref_api_args(&repo_flag, &branch)) {
+            warnings.push(format!("failed to delete branch {branch}: {error}"));
+        }
     }
-    run_gh(&args)?;
     Ok(GithubPrOutput {
         component_id: id,
         owner: repo.owner,
@@ -361,6 +366,7 @@ pub fn pr_merge(component_id: Option<&str>, options: PrMergeOptions) -> Result<G
         success: true,
         number: Some(options.number),
         state: Some("merged".to_string()),
+        warnings,
         ..Default::default()
     })
 }

--- a/src/core/git/pr_land.rs
+++ b/src/core/git/pr_land.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 use crate::core::error::{Error, Result};
 
 use super::gh_client::GhClient;
+use super::gh_client::{delete_branch_ref_api_args, pr_merge_api_args};
 
 #[derive(Debug, Clone, Default)]
 pub struct PrLandOptions {
@@ -90,8 +91,18 @@ struct RawPrView {
     status_check_rollup: Vec<Value>,
     #[serde(default, rename = "headRefOid")]
     head_ref_oid: Option<String>,
+    #[serde(default, rename = "headRefName")]
+    head_ref_name: Option<String>,
+    #[serde(default, rename = "headRepository")]
+    head_repository: Option<RawHeadRepository>,
     #[serde(default, rename = "mergedAt")]
     merged_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawHeadRepository {
+    #[serde(default, rename = "nameWithOwner")]
+    name_with_owner: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -104,6 +115,8 @@ struct PrView {
     checks: Option<String>,
     merge_state: Option<String>,
     head_sha: Option<String>,
+    head: Option<String>,
+    head_repository: Option<String>,
     merged_at: Option<String>,
 }
 
@@ -142,7 +155,7 @@ impl PrLandClient for GhPrLandClient {
             "-R".to_string(),
             self.repo.clone(),
             "--json".to_string(),
-            "number,title,url,state,isDraft,mergeStateStatus,statusCheckRollup,headRefOid,mergedAt"
+            "number,title,url,state,isDraft,mergeStateStatus,statusCheckRollup,headRefOid,headRefName,headRepository,mergedAt"
                 .to_string(),
         ])?;
         let parsed: RawPrView = serde_json::from_str(raw.trim()).map_err(|e| {
@@ -157,6 +170,10 @@ impl PrLandClient for GhPrLandClient {
             checks: summarize_checks(&parsed.status_check_rollup),
             merge_state: non_empty(parsed.merge_state_status),
             head_sha: non_empty(parsed.head_ref_oid),
+            head: non_empty(parsed.head_ref_name),
+            head_repository: parsed
+                .head_repository
+                .and_then(|repo| non_empty(repo.name_with_owner)),
             merged_at: parsed.merged_at,
         })
     }
@@ -168,18 +185,24 @@ impl PrLandClient for GhPrLandClient {
         method: &str,
         delete_branch: bool,
     ) -> Result<()> {
-        let mut args = vec![
-            "pr".to_string(),
-            "merge".to_string(),
-            number.to_string(),
-            "-R".to_string(),
-            self.repo.clone(),
-            format!("--{method}"),
-        ];
-        if delete_branch {
-            args.push("--delete-branch".to_string());
+        let branch_to_delete = if delete_branch {
+            let pr = self.view_pr(&self.repo.clone(), number)?;
+            (pr.head_repository.as_deref() == Some(self.repo.as_str()))
+                .then(|| pr.head.clone())
+                .flatten()
+        } else {
+            None
+        };
+
+        self.gh
+            .run(&pr_merge_api_args(&self.repo, number, method))?;
+        if let Some(branch) = branch_to_delete {
+            let _ = self
+                .gh
+                .run(&delete_branch_ref_api_args(&self.repo, &branch));
         }
-        self.gh.run(&args).map(|_| ())
+
+        Ok(())
     }
 
     fn refresh_pr(&mut self, repo: &str, pr: &PrView, helper: &PrLandRefreshHelper) -> Result<()> {
@@ -609,6 +632,8 @@ mod tests {
             checks: checks.map(str::to_string),
             merge_state: merge_state.map(str::to_string),
             head_sha: Some(format!("sha{number}")),
+            head: Some(format!("branch-{number}")),
+            head_repository: Some("Extra-Chill/homeboy".to_string()),
             merged_at: None,
         }
     }


### PR DESCRIPTION
## Summary

- Switch Homeboy PR merge flows from `gh pr merge` to GitHub API merge calls.
- Delete same-repository PR branches through the Git refs API after successful merges.
- Add command-construction coverage proving merge/delete cleanup does not use checkout-backed `gh pr merge`.

Fixes #6018.

## Tests

- `cargo fmt --check`
- `cargo test core::git::gh_client::tests::pr_merge_api_args_do_not_use_checkout_merger`
- `cargo test core::git::gh_client::tests::delete_branch_ref_api_args_do_not_checkout_default_branch`
- `cargo test core::git::pr_land::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code changes, tests, issue and PR drafting.
