### PR TITLE
fix(refactor): default rename target to cwd

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -590,6 +590,17 @@ pub struct RefactorBulkSummary {
 
 impl RefactorTargetArgs {
     fn resolve_targets(&self) -> homeboy::core::Result<Vec<RefactorTarget>> {
+        self.resolve_targets_with_cwd_fallback(false)
+    }
+
+    fn resolve_targets_for_file_operation(&self) -> homeboy::core::Result<Vec<RefactorTarget>> {
+        self.resolve_targets_with_cwd_fallback(true)
+    }
+
+    fn resolve_targets_with_cwd_fallback(
+        &self,
+        allow_cwd_fallback: bool,
+    ) -> homeboy::core::Result<Vec<RefactorTarget>> {
         let component_ids = collect_component_ids(&self.component_ids, &self.components);
         if self.path.is_some() && !component_ids.is_empty() {
             return Err(homeboy::core::Error::validation_invalid_argument(
@@ -608,6 +619,10 @@ impl RefactorTargetArgs {
         }
 
         if component_ids.is_empty() {
+            if allow_cwd_fallback {
+                return resolve_refactor_cwd_target();
+            }
+
             return Err(homeboy::core::Error::validation_missing_argument(vec![
                 "component".to_string(),
             ]));
@@ -622,6 +637,32 @@ impl RefactorTargetArgs {
             })
             .collect())
     }
+}
+
+fn resolve_refactor_cwd_target() -> homeboy::core::Result<Vec<RefactorTarget>> {
+    let cwd = std::env::current_dir().map_err(|error| {
+        homeboy::core::Error::internal_io(error.to_string(), Some("current directory".to_string()))
+    })?;
+    if !cwd.is_dir() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "path",
+            format!("Not a directory: {}", cwd.display()),
+            None,
+            None,
+        ));
+    }
+
+    let label = cwd
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(".")
+        .to_string();
+
+    Ok(vec![RefactorTarget {
+        component_id: None,
+        path: Some(cwd.to_string_lossy().to_string()),
+        label,
+    }])
 }
 
 fn resolve_refactor_target(
@@ -881,7 +922,7 @@ fn run_rename(
     context: &str,
     write: bool,
 ) -> CmdResult<RefactorOutput> {
-    let targets = target.resolve_targets()?;
+    let targets = target.resolve_targets_for_file_operation()?;
     run_across_targets("rename", targets, |component_id, path| {
         run_rename_single(
             from,

--- a/tests/refactor_transform_test.rs
+++ b/tests/refactor_transform_test.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use homeboy::core::refactor;
@@ -88,4 +89,63 @@ fn transform_no_match_status_fixture_is_successful_empty_result() {
     assert_eq!(fixture["data"]["total_replacements"], 0);
     assert_eq!(fixture["data"]["total_files"], 0);
     assert_eq!(fixture["data"]["written"], false);
+}
+
+#[test]
+fn rename_defaults_to_cwd_git_worktree_without_component_metadata() {
+    let root = tmp_dir("rename-cwd");
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn old_name() -> i32 { 1 }\npub fn call() -> i32 { old_name() }\n",
+    )
+    .unwrap();
+
+    let git_init = Command::new("git")
+        .arg("init")
+        .current_dir(&root)
+        .output()
+        .expect("git init");
+    assert!(
+        git_init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&git_init.stderr)
+    );
+
+    let output = homeboy_command()
+        .args([
+            "refactor",
+            "rename",
+            "--from",
+            "old_name",
+            "--to",
+            "new_name",
+            "--write",
+        ])
+        .current_dir(&root)
+        .env("HOME", &root)
+        .output()
+        .expect("run homeboy refactor rename");
+
+    assert!(
+        output.status.success(),
+        "refactor rename failed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let source = fs::read_to_string(root.join("src/lib.rs")).unwrap();
+    assert!(source.contains("new_name"));
+    assert!(!source.contains("old_name"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}
+
+fn homeboy_command() -> Command {
+    let mut command = Command::new(homeboy_bin());
+    command.env("HOMEBOY_NO_UPDATE_CHECK", "1");
+    command
 }


### PR DESCRIPTION
## Summary
- Let `homeboy refactor rename` use the current working directory when no component or `--path` is supplied.
- Scope the fallback to rename so other refactor commands keep their existing target behavior.
- Add coverage for running rename from a plain git worktree without Homeboy component metadata.

Fixes #6330.

## Testing
- `cargo test --test refactor_transform_test rename_defaults_to_cwd_git_worktree_without_component_metadata`
- `cargo test commands::refactor::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagent
- **Used for:** Implementing the CWD fallback, adding focused tests, and drafting this PR description.