### PR TITLE
feat(fuzz): plan execution from target inventory

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -8,7 +8,7 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--max-duration <duration>] [-- <runner-args>]
 homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--max-duration <duration>] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
-homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>]
+homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>]
 homeboy fuzz validate <results-file>
 homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--inventory <path>] [--output-envelope <path>]
 homeboy fuzz compare <baseline-envelope> <candidate-envelope>
@@ -71,6 +71,25 @@ embeds it in generated result envelope metadata when reporting, and exposes the
 path to runners as `HOMEBOY_FUZZ_INVENTORY_FILE`. The inventory contract is
 product-neutral; product-specific details belong in `metadata` or flattened extra
 fields on the inventory items.
+
+`homeboy fuzz plan --inventory <path>` emits a
+`homeboy/fuzz-execution-request/v1` request in the command output. The request
+metadata includes the planner strategy, selected target ids, selected operation
+families, selected operation ids, seed/corpus refs, effective budgets, isolation
+requirements, required artifact ids, inventory provenance, and skipped target or
+operation reasons. The planner is product-neutral: it uses inventory-declared
+operation families and safety classes, not product-specific target names.
+
+Selection strategies are intentionally small. `all` selects supported
+non-destructive inventory operations. `read-only` selects read-like families,
+`crud` selects create/update/delete families, and `coverage-gaps` currently uses
+the same neutral selection surface as `all` while recording the requested
+strategy for downstream runners that can prioritize gaps. Repeat `--operation`
+to filter by operation id, operation kind, or canonical family. Repeat
+`--operation-family` to filter by canonical family. Unknown or non-canonical
+operation families are preserved in the inventory and reported under skipped
+operations with reason `unsupported`; destructive surfaces are skipped with
+reason `destructive`.
 
 Operations keep the free-form `kind` string for product-owned semantics and can
 also carry a canonical `family` for cross-runner coverage reporting. When

