### PR TITLE
Expose fuzz sandbox descriptor

### DIFF
--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -177,7 +177,7 @@ mod tests {
     use clap::Parser;
     use homeboy::core::engine::run_dir::RunDir;
     use homeboy::core::extension::FuzzConfig;
-    use homeboy::core::fuzz::FuzzCampaign;
+    use homeboy::core::fuzz::{FuzzCampaign, FuzzCoverageSummary};
     use homeboy::core::observation::ObservationStore;
     use homeboy::core::rig::RigSpec;
     use homeboy::test_support::with_isolated_home;
@@ -187,6 +187,25 @@ mod tests {
     struct FuzzCli {
         #[command(flatten)]
         args: FuzzArgs,
+    }
+
+    fn zero_coverage_summary() -> FuzzCoverageSummary {
+        FuzzCoverageSummary {
+            schema: homeboy::core::fuzz::FUZZ_COVERAGE_SUMMARY_SCHEMA.to_string(),
+            declared_targets: 0,
+            executable_targets: 0,
+            proven_targets: 0,
+            declared_operations: 0,
+            executable_operations: 0,
+            proven_operations: 0,
+            skipped_targets: Vec::new(),
+            skipped_operations: Vec::new(),
+            surface_summaries: Vec::new(),
+            kind_summaries: Vec::new(),
+            artifact_ids: Vec::new(),
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        }
     }
 
     #[test]
@@ -313,8 +332,13 @@ mod tests {
         }));
         assert!(gates.iter().any(|gate| {
             gate.gate_id == "target-coverage-complete"
-                && gate.status == "passed"
-                && gate.observed == 1.0
+                && gate.status == "failed"
+                && gate.observed == 0.0
+        }));
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "operation-coverage-complete"
+                && gate.status == "failed"
+                && gate.observed == 0.0
         }));
     }
 
@@ -332,7 +356,7 @@ mod tests {
             cases: Vec::new(),
             seeds: Vec::new(),
             coverage: Vec::new(),
-            coverage_summary: None,
+            coverage_summary: Some(zero_coverage_summary()),
             findings: Vec::new(),
             artifacts: vec![homeboy::core::fuzz::FuzzArtifact {
                 schema: homeboy::core::fuzz::FUZZ_ARTIFACT_SCHEMA.to_string(),
@@ -372,7 +396,7 @@ mod tests {
             cases: Vec::new(),
             seeds: Vec::new(),
             coverage: Vec::new(),
-            coverage_summary: None,
+            coverage_summary: Some(zero_coverage_summary()),
             findings: Vec::new(),
             artifacts: Vec::new(),
             thresholds: Vec::new(),
@@ -398,6 +422,57 @@ mod tests {
         }));
         assert_eq!(summary.target_coverage_ratio, 1.0);
         assert_eq!(summary.operation_coverage_ratio, 1.0);
+    }
+
+    #[test]
+    fn fuzz_coverage_completeness_fails_closed_without_summary() {
+        let campaign = FuzzCampaign {
+            schema: homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA.to_string(),
+            version: homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+            id: "campaign-1".to_string(),
+            title: None,
+            safety_class: homeboy::core::fuzz::FuzzSafetyClass::ReadOnly,
+            surfaces: Vec::new(),
+            targets: Vec::new(),
+            workloads: Vec::new(),
+            cases: Vec::new(),
+            seeds: Vec::new(),
+            coverage: Vec::new(),
+            coverage_summary: None,
+            findings: Vec::new(),
+            artifacts: vec![homeboy::core::fuzz::FuzzArtifact {
+                schema: homeboy::core::fuzz::FUZZ_ARTIFACT_SCHEMA.to_string(),
+                id: "case-log".to_string(),
+                kind: "case_log".to_string(),
+                artifact: None,
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            }],
+            thresholds: Vec::new(),
+            lifecycle: None,
+            provenance: None,
+            replay: None,
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        };
+
+        let gates = evaluate_fuzz_gates(&campaign);
+        let summary = fuzz_coverage_completeness(&campaign);
+
+        assert_eq!(gate_status(&gates), "failed");
+        assert_eq!(summary.has_summary, false);
+        assert_eq!(summary.target_coverage_ratio, 0.0);
+        assert_eq!(summary.operation_coverage_ratio, 0.0);
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "target-coverage-complete"
+                && gate.status == "failed"
+                && gate.observed == 0.0
+        }));
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "operation-coverage-complete"
+                && gate.status == "failed"
+                && gate.observed == 0.0
+        }));
     }
 
     #[test]

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -209,7 +209,7 @@ fn coverage_ratio(
     total: impl Fn(&homeboy::core::fuzz::FuzzCoverageSummary) -> u64,
 ) -> f64 {
     let Some(summary) = summary else {
-        return 1.0;
+        return 0.0;
     };
     let total = total(summary);
     if total == 0 {
@@ -315,11 +315,11 @@ pub(super) fn fuzz_coverage_completeness(
             declared_targets: 0,
             executable_targets: 0,
             proven_targets: 0,
-            target_coverage_ratio: 1.0,
+            target_coverage_ratio: 0.0,
             declared_operations: 0,
             executable_operations: 0,
             proven_operations: 0,
-            operation_coverage_ratio: 1.0,
+            operation_coverage_ratio: 0.0,
             skipped_targets: 0,
             skipped_operations: 0,
             skipped_reason_counts: BTreeMap::new(),

--- a/src/core/http_api/sandbox_tools.rs
+++ b/src/core/http_api/sandbox_tools.rs
@@ -95,6 +95,35 @@ const SANDBOX_TOOLS: &[SandboxToolDescriptor] = &[
         ],
     },
     SandboxToolDescriptor {
+        id: "homeboy.fuzz",
+        command: "homeboy fuzz",
+        required_capability: "run:fuzz",
+        risk: "bounded_discovery_report",
+        runs_as_job: false,
+        allowed_arguments: &[
+            "subcommand",
+            "contract",
+            "list",
+            "plan",
+            "validate",
+            "report",
+            "replay",
+            "component",
+            "rig",
+            "extension",
+            "setting",
+            "workload",
+            "run_id",
+            "request_id",
+            "inventory",
+            "results_file",
+            "artifact",
+            "case_id",
+            "output_envelope",
+            "envelope_id",
+        ],
+    },
+    SandboxToolDescriptor {
         id: "homeboy.build",
         command: "homeboy build",
         required_capability: "run:build",
@@ -156,5 +185,27 @@ pub fn kind(id: &str) -> Result<JobReadyRunKind> {
             Some(id.to_string()),
             None,
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get, kind};
+
+    #[test]
+    fn fuzz_descriptor_exposes_safe_non_job_subcommands() {
+        let tool = get("homeboy.fuzz").expect("fuzz descriptor");
+
+        assert_eq!(tool.required_capability, "run:fuzz");
+        assert_eq!(tool.risk, "bounded_discovery_report");
+        assert!(!tool.runs_as_job);
+        for expected in ["contract", "list", "plan", "validate", "report", "replay"] {
+            assert!(
+                tool.allowed_arguments.contains(&expected),
+                "missing fuzz argument {expected}"
+            );
+        }
+        assert!(!tool.allowed_arguments.contains(&"run"));
+        assert!(kind(tool.id).is_err());
     }
 }

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -578,6 +578,24 @@ fn sandbox_tools_declare_capabilities_and_allowed_arguments() {
             && tool["required_capability"] == "run:review"
             && tool["risk"] == "bounded_local_run"
     }));
