### PR TITLE
Improve runner exec run naming

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -527,6 +527,7 @@ homeboy runner remove <id>
 homeboy runner exec <runner-id> -- <command...>
 homeboy runner exec <runner-id> --project <project-id> --cwd /runner/workspace/project -- <command...>
 homeboy runner exec <runner-id> --ssh --cwd /runner/workspace/project -- <command...>
+homeboy runner exec <runner-id> --run-id ssi-fixture-matrix-summary -- <command...>
 homeboy runner exec <runner-id> --cwd /runner/workspace/project --require-path /runner/workspace/project -- <command...>
 homeboy runner env <runner-id>
 homeboy runner env <runner-id> --show-values
@@ -541,6 +542,7 @@ Path rules:
 - Omitting `--cwd` on an SSH runner uses the runner `workspace_root`.
 - `--require-path <path>` preflights one or more runner-side paths before execution. Use it when a command references a lab worktree path so missing controller-only paths fail with a structured `require_path` error instead of an empty command failure.
 - `--project <id>` feeds the runner trust policy project allowlist check.
+- `--run-id <id>` sets the persisted controller-side runner-exec run id for ad hoc evidence commands. When omitted, Homeboy derives a run id prefix from the command domain, such as `trace-matrix-summary`.
 - `--ssh` is the explicit diagnostic fallback when `connect` is unavailable; daemon execution is preferred because it records job metadata and supports artifact-oriented workflows.
 - Diagnostic SSH output serializes as `mode: "diagnostic_ssh"` and does not include job/event evidence.
 - Raw SSH execution remains intentionally explicit and should not be used as production Lab/offload evidence; use connected daemon or reverse broker execution for job/event/artifact-compatible output.

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -399,6 +399,7 @@ fn run_rig_source_management_on_runner(
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
             runner_workload: None,
+            run_id: None,
             detach_after_handoff: false,
         },
     )?;

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -249,6 +249,10 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         dry_run: bool,
 
+        /// Explicit persisted run id for ad hoc runner exec evidence.
+        #[arg(long = "run-id")]
+        run_id: Option<String>,
+
         /// Print remote stdout/stderr directly instead of the structured JSON envelope.
         /// Use global --output to still write the full structured envelope to a file.
         #[arg(long)]

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -139,6 +139,7 @@ pub fn run(
             script_file,
             env,
             dry_run,
+            run_id,
             raw: _,
             command,
         } => map_execution(exec(
@@ -151,6 +152,7 @@ pub fn run(
             script_file,
             env,
             dry_run,
+            run_id,
             command,
         )),
         RunnerCommand::Env { id } => map_env(env_mod::env(&id)),
@@ -207,6 +209,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             script_file,
             env,
             dry_run,
+            run_id,
             raw: true,
             command,
         } => run_raw_exec(
@@ -219,6 +222,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             script_file,
             env,
             dry_run,
+            run_id,
             command,
         ),
         command => {
@@ -243,6 +247,7 @@ fn run_raw_exec(
     script_file: Option<String>,
     env: Vec<String>,
     dry_run: bool,
+    run_id: Option<String>,
     command: Vec<String>,
 ) -> JsonCommandRun {
     match exec(
@@ -255,6 +260,7 @@ fn run_raw_exec(
         script_file,
         env,
         dry_run,
+        run_id,
         command,
     ) {
         Ok((output, exit_code)) => raw_exec_command_run(output, exit_code),

--- a/src/commands/runner/exec.rs
+++ b/src/commands/runner/exec.rs
@@ -19,6 +19,7 @@ pub(super) fn exec(
     script_file: Option<String>,
     env: Vec<String>,
     dry_run: bool,
+    run_id: Option<String>,
     command: Vec<String>,
 ) -> CmdResult<RunnerExecOutput> {
     let script = script_file
@@ -64,9 +65,26 @@ pub(super) fn exec(
             required_extensions: Vec::new(),
             require_paths,
             runner_workload: None,
+            run_id: validate_runner_exec_run_id(run_id)?,
             detach_after_handoff: false,
         },
     )
+}
+
+fn validate_runner_exec_run_id(run_id: Option<String>) -> homeboy::core::Result<Option<String>> {
+    let Some(run_id) = run_id else {
+        return Ok(None);
+    };
+    let trimmed = run_id.trim();
+    if trimmed.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "run_id",
+            "runner exec --run-id must not be empty",
+            Some(run_id),
+            None,
+        ));
+    }
+    Ok(Some(trimmed.to_string()))
 }
 
 /// Maximum number of bytes retained when reading a runner exec script into

