### PR TITLE
Gate fuzz reports on required artifacts

### DIFF
--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -542,7 +542,7 @@ mod tests {
         let summary = fuzz_coverage_completeness(&campaign);
 
         assert_eq!(gate_status(&gates), "failed");
-        assert_eq!(summary.has_summary, false);
+        assert!(!summary.has_summary);
         assert_eq!(summary.target_coverage_ratio, 0.0);
         assert_eq!(summary.operation_coverage_ratio, 0.0);
         assert!(gates.iter().any(|gate| {
@@ -1054,6 +1054,20 @@ mod tests {
         }
     }
 
+    fn artifact_complete_fuzz_campaign() -> FuzzCampaign {
+        let mut campaign = empty_fuzz_campaign();
+        campaign.coverage_summary = Some(zero_coverage_summary());
+        campaign.artifacts = vec![homeboy::core::fuzz::FuzzArtifact {
+            schema: homeboy::core::fuzz::FUZZ_ARTIFACT_SCHEMA.to_string(),
+            id: "case-log".to_string(),
+            kind: "case_log".to_string(),
+            artifact: None,
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        }];
+        campaign
+    }
+
     fn fuzz_run_args_with_run_id(run_id: &str) -> FuzzRunArgs {
         FuzzRunArgs {
             comp: PositionalComponentArgs {
@@ -1220,6 +1234,77 @@ mod tests {
     }
 
     #[test]
+    fn fuzz_report_fails_required_artifact_gate_when_replay_data_is_missing() {
+        with_isolated_home(|home| {
+            let results_path = home.path().join("fuzz-campaign.json");
+            std::fs::write(
+                &results_path,
+                serde_json::to_string(&artifact_complete_fuzz_campaign())
+                    .expect("serialize campaign"),
+            )
+            .expect("results file");
+
+            let output = run_report(FuzzReportArgs {
+                results_file: results_path,
+                run: fuzz_run_args_with_run_id("report-run-missing-replay"),
+                output_envelope: None,
+                envelope_id: None,
+            })
+            .expect("fuzz report");
+
+            assert_eq!(output.status, "failed");
+            assert!(output.gates.iter().any(|gate| {
+                gate.gate_id == "has-required-artifact-replay-data"
+                    && gate.status == "failed"
+                    && gate.observed == 0.0
+            }));
+            assert!(output.gates.iter().any(|gate| {
+                gate.gate_id == "has-required-artifact-result-envelope" && gate.status == "passed"
+            }));
+            assert_eq!(output.envelope.status, output.status);
+        });
+    }
+
+    #[test]
+    fn fuzz_report_passes_required_artifact_gates_with_seed_replay_data() {
+        with_isolated_home(|home| {
+            let mut campaign = artifact_complete_fuzz_campaign();
+            campaign.seeds = vec![homeboy::core::fuzz::FuzzSeed {
+                schema: homeboy::core::fuzz::FUZZ_SEED_SCHEMA.to_string(),
+                id: "seed-1".to_string(),
+                kind: "literal".to_string(),
+                label: None,
+                value: Some("seed-value".to_string()),
+                artifact: None,
+                tags: Vec::new(),
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            }];
+            let results_path = home.path().join("fuzz-campaign.json");
+            std::fs::write(
+                &results_path,
+                serde_json::to_string(&campaign).expect("serialize campaign"),
+            )
+            .expect("results file");
+
+            let output = run_report(FuzzReportArgs {
+                results_file: results_path,
+                run: fuzz_run_args_with_run_id("report-run-with-replay"),
+                output_envelope: None,
+                envelope_id: None,
+            })
+            .expect("fuzz report");
+
+            assert_eq!(output.status, "passed");
+            assert!(output.gates.iter().any(|gate| {
+                gate.gate_id == "has-required-artifact-replay-data"
+                    && gate.status == "passed"
+                    && gate.observed == 1.0
+            }));
+        });
+    }
+
+    #[test]
     fn fuzz_report_records_existing_output_envelope_path_as_artifact() {
         with_isolated_home(|home| {
             seed_fuzz_run("report-run-output");
@@ -1348,8 +1433,7 @@ mod tests {
             Some("replay-1")
         );
         assert!(output.env.iter().any(|env| {
-            env.name == "HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE"
-                && env.value == path.to_string_lossy().to_string()
+            env.name == "HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE" && env.value == path.to_string_lossy()
         }));
         assert!(output
             .env

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -35,9 +35,7 @@ pub(super) fn run_validate(args: FuzzValidateArgs) -> homeboy::core::Result<Fuzz
 
 pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzReportOutput> {
     let campaign = parse_fuzz_results_file(&args.results_file)?;
-    let gates = evaluate_fuzz_gates(&campaign);
     let coverage_completeness = fuzz_coverage_completeness(&campaign);
-    let status = gate_status(&gates);
     let run_id = args.run.run_id.clone();
     let component = args.run.comp.id().unwrap_or("unknown").to_string();
     let request_id = args
@@ -52,11 +50,11 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
         .or_else(|| args.run.run_id.clone())
         .unwrap_or_else(|| campaign.id.clone());
     let metadata = fuzz_result_metadata(args.run.inventory.as_deref())?;
-    let envelope = FuzzResultEnvelope {
+    let mut envelope = FuzzResultEnvelope {
         schema: FUZZ_RESULT_ENVELOPE_SCHEMA.to_string(),
         version: FUZZ_CONTRACT_VERSION,
         id: envelope_id,
-        status: status.clone(),
+        status: "pending".to_string(),
         request: FuzzExecutionRequest {
             schema: FUZZ_EXECUTION_REQUEST_SCHEMA.to_string(),
             version: FUZZ_CONTRACT_VERSION,
@@ -81,6 +79,9 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
         metadata,
         extra: std::collections::BTreeMap::new(),
     };
+    let gates = evaluate_fuzz_result_envelope_gates(&envelope);
+    let status = gate_status(&gates);
+    envelope.status = status.clone();
 
     if let Some(path) = args.output_envelope.as_ref() {
         let json = fuzz_result_envelope_json(&envelope)?;
@@ -222,6 +223,123 @@ pub(super) fn evaluate_fuzz_gates(campaign: &FuzzCampaign) -> Vec<FuzzGateEvalua
             }
         })
         .collect()
+}
+
+pub(super) fn evaluate_fuzz_result_envelope_gates(
+    envelope: &FuzzResultEnvelope,
+) -> Vec<FuzzGateEvaluation> {
+    let mut gates = envelope
+        .campaign
+        .as_ref()
+        .map(evaluate_fuzz_gates)
+        .unwrap_or_default();
+
+    gates.extend(
+        envelope
+            .required_artifacts
+            .iter()
+            .filter(|artifact| artifact.required)
+            .map(|artifact| {
+                let observed = required_artifact_count(envelope, artifact.kind.as_str()) as f64;
+                FuzzGateEvaluation {
+                    gate_id: format!("has-required-artifact-{}", artifact.id),
+                    status: if observed >= 1.0 { "passed" } else { "failed" }.to_string(),
+                    metric: format!("required_artifact:{}", artifact.kind),
+                    observed,
+                    expected: 1.0,
+                }
+            }),
+    );
+
+    gates
+}
+
+fn required_artifact_count(envelope: &FuzzResultEnvelope, kind: &str) -> usize {
+    match kind {
+        "result_envelope" => 1,
+        "case_log" => envelope
+            .campaign
+            .as_ref()
+            .map(|campaign| case_evidence_artifact_count(campaign, &FuzzGateProfile::default()))
+            .unwrap_or(0),
+        "coverage_summary" => {
+            usize::from(
+                envelope
+                    .campaign
+                    .as_ref()
+                    .and_then(|campaign| campaign.coverage_summary.as_ref())
+                    .is_some(),
+            ) + artifact_ref_count(envelope, kind)
+        }
+        "replay_data" => replay_data_count(envelope) + artifact_ref_count(envelope, kind),
+        _ => artifact_ref_count(envelope, kind),
+    }
+}
+
+fn replay_data_count(envelope: &FuzzResultEnvelope) -> usize {
+    let Some(campaign) = envelope.campaign.as_ref() else {
+        return 0;
+    };
+
+    usize::from(campaign.replay.is_some())
+        + campaign
+            .cases
+            .iter()
+            .filter(|case| case.replay_id.is_some() || !case.input.is_null())
+            .count()
+        + campaign
+            .seeds
+            .iter()
+            .filter(|seed| seed.value.is_some() || seed.artifact.is_some())
+            .count()
+}
+
+fn artifact_ref_count(envelope: &FuzzResultEnvelope, kind: &str) -> usize {
+    let envelope_artifacts = envelope
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.kind == kind)
+        .count();
+    let campaign_artifacts = envelope
+        .campaign
+        .as_ref()
+        .map(|campaign| {
+            campaign
+                .artifacts
+                .iter()
+                .filter(|artifact| artifact.kind == kind)
+                .count()
+                + metadata_artifact_kind_count(&campaign.metadata, kind)
+        })
+        .unwrap_or(0);
+
+    envelope_artifacts + campaign_artifacts + metadata_artifact_kind_count(&envelope.metadata, kind)
+}
+
+fn metadata_artifact_kind_count(metadata: &serde_json::Value, kind: &str) -> usize {
+    ["artifact_refs", "artifactRefs"]
+        .into_iter()
+        .map(|key| {
+            metadata
+                .get(key)
+                .and_then(|value| value.as_array())
+                .map(|artifacts| {
+                    artifacts
+                        .iter()
+                        .filter(|artifact| metadata_artifact_has_kind(artifact, kind))
+                        .count()
+                })
+                .unwrap_or(0)
+        })
+        .sum()
+}
+
+fn metadata_artifact_has_kind(artifact: &serde_json::Value, kind: &str) -> bool {
+    artifact
+        .get("kind")
+        .or_else(|| artifact.get("role"))
+        .and_then(|value| value.as_str())
+        == Some(kind)
 }
 
 struct FuzzGateProfile {


### PR DESCRIPTION
## Summary
- derive `fuzz report` status from result-envelope gates, not only campaign gates
- add required artifact checks for result envelope, case log, coverage summary, and replay data
- count replay data from replay metadata, case input/replay IDs, seeds, or artifact refs

## Testing
- `cargo fmt -- src/commands/fuzz/report.rs src/commands/fuzz/mod.rs`
- `cargo test commands::fuzz::tests::fuzz_report`

## Notes
- Broader `cargo clippy --lib --tests -- -D warnings` and full fuzz module tests had existing unrelated failures in this checkout.
- The worktree has unrelated local dirty files that are not included in this branch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing fuzz contract gaps, drafting the implementation, and running focused verification.