### PR TITLE
fix: last 2 RED-main tests (cli_surface trace manifest + process_tree sigkill)

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1496,7 +1496,15 @@ mod tests {
             let manifest_entry = manifest
                 .find_path(&[entry.name])
                 .unwrap_or_else(|| panic!("manifest missing registered command `{}`", entry.name));
-            let output_notes_overridden_for_safety = matches!(entry.name, "release" | "upgrade");
+            // The manifest deliberately replaces the registry's generic output
+            // note with a safety-specific note for any command it classifies as
+            // mutating, operator-only, or guarded by dangerous flags. Those
+            // divergences are intentional, so only assert exact equality for
+            // commands without a safety classification (which still catches
+            // accidental drift on the common path).
+            let output_notes_overridden_for_safety = manifest_entry.mutates
+                || manifest_entry.operator
+                || !manifest_entry.dangerous_flags.is_empty();
 
             assert_eq!(
                 manifest_entry.docs.path,

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -113,6 +113,13 @@ pub struct ProcessTreeTermination {
 const SIGTERM_GRACE: std::time::Duration = std::time::Duration::from_millis(2000);
 #[cfg(unix)]
 const SIGTERM_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+/// How long to wait after SIGKILL for the kernel to actually tear the targets
+/// down before we declare them "surviving". `kill(2)` only queues the signal,
+/// so a pid can still read as running for a brief moment after the call
+/// returns; polling here keeps `surviving_pids` to genuinely unkillable
+/// processes instead of ones merely mid-teardown.
+#[cfg(unix)]
+const SIGKILL_REAP_GRACE: std::time::Duration = std::time::Duration::from_millis(2000);
 
 pub fn terminate_process_tree(owner_pid: u32) -> Result<ProcessTreeTermination> {
     if owner_pid > i32::MAX as u32 {
@@ -147,13 +154,11 @@ pub fn terminate_process_tree(owner_pid: u32) -> Result<ProcessTreeTermination> 
             killed_pids = survivors_after_term;
         }
 
-        // Anything still alive after SIGKILL is genuinely unkillable from here
-        // (uninterruptible sleep, different owner, ...). Surface it for recovery.
-        let surviving_pids: Vec<u32> = targets
-            .iter()
-            .copied()
-            .filter(|pid| pid_is_running(*pid))
-            .collect();
+        // `kill(2)` only queues SIGKILL, so a just-killed pid can still read as
+        // running for a moment after the call returns. Poll briefly for the
+        // tree to actually exit before snapshotting survivors so we don't
+        // misreport processes that are merely mid-teardown.
+        let surviving_pids = wait_for_exit(&targets, SIGKILL_REAP_GRACE);
 
         let signal = if killed_pids.is_empty() {
             "SIGTERM"


### PR DESCRIPTION
Final 2 of the 10 RED-main tests (other 8 fixed in #6355).

D: realigns cli_surface command-registry manifest output notes. Root cause was a SOURCE drift, not a flake: commit da14a66d ("classify additional command safety metadata") added a deliberate per-command safety output note in the manifest builder for `trace` (and `lint`/`cleanup`), but `command_registry_manifest_and_docs_metadata_align` only excepted `release`|`upgrade` from the exact-equality check. Rather than append literals one-off, the exception is now data-driven: any manifest entry classified as mutating, operator-only, or guarded by dangerous flags is allowed to carry a safety-specific note (registry stays the source of truth for non-safety commands, so accidental drift is still caught). This generalizes so future safety-classified commands do not reopen the test.

E: hardens terminate_process_tree SIGKILL escalation. This was a TIMING flake: `kill(2)` only queues SIGKILL, so a just-killed pid can still read as running for a brief moment after the call returns. The old code snapshotted `surviving_pids` immediately after sending SIGKILL, so a mid-teardown child was misreported as surviving. Now it reuses `wait_for_exit` with a bounded `SIGKILL_REAP_GRACE` to poll for the tree to actually exit before computing survivors. Genuinely unkillable pids still surface after the window. Verified 3/3 runs green; cooperative-child test unaffected.

Both verified via targeted --exact runs. cargo build --lib clean; out-of-scope fmt churn reverted.