--- a/src/core/runner/evidence/mirror.rs
+++ b/src/core/runner/evidence/mirror.rs
@@ -16,8 +16,8 @@ use super::detail::{
 };
 use super::tokens::is_retrievable_runner_artifact;
 use super::util::{
-    job_status_as_run_status, local_job_run_id, ms_to_rfc3339, result_summary, runner_metadata,
-    source_snapshot_from_result,
+    job_status_as_run_status, local_job_run_id, ms_to_rfc3339, result_summary,
+    runner_exec_run_label, runner_metadata, source_snapshot_from_result,
 };
 
 #[derive(Debug)]
@@ -39,9 +39,10 @@ pub fn mirror_daemon_evidence(
     job: &Job,
     events: &[JobEvent],
     result: &Value,
+    run_id: Option<&str>,
 ) -> Result<Option<MirroredDaemonEvidence>> {
     let store = ObservationStore::open_initialized()?;
-    let local_job_run = mirror_job_run(&store, runner, cwd, command, job, events, result)?;
+    let local_job_run = mirror_job_run(&store, runner, cwd, command, job, events, result, run_id)?;
     let remote_runs = mirror_remote_observation_runs(&store, runner, job, result)?;
     let patch = mirrored_patch_result(&store, runner, job, result.get("patch"))?;
     let primary_run = primary_mirrored_run(&remote_runs).unwrap_or(local_job_run);
@@ -59,9 +60,10 @@ pub fn mirror_reverse_broker_evidence(
     job: &Job,
     events: &[JobEvent],
     result: &Value,
+    run_id: Option<&str>,
 ) -> Result<Option<MirroredDaemonEvidence>> {
     let store = ObservationStore::open_initialized()?;
-    let mut run = mirror_job_run(&store, runner, cwd, command, job, events, result)?;
+    let mut run = mirror_job_run(&store, runner, cwd, command, job, events, result, run_id)?;
     let artifacts = mirror_reverse_broker_artifacts(&store, runner, broker_url, &run.id, job)?;
 
     let mut metadata = run.metadata_json.clone();
@@ -93,9 +95,19 @@ pub fn mirror_daemon_job_progress(
     command: &[String],
     job: &Job,
     events: &[JobEvent],
+    run_id: Option<&str>,
 ) -> Result<RunRecord> {
     let store = ObservationStore::open_initialized()?;
-    mirror_job_run(&store, runner, cwd, command, job, events, &json!({}))
+    mirror_job_run(
+        &store,
+        runner,
+        cwd,
+        command,
+        job,
+        events,
+        &json!({}),
+        run_id,
+    )
 }
 
 pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRecord>>> {
@@ -116,7 +128,7 @@ pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRe
         .as_ref()
         .map(|command| vec![command.clone()])
         .unwrap_or_default();
-    mirror_job_run(&store, &runner, cwd, &command, &job, &events, &result)?;
+    mirror_job_run(&store, &runner, cwd, &command, &job, &events, &result, None)?;
     Ok(Some(mirror_remote_observation_runs(
         &store, &runner, &job, &result,
     )?))
@@ -240,9 +252,13 @@ pub(super) fn mirror_job_run(
     job: &Job,
     events: &[JobEvent],
     result: &Value,
+    run_id: Option<&str>,
 ) -> Result<RunRecord> {
+    let inferred_label = runner_exec_run_label(command);
     let run = RunRecord {
-        id: local_job_run_id(&runner.id, &job.id.to_string()),
+        id: run_id
+            .map(str::to_string)
+            .unwrap_or_else(|| local_job_run_id(&runner.id, &job.id.to_string(), &inferred_label)),
         kind: "runner-exec".to_string(),
         component_id: None,
         started_at: ms_to_rfc3339(job.started_at_ms.unwrap_or(job.created_at_ms)),
@@ -260,6 +276,8 @@ pub(super) fn mirror_job_run(
                 "remote_events": events,
                 "result_summary": result_summary(result),
                 "source_snapshot": source_snapshot_from_result(result),
+                "run_label": inferred_label,
+                "explicit_run_id": run_id,
             }
         }),
     };

--- a/src/core/runner/evidence/mod.rs
+++ b/src/core/runner/evidence/mod.rs
@@ -20,4 +20,4 @@ pub use mirror::{
     mirror_reverse_broker_evidence, mirrored_runner_job_identity, refresh_mirrored_daemon_evidence,
     runner_job_log_snapshot, RunnerJobLogSnapshot,
 };
-pub(crate) use util::local_job_run_id;
+pub(crate) use util::{local_job_run_id, runner_exec_run_label};

--- a/src/core/runner/evidence/tests/mod.rs
+++ b/src/core/runner/evidence/tests/mod.rs
@@ -18,7 +18,7 @@ use super::tokens::{
     is_reportable_artifact_evidence_path, is_retrievable_runner_artifact, runner_artifact_token,
     RemoteArtifactToken,
 };
-use super::util::fuzz_run_id_from_command;
+use super::util::{fuzz_run_id_from_command, runner_exec_run_label};
 
 fn ssh_runner() -> Runner {
     Runner {
@@ -126,6 +126,7 @@ fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
             &job,
             &[],
             &json!({"exit_code":0,"output":{"command":"bench"}}),
+            None,
         )
         .expect("mirror job");
         assert_eq!(run.kind, "runner-exec");
@@ -138,6 +139,109 @@ fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
         assert_eq!(
             run.metadata_json["lab"]["remote_job"]["id"].as_str(),
             Some(job_id.to_string().as_str())
+        );
+    });
+}
+
+#[test]
+fn runner_exec_matrix_summary_run_names_come_from_command_domain() {
+    crate::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let job_id = Uuid::new_v4();
+        let job = Job {
+            id: job_id,
+            operation: "exec".to_string(),
+            status: JobStatus::Succeeded,
+            created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_001_000,
+            started_at_ms: Some(1_700_000_000_000),
+            finished_at_ms: Some(1_700_000_001_000),
+            event_count: 0,
+            source_snapshot: None,
+            stale_reason: None,
+            target_runner_id: None,
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+        };
+        let command = [
+            "homeboy".to_string(),
+            "trace".to_string(),
+            "matrix".to_string(),
+            "summary".to_string(),
+            "--json".to_string(),
+        ];
+
+        let run = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/srv/homeboy/static-site-importer",
+            &command,
+            &job,
+            &[],
+            &json!({"exit_code":0}),
+            None,
+        )
+        .expect("mirror job");
+
+        assert_eq!(runner_exec_run_label(&command), "trace-matrix-summary");
+        assert!(run.id.starts_with("runner-exec-trace-matrix-summary-lab-"));
+        assert!(!run.id.contains("woo-db-api-rest-query-profile"));
+        assert_eq!(
+            run.metadata_json["lab"]["run_label"].as_str(),
+            Some("trace-matrix-summary")
+        );
+    });
+}
+
+#[test]
+fn runner_exec_explicit_run_id_overrides_inferred_name() {
+    crate::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let job_id = Uuid::new_v4();
+        let job = Job {
+            id: job_id,
+            operation: "exec".to_string(),
+            status: JobStatus::Running,
+            created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_001_000,
+            started_at_ms: Some(1_700_000_000_000),
+            finished_at_ms: None,
+            event_count: 0,
+            source_snapshot: None,
+            stale_reason: None,
+            target_runner_id: None,
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+        };
+
+        let run = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/srv/homeboy/static-site-importer",
+            &[
+                "homeboy".to_string(),
+                "runs".to_string(),
+                "list".to_string(),
+            ],
+            &job,
+            &[],
+            &json!({}),
+            Some("ssi-fixture-matrix-summary"),
+        )
+        .expect("mirror job");
+
+        assert_eq!(run.id, "ssi-fixture-matrix-summary");
+        assert_eq!(
+            run.metadata_json["lab"]["explicit_run_id"].as_str(),
+            Some("ssi-fixture-matrix-summary")
         );
     });
 }

