### PR TITLE
feat(fuzz): raw fuzz result evidence + inspection (#5997)

### DIFF
--- a/src/commands/fuzz/dispatch.rs
+++ b/src/commands/fuzz/dispatch.rs
@@ -11,6 +11,7 @@ use homeboy::core::fuzz::{
 use super::super::{CmdResult, GlobalArgs};
 use super::compare::run_compare;
 use super::execution::run_run;
+use super::inspect::run_inspect;
 use super::planning::run_plan;
 use super::replay::run_replay;
 use super::report::{run_report, run_validate};
@@ -44,6 +45,11 @@ pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
         Some(FuzzCommand::Replay(replay_args)) => {
             let (output, exit) = run_replay(replay_args)?;
             Ok((FuzzOutput::Replay(output), exit))
+        }
+        Some(FuzzCommand::Inspect(inspect_args)) => {
+            let output = run_inspect(inspect_args)?;
+            let exit = i32::from(output.status != "ok");
+            Ok((FuzzOutput::Inspect(output), exit))
         }
         None => {
             let (output, exit) = run_run(args.run)?;

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -521,12 +521,14 @@ pub(super) fn fuzz_evidence_followups(
 ) -> Vec<String> {
     let mut followups = match run_id.filter(|run_id| !run_id.trim().is_empty()) {
         Some(run_id) => vec![
+            format!("homeboy fuzz inspect {run_id}"),
             format!("homeboy runs show {run_id}"),
             format!("homeboy runs evidence {run_id}"),
             format!("homeboy runs artifacts {run_id}"),
         ],
         None => vec![
             "Use --run-id <stable-id> when the downstream runner records persisted Homeboy evidence.".to_string(),
+            "Inspect the raw runner result with `homeboy fuzz inspect <run-id>` (no runner-log spelunking).".to_string(),
             "Inspect persisted proof with `homeboy runs show <run-id>` and `homeboy runs evidence <run-id>`.".to_string(),
         ],
     };

--- a/src/commands/fuzz/inspect.rs
+++ b/src/commands/fuzz/inspect.rs
@@ -1,0 +1,327 @@
+use std::path::Path;
+
+use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore};
+
+use super::types::{FuzzInspectArgs, FuzzInspectCandidate, FuzzInspectOutput};
+
+/// Artifact kinds that hold the raw fuzz runner input/result pair, ordered by
+/// inspection preference. `fuzz_results` is the verbatim file a runner wrote to
+/// `HOMEBOY_FUZZ_RESULTS_FILE`; `fuzz_result_envelope` is the normalized report
+/// envelope persisted by `homeboy fuzz report`.
+const RAW_FUZZ_RESULT_KINDS: &[&str] = &["fuzz_results", "fuzz_result_envelope"];
+
+/// Implement `homeboy fuzz inspect <run-id>`.
+///
+/// Resolves the raw fuzz runner result for a run and prints it directly so an
+/// operator debugging a remote Lab fuzz failure does not have to chase a remote
+/// temp path or read large runner job logs. Works against either the `fuzz` run
+/// id or the Lab `runner-exec` run id that offloaded it, because
+/// [`runs_service::list_artifacts_for_run`] already folds in downstream Lab job
+/// artifacts that share the same `remote_job_id`.
+pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzInspectOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let artifacts = runs_service::list_artifacts_for_run(&store, &args.run_id)?;
+
+    let candidates: Vec<&ArtifactRecord> = RAW_FUZZ_RESULT_KINDS
+        .iter()
+        .flat_map(|kind| {
+            artifacts
+                .iter()
+                .filter(move |artifact| &artifact.kind == kind && artifact.artifact_type == "file")
+        })
+        .collect();
+
+    let candidate_index = candidates
+        .iter()
+        .map(|artifact| FuzzInspectCandidate {
+            run_id: artifact.run_id.clone(),
+            artifact_id: artifact.id.clone(),
+            kind: artifact.kind.clone(),
+            artifact_type: artifact.artifact_type.clone(),
+            path: artifact.path.clone(),
+            exists: Path::new(&artifact.path).is_file(),
+        })
+        .collect::<Vec<_>>();
+
+    let Some(selected) = candidates
+        .iter()
+        .copied()
+        .find(|artifact| Path::new(&artifact.path).is_file())
+        .or_else(|| candidates.first().copied())
+    else {
+        return Ok(FuzzInspectOutput {
+            command: "fuzz.inspect".to_string(),
+            status: "not_found".to_string(),
+            run_id: args.run_id.clone(),
+            source_run_id: args.run_id.clone(),
+            artifact_id: String::new(),
+            artifact_kind: String::new(),
+            artifact_path: String::new(),
+            fetch_command: None,
+            result: None,
+            raw: None,
+            candidates: candidate_index,
+            next_steps: vec![
+                format!(
+                    "No raw fuzz result artifact ({}) is recorded for `{}`. Confirm the runner wrote HOMEBOY_FUZZ_RESULTS_FILE and that Lab evidence was mirrored before cleanup.",
+                    RAW_FUZZ_RESULT_KINDS.join(" / "),
+                    args.run_id
+                ),
+                format!("Inspect run evidence with `homeboy runs evidence {}`.", args.run_id),
+                format!("List recorded artifacts with `homeboy runs artifacts {}`.", args.run_id),
+            ],
+        });
+    };
+
+    let fetch_command = Some(format!(
+        "homeboy runs artifact get {} {} -o <path>",
+        selected.run_id, selected.id
+    ));
+
+    let path = Path::new(&selected.path);
+    if !path.is_file() {
+        return Ok(FuzzInspectOutput {
+            command: "fuzz.inspect".to_string(),
+            status: "unavailable".to_string(),
+            run_id: args.run_id.clone(),
+            source_run_id: selected.run_id.clone(),
+            artifact_id: selected.id.clone(),
+            artifact_kind: selected.kind.clone(),
+            artifact_path: selected.path.clone(),
+            fetch_command: fetch_command.clone(),
+            result: None,
+            raw: None,
+            candidates: candidate_index,
+            next_steps: vec![
+                format!(
+                    "Raw fuzz result artifact {} is recorded but its bytes are not present locally at {}.",
+                    selected.id, selected.path
+                ),
+                format!(
+                    "Fetch the bytes with `{}`.",
+                    fetch_command.as_deref().unwrap_or_default()
+                ),
+            ],
+        });
+    }
+
+    let bytes = std::fs::read(path).map_err(|error| {
+        homeboy::core::Error::internal_io(error.to_string(), Some(selected.path.clone()))
+    })?;
+    let text = String::from_utf8_lossy(&bytes).to_string();
+
+    let (result, raw) = if args.raw {
+        (None, Some(text))
+    } else {
+        match serde_json::from_slice::<serde_json::Value>(&bytes) {
+            Ok(value) => (Some(value), None),
+            Err(_) => (None, Some(text)),
+        }
+    };
+
+    Ok(FuzzInspectOutput {
+        command: "fuzz.inspect".to_string(),
+        status: "ok".to_string(),
+        run_id: args.run_id.clone(),
+        source_run_id: selected.run_id.clone(),
+        artifact_id: selected.id.clone(),
+        artifact_kind: selected.kind.clone(),
+        artifact_path: selected.path.clone(),
+        fetch_command,
+        result,
+        raw,
+        candidates: candidate_index,
+        next_steps: vec![
+            format!(
+                "Replay a failing case with `homeboy fuzz replay --run-id {} --case-id <id>`.",
+                selected.run_id
+            ),
+            format!(
+                "Review full run evidence with `homeboy runs evidence {}`.",
+                args.run_id
+            ),
+        ],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+    use homeboy::test_support::with_isolated_home;
+
+    use super::super::types::FuzzInspectArgs;
+    use super::run_inspect;
+
+    fn sample_run(kind: &str, metadata: serde_json::Value) -> NewRunRecord {
+        NewRunRecord::builder(kind)
+            .component_id("homeboy")
+            .command(format!("homeboy {kind} homeboy"))
+            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+            .homeboy_version("test-version")
+            .rig_id("studio")
+            .metadata(metadata)
+            .build()
+    }
+
+    #[test]
+    fn inspect_prints_raw_fuzz_results_for_fuzz_run() {
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("agent-readable-artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("fuzz", serde_json::json!({ "exit_code": 1 })))
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Fail, None)
+                .expect("finish");
+            let results_path = home.path().join("fuzz-results.json");
+            std::fs::write(
+                &results_path,
+                br#"{"schema":"homeboy/fuzz-result-envelope/v1","campaign":{"id":"raw"}}"#,
+            )
+            .expect("write results");
+            store
+                .record_artifact(&run.id, "fuzz_results", &results_path)
+                .expect("record");
+
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: run.id.clone(),
+                raw: false,
+            })
+            .expect("inspect");
+
+            assert_eq!(output.status, "ok");
+            assert_eq!(output.artifact_kind, "fuzz_results");
+            assert_eq!(output.source_run_id, run.id);
+            let result = output.result.expect("parsed json result");
+            assert_eq!(
+                result.pointer("/campaign/id").and_then(|v| v.as_str()),
+                Some("raw")
+            );
+            assert!(output.raw.is_none());
+            assert!(output
+                .fetch_command
+                .as_deref()
+                .unwrap()
+                .contains("runs artifact get"));
+            homeboy::core::set_artifact_root_override(None);
+        });
+    }
+
+    #[test]
+    fn inspect_resolves_raw_results_through_lab_runner_job() {
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("agent-readable-artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let store = ObservationStore::open_initialized().expect("store");
+            let remote_job_id = "remote-job-inspect-5997";
+            let runner_run = store
+                .start_run(sample_run(
+                    "runner-exec",
+                    serde_json::json!({
+                        "exit_code": 1,
+                        "lab": {
+                            "runner": { "id": "lab-runner" },
+                            "remote_job_id": remote_job_id
+                        }
+                    }),
+                ))
+                .expect("runner run");
+            store
+                .finish_run(&runner_run.id, RunStatus::Fail, None)
+                .expect("finish runner");
+            let fuzz_run = store
+                .start_run(sample_run(
+                    "fuzz",
+                    serde_json::json!({
+                        "exit_code": 1,
+                        "lab": { "remote_job_id": remote_job_id }
+                    }),
+                ))
+                .expect("fuzz run");
+            store
+                .finish_run(&fuzz_run.id, RunStatus::Fail, None)
+                .expect("finish fuzz");
+            let results_path = home.path().join("fuzz-results.json");
+            std::fs::write(&results_path, br#"{"campaign":{"id":"lab-raw"}}"#).expect("write");
+            store
+                .record_artifact(&fuzz_run.id, "fuzz_results", &results_path)
+                .expect("record");
+
+            // Inspecting the runner-exec run resolves the downstream fuzz raw result.
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: runner_run.id.clone(),
+                raw: false,
+            })
+            .expect("inspect");
+
+            assert_eq!(output.status, "ok");
+            assert_eq!(output.source_run_id, fuzz_run.id);
+            assert_eq!(
+                output
+                    .result
+                    .as_ref()
+                    .and_then(|v| v.pointer("/campaign/id"))
+                    .and_then(|v| v.as_str()),
+                Some("lab-raw")
+            );
+            homeboy::core::set_artifact_root_override(None);
+        });
+    }
+
+    #[test]
+    fn inspect_raw_flag_returns_text_body() {
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("agent-readable-artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("fuzz", serde_json::json!({})))
+                .expect("run");
+            let results_path = home.path().join("fuzz-results.json");
+            std::fs::write(&results_path, b"{\"ok\":true}").expect("write");
+            store
+                .record_artifact(&run.id, "fuzz_results", &results_path)
+                .expect("record");
+
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: run.id.clone(),
+                raw: true,
+            })
+            .expect("inspect");
+
+            assert_eq!(output.status, "ok");
+            assert!(output.result.is_none());
+            assert_eq!(output.raw.as_deref(), Some("{\"ok\":true}"));
+            homeboy::core::set_artifact_root_override(None);
+        });
+    }
+
+    #[test]
+    fn inspect_reports_not_found_without_raw_artifact() {
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("agent-readable-artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("fuzz", serde_json::json!({})))
+                .expect("run");
+
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: run.id.clone(),
+                raw: false,
+            })
+            .expect("inspect");
+
+            assert_eq!(output.status, "not_found");
+            assert!(output.result.is_none());
+            assert!(output.candidates.is_empty());
+            assert!(output
+                .next_steps
+                .iter()
+                .any(|step| step.contains("runs evidence")));
+            homeboy::core::set_artifact_root_override(None);
+        });
+    }
+}

