### PR TITLE
fix(rig): keep linked local checks on controller

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -46,13 +46,23 @@ impl RigArgs {
     }
 
     pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
-        if self.is_check_command() {
-            return CommandPortabilityContract::lab(LabCommandContract::portable_workload(
-                RIG_CHECK_LAB_LABEL,
-                None,
-                false,
-                LAB_NO_EXTRA_TOOLS,
-            ));
+        if let RigCommand::Check { rig_id } = &self.command {
+            let contract = if rig_check_uses_linked_local_source(rig_id) {
+                LabCommandContract::explicit_runner(
+                    RIG_CHECK_LAB_LABEL,
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                )
+            } else {
+                LabCommandContract::portable_workload(
+                    RIG_CHECK_LAB_LABEL,
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                )
+            };
+            return CommandPortabilityContract::lab(contract);
         }
         if self.is_hot_resource_command() {
             return CommandPortabilityContract::lab(LabCommandContract::local_only(
@@ -62,6 +72,10 @@ impl RigArgs {
         }
         CommandPortabilityContract::none()
     }
+}
+
+fn rig_check_uses_linked_local_source(rig_id: &str) -> bool {
+    rig::read_source_metadata(rig_id).is_some_and(|source| source.linked)
 }
 
 #[derive(Subcommand)]

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -546,6 +546,8 @@ mod tests {
     use super::*;
     use clap::Parser;
     use homeboy::command_contract::lab_runner_supports_contract_label;
+    use std::fs;
+    use std::path::Path;
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::tempdir;
 
@@ -614,6 +616,25 @@ mod tests {
         fn drop(&mut self) {
             std::env::set_current_dir(&self.previous).expect("restore current dir");
         }
+    }
+
+    fn write_rig_source_metadata(home: &Path, rig_id: &str, linked: bool) {
+        let sources_dir = home.join(".config").join("homeboy").join("rig-sources");
+        fs::create_dir_all(&sources_dir).expect("create rig sources dir");
+        let metadata = serde_json::json!({
+            "source": "/tmp/rig-package",
+            "source_root": "/tmp/rig-package",
+            "package_path": "/tmp/rig-package",
+            "rig_path": format!("/tmp/rig-package/rigs/{rig_id}/rig.json"),
+            "discovery_path": "/tmp/rig-package",
+            "linked": linked,
+            "materialized": false
+        });
+        fs::write(
+            sources_dir.join(format!("{rig_id}.json")),
+            serde_json::to_string_pretty(&metadata).expect("serialize rig source metadata"),
+        )
+        .expect("write rig source metadata");
     }
 
     #[test]
@@ -786,6 +807,57 @@ mod tests {
                 "list".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn linked_local_rig_check_disables_default_lab_offload() {
+        let temp_home = tempdir().expect("temp home");
+        let _home = EnvGuard::set("HOME", temp_home.path().to_str().expect("home path"));
+        write_rig_source_metadata(temp_home.path(), "linked-local", true);
+        let cli = Cli::parse_from(["homeboy", "rig", "check", "linked-local"]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(command.hot_label, "rig check");
+        assert!(command.portable);
+        assert!(!command.routing_policy.default_lab_offload);
+        assert!(!command.routing_policy.infer_source_path_tools);
+        assert!(cli.command.supports_lab_runner());
+    }
+
+    #[test]
+    fn linked_local_rig_check_stays_local_without_runner() {
+        let temp_home = tempdir().expect("temp home");
+        let _home = EnvGuard::set("HOME", temp_home.path().to_str().expect("home path"));
+        write_rig_source_metadata(temp_home.path(), "linked-local", true);
+        let normalized = vec![
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "check".to_string(),
+            "linked-local".to_string(),
+        ];
+        let cli = Cli::parse_from(&normalized);
+
+        let outcome = route_after_parse(&cli, &normalized, None)
+            .expect("linked local rig check should skip automatic Lab offload");
+
+        assert_eq!(outcome, None);
+        assert!(std::env::var(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV).is_err());
+    }
+
+    #[test]
+    fn installed_git_rig_check_keeps_default_lab_offload() {
+        let temp_home = tempdir().expect("temp home");
+        let _home = EnvGuard::set("HOME", temp_home.path().to_str().expect("home path"));
+        write_rig_source_metadata(temp_home.path(), "installed-git", false);
+        let cli = Cli::parse_from(["homeboy", "rig", "check", "installed-git"]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(command.hot_label, "rig check");
+        assert!(command.portable);
+        assert!(command.routing_policy.default_lab_offload);
+        assert!(!command.routing_policy.infer_source_path_tools);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Detect `rig check <id>` targets installed from linked local rig source metadata.
- Keep those checks portable for explicit `--runner`, but disable automatic default Lab offload so lightweight local validation stays on the controller.
- Preserve existing default Lab offload behavior for git/materialized rig sources.

## Related issues
- Closes #6311.
- Leaves #6310 as the broader remote linked-rig propagation/materialization work.

## Tests
- `cargo test linked_local_rig_check` passed.
- `cargo test installed_git_rig_check_keeps_default_lab_offload` passed.
- `rustfmt --check src/commands/rig/mod.rs src/commands/route.rs` passed.
- `cargo test commands::route::tests` failed on two pre-existing temp path canonicalization assertions (`/private/var` vs `/var`); new rig tests passed in that run.
- `cargo fmt --check` failed on unrelated pre-existing formatting drift outside the touched files.
- `cargo clippy --lib` passed with existing warnings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing and testing the linked local rig check offload policy improvement.