### PR TITLE
feat(runner): persist extension setup env for Lab fuzz (#5919)

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -103,7 +103,56 @@ pub fn run_setup(extension_id: &str) -> Result<ExtensionSetupResult> {
         ));
     }
 
+    // Persist the runtime env the extension's provider discovers now that setup
+    // has run. On a Lab runner, setup configures runner-local state (e.g. a
+    // freshly built WP Codebox core module path); persisting the resolved env
+    // lets a later capability execution (`homeboy fuzz run`) replay the same
+    // effective runtime env without manual operator injection. Persistence is
+    // best-effort: a discovery failure must not fail an otherwise-successful
+    // setup.
+    persist_setup_runtime_env(&extension, extension_id);
+
     Ok(ExtensionSetupResult { exit_code })
+}
+
+/// Capture and persist the runtime env an extension's env provider discovers
+/// after a successful setup, so later capability executions on the same runner
+/// replay the same effective env. Best-effort: failures are swallowed.
+fn persist_setup_runtime_env(extension: &ExtensionManifest, extension_id: &str) {
+    let Some(extension_path) = extension.extension_path.as_deref() else {
+        return;
+    };
+    if extension.env_provider_script().is_none() {
+        return;
+    }
+
+    // Seed the provider with the canonical exec-context vars so the discovery
+    // script sees the same baseline a capability execution would. We resolve the
+    // env against the extension path itself because setup has no component
+    // context; env providers that depend on runner-local setup state (rather
+    // than a specific component checkout) resolve correctly here.
+    let extension_dir = Path::new(extension_path);
+    let base_env = build_exec_env(
+        extension_id,
+        None,
+        None,
+        "{}",
+        Some(extension_path),
+        None,
+        None,
+        None,
+    );
+
+    match super::env_provider::env_vars(extension, extension_dir, &base_env) {
+        Ok(discovered) if !discovered.is_empty() => {
+            let _ = super::setup_env::persist(extension_id, &discovered);
+        }
+        // No discovered env (or a discovery error): clear any stale persisted
+        // document so a previous run's values never leak into fuzz execution.
+        _ => {
+            let _ = super::setup_env::persist(extension_id, &[]);
+        }
+    }
 }
 
 /// Backward-compatible alias for existing command API usage.
@@ -418,6 +467,15 @@ pub(crate) fn build_capability_env(
         None,
         Some(&component_path_value),
     );
+    // Replay the runtime env discovered during extension setup before invoking
+    // the live env provider. On a Lab runner, fuzz execution runs in a fresh
+    // process from the one that ran setup; the persisted setup env guarantees
+    // capability execution receives the same effective runtime env (e.g. the
+    // configured WP Codebox core module path) without manual injection. Live
+    // provider discovery below still overrides any value it can re-resolve.
+    let persisted_setup_env = super::setup_env::load(extension_name);
+    env.extend(persisted_setup_env.iter().cloned());
+
     let mut provider_env = env.clone();
     provider_env.extend(extra_env.iter().cloned());
     if let Ok(extension) = env_provider::load_manifest_from_dir(extension_path) {
@@ -933,6 +991,114 @@ mod tests {
         assert!(env
             .iter()
             .any(|(key, value)| key == "FIXTURE_ENV" && value == "fixture-component"));
+    }
+
+    #[test]
+    fn build_capability_env_replays_persisted_setup_runtime_env() {
+        // Regression for #5919: a Lab runner that discovers runtime env during
+        // extension setup (e.g. the WP Codebox core module path) must replay
+        // that same effective env into capability execution (fuzz) — without
+        // manual operator injection — even when the env provider does not
+        // re-resolve the value in the fresh capability process.
+        crate::test_support::with_isolated_home(|_| {
+            let extension = tempfile::tempdir().expect("extension dir");
+            let component = tempfile::tempdir().expect("component dir");
+            let extension_id = extension.path().file_name().unwrap().to_string_lossy();
+            // No env provider script: the only source of the runtime env is the
+            // value persisted during setup.
+            std::fs::write(
+                extension.path().join(format!("{extension_id}.json")),
+                r#"{ "name": "Fixture", "version": "1.0.0" }"#,
+            )
+            .expect("manifest");
+
+            super::super::setup_env::persist(
+                &extension_id,
+                &[(
+                    "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
+                    "/runner/wp-codebox/core.mjs".to_string(),
+                )],
+            )
+            .expect("persist setup env");
+
+            let env = build_capability_env(
+                &extension_id,
+                "fixture-component",
+                extension.path(),
+                component.path(),
+                "{}",
+                &[],
+            )
+            .expect("capability env");
+
+            assert!(
+                env.iter()
+                    .any(|(key, value)| key == "HOMEBOY_WP_CODEBOX_CORE_MODULE"
+                        && value == "/runner/wp-codebox/core.mjs"),
+                "fuzz capability env must replay persisted extension setup runtime env"
+            );
+        });
+    }
+
+    #[test]
+    fn build_capability_env_lets_live_provider_override_persisted_setup_env() {
+        // Live env-provider discovery is freshest: when both a persisted setup
+        // value and a live provider value exist for the same key, the live
+        // value must win so a rebuilt runner checkout is honored.
+        crate::test_support::with_isolated_home(|_| {
+            let extension = tempfile::tempdir().expect("extension dir");
+            let component = tempfile::tempdir().expect("component dir");
+            let extension_id = extension.path().file_name().unwrap().to_string_lossy();
+            std::fs::write(
+                extension.path().join(format!("{extension_id}.json")),
+                r#"{
+                    "name": "Fixture",
+                    "version": "1.0.0",
+                    "env_provider": { "script": "env.sh" }
+                }"#,
+            )
+            .expect("manifest");
+            std::fs::write(
+                extension.path().join("env.sh"),
+                "#!/bin/sh\nprintf '{\"SHARED_KEY\":\"live\"}'\n",
+            )
+            .expect("env provider");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut permissions = std::fs::metadata(extension.path().join("env.sh"))
+                    .expect("env provider metadata")
+                    .permissions();
+                permissions.set_mode(0o755);
+                std::fs::set_permissions(extension.path().join("env.sh"), permissions)
+                    .expect("env provider executable");
+            }
+
+            super::super::setup_env::persist(
+                &extension_id,
+                &[("SHARED_KEY".to_string(), "persisted".to_string())],
+            )
+            .expect("persist setup env");
+
+            let env = build_capability_env(
+                &extension_id,
+                "fixture-component",
+                extension.path(),
+                component.path(),
+                "{}",
+                &[],
+            )
+            .expect("capability env");
+
+            // Both entries are present; std Command applies env last-wins, so the
+            // live provider value (appended after the persisted value) wins.
+            let last_shared = env
+                .iter()
+                .filter(|(key, _)| key == "SHARED_KEY")
+                .next_back()
+                .map(|(_, value)| value.clone());
+            assert_eq!(last_shared.as_deref(), Some("live"));
+        });
     }
 
     #[test]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -26,6 +26,7 @@ mod runner_contract;
 mod runtime_helper;
 mod scope;
 pub mod self_check;
