### PR TITLE
fix(test): restore test-module imports broken by god-file splits

### DIFF
--- a/src/core/agent_task/tests.rs
+++ b/src/core/agent_task/tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use serde_json::json;
+use serde_json::{json, Value};
 
 #[test]
 fn request_round_trips_generic_agent_task_shape() {

--- a/src/core/agent_task_loop_controller/gate.rs
+++ b/src/core/agent_task_loop_controller/gate.rs
@@ -1,6 +1,6 @@
 use super::*;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskGateBundle {

--- a/src/core/agent_task_loop_controller/service.rs
+++ b/src/core/agent_task_loop_controller/service.rs
@@ -25,7 +25,7 @@ pub fn controller_status_diagnostics(
     })
 }
 
-fn controller_status_diagnostics_with<F>(
+pub(crate) fn controller_status_diagnostics_with<F>(
     record: &AgentTaskLoopControllerRecord,
     now: DateTime<Utc>,
     mut run_exists: F,

--- a/src/core/agent_task_loop_controller/tests.rs
+++ b/src/core/agent_task_loop_controller/tests.rs
@@ -1,8 +1,7 @@
 use super::*;
 use crate::test_support::with_isolated_home;
-
-use super::*;
-use crate::test_support::with_isolated_home;
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
 
 #[test]
 fn controller_persists_and_resumes_loop_state() {

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -1,8 +1,9 @@
 #![cfg(test)]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 use super::apply::{
     run_provider_command, AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,

--- a/src/core/agent_task_service/tests.rs
+++ b/src/core/agent_task_service/tests.rs
@@ -3,13 +3,18 @@
 use super::*;
 use crate::core::agent_task::{
     AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy,
-    AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA,
-    AGENT_TASK_REQUEST_SCHEMA,
+    AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkspace, AgentTaskWorkspaceMode,
+    AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::core::agent_task_lifecycle::{status as lifecycle_status, AgentTaskRunState};
-use crate::core::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskState};
+use crate::core::agent_task_schedule::AgentTaskPlan;
+use crate::core::agent_task_scheduler::{
+    AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskState,
+};
 use crate::core::run_lifecycle_record::RunExecutionState;
+use crate::core::{agent_task_lifecycle, worktree};
 use crate::test_support::with_isolated_home;
+use serde_json::Value;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 

--- a/src/core/component/tests.rs
+++ b/src/core/component/tests.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use super::*;
+use std::collections::HashMap;
 use std::path::Path;
 
 fn with_isolated_home<T>(f: impl FnOnce(&Path) -> T) -> T {


### PR DESCRIPTION
Recent god-file splits (#6377/#6382/#6388/#6389/#6392/#6393) extracted inline #[cfg(test)] mod tests blocks into tests.rs files that lost imports (serde_json json!/Value, std HashMap, chrono DateTime/Utc, crate::core modules, test_support helpers) the inline modules inherited via use super::*. cargo build --lib (used to verify the splits) does not compile #[cfg(test)] code and CI Test gate runs changed-scope, so the full-suite test-compile breakage slipped through. Restores the imports; verified with cargo build --lib --tests (zero errors).

## Changes
- `agent_task_loop_controller/tests.rs`: removed duplicated `use super::*;` / `with_isolated_home` lines; added `chrono::{DateTime, Utc}` + `serde_json::{json, Value}`
- `agent_task_loop_controller/service.rs`: made test-only helper `controller_status_diagnostics_with` `pub(crate)` so the sibling `tests.rs` can reach it
- `agent_task_loop_controller/gate.rs`: added `serde_json::json` (used by non-test `legacy_command_bundle` builder, exposed by the test build)
- `agent_task_service/tests.rs`: added `AgentTaskWorkspaceMode`, `AgentTaskPlan`, `AgentTaskExecutorAdapter`, `agent_task_lifecycle`, `worktree`, `serde_json::Value`
- `agent_task/tests.rs`: added `serde_json::Value`
- `agent_task_promotion/tests.rs`: added `std::path::Path` + `sha2::{Digest, Sha256}`
- `component/tests.rs`: added `std::collections::HashMap`

Import-only changes (plus one visibility widening for a test helper). No test logic modified.

Verified: `cargo build --lib --tests` exits 0 with zero errors.