### PR TITLE
fix(agent-task): bound command gate execution

### DIFF
--- a/src/core/agent_task_controller_service/actions.rs
+++ b/src/core/agent_task_controller_service/actions.rs
@@ -1,6 +1,13 @@
 //! Split from `agent_task_controller_service` god file (#5208). Structural move only.
 #![allow(unused_imports)]
 use super::*;
+use std::io::{self, Read};
+use std::process::Stdio;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const COMMAND_GATE_DEFAULT_TIMEOUT_SECONDS: u64 = 300;
+const COMMAND_GATE_OUTPUT_CAP_BYTES: usize = 64 * 1024;
 
 pub(super) fn execute_controller_action<E, D>(
     record: &mut AgentTaskLoopControllerRecord,
@@ -915,17 +922,59 @@ pub(super) fn run_command_gate_check(
                 None,
             )
         })?;
-    let output = Command::new("sh")
+    let cwd = check.input.get("cwd").and_then(Value::as_str);
+    let timeout_seconds = check
+        .input
+        .get("timeout_seconds")
+        .and_then(Value::as_u64)
+        .filter(|seconds| *seconds > 0)
+        .unwrap_or(COMMAND_GATE_DEFAULT_TIMEOUT_SECONDS);
+
+    let mut child_command = Command::new("sh");
+    child_command
         .arg("-lc")
         .arg(command)
-        .output()
-        .map_err(|error| {
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(cwd) = cwd {
+        child_command.current_dir(cwd);
+    }
+
+    let mut child = child_command.spawn().map_err(|error| {
+        Error::internal_io(
+            format!("failed to execute gate command '{command}': {error}"),
+            None,
+        )
+    })?;
+    let stdout = child.stdout.take().map(read_capped_command_output);
+    let stderr = child.stderr.take().map(read_capped_command_output);
+    let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
+    let mut timed_out = false;
+    let exit_status = loop {
+        if let Some(status) = child.try_wait().map_err(|error| {
             Error::internal_io(
-                format!("failed to execute gate command '{command}': {error}"),
+                format!("failed to poll gate command '{command}': {error}"),
                 None,
             )
-        })?;
-    let status = if output.status.success() {
+        })? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            timed_out = true;
+            let _ = child.kill();
+            break child.wait().map_err(|error| {
+                Error::internal_io(
+                    format!("failed to reap timed out gate command '{command}': {error}"),
+                    None,
+                )
+            })?;
+        }
+        thread::sleep(Duration::from_millis(25));
+    };
+    let stdout = collect_capped_command_output(stdout, command, "stdout")?;
+    let stderr = collect_capped_command_output(stderr, command, "stderr")?;
+
+    let status = if !timed_out && exit_status.success() {
         AgentTaskGateBundleStatus::Passed
     } else {
         AgentTaskGateBundleStatus::Failed
@@ -934,15 +983,83 @@ pub(super) fn run_command_gate_check(
         check_id: check.check_id.clone(),
         status,
         retryable: check.retryable,
-        classification: None,
+        classification: timed_out.then(|| "command_timed_out".to_string()),
         evidence: Vec::new(),
         details: serde_json::json!({
             "command": command,
-            "exit_code": output.status.code(),
-            "stdout": String::from_utf8_lossy(&output.stdout),
-            "stderr": String::from_utf8_lossy(&output.stderr),
+            "cwd": cwd,
+            "timeout_seconds": timeout_seconds,
+            "timed_out": timed_out,
+            "exit_code": exit_status.code(),
+            "stdout": String::from_utf8_lossy(&stdout.bytes).into_owned(),
+            "stderr": String::from_utf8_lossy(&stderr.bytes).into_owned(),
+            "stdout_bytes": stdout.total_bytes,
+            "stderr_bytes": stderr.total_bytes,
+            "stdout_stored_bytes": stdout.bytes.len(),
+            "stderr_stored_bytes": stderr.bytes.len(),
+            "stdout_truncated": stdout.truncated,
+            "stderr_truncated": stderr.truncated,
         }),
     })