--- a/src/core/runner/evidence/util.rs
+++ b/src/core/runner/evidence/util.rs
@@ -95,8 +95,65 @@ pub(super) fn job_status_as_run_status(status: JobStatus) -> &'static str {
     }
 }
 
-pub(crate) fn local_job_run_id(runner_id: &str, job_id: &str) -> String {
-    format!("runner-exec-{}-{}", sanitize_id_segment(runner_id), job_id)
+pub(crate) fn local_job_run_id(runner_id: &str, job_id: &str, label: &str) -> String {
+    format!(
+        "runner-exec-{}-{}-{}",
+        sanitize_id_segment(label).trim_matches('-'),
+        sanitize_id_segment(runner_id),
+        job_id
+    )
+}
+
+pub(crate) fn runner_exec_run_label(command: &[String]) -> String {
+    let mut tokens: Vec<String> = command
+        .iter()
+        .flat_map(|arg| {
+            if arg.contains("homeboy ") {
+                arg.split_whitespace().map(str::to_string).collect()
+            } else {
+                vec![arg.to_string()]
+            }
+        })
+        .collect();
+    if tokens.is_empty() {
+        return "generic".to_string();
+    }
+    if let Some(homeboy_pos) = tokens
+        .iter()
+        .position(|token| command_basename(token) == "homeboy")
+    {
+        tokens.drain(0..=homeboy_pos);
+    }
+    let mut parts = Vec::new();
+    for token in tokens {
+        if token == "--" || token.starts_with('-') {
+            break;
+        }
+        let part = command_basename(&token);
+        if part.is_empty() || matches!(part, "bash" | "sh" | "zsh" | "env") {
+            continue;
+        }
+        parts.push(part.to_string());
+        if parts.len() == 3 {
+            break;
+        }
+    }
+    let label = if parts.is_empty() {
+        "generic".to_string()
+    } else {
+        sanitize_id_segment(&parts.join("-"))
+            .trim_matches('-')
+            .to_string()
+    };
+    if label.is_empty() {
+        "generic".to_string()
+    } else {
+        label
+    }
+}
+
+fn command_basename(token: &str) -> &str {
+    token.rsplit('/').next().unwrap_or(token)
 }
 
 pub(super) fn sanitize_id_segment(value: &str) -> String {

--- a/src/core/runner/execution/broker.rs
+++ b/src/core/runner/execution/broker.rs
@@ -30,6 +30,7 @@ pub(super) fn exec_via_reverse_broker(
     source_snapshot_override: Option<SourceSnapshot>,
     require_paths: Vec<String>,
     runner_workload: Option<RunnerWorkload>,
+    run_id: Option<String>,
     detach_after_handoff: bool,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
@@ -80,7 +81,8 @@ pub(super) fn exec_via_reverse_broker(
             Some("parse reverse broker job".to_string()),
         )
     })?;
-    let persisted_run_id = persist_lab_offload_handoff_run(runner, &cwd, &command, &job);
+    let persisted_run_id =
+        persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref());
     if detach_after_handoff {
         return Ok(detached_handoff_output(
             runner,
@@ -140,8 +142,16 @@ pub(super) fn exec_via_reverse_broker(
         &redaction_secret_env_names,
     );
 
-    let mirror =
-        mirror_reverse_broker_evidence(runner, broker_url, &cwd, &command, &job, &events, &result)?;
+    let mirror = mirror_reverse_broker_evidence(
+        runner,
+        broker_url,
+        &cwd,
+        &command,
+        &job,
+        &events,
+        &result,
+        run_id.as_deref(),
+    )?;
     let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
     let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.clone());
     let artifacts = job.artifacts.clone();

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -18,7 +18,7 @@ use super::super::capabilities::{
 };
 use super::super::daemon_http_get::daemon_get;
 use super::super::evidence::{
-    local_job_run_id, mirror_daemon_evidence, mirror_daemon_job_progress,
+    local_job_run_id, mirror_daemon_evidence, mirror_daemon_job_progress, runner_exec_run_label,
 };
 use super::super::resource_metrics::RunnerResourceMetrics;
 use super::super::{Runner, RunnerCapabilityPreflight, RunnerJob, RunnerKind};
@@ -39,6 +39,7 @@ pub(super) fn exec_via_daemon(
     source_snapshot_override: Option<SourceSnapshot>,
     require_paths: Vec<String>,
     runner_workload: Option<RunnerWorkload>,
+    run_id: Option<String>,
     detach_after_handoff: bool,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
@@ -87,7 +88,8 @@ pub(super) fn exec_via_daemon(
     let mut job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
         Error::internal_json(err.to_string(), Some("parse daemon exec job".to_string()))
     })?;
-    let persisted_run_id = persist_lab_offload_handoff_run(runner, &cwd, &command, &job);
+    let persisted_run_id =
+        persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref());
     if detach_after_handoff {
         return Ok(detached_handoff_output(
             runner,
@@ -144,7 +146,15 @@ pub(super) fn exec_via_daemon(
         exit_code,
     } = runner_job_result_fields(&events, job.status, &env, &secret_env_names);
 
-    let mirror = mirror_daemon_evidence(runner, &cwd, &command, &job, &events, &result)?;
+    let mirror = mirror_daemon_evidence(
+        runner,
+        &cwd,
+        &command,
+        &job,
+        &events,
+        &result,
+        run_id.as_deref(),
+    )?;
     let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
     let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.clone());
     let artifacts = job.artifacts.clone();
@@ -474,7 +484,7 @@ pub(super) fn lab_terminal_result_transport_error(
     err: Error,
 ) -> Error {
     let job_id = job.id.to_string();
-    let run_id = local_job_run_id(&runner.id, &job_id);
+    let run_id = local_job_run_id(&runner.id, &job_id, &runner_exec_run_label(command));
     let mut error = Error::new(
         ErrorCode::RunnerLabTransportFailure,
         format!(
@@ -524,7 +534,7 @@ pub(super) fn daemon_job_wait_timeout(
     supports_cancellation: bool,
 ) -> Error {
     let job_id = job.id.to_string();
-    let mirrored = mirror_daemon_job_progress(runner, cwd, command, job, events);
+    let mirrored = mirror_daemon_job_progress(runner, cwd, command, job, events, None);
     let mirrored_run_id = mirrored.as_ref().ok().map(|run| run.id.clone());
     let timeout_hint = format!(
         "Set controller-side `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}` before invoking homeboy to change this wait budget, e.g. `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}=2400 homeboy ...`; workload settings are applied inside the remote job and cannot extend the controller wait."

--- a/src/core/runner/execution/handoff.rs
+++ b/src/core/runner/execution/handoff.rs
@@ -177,8 +177,9 @@ pub(super) fn persist_lab_offload_handoff_run(
     cwd: &str,
     command: &[String],
     job: &Job,
+    run_id: Option<&str>,
 ) -> Option<String> {
-    match mirror_daemon_job_progress(runner, cwd, command, job, &[]) {
+    match mirror_daemon_job_progress(runner, cwd, command, job, &[], run_id) {
         Ok(run) => Some(run.id),
         Err(err) => {
             eprintln!(

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -93,6 +93,7 @@ pub struct RunnerExecOptions {
     pub required_extensions: Vec<String>,
     pub require_paths: Vec<String>,
     pub runner_workload: Option<RunnerWorkload>,
+    pub run_id: Option<String>,
     pub detach_after_handoff: bool,
 }
 
@@ -346,6 +347,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 Some(plan.source_snapshot),
                 options.require_paths,
                 options.runner_workload,
+                options.run_id,
                 options.detach_after_handoff,
             )
         }
@@ -363,6 +365,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 Some(plan.source_snapshot),
                 options.require_paths,
                 options.runner_workload,
+                options.run_id,
                 options.detach_after_handoff,
             )
         }

--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -317,6 +317,7 @@ fn worker_local_workload_validation_uses_implicit_command_secret_names() {
                 required_extensions: Vec::new(),
                 require_paths: Vec::new(),
                 runner_workload: Some(workload),
+                run_id: None,
                 detach_after_handoff: false,
             },
             |_plan| {
@@ -357,6 +358,7 @@ fn test_exec_runs_local_runner_command() {
                 required_extensions: Vec::new(),
                 require_paths: Vec::new(),
                 runner_workload: None,
+                run_id: None,
                 detach_after_handoff: false,
             },
         )
@@ -413,6 +415,7 @@ fn test_exec_does_not_leak_ambient_process_env() {
                 required_extensions: Vec::new(),
                 require_paths: Vec::new(),
                 runner_workload: None,
+                run_id: None,
                 detach_after_handoff: false,
             },
         )
@@ -449,6 +452,7 @@ fn test_exec_preserves_explicit_request_env() {
                 required_extensions: Vec::new(),
                 require_paths: Vec::new(),
                 runner_workload: None,
+                run_id: None,
                 detach_after_handoff: false,
             },
         )
@@ -493,6 +497,7 @@ fn test_exec_rejects_missing_required_local_runner_path() {
                 required_extensions: Vec::new(),
                 require_paths: vec![missing.display().to_string()],
                 runner_workload: None,
+                run_id: None,
                 detach_after_handoff: false,
             },
         )
@@ -536,6 +541,7 @@ fn test_exec_reports_required_path_diagnostics() {
                 required_extensions: Vec::new(),
                 require_paths: vec![required_path.display().to_string()],
                 runner_workload: None,
+                run_id: None,
                 detach_after_handoff: false,
             },
         )
@@ -590,6 +596,7 @@ fn test_exec_rejects_disconnected_ssh_runner_without_diagnostic_fallback() {
                 required_extensions: Vec::new(),
                 require_paths: Vec::new(),
                 runner_workload: None,
+                run_id: None,
                 detach_after_handoff: false,
             },
         )
@@ -628,6 +635,7 @@ fn explicit_diagnostic_ssh_wins_for_ssh_runners() {
         required_extensions: Vec::new(),
         require_paths: Vec::new(),
         runner_workload: None,
+        run_id: None,
         detach_after_handoff: false,
     };
 

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -206,10 +206,11 @@ fn lab_offload_handoff_persists_run_when_job_is_accepted() {
             "/srv/homeboy/project",
             &["homeboy".to_string(), "trace".to_string()],
             &job,
+            None,
         )
         .expect("persist handoff run");
 
-        assert_eq!(run_id, format!("runner-exec-lab-{job_id}"));
+        assert_eq!(run_id, format!("runner-exec-trace-lab-{job_id}"));
         let store = crate::core::observation::ObservationStore::open_initialized().expect("store");
         let run = store
             .get_run(&run_id)
@@ -247,6 +248,7 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
             None,
             Vec::new(),
             None,
+            None,
             true,
         )
         .expect("reverse broker detached exec");
@@ -255,7 +257,7 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
         assert_eq!(output.mode, RunnerExecMode::ReverseBroker);
         let job_id = output.job_id.as_deref().expect("job id");
         let mirror_run_id = output.mirror_run_id.as_deref().expect("mirror run id");
-        assert_eq!(mirror_run_id, format!("runner-exec-lab-{job_id}"));
+        assert_eq!(mirror_run_id, format!("runner-exec-test-lab-{job_id}"));
         assert_eq!(
             output
                 .runner_result
@@ -379,6 +381,7 @@ fn reverse_broker_exec_submits_job_and_polls_result() {
             None,
             Vec::new(),
             None,
+            None,
             false,
         )
         .expect("reverse broker exec");
@@ -390,7 +393,7 @@ fn reverse_broker_exec_submits_job_and_polls_result() {
         assert_eq!(output.runner_id, "lab");
         assert!(output.job_id.is_some());
         let mirror_run_id = output.mirror_run_id.as_deref().expect("mirror run id");
-        assert!(mirror_run_id.starts_with("runner-exec-lab-"));
+        assert!(mirror_run_id.starts_with("runner-exec-test-lab-"));
         assert_eq!(
             output
                 .patch
@@ -493,6 +496,7 @@ fn daemon_exec_failure_without_error_field_is_actionable() {
         None,
         Vec::new(),
         None,
+        None,
         false,
     )
     .expect_err("daemon exec failure");
@@ -564,7 +568,7 @@ fn terminal_lab_result_transport_error_preserves_recovery_ids() {
         source,
     );
 
-    let run_id = format!("runner-exec-lab-{job_id}");
+    let run_id = format!("runner-exec-refactor-lab-{job_id}");
     assert_eq!(err.code, ErrorCode::RunnerLabTransportFailure);
     assert!(err.message.contains("Lab transport/reporting failure"));
     assert!(err.message.contains("not a remote command failure"));
@@ -651,6 +655,7 @@ fn daemon_exec_empty_envelope_over_http_is_actionable_not_null() {
         false,
         None,
         Vec::new(),
+        None,
         None,
         false,
     )

--- a/src/core/runner/execution/tests/policy.rs
+++ b/src/core/runner/execution/tests/policy.rs
@@ -39,6 +39,7 @@ fn test_runner_policy_denies_raw_ssh_exec_by_default() {
         required_extensions: Vec::new(),
         require_paths: Vec::new(),
         runner_workload: None,
+        run_id: None,
         detach_after_handoff: false,
     };
 
@@ -75,6 +76,7 @@ fn test_runner_policy_enforces_projects_commands_workspace_and_artifacts() {
         required_extensions: Vec::new(),
         require_paths: Vec::new(),
         runner_workload: None,
+        run_id: None,
         detach_after_handoff: false,
     };
     validate_runner_policy(

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -655,6 +655,7 @@ pub(crate) fn run_lab_offload_inner(
             required_extensions: contract.required_extensions.clone(),
             require_paths: Vec::new(),
             runner_workload: Some(runner_workload),
+            run_id: None,
             detach_after_handoff: request.detach_after_handoff,
         },
     );

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -146,6 +146,7 @@ pub(crate) fn run_runner_resident_lab_offload(
             required_extensions: contract.required_extensions.clone(),
             require_paths: Vec::new(),
             runner_workload: None,
+            run_id: None,
             detach_after_handoff: false,
         },
     )?;
@@ -240,6 +241,7 @@ pub(crate) fn refresh_managed_runner_sources(
                 required_extensions: Vec::new(),
                 require_paths: Vec::new(),
                 runner_workload: None,
+                run_id: None,
                 detach_after_handoff: false,
             },
         )?;

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -272,6 +272,7 @@ fn probe_agent_task_providers_on_runner(
             required_extensions,
             require_paths: Vec::new(),
             runner_workload: None,
+            run_id: None,
             detach_after_handoff: false,
         },
     )?;

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -493,6 +493,7 @@ fn run_runtime_overlay_install_step(
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
             runner_workload: None,
+            run_id: None,
             detach_after_handoff: false,
         },
     )?;

--- a/src/core/runner/lab_workspaces_deps.rs
+++ b/src/core/runner/lab_workspaces_deps.rs
@@ -478,6 +478,7 @@ pub(super) fn bootstrap_source_cli_node_dependencies(
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
             runner_workload: None,
+            run_id: None,
             detach_after_handoff: false,
         },
     )?;

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -229,6 +229,7 @@ pub(super) fn sync_lab_offload_rigs(
                 required_extensions: Vec::new(),
                 require_paths: Vec::new(),
                 runner_workload: None,
+                run_id: None,
                 detach_after_handoff: false,
             },
         )?;