+mod setup_env;
 mod summary;
 pub mod test;
 pub mod trace;

--- a/src/core/extension/setup_env.rs
+++ b/src/core/extension/setup_env.rs
@@ -1,0 +1,221 @@
+//! Persisted extension setup runtime env.
+//!
+//! When an extension's `setup` runs on a runner (e.g. a Lab runner), it can
+//! discover runtime-derived values — for example a WP Codebox core module path
+//! resolved from a freshly built checkout. Those values are produced by the
+//! extension's env provider but, historically, were only materialized live
+//! during the same process that ran setup. A subsequent capability execution
+//! (such as `homeboy fuzz run`) on the same runner started a fresh process and
+//! re-derived the env from scratch, which could fail if the live derivation
+//! depended on transient setup state.
+//!
+//! This module persists the setup-discovered runtime env to a small per-runner
+//! JSON file so capability execution replays the *same effective env* that setup
+//! discovered, removing the need for operators to inject runner-local
+//! env/settings manually after setup succeeds.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::core::engine::local_files;
+use crate::core::error::Result;
+use crate::core::paths;
+
+/// Schema marker for the persisted setup-env document.
+const SETUP_ENV_SCHEMA: &str = "homeboy/extension-setup-env/v1";
+
+/// Directory (under the machine-local homeboy data root) that stores persisted
+/// per-extension setup runtime env documents.
+fn setup_env_dir() -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?.join("extension-setup-env"))
+}
+
+/// Path to the persisted setup-env document for a single extension.
+fn setup_env_path(extension_id: &str) -> Result<PathBuf> {
+    Ok(setup_env_dir()?.join(format!("{}.json", sanitize_extension_id(extension_id))))
+}
+
+/// Keep file names filesystem-safe regardless of extension id formatting.
+fn sanitize_extension_id(extension_id: &str) -> String {
+    extension_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Persist the setup-discovered runtime env for `extension_id`.
+///
+/// Stored as a sorted map so replay is deterministic. Passing an empty env
+/// removes any previously persisted document so stale values never leak into a
+/// later capability execution.
+pub(crate) fn persist(extension_id: &str, env: &[(String, String)]) -> Result<()> {
+    let path = setup_env_path(extension_id)?;
+
+    if env.is_empty() {
+        if path.exists() {
+            let _ = std::fs::remove_file(&path);
+        }
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            crate::core::Error::internal_io(
+                error.to_string(),
+                Some("create extension setup-env directory".to_string()),
+            )
+        })?;
+    }
+
+    let env_map: BTreeMap<&str, &str> = env
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+    let document = serde_json::json!({
+        "schema": SETUP_ENV_SCHEMA,
+        "extension_id": extension_id,
+        "env": env_map,
+    });
+    let serialized = serde_json::to_string_pretty(&document).map_err(|error| {
+        crate::core::Error::internal_json(
+            error.to_string(),
+            Some("serialize extension setup env".to_string()),
+        )
+    })?;
+
+    local_files::write_file_atomic(&path, &serialized, "write extension setup env")
+}
+
+/// Load the persisted setup runtime env for `extension_id`.
+///
+/// Returns sorted `(key, value)` pairs, or an empty vec when nothing is
+/// persisted (or the document is unreadable/malformed — replay must never hard
+/// fail capability execution).
+pub(crate) fn load(extension_id: &str) -> Vec<(String, String)> {
+    let Ok(path) = setup_env_path(extension_id) else {
+        return Vec::new();
+    };
+    if !path.exists() {
+        return Vec::new();
+    }
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return Vec::new();
+    };
+    let Some(env) = value.get("env").and_then(|env| env.as_object()) else {
+        return Vec::new();
+    };
+
+    let mut pairs = env
+        .iter()
+        .filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_string())))
+        .collect::<Vec<_>>();
+    pairs.sort_by(|left, right| left.0.cmp(&right.0));
+    pairs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct HomeGuard {
+        prior_home: Option<String>,
+        prior_xdg: Option<String>,
+        _dir: tempfile::TempDir,
+    }
+
+    impl HomeGuard {
+        fn set() -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let prior_home = std::env::var("HOME").ok();
+            let prior_xdg = std::env::var("XDG_DATA_HOME").ok();
+            std::env::set_var("HOME", dir.path());
+            std::env::remove_var("XDG_DATA_HOME");
+            Self {
+                prior_home,
+                prior_xdg,
+                _dir: dir,
+            }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.prior_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match &self.prior_xdg {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn persist_then_load_round_trips_sorted_env() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock");
+        let _home = HomeGuard::set();
+
+        persist(
+            "wordpress",
+            &[
+                (
+                    "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
+                    "/runner/wp-codebox/core.mjs".to_string(),
+                ),
+                ("ANOTHER".to_string(), "value".to_string()),
+            ],
+        )
+        .expect("persist");
+
+        let loaded = load("wordpress");
+        assert_eq!(
+            loaded,
+            vec![
+                ("ANOTHER".to_string(), "value".to_string()),
+                (
+                    "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
+                    "/runner/wp-codebox/core.mjs".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn load_returns_empty_when_nothing_persisted() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock");
+        let _home = HomeGuard::set();
+
+        assert!(load("never-persisted").is_empty());
+    }
+
+    #[test]
+    fn persist_empty_clears_previous_document() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock");
+        let _home = HomeGuard::set();
+
+        persist("wordpress", &[("KEY".to_string(), "value".to_string())]).expect("persist");
+        assert!(!load("wordpress").is_empty());
+
+        persist("wordpress", &[]).expect("clear");
+        assert!(load("wordpress").is_empty());
+    }
+
+    #[test]
+    fn sanitizes_extension_id_for_filesystem_safety() {
+        assert_eq!(sanitize_extension_id("wp/codebox"), "wp_codebox");
+        assert_eq!(sanitize_extension_id("wordpress"), "wordpress");
+    }
+}


### PR DESCRIPTION
Closes #5919.

## Problem

Running `homeboy fuzz run --rig <rig> --workload <workload> --runner homeboy-lab` still failed with `WP Codebox canonical runtime contract manifest is unavailable` after extension setup succeeded on the runner. Extension *setup* discovered the runtime-derived env (e.g. the configured WP Codebox core module path), but the subsequent *fuzz execution* ran in a fresh process that never received it — forcing manual `--setting`/`HOMEBOY_WP_CODEBOX_CORE_MODULE` injection.

## Fix — persist setup runtime env, replay on capability execution

New `src/core/extension/setup_env.rs` persists the setup-discovered runtime env to a per-extension JSON document under the machine-local homeboy data root (`extension-setup-env/<extension_id>.json`).

- **`run_setup`** (`execution.rs`): after a successful setup command, runs the extension's env provider to capture the now-resolved runtime env and persists it (best-effort — discovery failure never fails an otherwise-successful setup; an empty result clears any stale document).
- **`build_capability_env`** (`execution.rs`): the canonical env builder used by fuzz/test/lint/etc. now replays the persisted setup env *before* the live env provider. The live provider still overrides any value it can freshly re-resolve (std `Command` applies env last-wins), so a rebuilt runner checkout is always honored.

Lab fuzz re-executes the full homeboy command on the runner, so the persisted env is written and replayed on the same runner — fuzz extension execution receives the same effective runtime env that setup discovered, with no operator injection.

## Regression coverage

- `build_capability_env_replays_persisted_setup_runtime_env` — proves fuzz capability env carries the persisted setup env even with no live provider.
- `build_capability_env_lets_live_provider_override_persisted_setup_env` — proves live discovery wins over stale persisted values.
- `setup_env` unit tests cover round-trip, empty-load, clear-on-empty, and id sanitization.

## Scope

Only `src/core/extension/` touched. `cargo build --lib` clean; `cargo fmt` applied (out-of-scope formatting drift reverted).