### PR TITLE
Bound controller run-from-spec output

### DIFF
--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -20,14 +20,28 @@ pub fn run(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Val
     dispatch(command, global)
 }
 
-pub fn run_command_output(command: Commands, global: &GlobalArgs) -> JsonCommandRun {
+pub fn run_command_output(
+    command: Commands,
+    global: &GlobalArgs,
+    output_file: Option<&str>,
+) -> JsonCommandRun {
     crate::commands::utils::tty::status("homeboy is working...");
 
     match command {
         Commands::AgentTask(args) => {
+            let run_from_spec_output_ref =
+                agent_task_controller_run_from_spec_output_ref_eligible(&args, output_file);
             let summary_kind = agent_task_summary_kind_for_output(&args);
             let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), global);
             let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
+                if let Some(output_file) = run_from_spec_output_ref {
+                    return render_controller_run_from_spec_output_ref(
+                        payload,
+                        exit_code,
+                        output_file,
+                    );
+                }
+
                 summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
             });
 
@@ -101,6 +115,113 @@ pub fn run_command_output(command: Commands, global: &GlobalArgs) -> JsonCommand
             JsonCommandRun::from_stdout_result(stdout_result, exit_code)
         }
     }
+}
+
+fn agent_task_controller_run_from_spec_output_ref_eligible<'a>(
+    args: &crate::commands::agent_task::AgentTaskArgs,
+    output_file: Option<&'a str>,
+) -> Option<&'a str> {
+    let output_file = output_file?;
+    match &args.command {
+        crate::commands::agent_task::AgentTaskCommand::Controller(controller)
+            if matches!(
+                &controller.command,
+                crate::commands::agent_task::AgentTaskControllerCommand::RunFromSpec(_)
+            ) =>
+        {
+            Some(output_file)
+        }
+        _ => None,
+    }
+}
+
+fn render_controller_run_from_spec_output_ref(
+    payload: &Value,
+    exit_code: i32,
+    output_file: &str,
+) -> Option<String> {
+    if payload.get("schema").and_then(Value::as_str)?
+        != "homeboy/agent-task-loop-controller-run-from-spec-result/v1"
+    {
+        return None;
+    }
+
+    let status = payload.get("status")?;
+    let controller = status.get("controller")?;
+    let diagnostics_summary = status
+        .get("diagnostics")
+        .and_then(|diagnostics| diagnostics.get("summary"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let terminal_outcomes = controller
+        .get("terminal_outcomes")
+        .and_then(Value::as_array)
+        .map(|outcomes| outcomes.len())
+        .unwrap_or(0);
+    let evidence_refs = controller_evidence_refs(controller);
+
+    serde_json::to_string(&serde_json::json!({
+        "success": exit_code == 0,
+        "data": {
+            "schema": "homeboy/agent-task-loop-controller-run-from-spec-output-ref/v1",
+            "result_schema": "homeboy/agent-task-loop-controller-run-from-spec-result/v1",
+            "loop_id": payload.get("loop_id").cloned().unwrap_or(Value::Null),
+            "stopped_reason": payload.get("stopped_reason").cloned().unwrap_or(Value::Null),
+            "max_actions": payload.get("max_actions").cloned().unwrap_or(Value::Null),
+            "output_file": output_file,
+            "result_ref": {
+                "kind": "output_file",
+                "path": output_file,
+                "contains": "complete_json_result"
+            },
+            "materialization_ref": {
+                "kind": "output_file_json_pointer",
+                "path": output_file,
+                "pointer": "/data/materialization"
+            },
+            "status_ref": {
+                "kind": "output_file_json_pointer",
+                "path": output_file,
+                "pointer": "/data/status"
+            },
+            "status_summary": {
+                "phase": controller.get("phase").cloned().unwrap_or(Value::Null),
+                "state": controller.get("state").cloned().unwrap_or(Value::Null),
+                "next_action_count": controller
+                    .get("next_actions")
+                    .and_then(Value::as_array)
+                    .map(|actions| actions.len())
+                    .unwrap_or(0),
+                "entity_count": controller
+                    .get("entities")
+                    .and_then(Value::as_object)
+                    .map(|entities| entities.len())
+                    .unwrap_or(0),
+                "terminal_outcome_count": terminal_outcomes,
+                "diagnostics": diagnostics_summary,
+                "evidence_refs": evidence_refs,
+            }
+        }
+    }))
+    .ok()
+    .map(|json| format!("{}\n", json))
+}
+
+fn controller_evidence_refs(controller: &Value) -> Vec<Value> {
+    let mut refs = Vec::new();
+    if let Some(entities) = controller.get("entities").and_then(Value::as_object) {
+        for entity in entities.values() {
+            for key in ["artifacts", "artifact_refs", "evidence"] {
+                if let Some(items) = entity.get(key).and_then(Value::as_array) {
+                    refs.extend(items.iter().take(8 - refs.len()).cloned());
+                    if refs.len() >= 8 {
+                        return refs;
+                    }
+                }
+            }
+        }
+    }
+    refs
 }
 
 /// Whether `homeboy runs show` should render the compact human summary
@@ -189,7 +310,10 @@ fn unsupported_raw_command(message: &'static str) -> JsonRun {
 mod tests {
     use super::*;
     use crate::command_contract::CommandDispatchFamily;
-    use crate::commands::agent_task::{AgentTaskArgs, AgentTaskCommand, StatusArgs};
+    use crate::commands::agent_task::{
+        AgentTaskArgs, AgentTaskCommand, AgentTaskControllerArgs, AgentTaskControllerCommand,
+        AgentTaskControllerRunFromSpecArgs, StatusArgs,
+    };
 
     #[test]
     fn manifest_dispatches_as_json_workspace_output() {
@@ -215,6 +339,95 @@ mod tests {
 
         assert!(agent_task_summary_kind_for_output_mode(&args, false).is_some());
         assert!(agent_task_summary_kind_for_output_mode(&args, true).is_none());
+    }
+
+    #[test]
+    fn controller_run_from_spec_with_output_file_emits_bounded_result_ref() {
+        let large = "x".repeat(2 * 1024 * 1024);
+        let payload = serde_json::json!({
+            "schema": "homeboy/agent-task-loop-controller-run-from-spec-result/v1",
+            "loop_id": "loop-large",
+            "max_actions": 3,
+            "stopped_reason": "terminal_state",
+            "materialization": {
+                "spec": { "large": large },
+                "proof": { "kind": "materialization-proof" }
+            },
+            "from_spec": { "initialized": true },
+            "results": [{ "large": large }],
+            "status": {
+                "controller": {
+                    "phase": "running",
+                    "state": "completed",
+                    "next_actions": [{ "action_id": "action-1" }],
+                    "entities": {
+                        "entity-1": {
+                            "evidence": [{ "kind": "proof", "uri": "artifact://proof" }]
+                        }
+                    },
+                    "terminal_outcomes": [{ "outcome_id": "done" }]
+                },
+                "diagnostics": {
+                    "summary": {
+                        "pending_action_count": 0,
+                        "stale_pending_action_count": 0,
+                        "orphaned_pending_action_count": 0,
+                        "acceptance_gate_count": 1,
+                        "missing_acceptance_gate_count": 0,
+                        "failed_acceptance_gate_count": 0
+                    }
+                }
+            }
+        });
+
+        let stdout = render_controller_run_from_spec_output_ref(&payload, 0, "result.json")
+            .expect("bounded output ref");
+        let rendered: Value = serde_json::from_str(&stdout).expect("json stdout");
+
+        assert!(stdout.len() < 4096, "stdout was {} bytes", stdout.len());
+        assert!(!stdout.contains(&large));
+        assert_eq!(rendered["success"], true);
+        assert_eq!(rendered["data"]["loop_id"], "loop-large");
+        assert_eq!(rendered["data"]["result_ref"]["path"], "result.json");
+        assert_eq!(
+            rendered["data"]["materialization_ref"]["pointer"],
+            "/data/materialization"
+        );
+        assert_eq!(rendered["data"]["status_ref"]["pointer"], "/data/status");
+        assert_eq!(rendered["data"]["status_summary"]["state"], "completed");
+        assert_eq!(
+            rendered["data"]["status_summary"]["evidence_refs"][0]["uri"],
+            "artifact://proof"
+        );
+    }
+
+    #[test]
+    fn controller_run_from_spec_output_ref_requires_global_output_file() {
+        let args = AgentTaskArgs {
+            command: AgentTaskCommand::Controller(AgentTaskControllerArgs {
+                command: AgentTaskControllerCommand::RunFromSpec(
+                    AgentTaskControllerRunFromSpecArgs {
+                        spec: "{}".to_string(),
+                        inputs: None,
+                        policy_results: Vec::new(),
+                        max_actions: 1,
+                        dispatch_backend: None,
+                        dispatch_selector: None,
+                        dispatch_model: None,
+                        dispatch_provider_config: None,
+                    },
+                ),
+            }),
+        };
+
+        assert_eq!(
+            agent_task_controller_run_from_spec_output_ref_eligible(&args, Some("result.json")),
+            Some("result.json")
+        );
+        assert_eq!(
+            agent_task_controller_run_from_spec_output_ref_eligible(&args, None),
+            None
+        );
     }
 
     #[test]

--- a/src/commands/output_runtime.rs
+++ b/src/commands/output_runtime.rs
@@ -124,7 +124,7 @@ pub fn run_command(
     match super::raw_output::prepare_command_run(command, global, plan.stdout) {
         super::raw_output::CommandRunPreparation::Handled(exit_code) => exit_code,
         super::raw_output::CommandRunPreparation::Json(command) => {
-            let run = run_json(*command, global, plan.output_file);
+            let run = run_json(*command, global, plan.output_file, output_file);
             output_service.emit_run(run, plan.output_file)
         }
         super::raw_output::CommandRunPreparation::Raw(raw_run) => {
@@ -181,6 +181,7 @@ pub fn run_json(
     command: Commands,
     global: &GlobalArgs,
     mode: CommandOutputFileMode,
+    output_file: Option<&str>,
 ) -> JsonCommandRun {
     match (mode, command) {
         (CommandOutputFileMode::TraceJsonSummaryArtifact, Commands::Trace(args)) => {
@@ -194,7 +195,7 @@ pub fn run_json(
                 presentation: CommandPresentation::default(),
             }
         }
-        (_, command) => super::json_output::run_command_output(command, global),
+        (_, command) => super::json_output::run_command_output(command, global, output_file),
     }
 }
 
@@ -328,6 +329,45 @@ mod tests {
                 .as_ref()
                 .unwrap(),
             &json!({ "kind": "stdout" })
+        );
+    }
+
+    #[test]
+    fn generic_output_file_keeps_complete_large_payload_with_compact_presentation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("controller-result.json");
+        let large = "x".repeat(2 * 1024 * 1024);
+        let run = JsonCommandRun::from_stdout_result(
+            Ok(json!({
+                "schema": "homeboy/agent-task-loop-controller-run-from-spec-result/v1",
+                "loop_id": "large-loop",
+                "results": [{ "payload": large }]
+            })),
+            0,
+        )
+        .with_presentation(CommandPresentation {
+            stdout: Some("{\"success\":true,\"data\":{\"loop_id\":\"large-loop\"}}\n".to_string()),
+            stderr: None,
+        });
+
+        assert!(run.presentation.stdout.as_ref().expect("stdout").len() < 256);
+
+        write_output_file(
+            &run,
+            CommandOutputFileMode::GenericEnvelope,
+            Some(path.to_str().expect("utf8 path")),
+        );
+
+        let written = std::fs::read_to_string(path).expect("artifact written");
+        let json: Value = serde_json::from_str(&written).expect("valid json");
+        assert_eq!(json["success"], true);
+        assert_eq!(json["data"]["loop_id"], "large-loop");
+        assert_eq!(
+            json["data"]["results"][0]["payload"]
+                .as_str()
+                .unwrap()
+                .len(),
+            2 * 1024 * 1024
         );
     }
 


### PR DESCRIPTION
## Summary
- Keep the complete `agent-task controller run-from-spec` JSON result available through global `--output <path>`.
- Emit a compact JSON stdout ref for `run-from-spec --output` with result/materialization/status pointers, final status summary, diagnostics summary, and evidence refs.
- Add regression coverage for large controller results staying bounded on stdout while preserving full output-file payloads.

## Tests
- `cargo fmt`
- `cargo test commands::json_output::tests && cargo test commands::output_runtime::tests && cargo test commands::agent_task::tests::controller_run`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the Homeboy output runtime, implementing bounded `run-from-spec --output` stdout behavior, and adding regression tests.