### PR TITLE
feat(lab): structured Lab offload overhead timings in run metadata (#3001)

### DIFF
--- a/src/core/runner/lab/fallback.rs
+++ b/src/core/runner/lab/fallback.rs
@@ -4,7 +4,7 @@ use crate::core::plan::HomeboyPlan;
 use crate::core::runner::lab_offload_metadata;
 use crate::core::Error;
 
-use super::offload::LabOffloadOutcome;
+use super::offload::{attach_lab_offload_overhead, LabOffloadOutcome, LabOffloadOverhead};
 
 /// Build the `RunLocal` outcome used whenever automatic Lab offload is skipped
 /// for a portability/default-runner reason. Centralizes the repeated
@@ -20,6 +20,31 @@ pub(super) fn skipped_automatic_run_local(plan: HomeboyPlan, reason: &str) -> La
             None,
             Some(reason),
         )),
+        plan,
+        messages: Vec::new(),
+    }
+}
+
+/// Same as [`skipped_automatic_run_local`], but also attaches the runner-agnostic
+/// Lab offload overhead (#3001) so a skipped/fallback-to-local run still records
+/// the per-phase setup timings and fallback reason gathered so far.
+pub(super) fn skipped_automatic_run_local_with_overhead(
+    plan: HomeboyPlan,
+    reason: &str,
+    overhead: &LabOffloadOverhead,
+) -> LabOffloadOutcome {
+    let mut metadata = lab_offload_metadata(
+        &plan,
+        "automatic",
+        None,
+        None,
+        "skipped",
+        None,
+        Some(reason),
+    );
+    attach_lab_offload_overhead(&mut metadata, overhead);
+    LabOffloadOutcome::RunLocal {
+        metadata: Some(metadata),
         plan,
         messages: Vec::new(),
     }

--- a/src/core/runner/lab/offload/errors.rs
+++ b/src/core/runner/lab/offload/errors.rs
@@ -243,17 +243,20 @@ pub(crate) fn automatic_capability_fallback(
     runner_id: &str,
     runner_status: &RunnerStatusReport,
     reason: String,
+    overhead: &LabOffloadOverhead,
 ) -> LabOffloadOutcome {
+    let mut metadata = lab_offload_metadata(
+        &plan,
+        "automatic",
+        Some(runner_id),
+        Some(status_tunnel_mode(runner_status).metadata_value()),
+        "fallback",
+        None,
+        Some(&reason),
+    );
+    attach_lab_offload_overhead(&mut metadata, overhead);
     LabOffloadOutcome::RunLocal {
-        metadata: Some(lab_offload_metadata(
-            &plan,
-            "automatic",
-            Some(runner_id),
-            Some(status_tunnel_mode(runner_status).metadata_value()),
-            "fallback",
-            None,
-            Some(&reason),
-        )),
+        metadata: Some(metadata),
         plan,
         messages: vec![format!("Lab offload: {reason}; running locally.")],
     }
@@ -267,6 +270,7 @@ pub(crate) fn automatic_capability_fallback_or_error(
     remediation: Vec<String>,
     allow_local_fallback: bool,
     deny_local_execution: bool,
+    overhead: &LabOffloadOverhead,
 ) -> Result<LabOffloadOutcome> {
     if deny_local_execution {
         return Err(local_execution_denied_error(
@@ -288,6 +292,7 @@ pub(crate) fn automatic_capability_fallback_or_error(
         &selection.runner_id,
         runner_status,
         reason,
+        overhead,
     ))
 }
 

--- a/src/core/runner/lab/offload/execute.rs
+++ b/src/core/runner/lab/offload/execute.rs
@@ -100,12 +100,20 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         request.normalized_args,
     )?;
 
+    // Begin runner-agnostic overhead accounting (#3001). Each setup phase
+    // (selection, preflight, workspace sync, output parse, artifact import) is
+    // timed independently so reports can separate `lab_overhead_ms` from the
+    // workload command duration, regardless of runner transport.
+    let mut overhead = LabOffloadOverhead::start();
+
+    let selection_timer = overhead.phase(LabOffloadPhase::Selection);
     let selection = resolve_lab_runner_selection(
         &contract,
         request.explicit_runner,
         request.force_hot,
         request.local_policy.allow_local_hot(),
     )?;
+    selection_timer.finish();
     let Some(selection) = selection else {
         let reason = if request.force_hot && request.local_policy.allow_local_hot() {
             "force_hot_local_override"
@@ -127,8 +135,22 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if request.local_policy.deny_local_execution() {
             return Err(local_execution_denied_error(reason, None));
         }
-        return Ok(skipped_automatic_run_local(plan, reason));
+        // No runner was selected: record the skip reason as the fallback so the
+        // overhead metadata consistently explains why this ran locally.
+        overhead.set_fallback_reason(reason);
+        return Ok(skipped_automatic_run_local_with_overhead(
+            plan, reason, &overhead,
+        ));
     };
+
+    // A runner was selected (explicit or default). Record the attempted
+    // selection up front so a later connect/preflight fallback still reports
+    // what the offload tried first.
+    overhead.set_attempted(
+        &selection.runner_id,
+        selection.source.metadata_value(),
+        Some(selection.mode.metadata_value()),
+    );
 
     let release_gate_local_hot_allowed =
         crate::core::defaults::resolve_release_gate_local_hot_policy().is_allowed();
@@ -168,7 +190,10 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             .build(),
     );
 
-    match prepare_lab_runner_for_offload(&selection)? {
+    let prepare_timer = overhead.phase(LabOffloadPhase::Preflight);
+    let preparation = prepare_lab_runner_for_offload(&selection)?;
+    prepare_timer.finish();
+    match preparation {
         LabRunnerPreparation::Ready => {
             plan = with_step(
                 plan,
@@ -223,23 +248,26 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
                     )],
                 ));
             }
+            overhead.set_fallback_reason(&reason);
+            let mut metadata = lab_offload_metadata(
+                &plan,
+                selection.source.metadata_value(),
+                Some(&selection.runner_id),
+                Some(selection.mode.metadata_value()),
+                "fallback",
+                None,
+                Some(&reason),
+            );
+            attach_lab_offload_overhead(&mut metadata, &overhead);
             return Ok(LabOffloadOutcome::RunLocal {
-                metadata: Some(lab_offload_metadata(
-                    &plan,
-                    selection.source.metadata_value(),
-                    Some(&selection.runner_id),
-                    Some(selection.mode.metadata_value()),
-                    "fallback",
-                    None,
-                    Some(&reason),
-                )),
+                metadata: Some(metadata),
                 plan,
                 messages: vec![format!("Lab offload: {reason}; running locally.")],
             });
         }
     }
 
