### PR TITLE
Support static workflow fanout declarations

### DIFF
--- a/src/commands/agent_task/tests/dispatch.rs
+++ b/src/commands/agent_task/tests/dispatch.rs
@@ -100,6 +100,7 @@ fn from_spec_dispatch_defaults_fall_back_to_current_git_checkout() {
             prompt: Some("cook the next workflow".to_string()),
             tasks: Vec::new(),
             entity_ids: Vec::new(),
+            fan_out: None,
             tools: Vec::new(),
             abilities: Vec::new(),
             artifacts: Vec::new(),

--- a/src/core/agent_task_controller_service/spec.rs
+++ b/src/core/agent_task_controller_service/spec.rs
@@ -193,6 +193,8 @@ pub struct AgentTaskRepoLoopSpecWorkflow {
     pub tasks: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entity_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fan_out: Option<AgentTaskRepoLoopSpecFanOut>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -213,6 +215,19 @@ pub struct AgentTaskRepoLoopSpecWorkflow {
     pub runtime_execution: Value,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub inputs: Value,
+}
+
+/// Generic fan-out declaration for a workflow.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskRepoLoopSpecFanOut {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, alias = "items", skip_serializing_if = "Vec::is_empty")]
+    pub entity_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_items: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fail_fast: Option<bool>,
 }
 
 /// Artifact contract declared by a repo loop spec.

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -542,21 +542,47 @@ pub(super) fn compile_loop_spec_workflow(
 ) -> Result<AgentTaskLoopPolicyAction> {
     let request = workflow_dispatch_request(spec, workflow)?;
     let dedupe_key = format!("workflow:{}", workflow.workflow_id);
-    if workflow.entity_ids.is_empty() {
+    let fan_out_entity_ids = workflow_fan_out_entity_ids(workflow)?;
+    if fan_out_entity_ids.is_empty() {
         Ok(AgentTaskLoopPolicyAction::SpawnTask {
             dedupe_key,
             entity_id: None,
             request,
         })
     } else {
+        let fan_out = workflow.fan_out.as_ref();
         Ok(AgentTaskLoopPolicyAction::FanOut {
             dedupe_key,
-            entity_ids: workflow.entity_ids.clone(),
-            max_items: crate::core::agent_task_loop_controller::DEFAULT_FAN_OUT_MAX_ITEMS,
-            fail_fast: true,
+            entity_ids: fan_out_entity_ids,
+            max_items: fan_out
+                .and_then(|fan_out| fan_out.max_items)
+                .unwrap_or(crate::core::agent_task_loop_controller::DEFAULT_FAN_OUT_MAX_ITEMS),
+            fail_fast: fan_out
+                .and_then(|fan_out| fan_out.fail_fast)
+                .unwrap_or(true),
             request_template: request,
         })
     }
+}
+
+fn workflow_fan_out_entity_ids(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Result<Vec<String>> {
+    if !workflow.entity_ids.is_empty() {
+        return Ok(workflow.entity_ids.clone());
+    }
+
+    let Some(fan_out) = &workflow.fan_out else {
+        return Ok(Vec::new());
+    };
+    if !fan_out.entity_ids.is_empty() {
+        return Ok(fan_out.entity_ids.clone());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "workflows[].fan_out",
+        "repo loop spec workflow fan_out requires concrete entity_ids/items; dynamic fan-out sources need artifact-to-entity expansion in the controller path",
+        Some(workflow.workflow_id.clone()),
+        fan_out.mode.as_ref().map(|mode| vec![format!("mode:{mode}")]),
+    ))
 }
 
 pub(super) fn workflow_dispatch_request(
@@ -803,7 +829,7 @@ pub(super) fn workflow_homeboy_plan(
         kind: "agent_task_dispatch".to_string(),
         label: Some(workflow.workflow_id.clone()),
         blocking: true,
-        scope: workflow.entity_ids.clone(),
+        scope: workflow_fan_out_entity_ids(workflow)?,
         needs: workflow.dependencies.clone(),
         needs_kind: PlanStepDependencyKind::Execution,
         status: PlanStepStatus::Ready,

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -518,6 +518,7 @@ fn repo_loop_reconcile_spec(loop_id: &str) -> AgentTaskRepoLoopSpec {
                 prompt: Some("Generate a static site candidate.".to_string()),
                 tasks: Vec::new(),
                 entity_ids: Vec::new(),
+                fan_out: None,
                 tools: Vec::new(),
                 abilities: vec!["github_pull_request_publish".to_string()],
                 artifacts: vec!["static_site_pull_request".to_string()],
@@ -535,6 +536,7 @@ fn repo_loop_reconcile_spec(loop_id: &str) -> AgentTaskRepoLoopSpec {
                 prompt: Some("Validate the generated static site.".to_string()),
                 tasks: Vec::new(),
                 entity_ids: Vec::new(),
+                fan_out: None,
                 tools: Vec::new(),
                 abilities: vec!["static_validation".to_string()],
                 artifacts: Vec::new(),
@@ -790,6 +792,7 @@ fn init_from_spec_compiles_repo_workflows_into_deduped_dispatch_actions() {
                 prompt: Some("Repair this finding and report evidence.".to_string()),
                 tasks: Vec::new(),
                 entity_ids: vec!["finding:abc".to_string()],
+                fan_out: None,
                 tools: vec!["repo-inspector".to_string()],
                 abilities: vec!["apply_patch".to_string()],
                 artifacts: vec!["patch".to_string()],
@@ -921,6 +924,77 @@ fn init_from_spec_compiles_repo_workflows_into_deduped_dispatch_actions() {
         assert_eq!(
             resumed.actions[0].status,
             AgentTaskLoopActionStatus::AlreadySatisfied
+        );
+    });
+}
+
+#[test]
+fn init_from_spec_compiles_workflow_fan_out_items_into_deduped_dispatch_action() {
+    with_isolated_home(|_| {
+        let spec: AgentTaskRepoLoopSpec = serde_json::from_value(json!({
+            "loop_id": "repo-loop-fan-out-items",
+            "workflows": [{
+                "workflow_id": "repair-findings",
+                "prompt": "Repair each routed finding.",
+                "fan_out": {
+                    "items": ["finding:alpha", "finding:beta"],
+                    "max_items": 1,
+                    "fail_fast": false
+                }
+            }]
+        }))
+        .expect("spec deserializes");
+
+        let report = init_from_spec(ControllerFromSpecRequest { spec }).expect("spec initialized");
+
+        assert_eq!(report.actions.len(), 1);
+        match &report.actions[0].action {
+            AgentTaskLoopPolicyAction::FanOut {
+                dedupe_key,
+                entity_ids,
+                max_items,
+                fail_fast,
+                ..
+            } => {
+                assert_eq!(dedupe_key, "workflow:repair-findings");
+                assert_eq!(
+                    entity_ids,
+                    &vec!["finding:alpha".to_string(), "finding:beta".to_string()]
+                );
+                assert_eq!(*max_items, 1);
+                assert!(!fail_fast);
+            }
+            other => panic!("expected fan_out workflow action, got {other:?}"),
+        }
+    });
+}
+
+#[test]
+fn init_from_spec_rejects_dynamic_artifact_fan_out_until_artifact_expansion_exists() {
+    with_isolated_home(|_| {
+        let spec: AgentTaskRepoLoopSpec = serde_json::from_value(json!({
+            "loop_id": "repo-loop-artifact-fan-out",
+            "workflows": [{
+                "workflow_id": "iterator",
+                "prompt": "Route each emitted finding group.",
+                "fan_out": {
+                    "mode": "per_artifact",
+                    "artifact": "finding_group",
+                    "group_by": ["owner_repo", "root_cause", "group_id"],
+                    "requires_non_empty": true
+                }
+            }]
+        }))
+        .expect("spec deserializes");
+
+        let error = init_from_spec(ControllerFromSpecRequest { spec })
+            .expect_err("dynamic artifact fan-out needs controller artifact expansion");
+
+        let message = error.to_string();
+        assert!(message.contains("workflows[].fan_out"), "{message}");
+        assert!(
+            message.contains("artifact-to-entity expansion"),
+            "{message}"
         );
     });
 }
@@ -1247,6 +1321,7 @@ fn init_from_spec_reconciles_removed_and_added_workflows() {
                 prompt: Some("Publish the validated static site.".to_string()),
                 tasks: Vec::new(),
                 entity_ids: Vec::new(),
+                fan_out: None,
                 tools: Vec::new(),
                 abilities: vec!["static_publication".to_string()],
                 artifacts: vec!["static_site_pull_request".to_string()],
@@ -1325,6 +1400,7 @@ fn init_from_spec_rejects_undeclared_workflow_requirements() {
                 prompt: Some("Repair with a declared tool.".to_string()),
                 tasks: Vec::new(),
                 entity_ids: Vec::new(),
+                fan_out: None,
                 tools: vec!["missing-tool".to_string()],
                 abilities: Vec::new(),
                 artifacts: Vec::new(),
@@ -2737,6 +2813,7 @@ fn from_spec_resume_drives_generic_workflow_gates_completion_and_lineage() {
                 prompt: Some("Repair each routed finding and report evidence.".to_string()),
                 tasks: Vec::new(),
                 entity_ids: vec!["finding:alpha".to_string(), "finding:beta".to_string()],
+                fan_out: None,
                 tools: vec!["repo-inspector".to_string()],
                 abilities: vec!["patch-writer".to_string()],
                 artifacts: vec!["candidate-patch".to_string()],

--- a/src/core/agent_task_loop_definition.rs
+++ b/src/core/agent_task_loop_definition.rs
@@ -585,6 +585,63 @@ mod tests {
     }
 
     #[test]
+    fn compiles_repo_loop_workflow_fan_out_items_into_concrete_agent_tasks() {
+        let plan = compile_loop_spec_value(json!({
+            "loop_id": "example/fan-out-items",
+            "workflows": [
+                {
+                    "workflow_id": "review-page",
+                    "prompt": "Review each page.",
+                    "fan_out": { "items": ["home", "about"] }
+                }
+            ]
+        }))
+        .expect("fan_out items repo loop spec compiles");
+
+        let task_ids: Vec<&str> = plan
+            .tasks
+            .iter()
+            .map(|task| task.task_id.as_str())
+            .collect();
+        assert_eq!(task_ids, vec!["review-page__home", "review-page__about"]);
+        assert_eq!(
+            plan.tasks[0].inputs["repo_loop"],
+            json!({ "entity_id": "home", "workflow_id": "review-page" })
+        );
+    }
+
+    #[test]
+    fn rejects_repo_loop_dynamic_fan_out_with_controller_diagnostic() {
+        let error = compile_loop_spec_value(json!({
+            "loop_id": "example/dynamic-fan-out",
+            "workflows": [
+                {
+                    "workflow_id": "iterator",
+                    "prompt": "Route each finding group.",
+                    "fan_out": {
+                        "mode": "per_artifact",
+                        "artifact": "finding_group",
+                        "group_by": ["owner_repo", "root_cause", "group_id"],
+                        "requires_non_empty": true
+                    }
+                }
+            ]
+        }))
+        .expect_err("dynamic fan_out requires controller artifact expansion");
+
+        assert!(error.message.contains("controller-only sections"));
+        let tried = error.details["tried"]
+            .as_array()
+            .expect("diagnostics are tried values")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(tried.contains("workflows[iterator].fan_out"));
+        assert!(tried.contains("expand artifacts into concrete entity ids"));
+    }
+
+    #[test]
     fn compiles_repo_loop_artifact_graph_edges_into_output_dependencies() {
         let plan = compile_loop_spec_value(json!({
             "loop_id": "example/artifact-graph",

--- a/src/core/agent_task_repo_loop_compile.rs
+++ b/src/core/agent_task_repo_loop_compile.rs
@@ -176,6 +176,12 @@ fn unsupported_repo_loop_spec_fields(spec: &AgentTaskRepoLoopSpec) -> Vec<String
             .push("initial_event: event evaluation belongs to agent-task controller".to_string());
     }
     for workflow in &spec.workflows {
+        if workflow_has_dynamic_fan_out(workflow) {
+            unsupported.push(format!(
+                "workflows[{}].fan_out: dynamic fan-out sources require the controller path to expand artifacts into concrete entity ids",
+                workflow.workflow_id
+            ));
+        }
         if !workflow.gates.is_empty() {
             unsupported.push(format!(
                 "workflows[{}].gates: gate execution belongs to the controller path; compile-loop only supports executable agent tasks",
@@ -196,10 +202,10 @@ fn unsupported_repo_loop_spec_fields(spec: &AgentTaskRepoLoopSpec) -> Vec<String
                 RepoLoopProducerScope::All,
             )
             .into_iter()
-            .filter(|(producer, _task_id)| !producer.entity_ids.is_empty())
+            .filter(|(producer, _task_id)| repo_loop_workflow_has_fan_out(producer))
             .map(|(producer, _task_id)| producer.workflow_id.clone())
             .collect();
-            if workflow.entity_ids.is_empty() && !fanout_producers.is_empty() {
+            if !repo_loop_workflow_has_fan_out(workflow) && !fanout_producers.is_empty() {
                 unsupported.push(format!(
                     "workflows[{}].consumes: join over fan-out artifact '{}' from workflows [{}] requires the controller path",
                     workflow.workflow_id,
@@ -213,15 +219,39 @@ fn unsupported_repo_loop_spec_fields(spec: &AgentTaskRepoLoopSpec) -> Vec<String
 }
 
 fn repo_loop_workflow_entity_ids(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Vec<Option<&str>> {
-    if workflow.entity_ids.is_empty() {
-        vec![None]
-    } else {
-        workflow
+    if !workflow.entity_ids.is_empty() {
+        return workflow
             .entity_ids
             .iter()
             .map(|entity_id| Some(entity_id.as_str()))
-            .collect()
+            .collect();
     }
+    if let Some(fan_out) = &workflow.fan_out {
+        if !fan_out.entity_ids.is_empty() {
+            return fan_out
+                .entity_ids
+                .iter()
+                .map(|entity_id| Some(entity_id.as_str()))
+                .collect();
+        }
+    }
+    vec![None]
+}
+
+fn repo_loop_workflow_has_fan_out(workflow: &AgentTaskRepoLoopSpecWorkflow) -> bool {
+    !workflow.entity_ids.is_empty()
+        || workflow
+            .fan_out
+            .as_ref()
+            .is_some_and(|fan_out| !fan_out.entity_ids.is_empty())
+}
+
+fn workflow_has_dynamic_fan_out(workflow: &AgentTaskRepoLoopSpecWorkflow) -> bool {
+    workflow.entity_ids.is_empty()
+        && workflow
+            .fan_out
+            .as_ref()
+            .is_some_and(|fan_out| fan_out.entity_ids.is_empty())
 }
 
 fn repo_loop_workflow_request(
@@ -652,24 +682,28 @@ fn repo_loop_artifact_producers<'a>(
                 })
         })
         .flat_map(|producer| match scope {
-            RepoLoopProducerScope::All if producer.entity_ids.is_empty() => {
+            RepoLoopProducerScope::All if !repo_loop_workflow_has_fan_out(producer) => {
                 vec![(producer, repo_loop_task_id(producer, None))]
             }
-            RepoLoopProducerScope::All => producer
-                .entity_ids
-                .iter()
+            RepoLoopProducerScope::All => repo_loop_workflow_entity_ids(producer)
+                .into_iter()
+                .flatten()
                 .map(|entity_id| (producer, repo_loop_task_id(producer, Some(entity_id))))
                 .collect(),
-            RepoLoopProducerScope::MatchingEntity(_) if producer.entity_ids.is_empty() => {
+            RepoLoopProducerScope::MatchingEntity(_)
+                if !repo_loop_workflow_has_fan_out(producer) =>
+            {
                 vec![(producer, repo_loop_task_id(producer, None))]
             }
-            RepoLoopProducerScope::MatchingEntity(Some(entity_id)) => producer
-                .entity_ids
-                .iter()
-                .any(|producer_entity_id| producer_entity_id == entity_id)
-                .then(|| (producer, repo_loop_task_id(producer, Some(entity_id))))
-                .into_iter()
-                .collect(),
+            RepoLoopProducerScope::MatchingEntity(Some(entity_id)) => {
+                repo_loop_workflow_entity_ids(producer)
+                    .into_iter()
+                    .flatten()
+                    .any(|producer_entity_id| producer_entity_id == entity_id)
+                    .then(|| (producer, repo_loop_task_id(producer, Some(entity_id))))
+                    .into_iter()
+                    .collect()
+            }
             RepoLoopProducerScope::MatchingEntity(None) => Vec::new(),
         })
         .collect()
@@ -789,7 +823,7 @@ fn validate_repo_loop_artifact_graph(spec: &AgentTaskRepoLoopSpec) -> Result<()>
             .find(|workflow| workflow.workflow_id == edge.to_workflow_id);
         match producer {
             Some(producer) => {
-                if !producer.entity_ids.is_empty() {
+                if repo_loop_workflow_has_fan_out(producer) {
                     diagnostics.push(format!(
                         "artifact_graph[{index}] producer workflow '{}' uses fan-out; graph compilation only supports one task per graph edge",
                         edge.from_workflow_id
@@ -811,7 +845,7 @@ fn validate_repo_loop_artifact_graph(spec: &AgentTaskRepoLoopSpec) -> Result<()>
         }
         match consumer {
             Some(consumer) => {
-                if !consumer.entity_ids.is_empty() {
+                if repo_loop_workflow_has_fan_out(consumer) {
                     diagnostics.push(format!(
                         "artifact_graph[{index}] consumer workflow '{}' uses fan-out; graph compilation only supports one task per graph edge",
                         edge.to_workflow_id


### PR DESCRIPTION
## Summary
- parse generic workflow.fan_out declarations in repo loop/controller specs
- compile static fan_out items/entity_ids into controller and repo-loop execution
- reject dynamic artifact-derived fanout with a clear diagnostic until artifact expansion is designed

## Testing
- rustfmt --check on touched files
- cargo test --lib workflow_fan_out -- --nocapture
- cargo test --lib dynamic_fan_out -- --nocapture
- cargo test --lib dynamic_artifact_fan_out -- --nocapture
- cargo test --lib entity_fanout -- --nocapture
- cargo test --lib fan_out_stops_after_max_items -- --nocapture

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting implementation, tests, diagnostics, and PR description.