### PR TITLE
fix(lab): fail invalid provider config specs locally

### DIFF
--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -1097,7 +1097,7 @@ fn prepare_lab_offload_workspace_stage(
         &offload_args,
         &remote_cwd,
     );
-    let remapped_args = remap_provider_config_in_args(&remapped_args, &path_remaps);
+    let remapped_args = remap_provider_config_in_args(&remapped_args, &path_remaps)?;
     let agent_task_specs = materialize_agent_task_specs_in_args(
         &remapped_args,
         &path_remaps,

--- a/src/core/runner/lab_args/envelope.rs
+++ b/src/core/runner/lab_args/envelope.rs
@@ -5,7 +5,7 @@
 //! rewrite helpers can consume the typed refs one path at a time while preserving
 //! the exact argv output they already produced.
 
-use super::path_remap::{rewrite_flag_value_args, try_rewrite_flag_value_args};
+use super::path_remap::try_rewrite_flag_value_args;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::core::runner) struct ExecutionEnvelope {
@@ -85,23 +85,24 @@ impl ExecutionEnvelope {
         }
     }
 
-    pub fn rewrite_provider_config_values(
+    pub fn try_rewrite_provider_config_values(
         &self,
-        mut rewrite: impl FnMut(&str) -> String,
-    ) -> Vec<String> {
-        rewrite_flag_value_args(&self.argv, |arg, iter, out| {
+        mut rewrite: impl FnMut(&str) -> crate::core::Result<String>,
+    ) -> crate::core::Result<Vec<String>> {
+        try_rewrite_flag_value_args(&self.argv, |arg, iter, out| {
             if arg == "--provider-config" {
                 out.push(arg.to_string());
                 if let Some(spec) = iter.next() {
-                    out.push(rewrite(spec));
+                    out.push(rewrite(spec)?);
                 }
-                return;
+                return Ok(());
             }
             if let Some(spec) = arg.strip_prefix("--provider-config=") {
-                out.push(format!("--provider-config={}", rewrite(spec)));
-                return;
+                out.push(format!("--provider-config={}", rewrite(spec)?));
+                return Ok(());
             }
             out.push(arg.to_string());
+            Ok(())
         })
     }
 

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -28,7 +28,7 @@ use super::path_remap::{remap_paths_in_value, LabPathRemap};
 pub(in crate::core::runner) fn remap_provider_config_in_args(
     args: &[String],
     mappings: &[LabPathRemap],
-) -> Vec<String> {
+) -> Result<Vec<String>> {
     let envelope = ExecutionEnvelope::from_args(args);
     // NOTE: do not early-return on empty mappings. A `--provider-config @file`
     // (or `-` stdin) spec must always be inlined to JSON before offload, because
@@ -47,7 +47,7 @@ pub(in crate::core::runner) fn remap_provider_config_in_args(
         )
     });
 
-    envelope.rewrite_provider_config_values(|spec| remap_provider_config_spec(spec, &ordered))
+    envelope.try_rewrite_provider_config_values(|spec| remap_provider_config_spec(spec, &ordered))
 }
 
 pub(in crate::core::runner) fn inject_agent_task_default_provider_config_in_args(
@@ -113,9 +113,10 @@ fn is_agent_task_dispatch_or_cook(args: &[String]) -> bool {
 /// mappings to apply; otherwise it is returned verbatim so behavior is never
 /// worse than passing the original argument through.
 ///
-/// If a `@file`/`-` spec cannot be read or parsed, the original spec is returned
-/// (the remote read will then surface the original, actionable error).
-fn remap_provider_config_spec(spec: &str, mappings: &[&LabPathRemap]) -> String {
+/// If a `@file`/`-` spec cannot be read or parsed, Lab offload fails locally with
+/// an actionable validation error instead of forwarding a controller-local spec
+/// to the remote runner.
+fn remap_provider_config_spec(spec: &str, mappings: &[&LabPathRemap]) -> Result<String> {
     let needs_inlining = is_provider_config_file_spec(spec);
 
     // Even with no mappings, an inline-JSON spec may carry stale controller-local
@@ -124,20 +125,41 @@ fn remap_provider_config_spec(spec: &str, mappings: &[&LabPathRemap]) -> String 
     // verbatim and breaks remote recipe validation, so we cannot early-return
     // here just because there is nothing to remap.
     if !needs_inlining && mappings.is_empty() && !spec_has_provider_plugin_paths(spec) {
-        return spec.to_string();
+        return Ok(spec.to_string());
     }
 
     let raw = match read_json_spec_to_string(spec) {
         Ok(raw) => raw,
-        Err(_) => return spec.to_string(),
+        Err(err) if needs_inlining => {
+            return Err(Error::validation_invalid_argument(
+                "provider-config",
+                "failed to read Lab offload --provider-config @file/- input",
+                Some(err.to_string()),
+                None,
+            )
+            .with_hint(
+                "Lab offload reads --provider-config @file/- specs on the controller before dispatch; provide a readable JSON file or inline JSON.",
+            ));
+        }
+        Err(_) => return Ok(spec.to_string()),
     };
     let mut value: Value = match serde_json::from_str(&raw) {
         Ok(value) => value,
-        Err(_) => return spec.to_string(),
+        Err(err) if needs_inlining => {
+            return Err(Error::validation_invalid_json(
+                err,
+                Some("parse Lab offload --provider-config @file/- input".to_string()),
+                Some(raw),
+            )
+            .with_hint(
+                "Lab offload inlines --provider-config @file/- specs before dispatch; fix the JSON or pass valid inline JSON.",
+            ));
+        }
+        Err(_) => return Ok(spec.to_string()),
     };
     remap_paths_in_value(&mut value, mappings);
     prune_unresolved_provider_plugin_paths(&mut value, mappings);
-    serde_json::to_string(&value).unwrap_or_else(|_| spec.to_string())
+    Ok(serde_json::to_string(&value).unwrap_or_else(|_| spec.to_string()))
 }
 
 /// Cheap pre-check so a plain inline-JSON spec with no mappings is only fully

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -196,7 +196,7 @@ fn remap_inlines_and_rewrites_provider_config_local_paths() {
         "fix it".to_string(),
     ];
 
-    let out = remap_provider_config_in_args(&args, &mappings);
+    let out = remap_provider_config_in_args(&args, &mappings).expect("remap provider config");
     let cfg_idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
     let remapped: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("inline json");
 
@@ -251,7 +251,7 @@ fn remap_prunes_stale_unresolved_provider_plugin_path() {
         config,
     ];
 
-    let out = remap_provider_config_in_args(&args, &mappings);
+    let out = remap_provider_config_in_args(&args, &mappings).expect("remap provider config");
     let cfg_idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
     let remapped: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("inline json");
 
@@ -290,7 +290,7 @@ fn remap_prunes_all_provider_plugin_paths_when_no_mappings() {
         config,
     ];
 
-    let out = remap_provider_config_in_args(&args, &[]);
+    let out = remap_provider_config_in_args(&args, &[]).expect("remap provider config");
     let cfg_idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
     let remapped: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("inline json");
 
@@ -325,7 +325,7 @@ fn remap_preserves_relative_and_materialized_provider_plugin_paths() {
         config,
     ];
 
-    let out = remap_provider_config_in_args(&args, &[]);
+    let out = remap_provider_config_in_args(&args, &[]).expect("remap provider config");
     let cfg_idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
     let remapped: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("inline json");
 
@@ -403,7 +403,8 @@ fn injected_default_provider_config_is_remappable() {
                 local: "/Users/user/Developer/example-provider@oauth".to_string(),
                 remote: "/home/user/Developer/_lab_workspaces/example-provider@oauth".to_string(),
             }],
-        );
+        )
+        .expect("remap provider config");
         let cfg_idx = remapped
             .iter()
             .position(|arg| arg == "--provider-config")
@@ -455,7 +456,7 @@ fn remap_handles_provider_config_equals_form_and_no_mappings() {
         "cook".to_string(),
         "--provider-config={\"workspace_root\":\"/local/repo\"}".to_string(),
     ];
-    let out = remap_provider_config_in_args(&args, &mappings);
+    let out = remap_provider_config_in_args(&args, &mappings).expect("remap provider config");
     let val = out
         .iter()
         .find(|a| a.starts_with("--provider-config="))
@@ -464,7 +465,7 @@ fn remap_handles_provider_config_equals_form_and_no_mappings() {
     assert!(!val.contains("/local/repo"));
 
     // No mappings -> inline JSON spec untouched (nothing to remap, no @file).
-    let unchanged = remap_provider_config_in_args(&args, &[]);
+    let unchanged = remap_provider_config_in_args(&args, &[]).expect("remap provider config");
     assert_eq!(unchanged, args);
 }
 
@@ -493,7 +494,7 @@ fn remap_inlines_provider_config_at_file_without_mappings() {
     ];
 
     // No mappings on purpose: inlining must still happen.
-    let out = remap_provider_config_in_args(&args, &[]);
+    let out = remap_provider_config_in_args(&args, &[]).expect("remap provider config");
     let cfg_idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
     let spec = &out[cfg_idx];
 
@@ -508,6 +509,54 @@ fn remap_inlines_provider_config_at_file_without_mappings() {
     // Unrelated args preserved.
     assert!(out.iter().any(|a| a == "--prompt"));
     assert!(out.iter().any(|a| a == "fix it"));
+}
+
+#[test]
+fn remap_provider_config_missing_at_file_fails_locally() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let missing = temp.path().join("missing-provider-config.json");
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--provider-config".to_string(),
+        format!("@{}", missing.display()),
+    ];
+
+    let err = remap_provider_config_in_args(&args, &[]).expect_err("missing @file should fail");
+
+    assert!(err
+        .to_string()
+        .contains("Invalid argument 'provider-config'"));
+    assert!(
+        err.hints.iter().any(|hint| hint
+            .message
+            .contains("provide a readable JSON file or inline JSON")),
+        "missing actionable hint: {err:?}"
+    );
+}
+
+#[test]
+fn remap_provider_config_malformed_at_file_fails_locally() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let cfg = temp.path().join("malformed-provider-config.json");
+    std::fs::write(&cfg, r#"{"provider":"example-oauth""#).expect("write provider config");
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        format!("--provider-config=@{}", cfg.display()),
+    ];
+
+    let err = remap_provider_config_in_args(&args, &[]).expect_err("malformed @file should fail");
+
+    assert_eq!(err.to_string(), "Invalid JSON");
+    assert!(
+        err.hints.iter().any(|hint| hint
+            .message
+            .contains("fix the JSON or pass valid inline JSON")),
+        "missing actionable hint: {err:?}"
+    );
 }
 
 #[test]
