### PR TITLE
feat(agent-task): self-explanatory dispatch provider/selector config (#6122)

### DIFF
--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -78,7 +78,11 @@ pub struct AgentTaskControllerFromSpecArgs {
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
 
-    /// Provider id to use for controller-spawned dispatch actions when the action omits one.
+    /// Extension-provider selector: the Homeboy executor provider id (e.g.
+    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
+    /// dispatch actions when the action omits one. This is NOT a model or AI
+    /// runtime name (codex, opencode, claude-code) — pass those in
+    /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "dispatch-selector",
         visible_alias = "dispatch-provider-id",
@@ -90,7 +94,10 @@ pub struct AgentTaskControllerFromSpecArgs {
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
 
-    /// Provider config JSON, @file, or - to use for controller-spawned dispatch actions when the action omits one.
+    /// Agent/model provider config (JSON, @file, or -): the nested AI
+    /// runtime/provider/model the selected executor uses for controller-spawned
+    /// dispatch actions when the action omits one. Put AI runtime names like
+    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }
@@ -133,7 +140,11 @@ pub struct AgentTaskControllerRunFromSpecArgs {
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
 
-    /// Provider id to use for controller-spawned dispatch actions when the action omits one.
+    /// Extension-provider selector: the Homeboy executor provider id (e.g.
+    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
+    /// dispatch actions when the action omits one. This is NOT a model or AI
+    /// runtime name (codex, opencode, claude-code) — pass those in
+    /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "dispatch-selector",
         visible_alias = "dispatch-provider-id",
@@ -145,7 +156,10 @@ pub struct AgentTaskControllerRunFromSpecArgs {
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
 
-    /// Provider config JSON, @file, or - to use for controller-spawned dispatch actions when the action omits one.
+    /// Agent/model provider config (JSON, @file, or -): the nested AI
+    /// runtime/provider/model the selected executor uses for controller-spawned
+    /// dispatch actions when the action omits one. Put AI runtime names like
+    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }
@@ -220,7 +234,11 @@ pub struct AgentTaskControllerRunNextArgs {
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
 
-    /// Provider id to use for controller-spawned dispatch actions when the action omits one.
+    /// Extension-provider selector: the Homeboy executor provider id (e.g.
+    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
+    /// dispatch actions when the action omits one. This is NOT a model or AI
+    /// runtime name (codex, opencode, claude-code) — pass those in
+    /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "dispatch-selector",
         visible_alias = "dispatch-provider-id",
@@ -232,7 +250,10 @@ pub struct AgentTaskControllerRunNextArgs {
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
 
-    /// Provider config JSON, @file, or - to use for controller-spawned dispatch actions when the action omits one.
+    /// Agent/model provider config (JSON, @file, or -): the nested AI
+    /// runtime/provider/model the selected executor uses for controller-spawned
+    /// dispatch actions when the action omits one. Put AI runtime names like
+    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }
@@ -250,7 +271,11 @@ pub struct AgentTaskControllerRunArgs {
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
 
-    /// Provider id to use for controller-spawned dispatch actions when the action omits one.
+    /// Extension-provider selector: the Homeboy executor provider id (e.g.
+    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
+    /// dispatch actions when the action omits one. This is NOT a model or AI
+    /// runtime name (codex, opencode, claude-code) — pass those in
+    /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "dispatch-selector",
         visible_alias = "dispatch-provider-id",
@@ -262,7 +287,10 @@ pub struct AgentTaskControllerRunArgs {
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
 
-    /// Provider config JSON, @file, or - to use for controller-spawned dispatch actions when the action omits one.
+    /// Agent/model provider config (JSON, @file, or -): the nested AI
+    /// runtime/provider/model the selected executor uses for controller-spawned
+    /// dispatch actions when the action omits one. Put AI runtime names like
+    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -62,7 +62,10 @@ pub struct AgentTaskFanoutInputArgs {
     #[arg(long = "backend", value_name = "BACKEND")]
     pub backend: Option<String>,
 
-    /// Default executor provider selector for cooks without one.
+    /// Default extension-provider selector for cooks without one: a Homeboy
+    /// executor provider id (e.g. `wordpress.codebox-agent-task-executor`), NOT
+    /// an AI runtime name (codex, opencode, claude-code). Set the AI runtime via
+    /// --provider-config. Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "selector",
         visible_alias = "provider-id",
@@ -481,7 +484,11 @@ pub struct AgentTaskLoopDefineArgs {
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
 
-    /// Provider id to use for loop-spawned dispatch actions when the action omits one.
+    /// Extension-provider selector: the Homeboy executor provider id (e.g.
+    /// `wordpress.codebox-agent-task-executor`) that runs loop-spawned dispatch
+    /// actions when the action omits one. This is NOT a model or AI runtime name
+    /// (codex, opencode, claude-code) — pass those in --dispatch-provider-config.
+    /// Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "dispatch-selector",
         visible_alias = "dispatch-provider-id",
@@ -493,7 +500,10 @@ pub struct AgentTaskLoopDefineArgs {
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
 
-    /// Provider config JSON, @file, or - for loop-spawned dispatch actions when the action omits one.
+    /// Agent/model provider config (JSON, @file, or -): the nested AI
+    /// runtime/provider/model the selected executor uses for loop-spawned
+    /// dispatch actions when the action omits one. Put AI runtime names like
+    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }
@@ -517,7 +527,11 @@ pub struct AgentTaskLoopResumeArgs {
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
 
-    /// Provider id to use for loop-spawned dispatch actions when the action omits one.
+    /// Extension-provider selector: the Homeboy executor provider id (e.g.
+    /// `wordpress.codebox-agent-task-executor`) that runs loop-spawned dispatch
+    /// actions when the action omits one. This is NOT a model or AI runtime name
+    /// (codex, opencode, claude-code) — pass those in --dispatch-provider-config.
+    /// Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "dispatch-selector",
         visible_alias = "dispatch-provider-id",
@@ -529,7 +543,10 @@ pub struct AgentTaskLoopResumeArgs {
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
 
-    /// Provider config JSON, @file, or - for loop-spawned dispatch actions when the action omits one.
+    /// Agent/model provider config (JSON, @file, or -): the nested AI
+    /// runtime/provider/model the selected executor uses for loop-spawned
+    /// dispatch actions when the action omits one. Put AI runtime names like
+    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -11,7 +11,7 @@ use homeboy::core::agent_tasks::promotion::{
     promote, AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
 use homeboy::core::agent_tasks::provider::{
-    AgentTaskProviderCatalog, ExtensionProviderAgentTaskExecutor,
+    AgentTaskExecutorProvider, AgentTaskProviderCatalog, ExtensionProviderAgentTaskExecutor,
 };
 use homeboy::core::agent_tasks::service as agent_task_service;
 use homeboy::core::agent_tasks::{AgentTaskAggregate, AgentTaskAggregateReport, AgentTaskRequest};
@@ -333,6 +333,7 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
                 "refreshed": args.refresh,
                 "version": catalog_version,
             },
+            "dispatch_config_layers": dispatch_config_layers(providers),
             "capability_contract": homeboy::core::agent_tasks::provider::provider_capability_contract(),
             "providers": providers,
             "readiness_validation": {
@@ -345,6 +346,66 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
         }),
         0,
     ))
+}
+
+/// Operator-facing explanation of the two distinct dispatch configuration
+/// layers, surfaced in `agent-task providers` so a new operator can tell the
+/// extension-provider selector apart from the nested AI runtime provider config
+/// without reading runtime internals (#6122).
+///
+/// The confusion this prevents: `--dispatch-selector codex` fails because
+/// `codex` is an AI runtime, not a Homeboy executor provider id. The correct
+/// selector is an executor provider id (e.g. `wordpress.codebox-agent-task-executor`),
+/// while `codex` belongs in `--dispatch-provider-config` as the nested provider.
+fn dispatch_config_layers(providers: &[AgentTaskExecutorProvider]) -> Value {
+    let selectable_ids: Vec<String> = providers
+        .iter()
+        .map(|provider| provider.id.clone())
+        .collect();
+
+    // Surface a worked example using a real registered executor provider id
+    // when one is available, so the operator can copy a known-good selector
+    // instead of guessing. Prefer a codebox-style provider (the case the
+    // issue called out) but fall back to the first provider, then to a
+    // documented literal when no providers are registered here.
+    let example_selector = providers
+        .iter()
+        .find(|provider| {
+            provider.id.contains("codebox")
+                || provider
+                    .extension_id
+                    .as_deref()
+                    .is_some_and(|id| id.contains("codebox"))
+        })
+        .or_else(|| providers.first())
+        .map(|provider| provider.id.clone())
+        .unwrap_or_else(|| "wordpress.codebox-agent-task-executor".to_string());
+
+    serde_json::json!({
+        "summary": "Dispatch configuration has two independent layers that are easy to confuse: the extension-provider selector picks which Homeboy executor runs the task, while the nested provider config picks which AI runtime/model that executor drives. Pass an executor provider id to --dispatch-selector, and pass the AI runtime (codex, opencode, claude-code, ...) inside --dispatch-provider-config — never the other way around.",
+        "layers": [
+            {
+                "layer": "extension_provider_selector",
+                "flags": ["--dispatch-selector", "--dispatch-provider-id", "--selector", "--provider-id"],
+                "selects": "Which Homeboy extension executor provider handles the task.",
+                "value_is": "A registered executor provider id (see the `providers[].id` values below), NOT a model or AI provider family.",
+                "registered_provider_ids": selectable_ids,
+            },
+            {
+                "layer": "agent_model_provider_config",
+                "flags": ["--dispatch-provider-config", "--provider-config", "--dispatch-model", "--model"],
+                "selects": "Which AI runtime/provider/model the selected executor uses (e.g. codex, opencode, claude-code).",
+                "value_is": "Nested provider config JSON (and/or a model override), passed to the executor — this is where an AI runtime name like `codex` belongs.",
+            }
+        ],
+        "common_mistake": "Passing an AI runtime name (codex, opencode, claude-code) to --dispatch-selector. That selects the executor, not the model, so it fails with 'no extension agent-task provider ... matched selector'. Put the AI runtime in --dispatch-provider-config instead.",
+        "example": {
+            "description": "Run a task with a Codebox-style executor (selector) driving the Codex AI runtime (nested provider config).",
+            "command": format!(
+                "homeboy agent-task cook --dispatch-selector {example_selector} --dispatch-provider-config '{{\"provider\":\"codex\"}}' --prompt @task.md"
+            ),
+        }
+    })
 }
 
 pub(crate) fn default_protected_branches() -> Vec<String> {
@@ -670,6 +731,64 @@ mod tests {
             .as_str()
             .expect("finalize command")
             .contains("--path /Users/user/Developer/homeboy@fix-runtime"));
+    }
+
+    #[test]
+    fn dispatch_config_layers_distinguish_selector_from_provider_config() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "wordpress.codebox-agent-task-executor",
+            "backend": "wordpress",
+            "extension_id": "wordpress.codebox",
+        }))
+        .expect("provider fixture");
+
+        let layers = dispatch_config_layers(std::slice::from_ref(&provider));
+
+        // The two layers are named and kept distinct.
+        let layer_names: Vec<&str> = layers["layers"]
+            .as_array()
+            .expect("layers array")
+            .iter()
+            .map(|layer| layer["layer"].as_str().expect("layer name"))
+            .collect();
+        assert_eq!(
+            layer_names,
+            vec!["extension_provider_selector", "agent_model_provider_config"]
+        );
+
+        // The selector layer surfaces the real registered provider id, not a model.
+        assert_eq!(
+            layers["layers"][0]["registered_provider_ids"],
+            serde_json::json!(["wordpress.codebox-agent-task-executor"])
+        );
+
+        // The worked example uses the discovered codebox selector and puts the
+        // AI runtime in the nested provider config.
+        let command = layers["example"]["command"]
+            .as_str()
+            .expect("example command");
+        assert!(command.contains("--dispatch-selector wordpress.codebox-agent-task-executor"));
+        assert!(command.contains("--dispatch-provider-config"));
+        assert!(command.contains("codex"));
+
+        // The common-mistake note calls out the codex-as-selector trap.
+        assert!(layers["common_mistake"]
+            .as_str()
+            .expect("common mistake")
+            .contains("codex"));
+    }
+
+    #[test]
+    fn dispatch_config_layers_falls_back_to_documented_selector_without_providers() {
+        let layers = dispatch_config_layers(&[]);
+        let command = layers["example"]["command"]
+            .as_str()
+            .expect("example command");
+        assert!(command.contains("--dispatch-selector wordpress.codebox-agent-task-executor"));
+        assert_eq!(
+            layers["layers"][0]["registered_provider_ids"],
+            serde_json::json!([])
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #6122. Dispatch provider/selector configuration is now clearly labeled and explained, distinguishing the extension-provider-selector from the other config layer.

## Summary
- `agent-task providers` output now includes a `dispatch_config_layers` block that names and contrasts the two layers: the **extension-provider selector** (`--dispatch-selector` → a Homeboy executor provider id) and the **agent/model provider config** (`--dispatch-provider-config` → the nested AI runtime/model like `codex`/`opencode`/`claude-code`).
- The layers block surfaces the registered provider ids and a copy-paste worked example (Codebox executor selector + Codex nested provider config), derived from a real discovered codebox provider when available, with a documented fallback.
- A `common_mistake` note calls out the exact trap from the issue: passing `codex` to `--dispatch-selector`.
- Clarified `--dispatch-selector`, `--dispatch-provider-config`, and `--selector` help text across controller/loop/cook args so each flag states which layer it configures and that AI runtime names belong in the provider config, not the selector.

## Notes
- Existing structured resolution hints (`selector_runtime_provider_hint`) already covered the error-message path; this PR focuses on the in-scope discoverability/help surface so a new operator finds the correct selector without reading runtime internals.
- Scope kept to `commands/agent_task/{args/controller.rs,args/mod.rs,review.rs}` + tests. `cargo build --lib`, `cargo clippy --lib --all-targets`, and `cargo fmt` clean.