### PR TITLE
feat(rig): check local rig sources

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -46,8 +46,8 @@ impl RigArgs {
     }
 
     pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
-        if let RigCommand::Check { rig_id } = &self.command {
-            let contract = if rig_check_uses_linked_local_source(rig_id) {
+        if let RigCommand::Check { target, .. } = &self.command {
+            let contract = if rig_check_uses_linked_local_source(target) {
                 LabCommandContract::explicit_runner(
                     RIG_CHECK_LAB_LABEL,
                     None,
@@ -75,6 +75,9 @@ impl RigArgs {
 }
 
 fn rig_check_uses_linked_local_source(rig_id: &str) -> bool {
+    if std::path::Path::new(rig_id).exists() {
+        return true;
+    }
     rig::read_source_metadata(rig_id).is_some_and(|source| source.linked)
 }
 
@@ -94,8 +97,11 @@ enum RigCommand {
     },
     /// Run a rig's `check` pipeline and report health
     Check {
-        /// Rig ID
-        rig_id: String,
+        /// Rig ID, local package path, or direct rig.json path
+        target: String,
+        /// Select a rig from a local package path containing multiple rigs
+        #[arg(long)]
+        id: Option<String>,
     },
     /// Tear down a rig: stop services and run its `down` pipeline
     Down {
@@ -195,7 +201,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::List => list(),
         RigCommand::Show { rig_id } => show(&rig_id),
         RigCommand::Up { rig_id } => up(&rig_id),
-        RigCommand::Check { rig_id } => check(&rig_id),
+        RigCommand::Check { target, id } => check(&target, id.as_deref()),
         RigCommand::Down { rig_id } => down(&rig_id),
         RigCommand::Repair { rig_id } => repair(&rig_id),
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
@@ -357,8 +363,20 @@ fn up(rig_id: &str) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn check(rig_id: &str) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn check(target: &str, id: Option<&str>) -> CmdResult<RigCommandOutput> {
+    let rig = if std::path::Path::new(target).exists() {
+        rig::load_local_source(target, id)?
+    } else {
+        if id.is_some() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "id",
+                "--id is only valid when checking a local package path",
+                id.map(str::to_string),
+                None,
+            ));
+        }
+        rig::load(target)?
+    };
     let report = rig::run_check(&rig)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((

--- a/src/core/rig/expand.rs
+++ b/src/core/rig/expand.rs
@@ -98,6 +98,9 @@ fn normalize_exclusive_resource(resource: String) -> String {
 
 fn resolve_token(rig: &RigSpec, token: &str) -> Option<String> {
     if token == "package.root" {
+        if let Some(package_root) = super::local_package_root(&rig.id) {
+            return Some(package_root.to_string_lossy().to_string());
+        }
         return super::install::read_source_metadata(&rig.id).map(|metadata| metadata.package_path);
     }
     if let Some(rest) = token.strip_prefix("components.") {

--- a/src/core/rig/lint.rs
+++ b/src/core/rig/lint.rs
@@ -65,6 +65,9 @@ fn empty_outcome() -> PipelineOutcome {
 }
 
 fn package_lint_root(rig: &RigSpec) -> Option<PathBuf> {
+    if let Some(package_root) = super::local_package_root(&rig.id) {
+        return package_root.is_dir().then(|| package_root.clone());
+    }
     let metadata = read_source_metadata(&rig.id)?;
     metadata
         .discovery_path

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -92,8 +92,33 @@ pub use workloads::{
 
 use crate::core::error::{Error, Result};
 use crate::core::paths;
+use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+static LOCAL_PACKAGE_ROOTS: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
+
+fn remember_local_package_root(id: &str, package_root: &Path) {
+    let roots = LOCAL_PACKAGE_ROOTS.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(mut roots) = roots.lock() {
+        roots.insert(id.to_string(), package_root.to_path_buf());
+    }
+}
+
+fn forget_local_package_root(id: &str) {
+    if let Some(roots) = LOCAL_PACKAGE_ROOTS.get() {
+        if let Ok(mut roots) = roots.lock() {
+            roots.remove(id);
+        }
+    }
+}
+
+pub(crate) fn local_package_root(id: &str) -> Option<PathBuf> {
+    LOCAL_PACKAGE_ROOTS
+        .get()
+        .and_then(|roots| roots.lock().ok()?.get(id).cloned())
+}
 
 /// Byte-compare the contents of two files.
 ///
@@ -128,7 +153,68 @@ fn read_config(id: &str) -> Result<(RigSpec, Option<String>)> {
     apply_trace_workload_defaults(&mut spec)?;
     let declared_id = (!spec.id.is_empty() && spec.id != id).then(|| spec.id.clone());
     spec.id = id.to_string();
+    forget_local_package_root(id);
     Ok((spec, declared_id))
+}
+
+fn read_spec_from_path(path: &Path, id_hint: Option<&str>, package_root: &Path) -> Result<RigSpec> {
+    let value = match install::materialize_rig_spec(path, package_root)? {
+        Some(value) => value,
+        None => {
+            let content = fs::read_to_string(path).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("read rig spec {}", path.display())),
+                )
+            })?;
+            serde_json::from_str(&content).map_err(|e| {
+                Error::validation_invalid_json(
+                    e,
+                    Some(format!("parse rig spec {}", path.display())),
+                    Some(content.chars().take(200).collect()),
+                )
+            })?
+        }
+    };
+    let mut spec: RigSpec = serde_json::from_value(value).map_err(|e| {
+        Error::validation_invalid_json(e, Some(format!("parse rig spec {}", path.display())), None)
+    })?;
+    if spec.id.is_empty() {
+        spec.id = id_hint.unwrap_or_default().to_string();
+    }
+    spec.id = crate::core::extension::slugify_id(&spec.id)?;
+    remember_local_package_root(&spec.id, package_root);
+    apply_trace_workload_defaults(&mut spec)?;
+    Ok(spec)
+}
+
+fn local_package_root_for_rig_json(path: &Path) -> PathBuf {
+    let Some(rig_dir) = path.parent() else {
+        return PathBuf::from(".");
+    };
+    if rig_dir
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        == Some("rigs")
+    {
+        return rig_dir
+            .parent()
+            .and_then(Path::parent)
+            .unwrap_or(rig_dir)
+            .to_path_buf();
+    }
+    rig_dir.to_path_buf()
+}
+
+fn absolute_path(path: &str) -> Result<PathBuf> {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(std::env::current_dir()
+        .map_err(|e| Error::internal_io(e.to_string(), Some("get current dir".into())))?
+        .join(path))
 }
 
 fn apply_trace_workload_defaults(spec: &mut RigSpec) -> Result<()> {
@@ -209,6 +295,64 @@ fn stale_source_error(id: &str, config_path: &Path) -> Option<Error> {
 /// Load a rig spec by ID from `~/.config/homeboy/rigs/{id}.json`.
 pub fn load(id: &str) -> Result<RigSpec> {
     read_config(id).map(|(spec, _)| spec)
+}
+
+/// Load a rig spec directly from a local package directory or `rig.json` path
+/// without installing it into the global rig registry.
+pub fn load_local_source(source: &str, id: Option<&str>) -> Result<RigSpec> {
+    let path = absolute_path(source)?;
+    if path.is_file() {
+        if path.file_name().and_then(|name| name.to_str()) != Some("rig.json") {
+            return Err(Error::validation_invalid_argument(
+                "source",
+                "Rig check path must point at rig.json or a package directory",
+                Some(source.to_string()),
+                None,
+            ));
+        }
+        let package_root = local_package_root_for_rig_json(&path);
+        let id_hint = path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str());
+        return read_spec_from_path(&path, id.or(id_hint), &package_root);
+    }
+    if !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!("Path does not exist: {}", path.display()),
+            Some(source.to_string()),
+            None,
+        ));
+    }
+
+    let mut rigs = discover_rigs(&path)?;
+    if let Some(id) = id {
+        let id = crate::core::extension::slugify_id(id)?;
+        rigs.retain(|rig| rig.id == id);
+        if rigs.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "id",
+                format!("Rig '{}' not found in package", id),
+                Some(id),
+                None,
+            ));
+        }
+    } else if rigs.len() != 1 {
+        let available = rigs.iter().map(|rig| rig.id.clone()).collect::<Vec<_>>();
+        return Err(Error::validation_invalid_argument(
+            "id",
+            format!(
+                "Package contains multiple rigs; pass --id <rig>. Available: {}",
+                available.join(", ")
+            ),
+            Some(source.to_string()),
+            Some(available),
+        ));
+    }
+
+    let rig = rigs.remove(0);
+    read_spec_from_path(&rig.rig_path, Some(&rig.id), &path)
 }
 
 /// A loaded rig spec paired with the resolved on-disk package root of its

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -1,8 +1,8 @@
 //! Rig install lifecycle tests. Covers `src/core/rig/install.rs`.
 
 use crate::core::rig::{
-    declared_id, discover_rigs, install, list, list_ids, load, read_source_metadata,
-    read_stack_source_metadata, run_check,
+    declared_id, discover_rigs, install, list, list_ids, load, load_local_source,
+    read_source_metadata, read_stack_source_metadata, run_check,
 };
 use crate::test_support::HomeGuard;
 use std::fs;
@@ -203,6 +203,62 @@ fn installed_rig_check_reports_package_lint_failures() {
                 .unwrap_or_default()
                 .contains("conflicted.txt")
     }));
