### PR TITLE
fix(fuzz): persist result envelopes with runs

### DIFF
--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -164,10 +164,13 @@ mod tests {
         persist_fuzz_run_evidence, FuzzRunEvidenceInput,
     };
     use super::replay::run_replay;
-    use super::report::{evaluate_fuzz_gates, fuzz_coverage_completeness, gate_status};
+    use super::report::{
+        evaluate_fuzz_gates, fuzz_coverage_completeness, gate_status, run_report,
+        FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
+    };
     use super::types::{
-        FuzzCommand, FuzzExecutionOutput, FuzzListOutput, FuzzOutput, FuzzReplayArgs, FuzzRunArgs,
-        FuzzRunOutput, FuzzRunnerContract, FuzzWorkloadOutput,
+        FuzzCommand, FuzzExecutionOutput, FuzzListOutput, FuzzOutput, FuzzReplayArgs,
+        FuzzReportArgs, FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract, FuzzWorkloadOutput,
     };
     use super::workloads::{
         fuzz_workloads, resolve_component_id, rig_component_for_fuzz, select_workload,
@@ -178,7 +181,7 @@ mod tests {
     use homeboy::core::engine::run_dir::RunDir;
     use homeboy::core::extension::FuzzConfig;
     use homeboy::core::fuzz::{FuzzCampaign, FuzzCoverageSummary};
-    use homeboy::core::observation::ObservationStore;
+    use homeboy::core::observation::{ObservationStore, RunRecord};
     use homeboy::core::rig::RigSpec;
     use homeboy::test_support::with_isolated_home;
     use std::path::{Path, PathBuf};
@@ -1051,6 +1054,48 @@ mod tests {
         }
     }
 
+    fn fuzz_run_args_with_run_id(run_id: &str) -> FuzzRunArgs {
+        FuzzRunArgs {
+            comp: PositionalComponentArgs {
+                component: Some("component-a".to_string()),
+                path: None,
+            },
+            rig: Some("package-fuzz".to_string()),
+            extension_override: ExtensionOverrideArgs { extensions: vec![] },
+            setting_args: SettingArgs {
+                setting: vec![],
+                setting_json: vec![],
+            },
+            workload_id: Some("parser".to_string()),
+            run_id: Some(run_id.to_string()),
+            seed: Some("1234".to_string()),
+            inventory: None,
+            max_duration: None,
+            args: vec![],
+        }
+    }
+
+    fn seed_fuzz_run(run_id: &str) {
+        let store = ObservationStore::open_initialized().expect("store");
+        let now = chrono::Utc::now().to_rfc3339();
+        store
+            .upsert_imported_run(&RunRecord {
+                id: run_id.to_string(),
+                kind: "fuzz".to_string(),
+                component_id: Some("component-a".to_string()),
+                started_at: now.clone(),
+                finished_at: Some(now),
+                status: "pass".to_string(),
+                command: Some(format!("homeboy fuzz run component-a --run-id {run_id}")),
+                cwd: None,
+                homeboy_version: Some("test-version".to_string()),
+                git_sha: None,
+                rig_id: Some("package-fuzz".to_string()),
+                metadata_json: serde_json::json!({}),
+            })
+            .expect("seed fuzz run");
+    }
+
     #[test]
     fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
         with_isolated_home(|home| {
@@ -1119,6 +1164,95 @@ mod tests {
             assert!(std::path::Path::new(&artifacts[0].path).is_file());
             let raw = std::fs::read_to_string(&artifacts[0].path).expect("raw artifact");
             assert!(raw.contains("unsupported/fuzz-result/v1"));
+        });
+    }
+
+    #[test]
+    fn fuzz_report_persists_result_envelope_artifact_for_run_id() {
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("agent-readable-artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            seed_fuzz_run("report-run-1");
+            let results_path = home.path().join("fuzz-campaign.json");
+            std::fs::write(
+                &results_path,
+                serde_json::to_string(&empty_fuzz_campaign()).expect("serialize campaign"),
+            )
+            .expect("results file");
+
+            let output = run_report(FuzzReportArgs {
+                results_file: results_path,
+                run: fuzz_run_args_with_run_id("report-run-1"),
+                output_envelope: None,
+                envelope_id: None,
+            })
+            .expect("fuzz report");
+
+            assert_eq!(output.envelope_file, None);
+            assert_eq!(output.envelope.id, "report-run-1");
+            let store = ObservationStore::open_initialized().expect("store");
+            let artifacts = store.list_artifacts("report-run-1").expect("artifacts");
+            let envelope_artifact = artifacts
+                .iter()
+                .find(|artifact| artifact.kind == FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND)
+                .expect("fuzz result envelope artifact");
+            assert_eq!(envelope_artifact.artifact_type, "file");
+            assert_eq!(envelope_artifact.mime.as_deref(), Some("application/json"));
+            assert_eq!(
+                envelope_artifact.metadata_json["envelope_id"],
+                "report-run-1"
+            );
+            let persisted =
+                std::fs::read_to_string(&envelope_artifact.path).expect("artifact file");
+            assert!(persisted.contains(homeboy::core::fuzz::FUZZ_RESULT_ENVELOPE_SCHEMA));
+
+            let artifact_index =
+                homeboy::core::observation::evidence_report::evidence_artifact_index(&artifacts);
+            assert_eq!(artifact_index.count, 1);
+            assert_eq!(artifact_index.file_count, 1);
+            assert_eq!(
+                artifact_index.artifacts[0].kind,
+                FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND
+            );
+            assert!(artifact_index.artifacts[0].fetch_command.is_some());
+            homeboy::core::set_artifact_root_override(None);
+        });
+    }
+
+    #[test]
+    fn fuzz_report_records_existing_output_envelope_path_as_artifact() {
+        with_isolated_home(|home| {
+            seed_fuzz_run("report-run-output");
+            let results_path = home.path().join("fuzz-campaign.json");
+            let envelope_path = home.path().join("fuzz-envelope.json");
+            std::fs::write(
+                &results_path,
+                serde_json::to_string(&empty_fuzz_campaign()).expect("serialize campaign"),
+            )
+            .expect("results file");
+
+            run_report(FuzzReportArgs {
+                results_file: results_path,
+                run: fuzz_run_args_with_run_id("report-run-output"),
+                output_envelope: Some(envelope_path.clone()),
+                envelope_id: Some("custom-envelope".to_string()),
+            })
+            .expect("fuzz report");
+
+            assert!(envelope_path.is_file());
+            let store = ObservationStore::open_initialized().expect("store");
+            let artifacts = store
+                .list_artifacts("report-run-output")
+                .expect("artifacts");
+            let envelope_artifact = artifacts
+                .iter()
+                .find(|artifact| artifact.kind == FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND)
+                .expect("fuzz result envelope artifact");
+            assert_eq!(
+                envelope_artifact.metadata_json["envelope_id"],
+                "custom-envelope"
+            );
+            assert!(std::path::Path::new(&envelope_artifact.path).is_file());
         });
     }
 

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -7,6 +7,9 @@ use homeboy::core::fuzz::{
     FuzzResultEnvelope, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
     FUZZ_RESULT_ENVELOPE_SCHEMA,
 };
