### PR TITLE
chore(core): reduce agnostic-core literal debt (#2240/#3034)

### DIFF
--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -610,9 +610,9 @@ mod tests {
     #[test]
     fn cluster_by_name_segments_groups_shared_prefixes() {
         let names = vec![
-            "extract_php_signatures",
-            "extract_rust_signatures",
-            "extract_js_signatures",
+            "extract_alpha_signatures",
+            "extract_beta_signatures",
+            "extract_gamma_signatures",
             "generate_stub",
             "generate_import",
             "generate_test",
@@ -629,14 +629,14 @@ mod tests {
         // All 3 extract_* functions should be in the same cluster
         let extract_cluster = clusters
             .iter()
-            .find(|(_, items)| items.contains(&"extract_php_signatures"));
+            .find(|(_, items)| items.contains(&"extract_alpha_signatures"));
         assert!(
             extract_cluster.is_some(),
             "extract_* functions should be clustered together"
         );
         let extract_items = &extract_cluster.unwrap().1;
-        assert!(extract_items.contains(&"extract_rust_signatures"));
-        assert!(extract_items.contains(&"extract_js_signatures"));
+        assert!(extract_items.contains(&"extract_beta_signatures"));
+        assert!(extract_items.contains(&"extract_gamma_signatures"));
 
         // All 3 generate_* functions should be in the same cluster
         let generate_cluster = clusters

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -244,14 +244,6 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
         term: "cargo",
     },
     ViolationKey {
-        path: "src/core/refactor/decompose.rs",
-        term: "php",
-    },
-    ViolationKey {
-        path: "src/core/refactor/decompose.rs",
-        term: "rust",
-    },
-    ViolationKey {
         path: "src/core/release/planning_worktree.rs",
         term: "npm",
     },
@@ -301,7 +293,7 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 79;
+const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 75;
 const CORE_AGNOSTIC_REPAIR_DIRECTIVE: &str = "This is a boundary violation, not a baseline chore. Do not add these findings to the baseline unless explicitly approved by a maintainer. Move platform-specific behavior into the owning extension or replace it with a generic core contract that extensions can populate.";
 
 #[test]


### PR DESCRIPTION
Partial #2240. Reduces the `TEST_CONTENT_BASELINE` core-owned ecosystem-literal debt tracked by #3034 by genericizing a fixture in `src/core/refactor/decompose.rs` whose ecosystem names were purely incidental, then removing the now-stale baseline rows in `core_agnostic_test.rs`.

## What changed
- `cluster_by_name_segments_groups_shared_prefixes` tests a generic name-prefix clustering algorithm. Its fixture used `extract_php_signatures` / `extract_rust_signatures` / `extract_js_signatures` — the ecosystem tokens were arbitrary noise (the test only asserts that `extract_*` share a prefix and cluster together). Renamed to `extract_alpha_/beta_/gamma_signatures`, which is identical in meaning and ecosystem-agnostic.
- Removed the corresponding `decompose.rs` `php` and `rust` rows from `TEST_CONTENT_BASELINE` and lowered `TEST_CONTENT_BASELINE_OCCURRENCES` 79 -> 75 (4 removed occurrences: php x2 + rust x2).

## Conservative scope
Left every legitimate entry untouched: detector/audit pattern files that must name languages to detect them (`core_fingerprint.rs`, `repeated_literal_shape.rs`, `test_quality.rs`, `symbol_graph.rs`), `env!("CARGO_PKG_VERSION")` std macros (`run_metadata.rs`, `run_builder.rs`), ecosystem-specific test fixtures that document real behavior (`context/mod.rs` manifest-driven discovery pairing `Cargo.toml`->`rust-like`, `report.rs` PHPUnit-skip scenario, `budget_findings.rs` WP-REST profile), and all `tests/...` fixtures. The enforcement test logic and exclude lists are unchanged.