### PR TITLE
fix(fuzz): keep render operation family generic

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -121,9 +121,11 @@ Operations keep the free-form `kind` string for product-owned semantics and can
 also carry a canonical `family` for cross-runner coverage reporting. When
 `family` is omitted, Homeboy normalizes known neutral kinds and HTTP-style verbs
 to families such as `read`, `create`, `update`, `delete`, `list`, `search`,
-`navigate`, `render`, `query`, `load`, `submit`, `block_render`, and
-`performance_probe`. Unknown `kind` values remain valid and are preserved without
-a canonical family.
+`navigate`, `render`, `query`, `load`, `submit`, and `performance_probe`.
+Product-specific render kinds, such as WordPress block rendering, should keep
+their precise meaning in `kind`, `target.kind`, tags, or metadata while using
+the generic `render` family for cross-runner reporting. Unknown `kind` values
+remain valid and are preserved without a canonical family.
 
 ```json
 {

--- a/src/commands/fuzz/planning.rs
+++ b/src/commands/fuzz/planning.rs
@@ -335,7 +335,6 @@ fn strategy_matches_operation(strategy: FuzzPlanStrategy, family: FuzzOperationF
                 | FuzzOperationFamily::Render
                 | FuzzOperationFamily::Query
                 | FuzzOperationFamily::Load
-                | FuzzOperationFamily::BlockRender
         ),
         FuzzPlanStrategy::Crud => matches!(
             family,
@@ -388,7 +387,6 @@ fn operation_family_name(family: FuzzOperationFamily) -> &'static str {
         FuzzOperationFamily::Query => "query",
         FuzzOperationFamily::Load => "load",
         FuzzOperationFamily::Submit => "submit",
-        FuzzOperationFamily::BlockRender => "block_render",
         FuzzOperationFamily::PerformanceProbe => "performance_probe",
     }
 }

--- a/src/core/fuzz/contract.rs
+++ b/src/core/fuzz/contract.rs
@@ -1,7 +1,7 @@
 //! Core fuzz contract envelope: safety classes, operation families, and the
 //! product-neutral schema registry surfaced by `fuzz_core_contract`.
 
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use super::schema_defaults::{
     fuzz_contract_version, fuzz_core_contract_schema, lifecycle_contract_schema,
@@ -73,8 +73,7 @@ pub enum FuzzSafetyClass {
     Destructive,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FuzzOperationFamily {
     Read,
     Create,
@@ -87,8 +86,61 @@ pub enum FuzzOperationFamily {
     Query,
     Load,
     Submit,
-    BlockRender,
     PerformanceProbe,
+}
+
+impl Serialize for FuzzOperationFamily {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(fuzz_operation_family_name(*self))
+    }
+}
+
+impl<'de> Deserialize<'de> for FuzzOperationFamily {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        canonical_operation_family(&value).ok_or_else(|| {
+            de::Error::unknown_variant(
+                &value,
+                &[
+                    "read",
+                    "create",
+                    "update",
+                    "delete",
+                    "list",
+                    "search",
+                    "navigate",
+                    "render",
+                    "query",
+                    "load",
+                    "submit",
+                    "performance_probe",
+                ],
+            )
+        })
+    }
+}
+
+fn fuzz_operation_family_name(family: FuzzOperationFamily) -> &'static str {
+    match family {
+        FuzzOperationFamily::Read => "read",
+        FuzzOperationFamily::Create => "create",
+        FuzzOperationFamily::Update => "update",
+        FuzzOperationFamily::Delete => "delete",
+        FuzzOperationFamily::List => "list",
+        FuzzOperationFamily::Search => "search",
+        FuzzOperationFamily::Navigate => "navigate",
+        FuzzOperationFamily::Render => "render",
+        FuzzOperationFamily::Query => "query",
+        FuzzOperationFamily::Load => "load",
+        FuzzOperationFamily::Submit => "submit",
+        FuzzOperationFamily::PerformanceProbe => "performance_probe",
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -110,11 +162,10 @@ pub fn canonical_operation_family(kind: &str) -> Option<FuzzOperationFamily> {
         "list" => Some(FuzzOperationFamily::List),
         "search" => Some(FuzzOperationFamily::Search),
         "navigate" => Some(FuzzOperationFamily::Navigate),
-        "render" => Some(FuzzOperationFamily::Render),
+        "render" | "block_render" => Some(FuzzOperationFamily::Render),
         "query" => Some(FuzzOperationFamily::Query),
         "load" => Some(FuzzOperationFamily::Load),
         "submit" => Some(FuzzOperationFamily::Submit),
-        "block_render" => Some(FuzzOperationFamily::BlockRender),
         "performance_probe" => Some(FuzzOperationFamily::PerformanceProbe),
         _ => None,
     }
@@ -180,7 +231,6 @@ pub(super) fn default_fuzz_operation_families() -> Vec<FuzzOperationFamily> {
         FuzzOperationFamily::Query,
         FuzzOperationFamily::Load,
         FuzzOperationFamily::Submit,
-        FuzzOperationFamily::BlockRender,
         FuzzOperationFamily::PerformanceProbe,
     ]
 }

--- a/src/core/fuzz/tests/contract_tests.rs
+++ b/src/core/fuzz/tests/contract_tests.rs
@@ -90,7 +90,7 @@ fn core_contract_deserializes_without_operation_families() {
         .contains(&FuzzOperationFamily::Read));
     assert!(contract
         .operation_families
-        .contains(&FuzzOperationFamily::BlockRender));
+        .contains(&FuzzOperationFamily::Render));
 }
 
 #[test]

--- a/src/core/fuzz/tests/surface_tests.rs
+++ b/src/core/fuzz/tests/surface_tests.rs
@@ -83,7 +83,7 @@ fn operation_normalizes_canonical_families_from_kind() {
             Some(FuzzOperationFamily::Create),
             Some(FuzzOperationFamily::Update),
             Some(FuzzOperationFamily::Delete),
-            Some(FuzzOperationFamily::BlockRender),
+            Some(FuzzOperationFamily::Render),
             Some(FuzzOperationFamily::PerformanceProbe),
         ]
     );
@@ -106,5 +106,30 @@ fn operation_preserves_declared_canonical_family() {
     assert_eq!(
         surface.operations[0].family,
         Some(FuzzOperationFamily::Search)
+    );
+}
+
+#[test]
+fn operation_reads_legacy_block_render_family_as_render() {
+    let surface = FuzzSurface::from_value(json!({
+        "id": "surface-1",
+        "kind": "renderer",
+        "safety_class": "read_only",
+        "operations": [
+            { "id": "render-specialized-unit", "kind": "block_render", "family": "block_render" }
+        ]
+    }))
+    .expect("surface contract");
+
+    assert_eq!(surface.operations[0].kind, "block_render");
+    assert_eq!(
+        surface.operations[0].family,
+        Some(FuzzOperationFamily::Render)
+    );
+
+    let serialized = serde_json::to_value(&surface).expect("serialized surface");
+    assert_eq!(
+        serialized["operations"][0]["family"],
+        serde_json::json!("render")
     );
 }


### PR DESCRIPTION
## Summary
- remove the Homeboy core-specific block_render operation family
- canonicalize legacy block_render operation kinds/families to generic render
- document that product-specific render semantics belong in kind, target.kind, tags, or metadata

## Testing
- cargo test fuzz::
- cargo test core_agnostic
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing the fuzz operation family boundary, implementing the cleanup, updating tests/docs, and running verification.