### PR TITLE
Fail fuzz runs on workload invariant counters

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -244,7 +244,28 @@ fn fuzz_metadata_reports_failure(value: &serde_json::Value) -> bool {
         .get("case_counts")
         .is_some_and(|counts| json_u64(counts, "failed") > 0 || json_u64(counts, "errored") > 0);
 
-    status_failed || success_failed || case_failed
+    status_failed || success_failed || case_failed || metadata_failure_count_reports_failure(value)
+}
+
+fn metadata_failure_count_reports_failure(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(object) => object.iter().any(|(key, value)| {
+            (is_failure_count_key(key) && json_numeric_value(value).is_some_and(|count| count > 0.0))
+                || metadata_failure_count_reports_failure(value)
+        }),
+        serde_json::Value::Array(values) => values.iter().any(metadata_failure_count_reports_failure),
+        _ => false,
+    }
+}
+
+fn is_failure_count_key(key: &str) -> bool {
+    key == "failure_count" || key.ends_with("_failure_count")
+}
+
+fn json_numeric_value(value: &serde_json::Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|value| value.parse::<f64>().ok()))
 }
 
 fn json_u64(value: &serde_json::Value, key: &str) -> u64 {

--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -1161,6 +1161,39 @@ mod tests {
         assert_eq!(outcome.exit_code, 1);
     }
 
+    #[test]
+    fn fuzz_run_outcome_fails_when_workload_reports_invariant_failure_count() {
+        let mut campaign = empty_fuzz_campaign();
+        campaign.metadata = serde_json::json!({
+            "wordpress_fuzz_result": {
+                "status": "passed",
+                "success": true,
+                "cases": [
+                    {
+                        "status": "passed",
+                        "metadata": {
+                            "observations": [
+                                {
+                                    "payload": {
+                                        "metrics": {
+                                            "side_effect_invariant_failure_count": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        });
+
+        let outcome = fuzz_run_outcome(0, true, Some(&campaign), None);
+
+        assert_eq!(outcome.status, "failed");
+        assert!(!outcome.success);
+        assert_eq!(outcome.exit_code, 1);
+    }
+
     fn empty_fuzz_campaign() -> FuzzCampaign {
         FuzzCampaign {
             schema: homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA.to_string(),


### PR DESCRIPTION
## Summary
- recursively detect workload-reported numeric failure counters in fuzz result metadata
- fail otherwise-successful fuzz runs when counters such as side_effect_invariant_failure_count are greater than zero
- add regression coverage for nested WordPress fuzz result observations

## Tests
- cargo test fuzz_run_outcome_fails_when_workload_reports_invariant_failure_count
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** diagnosing missing fuzz gate behavior, drafting the generic invariant counter detection, and running verification