+use homeboy::core::observation::{ArtifactRecord, ObservationStore};
+
+pub(super) const FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND: &str = "fuzz_result_envelope";
 
 use super::types::{
     FuzzCoverageCompletenessOutput, FuzzCoverageSelectorSummaryOutput, FuzzGateEvaluation,
@@ -80,15 +83,16 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
     };
 
     if let Some(path) = args.output_envelope.as_ref() {
-        let json = serde_json::to_string_pretty(&envelope).map_err(|error| {
-            homeboy::core::Error::internal_unexpected(format!(
-                "failed to encode fuzz result envelope: {error}"
-            ))
-        })?;
+        let json = fuzz_result_envelope_json(&envelope)?;
         std::fs::write(path, json).map_err(|error| {
             homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
         })?;
     }
+    persist_fuzz_result_envelope(
+        args.run.run_id.as_deref(),
+        &envelope,
+        args.output_envelope.as_deref(),
+    )?;
 
     Ok(FuzzReportOutput {
         command: "fuzz.report".to_string(),
@@ -100,6 +104,70 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
         envelope,
         coverage_completeness,
         gates,
+    })
+}
+
+pub(super) fn persist_fuzz_result_envelope(
+    run_id: Option<&str>,
+    envelope: &FuzzResultEnvelope,
+    envelope_path: Option<&Path>,
+) -> homeboy::core::Result<Option<ArtifactRecord>> {
+    let Some(run_id) = run_id.filter(|run_id| !run_id.trim().is_empty()) else {
+        return Ok(None);
+    };
+    let store = ObservationStore::open_initialized()?;
+    if store.get_run(run_id)?.is_none() {
+        return Ok(None);
+    }
+
+    if let Some(path) = envelope_path.filter(|path| path.is_file()) {
+        return record_fuzz_result_envelope_artifact(&store, run_id, path, envelope);
+    }
+
+    let mut artifact_file = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some("create temporary fuzz result envelope artifact".to_string()),
+            )
+        })?;
+    serde_json::to_writer_pretty(&mut artifact_file, envelope).map_err(|error| {
+        homeboy::core::Error::internal_unexpected(format!(
+            "failed to encode fuzz result envelope: {error}"
+        ))
+    })?;
+    record_fuzz_result_envelope_artifact(&store, run_id, artifact_file.path(), envelope)
+}
+
+fn record_fuzz_result_envelope_artifact(
+    store: &ObservationStore,
+    run_id: &str,
+    path: &Path,
+    envelope: &FuzzResultEnvelope,
+) -> homeboy::core::Result<Option<ArtifactRecord>> {
+    store
+        .record_artifact_with_metadata(
+            run_id,
+            FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
+            path,
+            serde_json::json!({
+                "schema": envelope.schema.as_str(),
+                "envelope_id": envelope.id.as_str(),
+                "status": envelope.status.as_str(),
+                "campaign_id": envelope.campaign.as_ref().map(|campaign| campaign.id.as_str()),
+                "source": "homeboy fuzz report",
+            }),
+        )
+        .map(Some)
+}
+
+fn fuzz_result_envelope_json(envelope: &FuzzResultEnvelope) -> homeboy::core::Result<String> {
+    serde_json::to_string_pretty(envelope).map_err(|error| {
+        homeboy::core::Error::internal_unexpected(format!(
+            "failed to encode fuzz result envelope: {error}"
+        ))
     })
 }
 


### PR DESCRIPTION
## Summary
- Persist `fuzz_result_envelope` artifacts through the existing observation artifact store
- Attach generated or explicitly written fuzz envelopes to the requested run id
- Add evidence-index coverage for persisted envelope artifacts

## Tests
- rustfmt --edition 2021 --check src/commands/fuzz/mod.rs src/commands/fuzz/report.rs
- cargo test fuzz_report_persists_result_envelope_artifact_for_run_id
- cargo test fuzz_report_records_existing_output_envelope_path_as_artifact
- cargo test fuzz_run_persists_requested_run_id_and_results_artifact
- cargo test fuzz_run_persists_raw_results_artifact_when_results_parse_fails
- cargo test evidence_includes_related_lab_fuzz_results_for_runner_failure

Note: broad `cargo test fuzz_report` currently fails on clean origin/main in `fuzz_gate_evaluation_accepts_case_level_fuzz_report_evidence`; this branch reproduces the same pre-existing failure.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, verification, correction pass, and PR preparation