### PR TITLE
Fix project component removal with stale remaining paths

### DIFF
--- a/src/core/project/component/report.rs
+++ b/src/core/project/component/report.rs
@@ -4,7 +4,10 @@ use serde::Serialize;
 
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
-use crate::core::project::{load, resolve_project_components, Project, ProjectComponentAttachment};
+use crate::core::project::{
+    component_local_path_blockers, load, resolve_project_components, Project,
+    ProjectComponentAttachment,
+};
 
 use super::{
     attach_discovered_component_path, clear_component_attachments, project_component_ids,
@@ -23,6 +26,8 @@ pub struct ProjectComponentsOutput {
     pub attached_path: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub components: Vec<Component>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 pub fn list_components(project_id: &str) -> Result<ProjectComponentsOutput> {
@@ -66,13 +71,13 @@ pub fn remove_components_report(
 ) -> Result<ProjectComponentsOutput> {
     remove_components(project_id, component_ids)?;
     let project = load(project_id)?;
-    build_components_output(project_id, "remove", &project)
+    build_components_summary(project_id, "remove", &project, None, None)
 }
 
 pub fn clear_components(project_id: &str) -> Result<ProjectComponentsOutput> {
     clear_component_attachments(project_id)?;
     let project = load(project_id)?;
-    build_components_output(project_id, "clear", &project)
+    build_components_summary(project_id, "clear", &project, None, None)
 }
 
 fn build_components_output(
@@ -90,6 +95,7 @@ fn build_components_output(
         attached_component_id: None,
         attached_path: None,
         components,
+        warnings: Vec::new(),
     })
 }
 
@@ -108,13 +114,15 @@ fn build_components_summary(
         attached_component_id,
         attached_path,
         components: Vec::new(),
+        warnings: component_local_path_blockers(project),
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::build_components_summary;
-    use crate::core::project::{Project, ProjectComponentAttachment};
+    use super::{build_components_summary, remove_components_report};
+    use crate::core::project::{load, save, Project, ProjectComponentAttachment};
+    use crate::test_support::with_isolated_home;
 
     #[test]
     fn attach_path_summary_omits_resolved_component_payload() {
@@ -141,5 +149,47 @@ mod tests {
         assert_eq!(output.component_count, 1);
         assert_eq!(output.attached_component_id.as_deref(), Some("plugin"));
         assert!(output.components.is_empty());
+        assert!(!output.warnings.is_empty());
+    }
+
+    #[test]
+    fn remove_component_succeeds_when_unrelated_remaining_path_is_stale() {
+        with_isolated_home(|_| {
+            save(&Project {
+                id: "site".to_string(),
+                components: vec![
+                    ProjectComponentAttachment {
+                        id: "remove-me".to_string(),
+                        local_path: "/tmp/homeboy-remove-me-missing".to_string(),
+                        remote_path: None,
+                    },
+                    ProjectComponentAttachment {
+                        id: "stale-remaining".to_string(),
+                        local_path: "/tmp/homeboy-stale-remaining-missing".to_string(),
+                        remote_path: None,
+                    },
+                ],
+                ..Default::default()
+            })
+            .expect("save project");
+
+            let output = remove_components_report("site", vec!["remove-me".to_string()])
+                .expect("remove should not resolve unrelated stale component paths");
+
+            assert_eq!(output.component_ids, vec!["stale-remaining"]);
+            assert_eq!(output.component_count, 1);
+            assert!(output.components.is_empty());
+            assert!(output.warnings.iter().any(|warning| warning.contains(
+                "Component 'stale-remaining' local_path '/tmp/homeboy-stale-remaining-missing' does not exist"
+            )));
+            assert!(!output
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("remove-me")));
+
+            let project = load("site").expect("project still loads");
+            assert_eq!(project.components.len(), 1);
+            assert_eq!(project.components[0].id, "stale-remaining");
+        });
     }
 }

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -34,6 +34,7 @@ pub use pins::{
     add_pin, list_pins, remove_pin, rename_pin, update_pin, PinUpdateOptions, ProjectPinChange,
     ProjectPinListItem, ProjectPinOutput,
 };
+pub(crate) use readiness::component_local_path_blockers;
 pub use readiness::{
     calculate_deploy_readiness, validate_component_local_path, validate_component_local_paths,
 };

--- a/src/core/project/readiness.rs
+++ b/src/core/project/readiness.rs
@@ -113,7 +113,7 @@ pub fn validate_component_local_path(project: &Project, component_id: &str) -> R
     Err(err)
 }
 
-fn component_local_path_blockers(project: &Project) -> Vec<String> {
+pub(crate) fn component_local_path_blockers(project: &Project) -> Vec<String> {
     project
         .components
         .iter()


### PR DESCRIPTION
## Summary
- allow `project components remove`/`clear` to return mutation summaries without resolving every remaining component checkout
- include remaining component local_path blockers as warnings after mutation
- add coverage for removing a component when another attached component has a stale local_path

Fixes #6374

## Tests
- `cargo test core::project --lib`
- `cargo test project::component::report --lib`
- `cargo test project::component --lib`
- `cargo test project::readiness --lib`
- `cargo clippy --lib -- -A warnings`
- `git diff --check`

Note: local full `cargo test` is blocked by existing macOS path normalization failure in `core::worktree::tests::queue_create_records_successful_dmc_worktree` (`/private/var/...` vs `/var/...`), unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the validation flow, implementing the scoped Rust change, adding tests, and running verification.