--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -15,15 +15,18 @@ pub use types::{
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::fuzz::{
     default_fuzz_gates, default_fuzz_required_artifacts, fuzz_core_contract, FuzzExecutionRequest,
+    FuzzOperation, FuzzOperationFamily, FuzzSafetyClass, FuzzTargetInventory,
     FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
 };
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::{CmdResult, GlobalArgs};
 use compare::run_compare;
 use execution::{default_runner_contract, run_run};
 use replay::run_replay;
 use report::{run_report, run_validate};
-use types::{FuzzCommand, FuzzListArgs, FuzzPlanArgs};
+use types::{FuzzCommand, FuzzListArgs, FuzzPlanArgs, FuzzPlanStrategy};
 use workloads::{
     build_target_inventory, fuzz_workloads, load_rig, resolve_component_id, resolve_fuzz_context,
     select_workload,
@@ -136,6 +139,7 @@ fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutput> {
         args.run.run_id.clone(),
         args.run.inventory.as_deref(),
     )?;
+    let planning_metadata = plan_inventory_selection(&args, &target_inventory)?;
 
     Ok(FuzzPlanOutput {
         command: "fuzz.plan".to_string(),
@@ -155,11 +159,324 @@ fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutput> {
             args: args.run.args,
             required_artifacts,
             gates,
-            metadata: serde_json::Value::Null,
+            metadata: planning_metadata,
             extra: std::collections::BTreeMap::new(),
         },
         runner_contract: default_runner_contract(),
     })
+}
+
+fn plan_inventory_selection(
+    args: &FuzzPlanArgs,
+    inventory: &FuzzTargetInventory,
+) -> homeboy::core::Result<serde_json::Value> {
+    let filters = operation_filters(args)?;
+    let workload = args.run.workload_id.as_deref().and_then(|id| {
+        inventory
+            .workloads
+            .iter()
+            .find(|workload| workload.id == id)
+    });
+    let workload_surface_ids = workload
+        .map(|workload| {
+            workload
+                .surface_ids
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    let workload_seed_ids = workload
+        .map(|workload| workload.seed_ids.iter().cloned().collect::<BTreeSet<_>>())
+        .unwrap_or_default();
+    let workload_operations = workload
+        .map(|workload| workload.operations.iter().cloned().collect::<BTreeSet<_>>())
+        .unwrap_or_default();
+    let surface_safety = inventory_surface_safety(inventory);
+
+    let mut selected_target_ids = BTreeSet::new();
+    let mut selected_families = BTreeSet::new();
+    let mut selected_operations = Vec::new();
+    let mut skipped_targets = Vec::new();
+    let mut skipped_operations = Vec::new();
+    let mut isolation_required = false;
+
+    for target in &inventory.targets {
+        let mut target_selected = false;
+        let target_operations = target
+            .operations
+            .iter()
+            .map(|operation| {
+                (
+                    operation,
+                    operation.target_id.as_deref().unwrap_or(&target.id),
+                )
+            })
+            .chain(inventory.surfaces.iter().flat_map(|surface| {
+                surface.operations.iter().filter_map(|operation| {
+                    let operation_target = operation
+                        .target_id
+                        .as_deref()
+                        .or(surface.target.as_deref())?;
+                    (operation_target == target.id).then_some((operation, operation_target))
+                })
+            }))
+            .collect::<Vec<_>>();
+
+        if target_operations.is_empty() {
+            skipped_targets.push(json!({
+                "id": target.id,
+                "reason": "unsupported",
+                "detail": "target declares no operations"
+            }));
+            continue;
+        }
+
+        for (operation, _) in target_operations {
+            let safety_class = surface_safety
+                .get(&target.id)
+                .copied()
+                .unwrap_or(FuzzSafetyClass::ReadOnly);
+            let family = operation.family;
+            let skip_reason = operation_skip_reason(
+                operation,
+                family,
+                safety_class,
+                args.strategy,
+                &filters,
+                &workload_operations,
+            );
+
+            if let Some(reason) = skip_reason {
+                skipped_operations.push(json!({
+                    "target_id": target.id,
+                    "operation_id": operation.id,
+                    "operation_kind": operation.kind,
+                    "reason": reason,
+                }));
+                continue;
+            }
+
+            target_selected = true;
+            selected_target_ids.insert(target.id.clone());
+            if let Some(family) = family {
+                selected_families.insert(operation_family_name(family));
+                if matches!(
+                    family,
+                    FuzzOperationFamily::Create
+                        | FuzzOperationFamily::Update
+                        | FuzzOperationFamily::Delete
+                        | FuzzOperationFamily::Submit
+                ) {
+                    isolation_required = true;
+                }
+            }
+            if matches!(
+                safety_class,
+                FuzzSafetyClass::Idempotent | FuzzSafetyClass::IsolatedMutation
+            ) {
+                isolation_required = true;
+            }
+            selected_operations.push(json!({
+                "target_id": target.id,
+                "operation_id": operation.id,
+                "operation_kind": operation.kind,
+                "operation_family": family.map(operation_family_name),
+            }));
+        }
+
+        if !target_selected {
+            skipped_targets.push(json!({
+                "id": target.id,
+                "reason": "unsupported",
+                "detail": "no operation matched the requested strategy or filters"
+            }));
+        }
+    }
+
+    let selected_seed_ids = if workload_seed_ids.is_empty() {
+        inventory
+            .seeds
+            .iter()
+            .map(|seed| seed.id.clone())
+            .collect::<Vec<_>>()
+    } else {
+        inventory
+            .seeds
+            .iter()
+            .filter(|seed| workload_seed_ids.contains(&seed.id))
+            .map(|seed| seed.id.clone())
+            .collect::<Vec<_>>()
+    };
+    let seed_refs = inventory
+        .seeds
+        .iter()
+        .filter(|seed| selected_seed_ids.contains(&seed.id))
+        .map(|seed| {
+            json!({
+                "id": seed.id,
+                "kind": seed.kind,
+                "artifact": seed.artifact,
+                "has_inline_value": seed.value.is_some(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(json!({
+        "planner": {
+            "strategy": args.strategy.as_str(),
+            "operation_filters": args.operations,
+            "operation_family_filters": args.operation_families,
+        },
+        "selection": {
+            "target_ids": selected_target_ids.into_iter().collect::<Vec<_>>(),
+            "operation_families": selected_families.into_iter().collect::<Vec<_>>(),
+            "operations": selected_operations,
+            "seed_ids": selected_seed_ids,
+            "seed_refs": seed_refs,
+        },
+        "budgets": {
+            "case_budget": args.case_budget.or_else(|| workload.and_then(|workload| workload.case_budget)),
+            "duration_budget_seconds": args.duration_budget_seconds.or_else(|| workload.and_then(|workload| workload.duration_budget_seconds)),
+            "max_duration": args.run.max_duration,
+        },
+        "isolation": {
+            "required": isolation_required,
+            "requirements": if isolation_required { vec!["isolated_mutation"] } else { Vec::<&str>::new() },
+        },
+        "required_artifact_ids": default_fuzz_required_artifacts().into_iter().map(|artifact| artifact.id).collect::<Vec<_>>(),
+        "provenance": inventory.provenance,
+        "skipped": {
+            "targets": skipped_targets,
+            "operations": skipped_operations,
+        },
+        "workload_scope": {
+            "surface_ids": workload_surface_ids.into_iter().collect::<Vec<_>>(),
+            "operation_filters": workload_operations.into_iter().collect::<Vec<_>>(),
+        }
+    }))
+}
+
+fn operation_filters(args: &FuzzPlanArgs) -> homeboy::core::Result<BTreeSet<String>> {
+    args.operations
+        .iter()
+        .chain(args.operation_families.iter())
+        .map(|filter| {
+            let normalized = normalize_operation_filter(filter);
+            if normalized.is_empty() {
+                Err(homeboy::core::Error::validation_invalid_argument(
+                    "operation",
+                    "operation filters must be non-empty".to_string(),
+                    Some(filter.clone()),
+                    None,
+                ))
+            } else {
+                Ok(normalized)
+            }
+        })
+        .collect()
+}
+
+fn operation_skip_reason(
+    operation: &FuzzOperation,
+    family: Option<FuzzOperationFamily>,
+    safety_class: FuzzSafetyClass,
+    strategy: FuzzPlanStrategy,
+    filters: &BTreeSet<String>,
+    workload_operations: &BTreeSet<String>,
+) -> Option<&'static str> {
+    if matches!(safety_class, FuzzSafetyClass::Destructive) {
+        return Some("destructive");
+    }
+    if family.is_none() {
+        return Some("unsupported");
+    }
+    if !workload_operations.is_empty()
+        && !workload_operations.contains(&operation.id)
+        && !workload_operations.contains(&operation.kind)
+        && !family
+            .map(operation_family_name)
+            .is_some_and(|name| workload_operations.contains(name))
+    {
+        return Some("unsupported");
+    }
+    if !filters.is_empty() && !operation_matches_filters(operation, family, filters) {
+        return Some("unsupported");
+    }
+    if !strategy_matches_operation(strategy, family.expect("family checked above")) {
+        return Some("unsupported");
+    }
+    None
+}
+
+fn strategy_matches_operation(strategy: FuzzPlanStrategy, family: FuzzOperationFamily) -> bool {
+    match strategy {
+        FuzzPlanStrategy::All | FuzzPlanStrategy::CoverageGaps => true,
+        FuzzPlanStrategy::ReadOnly => matches!(
+            family,
+            FuzzOperationFamily::Read
+                | FuzzOperationFamily::List
+                | FuzzOperationFamily::Search
+                | FuzzOperationFamily::Navigate
+                | FuzzOperationFamily::Render
+                | FuzzOperationFamily::Query
+                | FuzzOperationFamily::Load
+                | FuzzOperationFamily::BlockRender
+        ),
+        FuzzPlanStrategy::Crud => matches!(
+            family,
+            FuzzOperationFamily::Create | FuzzOperationFamily::Update | FuzzOperationFamily::Delete
+        ),
+    }
+}
+
+fn operation_matches_filters(
+    operation: &FuzzOperation,
+    family: Option<FuzzOperationFamily>,
+    filters: &BTreeSet<String>,
+) -> bool {
+    filters.contains(&normalize_operation_filter(&operation.id))
+        || filters.contains(&normalize_operation_filter(&operation.kind))
+        || family
+            .map(operation_family_name)
+            .is_some_and(|name| filters.contains(name))
+}
+
+fn inventory_surface_safety(inventory: &FuzzTargetInventory) -> BTreeMap<String, FuzzSafetyClass> {
+    let mut safety = BTreeMap::new();
+    for surface in &inventory.surfaces {
+        if let Some(target_id) = surface.target.as_ref() {
+            safety.insert(target_id.clone(), surface.safety_class);
+        }
+        for operation in &surface.operations {
+            if let Some(target_id) = operation.target_id.as_ref() {
+                safety.insert(target_id.clone(), surface.safety_class);
+            }
+        }
+    }
+    safety
+}
+
+fn normalize_operation_filter(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace(['-', ' '], "_")
+}
+
+fn operation_family_name(family: FuzzOperationFamily) -> &'static str {
+    match family {
+        FuzzOperationFamily::Read => "read",
+        FuzzOperationFamily::Create => "create",
+        FuzzOperationFamily::Update => "update",
+        FuzzOperationFamily::Delete => "delete",
+        FuzzOperationFamily::List => "list",
+        FuzzOperationFamily::Search => "search",
+        FuzzOperationFamily::Navigate => "navigate",
+        FuzzOperationFamily::Render => "render",
+        FuzzOperationFamily::Query => "query",
+        FuzzOperationFamily::Load => "load",
+        FuzzOperationFamily::Submit => "submit",
+        FuzzOperationFamily::BlockRender => "block_render",
+        FuzzOperationFamily::PerformanceProbe => "performance_probe",
+    }
 }
 
 #[cfg(test)]
@@ -175,9 +492,9 @@ mod tests {
         FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
     };
     use super::types::{
-        FuzzCommand, FuzzExecutionOutput, FuzzListOutput, FuzzOutput, FuzzReplayArgs,
-        FuzzReportArgs, FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract, FuzzValidateArgs,
-        FuzzWorkloadOutput,
+        FuzzCommand, FuzzExecutionOutput, FuzzListOutput, FuzzOutput, FuzzPlanArgs,
+        FuzzPlanStrategy, FuzzReplayArgs, FuzzReportArgs, FuzzRunArgs, FuzzRunOutput,
+        FuzzRunnerContract, FuzzValidateArgs, FuzzWorkloadOutput,
     };
     use super::workloads::{
         fuzz_workloads, resolve_component_id, rig_component_for_fuzz, select_workload,
@@ -187,7 +504,9 @@ mod tests {
     use clap::Parser;
     use homeboy::core::engine::run_dir::RunDir;
     use homeboy::core::extension::FuzzConfig;
-    use homeboy::core::fuzz::{FuzzCampaign, FuzzCoverageSummary, FuzzFinding, FuzzFindingStatus};
+    use homeboy::core::fuzz::{
+        FuzzCampaign, FuzzCoverageSummary, FuzzFinding, FuzzFindingStatus, FuzzTargetInventory,
+    };
     use homeboy::core::lifecycle::{
         LifecyclePhaseKind, LifecyclePhaseResult, LifecyclePhaseStatus, LifecycleResultMetadata,
         LIFECYCLE_CONTRACT_VERSION, LIFECYCLE_RESULT_SCHEMA,
@@ -221,6 +540,186 @@ mod tests {
             metadata: serde_json::Value::Null,
             extra: std::collections::BTreeMap::new(),
         }
+    }
+
+    fn planner_args() -> FuzzPlanArgs {
+        FuzzPlanArgs {
+            run: FuzzRunArgs {
+                comp: PositionalComponentArgs {
+                    component: Some("component-a".to_string()),
+                    path: None,
+                },
+                rig: None,
+                extension_override: ExtensionOverrideArgs::default(),
+                setting_args: SettingArgs::default(),
+                workload_id: Some("api-fuzz".to_string()),
+                run_id: Some("proof-1".to_string()),
+                seed: None,
+                inventory: None,
+                max_duration: None,
+                args: Vec::new(),
+            },
+            request_id: None,
+            strategy: FuzzPlanStrategy::All,
+            operations: Vec::new(),
+            operation_families: Vec::new(),
+            case_budget: None,
+            duration_budget_seconds: None,
+        }
+    }
+
+    fn planner_inventory() -> FuzzTargetInventory {
+        FuzzTargetInventory::from_value(serde_json::json!({
+            "schema": "homeboy/fuzz-target-inventory/v1",
+            "version": 1,
+            "id": "component-a-inventory",
+            "targets": [
+                {
+                    "schema": "homeboy/fuzz-target/v1",
+                    "id": "api.users",
+                    "kind": "api",
+                    "operations": [
+                        { "id": "api.users.read", "kind": "GET", "family": "read" },
+                        { "id": "api.users.create", "kind": "POST", "family": "create" }
+                    ]
+                }
+            ],
+            "workloads": [
+                {
+                    "schema": "homeboy/fuzz-workload/v1",
+                    "id": "api-fuzz",
+                    "safety_class": "isolated_mutation",
+                    "seed_ids": ["seed-a"],
+                    "case_budget": 25,
+                    "duration_budget_seconds": 120
+                }
+            ],
+            "seeds": [
+                {
+                    "schema": "homeboy/fuzz-seed/v1",
+                    "id": "seed-a",
+                    "kind": "corpus",
+                    "value": "inline-corpus"
+                }
+            ],
+            "provenance": {
+                "producer": "inventory-test",
+                "run_id": "inventory-discovery"
+            }
+        }))
+        .expect("inventory parses")
+    }
+
+    #[test]
+    fn fuzz_plan_selects_inventory_targets_operations_seeds_and_budgets() {
+        let args = planner_args();
+        let metadata = super::plan_inventory_selection(&args, &planner_inventory()).unwrap();
+
+        assert_eq!(
+            metadata["selection"]["target_ids"].as_array().unwrap(),
+            &vec![serde_json::json!("api.users")]
+        );
+        assert_eq!(
+            metadata["selection"]["operation_families"]
+                .as_array()
+                .unwrap(),
+            &vec![serde_json::json!("create"), serde_json::json!("read")]
+        );
+        assert_eq!(
+            metadata["selection"]["operations"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            metadata["selection"]["seed_ids"].as_array().unwrap(),
+            &vec![serde_json::json!("seed-a")]
+        );
+        assert_eq!(metadata["budgets"]["case_budget"], serde_json::json!(25));
+        assert_eq!(
+            metadata["budgets"]["duration_budget_seconds"],
+            serde_json::json!(120)
+        );
+        assert_eq!(metadata["isolation"]["required"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn fuzz_plan_operation_filter_limits_inventory_selection() {
+        let mut args = planner_args();
+        args.operations = vec!["read".to_string()];
+
+        let metadata = super::plan_inventory_selection(&args, &planner_inventory()).unwrap();
+
+        assert_eq!(
+            metadata["selection"]["operation_families"]
+                .as_array()
+                .unwrap(),
+            &vec![serde_json::json!("read")]
+        );
+        assert_eq!(
+            metadata["selection"]["operations"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            metadata["skipped"]["operations"].as_array().unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn fuzz_plan_budget_flags_override_inventory_workload_budgets() {
+        let mut args = planner_args();
+        args.case_budget = Some(5);
+        args.duration_budget_seconds = Some(10);
+        args.run.max_duration = Some("30s".to_string());
+
+        let metadata = super::plan_inventory_selection(&args, &planner_inventory()).unwrap();
+
+        assert_eq!(metadata["budgets"]["case_budget"], serde_json::json!(5));
+        assert_eq!(
+            metadata["budgets"]["duration_budget_seconds"],
+            serde_json::json!(10)
+        );
+        assert_eq!(
+            metadata["budgets"]["max_duration"],
+            serde_json::json!("30s")
+        );
+    }
+
+    #[test]
+    fn fuzz_plan_skips_unsupported_inventory_operations() {
+        let inventory = FuzzTargetInventory::from_value(serde_json::json!({
+            "schema": "homeboy/fuzz-target-inventory/v1",
+            "version": 1,
+            "id": "component-a-inventory",
+            "targets": [
+                {
+                    "schema": "homeboy/fuzz-target/v1",
+                    "id": "custom.surface",
+                    "kind": "api",
+                    "operations": [
+                        { "id": "custom.surface.invoke", "kind": "domain-specific" }
+                    ]
+                }
+            ]
+        }))
+        .expect("inventory parses");
+
+        let metadata = super::plan_inventory_selection(&planner_args(), &inventory).unwrap();
+
+        assert!(metadata["selection"]["operations"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            metadata["skipped"]["operations"][0]["reason"],
+            serde_json::json!("unsupported")
+        );
+        assert_eq!(metadata["skipped"]["targets"].as_array().unwrap().len(), 1);
     }
 
     #[test]

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 
 use homeboy::core::fuzz::{
     FuzzCampaign, FuzzExecutionRequest, FuzzGate, FuzzReplayMetadata, FuzzRequiredArtifact,
@@ -132,6 +132,45 @@ pub(crate) struct FuzzPlanArgs {
     /// Stable request id. Defaults to --run-id, then the selected workload id.
     #[arg(long = "request-id", value_name = "ID")]
     pub(crate) request_id: Option<String>,
+
+    /// Inventory selection strategy.
+    #[arg(long, value_enum, default_value_t = FuzzPlanStrategy::All)]
+    pub(crate) strategy: FuzzPlanStrategy,
+
+    /// Select operations by canonical family, operation kind, or operation id.
+    #[arg(long = "operation", value_name = "FILTER")]
+    pub(crate) operations: Vec<String>,
+
+    /// Select operations by canonical family.
+    #[arg(long = "operation-family", value_name = "FAMILY")]
+    pub(crate) operation_families: Vec<String>,
+
+    /// Maximum number of cases the downstream runner should generate.
+    #[arg(long = "case-budget", value_name = "COUNT")]
+    pub(crate) case_budget: Option<u64>,
+
+    /// Maximum execution budget in seconds for downstream runners.
+    #[arg(long = "duration-budget-seconds", value_name = "SECONDS")]
+    pub(crate) duration_budget_seconds: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum FuzzPlanStrategy {
+    All,
+    ReadOnly,
+    Crud,
+    CoverageGaps,
+}
+
+impl FuzzPlanStrategy {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::ReadOnly => "read-only",
+            Self::Crud => "crud",
+            Self::CoverageGaps => "coverage-gaps",
+        }
+    }
 }
 
 #[derive(Args, Clone)]


### PR DESCRIPTION
## Summary
- Extend `homeboy fuzz plan` with inventory-driven selection metadata in the existing `homeboy/fuzz-execution-request/v1` request.
- Add neutral planning flags for strategy, operation filters, and budget overrides.
- Record selected target ids, operation families, seed refs, budgets, isolation requirements, required artifact ids, provenance, and skipped target/operation reasons.
- Document the planner contract and supported strategies.

## Tests
- `cargo test fuzz_plan_ --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the inventory-driven fuzz planning changes, tests, docs, and PR preparation.