### PR TITLE
Fix Lab dispatch provider config remapping

### DIFF
--- a/src/core/runner/lab_args/envelope.rs
+++ b/src/core/runner/lab_args/envelope.rs
@@ -7,6 +7,8 @@
 
 use super::path_remap::try_rewrite_flag_value_args;
 
+const PROVIDER_CONFIG_FLAGS: &[&str] = &["--provider-config", "--dispatch-provider-config"];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::core::runner) struct ExecutionEnvelope {
     argv: Vec<String>,
@@ -46,18 +48,18 @@ impl ExecutionEnvelope {
                 passthrough = true;
                 continue;
             }
-            if arg == "--provider-config" {
+            if let Some(flag) = provider_config_flag(arg) {
                 inputs.provider_configs.push(ArgRef {
-                    flag: "--provider-config",
+                    flag,
                     value: iter
                         .next()
                         .map_or(ArgValue::Missing, |spec| provider_config_value(spec)),
                 });
                 continue;
             }
-            if let Some(spec) = arg.strip_prefix("--provider-config=") {
+            if let Some((flag, spec)) = provider_config_inline_arg(arg) {
                 inputs.provider_configs.push(ArgRef {
-                    flag: "--provider-config",
+                    flag,
                     value: provider_config_value(spec),
                 });
                 continue;
@@ -90,15 +92,15 @@ impl ExecutionEnvelope {
         mut rewrite: impl FnMut(&str) -> crate::core::Result<String>,
     ) -> crate::core::Result<Vec<String>> {
         try_rewrite_flag_value_args(&self.argv, |arg, iter, out| {
-            if arg == "--provider-config" {
+            if provider_config_flag(arg).is_some() {
                 out.push(arg.to_string());
                 if let Some(spec) = iter.next() {
                     out.push(rewrite(spec)?);
                 }
                 return Ok(());
             }
-            if let Some(spec) = arg.strip_prefix("--provider-config=") {
-                out.push(format!("--provider-config={}", rewrite(spec)?));
+            if let Some((flag, spec)) = provider_config_inline_arg(arg) {
+                out.push(format!("{}={}", flag, rewrite(spec)?));
                 return Ok(());
             }
             out.push(arg.to_string());
@@ -126,6 +128,25 @@ impl ExecutionEnvelope {
             Ok(())
         })
     }
+}
+
+fn provider_config_flag(arg: &str) -> Option<&'static str> {
+    PROVIDER_CONFIG_FLAGS
+        .iter()
+        .copied()
+        .find(|flag| arg == *flag)
+}
+
+fn provider_config_inline_arg(arg: &str) -> Option<(&'static str, &str)> {
+    for flag in PROVIDER_CONFIG_FLAGS {
+        if let Some(value) = arg
+            .strip_prefix(flag)
+            .and_then(|rest| rest.strip_prefix('='))
+        {
+            return Some((*flag, value));
+        }
+    }
+    None
 }
 
 fn provider_config_value(spec: &str) -> ArgValue {
@@ -185,6 +206,9 @@ mod tests {
             "@config.json".to_string(),
             "--provider-config={\"provider\":\"example-oauth\"}".to_string(),
             "--provider-config=-".to_string(),
+            "--dispatch-provider-config".to_string(),
+            "@dispatch.json".to_string(),
+            "--dispatch-provider-config={\"provider\":\"controller\"}".to_string(),
             "--".to_string(),
             "--provider-config".to_string(),
             "ignored".to_string(),
@@ -192,7 +216,7 @@ mod tests {
 
         let envelope = ExecutionEnvelope::from_args(&args);
 
-        assert_eq!(envelope.inputs.provider_configs.len(), 3);
+        assert_eq!(envelope.inputs.provider_configs.len(), 5);
         assert_eq!(
             envelope.inputs.provider_configs[0].flag,
             "--provider-config"
@@ -206,6 +230,18 @@ mod tests {
             ArgValue::InlineText("{\"provider\":\"example-oauth\"}".to_string())
         );
         assert_eq!(envelope.inputs.provider_configs[2].value, ArgValue::Stdin);
+        assert_eq!(
+            envelope.inputs.provider_configs[3].flag,
+            "--dispatch-provider-config"
+        );
+        assert_eq!(
+            envelope.inputs.provider_configs[3].value,
+            ArgValue::PathRef("dispatch.json".to_string())
+        );
+        assert_eq!(
+            envelope.inputs.provider_configs[4].value,
+            ArgValue::InlineText("{\"provider\":\"controller\"}".to_string())
+        );
     }
 
     #[test]

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -224,6 +224,66 @@ fn remap_inlines_and_rewrites_provider_config_local_paths() {
 }
 
 #[test]
+fn remap_inlines_and_rewrites_dispatch_provider_config_local_paths() {
+    let mappings = vec![
+        LabPathRemap {
+            local: "/Users/user/Developer/controller-runtime".to_string(),
+            remote: "/home/user/_lab_workspaces/controller-runtime".to_string(),
+        },
+        LabPathRemap {
+            local: "/Users/user/Developer/dispatch-provider".to_string(),
+            remote: "/home/user/_lab_workspaces/dispatch-provider".to_string(),
+        },
+    ];
+    let config = serde_json::json!({
+        "workspace_root": "/Users/user/Developer/controller-runtime",
+        "mounts": [{ "source": "/Users/user/Developer/controller-runtime", "target": "/workspace/runtime" }],
+        "runtime_component_paths": { "agent_runtime": "/Users/user/Developer/controller-runtime/runtime" },
+        "provider_plugin_paths": ["/Users/user/Developer/dispatch-provider/provider-plugin"],
+        "component_contracts": [{ "path": "/Users/user/Developer/dispatch-provider/contracts/component.json" }]
+    })
+    .to_string();
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "controller".to_string(),
+        "run-from-spec".to_string(),
+        "loop.json".to_string(),
+        "--dispatch-provider-config".to_string(),
+        config,
+    ];
+
+    let out = remap_provider_config_in_args(&args, &mappings).expect("remap dispatch config");
+    let cfg_idx = out
+        .iter()
+        .position(|a| a == "--dispatch-provider-config")
+        .unwrap()
+        + 1;
+    let remapped: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("inline json");
+
+    assert_eq!(
+        remapped["workspace_root"],
+        "/home/user/_lab_workspaces/controller-runtime"
+    );
+    assert_eq!(
+        remapped["mounts"][0]["source"],
+        "/home/user/_lab_workspaces/controller-runtime"
+    );
+    assert_eq!(
+        remapped["runtime_component_paths"]["agent_runtime"],
+        "/home/user/_lab_workspaces/controller-runtime/runtime"
+    );
+    assert_eq!(
+        remapped["provider_plugin_paths"][0],
+        "/home/user/_lab_workspaces/dispatch-provider/provider-plugin"
+    );
+    assert_eq!(
+        remapped["component_contracts"][0]["path"],
+        "/home/user/_lab_workspaces/dispatch-provider/contracts/component.json"
+    );
+}
+
+#[test]
 fn remap_prunes_stale_unresolved_provider_plugin_path() {
     // #4829: a `provider_plugin_paths` entry inherited from stale/global
     // settings points at a controller-local absolute directory that is not part

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -209,32 +209,30 @@ pub(super) fn provider_config_extra_workspaces(
     args: &[String],
     source_path: &Path,
 ) -> Result<Vec<ExtraLabWorkspace>> {
-    let Some(spec) = provider_config_spec(args) else {
-        return Ok(Vec::new());
-    };
-    let raw = match crate::core::config::read_json_spec_to_string(&spec) {
-        Ok(raw) => raw,
-        Err(_) => return Ok(Vec::new()),
-    };
-    let value: serde_json::Value = match serde_json::from_str(&raw) {
-        Ok(value) => value,
-        Err(_) => return Ok(Vec::new()),
-    };
-
     let source_canon = source_path
         .canonicalize()
         .unwrap_or_else(|_| source_path.to_path_buf());
 
     let mut seen = BTreeSet::new();
     let mut workspaces: Vec<ExtraLabWorkspace> = Vec::new();
-    for candidate in provider_config_candidate_paths(&value) {
-        add_candidate_extra_workspace(
-            &candidate,
-            "provider_config",
-            &source_canon,
-            &mut seen,
-            &mut workspaces,
-        )?;
+    for spec in provider_config_specs(args) {
+        let raw = match crate::core::config::read_json_spec_to_string(&spec) {
+            Ok(raw) => raw,
+            Err(_) => continue,
+        };
+        let value: serde_json::Value = match serde_json::from_str(&raw) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        for candidate in provider_config_candidate_paths(&value) {
+            add_candidate_extra_workspace(
+                &candidate,
+                "provider_config",
+                &source_canon,
+                &mut seen,
+                &mut workspaces,
+            )?;
+        }
     }
     Ok(workspaces)
 }
@@ -440,61 +438,71 @@ pub(super) fn preflight_provider_config_source_cli_dependencies(
         return Ok(());
     }
 
-    let Some(spec) = provider_config_spec(args) else {
-        return Ok(());
-    };
-    let raw = match crate::core::config::read_json_spec_to_string(&spec) {
-        Ok(raw) => raw,
-        Err(_) => return Ok(()),
-    };
-    let value: serde_json::Value = match serde_json::from_str(&raw) {
-        Ok(value) => value,
-        Err(_) => return Ok(()),
-    };
-
-    for file in provider_config_source_cli_files(&value) {
-        let content = match fs::read_to_string(&file) {
-            Ok(content) => content,
+    for spec in provider_config_specs(args) {
+        let raw = match crate::core::config::read_json_spec_to_string(&spec) {
+            Ok(raw) => raw,
             Err(_) => continue,
         };
-        let imports = bare_module_imports(&content);
-        if let Some(package) = imports.iter().next() {
-            return Err(Error::validation_invalid_argument(
-                "provider_config",
-                format!(
-                    "Lab offload cannot preflight source-built CLI `{}` because it imports package `{}` while node_modules is excluded from the synced snapshot",
-                    file.display(),
-                    package
-                ),
-                Some(file.display().to_string()),
-                Some(vec![
+        let value: serde_json::Value = match serde_json::from_str(&raw) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+
+        for file in provider_config_source_cli_files(&value) {
+            let content = match fs::read_to_string(&file) {
+                Ok(content) => content,
+                Err(_) => continue,
+            };
+            let imports = bare_module_imports(&content);
+            if let Some(package) = imports.iter().next() {
+                return Err(Error::validation_invalid_argument(
+                    "provider_config",
                     format!(
-                        "Materialize `{}` on the runner before execution, bundle it into the CLI artifact, or adjust runner snapshot policy to include the dependency path.",
+                        "Lab offload cannot preflight source-built CLI `{}` because it imports package `{}` while node_modules is excluded from the synced snapshot",
+                        file.display(),
                         package
                     ),
-                    "Use runner policy snapshot_includes for generated CLI outputs that must travel with the snapshot.".to_string(),
-                ]),
-            ));
+                    Some(file.display().to_string()),
+                    Some(vec![
+                        format!(
+                            "Materialize `{}` on the runner before execution, bundle it into the CLI artifact, or adjust runner snapshot policy to include the dependency path.",
+                            package
+                        ),
+                        "Use runner policy snapshot_includes for generated CLI outputs that must travel with the snapshot.".to_string(),
+                    ]),
+                ));
+            }
         }
     }
 
     Ok(())
 }
 
-fn provider_config_spec(args: &[String]) -> Option<String> {
+fn provider_config_specs(args: &[String]) -> Vec<String> {
+    const PROVIDER_CONFIG_FLAGS: &[&str] = &["--provider-config", "--dispatch-provider-config"];
+
+    let mut specs = Vec::new();
     let mut iter = args.iter().peekable();
     while let Some(arg) = iter.next() {
         if arg == "--" {
             break;
         }
-        if arg == "--provider-config" {
-            return iter.next().cloned();
+        if PROVIDER_CONFIG_FLAGS.iter().any(|flag| arg == *flag) {
+            if let Some(spec) = iter.next() {
+                specs.push(spec.clone());
+            }
+            continue;
         }
-        if let Some(value) = arg.strip_prefix("--provider-config=") {
-            return Some(value.to_string());
+        for flag in PROVIDER_CONFIG_FLAGS {
+            if let Some(value) = arg
+                .strip_prefix(flag)
+                .and_then(|rest| rest.strip_prefix('='))
+            {
+                specs.push(value.to_string());
+            }
         }
     }
-    None
+    specs
 }
 
 fn agent_task_plan_spec(args: &[String]) -> Option<String> {
@@ -752,6 +760,45 @@ mod provider_config_candidate_paths_tests {
             .snapshot_includes
             .contains(&"packages/cli/dist/**".to_string()));
         assert!(workspaces[0].bootstrap_node_dependencies);
+    }
+
+    #[test]
+    fn dispatch_provider_config_file_path_syncs_containing_checkout() {
+        let controller = tempfile::tempdir().expect("controller");
+        let source = controller.path().join("primary");
+        let provider = controller.path().join("dispatch-provider");
+        let contract = provider.join("contracts/component.json");
+        std::fs::create_dir_all(&source).expect("source dir");
+        std::fs::create_dir_all(contract.parent().unwrap()).expect("contract dir");
+        std::fs::write(&contract, "{}\n").expect("contract file");
+        git(&provider, &["init", "-b", "main"]);
+        git(&provider, &["config", "user.email", "test@example.com"]);
+        git(&provider, &["config", "user.name", "Homeboy Test"]);
+        git(&provider, &["add", "."]);
+        git(&provider, &["commit", "-m", "initial"]);
+
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "controller".to_string(),
+            "run-from-spec".to_string(),
+            "loop.json".to_string(),
+            "--dispatch-provider-config".to_string(),
+            serde_json::json!({
+                "provider_plugin_paths": [provider.join("provider-plugin")],
+                "component_contracts": [{ "path": contract }],
+            })
+            .to_string(),
+        ];
+
+        let workspaces = provider_config_extra_workspaces(&args, &source).expect("workspaces");
+
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].role, "provider_config");
+        assert_eq!(workspaces[0].path, provider.canonicalize().unwrap());
+        assert!(workspaces[0]
+            .snapshot_includes
+            .contains(&"contracts".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat `--dispatch-provider-config` like `--provider-config` in Lab argument envelopes.
- Sync provider config path dependencies discovered from controller dispatch configs.
- Remap dispatch provider config paths before remote Lab execution.

Fixes #6216.

## Verification
- `git diff --check`
- `cargo test --lib remap_inlines_and_rewrites_dispatch_provider_config_local_paths`
- `cargo test --lib dispatch_provider_config_file_path_syncs_containing_checkout`
- `cargo test --lib envelope_captures_provider_config_refs_before_passthrough`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode direct subagents
- **Used for:** Drafting and verifying the code change, tests, and PR description.