### PR TITLE
fix(release): component changelog URL includes subdirectory path (#6146)

### DIFF
--- a/src/core/release/executor/github_release/mod.rs
+++ b/src/core/release/executor/github_release/mod.rs
@@ -33,8 +33,8 @@ pub(crate) use crate::core::release::types::ReleaseStepResult;
 pub(crate) use gh_cli::{github_cli_env, github_release_artifact_paths};
 #[cfg(test)]
 pub(crate) use notes::{
-    fallback_release_notes, github_generated_notes_start_tag, github_release_notes_start_tag,
-    replace_full_changelog_footer, GitHubReleaseBody,
+    fallback_release_notes, github_changelog_url, github_generated_notes_start_tag,
+    github_release_notes_start_tag, replace_full_changelog_footer, GitHubReleaseBody,
 };
 #[cfg(test)]
 pub(crate) use repair::{

--- a/src/core/release/executor/github_release/notes.rs
+++ b/src/core/release/executor/github_release/notes.rs
@@ -145,21 +145,42 @@ fn github_generated_notes(
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-pub(super) fn github_changelog_url(
+pub(crate) fn github_changelog_url(
     component: &Component,
     github: &GitHubRepo,
     tag: &str,
 ) -> Option<String> {
     let changelog_path = changelog::resolve_changelog_path(component).ok()?;
     let local_path = std::path::Path::new(&component.local_path);
-    let relative = changelog_path
+    let component_relative = changelog_path
         .strip_prefix(local_path)
         .unwrap_or(&changelog_path)
         .to_string_lossy()
         .replace('\\', "/");
+
+    // The release URL is anchored at the repository root, but the changelog
+    // path above is relative to the component directory. For a component that
+    // lives in a monorepo subdirectory (e.g. `php-transformer`), prepend the
+    // component's path prefix so the link points at the real file
+    // (`php-transformer/CHANGELOG.md`) instead of a root-level `CHANGELOG.md`
+    // that does not exist (issue #6146).
+    let repo_relative =
+        match crate::core::git::MonorepoContext::detect(&component.local_path, &component.id) {
+            Some(ctx) => {
+                let prefix = ctx.path_prefix.replace('\\', "/");
+                let prefix = prefix.trim_matches('/');
+                if prefix.is_empty() {
+                    component_relative
+                } else {
+                    format!("{}/{}", prefix, component_relative)
+                }
+            }
+            None => component_relative,
+        };
+
     Some(format!(
         "https://{}/{}/{}/blob/{}/{}",
-        github.host, github.owner, github.repo, tag, relative
+        github.host, github.owner, github.repo, tag, repo_relative
     ))
 }
 

--- a/src/core/release/executor/github_release/tests/changelog_url_tests.rs
+++ b/src/core/release/executor/github_release/tests/changelog_url_tests.rs
@@ -1,0 +1,58 @@
+//! Tests for `github_changelog_url`, covering both root-level components and
+//! components that live in a monorepo subdirectory (issue #6146).
+
+use crate::core::component::Component;
+
+use super::super::github_changelog_url;
+use super::{commit_file, git_repo, run_git, test_repo};
+
+#[test]
+fn changelog_url_for_root_component_omits_subdirectory() {
+    let repo = git_repo();
+    let dir = repo.path();
+    commit_file(dir, "CHANGELOG.md", "# Changelog\n", "chore: add changelog");
+
+    let component = Component {
+        id: "homeboy".to_string(),
+        local_path: dir.to_string_lossy().to_string(),
+        changelog_target: Some("CHANGELOG.md".to_string()),
+        ..Default::default()
+    };
+
+    let url = github_changelog_url(&component, &test_repo(), "v1.2.3")
+        .expect("changelog url should be built");
+
+    assert_eq!(
+        url,
+        "https://github.com/example-org/studio-web/blob/v1.2.3/CHANGELOG.md"
+    );
+}
+
+#[test]
+fn changelog_url_for_subdirectory_component_includes_path_prefix() {
+    let repo = git_repo();
+    let root = repo.path();
+
+    // Component lives at <repo>/php-transformer with its own changelog.
+    let component_dir = root.join("php-transformer");
+    std::fs::create_dir_all(&component_dir).expect("create component subdir");
+    std::fs::write(component_dir.join("CHANGELOG.md"), "# Changelog\n")
+        .expect("write component changelog");
+    run_git(root, &["add", "."]);
+    run_git(root, &["commit", "-q", "-m", "chore: add component"]);
+
+    let component = Component {
+        id: "php-transformer".to_string(),
+        local_path: component_dir.to_string_lossy().to_string(),
+        changelog_target: Some("CHANGELOG.md".to_string()),
+        ..Default::default()
+    };
+
+    let url = github_changelog_url(&component, &test_repo(), "php-transformer-v0.1.3")
+        .expect("changelog url should be built");
+
+    assert_eq!(
+        url,
+        "https://github.com/example-org/studio-web/blob/php-transformer-v0.1.3/php-transformer/CHANGELOG.md"
+    );
+}

--- a/src/core/release/executor/github_release/tests/mod.rs
+++ b/src/core/release/executor/github_release/tests/mod.rs
@@ -7,6 +7,7 @@ use crate::core::deploy::release_download::GitHubRepo;
 
 use super::{github_release_repair_commands, GitHubReleaseBody, GitHubReleaseRepairCommands};
 
+mod changelog_url_tests;
 mod notes_tests;
 mod repair_tests;
 mod result_builders;


### PR DESCRIPTION
Closes #6146. Component changelog GitHub URL now includes the component subdirectory path.