### PR TITLE
feat(agent-task): materialize runtime dependency graph for Lab proofs (#6121)

### DIFF
--- a/src/commands/agent_task/tests/controller_run.rs
+++ b/src/commands/agent_task/tests/controller_run.rs
@@ -79,6 +79,9 @@ fn controller_run_next_executes_spawn_task_plan_and_records_dedupe_lineage() {
 #[test]
 fn controller_dispatch_runtime_component_contracts_reach_spawned_agent_task_request() {
     with_temp_home(|| {
+        let component = tempfile::tempdir().expect("agents-api checkout");
+        init_runtime_component_checkout(component.path());
+        let component_path = component.path().display().to_string();
         let observed_request = Arc::new(Mutex::new(None));
         let mut controller = agent_task_loop_controller::create_controller(
             "loop-controller-runtime-components",
@@ -101,7 +104,7 @@ fn controller_dispatch_runtime_component_contracts_reach_spawned_agent_task_requ
                             "inputs": {
                                 "runtime_component_contracts": [{
                                     "slug": "agents-api",
-                                    "path": "runtime/agents-api",
+                                    "path": component_path,
                                     "loadAs": "plugin",
                                     "activate": true,
                                     "opaque": { "source": "workflow-input" }
@@ -137,7 +140,7 @@ fn controller_dispatch_runtime_component_contracts_reach_spawned_agent_task_requ
         );
         assert_eq!(
             observed.component_contracts[0].path.as_deref(),
-            Some("runtime/agents-api")
+            Some(component_path.as_str())
         );
         assert_eq!(
             observed.component_contracts[0].load_as.as_deref(),
@@ -275,6 +278,9 @@ fn controller_run_from_spec_persists_dispatch_defaults_for_generated_actions() {
 #[test]
 fn controller_run_from_spec_preserves_runtime_execution_and_components() {
     with_temp_home(|| {
+        let component = tempfile::tempdir().expect("agents-api checkout");
+        init_runtime_component_checkout(component.path());
+        let component_path = component.path().display().to_string();
         let observed_request = Arc::new(Mutex::new(None));
         let (value, exit_code) = controller_run_from_spec_with_test_executor(
             AgentTaskControllerRunFromSpecArgs {
@@ -307,7 +313,7 @@ fn controller_run_from_spec_preserves_runtime_execution_and_components() {
                             "runtime_config": {
                                 "component_contracts": [{
                                     "slug": "agents-api",
-                                    "path": "runtime/agents-api",
+                                    "path": component_path,
                                     "loadAs": "plugin",
                                     "activate": true
                                 }]
@@ -371,7 +377,7 @@ fn controller_run_from_spec_preserves_runtime_execution_and_components() {
         );
         assert_eq!(
             observed.component_contracts[0].path.as_deref(),
-            Some("runtime/agents-api")
+            Some(component_path.as_str())
         );
         assert_eq!(
             value["materialization"]["spec"]["workflows"][0]["runtime_execution"]["ability"],

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -64,6 +64,26 @@ pub(in crate::commands::agent_task) use super::super::contract;
 pub(in crate::commands::agent_task) use super::super::loop_definition;
 pub(in crate::commands::agent_task) use super::super::{ContractArgs, ContractFormat};
 
+/// Create a committed, clean git checkout at `path` so dispatch-time runtime
+/// dependency-graph resolution accepts it as a materialized component at a
+/// known ref (#6121).
+pub(crate) fn init_runtime_component_checkout(path: &std::path::Path) {
+    let run = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .status()
+            .expect("git command runs");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    std::fs::write(path.join("plugin.php"), "<?php\n").expect("write component file");
+    run(&["init", "-b", "main"]);
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "Homeboy Test"]);
+    run(&["add", "plugin.php"]);
+    run(&["commit", "-m", "init"]);
+}
+
 pub(crate) struct InspectingExecutor {
     pub(crate) run_id: String,
     pub(crate) observed_status: Arc<Mutex<Option<AgentTaskRunRecord>>>,

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -16,6 +16,7 @@ use crate::core::agent_task::{
 use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
 use crate::core::agent_task_prompts;
 use crate::core::agent_task_provider::provider_requires_cwd_git_checkout;
+use crate::core::agent_task_runtime_dependency_graph;
 use crate::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskRetryPolicy};
 use crate::core::agent_task_secrets::validate_secret_env;
 use crate::core::{config, defaults, worktree, Error, Result};
@@ -83,8 +84,19 @@ pub fn build_dispatch_plan_with_provider_requirements(
     let mut provider_config =
         dispatch_provider_config(request, &repo, workspace_target.as_ref(), &client_context)?;
     let component_contracts = dispatch_component_contracts(&provider_config, &client_context)?;
+    // Resolve + materialize the declared runtime dependency graph at known refs
+    // and preflight-fail before dispatch when a required runtime dependency is
+    // unresolved or stale. The resolved refs/paths are recorded in plan/task
+    // metadata below so run evidence shows exactly which component refs a Lab
+    // proof ran against (#6121).
+    let runtime_dependency_graph =
+        agent_task_runtime_dependency_graph::resolve_runtime_dependency_graph(
+            &component_contracts,
+        )?;
     promote_component_contracts_to_provider_config(&mut provider_config, &component_contracts);
     let secret_env = dispatch_secret_env(request, &provider_config);
+    let runtime_dependency_graph_evidence = (!runtime_dependency_graph.is_empty())
+        .then(|| runtime_dependency_graph.to_evidence_value());
     let mut tasks = Vec::new();
     for (index, prompt_spec) in prompt_specs.iter().enumerate() {
         let instructions = dispatch_instructions(
@@ -168,6 +180,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 "prompt_source": &prompt_spec.prompt,
                 "dispatch": "agent-task cook",
                 "required_capabilities": request.required_capabilities,
+                "runtime_dependency_graph": runtime_dependency_graph_evidence,
             }),
         });
     }
@@ -189,6 +202,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
         "workspace_root": workspace_root.map(|path| path.display().to_string()),
         "client_context": client_context,
         "task_url": request.task_url,
+        "runtime_dependency_graph": runtime_dependency_graph_evidence,
     });
 
     Ok(plan)
@@ -1280,6 +1294,10 @@ mod tests {
 
     #[test]
     fn dispatch_plan_promotes_runtime_component_contracts_from_client_context_inputs() {
+        let component = tempfile::tempdir().expect("agents-api component");
+        init_git_repo(component.path());
+        let component_path = component.path().display().to_string();
+
         let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
             prompt: Some("Cook with runtime components.".to_string()),
             core: DispatchCoreInputs {
@@ -1289,7 +1307,7 @@ mod tests {
                         "inputs": {
                             "runtime_component_contracts": [{
                                 "slug": "agents-api",
-                                "path": "components/agents-api",
+                                "path": component_path,
                                 "loadAs": "plugin",
                                 "activate": true,
                                 "opaque": { "preserve": "yes" }
@@ -1307,18 +1325,39 @@ mod tests {
         let contracts = &plan.tasks[0].component_contracts;
         assert_eq!(contracts.len(), 1);
         assert_eq!(contracts[0].slug.as_deref(), Some("agents-api"));
-        assert_eq!(contracts[0].path.as_deref(), Some("components/agents-api"));
+        assert_eq!(contracts[0].path.as_deref(), Some(component_path.as_str()));
         assert_eq!(contracts[0].load_as.as_deref(), Some("plugin"));
         assert_eq!(contracts[0].activate, Some(true));
         assert_eq!(contracts[0].extra["opaque"]["preserve"], "yes");
         assert_eq!(
             plan.tasks[0].executor.config["component_contracts"][0]["path"],
-            "components/agents-api"
+            component_path
+        );
+
+        // The declared runtime dependency graph is resolved at a known ref and
+        // recorded in run evidence (#6121).
+        let graph = &plan.tasks[0].metadata["runtime_dependency_graph"];
+        assert_eq!(
+            graph["schema"],
+            crate::core::agent_task_runtime_dependency_graph::RUNTIME_DEPENDENCY_GRAPH_SCHEMA
+        );
+        assert_eq!(graph["dependencies"][0]["slug"], "agents-api");
+        assert!(graph["dependencies"][0]["resolved_ref"].is_string());
+        assert!(graph["dependencies"][0]["git_provenance"]
+            .as_bool()
+            .unwrap());
+        assert_eq!(
+            plan.metadata["runtime_dependency_graph"]["dependencies"][0]["slug"],
+            "agents-api"
         );
     }
 
     #[test]
     fn dispatch_plan_accepts_component_contracts_from_provider_config() {
+        let component = tempfile::tempdir().expect("runtime-helper component");
+        init_git_repo(component.path());
+        let component_path = component.path().display().to_string();
+
         let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
             prompt: Some("Cook with provider runtime components.".to_string()),
             core: DispatchCoreInputs {
@@ -1326,7 +1365,7 @@ mod tests {
                     serde_json::json!({
                         "component_contracts": [{
                             "slug": "runtime-helper",
-                            "path": "/opt/runtime-helper",
+                            "path": component_path,
                             "loadAs": "mu-plugin",
                             "activate": false,
                             "opaque_provider_hint": { "preserved": true }
@@ -1342,10 +1381,36 @@ mod tests {
 
         let contract = &plan.tasks[0].component_contracts[0];
         assert_eq!(contract.slug.as_deref(), Some("runtime-helper"));
-        assert_eq!(contract.path.as_deref(), Some("/opt/runtime-helper"));
+        assert_eq!(contract.path.as_deref(), Some(component_path.as_str()));
         assert_eq!(contract.load_as.as_deref(), Some("mu-plugin"));
         assert_eq!(contract.activate, Some(false));
         assert_eq!(contract.extra["opaque_provider_hint"]["preserved"], true);
+    }
+
+    #[test]
+    fn dispatch_plan_preflight_fails_on_unresolved_runtime_dependency() {
+        let error = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+            prompt: Some("Cook with a missing runtime dependency.".to_string()),
+            core: DispatchCoreInputs {
+                provider_config: Some(
+                    serde_json::json!({
+                        "component_contracts": [{
+                            "slug": "data-machine",
+                            "path": "/nonexistent/data-machine/checkout",
+                            "loadAs": "plugin",
+                            "activate": true
+                        }]
+                    })
+                    .to_string(),
+                ),
+                ..DispatchCoreInputs::default()
+            },
+            ..DispatchRequestOverrides::default()
+        }))
+        .expect_err("missing runtime dependency fails dispatch preflight");
+
+        assert!(error.message.contains("could not be resolved"));
+        assert!(error.message.contains("data-machine"));
     }
 
     struct NoopExecutor;

--- a/src/core/agent_task_runtime_dependency_graph.rs
+++ b/src/core/agent_task_runtime_dependency_graph.rs
@@ -1,0 +1,595 @@
+//! Resolve and materialize the declared runtime dependency graph for agent-task
+//! Lab proofs.
+//!
+//! WPSG (and other runtime-package loops) are thin wrappers around Homeboy's
+//! agent-task dispatch architecture. A runtime proof — e.g. driving a WP Codebox
+//! loop through `agents-api`, `data-machine`, `data-machine-code`, and the WPSG
+//! component — declares those runtime substrate components as
+//! [`AgentTaskComponentContract`]s on the dispatch request (`component_contracts`
+//! / `runtime_component_contracts` in provider-config or client-context).
+//!
+//! Historically those contracts only carried a *declared* path and ref. Nothing
+//! resolved the declared graph before dispatch, so proofs spent their time
+//! fighting stale or missing checkouts and manually exporting substrate path env
+//! vars (`WP_CODEBOX_AGENTS_API_PATH`, …) instead of testing loop behavior
+//! (#6121).
+//!
+//! This module gives dispatch a first-class, preflight-time materialization path:
+//!
+//! - Resolve each declared component contract to a concrete on-disk path.
+//! - Materialize each component at a **known ref** — the resolved git HEAD (or an
+//!   explicitly pinned ref) of the checkout — so run evidence records exactly the
+//!   `agents-api` / `data-machine` / `data-machine-code` / `wp-codebox` / WPSG
+//!   ref under test.
+//! - Surface an **actionable preflight failure** when a required runtime
+//!   dependency cannot be resolved (missing path) or is stale (dirty working
+//!   tree, or behind a pinned ref it cannot reach), *before* dispatch.
+//! - Return the resolved refs/paths so the caller can record them in run
+//!   evidence (the dispatch plan/task metadata).
+//!
+//! The resolver reuses the canonical git-provenance conventions established by
+//! the Lab git-dependency materialization path (#4314) and the rig-declared
+//! component resolution (#4012): a declared component is only accepted at a
+//! reproducible ref, never at an ambiguous dirty/unknown checkout.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::core::agent_task::AgentTaskComponentContract;
+use crate::core::git;
+use crate::core::{Error, Result};
+
+/// Schema tag for the resolved runtime dependency graph recorded in run
+/// evidence.
+pub const RUNTIME_DEPENDENCY_GRAPH_SCHEMA: &str = "homeboy/agent-task-runtime-dependency-graph/v1";
+
+/// A single component dependency resolved and materialized at a known ref.
+///
+/// Serialized into dispatch plan/task metadata so `homeboy runs evidence` and
+/// `agent-task status` surface exactly which `agents-api`, `data-machine`,
+/// `data-machine-code`, `wp-codebox`, and WPSG refs/paths a proof ran against.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedRuntimeDependency {
+    /// Component slug (`agents-api`, `data-machine`, `wp-codebox`, `wpsg`, …).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    /// Canonical absolute path of the materialized component checkout.
+    pub path: String,
+    /// The known ref the component was materialized at: the resolved git commit
+    /// (or the explicitly declared/pinned ref when the checkout is non-git).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_ref: Option<String>,
+    /// The branch the checkout is on, when resolvable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    /// The ref explicitly declared on the contract, when any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub declared_ref: Option<String>,
+    /// How the component is loaded into the runtime (plugin, mu-plugin, …).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_as: Option<String>,
+    /// Whether the component should be activated in the runtime.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activate: Option<bool>,
+    /// True when the materialized checkout is a real git work tree carrying
+    /// canonical provenance; false for a non-git declared path.
+    pub git_provenance: bool,
+}
+
+/// The fully resolved runtime dependency graph for a dispatch, recorded in run
+/// evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedRuntimeDependencyGraph {
+    pub schema: &'static str,
+    pub dependencies: Vec<ResolvedRuntimeDependency>,
+}
+
+impl ResolvedRuntimeDependencyGraph {
+    fn new(dependencies: Vec<ResolvedRuntimeDependency>) -> Self {
+        Self {
+            schema: RUNTIME_DEPENDENCY_GRAPH_SCHEMA,
+            dependencies,
+        }
+    }
+
+    /// True when the graph carried no declared component dependencies. Callers
+    /// can skip recording an empty graph into evidence.
+    pub fn is_empty(&self) -> bool {
+        self.dependencies.is_empty()
+    }
+
+    /// Serialize the resolved graph for run evidence.
+    pub fn to_evidence_value(&self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+}
+
+/// Resolve and materialize the declared runtime dependency graph from the
+/// component contracts on a dispatch.
+///
+/// Each contract that declares a concrete `path` is treated as a runtime
+/// dependency: its checkout is resolved to a known ref and validated for
+/// freshness. Contracts that only carry an opaque provider hint (no `path`) are
+/// passed through untouched — they are not on-disk runtime substrate.
+///
+/// Returns the resolved graph on success. On the first unresolved or stale
+/// dependency it returns an actionable preflight error so dispatch fails before
+/// the loop is dispatched.
+pub fn resolve_runtime_dependency_graph(
+    contracts: &[AgentTaskComponentContract],
+) -> Result<ResolvedRuntimeDependencyGraph> {
+    let mut resolved = Vec::new();
+    for contract in contracts {
+        let Some(path) = contract
+            .path
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            // No declared on-disk path: this is an opaque provider-hint contract,
+            // not runtime substrate. Nothing to materialize.
+            continue;
+        };
+        resolved.push(resolve_one(contract, path)?);
+    }
+    Ok(ResolvedRuntimeDependencyGraph::new(resolved))
+}
+
+fn resolve_one(
+    contract: &AgentTaskComponentContract,
+    declared_path: &str,
+) -> Result<ResolvedRuntimeDependency> {
+    let label = contract_label(contract, declared_path);
+    let declared_ref = declared_contract_ref(contract);
+
+    let path = PathBuf::from(declared_path);
+    if !path.exists() {
+        return Err(unresolved_dependency_error(
+            &label,
+            declared_path,
+            &declared_ref,
+        ));
+    }
+    let canonical = std::fs::canonicalize(&path).unwrap_or(path.clone());
+
+    if !canonical.is_dir() {
+        return Err(unresolved_dependency_error(
+            &label,
+            &canonical.display().to_string(),
+            &declared_ref,
+        ));
+    }
+
+    let provenance = resolve_checkout_provenance(&canonical, &label, declared_ref.as_deref())?;
+
+    Ok(ResolvedRuntimeDependency {
+        slug: contract.slug.clone(),
+        path: canonical.display().to_string(),
+        resolved_ref: provenance.resolved_ref.or_else(|| declared_ref.clone()),
+        branch: provenance.branch,
+        declared_ref,
+        load_as: contract.load_as.clone(),
+        activate: contract.activate,
+        git_provenance: provenance.git_provenance,
+    })
+}
+
+struct CheckoutProvenance {
+    resolved_ref: Option<String>,
+    branch: Option<String>,
+    git_provenance: bool,
+}
+
+/// Resolve a declared component checkout to a known ref and reject stale state.
+///
+/// A non-git declared path materializes at its declared ref (or none) with no
+/// provenance to verify. A git work tree must resolve to a concrete commit and
+/// be clean; when an explicit ref is declared the checkout must be able to reach
+/// it. A dirty or unreachable-pinned checkout is rejected as stale before
+/// dispatch so failures are never ambiguous between a code bug and a stale
+/// checkout.
+fn resolve_checkout_provenance(
+    path: &Path,
+    label: &str,
+    declared_ref: Option<&str>,
+) -> Result<CheckoutProvenance> {
+    if !path.join(".git").exists() {
+        return Ok(CheckoutProvenance {
+            resolved_ref: declared_ref.map(str::to_string),
+            branch: None,
+            git_provenance: false,
+        });
+    }
+
+    let head = git::run_git(
+        path,
+        &["rev-parse", "HEAD"],
+        "resolve runtime dependency HEAD",
+    )
+    .map(|value| value.trim().to_string())
+    .ok()
+    .filter(|value| !value.is_empty());
+    let Some(head) = head else {
+        return Err(unresolved_dependency_error(
+            label,
+            &path.display().to_string(),
+            &declared_ref.map(str::to_string),
+        ));
+    };
+
+    let branch = git::run_git(
+        path,
+        &["rev-parse", "--abbrev-ref", "HEAD"],
+        "resolve runtime dependency branch",
+    )
+    .map(|value| value.trim().to_string())
+    .ok()
+    .filter(|value| !value.is_empty() && value != "HEAD");
+
+    let status = git::run_git(
+        path,
+        &["status", "--porcelain=v1"],
+        "resolve runtime dependency status",
+    )
+    .map(|value| value.trim().to_string())
+    .unwrap_or_default();
+    if !status.is_empty() {
+        return Err(stale_dependency_error(
+            label,
+            &path.display().to_string(),
+            "the runtime dependency checkout has a dirty working tree",
+            vec![
+                "Commit, stash, or clean the dependency checkout before rerunning the Lab proof so the materialized ref is reproducible.".to_string(),
+                "A dirty runtime substrate makes proof failures ambiguous between a code bug and a stale checkout.".to_string(),
+            ],
+        ));
+    }
+
+    // When the contract pins an explicit ref, the checkout must be able to
+    // resolve it; otherwise the proof would silently run against the wrong code.
+    if let Some(declared) = declared_ref.filter(|value| !value.trim().is_empty()) {
+        let resolved_declared = git::run_git(
+            path,
+            &["rev-parse", "--verify", &format!("{declared}^{{commit}}")],
+            "verify pinned runtime dependency ref",
+        )
+        .map(|value| value.trim().to_string())
+        .ok()
+        .filter(|value| !value.is_empty());
+        let Some(resolved_declared) = resolved_declared else {
+            return Err(stale_dependency_error(
+                label,
+                &path.display().to_string(),
+                &format!("the checkout cannot resolve the declared ref `{declared}`"),
+                vec![
+                    format!(
+                        "Fetch or check out `{declared}` in the dependency checkout before rerunning the Lab proof: git -C {} fetch --all",
+                        path.display()
+                    ),
+                    "Or update the declared component ref to a commit the checkout can reach.".to_string(),
+                ],
+            ));
+        };
+        if resolved_declared != head {
+            return Err(stale_dependency_error(
+                label,
+                &path.display().to_string(),
+                &format!(
+                    "the checkout HEAD `{head}` does not match the declared ref `{declared}` (`{resolved_declared}`)"
+                ),
+                vec![
+                    format!(
+                        "Check out the declared ref before rerunning the Lab proof: git -C {} checkout {declared}",
+                        path.display()
+                    ),
+                    "A runtime dependency must be materialized at its declared ref so the proof runs against a known, reviewable component.".to_string(),
+                ],
+            ));
+        }
+    }
+
+    Ok(CheckoutProvenance {
+        resolved_ref: Some(head),
+        branch,
+        git_provenance: true,
+    })
+}
+
+/// The explicitly declared ref on a contract, if any. Accepts the common
+/// `ref` / `pinned_ref` / `revision` keys carried in the contract `extra` map.
+fn declared_contract_ref(contract: &AgentTaskComponentContract) -> Option<String> {
+    extra_string(
+        &contract.extra,
+        &["ref", "pinned_ref", "pinnedRef", "revision"],
+    )
+}
+
+fn extra_string(extra: &Map<String, Value>, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        if let Some(value) = extra
+            .get(*key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn contract_label(contract: &AgentTaskComponentContract, declared_path: &str) -> String {
+    contract
+        .slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| declared_path.to_string())
+}
+
+fn unresolved_dependency_error(
+    label: &str,
+    declared_path: &str,
+    declared_ref: &Option<String>,
+) -> Error {
+    let mut hints = vec![
+        format!(
+            "Materialize or check out the `{label}` runtime dependency at `{declared_path}` before dispatch."
+        ),
+        "Declare the component contract `path` to a real checkout so the Lab proof can resolve and materialize it at a known ref.".to_string(),
+    ];
+    if let Some(declared) = declared_ref {
+        hints.push(format!(
+            "The contract declared ref `{declared}`; ensure the checkout exists and can reach it."
+        ));
+    }
+    Error::validation_invalid_argument(
+        "runtime_component_contract",
+        format!(
+            "Lab proof preflight failed: required runtime dependency `{label}` could not be resolved at `{declared_path}`"
+        ),
+        Some(
+            serde_json::json!({
+                "schema": "homeboy/agent-task-runtime-dependency-preflight/v1",
+                "dependency": label,
+                "declared_path": declared_path,
+                "declared_ref": declared_ref,
+                "reason": "unresolved",
+            })
+            .to_string(),
+        ),
+        Some(hints),
+    )
+}
+
+fn stale_dependency_error(label: &str, path: &str, reason: &str, hints: Vec<String>) -> Error {
+    Error::validation_invalid_argument(
+        "runtime_component_contract",
+        format!(
+            "Lab proof preflight failed: runtime dependency `{label}` at `{path}` is stale — {reason}"
+        ),
+        Some(
+            serde_json::json!({
+                "schema": "homeboy/agent-task-runtime-dependency-preflight/v1",
+                "dependency": label,
+                "path": path,
+                "reason": "stale",
+                "detail": reason,
+            })
+            .to_string(),
+        ),
+        Some(hints),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+
+    fn contract(slug: &str, path: &str, extra: Value) -> AgentTaskComponentContract {
+        AgentTaskComponentContract {
+            slug: Some(slug.to_string()),
+            path: Some(path.to_string()),
+            load_as: Some("plugin".to_string()),
+            activate: Some(true),
+            extra: extra.as_object().cloned().unwrap_or_default(),
+        }
+    }
+
+    fn run_git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo(path: &Path) {
+        run_git(path, &["init", "-b", "main"]);
+        run_git(path, &["config", "user.email", "homeboy@example.test"]);
+        run_git(path, &["config", "user.name", "Homeboy Test"]);
+    }
+
+    fn commit_file(path: &Path, name: &str, contents: &str) -> String {
+        fs::write(path.join(name), contents).expect("write file");
+        run_git(path, &["add", name]);
+        run_git(path, &["commit", "-m", name]);
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(path)
+            .output()
+            .expect("rev-parse");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn resolves_git_component_at_known_head_ref() {
+        let repo = tempfile::tempdir().expect("repo");
+        init_repo(repo.path());
+        let head = commit_file(repo.path(), "plugin.php", "<?php");
+
+        let contracts = vec![contract(
+            "data-machine",
+            &repo.path().display().to_string(),
+            Value::Null,
+        )];
+
+        let graph = resolve_runtime_dependency_graph(&contracts).expect("resolved graph");
+
+        assert_eq!(graph.dependencies.len(), 1);
+        let dep = &graph.dependencies[0];
+        assert_eq!(dep.slug.as_deref(), Some("data-machine"));
+        assert_eq!(dep.resolved_ref.as_deref(), Some(head.as_str()));
+        assert_eq!(dep.branch.as_deref(), Some("main"));
+        assert!(dep.git_provenance);
+        assert_eq!(dep.load_as.as_deref(), Some("plugin"));
+        assert_eq!(dep.activate, Some(true));
+    }
+
+    #[test]
+    fn missing_component_path_fails_preflight() {
+        let contracts = vec![contract(
+            "agents-api",
+            "/nonexistent/agents-api/checkout",
+            Value::Null,
+        )];
+
+        let error =
+            resolve_runtime_dependency_graph(&contracts).expect_err("missing path fails preflight");
+
+        assert!(error.message.contains("could not be resolved"));
+        assert!(error.message.contains("agents-api"));
+        // The structured preflight payload is carried in the invalid-argument
+        // `id` field as a JSON string.
+        let payload: Value =
+            serde_json::from_str(error.details["id"].as_str().expect("structured id payload"))
+                .expect("parse preflight payload");
+        assert_eq!(payload["reason"], "unresolved");
+        assert_eq!(payload["dependency"], "agents-api");
+    }
+
+    #[test]
+    fn dirty_component_checkout_is_rejected_as_stale() {
+        let repo = tempfile::tempdir().expect("repo");
+        init_repo(repo.path());
+        commit_file(repo.path(), "plugin.php", "<?php");
+        fs::write(repo.path().join("dirty.txt"), "dirty").expect("write dirty");
+
+        let contracts = vec![contract(
+            "wp-codebox",
+            &repo.path().display().to_string(),
+            Value::Null,
+        )];
+
+        let error = resolve_runtime_dependency_graph(&contracts)
+            .expect_err("dirty checkout fails preflight");
+
+        assert!(error.message.contains("stale"));
+        assert!(error.message.contains("dirty working tree"));
+    }
+
+    #[test]
+    fn pinned_ref_mismatch_is_rejected_as_stale() {
+        let repo = tempfile::tempdir().expect("repo");
+        init_repo(repo.path());
+        let first = commit_file(repo.path(), "a.txt", "a");
+        let _second = commit_file(repo.path(), "b.txt", "b");
+
+        // Declare the older commit as the pinned ref while HEAD is newer.
+        let contracts = vec![contract(
+            "wpsg",
+            &repo.path().display().to_string(),
+            serde_json::json!({ "ref": first }),
+        )];
+
+        let error = resolve_runtime_dependency_graph(&contracts)
+            .expect_err("pinned ref mismatch fails preflight");
+
+        assert!(error.message.contains("stale"));
+        assert!(error.message.contains("does not match the declared ref"));
+    }
+
+    #[test]
+    fn pinned_ref_match_resolves() {
+        let repo = tempfile::tempdir().expect("repo");
+        init_repo(repo.path());
+        let head = commit_file(repo.path(), "a.txt", "a");
+
+        let contracts = vec![contract(
+            "wpsg",
+            &repo.path().display().to_string(),
+            serde_json::json!({ "ref": head }),
+        )];
+
+        let graph = resolve_runtime_dependency_graph(&contracts).expect("resolved graph");
+        let dep = &graph.dependencies[0];
+        assert_eq!(dep.resolved_ref.as_deref(), Some(head.as_str()));
+        assert_eq!(dep.declared_ref.as_deref(), Some(head.as_str()));
+    }
+
+    #[test]
+    fn non_git_path_materializes_without_provenance() {
+        let dir = tempfile::tempdir().expect("dir");
+        fs::write(dir.path().join("file.txt"), "x").expect("write");
+
+        let contracts = vec![contract(
+            "runtime-helper",
+            &dir.path().display().to_string(),
+            Value::Null,
+        )];
+
+        let graph = resolve_runtime_dependency_graph(&contracts).expect("resolved graph");
+        let dep = &graph.dependencies[0];
+        assert!(!dep.git_provenance);
+        assert_eq!(dep.resolved_ref, None);
+    }
+
+    #[test]
+    fn opaque_contracts_without_path_are_skipped() {
+        let contracts = vec![AgentTaskComponentContract {
+            slug: Some("opaque".to_string()),
+            path: None,
+            load_as: None,
+            activate: None,
+            extra: serde_json::json!({ "hint": "preserve" })
+                .as_object()
+                .cloned()
+                .unwrap_or_default(),
+        }];
+
+        let graph = resolve_runtime_dependency_graph(&contracts).expect("resolved graph");
+        assert!(graph.is_empty());
+    }
+
+    #[test]
+    fn resolved_graph_serializes_for_evidence() {
+        let repo = tempfile::tempdir().expect("repo");
+        init_repo(repo.path());
+        commit_file(repo.path(), "a.txt", "a");
+
+        let contracts = vec![contract(
+            "data-machine-code",
+            &repo.path().display().to_string(),
+            Value::Null,
+        )];
+
+        let graph = resolve_runtime_dependency_graph(&contracts).expect("resolved graph");
+        let value = graph.to_evidence_value();
+        assert_eq!(value["schema"], RUNTIME_DEPENDENCY_GRAPH_SCHEMA);
+        assert_eq!(value["dependencies"][0]["slug"], "data-machine-code");
+        assert!(value["dependencies"][0]["git_provenance"]
+            .as_bool()
+            .unwrap());
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -35,6 +35,7 @@ pub mod agent_task_promotion;
 pub mod agent_task_prompts;
 pub mod agent_task_provider;
 pub mod agent_task_repo_loop_compile;
+pub mod agent_task_runtime_dependency_graph;
 pub mod agent_task_schedule;
 pub mod agent_task_scheduler;
 pub mod agent_task_secrets;


### PR DESCRIPTION
Closes #6121.

## Summary
Gives agent-task Lab proofs a first-class, preflight-time path to resolve and materialize their declared runtime dependency graph, so WPSG (and other runtime-package loops) no longer have to manually export substrate path env vars or fight stale/missing checkouts.

New module `src/core/agent_task_runtime_dependency_graph.rs`:
- **Resolve** each declared `component_contract` / `runtime_component_contract` (already collected by the dispatch plan from provider-config and client-context) to a concrete on-disk path.
- **Materialize at a known ref**: resolves the checkout's git HEAD (or honors an explicitly declared `ref`/`pinned_ref`/`revision` in the contract `extra`) and records the branch + resolved commit. Non-git declared paths pass through without provenance.
- **Preflight-fail before dispatch** with an actionable message when a required runtime dependency is unresolved (declared path missing / not a directory / no resolvable HEAD) or stale (dirty working tree, declared ref the checkout can't resolve, or HEAD that doesn't match the pinned ref).
- **Record resolved refs/paths in run evidence**: the resolved graph (`homeboy/agent-task-runtime-dependency-graph/v1`) is written into both the dispatch plan metadata and every task's metadata, so `homeboy runs evidence` / `agent-task status` surface exactly which `agents-api`, `data-machine`, `data-machine-code`, `wp-codebox`, and WPSG refs/paths a proof ran against.

Wiring: `build_dispatch_plan_with_provider_requirements` resolves the graph right after contract collection and fails the dispatch on the first unresolved/stale dependency (before any executor runs). Reuses canonical git-provenance conventions from #4314 and rig-declared component resolution from #4012.

## Tests
- New unit tests in the module: git HEAD resolution, missing-path preflight failure, dirty-checkout staleness, pinned-ref match/mismatch, non-git passthrough, opaque (no-path) contract skip, evidence serialization.
- New dispatch-plan integration test asserting a missing runtime dependency fails dispatch preflight, plus assertions that the resolved graph lands in plan/task metadata.
- Updated existing contract-preservation tests (dispatch plan + controller run) to use real committed git checkouts; added an `init_runtime_component_checkout` test helper.

## Scope / deferred
- Edits confined to agent-task dispatch + tests. Resolution validates/records the declared graph in-place (canonical absolute path + known ref); it does not yet *clone* a missing checkout from a remote — a missing dependency is surfaced as an actionable preflight failure rather than auto-cloned. Remote auto-clone can be layered on later.
- Verified with `cargo build --lib` + `cargo fmt`; full test suite runs in CI.