### PR TITLE
Refresh managed runner sources before fuzz dispatch

### DIFF
--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -1091,6 +1091,28 @@ mod probes {
             details.insert("head".to_string(), head);
         }
 
+        let branch = common::remote_line(
+            client,
+            &format!(
+                "git -C {} symbolic-ref --quiet --short HEAD 2>/dev/null",
+                common::shell_word(&resolved_path)
+            ),
+        );
+        if let Some(branch) = branch.as_deref() {
+            details.insert("branch".to_string(), branch.to_string());
+        }
+
+        let dirty_files = common::remote_line(
+            client,
+            &format!(
+                "git -C {} status --porcelain 2>/dev/null | wc -l | tr -d ' '",
+                common::shell_word(&resolved_path)
+            ),
+        )
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(0);
+        details.insert("dirty_files".to_string(), dirty_files.to_string());
+
         if let (Some(declared_remote), Some(actual_remote)) =
             (contract.remote_url.as_deref(), actual_remote.as_deref())
         {
@@ -1107,6 +1129,16 @@ mod probes {
             }
         }
 
+        if let Some(check) = managed_runner_source_state_check(
+            contract,
+            id.clone(),
+            branch.as_deref(),
+            dirty_files,
+            details.clone(),
+        ) {
+            return check;
+        }
+
         checks::ok_with_details(
             id,
             format!(
@@ -1115,6 +1147,48 @@ mod probes {
             ),
             details,
         )
+    }
+
+    pub(super) fn managed_runner_source_state_check(
+        contract: &AgentTaskProviderRunnerSource,
+        id: String,
+        branch: Option<&str>,
+        dirty_files: u64,
+        details: BTreeMap<String, String>,
+    ) -> Option<RunnerCheck> {
+        if dirty_files > 0 {
+            return Some(checks::warning_with_details(
+                id,
+                format!(
+                    "Managed runner source `{}` has reconstructable local modifications on the Lab runner",
+                    contract.label
+                ),
+                contract.remediation.clone(),
+                details,
+            ));
+        }
+
+        let Some(git_ref) = contract
+            .git_ref
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        else {
+            return None;
+        };
+        let branch = branch.unwrap_or("").trim();
+        if branch != git_ref {
+            return Some(checks::warning_with_details(
+                id,
+                format!(
+                    "Managed runner source `{}` is not on declared ref `{git_ref}` on the Lab runner",
+                    contract.label
+                ),
+                contract.remediation.clone(),
+                details,
+            ));
+        }
+
+        None
     }
 
     fn provider_readiness_check(
@@ -1924,6 +1998,7 @@ mod repair {
         let target::RunnerTarget::Ssh {
             id,
             runner: runner_config,
+            client,
             ..
         } = target
         else {
@@ -1935,6 +2010,8 @@ mod repair {
             });
             return;
         };
+
+        repair_managed_sources(client, report);
 
         let daemon_failed = report
             .checks
@@ -1989,6 +2066,51 @@ mod repair {
                 });
             }
         }
+    }
+
+    fn repair_managed_sources(client: &SshClient, report: &mut RunnerDoctorOutput) {
+        let contracts = homeboy::core::agent_tasks::provider::provider_runner_source_contracts();
+        let plans = runner::plan_managed_runner_source_syncs(&contracts);
+        if plans.is_empty() {
+            return;
+        }
+
+        let mut failed = false;
+        for plan in plans {
+            let output = client.execute(&plan.script);
+            if !output.success {
+                failed = true;
+                report.repairs.push(RunnerRepair {
+                    id: format!("repair.managed_source.{}", plan.id),
+                    status: RunnerDoctorStatus::Error,
+                    message: format!(
+                        "Could not refresh managed runner source `{}`: {}",
+                        plan.label,
+                        output.stderr.trim()
+                    ),
+                    commands: Vec::new(),
+                });
+                continue;
+            }
+
+            report.repairs.push(RunnerRepair {
+                id: format!("repair.managed_source.{}", plan.id),
+                status: RunnerDoctorStatus::Ok,
+                message: format!("Refreshed managed runner source `{}`", plan.label),
+                commands: Vec::new(),
+            });
+        }
+
+        if failed {
+            return;
+        }
+
+        report
+            .checks
+            .retain(|check| !check.id.starts_with("lab.managed_source."));
+        report
+            .checks
+            .extend(probes::managed_runner_source_checks(client, &contracts));
     }
 }
 

--- a/src/commands/runner/doctor/tests.rs
+++ b/src/commands/runner/doctor/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use homeboy::core::agent_tasks::provider::{
     AgentTaskProviderEnvPathReadiness, AgentTaskProviderRunnerReadiness,
+    AgentTaskProviderRunnerSource,
 };
 use std::collections::BTreeMap;
 use types::{HomeboyProbe, RunnerDoctorStatus};
