### PR TITLE
Support lab extension refresh

### DIFF
--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -236,7 +236,10 @@ pub fn run(
 
 impl ExtensionArgs {
     pub(crate) fn is_update_command(&self) -> bool {
-        matches!(self.command, ExtensionCommand::Update { .. })
+        matches!(
+            self.command,
+            ExtensionCommand::Update { .. } | ExtensionCommand::Refresh { .. }
+        )
     }
 }
 

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -816,6 +816,33 @@ mod tests {
     }
 
     #[test]
+    fn extension_refresh_requires_explicit_lab_runner_without_extension_parity() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "lab",
+            "extension",
+            "refresh",
+            "https://github.com/Extra-Chill/homeboy-extensions.git",
+            "--id",
+            "wordpress",
+            "--ref",
+            "6ff93f43",
+        ]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(command.hot_label, "extension update");
+        assert!(command.portable);
+        assert!(!command.routing_policy.default_lab_offload);
+        assert!(command.unsupported_reason.is_none());
+        assert!(!command.routing_policy.requires_extension_parity);
+        assert!(command.required_extensions.is_empty());
+        assert!(!command.routing_policy.infer_source_path_tools);
+        assert!(cli.command.supports_lab_runner());
+    }
+
+    #[test]
     fn extension_update_routes_locally_without_explicit_lab_runner() {
         let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
         let normalized = vec![


### PR DESCRIPTION
## Summary
- Treat `homeboy extension refresh` as an explicit-runner Lab command like `extension update`.
- Add routing coverage for `extension refresh --runner`.

## Testing
- `cargo test commands::route::tests::extension_ --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the focused command-routing change and tests.