### PR TITLE
Add release package recovery command

### DIFF
--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -17,6 +17,8 @@ By default Homeboy auto-detects the bump from commit history. Use `--bump <major
 - `--apply`: Confirm risky real release modes such as `--deploy`, `--recover`, `--retag`, `--head`, or bare `--skip-checks`
 - `--deploy`: Deploy this component to all projects that use it after release
 - `--recover`: Recover from an interrupted release
+- `--package-only`: Regenerate only the release package for an existing tag at the checked-out commit
+- `--tag <TAG>`: Existing release tag to use with `--package-only`
 - `--head`: Finish the release pipeline for the version commit and tag already checked out at HEAD
 - `--from-artifacts <DIR>`: With `--head`, attach/publish existing artifacts from a directory instead of running `release.package`
 - `--skip-checks`: Skip pre-release lint/test checks
@@ -31,6 +33,8 @@ By default Homeboy auto-detects the bump from commit history. Use `--bump <major
 `homeboy release` executes component releases: detects or applies a version bump, finalizes generated changelog entries, commits, tags, pushes, and optionally publishes release artifacts. Use `--dry-run` to preview the release plan without making changes.
 
 `--head` is for CI jobs where another step already created the release commit and tag, but Homeboy should still own the rest of the release lifecycle. It keeps the safe preflight checks, skips changelog/version/git mutation steps, populates release state from the version and tag at HEAD, then runs `release.package` (unless `--from-artifacts` is provided), `github.release`, `release.publish`, cleanup, and post-release hooks through the normal pipeline.
+
+`--package-only --tag <TAG>` is for operator recovery when the release tag already exists but its package artifact needs to be regenerated. It requires the checked-out `HEAD` to match the existing tag, runs only the extension-owned `release.package` action, copies the produced files into Homeboy's artifact root under `release-packages/<component>/<tag>/`, writes `manifest.json`, and prints both paths. It does not create tags, push, create GitHub Releases, publish registries, deploy, or clean up the component build output.
 
 Risky real release modes require explicit `--apply`: `--deploy`, `--recover`, `--retag`, `--head`, and bare `--skip-checks`. Dry-run previews never require `--apply`, and granular skips such as `--skip-checks=lint` keep the normal release flow because other quality gates remain active.
 
@@ -47,6 +51,14 @@ homeboy release <component_id> --dry-run
 
 # 3. Execute the release
 homeboy release <component_id>
