### PR TITLE
fix(release): scope monorepo changelog commits

### DIFF
--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -24,6 +24,8 @@ pub struct MonorepoContext {
     pub git_root: String,
     /// Relative path from git root to the component (e.g. "api-client").
     pub path_prefix: String,
+    /// Pathspecs used to scope release commit collection.
+    pub path_prefixes: Vec<String>,
     /// Tag prefix for this component (e.g. "api-client"), used to create
     /// tags like `api-client-v1.0.0`.
     pub tag_prefix: String,
@@ -41,6 +43,7 @@ impl MonorepoContext {
         Some(MonorepoContext {
             git_root,
             path_prefix: path_prefix.clone(),
+            path_prefixes: vec![path_prefix.clone()],
             // Use component_id for tag prefix — it's the canonical name
             tag_prefix: component_id.to_string(),
         })
@@ -562,6 +565,17 @@ pub fn get_commits_since_tag_for_path(
     tag: Option<&str>,
     path_prefix: Option<&str>,
 ) -> Result<Vec<CommitInfo>> {
+    let path_prefixes = path_prefix.into_iter().collect::<Vec<_>>();
+    get_commits_since_tag_for_paths(path, tag, &path_prefixes)
+}
+
+/// Get commits since a given tag, optionally filtered to only those touching
+/// any of the provided path prefixes relative to the git root.
+pub fn get_commits_since_tag_for_paths(
+    path: &str,
+    tag: Option<&str>,
+    path_prefixes: &[&str],
+) -> Result<Vec<CommitInfo>> {
     let range = tag
         .map(|t| format!("{}..HEAD", t))
         .unwrap_or_else(|| "HEAD".to_string());
@@ -574,9 +588,11 @@ pub fn get_commits_since_tag_for_path(
         format_str,
     ];
 
-    // Add path filter for monorepo scoping: `git log <range> -- <path_prefix>`
-    if let Some(prefix) = path_prefix {
+    // Add path filters for monorepo scoping: `git log <range> -- <path>...`
+    if !path_prefixes.is_empty() {
         args.push("--".to_string());
+    }
+    for prefix in path_prefixes {
         args.push(prefix.to_string());
     }
 
@@ -1231,6 +1247,7 @@ mod tests {
         let ctx = MonorepoContext {
             git_root: "/repo".to_string(),
             path_prefix: "wordpress".to_string(),
+            path_prefixes: vec!["wordpress".to_string()],
             tag_prefix: "wordpress".to_string(),
         };
         assert_eq!(ctx.format_tag("1.2.3"), "wordpress-v1.2.3");

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -27,8 +27,8 @@ pub use changes::{
 pub(crate) use commits::extract_version_from_tag;
 pub use commits::{
     categorize_commits, find_version_commit, find_version_release_commit, get_commits_in_range,
-    get_commits_since_tag, get_commits_since_tag_for_path, get_last_n_commits, get_latest_tag,
-    get_latest_tag_any_with_prefix, get_latest_tag_with_prefix,
+    get_commits_since_tag, get_commits_since_tag_for_path, get_commits_since_tag_for_paths,
+    get_last_n_commits, get_latest_tag, get_latest_tag_any_with_prefix, get_latest_tag_with_prefix,
     get_previous_tag_before_any_with_prefix, get_previous_tag_before_with_prefix,
     recommended_bump_from_commits, strip_conventional_prefix, CommitCategory, CommitCounts,
     CommitInfo, MonorepoContext, SemverBump,

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -246,7 +246,7 @@ fn planned_release_tag_name(context: &ReleaseExecutionContext) -> Result<String>
                 )
             })?;
     let monorepo =
-        git::MonorepoContext::detect(&context.component.local_path, context.component_id);
+        super::planning_semver::release_monorepo_context(context.component, context.component_id);
 
     Ok(monorepo
         .as_ref()

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -129,7 +129,7 @@ fn initial_release_state(
     }
 
     let version_info = super::version::read_component_version(component)?;
-    let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
+    let monorepo = super::planning_semver::release_monorepo_context(component, component_id);
     let expected_tag = match monorepo.as_ref() {
         Some(ctx) => ctx.format_tag(&version_info.version),
         None => format!("v{}", version_info.version),

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -2,7 +2,6 @@
 
 use crate::core::engine::validation::ValidationCollector;
 use crate::core::error::{Error, Result};
-use crate::core::git;
 use crate::core::release::version;
 
 use super::context::{load_component, resolve_extensions};
@@ -11,7 +10,8 @@ use super::planning_changelog::{build_changelog_plan, generate_changelog_entries
 use super::planning_policy::release_skip_plan;
 use super::planning_semver::{
     build_semver_recommendation, current_version_tag_at_head, current_version_tag_name,
-    validate_current_version_tag_reachable, validate_release_version_floor,
+    release_monorepo_context, validate_current_version_tag_reachable,
+    validate_release_version_floor,
 };
 use super::planning_worktree::validate_release_worktree;
 use super::types::{
@@ -31,7 +31,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
 
     let mut v = ValidationCollector::new();
 
-    let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
+    let monorepo = release_monorepo_context(&component, component_id);
     let version_info = v.capture(version::read_component_version(&component), "version");
     if let Some(ref info) = version_info {
         if let Some(message) = v

--- a/src/core/release/planning_semver.rs
+++ b/src/core/release/planning_semver.rs
@@ -1,4 +1,4 @@
-use crate::core::component::Component;
+use crate::core::component::{resolve_component_scope, Component, ScopeCommand};
 use crate::core::error::{Error, Result};
 use crate::core::git;
 
@@ -62,6 +62,129 @@ pub(super) fn build_semver_recommendation(
         is_underbump,
         reasons: recommendation_reasons(&commits, recommended),
     }))
+}
+
+pub(super) fn release_monorepo_context(
+    component: &Component,
+    component_id: &str,
+) -> Option<git::MonorepoContext> {
+    let mut context = git::MonorepoContext::detect(&component.local_path, component_id);
+    let extra_prefixes = release_scope_prefixes(component);
+
+    if let Some(ctx) = context.as_mut() {
+        for prefix in extra_prefixes {
+            let component_prefix = ctx.path_prefix.trim_end_matches('/');
+            let scoped = if prefix == component_prefix
+                || prefix.starts_with(&format!("{}/", component_prefix))
+            {
+                prefix
+            } else {
+                format!("{}/{}", component_prefix, prefix)
+            };
+            if !ctx.path_prefixes.contains(&scoped) {
+                ctx.path_prefixes.push(scoped);
+            }
+        }
+        return context;
+    }
+
+    if extra_prefixes.is_empty() {
+        return None;
+    }
+
+    let git_root = git::get_git_root(&component.local_path).ok()?;
+    Some(git::MonorepoContext {
+        git_root,
+        path_prefix: extra_prefixes[0].clone(),
+        path_prefixes: extra_prefixes,
+        tag_prefix: component_id.to_string(),
+    })
+}
+
+fn release_scope_prefixes(component: &Component) -> Vec<String> {
+    let scope = resolve_component_scope(component, ScopeCommand::Release);
+    let mut prefixes: Vec<String> = scope
+        .include
+        .iter()
+        .filter_map(|path| normalize_release_scope_path(path))
+        .collect();
+
+    if prefixes.is_empty() {
+        if let Some(prefix) = infer_common_release_prefix(component) {
+            prefixes.push(prefix);
+        }
+    }
+
+    prefixes.sort();
+    prefixes.dedup();
+    prefixes
+}
+
+fn infer_common_release_prefix(component: &Component) -> Option<String> {
+    let mut paths = Vec::new();
+
+    if let Some(targets) = component.version_targets.as_ref() {
+        paths.extend(
+            targets
+                .iter()
+                .filter_map(|target| normalize_release_scope_path(&target.file)),
+        );
+    }
+
+    if let Some(target) = component.changelog_target.as_ref() {
+        if let Some(path) = normalize_release_scope_path(target) {
+            paths.push(path);
+        }
+    }
+
+    common_directory_prefix(&paths)
+}
+
+fn normalize_release_scope_path(path: &str) -> Option<String> {
+    let mut value = path.trim().trim_start_matches("./").trim_matches('/');
+    if value.is_empty() || value == "." {
+        return None;
+    }
+
+    if let Some(wildcard) = value.find('*') {
+        value = value[..wildcard].trim_end_matches('/');
+    }
+
+    if value.is_empty() || value == "." {
+        return None;
+    }
+
+    Some(value.to_string())
+}
+
+fn common_directory_prefix(paths: &[String]) -> Option<String> {
+    let mut iter = paths.iter();
+    let first = iter.next()?;
+    let mut prefix: Vec<&str> = first.split('/').collect();
+    if prefix.len() <= 1 {
+        return None;
+    }
+    prefix.pop();
+
+    for path in iter {
+        let mut dirs: Vec<&str> = path.split('/').collect();
+        if dirs.len() <= 1 {
+            return None;
+        }
+        dirs.pop();
+
+        let keep = prefix
+            .iter()
+            .zip(dirs.iter())
+            .take_while(|(left, right)| left == right)
+            .count();
+        prefix.truncate(keep);
+        if prefix.is_empty() {
+            return None;
+        }
+    }
+
+    Some(prefix.join("/"))
 }
 
 pub(super) fn validate_release_version_floor(
@@ -178,10 +301,11 @@ pub(super) fn resolve_tag_and_commits(
                 latest_tag.as_deref(),
                 Some(&ctx.tag_prefix),
             )?;
-            let commits = git::get_commits_since_tag_for_path(
+            let path_prefixes: Vec<&str> = ctx.path_prefixes.iter().map(String::as_str).collect();
+            let commits = git::get_commits_since_tag_for_paths(
                 &ctx.git_root,
                 latest_tag.as_deref(),
-                Some(&ctx.path_prefix),
+                &path_prefixes,
             )?;
             Ok((latest_tag, commits))
         }
@@ -299,10 +423,10 @@ fn commit_range(latest_tag: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_semver_recommendation, resolve_tag_and_commits,
+        build_semver_recommendation, release_monorepo_context, resolve_tag_and_commits,
         validate_current_version_tag_reachable, validate_release_version_floor,
     };
-    use crate::core::component::Component;
+    use crate::core::component::{CommandScopeConfig, Component, ScopeConfig, VersionTarget};
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
         let output = std::process::Command::new("git")
@@ -320,6 +444,9 @@ mod tests {
     }
 
     fn commit_file(dir: &std::path::Path, name: &str, content: &str, message: &str) {
+        if let Some(parent) = dir.join(name).parent() {
+            std::fs::create_dir_all(parent).expect("create fixture parent");
+        }
         std::fs::write(dir.join(name), content).expect("write fixture file");
         run_git(dir, &["add", name]);
         run_git(dir, &["commit", "-q", "-m", message]);
@@ -422,6 +549,86 @@ mod tests {
         assert_eq!(latest_tag.as_deref(), Some("v1.0.0"));
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].subject, "fix: patch bug");
+    }
+
+    #[test]
+    fn repo_root_component_uses_release_scope_for_commits() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "package-a-v1.0.0"]);
+        commit_file(
+            dir,
+            "packages/package-b/VERSION",
+            "1.0.1",
+            "fix: update sibling package",
+        );
+        commit_file(
+            dir,
+            "packages/package-a/VERSION",
+            "1.0.1",
+            "fix: update package a",
+        );
+        let mut component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        component.scopes = Some(ScopeConfig {
+            release: Some(CommandScopeConfig {
+                include: vec!["packages/package-a/**".to_string()],
+                exclude: vec![],
+            }),
+            ..Default::default()
+        });
+
+        let monorepo = release_monorepo_context(&component, "package-a")
+            .expect("release scope should create monorepo context");
+        let (latest_tag, commits) = resolve_tag_and_commits(&component.local_path, Some(&monorepo))
+            .expect("scoped commits should resolve");
+
+        assert_eq!(latest_tag.as_deref(), Some("package-a-v1.0.0"));
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].subject, "fix: update package a");
+    }
+
+    #[test]
+    fn repo_root_component_infers_commit_scope_from_release_files() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "package-a-v1.0.0"]);
+        commit_file(
+            dir,
+            "packages/package-b/VERSION",
+            "1.0.1",
+            "fix: update sibling package",
+        );
+        commit_file(
+            dir,
+            "packages/package-a/VERSION",
+            "1.0.1",
+            "fix: update package a",
+        );
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            changelog_target: Some("packages/package-a/docs/CHANGELOG.md".to_string()),
+            version_targets: Some(vec![VersionTarget {
+                file: "packages/package-a/VERSION".to_string(),
+                pattern: None,
+                artifact_path: None,
+            }]),
+            ..Default::default()
+        };
+
+        let monorepo = release_monorepo_context(&component, "package-a")
+            .expect("release files should create monorepo context");
+        assert_eq!(monorepo.path_prefixes, vec!["packages/package-a"]);
+        let (latest_tag, commits) = resolve_tag_and_commits(&component.local_path, Some(&monorepo))
+            .expect("scoped commits should resolve");
+
+        assert_eq!(latest_tag.as_deref(), Some("package-a-v1.0.0"));
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].subject, "fix: update package a");
     }
 
     #[test]

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -2,6 +2,7 @@ use crate::core::error::{Error, Result};
 use crate::core::git;
 
 use super::context::load_component;
+use super::planning_semver::release_monorepo_context;
 use super::types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseBumpPolicyOptions,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseExecutionPlan, ReleaseOptions, ReleasePlan,
@@ -64,7 +65,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         },
     )?;
 
-    let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
+    let monorepo = release_monorepo_context(&component, &input.component_id);
     let resolved_bump = if input.pipeline.head {
         None
     } else {

--- a/src/core/release/workflow_recover.rs
+++ b/src/core/release/workflow_recover.rs
@@ -27,7 +27,8 @@ pub(super) fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommand
         git::configure_identity(&component.local_path, &identity)?;
     }
 
-    let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
+    let monorepo =
+        super::planning_semver::release_monorepo_context(&component, &input.component_id);
     let version_info = crate::core::release::version::read_component_version(&component)?;
     let current_version = &version_info.version;
     let tag_name = format_tag(current_version, monorepo.as_ref());


### PR DESCRIPTION
## Summary
- Scope release/changelog commit collection with explicit release include paths when configured.
- Infer a monorepo commit scope from shared version/changelog target directories for repo-root component configs.
- Keep release command tag/bump paths using the same monorepo context as changelog generation.

## Testing
- cargo test planning_semver --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, regression tests, and PR drafting.