### PR TITLE
fix(refactor): preserve exact rename variants

### DIFF
--- a/src/core/refactor/rename/tests.rs
+++ b/src/core/refactor/rename/tests.rs
@@ -53,6 +53,61 @@ fn rename_spec_generates_variants() {
 }
 
 #[test]
+fn rename_spec_preserves_exact_branded_display_string() {
+    let spec = RenameSpec::new(
+        "Figma to WordPress",
+        "Figma to WordPress Studio",
+        RenameScope::All,
+    );
+
+    assert!(spec.variants.iter().any(|variant| {
+        variant.label == "exact"
+            && variant.from == "Figma to WordPress"
+            && variant.to == "Figma to WordPress Studio"
+    }));
+    assert!(spec
+        .variants
+        .iter()
+        .any(|variant| variant.from == "Figma To Word Press"));
+}
+
+#[test]
+fn normal_rename_matches_branded_display_string_without_literal() {
+    let dir = std::env::temp_dir().join("homeboy_refactor_branded_display_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    std::fs::write(
+        dir.join("test.md"),
+        "# Figma to WordPress\n\nFigma to WordPress workshop\n",
+    )
+    .unwrap();
+
+    let spec = RenameSpec::new(
+        "Figma to WordPress",
+        "Figma to WordPress Studio",
+        RenameScope::All,
+    );
+    assert!(!spec.literal);
+
+    let mut result = generate_renames(&spec, &dir);
+    assert_eq!(result.edits.len(), 1);
+    assert!(result.references.iter().any(|reference| {
+        reference.matched == "Figma to WordPress"
+            && reference.replacement == "Figma to WordPress Studio"
+    }));
+
+    apply_renames(&mut result, &dir).unwrap();
+    let content = std::fs::read_to_string(dir.join("test.md")).unwrap();
+    assert_eq!(
+        content,
+        "# Figma to WordPress Studio\n\nFigma to WordPress Studio workshop\n"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn find_references_in_temp_dir() {
     let dir = std::env::temp_dir().join("homeboy_refactor_test");
     let _ = std::fs::create_dir_all(&dir);

--- a/src/core/refactor/rename/types.rs
+++ b/src/core/refactor/rename/types.rs
@@ -261,6 +261,12 @@ impl RenameSpec {
 
         let mut variants = Vec::new();
 
+        variants.push(CaseVariant {
+            from: from.to_string(),
+            to: to.to_string(),
+            label: "exact".to_string(),
+        });
+
         // If word splitting produced words, generate cross-separator variants.
         // If it produced a single word (e.g., "widget"), the joins all collapse
         // to the same thing, and dedup handles it naturally.


### PR DESCRIPTION
## Summary
- Include the exact input/output pair in normal rename variant generation.
- Preserve branded/internal capitalization such as `Figma to WordPress` without requiring `--literal`.
- Add coverage for branded display-string renames.

Fixes #6331.

## Testing
- `cargo test --lib core::refactor::rename`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagent
- **Used for:** Implementing exact variant preservation, adding focused tests, and drafting this PR description.