### PR TITLE
Run rig prepare pipeline for fuzz workloads

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -6,7 +6,7 @@ use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner, FuzzConfig};
 use homeboy::core::fuzz::{parse_fuzz_results_file, FuzzCampaign};
 use homeboy::core::observation::{ObservationStore, RunRecord, RunStatus};
-use homeboy::core::rig::{self, RigSpec};
+use homeboy::core::rig::{self, FuzzPrepareReport, RigSpec};
 
 use super::report::{evaluate_fuzz_gates, fuzz_coverage_completeness};
 use super::types::{
@@ -20,6 +20,18 @@ use super::workloads::{
 
 pub(super) fn run_run(args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput, i32)> {
     let rig_context = load_rig(args.rig.as_deref(), &args.setting_args)?;
+    if let Some(context) = rig_context.as_ref() {
+        let prepare_settings = fuzz_prepare_settings(&args);
+        if let Some(prepare) = rig::run_fuzz_prepare(&context.spec, &prepare_settings)? {
+            if !prepare.success {
+                return Err(homeboy::core::Error::rig_pipeline_failed(
+                    &context.spec.id,
+                    "fuzz_prepare",
+                    fuzz_prepare_failure_message(&prepare),
+                ));
+            }
+        }
+    }
     let effective_id = resolve_component_id(
         &args.comp,
         rig_context.as_ref().map(|context| &context.spec),
@@ -138,6 +150,44 @@ pub(super) fn run_run(args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput
         },
         exit_code,
     ))
+}
+
+fn fuzz_prepare_settings(args: &FuzzRunArgs) -> Vec<(String, String)> {
+    args.setting_args
+        .setting
+        .iter()
+        .cloned()
+        .chain(
+            args.setting_args
+                .setting_json
+                .iter()
+                .map(|(key, value)| (key.clone(), value.to_string())),
+        )
+        .collect()
+}
+
+fn fuzz_prepare_failure_message(prepare: &FuzzPrepareReport) -> String {
+    let failed_steps = prepare
+        .pipeline
+        .steps
+        .iter()
+        .filter(|step| step.status == "fail")
+        .map(|step| match step.error.as_deref() {
+            Some(error) if !error.is_empty() => {
+                format!("{} `{}` failed: {}", step.kind, step.label, error)
+            }
+            _ => format!("{} `{}` failed", step.kind, step.label),
+        })
+        .collect::<Vec<_>>();
+
+    if failed_steps.is_empty() {
+        "rig fuzz preparation failed; refusing to run fuzz workload".to_string()
+    } else {
+        format!(
+            "rig fuzz preparation failed; refusing to run fuzz workload. Failed fuzz_prepare steps: {}",
+            failed_steps.join("; ")
+        )
+    }
 }
 
 pub(super) struct FuzzRunOutcome {

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -52,9 +52,10 @@ pub use install::{
 pub use lease::{acquire_active_run_lease, active_run_leases, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
-    head_sha_and_branch, run_bench_prepare, run_check, run_check_groups, run_down, run_repair,
-    run_status, run_up, snapshot_state, BenchPrepareReport, CheckReport, DownReport, RepairReport,
-    RepairResourceReport, RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
+    head_sha_and_branch, run_bench_prepare, run_check, run_check_groups, run_down,
+    run_fuzz_prepare, run_repair, run_status, run_up, snapshot_state, BenchPrepareReport,
+    CheckReport, DownReport, FuzzPrepareReport, RepairReport, RepairResourceReport,
+    RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -60,6 +60,14 @@ pub struct BenchPrepareReport {
     pub success: bool,
 }
 
+/// Report from a fuzz preparation pipeline.
+#[derive(Debug, Clone, Serialize)]
+pub struct FuzzPrepareReport {
+    pub rig_id: String,
+    pub pipeline: PipelineOutcome,
+    pub success: bool,
+}
+
 /// Report from `rig down`.
 #[derive(Debug, Clone, Serialize)]
 pub struct DownReport {
@@ -270,6 +278,27 @@ pub fn run_bench_prepare(
 
     let outcome = run_pipeline_with_settings(rig, "bench_prepare", true, settings)?;
     Ok(Some(BenchPrepareReport {
+        rig_id: rig.id.clone(),
+        success: outcome.is_success(),
+        pipeline: outcome,
+    }))
+}
+
+/// Run rig-owned setup required before fuzz workloads.
+///
+/// Missing `fuzz_prepare` pipelines are a no-op so existing rigs keep their
+/// previous fuzz behavior. Declared steps fail fast because fuzz runs need the
+/// same prepared runtime dependencies as the workload they exercise.
+pub fn run_fuzz_prepare(
+    rig: &RigSpec,
+    settings: &[(String, String)],
+) -> Result<Option<FuzzPrepareReport>> {
+    if !rig.pipeline.contains_key("fuzz_prepare") {
+        return Ok(None);
+    }
+
+    let outcome = run_pipeline_with_settings(rig, "fuzz_prepare", true, settings)?;
+    Ok(Some(FuzzPrepareReport {
         rig_id: rig.id.clone(),
         success: outcome.is_success(),
         pipeline: outcome,


### PR DESCRIPTION
## Summary
- add a rig-owned fuzz_prepare phase mirroring bench_prepare behavior
- run fuzz_prepare after fuzz rig setting overlays and before workload selection/execution
- fail fuzz runs early with the failed prepare step details when runtime dependencies cannot be prepared

## Tests
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** diagnosing the Woo fuzz activation failure, drafting the generic fuzz_prepare support, and running verification