### PR TITLE
feat(agent-task): reconcile stale controller state on proof runs (#6221)

### DIFF
--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -124,16 +124,23 @@ pub struct AgentTaskControllerRunFromSpecArgs {
     )]
     pub max_actions: u32,
 
+    /// One-flag safe proof-run mode: automatically reset stale persisted controller
+    /// state and re-derive isolated run-scoped state from this spec, with no manual
+    /// state cleanup. Use this for proof/rerun workflows when the persisted spec
+    /// fingerprint conflicts with the requested spec.
+    #[arg(long = "reconcile-stale", conflicts_with_all = ["replace", "fork", "resume_existing"])]
+    pub reconcile_stale: bool,
+
     /// Discard stale persisted controller state and re-create it from this spec before running.
-    #[arg(long, conflicts_with_all = ["fork", "resume_existing"])]
+    #[arg(long, conflicts_with_all = ["fork", "resume_existing", "reconcile_stale"])]
     pub replace: bool,
 
     /// Apply this spec under a derived fork loop id, leaving the original controller untouched.
-    #[arg(long, conflicts_with_all = ["replace", "resume_existing"])]
+    #[arg(long, conflicts_with_all = ["replace", "resume_existing", "reconcile_stale"])]
     pub fork: bool,
 
     /// Accept stale/mismatched persisted state and resume the existing controller as-is.
-    #[arg(long = "resume-existing", conflicts_with_all = ["replace", "fork"])]
+    #[arg(long = "resume-existing", conflicts_with_all = ["replace", "fork", "reconcile_stale"])]
     pub resume_existing: bool,
 
     /// Executor backend to use for controller-spawned dispatch actions when the action omits one.

--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -321,7 +321,12 @@ where
         ControllerFromSpecRequest {
             spec: materialized.spec.clone(),
         },
