### PR TITLE
fix(cli): smooth refactor and rig source no-ops

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -976,8 +976,6 @@ fn run_rename_single(
         RenameScope::All => "all",
     };
 
-    let exit_code = if result.total_references == 0 { 1 } else { 0 };
-
     Ok((
         RefactorOutput::Rename {
             from: from.to_string(),
@@ -1023,7 +1021,7 @@ fn run_rename_single(
                 .collect(),
             applied: result.applied,
         },
-        exit_code,
+        0,
     ))
 }
 
@@ -1061,6 +1059,7 @@ fn parse_rename_variants(values: &[String]) -> homeboy::core::Result<Vec<(String
 mod tests {
     use super::*;
     use clap::Parser;
+    use std::fs;
 
     #[derive(Parser)]
     struct TestCli {
@@ -1125,5 +1124,47 @@ mod tests {
         let targets = args.resolve_targets().unwrap();
         let labels: Vec<_> = targets.into_iter().map(|target| target.label).collect();
         assert_eq!(labels, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn rename_no_match_dry_run_is_successful_empty_result() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).expect("src dir");
+        fs::write(src.join("sample.rs"), "fn present_name() {}\n").expect("fixture file");
+
+        let (output, exit_code) = run_rename_single(
+            "missing_name",
+            "new_name",
+            None,
+            Some(dir.path().to_str().expect("utf8 path")),
+            "code",
+            false,
+            &[],
+            &[],
+            &[],
+            false,
+            "all",
+            false,
+        )
+        .expect("rename should return structured output");
+
+        assert_eq!(exit_code, 0);
+        let RefactorOutput::Rename {
+            total_references,
+            total_files,
+            edits,
+            file_renames,
+            applied,
+            ..
+        } = output
+        else {
+            panic!("expected rename output");
+        };
+        assert_eq!(total_references, 0);
+        assert_eq!(total_files, 0);
+        assert!(edits.is_empty());
+        assert!(file_renames.is_empty());
+        assert!(!applied);
     }
 }

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -153,7 +153,7 @@ enum RigCommand {
     /// Inspect or remove installed rig sources
     Sources {
         #[command(subcommand)]
-        command: sources::RigSourcesCommand,
+        command: Option<sources::RigSourcesCommand>,
     },
     /// Install, update, or remove this rig's desktop app launcher.
     App {
@@ -463,4 +463,27 @@ fn app_uninstall(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
         }),
         0,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        rig: RigArgs,
+    }
+
+    #[test]
+    fn parses_sources_without_nested_subcommand() {
+        let cli = TestCli::try_parse_from(["homeboy", "sources"])
+            .expect("rig sources should parse without nested subcommand");
+
+        let RigCommand::Sources { command } = cli.rig.command else {
+            panic!("expected rig sources command");
+        };
+        assert!(command.is_none());
+    }
 }

--- a/src/commands/rig/sources.rs
+++ b/src/commands/rig/sources.rs
@@ -22,11 +22,11 @@ pub(super) enum RigSourcesCommand {
     },
 }
 
-pub(super) fn run(command: RigSourcesCommand) -> CmdResult<RigCommandOutput> {
+pub(super) fn run(command: Option<RigSourcesCommand>) -> CmdResult<RigCommandOutput> {
     match command {
-        RigSourcesCommand::List => list(),
-        RigSourcesCommand::Remove { source } => remove(&source),
-        RigSourcesCommand::Refresh { source } => refresh(source.as_deref()),
+        None | Some(RigSourcesCommand::List) => list(),
+        Some(RigSourcesCommand::Remove { source }) => remove(&source),
+        Some(RigSourcesCommand::Refresh { source }) => refresh(source.as_deref()),
     }
 }
 
@@ -58,4 +58,26 @@ fn refresh(source: Option<&str>) -> CmdResult<RigCommandOutput> {
         }),
         0,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sources_without_subcommand_defaults_to_list() {
+        crate::test_support::with_isolated_home(|_| {
+            let (output, exit_code) = run(None).expect("sources default should list");
+
+            assert_eq!(exit_code, 0);
+            let RigCommandOutput::Sources(RigSourcesOutput { command, report }) = output else {
+                panic!("expected sources output");
+            };
+            assert_eq!(command, "rig.sources.list");
+            let RigSourcesReport::List(result) = report else {
+                panic!("expected list report");
+            };
+            assert!(result.sources.is_empty());
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- Make no-match `refactor rename` return a successful empty result instead of a failure envelope without an error.
- Let `homeboy rig sources` default to the source list view when no nested subcommand is provided.
- Add focused CLI parsing and result-envelope tests.

Fixes #6334.
Fixes #6335.

## Testing
- `cargo fmt`
- `cargo test commands::refactor::tests::rename_no_match_dry_run_is_successful_empty_result`
- `cargo test commands::rig::tests::parses_sources_without_nested_subcommand`
- `cargo test commands::rig::sources::tests::sources_without_subcommand_defaults_to_list`
- `git diff --check -- src/commands/refactor.rs src/commands/rig/mod.rs src/commands/rig/sources.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagent
- **Used for:** Implementing the CLI result-envelope/source defaults, adding focused tests, and drafting this PR description.