### PR TITLE
feat(lab): materialize validation dependency graph on Lab offload (#3292)

### DIFF
--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -81,7 +81,7 @@ use super::super::lab_workspaces::{
     preflight_provider_config_source_cli_dependencies, provider_config_extra_workspaces,
     rig_component_path_env_extra_workspaces, sync_extra_lab_workspaces,
     workspace_mapping_entries_for_git_dependency, workspace_mapping_entry,
-    LabWorkspaceMappingEntry,
+    workspace_mapping_entry_for_validation_dependency, LabWorkspaceMappingEntry,
 };
 use super::super::offload_changed_since::LabOffloadChangedSincePreflight;
 use super::super::{

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -106,6 +106,35 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
     .0;
     let remote_cwd = synced.remote_path.clone();
     let mut workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
+    // The primary workspace sync materializes each declared dependency checkout
+    // alongside the primary remote path (as a sibling) and reports them as
+    // `validation_dependencies`. Fold those into the offload workspace mapping so
+    // their controller-local -> remote path pairs propagate into the remote
+    // command's path remaps. Without this the dependency graph exists on the
+    // runner but the offloaded command still carries controller-local dependency
+    // paths, so a remote dependency resolver cannot find the materialized
+    // checkouts (#3292). Components with no declared dependencies produce an
+    // empty list here, leaving the single-checkout offload path unchanged.
+    for dependency in &synced.validation_dependencies {
+        workspace_mapping.push(workspace_mapping_entry_for_validation_dependency(
+            dependency,
+        ));
+    }
+    if !synced.validation_dependencies.is_empty() {
+        plan = with_step(
+            plan,
+            PlanStep::ready(
+                "lab.materialize_dependency_graph",
+                "lab.materialize_dependency_graph",
+            )
+            .inputs(
+                PlanValues::new()
+                    .json("count", synced.validation_dependencies.len())
+                    .json("dependencies", &synced.validation_dependencies),
+            )
+            .build(),
+        );
+    }
     plan = with_step(
         plan,
         PlanStep::ready("lab.sync_workspace", "lab.sync_workspace")

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -15,8 +15,8 @@ use super::lab_workspaces_deps::{
     provider_config_source_cli_files,
 };
 use super::{
-    sync_workspace, RunnerGitDependencyMaterializationOutput, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    sync_workspace, RunnerGitDependencyMaterializationOutput, RunnerValidationDependencySyncOutput,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
 pub(super) const LAB_EXTRA_WORKSPACES_ENV: &str = concat!("HOME", "BOY_LAB_EXTRA_WORKSPACES");
@@ -108,6 +108,31 @@ pub(super) fn workspace_mapping_entry(
         sync_mode: synced.sync_mode.label().to_string(),
         snapshot_identity: synced.snapshot_identity.clone(),
         dependency_freshness: None,
+    }
+}
+
+/// Build a workspace-mapping entry for a declared dependency checkout that the
+/// primary workspace sync already materialized on the runner (as a sibling of
+/// the primary remote path). Folding these into the offload workspace mapping
+/// propagates their local->remote path pairs into the remote command's path
+/// remaps, so an extension dependency resolver running on the runner receives
+/// usable remote paths instead of controller-local ones. Kept generic: the
+/// dependency graph is an opaque id->path mapping with no ecosystem semantics.
+pub(super) fn workspace_mapping_entry_for_validation_dependency(
+    dependency: &RunnerValidationDependencySyncOutput,
+) -> LabWorkspaceMappingEntry {
+    LabWorkspaceMappingEntry {
+        role: dependency.role.clone(),
+        local_path: dependency.local_path.clone(),
+        remote_path: dependency.remote_path.clone(),
+        sync_mode: RunnerWorkspaceSyncMode::Snapshot.label().to_string(),
+        snapshot_identity: dependency.id.clone(),
+        dependency_freshness: Some(serde_json::json!({
+            "id": dependency.id.as_str(),
+            "local_path": dependency.local_path.as_str(),
+            "evidence_path": dependency.evidence_path.as_str(),
+            "source_provenance": "validation_dependency_sibling",
+        })),
     }
 }
 
@@ -1193,5 +1218,47 @@ mod provider_config_candidate_paths_tests {
         assert_eq!(err.details["field"], "provider_config");
         assert!(err.message.contains("@example/provider-core"));
         assert!(err.message.contains("index.js"));
+    }
+}
+
+#[cfg(test)]
+mod validation_dependency_mapping_tests {
+    use super::workspace_mapping_entry_for_validation_dependency;
+    use crate::core::runner::RunnerValidationDependencySyncOutput;
+
+    fn dependency_output() -> RunnerValidationDependencySyncOutput {
+        RunnerValidationDependencySyncOutput {
+            id: "shared-runtime".to_string(),
+            role: "validation_dependency".to_string(),
+            local_path: "/Users/dev/Developer/shared-runtime".to_string(),
+            remote_path: "/srv/_lab_workspaces/shared-runtime".to_string(),
+            evidence_path: "/srv/_lab_workspaces/shared-runtime/.homeboy/lab-source-evidence.json"
+                .to_string(),
+        }
+    }
+
+    #[test]
+    fn maps_dependency_local_path_to_materialized_remote_path() {
+        let entry = workspace_mapping_entry_for_validation_dependency(&dependency_output());
+
+        // The controller-local checkout path must remap to the runner-side
+        // materialized path so remote dependency resolvers receive usable paths
+        // instead of controller-local ones (#3292).
+        assert_eq!(entry.local_path(), "/Users/dev/Developer/shared-runtime");
+        assert_eq!(entry.remote_path(), "/srv/_lab_workspaces/shared-runtime");
+    }
+
+    #[test]
+    fn preserves_dependency_role_and_identity_metadata() {
+        let entry = workspace_mapping_entry_for_validation_dependency(&dependency_output());
+
+        let value = serde_json::to_value(&entry).expect("serialize mapping entry");
+        assert_eq!(value["role"], "validation_dependency");
+        assert_eq!(value["snapshot_identity"], "shared-runtime");
+        assert_eq!(
+            value["dependency_freshness"]["source_provenance"],
+            "validation_dependency_sibling"
+        );
+        assert_eq!(value["dependency_freshness"]["id"], "shared-runtime");
     }
 }


### PR DESCRIPTION
Closes #3292.

## Problem
Lab offload synced only the requested component checkout into the remote `_lab_workspaces/...` dir. The primary workspace sync (`sync_workspace`) already materializes each declared dependency checkout as a sibling of the primary remote path and returns them as `validation_dependencies` — but the Lab offload path never consumed that list. The materialized dependency checkouts existed on the runner, yet the offloaded command still carried controller-local dependency paths, so a remote extension dependency resolver could not resolve them (`Could not resolve validation dependency <X>`).

## Fix
In `prepare_lab_offload_workspace_stage`, fold `synced.validation_dependencies` into the offload `workspace_mapping` right after the primary entry. This propagates each dependency's controller-local -> remote path pair into the command's path remaps, so the remote command receives usable remote dependency paths instead of local ones. A `lab.materialize_dependency_graph` plan step records the graph when present.

- Reuses the existing primary-sync materialization (no duplicate sync / no reinvented contract).
- Single-checkout behavior unchanged for components with no declared dependencies (empty list => no-op).
- Generic / language-agnostic: the dependency graph is an opaque id->path mapping; no ecosystem literals.

## Tests
Added `validation_dependency_mapping_tests`:
- `maps_dependency_local_path_to_materialized_remote_path` — verifies local->remote remap.
- `preserves_dependency_role_and_identity_metadata` — verifies role/identity/provenance metadata.

Verified `cargo build --lib` + `cargo fmt` (scope-only).