### PR TITLE
fix(agent-task): bound spec generator execution

### DIFF
--- a/src/commands/agent_task/tests/loop_compile.rs
+++ b/src/commands/agent_task/tests/loop_compile.rs
@@ -435,6 +435,95 @@ fn controller_materialize_runs_generator_manifest_and_records_evidence() {
 }
 
 #[test]
+fn controller_materialize_caps_generator_output_evidence() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let manifest_path = temp.path().join("generator.json");
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_string(&json!({
+            "schema": "homeboy/agent-task-loop-spec-generator/v1",
+            "command": [
+                "/bin/sh",
+                "-c",
+                "printf 1234567890abcdef; cat > generated-loop.json <<'JSON'\n{\"loop_id\":\"generated-output-cap-loop\",\"workflows\":[{\"workflow_id\":\"brief\",\"prompt\":\"Draft.\"}]}\nJSON"
+            ],
+            "output_path": "generated-loop.json",
+            "max_stdout_bytes": 12,
+            "max_stderr_bytes": 12
+        }))
+        .expect("manifest json"),
+    )
+    .expect("write manifest");
+
+    let (value, status) =
+        super::support::controller_materialize(AgentTaskControllerMaterializeArgs {
+            spec: format!("@{}", manifest_path.display()),
+            inputs: None,
+            policy_results: Vec::new(),
+        })
+        .expect("materialize generated spec");
+
+    assert_eq!(status, 0);
+    assert_eq!(value["spec"]["loop_id"], "generated-output-cap-loop");
+    assert_eq!(
+        value["generator_evidence"]["status"]["stdout"],
+        "1234567890ab"
+    );
+    assert_eq!(
+        value["generator_evidence"]["status"]["stdout_truncated"],
+        true
+    );
+    assert_eq!(
+        value["generator_evidence"]["status"]["stdout_bytes_read"],
+        16
+    );
+    assert_eq!(
+        value["generator_evidence"]["status"]["max_stdout_bytes"],
+        12
+    );
+}
+
+#[test]
+fn controller_materialize_reports_generator_timeout_diagnostics() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let manifest_path = temp.path().join("generator.json");
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_string(&json!({
+            "schema": "homeboy/agent-task-loop-spec-generator/v1",
+            "command": ["/bin/sh", "-c", "sleep 2"],
+            "output_path": "generated-loop.json",
+            "timeout_seconds": 1
+        }))
+        .expect("manifest json"),
+    )
+    .expect("write manifest");
+
+    let error = super::support::controller_materialize(AgentTaskControllerMaterializeArgs {
+        spec: format!("@{}", manifest_path.display()),
+        inputs: None,
+        policy_results: Vec::new(),
+    })
+    .expect_err("timeout is rejected");
+
+    assert_eq!(error.details["field"], "spec.command");
+    assert!(error.message.contains("timed out after 1 seconds"));
+    assert_eq!(
+        error.details["diagnostics"][0]["class"],
+        "generator.timeout"
+    );
+    assert_eq!(
+        error.details["diagnostics"][0]["data"]["timeout_seconds"],
+        1
+    );
+    assert_eq!(error.details["diagnostics"][0]["data"]["timed_out"], true);
+    assert!(error.details["diagnostics"][0]["data"]["cwd"]
+        .as_str()
+        .expect("cwd")
+        .contains(temp.path().to_str().expect("temp path")));
+}
+
+#[test]
 fn controller_materialize_reports_missing_generated_spec_path() {
     let temp = tempfile::tempdir().expect("tempdir");
     let manifest_path = temp.path().join("generator.json");

--- a/src/core/agent_task_controller_service/spec_source.rs
+++ b/src/core/agent_task_controller_service/spec_source.rs
@@ -7,8 +7,11 @@
 //! it, and assembles generator evidence. This orchestration belongs in core so
 //! the CLI adapter stays thin.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use serde::Deserialize;
 use serde_json::Value;
@@ -24,6 +27,9 @@ use crate::core::{Error, Result};
 use super::AgentTaskRepoLoopSpec;
 
 const CONTROLLER_SPEC_GENERATOR_SCHEMA: &str = "homeboy/agent-task-loop-spec-generator/v1";
+const DEFAULT_GENERATOR_TIMEOUT_SECONDS: u64 = 300;
+const DEFAULT_GENERATOR_MAX_STDOUT_BYTES: usize = 64 * 1024;
+const DEFAULT_GENERATOR_MAX_STDERR_BYTES: usize = 64 * 1024;
 
 /// Resolved controller materialize spec plus optional generator evidence.
 pub struct MaterializeSpecSource {
@@ -37,7 +43,34 @@ struct ControllerSpecGeneratorManifest {
     command: Vec<String>,
     output_path: String,
     #[serde(default)]
+    timeout_seconds: Option<u64>,
+    #[serde(default)]
+    max_stdout_bytes: Option<usize>,
+    #[serde(default)]
+    max_stderr_bytes: Option<usize>,
+    #[serde(default)]
     inputs: Value,
+}
+
+struct GeneratorExecutionBounds {
+    timeout: Duration,
+    timeout_seconds: u64,
+    max_stdout_bytes: usize,
+    max_stderr_bytes: usize,
+}
+
+struct BoundedOutput {
+    text: String,
+    truncated: bool,
+    bytes_read: usize,
+}
+
+struct GeneratorCommandOutput {
+    status: Option<ExitStatus>,
+    timed_out: bool,
+    stdout: BoundedOutput,
+    stderr: BoundedOutput,
+    cwd: String,
 }
 
 /// Load the materialize spec source, executing a generator manifest if the
@@ -162,6 +195,14 @@ fn validate_generator_manifest(
             None,
         ));
     }
