### PR TITLE
test(lab): strengthen vacuous offload test (#6265)

### DIFF
--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -423,8 +423,31 @@ fn lab_stream_truncation_fails_without_structured_output_file() {
 fn lab_stream_truncation_is_allowed_with_structured_output_file() {
     let output = truncated_runner_exec_output();
 
-    ensure_lab_offload_streams_not_truncated(&output, true)
-        .expect("structured output file preserves complete command result");
+    // Guard: the fixture must actually present a truncation condition, otherwise
+    // the function would short-circuit on the `!truncated` early return and this
+    // test would never reach the structured-output branch it is named for.
+    let capture = output
+        .capture
+        .as_ref()
+        .expect("fixture provides capture metadata");
+    assert!(
+        capture.stdout.truncated || capture.stderr.truncated,
+        "fixture must model a truncated stream so the structured-output branch is exercised"
+    );
+
+    // Same truncated output WITHOUT a structured output file is rejected, proving
+    // that it is specifically the structured output file that flips the decision.
+    let rejected = ensure_lab_offload_streams_not_truncated(&output, false);
+    let err = rejected.expect_err("truncated streams without structured output must be rejected");
+    assert_eq!(err.code, ErrorCode::InternalUnexpected);
+
+    // With a structured output file present, the real production decision allows
+    // the truncated streams (the complete result is preserved out-of-band).
+    let allowed = ensure_lab_offload_streams_not_truncated(&output, true);
+    assert!(
+        allowed.is_ok(),
+        "structured output file must permit truncated streams, got: {allowed:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #6265. Makes lab_stream_truncation_is_allowed_with_structured_output_file assert on real production behavior.

The test previously only called `ensure_lab_offload_streams_not_truncated(&output, true).expect(...)` with no explicit assertion. It now:
- Guards that the fixture actually models a truncated stream (so the structured-output branch is exercised, not the `!truncated` early return).
- Asserts the same truncated output WITHOUT a structured output file is rejected with `ErrorCode::InternalUnexpected`, proving the structured output file is the deciding factor.
- Asserts the real production decision returns `Ok` when a structured output file is present.