### PR TITLE
feat(agent-task): loop-spec to agent-task-plan compilation (#5101)

### DIFF
--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -51,6 +51,9 @@ pub const LIST_RESULT_SCHEMA: &str = "homeboy/agent-task-loop-controller-list/v1
 pub const FROM_SPEC_RESULT_SCHEMA: &str = "homeboy/agent-task-loop-controller-from-spec-result/v1";
 /// Schema for dry controller-spec plan reports.
 pub const PLAN_RESULT_SCHEMA: &str = "homeboy/agent-task-loop-controller-plan-result/v1";
+/// Schema for from-spec executable agent-task plan compilation reports.
+pub const EXECUTABLE_PLAN_RESULT_SCHEMA: &str =
+    "homeboy/agent-task-loop-controller-executable-plan-result/v1";
 
 mod action_state;
 mod actions;
@@ -76,7 +79,11 @@ pub use run_failure_summary::{
     CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA,
 };
 pub use spec::*;
-pub(crate) use spec_compile::validate_loop_spec;
+#[cfg(test)]
+pub(crate) use spec_compile::validate_artifact_flow_bindings;
+pub(crate) use spec_compile::{
+    compile_executable_plan_from_spec, homeboy_runtime_artifacts, validate_loop_spec,
+};
 use spec_compile::{
     compile_loop_spec_policy, compile_loop_spec_workflows, controller_spec_homeboy_plan,
     merge_policy_into_event_payload, reconcile_repo_loop_spec_actions, repo_loop_spec_fingerprint,
@@ -451,6 +458,35 @@ pub fn plan_from_spec(request: ControllerPlanRequest) -> Result<ControllerPlanRe
         plan,
         actions,
         run_command: Some("homeboy agent-task controller from-spec <spec> --resume".to_string()),
+    })
+}
+
+/// Compile a loop controller spec into an executable agent-task plan.
+///
+/// This is the from-spec compiler primitive requested in #5101: the executable
+/// plan builder consumes the loop controller spec as the single source of truth.
+/// It derives the executable plan stages and inter-stage dependencies from the
+/// spec's workflows and `artifact_flow` (artifact_graph) edges, validates task
+/// bindings against those edges, and represents Homeboy-owned runtime artifacts
+/// (e.g. `static_validation_run`) as synthetic runtime stages so downstream
+/// callers never hard-code Homeboy/Codebox internals. No controller state is
+/// written.
+pub fn compile_plan_from_spec(
+    request: ControllerPlanRequest,
+) -> Result<ControllerExecutablePlanReport> {
+    let spec = request.spec;
+    let plan = compile_executable_plan_from_spec(&spec)?;
+    let spec_fingerprint = repo_loop_spec_fingerprint(&spec)?;
+    let runtime_artifacts = homeboy_runtime_artifacts(&spec)
+        .into_iter()
+        .map(|artifact| artifact.artifact_id.clone())
+        .collect();
+    Ok(ControllerExecutablePlanReport {
+        schema: EXECUTABLE_PLAN_RESULT_SCHEMA,
+        loop_id: spec.loop_id,
+        spec_fingerprint,
+        runtime_artifacts,
+        plan,
     })
 }
 

--- a/src/core/agent_task_controller_service/reports.rs
+++ b/src/core/agent_task_controller_service/reports.rs
@@ -86,6 +86,24 @@ pub struct ControllerPlanReport {
     pub run_command: Option<String>,
 }
 
+/// Typed report returned by `compile_plan_from_spec`.
+///
+/// Carries the executable agent-task plan derived from a loop controller spec
+/// (#5101): stages and inter-stage dependencies are compiled from the spec's
+/// workflows and `artifact_flow` edges, and Homeboy-owned runtime artifacts are
+/// surfaced as synthetic runtime stages so downstream callers do not hard-code
+/// Homeboy internals.
+#[derive(Debug, Clone, Serialize)]
+pub struct ControllerExecutablePlanReport {
+    pub schema: &'static str,
+    pub loop_id: String,
+    pub spec_fingerprint: String,
+    /// Homeboy-owned runtime artifact ids the plan synthesizes (e.g. `static_validation_run`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_artifacts: Vec<String>,
+    pub plan: HomeboyPlan,
+}
+
 /// Typed report returned by `run_next` and `run_action`.
 #[derive(Debug, Clone, Serialize)]
 pub struct ControllerActionReport {

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -453,6 +453,380 @@ pub(super) fn validate_artifact_graph_edges(spec: &AgentTaskRepoLoopSpec) -> Res
     ))
 }
 
