### PR TITLE
fix(config): prevent concurrent attach-path write races

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -8,6 +8,7 @@ use crate::core::output::{
 use crate::core::paths;
 use crate::core::Result;
 use serde::{de::DeserializeOwned, Serialize};
+use std::fs::{self, File, OpenOptions};
 use std::path::PathBuf;
 
 mod json_io;
@@ -22,6 +23,68 @@ pub use json_ops::collect_array_fields;
 pub(crate) use json_ops::{merge_config, remove_config};
 pub(crate) use json_pointer::value_type_name;
 pub use json_pointer::{remove_json_pointer, set_json_pointer};
+
+pub(crate) fn with_config_lock<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    let lock_path = paths::homeboy()?.join("config.lock");
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("create config lock directory".to_string()),
+            )
+        })?;
+    }
+
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some("open config lock".to_string()))
+        })?;
+
+    let _guard = ConfigLockGuard::lock(lock_file)?;
+    operation()
+}
+
+struct ConfigLockGuard {
+    #[allow(dead_code)]
+    file: File,
+}
+
+impl ConfigLockGuard {
+    #[cfg(unix)]
+    fn lock(file: File) -> Result<Self> {
+        use std::os::fd::AsRawFd;
+
+        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if result != 0 {
+            return Err(Error::internal_io(
+                std::io::Error::last_os_error().to_string(),
+                Some("lock config".to_string()),
+            ));
+        }
+
+        Ok(Self { file })
+    }
+
+    #[cfg(not(unix))]
+    fn lock(file: File) -> Result<Self> {
+        Ok(Self { file })
+    }
+}
+
+impl Drop for ConfigLockGuard {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+        }
+    }
+}
 
 // ============================================================================
 // Config Entity Trait

--- a/src/core/engine/local_files.rs
+++ b/src/core/engine/local_files.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::core::error::{Error, Result};
 
@@ -70,7 +71,7 @@ impl FileSystem for LocalFs {
             )
         })?;
 
-        let tmp_path = parent.join(format!("{}.tmp", filename.to_string_lossy()));
+        let tmp_path = unique_temp_path(parent, filename.to_string_lossy().as_ref());
 
         fs::write(&tmp_path, content)
             .map_err(|e| Error::internal_io(e.to_string(), Some("write temp file".to_string())))?;
@@ -176,7 +177,7 @@ pub fn write_file_atomic(path: &Path, content: &str, operation: &str) -> Result<
         )
     })?;
 
