### PR TITLE
fix(agent-task): bound controller fanout

### DIFF
--- a/src/core/agent_task_controller_service/actions.rs
+++ b/src/core/agent_task_controller_service/actions.rs
@@ -243,12 +243,16 @@ where
         AgentTaskLoopPolicyAction::FanOut {
             dedupe_key,
             entity_ids,
+            max_items,
+            fail_fast,
             request_template,
         } => execute_fan_out_action(
             record,
             action,
             dedupe_key,
             entity_ids,
+            *max_items,
+            *fail_fast,
             request_template,
             executor,
             dispatch,
@@ -638,6 +642,8 @@ pub(super) fn execute_fan_out_action<E, D>(
     action: &AgentTaskLoopPolicyActionRecord,
     dedupe_key: &str,
     entity_ids: &[String],
+    max_items: usize,
+    fail_fast: bool,
     request_template: &Value,
     executor: E,
     dispatch: &D,
@@ -648,14 +654,14 @@ where
 {
     if entity_ids.is_empty() {
         return Ok((
-            serde_json::json!({ "mode": "fan_out", "item_count": 0, "results": [] }),
+            serde_json::json!({ "mode": "fan_out", "item_count": 0, "total_item_count": 0, "max_items": max_items, "fail_fast": fail_fast, "concurrency": 1, "results": [] }),
             0,
         ));
     }
 
     let mut results = Vec::new();
     let mut exit_code = 0;
-    for entity_id in entity_ids {
+    for entity_id in entity_ids.iter().take(max_items) {
         let request = materialize_fan_out_request(request_template, entity_id);
         let child_dedupe_key = format!("{dedupe_key}:{entity_id}");
         let child_action = AgentTaskLoopPolicyActionRecord {
@@ -684,9 +690,13 @@ where
             exit_code = child_exit_code;
         }
         results.push(result);
+        if child_exit_code != 0 && fail_fast {
+            break;
+        }
     }
+    let item_count = results.len();
     Ok((
-        serde_json::json!({ "mode": "fan_out", "item_count": entity_ids.len(), "results": results }),
+        serde_json::json!({ "mode": "fan_out", "item_count": item_count, "total_item_count": entity_ids.len(), "max_items": max_items, "fail_fast": fail_fast, "concurrency": 1, "truncated": item_count < entity_ids.len(), "results": results }),
         exit_code,
     ))
 }

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -551,6 +551,8 @@ pub(super) fn compile_loop_spec_workflow(
         Ok(AgentTaskLoopPolicyAction::FanOut {
             dedupe_key,
             entity_ids: workflow.entity_ids.clone(),
+            max_items: crate::core::agent_task_loop_controller::DEFAULT_FAN_OUT_MAX_ITEMS,
+            fail_fast: true,
             request_template: request,
         })
     }

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -10,6 +10,7 @@ use crate::core::agent_task_loop_controller::{
     AgentTaskGateBundle, AgentTaskGateBundleCheck, AgentTaskGateBundleCheckKind,
     AgentTaskGateBundleStatus, AgentTaskLoopFindingPacket, AgentTaskLoopPolicyAction,
     AgentTaskLoopTerminalStatus, AgentTaskLoopWait, AgentTaskLoopWaitStatus,
+    DEFAULT_FAN_OUT_MAX_ITEMS,
 };
 use crate::core::agent_task_scheduler::AgentTaskExecutionContext;
 use crate::test_support::with_isolated_home;
@@ -36,6 +37,11 @@ struct ArtifactDispatchHook {
 
 #[derive(Clone, Default)]
 struct TypedArtifactHandoffDispatchHook {
+    observed_requests: Arc<Mutex<Vec<Value>>>,
+}
+
+#[derive(Clone, Default)]
+struct CountingFailingDispatchHook {
     observed_requests: Arc<Mutex<Vec<Value>>>,
 }
 
@@ -139,6 +145,29 @@ impl ControllerDispatchHook for TypedArtifactHandoffDispatchHook {
             }]);
         }
         Ok((result, 0))
+    }
+}
+
+impl ControllerDispatchHook for CountingFailingDispatchHook {
+    fn dispatch(&self, request: &Value) -> Result<(Value, i32)> {
+        self.observed_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(request.clone());
+        let entity_id = request
+            .get("entity_id")
+            .and_then(Value::as_str)
+            .unwrap_or("workflow");
+        Ok((
+            json!({
+                "schema": "homeboy/test-generic-dispatch-result/v1",
+                "run_id": format!("generic-run-{}", entity_id.replace([':', '/', '#', ' '], "_")),
+                "diagnostics": [{
+                    "message": format!("synthetic failure for {entity_id}")
+                }]
+            }),
+            1,
+        ))
     }
 }
 
