### PR TITLE
fix(refactor): suppress keyword duplicate warnings

### DIFF
--- a/src/core/refactor/rename/safety.rs
+++ b/src/core/refactor/rename/safety.rs
@@ -205,6 +205,10 @@ pub(super) fn extract_field_identifier(trimmed: &str) -> Option<String> {
         return None;
     }
 
+    if is_language_keyword(&ident) {
+        return None;
+    }
+
     // Must be followed by : or ( or = or < (type params) to be an identifier.
     let after = &rest[ident.len()..].trim_start();
     if after.starts_with(':')
@@ -216,4 +220,49 @@ pub(super) fn extract_field_identifier(trimmed: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+fn is_language_keyword(ident: &str) -> bool {
+    matches!(
+        ident,
+        "as" | "async"
+            | "await"
+            | "break"
+            | "case"
+            | "catch"
+            | "class"
+            | "continue"
+            | "default"
+            | "do"
+            | "else"
+            | "enum"
+            | "export"
+            | "extends"
+            | "false"
+            | "finally"
+            | "for"
+            | "from"
+            | "if"
+            | "impl"
+            | "import"
+            | "in"
+            | "interface"
+            | "loop"
+            | "match"
+            | "mod"
+            | "return"
+            | "self"
+            | "static"
+            | "struct"
+            | "super"
+            | "switch"
+            | "this"
+            | "throw"
+            | "trait"
+            | "true"
+            | "try"
+            | "type"
+            | "use"
+            | "while"
+    )
 }

--- a/src/core/refactor/rename/tests.rs
+++ b/src/core/refactor/rename/tests.rs
@@ -282,6 +282,7 @@ fn extract_field_identifier_works() {
         extract_field_identifier("fn init("),
         Some("init".to_string())
     );
+    assert_eq!(extract_field_identifier("if (enabled) {"), None);
     assert_eq!(extract_field_identifier("// a comment"), None);
     assert_eq!(extract_field_identifier("#[serde(skip)]"), None);
     assert_eq!(extract_field_identifier(""), None);
@@ -330,6 +331,22 @@ fn detect_duplicate_identifiers_scopes_sibling_object_literals() {
     let content = "const tasks = [\n    {\n        promptFile: 'a.md',\n        graderFile: 'a.test.md',\n    },\n    {\n        promptFile: 'b.md',\n        graderFile: 'b.test.md',\n    },\n];\n";
     let mut warnings = Vec::new();
     detect_duplicate_identifiers("test.js", content, &mut warnings);
+    assert!(warnings.is_empty());
+}
+
+#[test]
+fn detect_duplicate_identifiers_ignores_repeated_control_flow_keywords() {
+    let content = r#"function run(items) {
+    if (items.length === 0) {
+        return;
+    }
+    if (items.length > 1) {
+        return;
+    }
+}
+"#;
+    let mut warnings = Vec::new();
+    detect_duplicate_identifiers("test.ts", content, &mut warnings);
     assert!(warnings.is_empty());
 }
 


### PR DESCRIPTION
## Summary
- Ignore common language/control-flow keywords when detecting duplicate identifiers during rename safety checks.
- Suppress noisy warnings for repeated `if` and similar tokens.
- Keep existing duplicate warnings for real identifier collisions.

Fixes #6332.

## Testing
- `cargo test --lib detect_duplicate_identifiers_ignores_repeated_control_flow_keywords`
- `cargo test --lib detect_duplicate_identifiers`
- `rustfmt --check src/core/refactor/rename/safety.rs src/core/refactor/rename/tests.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagent
- **Used for:** Implementing keyword suppression, adding focused tests, and drafting this PR description.