### PR TITLE
fix(fuzz): use generic campaign failure status

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -4,7 +4,8 @@ use homeboy::core::engine::execution_context;
 use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner, FuzzConfig};
-use homeboy::core::fuzz::{parse_fuzz_results_file, FuzzCampaign};
+use homeboy::core::fuzz::{parse_fuzz_results_file, FuzzCampaign, FuzzFindingStatus};
+use homeboy::core::lifecycle::LifecyclePhaseStatus;
 use homeboy::core::observation::{ObservationStore, RunRecord, RunStatus};
 use homeboy::core::rig::{self, FuzzPrepareReport, RigSpec};
 
@@ -202,8 +203,8 @@ pub(super) fn fuzz_run_outcome(
     results: Option<&FuzzCampaign>,
     results_error: Option<&str>,
 ) -> FuzzRunOutcome {
-    let nested_failed = results.is_some_and(fuzz_campaign_reports_failure);
-    let success = runner_success && !nested_failed && results_error.is_none();
+    let campaign_failed = results.is_some_and(fuzz_campaign_reports_failure);
+    let success = runner_success && !campaign_failed && results_error.is_none();
     FuzzRunOutcome {
         status: if success { "passed" } else { "failed" },
         success,
@@ -218,12 +219,19 @@ pub(super) fn fuzz_run_outcome(
 }
 
 fn fuzz_campaign_reports_failure(campaign: &FuzzCampaign) -> bool {
-    let nested_result_key = ["word", "press", "_fuzz_result"].concat();
     fuzz_metadata_reports_failure(&campaign.metadata)
-        || campaign
-            .metadata
-            .get(nested_result_key)
-            .is_some_and(fuzz_metadata_reports_failure)
+        || campaign.findings.iter().any(|finding| {
+            matches!(
+                finding.status,
+                FuzzFindingStatus::Open | FuzzFindingStatus::Confirmed
+            )
+        })
+        || campaign.lifecycle.as_ref().is_some_and(|lifecycle| {
+            lifecycle
+                .phases
+                .iter()
+                .any(|phase| phase.status == LifecyclePhaseStatus::Failed)
+        })
 }
 
 fn fuzz_metadata_reports_failure(value: &serde_json::Value) -> bool {

--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -180,7 +180,11 @@ mod tests {
     use clap::Parser;
     use homeboy::core::engine::run_dir::RunDir;
     use homeboy::core::extension::FuzzConfig;
-    use homeboy::core::fuzz::{FuzzCampaign, FuzzCoverageSummary};
+    use homeboy::core::fuzz::{FuzzCampaign, FuzzCoverageSummary, FuzzFinding, FuzzFindingStatus};
+    use homeboy::core::lifecycle::{
+        LifecyclePhaseKind, LifecyclePhaseResult, LifecyclePhaseStatus, LifecycleResultMetadata,
+        LIFECYCLE_CONTRACT_VERSION, LIFECYCLE_RESULT_SCHEMA,
+    };
     use homeboy::core::observation::{ObservationStore, RunRecord};
     use homeboy::core::rig::RigSpec;
     use homeboy::test_support::with_isolated_home;
@@ -1022,15 +1026,50 @@ mod tests {
     }
 
     #[test]
-    fn fuzz_run_outcome_fails_when_successful_command_reports_nested_runtime_error() {
+    fn fuzz_run_outcome_fails_when_successful_command_reports_open_finding() {
         let mut campaign = empty_fuzz_campaign();
-        let nested_result_key = ["word", "press", "_fuzz_result"].concat();
-        campaign.metadata = serde_json::json!({
-            nested_result_key: {
-                "status": "errored",
-                "success": false,
-                "case_counts": { "passed": 0, "failed": 0, "errored": 1 }
-            }
+        campaign.findings = vec![FuzzFinding {
+            schema: homeboy::core::fuzz::FUZZ_FINDING_SCHEMA.to_string(),
+            id: "finding-1".to_string(),
+            title: "runner surfaced a failing case".to_string(),
+            severity: "high".to_string(),
+            status: FuzzFindingStatus::Open,
+            surface_id: None,
+            target_id: None,
+            operation_id: None,
+            case_id: Some("case-1".to_string()),
+            workload_id: None,
+            seed_id: None,
+            fingerprint: None,
+            artifact_ids: Vec::new(),
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        }];
+
+        let outcome = fuzz_run_outcome(0, true, Some(&campaign), None);
+
+        assert_eq!(outcome.status, "failed");
+        assert!(!outcome.success);
+        assert_eq!(outcome.exit_code, 1);
+    }
+
+    #[test]
+    fn fuzz_run_outcome_fails_when_successful_command_reports_failed_lifecycle_phase() {
+        let mut campaign = empty_fuzz_campaign();
+        campaign.lifecycle = Some(LifecycleResultMetadata {
+            schema: LIFECYCLE_RESULT_SCHEMA.to_string(),
+            version: LIFECYCLE_CONTRACT_VERSION,
+            phases: vec![LifecyclePhaseResult {
+                id: "prepare".to_string(),
+                phase: LifecyclePhaseKind::Prepare,
+                status: LifecyclePhaseStatus::Failed,
+                snapshot_ref: None,
+                started_at: None,
+                finished_at: None,
+                message: Some("runtime prepare failed".to_string()),
+            }],
+            snapshot_refs: Vec::new(),
+            metadata: std::collections::BTreeMap::new(),
         });
 
         let outcome = fuzz_run_outcome(0, true, Some(&campaign), None);

--- a/src/commands/fuzz/workloads.rs
+++ b/src/commands/fuzz/workloads.rs
@@ -43,11 +43,7 @@ fn apply_fuzz_rig_setting_overrides(
         ))
     })?;
     for (key, raw) in &settings.setting {
-        apply_dotted_json_override(
-            &mut value,
-            key,
-            serde_json::Value::String(raw.clone()),
-        );
+        apply_dotted_json_override(&mut value, key, serde_json::Value::String(raw.clone()));
     }
     for (key, raw) in &settings.setting_json {
         apply_dotted_json_override(&mut value, key, raw.clone());
@@ -64,7 +60,10 @@ fn apply_fuzz_rig_setting_overrides(
 }
 
 fn apply_dotted_json_override(target: &mut serde_json::Value, key: &str, value: serde_json::Value) {
-    let parts = key.split('.').filter(|part| !part.is_empty()).collect::<Vec<_>>();
+    let parts = key
+        .split('.')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
     if parts.is_empty() {
         return;
     }
@@ -210,9 +209,9 @@ mod tests {
                     "path": "/workspace/stale/plugins/package",
                     "branch": "main",
                     "extensions": {
-                        "wordpress": {
-                            "wp_codebox_source_root": "/workspace/stale",
-                            "wp_codebox_source_subpath": "plugins/package"
+                        "generic-runtime": {
+                            "source_root": "/workspace/stale",
+                            "source_subpath": "packages/component"
                         }
                     }
                 }
@@ -226,7 +225,7 @@ mod tests {
                     "/workspace/current/plugins/package".to_string(),
                 ),
                 (
-                    "components.package.extensions.wordpress.wp_codebox_source_root".to_string(),
+                    "components.package.extensions.generic-runtime.source_root".to_string(),
                     "/workspace/current".to_string(),
                 ),
             ],
@@ -241,8 +240,8 @@ mod tests {
             component
                 .extensions
                 .as_ref()
-                .and_then(|extensions| extensions.get("wordpress"))
-                .and_then(|extension| extension.settings.get("wp_codebox_source_root"))
+                .and_then(|extensions| extensions.get("generic-runtime"))
+                .and_then(|extension| extension.settings.get("source_root"))
                 .and_then(serde_json::Value::as_str),
             Some("/workspace/current")
         );


### PR DESCRIPTION
## Summary
- Remove the WordPress-specific nested metadata failure hook from generic fuzz execution.
- Treat canonical fuzz findings and failed lifecycle phases as campaign failures when deriving fuzz run outcome.
- Neutralize a fuzz workload override fixture so the fuzz command product-neutrality guard covers this path.

## Tests
- `cargo test commands::fuzz` (fails on four existing unrelated fuzz test expectation mismatches: `fuzz_gate_evaluation_accepts_case_level_fuzz_report_evidence`, `fuzz_gate_evaluation_accepts_metadata_artifact_refs`, `select_workload_rejects_empty_fuzz_selection`, `select_workload_requires_explicit_id_for_ambiguous_fuzz_workloads`)
- `cargo test fuzz_run_outcome_fails_when_successful_command_reports_failed_campaign`
- `cargo test fuzz_run_outcome_fails_when_successful_command_reports_open_finding`
- `cargo test fuzz_run_outcome_fails_when_successful_command_reports_failed_lifecycle_phase`
- `cargo test fuzz_command_tests_keep_core_fixtures_product_neutral`
- `cargo test --test report_failure_digest_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the generic fuzz failure handling change, updating tests, running targeted verification, and drafting this PR description.
