### PR TITLE
fix(lab): forward offloaded output files

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -1056,4 +1056,35 @@ mod tests {
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
         assert!(err.message.contains("without --runner"));
     }
+
+    #[test]
+    fn wrapper_global_runner_preserves_trailing_output_request() {
+        let matches = Cli::command()
+            .try_get_matches_from([
+                "homeboy",
+                "--runner",
+                "homeboy-lab",
+                "agent-task",
+                "controller",
+                "run-from-spec",
+                "loop.json",
+                "--max-actions",
+                "1",
+                "--output",
+                "/tmp/controller-result.json",
+            ])
+            .expect("parse wrapper-style lab offload command");
+
+        assert_eq!(
+            matches
+                .try_get_one::<std::path::PathBuf>("output")
+                .expect("output arg")
+                .map(|path| path.to_string_lossy().to_string())
+                .as_deref(),
+            Some("/tmp/controller-result.json")
+        );
+
+        let cli = Cli::from_arg_matches(&matches).expect("typed cli");
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+    }
 }

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -638,8 +638,18 @@ fn run_runner_resident_lab_offload(
             .build(),
     );
 
-    let remapped_args = rewrite_runner_resident_lab_offload_args(request.normalized_args);
+    let remote_output_file = request
+        .output_file_requested
+        .then(|| remote_lab_output_file(runner_workspace_root));
+    let remapped_args = rewrite_runner_resident_lab_offload_args(
+        request.normalized_args,
+        remote_output_file.as_deref(),
+    );
     let mut command = vec![homeboy_path.to_string()];
+    if remote_output_file.is_some() && !args_contain_output_file(request.normalized_args) {
+        command.push("--output".to_string());
+        command.push(remote_output_file.clone().expect("remote output path"));
+    }
     command.extend(remapped_args.iter().skip(1).cloned());
     plan = with_step(
         plan,
@@ -746,12 +756,17 @@ fn run_runner_resident_lab_offload(
         append_runner_failure_context_summary(&mut stderr, &exec_output);
     }
 
+    let output_file_content = match remote_output_file.as_deref() {
+        Some(path) => Some(download_lab_output_file(runner_id, path)?),
+        None => None,
+    };
+
     Ok(LabOffloadOutcome::Offloaded {
         plan,
         stdout: exec_output.stdout,
         stderr,
         exit_code,
-        output_file_content: None,
+        output_file_content,
     })
 }
 