+```
+
+### Regenerate a package for an existing tag
+
+```sh
+# Check out the already-tagged commit, then rebuild just the release package.
+git checkout v1.2.3
+homeboy release <component_id> --package-only --tag v1.2.3 --apply
 ```
 
 ### Finish an already-tagged release

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -5,7 +5,7 @@ use homeboy::core::component;
 use homeboy::core::deploy::{self, ReleaseStateStatus};
 use homeboy::core::release::{
     self, BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult, ReleaseExecutionPlan,
-    ReleasePhase, ReleasePipelineOptions,
+    ReleasePackageResult, ReleasePhase, ReleasePipelineOptions,
 };
 use homeboy::core::scope::{self, Scope};
 
@@ -62,6 +62,15 @@ pub struct ReleaseArgs {
     /// Requires --head.
     #[arg(long, value_name = "DIR")]
     from_artifacts: Option<String>,
+
+    /// Regenerate only the release package for an existing tag at HEAD.
+    /// Writes copied artifacts and manifest under Homeboy's artifact root.
+    #[arg(long)]
+    package_only: bool,
+
+    /// Existing release tag to package with --package-only.
+    #[arg(long, value_name = "TAG")]
+    tag: Option<String>,
 
     /// Skip pre-release quality checks.
     ///
@@ -124,10 +133,18 @@ pub struct BatchReleaseOutput {
 }
 
 #[derive(Serialize)]
+#[serde(tag = "command", rename = "release.package")]
+pub struct ReleasePackageOutput {
+    pub variant: &'static str,
+    pub result: ReleasePackageResult,
+}
+
+#[derive(Serialize)]
 #[serde(untagged)]
 pub enum ReleaseCommandOutput {
     Single(ReleaseOutput),
     Batch(BatchReleaseOutput),
+    Package(ReleasePackageOutput),
 }
 
 impl ReleaseArgs {
@@ -158,6 +175,7 @@ impl ReleaseArgs {
             (self.recover, "--recover"),
             (self.retag, "--retag"),
             (self.head, "--head"),
+            (self.package_only, "--package-only"),
             (skip_checks, "bare --skip-checks"),
         ]
         .into_iter()
@@ -246,6 +264,8 @@ impl ReleaseArgs {
             retag: false,
             head,
             from_artifacts,
+            package_only: false,
+            tag: None,
             skip_checks: if skip_checks { Some(Vec::new()) } else { None },
             skip_build_validation: false,
             bump,
@@ -266,6 +286,10 @@ pub fn run(
     validate_apply_boundary(&execution)?;
     let component_ids = resolve_component_ids(&args, &args.components)?;
     let bump_override = args.bump.clone();
+
+    if args.package_only {
+        return run_package_only(args, &component_ids);
+    }
 
     // Single component: use the original single-release flow
     if component_ids.len() == 1 {
@@ -371,6 +395,84 @@ pub fn run(
             result: batch_result,
         }),
         exit_code,
+    ))
+}
+
+fn run_package_only(
+    args: ReleaseArgs,
+    component_ids: &[String],
+) -> CmdResult<ReleaseCommandOutput> {
+    if component_ids.len() != 1 {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "components",
+            "--package-only supports exactly one component",
+            None,
+            Some(vec![
+                "Run package recovery once per component: homeboy release <component-id> --package-only --tag <tag> --apply".to_string(),
+            ]),
+        ));
+    }
+    if args.project.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "project",
+            "--package-only does not support --project",
+            args.project.clone(),
+            None,
+        ));
+    }
+    if args.recover || args.retag || args.head || args.deploy || args.skip_publish {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "package-only",
+            "--package-only cannot be combined with release execution modes such as --recover, --retag, --head, --deploy, or --skip-publish",
+            None,
+            None,
+        ));
+    }
+    if args.from_artifacts.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "from-artifacts",
+            "--from-artifacts is for --head publish recovery; --package-only regenerates artifacts instead",
+            args.from_artifacts.clone(),
+            None,
+        ));
+    }
+    if args.dry_run_args.dry_run {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "dry-run",
+            "--package-only writes release artifacts and does not support --dry-run",
+            None,
+            Some(vec![
+                "Use a temporary artifact root to inspect output: homeboy --artifact-root <dir> release <component-id> --package-only --tag <tag> --apply".to_string(),
+            ]),
+        ));
+    }
+    if args.bump.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "bump",
+            "--package-only packages an existing tag and cannot be combined with --bump",
+            args.bump.clone(),
+            None,
+        ));
+    }
+    let tag = args.tag.clone().ok_or_else(|| {
+        homeboy::core::Error::validation_missing_argument(vec![
+            "--tag <existing-release-tag>".to_string()
+        ])
+    })?;
+
+    let result = release::package_existing_tag(
+        &component_ids[0],
+        args.path.clone(),
+        &tag,
+        args.skip_build_validation,
+    )?;
+
+    Ok((
+        ReleaseCommandOutput::Package(ReleasePackageOutput {
+            variant: "package",
+            result,
+        }),
+        0,
     ))
 }
 
@@ -538,6 +640,8 @@ mod tests {
             retag: false,
             head: false,
             from_artifacts: None,
+            package_only: false,
+            tag: None,
             skip_checks: skip_checks
                 .map(|values| values.iter().map(|value| value.to_string()).collect()),
             skip_build_validation: false,
@@ -595,6 +699,55 @@ mod tests {
         assert!(err
             .message
             .contains("Real releases with --head require explicit --apply"));
+    }
+
+    #[test]
+    fn package_only_real_release_requires_apply() {
+        let mut args = args(&["fixture"]);
+        args.dry_run_args.dry_run = false;
+        args.package_only = true;
+        args.tag = Some("v1.2.3".to_string());
+
+        let execution = args.execution_plan(false);
+        let err = validate_apply_boundary(&execution).expect_err("--package-only requires --apply");
+
+        assert!(err
+            .message
+            .contains("Real releases with --package-only require explicit --apply"));
+    }
+
+    #[test]
+    fn package_only_requires_tag() {
+        let mut args = args(&["fixture"]);
+        args.dry_run_args.dry_run = false;
+        args.package_only = true;
+        args.apply = true;
+
+        let err = match run_package_only(args, &["fixture".to_string()]) {
+            Ok(_) => panic!("package-only requires an explicit tag"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.code.as_str(), "validation.missing_argument");
+        assert_eq!(err.details["args"][0], "--tag <existing-release-tag>");
+    }
+
+    #[test]
+    fn package_only_rejects_publish_modes() {
+        let mut args = args(&["fixture"]);
+        args.dry_run_args.dry_run = false;
+        args.package_only = true;
+        args.apply = true;
+        args.head = true;
+        args.tag = Some("v1.2.3".to_string());
+
+        let err = match run_package_only(args, &["fixture".to_string()]) {
+            Ok(_) => panic!("package-only is mutually exclusive with --head"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("--package-only cannot be combined"));
     }
 
     #[test]

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -7,6 +7,7 @@ mod execution_plan;
 mod execution_projection;
 mod executor;
 mod orchestrator;
+mod package_recovery;
 mod pipeline;
 mod pipeline_capabilities;
 mod pipeline_summary;
@@ -24,6 +25,7 @@ pub mod version;
 mod workflow;
 mod workflow_recover;
 
+pub use package_recovery::{package_existing_tag, ReleasePackageResult};
 pub use pipeline::run;
 pub use planner::plan;
 pub use types::{

--- a/src/core/release/package_recovery.rs
+++ b/src/core/release/package_recovery.rs
@@ -1,0 +1,246 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::core::error::{Error, Result};
+use crate::core::{git, paths};
+
+use super::context::{load_component, resolve_extensions};
+use super::executor::run_package;
+use super::types::{ReleaseArtifact, ReleaseOptions, ReleaseState, ReleaseStepResult};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReleasePackageResult {
+    pub component_id: String,
+    pub tag: String,
+    pub version: String,
+    pub commit: String,
+    pub artifact_dir: String,
+    pub manifest_path: String,
+    pub artifacts: Vec<ReleaseArtifact>,
+    pub package_step: ReleaseStepResult,
+}
+
+pub fn package_existing_tag(
+    component_id: &str,
+    path_override: Option<String>,
+    tag: &str,
+    skip_build_validation: bool,
+) -> Result<ReleasePackageResult> {
+    let component = load_component(
+        component_id,
+        &ReleaseOptions {
+            path_override,
+            ..Default::default()
+        },
+    )?;
+    let head_commit = git::get_head_commit(&component.local_path)?;
+    validate_existing_tag_at_head(&component.local_path, tag, &head_commit)?;
+
+    let version = super::version::read_component_version(&component)?.version;
+    let extensions = resolve_extensions(&component)?;
+    let mut state = ReleaseState {
+        version: Some(version.clone()),
+        tag: Some(tag.to_string()),
+        ..Default::default()
+    };
+
+    let package_step = run_package(
+        &extensions,
+        &mut state,
+        component_id,
+        &component.local_path,
+        skip_build_validation,
+    )?;
+    if state.artifacts.is_empty() {
+        return Err(Error::internal_unexpected(
+            "release.package completed without producing any artifacts",
+        ));
+    }
+
+    let artifact_dir = release_package_dir(component_id, tag)?;
+    fs::create_dir_all(&artifact_dir).map_err(|error| {
+        Error::internal_io(
+            format!(
+                "Failed to create release package artifact directory {}: {}",
+                artifact_dir.display(),
+                error
+            ),
+            Some(artifact_dir.display().to_string()),
+        )
+    })?;
+
+    let artifacts = copy_release_artifacts(&component.local_path, &artifact_dir, &state.artifacts)?;
+    let manifest_path = artifact_dir.join("manifest.json");
+    let result = ReleasePackageResult {
+        component_id: component_id.to_string(),
+        tag: tag.to_string(),
+        version,
+        commit: head_commit,
+        artifact_dir: artifact_dir.display().to_string(),
+        manifest_path: manifest_path.display().to_string(),
+        artifacts,
+        package_step,
+    };
+    let manifest = serde_json::to_string_pretty(&result).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("release package manifest".to_string()),
+        )
+    })?;
+    fs::write(&manifest_path, manifest).map_err(|error| {
+        Error::internal_io(
+            format!(
+                "Failed to write release package manifest {}: {}",
+                manifest_path.display(),
+                error
+            ),
+            Some(manifest_path.display().to_string()),
+        )
+    })?;
+
+    log_status!(
+        "release",
+        "Release package artifacts written to {}",
+        artifact_dir.display()
+    );
+    log_status!(
+        "release",
+        "Release package manifest written to {}",
+        manifest_path.display()
+    );
+
+    Ok(result)
+}
+
+fn validate_existing_tag_at_head(local_path: &str, tag: &str, head_commit: &str) -> Result<()> {
+    let local_tag_commit = if git::tag_exists_locally(local_path, tag).unwrap_or(false) {
+        Some(git::get_tag_commit(local_path, tag)?)
+    } else {
+        None
+    };
+    let remote_tag_commit = git::remote_tag_commit(local_path, tag)?;
+    let tag_commit = local_tag_commit
+        .clone()
+        .or_else(|| remote_tag_commit.clone())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "tag",
+                format!("Release tag '{}' does not exist locally or on origin", tag),
+                Some(tag.to_string()),
+                Some(vec![
+                    format!("Fetch tags: git -C {} fetch --tags", local_path),
+                    "Then check out the tagged commit before regenerating the package".to_string(),
+                ]),
+            )
+        })?;
+
+    if tag_commit != head_commit {
+        return Err(Error::validation_invalid_argument(
+            "tag",
+            format!(
+                "Release tag '{}' points at {}, but HEAD is {}",
+                tag,
+                short_sha(&tag_commit),
+                short_sha(head_commit)
+            ),
+            Some(tag.to_string()),
+            Some(vec![format!(
+                "Check out the tagged commit first: git -C {} checkout {}",
+                local_path, tag
+            )]),
+        ));
+    }
+
+    Ok(())
+}
+
+fn release_package_dir(component_id: &str, tag: &str) -> Result<PathBuf> {
+    Ok(paths::artifact_root()?
+        .join("release-packages")
+        .join(paths::sanitize_path_segment(component_id))
+        .join(paths::sanitize_path_segment(tag)))
+}
+
+fn copy_release_artifacts(
+    component_local_path: &str,
+    artifact_dir: &Path,
+    artifacts: &[ReleaseArtifact],
+) -> Result<Vec<ReleaseArtifact>> {
+    let mut copied = Vec::new();
+    for artifact in artifacts {
+        let source = resolve_artifact_path(component_local_path, &artifact.path);
+        let file_name = source.file_name().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "release.artifacts.path",
+                format!("Release artifact path '{}' has no file name", artifact.path),
+                Some(artifact.path.clone()),
+                None,
+            )
+        })?;
+        let destination = artifact_dir.join(file_name);
+        fs::copy(&source, &destination).map_err(|error| {
+            Error::internal_io(
+                format!(
+                    "Failed to copy release artifact {} to {}: {}",
+                    source.display(),
+                    destination.display(),
+                    error
+                ),
+                Some(source.display().to_string()),
+            )
+        })?;
+        copied.push(ReleaseArtifact {
+            path: destination.display().to_string(),
+            artifact_type: artifact.artifact_type.clone(),
+            platform: artifact.platform.clone(),
+        });
+    }
+    Ok(copied)
+}
+
+fn resolve_artifact_path(component_local_path: &str, artifact_path: &str) -> PathBuf {
+    let path = PathBuf::from(artifact_path);
+    if path.is_absolute() {
+        path
+    } else {
+        Path::new(component_local_path).join(path)
+    }
+}
+
+fn short_sha(commit: &str) -> &str {
+    &commit[..8.min(commit.len())]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copy_release_artifacts_copies_relative_artifact_to_durable_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let component = temp.path().join("component");
+        let build = component.join("build");
+        let artifact_dir = temp.path().join("artifact-root");
+        fs::create_dir_all(&build).expect("build dir");
+        fs::create_dir_all(&artifact_dir).expect("artifact dir");
+        fs::write(build.join("plugin.zip"), "zip").expect("artifact");
+
+        let copied = copy_release_artifacts(
+            &component.display().to_string(),
+            &artifact_dir,
+            &[ReleaseArtifact {
+                path: "build/plugin.zip".to_string(),
+                artifact_type: Some("archive".to_string()),
+                platform: None,
+            }],
+        )
+        .expect("copy artifacts");
+
+        let copied_path = artifact_dir.join("plugin.zip");
+        assert_eq!(fs::read_to_string(&copied_path).expect("copied"), "zip");
+        assert_eq!(copied[0].path, copied_path.display().to_string());
+        assert_eq!(copied[0].artifact_type.as_deref(), Some("archive"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `homeboy release <component> --package-only --tag <tag> --apply` to regenerate release package artifacts for an existing tag at the checked-out commit.
- Copy package outputs into Homeboy's artifact root under `release-packages/<component>/<tag>/` and write/print `manifest.json`.
- Document the operator recovery workflow and validate incompatible release modes.

Closes #6054

## Testing
- `cargo test package_only --lib`
- `cargo test package_recovery --lib`
- `cargo run -- release --help`
- `cargo test release --lib` (fails in two existing tests that also fail individually: `core::release::executor::lockfile_guard::tests::local_file_dependency_guard_blocks_existing_targets_outside_checkout`, `core::release::execution_plan::tests::dry_run_preflight_refuses_remote_existing_release_tag`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the release package recovery command, tests, and documentation.