### PR TITLE
fix: repair 3 upgrade::runners tests (main RED)

### DIFF
--- a/src/core/upgrade/runners/tests.rs
+++ b/src/core/upgrade/runners/tests.rs
@@ -161,7 +161,7 @@ fn materializes_forced_source_upgrade_path_before_forwarding_to_runner() {
         Some("/home/user/Developer/_lab_workspaces/homeboy-source")
     );
     assert!(calls[1].0[2].contains("git fetch origin"));
-    assert!(calls[1].0[2].contains("git branch --set-upstream-to"));
+    assert!(calls[1].0[2].contains("git checkout --detach"));
     assert_eq!(
         calls[2].0,
         vec![
@@ -887,21 +887,22 @@ fn source_runner_upgrade_realigns_to_materialized_source_build_when_path_shadows
                     String::new(),
                     0,
                 ),
-                2 => ("{\"success\":true}\n".to_string(), String::new(), 0),
-                3 => (
-                    format!("homeboy {}+oldbuild\n", current_version()),
-                    String::new(),
-                    0,
-                ),
+                2 => ("prepared source checkout\n".to_string(), String::new(), 0),
+                3 => ("{\"success\":true}\n".to_string(), String::new(), 0),
                 4 => (
                     format!("homeboy {}+oldbuild\n", current_version()),
                     String::new(),
                     0,
                 ),
-                5 if options.command[0] == source_binary => {
+                5 => (
+                    format!("homeboy {}+oldbuild\n", current_version()),
+                    String::new(),
+                    0,
+                ),
+                6 if options.command[0] == source_binary => {
                     (format!("homeboy {}\n", current_version()), String::new(), 0)
                 }
-                6 if options.command[0] == source_binary => (
+                7 if options.command[0] == source_binary => (
                     format!("{}\n", build_identity::current().display),
                     String::new(),
                     0,
@@ -942,9 +943,10 @@ fn source_runner_upgrade_realigns_to_materialized_source_build_when_path_shadows
     assert_eq!(updated[0].bare_homeboy_version, None);
     assert_eq!(updated[0].path_drift, None);
     assert_eq!(path_updates, vec![("lab".to_string(), source_binary)]);
-    assert_eq!(commands[1][0], stale_path);
-    assert_eq!(commands[1][commands[1].len() - 2], "--source-path");
-    assert_eq!(commands[1][commands[1].len() - 1], remote_source);
+    assert_eq!(&commands[1][..2], &["sh".to_string(), "-lc".to_string()]);
+    assert_eq!(commands[2][0], stale_path);
+    assert_eq!(commands[2][commands[2].len() - 2], "--source-path");
+    assert_eq!(commands[2][commands[2].len() - 1], remote_source);
     assert!(updated[0].detail.contains("to source-built"));
 }
 
@@ -975,21 +977,22 @@ fn source_runner_upgrade_realigns_to_same_version_source_checkout_identity() {
                     String::new(),
                     0,
                 ),
-                2 => ("{\"success\":true}\n".to_string(), String::new(), 0),
-                3 => (
-                    format!("homeboy {}+oldbuild\n", current_version()),
-                    String::new(),
-                    0,
-                ),
+                2 => ("prepared source checkout\n".to_string(), String::new(), 0),
+                3 => ("{\"success\":true}\n".to_string(), String::new(), 0),
                 4 => (
                     format!("homeboy {}+oldbuild\n", current_version()),
                     String::new(),
                     0,
                 ),
-                5 if options.command[0] == source_binary => {
+                5 => (
+                    format!("homeboy {}+oldbuild\n", current_version()),
+                    String::new(),
+                    0,
+                ),
+                6 if options.command[0] == source_binary => {
                     (format!("homeboy {}\n", current_version()), String::new(), 0)
                 }
-                6 if options.command[0] == source_binary => {
+                7 if options.command[0] == source_binary => {
                     (format!("{expected_identity}\n"), String::new(), 0)
                 }
                 other => (


### PR DESCRIPTION
Fixes 3 upgrade::runners tests on main that went RED after the detached-source-checkout work (#5998 / commit fdedd6e8) and the earlier source-checkout prepare step (f9ecd25e).

## What broke
- `materializes_forced_source_upgrade_path_before_forwarding_to_runner` (tests.rs:164) — asserted the prepare script still emits `git branch --set-upstream-to`. Commit fdedd6e8 intentionally rewrote `runner_source_checkout_prepare_script()` to `git checkout --detach "$remote_head"` and removed the upstream-tracking branch logic. Stale assertion.
- `source_runner_upgrade_realigns_to_materialized_source_build_when_path_shadows_old_homeboy` (tests.rs:935) and `source_runner_upgrade_realigns_to_same_version_source_checkout_identity` (tests.rs:1021) — both asserted `updated[0].upgraded`. The `prepare_runner_source_checkout_for_upgrade` exec (added in f9ecd25e) now consumes an extra command slot before the upgrade, shifting the test executors' `commands.len()` match by one. The shift derailed the source-built realignment path so `source_path_realigned`/`upgraded` came back false.

## Fix (tests-only, production unchanged)
- Update assertion to expect `git checkout --detach` (matches current intentional production behavior).
- Insert the `prepared source checkout` response slot in both realignment test executors and renumber the subsequent command slots; bump the trailing `commands[...]` index assertions accordingly (now also asserting the inserted `sh -lc` prepare command at `commands[1]`).

Production changed intentionally in both cases — tests were just left stale. Scope is limited to `src/core/upgrade/runners/tests.rs`. Verified with `cargo build --lib` + `cargo fmt`; full test suite left to CI per VPS build constraints.