+}
+
+#[test]
+fn local_package_rig_check_loads_without_installing_source() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    fs::write(package.path().join("marker.txt"), "ok\n").expect("marker");
+    write_rig(
+        package.path(),
+        "local-alpha",
+        r#"{
+            "id": "local-alpha",
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "marker exists", "file": "${package.root}/marker.txt" }
+                ]
+            }
+        }"#,
+    );
+
+    let rig = load_local_source(package.path().to_str().unwrap(), Some("local-alpha"))
+        .expect("load local package rig");
+    let report = run_check(&rig).expect("check local package rig");
+
+    assert!(report.success, "local package check should pass");
+    assert!(read_source_metadata("local-alpha").is_none());
+    assert!(load("local-alpha").is_err(), "rig should not be installed");
+}
+
+#[test]
+fn local_direct_rig_json_check_resolves_package_root() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    fs::write(package.path().join("marker.txt"), "ok\n").expect("marker");
+    let rig_path = write_rig(
+        package.path(),
+        "direct-alpha",
+        r#"{
+            "id": "direct-alpha",
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "marker exists", "file": "${package.root}/marker.txt" }
+                ]
+            }
+        }"#,
+    );
+
+    let rig = load_local_source(rig_path.to_str().unwrap(), None).expect("load direct rig json");
+    let report = run_check(&rig).expect("check direct rig json");
+
+    assert!(report.success, "direct rig.json check should pass");
+    assert_eq!(
+        crate::core::rig::expand::expand_vars(&rig, "${package.root}/marker.txt"),
+        package.path().join("marker.txt").to_string_lossy()
+    );
+    assert!(read_source_metadata("direct-alpha").is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Allow `homeboy rig check` to target a local package directory or direct `rig.json` path without installing it first.
- Add `--id` for selecting a rig from a local multi-rig package.
- Preserve existing installed rig-id behavior.

Fixes #6333.

## Testing
- `cargo test local_package_rig_check_loads_without_installing_source`
- `cargo test local_direct_rig_json_check_resolves_package_root`
- `cargo run -- rig check --help`
- `git diff --check -- src/commands/rig/mod.rs src/core/rig/mod.rs src/core/rig/expand.rs src/core/rig/lint.rs tests/core/rig/install_test.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagent
- **Used for:** Implementing local rig source checks, adding focused tests, and drafting this PR description.