### PR TITLE
feat(lab): first-class homeboy lab fuzz run/list route (#5790)

### DIFF
--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -26,7 +26,7 @@ impl FuzzArgs {
     }
 
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
-        self.is_run_invocation()
+        self.is_lab_offload_command()
             .then(|| LabCommandContract::portable_workload(FUZZ_LAB_LABEL, None, true, &[]))
     }
 
@@ -34,8 +34,24 @@ impl FuzzArgs {
         matches!(self.command, None | Some(FuzzCommand::Run(_)))
     }
 
+    /// Fuzz subcommands that offload to the configured Lab runner. `run`
+    /// executes the workload remotely; `list` enumerates the runner-resident
+    /// rig/extension fuzz workloads so the operator sees the same inventory the
+    /// runner would execute rather than the (possibly empty) local one. This
+    /// mirrors `bench`'s `is_lab_offload_command`, which routes its discovery
+    /// subcommands to the runner alongside `run`.
+    pub fn is_lab_offload_command(&self) -> bool {
+        matches!(
+            self.command,
+            None | Some(FuzzCommand::Run(_)) | Some(FuzzCommand::List(_))
+        )
+    }
+
     pub fn extension_override_ids(&self) -> &[String] {
-        self.run.extension_override.extensions.as_slice()
+        match &self.command {
+            Some(FuzzCommand::List(list)) => list.extension_override.extensions.as_slice(),
+            _ => self.run.extension_override.extensions.as_slice(),
+        }
     }
 }
 

--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -205,6 +205,11 @@ pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
             purpose: "Resolve the latest benchmark run id for evidence inspection.",
         },
         LabFollowup {
+            label: "latest_fuzz_run",
+            command: "homeboy runs latest-run --kind fuzz".to_string(),
+            purpose: "Resolve the latest fuzz run id for evidence inspection.",
+        },
+        LabFollowup {
             label: "run_artifacts",
             command: "homeboy runs artifacts <run-id>".to_string(),
             purpose: "List recorded run artifacts through Homeboy.",
@@ -218,6 +223,11 @@ pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
             label: "run_refs",
             command: "homeboy runs refs --kind bench --limit 10".to_string(),
             purpose: "List recent benchmark run and artifact refs.",
+        },
+        LabFollowup {
+            label: "fuzz_run_refs",
+            command: "homeboy runs refs --kind fuzz --limit 10".to_string(),
+            purpose: "List recent fuzz run and artifact refs.",
         },
     ];
     let Some(runner_id) = runner_id else {

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -44,6 +44,13 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
         ),
         (parsed_command(&["homeboy", "fuzz"]), "fuzz"),
         (parsed_command(&["homeboy", "fuzz", "run"]), "fuzz"),
+        // `fuzz list` offloads (unlike `bench list`) because fuzz workloads are
+        // rig/extension-declared and may only exist on the runner, so the
+        // operator must see the runner-resident inventory, not the local one.
+        (
+            parsed_command(&["homeboy", "fuzz", "list", "--rig", "studio"]),
+            "fuzz",
+        ),
         (parsed_command(&["homeboy", "trace"]), "trace"),
         (
             parsed_command(&["homeboy", "refactor", "--from", "audit"]),
@@ -384,6 +391,43 @@ fn test_supports_lab_runner() {
     assert!(cli.force_hot);
     assert!(cli.allow_local_hot);
     assert!(cli.command.supports_lab_runner());
+}
+
+#[test]
+fn fuzz_run_and_list_offload_but_other_subcommands_stay_local() {
+    // `fuzz run` and `fuzz list` select the configured Lab runner so both the
+    // workload execution and the runner-resident workload inventory route to
+    // the runner. This mirrors how `bench run`/discovery offload while keeping
+    // the read-only/local-only fuzz subcommands (contract, plan, validate,
+    // report, compare, replay, inspect) local.
+    for args in [
+        ["homeboy", "fuzz", "run"].as_slice(),
+        ["homeboy", "fuzz", "list"].as_slice(),
+        ["homeboy", "fuzz", "list", "--rig", "studio"].as_slice(),
+    ] {
+        let command = parsed_command(args);
+        assert!(
+            command.supports_lab_runner(),
+            "expected {args:?} to support Lab offload"
+        );
+        let contract = command.lab_contract().expect("fuzz offload contract");
+        assert_eq!(contract.hot_label, "fuzz");
+        assert_eq!(contract.portability, LabCommandPortability::Portable);
+    }
+
+    for args in [
+        ["homeboy", "fuzz", "contract"].as_slice(),
+        ["homeboy", "fuzz", "plan"].as_slice(),
+        ["homeboy", "fuzz", "validate", "campaign.json"].as_slice(),
+        ["homeboy", "fuzz", "inspect", "run-123"].as_slice(),
+    ] {
+        let command = parsed_command(args);
+        assert!(
+            !command.supports_lab_runner(),
+            "expected {args:?} to stay local"
+        );
+        assert!(command.lab_contract().is_none());
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #5790.

## Context
The standalone `homeboy lab` command surface (`lab bench` / `lab extension-sync` / `lab status`) was **removed** in v0.253.1 ("Remove hidden lab command surface", commit `617fe0c6`) and folded into the portability-contract auto-offload model plus `homeboy runner status`. There is no longer a `homeboy lab <sub>` command to mirror — `homeboy fuzz`/`homeboy bench` already auto-offload to the configured Lab runner via their `lab_contract()`, and `homeboy runner status` surfaces the selected runner + managed followups. So this implements the issue's intent against the current architecture rather than reviving the deleted command.

## What this does
- **`homeboy fuzz list` now offloads to the configured Lab runner** (previously only `fuzz run` did). Fuzz workloads are rig/extension-declared and may only exist on the runner, so a local `fuzz list --rig <rig>` was misleading — it now enumerates the runner-resident inventory the runner would actually execute. This is the architecture-correct equivalent of the issue's requested `lab fuzz list --rig <rig>`. `fuzz run --rig --workload --run-id ...` already auto-offloaded and selects the configured runner Homeboy binary.
  - `FuzzArgs::lab_contract` now routes through a new `is_lab_offload_command()` (`None | run | list`), mirroring `bench`'s `is_lab_offload_command`.
  - `extension_override_ids()` reads the `list` subcommand's extension overrides so extension-parity preflight is correct for offloaded `fuzz list`.
  - Read-only/local fuzz subcommands (contract, plan, validate, report, compare, replay, inspect) stay local.
- **`homeboy runner status` now advertises fuzz evidence followups** alongside bench (`latest_fuzz_run` -> `runs latest-run --kind fuzz`, `fuzz_run_refs` -> `runs refs --kind fuzz`), so the operator gets the same structured evidence followups for fuzz as for bench. (The runner availability check already probes `fuzz --help`.)

## Tests
- Added `fuzz_run_and_list_offload_but_other_subcommands_stay_local` and a `fuzz list --rig` case to the supported-Lab-command matrix in `tests/command_contract/lab_test.rs`.

## Verification
- `cargo build --lib` clean; `cargo fmt` (reverted out-of-scope formatting churn — only the 3 intentional files committed).
- Scope limited to `src/commands/fuzz/types.rs`, `src/commands/runner/status.rs`, `tests/command_contract/lab_test.rs`. No changes to `lab bench`/`extension-sync` behavior, release/, or changelog.