### PR TITLE
refactor(lab): extract offload fallback helpers

### DIFF
--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -26,6 +26,7 @@
 mod agent_task_bridge;
 mod args_util;
 mod evidence;
+mod fallback;
 mod offload;
 mod provider_preflight;
 pub(super) mod secrets;

--- a/src/core/runner/lab/fallback.rs
+++ b/src/core/runner/lab/fallback.rs
@@ -1,0 +1,72 @@
+//! Local-run fallback and unsupported-command diagnostics for Lab offload.
+
+use crate::core::plan::HomeboyPlan;
+use crate::core::runner::lab_offload_metadata;
+use crate::core::Error;
+
+use super::offload::LabOffloadOutcome;
+
+/// Build the `RunLocal` outcome used whenever automatic Lab offload is skipped
+/// for a portability/default-runner reason. Centralizes the repeated
+/// "automatic / skipped" metadata shape used by `execute_lab_offload`.
+pub(super) fn skipped_automatic_run_local(plan: HomeboyPlan, reason: &str) -> LabOffloadOutcome {
+    LabOffloadOutcome::RunLocal {
+        metadata: Some(lab_offload_metadata(
+            &plan,
+            "automatic",
+            None,
+            None,
+            "skipped",
+            None,
+            Some(reason),
+        )),
+        plan,
+        messages: Vec::new(),
+    }
+}
+
+pub(super) fn local_execution_denied_error(reason: &str, runner_id: Option<&str>) -> Error {
+    let mut hints = vec![
+        "Use --runner <runner-id> to offload to Lab.".to_string(),
+        "Remove --lab-only only when local execution on this controller is intentional."
+            .to_string(),
+    ];
+    if let Some(runner_id) = runner_id {
+        hints.insert(
+            0,
+            format!("Reconnect or repair runner `{runner_id}` before retrying."),
+        );
+    }
+    Error::validation_invalid_argument(
+        "lab_only",
+        format!("Lab-only execution refused local execution: {reason}"),
+        runner_id.map(str::to_string),
+        Some(hints),
+    )
+}
+
+pub(super) fn is_build_command(args: &[String]) -> bool {
+    args.get(1).is_some_and(|arg| arg == "build")
+}
+
+fn build_lab_replacement_hints(runner_id: Option<&str>) -> Vec<String> {
+    let runner = runner_id.unwrap_or("<runner-id>");
+    vec![
+        format!(
+            "Materialize the build workspace first: homeboy runner workspace sync {runner} --path <local-worktree> --mode snapshot"
+        ),
+        format!(
+            "Then run the build in the returned runner_path: homeboy runner exec {runner} --cwd <runner_path> -- homeboy build <component>"
+        ),
+    ]
+}
+
+pub(super) fn unsupported_build_lab_error(field: &'static str, runner_id: Option<&str>) -> Error {
+    Error::validation_invalid_argument(
+        field,
+        "homeboy build is not Lab-portable yet; it requires an explicit runner workspace sync and runner exec handoff instead of --runner/--lab-only on build."
+            .to_string(),
+        runner_id.map(str::to_string),
+        Some(build_lab_replacement_hints(runner_id)),
+    )
+}

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -79,6 +79,10 @@ use super::agent_task_bridge::{
     parse_offloaded_agent_task_handoff_from_outputs, sync_inline_agent_task_file,
 };
 use super::evidence::terminal_lab_run_evidence;
+use super::fallback::{
+    is_build_command, local_execution_denied_error, skipped_automatic_run_local,
+    unsupported_build_lab_error,
+};
 use super::provider_preflight::preflight_agent_task_provider_on_runner;
 use super::secrets::{build_lab_secret_env_handoff_plan, preflight_agent_task_runner_secret_env};
 use super::trace_fetch_refs::lab_offload_git_fetch_refs;
@@ -168,71 +172,6 @@ fn record_synced_remapped_workspace_entry(
         PlanStep::ready(step_id, step_id)
             .inputs(PlanValues::new().json("workspace", &entry))
             .build(),
-    )
-}
-
-/// Build the `RunLocal` outcome used whenever automatic Lab offload is skipped
-/// for a portability/default-runner reason. Centralizes the repeated
-/// "automatic / skipped" metadata shape used by `execute_lab_offload`.
-fn skipped_automatic_run_local(plan: HomeboyPlan, reason: &str) -> LabOffloadOutcome {
-    LabOffloadOutcome::RunLocal {
-        metadata: Some(lab_offload_metadata(
-            &plan,
-            "automatic",
-            None,
-            None,
-            "skipped",
-            None,
-            Some(reason),
-        )),
-        plan,
-        messages: Vec::new(),
-    }
-}
-
-fn local_execution_denied_error(reason: &str, runner_id: Option<&str>) -> Error {
-    let mut hints = vec![
-        "Use --runner <runner-id> to offload to Lab.".to_string(),
-        "Remove --lab-only only when local execution on this controller is intentional."
-            .to_string(),
-    ];
-    if let Some(runner_id) = runner_id {
-        hints.insert(
-            0,
-            format!("Reconnect or repair runner `{runner_id}` before retrying."),
-        );
-    }
-    Error::validation_invalid_argument(
-        "lab_only",
-        format!("Lab-only execution refused local execution: {reason}"),
-        runner_id.map(str::to_string),
-        Some(hints),
-    )
-}
-
-fn is_build_command(args: &[String]) -> bool {
-    args.get(1).is_some_and(|arg| arg == "build")
-}
-
-fn build_lab_replacement_hints(runner_id: Option<&str>) -> Vec<String> {
-    let runner = runner_id.unwrap_or("<runner-id>");
-    vec![
-        format!(
-            "Materialize the build workspace first: homeboy runner workspace sync {runner} --path <local-worktree> --mode snapshot"
-        ),
-        format!(
-            "Then run the build in the returned runner_path: homeboy runner exec {runner} --cwd <runner_path> -- homeboy build <component>"
-        ),
-    ]
-}
-
-fn unsupported_build_lab_error(field: &'static str, runner_id: Option<&str>) -> Error {
-    Error::validation_invalid_argument(
-        field,
-        "homeboy build is not Lab-portable yet; it requires an explicit runner workspace sync and runner exec handoff instead of --runner/--lab-only on build."
-            .to_string(),
-        runner_id.map(str::to_string),
-        Some(build_lab_replacement_hints(runner_id)),
     )
 }
 


### PR DESCRIPTION
## Summary
- Move local Lab fallback and unsupported build diagnostics helpers out of the giant offload module.
- Keep helper visibility scoped to the Lab module.
- Preserve existing behavior.

## Verification
- `cargo test --lib build_runner_error_gives_managed_runner_replacement`
- `cargo test --lib build_lab_only_error_gives_managed_runner_replacement`
- `cargo test --lib lab_only_refuses_local_execution_without_lab_contract`
- `cargo test --lib plan_records_skipped_auto_offload`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the bounded refactor and verification.