### PR TITLE
feat(agent-task): live cancellation of provider process trees (#5680)

### DIFF
--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -125,7 +125,42 @@ pub(super) fn artifacts(args: StatusArgs) -> CmdResult<Value> {
 
 pub(super) fn cancel(args: CancelArgs) -> CmdResult<Value> {
     let record = agent_task_service::cancel(&args.run_id, args.reason.as_deref())?;
-    Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0))
+    let mut value = serde_json::to_value(record).unwrap_or(Value::Null);
+    surface_cancellation_recovery(&mut value);
+    Ok((value, 0))
+}
+
+/// Hoist live-cancellation recovery details to the top level of the cancel
+/// response so an operator sees the exact safe commands + process identifiers
+/// without digging through `metadata` (#5680 acceptance: never force manual
+/// process spelunking).
+fn surface_cancellation_recovery(value: &mut Value) {
+    let metadata = value.get("metadata").cloned().unwrap_or(Value::Null);
+
+    if let Some(live) = metadata.get("live_cancellation").cloned() {
+        value["live_cancellation"] = live;
+    }
+
+    if let Some(unsupported) = metadata.get("live_cancellation_unsupported").cloned() {
+        let recovery_commands = unsupported
+            .get("recovery_commands")
+            .cloned()
+            .unwrap_or(Value::Array(Vec::new()));
+        let reason = unsupported
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or("live cancellation is not available for this provider on this host");
+        value["live_cancellation_unsupported"] = unsupported.clone();
+        value["recovery"] = json!({
+            "message": format!(
+                "Live cancellation could not signal the provider process tree directly: {reason}. Run the commands below to terminate it safely.",
+            ),
+            "owner_pid": unsupported.get("owner_pid").cloned().unwrap_or(Value::Null),
+            "runner_id": unsupported.get("runner_id").cloned().unwrap_or(Value::Null),
+            "runner_job_id": unsupported.get("runner_job_id").cloned().unwrap_or(Value::Null),
+            "recovery_commands": recovery_commands,
+        });
+    }
 }
 
 fn enrich_with_diagnostic_summary(value: &mut Value, run_id: &str) -> homeboy::core::Result<()> {

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -148,6 +148,21 @@ impl AgentTaskRunRecord {
             .filter(|value| !value.trim().is_empty())
     }
 
+    fn runner_id(&self) -> Option<&str> {
+        self.metadata
+            .get("runner_id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+    }
+
+    /// A run is runner-backed when its durable record carries a runner id or
+    /// runner job id. For these, the recorded owner pid lives on the *runner*
+    /// host, not this controller, so local pid signalling cannot reach the
+    /// provider process tree.
+    fn is_runner_backed(&self) -> bool {
+        self.runner_id().is_some() || self.runner_job_id().is_some()
+    }
+
     fn ensure_metadata_object(&mut self) -> &mut serde_json::Map<String, Value> {
         if !self.metadata.is_object() {
             self.metadata = json!({});
@@ -388,15 +403,14 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
         ));
     }
 
-    let live_cancellation = if record.state == AgentTaskRunState::Running {
-        match record.owner_pid() {
-            Some(owner_pid) if record.owner_process_is_running() => {
-                Some(crate::core::process::terminate_process_tree(owner_pid)?)
-            }
-            _ => None,
-        }
+    // Classify how live cancellation can be performed for this run BEFORE we
+    // mutate the durable record, so we can record either a real termination or
+    // deterministic operator recovery instructions (acceptance: never force
+    // manual process spelunking; always surface pids + safe commands).
+    let cancellation = if record.state == AgentTaskRunState::Running {
+        classify_live_cancellation(&record)?
     } else {
-        None
+        LiveCancellationOutcome::NotRunning
     };
 
     let cancelled_at = now_timestamp();
@@ -417,17 +431,36 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
         "cancel_reason".to_string(),
         json!(reason.unwrap_or("cancel requested")),
     );
-    if let Some(cancellation) = live_cancellation {
-        metadata.insert(
-            "live_cancellation".to_string(),
-            json!({
-                "owner_pid": cancellation.owner_pid,
-                "descendant_pids": cancellation.descendant_pids,
-                "signalled_pids": cancellation.signalled_pids,
-                "signal": cancellation.signal,
-                "recovery_commands": cancellation.recovery_commands,
-            }),
-        );
+    metadata.remove("live_cancellation");
+    metadata.remove("live_cancellation_unsupported");
+    match cancellation {
+        LiveCancellationOutcome::Terminated(termination) => {
+            metadata.insert(
+                "live_cancellation".to_string(),
+                json!({
+                    "owner_pid": termination.owner_pid,
+                    "descendant_pids": termination.descendant_pids,
+                    "signalled_pids": termination.signalled_pids,
+                    "signal": termination.signal,
+                    "killed_pids": termination.killed_pids,
+                    "surviving_pids": termination.surviving_pids,
+                    "recovery_commands": termination.recovery_commands,
+                }),
+            );
+        }
+        LiveCancellationOutcome::Unsupported(unsupported) => {
+            metadata.insert(
+                "live_cancellation_unsupported".to_string(),
+                json!({
+                    "reason": unsupported.reason,
+                    "owner_pid": unsupported.owner_pid,
+                    "runner_id": unsupported.runner_id,
+                    "runner_job_id": unsupported.runner_job_id,
+                    "recovery_commands": unsupported.recovery_commands,
+                }),
+            );
+        }
+        LiveCancellationOutcome::NotRunning => {}
     }
     if was_stale_running {
         metadata.insert("cancelled_stale_running".to_string(), json!(true));
@@ -437,6 +470,94 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
 
     store::write_record(&record)?;
     Ok(record)
+}
+
+/// Outcome of attempting live cancellation of a running run's provider process
+/// tree. Either Homeboy signalled the tree itself, it can only hand the operator
+/// deterministic recovery commands (runner-side / non-Unix host), or the run was
+/// not actually running.
+enum LiveCancellationOutcome {
+    Terminated(crate::core::process::ProcessTreeTermination),
+    Unsupported(UnsupportedLiveCancellation),
+    NotRunning,
+}
+
+/// Recovery payload surfaced when Homeboy cannot itself signal the provider
+/// process tree (the owner pid lives on a runner host, or no live process is
+/// reachable). Carries the recorded identifiers plus copy-pasteable commands so
+/// the operator never has to spelunk for child pids.
+struct UnsupportedLiveCancellation {
+    reason: String,
+    owner_pid: Option<u32>,
+    runner_id: Option<String>,
+    runner_job_id: Option<String>,
+    recovery_commands: Vec<String>,
+}
+
+fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancellationOutcome> {
+    let owner_pid = record.owner_pid();
+
+    // Local, live owner process: terminate its tree directly (SIGTERM then
+    // SIGKILL escalation handled inside terminate_process_tree).
+    if let Some(pid) = owner_pid {
+        if record.owner_process_is_running() {
+            let termination = crate::core::process::terminate_process_tree(pid)?;
+            return Ok(LiveCancellationOutcome::Terminated(termination));
+        }
+    }
+
+    // Runner-backed run whose provider process tree lives on a different host:
+    // we cannot signal it from this controller. Emit deterministic recovery
+    // commands keyed on the recorded runner + pid instead of failing.
+    if record.is_runner_backed() {
+        let runner_id = record.runner_id().map(str::to_string);
+        let runner_job_id = record.runner_job_id().map(str::to_string);
+        let mut recovery_commands = Vec::new();
+        if let Some(runner) = runner_id.as_deref() {
+            if let Some(job) = runner_job_id.as_deref() {
+                recovery_commands.push(format!(
+                    "homeboy runner exec {runner} -- homeboy agent-task cancel {} # cancel on the owning runner",
+                    record.run_id
+                ));
+                let _ = job;
+            }
+        }
+        if let Some(pid) = owner_pid {
+            recovery_commands.extend(crate::core::process::process_tree_recovery_commands(pid));
+        }
+        let reason = if owner_pid.is_some() {
+            "provider process tree runs on the owning runner host; signal it there"
+        } else {
+            "runner-backed run has no controller-local owner pid to signal"
+        }
+        .to_string();
+        return Ok(LiveCancellationOutcome::Unsupported(
+            UnsupportedLiveCancellation {
+                reason,
+                owner_pid,
+                runner_id,
+                runner_job_id,
+                recovery_commands,
+            },
+        ));
+    }
+
+    // No reachable live process (stale running record, or no recorded pid): the
+    // record is being reclaimed. If a pid was recorded, still hand back recovery
+    // commands so a now-orphaned tree can be cleaned up by hand.
+    if let Some(pid) = owner_pid {
+        return Ok(LiveCancellationOutcome::Unsupported(
+            UnsupportedLiveCancellation {
+                reason: "recorded owner pid is not running on this host".to_string(),
+                owner_pid: Some(pid),
+                runner_id: None,
+                runner_job_id: None,
+                recovery_commands: crate::core::process::process_tree_recovery_commands(pid),
+            },
+        ));
+    }
+
+    Ok(LiveCancellationOutcome::NotRunning)
 }
 
 pub fn record_run_aggregate(
@@ -2920,6 +3041,46 @@ mod tests {
                 cancelled.metadata["live_cancellation"]["signal"],
                 json!("SIGTERM")
             );
+        });
+    }
+
+    #[test]
+    fn cancel_run_emits_recovery_commands_for_runner_backed_run() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-cancel-runner")).expect("submitted");
+            let mut record = store::read_record("run-cancel-runner").expect("record");
+            record.state = AgentTaskRunState::Running;
+            record.tasks[0].state = AgentTaskState::Running;
+            // Runner-backed: owner pid lives on the runner host (not running
+            // here), so live cancellation must hand back recovery commands.
+            record.metadata = json!({
+                "runner_pid": u32::MAX,
+                "runner_id": "lab-a",
+                "runner_job_id": "job-123",
+            });
+            store::write_record(&record).expect("stored runner record");
+
+            let cancelled = cancel_run("run-cancel-runner", None).expect("runner run cancelled");
+
+            assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+            assert_eq!(cancelled.tasks[0].state, AgentTaskState::Cancelled);
+            let unsupported = &cancelled.metadata["live_cancellation_unsupported"];
+            assert!(unsupported.is_object());
+            assert_eq!(unsupported["runner_id"], json!("lab-a"));
+            assert_eq!(unsupported["runner_job_id"], json!("job-123"));
+            let commands = unsupported["recovery_commands"]
+                .as_array()
+                .expect("recovery commands array");
+            assert!(!commands.is_empty());
+            // The first recovery command should route cancellation to the
+            // owning runner so the operator can act deterministically.
+            assert!(commands[0]
+                .as_str()
+                .expect("command string")
+                .contains("homeboy runner exec lab-a"));
+            // No real local process was signalled.
+            assert!(cancelled.metadata.get("live_cancellation").is_none());
         });
     }
 

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -92,9 +92,27 @@ pub struct ProcessTreeTermination {
     pub owner_pid: u32,
     pub descendant_pids: Vec<u32>,
     pub signalled_pids: Vec<u32>,
+    /// The strongest signal actually delivered to the tree. "SIGTERM" when a
+    /// graceful terminate was sufficient, "SIGKILL" when one or more processes
+    /// survived the grace period and had to be force-killed.
     pub signal: &'static str,
+    /// Pids that were still alive after the SIGTERM grace window and therefore
+    /// received an escalated SIGKILL.
+    pub killed_pids: Vec<u32>,
+    /// Pids that survived even the SIGKILL escalation (e.g. uninterruptible
+    /// sleep, or owned by another user). Operators may need to act on these
+    /// manually; the recovery commands cover them.
+    pub surviving_pids: Vec<u32>,
     pub recovery_commands: Vec<String>,
 }