-    run_lab_offload_inner(request, selection, contract, plan, messages)
+    run_lab_offload_inner(request, selection, contract, plan, messages, overhead)
 }
 
 pub(crate) fn unsupported_runner_hints(

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -151,6 +151,7 @@ pub(crate) fn run_lab_offload_inner(
     contract: LabOffloadCommand,
     mut plan: HomeboyPlan,
     mut messages: Vec<String>,
+    mut overhead: LabOffloadOverhead,
 ) -> Result<LabOffloadOutcome> {
     let runner_id = &selection.runner_id;
     let runner = load(runner_id)?;
@@ -202,6 +203,7 @@ pub(crate) fn run_lab_offload_inner(
             runner_workspace_root,
             runner.settings.homeboy_path.as_deref().unwrap_or("homeboy"),
             &runner_status,
+            overhead,
         );
     }
 
@@ -327,6 +329,10 @@ pub(crate) fn run_lab_offload_inner(
         .clone()
         .map(prepare_lab_runner_capability);
     if let Some(capability_plan) = &capability_plan {
+        // Capability/daemon preflight is runner setup overhead (#3001); time it
+        // and record the elapsed duration on every exit path so a fallback-to-
+        // local still reports the attempted preflight cost.
+        let capability_preflight_started = std::time::Instant::now();
         let decision = match evaluate_lab_runner_capabilities_for_runner(
             &runner,
             capability_plan,
@@ -334,6 +340,10 @@ pub(crate) fn run_lab_offload_inner(
         ) {
             Ok(decision) => decision,
             Err(err) if matches!(selection.source, LabRunnerSelectionSource::Default) => {
+                overhead.record(
+                    LabOffloadPhase::Preflight,
+                    capability_preflight_started.elapsed(),
+                );
                 let reason = format!("runner capability preflight failed: {}", err.message);
                 plan = with_step(
                     plan,
@@ -348,15 +358,21 @@ pub(crate) fn run_lab_offload_inner(
                 if request.local_policy.deny_local_execution() {
                     return Err(local_execution_denied_error(&reason, Some(runner_id)));
                 }
+                overhead.set_fallback_reason(&reason);
                 return Ok(automatic_capability_fallback(
                     plan,
                     runner_id,
                     &runner_status,
                     reason,
+                    &overhead,
                 ));
             }
             Err(err) => return Err(err),
         };
+        overhead.record(
+            LabOffloadPhase::Preflight,
+            capability_preflight_started.elapsed(),
+        );
 
         let gate_result = decision.clone();
         match decision {
@@ -386,6 +402,7 @@ pub(crate) fn run_lab_offload_inner(
                         .gate_result(gate_result)
                         .build(),
                     );
+                    overhead.set_fallback_reason(&reason);
                     return automatic_capability_fallback_or_error(
                         plan,
                         &selection,
@@ -394,6 +411,7 @@ pub(crate) fn run_lab_offload_inner(
                         remediation,
                         request.local_policy.allow_local_fallback(),
                         request.local_policy.deny_local_execution(),
+                        &overhead,
                     );
                 }
                 LabRunnerSelectionSource::Explicit => {
@@ -409,6 +427,7 @@ pub(crate) fn run_lab_offload_inner(
     }
 
     let capability_preflight: Option<RunnerCapabilityPreflight> = capability_plan.map(Into::into);
+    let workspace_sync_timer = overhead.phase(LabOffloadPhase::WorkspaceSync);
     let workspace_stage = prepare_lab_offload_workspace_stage(
         &request,
         &contract,
@@ -419,6 +438,7 @@ pub(crate) fn run_lab_offload_inner(
         &command_prefix.argv,
         runner.workspace_root.as_deref(),
     )?;
+    workspace_sync_timer.finish();
     let LabOffloadWorkspaceStage {
         plan: next_plan,
         sync_mode,
@@ -546,8 +566,18 @@ pub(crate) fn run_lab_offload_inner(
         "status": synced.workspace_cleanliness,
         "allow_dirty_lab_workspace": request.allow_dirty_lab_workspace,
     });
+    // Snapshot the setup overhead (selection + preflight + workspace sync)
+    // gathered so far into the metadata embedded in the runner env (#3001), so
+    // reports reading the offload metadata can separate `lab_overhead_ms` from
+    // the workload command duration. Post-exec phases (remote_exec, output
+    // parse, artifact import) are refreshed into the returned/captured metadata
+    // after the run completes below.
+    attach_lab_offload_overhead(&mut lab_metadata, &overhead);
     let mut env = build_lab_offload_env_with_passthroughs(&lab_metadata);
     env.extend(secret_env_handoff.env_delta.clone());
+    // The remaining pre-dispatch checks (secret-env, provider, path translation)
+    // are still runner setup overhead before the workload executes.
+    let pre_dispatch_started = std::time::Instant::now();
     preflight_agent_task_runner_secret_env(
         runner_id,
         &runner,
@@ -579,6 +609,10 @@ pub(crate) fn run_lab_offload_inner(
         &source_path,
         &remote_cwd,
     )?;
+    overhead.record(LabOffloadPhase::Preflight, pre_dispatch_started.elapsed());
+    // Time the workload command itself (kept separate from overhead so reports
+    // can subtract `lab_overhead_ms` from the workload duration).
+    let remote_exec_started = std::time::Instant::now();
     let exec_result = exec(
         runner_id,
         RunnerExecOptions {
@@ -598,6 +632,7 @@ pub(crate) fn run_lab_offload_inner(
             detach_after_handoff: request.detach_after_handoff,
         },
     );
+    overhead.record(LabOffloadPhase::RemoteExec, remote_exec_started.elapsed());
     let (exec_output, exit_code) = match exec_result {
         Ok(output) => output,
         Err(err) => {
@@ -681,6 +716,9 @@ pub(crate) fn run_lab_offload_inner(
     if exec_output.mirror_run_id.is_some() {
         plan = add_success_step(plan, "lab.mirror_evidence");
     }
+    // Parsing/applying the remote command output (patch extraction) is post-
+    // workload overhead, not workload time.
+    let output_parse_started = std::time::Instant::now();
     if request.capture_patch && exit_code == 0 {
         let apply_output = apply_lab_offload_patch(&exec_output)?;
         if apply_output.is_none() {
@@ -692,10 +730,17 @@ pub(crate) fn run_lab_offload_inner(
         }
         plan = with_lab_apply_patch_step(plan, apply_output);
     }
+    overhead.record(LabOffloadPhase::OutputParse, output_parse_started.elapsed());
+    // Importing the structured-output artifact back from the runner is overhead.
+    let artifact_import_started = std::time::Instant::now();
     let output_file_content = match remote_output_file.as_deref() {
         Some(path) => Some(download_lab_output_file(runner_id, path)?),
         None => None,
     };
+    overhead.record(
+        LabOffloadPhase::ArtifactImport,
+        artifact_import_started.elapsed(),
+    );
     ensure_lab_offload_streams_not_truncated(&exec_output, output_file_content.is_some())?;
     mirror_agent_task_run_plan_lifecycle(request.normalized_args, &exec_output.stdout)?;
 

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -21,6 +21,7 @@ mod execute;
 mod fallback_commands;
 mod inner;
 mod metadata;
+mod overhead;
 mod resident;
 mod types;
 mod workspace_stage;
@@ -105,7 +106,7 @@ use super::agent_task_bridge::{
 use super::evidence::terminal_lab_run_evidence;
 use super::fallback::{
     is_build_command, local_execution_denied_error, skipped_automatic_run_local,
-    unsupported_build_lab_error,
+    skipped_automatic_run_local_with_overhead, unsupported_build_lab_error,
 };
 use super::provider_preflight::preflight_agent_task_provider_on_runner;
 use super::secrets::{build_lab_secret_env_handoff_plan, preflight_agent_task_runner_secret_env};
@@ -122,5 +123,6 @@ pub(crate) use execute::*;
 pub(crate) use fallback_commands::*;
 pub(crate) use inner::*;
 pub(crate) use metadata::*;
+pub(crate) use overhead::*;
 pub(crate) use resident::*;
 pub(crate) use workspace_stage::*;

--- a/src/core/runner/lab/offload/overhead.rs
+++ b/src/core/runner/lab/offload/overhead.rs
@@ -1,0 +1,374 @@
+//! Runner-agnostic Lab offload overhead accounting (#3001).
+//!
+//! Lab benchmarks and hot-command runs need to distinguish time spent in
+//! runner *setup* (selecting a runner, connecting/preflighting it, syncing the
+//! workspace, importing artifacts) from time spent in the *workload* itself
+//! (the remote command). Without this split a benchmark can accidentally
+//! measure sync/connect churn instead of the command under test.
+//!
+//! [`LabOffloadOverhead`] records a per-phase `Duration` map plus a total
+//! `lab_overhead_ms`. It is deliberately runner-agnostic: the same phase model
+//! applies across local-fallback, SSH, daemon, and reverse-tunnel runners. The
+//! `remote_exec` phase captures the *workload* command duration separately so
+//! reports can subtract it from `lab_overhead_ms` — overhead is the sum of the
+//! setup phases only and never folds in workload time.
+
+use std::time::{Duration, Instant};
+
+/// The distinct phases of a Lab offload run that we time independently.
+///
+/// All variants except [`LabOffloadPhase::RemoteExec`] are *overhead* (runner
+/// setup). `RemoteExec` is the *workload* and is tracked separately so reports
+/// can separate `lab_overhead_ms` from workload command duration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum LabOffloadPhase {
+    /// Choosing which runner (or local fallback) will run the command.
+    Selection,
+    /// Connecting to / preflighting the chosen runner (capability, daemon
+    /// health, version-skew checks).
+    Preflight,
+    /// Synchronizing the workspace/source checkout to the runner.
+    WorkspaceSync,
+    /// Executing the workload command on the runner. This is the WORKLOAD, not
+    /// overhead; tracked separately so it stays subtractable from the total.
+    RemoteExec,
+    /// Parsing the remote command output/streams.
+    OutputParse,
+    /// Importing artifacts / structured-output files back from the runner.
+    ArtifactImport,
+}
+
+impl LabOffloadPhase {
+    /// Stable, runner-agnostic key used in serialized metadata.
+    pub(crate) const fn key(self) -> &'static str {
+        match self {
+            LabOffloadPhase::Selection => "selection",
+            LabOffloadPhase::Preflight => "preflight",
+            LabOffloadPhase::WorkspaceSync => "workspace_sync",
+            LabOffloadPhase::RemoteExec => "remote_exec",
+            LabOffloadPhase::OutputParse => "output_parse",
+            LabOffloadPhase::ArtifactImport => "artifact_import",
+        }
+    }
+
+    /// The setup phases in canonical order, used to render a stable per-phase
+    /// duration map even when some phases were never reached.
+    pub(crate) const fn overhead_phases() -> [LabOffloadPhase; 5] {
+        [
+            LabOffloadPhase::Selection,
+            LabOffloadPhase::Preflight,
+            LabOffloadPhase::WorkspaceSync,
+            LabOffloadPhase::OutputParse,
+            LabOffloadPhase::ArtifactImport,
+        ]
+    }
+}
+
+/// Records which runner the offload attempted to select before it either
+/// proceeded or fell back to local execution. Surfaced consistently for both
+/// automatic (default-runner) and explicit (`--runner`) selection so a
+/// fallback-to-local command always reports what it tried first.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct AttemptedSelection {
+    /// Runner id the offload attempted to use, if one was selected.
+    pub runner_id: Option<String>,
+    /// How the runner was selected (`explicit`, `default`, …).
+    pub source: Option<String>,
+    /// Runner transport mode (`ssh`, `daemon`, `reverse_tunnel`, …).
+    pub mode: Option<String>,
+}
+
+impl AttemptedSelection {
+    fn is_empty(&self) -> bool {
+        self.runner_id.is_none() && self.source.is_none() && self.mode.is_none()
+    }
+
+    fn to_metadata(&self) -> Option<serde_json::Value> {
+        if self.is_empty() {
+            return None;
+        }
+        Some(serde_json::json!({
+            "runner_id": self.runner_id,
+            "source": self.source,
+            "mode": self.mode,
+        }))
+    }
+}
+
+/// Accumulates per-phase Lab offload timings and the fallback reason / attempted
+/// selection so they can be attached to the run metadata.
+///
+/// Construct with [`LabOffloadOverhead::start`], wrap each phase with
+/// [`LabOffloadOverhead::phase`] (RAII timer) or
+/// [`LabOffloadOverhead::record`], and serialize with
+/// [`LabOffloadOverhead::to_metadata`].
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LabOffloadOverhead {
+    selection: Option<Duration>,
+    preflight: Option<Duration>,
+    workspace_sync: Option<Duration>,
+    remote_exec: Option<Duration>,
+    output_parse: Option<Duration>,
+    artifact_import: Option<Duration>,
+    attempted: AttemptedSelection,
+    fallback_reason: Option<String>,
+}
+
+impl LabOffloadOverhead {
+    /// Begin overhead accounting for a fresh offload attempt.
+    pub(crate) fn start() -> Self {
+        Self::default()
+    }
+
+    fn slot(&mut self, phase: LabOffloadPhase) -> &mut Option<Duration> {
+        match phase {
+            LabOffloadPhase::Selection => &mut self.selection,
+            LabOffloadPhase::Preflight => &mut self.preflight,
+            LabOffloadPhase::WorkspaceSync => &mut self.workspace_sync,
+            LabOffloadPhase::RemoteExec => &mut self.remote_exec,
+            LabOffloadPhase::OutputParse => &mut self.output_parse,
+            LabOffloadPhase::ArtifactImport => &mut self.artifact_import,
+        }
+    }
+
+    /// Add `elapsed` to a phase. Repeated records for the same phase accumulate
+    /// (e.g. multiple preflight checks) rather than overwrite.
+    pub(crate) fn record(&mut self, phase: LabOffloadPhase, elapsed: Duration) {
+        let slot = self.slot(phase);
+        *slot = Some(slot.unwrap_or_default() + elapsed);
+    }
+
+    /// Start a RAII timer for `phase`; the elapsed time is recorded when the
+    /// returned guard is dropped (or via [`PhaseTimer::finish`]).
+    pub(crate) fn phase(&mut self, phase: LabOffloadPhase) -> PhaseTimer<'_> {
+        PhaseTimer {
+            overhead: self,
+            phase,
+            started: Instant::now(),
+            done: false,
+        }
+    }
+
+    /// Record the runner the offload attempted to select. Always called once a
+    /// selection is resolved, before connect/preflight, so a later fallback
+    /// still reports what was attempted.
+    pub(crate) fn set_attempted(&mut self, runner_id: &str, source: &str, mode: Option<&str>) {
+        self.attempted = AttemptedSelection {
+            runner_id: Some(runner_id.to_string()),
+            source: Some(source.to_string()),
+            mode: mode.map(str::to_string),
+        };
+    }
+
+    /// Record why the offload fell back to local execution (or was skipped).
+    pub(crate) fn set_fallback_reason(&mut self, reason: &str) {
+        self.fallback_reason = Some(reason.to_string());
+    }
+
+    /// Sum of the setup phases only (workload `remote_exec` excluded).
+    pub(crate) fn overhead_total(&self) -> Duration {
+        LabOffloadPhase::overhead_phases()
+            .into_iter()
+            .filter_map(|phase| *self.peek(phase))
+            .sum()
+    }
+
+    fn peek(&self, phase: LabOffloadPhase) -> &Option<Duration> {
+        match phase {
+            LabOffloadPhase::Selection => &self.selection,
+            LabOffloadPhase::Preflight => &self.preflight,
+            LabOffloadPhase::WorkspaceSync => &self.workspace_sync,
+            LabOffloadPhase::RemoteExec => &self.remote_exec,
+            LabOffloadPhase::OutputParse => &self.output_parse,
+            LabOffloadPhase::ArtifactImport => &self.artifact_import,
+        }
+    }
+
+    fn millis(duration: Duration) -> u64 {
+        u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+    }
+
+    /// Serialize to a runner-agnostic metadata object:
+    ///
+    /// ```json
+    /// {
+    ///   "schema": "homeboy/lab-offload-overhead/v1",
+    ///   "phase_durations_ms": { "selection": 1, "preflight": 4, ... },
+    ///   "lab_overhead_ms": 12,
+    ///   "workload_ms": 980,
+    ///   "fallback_reason": null,
+    ///   "attempted_selection": { "runner_id": "...", "source": "...", "mode": "..." }
+    /// }
+    /// ```
+    pub(crate) fn to_metadata(&self) -> serde_json::Value {
+        let mut phase_durations = serde_json::Map::new();
+        for phase in LabOffloadPhase::overhead_phases() {
+            if let Some(duration) = self.peek(phase) {
+                phase_durations.insert(
+                    phase.key().to_string(),
+                    serde_json::json!(Self::millis(*duration)),
+                );
+            }
+        }
+        let workload_ms = self.remote_exec.map(Self::millis);
+        serde_json::json!({
+            "schema": "homeboy/lab-offload-overhead/v1",
+            "phase_durations_ms": phase_durations,
+            "lab_overhead_ms": Self::millis(self.overhead_total()),
+            "workload_ms": workload_ms,
+            "fallback_reason": self.fallback_reason,
+            "attempted_selection": self.attempted.to_metadata(),
+        })
+    }
+}
+
+/// Attach the serialized overhead object to an existing Lab offload metadata
+/// value under the `lab_offload_overhead` key, so reports and artifacts can
+/// read per-phase setup timings and the total `lab_overhead_ms` alongside the
+/// rest of the offload metadata. No-op-safe on any JSON object.
+pub(crate) fn attach_lab_offload_overhead(
+    metadata: &mut serde_json::Value,
+    overhead: &LabOffloadOverhead,
+) {
+    if let Some(map) = metadata.as_object_mut() {
+        map.insert("lab_offload_overhead".to_string(), overhead.to_metadata());
+    }
+}
+
+/// RAII timer that records its elapsed time into a [`LabOffloadOverhead`] phase
+/// when dropped. Lets a phase be wrapped without manual `Instant` bookkeeping.
+pub(crate) struct PhaseTimer<'a> {
+    overhead: &'a mut LabOffloadOverhead,
+    phase: LabOffloadPhase,
+    started: Instant,
+    done: bool,
+}
+
+impl PhaseTimer<'_> {
+    /// Stop timing now and record the elapsed duration.
+    pub(crate) fn finish(mut self) {
+        self.flush();
+    }
+
+    fn flush(&mut self) {
+        if self.done {
+            return;
+        }
+        self.done = true;
+        let elapsed = self.started.elapsed();
+        self.overhead.record(self.phase, elapsed);
+    }
+}
+
+impl Drop for PhaseTimer<'_> {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overhead_total_excludes_workload_and_sums_setup_phases() {
+        let mut overhead = LabOffloadOverhead::start();
+        overhead.record(LabOffloadPhase::Selection, Duration::from_millis(5));
+        overhead.record(LabOffloadPhase::Preflight, Duration::from_millis(10));
+        overhead.record(LabOffloadPhase::WorkspaceSync, Duration::from_millis(20));
+        overhead.record(LabOffloadPhase::OutputParse, Duration::from_millis(3));
+        overhead.record(LabOffloadPhase::ArtifactImport, Duration::from_millis(2));
+        // Workload is NOT overhead and must not inflate the total.
+        overhead.record(LabOffloadPhase::RemoteExec, Duration::from_millis(1000));
+
+        assert_eq!(overhead.overhead_total(), Duration::from_millis(40));
+
+        let metadata = overhead.to_metadata();
+        assert_eq!(metadata["lab_overhead_ms"], serde_json::json!(40));
+        assert_eq!(metadata["workload_ms"], serde_json::json!(1000));
+        assert_eq!(
+            metadata["schema"],
+            serde_json::json!("homeboy/lab-offload-overhead/v1")
+        );
+        let durations = metadata["phase_durations_ms"].as_object().unwrap();
+        assert_eq!(durations["selection"], serde_json::json!(5));
+        assert_eq!(durations["preflight"], serde_json::json!(10));
+        assert_eq!(durations["workspace_sync"], serde_json::json!(20));
+        assert_eq!(durations["output_parse"], serde_json::json!(3));
+        assert_eq!(durations["artifact_import"], serde_json::json!(2));
+        // The workload phase is not part of the overhead duration map.
+        assert!(!durations.contains_key("remote_exec"));
+    }
+
+    #[test]
+    fn records_per_phase_overhead_and_total_for_offloaded_run() {
+        let mut overhead = LabOffloadOverhead::start();
+        overhead.set_attempted("lab-ssh", "default", Some("ssh"));
+        {
+            let _selection = overhead.phase(LabOffloadPhase::Selection);
+        }
+        overhead.record(LabOffloadPhase::Preflight, Duration::from_millis(7));
+        overhead.record(LabOffloadPhase::WorkspaceSync, Duration::from_millis(11));
+        overhead.record(LabOffloadPhase::RemoteExec, Duration::from_millis(500));
+        overhead.record(LabOffloadPhase::OutputParse, Duration::from_millis(1));
+
+        let metadata = overhead.to_metadata();
+        // Per-phase map present for the setup phases that ran.
+        let durations = metadata["phase_durations_ms"].as_object().unwrap();
+        assert!(durations.contains_key("selection"));
+        assert!(durations.contains_key("preflight"));
+        assert!(durations.contains_key("workspace_sync"));
+        assert!(durations.contains_key("output_parse"));
+        // Total overhead present and workload separable.
+        assert!(metadata["lab_overhead_ms"].as_u64().is_some());
+        assert_eq!(metadata["workload_ms"], serde_json::json!(500));
+        // Fallback reason absent for a successful offload.
+        assert!(metadata["fallback_reason"].is_null());
+        // Attempted selection recorded.
+        let attempted = &metadata["attempted_selection"];
+        assert_eq!(attempted["runner_id"], serde_json::json!("lab-ssh"));
+        assert_eq!(attempted["source"], serde_json::json!("default"));
+        assert_eq!(attempted["mode"], serde_json::json!("ssh"));
+    }
+
+    #[test]
+    fn records_attempted_selection_and_reason_on_local_fallback() {
+        let mut overhead = LabOffloadOverhead::start();
+        // The offload attempted a default runner, ran selection + preflight,
+        // then fell back to local execution.
+        overhead.set_attempted("lab-explicit", "explicit", Some("daemon"));
+        overhead.record(LabOffloadPhase::Selection, Duration::from_millis(2));
+        overhead.record(LabOffloadPhase::Preflight, Duration::from_millis(9));
+        overhead.set_fallback_reason("runner capability preflight failed: missing toolchain");
+
+        let metadata = overhead.to_metadata();
+        assert_eq!(
+            metadata["fallback_reason"],
+            serde_json::json!("runner capability preflight failed: missing toolchain")
+        );
+        let attempted = &metadata["attempted_selection"];
+        assert_eq!(attempted["runner_id"], serde_json::json!("lab-explicit"));
+        assert_eq!(attempted["source"], serde_json::json!("explicit"));
+        assert_eq!(attempted["mode"], serde_json::json!("daemon"));
+        // The attempted selection/preflight overhead is still recorded even
+        // though the command ultimately ran locally.
+        let durations = metadata["phase_durations_ms"].as_object().unwrap();
+        assert_eq!(durations["selection"], serde_json::json!(2));
+        assert_eq!(durations["preflight"], serde_json::json!(9));
+        // No remote exec happened, so workload is absent.
+        assert!(metadata["workload_ms"].is_null());
+        assert_eq!(metadata["lab_overhead_ms"], serde_json::json!(11));
+    }
+
+    #[test]
+    fn attempted_selection_absent_when_no_runner_was_chosen() {
+        let mut overhead = LabOffloadOverhead::start();
+        overhead.set_fallback_reason("no_default_runner");
+        let metadata = overhead.to_metadata();
+        assert!(metadata["attempted_selection"].is_null());
+        assert_eq!(
+            metadata["fallback_reason"],
+            serde_json::json!("no_default_runner")
+        );
+    }
+}

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -12,10 +12,14 @@ pub(crate) fn run_runner_resident_lab_offload(
     runner_workspace_root: &str,
     homeboy_path: &str,
     runner_status: &RunnerStatusReport,
+    mut overhead: LabOffloadOverhead,
 ) -> Result<LabOffloadOutcome> {
     let runner_id = &selection.runner_id;
     let runner_homeboy = lab_runner_homeboy_metadata(runner_id, homeboy_path, runner_status);
+    // Refreshing managed runner-resident source checkouts is workspace setup.
+    let managed_sources_timer = overhead.phase(LabOffloadPhase::WorkspaceSync);
     let source_syncs = refresh_managed_runner_sources(runner_id, runner_workspace_root)?;
+    managed_sources_timer.finish();
     if source_syncs.is_empty() {
         plan = with_step(
             plan,
@@ -117,6 +121,7 @@ pub(crate) fn run_runner_resident_lab_offload(
     let mut env = build_lab_offload_env_with_passthroughs(&lab_metadata);
     env.extend(secret_env_handoff.env_delta);
 
+    let exec_timer = overhead.phase(LabOffloadPhase::RemoteExec);
     let (exec_output, exit_code) = exec(
         runner_id,
         RunnerExecOptions {
@@ -136,6 +141,7 @@ pub(crate) fn run_runner_resident_lab_offload(
             detach_after_handoff: false,
         },
     )?;
+    exec_timer.finish();
     plan = with_step(
         plan,
         PlanStep::builder(

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -188,6 +188,7 @@ fn default_runner_missing_capabilities_fails_without_local_fallback_opt_in() {
     };
     let status = reverse_status("homeboy-lab");
 
+    let overhead = LabOffloadOverhead::start();
     let result = automatic_capability_fallback_or_error(
         plan,
         &selection,
@@ -197,6 +198,7 @@ fn default_runner_missing_capabilities_fails_without_local_fallback_opt_in() {
         vec!["Install Playwright and browser binaries on the runner.".to_string()],
         false,
         false,
+        &overhead,
     );
 
     let Err(err) = result else {
@@ -222,6 +224,14 @@ fn default_runner_missing_capabilities_can_fallback_with_explicit_opt_in() {
     };
     let status = reverse_status("homeboy-lab");
 
+    let mut overhead = LabOffloadOverhead::start();
+    overhead.set_attempted("homeboy-lab", "default", Some("reverse_tunnel"));
+    overhead.record(
+        LabOffloadPhase::Preflight,
+        std::time::Duration::from_millis(8),
+    );
+    overhead
+        .set_fallback_reason("missing required capability parity for `trace`: tools: playwright");
     let outcome = automatic_capability_fallback_or_error(
         plan,
         &selection,
@@ -231,6 +241,7 @@ fn default_runner_missing_capabilities_can_fallback_with_explicit_opt_in() {
         Vec::new(),
         true,
         false,
+        &overhead,
     )
     .expect("explicit fallback opt-in should allow local run");
 
@@ -241,7 +252,25 @@ fn default_runner_missing_capabilities_can_fallback_with_explicit_opt_in() {
         panic!("expected local fallback");
     };
     assert!(messages[0].contains("running locally"));
-    assert_eq!(metadata.expect("metadata")["status"], "fallback");
+    let metadata = metadata.expect("metadata");
+    assert_eq!(metadata["status"], "fallback");
+    // The fallback-to-local outcome records the runner-agnostic overhead:
+    // the attempted selection/preflight cost plus the fallback reason (#3001).
+    let overhead_meta = &metadata["lab_offload_overhead"];
+    assert_eq!(overhead_meta["schema"], "homeboy/lab-offload-overhead/v1");
+    assert_eq!(
+        overhead_meta["attempted_selection"]["runner_id"],
+        "homeboy-lab"
+    );
+    assert_eq!(overhead_meta["attempted_selection"]["source"], "default");
+    assert!(overhead_meta["fallback_reason"]
+        .as_str()
+        .is_some_and(|reason| reason.contains("capability parity")));
+    assert!(overhead_meta["phase_durations_ms"]["preflight"]
+        .as_u64()
+        .is_some());
+    // Workload duration stays separable: no remote exec happened on fallback.
+    assert!(overhead_meta["workload_ms"].is_null());
 }
 
 #[test]


### PR DESCRIPTION
Closes #3001. Captures per-phase Lab offload overhead (runner selection, preflight, workspace sync, remote exec, output parse, artifact import) plus a total lab_overhead_ms in run metadata, and records fallback-to-local reason + attempted selection. Runner-agnostic across local/SSH/daemon/reverse-tunnel; workload duration stays separable from overhead; existing offload behavior unchanged.