### PR TITLE
Count metadata fuzz artifacts in gates

### DIFF
--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -359,6 +359,45 @@ mod tests {
     }
 
     #[test]
+    fn fuzz_gate_evaluation_accepts_metadata_artifact_refs() {
+        let campaign = FuzzCampaign {
+            schema: homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA.to_string(),
+            version: homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+            id: "campaign-1".to_string(),
+            title: None,
+            safety_class: homeboy::core::fuzz::FuzzSafetyClass::ReadOnly,
+            surfaces: Vec::new(),
+            targets: Vec::new(),
+            workloads: Vec::new(),
+            cases: Vec::new(),
+            seeds: Vec::new(),
+            coverage: Vec::new(),
+            coverage_summary: None,
+            findings: Vec::new(),
+            artifacts: Vec::new(),
+            thresholds: Vec::new(),
+            lifecycle: None,
+            provenance: None,
+            replay: None,
+            metadata: serde_json::json!({
+                "artifact_refs": [{
+                    "name": "external_http_guardrail",
+                    "path": "woocommerce-external-http-guardrail/external_http_guardrail.json",
+                    "role": "fuzz_report"
+                }]
+            }),
+            extra: std::collections::BTreeMap::new(),
+        };
+
+        let gates = evaluate_fuzz_gates(&campaign);
+        let summary = fuzz_coverage_completeness(&campaign);
+
+        assert_eq!(gate_status(&gates), "passed");
+        assert_eq!(summary.target_coverage_ratio, 1.0);
+        assert_eq!(summary.operation_coverage_ratio, 1.0);
+    }
+
+    #[test]
     fn fuzz_gate_evaluation_requires_complete_target_and_operation_coverage() {
         let mut campaign = FuzzCampaign {
             schema: homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA.to_string(),

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -178,7 +178,7 @@ fn coverage_ratio(
 }
 
 fn case_evidence_artifact_count(campaign: &FuzzCampaign) -> usize {
-    campaign
+    let campaign_artifacts = campaign
         .artifacts
         .iter()
         .filter(|artifact| {
@@ -192,7 +192,39 @@ fn case_evidence_artifact_count(campaign: &FuzzCampaign) -> usize {
                     | "repro_case"
             )
         })
-        .count()
+        .count();
+    campaign_artifacts + metadata_case_evidence_artifact_count(&campaign.metadata)
+}
+
+fn metadata_case_evidence_artifact_count(metadata: &serde_json::Value) -> usize {
+    metadata_artifact_refs(metadata.get("artifact_refs"))
+        + metadata_artifact_refs(metadata.get("artifactRefs"))
+        + metadata_artifact_refs(metadata.pointer("/wordpress_fuzz_result/artifacts"))
+        + metadata_artifact_refs(metadata.pointer("/wordpressFuzzResult/artifacts"))
+}
+
+fn metadata_artifact_refs(value: Option<&serde_json::Value>) -> usize {
+    value
+        .and_then(|value| value.as_array())
+        .map(|artifacts| {
+            artifacts
+                .iter()
+                .filter(|artifact| metadata_artifact_has_case_evidence_kind(artifact))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn metadata_artifact_has_case_evidence_kind(artifact: &serde_json::Value) -> bool {
+    let kind = artifact
+        .get("kind")
+        .or_else(|| artifact.get("role"))
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    matches!(
+        kind,
+        "case_log" | "fuzz_report" | "fuzz_case" | "case_artifact" | "failing_case" | "repro_case"
+    )
 }
 
 pub(super) fn fuzz_coverage_completeness(
@@ -243,11 +275,11 @@ pub(super) fn fuzz_coverage_completeness(
             declared_targets: 0,
             executable_targets: 0,
             proven_targets: 0,
-            target_coverage_ratio: 0.0,
+            target_coverage_ratio: 1.0,
             declared_operations: 0,
             executable_operations: 0,
             proven_operations: 0,
-            operation_coverage_ratio: 0.0,
+            operation_coverage_ratio: 1.0,
             skipped_targets: 0,
             skipped_operations: 0,
             skipped_reason_counts: BTreeMap::new(),


### PR DESCRIPTION
## Summary
- count normalized metadata artifact refs as fuzz case evidence
- support WP Codebox fuzz results that carry artifacts under campaign metadata
- report no-summary coverage completeness ratios as complete for artifact-only workloads

## Verification
- `cargo test commands::fuzz::tests::fuzz_gate_evaluation --lib`
- `cargo build --release`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing remaining artifact-only fuzz gate metadata handling, implementing the fix, and adding focused tests.