### PR TITLE
Add fuzz runtime doctor

### DIFF
--- a/src/commands/fuzz/dispatch.rs
+++ b/src/commands/fuzz/dispatch.rs
@@ -10,6 +10,7 @@ use homeboy::core::fuzz::{
 
 use super::super::{CmdResult, GlobalArgs};
 use super::compare::run_compare;
+use super::doctor::run_doctor;
 use super::execution::run_run;
 use super::inspect::run_inspect;
 use super::planning::run_plan;
@@ -24,6 +25,9 @@ use super::workloads::{fuzz_workloads, load_rig, resolve_component_id, resolve_f
 pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
     match args.command {
         Some(FuzzCommand::Contract) => Ok((FuzzOutput::Contract(run_contract()), 0)),
+        Some(FuzzCommand::Doctor(doctor_args)) => {
+            Ok((FuzzOutput::Doctor(run_doctor(doctor_args)?), 0))
+        }
         Some(FuzzCommand::Discover(discover_args)) => {
             Ok((FuzzOutput::Discover(run_discover(discover_args)?), 0))
         }

--- a/src/commands/fuzz/doctor.rs
+++ b/src/commands/fuzz/doctor.rs
@@ -1,0 +1,44 @@
+use homeboy::core::extension::{
+    check_update_available, extension_ready_status, is_extension_linked, load_extension,
+    read_source_revision,
+};
+
+use super::types::FuzzDoctorArgs;
+use super::types_extra::{FuzzDoctorExtensionOutput, FuzzDoctorHomeboyOutput, FuzzDoctorOutput};
+
+pub(super) fn run_doctor(args: FuzzDoctorArgs) -> homeboy::core::Result<FuzzDoctorOutput> {
+    let extension = load_extension(&args.extension_id)?;
+    let ready = extension_ready_status(&extension);
+    let linked = is_extension_linked(&extension.id);
+    let source_revision = read_source_revision(&extension.id);
+    let update = check_update_available(&extension.id);
+    let update_command = format!("homeboy extension update {}", extension.id);
+    let status = if ready.ready && update.is_none() {
+        "ok"
+    } else {
+        "attention"
+    };
+
+    Ok(FuzzDoctorOutput {
+        command: "fuzz.doctor".to_string(),
+        status: status.to_string(),
+        homeboy: FuzzDoctorHomeboyOutput {
+            controller_version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        extension: FuzzDoctorExtensionOutput {
+            id: extension.id.clone(),
+            name: extension.name.clone(),
+            version: extension.version.clone(),
+            path: extension.extension_path.clone().unwrap_or_default(),
+            linked,
+            ready: ready.ready,
+            ready_reason: ready.reason,
+            ready_detail: ready.detail,
+            source_url: extension.source_url.clone(),
+            source_revision,
+            commits_behind: update.map(|update| update.behind_count),
+            update_command,
+        },
+        update_hint: "Update source checkouts and the active installed extension; fuzz runs use the installed extension/runtime, not an arbitrary source checkout.".to_string(),
+    })
+}

--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -1,5 +1,6 @@
 mod compare;
 mod dispatch;
+mod doctor;
 mod execution;
 mod inspect;
 mod planning;

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -243,6 +243,18 @@ fn fuzz_run_parses_generic_contract_flags() {
 }
 
 #[test]
+fn fuzz_doctor_parses_extension_id() {
+    let cli = FuzzCli::parse_from(["fuzz", "doctor", "--extension", "runtime-a"]);
+
+    match cli.args.command {
+        Some(FuzzCommand::Doctor(doctor)) => {
+            assert_eq!(doctor.extension_id, "runtime-a");
+        }
+        _ => panic!("expected fuzz doctor command"),
+    }
+}
+
+#[test]
 fn fuzz_validate_accepts_case_log_artifact() {
     let dir = tempfile::tempdir().expect("temp dir");
     let results_file = dir.path().join("fuzz-results.json");

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -60,6 +60,8 @@ impl FuzzArgs {
 pub(crate) enum FuzzCommand {
     /// Print the product-neutral fuzz schema contract
     Contract,
+    /// Diagnose active fuzz runtime provenance and installed extension revision
+    Doctor(FuzzDoctorArgs),
     /// Normalize and merge discovered fuzz target inventory artifacts
     Discover(FuzzDiscoverArgs),
     /// List declared fuzz workloads without executing them
@@ -78,6 +80,13 @@ pub(crate) enum FuzzCommand {
     Replay(FuzzReplayArgs),
     /// Print the raw fuzz runner result for a run without spelunking runner logs
     Inspect(FuzzInspectArgs),
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct FuzzDoctorArgs {
+    /// Extension whose active install should be diagnosed.
+    #[arg(long = "extension", value_name = "ID", required = true)]
+    pub(crate) extension_id: String,
 }
 
 #[derive(Args, Clone)]
@@ -261,7 +270,6 @@ pub(crate) struct FuzzReportArgs {
     /// Stable envelope id. Defaults to --run-id, then the campaign id.
     #[arg(long = "envelope-id", value_name = "ID")]
     pub(crate) envelope_id: Option<String>,
-
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -11,6 +11,7 @@ use homeboy::core::performance_hotspots::PerformanceHotspotSummary;
 #[serde(tag = "variant", rename_all = "snake_case")]
 pub enum FuzzOutput {
     Contract(FuzzContractOutput),
+    Doctor(FuzzDoctorOutput),
     Discover(FuzzDiscoverOutput),
     List(FuzzListOutput),
     Plan(FuzzPlanOutput),
@@ -20,6 +21,41 @@ pub enum FuzzOutput {
     Compare(FuzzCompareOutput),
     Replay(FuzzReplayOutput),
     Inspect(FuzzInspectOutput),
+}
+
+#[derive(Serialize)]
+pub struct FuzzDoctorOutput {
+    pub command: String,
+    pub status: String,
+    pub homeboy: FuzzDoctorHomeboyOutput,
+    pub extension: FuzzDoctorExtensionOutput,
+    pub update_hint: String,
+}
+
+#[derive(Serialize)]
+pub struct FuzzDoctorHomeboyOutput {
+    pub controller_version: String,
+}
+
+#[derive(Serialize)]
+pub struct FuzzDoctorExtensionOutput {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub path: String,
+    pub linked: bool,
+    pub ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ready_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ready_detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits_behind: Option<usize>,
+    pub update_command: String,
 }
 
 /// Raw fuzz-result inspection output for `homeboy fuzz inspect <run-id>`.


### PR DESCRIPTION
## Summary
- Add `homeboy fuzz doctor --extension <ID>`.
- Report Homeboy controller version and active installed extension provenance.
- Include update guidance so stale source checkouts are distinguishable from installed runtime state.

## Verification
- cargo test fuzz::tests --lib
- cargo test fuzz_doctor_parses_extension_id --lib
- cargo run --quiet -- fuzz doctor --help
- cargo run --quiet -- fuzz doctor --extension wordpress
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the fuzz doctor command, typed output, parser coverage, and verification.