### PR TITLE
Preserve runtime workflow inputs

### DIFF
--- a/src/commands/agent_task/tests/controller_run.rs
+++ b/src/commands/agent_task/tests/controller_run.rs
@@ -265,6 +265,94 @@ fn controller_run_from_spec_persists_dispatch_defaults_for_generated_actions() {
 }
 
 #[test]
+fn controller_run_from_spec_preserves_runtime_execution_and_components() {
+    with_temp_home(|| {
+        let observed_request = Arc::new(Mutex::new(None));
+        let (value, exit_code) = controller_run_from_spec_with_test_executor(
+            AgentTaskControllerRunFromSpecArgs {
+                spec: serde_json::to_string(&json!({
+                    "loop_id": "run-from-spec-runtime-execution-loop",
+                    "workflows": [{
+                        "workflow_id": "store-idea",
+                        "prompt": "Generate a concept packet.",
+                        "runtime_execution": {
+                            "kind": "bundle",
+                            "ability": "runtime-package/run",
+                            "input": {
+                                "package": { "source": "bundles/store-idea-agent" },
+                                "workflow": { "id": "store-idea-artifact-flow" },
+                                "input": { "wait_for_completion": true }
+                            }
+                        },
+                        "emits": ["concept_packet"]
+                    }],
+                    "artifacts": [{
+                        "artifact_id": "concept_packet",
+                        "kind": "wp-site-generator/ConceptPacket/v1",
+                        "required": true
+                    }]
+                }))
+                .expect("spec json"),
+                inputs: Some(
+                    serde_json::to_string(&json!({
+                        "inputs": {
+                            "runtime_config": {
+                                "component_contracts": [{
+                                    "slug": "agents-api",
+                                    "path": "runtime/agents-api",
+                                    "loadAs": "plugin",
+                                    "activate": true
+                                }]
+                            }
+                        }
+                    }))
+                    .expect("inputs json"),
+                ),
+                policy_results: Vec::new(),
+                max_actions: 1,
+                dispatch_backend: Some("fixture".to_string()),
+                dispatch_selector: None,
+                dispatch_model: None,
+                dispatch_provider_config: None,
+            },
+            CapturingExecutor {
+                observed_request: Arc::clone(&observed_request),
+            },
+        )
+        .expect("run from spec");
+
+        let observed = observed_request
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .expect("provider saw request");
+
+        assert_eq!(exit_code, 1, "{value:#}");
+        assert_eq!(
+            observed.inputs["runtime_task"]["ability"],
+            "runtime-package/run"
+        );
+        assert_eq!(
+            observed.inputs["runtime_task"]["input"]["package"]["source"],
+            "bundles/store-idea-agent"
+        );
+        assert_eq!(observed.component_contracts.len(), 1);
+        assert_eq!(
+            observed.component_contracts[0].slug.as_deref(),
+            Some("agents-api")
+        );
+        assert_eq!(
+            observed.component_contracts[0].path.as_deref(),
+            Some("runtime/agents-api")
+        );
+        assert_eq!(
+            value["materialization"]["spec"]["workflows"][0]["runtime_execution"]["ability"],
+            "runtime-package/run"
+        );
+    });
+}
+
+#[test]
 fn controller_run_from_spec_rejects_unbounded_zero_max_actions() {
     with_temp_home(|| {
         let error = controller_run_from_spec_with_test_executor(

--- a/src/commands/agent_task/tests/dispatch.rs
+++ b/src/commands/agent_task/tests/dispatch.rs
@@ -108,6 +108,7 @@ fn from_spec_dispatch_defaults_fall_back_to_current_git_checkout() {
             dependencies: Vec::new(),
             gates: Vec::new(),
             metrics: Vec::new(),
+            runtime_execution: Value::Null,
             inputs: Value::Null,
         },
     );

--- a/src/core/agent_task_controller_service/spec.rs
+++ b/src/core/agent_task_controller_service/spec.rs
@@ -179,6 +179,8 @@ pub struct AgentTaskRepoLoopSpecWorkflow {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub metrics: Vec<String>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub runtime_execution: Value,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
     pub inputs: Value,
 }
 

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -647,8 +647,64 @@ pub(super) fn workflow_client_context(
         "dependencies": select_by_id(&spec.dependencies, &workflow.dependencies, |dependency| &dependency.dependency_id),
         "gates": select_by_id(&spec.gates, &workflow.gates, |gate| &gate.gate_id),
         "metrics": select_by_id(&spec.metrics, &workflow.metrics, |metric| &metric.metric_id),
-        "inputs": workflow.inputs,
+        "inputs": workflow_context_inputs(workflow),
     }))
+}
+
+fn workflow_context_inputs(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Value {
+    let mut inputs = match workflow.inputs.clone() {
+        Value::Object(map) => map,
+        Value::Null => serde_json::Map::new(),
+        other => {
+            let mut map = serde_json::Map::new();
+            map.insert("workflow_inputs".to_string(), other);
+            map
+        }
+    };
+
+    if let Some(runtime_task) = runtime_task_from_workflow_execution(&workflow.runtime_execution) {
+        inputs
+            .entry("runtime_task".to_string())
+            .or_insert(runtime_task);
+    }
+
+    if let Some(component_contracts) = inputs
+        .get("runtime_config")
+        .and_then(|runtime_config| runtime_config.get("component_contracts"))
+        .cloned()
+    {
+        inputs
+            .entry("runtime_component_contracts".to_string())
+            .or_insert(component_contracts);
+    }
+
+    Value::Object(inputs)
+}
+
+fn runtime_task_from_workflow_execution(runtime_execution: &Value) -> Option<Value> {
+    let execution = runtime_execution.as_object()?;
+    let ability = execution.get("ability")?.as_str()?.trim();
+    if ability.is_empty() {
+        return None;
+    }
+
+    let mut runtime_task = serde_json::Map::new();
+    runtime_task.insert("ability".to_string(), Value::String(ability.to_string()));
+    runtime_task.insert(
+        "input".to_string(),
+        execution
+            .get("input")
+            .cloned()
+            .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
+    );
+    if let Some(kind) = execution
+        .get("kind")
+        .and_then(Value::as_str)
+        .filter(|kind| !kind.trim().is_empty())
+    {
+        runtime_task.insert("kind".to_string(), Value::String(kind.to_string()));
+    }
+    Some(Value::Object(runtime_task))
 }
 
 pub(super) fn workflow_homeboy_plan(

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -368,6 +368,7 @@ fn repo_loop_reconcile_spec(loop_id: &str) -> AgentTaskRepoLoopSpec {
                 dependencies: Vec::new(),
                 gates: Vec::new(),
                 metrics: Vec::new(),
+                runtime_execution: Value::Null,
                 inputs: Value::Null,
             },
             AgentTaskRepoLoopSpecWorkflow {
@@ -384,6 +385,7 @@ fn repo_loop_reconcile_spec(loop_id: &str) -> AgentTaskRepoLoopSpec {
                 dependencies: vec!["static_site_pull_request".to_string()],
                 gates: Vec::new(),
                 metrics: Vec::new(),
+                runtime_execution: Value::Null,
                 inputs: Value::Null,
             },
         ],
@@ -641,6 +643,7 @@ fn init_from_spec_compiles_repo_workflows_into_deduped_dispatch_actions() {
                 ],
                 gates: vec!["quality".to_string()],
                 metrics: vec!["visual-parity".to_string()],
+                runtime_execution: Value::Null,
                 inputs: json!({ "finding_key": "abc" }),
             }],
             artifacts: vec![
@@ -902,6 +905,7 @@ fn init_from_spec_reconciles_removed_and_added_workflows() {
                 dependencies: vec!["static_site_candidate".to_string()],
                 gates: Vec::new(),
                 metrics: Vec::new(),
+                runtime_execution: Value::Null,
                 inputs: Value::Null,
             });
         });