-        resume_state_resolution(args.replace, args.fork, args.resume_existing),
+        resume_state_resolution(
+            args.reconcile_stale,
+            args.replace,
+            args.fork,
+            args.resume_existing,
+        ),
     )?;
     let dispatch = CliDispatchHook {
         executor: executor.clone(),
@@ -464,11 +469,14 @@ fn controller_plan(args: AgentTaskControllerPlanArgs) -> CmdResult<Value> {
 /// flags into a controller stale-state resolution. Clap enforces exclusivity,
 /// so at most one is set; none selected falls back to the guarded default.
 fn resume_state_resolution(
+    reconcile_stale: bool,
     replace: bool,
     fork: bool,
     resume_existing: bool,
 ) -> ControllerResumeStateResolution {
-    if replace {
+    if reconcile_stale {
+        ControllerResumeStateResolution::ReconcileStale
+    } else if replace {
         ControllerResumeStateResolution::Replace
     } else if fork {
         ControllerResumeStateResolution::Fork
@@ -498,7 +506,7 @@ pub(super) fn controller_from_spec(args: AgentTaskControllerFromSpecArgs) -> Cmd
     let report = if args.resume {
         init_from_spec_for_resume_with_resolution(
             ControllerFromSpecRequest { spec },
-            resume_state_resolution(args.replace, args.fork, args.resume_existing),
+            resume_state_resolution(false, args.replace, args.fork, args.resume_existing),
         )?
     } else {
         agent_task_controller_service::init_from_spec(ControllerFromSpecRequest { spec })?

--- a/src/commands/agent_task/tests/controller_run.rs
+++ b/src/commands/agent_task/tests/controller_run.rs
@@ -173,6 +173,7 @@ fn controller_run_from_spec_materializes_runs_bounded_actions_and_returns_status
                 ),
                 policy_results: Vec::new(),
                 max_actions: 1,
+                reconcile_stale: false,
                 replace: false,
                 fork: false,
                 resume_existing: false,
@@ -229,6 +230,7 @@ fn controller_run_from_spec_persists_dispatch_defaults_for_generated_actions() {
                 inputs: None,
                 policy_results: Vec::new(),
                 max_actions: 1,
+                reconcile_stale: false,
                 replace: false,
                 fork: false,
                 resume_existing: false,
@@ -316,6 +318,7 @@ fn controller_run_from_spec_preserves_runtime_execution_and_components() {
                 ),
                 policy_results: Vec::new(),
                 max_actions: 1,
+                reconcile_stale: false,
                 replace: false,
                 fork: false,
                 resume_existing: false,
@@ -390,6 +393,7 @@ fn controller_run_from_spec_rejects_unbounded_zero_max_actions() {
                 inputs: None,
                 policy_results: Vec::new(),
                 max_actions: 0,
+                reconcile_stale: false,
                 replace: false,
                 fork: false,
                 resume_existing: false,
@@ -404,6 +408,106 @@ fn controller_run_from_spec_rejects_unbounded_zero_max_actions() {
 
         assert_eq!(error.details["field"], "max-actions");
         assert!(error.message.contains("greater than zero"));
+    });
+}
+
+fn run_from_spec_proof_args(
+    loop_id: &str,
+    prompt: &str,
+    reconcile_stale: bool,
+) -> AgentTaskControllerRunFromSpecArgs {
+    AgentTaskControllerRunFromSpecArgs {
+        spec: serde_json::to_string(&json!({
+            "loop_id": loop_id,
+            "workflows": [{ "workflow_id": "brief", "prompt": prompt }]
+        }))
+        .expect("spec json"),
+        inputs: None,
+        policy_results: Vec::new(),
+        max_actions: 1,
+        reconcile_stale,
+        replace: false,
+        fork: false,
+        resume_existing: false,
+        dispatch_backend: Some("fixture".to_string()),
+        dispatch_selector: None,
+        dispatch_model: None,
+        dispatch_provider_config: None,
+    }
+}
+
+#[test]
+fn controller_run_from_spec_guards_stale_state_with_actionable_diagnostics() {
+    with_temp_home(|| {
+        // First proof run persists base controller state.
+        controller_run_from_spec_with_test_executor(
+            run_from_spec_proof_args("run-from-spec-stale-guard", "Draft the brief.", false),
+            ArtifactCapturingExecutor::default(),
+        )
+        .expect("base proof run");
+
+        // A changed spec under the same loop id must NOT silently reuse the
+        // stale base controller state on a run-scoped proof run.
+        let error = controller_run_from_spec_with_test_executor(
+            run_from_spec_proof_args("run-from-spec-stale-guard", "Rewrite the brief.", false),
+            ArtifactCapturingExecutor::default(),
+        )
+        .expect_err("stale state is guarded");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error
+            .message
+            .contains("refusing to reuse stale persisted controller state"));
+        let tried = error
+            .details
+            .get("tried")
+            .and_then(Value::as_array)
+            .expect("guard diagnostic lists tried details");
+        let detail_has = |needle: &str| {
+            tried.iter().any(|detail| {
+                detail
+                    .as_str()
+                    .is_some_and(|detail| detail.contains(needle))
+            })
+        };
+        assert!(detail_has("state_path="), "{tried:?}");
+        assert!(detail_has("prior_spec_fingerprint="), "{tried:?}");
+        assert!(detail_has("requested_spec_fingerprint="), "{tried:?}");
+        assert!(
+            detail_has("safe_next_action=--reconcile-stale"),
+            "{tried:?}"
+        );
+    });
+}
+
+#[test]
+fn controller_run_from_spec_reconcile_stale_recovers_without_manual_cleanup() {
+    with_temp_home(|| {
+        controller_run_from_spec_with_test_executor(
+            run_from_spec_proof_args("run-from-spec-reconcile", "Draft the brief.", false),
+            ArtifactCapturingExecutor::default(),
+        )
+        .expect("base proof run");
+
+        // The one-flag safe mode resets run-scoped state automatically.
+        let (value, exit_code) = controller_run_from_spec_with_test_executor(
+            run_from_spec_proof_args("run-from-spec-reconcile", "Rewrite the brief.", true),
+            ArtifactCapturingExecutor::default(),
+        )
+        .expect("reconcile-stale recovers the proof run");
+
+        assert_eq!(exit_code, 0, "{value:#}");
+        assert_eq!(value["loop_id"], "run-from-spec-reconcile");
+        assert_eq!(value["from_spec"]["initialized"], true);
+        assert_eq!(value["from_spec"]["resume_state"]["action"], "replacing");
+        assert_eq!(
+            value["from_spec"]["resume_state"]["resolution"],
+            "reconcile-stale"
+        );
+        assert_eq!(
+            value["from_spec"]["resume_state"]["fingerprint_match"],
+            false
+        );
     });
 }
 

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -411,6 +411,7 @@ mod tests {
                         inputs: None,
                         policy_results: Vec::new(),
                         max_actions: 1,
+                        reconcile_stale: false,
                         replace: false,
                         fork: false,
                         resume_existing: false,

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -286,20 +286,32 @@ pub fn init_from_spec_for_resume_with_resolution(
 
     // Persisted state is stale/incompatible. Honor the operator's resolution.
     match resolution {
-        ControllerResumeStateResolution::Guard => Err(Error::validation_invalid_argument(
-            "spec_fingerprint",
-            format!(
-                "agent-task controller from-spec --resume refuses to resume existing controller '{}' because the persisted spec fingerprint is missing or different; choose --replace, --fork, or --resume-existing, use a fresh loop_id, or re-run from-spec without --resume to reconcile state explicitly",
-                record.loop_id
-            ),
-            previous,
-            Some(vec![
-                format!("current_spec_fingerprint={spec_fingerprint}"),
-                format!("controller_path={controller_path}"),
-                "resolutions=--replace|--fork|--resume-existing".to_string(),
-            ]),
-        )),
-        ControllerResumeStateResolution::Replace => {
+        ControllerResumeStateResolution::Guard => {
+            let prior = previous
+                .as_deref()
+                .map(|fingerprint| format!("prior_spec_fingerprint={fingerprint}"))
+                .unwrap_or_else(|| "prior_spec_fingerprint=<none>".to_string());
+            Err(Error::validation_invalid_argument(
+                "spec_fingerprint",
+                format!(
+                    "refusing to reuse stale persisted controller state for '{}': the persisted spec fingerprint is missing or different from the requested spec. Re-run with --reconcile-stale to safely reset run-scoped state automatically, or choose --replace, --fork, or --resume-existing; a fresh loop_id also avoids the conflict",
+                    record.loop_id
+                ),
+                previous.clone(),
+                Some(vec![
+                    format!("state_path={controller_path}"),
+                    prior,
+                    format!("requested_spec_fingerprint={spec_fingerprint}"),
+                    "safe_next_action=--reconcile-stale (auto reset run-scoped state, no manual cleanup)".to_string(),
+                    "resolutions=--reconcile-stale|--replace|--fork|--resume-existing".to_string(),
+                ]),
+            ))
+        }
+        ControllerResumeStateResolution::Replace
+        | ControllerResumeStateResolution::ReconcileStale => {
+            // Both discard the stale persisted record and re-create isolated
+            // run-scoped state from the spec; `ReconcileStale` is the one-flag
+            // proof-run alias surfaced under its own evidence keyword (#6221).
             reset_controller_state(&record.loop_id)?;
             let mut report = init_from_spec(request)?;
             report.resume_state = Some(ControllerResumeStateReport {

--- a/src/core/agent_task_controller_service/spec.rs
+++ b/src/core/agent_task_controller_service/spec.rs
@@ -33,6 +33,13 @@ pub enum ControllerResumeStateResolution {
     Fork,
     /// Resume the persisted controller as-is, accepting the stale/mismatched state.
     ResumeExisting,
+    /// One-flag safe proof-run mode: reset stale persisted state automatically,
+    /// re-deriving isolated run-scoped controller state from the spec without
+    /// any manual state cleanup. Behaves like [`Replace`] for stale state but is
+    /// surfaced as its own keyword so proof-run evidence reads cleanly (#6221).
+    ///
+    /// [`Replace`]: ControllerResumeStateResolution::Replace
+    ReconcileStale,
 }
 
 impl ControllerResumeStateResolution {
@@ -43,6 +50,7 @@ impl ControllerResumeStateResolution {
             ControllerResumeStateResolution::Replace => "replace",
             ControllerResumeStateResolution::Fork => "fork",
             ControllerResumeStateResolution::ResumeExisting => "resume-existing",
+            ControllerResumeStateResolution::ReconcileStale => "reconcile-stale",
         }
     }
 }

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -1043,17 +1043,60 @@ fn init_from_spec_for_resume_rejects_changed_existing_spec() {
         assert_eq!(error.code.as_str(), "validation.invalid_argument");
         assert!(error
             .message
-            .contains("persisted spec fingerprint is missing or different"));
+            .contains("refusing to reuse stale persisted controller state"));
         assert!(error
             .message
-            .contains("--replace, --fork, or --resume-existing"));
-        assert!(error
+            .contains("--reconcile-stale to safely reset run-scoped state"));
+        let tried = error
             .details
             .get("tried")
             .and_then(Value::as_array)
-            .is_some_and(|details| details.iter().any(|detail| detail
-                .as_str()
-                .is_some_and(|detail| detail.contains("controller_path=")))));
+            .expect("guard diagnostic lists tried details");
+        let detail_has = |needle: &str| {
+            tried.iter().any(|detail| {
+                detail
+                    .as_str()
+                    .is_some_and(|detail| detail.contains(needle))
+            })
+        };
+        // Diagnostic must name the state path, prior + requested fingerprint,
+        // and the safe next action (#6221 acceptance criteria).
+        assert!(detail_has("state_path="), "{tried:?}");
+        assert!(detail_has("prior_spec_fingerprint="), "{tried:?}");
+        assert!(detail_has("requested_spec_fingerprint="), "{tried:?}");
+        assert!(
+            detail_has("safe_next_action=--reconcile-stale"),
+            "{tried:?}"
+        );
+    });
+}
+
+#[test]
+fn init_from_spec_for_resume_reconcile_stale_resets_state_without_manual_cleanup() {
+    with_isolated_home(|_| {
+        let (base, changed) = changed_resume_spec("repo-loop-resume-reconcile-stale");
+        init_from_spec_for_resume(ControllerFromSpecRequest { spec: base })
+            .expect("base initialized");
+
+        // One flag: no prior manual state cleanup required.
+        let report = init_from_spec_for_resume_with_resolution(
+            ControllerFromSpecRequest {
+                spec: changed.clone(),
+            },
+            ControllerResumeStateResolution::ReconcileStale,
+        )
+        .expect("reconcile-stale re-initializes controller");
+        let resume_state = report.resume_state.expect("resume_state present");
+        assert_eq!(resume_state.action, "replacing");
+        assert_eq!(resume_state.resolution, "reconcile-stale");
+        assert!(resume_state.existing_controller);
+        assert!(!resume_state.fingerprint_match);
+        // Run-scoped state is re-derived from the requested spec, not the stale base.
+        assert_eq!(
+            repo_loop_spec_fingerprint_from_metadata(&report.controller),
+            Some(repo_loop_spec_fingerprint(&changed).expect("fingerprint"))
+        );
+        assert_eq!(report.loop_id, "repo-loop-resume-reconcile-stale");
     });
 }
 


### PR DESCRIPTION
Closes #6221.

## Summary
`run-from-spec` now detects stale-state/fingerprint conflicts with clear diagnostics and a one-flag safe replace/fork mode for proof runs.

## Changes
- **One-flag safe mode** — new `--reconcile-stale` flag on `agent-task controller run-from-spec`. When persisted controller state conflicts with the requested spec, this automatically resets isolated run-scoped state from the spec with **no manual state cleanup**. Backed by a new `ControllerResumeStateResolution::ReconcileStale` (Replace semantics, surfaced under its own `reconcile-stale` evidence keyword).
- **Never silently reuses stale state** — the default `Guard` resolution still fails closed on a run-scoped proof when the persisted fingerprint is missing/different (builds on the #6123 stale-guard).
- **Actionable conflict diagnostic** — the Guard error now names the four required facts: `state_path`, `prior_spec_fingerprint`, `requested_spec_fingerprint`, and the `safe_next_action=--reconcile-stale`, plus the full resolution list.

## Acceptance criteria
- [x] `run-from-spec` never silently reuses stale base controller state for a run-scoped proof.
- [x] On conflict, diagnostics name the state path, prior fingerprint, requested fingerprint, and safe next action.
- [x] One-flag safe replace/fork mode (`--reconcile-stale`) requires no manual state cleanup.

## Tests
- Service-level: guard diagnostic asserts all four required fields; `reconcile-stale` resets state without manual cleanup.
- Command-level: `run-from-spec` guards a stale rerun with actionable diagnostics, and `--reconcile-stale` recovers the proof run.

## Verification
- `cargo build --lib` (clean) + `cargo fmt`. Out-of-scope fmt drift reverted; only agent-task controller files + tests committed. Heavy test/clippy left to CI.