@@ -533,7 +582,7 @@ fn remap_inlines_and_rewrites_provider_config_at_file_with_mappings() {
         format!("--provider-config=@{}", cfg.display()),
     ];
 
-    let out = remap_provider_config_in_args(&args, &mappings);
+    let out = remap_provider_config_in_args(&args, &mappings).expect("remap provider config");
     let val = out
         .iter()
         .find(|a| a.starts_with("--provider-config="))
@@ -559,7 +608,7 @@ fn remap_provider_config_inline_json_without_mappings_is_untouched() {
         "--provider-config".to_string(),
         r#"{"model":"claude-opus-4-8"}"#.to_string(),
     ];
-    let out = remap_provider_config_in_args(&args, &[]);
+    let out = remap_provider_config_in_args(&args, &[]).expect("remap provider config");
     assert_eq!(out, args);
 }
 
@@ -1029,7 +1078,7 @@ fn remap_does_not_match_sibling_path_prefixes() {
         "--provider-config".to_string(),
         serde_json::json!({ "p": "/a/bc/keep", "q": "/a/b/move" }).to_string(),
     ];
-    let out = remap_provider_config_in_args(&args, &mappings);
+    let out = remap_provider_config_in_args(&args, &mappings).expect("remap provider config");
     let idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
     let v: serde_json::Value = serde_json::from_str(&out[idx]).unwrap();
     assert_eq!(v["p"], "/a/bc/keep"); // sibling prefix untouched


### PR DESCRIPTION
## Summary
- Make Lab offload read/parse `--provider-config @file` and `-` specs on the controller before dispatch.
- Return actionable local validation errors for missing or malformed provider-config files.
- Preserve pass-through behavior for untouched inline JSON specs.

## Verification
- `cargo test --lib core::runner::lab_args::tests`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the bounded validation change, tests, and verification.