### PR TITLE
Add Lab runtime dependency reconciliation diagnostics

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -451,6 +451,14 @@ pub(crate) fn run_lab_offload_inner(
         &workspace_mapping_metadata,
         &synced_rigs,
     );
+    lab_metadata["runtime_dependency_manifest"] = lab_runtime_dependency_manifest_metadata(
+        &command_prefix.argv,
+        &contract.required_extensions,
+        &runner_homeboy,
+        &source_checkout,
+        &workspace_mapping_metadata,
+        &remapped_args,
+    );
     let mut env_delta = std::collections::HashMap::new();
     let rig_component_path_env =
         forward_rig_component_path_env(&mut env_delta, &workspace_mapping)?;

--- a/src/core/runner/lab/offload/metadata.rs
+++ b/src/core/runner/lab/offload/metadata.rs
@@ -119,6 +119,28 @@ pub(crate) fn lab_materialization_proof_metadata(
     })
 }
 
+pub(crate) fn lab_runtime_dependency_manifest_metadata(
+    command_prefix: &[String],
+    required_extensions: &[String],
+    runner_homeboy: &serde_json::Value,
+    source_checkout: &serde_json::Value,
+    workspace_mapping: &serde_json::Value,
+    remapped_args: &[String],
+) -> serde_json::Value {
+    serde_json::json!({
+        "schema": "homeboy/lab-runtime-dependency-manifest/v1",
+        "homeboy_binary": runner_homeboy,
+        "extension_runtime": {
+            "required_extensions": required_extensions,
+            "command_prefix": redact_argv(command_prefix),
+        },
+        "executor_runtime": provider_config_runtime_manifest(remapped_args),
+        "provider_plugins": provider_config_runtime_manifest(remapped_args),
+        "components": workspace_mapping,
+        "source_checkout": source_checkout,
+    })
+}
+
 pub(crate) fn source_checkout_ref_display(metadata: &serde_json::Value) -> String {
     let branch = metadata
         .get("git_branch")

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -58,7 +58,8 @@ use super::super::execution::{
 use super::super::lab_apply::apply_lab_offload_patch;
 use super::super::lab_args::{
     inject_agent_task_default_provider_config_in_args, lab_at_file_specs, lab_offload_source_path,
-    materialize_agent_task_specs_in_args, remap_lab_at_file_args, remap_path_settings_in_args,
+    materialize_agent_task_specs_in_args, preflight_provider_config_paths_materialized_in_args,
+    provider_config_runtime_manifest, remap_lab_at_file_args, remap_path_settings_in_args,
     remap_provider_config_in_args, rewrite_lab_offload_args,
     rewrite_runner_resident_lab_offload_args, LabAtFileSpec, LabPathRemap,
 };

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -260,6 +260,7 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
         })
         .collect();
     preflight_provider_config_source_cli_dependencies(&offload_args, &synced.excludes)?;