@@ -1115,14 +1130,21 @@ fn prepare_lab_offload_workspace_stage(
         .output_file_requested
         .then(|| remote_lab_output_file(&remote_cwd));
     let mut command = command_prefix_argv.to_vec();
-    if let Some(path) = &remote_output_file {
-        command.push("--output".to_string());
-        command.push(path.clone());
+    if !args_contain_output_file(&remapped_args) {
+        if let Some(path) = &remote_output_file {
+            command.push("--output".to_string());
+            command.push(path.clone());
+        }
     }
     command.extend(
-        rewrite_lab_offload_args(&remapped_args, &remote_cwd, &path_remaps)
-            .into_iter()
-            .skip(1),
+        rewrite_lab_offload_args(
+            &remapped_args,
+            &remote_cwd,
+            &path_remaps,
+            remote_output_file.as_deref(),
+        )
+        .into_iter()
+        .skip(1),
     );
     let remote_command = command.clone();
     plan = with_step(
@@ -1160,6 +1182,20 @@ fn remote_lab_output_file(remote_cwd: &str) -> String {
         remote_cwd.trim_end_matches('/'),
         nonce
     )
+}
+
+fn args_contain_output_file(args: &[String]) -> bool {
+    let mut passthrough = false;
+    args.iter().any(|arg| {
+        if passthrough {
+            return false;
+        }
+        if arg == "--" {
+            passthrough = true;
+            return false;
+        }
+        arg == "--output" || arg.starts_with("--output=")
+    })
 }
 
 fn materialize_lab_at_files_on_runner(runner_id: &str, specs: &[LabAtFileSpec]) -> Result<()> {

--- a/src/core/runner/lab_arg_tests.rs
+++ b/src/core/runner/lab_arg_tests.rs
@@ -23,7 +23,7 @@ fn rewrites_lab_offload_path_and_strips_runner_and_output_flags() {
     ]);
 
     assert_eq!(
-        rewrite_lab_offload_args(&input, "/home/user/Developer/project", &[]),
+        rewrite_lab_offload_args(&input, "/home/user/Developer/project", &[], None),
         args(&[
             "homeboy",
             "--force-hot",
@@ -31,6 +31,44 @@ fn rewrites_lab_offload_path_and_strips_runner_and_output_flags() {
             "--path",
             "/home/user/Developer/project",
             "--json-summary",
+        ])
+    );
+}
+
+#[test]
+fn maps_command_output_path_to_runner_output_path() {
+    let input = args(&[
+        "homeboy",
+        "--runner",
+        "homeboy-lab",
+        "agent-task",
+        "controller",
+        "run-from-spec",
+        "loop.json",
+        "--max-actions",
+        "1",
+        "--output",
+        "/tmp/local-result.json",
+    ]);
+
+    assert_eq!(
+        rewrite_lab_offload_args(
+            &input,
+            "/home/user/Developer/project",
+            &[],
+            Some("/home/user/Developer/project/homeboy-lab-structured-output.json"),
+        ),
+        args(&[
+            "homeboy",
+            "--force-hot",
+            "agent-task",
+            "controller",
+            "run-from-spec",
+            "loop.json",
+            "--max-actions",
+            "1",
+            "--output",
+            "/home/user/Developer/project/homeboy-lab-structured-output.json",
         ])
     );
 }
@@ -51,7 +89,7 @@ fn strips_controller_artifact_root_from_lab_offload_command() {
     ]);
 
     assert_eq!(
-        rewrite_lab_offload_args(&input, "/home/user/Developer/project", &[]),
+        rewrite_lab_offload_args(&input, "/home/user/Developer/project", &[], None),
         args(&[
             "homeboy",
             "--force-hot",
@@ -78,7 +116,7 @@ fn strips_controller_artifact_root_from_runner_resident_command() {
     ]);
 
     assert_eq!(
-        rewrite_runner_resident_lab_offload_args(&input),
+        rewrite_runner_resident_lab_offload_args(&input, None),
         args(&[
             "homeboy",
             "--force-hot",
@@ -102,7 +140,7 @@ fn leaves_passthrough_path_args_untouched() {
     ]);
 
     assert_eq!(
-        rewrite_lab_offload_args(&input, "/home/user/Developer/project", &[]),
+        rewrite_lab_offload_args(&input, "/home/user/Developer/project", &[], None),
         args(&[
             "homeboy",
             "--force-hot",
@@ -130,7 +168,7 @@ fn strips_internal_passthrough_sentinel_from_lab_offload_command() {
     ]);
 
     assert_eq!(
-        rewrite_lab_offload_args(&input, "/home/user/Developer/sample-plugin@fix", &[]),
+        rewrite_lab_offload_args(&input, "/home/user/Developer/sample-plugin@fix", &[], None),
         args(&[
             "homeboy",
             "--force-hot",
@@ -157,7 +195,7 @@ fn rewrite_lab_offload_args_does_not_duplicate_force_hot() {
     ]);
 
     assert_eq!(
-        rewrite_lab_offload_args(&input, "/home/user/Developer/project", &[]),
+        rewrite_lab_offload_args(&input, "/home/user/Developer/project", &[], None),
         args(&[
             "homeboy",
             "--force-hot",

--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -57,6 +57,7 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
     args: &[String],
     remote_path: &str,
     mappings: &[LabPathRemap],
+    remote_output_file: Option<&str>,
 ) -> Vec<String> {
     let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
     ordered.sort_by_key(|mapping| {
@@ -111,11 +112,25 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
         if arg.starts_with("--runner=") {
             continue;
         }
-        if arg == "--output" || arg == "--artifact-root" {
+        if arg == "--output" {
+            let _ = iter.next();
+            if let Some(path) = remote_output_file {
+                stripped.push(arg.clone());
+                stripped.push(path.to_string());
+            }
+            continue;
+        }
+        if arg.starts_with("--output=") {
+            if let Some(path) = remote_output_file {
+                stripped.push(format!("--output={path}"));
+            }
+            continue;
+        }
+        if arg == "--artifact-root" {
             let _ = iter.next();
             continue;
         }
-        if arg.starts_with("--output=") || arg.starts_with("--artifact-root=") {
+        if arg.starts_with("--artifact-root=") {
             continue;
         }
         stripped.push(remap_lab_offload_arg(arg, &ordered));
@@ -149,6 +164,7 @@ fn remap_lab_offload_arg(arg: &str, mappings: &[&LabPathRemap]) -> String {
 
 pub(in crate::core::runner) fn rewrite_runner_resident_lab_offload_args(
     args: &[String],
+    remote_output_file: Option<&str>,
 ) -> Vec<String> {
     // A runner-side `tunnel service expose` should not require a separate
     // server declaration for the selected runner: in that context the runner
@@ -180,11 +196,25 @@ pub(in crate::core::runner) fn rewrite_runner_resident_lab_offload_args(
         if arg.starts_with("--runner=") {
             continue;
         }
-        if arg == "--output" || arg == "--artifact-root" {
+        if arg == "--output" {
+            let _ = iter.next();
+            if let Some(path) = remote_output_file {
+                stripped.push(arg.clone());
+                stripped.push(path.to_string());
+            }
+            continue;
+        }
+        if arg.starts_with("--output=") {
+            if let Some(path) = remote_output_file {
+                stripped.push(format!("--output={path}"));
+            }
+            continue;
+        }
+        if arg == "--artifact-root" {
             let _ = iter.next();
             continue;
         }
-        if arg.starts_with("--output=") || arg.starts_with("--artifact-root=") {
+        if arg.starts_with("--artifact-root=") {
             continue;
         }
         if is_service_expose && arg == "--server" {

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -40,7 +40,7 @@ fn runner_resident_rewrite_preserves_runner_side_cwd() {
     ];
 
     assert_eq!(
-        rewrite_runner_resident_lab_offload_args(&args),
+        rewrite_runner_resident_lab_offload_args(&args, None),
         vec![
             "homeboy".to_string(),
             "--force-hot".to_string(),
@@ -80,7 +80,7 @@ fn runner_resident_rewrite_expose_drops_server_and_marks_runner_local() {
         "ssh-only".to_string(),
     ];
 
-    let rewritten = rewrite_runner_resident_lab_offload_args(&args);
+    let rewritten = rewrite_runner_resident_lab_offload_args(&args, None);
     assert_eq!(
         rewritten,
         vec![
@@ -117,7 +117,7 @@ fn runner_resident_rewrite_expose_handles_inline_server_value() {
         "127.0.0.1".to_string(),
     ];
 
-    let rewritten = rewrite_runner_resident_lab_offload_args(&args);
+    let rewritten = rewrite_runner_resident_lab_offload_args(&args, None);
     assert!(!rewritten.iter().any(|arg| arg.starts_with("--server")));
     assert!(rewritten.iter().any(|arg| arg == "--runner-local"));
 }
@@ -976,7 +976,7 @@ fn lab_args_rewrite_agent_task_dispatch_cwd() {
     ];
 
     assert_eq!(
-        rewrite_lab_offload_args(&args, "/home/user/Developer/wp-site-generator", &[]),
+        rewrite_lab_offload_args(&args, "/home/user/Developer/wp-site-generator", &[], None),
         vec![
             "homeboy".to_string(),
             "--force-hot".to_string(),
@@ -1003,7 +1003,7 @@ fn lab_args_rewrite_path_with_dependency_mapping() {
     }];
 
     assert_eq!(
-        rewrite_lab_offload_args(&args, "/runner/primary", &mappings),
+        rewrite_lab_offload_args(&args, "/runner/primary", &mappings, None),
         vec![
             "homeboy".to_string(),
             "--force-hot".to_string(),
@@ -1033,7 +1033,7 @@ fn lab_args_rewrite_path_prefers_more_specific_duplicate_local_mapping() {
     ];
 
     assert_eq!(
-        rewrite_lab_offload_args(&args, "/runner/primary", &mappings),
+        rewrite_lab_offload_args(&args, "/runner/primary", &mappings, None),
         vec![
             "homeboy".to_string(),
             "--force-hot".to_string(),
@@ -1061,7 +1061,12 @@ fn lab_args_rewrite_remaps_absolute_at_file_args() {
     }];
 
     assert_eq!(
-        rewrite_lab_offload_args(&args, "/home/user/_lab_workspaces/wp-site-generator", &mappings),
+        rewrite_lab_offload_args(
+            &args,
+            "/home/user/_lab_workspaces/wp-site-generator",
+            &mappings,
+            None,
+        ),
         vec![
             "homeboy".to_string(),
             "--force-hot".to_string(),
@@ -1090,7 +1095,7 @@ fn lab_args_rewrite_remaps_standalone_absolute_file_args() {
     }];
 
     assert_eq!(
-        rewrite_lab_offload_args(&args, "/home/user/_lab_workspaces/project", &mappings),
+        rewrite_lab_offload_args(&args, "/home/user/_lab_workspaces/project", &mappings, None),
         vec![
             "homeboy".to_string(),
             "--force-hot".to_string(),


### PR DESCRIPTION
## Summary
- Remap command-side `--output <path>` to a runner-local structured output file during Lab offload instead of stripping it.
- Download the remote structured output back to the requested local output path through the existing offload output path handling.
- Add regressions for wrapper-style `homeboy --runner homeboy-lab agent-task controller run-from-spec ... --output /tmp/result.json` parsing and output-path remapping.

## Tests
- `cargo test wrapper_global_runner_preserves_trailing_output_request -- --nocapture`
- `cargo test maps_command_output_path_to_runner_output_path -- --nocapture`
- `cargo test lab_arg_tests -- --nocapture`
- `cargo test core::runner::lab_args -- --nocapture`
- `cargo test --test output_errors -- --nocapture`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging the Lab offload structured-output path, implementing the fix, adding regression coverage, and running verification.