@@ -979,6 +983,7 @@ fn init_from_spec_rejects_undeclared_workflow_requirements() {
                 dependencies: Vec::new(),
                 gates: Vec::new(),
                 metrics: Vec::new(),
+                runtime_execution: Value::Null,
                 inputs: Value::Null,
             }],
             artifacts: Vec::new(),
@@ -2106,6 +2111,7 @@ fn from_spec_resume_drives_generic_workflow_gates_completion_and_lineage() {
                 dependencies: vec!["source-tree".to_string()],
                 gates: vec!["quality".to_string()],
                 metrics: vec!["coverage".to_string()],
+                runtime_execution: Value::Null,
                 inputs: json!({ "scope": "changed findings" }),
             }],
             artifacts: vec![AgentTaskRepoLoopSpecArtifact {

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -116,7 +116,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 config: provider_config.clone(),
             },
             instructions,
-            inputs: Value::Null,
+            inputs: dispatch_request_inputs(&client_context),
             source_refs,
             workspace: AgentTaskWorkspace {
                 mode: AgentTaskWorkspaceMode::Existing,
@@ -514,6 +514,10 @@ fn dispatch_component_contracts(
         collect_component_contracts_from_value(inputs, "client-context.inputs", &mut contracts)?;
     }
     Ok(contracts)
+}
+
+fn dispatch_request_inputs(client_context: &Value) -> Value {
+    client_context.get("inputs").cloned().unwrap_or(Value::Null)
 }
 
 fn collect_component_contracts_from_value(

--- a/src/core/agent_task_repo_loop_compile.rs
+++ b/src/core/agent_task_repo_loop_compile.rs
@@ -11,8 +11,9 @@ use std::collections::{HashMap, HashSet};
 use serde_json::Value;
 
 use crate::core::agent_task::{
-    AgentTaskArtifactDeclaration, AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy,
-    AgentTaskRequest, AgentTaskWorkspace, AgentTaskWorkspaceMode, AGENT_TASK_REQUEST_SCHEMA,
+    AgentTaskArtifactDeclaration, AgentTaskComponentContract, AgentTaskExecutor, AgentTaskLimits,
+    AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AgentTaskWorkspaceMode,
+    AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::core::agent_task_controller_service::{
     AgentTaskRepoLoopSpec, AgentTaskRepoLoopSpecArtifact, AgentTaskRepoLoopSpecArtifactGraphEdge,
@@ -263,6 +264,7 @@ fn repo_loop_workflow_request(
 
     let task_id = repo_loop_task_id(workflow, entity_id);
     let inputs = repo_loop_workflow_inputs(workflow, entity_id);
+    let component_contracts = repo_loop_workflow_component_contracts(&inputs)?;
 
     Ok(AgentTaskRequest {
         schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
@@ -282,7 +284,7 @@ fn repo_loop_workflow_request(
         inputs,
         source_refs: Vec::new(),
         workspace: repo_loop_workspace(spec),
-        component_contracts: Vec::new(),
+        component_contracts,
         policy: AgentTaskPolicy::default(),
         limits: AgentTaskLimits::default(),
         expected_artifacts: Vec::new(),
@@ -333,9 +335,6 @@ fn repo_loop_workflow_inputs(
     workflow: &AgentTaskRepoLoopSpecWorkflow,
     entity_id: Option<&str>,
 ) -> Value {
-    let Some(entity_id) = entity_id else {
-        return workflow.inputs.clone();
-    };
     let mut inputs = match workflow.inputs.clone() {
         Value::Object(map) => map,
         Value::Null => serde_json::Map::new(),
@@ -344,6 +343,16 @@ fn repo_loop_workflow_inputs(
             map.insert("workflow_inputs".to_string(), other);
             map
         }
+    };
+
+    if let Some(runtime_task) = runtime_task_from_workflow_execution(&workflow.runtime_execution) {
+        inputs
+            .entry("runtime_task".to_string())
+            .or_insert(runtime_task);
+    }
+
+    let Some(entity_id) = entity_id else {
+        return Value::Object(inputs);
     };
     let mut repo_loop = inputs
         .remove("repo_loop")
@@ -359,6 +368,54 @@ fn repo_loop_workflow_inputs(
     );
     inputs.insert("repo_loop".to_string(), Value::Object(repo_loop));
     Value::Object(inputs)
+}
+
+fn runtime_task_from_workflow_execution(runtime_execution: &Value) -> Option<Value> {
+    let execution = runtime_execution.as_object()?;
+    let ability = execution.get("ability")?.as_str()?.trim();
+    if ability.is_empty() {
+        return None;
+    }
+
+    let mut runtime_task = serde_json::Map::new();
+    runtime_task.insert("ability".to_string(), Value::String(ability.to_string()));
+    runtime_task.insert(
+        "input".to_string(),
+        execution
+            .get("input")
+            .cloned()
+            .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
+    );
+    if let Some(kind) = execution
+        .get("kind")
+        .and_then(Value::as_str)
+        .filter(|kind| !kind.trim().is_empty())
+    {
+        runtime_task.insert("kind".to_string(), Value::String(kind.to_string()));
+    }
+    Some(Value::Object(runtime_task))
+}
+
+fn repo_loop_workflow_component_contracts(
+    inputs: &Value,
+) -> Result<Vec<AgentTaskComponentContract>> {
+    let Some(raw) = inputs
+        .get("runtime_config")
+        .and_then(|runtime_config| runtime_config.get("component_contracts"))
+    else {
+        return Ok(Vec::new());
+    };
+
+    serde_json::from_value(raw.clone()).map_err(|error| {
+        Error::validation_invalid_argument(
+            "workflows[].inputs.runtime_config.component_contracts",
+            format!(
+                "repo loop workflow runtime_config.component_contracts must be an array of component contracts: {error}"
+            ),
+            Some(raw.to_string()),
+            None,
+        )
+    })
 }
 
 fn repo_loop_workspace(spec: &AgentTaskRepoLoopSpec) -> AgentTaskWorkspace {


### PR DESCRIPTION
## Summary
- preserve repo-loop workflow runtime_execution through run-from-spec materialization
- project runtime_execution into dispatch inputs.runtime_task
- carry runtime component contracts into dispatched agent task requests

## Testing
- homeboy lint --path /Users/chubes/Developer/homeboy@fix-run-from-spec-runtime-inputs --runner homeboy-lab --lab-only --force-hot --changed-only
- homeboy test --path /Users/chubes/Developer/homeboy@fix-run-from-spec-runtime-inputs --runner homeboy-lab --lab-only --force-hot -- controller_run_from_spec

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Diagnosing the run-from-spec runtime input propagation gap, implementing the fix, adding regression coverage, and running Lab-backed verification.