### PR TITLE
fix: repair 6 dead_guard tests (main RED)

### DIFF
--- a/src/core/code_audit/detectors/dead_guard.rs
+++ b/src/core/code_audit/detectors/dead_guard.rs
@@ -552,7 +552,12 @@ mod tests {
                             {"name": "runtime_schedule_once", "kind": "function"}
                         ]
                     }
-                ]
+                ],
+                "source_scan": {
+                    "entry_file_extensions": ["php"],
+                    "require_keywords": ["require_once", "require", "include_once", "include"],
+                    "guard_markers": ["class_exists", "function_exists", "defined"]
+                }
             }
         }))
         .unwrap()


### PR DESCRIPTION
## Summary
Fixes 6 `dead_guard` detector tests failing on main (expected 1 finding, got 0).

## Root cause
Not a detector regression — a **test-fixture config gap**. Commit `ca48b015` ("de-hardcode ecosystem validate/format fallbacks") changed `find_file_with_marker` in `requirements.rs` to require an extension-declared `source_scan.entry_file_extensions` list, early-returning `None` when it is empty. That commit updated `requirements.rs`'s own `test_config()` to declare a `source_scan` block, but **left `dead_guard.rs`'s `test_config()` untouched**.

Because `dead_guard`'s test config had no `source_scan`, `entry_file_extensions` was empty → the `plugin.php` entry file written by `write_plugin_main` was never matched → header-version symbols were never seeded → `known_available_symbols` returned empty → `detect_with_config` short-circuited at the empty-known-symbols guard → **0 findings** where the 6 tests assert 1.

## Fix
Added a `source_scan` block to `dead_guard.rs`'s `test_config()` declaring `entry_file_extensions: ["php"]` plus the standard `require_keywords` / `guard_markers` (the latter are needed by `configured_bootstrap_provider_guard_becomes_dead_when_required`, which exercises bootstrap-require scanning of a `.php` provider file).

**Detector logic unchanged; no test expectations weakened.** Repairs the fixture to match the new source-scan contract.

Verified locally with `cargo build --lib` (compiles) + `cargo fmt`. Test execution left to CI.