### PR TITLE
Fix GHE release gh environment

### DIFF
--- a/src/core/git/gh_client.rs
+++ b/src/core/git/gh_client.rs
@@ -198,6 +198,14 @@ pub fn command_probe_succeeds(mut command: Command) -> bool {
 }
 
 pub fn github_cli_env(host: &str, config: &GithubConfig) -> Vec<(String, String)> {
+    github_cli_env_with_inherited(host, config, |key| std::env::var(key).ok())
+}
+
+fn github_cli_env_with_inherited(
+    host: &str,
+    config: &GithubConfig,
+    inherited_env: impl Fn(&str) -> Option<String>,
+) -> Vec<(String, String)> {
     let mut env = Vec::new();
     if host != "github.com" {
         env.push(("GH_HOST".to_string(), host.to_string()));
@@ -206,10 +214,31 @@ pub fn github_cli_env(host: &str, config: &GithubConfig) -> Vec<(String, String)
     let host_config = config.hosts.get(host);
     if let Some(proxy) = host_config
         .and_then(|host_config| host_config.proxy.clone())
-        .or_else(|| inherited_enterprise_https_proxy(host))
+        .or_else(|| inherited_enterprise_https_proxy(host, &inherited_env))
         .filter(|proxy| !proxy.is_empty())
     {
         env.push(("HTTPS_PROXY".to_string(), proxy));
+    }
+
+    if host != "github.com" {
+        for key in [
+            "HTTPS_PROXY",
+            "https_proxy",
+            "HTTP_PROXY",
+            "http_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+        ] {
+            if env.iter().any(|(existing, _)| existing == key) {
+                continue;
+            }
+            if let Some(value) = inherited_env(key)
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+            {
+                env.push((key.to_string(), value));
+            }
+        }
     }
 
     let Some(host_config) = host_config else {
@@ -226,14 +255,16 @@ pub fn github_cli_env(host: &str, config: &GithubConfig) -> Vec<(String, String)
     env
 }
 
-fn inherited_enterprise_https_proxy(host: &str) -> Option<String> {
+fn inherited_enterprise_https_proxy(
+    host: &str,
+    inherited_env: &impl Fn(&str) -> Option<String>,
+) -> Option<String> {
     if host == "github.com" {
         return None;
     }
 
-    std::env::var("HTTPS_PROXY")
-        .or_else(|_| std::env::var("https_proxy"))
-        .ok()
+    inherited_env("HTTPS_PROXY")
+        .or_else(|| inherited_env("https_proxy"))
         .map(|proxy| proxy.trim().to_string())
         .filter(|proxy| !proxy.is_empty())
 }
@@ -244,7 +275,10 @@ mod tests {
 
     use crate::core::component::{GithubConfig, GithubHostConfig};
 
-    use super::{delete_branch_ref_api_args, github_cli_env, pr_merge_api_args, GhClient};
+    use super::{
+        delete_branch_ref_api_args, github_cli_env, github_cli_env_with_inherited,
+        pr_merge_api_args, GhClient,
+    };
 
     #[test]
     fn repo_arg_accepts_host_qualified_repo() {
@@ -277,12 +311,91 @@ mod tests {
 
     #[test]
     fn github_cli_env_sets_enterprise_host_without_implicit_proxy() {
-        let env = github_cli_env("github.enterprise.test", &GithubConfig::default());
+        let env = github_cli_env_with_inherited(
+            "github.enterprise.test",
+            &GithubConfig::default(),
+            |_| None,
+        );
 
         assert_eq!(
             env,
             vec![("GH_HOST".to_string(), "github.enterprise.test".to_string())]
         );
+    }
+
+    #[test]
+    fn github_cli_env_inherits_enterprise_proxy_context() {
+        let inherited = HashMap::from([
+            (
+                "HTTP_PROXY".to_string(),
+                "http://proxy.example.test:8080".to_string(),
+            ),
+            (
+                "ALL_PROXY".to_string(),
+                "socks5://127.0.0.1:8080".to_string(),
+            ),
+        ]);
+
+        let env = github_cli_env_with_inherited(
+            "github.enterprise.test",
+            &GithubConfig::default(),
+            |key| inherited.get(key).cloned(),
+        );
+
+        assert_eq!(
+            env,
+            vec![
+                ("GH_HOST".to_string(), "github.enterprise.test".to_string()),
+                (
+                    "HTTP_PROXY".to_string(),
+                    "http://proxy.example.test:8080".to_string()
+                ),
+                (
+                    "ALL_PROXY".to_string(),
+                    "socks5://127.0.0.1:8080".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn github_cli_env_keeps_configured_proxy_ahead_of_inherited_context() {
+        let mut hosts = HashMap::new();
+        hosts.insert(
+            "github.enterprise.test".to_string(),
+            GithubHostConfig {
+                proxy: Some("https://configured-proxy.example.test:8443".to_string()),
+                env: HashMap::new(),
+            },
+        );
+        let config = GithubConfig { hosts };
+        let inherited = HashMap::from([
+            (
+                "HTTPS_PROXY".to_string(),
+                "https://inherited-proxy.example.test:9443".to_string(),
+            ),
+            (
+                "HTTP_PROXY".to_string(),
+                "http://proxy.example.test:8080".to_string(),
+            ),
+        ]);
+
+        let env = github_cli_env_with_inherited("github.enterprise.test", &config, |key| {
+            inherited.get(key).cloned()
+        });
+
+        assert!(env.contains(&(
+            "HTTPS_PROXY".to_string(),
+            "https://configured-proxy.example.test:8443".to_string()
+        )));
+        assert!(env.contains(&(
+            "HTTP_PROXY".to_string(),
+            "http://proxy.example.test:8080".to_string()
+        )));
+        assert!(!env.contains(&(
+            "HTTPS_PROXY".to_string(),
+            "https://inherited-proxy.example.test:9443".to_string()
+        )));
     }
 
     #[test]

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -132,6 +132,7 @@ pub(crate) fn run_github_release(
 
     if !gh_is_authenticated(&github, &component.github) {
         let repair = repair_commands(None, None);
+        let auth_error = gh_auth_failure_message(&github, &repair);
         log_status!(
             "release",
             "✗ `gh` is not authenticated — GitHub Release was NOT created"
@@ -142,7 +143,7 @@ pub(crate) fn run_github_release(
             &tag,
             &github,
             "gh-not-authenticated",
-            "`gh` is not authenticated; GitHub Release was not created.",
+            &auth_error,
             repair,
         ));
     }
@@ -964,24 +965,54 @@ fn gh_env_hint(github: &GitHubRepo, env: &[(String, String)]) -> Option<String> 
     }
 
     let mut hints = Vec::new();
-    let has_proxy = env
+    let proxy_keys = env
         .iter()
-        .any(|(key, value)| key.eq_ignore_ascii_case("HTTPS_PROXY") && !value.is_empty());
+        .filter(|(key, value)| is_proxy_env_key(key) && !value.is_empty())
+        .map(|(key, _)| key.as_str())
+        .collect::<Vec<_>>();
     if github.host != "github.com" {
         hints.push(format!(
             "GitHub Enterprise host detected: repair commands include GH_HOST={}",
             github.host
         ));
     }
-    if has_proxy {
-        hints.push("Configured HTTPS_PROXY is included in repair commands.".to_string());
+    if !proxy_keys.is_empty() {
+        hints.push(format!(
+            "Proxy environment is included in repair commands: {}.",
+            proxy_keys.join(", ")
+        ));
     } else if github.host != "github.com" {
         hints.push(
-            "If this Enterprise host requires a proxy, prefix the commands with HTTPS_PROXY=<proxy-url>.".to_string(),
+            "If this Enterprise host requires a proxy, prefix the commands with the needed HTTPS_PROXY/HTTP_PROXY/ALL_PROXY value.".to_string(),
         );
     }
 
     Some(hints.join(" "))
+}
+
+fn is_proxy_env_key(key: &str) -> bool {
+    matches!(
+        key,
+        "HTTPS_PROXY" | "https_proxy" | "HTTP_PROXY" | "http_proxy" | "ALL_PROXY" | "all_proxy"
+    )
+}
+
+fn gh_auth_failure_message(github: &GitHubRepo, repair: &GitHubReleaseRepairCommands) -> String {
+    if github.host == "github.com" {
+        return "`gh` is not authenticated; GitHub Release was not created.".to_string();
+    }
+
+    let proxy_context = repair
+        .env_hint
+        .as_deref()
+        .filter(|hint| hint.contains("Proxy environment is included"))
+        .map(|_| " with the inherited/configured proxy environment")
+        .unwrap_or("");
+
+    format!(
+        "`gh auth status --hostname {}` failed{}; GitHub Release was not created. Authenticate this host with `gh auth login --hostname {}`, or verify the proxy/keyring environment used by the printed repair commands.",
+        github.host, proxy_context, github.host
+    )
 }
 
 fn safe_filename(value: &str) -> String {
@@ -1047,7 +1078,7 @@ mod tests {
     use crate::core::release::types::{ReleaseState, ReleaseStepStatus};
 
     use super::{
-        create_failed_result, fallback_release_notes, github_cli_env,
+        create_failed_result, fallback_release_notes, gh_auth_failure_message, github_cli_env,
         github_generated_notes_start_tag, github_release_repair_commands, not_created_result,
         upload_failed_result, GitHubReleaseBody,
     };
@@ -1430,7 +1461,77 @@ mod tests {
             .env_hint
             .as_deref()
             .unwrap_or_default()
-            .contains("Configured HTTPS_PROXY is included"));
+            .contains("Proxy environment is included"));
+    }
+
+    #[test]
+    fn repair_commands_include_configured_enterprise_proxy_env() {
+        let github = GitHubRepo {
+            host: "github.enterprise.test".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        };
+        let config = GithubConfig {
+            hosts: HashMap::from([(
+                "github.enterprise.test".to_string(),
+                GithubHostConfig {
+                    proxy: None,
+                    env: HashMap::from([
+                        (
+                            "HTTP_PROXY".to_string(),
+                            "http://proxy.example.test:8080".to_string(),
+                        ),
+                        (
+                            "ALL_PROXY".to_string(),
+                            "socks5://127.0.0.1:8080".to_string(),
+                        ),
+                    ]),
+                },
+            )]),
+        };
+
+        let repair = github_release_repair_commands(
+            "v1.2.3",
+            &github,
+            &config,
+            &[],
+            None,
+            Some("build/v1.2.3-release-notes.md"),
+        );
+
+        assert!(repair.create_command.starts_with(
+            "GH_HOST=github.enterprise.test HTTP_PROXY=http://proxy.example.test:8080 ALL_PROXY=socks5://127.0.0.1:8080 gh release create v1.2.3"
+        ));
+        assert!(repair
+            .env_hint
+            .as_deref()
+            .unwrap_or_default()
+            .contains("HTTP_PROXY, ALL_PROXY"));
+    }
+
+    #[test]
+    fn enterprise_auth_failure_mentions_proxy_keyring_context() {
+        let github = GitHubRepo {
+            host: "github.enterprise.test".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        };
+        let config = GithubConfig {
+            hosts: HashMap::from([(
+                "github.enterprise.test".to_string(),
+                GithubHostConfig {
+                    proxy: Some("https://proxy.example.test:8443".to_string()),
+                    env: HashMap::new(),
+                },
+            )]),
+        };
+        let repair = github_release_repair_commands("v1.2.3", &github, &config, &[], None, None);
+
+        let message = gh_auth_failure_message(&github, &repair);
+
+        assert!(message.contains("gh auth status --hostname github.enterprise.test"));
+        assert!(message.contains("Authenticate this host"));
+        assert!(message.contains("proxy/keyring environment"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Include inherited Enterprise proxy context in shared gh command environment and repair commands.
- Preserve configured GitHub host proxy/env overrides while adding HTTP_PROXY/ALL_PROXY variants when present.
- Improve Enterprise auth failure diagnostics to mention missing auth versus proxy/keyring environment mismatch.

Fixes #6052

## Tests
- cargo fmt
- cargo test github_cli_env --lib
- cargo test repair_commands_include_configured_enterprise_proxy_env --lib
- cargo test enterprise_auth_failure_mentions_proxy_keyring_context --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the release code path, implementing the fix, adding focused tests, and drafting this PR description.