+}
+
+struct CappedCommandOutput {
+    bytes: Vec<u8>,
+    total_bytes: usize,
+    truncated: bool,
+}
+
+fn read_capped_command_output<R>(
+    mut reader: R,
+) -> thread::JoinHandle<io::Result<CappedCommandOutput>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut bytes = Vec::with_capacity(COMMAND_GATE_OUTPUT_CAP_BYTES);
+        let mut total_bytes = 0usize;
+        let mut buffer = [0u8; 8192];
+        loop {
+            let read = reader.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            total_bytes = total_bytes.saturating_add(read);
+            if bytes.len() < COMMAND_GATE_OUTPUT_CAP_BYTES {
+                let remaining = COMMAND_GATE_OUTPUT_CAP_BYTES - bytes.len();
+                bytes.extend_from_slice(&buffer[..read.min(remaining)]);
+            }
+        }
+        Ok(CappedCommandOutput {
+            bytes,
+            total_bytes,
+            truncated: total_bytes > COMMAND_GATE_OUTPUT_CAP_BYTES,
+        })
+    })
+}
+
+fn collect_capped_command_output(
+    handle: Option<thread::JoinHandle<io::Result<CappedCommandOutput>>>,
+    command: &str,
+    stream: &str,
+) -> Result<CappedCommandOutput> {
+    handle
+        .ok_or_else(|| {
+            Error::internal_io(format!("gate command '{command}' missing {stream}"), None)
+        })?
+        .join()
+        .map_err(|_| {
+            Error::internal_io(
+                format!("gate command '{command}' {stream} reader panicked"),
+                None,
+            )
+        })?
+        .map_err(|error| {
+            Error::internal_io(
+                format!("failed to read gate command '{command}' {stream}: {error}"),
+                None,
+            )
+        })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -2179,6 +2179,58 @@ fn run_gates_executes_command_bundle_and_records_result() {
 }
 
 #[test]
+fn command_gate_check_runs_from_configured_cwd() {
+    let cwd = tempfile::tempdir().expect("cwd tempdir");
+    let cwd_path = cwd.path().to_string_lossy().into_owned();
+    std::fs::write(cwd.path().join("gate-marker"), "ok").expect("marker file");
+    let check = AgentTaskGateBundleCheck {
+        check_id: "pwd-command".to_string(),
+        kind: AgentTaskGateBundleCheckKind::Command,
+        input: json!({
+            "command": "test -f gate-marker && printf ok",
+            "cwd": cwd_path,
+        }),
+        retryable: false,
+    };
+
+    let result = run_command_gate_check(&check).expect("command gate executed");
+
+    assert_eq!(result.status, AgentTaskGateBundleStatus::Passed);
+    assert_eq!(result.details["stdout"].as_str(), Some("ok"));
+    assert_eq!(result.details["cwd"].as_str(), Some(cwd_path.as_str()));
+}
+
+#[test]
+fn command_gate_check_caps_stored_stdout_and_records_truncation() {
+    let check = AgentTaskGateBundleCheck {
+        check_id: "large-output-command".to_string(),
+        kind: AgentTaskGateBundleCheckKind::Command,
+        input: json!({
+            "command": "yes x | head -c 70000",
+            "timeout_seconds": 5,
+        }),
+        retryable: false,
+    };
+
+    let result = run_command_gate_check(&check).expect("command gate executed");
+
+    assert_eq!(result.status, AgentTaskGateBundleStatus::Passed);
+    assert_eq!(result.details["stdout_truncated"].as_bool(), Some(true));
+    assert_eq!(
+        result.details["stdout_stored_bytes"].as_u64(),
+        Some(64 * 1024)
+    );
+    assert_eq!(result.details["stdout_bytes"].as_u64(), Some(70000));
+    assert_eq!(
+        result.details["stdout"]
+            .as_str()
+            .expect("stdout stored")
+            .len(),
+        64 * 1024
+    );
+}
+
+#[test]
 fn from_spec_resume_drives_generic_workflow_gates_completion_and_lineage() {
     with_isolated_home(|_| {
         let spec = AgentTaskRepoLoopSpec {


### PR DESCRIPTION
## Summary
- Add cwd and timeout handling for controller command gates
- Cap captured stdout/stderr and record truncation metadata
- Add tests for cwd execution and output capping

## Tests
- rustfmt --check src/core/agent_task_controller_service/actions.rs src/core/agent_task_controller_service/tests.rs
- cargo test command_gate_check
- cargo test run_gates_executes_command_bundle_and_records_result
- cargo test core::agent_task_controller_service::tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, verification, and PR preparation