### PR TITLE
feat(runner): add job broker wrappers

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -224,6 +224,14 @@ The broker exposes `POST /runner/jobs`, `POST /runner/jobs/claim`,
 controllers can queue work and reverse runners can claim, stream progress, and
 return results without inbound access to the lab machine.
 
+Use Homeboy wrappers for broker maintenance and artifact lookup instead of raw
+HTTP calls:
+
+```sh
+homeboy runner job reconcile <runner-id>
+homeboy runner job artifacts <runner-id> <job-id> <artifact-id>
+```
+
 #### Broker authentication and pairing
 
 Every `/runner/*` broker route requires an authenticated, scoped bearer token

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -141,6 +141,7 @@ pub enum RunnerCommandOutput {
     Execution(RunnerExecOutput),
     Env(RunnerEnvOutput),
     Job(RunnerJobOutput),
+    BrokerJob(RunnerBrokerJobOutput),
     Worker(ReverseRunnerWorkerOutput),
     Workspace(workspace::RunnerWorkspaceOutput),
     Broker(RunnerBrokerOutput),
@@ -188,6 +189,18 @@ pub struct RunnerJobOutput {
     pub job: Job,
     pub runner_job: homeboy::core::runners::RunnerJob,
     pub events: Vec<JobEvent>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerBrokerJobOutput {
+    pub variant: &'static str,
+    pub command: &'static str,
+    pub runner_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_id: Option<String>,
+    pub response: Value,
 }
 
 #[derive(Debug, Serialize)]
@@ -592,6 +605,22 @@ enum RunnerJobCommand {
 
         /// Runner daemon job ID from runner exec/Lab output or error details
         job_id: String,
+    },
+    /// Reconcile expired reverse-runner broker claims
+    Reconcile {
+        /// Reverse-connected runner ID
+        runner_id: String,
+    },
+    /// Inspect broker-held reverse-runner artifact metadata
+    Artifacts {
+        /// Reverse-connected runner ID
+        runner_id: String,
+
+        /// Reverse broker job ID
+        job_id: String,
+
+        /// Artifact ID reported by the finished broker job
+        artifact_id: String,
     },
 }
 
@@ -1048,8 +1077,18 @@ fn map_env(result: CmdResult<RunnerEnvOutput>) -> CmdResult<RunnerCommandOutput>
     result.map(|(output, exit_code)| (RunnerCommandOutput::Env(output), exit_code))
 }
 
-fn map_job(result: CmdResult<RunnerJobOutput>) -> CmdResult<RunnerCommandOutput> {
-    result.map(|(output, exit_code)| (RunnerCommandOutput::Job(output), exit_code))
+fn map_job(result: CmdResult<RunnerJobCommandOutput>) -> CmdResult<RunnerCommandOutput> {
+    result.map(|(output, exit_code)| match output {
+        RunnerJobCommandOutput::Daemon(output) => (RunnerCommandOutput::Job(output), exit_code),
+        RunnerJobCommandOutput::Broker(output) => {
+            (RunnerCommandOutput::BrokerJob(output), exit_code)
+        }
+    })
+}
+
+enum RunnerJobCommandOutput {
+    Daemon(RunnerJobOutput),
+    Broker(RunnerBrokerJobOutput),
 }
 
 fn map_worker(result: CmdResult<ReverseRunnerWorkerOutput>) -> CmdResult<RunnerCommandOutput> {
@@ -1606,8 +1645,8 @@ fn reverse_runner_status_hints(
     ));
     if report.active_job_count > 0 {
         hints.push(format!(
-            "Cancel known reverse broker jobs with `homeboy runner job cancel {} <job-id>`; if a claim lease expires, reconcile broker state with POST /runner/jobs/reconcile instead of mutating the job store manually.",
-            report.runner_id
+            "Cancel known reverse broker jobs with `homeboy runner job cancel {} <job-id>`; if a claim lease expires, reconcile broker state with `homeboy runner job reconcile {}` instead of mutating the job store manually.",
+            report.runner_id, report.runner_id
         ));
     }
 }
