### PR TITLE
Fix runner daemon exec handoff

### DIFF
--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpStream};
 use std::time::{Duration, Instant};
 
 use reqwest::blocking::Client;
@@ -40,31 +42,28 @@ pub(super) fn exec_via_daemon(
     detach_after_handoff: bool,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
+        .no_proxy()
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
     let source_snapshot = source_snapshot_override.unwrap_or_else(|| {
         SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref())
     });
-    let response = client
-        .post(format!("{}/exec", local_url.trim_end_matches('/')))
-        .json(&json!({
-            "runner_id": runner.id,
-            "runner": runner,
-            "project_id": project_id,
-            "cwd": cwd,
-            "command": command,
-            "env": env,
-            "secret_env_names": secret_env_names,
-            "capture_patch": capture_patch,
-            "source_snapshot": source_snapshot.clone(),
-            "require_paths": require_paths.clone(),
-            "runner_workload": runner_workload,
-        }))
-        .send()
-        .map_err(|err| daemon_exec_transport_error(&runner.id, err))?;
-    let status_code = response.status().as_u16();
-    let envelope: DaemonEnvelope = response.json().map_err(|err| {
+    let payload = json!({
+        "runner_id": runner.id,
+        "project_id": project_id,
+        "cwd": cwd,
+        "command": command,
+        "env": env,
+        "secret_env_names": secret_env_names,
+        "capture_patch": capture_patch,
+        "source_snapshot": source_snapshot.clone(),
+        "require_paths": require_paths.clone(),
+        "runner_workload": runner_workload,
+    });
+    let (status_code, response_body) = daemon_loopback_post_json(local_url, "/exec", &payload)
+        .map_err(|err| daemon_exec_loopback_transport_error(&runner.id, err))?;
+    let envelope: DaemonEnvelope = serde_json::from_str(&response_body).map_err(|err| {
         // A stale/restarting daemon can answer the tunnel with a non-JSON or
         // empty body. Surface a clear, actionable error instead of a bare parse
         // failure so the caller knows to reconnect (#3631, #3624).
@@ -203,6 +202,101 @@ pub(super) fn exec_via_daemon(
         },
         exit_code,
     ))
+}
+
+fn daemon_loopback_post_json(
+    local_url: &str,
+    path: &str,
+    payload: &Value,
+) -> std::io::Result<(u16, String)> {
+    let address = local_url
+        .trim_end_matches('/')
+        .strip_prefix("http://")
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "runner daemon URL must be http:// loopback",
+            )
+        })?;
+    if !(address.starts_with("127.0.0.1:") || address.starts_with("localhost:")) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "runner daemon URL must target loopback",
+        ));
+    }
+    let body = serde_json::to_string(payload)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    let mut stream = TcpStream::connect(address)?;
+    write!(
+        stream,
+        "POST {path} HTTP/1.1\r\nHost: {address}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )?;
+    stream.flush()?;
+    stream.shutdown(Shutdown::Write)?;
+    let mut response = Vec::new();
+    let header_end = loop {
+        let mut chunk = [0_u8; 1024];
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            break None;
+        }
+        response.extend_from_slice(&chunk[..read]);
+        if let Some(index) = response.windows(4).position(|window| window == b"\r\n\r\n") {
+            break Some(index + 4);
+        }
+    }
+    .ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "daemon HTTP response missing header boundary",
+        )
+    })?;
+    let head = String::from_utf8_lossy(&response[..header_end - 4]);
+    let status_code = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse::<u16>().ok())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "daemon HTTP response missing status code",
+            )
+        })?;
+    let content_length = head
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())
+                .flatten()
+        })
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "daemon HTTP response missing content-length",
+            )
+        })?;
+    while response.len().saturating_sub(header_end) < content_length {
+        let mut chunk = [0_u8; 1024];
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+        response.extend_from_slice(&chunk[..read]);
+    }
+    let body_end = header_end + content_length;
+    if response.len() < body_end {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "daemon HTTP response ended before content-length bytes were read",
+        ));
+    }
+    let body = String::from_utf8(response[header_end..body_end].to_vec())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    Ok((status_code, body))
 }
 
 pub(super) fn preflight_runner_capability_plan(

--- a/src/core/runner/execution/daemon_api.rs
+++ b/src/core/runner/execution/daemon_api.rs
@@ -39,6 +39,7 @@ pub(super) fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> R
         ));
     };
     let client = Client::builder()
+        .no_proxy()
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;

--- a/src/core/runner/execution/failure.rs
+++ b/src/core/runner/execution/failure.rs
@@ -302,12 +302,9 @@ pub(super) fn daemon_exec_request_failed_error(
     }
 }
 
-/// The exec POST itself failed at the transport layer (connection refused /
-/// reset while the daemon restarts, tunnel torn down, etc.). Surface a clear
-/// reconnect path rather than a bare reqwest error string (#3631, #3624).
-pub(super) fn daemon_exec_transport_error(runner_id: &str, err: reqwest::Error) -> Error {
+pub(super) fn daemon_exec_loopback_transport_error(runner_id: &str, err: std::io::Error) -> Error {
     Error::internal_unexpected(format!(
-        "could not reach runner `{runner_id}` daemon to submit the exec request: {err}"
+        "could not reach runner `{runner_id}` daemon to submit the exec request over loopback HTTP: {err}"
     ))
     .with_hint(format!(
         "The daemon tunnel may be stale or the daemon may have restarted. Reconnect with `homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}` and retry."


### PR DESCRIPTION
## Summary
- Send runner daemon exec submissions through a loopback-only HTTP handoff that reads bounded response bodies by Content-Length.
- Avoid serializing the full runner registry object into daemon exec POSTs.
- Disable proxy lookup for generic daemon API reads.

## Tests
- cargo test daemon_exec --tests -- --test-threads=1
- cargo test runner_exec --tests -- --test-threads=1
- Live verification: homeboy runner exec homeboy-lab --cwd /home/chubes/Developer -- true

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging the runner daemon handoff failure, implementing the loopback handoff fix, and running validation commands.
