### PR TITLE
fix(deploy): scope project local path validation

### DIFF
--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -38,7 +38,7 @@ use crate::core::project;
 /// and SSH context resolution, keeping those details encapsulated.
 pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestrationResult> {
     let project = project::load(project_id)?;
-    project::validate_component_local_paths(&project)?;
+    project::validate_deploy_component_local_paths(&project, &config.component_ids)?;
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)?;
     orchestration::deploy_components(config, &project, &ctx, &base_path)
 }
@@ -306,7 +306,7 @@ mod tests {
             let err = run("site", &deploy_config()).expect_err("missing local_path should block");
 
             assert_eq!(err.code.as_str(), "validation.invalid_argument");
-            assert!(err.message.contains("component local_path blockers"));
+            assert!(err.message.contains("missing local_path"));
             assert!(err.hints.iter().any(|hint| {
                 hint.message.contains(
                     "Component 'plugin' local_path '/tmp/homeboy-missing-component-path' does not exist",

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -36,6 +36,7 @@ pub use pins::{
 };
 pub use readiness::{
     calculate_deploy_readiness, validate_component_local_path, validate_component_local_paths,
+    validate_deploy_component_local_paths,
 };
 pub use report::{
     build_components_output, build_create_output, build_delete_output, build_init_output,

--- a/src/core/project/readiness.rs
+++ b/src/core/project/readiness.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::core::component;
 use crate::core::error::{Error, Result};
 
@@ -87,6 +89,73 @@ pub fn validate_component_local_paths(project: &Project) -> Result<()> {
     Err(err)
 }
 
+pub fn validate_deploy_component_local_paths(
+    project: &Project,
+    component_ids: &[String],
+) -> Result<()> {
+    if component_ids.is_empty() {
+        return validate_component_local_paths(project);
+    }
+
+    let mut scoped_ids = component_ids.iter().cloned().collect::<HashSet<_>>();
+    let standalone_snapshot = super::StandaloneComponentConfigSnapshot::load();
+    for component_id in component_ids {
+        validate_component_local_path(project, component_id)?;
+        let component = super::resolve_project_component_with_standalone_snapshot(
+            project,
+            component_id,
+            Some(&standalone_snapshot),
+        )?;
+
+        scoped_ids.extend(component.deploy_together);
+        scoped_ids.extend(
+            component
+                .artifact_inputs
+                .into_iter()
+                .map(|input| input.component),
+        );
+    }
+
+    let mut scoped_blockers = Vec::new();
+    let mut hygiene_blockers = Vec::new();
+    for attachment in &project.components {
+        let Some(blocker) =
+            component_local_path_blocker(project, &attachment.id, &attachment.local_path)
+        else {
+            continue;
+        };
+
+        if scoped_ids.contains(&attachment.id) {
+            scoped_blockers.push(blocker);
+        } else {
+            hygiene_blockers.push(blocker);
+        }
+    }
+
+    for blocker in hygiene_blockers {
+        log_status!(
+            "deploy",
+            "Project component local_path hygiene warning: {}",
+            blocker
+        );
+    }
+
+    if scoped_blockers.is_empty() {
+        return Ok(());
+    }
+
+    let mut err = Error::validation_invalid_argument(
+        "components.local_path",
+        "Scoped deploy has component local_path blockers",
+        Some(project.id.clone()),
+        Some(scoped_blockers.clone()),
+    );
+    for blocker in scoped_blockers {
+        err = err.with_hint(blocker);
+    }
+    Err(err)
+}
+
 pub fn validate_component_local_path(project: &Project, component_id: &str) -> Result<()> {
     let blockers = project
         .components
@@ -152,6 +221,7 @@ fn component_local_path_blocker(
 mod tests {
     use super::*;
     use crate::core::project::ProjectComponentAttachment;
+    use tempfile::TempDir;
 
     fn project_with_component(local_path: String) -> Project {
         Project {
@@ -163,6 +233,39 @@ mod tests {
                 local_path,
                 remote_path: Some("wp-content/plugins/plugin".to_string()),
             }],
+            ..Project::default()
+        }
+    }
+
+    fn repo_with_component(id: &str, extra: serde_json::Value) -> TempDir {
+        let dir = TempDir::new().expect("temp dir");
+        let mut component = serde_json::json!({
+            "id": id,
+            "remote_path": format!("wp-content/plugins/{id}"),
+            "build_artifact": format!("dist/{id}.zip")
+        });
+        let component_obj = component.as_object_mut().expect("component object");
+        for (key, value) in extra.as_object().expect("extra object") {
+            component_obj.insert(key.clone(), value.clone());
+        }
+        std::fs::write(dir.path().join("homeboy.json"), component.to_string())
+            .expect("write homeboy.json");
+        dir
+    }
+
+    fn project_with_components(components: Vec<(&str, String)>) -> Project {
+        Project {
+            id: "site".to_string(),
+            server_id: Some("server".to_string()),
+            base_path: Some("/srv/site".to_string()),
+            components: components
+                .into_iter()
+                .map(|(id, local_path)| ProjectComponentAttachment {
+                    id: id.to_string(),
+                    local_path,
+                    remote_path: Some(format!("wp-content/plugins/{id}")),
+                })
+                .collect(),
             ..Project::default()
         }
     }
@@ -190,5 +293,108 @@ mod tests {
         assert!(err.hints.iter().any(|hint| hint
             .message
             .contains("local_path '/tmp/homeboy-missing-component-path' does not exist")));
+    }
+
+    #[test]
+    fn scoped_deploy_validation_ignores_unrelated_missing_component_local_path() {
+        let requested = repo_with_component("requested", serde_json::json!({}));
+        let project = project_with_components(vec![
+            ("requested", requested.path().to_string_lossy().to_string()),
+            (
+                "stale",
+                "/tmp/homeboy-stale-unrelated-component".to_string(),
+            ),
+        ]);
+
+        validate_deploy_component_local_paths(&project, &["requested".to_string()])
+            .expect("unrelated stale local_path should be hygiene-only");
+    }
+
+    #[test]
+    fn scoped_deploy_validation_blocks_missing_direct_dependency_local_path() {
+        let requested = repo_with_component(
+            "requested",
+            serde_json::json!({ "deploy_together": ["required"] }),
+        );
+        let project = project_with_components(vec![
+            ("requested", requested.path().to_string_lossy().to_string()),
+            (
+                "required",
+                "/tmp/homeboy-stale-required-component".to_string(),
+            ),
+            (
+                "stale",
+                "/tmp/homeboy-stale-unrelated-component".to_string(),
+            ),
+        ]);
+
+        let err = validate_deploy_component_local_paths(&project, &["requested".to_string()])
+            .expect_err("stale direct dependency should block scoped deploy");
+
+        assert!(err.message.contains("Scoped deploy"));
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("Component 'required' local_path '/tmp/homeboy-stale-required-component' does not exist")));
+        assert!(!err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("homeboy-stale-unrelated-component")));
+    }
+
+    #[test]
+    fn scoped_deploy_validation_blocks_missing_artifact_input_dependency_local_path() {
+        let requested = repo_with_component(
+            "requested",
+            serde_json::json!({
+                "artifact_inputs": [{
+                    "component": "producer",
+                    "artifact": "dist/producer.zip",
+                    "target": "vendor/producer.zip",
+                    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }]
+            }),
+        );
+        let project = project_with_components(vec![
+            ("requested", requested.path().to_string_lossy().to_string()),
+            (
+                "producer",
+                "/tmp/homeboy-stale-producer-component".to_string(),
+            ),
+            (
+                "stale",
+                "/tmp/homeboy-stale-unrelated-component".to_string(),
+            ),
+        ]);
+
+        let err = validate_deploy_component_local_paths(&project, &["requested".to_string()])
+            .expect_err("stale artifact producer should block scoped deploy");
+
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("Component 'producer' local_path '/tmp/homeboy-stale-producer-component' does not exist")));
+        assert!(!err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("homeboy-stale-unrelated-component")));
+    }
+
+    #[test]
+    fn full_project_deploy_validation_remains_strict_for_all_components() {
+        let requested = repo_with_component("requested", serde_json::json!({}));
+        let project = project_with_components(vec![
+            ("requested", requested.path().to_string_lossy().to_string()),
+            (
+                "stale",
+                "/tmp/homeboy-stale-unrelated-component".to_string(),
+            ),
+        ]);
+
+        let err = validate_deploy_component_local_paths(&project, &[])
+            .expect_err("full-project deploy should validate every component");
+
+        assert!(err.message.contains("component local_path blockers"));
+        assert!(err.hints.iter().any(|hint| hint.message.contains(
+            "Component 'stale' local_path '/tmp/homeboy-stale-unrelated-component' does not exist"
+        )));
     }
 }


### PR DESCRIPTION
## Summary
- Scope deploy-time project component local_path validation to explicitly requested components and direct dependencies for component-scoped deploys.
- Keep full-project selectors strict by validating every attached component local_path.
- Report unrelated stale scoped-deploy local_path entries as deploy hygiene warnings instead of fatal blockers.

Fixes #6373

## Tests
- cargo test core::project::readiness::tests --lib
- cargo test core::deploy::planning::tests --lib
- cargo test deploy_
- cargo clippy --lib (completed with existing warnings)

## Lint note
- cargo clippy --all-targets -- -D warnings is currently blocked by existing repository-wide warnings unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the scoped validation change, adding tests, and preparing this PR.