### PR TITLE
fix: restore runs and release test builds

### DIFF
--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -168,7 +168,7 @@ pub fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
     }
 }
 
-pub(super) fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
+pub(crate) fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     let artifact = runs_service::resolve_artifact_for_run(&store, &args.run_id, &args.artifact_id)?;
 

--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -48,10 +48,14 @@ pub use types::{RunsArgs, RunsOutput, WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER};
 // `use` (still reachable by descendant submodules) so the re-export never
 // widens their visibility.
 pub(crate) use common::RunSummary;
+#[cfg(test)]
+pub(crate) use handlers::artifact_get;
 pub(crate) use handlers::run_summary;
 use handlers::require_run;
 use types::DEFAULT_LIMIT;
-pub(crate) use types::{RunsArtifactGetArgs, RunsListArgs, RunsListOutput};
+#[cfg(test)]
+pub(crate) use types::RunsArtifactGetArgs;
+pub(crate) use types::{RunsListArgs, RunsListOutput};
 
 pub(crate) use bench::bench_compare_from_args;
 pub use bench::{bench_compare, BenchCompareOutput, RunsBenchCompareArgs};

--- a/src/core/release/package_recovery.rs
+++ b/src/core/release/package_recovery.rs
@@ -196,7 +196,6 @@ fn copy_release_artifacts(
             durable_path: Some(destination.display().to_string()),
             artifact_type: artifact.artifact_type.clone(),
             platform: artifact.platform.clone(),
-            durable_path: None,
         });
     }
     Ok(copied)
@@ -237,7 +236,6 @@ mod tests {
                 durable_path: None,
                 artifact_type: Some("archive".to_string()),
                 platform: None,
-                durable_path: None,
             }],
         )
         .expect("copy artifacts");


### PR DESCRIPTION
## Summary
- Remove duplicate `ReleaseArtifact::durable_path` initializers in release package recovery
- Re-export the runs artifact get handler for sibling test modules after the runs split
- Keep the `RunsArtifactGetArgs` re-export test-only to avoid a new unused import warning

## Tests
- cargo test copy_release_artifacts_copies_relative_artifact_to_durable_dir
- cargo test metadata_only_artifact

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Compile-break diagnosis, implementation, and targeted verification