### PR TITLE
fix(rig): filter local package checks by id before parsing

### DIFF
--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -92,6 +92,7 @@ pub use workloads::{
 
 use crate::core::error::{Error, Result};
 use crate::core::paths;
+use discovery::discover_rigs_for_install;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -326,10 +327,13 @@ pub fn load_local_source(source: &str, id: Option<&str>) -> Result<RigSpec> {
         ));
     }
 
-    let mut rigs = discover_rigs(&path)?;
+    let mut rigs = if id.is_some() {
+        discover_rigs_for_install(&path, id, false)?
+    } else {
+        discover_rigs(&path)?
+    };
     if let Some(id) = id {
         let id = crate::core::extension::slugify_id(id)?;
-        rigs.retain(|rig| rig.id == id);
         if rigs.is_empty() {
             return Err(Error::validation_invalid_argument(
                 "id",

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -233,6 +233,33 @@ fn local_package_rig_check_loads_without_installing_source() {
 }
 
 #[test]
+fn local_package_rig_check_with_id_ignores_unselected_sibling_rigs() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    fs::write(package.path().join("marker.txt"), "ok\n").expect("marker");
+    write_rig(
+        package.path(),
+        "local-alpha",
+        r#"{
+            "id": "local-alpha",
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "marker exists", "file": "${package.root}/marker.txt" }
+                ]
+            }
+        }"#,
+    );
+    let sibling_dir = package.path().join("rigs/broken-sibling");
+    fs::create_dir_all(&sibling_dir).expect("sibling rig dir");
+    fs::write(sibling_dir.join("rig.json"), "{ definitely not json").expect("sibling rig json");
+
+    let rig = load_local_source(package.path().to_str().unwrap(), Some("local-alpha"))
+        .expect("load selected local package rig");
+
+    assert_eq!(rig.id, "local-alpha");
+}
+
+#[test]
 fn local_direct_rig_json_check_resolves_package_root() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");


### PR DESCRIPTION
## Summary
- Reuse filtered rig discovery when loading a local package with `--id`.
- Avoid parsing unrelated sibling rig specs before selecting the requested rig.
- Add a regression test with a malformed unselected sibling rig.

## Testing
- `cargo test -q local_package_rig_check_with_id_ignores_unselected_sibling_rigs`
- `cargo test -q core::rig::install::install_test`
- `cargo run --quiet -- rig check "/Users/chubes/Developer/homeboy-rigs@figma-to-wordpress-studio-rig/Automattic/studio" --id studio-figma-to-wordpress-import`
- `cargo run --quiet -- rig install "/Users/chubes/Developer/homeboy-rigs@figma-to-wordpress-studio-rig/Automattic/studio" --id studio-figma-to-wordpress-import --reinstall`
- `cargo run --quiet -- rig check studio-figma-to-wordpress-import`

## Notes
- `cargo fmt --check` currently reports pre-existing formatter drift in unrelated files; this PR only changes `src/core/rig/mod.rs` and `tests/core/rig/install_test.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the local rig selection bug, implementing the narrow fix, adding the regression test, and running validation.