@@ -1658,14 +1697,14 @@ fn runner_status_operator_commands(report: &RunnerStatusReport) -> Vec<RunnerOpe
     }
 
     if session.mode == RunnerTunnelMode::Reverse {
-        if let Some(broker_url) = session.broker_url.as_deref() {
+        if session.broker_url.is_some() {
             commands.push(RunnerOperatorCommand {
                 scope: "broker_reconcile",
                 runner_id: report.runner_id.clone(),
                 job_id: None,
                 command: format!(
-                    "curl -fsS -X POST {}/runner/jobs/reconcile",
-                    broker_url.trim_end_matches('/')
+                    "homeboy runner job reconcile {}",
+                    shell_arg(&report.runner_id)
                 ),
                 description:
                     "Fail expired reverse-runner claims through the broker-owned lifecycle path."
@@ -1677,9 +1716,9 @@ fn runner_status_operator_commands(report: &RunnerStatusReport) -> Vec<RunnerOpe
                     runner_id: report.runner_id.clone(),
                     job_id: Some(job.job_id.clone()),
                     command: format!(
-                        "curl -fsS {}/runner/jobs/{}/artifacts/<artifact-id>",
-                        broker_url.trim_end_matches('/'),
-                        job.job_id
+                        "homeboy runner job artifacts {} {} <artifact-id>",
+                        shell_arg(&report.runner_id),
+                        shell_arg(&job.job_id)
                     ),
                     description: "Inspect broker-held reverse-runner artifact metadata."
                         .to_string(),
@@ -2002,16 +2041,66 @@ fn env(runner_id: &str) -> CmdResult<RunnerEnvOutput> {
     ))
 }
 
-fn job(command: RunnerJobCommand) -> CmdResult<RunnerJobOutput> {
+fn job(command: RunnerJobCommand) -> CmdResult<RunnerJobCommandOutput> {
     match command {
         RunnerJobCommand::Logs {
             runner_id,
             job_id,
             follow,
             poll_ms,
-        } => job_logs(&runner_id, &job_id, follow, poll_ms),
-        RunnerJobCommand::Cancel { runner_id, job_id } => job_cancel(&runner_id, &job_id),
+        } => job_logs(&runner_id, &job_id, follow, poll_ms).map_job_daemon(),
+        RunnerJobCommand::Cancel { runner_id, job_id } => {
+            job_cancel(&runner_id, &job_id).map_job_daemon()
+        }
+        RunnerJobCommand::Reconcile { runner_id } => job_reconcile(&runner_id),
+        RunnerJobCommand::Artifacts {
+            runner_id,
+            job_id,
+            artifact_id,
+        } => job_artifacts(&runner_id, &job_id, &artifact_id),
     }
+}
+
+trait RunnerJobCommandResultExt {
+    fn map_job_daemon(self) -> CmdResult<RunnerJobCommandOutput>;
+}
+
+impl RunnerJobCommandResultExt for CmdResult<RunnerJobOutput> {
+    fn map_job_daemon(self) -> CmdResult<RunnerJobCommandOutput> {
+        self.map(|(output, exit_code)| (RunnerJobCommandOutput::Daemon(output), exit_code))
+    }
+}
+
+fn job_reconcile(runner_id: &str) -> CmdResult<RunnerJobCommandOutput> {
+    Ok((
+        RunnerJobCommandOutput::Broker(RunnerBrokerJobOutput {
+            variant: "job_reconcile",
+            command: "runner.job.reconcile",
+            runner_id: runner_id.to_string(),
+            job_id: None,
+            artifact_id: None,
+            response: runner::reverse_broker_reconcile(runner_id)?,
+        }),
+        0,
+    ))
+}
+
+fn job_artifacts(
+    runner_id: &str,
+    job_id: &str,
+    artifact_id: &str,
+) -> CmdResult<RunnerJobCommandOutput> {
+    Ok((
+        RunnerJobCommandOutput::Broker(RunnerBrokerJobOutput {
+            variant: "job_artifacts",
+            command: "runner.job.artifacts",
+            runner_id: runner_id.to_string(),
+            job_id: Some(job_id.to_string()),
+            artifact_id: Some(artifact_id.to_string()),
+            response: runner::reverse_broker_artifact(runner_id, job_id, artifact_id)?,
+        }),
+        0,
+    ))
 }
 
 fn job_cancel(runner_id: &str, job_id: &str) -> CmdResult<RunnerJobOutput> {
@@ -2322,11 +2411,11 @@ mod tests {
         assert!(serialized.contains("homeboy runner job logs homeboy-lab job-123 --follow"));
         assert!(serialized.contains("homeboy runner job cancel homeboy-lab job-123"));
         assert!(serialized.contains("homeboy runs artifact get run-123 <artifact-id> -o <path>"));
-        assert!(serialized
-            .contains("curl -fsS -X POST https://broker.example.test/runner/jobs/reconcile"));
-        assert!(serialized.contains(
-            "curl -fsS https://broker.example.test/runner/jobs/job-123/artifacts/<artifact-id>"
-        ));
+        assert!(serialized.contains("homeboy runner job reconcile homeboy-lab"));
+        assert!(
+            serialized.contains("homeboy runner job artifacts homeboy-lab job-123 <artifact-id>")
+        );
+        assert!(!serialized.contains("curl -fsS"));
     }
 
     #[test]

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -14,13 +14,13 @@ use crate::core::error::{Error, Result};
 use crate::core::paths;
 use crate::core::server::{self, Server, ServerAuthMode, SshClient};
 
-use super::broker_http;
 use super::session::{
     ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
     RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
     RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
     RunnerTunnelMode,
 };
+use super::{broker_auth, broker_http};
 use super::{load, Runner, RunnerKind};
 
 const REVERSE_RUNNER_HEARTBEAT_TTL: Duration = Duration::from_secs(90);
@@ -401,6 +401,71 @@ fn runner_jobs(
             })
             .collect(),
     ))
+}
+
+pub fn reverse_broker_reconcile(runner_id: &str) -> Result<Value> {
+    let broker_url = reverse_broker_url(runner_id)?;
+    let client = broker_client("build broker reconcile client")?;
+    broker_http::post_json(
+        &client,
+        &broker_url,
+        "/runner/jobs/reconcile",
+        Value::Null,
+        "reconcile reverse runner broker jobs",
+        broker_auth::broker_token_from_env().as_deref(),
+    )
+}
+
+pub fn reverse_broker_artifact(runner_id: &str, job_id: &str, artifact_id: &str) -> Result<Value> {
+    let broker_url = reverse_broker_url(runner_id)?;
+    let artifact_id = crate::core::execution_contract::encode_uri_component(artifact_id);
+    let client = broker_client("build broker artifact client")?;
+    broker_http::get_json(
+        &client,
+        &broker_url,
+        &format!("/runner/jobs/{job_id}/artifacts/{artifact_id}"),
+        "lookup reverse runner broker artifact",
+        broker_auth::broker_token_from_env().as_deref(),
+    )
+}
+
+fn reverse_broker_url(runner_id: &str) -> Result<String> {
+    let report = status(runner_id)?;
+    let Some(session) = report.session.filter(|_| report.connected) else {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            format!("runner `{runner_id}` is not connected"),
+            Some(runner_id.to_string()),
+            None,
+        ));
+    };
+    if session.mode != RunnerTunnelMode::Reverse {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            format!("runner `{runner_id}` is not reverse-connected"),
+            Some(runner_id.to_string()),
+            Some(vec![
+                "Broker job wrappers require a reverse runner session.".to_string(),
+            ]),
+        ));
+    }
+    session.broker_url.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runner_id",
+            format!("reverse runner `{runner_id}` has no broker URL"),
+            Some(runner_id.to_string()),
+            Some(vec![
+                "Reconnect with `homeboy runner connect <controller-id> --reverse --reverse-runner <runner-id> --broker-url <url>`.".to_string(),
+            ]),
+        )
+    })
+}
+
+fn broker_client(action: &str) -> Result<Client> {
+    Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("{action}: {err}")))
 }
 
 fn stale_daemon_warning(

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -70,7 +70,10 @@ pub use command_path::preflight_remote_argv_path_translation;
 pub(crate) use command_path::{
     normalize_runner_command_env, quote_runner_env_value, remote_shell_path_preamble,
 };
-pub use connection::{connect, connect_reverse, disconnect, status, statuses};
+pub use connection::{
+    connect, connect_reverse, disconnect, reverse_broker_artifact, reverse_broker_reconcile,
+    status, statuses,
+};
 pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::runner_artifact_store_token;
 pub use evidence::{

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -26,8 +26,9 @@
 
 pub use super::runner::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path, broker_token_from_env,
-    capture_lab_offload_subprocess_metadata, connect, BrokerAuthGrant, BrokerAuthStore,
-    BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    capture_lab_offload_subprocess_metadata, connect, reverse_broker_artifact,
+    reverse_broker_reconcile, BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope,
+    MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use super::runner::{
     connect_reverse, disconnect, download_remote_artifact,

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -522,6 +522,22 @@ fn runner_job_logs_command_parses() {
 }
 
 #[test]
+fn runner_job_broker_wrapper_commands_parse() {
+    Cli::try_parse_from(["homeboy", "runner", "job", "reconcile", "homeboy-lab"])
+        .expect("runner job reconcile command should parse");
+    Cli::try_parse_from([
+        "homeboy",
+        "runner",
+        "job",
+        "artifacts",
+        "homeboy-lab",
+        "00000000-0000-0000-0000-000000000000",
+        "report.txt",
+    ])
+    .expect("runner job artifacts command should parse");
+}
+
+#[test]
 fn runner_exec_raw_command_parses_before_trailing_command() {
     Cli::try_parse_from([
         "homeboy",


### PR DESCRIPTION
## Summary
- Add Homeboy wrappers for runner broker job reconcile and artifact fetch
- Reuse broker token plumbing instead of exposing raw curl status hints
- Update runner docs and command-surface coverage

## Tests
- cargo test --test command_surface_test runner_job_broker_wrapper_commands_parse
- cargo test --test command_surface_test runner_job_logs_command_parses
- cargo test reverse_runner_status_commands_include_lifecycle_operations
- cargo test --test command_surface_test
- cargo test runner_job

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, verification, and PR preparation