### PR TITLE
feat(runtime): reconcile dependency conflicts before Codebox dispatch (#6223)

### DIFF
--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -14,7 +14,7 @@ use crate::core::agent_task_lifecycle as lifecycle;
 use crate::core::agent_task_lifecycle::{AgentTaskRunRecord, AgentTaskRunState};
 use crate::core::agent_task_provider::{
     apply_provider_runner_secret_env_contracts, default_backend_for_component,
-    AgentTaskProviderCatalog,
+    reconcile_staged_runtime_for_plan, AgentTaskProviderCatalog,
 };
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskScheduler,
@@ -138,6 +138,11 @@ where
             catalog.provider_requires_cwd_git_checkout(backend, selector)
         })?;
     catalog.apply_provider_runner_secret_env_contracts(&mut plan);
+    // Reconcile runtime dependency conflicts before dispatch: refuse a staged
+    // provider plugin that vendors a runtime-owned package which would shadow the
+    // runtime copy and fatal on activation, with an actionable owner/contract
+    // error instead of a raw runtime fatal. Lab and local share this gate (#6223).
+    catalog.reconcile_staged_runtime_for_plan(&plan)?;
     preflight_dispatch_provider_secrets(&plan)?;
     let submitted = lifecycle::submit_plan(&plan, request.run_id.as_deref())?;
     let run_id = submitted.run_id.clone();
@@ -174,6 +179,9 @@ where
         provider_requires_cwd_git_checkout,
     )?;
     apply_provider_runner_secret_env_contracts(&mut plan);
+    // Reconcile runtime dependency conflicts before dispatch (#6223); see
+    // `dispatch_with_provider_catalog` for rationale. Shared with Lab dispatch.
+    reconcile_staged_runtime_for_plan(&plan)?;
     preflight_dispatch_provider_secrets(&plan)?;
     let submitted = lifecycle::submit_plan(&plan, request.run_id.as_deref())?;
     let run_id = submitted.run_id.clone();

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -38,6 +38,7 @@ mod outcome_normalization;
 mod resolution;
 mod runner_readiness;
 mod secrets;
+mod staging_reconciliation;
 mod types;
 
 #[cfg(test)]
@@ -52,12 +53,17 @@ pub(crate) use secrets::{
     provider_runner_secret_env_for_plan_with_providers,
     provider_secret_sources_for_plan_with_providers,
 };
