### PR TITLE
refactor(lab): centralize agent-task spec materialization

### DIFF
--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -1,8 +1,7 @@
 //! Bridges between Lab offload execution and the local AgentTask lifecycle.
 //!
 //! - Inline `--plan` JSON arguments are materialized to a synced workspace file
-//!   so the runner can resolve them remotely (see
-//!   `materialize_inline_agent_task_plan_arg`).
+//!   so the runner can resolve them remotely.
 //! - Once the runner streams output back, `mirror_agent_task_run_plan_lifecycle`
 //!   replays the run-plan aggregate into the controller's lifecycle store so
 //!   `homeboy agent-task status/logs` keeps working transparently.
@@ -26,128 +25,36 @@ use crate::core::{config, Error, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+#[cfg(test)]
+use super::super::lab_args::materialize_inline_agent_task_json_specs_in_args;
+use super::super::lab_args::AgentTaskInlineJsonSpec;
 use super::super::lab_workspaces::{workspace_mapping_entry, LabWorkspaceMappingEntry};
 use super::super::{sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
 use super::args_util::{subcommand_index, ArgEditor, CommandInvocation};
 
-pub(super) fn materialize_inline_agent_task_plan_arg(
-    runner_id: &str,
-    args: &[String],
-) -> Result<(Vec<String>, Option<LabWorkspaceMappingEntry>)> {
-    let in_context = subcommand_index(args, "agent-task")
-        .and_then(|index| args.get(index + 1).filter(|arg| arg.as_str() == "run-plan"))
-        .is_some();
-
-    materialize_inline_json_option(args, in_context, "--plan", |spec| {
-        sync_inline_agent_task_plan(runner_id, spec)
-    })
-}
-
-pub(super) fn materialize_inline_agent_task_tasks_arg(
-    runner_id: &str,
-    args: &[String],
-) -> Result<(Vec<String>, Option<LabWorkspaceMappingEntry>)> {
-    materialize_inline_agent_task_tasks_arg_with(args, |spec| {
-        sync_inline_agent_task_file(
-            runner_id,
-            spec,
-            "agent-task-tasks.json",
-            "agent_task_tasks_remapped",
-        )
-    })
-}
-
+#[cfg(test)]
 fn materialize_inline_agent_task_tasks_arg_with(
     args: &[String],
-    sync: impl FnMut(&str) -> Result<Option<(String, LabWorkspaceMappingEntry)>>,
-) -> Result<(Vec<String>, Option<LabWorkspaceMappingEntry>)> {
-    let in_context = subcommand_index(args, "agent-task")
-        .and_then(|index| {
-            args.get(index + 1)
-                .filter(|arg| matches!(arg.as_str(), "dispatch" | "cook"))
-        })
-        .is_some();
-
-    materialize_inline_json_option(args, in_context, "--tasks", sync)
-}
-
-/// Scans `args` for a single `--flag <json>` / `--flag=<json>` occurrence and,
-/// when `in_context` and the supplied `sync` closure produce a remapped spec,
-/// rewrites that argument to point at the synced workspace file. Parsing stops
-/// at the `--` passthrough boundary; this is argv materialization only and does
-/// not interpret anything past `--`.
-fn materialize_inline_json_option(
-    args: &[String],
-    in_context: bool,
-    flag: &str,
     mut sync: impl FnMut(&str) -> Result<Option<(String, LabWorkspaceMappingEntry)>>,
 ) -> Result<(Vec<String>, Option<LabWorkspaceMappingEntry>)> {
-    if !in_context {
-        return Ok((args.to_vec(), None));
-    }
-
-    let flag_eq = format!("{flag}=");
-    let mut out = Vec::with_capacity(args.len());
-    let mut iter = args.iter().peekable();
-    let mut passthrough = false;
-
-    while let Some(arg) = iter.next() {
-        if passthrough {
-            out.push(arg.clone());
-            continue;
+    let (rewritten, entries) = materialize_inline_agent_task_json_specs_in_args(args, |spec| {
+        if spec.role == "agent_task_tasks_remapped" {
+            sync(spec.spec)
+        } else {
+            Ok(None)
         }
-        if arg == "--" {
-            passthrough = true;
-            out.push(arg.clone());
-            continue;
-        }
-        if arg == flag {
-            out.push(arg.clone());
-            if let Some(spec) = iter.next() {
-                if let Some((remapped_spec, entry)) = sync(spec)? {
-                    out.push(remapped_spec);
-                    out.extend(iter.cloned());
-                    return Ok((out, Some(entry)));
-                }
-                out.push(spec.clone());
-            }
-            continue;
-        }
-        if let Some(spec) = arg.strip_prefix(&flag_eq) {
-            if let Some((remapped_spec, entry)) = sync(spec)? {
-                out.push(format!("{flag}={remapped_spec}"));
-                out.extend(iter.cloned());
-                return Ok((out, Some(entry)));
-            }
-        }
-        out.push(arg.clone());
-    }
-
-    Ok((out, None))
+    })?;
+    Ok((
+        rewritten,
+        entries.into_iter().next().map(|entry| entry.entry),
+    ))
 }
 
-fn sync_inline_agent_task_plan(
+pub(super) fn sync_inline_agent_task_file(
     runner_id: &str,
-    spec: &str,
+    spec: AgentTaskInlineJsonSpec<'_>,
 ) -> Result<Option<(String, LabWorkspaceMappingEntry)>> {
-    sync_inline_agent_task_file(
-        runner_id,
-        spec,
-        "agent-task-plan.json",
-        "agent_task_plan_remapped",
-    )
-}
-
-fn sync_inline_agent_task_file(
-    runner_id: &str,
-    spec: &str,
-    filename: &str,
-    role: &str,
-) -> Result<Option<(String, LabWorkspaceMappingEntry)>> {
-    if spec == "-" || spec.starts_with('@') || !looks_like_inline_json(spec) {
-        return Ok(None);
-    }
-    serde_json::from_str::<serde_json::Value>(spec).map_err(|err| {
+    serde_json::from_str::<serde_json::Value>(spec.spec).map_err(|err| {
         Error::internal_json(
             err.to_string(),
             Some("parse remapped agent-task plan".to_string()),
@@ -160,8 +67,8 @@ fn sync_inline_agent_task_file(
             Some("create remapped agent-task plan workspace".to_string()),
         )
     })?;
-    let plan_file = temp.path().join(filename);
-    fs::write(&plan_file, spec).map_err(|err| {
+    let plan_file = temp.path().join(spec.filename);
+    fs::write(&plan_file, spec.spec).map_err(|err| {
         Error::internal_io(
             err.to_string(),
             Some("write remapped agent-task plan".to_string()),
@@ -181,14 +88,13 @@ fn sync_inline_agent_task_file(
         },
     )?
     .0;
-    let remote_spec = format!("@{}/{}", synced.remote_path.trim_end_matches('/'), filename);
-    let entry = workspace_mapping_entry(role, &synced);
+    let remote_spec = format!(
+        "@{}/{}",
+        synced.remote_path.trim_end_matches('/'),
+        spec.filename
+    );
+    let entry = workspace_mapping_entry(spec.role, &synced);
     Ok(Some((remote_spec, entry)))
-}
-
-fn looks_like_inline_json(spec: &str) -> bool {
-    let trimmed = spec.trim_start();
-    trimmed.starts_with('{') || trimmed.starts_with('[')
 }
 
 pub(super) fn mirror_agent_task_run_plan_lifecycle(args: &[String], stdout: &str) -> Result<()> {
@@ -537,7 +443,7 @@ fn agent_task_run_plan_recording_args(args: &[String]) -> Option<(String, String
 
 pub(super) fn agent_task_dispatch_requested_run_id(args: &[String]) -> Option<String> {
     let invocation = CommandInvocation::for_subcommand(args, "agent-task")?;
-    let action_index = invocation.child_index_matching(&["cook"])?;
+    let action_index = invocation.child_index_matching(&["cook", "dispatch"])?;
     invocation
         .option_value_after(action_index, "--run-id")
         .map(str::to_string)
@@ -556,7 +462,7 @@ pub(super) fn ensure_agent_task_dispatch_run_id_with(
     preferred: Option<&str>,
 ) -> Option<(Vec<String>, String)> {
     let invocation = CommandInvocation::for_subcommand(args, "agent-task")?;
-    let action_index = invocation.child_index_matching(&["cook"])?;
+    let action_index = invocation.child_index_matching(&["cook", "dispatch"])?;
 
     if let Some(run_id) = agent_task_dispatch_requested_run_id(args) {
         return Some((args.to_vec(), run_id));

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -36,11 +36,10 @@ use super::super::execution::{
 };
 use super::super::lab_apply::apply_lab_offload_patch;
 use super::super::lab_args::{
-    inject_agent_task_default_provider_config_in_args, inline_agent_task_prompt_files_in_args,
-    lab_at_file_specs, lab_offload_source_path, remap_agent_task_plan_in_args,
-    remap_lab_at_file_args, remap_path_settings_in_args, remap_provider_config_in_args,
-    rewrite_lab_offload_args, rewrite_runner_resident_lab_offload_args, LabAtFileSpec,
-    LabPathRemap,
+    inject_agent_task_default_provider_config_in_args, lab_at_file_specs, lab_offload_source_path,
+    materialize_agent_task_specs_in_args, remap_lab_at_file_args, remap_path_settings_in_args,
+    remap_provider_config_in_args, rewrite_lab_offload_args,
+    rewrite_runner_resident_lab_offload_args, LabAtFileSpec, LabPathRemap,
 };
 use super::super::lab_capabilities::lab_runner_capability_contract;
 use super::super::lab_command::lab_offload_command_prefix;
@@ -76,9 +75,8 @@ use super::super::{
 use super::super::workload::{build_runner_workload, RunnerWorkloadBuildInput};
 use super::agent_task_bridge::{
     agent_task_dispatch_run_isolation_token, ensure_agent_task_dispatch_run_id_with,
-    lab_pre_dispatch_failure_message, materialize_inline_agent_task_plan_arg,
-    materialize_inline_agent_task_tasks_arg, mirror_agent_task_run_plan_lifecycle,
-    parse_offloaded_agent_task_handoff_from_outputs,
+    lab_pre_dispatch_failure_message, mirror_agent_task_run_plan_lifecycle,
+    parse_offloaded_agent_task_handoff_from_outputs, sync_inline_agent_task_file,
 };
 use super::evidence::terminal_lab_run_evidence;
 use super::provider_preflight::preflight_agent_task_provider_on_runner;
@@ -1100,28 +1098,23 @@ fn prepare_lab_offload_workspace_stage(
         &remote_cwd,
     );
     let remapped_args = remap_provider_config_in_args(&remapped_args, &path_remaps);
-    let remapped_args =
-        remap_agent_task_plan_in_args(&remapped_args, &path_remaps, Path::new(&synced.local_path))?;
-    let remapped_args =
-        inline_agent_task_prompt_files_in_args(&remapped_args, Path::new(&synced.local_path))?;
+    let agent_task_specs = materialize_agent_task_specs_in_args(
+        &remapped_args,
+        &path_remaps,
+        Path::new(&synced.local_path),
+        |spec| sync_inline_agent_task_file(runner_id, spec),
+    )?;
+    let remapped_args = agent_task_specs.argv;
+    for synced_entry in agent_task_specs.workspace_entries {
+        plan = record_synced_remapped_workspace_entry(
+            plan,
+            &mut workspace_mapping,
+            Some(synced_entry.entry),
+            synced_entry.step_id,
+        );
+    }
     let remapped_args = remap_path_settings_in_args(&remapped_args, &path_remaps);
     let remapped_args = remap_lab_at_file_args(&remapped_args, &at_file_specs);
-    let (remapped_args, synced_remapped_tasks) =
-        materialize_inline_agent_task_tasks_arg(runner_id, &remapped_args)?;
-    plan = record_synced_remapped_workspace_entry(
-        plan,
-        &mut workspace_mapping,
-        synced_remapped_tasks,
-        "lab.sync_remapped_agent_task_tasks",
-    );
-    let (remapped_args, synced_remapped_plan) =
-        materialize_inline_agent_task_plan_arg(runner_id, &remapped_args)?;
-    plan = record_synced_remapped_workspace_entry(
-        plan,
-        &mut workspace_mapping,
-        synced_remapped_plan,
-        "lab.sync_remapped_agent_task_plan",
-    );
     let (remapped_args, agent_task_run_id) =
         ensure_agent_task_dispatch_run_id_with(&remapped_args, run_isolation_token.as_deref())
             .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));

--- a/src/core/runner/lab_args/agent_task_specs.rs
+++ b/src/core/runner/lab_args/agent_task_specs.rs
@@ -19,6 +19,68 @@ use super::path_remap::{
     order_mappings_by_specificity, remap_paths_in_value, try_rewrite_flag_value_args, LabPathRemap,
 };
 
+pub(in crate::core::runner) struct AgentTaskSpecMaterialization<T> {
+    pub(in crate::core::runner) argv: Vec<String>,
+    pub(in crate::core::runner) workspace_entries: Vec<AgentTaskSpecWorkspaceEntry<T>>,
+}
+
+pub(in crate::core::runner) struct AgentTaskSpecWorkspaceEntry<T> {
+    pub(in crate::core::runner) step_id: &'static str,
+    pub(in crate::core::runner) entry: T,
+}
+
+pub(in crate::core::runner) struct AgentTaskInlineJsonSpec<'a> {
+    pub(in crate::core::runner) spec: &'a str,
+    pub(in crate::core::runner) filename: &'static str,
+    pub(in crate::core::runner) role: &'static str,
+}
+
+pub(in crate::core::runner) fn materialize_agent_task_specs_in_args<T>(
+    args: &[String],
+    mappings: &[LabPathRemap],
+    source_path: &Path,
+    mut sync_inline_json: impl FnMut(AgentTaskInlineJsonSpec<'_>) -> Result<Option<(String, T)>>,
+) -> Result<AgentTaskSpecMaterialization<T>> {
+    let remapped_args = remap_agent_task_plan_in_args(args, mappings, source_path)?;
+    let remapped_args = inline_agent_task_prompt_files_in_args(&remapped_args, source_path)?;
+    let (argv, workspace_entries) =
+        materialize_inline_agent_task_json_specs_in_args(&remapped_args, |spec| {
+            sync_inline_json(spec)
+        })?;
+
+    Ok(AgentTaskSpecMaterialization {
+        argv,
+        workspace_entries,
+    })
+}
+
+pub(in crate::core::runner) fn materialize_inline_agent_task_json_specs_in_args<T>(
+    args: &[String],
+    mut sync_inline_json: impl FnMut(AgentTaskInlineJsonSpec<'_>) -> Result<Option<(String, T)>>,
+) -> Result<(Vec<String>, Vec<AgentTaskSpecWorkspaceEntry<T>>)> {
+    let (args, task_entry) = materialize_inline_json_option(
+        args,
+        agent_task_subcommand_is(args, &["dispatch", "cook"]),
+        "--tasks",
+        "agent-task-tasks.json",
+        "agent_task_tasks_remapped",
+        "lab.sync_remapped_agent_task_tasks",
+        |spec| sync_inline_json(spec),
+    )?;
+    let (args, plan_entry) = materialize_inline_json_option(
+        &args,
+        agent_task_subcommand_is(&args, &["run-plan"]),
+        "--plan",
+        "agent-task-plan.json",
+        "agent_task_plan_remapped",
+        "lab.sync_remapped_agent_task_plan",
+        |spec| sync_inline_json(spec),
+    )?;
+
+    let workspace_entries = task_entry.into_iter().chain(plan_entry).collect();
+    Ok((args, workspace_entries))
+}
+
 pub(in crate::core::runner) fn remap_agent_task_plan_in_args(
     args: &[String],
     mappings: &[LabPathRemap],
@@ -195,4 +257,97 @@ fn read_agent_task_text_spec_to_inline(
         Some(spec.to_string()),
         Some(tried),
     ))
+}
+
+fn agent_task_subcommand_is(args: &[String], subcommands: &[&str]) -> bool {
+    subcommand_index(args, "agent-task")
+        .and_then(|index| args.get(index + 1))
+        .is_some_and(|arg| subcommands.iter().any(|subcommand| arg == subcommand))
+}
+
+fn subcommand_index(args: &[String], command: &str) -> Option<usize> {
+    args.iter().position(|arg| arg == command)
+}
+
+/// Scans `args` for a single `--flag <json>` / `--flag=<json>` occurrence and,
+/// when `in_context` and the supplied `sync` closure produce a remapped spec,
+/// rewrites that argument to point at the synced workspace file. Parsing stops
+/// at the `--` passthrough boundary; this is argv materialization only and does
+/// not interpret anything past `--`.
+fn materialize_inline_json_option<T>(
+    args: &[String],
+    in_context: bool,
+    flag: &'static str,
+    filename: &'static str,
+    role: &'static str,
+    step_id: &'static str,
+    mut sync: impl FnMut(AgentTaskInlineJsonSpec<'_>) -> Result<Option<(String, T)>>,
+) -> Result<(Vec<String>, Option<AgentTaskSpecWorkspaceEntry<T>>)> {
+    if !in_context {
+        return Ok((args.to_vec(), None));
+    }
+
+    let flag_eq = format!("{flag}=");
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+
+    while let Some(arg) = iter.next() {
+        if passthrough {
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == flag {
+            out.push(arg.clone());
+            if let Some(spec) = iter.next() {
+                if let Some((remapped_spec, entry)) =
+                    sync_inline_json_spec(spec, filename, role, &mut sync)?
+                {
+                    out.push(remapped_spec);
+                    out.extend(iter.cloned());
+                    return Ok((out, Some(AgentTaskSpecWorkspaceEntry { step_id, entry })));
+                }
+                out.push(spec.clone());
+            }
+            continue;
+        }
+        if let Some(spec) = arg.strip_prefix(&flag_eq) {
+            if let Some((remapped_spec, entry)) =
+                sync_inline_json_spec(spec, filename, role, &mut sync)?
+            {
+                out.push(format!("{flag}={remapped_spec}"));
+                out.extend(iter.cloned());
+                return Ok((out, Some(AgentTaskSpecWorkspaceEntry { step_id, entry })));
+            }
+        }
+        out.push(arg.clone());
+    }
+
+    Ok((out, None))
+}
+
+fn sync_inline_json_spec<T>(
+    spec: &str,
+    filename: &'static str,
+    role: &'static str,
+    sync: &mut impl FnMut(AgentTaskInlineJsonSpec<'_>) -> Result<Option<(String, T)>>,
+) -> Result<Option<(String, T)>> {
+    if spec == "-" || spec.starts_with('@') || !looks_like_inline_json(spec) {
+        return Ok(None);
+    }
+    sync(AgentTaskInlineJsonSpec {
+        spec,
+        filename,
+        role,
+    })
+}
+
+fn looks_like_inline_json(spec: &str) -> bool {
+    let trimmed = spec.trim_start();
+    trimmed.starts_with('{') || trimmed.starts_with('[')
 }

--- a/src/core/runner/lab_args/mod.rs
+++ b/src/core/runner/lab_args/mod.rs
@@ -25,9 +25,13 @@ mod tests;
 /// Lab offload rewriting can distinguish it from synthesized passthrough args.
 pub(super) const EXPLICIT_PASSTHROUGH_SENTINEL: &str = "__homeboy_explicit_passthrough__";
 
+#[cfg(test)]
+pub(super) use agent_task_specs::materialize_inline_agent_task_json_specs_in_args;
+#[cfg(test)]
 pub(super) use agent_task_specs::{
     inline_agent_task_prompt_files_in_args, remap_agent_task_plan_in_args,
 };
+pub(super) use agent_task_specs::{materialize_agent_task_specs_in_args, AgentTaskInlineJsonSpec};
 pub(super) use at_files::{lab_at_file_specs, remap_lab_at_file_args, LabAtFileSpec};
 pub(super) use offload::{
     lab_offload_source_path, rewrite_lab_offload_args, rewrite_runner_resident_lab_offload_args,

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -894,6 +894,80 @@ fn inline_agent_task_prompt_files_rejects_missing_file() {
 }
 
 #[test]
+fn materialize_agent_task_specs_syncs_inline_and_file_plan_json() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let plan = serde_json::json!({
+        "schema": "homeboy/agent-task-plan/v1",
+        "tasks": [{ "task_id": "task-1", "instructions": "test" }]
+    })
+    .to_string();
+    let plan_file = temp.path().join("plan.json");
+    std::fs::write(&plan_file, &plan).expect("write plan");
+
+    for spec in [plan, format!("@{}", plan_file.display())] {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            spec,
+        ];
+        let out = materialize_agent_task_specs_in_args(&args, &[], temp.path(), |spec| {
+            assert_eq!(spec.filename, "agent-task-plan.json");
+            assert_eq!(spec.role, "agent_task_plan_remapped");
+            Ok(Some((
+                "@/remote/agent-task-plan.json".to_string(),
+                spec.role,
+            )))
+        })
+        .expect("materialize plan");
+
+        assert_eq!(out.argv[4], "@/remote/agent-task-plan.json");
+        assert_eq!(out.workspace_entries.len(), 1);
+        assert_eq!(
+            out.workspace_entries[0].step_id,
+            "lab.sync_remapped_agent_task_plan"
+        );
+        assert_eq!(out.workspace_entries[0].entry, "agent_task_plan_remapped");
+    }
+}
+
+#[test]
+fn materialize_agent_task_specs_syncs_inline_and_file_tasks_json() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let tasks = serde_json::json!([{ "prompt": "Fix issue" }]).to_string();
+    let tasks_file = temp.path().join("tasks.json");
+    std::fs::write(&tasks_file, &tasks).expect("write tasks");
+
+    for spec in [tasks, format!("@{}", tasks_file.display())] {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--tasks".to_string(),
+            spec,
+        ];
+        let out = materialize_agent_task_specs_in_args(&args, &[], temp.path(), |spec| {
+            assert_eq!(spec.filename, "agent-task-tasks.json");
+            assert_eq!(spec.role, "agent_task_tasks_remapped");
+            Ok(Some((
+                "@/remote/agent-task-tasks.json".to_string(),
+                spec.role,
+            )))
+        })
+        .expect("materialize tasks");
+
+        assert_eq!(out.argv[4], "@/remote/agent-task-tasks.json");
+        assert_eq!(out.workspace_entries.len(), 1);
+        assert_eq!(
+            out.workspace_entries[0].step_id,
+            "lab.sync_remapped_agent_task_tasks"
+        );
+        assert_eq!(out.workspace_entries[0].entry, "agent_task_tasks_remapped");
+    }
+}
+
+#[test]
 fn remap_path_settings_rewrites_local_path_values() {
     let mappings = vec![LabPathRemap {
         local: "/Users/user/Developer/tool-runner".to_string(),


### PR DESCRIPTION
## Summary
- Add a shared Lab agent-task spec materializer for plan/task/prompt inputs
- Route offload and bridge inline JSON handling through the shared path
- Add materialization coverage for inline and file-backed `--plan` / `--tasks` inputs

## Tests
- cargo test --lib materialize_agent_task_specs
- cargo test --lib core::runner::lab::agent_task_bridge::tests
- cargo test --lib core::runner::lab_args::tests
- cargo check --lib
- git diff --check

Note: broad `cargo test --lib agent_task` has existing failures on clean origin/main. This branch fixes three Lab bridge failures from that broad set; scoped Lab materialization tests pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, verification, correction pass, and PR preparation