@@ -306,6 +307,72 @@ fn path_within_canonical_root_is_segment_aware() {
     ));
     // Empty root is treated as "no canonical constraint".
     assert!(probes::path_within_canonical_root("/anywhere", ""));
+}
+
+#[test]
+fn managed_runner_source_warns_on_dirty_generated_cache_state() {
+    let contract = AgentTaskProviderRunnerSource {
+        id: "wp-codebox".to_string(),
+        label: "WP Codebox".to_string(),
+        path: "/home/chubes/.cache/homeboy/wp-codebox/source".to_string(),
+        remote_url: Some("https://github.com/Automattic/wp-codebox.git".to_string()),
+        git_ref: Some("main".to_string()),
+        remediation: Some("Run runner doctor with --repair".to_string()),
+        extra: BTreeMap::new(),
+    };
+    let mut details = BTreeMap::new();
+    details.insert("dirty_files".to_string(), "1".to_string());
+
+    let check = probes::managed_runner_source_state_check(
+        &contract,
+        "lab.managed_source.wp-codebox".to_string(),
+        Some("main"),
+        1,
+        details,
+    )
+    .expect("dirty source warning");
+
+    assert_eq!(check.status, RunnerDoctorStatus::Warning);
+    assert!(check
+        .message
+        .contains("reconstructable local modifications"));
+    assert_eq!(
+        check.details.get("dirty_files").map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        check.remediation.as_deref(),
+        contract.remediation.as_deref()
+    );
+}
+
+#[test]
+fn managed_runner_source_warns_on_detached_declared_ref() {
+    let contract = AgentTaskProviderRunnerSource {
+        id: "wp-codebox".to_string(),
+        label: "WP Codebox".to_string(),
+        path: "/home/chubes/.cache/homeboy/wp-codebox/source".to_string(),
+        remote_url: Some("https://github.com/Automattic/wp-codebox.git".to_string()),
+        git_ref: Some("main".to_string()),
+        remediation: Some("Run runner doctor with --repair".to_string()),
+        extra: BTreeMap::new(),
+    };
+
+    let check = probes::managed_runner_source_state_check(
+        &contract,
+        "lab.managed_source.wp-codebox".to_string(),
+        None,
+        0,
+        BTreeMap::new(),
+    )
+    .expect("detached source warning");
+
+    assert_eq!(check.status, RunnerDoctorStatus::Warning);
+    assert!(check.message.contains("declared ref `main`"));
+    assert_eq!(
+        check.remediation.as_deref(),
+        contract.remediation.as_deref()
+    );
 }
 
 #[test]

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 
 use crate::command_contract::lab_runner_support_summary;
 use crate::core::agent_task_lifecycle;