--- a/src/core/runner/rig_materialization/rig_source_install.rs
+++ b/src/core/runner/rig_materialization/rig_source_install.rs
@@ -79,6 +79,7 @@ fn exec_runner_rig_sources_command(
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
             runner_workload: None,
+            run_id: None,
             detach_after_handoff: false,
         },
     )

--- a/src/core/runner/worker/run.rs
+++ b/src/core/runner/worker/run.rs
@@ -285,6 +285,7 @@ fn run_once_output(
             required_extensions: claim.request.required_extensions(),
             require_paths: claim.request.require_paths.clone(),
             runner_workload: claim.request.runner_workload.clone(),
+            run_id: None,
             detach_after_handoff: false,
         },
         || {

--- a/src/core/upgrade/runners/commands.rs
+++ b/src/core/upgrade/runners/commands.rs
@@ -157,6 +157,7 @@ pub fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecO
         required_extensions: Vec::new(),
         require_paths: Vec::new(),
         runner_workload: None,
+        run_id: None,
         detach_after_handoff: false,
     }
 }

--- a/src/core/upgrade/runners/source_checkout.rs
+++ b/src/core/upgrade/runners/source_checkout.rs
@@ -110,6 +110,7 @@ pub fn runner_source_checkout_prepare_options(
         required_extensions: Vec::new(),
         require_paths: Vec::new(),
         runner_workload: None,
+        run_id: None,
         detach_after_handoff: false,
     }
 }

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -599,6 +599,25 @@ fn runner_exec_raw_command_parses_before_trailing_command() {
 }
 
 #[test]
