### PR TITLE
Consume public Codebox result envelopes

### DIFF
--- a/src/core/agent_task_provider/outcome_normalization.rs
+++ b/src/core/agent_task_provider/outcome_normalization.rs
@@ -6,8 +6,175 @@ pub(super) fn normalize_provider_outcome_roles(
 ) {
     normalize_provider_artifact_roles(&mut outcome.artifacts, &provider.role_aliases);
     normalize_provider_run_result_output(outcome, &provider.role_aliases);
+    let codebox_public_envelope_valid = normalize_codebox_public_result_envelope(outcome, provider);
     normalize_provider_runtime_contract(outcome, provider);
-    surface_provider_run_result_diagnostics(outcome);
+    if codebox_public_envelope_valid {
+        surface_provider_run_result_diagnostics(outcome);
+    }
+}
+
+const CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA: &str =
+    "wp-codebox/artifact-result-envelope/v1";
+
+fn normalize_codebox_public_result_envelope(
+    outcome: &mut AgentTaskOutcome,
+    provider: &AgentTaskExecutorProvider,
+) -> bool {
+    if provider.backend != "codebox" {
+        return true;
+    }
+
+    let envelope = output_value(&outcome.outputs, "provider_run_result").cloned();
+    let Some(envelope) = envelope else {
+        fail_codebox_public_envelope_boundary(
+            outcome,
+            "codebox.public_result_envelope_missing",
+            "WP Codebox provider result did not include the public artifact result envelope.",
+            json!({
+                "expected_schema": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+                "provider_backend": provider.backend,
+            }),
+        );
+        return false;
+    };
+
+    if envelope.get("schema").and_then(Value::as_str)
+        != Some(CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA)
+    {
+        fail_codebox_public_envelope_boundary(
+            outcome,
+            "codebox.public_result_envelope_missing",
+            "WP Codebox provider result used a non-public result shape; Homeboy only consumes the public artifact result envelope.",
+            json!({
+                "expected_schema": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+                "actual_schema": envelope.get("schema").and_then(Value::as_str),
+                "private_shape_detected": codebox_private_result_shape_detected(&envelope),
+            }),
+        );
+        return false;
+    }
+
+    let typed_artifacts = codebox_public_typed_artifacts(&envelope);
+    if typed_artifacts.is_empty() {
+        fail_codebox_public_envelope_boundary(
+            outcome,
+            "codebox.public_result_typed_artifacts_missing",
+            "WP Codebox public artifact result envelope did not include any typed artifacts.",
+            json!({
+                "expected_schema": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+                "envelope_status": envelope.get("status").and_then(Value::as_str),
+            }),
+        );
+        return true;
+    }
+
+    for typed_artifact in typed_artifacts {
+        if outcome
+            .typed_artifacts
+            .iter()
+            .any(|existing| existing.name == typed_artifact.name)
+        {
+            continue;
+        }
+        outcome.typed_artifacts.push(typed_artifact);
+    }
+
+    true
+}
+
+fn fail_codebox_public_envelope_boundary(
+    outcome: &mut AgentTaskOutcome,
+    class: &str,
+    message: &str,
+    data: Value,
+) {
+    outcome.status = AgentTaskOutcomeStatus::Failed;
+    outcome.failure_classification = Some(AgentTaskFailureClassification::Provider);
+    push_unique_diagnostic(
+        &mut outcome.diagnostics,
+        class.to_string(),
+        message.to_string(),
+        data,
+    );
+}
+
+fn codebox_private_result_shape_detected(value: &Value) -> bool {
+    value.get("agent_result").is_some()
+        || value
+            .get("metadata")
+            .and_then(|metadata| metadata.get("agent_runtime"))
+            .is_some()
+}
+
+fn codebox_public_typed_artifacts(envelope: &Value) -> Vec<AgentTaskTypedArtifact> {
+    let Some(value) = envelope
+        .get("typed_artifacts")
+        .or_else(|| envelope.get("typedArtifacts"))
+    else {
+        return Vec::new();
+    };
+
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .filter_map(codebox_public_typed_artifact_from_value)
+            .collect(),
+        Value::Object(map) => map
+            .iter()
+            .filter_map(|(name, payload)| {
+                codebox_public_typed_artifact_from_value(payload).or_else(|| {
+                    Some(AgentTaskTypedArtifact {
+                        name: name.clone(),
+                        artifact_type: payload
+                            .get("type")
+                            .or_else(|| payload.get("artifact_type"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        artifact_schema: payload
+                            .get("artifact_schema")
+                            .or_else(|| payload.get("schema"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        payload: payload.clone(),
+                        artifact: None,
+                        metadata: json!({ "source": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA }),
+                    })
+                })
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn codebox_public_typed_artifact_from_value(value: &Value) -> Option<AgentTaskTypedArtifact> {
+    let name = value
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())?
+        .to_string();
+    Some(AgentTaskTypedArtifact {
+        name,
+        artifact_type: value
+            .get("type")
+            .or_else(|| value.get("artifact_type"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        artifact_schema: value
+            .get("artifact_schema")
+            .or_else(|| value.get("schema"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        payload: value
+            .get("payload")
+            .cloned()
+            .unwrap_or_else(|| value.clone()),
+        artifact: None,
+        metadata: value
+            .get("metadata")
+            .cloned()
+            .unwrap_or_else(|| json!({ "source": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA })),
+    })
 }
 
 /// Whether an outcome status represents a failure for which we want to mine the

--- a/src/core/agent_task_provider/tests.rs
+++ b/src/core/agent_task_provider/tests.rs
@@ -1389,6 +1389,87 @@ fn provider_outcome_roles_normalize_from_declared_aliases() {
     );
 }
 
+#[test]
+fn codebox_provider_rejects_private_runtime_result_shape() {
+    let (_, mut provider) = request("task-codebox-private", "node provider.js".to_string());
+    provider.backend = "codebox".to_string();
+    let mut outcome = failed_outcome_with_run_result(json!({
+        "agent_result": { "status": "succeeded" },
+        "metadata": { "agent_runtime": { "id": "runtime-private" } }
+    }));
+    outcome.status = AgentTaskOutcomeStatus::Succeeded;
+    outcome.failure_classification = None;
+
+    normalize_provider_outcome_roles(&mut outcome, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Failed);
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::Provider)
+    );
+    let diagnostic = outcome
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.class == "codebox.public_result_envelope_missing")
+        .expect("missing public envelope diagnostic");
+    assert_eq!(diagnostic.data["private_shape_detected"], true);
+    assert!(outcome.typed_artifacts.is_empty());
+}
+
+#[test]
+fn codebox_provider_consumes_public_typed_artifacts() {
+    let (_, mut provider) = request("task-codebox-public", "node provider.js".to_string());
+    provider.backend = "codebox".to_string();
+    let mut outcome = failed_outcome_with_run_result(json!({
+        "schema": "wp-codebox/artifact-result-envelope/v1",
+        "status": "succeeded",
+        "typed_artifacts": [{
+            "name": "agent_result",
+            "type": "agent_result",
+            "artifact_schema": "wp-codebox/agent-result/v1",
+            "payload": { "summary": "created patch" }
+        }]
+    }));
+    outcome.status = AgentTaskOutcomeStatus::Succeeded;
+    outcome.failure_classification = None;
+
+    normalize_provider_outcome_roles(&mut outcome, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    assert!(outcome.diagnostics.is_empty());
+    assert_eq!(outcome.typed_artifacts.len(), 1);
+    assert_eq!(outcome.typed_artifacts[0].name, "agent_result");
+    assert_eq!(
+        outcome.typed_artifacts[0].artifact_schema.as_deref(),
+        Some("wp-codebox/agent-result/v1")
+    );
+    assert_eq!(
+        outcome.typed_artifacts[0].payload["summary"],
+        "created patch"
+    );
+}
+
+#[test]
+fn codebox_public_envelope_reports_missing_typed_artifacts() {
+    let (_, mut provider) = request("task-codebox-empty", "node provider.js".to_string());
+    provider.backend = "codebox".to_string();
+    let mut outcome = failed_outcome_with_run_result(json!({
+        "schema": "wp-codebox/artifact-result-envelope/v1",
+        "status": "succeeded",
+        "typed_artifacts": []
+    }));
+    outcome.status = AgentTaskOutcomeStatus::Succeeded;
+    outcome.failure_classification = None;
+
+    normalize_provider_outcome_roles(&mut outcome, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Failed);
+    assert!(outcome.diagnostics.iter().any(|diagnostic| {
+        diagnostic.class == "codebox.public_result_typed_artifacts_missing"
+            && diagnostic.message.contains("typed artifacts")
+    }));
+}
+
 fn failed_outcome_with_run_result(run_result: Value) -> AgentTaskOutcome {
     AgentTaskOutcome {
         schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),

--- a/src/core/runner/execution/secrets.rs
+++ b/src/core/runner/execution/secrets.rs
@@ -139,7 +139,7 @@ pub(super) fn provider_file_secret_source_provisions(
         let Some(source) = fallback_sources.get(name) else {
             continue;
         };
-        if source.source != "json-file" {
+        if source.source != "json-file" && source.source != "json-file-jwt-expiration" {
             continue;
         }
         let Some(path) = source

--- a/src/core/runner/execution/tests/secret_source.rs
+++ b/src/core/runner/execution/tests/secret_source.rs
@@ -49,6 +49,40 @@ fn provider_file_secret_source_provisions_group_json_file_sources_without_values
 }
 
 #[test]
+fn provider_file_secret_source_provisions_include_json_file_jwt_expiration_sources() {
+    let mut expires_at = json_file_source("~/.codex/auth.json", "tokens.access_token");
+    expires_at.source = "json-file-jwt-expiration".to_string();
+    let sources = HashMap::from([
+        (
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
+            json_file_source("~/.codex/auth.json", "tokens.access_token"),
+        ),
+        (
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT".to_string(),
+            expires_at,
+        ),
+    ]);
+
+    let provisions = provider_file_secret_source_provisions(
+        &[
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT".to_string(),
+        ],
+        &sources,
+    );
+
+    assert_eq!(provisions.len(), 1);
+    assert_eq!(provisions[0].path, "~/.codex/auth.json");
+    assert_eq!(
+        provisions[0].env_names,
+        vec![
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT".to_string(),
+        ]
+    );
+}
+
+#[test]
 fn runner_secret_env_resolution_uses_provider_json_file_source_values() {
     crate::test_support::with_isolated_home(|home| {
         let provider_dir = home.path().join(".provider");


### PR DESCRIPTION
## Summary
- Require Codebox provider results to cross the public `wp-codebox/artifact-result-envelope/v1` boundary.
- Report distinct diagnostics for missing public envelopes and missing typed artifacts inside public envelopes.
- Hydrate `json-file-jwt-expiration` provider secret sources consistently with other JSON file sources for Codex auth.

## Tests
- `cargo test codebox_provider --lib`
- `cargo test codebox_public_envelope --lib`
- `cargo test provider_file_secret_source_provisions --lib`
- `cargo test hydrate_agent_task_secret_env_resolves_provider_default_run_plan_secrets_on_controller --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the envelope boundary normalization, secret-source handling, tests, and PR preparation.