### PR TITLE
feat(agent-task): compact controller failure summary (#6220)

### DIFF
--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -4,7 +4,8 @@
 use serde_json::Value;
 
 use homeboy::core::agent_task_controller_service::{
-    init_from_spec_for_resume_with_resolution, ControllerResumeStateResolution,
+    build_run_failure_summary, init_from_spec_for_resume_with_resolution,
+    ControllerResumeStateResolution,
 };
 use homeboy::core::agent_task_loop_definition::{
     materialize_repo_loop_spec, AgentTaskLoopPolicyResultMaterialization,
@@ -341,19 +342,41 @@ where
 
     let status =
         homeboy::core::agent_tasks::loop_controller::controller_status_report(&from_spec.loop_id)?;
-    Ok((
-        serde_json::json!({
-            "schema": "homeboy/agent-task-loop-controller-run-from-spec-result/v1",
-            "loop_id": from_spec.loop_id.clone(),
-            "max_actions": args.max_actions,
-            "stopped_reason": stopped_reason,
-            "materialization": materialized.value,
-            "from_spec": from_spec,
-            "results": results,
-            "status": status,
-        }),
-        exit_code,
-    ))
+
+    // On a terminal failure, normalize the nested provider/runtime failures into
+    // a compact root-cause `failure_summary` with durable evidence refs so
+    // operators never have to hand-traverse the envelope below it (#6220).
+    let failure_summary = if exit_code != 0 {
+        let status_value = serde_json::to_value(&status)
+            .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
+        Some(build_run_failure_summary(
+            &from_spec.loop_id,
+            &stopped_reason,
+            &results,
+            &status_value,
+        ))
+    } else {
+        None
+    };
+
+    let mut envelope = serde_json::json!({
+        "schema": "homeboy/agent-task-loop-controller-run-from-spec-result/v1",
+        "loop_id": from_spec.loop_id.clone(),
+        "max_actions": args.max_actions,
+        "stopped_reason": stopped_reason,
+        "materialization": materialized.value,
+        "from_spec": from_spec,
+        "results": results,
+        "status": status,
+    });
+    if let Some(summary) = failure_summary {
+        let summary_value = serde_json::to_value(summary)
+            .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
+        if let Value::Object(map) = &mut envelope {
+            map.insert("failure_summary".to_string(), summary_value);
+        }
+    }
+    Ok((envelope, exit_code))
 }
 
 fn materialize_controller_spec(

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -59,6 +59,7 @@ mod dispatch_defaults;
 mod pr_ownership;
 mod reports;
 mod request;
+mod run_failure_summary;
 mod spec;
 mod spec_compile;
 mod spec_source;
@@ -70,6 +71,10 @@ pub use dispatch_defaults::*;
 use pr_ownership::*;
 pub use reports::*;
 pub use request::*;
+pub use run_failure_summary::{
+    build_run_failure_summary, ControllerRunEvidenceRef, ControllerRunFailureSummary,
+    CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA,
+};
 pub use spec::*;
 pub(crate) use spec_compile::validate_loop_spec;
 use spec_compile::{

--- a/src/core/agent_task_controller_service/run_failure_summary.rs
+++ b/src/core/agent_task_controller_service/run_failure_summary.rs
@@ -1,0 +1,463 @@
+//! Compact root-cause failure summaries for `agent-task controller run-from-spec`.
+//!
+//! Diagnosing a failed controller run used to require manually traversing huge
+//! nested JSON envelopes (resume results, action reports, provider/runtime
+//! diagnostics, Codebox evidence) to find the actual blocker, the owning
+//! surface, and the durable artifacts/logs that prove what happened (#6220).
+//!
+//! This module normalizes those nested provider/runtime failures into a small
+//! [`ControllerRunFailureSummary`] object that names the phase, the owner
+//! surface that failed, the root blocker message, the first actionable
+//! diagnostic, durable evidence refs (runner job logs, persisted run evidence,
+//! provider artifact bundles), and the next recommended Homeboy command. The
+//! orchestrator prints it on every terminal failure so operators never have to
+//! hand-extract the root cause again.
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// Owner surface that a controller run blocker is attributed to.
+///
+/// Ordered roughly outside-in so the most specific reachable surface wins when
+/// several layers report context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OwnerSurface {
+    Homeboy,
+    LabRunner,
+    ExtensionProvider,
+    WpCodebox,
+    WordPressRuntime,
+    ProviderPlugin,
+    AgentOutput,
+}
+
+impl OwnerSurface {
+    fn as_str(self) -> &'static str {
+        match self {
+            OwnerSurface::Homeboy => "homeboy",
+            OwnerSurface::LabRunner => "lab_runner",
+            OwnerSurface::ExtensionProvider => "extension_provider",
+            OwnerSurface::WpCodebox => "wp_codebox",
+            OwnerSurface::WordPressRuntime => "wordpress_runtime",
+            OwnerSurface::ProviderPlugin => "provider_plugin",
+            OwnerSurface::AgentOutput => "agent_output",
+        }
+    }
+}
+
+/// A durable, Homeboy-owned reference to evidence behind a controller failure.
+///
+/// `kind` classifies the ref (`runner_job_log`, `run_evidence`,
+/// `artifact_bundle`, ...) so operators can pick the right follow-up without
+/// guessing at URI shapes.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ControllerRunEvidenceRef {
+    pub kind: String,
+    pub uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// Compact, operator-facing root-cause summary for a failed controller run.
+///
+/// Built purely from the `run-from-spec` result envelope (resume results,
+/// per-action failure summaries, controller status), so it stays in lockstep
+/// with whatever the run actually emitted without a second source of truth.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ControllerRunFailureSummary {
+    pub schema: &'static str,
+    /// Why the run stopped (`action_failed`, `terminal_state`, ...).
+    pub stopped_reason: String,
+    /// Controller phase that was executing when the run failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    /// Owner surface the blocker is attributed to.
+    pub owner_surface: String,
+    /// Root blocker message — the single most actionable line.
+    pub root_blocker: String,
+    /// First actionable diagnostic (may equal `root_blocker` when only one is known).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_diagnostic: Option<String>,
+    /// Failed action id, when the failure is tied to a specific action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<String>,
+    /// Provider implicated in the failure, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    /// Provider/runtime failure phase, when known (e.g. `secret_handoff`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_phase: Option<String>,
+    /// Durable evidence refs (runner job logs, run evidence, artifact bundles).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub evidence_refs: Vec<ControllerRunEvidenceRef>,
+    /// Next recommended Homeboy command to investigate or resume.
+    pub next_command: String,
+}
+
+pub const CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA: &str =
+    "homeboy/agent-task-loop-controller-run-failure-summary/v1";
+
+/// Build a compact failure summary from a `run-from-spec` result envelope.
+///
+/// `loop_id`, `stopped_reason`, `results`, and `status` come straight from the
+/// envelope the command is about to return. Returns `None` when nothing in the
+/// envelope indicates a failure (callers only attach the summary on a non-zero
+/// exit).
+pub fn build_run_failure_summary(
+    loop_id: &str,
+    stopped_reason: &str,
+    results: &[Value],
+    status: &Value,
+) -> ControllerRunFailureSummary {
+    let failed_action = results.iter().rev().find(|result| {
+        result.get("failure_summary").is_some()
+            || result.get("status").and_then(Value::as_str) == Some("failed")
+            || result
+                .get("status")
+                .and_then(Value::as_str)
+                .map(|status| status.starts_with("blocked_"))
+                .unwrap_or(false)
+    });
+
+    let failure_summary = failed_action.and_then(|result| result.get("failure_summary"));
+
+    let action_id = failure_summary
+        .and_then(|summary| string_field(summary, "action_id"))
+        .or_else(|| failed_action.and_then(|result| string_field(result, "action_id")));
+    let provider = failure_summary.and_then(|summary| string_field(summary, "provider"));
+    let failure_phase = failure_summary.and_then(|summary| string_field(summary, "failure_phase"));
+
+    let phase = failure_summary
+        .and_then(|summary| string_field(summary, "phase"))
+        .or_else(|| nested_string(status, &["controller", "phase"]))
+        .or_else(|| nested_string(status, &["phase"]));
+
+    let action_status = failed_action.and_then(|result| string_field(result, "status"));
+
+    let root_blocker = failure_summary
+        .and_then(|summary| string_field(summary, "diagnostic"))
+        .or_else(|| deep_diagnostic_message(failed_action))
+        .or_else(|| stopped_reason_blocker(stopped_reason, action_status.as_deref()))
+        .unwrap_or_else(|| "controller run failed".to_string());
+
+    let first_diagnostic =
+        deep_diagnostic_message(failed_action).filter(|diagnostic| *diagnostic != root_blocker);
+
+    let owner_surface = classify_owner_surface(
+        provider.as_deref(),
+        failure_phase.as_deref(),
+        action_status.as_deref(),
+        &root_blocker,
+    );
+
+    let evidence_refs = collect_evidence_refs(loop_id, failed_action, status);
+
+    let next_command = next_command(loop_id, owner_surface, action_status.as_deref());
+
+    ControllerRunFailureSummary {
+        schema: CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA,
+        stopped_reason: stopped_reason.to_string(),
+        phase,
+        owner_surface: owner_surface.as_str().to_string(),
+        root_blocker,
+        first_diagnostic,
+        action_id,
+        provider,
+        failure_phase,
+        evidence_refs,
+        next_command,
+    }
+}
+
+/// Attribute the blocker to the most specific reachable owner surface.
+///
+/// Uses explicit provider/phase hints first, then falls back to scanning the
+/// root blocker text for ecosystem-agnostic surface signals.
+fn classify_owner_surface(
+    provider: Option<&str>,
+    failure_phase: Option<&str>,
+    action_status: Option<&str>,
+    root_blocker: &str,
+) -> OwnerSurface {
+    if let Some(status) = action_status {
+        if status.starts_with("blocked_") || status.contains("runner") {
+            // Runner-policy blocks are a Homeboy-side scheduling decision unless
+            // the message clearly points at the remote runner.
+            if root_blocker.to_ascii_lowercase().contains("runner") {
+                return OwnerSurface::LabRunner;
+            }
+            return OwnerSurface::Homeboy;
+        }
+    }
+
+    let haystack = root_blocker.to_ascii_lowercase();
+    let phase = failure_phase.unwrap_or("").to_ascii_lowercase();
+
+    if phase.contains("runner")
+        || haystack.contains("runner job")
+        || haystack.contains("lab runner")
+    {
+        return OwnerSurface::LabRunner;
+    }
+    if phase.contains("secret")
+        || haystack.contains("secret handoff")
+        || haystack.contains("secret")
+    {
+        return OwnerSurface::ExtensionProvider;
+    }
+    if haystack.contains("codebox") || haystack.contains("plugin activation") {
+        return OwnerSurface::WpCodebox;
+    }
+    if haystack.contains("php fatal")
+        || haystack.contains("fatal error")
+        || haystack.contains("wp-cli")
+        || haystack.contains("wordpress")
+    {
+        return OwnerSurface::WordPressRuntime;
+    }
+    if haystack.contains("plugin") {
+        return OwnerSurface::ProviderPlugin;
+    }
+    if provider.is_some() {
+        return OwnerSurface::ExtensionProvider;
+    }
+    if haystack.contains("missing required artifact")
+        || haystack.contains("artifact")
+        || haystack.contains("agent output")
+    {
+        return OwnerSurface::AgentOutput;
+    }
+
+    OwnerSurface::Homeboy
+}
+
+/// Collect durable, Homeboy-owned evidence refs behind the failure.
+///
+/// Pulls runner job ids, run ids, task ids, and any declared artifact/evidence
+/// refs out of the failed action result and the controller status, then renders
+/// them as stable `homeboy <command>` / URI references operators can follow.
+fn collect_evidence_refs(
+    loop_id: &str,
+    failed_action: Option<&Value>,
+    status: &Value,
+) -> Vec<ControllerRunEvidenceRef> {
+    let mut refs: Vec<ControllerRunEvidenceRef> = Vec::new();
+
+    // Persisted run evidence: the controller record itself is the durable index.
+    push_ref(
+        &mut refs,
+        ControllerRunEvidenceRef {
+            kind: "run_evidence".to_string(),
+            uri: format!("homeboy agent-task controller status {loop_id} --json"),
+            label: Some("persisted controller run evidence".to_string()),
+        },
+    );
+
+    if let Some(action) = failed_action {
+        // Runner job logs.
+        for job_id in find_all_strings(action, &["runner_job_id", "job_id"]) {
+            push_ref(
+                &mut refs,
+                ControllerRunEvidenceRef {
+                    kind: "runner_job_log".to_string(),
+                    uri: format!("homeboy logs runner-job {job_id}"),
+                    label: Some(format!("runner job {job_id} log")),
+                },
+            );
+        }
+
+        // Per-run evidence keyed by run id.
+        for run_id in find_all_strings(action, &["run_id"]) {
+            push_ref(
+                &mut refs,
+                ControllerRunEvidenceRef {
+                    kind: "run_evidence".to_string(),
+                    uri: format!("homeboy agent-task show {run_id} --json"),
+                    label: Some(format!("agent-task run {run_id} evidence")),
+                },
+            );
+        }
+
+        // Provider artifact bundles declared on the failed action.
+        for evidence in collect_declared_refs(action) {
+            push_ref(&mut refs, evidence);
+        }
+    }
+
+    // Evidence index recorded on the controller status (artifact bundles).
+    for evidence in collect_declared_refs(status) {
+        push_ref(&mut refs, evidence);
+    }
+
+    refs
+}
+
+/// Extract declared artifact/evidence refs (`uri`/`url`/`path`) from any nested
+/// `artifacts`, `artifact_refs`, or `evidence_refs` arrays.
+fn collect_declared_refs(value: &Value) -> Vec<ControllerRunEvidenceRef> {
+    let mut out = Vec::new();
+    collect_declared_refs_into(value, &mut out);
+    out
+}
+
+fn collect_declared_refs_into(value: &Value, out: &mut Vec<ControllerRunEvidenceRef>) {
+    match value {
+        Value::Object(map) => {
+            for key in [
+                "artifacts",
+                "artifact_refs",
+                "typed_artifacts",
+                "evidence_refs",
+            ] {
+                if let Some(Value::Array(items)) = map.get(key) {
+                    for item in items {
+                        if let Some(reference) = declared_ref_from_item(key, item) {
+                            out.push(reference);
+                        }
+                    }
+                }
+            }
+            for nested in map.values() {
+                collect_declared_refs_into(nested, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_declared_refs_into(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn declared_ref_from_item(container_key: &str, item: &Value) -> Option<ControllerRunEvidenceRef> {
+    let uri = string_field(item, "uri")
+        .or_else(|| string_field(item, "url"))
+        .or_else(|| string_field(item, "path"))?;
+    let kind = string_field(item, "kind").unwrap_or_else(|| {
+        if container_key == "evidence_refs" {
+            "evidence_bundle".to_string()
+        } else {
+            "artifact_bundle".to_string()
+        }
+    });
+    let label = string_field(item, "label")
+        .or_else(|| string_field(item, "name"))
+        .or_else(|| string_field(item, "role"));
+    Some(ControllerRunEvidenceRef { kind, uri, label })
+}
+
+/// Next recommended Homeboy command, tailored to the owning surface.
+fn next_command(loop_id: &str, owner: OwnerSurface, action_status: Option<&str>) -> String {
+    if action_status
+        .map(|status| status.starts_with("blocked_"))
+        .unwrap_or(false)
+    {
+        return format!(
+            "homeboy agent-task controller status {loop_id} --json  # resolve the runner block, then re-run with --resume"
+        );
+    }
+    match owner {
+        OwnerSurface::LabRunner => {
+            format!("homeboy runner status  # then `homeboy agent-task controller status {loop_id} --json`")
+        }
+        OwnerSurface::WpCodebox | OwnerSurface::WordPressRuntime | OwnerSurface::ProviderPlugin => {
+            format!("homeboy agent-task controller status {loop_id} --json  # inspect provider/runtime evidence refs above")
+        }
+        _ => format!("homeboy agent-task controller status {loop_id} --json"),
+    }
+}
+
+fn stopped_reason_blocker(stopped_reason: &str, action_status: Option<&str>) -> Option<String> {
+    match stopped_reason {
+        "action_failed" => {
+            Some("a controller action failed without an embedded diagnostic".to_string())
+        }
+        "terminal_state" => action_status.map(|status| {
+            format!("controller reached terminal state with failed action status '{status}'")
+        }),
+        "max_actions_reached" => {
+            Some("controller hit the run-from-spec --max-actions cap before completing".to_string())
+        }
+        "idle" => Some("controller is idle with no pending actions to run".to_string()),
+        _ => None,
+    }
+}
+
+/// Find the deepest/first diagnostic message inside a result's nested
+/// `diagnostics` arrays (provider/runtime envelopes bury these).
+fn deep_diagnostic_message(value: Option<&Value>) -> Option<String> {
+    let value = value?;
+    find_diagnostic_message(value)
+}
+
+fn find_diagnostic_message(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::Array(diagnostics)) = map.get("diagnostics") {
+                for diagnostic in diagnostics {
+                    if let Some(message) = string_field(diagnostic, "message") {
+                        if !message.trim().is_empty() {
+                            return Some(message);
+                        }
+                    }
+                }
+            }
+            map.values().find_map(find_diagnostic_message)
+        }
+        Value::Array(items) => items.iter().find_map(find_diagnostic_message),
+        _ => None,
+    }
+}
+
+fn string_field(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn nested_string(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current.as_str().map(str::to_string)
+}
+
+/// Recursively collect every string value found under any of `fields`.
+fn find_all_strings(value: &Value, fields: &[&str]) -> Vec<String> {
+    let mut out = Vec::new();
+    find_all_strings_into(value, fields, &mut out);
+    out
+}
+
+fn find_all_strings_into(value: &Value, fields: &[&str], out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, nested) in map {
+                if fields.contains(&key.as_str()) {
+                    if let Some(found) = nested.as_str() {
+                        if !found.trim().is_empty() && !out.iter().any(|seen| seen == found) {
+                            out.push(found.to_string());
+                        }
+                    }
+                }
+                find_all_strings_into(nested, fields, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                find_all_strings_into(item, fields, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_ref(refs: &mut Vec<ControllerRunEvidenceRef>, candidate: ControllerRunEvidenceRef) {
+    if !refs.iter().any(|existing| existing.uri == candidate.uri) {
+        refs.push(candidate);
+    }
+}

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -3031,3 +3031,108 @@ fn apply_event_persists_actions_and_keeps_event_envelope() {
             .all(|event| event.event_type == "controller.action.claimed"));
     });
 }
+
+#[test]
+fn run_failure_summary_normalizes_nested_provider_failure() {
+    // Mirrors a real run-from-spec envelope: the root cause is buried under
+    // results[*].failure_summary + a nested provider diagnostics array.
+    let results = vec![serde_json::json!({
+        "schema": ACTION_RESULT_SCHEMA,
+        "status": "failed",
+        "action_id": "spawn-impl",
+        "failure_summary": {
+            "action_id": "spawn-impl",
+            "provider": "wp-codebox",
+            "failure_phase": "plugin_activation",
+            "run_id": "run-42",
+            "diagnostic": "PHP fatal: Uncaught Error: Class 'Foo' not found",
+        },
+        "execution": {
+            "runner_job_id": "job-77",
+            "diagnostics": [
+                { "message": "PHP fatal: Uncaught Error: Class 'Foo' not found" }
+            ],
+            "artifacts": [
+                { "kind": "log_bundle", "uri": "file:///runs/run-42/codebox.log", "label": "codebox log" }
+            ],
+        },
+    })];
+    let status = serde_json::json!({
+        "controller": { "phase": "implement" },
+    });
+
+    let summary = build_run_failure_summary("loop-9", "action_failed", &results, &status);
+
+    assert_eq!(summary.schema, CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA);
+    assert_eq!(summary.stopped_reason, "action_failed");
+    assert_eq!(summary.phase.as_deref(), Some("implement"));
+    assert_eq!(summary.owner_surface, "wp_codebox");
+    assert_eq!(
+        summary.root_blocker,
+        "PHP fatal: Uncaught Error: Class 'Foo' not found"
+    );
+    assert_eq!(summary.action_id.as_deref(), Some("spawn-impl"));
+    assert_eq!(summary.provider.as_deref(), Some("wp-codebox"));
+    assert_eq!(summary.failure_phase.as_deref(), Some("plugin_activation"));
+    assert!(summary.next_command.contains("loop-9"));
+
+    // Durable evidence refs: persisted run evidence, runner job log, per-run
+    // evidence, and the declared provider artifact bundle.
+    let kinds: Vec<&str> = summary
+        .evidence_refs
+        .iter()
+        .map(|reference| reference.kind.as_str())
+        .collect();
+    assert!(kinds.contains(&"runner_job_log"), "kinds={kinds:?}");
+    assert!(kinds.contains(&"run_evidence"), "kinds={kinds:?}");
+    assert!(kinds.contains(&"artifact_bundle"), "kinds={kinds:?}");
+    assert!(summary
+        .evidence_refs
+        .iter()
+        .any(|reference| reference.uri.contains("job-77")));
+    assert!(summary
+        .evidence_refs
+        .iter()
+        .any(|reference| reference.uri == "file:///runs/run-42/codebox.log"));
+}
+
+#[test]
+fn run_failure_summary_handles_runner_block_without_diagnostic_message() {
+    let results = vec![serde_json::json!({
+        "schema": ACTION_RESULT_SCHEMA,
+        "status": "blocked_runner_unavailable",
+        "action_id": "gate-run",
+        "failure_summary": {
+            "action_id": "gate-run",
+            "diagnostic": "runner `lab-1` is not available for controller action execution",
+        },
+    })];
+    let status = serde_json::json!({ "controller": { "phase": "verify" } });
+
+    let summary = build_run_failure_summary("loop-7", "action_failed", &results, &status);
+
+    assert_eq!(summary.owner_surface, "lab_runner");
+    assert!(summary.root_blocker.contains("runner"));
+    assert!(summary.next_command.contains("--resume"));
+    // Still always surfaces the persisted run-evidence ref.
+    assert!(summary
+        .evidence_refs
+        .iter()
+        .any(|reference| reference.kind == "run_evidence"));
+}
+
+#[test]
+fn run_failure_summary_falls_back_to_stopped_reason() {
+    // No per-action failure_summary and no diagnostics: the summary still names
+    // a sensible blocker derived from the stopped reason.
+    let results: Vec<Value> = Vec::new();
+    let status = serde_json::json!({ "phase": "plan" });
+
+    let summary = build_run_failure_summary("loop-3", "max_actions_reached", &results, &status);
+
+    assert_eq!(summary.stopped_reason, "max_actions_reached");
+    assert_eq!(summary.owner_surface, "homeboy");
+    assert!(summary.root_blocker.contains("max-actions"));
+    assert_eq!(summary.phase.as_deref(), Some("plan"));
+    assert!(!summary.evidence_refs.is_empty());
+}


### PR DESCRIPTION
Closes #6220.

## Summary
Failed `agent-task controller run-from-spec` runs now emit a compact, root-cause `failure_summary` so operators no longer have to hand-traverse huge nested JSON envelopes (resume results, action reports, provider/runtime diagnostics, Codebox evidence) to find the real blocker.

## What it does
A new in-scope module `agent_task_controller_service/run_failure_summary.rs` normalizes nested provider/runtime failures into a small `ControllerRunFailureSummary` object built purely from the run-from-spec envelope (resume `results`, per-action `failure_summary`, controller `status`). On a non-zero terminal exit, `controller_run_from_spec_with_executor` attaches it to the result envelope under `failure_summary`.

The summary includes:
- **Phase** the controller was in when it failed.
- **Owner surface** — `homeboy`, `lab_runner`, `extension_provider`, `wp_codebox`, `wordpress_runtime`, `provider_plugin`, or `agent_output` — classified from provider/phase hints and the blocker text.
- **Root blocker** — the single most actionable line, dug out of the deepest nested `diagnostics` array.
- **First actionable diagnostic** (when distinct from the root blocker).
- **Durable, Homeboy-owned evidence refs** — runner job logs (`homeboy logs runner-job <id>`), persisted run evidence (`homeboy agent-task controller status <loop> --json`, `homeboy agent-task show <run> --json`), and declared provider artifact bundles (`uri`/`url`/`path`).
- **Next recommended Homeboy command**, tailored to the owning surface.

## Acceptance criteria
- [x] A failed controller run prints a concise root-cause summary without manual JSON traversal.
- [x] Nested provider/runtime failures are normalized into a small `failure_summary` object.
- [x] The summary links to runner job logs, persisted run evidence, and provider artifact bundles via Homeboy-owned refs.

## Tests
Added 3 unit tests covering nested provider/Codebox PHP-fatal normalization + evidence ref extraction, a runner-policy block without a diagnostic message, and the stopped-reason fallback path.

## Verification
`cargo build --lib` clean; `cargo fmt` applied to in-scope files only.