### PR TITLE
Use body files for GitHub issue markdown

### DIFF
--- a/src/core/agent_tool_control_plane.rs
+++ b/src/core/agent_tool_control_plane.rs
@@ -448,9 +448,10 @@ fn github_issue_create(
         repo.to_string(),
         "--title".to_string(),
         title.to_string(),
-        "--body".to_string(),
-        body.to_string(),
     ];
+    let mut body_files = Vec::new();
+    git::push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", body)
+        .map_err(|error| validation_error("github_body_file", &error.to_string(), Value::Null))?;
     for label in optional_string_array(input, "labels").unwrap_or_default() {
         args.push("--label".to_string());
         args.push(label);
@@ -492,9 +493,10 @@ fn github_pull_create(
         head.to_string(),
         "--title".to_string(),
         title.to_string(),
-        "--body".to_string(),
-        body.to_string(),
     ];
+    let mut body_files = Vec::new();
+    git::push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", body)
+        .map_err(|error| validation_error("github_body_file", &error.to_string(), Value::Null))?;
     if bool_input(input, "draft") {
         args.push("--draft".to_string());
     }
@@ -507,18 +509,17 @@ fn github_pull_comment(
     let repo = required_string(input, &["repo"])?;
     let number = required_u64(input, &["number", "pr", "pull_number"])?;
     let body = required_string(input, &["body", "comment"])?;
-    run_gh_url(
-        &[
-            "pr".to_string(),
-            "comment".to_string(),
-            number.to_string(),
-            "-R".to_string(),
-            repo.to_string(),
-            "--body".to_string(),
-            body.to_string(),
-        ],
-        "pr.comment",
-    )
+    let mut args = vec![
+        "pr".to_string(),
+        "comment".to_string(),
+        number.to_string(),
+        "-R".to_string(),
+        repo.to_string(),
+    ];
+    let mut body_files = Vec::new();
+    git::push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", body)
+        .map_err(|error| validation_error("github_body_file", &error.to_string(), Value::Null))?;
+    run_gh_url(&args, "pr.comment")
 }
 
 fn run_gh_json(args: &[&str]) -> Result<Value, AgentTaskDiagnostic> {

--- a/src/core/git/github/body_file.rs
+++ b/src/core/git/github/body_file.rs
@@ -1,0 +1,108 @@
+//! Safe Markdown body handling for `gh` CLI mutations.
+
+use std::io::Write;
+
+use tempfile::NamedTempFile;
+
+use crate::core::error::{Error, Result};
+
+const MAX_GITHUB_MARKDOWN_BODY_BYTES: usize = 60_000;
+const TRUNCATION_NOTICE: &str =
+    "\n\n---\n\n_Additional output omitted by Homeboy to keep the GitHub body bounded._\n";
+
+pub(in crate::core) struct GhBodyFile {
+    file: NamedTempFile,
+    path: String,
+}
+
+impl GhBodyFile {
+    pub(in crate::core) fn path(&self) -> &str {
+        let _keep_file_alive = &self.file;
+        &self.path
+    }
+}
+
+pub(in crate::core) fn push_markdown_body_file_arg(
+    args: &mut Vec<String>,
+    body_files: &mut Vec<GhBodyFile>,
+    flag: &str,
+    body: &str,
+) -> Result<()> {
+    let body_file = write_markdown_body_file(body)?;
+    args.push(flag.to_string());
+    args.push(body_file.path().to_string());
+    body_files.push(body_file);
+    Ok(())
+}
+
+fn write_markdown_body_file(body: &str) -> Result<GhBodyFile> {
+    let rendered = bounded_markdown_body(body);
+    let mut file = NamedTempFile::new().map_err(|error| {
+        Error::internal_io(
+            format!("Failed to create temporary GitHub body file: {}", error),
+            None,
+        )
+    })?;
+    file.write_all(rendered.as_bytes()).map_err(|error| {
+        Error::internal_io(
+            format!("Failed to write temporary GitHub body file: {}", error),
+            file.path().to_str().map(ToString::to_string),
+        )
+    })?;
+    let path = file.path().to_string_lossy().into_owned();
+    Ok(GhBodyFile { file, path })
+}
+
+fn bounded_markdown_body(body: &str) -> String {
+    if body.len() <= MAX_GITHUB_MARKDOWN_BODY_BYTES {
+        return body.to_string();
+    }
+
+    let retained = MAX_GITHUB_MARKDOWN_BODY_BYTES.saturating_sub(TRUNCATION_NOTICE.len());
+    let mut boundary = retained.min(body.len());
+    while !body.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    let mut truncated = body[..boundary].to_string();
+    truncated.push_str(TRUNCATION_NOTICE);
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_file_preserves_shell_sensitive_markdown_without_argv_inline_body() {
+        let body = "`homeboy-lab run`\n/home/chubes/.cache/homeboy/wp-codebox/source\n> quoted";
+        let mut args = vec!["issue".to_string(), "create".to_string()];
+        let mut files = Vec::new();
+
+        push_markdown_body_file_arg(&mut args, &mut files, "--body-file", body).expect("body file");
+
+        assert_eq!(args[2], "--body-file");
+        assert_ne!(args[3], body);
+        assert!(!args.iter().any(|arg| arg == body));
+        let persisted = std::fs::read_to_string(files[0].path()).expect("read body file");
+        assert_eq!(persisted, body);
+    }
+
+    #[test]
+    fn body_file_truncates_large_bodies_on_utf8_boundary() {
+        let body = format!(
+            "{}{}",
+            "a".repeat(MAX_GITHUB_MARKDOWN_BODY_BYTES + 500),
+            " 🧑‍🍳"
+        );
+        let mut args = Vec::new();
+        let mut files = Vec::new();
+
+        push_markdown_body_file_arg(&mut args, &mut files, "--body-file", &body)
+            .expect("body file");
+
+        let persisted = std::fs::read_to_string(files[0].path()).expect("read body file");
+        assert!(persisted.len() <= MAX_GITHUB_MARKDOWN_BODY_BYTES);
+        assert!(persisted.ends_with(TRUNCATION_NOTICE));
+        assert!(persisted.is_char_boundary(persisted.len()));
+    }
+}

--- a/src/core/git/github/issues.rs
+++ b/src/core/git/github/issues.rs
@@ -9,6 +9,7 @@ use super::super::github_types::{
 use super::client::{
     ensure_gh_ready, parse_issue_number_from_url, resolve_component_github, run_gh,
 };
+use super::push_markdown_body_file_arg;
 
 /// Create a new issue on the component's GitHub repository.
 pub fn issue_create(
@@ -35,9 +36,9 @@ pub fn issue_create(
         repo_flag.clone(),
         "--title".into(),
         options.title.clone(),
-        "--body".into(),
-        options.body.clone(),
     ];
+    let mut body_files = Vec::new();
+    push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &options.body)?;
     for label in &options.labels {
         args.push("--label".into());
         args.push(label.clone());
@@ -69,15 +70,15 @@ pub fn issue_comment(
     ensure_gh_ready()?;
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
-    let args: Vec<String> = vec![
+    let mut args: Vec<String> = vec![
         "issue".into(),
         "comment".into(),
         options.number.to_string(),
         "-R".into(),
         repo_flag,
-        "--body".into(),
-        options.body.clone(),
     ];
+    let mut body_files = Vec::new();
+    push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &options.body)?;
 
     let output = run_gh(&args)?;
     Ok(GithubIssueOutput {
@@ -171,13 +172,13 @@ pub fn issue_edit(
         "-R".into(),
         repo_flag,
     ];
+    let mut body_files = Vec::new();
     if let Some(title) = &options.title {
         args.push("--title".into());
         args.push(title.clone());
     }
     if let Some(body) = &options.body {
-        args.push("--body".into());
-        args.push(body.clone());
+        push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", body)?;
     }
     for label in &options.add_labels {
         args.push("--add-label".into());

--- a/src/core/git/github/mod.rs
+++ b/src/core/git/github/mod.rs
@@ -30,6 +30,7 @@
 //! - [`fleet`] — batch PR reporting and landing.
 //! - [`readiness`] — CI-check classification and merge-readiness reasoning.
 
+mod body_file;
 mod client;
 mod fleet;
 mod issues;
@@ -51,6 +52,7 @@ pub use super::github_types::{
 // Internal helpers shared with sibling modules (e.g. `github_pr_comments`),
 // re-exported at this module path so existing `super::github::X` paths keep
 // resolving after the split.
+pub(in crate::core) use body_file::push_markdown_body_file_arg;
 pub(in crate::core::git) use client::{ensure_gh_ready, resolve_component_github, run_gh};
 
 // Public probe/token helpers.

--- a/src/core/git/github/pulls.rs
+++ b/src/core/git/github/pulls.rs
@@ -13,6 +13,7 @@ use super::super::github_types::{
 use super::client::{
     ensure_gh_ready, parse_issue_number_from_url, resolve_component_github, run_gh, string_value,
 };
+use super::push_markdown_body_file_arg;
 use super::readiness::classify_pr_ci;
 
 /// Open a new pull request.
@@ -49,9 +50,9 @@ pub fn pr_create(component_id: Option<&str>, options: PrCreateOptions) -> Result
         options.head.clone(),
         "--title".into(),
         options.title.clone(),
-        "--body".into(),
-        options.body.clone(),
     ];
+    let mut body_files = Vec::new();
+    push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &options.body)?;
     if options.draft {
         args.push("--draft".into());
     }
@@ -98,13 +99,13 @@ pub fn pr_edit(component_id: Option<&str>, options: PrEditOptions) -> Result<Git
         "-R".into(),
         repo_flag,
     ];
+    let mut body_files = Vec::new();
     if let Some(title) = &options.title {
         args.push("--title".into());
         args.push(title.clone());
     }
     if let Some(body) = &options.body {
-        args.push("--body".into());
-        args.push(body.clone());
+        push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", body)?;
     }
 
     let output = run_gh(&args)?;

--- a/src/core/git/github_pr_comments.rs
+++ b/src/core/git/github_pr_comments.rs
@@ -3,7 +3,9 @@
 use crate::core::deploy::release_download::GitHubRepo;
 use crate::core::error::{Error, Result};
 
-use super::github::{ensure_gh_ready, resolve_component_github, run_gh, GithubPrOutput};
+use super::github::{
+    ensure_gh_ready, push_markdown_body_file_arg, resolve_component_github, run_gh, GithubPrOutput,
+};
 use super::github_comment_sections::{
     comment_matches_key, extract_footer, extract_header, merge_section, parse_comment_sections,
     render_comment,
@@ -120,15 +122,15 @@ fn pr_comment_fresh(
     options: PrCommentOptions,
 ) -> Result<GithubPrOutput> {
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
-    let args: Vec<String> = vec![
+    let mut args: Vec<String> = vec![
         "pr".into(),
         "comment".into(),
         options.number.to_string(),
         "-R".into(),
         repo_flag,
-        "--body".into(),
-        options.body,
     ];
+    let mut body_files = Vec::new();
+    push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &options.body)?;
     let output = run_gh(&args)?;
     Ok(GithubPrOutput {
         component_id: id,
@@ -178,15 +180,15 @@ fn pr_comment_sticky_whole(
     }
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
-    let args: Vec<String> = vec![
+    let mut args: Vec<String> = vec![
         "pr".into(),
         "comment".into(),
         pr_number.to_string(),
         "-R".into(),
         repo_flag,
-        "--body".into(),
-        full_body,
     ];
+    let mut body_files = Vec::new();
+    push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &full_body)?;
     let output = run_gh(&args)?;
     Ok(GithubPrOutput {
         component_id: id,
@@ -237,15 +239,15 @@ fn pr_comment_sectioned(
             footer.as_deref(),
         );
         let repo_flag = format!("{}/{}", repo.owner, repo.repo);
-        let args: Vec<String> = vec![
+        let mut args: Vec<String> = vec![
             "pr".into(),
             "comment".into(),
             pr_number.to_string(),
             "-R".into(),
             repo_flag,
-            "--body".into(),
-            rendered,
         ];
+        let mut body_files = Vec::new();
+        push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &rendered)?;
         let output = run_gh(&args)?;
         return Ok(GithubPrOutput {
             component_id: id,

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -34,6 +34,7 @@ pub use commits::{
     CommitInfo, MonorepoContext, SemverBump,
 };
 pub use gh_client::{github_cli_env, GhClient};
+pub(in crate::core) use github::push_markdown_body_file_arg;
 pub use github::{
     gh_probe_succeeds, github_token_from_env_or_gh, issue_close, issue_comment, issue_create,
     issue_edit, issue_find, pr_create, pr_edit, pr_files, pr_find, pr_find_by_commit, pr_fleet,

--- a/tests/agent_tool_dispatch.rs
+++ b/tests/agent_tool_dispatch.rs
@@ -136,15 +136,26 @@ fn agent_tool_dispatch_outputs_raw_control_plane_validation_result() {
 }
 
 fn run_tool_dispatch(policy: Value, request: Value) -> std::process::Output {
-    let mut child = Command::new(homeboy_bin())
+    run_tool_dispatch_with_env(policy, request, &[])
+}
+
+fn run_tool_dispatch_with_env(
+    policy: Value,
+    request: Value,
+    envs: &[(&str, String)],
+) -> std::process::Output {
+    let mut command = Command::new(homeboy_bin());
+    command
         .args(["agent-task", "tool", "dispatch"])
         .env("HOMEBOY_NO_UPDATE_CHECK", "1")
         .env("HOMEBOY_AGENT_TOOL_POLICY_JSON", policy.to_string())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn homeboy");
+        .stderr(Stdio::piped());
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    let mut child = command.spawn().expect("spawn homeboy");
     child
         .stdin
         .as_mut()
@@ -175,6 +186,76 @@ fn run_tool_dispatch(policy: Value, request: Value) -> std::process::Output {
     output.stdout = stdout;
     output.stderr = stderr;
     output
+}
+
+#[test]
+fn agent_tool_github_issue_create_uses_body_file_for_shell_sensitive_markdown() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let gh_path = dir.path().join("gh");
+    let capture_prefix = dir.path().join("gh-capture");
+    std::fs::write(
+        &gh_path,
+        r#"#!/bin/sh
+set -eu
+out="$HOMEBOY_FAKE_GH_OUTPUT"
+printf '%s
+' "$@" > "$out.args"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--body-file" ]; then
+    shift
+    cp "$1" "$out.body"
+  fi
+  shift || true
+done
+printf '%s
+' 'https://github.com/Extra-Chill/homeboy/issues/1'
+"#,
+    )
+    .expect("write fake gh");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake gh");
+    }
+
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{}", dir.path().display(), old_path);
+    let body = "`homeboy-lab run`\n/home/chubes/.cache/homeboy/wp-codebox/source\n> quoted";
+    let output = run_tool_dispatch_with_env(
+        json!({
+            "schema": "homeboy/agent-tool-policy/v1",
+            "default_location": "control_plane"
+        }),
+        json!({
+            "schema": "homeboy/agent-tool-request/v1",
+            "request_id": "request-gh-issue",
+            "task_id": "task-1",
+            "tool": "create_github_issue",
+            "input": {
+                "repo": "Extra-Chill/homeboy",
+                "title": "Safe issue body files",
+                "body": body
+            }
+        }),
+        &[
+            ("PATH", path),
+            (
+                "HOMEBOY_FAKE_GH_OUTPUT",
+                capture_prefix.to_string_lossy().into_owned(),
+            ),
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("dispatch json");
+    assert_eq!(stdout["status"], "succeeded");
+    let args = std::fs::read_to_string(capture_prefix.with_extension("args")).expect("gh args");
+    assert!(args.contains("--body-file\n"));
+    assert!(!args.contains(body));
+    let captured_body =
+        std::fs::read_to_string(capture_prefix.with_extension("body")).expect("gh body");
+    assert_eq!(captured_body, body);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Route Homeboy GitHub issue/PR Markdown bodies through temporary body files instead of inline `gh --body` arguments.
- Bound generated GitHub Markdown bodies before writing them to disk so huge command output cannot be sent unbounded.
- Cover shell-sensitive Markdown and body-file use with focused unit and dispatch tests.

Fixes #6022.

## Tests
- `cargo fmt --check`
- `cargo test body_file`
- `cargo test --test agent_tool_dispatch agent_tool_github_issue_create_uses_body_file_for_shell_sensitive_markdown`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and applying the code/test changes, running targeted verification, and preparing this PR description.
