### PR TITLE
feat(runner): snapshot workspaces satisfy git-checkout requirements (#6136)

### DIFF
--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -1041,6 +1041,7 @@ mod tests {
                 source_commit: None,
                 source_ref: None,
                 source_dirty: None,
+                synthetic_checkout_commit: None,
             },
             workspace_lease: crate::core::runner::RunnerWorkspaceLease {
                 runner_id: "lab".to_string(),

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -2981,6 +2981,7 @@ mod tests {
                 source_commit: None,
                 source_ref: None,
                 source_dirty: None,
+                synthetic_checkout_commit: None,
             },
             workspace_lease: crate::core::runner::RunnerWorkspaceLease {
                 runner_id: "lab".to_string(),
@@ -3018,6 +3019,7 @@ mod tests {
                 source_commit: Some("abc123".to_string()),
                 source_ref: Some("main".to_string()),
                 source_dirty: Some(false),
+                synthetic_checkout_commit: None,
             },
             workspace_lease: crate::core::runner::RunnerWorkspaceLease {
                 runner_id: "lab".to_string(),

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -408,6 +408,7 @@ mod tests {
                     source_commit: None,
                     source_ref: None,
                     source_dirty: None,
+                    synthetic_checkout_commit: None,
                 },
                 workspace_lease: crate::core::runner::RunnerWorkspaceLease {
                     runner_id: "homeboy-lab".to_string(),

--- a/src/core/runner/workspace/snapshot.rs
+++ b/src/core/runner/workspace/snapshot.rs
@@ -11,7 +11,7 @@ use super::super::{Runner, RunnerKind};
 use super::types::SnapshotStats;
 use super::util::{
     git_output, hex_prefix, owner_capture_shell, owner_restore_shell, parent_remote_path,
-    run_shell_command, ssh_args, ssh_client_for_runner, tar_exclude_args,
+    run_shell_capture, run_shell_command, ssh_args, ssh_client_for_runner, tar_exclude_args,
 };
 
 pub(crate) fn snapshot_identity(
@@ -203,9 +203,19 @@ pub(crate) fn materialize_snapshot_git(
     remote_path: &str,
     excludes: &[String],
     snapshot: &str,
-) -> Result<()> {
+) -> Result<SyntheticCheckoutIdentity> {
     materialize_snapshot(runner, local_path, remote_path, excludes)?;
     initialize_synthetic_git_checkout(runner, local_path, remote_path, snapshot)
+}
+
+/// Identity of the synthetic git checkout materialized for a `snapshot-git`
+/// sync. Surfaced as run evidence so write-capable agent-task dispatches can
+/// trace the dirty controller-side worktree back to the synthetic commit that
+/// carries the snapshot into the runner workspace.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SyntheticCheckoutIdentity {
+    /// Commit SHA of the synthetic checkout created in the runner workspace.
+    pub(crate) synthetic_commit: Option<String>,
 }
 
 fn initialize_synthetic_git_checkout(
@@ -213,7 +223,7 @@ fn initialize_synthetic_git_checkout(
     local_path: &Path,
     remote_path: &str,
     snapshot: &str,
-) -> Result<()> {
+) -> Result<SyntheticCheckoutIdentity> {
     let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"]).ok();
     let source_head = git_output(local_path, &["rev-parse", "HEAD"]).ok();
     let command = synthetic_git_checkout_command(
@@ -225,12 +235,12 @@ fn initialize_synthetic_git_checkout(
 
     match runner.kind {
         RunnerKind::Local => {
-            run_shell_command(&command, "initialize synthetic snapshot git checkout")
+            run_shell_command(&command, "initialize synthetic snapshot git checkout")?;
         }
         RunnerKind::Ssh => {
             let (_server, client) = ssh_client_for_runner(runner)?;
             if client.is_local {
-                run_shell_command(&command, "initialize synthetic snapshot git checkout")
+                run_shell_command(&command, "initialize synthetic snapshot git checkout")?;
             } else {
                 let remote = format!("{}@{}", client.user, client.host);
                 let ssh_command = format!(
@@ -242,7 +252,46 @@ fn initialize_synthetic_git_checkout(
                 run_shell_command(
                     &ssh_command,
                     "initialize SSH synthetic snapshot git checkout",
-                )
+                )?;
+            }
+        }
+    }
+
+    // Read the synthetic commit back so the synced workspace can record the
+    // checkout identity as run evidence (acceptance criterion: run evidence
+    // records the source commit, dirty snapshot identity, and synthetic
+    // checkout identity). Best-effort: a read-back failure must not fail the
+    // sync, since the checkout itself already succeeded above. The source
+    // commit is recorded separately via the local worktree git state.
+    let synthetic_commit = synthetic_checkout_head(runner, remote_path);
+
+    Ok(SyntheticCheckoutIdentity { synthetic_commit })
+}
+
+/// Best-effort read of the synthetic checkout's HEAD commit SHA from the
+/// materialized runner workspace. Returns `None` when the runner is remote and
+/// unreachable, or the read otherwise fails — provenance is advisory evidence,
+/// not a correctness gate.
+fn synthetic_checkout_head(runner: &Runner, remote_path: &str) -> Option<String> {
+    match runner.kind {
+        RunnerKind::Local => git_output(Path::new(remote_path), &["rev-parse", "HEAD"]).ok(),
+        RunnerKind::Ssh => {
+            let (_server, client) = ssh_client_for_runner(runner).ok()?;
+            if client.is_local {
+                git_output(Path::new(remote_path), &["rev-parse", "HEAD"]).ok()
+            } else {
+                let remote = format!("{}@{}", client.user, client.host);
+                let remote_command = format!(
+                    "git -C {remote_path} rev-parse HEAD",
+                    remote_path = shell::quote_arg(remote_path),
+                );
+                let ssh_command = format!(
+                    "ssh {ssh_args} {remote} {remote_command}",
+                    ssh_args = ssh_args(&client),
+                    remote = shell::quote_arg(&remote),
+                    remote_command = shell::quote_arg(&remote_command),
+                );
+                run_shell_capture(&ssh_command)
             }
         }
     }

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -67,19 +67,27 @@ pub fn sync_workspace(
                 "",
             );
             let stats = local_snapshot_stats(&local_path, &excludes, &includes)?;
-            if options.mode == RunnerWorkspaceSyncMode::SnapshotGit {
-                materialize_snapshot_git(&runner, &local_path, &remote_path, &excludes, &snapshot)?;
+            let synthetic_checkout_commit = if options.mode == RunnerWorkspaceSyncMode::SnapshotGit
+            {
+                materialize_snapshot_git(&runner, &local_path, &remote_path, &excludes, &snapshot)?
+                    .synthetic_commit
             } else {
                 materialize_snapshot(&runner, &local_path, &remote_path, &excludes)?;
-            }
+                None
+            };
             let validation_dependencies = sync_validation_dependency_workspaces(
                 &runner,
                 &local_path,
                 &remote_path,
                 &excludes,
             )?;
-            let current_workspace =
-                current_workspace_summary(&local_path, &remote_path, options.mode, true);
+            let current_workspace = current_workspace_summary(
+                &local_path,
+                &remote_path,
+                options.mode,
+                true,
+                synthetic_checkout_commit,
+            );
             let workspace_lease = workspace_lease(&runner.id, &current_workspace);
             Ok((
                 RunnerWorkspaceSyncOutput {
@@ -162,6 +170,7 @@ pub fn sync_workspace(
                 &remote_path,
                 RunnerWorkspaceSyncMode::Git,
                 true,
+                None,
             );
             let workspace_lease = workspace_lease(&runner.id, &current_workspace);
             Ok((
@@ -213,6 +222,7 @@ fn current_workspace_summary(
     remote_path: &str,
     sync_mode: RunnerWorkspaceSyncMode,
     materialized: bool,
+    synthetic_checkout_commit: Option<String>,
 ) -> RunnerWorkspaceCurrentSummary {
     let git_state = local_git_state(local_path);
     RunnerWorkspaceCurrentSummary {
@@ -223,6 +233,7 @@ fn current_workspace_summary(
         source_commit: git_state.commit,
         source_ref: git_state.ref_name,
         source_dirty: git_state.dirty,
+        synthetic_checkout_commit,
     }
 }
 

--- a/src/core/runner/workspace/tests/snapshot.rs
+++ b/src/core/runner/workspace/tests/snapshot.rs
@@ -306,6 +306,25 @@ fn snapshot_git_sync_materializes_dirty_source_as_synthetic_git_checkout() {
         assert!(git_output(remote, &["log", "-1", "--pretty=%B"])
             .unwrap()
             .contains(&output.snapshot_identity));
+
+        // The synthetic checkout identity must be surfaced as run evidence so a
+        // write-capable agent-task dispatch can trace the dirty controller-side
+        // worktree back to the synthetic commit carrying it into the runner
+        // workspace (#6136 acceptance criterion #2).
+        let synthetic_commit = output
+            .current_workspace
+            .synthetic_checkout_commit
+            .clone()
+            .expect("synthetic checkout commit recorded as run evidence");
+        assert_eq!(
+            synthetic_commit,
+            git_output(remote, &["rev-parse", "HEAD"]).unwrap(),
+            "recorded synthetic checkout commit must match the materialized workspace HEAD"
+        );
+        assert!(
+            output.current_workspace.source_commit.is_some(),
+            "snapshot-git evidence must also record the source commit"
+        );
     });
 }
 

--- a/src/core/runner/workspace/types.rs
+++ b/src/core/runner/workspace/types.rs
@@ -106,6 +106,12 @@ pub struct RunnerWorkspaceCurrentSummary {
     pub source_ref: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_dirty: Option<bool>,
+    /// Commit SHA of the synthetic git checkout created for a `snapshot-git`
+    /// sync, so write-capable agent-task dispatches can trace the dirty
+    /// controller-side worktree back to the synthetic commit that carries it
+    /// into the runner workspace. `None` for plain `snapshot`/`git` syncs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synthetic_checkout_commit: Option<String>,
 }
 
 /// File + byte counts for a synced/snapshotted workspace tree.

--- a/src/core/runner/workspace/util.rs
+++ b/src/core/runner/workspace/util.rs
@@ -94,6 +94,23 @@ pub(crate) fn ssh_client_for_runner(runner: &Runner) -> Result<(Server, SshClien
     Ok((server, client))
 }
 
+/// Best-effort capture of a shell command's trimmed stdout. Returns `None` on
+/// spawn failure or non-zero exit. Used for advisory provenance reads (e.g.
+/// reading a synthetic snapshot checkout's HEAD over SSH) where a failure must
+/// not abort the surrounding operation.
+pub(super) fn run_shell_capture(command: &str) -> Option<String> {
+    let output = Command::new("sh").args(["-c", command]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
 pub(super) fn run_shell_command(command: &str, action: &str) -> Result<()> {
     let output = Command::new("sh")
         .args(["-c", command])


### PR DESCRIPTION
Closes #6136. Runner snapshot workspaces now preserve git state so write-capable agent tasks satisfy git-checkout requirements.

## Summary
- The `snapshot-git` sync mode already materializes dirty controller-side worktrees into a synthetic git checkout (proper `.git`, index, HEAD) on the runner, satisfying the executor's git-checkout preflight for patch-artifact providers.
- This PR closes the remaining acceptance-criteria gap: **run evidence now records the synthetic checkout identity**. After the synthetic checkout is initialized, its HEAD commit SHA is read back (best-effort, local + SSH) and surfaced as `synthetic_checkout_commit` on `RunnerWorkspaceCurrentSummary`, alongside the existing `source_commit` / `source_dirty` / `snapshot_identity` evidence.
- A read-back failure is non-fatal (advisory provenance, not a correctness gate) — the materialized checkout already succeeded.

## Changes
- `workspace/snapshot.rs`: `materialize_snapshot_git` now returns a `SyntheticCheckoutIdentity` carrying the synthetic commit SHA; new `synthetic_checkout_head` reads HEAD from the runner workspace (local or over SSH).
- `workspace/util.rs`: add best-effort `run_shell_capture` helper for advisory stdout reads.
- `workspace/types.rs` / `sync.rs`: thread `synthetic_checkout_commit` into the workspace summary so it lands in sync output as run evidence.
- `workspace/tests/snapshot.rs`: extend the snapshot-git test to assert the recorded synthetic commit matches the materialized workspace HEAD and that the source commit is recorded.
- Mechanical compile-fixes (single `synthetic_checkout_commit: None` field) in three `#[cfg(test)]` struct literals.

## Verification
- `cargo build --lib` (pass)
- `cargo clippy --lib --all-targets` (pass, no errors)
- `cargo fmt` (pass)