### PR TITLE
fix(rig): isolate id installs from stale sources

### DIFF
--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -88,7 +88,11 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
     let prepared = prepare_source(source)?;
     let discovered = discover_rigs_for_install(&prepared.discovery_path, id, all)?;
     let selected = select_rigs(discovered, id, all, source)?;
-    let discovered_stacks = discover_stacks(&prepared.discovery_path)?;
+    let discovered_stacks = if id.is_some() && !all {
+        Vec::new()
+    } else {
+        discover_stacks(&prepared.discovery_path)?
+    };
 
     fs::create_dir_all(paths::rigs()?)
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rigs dir".into())))?;

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -360,6 +360,36 @@ fn install_multi_rig_package_can_select_id() {
 }
 
 #[test]
+#[cfg(unix)]
+fn install_id_skips_stacks_from_stale_unrelated_installed_sources() {
+    let _home = HomeGuard::new();
+    let stale_source = tempfile::tempdir().expect("stale source");
+    write_rig(stale_source.path(), "stale-rig", &minimal_rig("stale-rig"));
+    let stale_stack = write_stack(stale_source.path(), "stale-stack", "stale-component");
+    install(stale_source.path().to_str().unwrap(), None, false).expect("install stale source");
+    fs::remove_dir_all(stale_source.path()).expect("remove stale source");
+
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    write_rig(package.path(), "beta", &minimal_rig("beta"));
+    write_stack(package.path(), "stale-stack", "other-component");
+
+    let result = install(package.path().to_str().unwrap(), Some("alpha"), false)
+        .expect("install requested rig despite stale unrelated stack source");
+
+    assert_eq!(result.installed.len(), 1);
+    assert_eq!(result.installed[0].id, "alpha");
+    assert!(result.installed_stacks.is_empty());
+    assert!(crate::core::paths::rig_config("alpha").unwrap().exists());
+    assert!(!crate::core::paths::rig_config("beta").unwrap().exists());
+    assert_eq!(
+        fs::read_link(crate::core::paths::stack_config("stale-stack").unwrap())
+            .expect("stale stack symlink remains reported by sources list"),
+        stale_stack
+    );
+}
+
+#[test]
 fn install_id_skips_invalid_unrelated_rigs_in_package() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");


### PR DESCRIPTION
## Summary
- Keep targeted `rig install --id` installs scoped to the requested rig.
- Avoid package-level stack refresh/install work for unrelated stale sources during targeted local installs.
- Add a regression covering deleted/stale installed source state.

Fixes #6329.

## Testing
- `cargo test --lib install_id_skips_stacks_from_stale_unrelated_installed_sources`
- `cargo test --lib install_multi_rig_package_can_select_id`
- `cargo test --lib install_package_with_sibling_stacks_installs_stack_specs`
- `cargo test --lib sources_list_reports_missing_linked_source_paths`
- `cargo test --lib core::rig::install::install_test`
- `rustfmt --check src/core/rig/install.rs tests/core/rig/install_test.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagent
- **Used for:** Implementing the scoped rig install fix, adding focused regression coverage, and drafting this PR description.