+/// Schema emitted by [`compile_executable_plan_from_spec`].
+///
+/// Distinct from the `homeboy/controller-spec-plan/v1` projection produced by
+/// [`controller_spec_homeboy_plan`]: the controller-spec plan flattens queued
+/// controller actions for dry-run inspection, whereas this schema is the
+/// executable agent-task plan whose stages and inter-stage dependencies are
+/// derived from the loop controller spec as the single source of truth.
+pub(crate) const EXECUTABLE_PLAN_FROM_SPEC_SCHEMA: &str = "homeboy/agent-task-plan-from-spec/v1";
+
+/// Artifact `kind` suffix that marks an artifact as a Homeboy-owned runtime
+/// artifact (e.g. `static_validation_run`). Runtime artifacts are synthesized
+/// by a Homeboy runtime stage rather than authored/emitted by a repo workflow,
+/// so downstream specs can reference them without hard-coding Homeboy/Codebox
+/// internals.
+pub(crate) const HOMEBOY_RUNTIME_ARTIFACT_KIND_SUFFIX: &str = "_run";
+
+/// Stage `kind` used for the synthetic Homeboy runtime stage that produces a
+/// Homeboy-owned runtime artifact in the executable plan.
+pub(crate) const HOMEBOY_RUNTIME_STAGE_KIND: &str = "homeboy_runtime_artifact";
+
+/// True when an artifact is a Homeboy-owned runtime artifact: either its `kind`
+/// carries the runtime suffix, or no declared workflow produces it while at
+/// least one workflow consumes it (so the producer must be a Homeboy runtime,
+/// not a repo workflow). Keeping this derivation generic lets repos reference
+/// runtime artifacts like `static_validation_run` without WPSG embedding
+/// Homeboy-owned producers in its own spec.
+pub(crate) fn is_homeboy_runtime_artifact(
+    spec: &AgentTaskRepoLoopSpec,
+    artifact: &AgentTaskRepoLoopSpecArtifact,
+) -> bool {
+    if artifact
+        .kind
+        .ends_with(HOMEBOY_RUNTIME_ARTIFACT_KIND_SUFFIX)
+    {
+        return true;
+    }
+    let produced_by_workflow = spec.workflows.iter().any(|workflow| {
+        workflow.artifacts.contains(&artifact.artifact_id)
+            || workflow.emits.contains(&artifact.artifact_id)
+            || spec.artifact_graph.iter().any(|edge| {
+                edge.artifact_id == artifact.artifact_id
+                    && edge.from_workflow_id == workflow.workflow_id
+            })
+    });
+    if produced_by_workflow {
+        return false;
+    }
+    let consumed_by_workflow = spec.workflows.iter().any(|workflow| {
+        workflow.consumes.contains(&artifact.artifact_id)
+            || workflow.dependencies.contains(&artifact.artifact_id)
+            || spec.artifact_graph.iter().any(|edge| {
+                edge.artifact_id == artifact.artifact_id
+                    && edge.to_workflow_id == workflow.workflow_id
+            })
+    });
+    consumed_by_workflow
+}
+
+/// Collect the Homeboy-owned runtime artifacts a spec depends on, in declared order.
+pub(crate) fn homeboy_runtime_artifacts(
+    spec: &AgentTaskRepoLoopSpec,
+) -> Vec<&AgentTaskRepoLoopSpecArtifact> {
+    spec.artifacts
+        .iter()
+        .filter(|artifact| is_homeboy_runtime_artifact(spec, artifact))
+        .collect()
+}
+
+/// Validate that the spec's executable task bindings (`consumes`/`emits` and
+/// `dependencies` that reference artifacts) are backed by declared
+/// `artifact_flow` edges, so the executable plan can consume the controller
+/// spec as the single source of truth without inferring undeclared data flow.
+///
+/// Surfaces every binding violation at once as structured diagnostics rather
+/// than failing on the first mismatch, so a repo author can fix the spec in one
+/// pass. Homeboy-owned runtime artifacts are exempt from requiring a producer
+/// workflow edge because their producer is a Homeboy runtime stage, not a repo
+/// workflow.
+pub(crate) fn validate_artifact_flow_bindings(spec: &AgentTaskRepoLoopSpec) -> Result<()> {
+    let mut diagnostics = Vec::new();
+    for workflow in &spec.workflows {
+        let mut consumed: Vec<&String> = workflow.consumes.iter().collect();
+        for dependency in &workflow.dependencies {
+            if spec
+                .artifacts
+                .iter()
+                .any(|artifact| &artifact.artifact_id == dependency)
+                && !consumed.contains(&dependency)
+            {
+                consumed.push(dependency);
+            }
+        }
+        for artifact_id in consumed {
+            let runtime_owned = spec
+                .artifacts
+                .iter()
+                .find(|artifact| &artifact.artifact_id == artifact_id)
+                .map(|artifact| is_homeboy_runtime_artifact(spec, artifact))
+                .unwrap_or(false);
+            if runtime_owned {
+                // Producer is a Homeboy runtime stage; no repo workflow edge required.
+                continue;
+            }
+            let has_flow_edge = spec.artifact_graph.iter().any(|edge| {
+                &edge.artifact_id == artifact_id && edge.to_workflow_id == workflow.workflow_id
+            });
+            let has_repo_producer = spec.workflows.iter().any(|producer| {
+                producer.workflow_id != workflow.workflow_id
+                    && (producer.artifacts.contains(artifact_id)
+                        || producer.emits.contains(artifact_id))
+            });
+            if !has_flow_edge && !has_repo_producer {
+                diagnostics.push(format!(
+                    "workflow '{}' consumes artifact '{}' but no artifact_flow edge or producing workflow declares it; add an artifact_graph edge or declare the artifact as a Homeboy-owned runtime artifact",
+                    workflow.workflow_id, artifact_id
+                ));
+            }
+        }
+        for artifact_id in &workflow.emits {
+            let declared = spec
+                .artifacts
+                .iter()
+                .any(|artifact| &artifact.artifact_id == artifact_id);
+            if !declared {
+                diagnostics.push(format!(
+                    "workflow '{}' emits undeclared artifact '{}'",
+                    workflow.workflow_id, artifact_id
+                ));
+            }
+        }
+    }
+    if diagnostics.is_empty() {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "artifact_flow",
+        "repo loop spec task bindings must be backed by declared artifact_flow edges or producing workflows",
+        Some(spec.loop_id.clone()),
+        Some(diagnostics),
+    ))
+}
+
+/// Compile a loop controller spec into an executable agent-task plan whose
+/// stages and inter-stage dependencies are derived from the spec.
+///
+/// This is the from-spec compiler primitive (#5101): the executable plan builder
+/// consumes the controller spec as the single source of truth instead of being
+/// authored separately. Each workflow becomes one executable stage; stage
+/// dependencies (`needs`) are derived from `artifact_flow` (artifact_graph)
+/// edges plus `consumes`/`emits` bindings. Homeboy-owned runtime artifacts (e.g.
+/// `static_validation_run`) are represented as synthetic runtime stages that the
+/// consuming workflow stages depend on, so the data flow is complete without the
+/// repo declaring Homeboy internals.
+///
+/// Validation (`validate_loop_spec` + `validate_artifact_flow_bindings`) runs
+/// first; binding violations are surfaced as structured errors.
+pub(crate) fn compile_executable_plan_from_spec(
+    spec: &AgentTaskRepoLoopSpec,
+) -> Result<HomeboyPlan> {
+    validate_loop_spec(spec)?;
+    validate_artifact_flow_bindings(spec)?;
+
+    let spec_fingerprint = repo_loop_spec_fingerprint(spec)?;
+    let mut plan = HomeboyPlan::for_description(
+        PlanKind::AgentTask,
+        format!("executable plan from loop spec {}", spec.loop_id),
+    );
+    plan.id = format!("plan-from-spec.{}", spec.loop_id);
+    plan.mode = Some("plan".to_string());
+    plan.inputs.insert(
+        "schema".to_string(),
+        Value::String(EXECUTABLE_PLAN_FROM_SPEC_SCHEMA.to_string()),
+    );
+    plan.inputs
+        .insert("loop_id".to_string(), Value::String(spec.loop_id.clone()));
+    plan.inputs.insert(
+        "spec_fingerprint".to_string(),
+        Value::String(spec_fingerprint),
+    );
+    plan.inputs.insert(
+        "declarations".to_string(),
+        controller_spec_declarations(spec)?,
+    );
+
+    // Synthetic Homeboy-owned runtime stages: one per runtime artifact, emitting
+    // the artifact so consuming workflow stages can declare a dependency on a
+    // concrete producer stage instead of hard-coding Homeboy internals.
+    let runtime_artifacts = homeboy_runtime_artifacts(spec);
+    let runtime_stage_id = |artifact_id: &str| -> String { format!("runtime:{artifact_id}") };
+    for artifact in &runtime_artifacts {
+        let mut data = HashMap::new();
+        data.insert("kind".to_string(), Value::String(artifact.kind.clone()));
+        data.insert("required".to_string(), Value::Bool(artifact.required));
+        data.insert(
+            "owner".to_string(),
+            Value::String("homeboy_runtime".to_string()),
+        );
+        if let Some(description) = &artifact.description {
+            data.insert(
+                "description".to_string(),
+                Value::String(description.clone()),
+            );
+        }
+        plan.artifacts.push(PlanArtifact {
+            id: artifact.artifact_id.clone(),
+            path: None,
+            artifact_type: Some(artifact.kind.clone()),
+            data,
+        });
+        plan.steps.push(PlanStep {
+            id: runtime_stage_id(&artifact.artifact_id),
+            kind: HOMEBOY_RUNTIME_STAGE_KIND.to_string(),
+            label: Some(artifact.artifact_id.clone()),
+            blocking: artifact.required,
+            scope: Vec::new(),
+            needs: Vec::new(),
+            needs_kind: PlanStepDependencyKind::Execution,
+            status: PlanStepStatus::Ready,
+            inputs: HashMap::from([(
+                "runtime_artifact".to_string(),
+                serde_json::json!({
+                    "artifact_id": artifact.artifact_id,
+                    "kind": artifact.kind,
+                    "required": artifact.required,
+                    "owner": "homeboy_runtime",
+                }),
+            )]),
+            outputs: HashMap::from([(
+                "emits".to_string(),
+                Value::Array(vec![Value::String(artifact.artifact_id.clone())]),
+            )]),
+            skip_reason: None,
+            policy: HashMap::new(),
+            missing: Vec::new(),
+        });
+    }
+
+    // One executable stage per workflow; dependencies derived from artifact flow.
+    for workflow in &spec.workflows {
+        let needs = executable_stage_dependencies(spec, workflow, &runtime_artifacts);
+        plan.steps.push(PlanStep {
+            id: format!("stage:{}", workflow.workflow_id),
+            kind: "agent_task_dispatch".to_string(),
+            label: Some(workflow.workflow_id.clone()),
+            blocking: true,
+            scope: workflow_fan_out_entity_ids(workflow)?,
+            needs,
+            needs_kind: PlanStepDependencyKind::Execution,
+            status: PlanStepStatus::Ready,
+            inputs: HashMap::from([
+                (
+                    "workflow".to_string(),
+                    workflow_declaration_context(spec, workflow)?,
+                ),
+                (
+                    "plan".to_string(),
+                    serde_json::to_value(workflow_homeboy_plan(spec, workflow)?)
+                        .map_err(|error| Error::internal_json(error.to_string(), None))?,
+                ),
+            ]),
+            outputs: HashMap::from([(
+                "emits".to_string(),
+                Value::Array(
+                    workflow_emitted_artifacts(workflow)
+                        .into_iter()
+                        .map(Value::String)
+                        .collect(),
+                ),
+            )]),
+            skip_reason: None,
+            policy: HashMap::new(),
+            missing: Vec::new(),
+        });
+    }
+
+    plan.summary = Some(crate::core::plan::PlanSummary::from_steps(&plan.steps));
+    Ok(plan)
+}
+
+/// Artifacts a workflow produces (`artifacts` + `emits` + outbound flow edges).
+fn workflow_emitted_artifacts(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Vec<String> {
+    let mut emitted = workflow.artifacts.clone();
+    for artifact_id in &workflow.emits {
+        if !emitted.contains(artifact_id) {
+            emitted.push(artifact_id.clone());
+        }
+    }
+    emitted
+}
+
+/// Derive the executable stage dependencies (`needs`) for a workflow from the
+/// artifact flow: every consumed artifact resolves to the stage that produces
+/// it — either the producing workflow stage or the synthetic Homeboy runtime
+/// stage for a Homeboy-owned runtime artifact. Explicit workflow-id
+/// dependencies are preserved as stage dependencies as well.
+fn executable_stage_dependencies(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+    runtime_artifacts: &[&AgentTaskRepoLoopSpecArtifact],
+) -> Vec<String> {
+    let mut needs: Vec<String> = Vec::new();
+    fn push_unique(needs: &mut Vec<String>, value: String) {
+        if !needs.contains(&value) {
+            needs.push(value);
+        }
+    }
+
+    // Consumed artifacts: map each to its producing stage.
+    let mut consumed: Vec<String> = workflow.consumes.clone();
+    for dependency in &workflow.dependencies {
+        if spec
+            .artifacts
+            .iter()
+            .any(|artifact| &artifact.artifact_id == dependency)
+            && !consumed.contains(dependency)
+        {
+            consumed.push(dependency.clone());
+        }
+    }
+    for edge in spec
+        .artifact_graph
+        .iter()
+        .filter(|edge| edge.to_workflow_id == workflow.workflow_id)
+    {
+        if !consumed.contains(&edge.artifact_id) {
+            consumed.push(edge.artifact_id.clone());
+        }
+    }
+
+    for artifact_id in &consumed {
+        if runtime_artifacts
+            .iter()
+            .any(|artifact| &artifact.artifact_id == artifact_id)
+        {
+            push_unique(&mut needs, format!("runtime:{artifact_id}"));
+            continue;
+        }
+        // Prefer the explicit flow edge producer; otherwise any producing workflow.
+        let producer = spec
+            .artifact_graph
+            .iter()
+            .find(|edge| {
+                &edge.artifact_id == artifact_id && edge.to_workflow_id == workflow.workflow_id
+            })
+            .map(|edge| edge.from_workflow_id.clone())
+            .or_else(|| {
+                spec.workflows
+                    .iter()
+                    .find(|producer| {
+                        producer.workflow_id != workflow.workflow_id
+                            && (producer.artifacts.contains(artifact_id)
+                                || producer.emits.contains(artifact_id))
+                    })
+                    .map(|producer| producer.workflow_id.clone())
+            });
+        if let Some(producer) = producer {
+            push_unique(&mut needs, format!("stage:{producer}"));
+        }
+    }
+
+    // Explicit workflow-id dependencies become stage dependencies.
+    for dependency in &workflow.dependencies {
+        if spec
+            .workflows
+            .iter()
+            .any(|candidate| &candidate.workflow_id == dependency)
+        {
+            push_unique(&mut needs, format!("stage:{dependency}"));
+        }
+    }
+
+    needs
+}
+
 pub(super) fn validate_declared_ids<T, F>(
     field: String,
     requested: &[String],

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -3179,3 +3179,149 @@ fn run_failure_summary_falls_back_to_stopped_reason() {
     assert_eq!(summary.phase.as_deref(), Some("plan"));
     assert!(!summary.evidence_refs.is_empty());
 }
+
+fn plan_stage<'a>(plan: &'a HomeboyPlan, id: &str) -> &'a PlanStep {
+    plan.steps
+        .iter()
+        .find(|step| step.id == id)
+        .unwrap_or_else(|| panic!("plan stage '{id}' exists"))
+}
+
+#[test]
+fn compile_plan_from_spec_derives_stage_dependencies_from_artifact_flow() {
+    let mut spec = repo_loop_reconcile_spec("loop-plan-from-spec-flow");
+    spec.workflows
+        .iter_mut()
+        .find(|workflow| workflow.workflow_id == "generation")
+        .expect("generation workflow")
+        .emits = vec!["static_site_pull_request".to_string()];
+    let validation = spec
+        .workflows
+        .iter_mut()
+        .find(|workflow| workflow.workflow_id == "static_validation")
+        .expect("static validation workflow");
+    validation.dependencies = Vec::new();
+    validation.consumes = vec!["static_site_pull_request".to_string()];
+    spec.artifact_graph = vec![AgentTaskRepoLoopSpecArtifactGraphEdge {
+        artifact_id: "static_site_pull_request".to_string(),
+        from_workflow_id: "generation".to_string(),
+        to_workflow_id: "static_validation".to_string(),
+        required: true,
+    }];
+
+    let report = compile_plan_from_spec(ControllerPlanRequest { spec }).expect("plan compiles");
+
+    assert_eq!(report.schema, EXECUTABLE_PLAN_RESULT_SCHEMA);
+    assert_eq!(report.loop_id, "loop-plan-from-spec-flow");
+    assert!(report.spec_fingerprint.starts_with("sha256:"));
+    assert_eq!(report.plan.kind, PlanKind::AgentTask);
+
+    let generation = plan_stage(&report.plan, "stage:generation");
+    assert!(generation.needs.is_empty());
+    assert_eq!(
+        generation.outputs["emits"],
+        json!(["static_site_pull_request"])
+    );
+
+    let validation = plan_stage(&report.plan, "stage:static_validation");
+    assert_eq!(validation.needs, vec!["stage:generation".to_string()]);
+}
+
+#[test]
+fn compile_plan_from_spec_synthesizes_homeboy_runtime_artifact_stage() {
+    let mut spec = repo_loop_reconcile_spec("loop-plan-from-spec-runtime");
+    spec.workflows
+        .iter_mut()
+        .find(|workflow| workflow.workflow_id == "generation")
+        .expect("generation workflow")
+        .emits = vec!["static_site_pull_request".to_string()];
+    let validation = spec
+        .workflows
+        .iter_mut()
+        .find(|workflow| workflow.workflow_id == "static_validation")
+        .expect("static validation workflow");
+    validation.dependencies = Vec::new();
+    validation.consumes = vec![
+        "static_site_pull_request".to_string(),
+        "static_validation_run".to_string(),
+    ];
+    // Homeboy-owned runtime artifact: no workflow produces it, kind ends in `_run`.
+    spec.artifacts.push(AgentTaskRepoLoopSpecArtifact {
+        artifact_id: "static_validation_run".to_string(),
+        kind: "static_validation_run".to_string(),
+        description: Some("Homeboy static validation run".to_string()),
+        required: true,
+    });
+    spec.artifact_graph = vec![AgentTaskRepoLoopSpecArtifactGraphEdge {
+        artifact_id: "static_site_pull_request".to_string(),
+        from_workflow_id: "generation".to_string(),
+        to_workflow_id: "static_validation".to_string(),
+        required: true,
+    }];
+
+    let report = compile_plan_from_spec(ControllerPlanRequest { spec }).expect("plan compiles");
+
+    assert_eq!(
+        report.runtime_artifacts,
+        vec!["static_validation_run".to_string()]
+    );
+
+    let runtime_stage = plan_stage(&report.plan, "runtime:static_validation_run");
+    assert_eq!(runtime_stage.kind, "homeboy_runtime_artifact");
+    assert_eq!(
+        runtime_stage.inputs["runtime_artifact"]["owner"],
+        json!("homeboy_runtime")
+    );
+
+    let validation = plan_stage(&report.plan, "stage:static_validation");
+    assert!(validation.needs.contains(&"stage:generation".to_string()));
+    assert!(validation
+        .needs
+        .contains(&"runtime:static_validation_run".to_string()));
+
+    assert!(report
+        .plan
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.id == "static_validation_run"));
+}
+
+#[test]
+fn compile_plan_from_spec_rejects_unbacked_artifact_consumption() {
+    let mut spec = repo_loop_reconcile_spec("loop-plan-from-spec-unbacked");
+    let validation = spec
+        .workflows
+        .iter_mut()
+        .find(|workflow| workflow.workflow_id == "static_validation")
+        .expect("static validation workflow");
+    validation.dependencies = Vec::new();
+    // Consumes a repo artifact that no workflow emits and no artifact_flow edge backs.
+    validation.consumes = vec!["static_site_pull_request".to_string()];
+
+    let error = compile_plan_from_spec(ControllerPlanRequest { spec })
+        .expect_err("unbacked consumption rejected");
+    let message = error.to_string();
+    assert!(
+        message.contains("artifact_flow") || message.contains("static_site_pull_request"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
+fn validate_artifact_flow_bindings_accepts_emit_consume_pairing() {
+    let mut spec = repo_loop_reconcile_spec("loop-flow-bindings");
+    spec.workflows
+        .iter_mut()
+        .find(|workflow| workflow.workflow_id == "generation")
+        .expect("generation workflow")
+        .emits = vec!["static_site_pull_request".to_string()];
+    let validation = spec
+        .workflows
+        .iter_mut()
+        .find(|workflow| workflow.workflow_id == "static_validation")
+        .expect("static validation workflow");
+    validation.dependencies = Vec::new();
+    validation.consumes = vec!["static_site_pull_request".to_string()];
+
+    validate_artifact_flow_bindings(&spec).expect("emit/consume pairing is valid");
+}


### PR DESCRIPTION
Closes #5101. Adds a from-spec compiler/validation primitive that derives executable plan stages/dependencies from the loop controller spec and validates task bindings against artifact_flow edges.

## Summary
- New primitive `compile_executable_plan_from_spec` (in `spec_compile.rs`) reads a loop controller spec and derives an executable agent-task plan (`homeboy/agent-task-plan-from-spec/v1`): one stage per workflow, with inter-stage `needs` dependencies derived from `artifact_flow` (artifact_graph) edges plus `consumes`/`emits` bindings — the executable plan now consumes the controller spec as the single source of truth.
- New `validate_artifact_flow_bindings` validates that every workflow's consumed-artifact task bindings are backed by a declared `artifact_flow` edge or a producing workflow, surfacing all violations at once as structured diagnostics.
- Homeboy-owned runtime artifacts (e.g. `static_validation_run`) are represented generically (kind suffix `_run`, or consumed-but-unproduced) as synthetic `homeboy_runtime_artifact` stages that consuming workflow stages depend on — so downstream specs (WPSG) reference them without hard-coding Homeboy/Codebox internals.
- Public service entry point `agent_task_controller_service::compile_plan_from_spec` returns a typed `ControllerExecutablePlanReport` (plan + runtime artifact ids + spec fingerprint). No controller state is written.

## Scope
- Edited only `src/core/agent_task_controller_service/*` (mod.rs, reports.rs, spec_compile.rs, tests.rs). Out-of-scope `cargo fmt` churn reverted.

## Verification
- `cargo build --lib` clean (no new warnings).
- `cargo fmt` / `rustfmt --check` clean on scoped files.
- Added tests: stage-dependency derivation from artifact flow, runtime-artifact stage synthesis, rejection of unbacked artifact consumption, and emit/consume binding acceptance. CI runs the test suite.

## Deferred
- No CLI command surface added; the primitive is exposed at the service layer for callers (CLI/daemon/WPSG) to wire as needed.