@@ -1231,6 +1260,8 @@ fn run_next_treats_zero_item_fan_out_as_deterministic_no_actionable_findings() {
             AgentTaskLoopPolicyAction::FanOut {
                 dedupe_key: "workflow:empty".to_string(),
                 entity_ids: Vec::new(),
+                max_items: DEFAULT_FAN_OUT_MAX_ITEMS,
+                fail_fast: true,
                 request_template: json!({ "mode": "dispatch" }),
             },
             "no findings emitted",
@@ -1268,6 +1299,112 @@ fn run_next_treats_zero_item_fan_out_as_deterministic_no_actionable_findings() {
 }
 
 #[test]
+fn fan_out_stops_after_max_items() {
+    with_isolated_home(|_| {
+        let mut record = init(ControllerInitRequest {
+            loop_id: "loop-service-fanout-max-items".to_string(),
+            phase: "review".to_string(),
+            config_version: "v1".to_string(),
+        })
+        .expect("controller initialized");
+
+        record.record_action(
+            AgentTaskLoopPolicyAction::FanOut {
+                dedupe_key: "candidate:bounded-review".to_string(),
+                entity_ids: vec![
+                    "candidate:first".to_string(),
+                    "candidate:second".to_string(),
+                    "candidate:third".to_string(),
+                ],
+                max_items: 2,
+                fail_fast: true,
+                request_template: json!({ "mode": "dispatch" }),
+            },
+            "review bounded candidates",
+        );
+        controller::write_controller(&record).expect("controller written");
+
+        let dispatch = CapturingDispatchHook::default();
+        let result = run_next(
+            "loop-service-fanout-max-items",
+            CapturingExecutor::default(),
+            &dispatch,
+        )
+        .expect("fan-out action executed");
+
+        assert_eq!(result.exit_code, 0);
+        let execution = result.value.execution.as_ref().expect("execution");
+        assert_eq!(execution["item_count"], json!(2));
+        assert_eq!(execution["total_item_count"], json!(3));
+        assert_eq!(execution["max_items"], json!(2));
+        assert_eq!(execution["fail_fast"], json!(true));
+        assert_eq!(execution["concurrency"], json!(1));
+        assert_eq!(execution["truncated"], json!(true));
+        assert_eq!(execution["results"].as_array().expect("results").len(), 2);
+        let observed = dispatch
+            .observed_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        assert_eq!(observed.len(), 2);
+        assert_eq!(observed[0]["entity_id"], json!("candidate:first"));
+        assert_eq!(observed[1]["entity_id"], json!("candidate:second"));
+    });
+}
+
+#[test]
+fn fan_out_fail_fast_stops_after_first_failure() {
+    with_isolated_home(|_| {
+        let mut record = init(ControllerInitRequest {
+            loop_id: "loop-service-fanout-fail-fast".to_string(),
+            phase: "review".to_string(),
+            config_version: "v1".to_string(),
+        })
+        .expect("controller initialized");
+
+        record.record_action(
+            AgentTaskLoopPolicyAction::FanOut {
+                dedupe_key: "candidate:fail-fast-review".to_string(),
+                entity_ids: vec![
+                    "candidate:first".to_string(),
+                    "candidate:second".to_string(),
+                ],
+                max_items: DEFAULT_FAN_OUT_MAX_ITEMS,
+                fail_fast: true,
+                request_template: json!({ "mode": "dispatch" }),
+            },
+            "review candidates until failure",
+        );
+        controller::write_controller(&record).expect("controller written");
+
+        let dispatch = CountingFailingDispatchHook::default();
+        let result = run_next(
+            "loop-service-fanout-fail-fast",
+            CapturingExecutor::default(),
+            &dispatch,
+        )
+        .expect("fan-out action executed");
+
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.status.as_deref(), Some("failed"));
+        let execution = result.value.execution.as_ref().expect("execution");
+        assert_eq!(execution["item_count"], json!(1));
+        assert_eq!(execution["total_item_count"], json!(2));
+        assert_eq!(execution["fail_fast"], json!(true));
+        assert_eq!(execution["concurrency"], json!(1));
+        assert_eq!(execution["truncated"], json!(true));
+        assert_eq!(execution["results"].as_array().expect("results").len(), 1);
+        let observed = dispatch
+            .observed_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        assert_eq!(observed.len(), 1);
+        assert_eq!(observed[0]["entity_id"], json!("candidate:first"));
+    });
+}
+
+#[test]
 fn fan_out_indexes_each_child_task_evidence_on_its_entity() {
     with_isolated_home(|_| {
         let mut record = init(ControllerInitRequest {
@@ -1283,6 +1420,8 @@ fn fan_out_indexes_each_child_task_evidence_on_its_entity() {
             AgentTaskLoopPolicyAction::FanOut {
                 dedupe_key: "candidate:review".to_string(),
                 entity_ids: vec![first.clone(), second.clone()],
+                max_items: DEFAULT_FAN_OUT_MAX_ITEMS,
+                fail_fast: true,
                 request_template: json!({
                     "mode": "run_plan",
                     "plan": test_plan(),

--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -222,6 +222,13 @@ pub enum AgentTaskLoopPolicyAction {
         dedupe_key: String,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         entity_ids: Vec<String>,
+        #[serde(
+            default = "default_fan_out_max_items",
+            skip_serializing_if = "is_default_fan_out_max_items"
+        )]
+        max_items: usize,
+        #[serde(default = "default_true", skip_serializing_if = "is_true")]
+        fail_fast: bool,
         #[serde(default, skip_serializing_if = "Value::is_null")]
         request_template: Value,
     },
@@ -2242,6 +2249,24 @@ fn default_controller_phase() -> String {
     "init".to_string()
 }
 
+pub const DEFAULT_FAN_OUT_MAX_ITEMS: usize = 50;
+
+fn default_fan_out_max_items() -> usize {
+    DEFAULT_FAN_OUT_MAX_ITEMS
+}
+
+fn is_default_fan_out_max_items(value: &usize) -> bool {
+    *value == DEFAULT_FAN_OUT_MAX_ITEMS
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn is_true(value: &bool) -> bool {
+    *value
+}
+
 fn default_config_version() -> String {
     "v1".to_string()
 }
@@ -2893,6 +2918,8 @@ mod tests {
                 actions: vec![AgentTaskLoopPolicyAction::FanOut {
                     dedupe_key: "validation:run-1:actionable-findings".to_string(),
                     entity_ids: vec!["finding:a".to_string()],
+                    max_items: DEFAULT_FAN_OUT_MAX_ITEMS,
+                    fail_fast: true,
                     request_template: json!({ "kind": "repair" }),
                 }],
             }],
@@ -3009,6 +3036,8 @@ mod tests {
         let action = AgentTaskLoopPolicyAction::FanOut {
             dedupe_key: "fanout:lab".to_string(),
             entity_ids: vec!["finding:1".to_string()],
+            max_items: DEFAULT_FAN_OUT_MAX_ITEMS,
+            fail_fast: true,
             request_template: json!({
                 "task": "repair",
                 "runner": "homeboy-lab",


### PR DESCRIPTION
## Summary
- Add finite `max_items` and `fail_fast` policy fields for controller fan-out
- Stop fan-out after the item cap or first child failure by default
- Report serial fan-out policy metadata and add max/fail-fast coverage

## Tests
- cargo test --lib fan_out
- cargo test --lib core::agent_task_controller_service::tests
- cargo test --lib core::agent_task_loop_controller::tests
- rustfmt --check src/core/agent_task_loop_controller.rs src/core/agent_task_controller_service/actions.rs src/core/agent_task_controller_service/spec_compile.rs src/core/agent_task_controller_service/tests.rs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, verification, and PR preparation