### PR TITLE
fix(lab): sync rig check packages before offload

### DIFF
--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -732,6 +732,13 @@ fn lab_offload_rig_ids(args: &[String]) -> Vec<String> {
             passthrough = true;
             continue;
         }
+        if arg == "rig" && iter.peek().map(|value| value.as_str()) == Some("check") {
+            iter.next();
+            if let Some(rig_id) = iter.next().filter(|value| !value.starts_with('-')) {
+                push_unique(&mut rig_ids, rig_id.to_string());
+            }
+            continue;
+        }
         let raw = if arg == "--rig" {
             iter.next().map(String::as_str)
         } else {
@@ -1081,6 +1088,33 @@ mod tests {
                 "/home/user/Developer/_lab_workspaces/studio-web-release-clean-abc",
             ]
         );
+    }
+
+    #[test]
+    fn lab_offload_rig_ids_includes_rig_check_positional_rig() {
+        let args = vec![
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "check".to_string(),
+            "static-site-fixture-matrix".to_string(),
+        ];
+
+        assert_eq!(
+            lab_offload_rig_ids(&args),
+            vec!["static-site-fixture-matrix".to_string()]
+        );
+    }
+
+    #[test]
+    fn lab_offload_rig_ids_ignores_non_check_rig_positionals() {
+        let args = vec![
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "status".to_string(),
+            "static-site-fixture-matrix".to_string(),
+        ];
+
+        assert!(lab_offload_rig_ids(&args).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Include `homeboy rig check <rig-id>` positional rig IDs in Lab rig materialization detection.
- Ensures offloaded rig checks run the existing runner-side `homeboy rig install` materialization path for linked local rig packages before the remote command executes.
- Adds regression tests for `rig check` positional detection while keeping non-check rig subcommands out of offload rig sync.

Fixes https://github.com/Extra-Chill/homeboy/issues/6310

## Tests
- PASS: `cargo test core::runner::rig_materialization` (27 passed)
- PASS: `cargo test command_contract::lab` (21 passed)
- PASS: `cargo check`
- PASS: `rustfmt --check src/core/runner/rig_materialization/mod.rs`
- FAIL: `cargo fmt --check` reports pre-existing formatting drift in unrelated files including `src/commands/fuzz/tests/report_tests.rs`, `src/commands/runner/doctor/checks.rs`, and `src/core/preview_ingress/routes.rs`; the touched file passes file-scoped rustfmt check.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing and testing the linked local rig package propagation fix.
