### PR TITLE
fix: repair remaining main-RED tests

### DIFF
--- a/src/core/api_jobs/remote_runner.rs
+++ b/src/core/api_jobs/remote_runner.rs
@@ -458,11 +458,15 @@ impl JobStore {
             ));
         }
         if stored.job.claimed_by_runner_id.as_deref() != Some(runner_id) {
-            return Err(Error::validation_invalid_argument(
-                "runner_id",
+            // A runner attempting to act on a job claimed by a *different*
+            // runner is an authorization violation, not a plain validation
+            // error: it must surface as a `broker.auth_denied` (401) so a
+            // second runner with its own valid token cannot finish/heartbeat
+            // another runner's job.
+            return Err(Error::broker_auth_denied(
                 "remote runner job is not claimed by this runner",
                 Some(runner_id.to_string()),
-                None,
+                Vec::new(),
             ));
         }
         if claim_id.trim().is_empty() {

--- a/src/core/release/executor/lockfile_guard.rs
+++ b/src/core/release/executor/lockfile_guard.rs
@@ -459,14 +459,24 @@ fn local_file_dependency_error(offenders: &[LocalFileDependency]) -> Error {
         ));
     }
 
+    let hints = vec![
+        "Use a published package version for releaseable dependencies.".to_string(),
+        "If this is an intentional workspace release, configure the dependency through the workspace release path instead of a checkout-external file: path.".to_string(),
+    ];
+
+    // Surface the remediation guidance in the message body too (not just hints)
+    // so callers that only inspect the error message still see how to resolve a
+    // checkout-external file: dependency.
+    lines.push(String::new());
+    for hint in &hints {
+        lines.push(format!("  - {hint}"));
+    }
+
     Error::validation_invalid_argument(
         "release.preflight.local_file_dependencies",
         lines.join("\n"),
         None,
-        Some(vec![
-            "Use a published package version for releaseable dependencies.".to_string(),
-            "If this is an intentional workspace release, configure the dependency through the workspace release path instead of a checkout-external file: path.".to_string(),
-        ]),
+        Some(hints),
     )
 }
 

--- a/src/core/triage/ci_failure.rs
+++ b/src/core/triage/ci_failure.rs
@@ -328,9 +328,16 @@ pub(super) fn extract_failure_snippets(log: &str, context_lines: usize) -> Vec<C
         }
         let start = index.saturating_sub(context_lines / 2);
         let end = (index + (context_lines / 2) + 1).min(lines.len());
+        // Skip only failure lines already captured by the previous snippet's
+        // covered range. `line_end` is the exclusive end index, so the previous
+        // snippet covers 0-based line indices `[line_start - 1, line_end)`.
+        // Comparing the failure-line `index` (rather than the widened snippet
+        // `start`) against that range lets a distinct failure line just past the
+        // previous window open its own concise snippet instead of being swallowed
+        // by overlap of the surrounding context lines.
         if snippets
             .last()
-            .is_some_and(|snippet: &CiFailureSnippet| start < snippet.line_end)
+            .is_some_and(|snippet: &CiFailureSnippet| index < snippet.line_end)
         {
             continue;
         }


### PR DESCRIPTION
## Summary
Repairs the remaining RED tests on `main`. For each listed test I read the test + the production fn it exercises and decided regression (fix prod) vs already-fixed (skip).

### Fixed (3 production regressions)
- **`core::daemon::remote_runner::auth_tests::wrong_runner_id_cannot_finish_anothers_job`** — `ensure_remote_runner_claim` returned `validation.invalid_argument` (400) when a runner acted on a job claimed by a *different* runner. A cross-runner action is an authorization violation, so it now returns `broker.auth_denied` (401). A second runner with its own valid token can no longer finish/heartbeat another runner's job.
- **`core::release::executor::lockfile_guard::tests::local_file_dependency_guard_blocks_existing_targets_outside_checkout`** — the `published package version` / `workspace release path` remediation guidance lived only in the error *hints*; the test asserts it in `err.message`. Guidance is now appended to the message body as well.
- **`core::triage::tests::parsing::ci_failure_helpers_classify_and_extract_concise_snippets`** — snippet dedup compared the *widened* `start` against the previous snippet's range, swallowing a distinct failure line just past the previous context window (got 1 snippet, expected 2). Now dedups against the failure-line `index`.

### Already green at this main HEAD (skipped, verified by reading code)
`cli_surface::suspicious_command_paths_require_safety_classification`, `commands::adapter::command_adapter_recognizes_migrated_json_commands`, the 3 `commands::fuzz` gate/report tests, `commands::route::agent_task_fanout_submit_batch_requires_explicit_runner_under_lab_only`, `core::agent_task_controller_service::init_from_spec_for_resume_fork_isolates_under_derived_loop_id`, `core::deploy::deploy_planning_fails_closed_when_project_component_local_path_is_missing`, and `core::runner::execution::tests::handoff::reverse_broker_exec_submits_job_and_polls_result`. These were resolved by #6244/#6246/#6248 and earlier merges.

## Verification
- `cargo build --lib` (only pre-existing dead-code warnings, none in edited files)
- `cargo fmt` (reverted formatting churn in unrelated files; commit touches only the 3 intentionally-changed files)
- Heavy test suite left to CI per repo policy.