### PR TITLE
Fix Lab failure envelope contract-field placeholder

### DIFF
--- a/src/core/runner/execution/failure.rs
+++ b/src/core/runner/execution/failure.rs
@@ -45,24 +45,30 @@ pub fn runner_exec_failure_error(output: &RunnerExecOutput) -> Option<Error> {
         details["failure_context"] = serde_json::to_value(failure_context).unwrap_or(Value::Null);
     }
 
-    Some(
-        Error::new(
-            ErrorCode::RemoteCommandFailed,
-            format!(
-                "Runner command failed on `{}` with exit code {}: {}",
-                output.runner_id, output.exit_code, cause
-            ),
-            details,
-        )
-        .with_hint(format!(
-            "Runner `{}` executed `{}` from `{}`.", output.runner_id, command, output.remote_cwd
-        ))
-        .with_hint(runner_exec_failure_context_hint(output))
-        .with_hint(
-            "Homeboy parsed runner-side JSON errors from stdout, stderr, and job event messages when present; inspect error.details.execution for the full job evidence."
-                .to_string(),
+    let mut error = Error::new(
+        ErrorCode::RemoteCommandFailed,
+        format!(
+            "Runner command failed on `{}` with exit code {}: {}",
+            output.runner_id, output.exit_code, cause
         ),
+        details,
     )
+    .with_hint(format!(
+        "Runner `{}` executed `{}` from `{}`.",
+        output.runner_id, command, output.remote_cwd
+    ))
+    .with_hint(runner_exec_failure_context_hint(output))
+    .with_hint(
+        "Homeboy parsed runner-side JSON errors from stdout, stderr, and job event messages when present; inspect error.details.execution for the full job evidence."
+            .to_string(),
+    );
+    if let Some(failure_context) = failure_context.as_ref() {
+        if let Some(hint) = runner_exec_failure_context_remediation_hint(failure_context) {
+            error = error.with_hint(hint);
+        }
+    }
+
+    Some(error)
 }
 
 pub(super) fn string_field(value: &Value, key: &str) -> String {
@@ -114,6 +120,10 @@ pub(super) fn runner_exec_failure_context(
         .and_then(|error| error.get("message"))
         .and_then(Value::as_str)
         .map(str::to_string);
+    let error_details = runner_error
+        .as_ref()
+        .and_then(|error| error.get("details"))
+        .cloned();
     let reason = error_message
         .clone()
         .or_else(|| error_code.clone())
@@ -132,6 +142,7 @@ pub(super) fn runner_exec_failure_context(
         reason,
         error_code,
         error_message,
+        error_details,
     })
 }
 
@@ -139,20 +150,46 @@ pub(super) fn runner_exec_failure_context_hint(output: &RunnerExecOutput) -> Str
     let Some(context) = runner_exec_failure_context_from_output(output) else {
         return "Canonical failed command context was unavailable; inspect error.details.execution for raw runner evidence.".to_string();
     };
-    let field = context
-        .contract_field
-        .as_deref()
-        .unwrap_or("unknown contract field");
     let job = context.job_id.as_deref().unwrap_or("unknown runner job");
     let run = context
         .persisted_run_id
         .as_deref()
         .unwrap_or("unknown persisted run");
-    format!(
-        "Canonical failed command: `{}`; runner job: `{job}`; persisted run: `{run}`; contract field: `{field}`; reason: {}.",
-        redact_argv_display(&context.command),
-        context.reason
-    )
+    let mut hint = format!(
+        "Canonical failed command: `{}`; runner job: `{job}`; persisted run: `{run}`",
+        redact_argv_display(&context.command)
+    );
+    append_failure_context_error_summary(&mut hint, &context);
+    hint.push('.');
+    hint
+}
+
+pub(crate) fn append_failure_context_error_summary(
+    summary: &mut String,
+    context: &RunnerExecFailureContext,
+) {
+    if let Some(field) = context.contract_field.as_deref() {
+        summary.push_str(&format!("; contract field: `{field}`"));
+    }
+    if let Some(code) = context.error_code.as_deref() {
+        summary.push_str(&format!("; structured error: `{code}`"));
+    }
+    if let Some(details) = context.error_details.as_ref() {
+        summary.push_str(&format!("; details: {details}"));
+    }
+    summary.push_str(&format!("; reason: {}", context.reason));
+}
+
+pub(crate) fn runner_exec_failure_context_remediation_hint(
+    context: &RunnerExecFailureContext,
+) -> Option<String> {
+    match context.error_code.as_deref() {
+        Some("rig.not_found") => Some(format!(
+            "Verify the rig exists on runner `{}` with `homeboy runner exec {} -- homeboy rig list`, then rerun with an existing rig or register/sync the missing rig on that runner.",
+            context.runner_id, context.runner_id
+        )),
+        _ => None,
+    }
 }
 
 pub(super) fn error_contract_field(error: &Value) -> Option<&str> {

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -63,7 +63,10 @@ use secrets::*;
 // lab_env, lab/offload) and re-exported by the parent `runner` module.
 pub(crate) use daemon::result_event_data;
 pub(crate) use daemon_api::{canonical_daemon_body, daemon_api_get};
-pub(crate) use failure::runner_exec_failure_context_from_output;
+pub(crate) use failure::{
+    append_failure_context_error_summary, runner_exec_failure_context_from_output,
+    runner_exec_failure_context_remediation_hint,
+};
 pub(crate) use handoff::lab_offload_handoff_hints;
 pub(crate) use process::{execute_runner_process_until_cancelled, prepare_daemon_local_process};
 pub(crate) use secrets::runner_exec_secret_env_names;
@@ -162,6 +165,8 @@ pub struct RunnerExecFailureContext {
     pub error_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_details: Option<Value>,
 }
 
 pub(super) struct RunnerExecFailureContextInput<'a> {

--- a/src/core/runner/execution/tests/redaction.rs
+++ b/src/core/runner/execution/tests/redaction.rs
@@ -147,6 +147,45 @@ fn runner_exec_failure_error_surfaces_canonical_failure_context() {
 }
 
 #[test]
+fn runner_exec_failure_error_keeps_rig_not_found_without_contract_field() {
+    let output = failed_runner_exec_output(
+        "",
+        r#"{"success":false,"error":{"code":"rig.not_found","message":"Rig not found","details":{"rig":"missing"}}}"#,
+    );
+
+    let err = runner_exec_failure_error(&output).expect("runner failure error");
+
+    assert_eq!(
+        err.details["failure_context"]["error_code"].as_str(),
+        Some("rig.not_found")
+    );
+    assert_eq!(
+        err.details["failure_context"]["error_details"]["rig"].as_str(),
+        Some("missing")
+    );
+    assert!(err.details["failure_context"]
+        .get("contract_field")
+        .is_none());
+    let hints = err
+        .hints
+        .iter()
+        .map(|hint| hint.message.as_str())
+        .collect::<Vec<_>>();
+    assert!(hints
+        .iter()
+        .any(|hint| hint.contains("structured error: `rig.not_found`")));
+    assert!(hints
+        .iter()
+        .any(|hint| hint.contains("details: {\"rig\":\"missing\"}")));
+    assert!(hints
+        .iter()
+        .any(|hint| hint.contains("homeboy runner exec lab -- homeboy rig list")));
+    assert!(!hints
+        .iter()
+        .any(|hint| hint.contains("unknown contract field")));
+}
+
+#[test]
 fn runner_exec_failure_error_promotes_homeboy_job_event_message_error() {
     let mut output = failed_runner_exec_output("", "generic stderr");
     output.job_events = Some(vec![crate::core::api_jobs::JobEvent {

--- a/src/core/runner/lab/offload/errors.rs
+++ b/src/core/runner/lab/offload/errors.rs
@@ -392,16 +392,18 @@ pub(crate) fn append_runner_failure_context_summary(
         .persisted_run_id
         .as_deref()
         .unwrap_or("unknown persisted run");
-    let field = context
-        .contract_field
-        .as_deref()
-        .unwrap_or("unknown contract field");
-    stderr.push_str(&format!(
-        "Lab offload failure context: command `{}` failed on runner `{}`; runner job `{job}`; persisted run `{run}`; contract field `{field}`; reason: {}.\n",
+    let mut summary = format!(
+        "Lab offload failure context: command `{}` failed on runner `{}`; runner job `{job}`; persisted run `{run}`",
         redact_argv_display(&context.command),
-        context.runner_id,
-        context.reason
-    ));
+        context.runner_id
+    );
+    append_failure_context_error_summary(&mut summary, &context);
+    stderr.push_str(&summary);
+    stderr.push_str(".\n");
+    if let Some(hint) = runner_exec_failure_context_remediation_hint(&context) {
+        stderr.push_str(&hint);
+        stderr.push('\n');
+    }
 }
 
 pub(crate) fn append_runner_component_registry_repair_hint(

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -55,7 +55,9 @@ use crate::core::{Error, ErrorCode, Result};
 use super::super::command_path::preflight_remote_argv_path_translation;
 use super::super::daemon_health::runner_daemon_health_failure;
 use super::super::execution::{
-    lab_offload_handoff_hints, runner_exec_failure_context_from_output, DaemonJobHandoffState,
+    append_failure_context_error_summary, lab_offload_handoff_hints,
+    runner_exec_failure_context_from_output, runner_exec_failure_context_remediation_hint,
+    DaemonJobHandoffState,
 };
 use super::super::lab_apply::apply_lab_offload_patch;
 use super::super::lab_args::{

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -101,8 +101,53 @@ fn lab_offload_failure_summary_uses_runner_failure_context() {
     assert!(stderr.contains("command `homeboy test`"));
     assert!(stderr.contains("runner job `job-123`"));
     assert!(stderr.contains("persisted run `runner-exec-lab-default-job-123`"));
-    assert!(stderr.contains("contract field `cwd`"));
+    assert!(stderr.contains("contract field: `cwd`"));
     assert!(stderr.contains("Missing required field: cwd"));
+}
+
+#[test]
+fn lab_offload_failure_summary_keeps_rig_not_found_without_contract_field() {
+    let exec_output = RunnerExecOutput {
+        variant: "exec",
+        command: "runner.exec",
+        runner_id: "lab-default".to_string(),
+        dry_run: false,
+        mode: RunnerExecMode::Daemon,
+        argv: vec![
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "up".to_string(),
+            "missing".to_string(),
+        ],
+        remote_cwd: "/srv/homeboy/_lab_workspaces/sample-plugin-code".to_string(),
+        exit_code: 1,
+        stdout: String::new(),
+        stderr: r#"{"success":false,"error":{"code":"rig.not_found","message":"Rig not found","details":{"rig":"missing"}}}"#.to_string(),
+        source_snapshot: None,
+        job: None,
+        runner_job: None,
+        job_id: Some("job-123".to_string()),
+        job_events: None,
+        mirror_run_id: Some("runner-exec-lab-default-job-123".to_string()),
+        patch: None,
+        mutation_artifacts: None,
+        artifacts: Vec::new(),
+        metrics: None,
+        capture: None,
+        runner_result: None,
+        handoff: None,
+        diagnostics: None,
+    };
+    let mut stderr = String::new();
+
+    append_runner_failure_context_summary(&mut stderr, &exec_output);
+
+    assert!(stderr.contains("structured error: `rig.not_found`"));
+    assert!(stderr.contains("reason: Rig not found"));
+    assert!(stderr.contains("details: {\"rig\":\"missing\"}"));
+    assert!(stderr.contains("homeboy runner exec lab-default -- homeboy rig list"));
+    assert!(!stderr.contains("unknown contract field"));
+    assert!(!stderr.contains("contract field"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Stop rendering `unknown contract field` for runner failures that do not carry contract-field metadata.
- Preserve structured runner error code/details in Lab offload failure context summaries and canonical failure hints.
- Add a `rig.not_found` remediation hint that points operators at runner-side rig inventory.

Fixes https://github.com/Extra-Chill/homeboy/issues/6312

## Testing
- `rustfmt --check src/core/runner/execution/mod.rs src/core/runner/execution/failure.rs src/core/runner/execution/tests/redaction.rs src/core/runner/lab/offload/mod.rs src/core/runner/lab/offload/errors.rs src/core/runner/lab/offload/tests/exec_errors.rs`
- `cargo test runner_exec_failure_error_keeps_rig_not_found_without_contract_field`
- `cargo test lab_offload_failure_summary_keeps_rig_not_found_without_contract_field`
- `cargo test runner_exec_failure_error_surfaces_canonical_failure_context`
- `cargo test lab_offload_failure_summary_uses_runner_failure_context`
- `cargo check`
- `cargo clippy --all-targets` (passes with existing warnings)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing and testing the Lab offload failure envelope fix.
