### PR TITLE
fix(release): keep recovered artifact durable path

### DIFF
--- a/src/core/release/package_recovery.rs
+++ b/src/core/release/package_recovery.rs
@@ -193,6 +193,7 @@ fn copy_release_artifacts(
         })?;
         copied.push(ReleaseArtifact {
             path: destination.display().to_string(),
+            durable_path: Some(destination.display().to_string()),
             artifact_type: artifact.artifact_type.clone(),
             platform: artifact.platform.clone(),
         });
@@ -232,6 +233,7 @@ mod tests {
             &artifact_dir,
             &[ReleaseArtifact {
                 path: "build/plugin.zip".to_string(),
+                durable_path: None,
                 artifact_type: Some("archive".to_string()),
                 platform: None,
             }],


### PR DESCRIPTION
## Summary
- Initialize `ReleaseArtifact::durable_path` when recovery copies artifacts into durable storage
- Update the recovery unit test fixture for the new artifact field

## Tests
- cargo test copy_release_artifacts_copies_relative_artifact_to_durable_dir

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Upstream compile-break diagnosis, implementation, and targeted verification