+    if manifest.timeout_seconds == Some(0) {
+        return Err(Error::validation_invalid_argument(
+            "spec.timeout_seconds",
+            "generator timeout_seconds must be greater than zero when present",
+            Some(source.to_string()),
+            None,
+        ));
+    }
     Ok(())
 }
 
@@ -188,36 +229,204 @@ fn run_spec_generator_command(
     manifest: &ControllerSpecGeneratorManifest,
     manifest_dir: Option<&Path>,
 ) -> Result<Value> {
+    let bounds = generator_execution_bounds(manifest);
+    let cwd = generator_cwd_display(manifest_dir);
     let mut command = Command::new(&manifest.command[0]);
     command.args(&manifest.command[1..]);
     if let Some(manifest_dir) = manifest_dir {
         command.current_dir(manifest_dir);
     }
-    let output = command.output().map_err(|error| {
+    let output = run_bounded_command(command, &bounds, cwd.clone()).map_err(|error| {
         Error::validation_invalid_argument(
             "spec.command",
-            format!("failed to execute generator command: {error}"),
+            format!("failed to execute generator command in {cwd}: {error}"),
             Some(manifest.command.join(" ")),
             None,
         )
     })?;
-    let code = output.status.code();
-    if !output.status.success() {
-        return Err(Error::validation_invalid_argument(
+    let code = output.status.and_then(|status| status.code());
+    if output.timed_out {
+        let mut error = Error::validation_invalid_argument(
+            "spec.command",
+            format!(
+                "generator command timed out after {} seconds",
+                bounds.timeout_seconds
+            ),
+            Some(manifest.command.join(" ")),
+            None,
+        );
+        attach_generator_failure_diagnostics(
+            &mut error,
+            "generator.timeout",
+            &output,
+            &bounds,
+            "generator command exceeded timeout_seconds",
+        );
+        return Err(error);
+    }
+    if !output
+        .status
+        .map(|status| status.success())
+        .unwrap_or(false)
+    {
+        let mut error = Error::validation_invalid_argument(
             "spec.command",
             format!(
                 "generator command exited with status {}; stderr: {}",
                 code.map(|value| value.to_string())
                     .unwrap_or_else(|| "terminated by signal".to_string()),
-                String::from_utf8_lossy(&output.stderr).trim()
+                output.stderr.text.trim()
             ),
             Some(manifest.command.join(" ")),
             None,
-        ));
+        );
+        attach_generator_failure_diagnostics(
+            &mut error,
+            "generator.exit_status",
+            &output,
+            &bounds,
+            "generator command exited unsuccessfully",
+        );
+        return Err(error);
     }
     Ok(serde_json::json!({
         "exit_code": code,
-        "stdout": String::from_utf8_lossy(&output.stdout).trim(),
-        "stderr": String::from_utf8_lossy(&output.stderr).trim(),
+        "stdout": output.stdout.text.trim(),
+        "stderr": output.stderr.text.trim(),
+        "stdout_truncated": output.stdout.truncated,
+        "stderr_truncated": output.stderr.truncated,
+        "stdout_bytes_read": output.stdout.bytes_read,
+        "stderr_bytes_read": output.stderr.bytes_read,
+        "max_stdout_bytes": bounds.max_stdout_bytes,
+        "max_stderr_bytes": bounds.max_stderr_bytes,
+        "timeout_seconds": bounds.timeout_seconds,
+        "timed_out": false,
+        "cwd": output.cwd,
     }))
+}
+
+fn generator_execution_bounds(
+    manifest: &ControllerSpecGeneratorManifest,
+) -> GeneratorExecutionBounds {
+    let timeout_seconds = manifest
+        .timeout_seconds
+        .unwrap_or(DEFAULT_GENERATOR_TIMEOUT_SECONDS);
+    GeneratorExecutionBounds {
+        timeout: Duration::from_secs(timeout_seconds),
+        timeout_seconds,
+        max_stdout_bytes: manifest
+            .max_stdout_bytes
+            .unwrap_or(DEFAULT_GENERATOR_MAX_STDOUT_BYTES),
+        max_stderr_bytes: manifest
+            .max_stderr_bytes
+            .unwrap_or(DEFAULT_GENERATOR_MAX_STDERR_BYTES),
+    }
+}
+
+fn generator_cwd_display(manifest_dir: Option<&Path>) -> String {
+    manifest_dir
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::current_dir().ok())
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "<unknown>".to_string())
+}
+
+fn run_bounded_command(
+    mut command: Command,
+    bounds: &GeneratorExecutionBounds,
+    cwd: String,
+) -> std::io::Result<GeneratorCommandOutput> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdout = child.stdout.take().expect("stdout piped");
+    let stderr = child.stderr.take().expect("stderr piped");
+    let stdout_handle = thread::spawn({
+        let max_bytes = bounds.max_stdout_bytes;
+        move || read_bounded_output(stdout, max_bytes)
+    });
+    let stderr_handle = thread::spawn({
+        let max_bytes = bounds.max_stderr_bytes;
+        move || read_bounded_output(stderr, max_bytes)
+    });
+    let started = Instant::now();
+    let mut timed_out = false;
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break Some(status);
+        }
+        if started.elapsed() >= bounds.timeout {
+            timed_out = true;
+            let _ = child.kill();
+            break Some(child.wait()?);
+        }
+        thread::sleep(Duration::from_millis(25));
+    };
+
+    Ok(GeneratorCommandOutput {
+        status,
+        timed_out,
+        stdout: join_bounded_output(stdout_handle),
+        stderr: join_bounded_output(stderr_handle),
+        cwd,
+    })
+}
+
+fn read_bounded_output(mut reader: impl Read, max_bytes: usize) -> BoundedOutput {
+    let mut stored = Vec::new();
+    let mut bytes_read = 0usize;
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(_) => break,
+        };
+        bytes_read = bytes_read.saturating_add(read);
+        let remaining = max_bytes.saturating_sub(stored.len());
+        if remaining > 0 {
+            stored.extend_from_slice(&buffer[..read.min(remaining)]);
+        }
+    }
+    BoundedOutput {
+        text: String::from_utf8_lossy(&stored).to_string(),
+        truncated: bytes_read > stored.len(),
+        bytes_read,
+    }
+}
+
+fn join_bounded_output(handle: thread::JoinHandle<BoundedOutput>) -> BoundedOutput {
+    handle.join().unwrap_or_else(|_| BoundedOutput {
+        text: String::new(),
+        truncated: false,
+        bytes_read: 0,
+    })
+}
+
+fn attach_generator_failure_diagnostics(
+    error: &mut Error,
+    class: &str,
+    output: &GeneratorCommandOutput,
+    bounds: &GeneratorExecutionBounds,
+    message: &str,
+) {
+    error.details["diagnostics"] = serde_json::json!([{
+        "class": class,
+        "message": message,
+        "data": {
+            "cwd": output.cwd,
+            "exit_code": output.status.and_then(|status| status.code()),
+            "timed_out": output.timed_out,
+            "timeout_seconds": bounds.timeout_seconds,
+            "stdout": output.stdout.text.trim(),
+            "stderr": output.stderr.text.trim(),
+            "stdout_truncated": output.stdout.truncated,
+            "stderr_truncated": output.stderr.truncated,
+            "stdout_bytes_read": output.stdout.bytes_read,
+            "stderr_bytes_read": output.stderr.bytes_read,
+            "max_stdout_bytes": bounds.max_stdout_bytes,
+            "max_stderr_bytes": bounds.max_stderr_bytes,
+        }
+    }]);
 }


### PR DESCRIPTION
## Summary
- Add timeout and output caps to controller spec generator execution
- Record bounded stdout/stderr, cwd, timeout, and truncation diagnostics
- Add generator materialization coverage for capped output and timeout diagnostics

## Tests
- cargo test commands::agent_task::tests::loop_compile::controller_materialize -- --nocapture
- cargo check --lib
- git diff --check -- src/core/agent_task_controller_service/spec_source.rs src/commands/agent_task/tests/loop_compile.rs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, verification, correction pass, and PR preparation