### PR TITLE
Expose agent task bridge status

### DIFF
--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -576,9 +576,17 @@ pub struct StatusArgs {
     /// Durable run id returned by `agent-task submit` or `agent-task run-plan --record-run-id`.
     pub run_id: String,
 
+    /// Emit the bridge-friendly durable run status envelope.
+    #[arg(long)]
+    pub bridge: bool,
+
+    /// Return only bridge events after this cursor.
+    #[arg(long, value_name = "CURSOR", requires = "bridge")]
+    pub since_cursor: Option<u64>,
+
     /// Emit the full verbose payload (all artifact/evidence refs) instead of the
     /// default compact, recovery-first summary.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "bridge")]
     pub full: bool,
 }
 

--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -22,6 +22,14 @@ use super::args::{CancelArgs, StatusArgs};
 const COMPACT_REF_LIMIT: usize = 12;
 
 pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
+    if args.bridge {
+        let bridge_status = agent_task_service::run_status(&args.run_id, args.since_cursor)?;
+        return Ok((
+            serde_json::to_value(bridge_status).unwrap_or(Value::Null),
+            0,
+        ));
+    }
+
     let record = agent_task_service::status(&args.run_id)?;
     let mut value = serde_json::to_value(&record).unwrap_or(Value::Null);
     enrich_with_diagnostic_summary(&mut value, &args.run_id)?;

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -48,18 +48,35 @@ fn submit_run_status_reports_terminal_state() {
         .expect("submitted");
         let (_, run_exit_code) = run_submitted(StatusArgs {
             run_id: "run-cli-terminal".to_string(),
+            bridge: false,
+            since_cursor: None,
             full: false,
         })
         .expect("run completed");
         let (status_json, status_exit_code) = status(StatusArgs {
             run_id: "run-cli-terminal".to_string(),
+            bridge: false,
+            since_cursor: None,
             full: true,
         })
         .expect("status loaded");
+        let (bridge_status_json, bridge_status_exit_code) = status(StatusArgs {
+            run_id: "run-cli-terminal".to_string(),
+            bridge: true,
+            since_cursor: Some(0),
+            full: false,
+        })
+        .expect("bridge status loaded");
         let record: AgentTaskRunRecord = serde_json::from_value(status_json).expect("record");
 
         assert_eq!(run_exit_code, 1);
         assert_eq!(status_exit_code, 0);
+        assert_eq!(bridge_status_exit_code, 0);
+        assert_eq!(
+            bridge_status_json["schema"],
+            "homeboy/agent-task-run-status/v1"
+        );
+        assert!(bridge_status_json["normalized_events"].is_array());
         assert_eq!(record.state, AgentTaskRunState::Failed);
         assert_eq!(record.tasks[0].state, AgentTaskState::Failed);
         assert_eq!(record.totals.expect("totals").failed, 1);
@@ -75,11 +92,15 @@ fn failed_run_status_logs_and_review_include_outcome_diagnostic_summary() {
 
         let (status_value, _) = status(StatusArgs {
             run_id: run_id.to_string(),
+            bridge: false,
+            since_cursor: None,
             full: false,
         })
         .expect("status loaded");
         let (logs_value, _) = logs(StatusArgs {
             run_id: run_id.to_string(),
+            bridge: false,
+            since_cursor: None,
             full: false,
         })
         .expect("logs loaded");

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -333,6 +333,8 @@ mod tests {
         let args = AgentTaskArgs {
             command: AgentTaskCommand::Status(StatusArgs {
                 run_id: "run-1".to_string(),
+                bridge: false,
+                since_cursor: None,
                 full: false,
             }),
         };

--- a/src/core/agent_task_lifecycle/conversion.rs
+++ b/src/core/agent_task_lifecycle/conversion.rs
@@ -214,6 +214,54 @@ pub(crate) fn queued_events(tasks: &[AgentTaskRunTask]) -> Vec<AgentTaskProgress
         .collect()
 }
 
+pub(crate) fn totals_for_tasks(tasks: &[AgentTaskRunTask]) -> AgentTaskAggregateTotals {
+    let mut totals = AgentTaskAggregateTotals::default();
+    for task in tasks {
+        match task.state {
+            AgentTaskState::Queued => totals.queued += 1,
+            AgentTaskState::Running => totals.running += 1,
+            AgentTaskState::Blocked => totals.blocked += 1,
+            AgentTaskState::Skipped => totals.skipped += 1,
+            AgentTaskState::Succeeded => totals.succeeded += 1,
+            AgentTaskState::Failed => totals.failed += 1,
+            AgentTaskState::Cancelled => totals.cancelled += 1,
+            AgentTaskState::TimedOut => totals.timed_out += 1,
+        }
+    }
+    totals
+}
+
+pub(crate) fn normalize_progress_events(
+    run_id: &str,
+    events: &[AgentTaskProgressEvent],
+    artifact_refs: &[AgentTaskArtifactRef],
+) -> Vec<AgentTaskEventEnvelope> {
+    events
+        .iter()
+        .enumerate()
+        .map(|(index, event)| AgentTaskEventEnvelope {
+            schema: schemas::EVENT.to_string(),
+            run_id: run_id.to_string(),
+            task_id: event.task_id.clone(),
+            sequence: (index + 1) as u64,
+            event_type: "agent_task.state_changed".to_string(),
+            status: event.state,
+            message: event.message.clone(),
+            progress: json!({
+                "attempt": event.attempt,
+            }),
+            artifact_refs: artifact_refs
+                .iter()
+                .filter(|artifact_ref| artifact_ref.task_id == event.task_id)
+                .cloned()
+                .collect(),
+            metadata: json!({
+                "source_schema": AGENT_TASK_AGGREGATE_SCHEMA,
+            }),
+        })
+        .collect()
+}
+
 pub(crate) fn artifact_refs_for_outcomes(
     outcomes: &[AgentTaskOutcome],
 ) -> Vec<AgentTaskArtifactRef> {

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -172,6 +172,42 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     Ok(record)
 }
 
+pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRunStatus> {
+    let record = status(run_id)?;
+    let (events, artifact_refs) = match store::read_aggregate(&record.run_id) {
+        Ok(aggregate) => {
+            let refs = artifact_refs_for_outcomes(&aggregate.outcomes);
+            (aggregate.events, refs)
+        }
+        Err(_) => (queued_events(&record.tasks), record.artifact_refs.clone()),
+    };
+    let normalized_events = normalize_progress_events(&record.run_id, &events, &artifact_refs);
+    let latest_event_cursor = normalized_events
+        .last()
+        .map(|event| event.sequence)
+        .unwrap_or(0);
+    let cursor = since_cursor.unwrap_or(0);
+    let normalized_events = normalized_events
+        .into_iter()
+        .filter(|event| event.sequence > cursor)
+        .collect();
+
+    Ok(AgentTaskRunStatus {
+        schema: schemas::RUN_STATUS.to_string(),
+        run_id: record.run_id,
+        plan_id: record.plan_id,
+        state: record.state,
+        submitted_at: record.submitted_at,
+        updated_at: record.updated_at,
+        totals: record
+            .totals
+            .unwrap_or_else(|| totals_for_tasks(&record.tasks)),
+        latest_event_cursor,
+        artifact_refs: record.artifact_refs,
+        normalized_events,
+    })
+}
+
 #[cfg(test)]
 pub(crate) fn write_run_record_for_test(record: &AgentTaskRunRecord) -> Result<()> {
     store::write_record(record)
@@ -244,13 +280,19 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
     let run_id = sanitize_run_id(run_id);
     let record = store::read_record(&run_id)?;
-    let events = store::read_aggregate(&run_id)
-        .map(|aggregate| aggregate.events)
-        .unwrap_or_else(|_| queued_events(&record.tasks));
+    let (events, artifact_refs) = match store::read_aggregate(&run_id) {
+        Ok(aggregate) => {
+            let refs = artifact_refs_for_outcomes(&aggregate.outcomes);
+            (aggregate.events, refs)
+        }
+        Err(_) => (queued_events(&record.tasks), record.artifact_refs.clone()),
+    };
+    let normalized_events = normalize_progress_events(&run_id, &events, &artifact_refs);
     Ok(AgentTaskRunLog {
         schema: schemas::RUN_LOG.to_string(),
         run_id,
         events,
+        normalized_events,
     })
 }
 

--- a/src/core/agent_task_lifecycle/records.rs
+++ b/src/core/agent_task_lifecycle/records.rs
@@ -3,6 +3,8 @@ use super::*;
 pub(crate) mod schemas {
     pub(crate) const RUN: &str = "homeboy/agent-task-run/v1";
     pub(crate) const RUN_LOG: &str = "homeboy/agent-task-run-log/v1";
+    pub(crate) const EVENT: &str = "homeboy/agent-task-event/v1";
+    pub(crate) const RUN_STATUS: &str = "homeboy/agent-task-run-status/v1";
     pub(crate) const RUN_ARTIFACTS: &str = "homeboy/agent-task-run-artifacts/v1";
 }
 
@@ -204,6 +206,44 @@ pub struct AgentTaskRunLog {
     pub schema: String,
     pub run_id: String,
     pub events: Vec<AgentTaskProgressEvent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub normalized_events: Vec<AgentTaskEventEnvelope>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskEventEnvelope {
+    pub schema: String,
+    pub run_id: String,
+    pub task_id: String,
+    pub sequence: u64,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub status: AgentTaskState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub progress: Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<AgentTaskArtifactRef>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskRunStatus {
+    pub schema: String,
+    pub run_id: String,
+    pub plan_id: String,
+    pub state: AgentTaskRunState,
+    pub submitted_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    pub totals: AgentTaskAggregateTotals,
+    pub latest_event_cursor: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<AgentTaskArtifactRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub normalized_events: Vec<AgentTaskEventEnvelope>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -1402,6 +1402,91 @@ fn status_filters_empty_uri_artifact_refs() {
     });
 }
 
+#[test]
+fn run_status_reports_bridge_envelope_and_cursor_filtered_events() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.events = vec![
+            AgentTaskProgressEvent {
+                task_id: "task-a".to_string(),
+                state: AgentTaskState::Running,
+                attempt: 1,
+                message: Some("started".to_string()),
+            },
+            AgentTaskProgressEvent {
+                task_id: "task-a".to_string(),
+                state: AgentTaskState::Succeeded,
+                attempt: 1,
+                message: Some("ok".to_string()),
+            },
+        ];
+        aggregate.outcomes[0].artifacts = vec![artifact_ref_artifact(
+            "bundle",
+            "artifact-bundle",
+            Some("file:///tmp/bundle.json"),
+            None,
+        )];
+
+        record_completed_run(&plan, &aggregate, Some("run-status-bridge")).expect("recorded");
+
+        let status = run_status("run-status-bridge", Some(1)).expect("bridge status");
+
+        assert_eq!(status.schema, schemas::RUN_STATUS);
+        assert_eq!(status.state, AgentTaskRunState::Succeeded);
+        assert_eq!(status.latest_event_cursor, 2);
+        assert_eq!(status.normalized_events.len(), 1);
+        assert_eq!(status.normalized_events[0].sequence, 2);
+        assert_eq!(status.normalized_events[0].schema, schemas::EVENT);
+        assert_eq!(
+            status.normalized_events[0].event_type,
+            "agent_task.state_changed"
+        );
+        assert_eq!(status.normalized_events[0].artifact_refs.len(), 1);
+        assert_eq!(status.artifact_refs[0].kind, "artifact-bundle");
+    });
+}
+
+#[test]
+fn logs_include_normalized_event_envelopes() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.events = vec![
+            AgentTaskProgressEvent {
+                task_id: "task-a".to_string(),
+                state: AgentTaskState::Running,
+                attempt: 1,
+                message: Some("started".to_string()),
+            },
+            AgentTaskProgressEvent {
+                task_id: "task-a".to_string(),
+                state: AgentTaskState::Succeeded,
+                attempt: 1,
+                message: Some("ok".to_string()),
+            },
+        ];
+        aggregate.outcomes[0].evidence_refs = vec![AgentTaskEvidenceRef {
+            kind: "transcript".to_string(),
+            uri: "file:///tmp/transcript.json".to_string(),
+            label: Some("Transcript".to_string()),
+        }];
+
+        record_completed_run(&plan, &aggregate, Some("run-event-envelope")).expect("recorded");
+
+        let log = logs("run-event-envelope").expect("logs");
+
+        assert_eq!(log.normalized_events.len(), 2);
+        assert_eq!(log.normalized_events[0].schema, schemas::EVENT);
+        assert_eq!(log.normalized_events[0].run_id, "run-event-envelope");
+        assert_eq!(log.normalized_events[0].task_id, "task-a");
+        assert_eq!(log.normalized_events[0].sequence, 1);
+        assert_eq!(log.normalized_events[0].status, AgentTaskState::Running);
+        assert_eq!(log.normalized_events[1].message.as_deref(), Some("ok"));
+        assert_eq!(log.normalized_events[1].artifact_refs.len(), 1);
+    });
+}
+
 fn test_plan() -> AgentTaskPlan {
     AgentTaskPlan::new(
         "plan-a",

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use crate::core::agent_task::{AgentTaskRequest, AgentTaskWorkspaceMode};
 use crate::core::agent_task_lifecycle::{
-    self, AgentTaskRunArtifacts, AgentTaskRunLog, AgentTaskRunRecord,
+    self, AgentTaskRunArtifacts, AgentTaskRunLog, AgentTaskRunRecord, AgentTaskRunStatus,
 };
 use crate::core::agent_task_provider::{
     apply_provider_runner_secret_env_contracts, provider_secret_sources_for_plan,
@@ -126,6 +126,10 @@ pub struct AgentTaskRetryServiceResult {
 
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     agent_task_lifecycle::status(run_id)
+}
+
+pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRunStatus> {
+    agent_task_lifecycle::run_status(run_id, since_cursor)
 }
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -232,9 +232,10 @@ pub mod lifecycle {
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run, list_records,
         load_plan, logs, mark_resuming, mark_running, record_completed_run,
         record_pre_dispatch_failure, record_promotion, record_remote_dispatch_failure,
-        record_run_aggregate, retry, run_record_exists, status, submit_plan, AgentTaskArtifactRef,
-        AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts,
-        AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState,
+        record_run_aggregate, retry, run_record_exists, run_status, status, submit_plan,
+        AgentTaskArtifactRef, AgentTaskEventEnvelope, AgentTaskPreDispatchFailure,
+        AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts, AgentTaskRunLog,
+        AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState, AgentTaskRunStatus,
         AgentTaskRunTask,
     };
 }
@@ -344,9 +345,9 @@ pub mod service {
     pub use super::super::agent_task_service::{
         aggregate_exit_code, artifacts, cancel, discover_runs, logs, normalize_plan_workspaces,
         promotion_source, read_plan, resume, retry, run_cook, run_loaded_plan, run_next,
-        run_submitted, status, submit_plan_spec, AgentTaskCookAttemptReport, AgentTaskCookReport,
-        AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts,
-        AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport, AgentTaskDiscoveryRun,
-        AgentTaskRetryServiceResult, AgentTaskRunResult,
+        run_status, run_submitted, status, submit_plan_spec, AgentTaskCookAttemptReport,
+        AgentTaskCookReport, AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands,
+        AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
+        AgentTaskDiscoveryRun, AgentTaskRetryServiceResult, AgentTaskRunResult,
     };
 }


### PR DESCRIPTION
## Summary
- Add normalized `homeboy/agent-task-event/v1` envelopes to agent-task logs.
- Add `homeboy/agent-task-run-status/v1` with cursor-filtered normalized events for external/headless run-control bridges.
- Expose the bridge envelope via `homeboy agent-task status --bridge --since-cursor <CURSOR>`.

## Verification
- cargo test core::agent_task_lifecycle::tests::run_status_reports_bridge_envelope_and_cursor_filtered_events -- --nocapture
- cargo test core::agent_task_lifecycle::tests::logs_include_normalized_event_envelopes -- --nocapture
- cargo test commands::agent_task::tests::lifecycle -- --nocapture
- cargo test commands::json_output::tests::lab_offload_agent_task_subprocess_keeps_json_stdout -- --nocapture
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Porting the bridge status/event envelope onto the current split lifecycle modules, adding tests, and drafting this PR description.