### PR TITLE
feat(agent-task): from-spec propagates runtime provider/model options (#6125)

### DIFF
--- a/src/commands/agent_task/tests/loop_compile.rs
+++ b/src/commands/agent_task/tests/loop_compile.rs
@@ -120,6 +120,63 @@ fn compile_loop_command_emits_plan_from_repo_loop_spec() {
 }
 
 #[test]
+fn compile_loop_command_propagates_runtime_provider_model_options_into_runtime_task_input() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let definition_path = temp.path().join("repo-loop-runtime-opts.json");
+    std::fs::write(
+        &definition_path,
+        serde_json::to_string(&json!({
+            "schema": "wpsg/loop-spec/v1",
+            "loop_id": "wpsg/runtime-opts-loop",
+            "metadata": {
+                "dispatch_defaults": {
+                    "backend": "fixture",
+                    "model": "gpt-cli",
+                    "provider_config": json!({
+                        "provider": "codex",
+                        "model": "gpt-config",
+                        "options": { "reasoning_effort": "high" }
+                    })
+                    .to_string()
+                }
+            },
+            "workflows": [
+                {
+                    "workflow_id": "store-idea",
+                    "prompt": "Generate a concept packet.",
+                    "runtime_execution": {
+                        "kind": "bundle",
+                        "ability": "runtime-package/run",
+                        "input": {
+                            "package": { "source": "bundles/store-idea-agent" }
+                        }
+                    }
+                }
+            ]
+        }))
+        .expect("definition json"),
+    )
+    .expect("write definition");
+
+    let (value, status) = loop_definition::compile_loop(CompileLoopArgs {
+        definition: format!("@{}", definition_path.display()),
+    })
+    .expect("compile loop");
+
+    assert_eq!(status, 0);
+    let runtime_task = &value["tasks"][0]["inputs"]["runtime_task"];
+    assert_eq!(runtime_task["ability"], "runtime-package/run");
+    assert_eq!(
+        runtime_task["input"]["package"]["source"],
+        "bundles/store-idea-agent"
+    );
+    // CLI/provider runtime selection must be preserved into runtime_task.input.
+    assert_eq!(runtime_task["input"]["provider"], "codex");
+    assert_eq!(runtime_task["input"]["model"], "gpt-cli");
+    assert_eq!(runtime_task["input"]["options"]["reasoning_effort"], "high");
+}
+
+#[test]
 fn compile_loop_command_rejects_controller_only_sections() {
     let error = loop_definition::compile_loop(CompileLoopArgs {
         definition: serde_json::to_string(&json!({

--- a/src/core/agent_task_repo_loop_compile.rs
+++ b/src/core/agent_task_repo_loop_compile.rs
@@ -263,7 +263,7 @@ fn repo_loop_workflow_request(
         .unwrap_or(Value::Null);
 
     let task_id = repo_loop_task_id(workflow, entity_id);
-    let inputs = repo_loop_workflow_inputs(workflow, entity_id);
+    let inputs = repo_loop_workflow_inputs(spec, workflow, entity_id);
     let component_contracts = repo_loop_workflow_component_contracts(&inputs)?;
 
     Ok(AgentTaskRequest {
@@ -332,6 +332,7 @@ fn sanitize_repo_loop_task_id_segment(value: &str) -> String {
 }
 
 fn repo_loop_workflow_inputs(
+    spec: &AgentTaskRepoLoopSpec,
     workflow: &AgentTaskRepoLoopSpecWorkflow,
     entity_id: Option<&str>,
 ) -> Value {
@@ -345,7 +346,9 @@ fn repo_loop_workflow_inputs(
         }
     };
 
-    if let Some(runtime_task) = runtime_task_from_workflow_execution(&workflow.runtime_execution) {
+    if let Some(runtime_task) =
+        runtime_task_from_workflow_execution(spec, &workflow.runtime_execution)
+    {
         inputs
             .entry("runtime_task".to_string())
             .or_insert(runtime_task);
@@ -370,7 +373,10 @@ fn repo_loop_workflow_inputs(
     Value::Object(inputs)
 }
 
-fn runtime_task_from_workflow_execution(runtime_execution: &Value) -> Option<Value> {
+fn runtime_task_from_workflow_execution(
+    spec: &AgentTaskRepoLoopSpec,
+    runtime_execution: &Value,
+) -> Option<Value> {
     let execution = runtime_execution.as_object()?;
     let ability = execution.get("ability")?.as_str()?.trim();
     if ability.is_empty() {
@@ -379,13 +385,12 @@ fn runtime_task_from_workflow_execution(runtime_execution: &Value) -> Option<Val
 
     let mut runtime_task = serde_json::Map::new();
     runtime_task.insert("ability".to_string(), Value::String(ability.to_string()));
-    runtime_task.insert(
-        "input".to_string(),
-        execution
-            .get("input")
-            .cloned()
-            .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
-    );
+    let mut input = execution
+        .get("input")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+    apply_runtime_task_dispatch_defaults(spec, &mut input);
+    runtime_task.insert("input".to_string(), input);
     if let Some(kind) = execution
         .get("kind")
         .and_then(Value::as_str)
@@ -394,6 +399,54 @@ fn runtime_task_from_workflow_execution(runtime_execution: &Value) -> Option<Val
         runtime_task.insert("kind".to_string(), Value::String(kind.to_string()));
     }
     Some(Value::Object(runtime_task))
+}
+
+/// Propagate the runtime provider/model/options configuration from the spec's
+/// `dispatch_defaults` metadata into the generated `runtime_task.input` so that
+/// `from-spec` compilation preserves the CLI/provider runtime selection instead
+/// of silently dropping it (#6125). Existing keys on the input are preserved.
+fn apply_runtime_task_dispatch_defaults(spec: &AgentTaskRepoLoopSpec, input: &mut Value) {
+    let Some(input) = input.as_object_mut() else {
+        return;
+    };
+    let Some(defaults) = spec
+        .metadata
+        .get("dispatch_defaults")
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+
+    if let Some(model) = defaults
+        .get("model")
+        .and_then(Value::as_str)
+        .filter(|model| !model.trim().is_empty())
+    {
+        input
+            .entry("model".to_string())
+            .or_insert_with(|| Value::String(model.to_string()));
+    }
+
+    let Some(provider_config) = defaults
+        .get("provider_config")
+        .and_then(|value| match value {
+            Value::String(raw) => serde_json::from_str::<Value>(raw).ok(),
+            Value::Object(_) => Some(value.clone()),
+            _ => None,
+        })
+    else {
+        return;
+    };
+    let Some(provider_config) = provider_config.as_object() else {
+        return;
+    };
+    for key in ["provider", "model", "options"] {
+        if let Some(value) = provider_config.get(key).filter(|value| !value.is_null()) {
+            input
+                .entry(key.to_string())
+                .or_insert_with(|| value.clone());
+        }
+    }
 }
 
 fn repo_loop_workflow_component_contracts(


### PR DESCRIPTION
Closes #6125. from-spec now preserves runtime provider/model configuration into generated runtime_task input.