### PR TITLE
fix(lab): pin runner workload extension revisions

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -27,9 +27,10 @@ pub use lab::{
     LabLocalExecutionPolicy, LabLocalHotPolicy, LabRoutingPolicy, LabRunnerSupportSummary,
     LabSelectedRunnerFallbackPolicy, LabSourcePathMode, LabWorkspaceModePolicy, RunnerWorkload,
     RunnerWorkloadArtifactRef, RunnerWorkloadAssignment, RunnerWorkloadCapability,
-    RunnerWorkloadCommandFamily, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
-    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
-    RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS, RUNNER_WORKLOAD_SCHEMA,
+    RunnerWorkloadCommandFamily, RunnerWorkloadExtensionRevision, RunnerWorkloadKind,
+    RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
+    RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS,
+    RUNNER_WORKLOAD_SCHEMA,
 };
 pub(crate) use lab::{
     AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LAB_NO_EXTRA_TOOLS, LINT_LAB_LABEL,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -123,10 +123,18 @@ pub struct RunnerWorkload {
     pub required_capabilities: Vec<RunnerWorkloadCapability>,
     pub required_secrets: RunnerWorkloadSecrets,
     pub required_extensions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_extension_revisions: Vec<RunnerWorkloadExtensionRevision>,
     pub mutation_policy: RunnerWorkloadMutationPolicy,
     pub assignment: RunnerWorkloadAssignment,
     pub state: RunnerWorkloadState,
     pub result_refs: RunnerWorkloadResultRefs,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerWorkloadExtensionRevision {
+    pub extension_id: String,
+    pub source_revision: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -187,9 +187,10 @@ mod tests {
         LAB_OFFLOAD_METADATA_SCHEMA,
     };
     use crate::command_contract::{
-        RunnerWorkload, RunnerWorkloadAssignment, RunnerWorkloadCommandFamily, RunnerWorkloadKind,
-        RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
-        RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
+        RunnerWorkload, RunnerWorkloadAssignment, RunnerWorkloadCommandFamily,
+        RunnerWorkloadExtensionRevision, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
+        RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
+        RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
     };
     use crate::core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
     use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
@@ -360,6 +361,10 @@ mod tests {
                 categories: Vec::new(),
             },
             required_extensions: vec!["browser".to_string()],
+            required_extension_revisions: vec![RunnerWorkloadExtensionRevision {
+                extension_id: "browser".to_string(),
+                source_revision: "abc1234".to_string(),
+            }],
             mutation_policy: RunnerWorkloadMutationPolicy {
                 capture_patch: false,
                 mutation_flag: None,
@@ -413,6 +418,14 @@ mod tests {
         assert_eq!(
             metadata["runner_workload"]["required_extensions"][0],
             "browser"
+        );
+        assert_eq!(
+            metadata["runner_workload"]["required_extension_revisions"][0]["extension_id"],
+            "browser"
+        );
+        assert_eq!(
+            metadata["runner_workload"]["required_extension_revisions"][0]["source_revision"],
+            "abc1234"
         );
     }
 

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -1,8 +1,8 @@
 use crate::command_contract::{
     RunnerWorkload, RunnerWorkloadAssignment, RunnerWorkloadCapability,
-    RunnerWorkloadCommandFamily, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
-    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
-    RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
+    RunnerWorkloadCommandFamily, RunnerWorkloadExtensionRevision, RunnerWorkloadKind,
+    RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
+    RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
 };
 use crate::core::error::{Error, Result};
 use crate::core::plan::HomeboyPlan;
@@ -50,6 +50,9 @@ pub(crate) fn build_runner_workload(input: RunnerWorkloadBuildInput<'_>) -> Runn
             categories: required_secret_categories(input.command.hot_label),
         },
         required_extensions: input.command.required_extensions.clone(),
+        required_extension_revisions: required_extension_revisions(
+            &input.command.required_extensions,
+        ),
         mutation_policy: RunnerWorkloadMutationPolicy {
             capture_patch: input.capture_patch,
             mutation_flag: input.mutation_flag.map(str::to_string),
@@ -74,6 +77,30 @@ pub(crate) fn build_runner_workload(input: RunnerWorkloadBuildInput<'_>) -> Runn
             artifacts: Vec::new(),
         },
     }
+}
+
+fn required_extension_revisions(
+    required_extensions: &[String],
+) -> Vec<RunnerWorkloadExtensionRevision> {
+    required_extension_revisions_with(
+        required_extensions,
+        crate::core::extension::read_source_revision,
+    )
+}
+
+fn required_extension_revisions_with(
+    required_extensions: &[String],
+    mut read_revision: impl FnMut(&str) -> Option<String>,
+) -> Vec<RunnerWorkloadExtensionRevision> {
+    required_extensions
+        .iter()
+        .filter_map(|extension_id| {
+            read_revision(extension_id).map(|source_revision| RunnerWorkloadExtensionRevision {
+                extension_id: extension_id.clone(),
+                source_revision,
+            })
+        })
+        .collect()
 }
 
 pub(crate) fn validate_runner_workload_dispatch(
@@ -542,6 +569,7 @@ mod tests {
         assert_eq!(workload.required_capabilities[1].name, "playwright");
         assert_eq!(workload.required_secrets.categories, vec!["trace"]);
         assert_eq!(workload.required_extensions, vec!["browser"]);
+        assert!(workload.required_extension_revisions.is_empty());
         assert_eq!(
             workload.mutation_policy.mutation_flag.as_deref(),
             Some("--keep-overlay")
@@ -553,6 +581,21 @@ mod tests {
         );
         assert_eq!(workload.result_refs.plan_id, "lab_offload.test");
         assert_eq!(workload.result_refs.proof_id.as_deref(), Some("proof-1"));
+    }
+
+    #[test]
+    fn runner_workload_extension_revisions_pin_installed_required_extensions() {
+        let revisions = required_extension_revisions_with(
+            &["browser".to_string(), "missing".to_string()],
+            |extension_id| match extension_id {
+                "browser" => Some("abc1234".to_string()),
+                _ => None,
+            },
+        );
+
+        assert_eq!(revisions.len(), 1);
+        assert_eq!(revisions[0].extension_id, "browser");
+        assert_eq!(revisions[0].source_revision, "abc1234");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds job-scoped required extension revision metadata to Lab runner workload payloads.
- Populates revisions from installed extension source metadata when a Lab command declares required extensions.
- Keeps existing required extension routing unchanged while making each job's expected extension snapshot auditable.

Fixes #6336

## Tests
- cargo test core::runner::workload::tests --lib
- cargo test core::runner::offload_metadata::tests::lab_offload_metadata_records_runner_workload_when_supplied --lib
- cargo test core::runner --lib (one reverse-worker cancellation test failed with a transient local HTTP request error; exact failed test passed on rerun)
- cargo test core::runner::worker::tests::worker_tests::reverse_worker_skips_finish_when_cancelled_after_execution --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the focused Lab runner workload metadata change, adding tests, and preparing the PR.