### PR TITLE
feat(fuzz): execute replay commands

### DIFF
--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -43,7 +43,8 @@ pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
             Ok((FuzzOutput::Report(run_report(report_args)?), 0))
         }
         Some(FuzzCommand::Replay(replay_args)) => {
-            Ok((FuzzOutput::Replay(run_replay(replay_args)?), 0))
+            let (output, exit) = run_replay(replay_args)?;
+            Ok((FuzzOutput::Replay(output), exit))
         }
         None => {
             let (output, exit) = run_run(args.run)?;
@@ -184,6 +185,7 @@ mod tests {
     use homeboy::core::observation::{ObservationStore, RunRecord};
     use homeboy::core::rig::RigSpec;
     use homeboy::test_support::with_isolated_home;
+    use std::fs;
     use std::path::{Path, PathBuf};
 
     #[derive(Parser)]
@@ -1380,6 +1382,8 @@ mod tests {
             "fuzz",
             "replay",
             "/tmp/fuzz-results.json",
+            "--component",
+            "component-a",
             "--case-id",
             "case-1",
             "--run-id",
@@ -1390,6 +1394,7 @@ mod tests {
 
         match cli.args.command {
             Some(FuzzCommand::Replay(replay)) => {
+                assert_eq!(replay.component.as_deref(), Some("component-a"));
                 assert_eq!(
                     replay.artifact_or_case.as_deref(),
                     Some("/tmp/fuzz-results.json")
@@ -1428,14 +1433,22 @@ mod tests {
         std::fs::write(&path, serde_json::to_string(&campaign).unwrap()).expect("write campaign");
 
         let output = run_replay(FuzzReplayArgs {
+            component: None,
+            path: None,
+            rig: None,
+            extension_override: ExtensionOverrideArgs::default(),
+            setting_args: SettingArgs::default(),
             artifact_or_case: Some(path.to_string_lossy().to_string()),
             artifact: None,
             case_id: Some("case-1".to_string()),
             run_id: Some("proof-1".to_string()),
+            dry_run: true,
             args: vec!["--runner-flag".to_string()],
         })
         .expect("resolve replay");
+        let (output, exit) = output;
 
+        assert_eq!(exit, 0);
         assert_eq!(output.status, "dry_run");
         assert_eq!(output.campaign_id.as_deref(), Some("campaign-1"));
         assert_eq!(output.case_id.as_deref(), Some("case-1"));
@@ -1455,6 +1468,165 @@ mod tests {
             .iter()
             .any(|env| { env.name == "HOMEBOY_FUZZ_REPLAY_SEED" && env.value == "1234" }));
         assert_eq!(output.passthrough_args, vec!["--runner-flag"]);
+    }
+
+    #[test]
+    fn fuzz_replay_executes_manifest_replay_command_with_env() {
+        with_isolated_home(|home| {
+            let component_dir = tempfile::tempdir().expect("component dir");
+            write_fuzz_extension(
+                home.path(),
+                "fixture-fuzz",
+                Some(
+                    r#"sh -c 'printf %s:%s:%s "$HOMEBOY_FUZZ_REPLAY_CASE_ID" "$HOMEBOY_FUZZ_REPLAY_SEED" "$1"' replay-runner {case}"#,
+                ),
+            );
+            write_fuzz_rig(
+                home,
+                "fixture-rig",
+                "component-a",
+                component_dir.path(),
+                "fixture-fuzz",
+            );
+            let path = write_replay_campaign(component_dir.path());
+
+            let (output, exit) = run_replay(FuzzReplayArgs {
+                component: Some("component-a".to_string()),
+                path: None,
+                rig: Some("fixture-rig".to_string()),
+                extension_override: ExtensionOverrideArgs::default(),
+                setting_args: SettingArgs::default(),
+                artifact_or_case: Some(path.to_string_lossy().to_string()),
+                artifact: None,
+                case_id: Some("case-1".to_string()),
+                run_id: Some("proof-1".to_string()),
+                dry_run: false,
+                args: vec!["--extra".to_string()],
+            })
+            .expect("execute replay");
+
+            assert_eq!(exit, 0);
+            assert_eq!(output.status, "passed");
+            assert!(output.replay_command.as_deref().unwrap().contains("case-1"));
+            assert!(output.env.iter().any(|env| {
+                env.name == "HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE"
+                    && env.value == path.to_string_lossy()
+            }));
+            let execution = output.execution.expect("execution");
+            assert_eq!(execution.extension_id, "fixture-fuzz");
+            assert_eq!(execution.stdout, "case-1:1234:case-1");
+        });
+    }
+
+    #[test]
+    fn fuzz_replay_reports_unsupported_when_manifest_has_no_replay_command() {
+        with_isolated_home(|home| {
+            let component_dir = tempfile::tempdir().expect("component dir");
+            write_fuzz_extension(home.path(), "fixture-fuzz", None);
+            write_fuzz_rig(
+                home,
+                "fixture-rig",
+                "component-a",
+                component_dir.path(),
+                "fixture-fuzz",
+            );
+            let path = write_replay_campaign(component_dir.path());
+
+            let (output, exit) = run_replay(FuzzReplayArgs {
+                component: Some("component-a".to_string()),
+                path: None,
+                rig: Some("fixture-rig".to_string()),
+                extension_override: ExtensionOverrideArgs::default(),
+                setting_args: SettingArgs::default(),
+                artifact_or_case: Some(path.to_string_lossy().to_string()),
+                artifact: None,
+                case_id: Some("case-1".to_string()),
+                run_id: Some("proof-1".to_string()),
+                dry_run: false,
+                args: Vec::new(),
+            })
+            .expect("resolve unsupported replay");
+
+            assert_eq!(exit, 1);
+            assert_eq!(output.status, "unsupported");
+            assert!(output
+                .message
+                .contains("does not declare fuzz.replay_command"));
+            assert!(output.execution.is_none());
+        });
+    }
+
+    fn write_fuzz_extension(home: &Path, id: &str, replay_command: Option<&str>) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        let mut fuzz = serde_json::json!({
+            "workloads": [{ "id": "replay-fixture" }]
+        });
+        if let Some(command) = replay_command {
+            fuzz["replay_command"] = serde_json::Value::String(command.to_string());
+        }
+        fs::write(
+            extension_dir.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": id,
+                "version": "0.0.0",
+                "fuzz": fuzz
+            })
+            .to_string(),
+        )
+        .expect("write fuzz extension manifest");
+    }
+
+    fn write_fuzz_rig(
+        home: &tempfile::TempDir,
+        rig_id: &str,
+        component_id: &str,
+        path: &Path,
+        extension_id: &str,
+    ) {
+        let rig_dir = home.path().join(".config/homeboy/rigs");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join(format!("{rig_id}.json")),
+            format!(
+                r#"{{
+                    "components": {{
+                        "{component_id}": {{
+                            "path": "{}",
+                            "extensions": {{ "{extension_id}": {{}} }}
+                        }}
+                    }},
+                    "fuzz": {{ "default_component": "{component_id}" }}
+                }}"#,
+                path.display()
+            ),
+        )
+        .expect("write fuzz rig");
+    }
+
+    fn write_replay_campaign(dir: &Path) -> PathBuf {
+        let path = dir.join("fuzz-results.json");
+        let campaign = serde_json::json!({
+            "schema": homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA,
+            "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+            "id": "campaign-1",
+            "safety_class": "read_only",
+            "cases": [
+                {
+                    "schema": homeboy::core::fuzz::FUZZ_CASE_SCHEMA,
+                    "id": "case-1",
+                    "replay_id": "replay-1"
+                }
+            ],
+            "replay": {
+                "schema": homeboy::core::fuzz::FUZZ_REPLAY_SCHEMA,
+                "id": "replay-1",
+                "seed": "1234",
+                "artifact_id": "case-artifact"
+            }
+        });
+        fs::write(&path, serde_json::to_string(&campaign).unwrap()).expect("write campaign");
+        path
     }
 
     #[test]

--- a/src/commands/fuzz/replay.rs
+++ b/src/commands/fuzz/replay.rs
@@ -1,13 +1,17 @@
 use std::path::{Path, PathBuf};
 
+use homeboy::core::engine::run_dir::RunDir;
+use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner};
 use homeboy::core::fuzz::{
     FuzzCampaign, FuzzReplayMetadata, FuzzResultEnvelope, FUZZ_CAMPAIGN_SCHEMA,
     FUZZ_RESULT_ENVELOPE_SCHEMA,
 };
 
