### PR TITLE
Add generic loop runtime dispatch support

### DIFF
--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -313,9 +313,10 @@ where
         &args.policy_results,
         Some(&defaults),
     )?;
-    let from_spec = agent_task_controller_service::init_from_spec(ControllerFromSpecRequest {
-        spec: materialized.spec.clone(),
-    })?;
+    let from_spec =
+        agent_task_controller_service::init_from_spec_for_resume(ControllerFromSpecRequest {
+            spec: materialized.spec.clone(),
+        })?;
     let dispatch = CliDispatchHook {
         executor: executor.clone(),
         defaults,
@@ -447,7 +448,13 @@ pub(super) fn controller_from_spec(args: AgentTaskControllerFromSpecArgs) -> Cmd
     if args.doctor {
         return controller_from_spec_doctor(spec, &args);
     }
-    let report = agent_task_controller_service::init_from_spec(ControllerFromSpecRequest { spec })?;
+    let report = if args.resume {
+        agent_task_controller_service::init_from_spec_for_resume(ControllerFromSpecRequest {
+            spec,
+        })?
+    } else {
+        agent_task_controller_service::init_from_spec(ControllerFromSpecRequest { spec })?
+    };
     if !args.resume {
         return Ok((command_json_value(report)?, 0));
     }

--- a/src/commands/agent_task/tests/controller_run.rs
+++ b/src/commands/agent_task/tests/controller_run.rs
@@ -312,8 +312,15 @@ fn controller_run_from_spec_preserves_runtime_execution_and_components() {
                 max_actions: 1,
                 dispatch_backend: Some("fixture".to_string()),
                 dispatch_selector: None,
-                dispatch_model: None,
-                dispatch_provider_config: None,
+                dispatch_model: Some("gpt-cli".to_string()),
+                dispatch_provider_config: Some(
+                    json!({
+                        "provider": "codex",
+                        "model": "gpt-config",
+                        "options": { "reasoning_effort": "high" }
+                    })
+                    .to_string(),
+                ),
             },
             CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
@@ -335,6 +342,15 @@ fn controller_run_from_spec_preserves_runtime_execution_and_components() {
         assert_eq!(
             observed.inputs["runtime_task"]["input"]["package"]["source"],
             "bundles/store-idea-agent"
+        );
+        assert_eq!(
+            observed.inputs["runtime_task"]["input"]["provider"],
+            "codex"
+        );
+        assert_eq!(observed.inputs["runtime_task"]["input"]["model"], "gpt-cli");
+        assert_eq!(
+            observed.inputs["runtime_task"]["input"]["options"]["reasoning_effort"],
+            "high"
         );
         assert_eq!(observed.component_contracts.len(), 1);
         assert_eq!(

--- a/src/commands/runner/workspace/mod.rs
+++ b/src/commands/runner/workspace/mod.rs
@@ -25,7 +25,7 @@ pub(super) enum RunnerWorkspaceCommand {
         #[arg(long)]
         path: String,
 
-        /// Sync mode. snapshot streams source from the controller; git is only for public/runner-accessible remotes.
+        /// Sync mode. snapshot streams source from the controller; snapshot-git also initializes a synthetic git checkout; git is only for clean public/runner-accessible remotes.
         #[arg(long, value_enum, default_value_t = RunnerWorkspaceSyncModeArg::Snapshot)]
         mode: RunnerWorkspaceSyncModeArg,
 
@@ -48,6 +48,7 @@ pub(super) enum RunnerWorkspaceCommand {
 pub(super) enum RunnerWorkspaceSyncModeArg {
     #[default]
     Snapshot,
+    SnapshotGit,
     Git,
 }
 
@@ -71,6 +72,7 @@ impl From<RunnerWorkspaceSyncModeArg> for RunnerWorkspaceSyncMode {
     fn from(value: RunnerWorkspaceSyncModeArg) -> Self {
         match value {
             RunnerWorkspaceSyncModeArg::Snapshot => RunnerWorkspaceSyncMode::Snapshot,
+            RunnerWorkspaceSyncModeArg::SnapshotGit => RunnerWorkspaceSyncMode::SnapshotGit,
             RunnerWorkspaceSyncModeArg::Git => RunnerWorkspaceSyncMode::Git,
         }
     }

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -203,6 +203,39 @@ pub fn init_from_spec(request: ControllerFromSpecRequest) -> Result<ControllerFr
     })
 }
 
+/// Initialize a controller from a repo-owned loop spec for immediate resume.
+///
+/// Unlike plain `from-spec`, this fails closed when an existing controller was
+/// created from a different spec fingerprint. That keeps proof reruns from
+/// silently draining stale actions after a loop spec changed.
+pub fn init_from_spec_for_resume(
+    request: ControllerFromSpecRequest,
+) -> Result<ControllerFromSpecReport> {
+    let spec_fingerprint = repo_loop_spec_fingerprint(&request.spec)?;
+    if let Some(record) = existing_controller(&request.spec.loop_id)? {
+        let previous = repo_loop_spec_fingerprint_from_metadata(&record);
+        if previous.as_deref() != Some(spec_fingerprint.as_str()) {
+            return Err(Error::validation_invalid_argument(
+                "spec_fingerprint",
+                format!(
+                    "agent-task controller from-spec --resume refuses to resume existing controller '{}' because the persisted spec fingerprint is missing or different; use a fresh loop_id or re-run from-spec without --resume to reconcile state explicitly",
+                    record.loop_id
+                ),
+                previous,
+                Some(vec![
+                    format!("current_spec_fingerprint={spec_fingerprint}"),
+                    format!(
+                        "controller_path={}",
+                        controller::controller_record_path(&record.loop_id)?.display()
+                    ),
+                ]),
+            ));
+        }
+    }
+
+    init_from_spec(request)
+}
+
 /// Compile a declarative controller spec into a generic Homeboy plan without writing state.
 pub fn plan_from_spec(request: ControllerPlanRequest) -> Result<ControllerPlanReport> {
     let spec = request.spec;

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -1,6 +1,7 @@
 //! Split from `agent_task_controller_service` god file (#5208). Structural move only.
 #![allow(unused_imports)]
 use super::*;
+use crate::core::component::{self, TargetSpec};
 use crate::core::plan::PlanStepDependencyKind;
 
 pub(super) const REPO_LOOP_SPEC_METADATA_KEY: &str = "repo_loop_spec";
@@ -647,13 +648,17 @@ pub(super) fn workflow_client_context(
         "artifact_dependencies": workflow_artifact_dependencies(spec, workflow),
         "artifact_graph_edges": workflow_artifact_graph_edges(spec, workflow),
         "dependencies": select_by_id(&spec.dependencies, &workflow.dependencies, |dependency| &dependency.dependency_id),
+        "runtime_component_contracts": workflow_runtime_component_contracts(spec, workflow)?,
         "gates": select_by_id(&spec.gates, &workflow.gates, |gate| &gate.gate_id),
         "metrics": select_by_id(&spec.metrics, &workflow.metrics, |metric| &metric.metric_id),
-        "inputs": workflow_context_inputs(workflow),
+        "inputs": workflow_context_inputs(spec, workflow),
     }))
 }
 
-fn workflow_context_inputs(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Value {
+fn workflow_context_inputs(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+) -> Value {
     let mut inputs = match workflow.inputs.clone() {
         Value::Object(map) => map,
         Value::Null => serde_json::Map::new(),
@@ -664,7 +669,9 @@ fn workflow_context_inputs(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Value {
         }
     };
 
-    if let Some(runtime_task) = runtime_task_from_workflow_execution(&workflow.runtime_execution) {
+    if let Some(runtime_task) =
+        runtime_task_from_workflow_execution(spec, &workflow.runtime_execution)
+    {
         inputs
             .entry("runtime_task".to_string())
             .or_insert(runtime_task);
@@ -683,7 +690,10 @@ fn workflow_context_inputs(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Value {
     Value::Object(inputs)
 }
 
-fn runtime_task_from_workflow_execution(runtime_execution: &Value) -> Option<Value> {
+fn runtime_task_from_workflow_execution(
+    spec: &AgentTaskRepoLoopSpec,
+    runtime_execution: &Value,
+) -> Option<Value> {
     let execution = runtime_execution.as_object()?;
     let ability = execution.get("ability")?.as_str()?.trim();
     if ability.is_empty() {
@@ -692,13 +702,12 @@ fn runtime_task_from_workflow_execution(runtime_execution: &Value) -> Option<Val
 
     let mut runtime_task = serde_json::Map::new();
     runtime_task.insert("ability".to_string(), Value::String(ability.to_string()));
-    runtime_task.insert(
-        "input".to_string(),
-        execution
-            .get("input")
-            .cloned()
-            .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
-    );
+    let mut input = execution
+        .get("input")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+    apply_runtime_task_dispatch_defaults(spec, &mut input);
+    runtime_task.insert("input".to_string(), input);
     if let Some(kind) = execution
         .get("kind")
         .and_then(Value::as_str)
@@ -707,6 +716,47 @@ fn runtime_task_from_workflow_execution(runtime_execution: &Value) -> Option<Val
         runtime_task.insert("kind".to_string(), Value::String(kind.to_string()));
     }
     Some(Value::Object(runtime_task))
+}
+
+fn apply_runtime_task_dispatch_defaults(spec: &AgentTaskRepoLoopSpec, input: &mut Value) {
+    let Some(input) = input.as_object_mut() else {
+        return;
+    };
+    let Some(defaults) = spec
+        .metadata
+        .get("dispatch_defaults")
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+
+    if let Some(model) = defaults
+        .get("model")
+        .and_then(Value::as_str)
+        .filter(|model| !model.trim().is_empty())
+    {
+        input
+            .entry("model".to_string())
+            .or_insert_with(|| Value::String(model.to_string()));
+    }
+
+    let Some(provider_config) = defaults
+        .get("provider_config")
+        .and_then(Value::as_str)
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+    else {
+        return;
+    };
+    let Some(provider_config) = provider_config.as_object() else {
+        return;
+    };
+    for key in ["provider", "model", "options"] {
+        if let Some(value) = provider_config.get(key).filter(|value| !value.is_null()) {
+            input
+                .entry(key.to_string())
+                .or_insert_with(|| value.clone());
+        }
+    }
 }
 
 pub(super) fn workflow_homeboy_plan(
@@ -802,10 +852,56 @@ pub(super) fn workflow_declaration_context(
         "artifact_dependencies": workflow_artifact_dependencies(spec, workflow),
         "artifact_graph_edges": workflow_artifact_graph_edges(spec, workflow),
         "dependencies": select_by_id(&spec.dependencies, &workflow.dependencies, |dependency| &dependency.dependency_id),
+        "runtime_component_contracts": workflow_runtime_component_contracts(spec, workflow)?,
         "gates": select_by_id(&spec.gates, &workflow.gates, |gate| &gate.gate_id),
         "metrics": select_by_id(&spec.metrics, &workflow.metrics, |metric| &metric.metric_id),
         "inputs": workflow.inputs,
     }))
+}
+
+fn workflow_runtime_component_contracts(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+) -> Result<Vec<Value>> {
+    let mut contracts = Vec::new();
+    for dependency in select_by_id(&spec.dependencies, &workflow.dependencies, |dependency| {
+        &dependency.dependency_id
+    }) {
+        if !matches!(
+            dependency.kind.as_str(),
+            "component" | "runtime_component" | "component_contract"
+        ) {
+            continue;
+        }
+        let path = match dependency
+            .value
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            Some(value) => value.to_string(),
+            None => match component::resolve_target(TargetSpec {
+                component_id: Some(&dependency.dependency_id),
+                path_override: None,
+                project: None,
+                capability: None,
+                allow_synthetic: false,
+                accept_bare_directory: false,
+                ..TargetSpec::default()
+            }) {
+                Ok(target) => target.source_path.display().to_string(),
+                Err(error) if dependency.required => return Err(error),
+                Err(_) => continue,
+            },
+        };
+        contracts.push(serde_json::json!({
+            "slug": dependency.dependency_id,
+            "path": path,
+            "required": dependency.required,
+            "source": "repo_loop_spec_dependency",
+            "dependency_kind": dependency.kind,
+        }));
+    }
+    Ok(contracts)
 }
 
 pub(super) fn workflow_required_capabilities(

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -821,6 +821,69 @@ fn init_from_spec_reconciles_changed_workflow_dependencies() {
 }
 
 #[test]
+fn init_from_spec_for_resume_rejects_changed_existing_spec() {
+    with_isolated_home(|_| {
+        let base = repo_loop_reconcile_spec("repo-loop-resume-stale-guard");
+        init_from_spec_for_resume(ControllerFromSpecRequest { spec: base.clone() })
+            .expect("base spec initialized for resume");
+
+        let mut changed = base;
+        changed
+            .workflows
+            .iter_mut()
+            .find(|workflow| workflow.workflow_id == "static_validation")
+            .expect("static validation workflow")
+            .dependencies = vec!["static_site_candidate".to_string()];
+
+        let error = init_from_spec_for_resume(ControllerFromSpecRequest { spec: changed })
+            .expect_err("changed spec is blocked before resume");
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error
+            .message
+            .contains("persisted spec fingerprint is missing or different"));
+        assert!(error
+            .details
+            .get("tried")
+            .and_then(Value::as_array)
+            .is_some_and(|details| details.iter().any(|detail| detail
+                .as_str()
+                .is_some_and(|detail| detail.contains("controller_path=")))));
+    });
+}
+
+#[test]
+fn init_from_spec_projects_runtime_component_dependencies_to_contracts() {
+    with_isolated_home(|_| {
+        let mut spec = repo_loop_reconcile_spec("repo-loop-runtime-components");
+        spec.dependencies.push(AgentTaskRepoLoopSpecDependency {
+            dependency_id: "agents-api".to_string(),
+            kind: "runtime_component".to_string(),
+            value: Some("/tmp/homeboy-test/agents-api".to_string()),
+            required: true,
+        });
+        spec.workflows
+            .iter_mut()
+            .find(|workflow| workflow.workflow_id == "static_validation")
+            .expect("static validation workflow")
+            .dependencies = vec!["agents-api".to_string()];
+
+        let report = init_from_spec(ControllerFromSpecRequest { spec }).expect("spec initializes");
+        let context = workflow_action_context(&report, "static_validation");
+
+        assert_eq!(
+            context["runtime_component_contracts"],
+            json!([{
+                "slug": "agents-api",
+                "path": "/tmp/homeboy-test/agents-api",
+                "required": true,
+                "source": "repo_loop_spec_dependency",
+                "dependency_kind": "runtime_component"
+            }])
+        );
+    });
+}
+
+#[test]
 fn init_from_spec_maps_workflow_consumes_to_artifact_dependencies() {
     with_isolated_home(|_| {
         let mut spec = repo_loop_reconcile_spec("repo-loop-consumes-artifacts");

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -5,11 +5,12 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 use crate::core::agent_task::{
-    AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskExecutionHandle,
-    AgentTaskExecutionHandleKind, AgentTaskExecutor, AgentTaskFailureClassification,
-    AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest,
-    AgentTaskSourceRef, AgentTaskWorkflowEvidence, AgentTaskWorkspace, AgentTaskWorkspaceMode,
-    AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+    AgentTaskArtifact, AgentTaskComponentContract, AgentTaskDiagnostic, AgentTaskEvidenceRef,
+    AgentTaskExecutionHandle, AgentTaskExecutionHandleKind, AgentTaskExecutor,
+    AgentTaskFailureClassification, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus,
+    AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkflowEvidence,
+    AgentTaskWorkspace, AgentTaskWorkspaceMode, AGENT_TASK_OUTCOME_SCHEMA,
+    AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::core::agent_task_provider::{role_aliases_for_provider, AgentTaskProviderRoleAliases};
 use crate::core::agent_task_scheduler::{
@@ -54,10 +55,45 @@ pub struct AgentTaskRunRecord {
     pub artifact_refs: Vec<AgentTaskArtifactRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub provider_handles: Vec<AgentTaskRunProviderHandle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_executor_evidence: Option<AgentTaskLatestExecutorEvidence>,
     #[serde(default)]
     pub lifecycle: RunLifecycleRecord,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskLatestExecutorEvidence {
+    pub task_id: String,
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub input_ref: AgentTaskEvidenceRef,
+    pub normalized_output_ref: AgentTaskEvidenceRef,
+    pub outcome_ref: AgentTaskEvidenceRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub component_contracts: Vec<AgentTaskComponentContract>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_component_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_artifacts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub typed_artifact_expectations: Vec<String>,
+}
+
+impl AgentTaskLatestExecutorEvidence {
+    fn refs(&self) -> [AgentTaskEvidenceRef; 3] {
+        [
+            self.input_ref.clone(),
+            self.normalized_output_ref.clone(),
+            self.outcome_ref.clone(),
+        ]
+    }
 }
 
 impl AgentTaskRunRecord {
@@ -227,6 +263,7 @@ pub fn submit_plan(
         tasks: plan.tasks.iter().map(queued_task).collect(),
         artifact_refs: Vec::new(),
         provider_handles: Vec::new(),
+        latest_executor_evidence: None,
         lifecycle: lifecycle_for_submitted_plan(plan),
         metadata,
     };
@@ -953,14 +990,22 @@ fn apply_aggregate_to_record(
     record.tasks = tasks_for_aggregate(plan, aggregate);
     record.artifact_refs = artifact_refs_for_outcomes(&aggregate.outcomes);
     record.provider_handles = provider_handles_for_outcomes(&aggregate.outcomes);
+    record.latest_executor_evidence = latest_executor_evidence(&record.run_id, plan, aggregate);
     update_lifecycle_from_record(record, plan);
     let provider_run_ids: Vec<String> = record
         .provider_handles
         .iter()
         .map(|handle| handle.provider_run_id.clone())
         .collect();
+    let latest_executor_evidence_value = record
+        .latest_executor_evidence
+        .as_ref()
+        .map(|evidence| serde_json::to_value(evidence).unwrap_or(Value::Null));
     let metadata = record.ensure_metadata_object();
     metadata.insert("provider_run_ids".to_string(), json!(provider_run_ids));
+    if let Some(evidence) = latest_executor_evidence_value {
+        metadata.insert("latest_executor_evidence".to_string(), evidence);
+    }
 }
 
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
@@ -1018,7 +1063,7 @@ pub fn list_records() -> Result<Vec<AgentTaskRunRecord>> {
 }
 
 pub fn run_record_exists(run_id: &str) -> Result<bool> {
-    store::record_exists(run_id)
+    store::record_exists(&sanitize_run_id(run_id))
 }
 
 pub fn cancel(run_id: &str) -> Result<AgentTaskRunRecord> {
@@ -1119,13 +1164,14 @@ pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
 
 pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
     let run_id = sanitize_run_id(run_id);
-    store::read_record(&run_id)?;
+    let record = store::read_record(&run_id)?;
     let aggregate = store::read_aggregate(&run_id).ok();
+    let latest_executor_evidence = record.latest_executor_evidence.as_ref();
     Ok(AgentTaskRunArtifacts {
         schema: schemas::RUN_ARTIFACTS.to_string(),
         run_id,
         artifacts: aggregate_artifacts(aggregate.as_ref()),
-        evidence_refs: aggregate_evidence_refs(aggregate.as_ref()),
+        evidence_refs: aggregate_evidence_refs(aggregate.as_ref(), latest_executor_evidence),
     })
 }
 
@@ -1184,16 +1230,107 @@ fn aggregate_artifacts(aggregate: Option<&AgentTaskAggregate>) -> Vec<AgentTaskA
         .unwrap_or_default()
 }
 
-fn aggregate_evidence_refs(aggregate: Option<&AgentTaskAggregate>) -> Vec<AgentTaskEvidenceRef> {
-    aggregate
+fn aggregate_evidence_refs(
+    aggregate: Option<&AgentTaskAggregate>,
+    latest_executor_evidence: Option<&AgentTaskLatestExecutorEvidence>,
+) -> Vec<AgentTaskEvidenceRef> {
+    let mut refs: Vec<AgentTaskEvidenceRef> = aggregate
         .map(|aggregate| {
             aggregate
                 .outcomes
                 .iter()
                 .flat_map(evidence_refs_for_outcome)
-                .collect()
+                .collect::<Vec<_>>()
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    refs.extend(
+        latest_executor_evidence
+            .into_iter()
+            .flat_map(AgentTaskLatestExecutorEvidence::refs),
+    );
+    dedup_evidence_refs(&mut refs);
+    refs
+}
+
+fn latest_executor_evidence(
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+) -> Option<AgentTaskLatestExecutorEvidence> {
+    let outcome = aggregate.outcomes.last()?;
+    let request = plan
+        .tasks
+        .iter()
+        .find(|task| task.task_id == outcome.task_id)?;
+    let task_id = outcome.task_id.clone();
+    let base = format!("homeboy://agent-task/run/{run_id}");
+    let component_contracts = if request.component_contracts.is_empty() {
+        plan.component_contracts.clone()
+    } else {
+        request.component_contracts.clone()
+    };
+
+    Some(AgentTaskLatestExecutorEvidence {
+        task_id: task_id.clone(),
+        backend: request.executor.backend.clone(),
+        selector: request.executor.selector.clone(),
+        model: request.executor.model.clone(),
+        input_ref: AgentTaskEvidenceRef {
+            kind: "executor-input".to_string(),
+            uri: format!("{base}/plan#task={task_id}"),
+            label: Some("Latest raw executor input".to_string()),
+        },
+        normalized_output_ref: AgentTaskEvidenceRef {
+            kind: "executor-normalized-output".to_string(),
+            uri: format!("{base}/aggregate#outcome={task_id}"),
+            label: Some("Latest normalized executor output".to_string()),
+        },
+        outcome_ref: AgentTaskEvidenceRef {
+            kind: "executor-outcome".to_string(),
+            uri: format!("{base}/artifacts#task={task_id}"),
+            label: Some("Latest executor outcome evidence".to_string()),
+        },
+        provider_run_id: first_non_empty_json_string_value([
+            outcome.metadata.get("provider_run_id"),
+            outcome.metadata.get("remote_run_id"),
+            outcome.metadata.pointer("/provider_handle/provider_run_id"),
+            outcome.outputs.pointer("/provider_run_result/run_id"),
+            outcome.outputs.pointer("/provider_run_result/id"),
+        ]),
+        runtime_component_paths: runtime_component_paths(request),
+        expected_artifacts: request.expected_artifacts.clone(),
+        typed_artifact_expectations: typed_artifact_expectations(request),
+        component_contracts,
+    })
+}
+
+fn runtime_component_paths(request: &AgentTaskRequest) -> Vec<String> {
+    let mut paths: Vec<String> = request
+        .component_contracts
+        .iter()
+        .filter_map(|contract| contract.path.clone())
+        .collect();
+    for pointer in [
+        "/runtime_component_paths",
+        "/runtime/component_paths",
+        "/runtime/components",
+        "/component_paths",
+    ] {
+        if let Some(values) = request.metadata.pointer(pointer).and_then(Value::as_array) {
+            paths.extend(values.iter().filter_map(Value::as_str).map(str::to_string));
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn typed_artifact_expectations(request: &AgentTaskRequest) -> Vec<String> {
+    request
+        .artifact_declarations
+        .iter()
+        .map(|declaration| declaration.name.clone())
+        .collect()
 }
 
 fn evidence_refs_for_outcome(outcome: &AgentTaskOutcome) -> Vec<AgentTaskEvidenceRef> {
@@ -1349,12 +1486,29 @@ fn first_non_empty_uri<'a>(
         .find(|uri| !uri.is_empty())
 }
 
+fn first_non_empty_json_string_value<'a>(
+    values: impl IntoIterator<Item = Option<&'a Value>>,
+) -> Option<String> {
+    values.into_iter().flatten().find_map(|value| {
+        value
+            .as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+    })
+}
+
 /// Drops exact-duplicate refs, keeping the first occurrence of each so status
 /// output is not noisy when an artifact surfaces through both `artifacts` and
 /// `evidence_refs` (or workflow evidence).
 fn dedup_preserve_order(refs: &mut Vec<AgentTaskArtifactRef>) {
     let mut seen = std::collections::HashSet::new();
     refs.retain(|item| seen.insert(item.clone()));
+}
+
+fn dedup_evidence_refs(refs: &mut Vec<AgentTaskEvidenceRef>) {
+    let mut seen = std::collections::HashSet::new();
+    refs.retain(|item| seen.insert((item.kind.clone(), item.uri.clone())));
 }
 
 fn provider_handles_for_outcomes(outcomes: &[AgentTaskOutcome]) -> Vec<AgentTaskRunProviderHandle> {
@@ -1655,10 +1809,10 @@ fn sanitize_run_id(run_id: &str) -> String {
 mod tests {
     use super::*;
     use crate::core::agent_task::{
-        AgentTaskExecutionHandle, AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy,
-        AgentTaskRequest, AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence,
-        AgentTaskWorkflowStepStatus, AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA,
-        AGENT_TASK_WORKFLOW_SCHEMA,
+        AgentTaskArtifactDeclaration, AgentTaskExecutionHandle, AgentTaskExecutor, AgentTaskLimits,
+        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkflowEvidence,
+        AgentTaskWorkflowStepEvidence, AgentTaskWorkflowStepStatus, AgentTaskWorkspace,
+        AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
     };
     use crate::core::agent_task_scheduler::{
         AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
@@ -2249,6 +2403,90 @@ mod tests {
     }
 
     #[test]
+    fn completed_run_exposes_latest_executor_input_output_and_expectations() {
+        with_isolated_home(|_| {
+            let mut plan = test_plan();
+            let request = &mut plan.tasks[0];
+            request.executor.backend = "codebox".to_string();
+            request.executor.model = Some("gpt-fixture".to_string());
+            request.component_contracts = vec![AgentTaskComponentContract {
+                slug: Some("wp-site-generator".to_string()),
+                path: Some("/workspace/wp-site-generator".to_string()),
+                load_as: Some("plugin".to_string()),
+                activate: Some(true),
+                extra: Default::default(),
+            }];
+            request.metadata = json!({
+                "runtime_component_paths": ["/runtime/plugins/wp-codebox"]
+            });
+            request.expected_artifacts = vec!["patch".to_string()];
+            request.artifact_declarations = vec![AgentTaskArtifactDeclaration {
+                name: "proof_bundle".to_string(),
+                artifact_type: Some("bundle".to_string()),
+                artifact_schema: None,
+                path: None,
+                required: true,
+                description: None,
+                metadata: Value::Null,
+            }];
+
+            let mut aggregate = succeeded_aggregate(&plan);
+            aggregate.outcomes[0].outputs = json!({
+                "provider_run_result": {
+                    "run_id": "provider-run-123",
+                    "status": "succeeded"
+                }
+            });
+
+            let record =
+                record_completed_run(&plan, &aggregate, Some("run-evidence")).expect("recorded");
+            let evidence = record
+                .latest_executor_evidence
+                .as_ref()
+                .expect("latest executor evidence");
+            let artifact_report = artifacts("run-evidence").expect("artifacts loaded");
+
+            assert_eq!(evidence.task_id, "task-a");
+            assert_eq!(evidence.backend, "codebox");
+            assert_eq!(evidence.selector.as_deref(), Some("fixture"));
+            assert_eq!(evidence.model.as_deref(), Some("gpt-fixture"));
+            assert_eq!(
+                evidence.provider_run_id.as_deref(),
+                Some("provider-run-123")
+            );
+            assert_eq!(evidence.component_contracts.len(), 1);
+            assert_eq!(
+                evidence.runtime_component_paths,
+                vec![
+                    "/runtime/plugins/wp-codebox".to_string(),
+                    "/workspace/wp-site-generator".to_string()
+                ]
+            );
+            assert_eq!(evidence.expected_artifacts, vec!["patch".to_string()]);
+            assert_eq!(
+                evidence.typed_artifact_expectations,
+                vec!["proof_bundle".to_string()]
+            );
+            assert_eq!(
+                record.metadata["latest_executor_evidence"]["input_ref"]["uri"],
+                "homeboy://agent-task/run/run-evidence/plan#task=task-a"
+            );
+            assert!(artifact_report
+                .evidence_refs
+                .iter()
+                .any(|evidence| evidence.kind == "executor-input"));
+            assert!(artifact_report
+                .evidence_refs
+                .iter()
+                .any(|evidence| evidence.kind == "executor-normalized-output"));
+            assert!(artifact_report
+                .evidence_refs
+                .iter()
+                .any(|evidence| evidence.kind == "executor-outcome"));
+        });
+    }
+
+    #[test]
     fn submitted_run_can_be_loaded_marked_running_and_completed() {
         with_isolated_home(|_| {
             let plan = test_plan();
@@ -2463,11 +2701,15 @@ mod tests {
             assert_eq!(durable_status.state, AgentTaskRunState::Failed);
             assert_eq!(durable_status.artifact_refs.len(), 1);
             assert_eq!(durable_status.artifact_refs[0].kind, "provider-transcript");
-            assert_eq!(durable_artifacts.evidence_refs.len(), 1);
+            assert_eq!(durable_artifacts.evidence_refs.len(), 4);
             assert_eq!(
                 durable_artifacts.evidence_refs[0].uri,
                 "provider://runs/provider-run-123/transcript"
             );
+            assert!(durable_artifacts
+                .evidence_refs
+                .iter()
+                .any(|evidence| evidence.kind == "executor-input"));
         });
     }
 

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -2407,17 +2407,17 @@ mod tests {
         with_isolated_home(|_| {
             let mut plan = test_plan();
             let request = &mut plan.tasks[0];
-            request.executor.backend = "codebox".to_string();
+            request.executor.backend = "sandbox".to_string();
             request.executor.model = Some("gpt-fixture".to_string());
             request.component_contracts = vec![AgentTaskComponentContract {
-                slug: Some("wp-site-generator".to_string()),
-                path: Some("/workspace/wp-site-generator".to_string()),
+                slug: Some("runtime-engine".to_string()),
+                path: Some("/workspace/runtime-engine".to_string()),
                 load_as: Some("plugin".to_string()),
                 activate: Some(true),
                 extra: Default::default(),
             }];
             request.metadata = json!({
-                "runtime_component_paths": ["/runtime/plugins/wp-codebox"]
+                "runtime_component_paths": ["/runtime/components/sandbox-host"]
             });
             request.expected_artifacts = vec!["patch".to_string()];
             request.artifact_declarations = vec![AgentTaskArtifactDeclaration {
@@ -2447,7 +2447,7 @@ mod tests {
             let artifact_report = artifacts("run-evidence").expect("artifacts loaded");
 
             assert_eq!(evidence.task_id, "task-a");
-            assert_eq!(evidence.backend, "codebox");
+            assert_eq!(evidence.backend, "sandbox");
             assert_eq!(evidence.selector.as_deref(), Some("fixture"));
             assert_eq!(evidence.model.as_deref(), Some("gpt-fixture"));
             assert_eq!(
@@ -2458,8 +2458,8 @@ mod tests {
             assert_eq!(
                 evidence.runtime_component_paths,
                 vec![
-                    "/runtime/plugins/wp-codebox".to_string(),
-                    "/workspace/wp-site-generator".to_string()
+                    "/runtime/components/sandbox-host".to_string(),
+                    "/workspace/runtime-engine".to_string()
                 ]
             );
             assert_eq!(evidence.expected_artifacts, vec!["patch".to_string()]);

--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -1828,6 +1828,10 @@ fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<()> {
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
 }
 
+pub fn controller_record_path(loop_id: &str) -> Result<PathBuf> {
+    controller_path(loop_id)
+}
+
 fn controller_path(loop_id: &str) -> Result<PathBuf> {
     Ok(controllers_root()?
         .join(sanitize_loop_id(loop_id))

--- a/src/core/agent_task_loop_definition.rs
+++ b/src/core/agent_task_loop_definition.rs
@@ -140,6 +140,14 @@ pub fn materialize_repo_loop_spec(
             .then_some(request.run_inputs)
     });
     if let Some(explicit_inputs) = explicit_inputs.filter(|value| !value.is_null()) {
+        if let Some(loop_id) = explicit_inputs
+            .get("loop_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|loop_id| !loop_id.is_empty())
+        {
+            spec.loop_id = loop_id.to_string();
+        }
         for workflow in &mut spec.workflows {
             merge_workflow_inputs(&mut workflow.inputs, explicit_inputs);
         }
@@ -494,6 +502,36 @@ mod tests {
         assert_eq!(
             plan.artifact_outputs["idea"][0].kind,
             "example/ConceptPacket/v1"
+        );
+    }
+
+    #[test]
+    fn materializes_repo_loop_id_from_run_inputs() {
+        let spec: AgentTaskRepoLoopSpec = serde_json::from_value(json!({
+            "schema": "homeboy/agent-task-loop-spec/v1",
+            "loop_id": "example/base-loop",
+            "workflows": [
+                { "workflow_id": "idea", "prompt": "Generate an idea." }
+            ]
+        }))
+        .expect("spec parses");
+
+        let materialized = materialize_repo_loop_spec(AgentTaskLoopSpecMaterializationRequest {
+            spec: &spec,
+            run_inputs: &json!({
+                "inputs": {
+                    "loop_id": "example/base-loop/rerun-41",
+                    "run_id": "rerun-41"
+                }
+            }),
+            policy_results: &[],
+        })
+        .expect("spec materializes");
+
+        assert_eq!(materialized.spec.loop_id, "example/base-loop/rerun-41");
+        assert_eq!(
+            materialized.spec.workflows[0].inputs["run_id"],
+            json!("rerun-41")
         );
     }
 

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -46,7 +46,7 @@ mod tests;
 pub use catalog::*;
 pub(crate) use resolution::{
     resolve_provider_for_backend, role_aliases_for_executor, role_aliases_for_provider,
-    timeout_artifact_discovery_for_executor, ProviderResolution,
+    selector_runtime_provider_hint, timeout_artifact_discovery_for_executor, ProviderResolution,
 };
 pub(crate) use secrets::{
     provider_runner_secret_env_for_plan_with_providers,

--- a/src/core/agent_task_provider/catalog.rs
+++ b/src/core/agent_task_provider/catalog.rs
@@ -210,6 +210,13 @@ pub(super) fn validate_provider_runner_readiness_for_backend_with_providers(
             ));
         }
         ProviderResolution::SelectorMismatch { available_ids } => {
+            let mut suggestions = vec![format!(
+                "Available provider ids for backend '{backend}': {}.",
+                available_ids.join(", ")
+            )];
+            if let Some(hint) = selector_runtime_provider_hint(backend, selector) {
+                suggestions.push(hint);
+            }
             return Err(Error::validation_invalid_argument(
                 "selector",
                 format!(
@@ -217,10 +224,7 @@ pub(super) fn validate_provider_runner_readiness_for_backend_with_providers(
                     selector.unwrap_or("")
                 ),
                 selector.map(str::to_string),
-                Some(vec![format!(
-                    "Available provider ids for backend '{backend}': {}.",
-                    available_ids.join(", ")
-                )]),
+                Some(suggestions),
             ));
         }
     };

--- a/src/core/agent_task_provider/executor.rs
+++ b/src/core/agent_task_provider/executor.rs
@@ -86,16 +86,31 @@ fn provider_resolution_failure_outcome(
             AgentTaskOutcomeStatus::Failed,
             AgentTaskFailureClassification::CapabilityMissing,
             "agent_task.provider_selector_mismatch",
-            format!(
-                "no extension agent-task provider for backend '{}' matched selector '{}'",
-                request.executor.backend,
-                request.executor.selector.as_deref().unwrap_or("")
+            selector_mismatch_message(
+                &request.executor.backend,
+                request.executor.selector.as_deref(),
             ),
             json!({
                 "backend": request.executor.backend,
                 "selector": request.executor.selector,
                 "available_provider_ids": available_ids,
+                "hint": selector_runtime_provider_hint(
+                    &request.executor.backend,
+                    request.executor.selector.as_deref(),
+                ),
             }),
         ),
+    }
+}
+
+fn selector_mismatch_message(backend: &str, selector: Option<&str>) -> String {
+    let base = format!(
+        "no extension agent-task provider for backend '{}' matched selector '{}'",
+        backend,
+        selector.unwrap_or("")
+    );
+    match selector_runtime_provider_hint(backend, selector) {
+        Some(hint) => format!("{base}; {hint}"),
+        None => base,
     }
 }

--- a/src/core/agent_task_provider/resolution.rs
+++ b/src/core/agent_task_provider/resolution.rs
@@ -87,6 +87,20 @@ pub(crate) enum ProviderResolution<'a> {
     SelectorMismatch { available_ids: Vec<String> },
 }
 
+pub(crate) fn selector_runtime_provider_hint(
+    backend: &str,
+    selector: Option<&str>,
+) -> Option<String> {
+    let selector = selector?.trim();
+    if !matches!(selector, "codex" | "opencode" | "claude-code") {
+        return None;
+    }
+
+    Some(format!(
+        "'{selector}' looks like a nested AI runtime provider, not a dispatch selector. --dispatch-selector selects the Homeboy executor provider id for backend '{backend}'; pass the AI provider in --dispatch-provider-config instead."
+    ))
+}
+
 impl<'a> ProviderResolution<'a> {
     pub(crate) fn resolved(self) -> Option<&'a AgentTaskExecutorProvider> {
         match self {

--- a/src/core/agent_task_provider/tests.rs
+++ b/src/core/agent_task_provider/tests.rs
@@ -715,12 +715,12 @@ fn provider_selection_reports_exact_backend_selector_mismatch() {
 #[test]
 fn provider_readiness_selector_mismatch_explains_runtime_provider_confusion() {
     let (_, mut provider) = request("task-a", "node provider.js".to_string());
-    provider.id = "wordpress.codebox-agent-task-executor".to_string();
-    provider.backend = "codebox".to_string();
+    provider.id = "example.sandbox-agent-task-executor".to_string();
+    provider.backend = "sandbox".to_string();
 
     let error = validate_provider_runner_readiness_for_backend_with_providers(
         &[provider],
-        "codebox",
+        "sandbox",
         Some("codex"),
     )
     .expect_err("selector mismatch should fail before runner readiness");
@@ -734,7 +734,7 @@ fn provider_readiness_selector_mismatch_explains_runtime_provider_confusion() {
         .is_some_and(|suggestion| suggestion.contains("nested AI runtime provider"))));
     assert!(suggestions.iter().any(|value| value
         .as_str()
-        .is_some_and(|suggestion| suggestion.contains("wordpress.codebox-agent-task-executor"))));
+        .is_some_and(|suggestion| suggestion.contains("example.sandbox-agent-task-executor"))));
 }
 
 #[test]

--- a/src/core/agent_task_provider/tests.rs
+++ b/src/core/agent_task_provider/tests.rs
@@ -713,6 +713,31 @@ fn provider_selection_reports_exact_backend_selector_mismatch() {
 }
 
 #[test]
+fn provider_readiness_selector_mismatch_explains_runtime_provider_confusion() {
+    let (_, mut provider) = request("task-a", "node provider.js".to_string());
+    provider.id = "wordpress.codebox-agent-task-executor".to_string();
+    provider.backend = "codebox".to_string();
+
+    let error = validate_provider_runner_readiness_for_backend_with_providers(
+        &[provider],
+        "codebox",
+        Some("codex"),
+    )
+    .expect_err("selector mismatch should fail before runner readiness");
+
+    assert_eq!(error.details["field"], "selector");
+    let suggestions = error.details["tried"]
+        .as_array()
+        .expect("tried suggestions");
+    assert!(suggestions.iter().any(|value| value
+        .as_str()
+        .is_some_and(|suggestion| suggestion.contains("nested AI runtime provider"))));
+    assert!(suggestions.iter().any(|value| value
+        .as_str()
+        .is_some_and(|suggestion| suggestion.contains("wordpress.codebox-agent-task-executor"))));
+}
+
+#[test]
 fn provider_selection_matches_unique_extension_alias() {
     let (_, mut provider) = request("task-a", "node provider.js".to_string());
     provider.id = "extension-a.provider".to_string();
@@ -1936,7 +1961,7 @@ fn scheduler_reports_missing_extension_provider() {
 fn scheduler_reports_provider_selector_mismatch() {
     let (mut request, mut provider) = request("task-selector-mismatch", "unused".to_string());
     request.executor.backend = "synthetic-runtime".to_string();
-    request.executor.selector = Some("fast".to_string());
+    request.executor.selector = Some("codex".to_string());
     provider.id = "example.synthetic-agent-task-executor".to_string();
     provider.backend = "synthetic-runtime".to_string();
     let scheduler =
@@ -1954,6 +1979,13 @@ fn scheduler_reports_provider_selector_mismatch() {
     assert_eq!(
         aggregate.outcomes[0].diagnostics[0].data["available_provider_ids"],
         json!(["example.synthetic-agent-task-executor"])
+    );
+    assert!(aggregate.outcomes[0].diagnostics[0]
+        .message
+        .contains("nested AI runtime provider"));
+    assert_eq!(
+        aggregate.outcomes[0].diagnostics[0].data["hint"],
+        "'codex' looks like a nested AI runtime provider, not a dispatch selector. --dispatch-selector selects the Homeboy executor provider id for backend 'synthetic-runtime'; pass the AI provider in --dispatch-provider-config instead."
     );
 }
 

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -149,7 +149,7 @@ pub use super::agent_task_provider::{
 pub mod controller_service {
     pub use super::super::agent_task_controller_service::{
         apply_event, apply_spec_dispatch_defaults, apply_spec_dispatch_defaults_with_cwd,
-        controller_request_dispatch_command, init, init_from_spec, list,
+        controller_request_dispatch_command, init, init_from_spec, init_from_spec_for_resume, list,
         load_materialize_spec_source, mark_human_ready, optional_bool, optional_string,
         optional_string_array, optional_u32, optional_usize, plan_from_controller_request,
         plan_from_spec, resume, resume_with_options, run_action, run_next, status,

--- a/src/core/runner/workspace/snapshot.rs
+++ b/src/core/runner/workspace/snapshot.rs
@@ -197,6 +197,83 @@ pub(crate) fn materialize_snapshot(
     }
 }
 
+pub(crate) fn materialize_snapshot_git(
+    runner: &Runner,
+    local_path: &Path,
+    remote_path: &str,
+    excludes: &[String],
+    snapshot: &str,
+) -> Result<()> {
+    materialize_snapshot(runner, local_path, remote_path, excludes)?;
+    initialize_synthetic_git_checkout(runner, local_path, remote_path, snapshot)
+}
+
+fn initialize_synthetic_git_checkout(
+    runner: &Runner,
+    local_path: &Path,
+    remote_path: &str,
+    snapshot: &str,
+) -> Result<()> {
+    let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"]).ok();
+    let source_head = git_output(local_path, &["rev-parse", "HEAD"]).ok();
+    let command = synthetic_git_checkout_command(
+        remote_path,
+        snapshot,
+        remote_url.as_deref(),
+        source_head.as_deref(),
+    );
+
+    match runner.kind {
+        RunnerKind::Local => {
+            run_shell_command(&command, "initialize synthetic snapshot git checkout")
+        }
+        RunnerKind::Ssh => {
+            let (_server, client) = ssh_client_for_runner(runner)?;
+            if client.is_local {
+                run_shell_command(&command, "initialize synthetic snapshot git checkout")
+            } else {
+                let remote = format!("{}@{}", client.user, client.host);
+                let ssh_command = format!(
+                    "ssh {ssh_args} {remote} {command}",
+                    ssh_args = ssh_args(&client),
+                    remote = shell::quote_arg(&remote),
+                    command = shell::quote_arg(&command),
+                );
+                run_shell_command(
+                    &ssh_command,
+                    "initialize SSH synthetic snapshot git checkout",
+                )
+            }
+        }
+    }
+}
+
+fn synthetic_git_checkout_command(
+    remote_path: &str,
+    snapshot: &str,
+    remote_url: Option<&str>,
+    source_head: Option<&str>,
+) -> String {
+    let remote_path = shell::quote_arg(remote_path);
+    let snapshot = shell::quote_arg(snapshot);
+    let source_head = shell::quote_arg(source_head.unwrap_or("unknown"));
+    let set_remote = remote_url
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| {
+            format!(
+                " && git -C {remote_path} remote add origin {remote_url}",
+                remote_url = shell::quote_arg(value)
+            )
+        })
+        .unwrap_or_default();
+
+    format!(
+        "git -C {remote_path} init && git -C {remote_path} config user.email homeboy-snapshot@localhost && git -C {remote_path} config user.name 'Homeboy Snapshot' && git -C {remote_path} add -A && git -C {remote_path} commit --allow-empty -m {message} --no-gpg-sign && git -C {remote_path} notes --ref=homeboy-snapshot add -m {note} HEAD{set_remote}",
+        message = shell::quote_arg(&format!("Homeboy snapshot {snapshot}")),
+        note = shell::quote_arg(&format!("snapshot_identity={snapshot}\nsource_head={source_head}")),
+    )
+}
+
 pub(crate) fn copy_snapshot_to_directory(
     local_path: &Path,
     destination: &Path,

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -9,11 +9,13 @@ use super::super::{
 };
 use super::git::{git_snapshot, materialize_git, materialize_git_from_controller_bundle};
 use super::snapshot::{
-    effective_snapshot_excludes, local_snapshot_stats, materialize_snapshot, snapshot_identity,
+    effective_snapshot_excludes, local_snapshot_stats, materialize_snapshot,
+    materialize_snapshot_git, snapshot_identity,
 };
 use super::types::{
     canonical_workspace_path, ByteFileCounts, LocalGitState, RunnerWorkspaceCurrentSummary,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput, DEFAULT_EXCLUDES,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    DEFAULT_EXCLUDES,
 };
 use super::util::{deterministic_remote_path, git_output, validate_absolute_path};
 
@@ -53,7 +55,7 @@ pub fn sync_workspace(
     let excludes = effective_snapshot_excludes(excludes, &includes);
 
     match options.mode {
-        RunnerWorkspaceSyncMode::Snapshot => {
+        RunnerWorkspaceSyncMode::Snapshot | RunnerWorkspaceSyncMode::SnapshotGit => {
             let snapshot = snapshot_identity(&local_path, &excludes, &includes)?;
             let remote_path = temp::unique_name(
                 &deterministic_remote_path(
@@ -65,19 +67,19 @@ pub fn sync_workspace(
                 "",
             );
             let stats = local_snapshot_stats(&local_path, &excludes, &includes)?;
-            materialize_snapshot(&runner, &local_path, &remote_path, &excludes)?;
+            if options.mode == RunnerWorkspaceSyncMode::SnapshotGit {
+                materialize_snapshot_git(&runner, &local_path, &remote_path, &excludes, &snapshot)?;
+            } else {
+                materialize_snapshot(&runner, &local_path, &remote_path, &excludes)?;
+            }
             let validation_dependencies = sync_validation_dependency_workspaces(
                 &runner,
                 &local_path,
                 &remote_path,
                 &excludes,
             )?;
-            let current_workspace = current_workspace_summary(
-                &local_path,
-                &remote_path,
-                RunnerWorkspaceSyncMode::Snapshot,
-                true,
-            );
+            let current_workspace =
+                current_workspace_summary(&local_path, &remote_path, options.mode, true);
             let workspace_lease = workspace_lease(&runner.id, &current_workspace);
             Ok((
                 RunnerWorkspaceSyncOutput {
@@ -88,12 +90,16 @@ pub fn sync_workspace(
                     remote_path,
                     current_workspace,
                     workspace_lease,
-                    sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+                    sync_mode: options.mode,
                     snapshot_identity: snapshot,
                     counts: stats,
                     excludes,
                     includes,
-                    workspace_cleanliness: "snapshot_unique_workspace".to_string(),
+                    workspace_cleanliness: if options.mode == RunnerWorkspaceSyncMode::SnapshotGit {
+                        "snapshot_synthetic_git_unique_workspace".to_string()
+                    } else {
+                        "snapshot_unique_workspace".to_string()
+                    },
                     validation_dependencies,
                 },
                 0,

--- a/src/core/runner/workspace/tests/snapshot.rs
+++ b/src/core/runner/workspace/tests/snapshot.rs
@@ -1,11 +1,14 @@
+use super::git;
+
 use std::fs;
 use std::path::Path;
 
-use crate::core::runner::workspace::snapshot::{snapshot_archive_command, snapshot_install_command};
-use crate::core::runner::workspace::sync::sync_workspace;
-use crate::core::runner::workspace::types::{
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+use crate::core::runner::workspace::snapshot::{
+    snapshot_archive_command, snapshot_install_command,
 };
+use crate::core::runner::workspace::sync::sync_workspace;
+use crate::core::runner::workspace::types::{RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
+use crate::core::runner::workspace::util::git_output;
 
 #[test]
 fn runner_snapshot_includes_override_generated_output_excludes() {
@@ -124,8 +127,7 @@ fn test_sync_workspace() {
             "#!/bin/sh\n",
         )
         .expect("extension setup source file");
-        fs::write(source.path().join(".git/HEAD"), "ref: refs/heads/main\n")
-            .expect("git metadata");
+        fs::write(source.path().join(".git/HEAD"), "ref: refs/heads/main\n").expect("git metadata");
         fs::write(source.path().join("src/._main.rs"), "appledouble").expect("sidecar file");
         fs::write(source.path().join(".env.local"), "SECRET=1\n").expect("secret file");
         fs::write(source.path().join("target/debug/homeboy"), "binary").expect("build file");
@@ -201,8 +203,7 @@ fn snapshot_sync_uses_unique_clean_workspace_for_same_snapshot() {
     crate::test_support::with_isolated_home(|_| {
         let source = tempfile::tempdir().expect("source tempdir");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
-        fs::write(source.path().join("Cargo.toml"), "[package]\nname='app'\n")
-            .expect("manifest");
+        fs::write(source.path().join("Cargo.toml"), "[package]\nname='app'\n").expect("manifest");
 
         crate::core::runner::create(
             &format!(
@@ -236,6 +237,75 @@ fn snapshot_sync_uses_unique_clean_workspace_for_same_snapshot() {
         assert!(second_remote_path.join("Cargo.toml").exists());
         assert!(!second_remote_path.join("sentinel.txt").exists());
         assert!(remote_path.join("sentinel.txt").exists());
+    });
+}
+
+#[test]
+fn snapshot_git_sync_materializes_dirty_source_as_synthetic_git_checkout() {
+    crate::test_support::with_isolated_home(|_| {
+        let source = super::dirty_git_repo();
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        git(
+            source.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/app.git",
+            ],
+        );
+
+        crate::core::runner::create(
+            &format!(
+                r#"{{"id":"lab-local-snapshot-git","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let (output, exit_code) = sync_workspace(
+            "lab-local-snapshot-git",
+            RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::SnapshotGit,
+                controller_routed_git: false,
+                changed_since_base: None,
+                git_fetch_refs: Vec::new(),
+                snapshot_includes: Vec::new(),
+                allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
+            },
+        )
+        .expect("sync workspace");
+
+        let remote = Path::new(&output.remote_path);
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::SnapshotGit);
+        assert_eq!(
+            output.current_workspace.sync_mode,
+            RunnerWorkspaceSyncMode::SnapshotGit
+        );
+        assert_eq!(output.current_workspace.source_dirty, Some(true));
+        assert_eq!(
+            output.workspace_cleanliness,
+            "snapshot_synthetic_git_unique_workspace"
+        );
+        assert_eq!(
+            fs::read_to_string(remote.join("file.txt")).unwrap(),
+            "dirty\n"
+        );
+        assert_eq!(
+            git_output(remote, &["rev-parse", "--is-inside-work-tree"]).unwrap(),
+            "true"
+        );
+        assert_eq!(
+            git_output(remote, &["config", "--get", "remote.origin.url"]).unwrap(),
+            "https://github.com/example/app.git"
+        );
+        assert!(git_output(remote, &["log", "-1", "--pretty=%B"])
+            .unwrap()
+            .contains(&output.snapshot_identity));
     });
 }
 

--- a/src/core/runner/workspace/types.rs
+++ b/src/core/runner/workspace/types.rs
@@ -40,6 +40,7 @@ pub(crate) const DEFAULT_EXCLUDES: &[&str] = &[
 pub enum RunnerWorkspaceSyncMode {
     #[default]
     Snapshot,
+    SnapshotGit,
     Git,
 }
 
@@ -47,6 +48,7 @@ impl RunnerWorkspaceSyncMode {
     pub fn label(self) -> &'static str {
         match self {
             Self::Snapshot => "snapshot",
+            Self::SnapshotGit => "snapshot-git",
             Self::Git => "git",
         }
     }


### PR DESCRIPTION
## Summary
- Materialize loop-spec runtime component dependencies into task runtime component contracts.
- Carry dispatch provider/model/options through generic runtime task inputs.
- Add stale controller-state guardrails for resume flows.
- Expose latest executor input/output/outcome evidence refs for agent-task runs.
- Add snapshot-git workspace sync so dirty snapshot workspaces can be materialized as synthetic git checkouts for write-capable tasks.
- Improve selector diagnostics when a nested AI provider id is accidentally passed as the Homeboy dispatch selector.

## Testing
- cargo test snapshot_git_sync_materializes_dirty_source_as_synthetic_git_checkout
- cargo test core::runner::workspace::tests
- cargo test completed_run_exposes_latest_executor_input_output_and_expectations
- cargo test provider_readiness_selector_mismatch_explains_runtime_provider_confusion
- cargo check --lib
- cargo build --bin homeboy

## Notes
- This PR is generic Homeboy runtime/controller support. Product-specific loop declarations and runtime adapters belong outside Homeboy core.
- Earlier repo-wide cargo fmt --check hit unrelated pre-existing formatting drift outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Runtime/controller debugging, implementation, test neutralization, and targeted verification.