### PR TITLE
fix: repair command/file/route tests (main RED)

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -506,8 +506,17 @@ impl Commands {
         // returns true for the run/from-spec commands that own a portable or
         // explicit-runner base, so the other arms (which set their own
         // runner-resident policy) are left untouched.
+        //
+        // The loop-controller spec-materialization family (from-spec --resume /
+        // run-from-spec / materialize) always materializes a real worktree to
+        // apply patches, so it requires a git checkout regardless of which
+        // dispatch provider (if any) is configured — the provider predicate only
+        // covers the backend-specific path, which is `None` when no
+        // `--dispatch-backend` is supplied.
         if let Commands::AgentTask(args) = self {
-            if agent_task_provider_requires_cwd_git_checkout(&args.command) {
+            if agent_task_controller_materializes_worktree(&args.command)
+                || agent_task_provider_requires_cwd_git_checkout(&args.command)
+            {
                 contract.workspace_mode_policy = LabWorkspaceModePolicy::GitCheckoutRequired;
             }
         }
@@ -627,6 +636,22 @@ impl Commands {
         };
         CommandPortabilityContract::lab(contract)
     }
+}
+
+/// The loop-controller spec-materialization family always lays down a real git
+/// checkout of the target workspace so the controller can apply patch artifacts
+/// across actions. This holds regardless of dispatch backend, so it is decided
+/// purely from the parsed command shape (not provider resolution).
+fn agent_task_controller_materializes_worktree(command: &agent_task::AgentTaskCommand) -> bool {
+    matches!(
+        command,
+        agent_task::AgentTaskCommand::Controller(agent_task::AgentTaskControllerArgs {
+            command: agent_task::AgentTaskControllerCommand::FromSpec(
+                agent_task::AgentTaskControllerFromSpecArgs { resume: true, .. },
+            ) | agent_task::AgentTaskControllerCommand::RunFromSpec(_)
+                | agent_task::AgentTaskControllerCommand::Materialize(_),
+        })
+    )
 }
 
 fn agent_task_provider_requires_cwd_git_checkout(command: &agent_task::AgentTaskCommand) -> bool {

--- a/src/core/project/files.rs
+++ b/src/core/project/files.rs
@@ -260,19 +260,37 @@ fn generate_unique_delimiter(content: &str) -> String {
     delimiter
 }
 
+/// Build the shell command that writes `content` to `quoted_path` byte-for-byte.
+///
+/// A heredoc always appends a single trailing newline after its body, so writing
+/// `content` directly would silently add a `\n` that the caller never asked for
+/// (e.g. a pattern replacement on a file with no final newline). To preserve the
+/// caller's exact trailing-newline state we strip one trailing newline from the
+/// heredoc body (the heredoc re-adds exactly one) and, when the original content
+/// had no trailing newline at all, drop the heredoc's extra byte afterwards.
+fn write_content_command(quoted_path: &str, content: &str) -> String {
+    let delimiter = generate_unique_delimiter(content);
+    // The heredoc body emits `body` + a single trailing newline. Removing one
+    // trailing newline from `content` keeps multi-newline endings intact while
+    // letting the heredoc supply the final newline for content that ends in one.
+    let body = content.strip_suffix('\n').unwrap_or(content);
+    let mut command = format!("cat > {quoted_path} << '{delimiter}'\n{body}\n{delimiter}");
+
+    if !content.ends_with('\n') {
+        // Heredoc added a trailing newline the caller never wanted; drop it so the
+        // written file matches `content` exactly.
+        command.push_str(&format!("\ntruncate -s -1 {quoted_path}"));
+    }
+
+    command
+}
+
 /// Write content to file.
 pub fn write(project_id: &str, path: &str, content: &str) -> Result<WriteResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
     let full_path = resolve_remote_path(&project, &project_base_path, path)?;
-    let delimiter = generate_unique_delimiter(content);
-    let command = format!(
-        "cat > {} << '{}'\n{}\n{}",
-        shell::quote_path(&full_path),
-        delimiter,
-        content,
-        delimiter
-    );
+    let command = write_content_command(&shell::quote_path(&full_path), content);
     let output = execute_for_project(&project, &command)?;
     command::require_success(output.success, &output.stderr, "WRITE")?;
 


### PR DESCRIPTION
## Summary
Repairs the genuine regressions behind the RED `main` command-surface tests. Root-caused two production bugs one layer below the reported test modules.

### `files::write` trailing-newline corruption
A heredoc (`cat > file << 'EOF'`) always emits the body followed by exactly one newline, so any write of content **without** a trailing newline silently gained a spurious `\n`. This broke pattern-replacement and line-edit round-trips on files with no final newline.

`write_content_command` now strips one trailing newline from the heredoc body (the heredoc re-adds it) and, when the original content had no trailing newline at all, drops the heredoc's extra byte with `truncate -s -1`. Writes are now byte-exact.

Fixes:
- `commands::file::file_test::file_edit_without_dry_run_writes_file`
- `commands::file::file_test::file_edit_force_allows_first_replacement_when_pattern_has_multiple_matches`

### run-from-spec lab routing workspace policy
The loop-controller spec-materialization family (`controller from-spec --resume` / `run-from-spec` / `materialize`) always lays down a real git checkout to apply patch artifacts across actions. The previous logic only upgraded to `GitCheckoutRequired` via the provider predicate, which returns `None`/false when no `--dispatch-backend` is configured (the default in a clean test env). It now upgrades unconditionally for that command family, decided from the parsed command shape.

Fixes:
- `commands::route::tests::agent_task_controller_run_from_spec_supports_lab_only_runner_routing`

## Verification
- `cargo build --lib` (clean; only pre-existing dead-code warnings)
- `cargo fmt` (out-of-scope pre-existing fmt drift reverted to keep the diff surgical)
- Heavy test/compile left to CI per repo policy.

## Notes on the remaining reported tests
The cli_surface (`suspicious_command_paths_require_safety_classification`), adapter (`command_adapter_recognizes_migrated_json_commands`), fuzz gate/report (`fuzz_gate_evaluation_accepts_metadata_artifact_refs`, `select_workload_*`), and route fanout (`agent_task_fanout_submit_batch_requires_explicit_runner_under_lab_only`) cases were verified against current production code and already satisfied (safety arm + classification present, `Manifest` correctly unmigrated → `Err`, gate/coverage and `with_hint`-populated error hints already correct, lab-only refusal message intact). They build on the same lib test binary as the two real failures; CI will confirm they go green alongside the fixes.