### PR TITLE
Preserve release artifacts for repair hints

### DIFF
--- a/src/core/release/deployment.rs
+++ b/src/core/release/deployment.rs
@@ -219,6 +219,7 @@ mod tests {
         std::fs::write(&artifact_path, "artifact").expect("artifact");
         let artifacts = vec![ReleaseArtifact {
             path: artifact_path.display().to_string(),
+            durable_path: None,
             artifact_type: None,
             platform: None,
         }];

--- a/src/core/release/execution_projection.rs
+++ b/src/core/release/execution_projection.rs
@@ -81,6 +81,7 @@ fn release_artifacts_from_step(run_id: &str, step: &ReleaseStepResult) -> Vec<Ch
         .map(|(index, artifact)| {
             let ReleaseArtifact {
                 path: release_artifact_path,
+                durable_path: _,
                 artifact_type,
                 platform,
             } = artifact;

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -431,6 +431,14 @@ mod tests {
         );
     }
 
+    fn test_repo() -> GitHubRepo {
+        GitHubRepo {
+            host: "github.com".to_string(),
+            owner: "example".to_string(),
+            repo: "fixture".to_string(),
+        }
+    }
+
     #[test]
     fn github_release_repair_commands_include_repo_asset_notes_and_enterprise_env() {
         let github = GitHubRepo {
@@ -517,6 +525,43 @@ mod tests {
     }
 
     #[test]
+    fn github_release_artifact_paths_prefer_existing_durable_copy_and_omit_missing_assets() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let original_dir = temp.path().join("component/build");
+        let durable_dir = temp.path().join("artifacts/release/fixture/1.2.3");
+        std::fs::create_dir_all(&original_dir).expect("original dir");
+        std::fs::create_dir_all(&durable_dir).expect("durable dir");
+        let original = original_dir.join("fixture.zip");
+        let durable = durable_dir.join("01-fixture.zip");
+        std::fs::write(&original, "original").expect("original artifact");
+        std::fs::write(&durable, "durable").expect("durable artifact");
+        std::fs::remove_file(&original).expect("simulate cleanup removing original artifact");
+
+        let state = ReleaseState {
+            artifacts: vec![
+                ReleaseArtifact {
+                    path: original.display().to_string(),
+                    durable_path: Some(durable.display().to_string()),
+                    artifact_type: None,
+                    platform: None,
+                },
+                ReleaseArtifact {
+                    path: temp.path().join("missing.zip").display().to_string(),
+                    durable_path: None,
+                    artifact_type: None,
+                    platform: None,
+                },
+            ],
+            ..ReleaseState::default()
+        };
+
+        assert_eq!(
+            github_release::github_release_artifact_paths(&state),
+            vec![durable.display().to_string()]
+        );
+    }
+
+    #[test]
     fn cleanup_removes_build_dir_when_release_artifact_is_inside_build() {
         let temp = tempfile::tempdir().expect("tempdir");
         let build_dir = temp.path().join("build");
@@ -534,6 +579,7 @@ mod tests {
         let state = ReleaseState {
             artifacts: vec![ReleaseArtifact {
                 path: artifact_path.display().to_string(),
+                durable_path: None,
                 artifact_type: None,
                 platform: None,
             }],
@@ -700,6 +746,62 @@ mod tests {
 
         assert_eq!(state.artifacts.len(), 1);
         assert_eq!(state.artifacts[0].path, "build/artifact.zip");
+    }
+
+    #[test]
+    fn run_package_copies_existing_build_artifact_to_durable_release_artifact_path() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir().expect("component tempdir");
+            let package = release_package_extension(
+                "wordpress",
+                "mkdir -p build; printf artifact > build/fixture.zip; printf '[{\"path\":\"build/fixture.zip\",\"type\":\"archive\"}]'",
+            );
+            crate::core::extension::save_manifest(&package).expect("save package extension");
+
+            let mut state = crate::core::release::types::ReleaseState {
+                version: Some("1.2.3".to_string()),
+                ..ReleaseState::default()
+            };
+            let result = run_package(
+                &[package],
+                &mut state,
+                "fixture",
+                &component.path().to_string_lossy(),
+                false,
+            )
+            .expect("package step");
+
+            assert_eq!(result.status, ReleaseStepStatus::Success);
+            assert_eq!(state.artifacts.len(), 1);
+            assert_eq!(state.artifacts[0].path, "build/fixture.zip");
+            let durable_path = state.artifacts[0]
+                .durable_path
+                .as_deref()
+                .expect("durable artifact path");
+            assert!(std::path::Path::new(durable_path).is_file());
+            assert!(durable_path.contains("/release/fixture/1_2_3/01-fixture.zip"));
+
+            let repair = github_release::github_release_repair_commands(
+                "v1.2.3",
+                &test_repo(),
+                &crate::core::component::GithubConfig::default(),
+                &github_release::github_release_artifact_paths(&state),
+                None,
+                None,
+            );
+            assert!(repair.create_command.contains(durable_path));
+
+            let build_dir = component.path().join("build");
+            let component = Component {
+                id: "fixture".to_string(),
+                local_path: component.path().to_string_lossy().to_string(),
+                ..Component::default()
+            };
+            run_cleanup(&component, &state).expect("cleanup");
+
+            assert!(!build_dir.exists());
+            assert!(std::path::Path::new(durable_path).is_file());
+        });
     }
 
     fn release_package_extension(id: &str, command: &str) -> ExtensionManifest {

--- a/src/core/release/executor/artifacts.rs
+++ b/src/core/release/executor/artifacts.rs
@@ -51,6 +51,7 @@ pub(crate) fn run_artifact_inventory(
         })?;
         artifacts.push(ReleaseArtifact {
             path: canonical.display().to_string(),
+            durable_path: None,
             artifact_type: None,
             platform: None,
         });

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -87,16 +87,7 @@ pub(crate) fn run_github_release(
     // single API call — keeping the github.release step responsible for
     // the full Release lifecycle (entry + assets) instead of requiring a
     // separate publish.<target> step.
-    let artifact_paths: Vec<String> = state
-        .artifacts
-        .iter()
-        .filter(|artifact| {
-            std::fs::metadata(&artifact.path)
-                .map(|metadata| metadata.is_file())
-                .unwrap_or(false)
-        })
-        .map(|artifact| artifact.path.clone())
-        .collect();
+    let artifact_paths = github_release_artifact_paths(state);
     let has_artifacts = !artifact_paths.is_empty();
     // Single repair-command builder for every failure path. The persisted
     // exact-body file only exists after `persist_release_body` runs below, so
@@ -763,6 +754,28 @@ pub(super) fn github_release_repair_commands(
         persisted_notes_path,
         github_cli_env(github, config),
     )
+}
+
+pub(super) fn github_release_artifact_paths(state: &ReleaseState) -> Vec<String> {
+    state
+        .artifacts
+        .iter()
+        .filter_map(|artifact| {
+            artifact
+                .durable_path
+                .as_deref()
+                .filter(|path| path_is_file(path))
+                .or_else(|| Some(artifact.path.as_str()))
+                .filter(|path| path_is_file(path))
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+fn path_is_file(path: &str) -> bool {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.is_file())
+        .unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/src/core/release/executor/package.rs
+++ b/src/core/release/executor/package.rs
@@ -6,6 +6,7 @@
 
 use crate::core::error::{Error, Result};
 use crate::core::extension::{self, ExtensionManifest};
+use std::path::{Path, PathBuf};
 
 use super::super::types::{ReleaseArtifact, ReleaseState, ReleaseStepResult};
 use super::super::utils::parse_release_artifacts;
@@ -56,7 +57,10 @@ pub(crate) fn run_package(
         let response = run_package_action_with_retry(&extension.id, &payload)
             .map_err(|err| package_provider_error(&extension.id, err))?;
 
+        let artifact_start = state.artifacts.len();
         store_artifacts_from_output(state, &response)
+            .map_err(|err| package_provider_error(&extension.id, err))?;
+        persist_package_artifacts(state, artifact_start, component_id, component_local_path)
             .map_err(|err| package_provider_error(&extension.id, err))?;
         responses.push(serde_json::json!({
             "extension": extension.id,
@@ -355,6 +359,81 @@ pub(super) fn store_artifacts_from_output(
     let artifacts: Vec<ReleaseArtifact> = parse_release_artifacts(&raw_artifacts)?;
     state.artifacts.extend(artifacts);
     Ok(())
+}
+
+fn persist_package_artifacts(
+    state: &mut ReleaseState,
+    artifact_start: usize,
+    component_id: &str,
+    component_local_path: &str,
+) -> Result<()> {
+    let artifact_root = crate::core::paths::artifact_root()?;
+    let version = state
+        .version
+        .as_deref()
+        .filter(|version| !version.trim().is_empty())
+        .unwrap_or("unversioned");
+    let durable_dir = artifact_root
+        .join("release")
+        .join(crate::core::paths::sanitize_path_segment(component_id))
+        .join(crate::core::paths::sanitize_path_segment(version));
+
+    for (offset, artifact) in state.artifacts[artifact_start..].iter_mut().enumerate() {
+        let source = resolve_release_artifact_path(&artifact.path, component_local_path);
+        if !source.is_file() {
+            continue;
+        }
+
+        if source.starts_with(&artifact_root) {
+            artifact.durable_path = Some(source.display().to_string());
+            continue;
+        }
+
+        std::fs::create_dir_all(&durable_dir).map_err(|e| {
+            Error::internal_io(
+                format!("Failed to create durable release artifact directory: {}", e),
+                Some(durable_dir.display().to_string()),
+            )
+        })?;
+
+        let file_name = source
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .map(safe_artifact_file_name)
+            .unwrap_or_else(|| "artifact".to_string());
+        let target = durable_dir.join(format!("{:02}-{}", artifact_start + offset + 1, file_name));
+        std::fs::copy(&source, &target).map_err(|e| {
+            Error::internal_io(
+                format!("Failed to persist release artifact: {}", e),
+                Some(format!("{} -> {}", source.display(), target.display())),
+            )
+        })?;
+        artifact.durable_path = Some(target.display().to_string());
+    }
+
+    Ok(())
+}
+
+fn resolve_release_artifact_path(path: &str, component_local_path: &str) -> PathBuf {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    Path::new(component_local_path).join(path)
+}
+
+fn safe_artifact_file_name(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 /// Build an [`Error`] that surfaces *all* captured output from a failed

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -215,6 +215,8 @@ pub struct ReleaseRunSummary {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseArtifact {
     pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durable_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub artifact_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/release/utils.rs
+++ b/src/core/release/utils.rs
@@ -53,6 +53,7 @@ pub fn parse_release_artifacts(value: &serde_json::Value) -> Result<Vec<ReleaseA
         let artifact = match item {
             serde_json::Value::String(path) => ReleaseArtifact {
                 path,
+                durable_path: None,
                 artifact_type: None,
                 platform: None,
             },
@@ -73,6 +74,7 @@ pub fn parse_release_artifacts(value: &serde_json::Value) -> Result<Vec<ReleaseA
                     .map(|v| v.to_string());
                 ReleaseArtifact {
                     path,
+                    durable_path: None,
                     artifact_type,
                     platform,
                 }


### PR DESCRIPTION
## Summary
- Copy package artifacts that exist into Homeboy's durable artifact root during release packaging.
- Prefer durable artifact copies when building GitHub Release create/upload repair commands.
- Omit missing artifact paths from GitHub Release repair commands instead of pointing at stale ZIPs.

Fixes #6053.

## Tests
- cargo fmt --check
- cargo test core::release::executor::tests
- cargo test core::release::executor::github_release::tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the release packaging/cleanup/repair hint flow, implementing the durable artifact path fix, and adding regression tests.