### PR TITLE
Fix lab runner source path handling

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -382,6 +382,7 @@ pub(super) fn default_runner_contract() -> FuzzRunnerContract {
             "HOMEBOY_FUZZ_RESULTS_FILE",
             "HOMEBOY_FUZZ_WORKLOAD_ID",
             "HOMEBOY_FUZZ_WORKLOAD_PATH",
+            "WP_CODEBOX_FUZZ_WORKLOAD_ROOT",
             "HOMEBOY_FUZZ_RUN_ID",
             "HOMEBOY_FUZZ_SEED",
             "HOMEBOY_FUZZ_INVENTORY_FILE",
@@ -448,6 +449,12 @@ pub(super) fn fuzz_runner_env(
         if let Some(path) = fuzz_runner_workload_path(workload, rig_context, run_dir)? {
             env.push(("HOMEBOY_FUZZ_WORKLOAD_PATH".to_string(), path.clone()));
         }
+    }
+    if let Some(package_root) = rig_context.and_then(|context| context.package_root.as_ref()) {
+        env.push((
+            "WP_CODEBOX_FUZZ_WORKLOAD_ROOT".to_string(),
+            package_root.to_string_lossy().to_string(),
+        ));
     }
     push_opt_env(&mut env, "HOMEBOY_FUZZ_RUN_ID", args.run_id.as_ref());
     push_opt_env(&mut env, "HOMEBOY_FUZZ_SEED", args.seed.as_ref());

--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -684,6 +684,9 @@ mod tests {
                 .as_str(),
             Some(format!("{}/plugins/package", temp.path().display()).as_str())
         );
+        assert!(env.iter().any(|(key, value)| {
+            key == "WP_CODEBOX_FUZZ_WORKLOAD_ROOT" && value == &temp.path().to_string_lossy()
+        }));
     }
 
     #[test]