-    let tmp_path = parent.join(format!("{}.tmp", filename.to_string_lossy()));
+    let tmp_path = unique_temp_path(parent, filename.to_string_lossy().as_ref());
 
     fs::write(&tmp_path, content).map_err(|e| {
         Error::internal_io(e.to_string(), Some(format!("{} (write temp)", operation)))
@@ -188,10 +189,22 @@ pub fn write_file_atomic(path: &Path, content: &str, operation: &str) -> Result<
     Ok(())
 }
 
+fn unique_temp_path(parent: &Path, filename: &str) -> PathBuf {
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    parent.join(format!(
+        ".{}.{}.{}.tmp",
+        filename,
+        std::process::id(),
+        TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::sync::{Arc, Barrier};
     use tempfile::tempdir;
     use tempfile::NamedTempFile;
 
@@ -204,6 +217,41 @@ mod tests {
         fs.write(&path, "hello world").unwrap();
         let content = fs.read(&path).unwrap();
         assert_eq!(content, "hello world");
+    }
+
+    #[test]
+    fn local_fs_write_uses_unique_temp_paths_for_concurrent_writers() {
+        let dir = tempdir().unwrap();
+        let path = Arc::new(dir.path().join("config.json"));
+        let barrier = Arc::new(Barrier::new(8));
+        let handles: Vec<_> = (0..8)
+            .map(|index| {
+                let path = Arc::clone(&path);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    local()
+                        .write(&path, &format!(r#"{{"writer":{index}}}"#))
+                        .expect("concurrent write succeeds");
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("writer thread");
+        }
+
+        let content = fs::read_to_string(path.as_ref()).expect("read final config");
+        serde_json::from_str::<serde_json::Value>(&content).expect("valid json");
+        let temp_files: Vec<_> = fs::read_dir(dir.path())
+            .expect("list tempdir")
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "tmp"))
+            .collect();
+        assert!(
+            temp_files.is_empty(),
+            "temp files left behind: {temp_files:?}"
+        );
     }
 
     #[test]

--- a/src/core/project/component/attachments.rs
+++ b/src/core/project/component/attachments.rs
@@ -27,6 +27,15 @@ pub fn set_component_attachments(
     project_id: &str,
     components: Vec<ProjectComponentAttachment>,
 ) -> Result<Vec<String>> {
+    crate::core::config::with_config_lock(|| {
+        set_component_attachments_unlocked(project_id, components)
+    })
+}
+
+fn set_component_attachments_unlocked(
+    project_id: &str,
+    components: Vec<ProjectComponentAttachment>,
+) -> Result<Vec<String>> {
     if components.is_empty() {
         return Err(Error::validation_invalid_argument(
             "components",
@@ -59,6 +68,10 @@ pub fn set_component_attachments(
 }
 
 pub fn remove_components(project_id: &str, component_ids: Vec<String>) -> Result<Vec<String>> {
+    crate::core::config::with_config_lock(|| remove_components_unlocked(project_id, component_ids))
+}
+
+fn remove_components_unlocked(project_id: &str, component_ids: Vec<String>) -> Result<Vec<String>> {
     if component_ids.is_empty() {
         return Err(Error::validation_invalid_argument(
             "componentIds",
@@ -94,6 +107,10 @@ pub fn remove_components(project_id: &str, component_ids: Vec<String>) -> Result
 }
 
 pub fn clear_component_attachments(project_id: &str) -> Result<Vec<String>> {
+    crate::core::config::with_config_lock(|| clear_component_attachments_unlocked(project_id))
+}
+
+fn clear_component_attachments_unlocked(project_id: &str) -> Result<Vec<String>> {
     let mut project = load(project_id)?;
     project.components.clear();
     save(&project)?;
@@ -101,6 +118,16 @@ pub fn clear_component_attachments(project_id: &str) -> Result<Vec<String>> {
 }
 
 pub fn attach_component_path(project_id: &str, component_id: &str, local_path: &str) -> Result<()> {
+    crate::core::config::with_config_lock(|| {
+        attach_component_path_unlocked(project_id, component_id, local_path)
+    })
+}
+
+fn attach_component_path_unlocked(
+    project_id: &str,
+    component_id: &str,
+    local_path: &str,
+) -> Result<()> {
     let mut project = load(project_id)?;
 
     let is_update = project.components.iter().any(|c| c.id == component_id);
@@ -178,6 +205,15 @@ fn preserve_remote_path_on_reattach(
 }
 
 pub fn attach_discovered_component_path(project_id: &str, local_path: &Path) -> Result<String> {
+    crate::core::config::with_config_lock(|| {
+        attach_discovered_component_path_unlocked(project_id, local_path)
+    })
+}
+
+fn attach_discovered_component_path_unlocked(
+    project_id: &str,
+    local_path: &Path,
+) -> Result<String> {
     let inferred_id = infer_attached_component_id(local_path)?;
 
     // When the inferred ID doesn't match any existing project component, check
@@ -192,7 +228,7 @@ pub fn attach_discovered_component_path(project_id: &str, local_path: &Path) -> 
         find_prefix_match(&project, &inferred_id).unwrap_or(inferred_id)
     };
 
-    attach_component_path(project_id, &component_id, &local_path.to_string_lossy())?;
+    attach_component_path_unlocked(project_id, &component_id, &local_path.to_string_lossy())?;
     Ok(component_id)
 }
 
@@ -244,6 +280,9 @@ fn find_prefix_match(project: &Project, inferred_id: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_isolated_home;
+    use std::fs;
+    use std::sync::{Arc, Barrier};
 
     fn project_with_components(ids: &[&str]) -> Project {
         let mut project = Project::default();
@@ -305,5 +344,46 @@ mod tests {
     fn find_prefix_match_no_components() {
         let project = project_with_components(&[]);
         assert_eq!(find_prefix_match(&project, "anything-v1"), None);
+    }
+
+    #[test]
+    fn concurrent_attach_discovered_component_path_preserves_all_writes() {
+        with_isolated_home(|home| {
+            let project = Project {
+                id: "site".to_string(),
+                ..Default::default()
+            };
+            save(&project).expect("save project");
+
+            let repo_a = home.path().join("component-a");
+            let repo_b = home.path().join("component-b");
+            fs::create_dir_all(&repo_a).expect("repo a");
+            fs::create_dir_all(&repo_b).expect("repo b");
+            fs::write(repo_a.join("homeboy.json"), r#"{"id":"component-a"}"#)
+                .expect("component a config");
+            fs::write(repo_b.join("homeboy.json"), r#"{"id":"component-b"}"#)
+                .expect("component b config");
+
+            let barrier = Arc::new(Barrier::new(2));
+            let handles: Vec<_> = [repo_a, repo_b]
+                .into_iter()
+                .map(|repo| {
+                    let barrier = Arc::clone(&barrier);
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        attach_discovered_component_path("site", &repo)
+                            .expect("concurrent attach succeeds");
+                    })
+                })
+                .collect();
+
+            for handle in handles {
+                handle.join().expect("attach thread");
+            }
+
+            let mut ids = project_component_ids(&load("site").expect("load project"));
+            ids.sort();
+            assert_eq!(ids, vec!["component-a", "component-b"]);
+        });
     }
 }


### PR DESCRIPTION
Fixes #6375.

## Summary
- Use per-process unique temp file paths for local atomic writes so concurrent writes do not share the same target tmp rename source.
- Add a config lock around project component read-modify-write mutations, including project components attach-path, so concurrent attachments preserve each other updates.
- Add concurrency coverage for both the atomic write temp path and attach-path project config mutation.

## Tests
- git diff --check
- cargo test local_fs_write_uses_unique_temp_paths_for_concurrent_writers
- cargo test concurrent_attach_discovered_component_path_preserves_all_writes
- cargo check

Notes: Full local cargo test was attempted but timed out after 20 minutes after unrelated worker test flakes and an unrelated macOS /private/var path assertion in core::worktree::tests::queue_create_records_successful_dmc_worktree; the individual worker tests passed on rerun. cargo clippy --all-targets -- -D warnings currently fails on pre-existing lints outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the config-write race fix, adding concurrency tests, and running local verification.