### PR TITLE
fix: restore 10 RED-main tests (post-merge-burst drift)

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -995,8 +995,9 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
                 "mutates persisted audit baseline data in component configuration";
         }
         ["refactor"] => {
+            // output_notes is sourced from the authoritative command registry
+            // (refactor_command_registry_entry).
             metadata.mutates = true;
-            metadata.output_notes = "refactor subcommands can rewrite source files; use planning/dry-run modes where available";
             metadata.dangerous_flags = vec!["--write", "--commit"];
         }
         ["refactor", "rename"]

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -742,12 +742,14 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.dangerous_flags = vec!["--force", "--upgrade-runner"];
         }
         ["trace"] => {
+            // output_notes is sourced from the authoritative command registry
+            // (trace_command_registry_entry); only the path-specific mutates
+            // flag is set here.
             metadata.mutates = true;
-            metadata.output_notes = "runs trace workflows and records observation artifacts unless using read-only subcommands";
         }
         ["lint"] => {
-            metadata.output_notes =
-                "runs lint workflows; pass --fix to apply auto-fixable findings in place";
+            // output_notes is sourced from the authoritative command registry
+            // (lint_command_registry_entry).
             metadata.dangerous_flags = vec!["--fix", "--force"];
         }
         ["deps", "install"] | ["deps", "update"] | ["deps", "stack", "apply"] => {
@@ -761,9 +763,9 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.output_notes = "commits and pushes prepared CI autofix changes";
         }
         ["cleanup"] => {
+            // output_notes is sourced from the authoritative command registry
+            // (cleanup_command_registry_entry).
             metadata.mutates = true;
-            metadata.output_notes =
-                "cleanup subcommands report plans by default and require --apply for removals";
             metadata.dangerous_flags = vec!["--apply"];
         }
         ["cleanup", "artifacts"] => {

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1149,8 +1149,9 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.output_notes = "pushes the configured stack target branch to its remote";
         }
         ["undo"] => {
+            // output_notes is sourced from the authoritative command registry
+            // (undo_command_registry_entry).
             metadata.mutates = true;
-            metadata.output_notes = "restores files from the latest or selected undo snapshot";
         }
         ["undo", "delete"] => {
             metadata.mutates = true;

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -139,6 +139,37 @@ const fn manifest_command_registry_entry() -> CommandRegistryEntry {
     }
 }
 
+const fn trace_command_registry_entry() -> CommandRegistryEntry {
+    CommandRegistryEntry {
+        output_notes:
+            "runs trace workflows and records observation artifacts unless using read-only subcommands",
+        ..lab_command_registry_entry(
+            "trace",
+            CommandJsonFamily::Quality,
+            "portable Lab offload is available for trace runs",
+        )
+    }
+}
+
+const fn lint_command_registry_entry() -> CommandRegistryEntry {
+    CommandRegistryEntry {
+        output_notes: "runs lint workflows; pass --fix to apply auto-fixable findings in place",
+        ..lab_command_registry_entry(
+            "lint",
+            CommandJsonFamily::Quality,
+            "portable Lab offload is available for changed-scope lint runs",
+        )
+    }
+}
+
+const fn cleanup_command_registry_entry() -> CommandRegistryEntry {
+    CommandRegistryEntry {
+        output_notes:
+            "cleanup subcommands report plans by default and require --apply for removals",
+        ..command_registry_entry("cleanup", CommandJsonFamily::Workspace)
+    }
+}
+
 pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
     lab_command_registry_entry(
         "agent-task",
@@ -163,17 +194,9 @@ pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
         CommandJsonFamily::Quality,
         "portable Lab offload is available for fuzz runs",
     ),
-    lab_command_registry_entry(
-        "trace",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for trace runs",
-    ),
+    trace_command_registry_entry(),
     command_registry_entry("observe", CommandJsonFamily::Quality),
-    lab_command_registry_entry(
-        "lint",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for changed-scope lint runs",
-    ),
+    lint_command_registry_entry(),
     command_registry_entry("db", CommandJsonFamily::Ops),
     command_registry_entry("deps", CommandJsonFamily::Ops),
     command_registry_entry("ci", CommandJsonFamily::Ops),
@@ -191,7 +214,7 @@ pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
     command_registry_entry("docs", CommandJsonFamily::Workspace),
     manifest_command_registry_entry(),
     command_registry_entry("changelog", CommandJsonFamily::Workspace),
-    command_registry_entry("cleanup", CommandJsonFamily::Workspace),
+    cleanup_command_registry_entry(),
     command_registry_entry("git", CommandJsonFamily::Ops),
     command_registry_entry("issues", CommandJsonFamily::Ops),
     command_registry_entry("version", CommandJsonFamily::Workspace),

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -170,6 +170,18 @@ const fn cleanup_command_registry_entry() -> CommandRegistryEntry {
     }
 }
 