+use crate::core::agent_tasks::provider::provider_runner_source_contracts;
 use crate::core::engine::shell;
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::redaction::{redact_argv, redact_argv_display};
@@ -63,11 +64,12 @@ use super::super::lab_workspaces::{
 use super::super::offload_changed_since::LabOffloadChangedSincePreflight;
 use super::super::{
     evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_metadata,
-    lab_offload_metadata_with_workspace_mapping, load, preflight_lab_offload_changed_since,
-    prepare_git_lab_offload_changed_since, prepare_lab_runner_capability, rig_materialization,
-    status, sync_workspace, LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions,
-    RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    lab_offload_metadata_with_workspace_mapping, load, plan_managed_runner_source_syncs,
+    preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
+    prepare_lab_runner_capability, rig_materialization, status, sync_workspace,
+    LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions, RunnerStatusReport,
+    RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    RunnerWorkspaceSyncOutput,
 };
 
 use super::super::workload::{build_runner_workload, RunnerWorkloadBuildInput};
@@ -596,6 +598,36 @@ fn run_runner_resident_lab_offload(
 ) -> Result<LabOffloadOutcome> {
     let runner_id = &selection.runner_id;
     let runner_homeboy = lab_runner_homeboy_metadata(runner_id, homeboy_path, runner_status);
+    let source_syncs = refresh_managed_runner_sources(runner_id, runner_workspace_root)?;
+    if source_syncs.is_empty() {
+        plan = with_step(
+            plan,
+            PlanStep::builder(
+                "lab.managed_sources",
+                "lab.managed_sources",
+                PlanStepStatus::Skipped,
+            )
+            .skip_reason("no extension-declared managed runner sources")
+            .build(),
+        );
+    } else {
+        let syncs_json = serde_json::to_value(&source_syncs).map_err(|err| {
+            Error::internal_json(
+                format!("failed to serialize managed source syncs: {err}"),
+                None,
+            )
+        })?;
+        plan = with_step(
+            plan,
+            PlanStep::ready("lab.managed_sources", "lab.managed_sources")
+                .inputs(PlanValues::new().json("sources", &syncs_json))
+                .build(),
+        );
+        messages.push(format!(
+            "Lab offload: refreshed {} managed runner source checkout(s) before dispatch.",
+            source_syncs.len()
+        ));
+    }
     plan = with_step(
         plan,
         PlanStep::ready("lab.runner_homeboy", "lab.runner_homeboy")
@@ -717,6 +749,73 @@ fn run_runner_resident_lab_offload(
         stderr,
         exit_code,
     })
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct ManagedRunnerSourceRefreshOutput {
+    id: String,
+    label: String,
+    path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    git_ref: Option<String>,
+    stdout: String,
+    stderr: String,
+}
+
+fn refresh_managed_runner_sources(
+    runner_id: &str,
+    cwd: &str,
+) -> Result<Vec<ManagedRunnerSourceRefreshOutput>> {
+    let plans = plan_managed_runner_source_syncs(&provider_runner_source_contracts());
+    let mut refreshed = Vec::new();
+
+    for source in plans {
+        let (output, exit_code) = exec(
+            runner_id,
+            RunnerExecOptions {
+                cwd: Some(cwd.to_string()),
+                project_id: None,
+                allow_diagnostic_ssh: false,
+                command: vec!["sh".to_string(), "-lc".to_string(), source.script.clone()],
+                env: Default::default(),
+                secret_env_names: Vec::new(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: None,
+                capability_preflight: None,
+                required_extensions: Vec::new(),
+                require_paths: Vec::new(),
+                runner_workload: None,
+                detach_after_handoff: false,
+            },
+        )?;
+        if exit_code != 0 {
+            return Err(Error::validation_invalid_argument(
+                "managed_runner_source",
+                format!(
+                    "Managed runner source `{}` could not be refreshed before Lab dispatch",
+                    source.label
+                ),
+                Some(source.id),
+                Some(vec![format!(
+                    "Run `homeboy runner doctor {runner_id} --scope lab-offload --repair` for the first-class repair report before retrying."
+                )]),
+            ));
+        }
+        refreshed.push(ManagedRunnerSourceRefreshOutput {
+            id: source.id,
+            label: source.label,
+            path: source.path,
+            remote_url: source.remote_url,
+            git_ref: source.git_ref,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        });
+    }
+
+    Ok(refreshed)
 }
 
 struct LabOffloadWorkspaceStage {

--- a/src/core/runner/managed_source.rs
+++ b/src/core/runner/managed_source.rs
@@ -151,7 +151,7 @@ fn render_sync_script(path: &str, remote_url: Option<&str>, git_ref: Option<&str
             script.push_str("  echo \"managed runner source ref not found: $ref\" >&2\n");
             script.push_str("  exit 1\n");
             script.push_str("fi\n");
-            script.push_str("git -C \"$dir\" checkout --quiet --force \"$ref\" 2>/dev/null || git -C \"$dir\" checkout --quiet --force --detach \"$target\"\n");
+            script.push_str("git -C \"$dir\" checkout --quiet --force -B \"$ref\" \"$target\" 2>/dev/null || git -C \"$dir\" checkout --quiet --force --detach \"$target\"\n");
             script.push_str("git -C \"$dir\" reset --hard \"$target\"\n");
         }
         None => {
@@ -263,6 +263,21 @@ mod tests {
         assert!(plan
             .script
             .contains("rev-parse --verify --quiet \"origin/$ref\""));
+        assert!(plan
+            .script
+            .contains("git -C \"$dir\" reset --hard \"$target\""));
+    }
+
+    #[test]
+    fn script_restores_declared_branch_from_detached_dirty_checkout() {
+        let mut decl = source("src", "/home/r/.cache/src");
+        decl.remote_url = Some("https://example.test/repo.git".to_string());
+        decl.git_ref = Some("main".to_string());
+        let plan = plan_managed_runner_source_sync(&decl).expect("plan");
+
+        assert!(plan
+            .script
+            .contains("git -C \"$dir\" checkout --quiet --force -B \"$ref\" \"$target\""));
         assert!(plan
             .script
             .contains("git -C \"$dir\" reset --hard \"$target\""));


### PR DESCRIPTION
## Summary
- Refresh extension-declared managed runner source caches before runner-resident Lab dispatch, including fuzz workloads.
- Teach the managed-source sync script to restore the declared branch/ref from detached dirty checkouts.
- Surface dirty and detached managed-source state in runner doctor, and wire `--repair` to run the managed-source refresh lifecycle.

Fixes #6019.

## Tests
- `cargo fmt --check`
- `cargo test managed_runner_source`
- `cargo test detached_declared_ref`
- `cargo test script_restores_declared_branch_from_detached_dirty_checkout`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the managed runner source lifecycle changes, tests, and PR description.
