### PR TITLE
feat(runner): Lab artifacts no longer dirty runner workspace (#6219)

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -3,16 +3,58 @@
 
 use super::*;
 
-pub(crate) fn remote_lab_output_file(remote_cwd: &str) -> String {
+/// Homeboy-owned Lab artifact directory for a given runner checkout root.
+///
+/// Lab structured output is a Homeboy-owned artifact, not part of the synced
+/// source tree. Writing it inside `checkout_root` made the runner checkout
+/// dirty and the next Lab run failed the dirty-workspace preflight (#6219).
+/// Derive a sibling directory (a `-homeboy-artifacts` suffix on the checkout
+/// path) so the artifact lives OUTSIDE the git checkout and never dirties it.
+pub(crate) fn remote_lab_artifact_dir(checkout_root: &str) -> String {
+    format!("{}-homeboy-artifacts", checkout_root.trim_end_matches('/'))
+}
+
+/// Remote path for the Lab structured-output JSON file.
+///
+/// `checkout_root` is the runner-side synced checkout (or the resident
+/// workspace root). The structured output is written to a Homeboy-owned
+/// sibling artifact directory rather than into the checkout itself so repeated
+/// Lab runs against the same checkout never fail the dirty-workspace preflight.
+pub(crate) fn remote_lab_output_file(checkout_root: &str) -> String {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
         .unwrap_or_default();
     format!(
         "{}/homeboy-lab-structured-output-{}.json",
-        remote_cwd.trim_end_matches('/'),
+        remote_lab_artifact_dir(checkout_root),
         nonce
     )
+}
+
+/// Ensure the Homeboy-owned Lab artifact directory exists on the runner before
+/// a command writes its structured output there. The directory is a sibling of
+/// the checkout, so it is not created by workspace sync and must be made
+/// explicitly. Failure here is non-fatal preparation: surface a clear error so
+/// the missing `--output` target is diagnosable instead of a late download
+/// failure.
+pub(crate) fn ensure_remote_lab_artifact_dir(runner_id: &str, output_file: &str) -> Result<()> {
+    let parent = output_file
+        .rsplit_once('/')
+        .map(|(parent, _)| if parent.is_empty() { "/" } else { parent })
+        .unwrap_or(".");
+    let client = ssh_client_for_lab_runner(runner_id)?;
+    let mkdir = client.execute(&format!("mkdir -p {}", shell::quote_arg(parent)));
+    if !mkdir.success {
+        return Err(Error::internal_unexpected(format!(
+            "Lab offload could not create Homeboy-owned artifact directory `{parent}` on runner `{runner_id}`: {}",
+            mkdir.stderr.trim()
+        ))
+        .with_hint(
+            "Lab structured output is written outside the synced checkout so it does not dirty the runner workspace; the runner workspace parent must be writable.".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn args_contain_output_file(args: &[String]) -> bool {
@@ -394,6 +436,14 @@ pub(crate) fn run_lab_offload_inner(
         rig_component_path_overrides,
     } = workspace_stage;
     plan = next_plan;
+
+    // The structured-output file lives in a Homeboy-owned artifact directory
+    // that is a sibling of the synced checkout (#6219), so it is never created
+    // by workspace sync. Create it explicitly before dispatch so the remote
+    // command can write its `--output` target outside the git tree.
+    if let Some(output_file) = remote_output_file.as_deref() {
+        ensure_remote_lab_artifact_dir(runner_id, output_file)?;
+    }
 
     eprintln!(
         "Lab offload: running `{}` on runner `{}` in `{}`.",

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -55,6 +55,11 @@ pub(crate) fn run_runner_resident_lab_offload(
     let remote_output_file = request
         .output_file_requested
         .then(|| remote_lab_output_file(runner_workspace_root));
+    // Structured output goes to a Homeboy-owned sibling artifact directory
+    // outside the resident checkout (#6219); create it before dispatch.
+    if let Some(output_file) = remote_output_file.as_deref() {
+        ensure_remote_lab_artifact_dir(runner_id, output_file)?;
+    }
     let remapped_args = rewrite_runner_resident_lab_offload_args(
         request.normalized_args,
         remote_output_file.as_deref(),

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -426,3 +426,47 @@ fn lab_stream_truncation_is_allowed_with_structured_output_file() {
     ensure_lab_offload_streams_not_truncated(&output, true)
         .expect("structured output file preserves complete command result");
 }
+
+#[test]
+fn lab_artifact_dir_is_a_sibling_outside_the_checkout() {
+    let checkout = "/srv/runner/workspaces/homeboy-core";
+    let artifact_dir = remote_lab_artifact_dir(checkout);
+
+    // The artifact directory must NOT live inside the synced git checkout,
+    // otherwise its structured output would dirty the workspace (#6219).
+    assert_eq!(
+        artifact_dir,
+        "/srv/runner/workspaces/homeboy-core-homeboy-artifacts"
+    );
+    assert!(
+        !artifact_dir.starts_with(&format!("{checkout}/")),
+        "artifact dir `{artifact_dir}` must not be nested inside checkout `{checkout}`"
+    );
+}
+
+#[test]
+fn lab_artifact_dir_ignores_trailing_slash_on_checkout() {
+    assert_eq!(
+        remote_lab_artifact_dir("/srv/runner/workspaces/homeboy-core/"),
+        "/srv/runner/workspaces/homeboy-core-homeboy-artifacts"
+    );
+}
+
+#[test]
+fn lab_structured_output_file_is_written_outside_the_checkout() {
+    let checkout = "/srv/runner/workspaces/homeboy-core";
+    let output_file = remote_lab_output_file(checkout);
+
+    // Structured output goes into the Homeboy-owned sibling artifact directory,
+    // never directly into the synced checkout root.
+    assert!(
+        output_file.starts_with(&format!("{checkout}-homeboy-artifacts/")),
+        "structured output `{output_file}` must live in the sibling artifact dir"
+    );
+    assert!(
+        !output_file.starts_with(&format!("{checkout}/")),
+        "structured output `{output_file}` must not dirty the checkout `{checkout}`"
+    );
+    assert!(output_file.ends_with(".json"));
+    assert!(output_file.contains("homeboy-lab-structured-output-"));
+}


### PR DESCRIPTION
Closes #6219. Homeboy-owned Lab outputs (structured output, state, transient results, evidence) are written outside the synced checkout / classified reconstructable, so repeated Lab runs do not fail on dirty-workspace preflight.

## What changed
- `remote_lab_output_file` now writes the structured-output JSON into a Homeboy-owned sibling artifact directory (`<checkout>-homeboy-artifacts/`) instead of inside the synced runner checkout. The artifact lives OUTSIDE the git tree so it never dirties the workspace.
- Added `remote_lab_artifact_dir` (derives the sibling dir) and `ensure_remote_lab_artifact_dir` (mkdir -p the dir on the runner before dispatch, since it is not created by workspace sync).
- Wired the dir-creation into both the standard offload path (`inner.rs`) and the runner-resident path (`resident.rs`).

## Why
Structured output was previously written to the checkout root, leaving an untracked JSON file that made the synced git checkout dirty. The next Lab run then failed the dirty-workspace preflight before executing. Operators should not have to clean Homeboy-owned output files.

## Tests
- `lab_artifact_dir_is_a_sibling_outside_the_checkout`
- `lab_artifact_dir_ignores_trailing_slash_on_checkout`
- `lab_structured_output_file_is_written_outside_the_checkout`

Verified with `cargo build --lib` + `cargo fmt` (out-of-scope fmt changes reverted; only `src/core/runner/lab/offload/` touched). Heavy test/clippy left to CI.