### PR TITLE
feat(fuzz): discover inventory artifacts

### DIFF
--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -7,16 +7,17 @@ mod workloads;
 
 pub use types::{
     FuzzArgs, FuzzCampaignContract, FuzzContractOutput, FuzzCoverageCompletenessOutput,
-    FuzzCoverageSelectorSummaryOutput, FuzzExecutionOutput, FuzzGateEvaluation, FuzzListOutput,
-    FuzzOutput, FuzzPlanOutput, FuzzReplayEnv, FuzzReplayOutput, FuzzReportOutput, FuzzRunArgs,
-    FuzzRunOutput, FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
+    FuzzCoverageSelectorSummaryOutput, FuzzDiscoverOutput, FuzzDiscoverSummary,
+    FuzzExecutionOutput, FuzzGateEvaluation, FuzzListOutput, FuzzOutput, FuzzPlanOutput,
+    FuzzReplayEnv, FuzzReplayOutput, FuzzReportOutput, FuzzRunArgs, FuzzRunOutput,
+    FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
 };
 
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::fuzz::{
     default_fuzz_gates, default_fuzz_required_artifacts, fuzz_core_contract, FuzzExecutionRequest,
-    FuzzOperation, FuzzOperationFamily, FuzzSafetyClass, FuzzTargetInventory,
-    FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
+    FuzzOperation, FuzzOperationFamily, FuzzProvenance, FuzzSafetyClass, FuzzTargetInventory,
+    FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_PROVENANCE_SCHEMA,
 };
 use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet};
@@ -24,9 +25,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use super::{CmdResult, GlobalArgs};
 use compare::run_compare;
 use execution::{default_runner_contract, run_run};
+use homeboy::core::fuzz::{merge_fuzz_target_inventory, parse_fuzz_target_inventory_file};
 use replay::run_replay;
 use report::{run_report, run_validate};
-use types::{FuzzCommand, FuzzListArgs, FuzzPlanArgs, FuzzPlanStrategy};
+use types::{FuzzCommand, FuzzDiscoverArgs, FuzzListArgs, FuzzPlanArgs, FuzzPlanStrategy};
 use workloads::{
     build_target_inventory, fuzz_workloads, load_rig, resolve_component_id, resolve_fuzz_context,
     select_workload,
@@ -35,6 +37,9 @@ use workloads::{
 pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
     match args.command {
         Some(FuzzCommand::Contract) => Ok((FuzzOutput::Contract(run_contract()), 0)),
+        Some(FuzzCommand::Discover(discover_args)) => {
+            Ok((FuzzOutput::Discover(run_discover(discover_args)?), 0))
+        }
         Some(FuzzCommand::List(list_args)) => Ok((FuzzOutput::List(run_list(list_args)?), 0)),
         Some(FuzzCommand::Plan(plan_args)) => Ok((FuzzOutput::Plan(run_plan(plan_args)?), 0)),
         Some(FuzzCommand::Run(run_args)) => {
@@ -59,6 +64,62 @@ pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
             Ok((FuzzOutput::Run(output), exit))
         }
     }
+}
+
+fn run_discover(args: FuzzDiscoverArgs) -> homeboy::core::Result<FuzzDiscoverOutput> {
+    let mut inventory_files = Vec::new();
+    let mut merged: Option<FuzzTargetInventory> = None;
+
+    for path in &args.inventories {
+        let discovered = parse_fuzz_target_inventory_file(path)?;
+        inventory_files.push(path.display().to_string());
+        if let Some(base) = &mut merged {
+            merge_fuzz_target_inventory(base, discovered);
+        } else {
+            merged = Some(discovered);
+        }
+    }
+
+    let mut target_inventory = merged.ok_or_else(|| {
+        homeboy::core::Error::validation_invalid_argument(
+            "inventory",
+            "at least one --inventory artifact is required",
+            None,
+            None,
+        )
+    })?;
+    if let Some(id) = args.inventory_id.as_deref() {
+        target_inventory.id = id.trim().to_string();
+    }
+    target_inventory.provenance = Some(FuzzProvenance {
+        schema: FUZZ_PROVENANCE_SCHEMA.to_string(),
+        producer: "homeboy fuzz discover".to_string(),
+        producer_version: None,
+        invocation: Some("artifact-ingest".to_string()),
+        run_id: None,
+        source_ref: Some(args.source_label.clone()),
+        created_at: None,
+        metadata: json!({
+            "inventory_files": inventory_files.clone(),
+            "source_label": args.source_label.clone(),
+            "discovery_mode": "artifact"
+        }),
+        extra: BTreeMap::new(),
+    });
+
+    Ok(FuzzDiscoverOutput {
+        command: "fuzz.discover".to_string(),
+        status: "ok".to_string(),
+        source_label: args.source_label,
+        inventory_files,
+        summary: FuzzDiscoverSummary {
+            surfaces: target_inventory.surfaces.len(),
+            targets: target_inventory.targets.len(),
+            workloads: target_inventory.workloads.len(),
+            seeds: target_inventory.seeds.len(),
+        },
+        target_inventory,
+    })
 }
 
 fn run_contract() -> FuzzContractOutput {
@@ -492,8 +553,8 @@ mod tests {
         FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
     };
     use super::types::{
-        FuzzCommand, FuzzExecutionOutput, FuzzListOutput, FuzzOutput, FuzzPlanArgs,
-        FuzzPlanStrategy, FuzzReplayArgs, FuzzReportArgs, FuzzRunArgs, FuzzRunOutput,
+        FuzzCommand, FuzzDiscoverArgs, FuzzExecutionOutput, FuzzListOutput, FuzzOutput,
+        FuzzPlanArgs, FuzzPlanStrategy, FuzzReplayArgs, FuzzReportArgs, FuzzRunArgs, FuzzRunOutput,
         FuzzRunnerContract, FuzzValidateArgs, FuzzWorkloadOutput,
     };
     use super::workloads::{
@@ -608,6 +669,67 @@ mod tests {
             }
         }))
         .expect("inventory parses")