+    let fuzz = tools
+        .iter()
+        .find(|tool| tool["id"] == "homeboy.fuzz")
+        .expect("fuzz tool descriptor");
+    assert_eq!(fuzz["required_capability"], "run:fuzz");
+    assert_eq!(fuzz["risk"], "bounded_discovery_report");
+    assert_eq!(fuzz["runs_as_job"], false);
+    let fuzz_args = fuzz["allowed_arguments"].as_array().expect("fuzz args");
+    for expected in ["contract", "list", "plan", "validate", "report", "replay"] {
+        assert!(
+            fuzz_args.iter().any(|arg| arg == expected),
+            "missing fuzz arg {expected}"
+        );
+    }
+    assert!(
+        !fuzz_args.iter().any(|arg| arg == "run"),
+        "fuzz run is not exposed until the sandbox has a job-ready fuzz contract"
+    );
     assert!(tools.iter().all(|tool| {
         !tool["required_capability"]
             .as_str()
@@ -635,6 +653,17 @@ fn sandbox_tool_run_rejects_unallowlisted_tool_and_arguments() {
     )
     .expect_err("review report output is rejected");
     assert!(mutating.to_string().contains("JSON output"));
+
+    let fuzz_run = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: "/tools/homeboy.fuzz/run".to_string(),
+            body: Some(serde_json::json!({ "subcommand": "run" })),
+        },
+        &JobStore::default(),
+    )
+    .expect_err("fuzz run is not job-ready");
+    assert!(fuzz_run.to_string().contains("not executable"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Expose `homeboy.fuzz` through the sandbox tool descriptor with conservative non-job subcommands.
- Keep `fuzz run` out of the sandbox descriptor until a bounded job-ready run kind exists.
- Make missing fuzz `coverage_summary` fail completeness gates instead of passing by default.

## Testing
- `cargo fmt`
- `cargo test fuzz_descriptor_exposes_safe_non_job_subcommands`
- `cargo test fuzz_gate_evaluation`
- `cargo test fuzz_coverage_completeness`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, test updates, and PR description drafting.