+fn runner_exec_run_id_parses_before_trailing_command() {
+    Cli::try_parse_from([
+        "homeboy",
+        "runner",
+        "exec",
+        "homeboy-lab",
+        "--run-id",
+        "ssi-fixture-matrix-summary",
+        "--cwd",
+        "/home/user/Developer",
+        "homeboy",
+        "trace",
+        "matrix",
+        "summary",
+    ])
+    .expect("runner exec --run-id should parse before the trailing remote command");
+}
+
+#[test]
 fn runner_env_rejects_legacy_show_values_flag() {
     assert!(
         Cli::try_parse_from(["homeboy", "runner", "env", "homeboy-lab", "--show-values"]).is_err(),

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1139,6 +1139,7 @@ fn runner_exec_rejects_requests_that_violate_runner_policy_before_daemon_dispatc
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
             runner_workload: None,
+            run_id: None,
             detach_after_handoff: false,
         },
     )


### PR DESCRIPTION
## Summary
- Adds `runner exec --run-id` so callers can supply durable domain-specific run IDs.
- Improves inferred runner exec run names from command/domain context.
- Covers CLI parsing and runner evidence naming behavior.

Fixes #6362.

## Testing
- `git diff --check`
- `cargo test command_surface`
- `cargo test runner_exec_run_id_parses_before_trailing_command`
- `cargo test runner_exec -- --test-threads=1`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the implementation.