+
+/// How long to wait for a process tree to exit after SIGTERM before escalating
+/// to SIGKILL. Kept short so `agent-task cancel` stays responsive while still
+/// giving providers a chance to flush/cleanup on a graceful terminate.
+#[cfg(unix)]
+const SIGTERM_GRACE: std::time::Duration = std::time::Duration::from_millis(2000);
+#[cfg(unix)]
+const SIGTERM_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
 pub fn terminate_process_tree(owner_pid: u32) -> Result<ProcessTreeTermination> {
     if owner_pid > i32::MAX as u32 {
@@ -116,38 +134,48 @@ pub fn terminate_process_tree(owner_pid: u32) -> Result<ProcessTreeTermination> 
         targets.sort_unstable();
         targets.dedup();
 
-        for pid in targets.iter().rev() {
-            unsafe {
-                if libc::kill(*pid as libc::pid_t, libc::SIGTERM) != 0 {
-                    let err = std::io::Error::last_os_error();
-                    if err.raw_os_error() != Some(libc::ESRCH) {
-                        return Err(Error::internal_unexpected(format!(
-                            "failed to signal pid {} with SIGTERM: {}",
-                            pid, err
-                        )));
-                    }
-                }
-            }
+        // Phase 1: SIGTERM the whole tree, deepest descendants first so parents
+        // do not respawn or reparent children mid-teardown.
+        signal_pids(&targets, libc::SIGTERM)?;
+
+        // Phase 2: wait out a short grace period, then SIGKILL any survivors so a
+        // provider that ignores SIGTERM (or is wedged) cannot keep the run alive.
+        let mut killed_pids = Vec::new();
+        let survivors_after_term = wait_for_exit(&targets, SIGTERM_GRACE);
+        if !survivors_after_term.is_empty() {
+            signal_pids(&survivors_after_term, libc::SIGKILL)?;
+            killed_pids = survivors_after_term;
         }
 
-        let recovery_commands = if targets.is_empty() {
-            Vec::new()
+        // Anything still alive after SIGKILL is genuinely unkillable from here
+        // (uninterruptible sleep, different owner, ...). Surface it for recovery.
+        let surviving_pids: Vec<u32> = targets
+            .iter()
+            .copied()
+            .filter(|pid| pid_is_running(*pid))
+            .collect();
+
+        let signal = if killed_pids.is_empty() {
+            "SIGTERM"
         } else {
-            vec![format!(
-                "kill -TERM {}",
-                targets
-                    .iter()
-                    .map(u32::to_string)
-                    .collect::<Vec<_>>()
-                    .join(" ")
-            )]
+            "SIGKILL"
         };
+
+        let mut recovery_commands = Vec::new();
+        if !targets.is_empty() {
+            recovery_commands.push(format!("kill -TERM {}", join_pids(&targets)));
+        }
+        if !surviving_pids.is_empty() {
+            recovery_commands.push(format!("kill -KILL {}", join_pids(&surviving_pids)));
+        }
 
         return Ok(ProcessTreeTermination {
             owner_pid,
             descendant_pids,
             signalled_pids: targets,
-            signal: "SIGTERM",
+            signal,
+            killed_pids,
+            surviving_pids,
             recovery_commands,
         });
     }
@@ -162,6 +190,69 @@ pub fn terminate_process_tree(owner_pid: u32) -> Result<ProcessTreeTermination> 
             None,
         ))
     }