--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -1,6 +1,7 @@
 mod compare;
 mod dispatch;
 mod execution;
+mod inspect;
 mod planning;
 mod replay;
 mod report;

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -59,6 +59,20 @@ pub(crate) enum FuzzCommand {
     Compare(FuzzCompareArgs),
     /// Resolve replay metadata for persisted fuzz cases
     Replay(FuzzReplayArgs),
+    /// Print the raw fuzz runner result for a run without spelunking runner logs
+    Inspect(FuzzInspectArgs),
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct FuzzInspectArgs {
+    /// Homeboy run id whose raw fuzz result should be inspected. Accepts the
+    /// fuzz run id or the Lab runner-exec run id that offloaded it.
+    #[arg(value_name = "RUN_ID")]
+    pub(crate) run_id: String,
+
+    /// Print the result body as raw bytes/text instead of pretty JSON.
+    #[arg(long = "raw")]
+    pub(crate) raw: bool,
 }
 
 #[derive(Args, Clone)]
@@ -325,7 +339,7 @@ pub use super::types_extra::{
     FuzzCompareHotspotSummary, FuzzCompareOutput, FuzzCompareSnapshot, FuzzContractOutput,
     FuzzCoverageCompletenessOutput, FuzzCoverageSelectorSummaryOutput, FuzzDiscoverOutput,
     FuzzDiscoverSummary, FuzzExecutionOutput, FuzzGateEvaluation, FuzzGateStatusChange,
-    FuzzListOutput, FuzzOutput, FuzzPlanOutput, FuzzReplayEnv, FuzzReplayExecution,
-    FuzzReplayOutput, FuzzReportOutput, FuzzRunOutput, FuzzRunnerContract, FuzzValidateOutput,
-    FuzzWorkloadOutput,
+    FuzzInspectCandidate, FuzzInspectOutput, FuzzListOutput, FuzzOutput, FuzzPlanOutput,
+    FuzzReplayEnv, FuzzReplayExecution, FuzzReplayOutput, FuzzReportOutput, FuzzRunOutput,
+    FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
 };

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -19,6 +19,44 @@ pub enum FuzzOutput {
     Report(FuzzReportOutput),
     Compare(FuzzCompareOutput),
     Replay(FuzzReplayOutput),
+    Inspect(FuzzInspectOutput),
+}
+
+/// Raw fuzz-result inspection output for `homeboy fuzz inspect <run-id>`.
+///
+/// Surfaces the bytes a runner wrote to `HOMEBOY_FUZZ_RESULTS_FILE`
+/// (and/or the persisted result envelope) without requiring the operator
+/// to spelunk runner job logs or chase remote temp paths.
+#[derive(Serialize)]
+pub struct FuzzInspectOutput {
+    pub command: String,
+    pub status: String,
+    pub run_id: String,
+    /// The run id that actually owns the raw fuzz-result artifact. For a
+    /// Lab-offloaded run this is the downstream `fuzz` run discovered via the
+    /// shared `remote_job_id`, which may differ from the queried `run_id`.
+    pub source_run_id: String,
+    pub artifact_id: String,
+    pub artifact_kind: String,
+    pub artifact_path: String,
+    pub fetch_command: Option<String>,
+    /// Parsed JSON body when the raw result is valid JSON; otherwise null.
+    pub result: Option<serde_json::Value>,
+    /// Raw text body when the result is not valid JSON (or `--raw` text fallback).
+    pub raw: Option<String>,
+    pub candidates: Vec<FuzzInspectCandidate>,
+    pub next_steps: Vec<String>,
+}
+
+/// One discoverable raw fuzz-result artifact considered by `fuzz inspect`.
+#[derive(Serialize)]
+pub struct FuzzInspectCandidate {
+    pub run_id: String,
+    pub artifact_id: String,
+    pub kind: String,
+    pub artifact_type: String,
+    pub path: String,
+    pub exists: bool,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Closes #5997.

## Summary
Adds a direct, first-class way to inspect the raw fuzz runner result for a run — without spelunking large runner job logs or chasing remote temp paths — and ensures the raw `HOMEBOY_FUZZ_RESULTS_FILE` artifact surfaces in run evidence.

## Command surface
- **New: `homeboy fuzz inspect <run-id> [--raw]`** — resolves and prints the raw fuzz runner result (`fuzz_results`, falling back to `fuzz_result_envelope`) for a run.
  - Accepts either the `fuzz` run id **or** the Lab `runner-exec` run id that offloaded it: it reuses `runs_service::list_artifacts_for_run`, which already folds in downstream Lab job artifacts sharing the same `remote_job_id`. The output reports `source_run_id` so the operator knows which run owned the bytes.
  - Pretty-prints the parsed JSON `result` by default; `--raw` (or non-JSON bodies) emit the verbatim text `raw` body.
  - Emits a `fetch_command` (`homeboy runs artifact get …`), candidate list, and `next_steps`. Non-zero exit when no raw result is found.

## Evidence + failure pointers
- `homeboy runs evidence <run-id>` already includes the raw `fuzz_results` artifact for Lab runner failures (covered by the existing `evidence_includes_related_lab_fuzz_results_for_runner_failure` test). Remote temp result files are mirrored into Homeboy-owned artifacts via the existing Lab evidence-mirror flow before remote cleanup.
- Fuzz failure followups now point at the exact `homeboy fuzz inspect <run-id>` command so the failure mode directs operators straight to the raw result.

## Tests
- New unit tests in `inspect.rs`: direct fuzz-run inspection, resolution through the Lab runner-exec → fuzz `remote_job_id` chain, `--raw` text fallback, and the not-found path.

## Verification
- `cargo build --lib` (single) — green.
- `cargo fmt` — only intended in-scope files committed; out-of-scope fmt collateral reverted. Full test suite runs in CI.