### PR TITLE
fix(fuzz): fail missing coverage evidence

### DIFF
--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -313,8 +313,13 @@ mod tests {
         }));
         assert!(gates.iter().any(|gate| {
             gate.gate_id == "target-coverage-complete"
-                && gate.status == "passed"
-                && gate.observed == 1.0
+                && gate.status == "failed"
+                && gate.observed == 0.0
+        }));
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "operation-coverage-complete"
+                && gate.status == "failed"
+                && gate.observed == 0.0
         }));
     }
 
@@ -352,7 +357,7 @@ mod tests {
 
         let gates = evaluate_fuzz_gates(&campaign);
 
-        assert_eq!(gate_status(&gates), "passed");
+        assert_eq!(gate_status(&gates), "failed");
         assert!(gates.iter().any(|gate| {
             gate.gate_id == "has-case-evidence" && gate.status == "passed" && gate.observed == 1.0
         }));
@@ -392,12 +397,91 @@ mod tests {
         let gates = evaluate_fuzz_gates(&campaign);
         let summary = fuzz_coverage_completeness(&campaign);
 
-        assert_eq!(gate_status(&gates), "passed");
+        assert_eq!(gate_status(&gates), "failed");
         assert!(gates.iter().any(|gate| {
             gate.gate_id == "has-case-evidence" && gate.status == "passed" && gate.observed == 1.0
         }));
+        assert!(!summary.has_summary);
+        assert_eq!(summary.target_coverage_ratio, 0.0);
+        assert_eq!(summary.operation_coverage_ratio, 0.0);
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "target-coverage-complete"
+                && gate.status == "failed"
+                && gate.observed == 0.0
+        }));
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "operation-coverage-complete"
+                && gate.status == "failed"
+                && gate.observed == 0.0
+        }));
+    }
+
+    #[test]
+    fn fuzz_gate_evaluation_accepts_zero_declared_coverage_summary() {
+        let campaign = FuzzCampaign {
+            schema: homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA.to_string(),
+            version: homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+            id: "campaign-1".to_string(),
+            title: None,
+            safety_class: homeboy::core::fuzz::FuzzSafetyClass::ReadOnly,
+            surfaces: Vec::new(),
+            targets: Vec::new(),
+            workloads: Vec::new(),
+            cases: Vec::new(),
+            seeds: Vec::new(),
+            coverage: Vec::new(),
+            coverage_summary: Some(homeboy::core::fuzz::FuzzCoverageSummary {
+                schema: homeboy::core::fuzz::FUZZ_COVERAGE_SUMMARY_SCHEMA.to_string(),
+                declared_targets: 0,
+                executable_targets: 0,
+                proven_targets: 0,
+                declared_operations: 0,
+                executable_operations: 0,
+                proven_operations: 0,
+                skipped_targets: Vec::new(),
+                skipped_operations: Vec::new(),
+                surface_summaries: Vec::new(),
+                kind_summaries: Vec::new(),
+                artifact_ids: vec!["coverage-report".to_string()],
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            }),
+            findings: Vec::new(),
+            artifacts: vec![homeboy::core::fuzz::FuzzArtifact {
+                schema: homeboy::core::fuzz::FUZZ_ARTIFACT_SCHEMA.to_string(),
+                id: "case-log".to_string(),
+                kind: "case_log".to_string(),
+                artifact: None,
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            }],
+            thresholds: Vec::new(),
+            lifecycle: None,
+            provenance: None,
+            replay: None,
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        };
+
+        let gates = evaluate_fuzz_gates(&campaign);
+        let summary = fuzz_coverage_completeness(&campaign);
+
+        assert_eq!(gate_status(&gates), "passed");
+        assert!(summary.has_summary);
+        assert_eq!(summary.declared_targets, 0);
         assert_eq!(summary.target_coverage_ratio, 1.0);
+        assert_eq!(summary.declared_operations, 0);
         assert_eq!(summary.operation_coverage_ratio, 1.0);
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "target-coverage-complete"
+                && gate.status == "passed"
+                && gate.observed == 1.0
+        }));
+        assert!(gates.iter().any(|gate| {
+            gate.gate_id == "operation-coverage-complete"
+                && gate.status == "passed"
+                && gate.observed == 1.0
+        }));
     }
 
     #[test]

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -209,7 +209,7 @@ fn coverage_ratio(
     total: impl Fn(&homeboy::core::fuzz::FuzzCoverageSummary) -> u64,
 ) -> f64 {
     let Some(summary) = summary else {
-        return 1.0;
+        return 0.0;
     };
     let total = total(summary);
     if total == 0 {
@@ -315,11 +315,11 @@ pub(super) fn fuzz_coverage_completeness(
             declared_targets: 0,
             executable_targets: 0,
             proven_targets: 0,
-            target_coverage_ratio: 1.0,
+            target_coverage_ratio: 0.0,
             declared_operations: 0,
             executable_operations: 0,
             proven_operations: 0,
-            operation_coverage_ratio: 1.0,
+            operation_coverage_ratio: 0.0,
             skipped_targets: 0,
             skipped_operations: 0,
             skipped_reason_counts: BTreeMap::new(),


### PR DESCRIPTION
## Summary
- Treat missing fuzz coverage summaries as incomplete instead of fully covered
- Preserve complete ratios for explicit zero-declared coverage summaries
- Add coverage gate regression tests for missing, zero-declared, and partial summaries

## Tests
- cargo test fuzz_gate_evaluation
- cargo test fuzz_coverage_completeness
- cargo test fuzz_report

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, and targeted test updates