+pub use staging_reconciliation::{
+    ensure_staged_plugins_reconciled, reconcile_staged_plugins, StagingReadiness,
+    StagingReconciliationConflict,
+};
 pub(crate) use types::wildcard_match;
 pub use types::*;
 
 #[cfg(test)]
 use catalog::{
-    component_default_backend, validate_provider_runner_readiness_for_backend_with_providers,
+    component_default_backend, reconcile_staged_runtime_for_plan_with_providers,
+    validate_provider_runner_readiness_for_backend_with_providers,
 };
 #[cfg(test)]
 use command_runner::{

--- a/src/core/agent_task_provider/catalog.rs
+++ b/src/core/agent_task_provider/catalog.rs
@@ -1,7 +1,7 @@
 use super::resolution::{
     discover_agent_task_executor_providers, lab_runtime_component_ids_for_plan_with_providers,
     provider_requires_cwd_git_checkout_with_providers,
-    required_extension_ids_for_plan_with_providers,
+    required_extension_ids_for_plan_with_providers, select_provider,
 };
 use super::runner_readiness::provider_executable_env;
 use super::secrets::{
@@ -9,6 +9,7 @@ use super::secrets::{
     provider_runner_secret_env_for_plan_with_providers, provider_secret_sources,
     provider_secret_sources_for_plan_with_providers,
 };
+use super::staging_reconciliation::ensure_staged_plugins_reconciled;
 use super::*;
 
 #[cfg(not(test))]
@@ -74,6 +75,19 @@ impl AgentTaskProviderCatalog {
 
     pub fn apply_provider_runner_secret_env_contracts(&self, plan: &mut AgentTaskPlan) {
         apply_provider_runner_secret_env_contracts_with_providers(plan, &self.providers);
+    }
+
+    /// Reconcile every task's staged plugin component contracts against the
+    /// resolved provider's runtime staging contract before dispatch. Fails with
+    /// an actionable owner/package/contract error when a staged plugin vendors a
+    /// runtime-owned package that would shadow the runtime copy and fatal on
+    /// activation (#6223). Local and Lab dispatch share this single check so the
+    /// reconciled staging contract is enforced identically on both surfaces.
+    pub fn reconcile_staged_runtime_for_plan(
+        &self,
+        plan: &AgentTaskPlan,
+    ) -> crate::core::Result<()> {
+        reconcile_staged_runtime_for_plan_with_providers(plan, &self.providers)
     }
 
     pub fn provider_secret_sources_for_providers(
@@ -267,6 +281,34 @@ pub fn provider_requires_cwd_git_checkout(backend: &str, selector: Option<&str>)
 
 pub fn apply_provider_runner_secret_env_contracts(plan: &mut AgentTaskPlan) {
     AgentTaskProviderCatalog::discover().apply_provider_runner_secret_env_contracts(plan);
+}
+
+/// Reconcile a plan's staged plugin component contracts against the discovered
+/// providers' runtime staging contracts before dispatch (#6223).
+pub fn reconcile_staged_runtime_for_plan(plan: &AgentTaskPlan) -> crate::core::Result<()> {
+    AgentTaskProviderCatalog::discover().reconcile_staged_runtime_for_plan(plan)
+}
+
+/// Per-provider reconciliation of a plan's staged plugins. Resolves the provider
+/// for each task's backend/selector, then validates that task's plugin component
+/// contracts against the provider's runtime staging contract. Keeping this on a
+/// concrete provider slice lets the local dispatch service and the Lab preflight
+/// share one implementation against whichever provider list they hold.
+pub(super) fn reconcile_staged_runtime_for_plan_with_providers(
+    plan: &AgentTaskPlan,
+    providers: &[AgentTaskExecutorProvider],
+) -> crate::core::Result<()> {
+    for request in &plan.tasks {
+        let Some(provider) = select_provider(providers, request) else {
+            continue;
+        };
+        let contract = &provider.runtime_contract.staging;
+        if contract.is_empty() {
+            continue;
+        }
+        ensure_staged_plugins_reconciled(contract, &request.component_contracts)?;
+    }
+    Ok(())
 }
 
 pub fn provider_runner_secret_env_for_plan(plan: &AgentTaskPlan) -> Vec<String> {

--- a/src/core/agent_task_provider/staging_reconciliation.rs
+++ b/src/core/agent_task_provider/staging_reconciliation.rs
@@ -1,0 +1,364 @@
+//! Runtime dependency conflict reconciliation for staged provider plugins
+//! (#6223).
+//!
+//! A provider plugin can carry a vendored runtime library that SHADOWS the
+//! runtime-provided version (e.g. the runtime/overlay supplies a Composer
+//! package that the staged plugin also vendors). When that happens, plugin
+//! activation can fatal at runtime. Homeboy owns the contract and the
+//! readiness check at the orchestration boundary: before dispatch it validates
+//! the *effective staged plugin* against the provider's declared runtime
+//! staging contract and refuses the run with an actionable owner/package/
+//! contract message instead of letting the runtime emit a raw fatal.
+//!
+//! Both Lab and local execution funnel through the same
+//! [`reconcile_staged_plugins`] check, so the reconciled staging contract is
+//! shared rather than re-implemented per execution surface.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::core::agent_task::AgentTaskComponentContract;
+use crate::core::{Error, Result};
+
+use super::types::{AgentTaskRuntimeReconciledPackage, AgentTaskRuntimeStagingContract};
+
+/// A single detected conflict: a staged plugin vendors a package the runtime
+/// owns. Carries enough provenance to name the owner, the package, and the
+/// exact shadowing path in an actionable error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StagingReconciliationConflict {
+    /// The staged plugin (component contract slug) that shadows a runtime package.
+    pub plugin: String,
+    /// The package the runtime owns (e.g. a Composer package name).
+    pub package: String,
+    /// The runtime/overlay that supplies the canonical copy of the package.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    /// The staged-plugin-relative path whose presence proves the shadowing.
+    pub vendored_subpath: String,
+    /// The absolute path inside the staged plugin that vendors the package.
+    pub vendored_path: String,
+    /// Optional per-package remediation declared by the contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remediation: Option<String>,
+}
+
+/// Structured readiness outcome of reconciling a staged plugin against the
+/// runtime staging contract. Mirrors the shape a runtime/Codebox can return so
+/// Homeboy can either compute readiness itself or accept a structured result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+pub struct StagingReadiness {
+    /// True when no staged plugin shadows a runtime-owned package.
+    pub ready: bool,
+    /// Conflicts found, empty when ready.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub conflicts: Vec<StagingReconciliationConflict>,
+}
+
+impl StagingReadiness {
+    fn ready() -> Self {
+        Self {
+            ready: true,
+            conflicts: Vec::new(),
+        }
+    }
+}
+
+/// Reconcile staged plugin component contracts against a provider's runtime
+/// staging contract. Returns the structured readiness so callers can record it
+/// as evidence; use [`ensure_staged_plugins_reconciled`] for the gating variant
+/// that turns a conflict into an actionable pre-dispatch error.
+pub fn reconcile_staged_plugins(
+    contract: &AgentTaskRuntimeStagingContract,
+    component_contracts: &[AgentTaskComponentContract],
+) -> StagingReadiness {
+    if contract.reconciled_packages.is_empty() {
+        return StagingReadiness::ready();
+    }
+
+    let mut conflicts = Vec::new();
+    for component in component_contracts {
+        if !contract_is_staged_plugin(component) {
+            continue;
+        }
+        let Some(plugin_root) = component
+            .path
+            .as_deref()
+            .filter(|path| !path.trim().is_empty())
+        else {
+            continue;
+        };
+        let plugin_root = PathBuf::from(plugin_root);
+        let plugin_label = component
+            .slug
+            .clone()
+            .or_else(|| {
+                plugin_root
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| plugin_root.display().to_string());
+
+        for package in &contract.reconciled_packages {
+            collect_package_conflicts(&plugin_root, &plugin_label, package, &mut conflicts);
+        }
+    }
+
+    if conflicts.is_empty() {
+        StagingReadiness::ready()
+    } else {
+        StagingReadiness {
+            ready: false,
+            conflicts,
+        }
+    }
+}
+
+/// Gate a dispatch on the reconciled staging contract. When the contract
+/// enforces pre-dispatch validation and a staged plugin shadows a runtime
+/// package, this returns an actionable error that names the owner, the package,
+/// and the shadowing contract — not a raw runtime fatal.
+pub fn ensure_staged_plugins_reconciled(
+    contract: &AgentTaskRuntimeStagingContract,
+    component_contracts: &[AgentTaskComponentContract],
+) -> Result<StagingReadiness> {
+    let readiness = reconcile_staged_plugins(contract, component_contracts);
+    if readiness.ready || !contract.enforces_pre_dispatch() {
+        return Ok(readiness);
+    }
+    Err(staging_reconciliation_error(contract, &readiness.conflicts))
+}
+
+fn contract_is_staged_plugin(component: &AgentTaskComponentContract) -> bool {
+    // Treat any component the runtime loads/activates as a plugin as in scope.
+    // `loadAs == "plugin"` is the canonical signal; `activate` also implies a
+    // loaded plugin. Core stays runtime-agnostic — it never assumes WordPress.
+    component
+        .load_as
+        .as_deref()
+        .is_some_and(|load_as| load_as.eq_ignore_ascii_case("plugin"))
+        || component.activate == Some(true)
+}
+
+fn collect_package_conflicts(
+    plugin_root: &Path,
+    plugin_label: &str,
+    package: &AgentTaskRuntimeReconciledPackage,
+    conflicts: &mut Vec<StagingReconciliationConflict>,
+) {
+    for subpath in package.effective_vendor_subpaths() {
+        let vendored_path = plugin_root.join(&subpath);
+        if vendored_path.exists() {
+            conflicts.push(StagingReconciliationConflict {
+                plugin: plugin_label.to_string(),
+                package: package.name.clone(),
+                owner: package.owner.clone(),
+                vendored_subpath: subpath,
+                vendored_path: vendored_path.display().to_string(),
+                remediation: package.remediation.clone(),
+            });
+        }
+    }
+}
+
+fn staging_reconciliation_error(
+    contract: &AgentTaskRuntimeStagingContract,
+    conflicts: &[StagingReconciliationConflict],
+) -> Error {
+    let summary = conflicts
+        .iter()
+        .map(|conflict| {
+            let owner = conflict.owner.as_deref().unwrap_or("the runtime");
+            format!(
+                "staged plugin `{}` vendors `{}` (owned by `{}`) at `{}`",
+                conflict.plugin, conflict.package, owner, conflict.vendored_subpath
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    let mut hints = vec![
+        "Rebuild the staged plugin without the vendored runtime package so the runtime-provided version is used.".to_string(),
+        "This is a runtime dependency contract conflict reconciled by Homeboy before dispatch, not a task failure — no task cells were queued.".to_string(),
+    ];
+    for conflict in conflicts {
+        if let Some(owner) = conflict.owner.as_deref() {
+            hints.push(format!(
+                "`{}` is supplied by `{}`; remove `{}` from staged plugin `{}` so it cannot shadow the runtime copy and fatal on activation.",
+                conflict.package, owner, conflict.vendored_path, conflict.plugin
+            ));
+        }
+        if let Some(remediation) = conflict.remediation.as_deref() {
+            hints.push(remediation.to_string());
+        }
+    }
+    if let Some(remediation) = contract.remediation.as_deref() {
+        hints.push(remediation.to_string());
+    }
+
+    let details = serde_json::json!({
+        "conflicts": conflicts,
+    })
+    .to_string();
+
+    Error::validation_invalid_argument(
+        "staged_plugin",
+        format!(
+            "Homeboy refused dispatch: runtime dependency reconciliation found {} staged plugin package conflict(s): {summary}. A vendored runtime library would shadow the runtime-provided version and fatal during plugin activation.",
+            conflicts.len()
+        ),
+        Some(details),
+        Some(hints),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_task::AgentTaskComponentContract;
+
+    fn package(name: &str, owner: &str) -> AgentTaskRuntimeReconciledPackage {
+        AgentTaskRuntimeReconciledPackage {
+            name: name.to_string(),
+            owner: Some(owner.to_string()),
+            ..AgentTaskRuntimeReconciledPackage::default()
+        }
+    }
+
+    fn plugin_contract(slug: &str, path: &Path) -> AgentTaskComponentContract {
+        AgentTaskComponentContract {
+            slug: Some(slug.to_string()),
+            path: Some(path.display().to_string()),
+            load_as: Some("plugin".to_string()),
+            activate: Some(true),
+            extra: Default::default(),
+        }
+    }
+
+    #[test]
+    fn ready_when_no_vendored_package_shadows_runtime() {
+        let plugin = tempfile::tempdir().expect("plugin dir");
+        let contract = AgentTaskRuntimeStagingContract {
+            reconciled_packages: vec![package("acme/runtime-lib", "wordpress-7.0")],
+            ..AgentTaskRuntimeStagingContract::default()
+        };
+
+        let readiness = ensure_staged_plugins_reconciled(
+            &contract,
+            &[plugin_contract("provider-plugin", plugin.path())],
+        )
+        .expect("clean staged plugin reconciles");
+
+        assert!(readiness.ready);
+        assert!(readiness.conflicts.is_empty());
+    }
+
+    #[test]
+    fn conflict_names_owner_package_and_path() {
+        let plugin = tempfile::tempdir().expect("plugin dir");
+        let vendored = plugin.path().join("vendor/acme/runtime-lib");
+        std::fs::create_dir_all(&vendored).expect("create vendored dir");
+        let contract = AgentTaskRuntimeStagingContract {
+            reconciled_packages: vec![package("acme/runtime-lib", "wordpress-7.0")],
+            ..AgentTaskRuntimeStagingContract::default()
+        };
+
+        let err = ensure_staged_plugins_reconciled(
+            &contract,
+            &[plugin_contract("provider-plugin", plugin.path())],
+        )
+        .expect_err("shadowed runtime package is refused before dispatch");
+
+        assert_eq!(err.details["field"], "staged_plugin");
+        assert!(err.message.contains("acme/runtime-lib"));
+        assert!(err.message.contains("wordpress-7.0"));
+        assert!(err.message.contains("provider-plugin"));
+        assert!(err.message.contains("shadow"));
+        let tried = err.details["tried"].as_array().expect("hints");
+        assert!(tried.iter().any(|hint| hint
+            .as_str()
+            .is_some_and(|hint| hint.contains("Rebuild the staged plugin"))));
+        // The structured conflict provenance is preserved in the error id payload.
+        let conflicts: serde_json::Value =
+            serde_json::from_str(err.details["id"].as_str().expect("id payload"))
+                .expect("conflicts json");
+        assert_eq!(conflicts["conflicts"][0]["package"], "acme/runtime-lib");
+        assert_eq!(conflicts["conflicts"][0]["owner"], "wordpress-7.0");
+    }
+
+    #[test]
+    fn declared_vendor_subpaths_override_default() {
+        let plugin = tempfile::tempdir().expect("plugin dir");
+        let vendored = plugin.path().join("lib/embedded/runtime-lib");
+        std::fs::create_dir_all(&vendored).expect("create vendored dir");
+        let contract = AgentTaskRuntimeStagingContract {
+            reconciled_packages: vec![AgentTaskRuntimeReconciledPackage {
+                name: "acme/runtime-lib".to_string(),
+                owner: Some("wordpress-7.0".to_string()),
+                vendor_subpaths: vec!["lib/embedded/runtime-lib".to_string()],
+                ..AgentTaskRuntimeReconciledPackage::default()
+            }],
+            ..AgentTaskRuntimeStagingContract::default()
+        };
+
+        let readiness = reconcile_staged_plugins(
+            &contract,
+            &[plugin_contract("provider-plugin", plugin.path())],
+        );
+
+        assert!(!readiness.ready);
+        assert_eq!(readiness.conflicts.len(), 1);
+        assert_eq!(
+            readiness.conflicts[0].vendored_subpath,
+            "lib/embedded/runtime-lib"
+        );
+    }
+
+    #[test]
+    fn validate_before_dispatch_false_records_without_gating() {
+        let plugin = tempfile::tempdir().expect("plugin dir");
+        std::fs::create_dir_all(plugin.path().join("vendor/acme/runtime-lib"))
+            .expect("create vendored dir");
+        let contract = AgentTaskRuntimeStagingContract {
+            reconciled_packages: vec![package("acme/runtime-lib", "wordpress-7.0")],
+            validate_before_dispatch: Some(false),
+            ..AgentTaskRuntimeStagingContract::default()
+        };
+
+        // Codebox-delegated readiness: the contract is recorded and conflicts are
+        // still computed for evidence, but Homeboy does not hard-gate dispatch.
+        let readiness = ensure_staged_plugins_reconciled(
+            &contract,
+            &[plugin_contract("provider-plugin", plugin.path())],
+        )
+        .expect("non-enforcing contract does not gate dispatch");
+
+        assert!(!readiness.ready);
+        assert_eq!(readiness.conflicts.len(), 1);
+    }
+
+    #[test]
+    fn non_plugin_component_is_ignored() {
+        let plugin = tempfile::tempdir().expect("plugin dir");
+        std::fs::create_dir_all(plugin.path().join("vendor/acme/runtime-lib"))
+            .expect("create vendored dir");
+        let contract = AgentTaskRuntimeStagingContract {
+            reconciled_packages: vec![package("acme/runtime-lib", "wordpress-7.0")],
+            ..AgentTaskRuntimeStagingContract::default()
+        };
+        let component = AgentTaskComponentContract {
+            slug: Some("not-a-plugin".to_string()),
+            path: Some(plugin.path().display().to_string()),
+            load_as: Some("library".to_string()),
+            activate: Some(false),
+            extra: Default::default(),
+        };
+
+        let readiness = ensure_staged_plugins_reconciled(&contract, &[component])
+            .expect("non-plugin components are out of scope");
+
+        assert!(readiness.ready);
+    }
+}

--- a/src/core/agent_task_provider/tests.rs
+++ b/src/core/agent_task_provider/tests.rs
@@ -320,6 +320,7 @@ fn runtime_contract_normalizes_provider_outputs_to_canonical_artifacts() {
             ],
         },
         apply_back: AgentTaskRuntimeApplyBack::default(),
+        staging: AgentTaskRuntimeStagingContract::default(),
     };
 
     let outcome = run_provider_command(&request, &provider);
@@ -2519,4 +2520,74 @@ fn provider_exhausts_bounded_transient_retries() {
         "exhaustion should be surfaced as a diagnostic"
     );
     let _ = fs::remove_file(&state_path);
+}
+
+fn plugin_component_contract(
+    slug: &str,
+    path: &std::path::Path,
+) -> crate::core::agent_task::AgentTaskComponentContract {
+    crate::core::agent_task::AgentTaskComponentContract {
+        slug: Some(slug.to_string()),
+        path: Some(path.display().to_string()),
+        load_as: Some("plugin".to_string()),
+        activate: Some(true),
+        extra: Default::default(),
+    }
+}
+
+fn staging_provider() -> AgentTaskExecutorProvider {
+    let (_, mut provider) = request("staging", "noop".to_string());
+    provider.runtime_contract.staging = AgentTaskRuntimeStagingContract {
+        reconciled_packages: vec![AgentTaskRuntimeReconciledPackage {
+            name: "acme/runtime-lib".to_string(),
+            owner: Some("wordpress-7.0".to_string()),
+            ..AgentTaskRuntimeReconciledPackage::default()
+        }],
+        ..AgentTaskRuntimeStagingContract::default()
+    };
+    provider
+}
+
+fn staging_plan(component: crate::core::agent_task::AgentTaskComponentContract) -> AgentTaskPlan {
+    let (mut req, _) = request("staging", "noop".to_string());
+    req.component_contracts = vec![component];
+    AgentTaskPlan::new("plan-staging".to_string(), vec![req])
+}
+
+#[test]
+fn plan_reconciliation_passes_when_no_staged_plugin_shadows_runtime() {
+    let plugin = tempfile::tempdir().expect("plugin dir");
+    let plan = staging_plan(plugin_component_contract("provider-plugin", plugin.path()));
+
+    reconcile_staged_runtime_for_plan_with_providers(&plan, &[staging_provider()])
+        .expect("clean staged plugin reconciles before dispatch");
+}
+
+#[test]
+fn plan_reconciliation_refuses_shadowed_runtime_package_before_dispatch() {
+    let plugin = tempfile::tempdir().expect("plugin dir");
+    fs::create_dir_all(plugin.path().join("vendor/acme/runtime-lib"))
+        .expect("create vendored runtime dir");
+    let plan = staging_plan(plugin_component_contract("provider-plugin", plugin.path()));
+
+    let err = reconcile_staged_runtime_for_plan_with_providers(&plan, &[staging_provider()])
+        .expect_err("shadowed runtime package is refused before dispatch");
+
+    assert_eq!(err.details["field"], "staged_plugin");
+    assert!(err.message.contains("acme/runtime-lib"));
+    assert!(err.message.contains("wordpress-7.0"));
+    assert!(err.message.contains("provider-plugin"));
+}
+
+#[test]
+fn plan_reconciliation_skips_provider_without_staging_contract() {
+    let plugin = tempfile::tempdir().expect("plugin dir");
+    fs::create_dir_all(plugin.path().join("vendor/acme/runtime-lib"))
+        .expect("create vendored runtime dir");
+    let plan = staging_plan(plugin_component_contract("provider-plugin", plugin.path()));
+    // Default provider has an empty staging contract: nothing to reconcile.
+    let (_, provider) = request("staging", "noop".to_string());
+
+    reconcile_staged_runtime_for_plan_with_providers(&plan, &[provider])
+        .expect("provider without a staging contract is a no-op");
 }

--- a/src/core/agent_task_provider/types.rs
+++ b/src/core/agent_task_provider/types.rs
@@ -105,6 +105,17 @@ pub struct AgentTaskRuntimeContract {
     pub normalization: AgentTaskRuntimeNormalization,
     #[serde(default, skip_serializing_if = "AgentTaskRuntimeApplyBack::is_empty")]
     pub apply_back: AgentTaskRuntimeApplyBack,
+    /// Runtime dependency reconciliation contract: packages the runtime/overlay
+    /// (e.g. "WordPress 7.0 supplies this Composer package") provides, which a
+    /// staged provider plugin must NOT vendor/shadow. Homeboy validates the
+    /// effective staged plugin against this before dispatch so a stale vendored
+    /// runtime library fails with an actionable owner/contract message instead of
+    /// a raw PHP fatal during plugin activation (#6223).
+    #[serde(
+        default,
+        skip_serializing_if = "AgentTaskRuntimeStagingContract::is_empty"
+    )]
+    pub staging: AgentTaskRuntimeStagingContract,
 }
 
 impl AgentTaskRuntimeContract {
@@ -113,6 +124,100 @@ impl AgentTaskRuntimeContract {
             && self.lifecycle_states.is_empty()
             && self.normalization.is_empty()
             && self.apply_back.is_empty()
+            && self.staging.is_empty()
+    }
+}
+
+/// Declares the runtime dependency reconciliation surface for a provider's
+/// staged plugins. Core is runtime-agnostic: it does not know that a package is
+/// a Composer dependency or that the owner is WordPress — the declaring
+/// extension supplies the package name, the owner that provides it at runtime,
+/// and the vendor subpaths a staged plugin would use to shadow it. Homeboy uses
+/// this to reconcile staged plugins before dispatch (#6223).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentTaskRuntimeStagingContract {
+    /// Packages the runtime/overlay owns. A staged provider plugin that vendors
+    /// any of these would shadow the runtime-provided version and is refused
+    /// before dispatch with an actionable owner/package/contract error.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reconciled_packages: Vec<AgentTaskRuntimeReconciledPackage>,
+    /// Optional human-facing remediation appended to reconciliation conflict
+    /// errors (e.g. how to rebuild the staged plugin without the vendored copy).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remediation: Option<String>,
+    /// When true (default), Homeboy validates staged plugins against this
+    /// contract before dispatch. Set false to declare the contract for evidence
+    /// without enforcing the pre-dispatch gate (e.g. when WP Codebox owns the
+    /// authoritative readiness check and returns a structured result).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validate_before_dispatch: Option<bool>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl AgentTaskRuntimeStagingContract {
+    pub fn is_empty(&self) -> bool {
+        self.reconciled_packages.is_empty()
+            && self.remediation.is_none()
+            && self.validate_before_dispatch.is_none()
+            && self.extra.is_empty()
+    }
+
+    /// Whether the pre-dispatch validation gate is enforced. Defaults to true
+    /// when any reconciled package is declared, so declaring a package is enough
+    /// to opt into the gate; an explicit `validate_before_dispatch: false`
+    /// records the contract for evidence/Codebox delegation without gating.
+    pub fn enforces_pre_dispatch(&self) -> bool {
+        self.validate_before_dispatch.unwrap_or(true) && !self.reconciled_packages.is_empty()
+    }
+}
+
+/// A single package the runtime owns that staged provider plugins must not
+/// vendor. Generic by design: `name` is the package identity, `owner` is the
+/// runtime/overlay that supplies it (named in conflict errors), and
+/// `vendor_subpaths` are the staged-plugin-relative paths whose presence proves
+/// the staged plugin shadows the runtime copy (e.g. `vendor/<org>/<pkg>`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentTaskRuntimeReconciledPackage {
+    /// Package identity (e.g. a Composer package name `org/library`).
+    pub name: String,
+    /// The runtime/overlay that supplies this package at runtime. Surfaced in
+    /// conflict errors so the operator knows who owns the canonical copy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    /// Staged-plugin-relative paths that, if present in the effective staged
+    /// plugin, prove it vendors (and would shadow) the runtime-owned package.
+    /// When omitted, `vendor/<name>` is checked by default.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vendor_subpaths: Vec<String>,
+    /// Optional reason/why this package is reconciled, surfaced in diagnostics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Optional per-package remediation, surfaced when this package conflicts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remediation: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl AgentTaskRuntimeReconciledPackage {
+    /// The staged-plugin-relative subpaths whose presence indicates a shadowed
+    /// runtime package. Falls back to `vendor/<name>` when none are declared.
+    pub fn effective_vendor_subpaths(&self) -> Vec<String> {
+        let declared: Vec<String> = self
+            .vendor_subpaths
+            .iter()
+            .map(|subpath| subpath.trim().trim_matches('/').to_string())
+            .filter(|subpath| !subpath.is_empty())
+            .collect();
+        if !declared.is_empty() {
+            return declared;
+        }
+        let name = self.name.trim().trim_matches('/');
+        if name.is_empty() {
+            return Vec::new();
+        }
+        vec![format!("vendor/{name}")]
     }
 }
 


### PR DESCRIPTION
Closes #6223.

## Summary
Homeboy now owns runtime dependency conflict reconciliation at the orchestration boundary, so a staged provider plugin can no longer accidentally shadow a runtime-provided package and fatal during plugin activation.

- **Runtime contract declares reconciled packages.** Added `AgentTaskRuntimeStagingContract` to the provider's `runtime_contract` (`staging`). Extensions declare the packages the runtime/overlay owns (`reconciled_packages`: `name`, `owner`, `vendor_subpaths`, `reason`, `remediation`). Core stays runtime-agnostic — it never assumes Composer/WordPress; the declaring extension supplies the package identity, the owner, and the vendor subpaths that prove a shadow.
- **Pre-dispatch validation of the effective staged plugin.** New `staging_reconciliation` module scans each staged plugin component contract (the `loadAs: plugin` / `activate` contracts resolved by #6121's runtime dependency graph) for vendored copies of runtime-owned packages and returns a structured `StagingReadiness`. `validate_before_dispatch: false` records the contract/conflicts for evidence without gating — the hook for delegating the authoritative readiness check to WP Codebox while Homeboy still owns the contract.
- **Actionable owner/contract errors, not raw fatals.** A conflict fails dispatch with a `validation.invalid_argument` error naming the staged plugin, the package, the owning runtime, and the shadowing path, plus remediation hints and structured conflict provenance — instead of a raw PHP fatal at activation.
- **Lab and local share the reconciled contract.** Reconciliation lives in the single dispatch service chokepoint (`dispatch_with_provider_catalog` + `dispatch_with_provider_requirements`), which both local CLI dispatch and Lab-offloaded `agent-task cook` flow through, so the same gate is enforced on both surfaces.

## Tests
- 5 unit tests for the reconciliation scanner (clean pass, conflict provenance, custom vendor subpaths, non-enforcing record-only mode, non-plugin components ignored).
- 3 plan-level tests covering provider resolution → staged plugin reconciliation (pass, refuse, and no-op when the provider declares no staging contract).

Verified with `cargo build --lib`, `cargo check --lib --tests`, `cargo fmt`, and the new + existing dispatch/provider tests (45 passing). Heavy build/test left to CI per repo policy.