-use super::types::{FuzzReplayArgs, FuzzReplayEnv, FuzzReplayOutput};
+use super::super::utils::args::PositionalComponentArgs;
+use super::types::{FuzzReplayArgs, FuzzReplayEnv, FuzzReplayExecution, FuzzReplayOutput};
+use super::workloads::{load_rig, resolve_component_id, resolve_fuzz_context};
 
-pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<FuzzReplayOutput> {
+pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
     let artifact_file = replay_artifact_path(&args);
     let positional_case = args.artifact_or_case.as_ref().and_then(|value| {
         if artifact_file.is_some() && !Path::new(value).exists() {
@@ -36,33 +40,237 @@ pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<FuzzRepl
         replay.as_ref(),
         args.run_id.as_ref(),
     );
+    let replay_context = resolve_replay_context(&args)?;
+    let replay_command = replay_context
+        .as_ref()
+        .and_then(|context| context.replay_command.clone())
+        .map(|command| render_replay_command(&command, &env, args.args.as_slice()));
 
-    let status = if artifact_file.is_some() {
-        "dry_run"
-    } else {
-        "needs_artifact"
+    if args.dry_run {
+        let status = if artifact_file.is_some() {
+            "dry_run"
+        } else {
+            "needs_artifact"
+        };
+
+        return Ok((
+            FuzzReplayOutput {
+                command: "fuzz.replay".to_string(),
+                status: status.to_string(),
+                message: replay_message(replay_command.as_ref(), true),
+                artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
+                campaign_id: resolved
+                    .as_ref()
+                    .and_then(|resolved| resolved.campaign_id.clone()),
+                envelope_id: resolved
+                    .as_ref()
+                    .and_then(|resolved| resolved.envelope_id.clone()),
+                case_id,
+                run_id: args.run_id,
+                replay,
+                env,
+                replay_command,
+                execution: None,
+                passthrough_args: args.args,
+                next_steps: replay_next_steps(true),
+            },
+            0,
+        ));
+    }
+
+    let Some(context) = replay_context else {
+        return Ok((FuzzReplayOutput {
+            command: "fuzz.replay".to_string(),
+            status: "unsupported".to_string(),
+            message: "Generic fuzz replay execution requires a component/rig extension context with fuzz.replay_command; use --dry-run to inspect metadata only."
+                .to_string(),
+            artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
+            campaign_id: resolved.as_ref().and_then(|resolved| resolved.campaign_id.clone()),
+            envelope_id: resolved.as_ref().and_then(|resolved| resolved.envelope_id.clone()),
+            case_id,
+            run_id: args.run_id,
+            replay,
+            env,
+            replay_command: None,
+            execution: None,
+            passthrough_args: args.args,
+            next_steps: replay_next_steps(false),
+        }, 1));
     };
 
-    Ok(FuzzReplayOutput {
-        command: "fuzz.replay".to_string(),
-        status: status.to_string(),
-        message: "Generic fuzz replay resolves replay metadata and prints the extension-owned execution contract; it does not execute local fuzz code without a component/extension context."
-            .to_string(),
-        artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
-        campaign_id: resolved.as_ref().and_then(|resolved| resolved.campaign_id.clone()),
-        envelope_id: resolved.as_ref().and_then(|resolved| resolved.envelope_id.clone()),
-        case_id,
-        run_id: args.run_id,
-        replay,
-        env,
-        passthrough_args: args.args,
-        next_steps: vec![
-            "Pass the reported HOMEBOY_FUZZ_REPLAY_* values to the originating extension replay runner."
-                .to_string(),
-            "Use `homeboy runs artifacts <run-id>` to locate persisted fuzz evidence when a runner records it."
-                .to_string(),
-        ],
-    })
+    let Some(command) = replay_command.clone() else {
+        return Ok((FuzzReplayOutput {
+            command: "fuzz.replay".to_string(),
+            status: "unsupported".to_string(),
+            message: format!(
+                "Extension '{}' does not declare fuzz.replay_command; replay execution is unsupported for this context.",
+                context.execution_context.extension_id
+            ),
+            artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
+            campaign_id: resolved.as_ref().and_then(|resolved| resolved.campaign_id.clone()),
+            envelope_id: resolved.as_ref().and_then(|resolved| resolved.envelope_id.clone()),
+            case_id,
+            run_id: args.run_id,
+            replay,
+            env,
+            replay_command: None,
+            execution: None,
+            passthrough_args: args.args,
+            next_steps: replay_next_steps(false),
+        }, 1));
+    };
+
+    let run_dir = RunDir::create()?;
+    let mut runner = ExtensionRunner::for_context(context.execution_context.clone())
+        .component(context.component)
+        .settings(&args.setting_args.setting)
+        .settings_json(&args.setting_args.setting_json)
+        .path_override(args.path.clone())
+        .with_run_dir(&run_dir)
+        .command_override(command.clone())
+        .passthrough(false);
+    for item in &env {
+        runner = runner.env(&item.name, &item.value);
+    }
+    let output = runner.run()?;
+    let exit_code = if output.success { 0 } else { output.exit_code };
+
+    Ok((
+        FuzzReplayOutput {
+            command: "fuzz.replay".to_string(),
+            status: if output.success { "passed" } else { "failed" }.to_string(),
+            message: replay_message(Some(&command), false),
+            artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
+            campaign_id: resolved
+                .as_ref()
+                .and_then(|resolved| resolved.campaign_id.clone()),
+            envelope_id: resolved
+                .as_ref()
+                .and_then(|resolved| resolved.envelope_id.clone()),
+            case_id,
+            run_id: args.run_id,
+            replay,
+            env,
+            replay_command: Some(command),
+            execution: Some(FuzzReplayExecution {
+                kind: "fuzz_replay".to_string(),
+                extension_id: context.execution_context.extension_id,
+                exit_code: output.exit_code,
+                success: output.success,
+                run_dir: run_dir.path().to_string_lossy().to_string(),
+                stdout: output.stdout,
+                stderr: output.stderr,
+            }),
+            passthrough_args: args.args,
+            next_steps: replay_next_steps(false),
+        },
+        exit_code,
+    ))
+}
+
+#[derive(Clone)]
+struct ResolvedReplayContext {
+    execution_context: homeboy::core::extension::ExtensionExecutionContext,
+    component: homeboy::core::component::Component,
+    replay_command: Option<String>,
+}
+
+fn resolve_replay_context(
+    args: &FuzzReplayArgs,
+) -> homeboy::core::Result<Option<ResolvedReplayContext>> {
+    let comp = replay_component_args(args);
+    if comp.id().is_none() && args.rig.is_none() {
+        return Ok(None);
+    }
+
+    let rig_context = load_rig(args.rig.as_deref(), &args.setting_args)?;
+    let effective_id =
+        resolve_component_id(&comp, rig_context.as_ref().map(|context| &context.spec))?;
+    let ctx = resolve_fuzz_context(
+        &effective_id,
+        &comp,
+        &args.setting_args,
+        &args.extension_override,
+        ExtensionCapability::Fuzz,
+        rig_context.as_ref(),
+    )?;
+    let execution_context =
+        extension::resolve_execution_context(&ctx.component, ExtensionCapability::Fuzz)?;
+    let replay_command = extension::load_extension(&execution_context.extension_id)
+        .ok()
+        .and_then(|manifest| manifest.fuzz)
+        .and_then(|fuzz| fuzz.replay_command);
+
+    Ok(Some(ResolvedReplayContext {
+        execution_context,
+        component: ctx.component,
+        replay_command,
+    }))
+}
+
+fn replay_component_args(args: &FuzzReplayArgs) -> PositionalComponentArgs {
+    PositionalComponentArgs {
+        component: args.component.clone(),
+        path: args.path.clone(),
+    }
+}
+
+fn replay_message(command: Option<&String>, dry_run: bool) -> String {
+    match (command, dry_run) {
+        (Some(_), true) => "Generic fuzz replay resolved an extension replay_command and printed the execution environment without running it.".to_string(),
+        (Some(_), false) => "Generic fuzz replay executed the extension replay_command with canonical Homeboy fuzz replay environment.".to_string(),
+        (None, _) => "Generic fuzz replay resolved replay metadata and printed the extension-owned execution contract; no replay_command is available to execute.".to_string(),
+    }
+}
+
+fn replay_next_steps(dry_run: bool) -> Vec<String> {
+    if dry_run {
+        return vec![
+            "Run without --dry-run to execute the resolved extension replay_command.".to_string(),
+            "Use `homeboy runs artifacts <run-id>` to locate persisted fuzz evidence when a runner records it.".to_string(),
+        ];
+    }
+
+    vec![
+        "Inspect execution stdout/stderr in this replay result for runner-owned reproduction details.".to_string(),
+        "Use `homeboy runs artifacts <run-id>` to locate persisted fuzz evidence when a runner records it.".to_string(),
+    ]
+}
+
+fn render_replay_command(command: &str, env: &[FuzzReplayEnv], args: &[String]) -> String {
+    let mut rendered = command.to_string();
+    for (placeholder, env_name) in [
+        ("artifact", "HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE"),
+        ("artifact_file", "HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE"),
+        ("case", "HOMEBOY_FUZZ_REPLAY_CASE_ID"),
+        ("case_id", "HOMEBOY_FUZZ_REPLAY_CASE_ID"),
+        ("run_id", "HOMEBOY_FUZZ_REPLAY_RUN_ID"),
+        ("replay", "HOMEBOY_FUZZ_REPLAY_ID"),
+        ("replay_id", "HOMEBOY_FUZZ_REPLAY_ID"),
+        ("seed", "HOMEBOY_FUZZ_REPLAY_SEED"),
+        ("replay_seed", "HOMEBOY_FUZZ_REPLAY_SEED"),
+        ("replay_artifact_id", "HOMEBOY_FUZZ_REPLAY_ARTIFACT_ID"),
+    ] {
+        if let Some(value) = env_value(env, env_name) {
+            rendered = rendered.replace(
+                &format!("{{{placeholder}}}"),
+                &homeboy::core::engine::shell::quote_arg(value),
+            );
+        }
+    }
+
+    if !args.is_empty() {
+        rendered.push(' ');
+        rendered.push_str(&homeboy::core::engine::shell::quote_args(args));
+    }
+
+    rendered
+}
+
+fn env_value<'a>(env: &'a [FuzzReplayEnv], name: &str) -> Option<&'a str> {
+    env.iter()
+        .find(|item| item.name == name)
+        .map(|item| item.value.as_str())
 }
 
 #[derive(Clone, Debug)]
@@ -225,6 +433,7 @@ fn fuzz_replay_env(
     }
     if let Some(run_id) = run_id.filter(|run_id| !run_id.trim().is_empty()) {
         push_replay_env(&mut env, "HOMEBOY_FUZZ_RUN_ID", run_id.clone());
+        push_replay_env(&mut env, "HOMEBOY_FUZZ_REPLAY_RUN_ID", run_id.clone());
     }
     if let Some(replay) = replay {
         push_replay_env(&mut env, "HOMEBOY_FUZZ_REPLAY_ID", replay.id.clone());

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -159,6 +159,24 @@ pub(crate) struct FuzzReportArgs {
 
 #[derive(Args, Clone)]
 pub(crate) struct FuzzReplayArgs {
+    /// Component ID used to resolve the extension replay_command.
+    #[arg(long = "component", value_name = "ID")]
+    pub(crate) component: Option<String>,
+
+    /// Override the component checkout path for replay command execution.
+    #[arg(long)]
+    pub(crate) path: Option<String>,
+
+    /// Resolve replay through a rig's component path and extension config.
+    #[arg(long, value_name = "RIG_ID")]
+    pub(crate) rig: Option<String>,
+
+    #[command(flatten)]
+    pub(crate) extension_override: ExtensionOverrideArgs,
+
+    #[command(flatten)]
+    pub(crate) setting_args: SettingArgs,
+
     /// Fuzz campaign/result envelope path, or a case id when --artifact is used.
     #[arg(value_name = "ARTIFACT_OR_CASE")]
     pub(crate) artifact_or_case: Option<String>,
@@ -175,7 +193,11 @@ pub(crate) struct FuzzReplayArgs {
     #[arg(long = "run-id", value_name = "ID")]
     pub(crate) run_id: Option<String>,
 
-    /// Additional runner arguments reserved for future fuzz replay support.
+    /// Resolve replay metadata and command environment without executing replay_command.
+    #[arg(long = "dry-run")]
+    pub(crate) dry_run: bool,
+
+    /// Additional arguments passed to the extension replay command.
     #[arg(last = true)]
     pub(crate) args: Vec<String>,
 }
@@ -277,8 +299,21 @@ pub struct FuzzReplayOutput {
     pub run_id: Option<String>,
     pub replay: Option<FuzzReplayMetadata>,
     pub env: Vec<FuzzReplayEnv>,
+    pub replay_command: Option<String>,
+    pub execution: Option<FuzzReplayExecution>,
     pub passthrough_args: Vec<String>,
     pub next_steps: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct FuzzReplayExecution {
+    pub kind: String,
+    pub extension_id: String,
+    pub exit_code: i32,
+    pub success: bool,
+    pub run_dir: String,
+    pub stdout: String,
+    pub stderr: String,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary
- Execute `homeboy fuzz replay` through extension manifest `fuzz.replay_command` when a component/rig extension context resolves.
- Preserve metadata-only behavior behind `--dry-run` and return structured unsupported output when replay execution is unavailable.
- Pass canonical replay env vars and include replay command/execution details in the JSON output.
- Add targeted replay tests for CLI parsing, dry-run metadata, manifest command execution/env/output, and unsupported missing replay command.

## Tests
- `cargo test fuzz_replay --lib`
- `cargo test fuzz_campaign_contract_surfaces_extension_metadata --lib`
- `cargo test fuzz_manifest --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing executable fuzz replay orchestration, tests, and PR preparation.