### PR TITLE
feat(lab): actionable error context for Lab orchestration failures (#4336)

### DIFF
--- a/src/core/runner/lab/offload/errors.rs
+++ b/src/core/runner/lab/offload/errors.rs
@@ -422,3 +422,109 @@ pub(crate) fn append_runner_component_registry_repair_hint(
 pub(crate) fn contains_component_not_found(output: &str) -> bool {
     output.contains("component.not_found") || output.contains("Component not found")
 }
+
+/// Known orchestration context for a Lab offload pre-execution stage. Every
+/// field that is populated is woven into a Lab-cannot-proceed error so the
+/// operator can self-serve a fix without SSH-ing into the runner to reconstruct
+/// which runner/workspace/ref/dependency the offload was working against
+/// (#4336).
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LabOrchestrationContext {
+    /// Runner the offload selected to execute on.
+    pub(crate) runner_id: Option<String>,
+    /// Controller-local primary workspace path being materialized to the runner.
+    pub(crate) workspace_path: Option<String>,
+    /// Requested ref/base (e.g. the `--changed-since` ref) when one was named.
+    pub(crate) ref_base: Option<String>,
+    /// Dependency (checkout/override) at fault, when the failure is attributable
+    /// to a specific declared dependency rather than the primary workspace.
+    pub(crate) dependency: Option<String>,
+}
+
+impl LabOrchestrationContext {
+    pub(crate) fn for_runner_workspace(runner_id: &str, workspace_path: &str) -> Self {
+        Self {
+            runner_id: Some(runner_id.to_string()),
+            workspace_path: Some(workspace_path.to_string()),
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn with_ref_base(mut self, ref_base: Option<String>) -> Self {
+        self.ref_base = ref_base.filter(|value| !value.trim().is_empty());
+        self
+    }
+
+    /// True once at least one orchestration fact is known and worth surfacing.
+    fn has_context(&self) -> bool {
+        self.runner_id.is_some()
+            || self.workspace_path.is_some()
+            || self.ref_base.is_some()
+            || self.dependency.is_some()
+    }
+}
+
+/// Enrich a Lab-cannot-proceed error with the orchestration context the
+/// operator needs to self-serve a fix: the selected runner, the primary
+/// workspace path, the ref/base, the dependency at fault (when known), plus a
+/// concrete Homeboy command to reconcile runner state and retry.
+///
+/// Idempotent: re-enriching an already-enriched error (e.g. when the same error
+/// bubbles through nested stages) does not duplicate the context block or the
+/// fix hints. Keeps the original error code/message; only adds details + hints.
+pub(crate) fn enrich_lab_cannot_proceed_error(
+    mut error: Error,
+    context: &LabOrchestrationContext,
+) -> Error {
+    if !context.has_context() {
+        return error;
+    }
+    // Idempotency guard: only attach the orchestration context once.
+    if error.details.get("lab_orchestration_context").is_some() {
+        return error;
+    }
+
+    if error.details.is_object() {
+        if let Some(map) = error.details.as_object_mut() {
+            map.insert(
+                "lab_orchestration_context".to_string(),
+                serde_json::json!({
+                    "runner_id": context.runner_id,
+                    "workspace_path": context.workspace_path,
+                    "ref_base": context.ref_base,
+                    "dependency": context.dependency,
+                }),
+            );
+        }
+    }
+
+    if let Some(runner_id) = &context.runner_id {
+        error = error.with_hint(format!(
+            "Lab cannot proceed on selected runner `{runner_id}`."
+        ));
+    }
+    if let Some(workspace_path) = &context.workspace_path {
+        error = error.with_hint(format!("Primary workspace: `{workspace_path}`."));
+    }
+    if let Some(ref_base) = &context.ref_base {
+        error = error.with_hint(format!("Requested ref/base: `{ref_base}`."));
+    }
+    if let Some(dependency) = &context.dependency {
+        error = error.with_hint(format!("Dependency at fault: `{dependency}`."));
+    }
+
+    // Concrete Homeboy command to fix it. Kept generic (homeboy subcommands
+    // only — no ecosystem tooling) so the core-agnostic-source gate stays green.
+    if let Some(runner_id) = &context.runner_id {
+        error = error.with_hint(format!(
+            "Fix runner state and retry: `homeboy runner status {runner_id}`, then re-materialize dependencies with `homeboy deps install` and re-run the Lab command."
+        ));
+    } else {
+        error = error.with_hint(
+            "Fix runner state and retry: select an available runner with `homeboy runner status`, re-materialize dependencies with `homeboy deps install`, and re-run the Lab command."
+                .to_string(),
+        );
+    }
+
+    error
+}

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -87,13 +87,13 @@ use super::super::lab_workspaces::{
 };
 use super::super::offload_changed_since::LabOffloadChangedSincePreflight;
 use super::super::{
-    evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_metadata,
-    lab_offload_metadata_with_workspace_mapping, load, plan_managed_runner_source_syncs,
-    preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
-    prepare_lab_runner_capability, rig_materialization, status, sync_workspace,
-    LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions, RunnerStatusReport,
-    RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
-    RunnerWorkspaceSyncOutput,
+    evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_changed_since_ref,
+    lab_offload_metadata, lab_offload_metadata_with_workspace_mapping, load,
+    plan_managed_runner_source_syncs, preflight_lab_offload_changed_since,
+    prepare_git_lab_offload_changed_since, prepare_lab_runner_capability, rig_materialization,
+    status, sync_workspace, LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions,
+    RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
 use super::super::workload::{build_runner_workload, RunnerWorkloadBuildInput};

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -493,3 +493,89 @@ fn lab_structured_output_file_is_written_outside_the_checkout() {
     assert!(output_file.ends_with(".json"));
     assert!(output_file.contains("homeboy-lab-structured-output-"));
 }
+
+#[test]
+fn lab_cannot_proceed_error_names_runner_workspace_ref_dependency_and_fix_command() {
+    // A bare dependency-resolution failure as it surfaces today, before
+    // orchestration context is woven in.
+    let bare = Error::validation_invalid_argument(
+        "dependency",
+        "Could not resolve dependency checkout",
+        Some("sample-dependency".to_string()),
+        None,
+    );
+
+    let mut context = LabOrchestrationContext::for_runner_workspace(
+        "homeboy-lab",
+        "/Users/dev/Developer/sample-project",
+    )
+    .with_ref_base(Some("origin/main".to_string()));
+    context.dependency = Some("sample-dependency".to_string());
+
+    let enriched = enrich_lab_cannot_proceed_error(bare, &context);
+
+    // Structured context for machine consumers.
+    let ctx = &enriched.details["lab_orchestration_context"];
+    assert_eq!(ctx["runner_id"], "homeboy-lab");
+    assert_eq!(ctx["workspace_path"], "/Users/dev/Developer/sample-project");
+    assert_eq!(ctx["ref_base"], "origin/main");
+    assert_eq!(ctx["dependency"], "sample-dependency");
+
+    // Operator-facing hints name each known fact plus a Homeboy fix command.
+    let hints = enriched
+        .hints
+        .iter()
+        .map(|hint| hint.message.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        hints.iter().any(|hint| hint.contains("homeboy-lab")),
+        "missing selected runner: {hints:?}"
+    );
+    assert!(
+        hints
+            .iter()
+            .any(|hint| hint.contains("/Users/dev/Developer/sample-project")),
+        "missing workspace path: {hints:?}"
+    );
+    assert!(
+        hints.iter().any(|hint| hint.contains("origin/main")),
+        "missing ref/base: {hints:?}"
+    );
+    assert!(
+        hints.iter().any(|hint| hint.contains("sample-dependency")),
+        "missing dependency: {hints:?}"
+    );
+    assert!(
+        hints
+            .iter()
+            .any(|hint| hint.contains("homeboy runner status homeboy-lab")
+                && hint.contains("homeboy deps install")),
+        "missing concrete Homeboy fix command: {hints:?}"
+    );
+}
+
+#[test]
+fn lab_cannot_proceed_enrichment_is_idempotent() {
+    let bare = Error::validation_invalid_argument(
+        "changed_since",
+        "Lab offload cannot resolve the requested --changed-since base before dispatch",
+        Some("origin/main".to_string()),
+        None,
+    );
+    let context = LabOrchestrationContext::for_runner_workspace(
+        "homeboy-lab",
+        "/Users/dev/Developer/sample-project",
+    )
+    .with_ref_base(Some("origin/main".to_string()));
+
+    let once = enrich_lab_cannot_proceed_error(bare, &context);
+    let hints_after_first = once.hints.len();
+    let twice = enrich_lab_cannot_proceed_error(once, &context);
+
+    // Re-enriching the same error must not duplicate context or fix hints.
+    assert_eq!(twice.hints.len(), hints_after_first);
+    assert_eq!(
+        twice.details["lab_orchestration_context"]["runner_id"],
+        "homeboy-lab"
+    );
+}

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -28,6 +28,42 @@ pub(crate) struct LabOffloadWorkspaceStage {
 pub(crate) fn prepare_lab_offload_workspace_stage(
     request: &LabOffloadRequest<'_>,
     contract: &LabOffloadCommand,
+    plan: HomeboyPlan,
+    runner_id: &str,
+    source_path: &Path,
+    homeboy_path: &str,
+    command_prefix_argv: &[String],
+    runner_workspace_root: Option<&str>,
+) -> Result<LabOffloadWorkspaceStage> {
+    // Capture the orchestration facts known *before* staging so any
+    // Lab-cannot-proceed error bubbling out of the pre-execution/dispatch path
+    // names the selected runner, primary workspace, and ref/base, plus a
+    // Homeboy command to fix it — instead of a bare resolver/sync error that
+    // forces the operator to SSH into the runner to reconstruct context
+    // (#4336).
+    let context = LabOrchestrationContext::for_runner_workspace(
+        runner_id,
+        &source_path.display().to_string(),
+    )
+    .with_ref_base(lab_offload_changed_since_ref(request.normalized_args));
+
+    prepare_lab_offload_workspace_stage_inner(
+        request,
+        contract,
+        plan,
+        runner_id,
+        source_path,
+        homeboy_path,
+        command_prefix_argv,
+        runner_workspace_root,
+    )
+    .map_err(|error| enrich_lab_cannot_proceed_error(error, &context))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_lab_offload_workspace_stage_inner(
+    request: &LabOffloadRequest<'_>,
+    contract: &LabOffloadCommand,
     mut plan: HomeboyPlan,
     runner_id: &str,
     source_path: &Path,


### PR DESCRIPTION
Partial #4336 (error-context slice). Lab-cannot-proceed errors now name the selected runner, workspace, ref/base, and dependency at fault, plus a Homeboy command to fix it — so routine Lab verification does not require SSH spelunking. Kept generic/agnostic; reuses the existing failure-summary/fix-hint pattern. Other #4336 bullets (env parity, managed dep build/rerun, artifact path classification, durable status promotion) remain as follow-up slices.