+    preflight_provider_config_paths_materialized_in_args(&offload_args, &path_remaps)?;
     let remapped_args = rig_materialization::remap_bench_rig_default_component_to_primary_snapshot(
         &offload_args,
         &remote_cwd,

--- a/src/core/runner/lab_args/mod.rs
+++ b/src/core/runner/lab_args/mod.rs
@@ -38,5 +38,7 @@ pub(super) use offload::{
 };
 pub(super) use path_remap::{remap_path_settings_in_args, LabPathRemap};
 pub(super) use provider_config::{
-    inject_agent_task_default_provider_config_in_args, remap_provider_config_in_args,
+    inject_agent_task_default_provider_config_in_args,
+    preflight_provider_config_paths_materialized_in_args, provider_config_runtime_manifest,
+    remap_provider_config_in_args,
 };

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -4,6 +4,8 @@
 //! supplied as `@file`/inline JSON. These helpers inline file specs, remap
 //! embedded paths, and inject a default provider config for agent-task dispatch.
 
+use std::path::Path;
+
 use serde_json::Value;
 
 use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
@@ -11,8 +13,81 @@ use crate::core::config::read_json_spec_to_string;
 use crate::core::defaults;
 use crate::core::{Error, Result};
 
-use super::envelope::ExecutionEnvelope;
-use super::path_remap::{remap_paths_in_value, LabPathRemap};
+use super::envelope::{ArgValue, ExecutionEnvelope};
+use super::path_remap::{remap_local_path, remap_paths_in_value, LabPathRemap};
+
+const RUNTIME_MANIFEST_SCHEMA: &str = "homeboy/lab-provider-config-runtime/v1";
+
+pub(in crate::core::runner) fn preflight_provider_config_paths_materialized_in_args(
+    args: &[String],
+    mappings: &[LabPathRemap],
+) -> Result<()> {
+    let envelope = ExecutionEnvelope::from_args(args);
+    let mut failures = Vec::new();
+
+    for config in &envelope.inputs.provider_configs {
+        let Some((_source, raw)) = provider_config_raw_value(&config.value)? else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        collect_unmaterialized_paths(&value, "$", mappings, &mut failures);
+    }
+
+    if failures.is_empty() {
+        return Ok(());
+    }
+
+    let preview = failures
+        .iter()
+        .take(5)
+        .map(|failure| {
+            format!(
+                "{} at {} ({})",
+                failure.path, failure.location, failure.reason
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(Error::validation_invalid_argument(
+        "provider-config",
+        format!(
+            "Lab offload cannot dispatch because {} provider-config runtime path(s) were not materialized on the selected runner",
+            failures.len()
+        ),
+        Some(preview),
+        Some(vec![
+            "Use controller-local paths that exist so Lab can sync and rewrite them to runner paths before dispatch.".to_string(),
+            "Remove stale runtime/component/provider-plugin paths from the provider config when the run should use runner-installed defaults.".to_string(),
+            "Run with --force-hot --allow-local-hot only if you intentionally want to bypass Lab offload and execute locally.".to_string(),
+        ]),
+    ))
+}
+
+pub(in crate::core::runner) fn provider_config_runtime_manifest(args: &[String]) -> Value {
+    let envelope = ExecutionEnvelope::from_args(args);
+    let mut configs = Vec::new();
+    for config in &envelope.inputs.provider_configs {
+        let Ok(Some((source, raw))) = provider_config_raw_value(&config.value) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        let mut paths = Vec::new();
+        collect_runtime_manifest_paths(&value, "$", &mut paths);
+        configs.push(serde_json::json!({
+            "source": source,
+            "paths": paths,
+        }));
+    }
+
+    serde_json::json!({
+        "schema": RUNTIME_MANIFEST_SCHEMA,
+        "provider_configs": configs,
+    })
+}
 
 /// Rewrite controller-local absolute paths inside a `--provider-config` value to
 /// their synced remote equivalents, and inline the result so the runner does not
@@ -102,6 +177,175 @@ fn is_agent_task_dispatch_or_cook(args: &[String]) -> bool {
         .skip(agent_task_index + 1)
         .find(|arg| !arg.starts_with('-'))
         .is_some_and(|command| matches!(command.as_str(), "dispatch" | "cook"))
+}
+
+fn provider_config_raw_value(value: &ArgValue) -> Result<Option<(String, String)>> {
+    match value {
+        ArgValue::InlineText(raw) => Ok(Some(("inline".to_string(), raw.clone()))),
+        ArgValue::PathRef(path) => {
+            let spec = format!("@{path}");
+            let raw = read_json_spec_to_string(&spec).map_err(|err| {
+                Error::validation_invalid_argument(
+                    "provider-config",
+                    "failed to read Lab offload --provider-config @file input",
+                    Some(err.to_string()),
+                    None,
+                )
+                .with_hint(
+                    "Lab offload reads --provider-config @file specs on the controller before dispatch; provide a readable JSON file or inline JSON.",
+                )
+            })?;
+            Ok(Some((spec, raw)))
+        }
+        ArgValue::Stdin | ArgValue::Missing => Ok(None),
+    }
+}
+
+#[derive(Debug)]
+struct UnmaterializedPath {
+    location: String,
+    path: String,
+    reason: &'static str,
+}
+
+fn collect_unmaterialized_paths(
+    value: &Value,
+    location: &str,
+    mappings: &[LabPathRemap],
+    failures: &mut Vec<UnmaterializedPath>,
+) {
+    match value {
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                collect_unmaterialized_paths(
+                    item,
+                    &format!("{location}[{index}]"),
+                    mappings,
+                    failures,
+                );
+            }
+        }
+        Value::Object(map) => {
+            for (key, item) in map {
+                let child_location = format!("{location}.{key}");
+                if is_materializable_provider_config_path_key(key) {
+                    collect_unmaterialized_path_strings(item, &child_location, mappings, failures);
+                } else {
+                    collect_unmaterialized_paths(item, &child_location, mappings, failures);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_unmaterialized_path_strings(
+    value: &Value,
+    location: &str,
+    mappings: &[LabPathRemap],
+    failures: &mut Vec<UnmaterializedPath>,
+) {
+    match value {
+        Value::String(text) if is_controller_path_like(text) => {
+            if let Some(reason) = unmaterialized_path_reason(text, mappings) {
+                failures.push(UnmaterializedPath {
+                    location: location.to_string(),
+                    path: text.to_string(),
+                    reason,
+                });
+            }
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                collect_unmaterialized_path_strings(
+                    item,
+                    &format!("{location}[{index}]"),
+                    mappings,
+                    failures,
+                );
+            }
+        }
+        Value::Object(map) => {
+            for (key, item) in map {
+                collect_unmaterialized_path_strings(
+                    item,
+                    &format!("{location}.{key}"),
+                    mappings,
+                    failures,
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_materializable_provider_config_path_key(key: &str) -> bool {
+    matches!(
+        key,
+        "workspace_root"
+            | "source"
+            | "source_cli"
+            | "provider_root"
+            | "provider_support"
+            | "runtime_component_paths"
+            | "provider_plugin_paths"
+            | "component_contracts"
+            | "path"
+    )
+}
+
+fn unmaterialized_path_reason(path: &str, mappings: &[LabPathRemap]) -> Option<&'static str> {
+    let expanded = shellexpand::tilde(path).to_string();
+    if !Path::new(&expanded).exists() {
+        return Some("controller path does not exist");
+    }
+
+    let ordered = super::path_remap::order_mappings_by_specificity(mappings);
+    if remap_local_path(path, &ordered).is_some() || path_is_under_remote_mapping(path, mappings) {
+        return None;
+    }
+
+    Some("controller path was not synced to the runner")
+}
+
+fn path_is_under_remote_mapping(path: &str, mappings: &[LabPathRemap]) -> bool {
+    mappings.iter().any(|mapping| {
+        if mapping.remote.is_empty() {
+            return false;
+        }
+        path == mapping.remote
+            || path.starts_with(&format!("{}/", mapping.remote.trim_end_matches('/')))
+    })
+}
+
+fn collect_runtime_manifest_paths(value: &Value, location: &str, paths: &mut Vec<Value>) {
+    match value {
+        Value::String(text) if is_runtime_manifest_path(text) => {
+            paths.push(serde_json::json!({
+                "location": location,
+                "path": text,
+            }));
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                collect_runtime_manifest_paths(item, &format!("{location}[{index}]"), paths);
+            }
+        }
+        Value::Object(map) => {
+            for (key, item) in map {
+                collect_runtime_manifest_paths(item, &format!("{location}.{key}"), paths);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_runtime_manifest_path(value: &str) -> bool {
+    is_controller_path_like(value) || value.starts_with('.')
+}
+
+fn is_controller_path_like(value: &str) -> bool {
+    value.starts_with('/') || value.starts_with("~/")
 }
 
 /// Resolve a provider-config spec (inline JSON / `@file`), remap its

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -224,6 +224,99 @@ fn remap_inlines_and_rewrites_provider_config_local_paths() {
 }
 
 #[test]
+fn provider_config_materialization_preflight_rejects_missing_runtime_path() {
+    let config = serde_json::json!({
+        "runtime_component_paths": {
+            "runtime_core": "/definitely/missing/homeboy-runtime-core"
+        }
+    })
+    .to_string();
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--provider-config".to_string(),
+        config,
+    ];
+
+    let err = preflight_provider_config_paths_materialized_in_args(&args, &[])
+        .expect_err("missing runtime path should fail before dispatch");
+
+    assert!(err.message.contains("provider-config runtime path"));
+    assert!(err
+        .details
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|value| value.contains("/definitely/missing/homeboy-runtime-core")));
+}
+
+#[test]
+fn provider_config_materialization_preflight_accepts_synced_runtime_paths() {
+    let controller = tempfile::tempdir().expect("controller");
+    let runtime = controller.path().join("runtime-core");
+    let nested = runtime.join("packages/cli/dist/index.js");
+    std::fs::create_dir_all(nested.parent().unwrap()).expect("runtime dirs");
+    std::fs::write(&nested, "#!/usr/bin/env node\n").expect("runtime cli");
+    let local_runtime = runtime.to_string_lossy().to_string();
+    let local_nested = nested.to_string_lossy().to_string();
+    let config = serde_json::json!({
+        "runtime_component_paths": {
+            "runtime_core": local_runtime,
+        },
+        "source_cli": local_nested,
+        "mounts": [{ "source": runtime, "target": "/workspace/runtime-core" }],
+    })
+    .to_string();
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--provider-config".to_string(),
+        config,
+    ];
+    let mappings = vec![LabPathRemap {
+        local: runtime
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string(),
+        remote: "/runner/runtime-core".to_string(),
+    }];
+
+    preflight_provider_config_paths_materialized_in_args(&args, &mappings)
+        .expect("synced runtime paths should pass readiness preflight");
+}
+
+#[test]
+fn provider_config_runtime_manifest_records_effective_paths() {
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--provider-config".to_string(),
+        serde_json::json!({
+            "runtime_component_paths": { "runtime_core": "/runner/runtime-core" },
+            "provider_plugin_paths": ["/runner/provider-plugin"],
+            "model": "example-model"
+        })
+        .to_string(),
+    ];
+
+    let manifest = provider_config_runtime_manifest(&args);
+    let paths = manifest["provider_configs"][0]["paths"]
+        .as_array()
+        .expect("paths");
+
+    assert!(paths
+        .iter()
+        .any(|entry| entry["path"] == "/runner/runtime-core"));
+    assert!(paths
+        .iter()
+        .any(|entry| entry["path"] == "/runner/provider-plugin"));
+    assert!(!paths.iter().any(|entry| entry["path"] == "example-model"));
+}
+
+#[test]
 fn remap_prunes_stale_unresolved_provider_plugin_path() {
     // #4829: a `provider_plugin_paths` entry inherited from stale/global
     // settings points at a controller-local absolute directory that is not part


### PR DESCRIPTION
## Summary
- Add a generic Lab runtime dependency manifest to offload metadata.
- Preflight provider-config runtime/component paths before remote dispatch so stale local paths fail before raw runtime errors.
- Record effective provider-config runtime paths for diagnostics.

Fixes #6217.

## Verification
- `git diff --check`
- `cargo test --lib provider_config_materialization_preflight`
- `cargo test --lib provider_config_runtime_manifest_records_effective_paths`
- `cargo test --lib remap_inlines_and_rewrites_dispatch_provider_config_local_paths`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode direct subagents
- **Used for:** Drafting and verifying the code change, tests, conflict resolution, and PR description.