+    }
+
+    fn write_inventory(path: &Path, inventory: &FuzzTargetInventory) {
+        fs::write(
+            path,
+            serde_json::to_string(inventory).expect("serialize inventory"),
+        )
+        .expect("write inventory");
+    }
+
+    #[test]
+    fn fuzz_discover_merges_inventory_artifacts_with_provenance() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first = temp.path().join("first.json");
+        let second = temp.path().join("second.json");
+        let mut second_inventory = planner_inventory();
+        second_inventory.id = "second-inventory".to_string();
+        second_inventory.targets[0].id = "api.orders".to_string();
+        second_inventory.workloads.clear();
+        second_inventory.seeds.clear();
+        write_inventory(&first, &planner_inventory());
+        write_inventory(&second, &second_inventory);
+
+        let output = super::run_discover(FuzzDiscoverArgs {
+            inventories: vec![first.clone(), second.clone()],
+            inventory_id: Some("merged-inventory".to_string()),
+            source_label: "unit-test".to_string(),
+        })
+        .expect("discover inventory");
+
+        assert_eq!(output.command, "fuzz.discover");
+        assert_eq!(output.status, "ok");
+        assert_eq!(output.target_inventory.id, "merged-inventory");
+        assert_eq!(output.summary.targets, 2);
+        assert_eq!(output.summary.workloads, 1);
+        assert_eq!(output.summary.seeds, 1);
+        assert_eq!(
+            output.inventory_files,
+            vec![first.display().to_string(), second.display().to_string()]
+        );
+        let provenance = output.target_inventory.provenance.expect("provenance");
+        assert_eq!(provenance.producer, "homeboy fuzz discover");
+        assert_eq!(provenance.source_ref.as_deref(), Some("unit-test"));
+        assert_eq!(
+            provenance.metadata["discovery_mode"],
+            serde_json::json!("artifact")
+        );
+    }
+
+    #[test]
+    fn fuzz_discover_requires_inventory_artifacts() {
+        let error = super::run_discover(FuzzDiscoverArgs {
+            inventories: Vec::new(),
+            inventory_id: None,
+            source_label: "artifact".to_string(),
+        })
+        .expect_err("empty discovery should fail");
+
+        assert!(error
+            .to_string()
+            .contains("at least one --inventory artifact is required"));
     }
 
     #[test]

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -50,6 +50,8 @@ impl FuzzArgs {
 pub(crate) enum FuzzCommand {
     /// Print the product-neutral fuzz schema contract
     Contract,
+    /// Normalize and merge discovered fuzz target inventory artifacts
+    Discover(FuzzDiscoverArgs),
     /// List declared fuzz workloads without executing them
     List(FuzzListArgs),
     /// Build a fuzz execution request without executing it
@@ -64,6 +66,25 @@ pub(crate) enum FuzzCommand {
     Compare(FuzzCompareArgs),
     /// Resolve replay metadata for persisted fuzz cases
     Replay(FuzzReplayArgs),
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct FuzzDiscoverArgs {
+    /// Existing fuzz target inventory artifact to ingest.
+    #[arg(long = "inventory", value_name = "PATH", required = true)]
+    pub(crate) inventories: Vec<PathBuf>,
+
+    /// Stable id for the merged inventory artifact.
+    #[arg(long = "inventory-id", value_name = "ID")]
+    pub(crate) inventory_id: Option<String>,
+
+    /// Human-readable source label recorded in merged provenance.
+    #[arg(
+        long = "source-label",
+        value_name = "LABEL",
+        default_value = "artifact"
+    )]
+    pub(crate) source_label: String,
 }
 
 #[derive(Args, Clone)]
@@ -262,6 +283,7 @@ pub(crate) struct FuzzReplayArgs {
 #[serde(tag = "variant", rename_all = "snake_case")]
 pub enum FuzzOutput {
     Contract(FuzzContractOutput),
+    Discover(FuzzDiscoverOutput),
     List(FuzzListOutput),
     Plan(FuzzPlanOutput),
     Run(FuzzRunOutput),
@@ -277,6 +299,24 @@ pub struct FuzzContractOutput {
     pub contract: homeboy::core::fuzz::FuzzCoreContract,
     pub required_artifacts: Vec<FuzzRequiredArtifact>,
     pub gates: Vec<FuzzGate>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FuzzDiscoverOutput {
+    pub command: String,
+    pub status: String,
+    pub source_label: String,
+    pub inventory_files: Vec<String>,
+    pub target_inventory: FuzzTargetInventory,
+    pub summary: FuzzDiscoverSummary,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FuzzDiscoverSummary {
+    pub surfaces: usize,
+    pub targets: usize,
+    pub workloads: usize,
+    pub seeds: usize,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary
- Add `homeboy fuzz discover` for product-neutral fuzz target inventory artifact ingestion.
- Merge one or more `homeboy/fuzz-target-inventory/v1` files and attach Homeboy provenance.
- Return merged inventory counts so downstream planners can consume discovery output without product-specific logic.

## Testing
- `cargo test fuzz_discover --lib`
- `cargo test fuzz_plan_ --lib`
- `cargo test fuzz_output_contract_has_stable_variant_discriminators --lib`

## Notes
- `cargo fmt --check` still reports pre-existing formatting drift in unrelated files, so formatting was limited to the touched fuzz command files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fuzz inventory discovery command, tests, and PR preparation.