+const fn refactor_command_registry_entry() -> CommandRegistryEntry {
+    CommandRegistryEntry {
+        output_notes:
+            "refactor subcommands can rewrite source files; use planning/dry-run modes where available",
+        ..lab_command_registry_entry(
+            "refactor",
+            CommandJsonFamily::Workspace,
+            "portable Lab offload is available for refactor source runs",
+        )
+    }
+}
+
 pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
     lab_command_registry_entry(
         "agent-task",
@@ -233,11 +245,7 @@ pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
         "portable Lab offload is available for audit source runs",
     ),
     command_registry_entry("audit-baseline", CommandJsonFamily::Quality),
-    lab_command_registry_entry(
-        "refactor",
-        CommandJsonFamily::Workspace,
-        "portable Lab offload is available for refactor source runs",
-    ),
+    refactor_command_registry_entry(),
     command_registry_entry("refs", CommandJsonFamily::Workspace),
     lab_command_registry_entry(
         "rig",

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -182,6 +182,13 @@ const fn refactor_command_registry_entry() -> CommandRegistryEntry {
     }
 }
 
+const fn undo_command_registry_entry() -> CommandRegistryEntry {
+    CommandRegistryEntry {
+        output_notes: "restores files from the latest or selected undo snapshot",
+        ..command_registry_entry("undo", CommandJsonFamily::Workspace)
+    }
+}
+
 pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
     lab_command_registry_entry(
         "agent-task",
@@ -263,7 +270,7 @@ pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
     command_registry_entry("runs", CommandJsonFamily::Workspace),
     command_registry_entry("self", CommandJsonFamily::Ops),
     command_registry_entry("stack", CommandJsonFamily::Workspace),
-    command_registry_entry("undo", CommandJsonFamily::Workspace),
+    undo_command_registry_entry(),
     command_registry_entry("auth", CommandJsonFamily::Ops),
     command_registry_entry("api", CommandJsonFamily::Ops),
     command_registry_entry("http", CommandJsonFamily::Ops),

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -827,6 +827,9 @@ mod tests {
 
     #[test]
     fn linked_local_rig_check_stays_local_without_runner() {
+        // Scope the offload-metadata env var so a parallel test that sets it
+        // (process-global) cannot leak into this local/no-runner assertion.
+        let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
         let temp_home = tempdir().expect("temp home");
         let _home = EnvGuard::set("HOME", temp_home.path().to_str().expect("home path"));
         write_rig_source_metadata(temp_home.path(), "linked-local", true);
@@ -1158,6 +1161,10 @@ mod tests {
 
     #[test]
     fn agent_task_fanout_submit_batch_requires_explicit_runner_under_lab_only() {
+        // Isolate from a parallel test leaking the offload-metadata env var,
+        // which would otherwise short-circuit route_after_parse as a Lab
+        // offload subprocess and return Ok(None) instead of the deny error.
+        let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
         let normalized = vec![
             "homeboy".to_string(),
             "--lab-only".to_string(),

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -391,7 +391,10 @@ fn derive_fork_loop_id(requested_loop_id: &str, spec_fingerprint: &str) -> Strin
         .chars()
         .take(12)
         .collect::<String>();
-    format!("{requested_loop_id}/fork-{short}")
+    // Use a sanitization-stable separator: the loop_id becomes a single path
+    // segment (slashes are collapsed to `_` by sanitize_path_segment), so the
+    // persisted `record.loop_id` would otherwise diverge from the derived id.
+    format!("{requested_loop_id}-fork-{short}")
 }
 
 /// Remove a persisted controller record (and its directory) so a replace

--- a/src/core/agent_task_controller_service/run_failure_summary.rs
+++ b/src/core/agent_task_controller_service/run_failure_summary.rs
@@ -205,7 +205,13 @@ fn classify_owner_surface(
     {
         return OwnerSurface::ExtensionProvider;
     }
-    if haystack.contains("codebox") || haystack.contains("plugin activation") {
+    let provider_hint = provider.unwrap_or("").to_ascii_lowercase();
+    if haystack.contains("codebox")
+        || provider_hint.contains("codebox")
+        || phase.contains("codebox")
+        || phase.contains("plugin_activation")
+        || haystack.contains("plugin activation")
+    {
         return OwnerSurface::WpCodebox;
     }
     if haystack.contains("php fatal")
@@ -334,13 +340,15 @@ fn declared_ref_from_item(container_key: &str, item: &Value) -> Option<Controlle
     let uri = string_field(item, "uri")
         .or_else(|| string_field(item, "url"))
         .or_else(|| string_field(item, "path"))?;
-    let kind = string_field(item, "kind").unwrap_or_else(|| {
-        if container_key == "evidence_refs" {
-            "evidence_bundle".to_string()
-        } else {
-            "artifact_bundle".to_string()
-        }
-    });
+    // The evidence-ref `kind` is its own taxonomy (`artifact_bundle`,
+    // `evidence_bundle`, ...) keyed by the declaring container, not by the
+    // artifact's intrinsic `kind` (e.g. `log_bundle`). Classify by container so
+    // declared provider artifacts surface as `artifact_bundle`.
+    let kind = if container_key == "evidence_refs" {
+        "evidence_bundle".to_string()
+    } else {
+        "artifact_bundle".to_string()
+    };
     let label = string_field(item, "label")
         .or_else(|| string_field(item, "name"))
         .or_else(|| string_field(item, "role"));

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -559,10 +559,12 @@ pub(crate) fn validate_artifact_flow_bindings(spec: &AgentTaskRepoLoopSpec) -> R
             let has_flow_edge = spec.artifact_graph.iter().any(|edge| {
                 &edge.artifact_id == artifact_id && edge.to_workflow_id == workflow.workflow_id
             });
+            // A consume binding must be backed by an explicit emit or an
+            // artifact_flow edge. A producer merely declaring the artifact in
+            // its `artifacts` set does not establish a consume flow.
             let has_repo_producer = spec.workflows.iter().any(|producer| {
                 producer.workflow_id != workflow.workflow_id
-                    && (producer.artifacts.contains(artifact_id)
-                        || producer.emits.contains(artifact_id))
+                    && producer.emits.contains(artifact_id)
             });
             if !has_flow_edge && !has_repo_producer {
                 diagnostics.push(format!(

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -563,8 +563,7 @@ pub(crate) fn validate_artifact_flow_bindings(spec: &AgentTaskRepoLoopSpec) -> R
             // artifact_flow edge. A producer merely declaring the artifact in
             // its `artifacts` set does not establish a consume flow.
             let has_repo_producer = spec.workflows.iter().any(|producer| {
-                producer.workflow_id != workflow.workflow_id
-                    && producer.emits.contains(artifact_id)
+                producer.workflow_id != workflow.workflow_id && producer.emits.contains(artifact_id)
             });
             if !has_flow_edge && !has_repo_producer {
                 diagnostics.push(format!(

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -1194,7 +1194,7 @@ fn init_from_spec_for_resume_fork_isolates_under_derived_loop_id() {
         assert_eq!(resume_state.action, "forking");
         assert_eq!(resume_state.requested_loop_id, "repo-loop-resume-fork");
         assert_ne!(report.loop_id, "repo-loop-resume-fork");
-        assert!(report.loop_id.starts_with("repo-loop-resume-fork/fork-"));
+        assert!(report.loop_id.starts_with("repo-loop-resume-fork-fork-"));
 
         // The original controller still carries the base fingerprint, untouched.
         let original = status("repo-loop-resume-fork").expect("original controller intact");

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -113,6 +113,12 @@ pub struct ProcessTreeTermination {
 const SIGTERM_GRACE: std::time::Duration = std::time::Duration::from_millis(2000);
 #[cfg(unix)]
 const SIGTERM_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+/// How long to wait after escalating to SIGKILL before declaring a pid an
+/// unkillable survivor. SIGKILL delivery/reaping is asynchronous, so a process
+/// that is being torn down can still appear briefly running; without this grace
+/// the survivor set is racy (a freshly SIGKILL'd child reports as surviving).
+#[cfg(unix)]
+const SIGKILL_GRACE: std::time::Duration = std::time::Duration::from_millis(2000);
 
 pub fn terminate_process_tree(owner_pid: u32) -> Result<ProcessTreeTermination> {
     if owner_pid > i32::MAX as u32 {
@@ -144,6 +150,9 @@ pub fn terminate_process_tree(owner_pid: u32) -> Result<ProcessTreeTermination> 
         let survivors_after_term = wait_for_exit(&targets, SIGTERM_GRACE);
         if !survivors_after_term.is_empty() {
             signal_pids(&survivors_after_term, libc::SIGKILL)?;
+            // SIGKILL delivery/reaping is asynchronous; poll for the kill to
+            // take effect before declaring any pid an unkillable survivor.
+            wait_for_exit(&survivors_after_term, SIGKILL_GRACE);
             killed_pids = survivors_after_term;
         }
 

--- a/src/core/project/readiness.rs
+++ b/src/core/project/readiness.rs
@@ -75,12 +75,16 @@ pub fn validate_component_local_paths(project: &Project) -> Result<()> {
         return Ok(());
     }
 
-    Err(Error::validation_invalid_argument(
+    let mut err = Error::validation_invalid_argument(
         "components.local_path",
         "Project has component local_path blockers",
         Some(project.id.clone()),
-        Some(blockers),
-    ))
+        Some(blockers.clone()),
+    );
+    for blocker in blockers {
+        err = err.with_hint(blocker);
+    }
+    Err(err)
 }
 
 pub fn validate_component_local_path(project: &Project, component_id: &str) -> Result<()> {
@@ -97,12 +101,16 @@ pub fn validate_component_local_path(project: &Project, component_id: &str) -> R
         return Ok(());
     }
 
-    Err(Error::validation_invalid_argument(
+    let mut err = Error::validation_invalid_argument(
         "components.local_path",
         "Project component has a missing local_path",
         Some(project.id.clone()),
-        Some(blockers),
-    ))
+        Some(blockers.clone()),
+    );
+    for blocker in blockers {
+        err = err.with_hint(blocker);
+    }
+    Err(err)
 }
 
 fn component_local_path_blockers(project: &Project) -> Vec<String> {


### PR DESCRIPTION
## Summary

Main went RED (5960 passed; 10 failed) after a high merge volume, blocking the release pipeline. This restores all 10 failing tests, fixing the **source of drift** wherever possible (only updating a stale assertion when the new behavior was clearly the intended one).

## Fixes by cluster

**A — component `local_path` error-hint wording (3 tests, source fix)**
`validate_component_local_paths` / `validate_component_local_path` packed the missing-path blockers only into `details.tried`, never as `hints`, but the tests (added in `cc91c81a`) assert the blocker appears in `err.hints`. Now the blockers are attached as hints (still also in `tried`). Covers deploy `run`, resolution `resolve_project_component`, and readiness validation.

**B — agent-task controller (3 tests, source fix + 1 stale-assertion update)**
- `compile_plan_from_spec_rejects_unbacked_artifact_consumption`: `validate_artifact_flow_bindings` treated a producer merely declaring an artifact in its `artifacts` set as backing a consume edge, so unbacked consumption compiled. Backing now requires an explicit `emits` or an `artifact_flow` edge (matches the sibling `..._accepts_emit_consume_pairing` test which sets `emits`).
- `init_from_spec_for_resume_fork_isolates_under_derived_loop_id`: `derive_fork_loop_id` produced `…/fork-<hash>`, but the loop_id becomes a single sanitized path segment (`sanitize_path_segment` collapses `/`→`_`), so the persisted `report.loop_id` diverged. Switched the derived id to the sanitization-stable `…-fork-<hash>` and updated the assertion to match.
- `run_failure_summary_normalizes_nested_provider_failure`: two drifts — owner-surface classification ignored the `provider`/`failure_phase` codebox signal (fell through to `wordpress_runtime`), and declared artifacts carried their intrinsic `kind` (`log_bundle`) instead of the evidence-ref taxonomy. Codebox classification now considers provider/phase, and declared-artifact refs are classified by container as `artifact_bundle`.

**C — route Lab routing (2 tests, test-isolation fix)**
Both failed due to the process-global `LAB_OFFLOAD_METADATA_ENV` leaking from a parallel test (its presence makes `route_after_parse` short-circuit as a Lab-offload subprocess → `Ok(None)`). Added the same `EnvGuard::remove(LAB_OFFLOAD_METADATA_ENV)` scoping guard the sibling tests already use, so the preconditions hold regardless of test ordering.

**D — cli_surface manifest (1 test, source fix)**
`command_registry_manifest_and_docs_metadata_align` enforces that the registry is authoritative for `output_notes`, but `da14a66d` added single-segment `output_notes` overrides in `command_safety_metadata` for `trace`/`lint`/`cleanup`/`refactor`/`undo` without syncing `COMMAND_REGISTRY`. Moved those strings into dedicated registry constructors and dropped the per-path `output_notes` overrides (keeping path-specific `mutates`/`dangerous_flags`).

**E — process_tree SIGKILL escalation (1 test, source fix)**
`terminate_process_tree` computed `surviving_pids` immediately after sending SIGKILL, but kill delivery/reaping is asynchronous, so a freshly-killed child could still report running → racy `surviving_pids`. Now polls `wait_for_exit` on the killed set (`SIGKILL_GRACE`) before computing survivors, making escalation deterministic (assertion not weakened).

## Verification
- `cargo build --lib` clean.
- `cargo fmt` (out-of-scope reformatting reverted; only the edited closure kept).
- Each fixed test verified via targeted `cargo test --lib '<path>' -- --exact`; full `cli_surface::tests` (17) and `process_tree_tests` (4) modules pass.

## Notes
- All fixes are at the source of drift except the resume-fork loop_id prefix (intended-behavior assertion update) and the two route env-isolation guards (test-hardening). No new ecosystem literals were introduced into agnostic core behavioral code.