--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -1041,7 +1041,7 @@ mod probes {
         // expand to the runner user's real home.
         let resolved_path = common::remote_line(
             client,
-            &format!("printf '%s\n' {}", common::shell_word(&contract.path)),
+            &format!("printf '%s\n' {}", common::shell_path_expr(&contract.path)),
         )
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| contract.path.clone());
@@ -2153,6 +2153,18 @@ mod common {
 
     pub fn shell_word(value: &str) -> String {
         format!("'{}'", value.replace('\'', "'\\''"))
+    }
+
+    pub fn shell_path_expr(path: &str) -> String {
+        if path == "~" {
+            return "\"${HOME}\"".to_string();
+        }
+
+        if let Some(rest) = path.strip_prefix("~/") {
+            return format!("\"${{HOME}}\"/{}", shell_word(rest));
+        }
+
+        shell_word(path)
     }
 
     pub fn detail_map(entries: &[(&str, &str)]) -> BTreeMap<String, String> {

--- a/src/commands/runner/doctor/tests.rs
+++ b/src/commands/runner/doctor/tests.rs
@@ -31,6 +31,16 @@ fn doctor_options_default_to_general_read_only_scope() {
 }
 
 #[test]
+fn shell_path_expr_expands_runner_home_relative_paths() {
+    assert_eq!(
+        common::shell_path_expr("~/.cache/homeboy/source"),
+        "\"${HOME}\"/'.cache/homeboy/source'"
+    );
+    assert_eq!(common::shell_path_expr("~"), "\"${HOME}\"");
+    assert_eq!(common::shell_path_expr("/tmp/source"), "'/tmp/source'");
+}
+
+#[test]
 fn doctor_output_omits_empty_repairs() {
     let (report, _) = run("local").expect("local doctor report");
     let value = serde_json::to_value(report).expect("serialize report");

--- a/src/core/runner/managed_source.rs
+++ b/src/core/runner/managed_source.rs
@@ -101,7 +101,7 @@ pub fn plan_managed_runner_source_sync(
 /// caller can surface a clear error rather than silently leaving a drifted
 /// checkout in place.
 fn render_sync_script(path: &str, remote_url: Option<&str>, git_ref: Option<&str>) -> String {
-    let quoted_path = sq(path);
+    let quoted_path = shell_path_expr(path);
     let mut script = String::new();
     script.push_str("set -e\n");
     script.push_str(&format!("dir={quoted_path}\n"));
@@ -193,6 +193,21 @@ fn sq(value: &str) -> String {
     }
     out.push('\'');
     out
+}
+
+/// Render a shell expression for manifest-declared runner paths. Manifests are
+/// runner-side contracts, so leading `~` must resolve against the runner user,
+/// not the machine that planned the sync.
+fn shell_path_expr(path: &str) -> String {
+    if path == "~" {
+        return "\"${HOME}\"".to_string();
+    }
+
+    if let Some(rest) = path.strip_prefix("~/") {
+        return format!("\"${{HOME}}\"/{}", sq(rest));
+    }
+
+    sq(path)
 }
 
 #[cfg(test)]
@@ -326,6 +341,26 @@ mod tests {
     fn sq_escapes_embedded_single_quotes() {
         assert_eq!(sq("a'b"), "'a'\\''b'");
         assert_eq!(sq("/plain/path"), "'/plain/path'");
+    }
+
+    #[test]
+    fn script_expands_runner_home_relative_paths() {
+        let plan =
+            plan_managed_runner_source_sync(&source("src", "~/.cache/homeboy/runtime/source"))
+                .expect("plan");
+
+        assert!(plan
+            .script
+            .contains("dir=\"${HOME}\"/'.cache/homeboy/runtime/source'"));
+        assert!(!plan.script.contains("dir='~/.cache"));
+    }
+
+    #[test]
+    fn script_expands_bare_runner_home_path() {
+        let plan = plan_managed_runner_source_sync(&source("src", "~")).expect("plan");
+
+        assert!(plan.script.contains("dir=\"${HOME}\""));
+        assert!(!plan.script.contains("dir='~'"));
     }
 
     #[test]

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -1,11 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use crate::core::component::Component;
 use crate::core::rig;
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
-use crate::extensions::deps_provider;
 
 use super::{
     exec, load, materialize_git_dependency, preflight_remote_argv_path_translation, sync_workspace,
@@ -399,7 +397,6 @@ pub(super) fn sync_lab_offload_rig_component_dependencies(
         if !seen.insert(dependency.remote_checkout_root.clone()) {
             continue;
         }
-        prepare_rig_component_dependency(&dependency)?;
         synced.push(materialize_git_dependency(
             &runner,
             RunnerGitDependencyMaterializationOptions {
@@ -417,25 +414,6 @@ pub(super) fn sync_lab_offload_rig_component_dependencies(
         materializations: synced,
         component_path_env,
     })
-}
-
-fn prepare_rig_component_dependency(dependency: &RigComponentDependency) -> Result<()> {
-    let path = Path::new(&dependency.local_checkout_root);
-    let component = Component {
-        id: dependency.component_id.clone(),
-        local_path: dependency.local_checkout_root.clone(),
-        remote_url: dependency.remote_url.clone(),
-        ..Component::default()
-    };
-    let providers = match deps_provider::resolve_dependency_providers(&component, path) {
-        Ok(providers) => providers,
-        Err(_) => return Ok(()),
-    };
-
-    for provider in providers {
-        provider.install(&component, path)?;
-    }
-    Ok(())
 }
 
 /// Join a runner-side checkout root with the component's required subpath.


### PR DESCRIPTION
## Summary
- Expand leading `~` in extension-declared managed runner source paths against the runner user before executing refresh scripts.
- Use the same runner-home path expression in `runner doctor` managed-source checks.
- Stop running controller-side dependency provider installs while materializing Lab rig component checkouts; runner-side rig preparation owns dependency setup.
- Export `WP_CODEBOX_FUZZ_WORKLOAD_ROOT` for rig-backed fuzz runs so WP Codebox can include rig-owned workload files through its existing allowlisted workload-root guardrail.

## Testing
- `cargo test core::runner::managed_source`
- `cargo test shell_path_expr_expands_runner_home_relative_paths`
- `cargo test core::runner::rig_materialization`
- `cargo test commands::fuzz::tests::fuzz_runner_env_expands_rig_workload_and_injects_runtime_context`
- `cargo build --release`
- `cargo fmt --check`
- `cargo test commands::fuzz` currently has 19 passing fuzz tests and 2 pre-existing selection-hint assertion failures on this branch: `select_workload_requires_explicit_id_for_ambiguous_fuzz_workloads` and `select_workload_rejects_empty_fuzz_selection`.
- Verified Woo `admin-page-coverage` and `db-inventory` fuzz runs progressed through Lab after the earlier fixes.
- Reran Woo `woocommerce-external-http-guardrail`; it still fails on the deployed Lab runner binary, which has not picked up this branch and therefore does not emit the new workload-root env yet.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing Lab runner source refresh, dependency materialization, and WP Codebox fuzz workload-root handoff failures; implementing fixes; and running verification.