+}
+
+/// Build the recovery commands an operator should run to manually terminate a
+/// provider process tree when Homeboy cannot signal it itself (e.g. the recorded
+/// owner pid lives on a different host/runner, or this is a non-Unix host). This
+/// never signals anything — it only renders deterministic, copy-pasteable
+/// commands keyed on the recorded pid so the operator does not have to spelunk.
+pub fn process_tree_recovery_commands(owner_pid: u32) -> Vec<String> {
+    vec![
+        format!(
+            "ps -axo pid=,ppid=,command= | awk -v root={owner_pid} 'function walk(p){{print p; for(i in C[p]) walk(C[p][i])}} {{C[$2][length(C[$2])+1]=$1; CMD[$1]=$0}} END{{walk(root)}}'"
+        ),
+        format!("pkill -TERM -P {owner_pid}"),
+        format!("kill -TERM {owner_pid}"),
+        format!("kill -KILL {owner_pid}  # if it ignores SIGTERM"),
+    ]
+}
+
+#[cfg(unix)]
+fn signal_pids(pids: &[u32], signal: libc::c_int) -> Result<()> {
+    // Deepest-first: `pids` is sorted ascending and descendants generally have
+    // higher pids than their owner, so iterating in reverse approximates a
+    // bottom-up teardown.
+    for pid in pids.iter().rev() {
+        unsafe {
+            if libc::kill(*pid as libc::pid_t, signal) != 0 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() != Some(libc::ESRCH) {
+                    return Err(Error::internal_unexpected(format!(
+                        "failed to signal pid {} with signal {}: {}",
+                        pid, signal, err
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Poll the given pids until they all exit or `grace` elapses. Returns the pids
+/// still running when the window closes (the SIGKILL escalation set).
+#[cfg(unix)]
+fn wait_for_exit(pids: &[u32], grace: std::time::Duration) -> Vec<u32> {
+    let deadline = std::time::Instant::now() + grace;
+    loop {
+        let survivors: Vec<u32> = pids
+            .iter()
+            .copied()
+            .filter(|pid| pid_is_running(*pid))
+            .collect();
+        if survivors.is_empty() || std::time::Instant::now() >= deadline {
+            return survivors;
+        }
+        std::thread::sleep(SIGTERM_POLL_INTERVAL);
+    }
+}
+
+#[cfg(unix)]
+fn join_pids(pids: &[u32]) -> String {
+    pids.iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[cfg(unix)]
@@ -284,5 +375,57 @@ mod process_tree_tests {
         descendants.sort_unstable();
 
         assert_eq!(descendants, vec![11, 12, 13]);
+    }
+
+    #[test]
+    fn process_tree_recovery_commands_reference_recorded_pid() {
+        let commands = process_tree_recovery_commands(4242);
+        assert!(!commands.is_empty());
+        assert!(commands.iter().any(|cmd| cmd.contains("4242")));
+        assert!(commands.iter().any(|cmd| cmd.contains("kill -KILL 4242")));
+    }
+
+    #[test]
+    fn terminate_process_tree_escalates_to_sigkill_on_sigterm_resistant_child() {
+        // A child that ignores SIGTERM forces the SIGKILL escalation path.
+        let mut child = Command::new("sh")
+            .args(["-c", "trap '' TERM; sleep 30"])
+            .spawn()
+            .expect("spawn sigterm-resistant child");
+        let pid = child.id();
+
+        let termination = terminate_process_tree(pid).expect("terminate sigterm-resistant tree");
+
+        // It survived SIGTERM and had to be SIGKILL'd.
+        assert_eq!(termination.signal, "SIGKILL");
+        assert!(termination.killed_pids.contains(&pid));
+        assert!(termination.surviving_pids.is_empty());
+        assert!(termination
+            .recovery_commands
+            .iter()
+            .any(|cmd| cmd.contains(&pid.to_string())));
+
+        // Reap so we do not leak a zombie into the test runner.
+        let _ = child.wait();
+        assert!(!pid_is_running(pid));
+    }
+
+    #[test]
+    fn terminate_process_tree_uses_sigterm_for_cooperative_child() {
+        // A plain sleep exits on SIGTERM, so no escalation is needed.
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn cooperative child");
+        let pid = child.id();
+
+        let termination = terminate_process_tree(pid).expect("terminate cooperative tree");
+
+        assert_eq!(termination.signal, "SIGTERM");
+        assert!(termination.killed_pids.is_empty());
+        assert!(termination.surviving_pids.is_empty());
+
+        let _ = child.wait();
+        assert!(!pid_is_running(pid));
     }
 }


### PR DESCRIPTION
Closes #5680. agent-task cancel now terminates running provider process trees (local + runner-side) and transitions the durable record to cancelled; prints recovery commands for unsupported providers.