### PR TITLE
feat(fuzz): persist artifacts and compare runs

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -67,8 +67,10 @@ the command run directory for raw artifacts that are too specific to normalize i
 core during execution. Runners can place case logs, coverage reports, replay
 data, minimized reproducers, hotspot sets, and engine-native traces there, then
 reference those files from the campaign `artifacts` list or `metadata.artifact_refs`.
-Homeboy core owns the path contract; extensions own artifact meaning and any
-runner/offload upload implementation beyond the persisted fuzz result envelope.
+`homeboy fuzz run` persists this directory as a `fuzz_artifacts` run artifact and
+validates local refs that point inside it when possible. Homeboy core owns the
+path contract; extensions own artifact meaning and any runner/offload upload
+implementation beyond the persisted fuzz result envelope.
 
 Runners that collect action, query, resource, timing, or counter measurements can
 emit a `homeboy/fuzz-observation-set/v1` artifact. Each observation includes a
@@ -144,6 +146,11 @@ Product-specific render kinds, such as WordPress block rendering, should keep
 their precise meaning in `kind`, `target.kind`, tags, or metadata while using
 the generic `render` family for cross-runner reporting. Unknown `kind` values
 remain valid and are preserved without a canonical family.
+
+Targets, operations, findings, and hotspots may include optional `source_refs`
+for generic code/corpus/config coverage pointers. Source ref meaning is
+producer-owned; Homeboy preserves the refs for cross-artifact reporting without
+embedding product-specific source taxonomies.
 
 ```json
 {

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -10,6 +10,7 @@ homeboy runs distribution --field <metadata.path> [--kind bench] [--component <i
 homeboy runs latest-run [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>]
 homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
 homeboy runs bench-compare --from-run <run-id> --to-run <run-id> [--metric <name>]
+homeboy runs fuzz-compare --from-run <run-id> --to-run <run-id> [--hotspot-policy <advisory|blocking|off>]
 homeboy runs show <run-id> [--json]
 homeboy runs resume-plan <run-id>
 homeboy runs evidence <run-id>
@@ -101,6 +102,8 @@ homeboy runs compare --kind bench --component studio --metric total_elapsed_ms -
 Metric lookup supports top-level run metadata such as `results.total_elapsed_ms`, direct dotted paths, and benchmark scenario metrics recorded under `scenario_metrics[].metrics` or `metric_groups`.
 
 `homeboy runs bench-compare --from-run <baseline-run-id> --to-run <candidate-run-id>` compares numeric metrics recorded in two exact benchmark runs. It captures both run IDs, component state, shared benchmark context, selected metric deltas, and a Markdown table under `reports.markdown` in the JSON payload.
+
+`homeboy runs fuzz-compare --from-run <baseline-run-id> --to-run <candidate-run-id>` compares persisted fuzz result envelope artifacts for two exact runs. It resolves `fuzz_result_envelope` artifacts from the observation store, folds in related persisted fuzz hotspot/observation artifacts for hotspot analysis, and returns the same `homeboy/fuzz-compare/v1` payload as `homeboy fuzz compare` without requiring local file paths.
 
 ## Related Readers
 

--- a/src/commands/fuzz/compare.rs
+++ b/src/commands/fuzz/compare.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use homeboy::core::fuzz::{
-    parse_fuzz_hotspot_set_value, parse_fuzz_result_envelope_file, FuzzHotspot, FuzzResultEnvelope,
+    parse_fuzz_hotspot_set_value, parse_fuzz_observation_set_value,
+    parse_fuzz_result_envelope_file, FuzzHotspot, FuzzObservationFamily, FuzzResultEnvelope,
 };
 
 use super::report::{
@@ -19,10 +20,28 @@ const FUZZ_COMPARE_SCHEMA: &str = "homeboy/fuzz-compare/v1";
 pub(super) fn run_compare(args: FuzzCompareArgs) -> homeboy::core::Result<FuzzCompareOutput> {
     let baseline_envelope = parse_fuzz_result_envelope_file(&args.baseline)?;
     let candidate_envelope = parse_fuzz_result_envelope_file(&args.candidate)?;
+    compare_envelopes(
+        baseline_envelope,
+        candidate_envelope,
+        args.hotspot_policy,
+        args.baseline.to_string_lossy().to_string(),
+        args.candidate.to_string_lossy().to_string(),
+        "fuzz.compare",
+    )
+}
+
+pub(crate) fn compare_envelopes(
+    baseline_envelope: FuzzResultEnvelope,
+    candidate_envelope: FuzzResultEnvelope,
+    hotspot_policy: FuzzCompareHotspotPolicy,
+    baseline_ref: String,
+    candidate_ref: String,
+    command: &str,
+) -> homeboy::core::Result<FuzzCompareOutput> {
     let baseline = snapshot(&baseline_envelope);
     let candidate = snapshot(&candidate_envelope);
-    let deltas = deltas(&baseline, &candidate, args.hotspot_policy);
-    let hotspot_summary = hotspot_summary(&deltas, args.hotspot_policy);
+    let deltas = deltas(&baseline, &candidate, hotspot_policy);
+    let hotspot_summary = hotspot_summary(&deltas, hotspot_policy);
     let regressions = regressions(&deltas);
     let advisories = advisories(&deltas);
     let improvements = improvements(&deltas);
@@ -39,11 +58,11 @@ pub(super) fn run_compare(args: FuzzCompareArgs) -> homeboy::core::Result<FuzzCo
 
     Ok(FuzzCompareOutput {
         schema: FUZZ_COMPARE_SCHEMA.to_string(),
-        command: "fuzz.compare".to_string(),
+        command: command.to_string(),
         status: status.clone(),
         advisory_status: advisory_status(&status, &advisories),
-        baseline_file: args.baseline.to_string_lossy().to_string(),
-        candidate_file: args.candidate.to_string_lossy().to_string(),
+        baseline_file: baseline_ref,
+        candidate_file: candidate_ref,
         baseline,
         candidate,
         deltas,
@@ -53,7 +72,7 @@ pub(super) fn run_compare(args: FuzzCompareArgs) -> homeboy::core::Result<FuzzCo
         improvements,
         summary: vec![
             format!("fuzz compare status: {status}"),
-            format!("hotspot policy: {}", args.hotspot_policy.as_str()),
+            format!("hotspot policy: {}", hotspot_policy.as_str()),
         ],
     })
 }
@@ -290,6 +309,45 @@ fn collect_hotspots_from_value(
 ) {
     if let Some(set) = parse_fuzz_hotspot_set_value(value) {
         hotspots.extend(set.items.into_iter().map(hotspot_snapshot));
+        return;
+    }
+    if let Some(set) = parse_fuzz_observation_set_value(value) {
+        hotspots.extend(set.observations.into_iter().map(|observation| {
+            let dimension = match observation.family {
+                FuzzObservationFamily::Action => "action",
+                FuzzObservationFamily::Query => "query",
+                FuzzObservationFamily::Resource => "resource",
+                FuzzObservationFamily::Timing => "timing",
+                FuzzObservationFamily::Counter => "counter",
+            }
+            .to_string();
+            let id = observation.fingerprint.clone().unwrap_or_else(|| {
+                [
+                    Some(dimension.as_str()),
+                    Some(observation.subject.as_str()),
+                    Some(observation.metric.as_str()),
+                    observation.operation_id.as_deref(),
+                    observation.case_id.as_deref(),
+                ]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
+                .join(":")
+            });
+            FuzzCompareHotspotSnapshot {
+                id,
+                dimension,
+                kind: Some("observation".to_string()),
+                metric: observation.metric,
+                value: observation.value,
+                unit: observation.unit,
+                basis: Some("fuzz_observation_set".to_string()),
+                sample_count: observation.sample_count,
+                rank: None,
+                relative_score: Some(observation.value.abs()),
+                label: Some(observation.subject),
+            }
+        }));
         return;
     }
 
@@ -786,6 +844,38 @@ mod tests {
     }
 
     #[test]
+    fn fuzz_compare_promotes_observation_sets_to_hotspots() {
+        let mut envelope = envelope("candidate", 0, 0, 0, 0, &[], &[], true);
+        envelope.metadata = serde_json::json!({
+            "observations": {
+                "schema": "homeboy/fuzz-observation-set/v1",
+                "version": 1,
+                "id": "candidate-observations",
+                "observations": [
+                    {
+                        "id": "observation-1",
+                        "family": "timing",
+                        "subject": "page-load",
+                        "metric": "duration",
+                        "value": 123.0,
+                        "unit": "ms",
+                        "sample_count": 4,
+                        "fingerprint": "page-load:duration"
+                    }
+                ]
+            }
+        });
+
+        let snapshot = snapshot(&envelope);
+
+        assert_eq!(snapshot.hotspots.len(), 1);
+        assert_eq!(snapshot.hotspots[0].id, "page-load:duration");
+        assert_eq!(snapshot.hotspots[0].dimension, "timing");
+        assert_eq!(snapshot.hotspots[0].kind.as_deref(), Some("observation"));
+        assert_eq!(snapshot.hotspots[0].relative_score, Some(123.0));
+    }
+
+    #[test]
     fn fuzz_compare_blocking_hotspot_policy_affects_compare_status_data() {
         let mut baseline = envelope("baseline", 0, 0, 0, 0, &[], &[], true);
         baseline.metadata = serde_json::json!({
@@ -901,6 +991,7 @@ mod tests {
                     seed_id: None,
                     fingerprint: Some(format!("fingerprint-{index}")),
                     artifact_ids: Vec::new(),
+                    source_refs: Vec::new(),
                     metadata: serde_json::Value::Null,
                     extra: BTreeMap::new(),
                 })

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use homeboy::core::engine::execution_context;
 use homeboy::core::engine::invocation::InvocationRequirements;
@@ -90,10 +90,14 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     } else {
         (None, None)
     };
+    let artifacts_dir =
+        run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_ARTIFACTS_DIR);
+    let artifact_ref_validation = fuzz_artifact_ref_validation(results.as_ref(), &artifacts_dir);
     let artifact_validation_error = fuzz_run_artifact_validation_error(&args, results.as_ref());
     let combined_results_error = results_error
         .as_deref()
-        .or(artifact_validation_error.as_deref());
+        .or(artifact_validation_error.as_deref())
+        .or(artifact_ref_validation.error.as_deref());
     let outcome = fuzz_run_outcome(
         runner_output.exit_code,
         runner_output.success,
@@ -119,8 +123,10 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         success,
         args: &args,
         results_path: &results_path,
+        artifacts_dir: &artifacts_dir,
         results: results.as_ref(),
         results_error: combined_results_error,
+        missing_artifact_refs: &artifact_ref_validation.missing_refs,
     })?;
     let evidence_followups = fuzz_evidence_followups(
         args.run_id.as_deref(),
@@ -410,8 +416,10 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) success: bool,
     pub(super) args: &'a FuzzRunArgs,
     pub(super) results_path: &'a Path,
+    pub(super) artifacts_dir: &'a Path,
     pub(super) results: Option<&'a FuzzCampaign>,
     pub(super) results_error: Option<&'a str>,
+    pub(super) missing_artifact_refs: &'a [String],
 }
 
 pub(super) fn persist_fuzz_run_evidence(
@@ -436,6 +444,7 @@ pub(super) fn persist_fuzz_run_evidence(
         "status": input.status,
         "campaign_id": input.results.map(|campaign| campaign.id.as_str()),
         "results_error": input.results_error,
+        "missing_artifact_refs": input.missing_artifact_refs,
         "coverage_completeness": input.results.map(fuzz_coverage_completeness),
         "gates": input.results.map(evaluate_fuzz_gates),
     });
@@ -468,7 +477,140 @@ pub(super) fn persist_fuzz_run_evidence(
     if input.results_path.is_file() {
         store.record_artifact(&run_id, "fuzz_results", input.results_path)?;
     }
+    if input.artifacts_dir.is_dir() {
+        store.record_directory_artifact_with_metadata(
+            &run_id,
+            "fuzz_artifacts",
+            input.artifacts_dir,
+            serde_json::json!({
+                "source": "HOMEBOY_FUZZ_ARTIFACTS_DIR",
+                "missing_artifact_refs": input.missing_artifact_refs,
+            }),
+        )?;
+    }
     Ok(Some(run))
+}
+
+#[derive(Default)]
+pub(super) struct FuzzArtifactRefValidation {
+    pub(super) missing_refs: Vec<String>,
+    pub(super) error: Option<String>,
+}
+
+pub(super) fn fuzz_artifact_ref_validation(
+    results: Option<&FuzzCampaign>,
+    artifacts_dir: &Path,
+) -> FuzzArtifactRefValidation {
+    let Some(campaign) = results else {
+        return FuzzArtifactRefValidation::default();
+    };
+    let mut missing_refs = Vec::new();
+    for artifact in &campaign.artifacts {
+        if let Some(path) = artifact
+            .artifact
+            .as_ref()
+            .and_then(|artifact| artifact.path.as_deref())
+        {
+            collect_missing_artifact_ref(path, artifacts_dir, &mut missing_refs);
+        }
+    }
+    collect_missing_artifact_refs_from_metadata(
+        &campaign.metadata,
+        artifacts_dir,
+        &mut missing_refs,
+    );
+    missing_refs.sort();
+    missing_refs.dedup();
+
+    let error = (!missing_refs.is_empty()).then(|| {
+        format!(
+            "fuzz campaign references artifact path(s) missing from HOMEBOY_FUZZ_ARTIFACTS_DIR: {}",
+            missing_refs.join(", ")
+        )
+    });
+    FuzzArtifactRefValidation {
+        missing_refs,
+        error,
+    }
+}
+
+fn collect_missing_artifact_refs_from_metadata(
+    value: &serde_json::Value,
+    artifacts_dir: &Path,
+    missing_refs: &mut Vec<String>,
+) {
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(refs) = object.get("artifact_refs") {
+                collect_artifact_refs_value(refs, artifacts_dir, missing_refs);
+            }
+            for value in object.values() {
+                collect_missing_artifact_refs_from_metadata(value, artifacts_dir, missing_refs);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_missing_artifact_refs_from_metadata(value, artifacts_dir, missing_refs);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_artifact_refs_value(
+    value: &serde_json::Value,
+    artifacts_dir: &Path,
+    missing_refs: &mut Vec<String>,
+) {
+    match value {
+        serde_json::Value::String(path) => {
+            collect_missing_artifact_ref(path, artifacts_dir, missing_refs)
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_artifact_refs_value(value, artifacts_dir, missing_refs);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            for key in ["path", "artifact", "ref"] {
+                if let Some(path) = object.get(key).and_then(serde_json::Value::as_str) {
+                    collect_missing_artifact_ref(path, artifacts_dir, missing_refs);
+                    return;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_missing_artifact_ref(path: &str, artifacts_dir: &Path, missing_refs: &mut Vec<String>) {
+    let Some(resolved) = resolve_local_fuzz_artifact_ref(path, artifacts_dir) else {
+        return;
+    };
+    if !resolved.exists() {
+        missing_refs.push(path.to_string());
+    }
+}
+
+fn resolve_local_fuzz_artifact_ref(path: &str, artifacts_dir: &Path) -> Option<PathBuf> {
+    let trimmed = path.trim();
+    if trimmed.is_empty()
+        || trimmed.contains("://")
+        || trimmed.starts_with("homeboy://")
+        || trimmed.starts_with("runner-artifact://")
+    {
+        return None;
+    }
+    let candidate = Path::new(trimmed);
+    if candidate.is_absolute() {
+        candidate
+            .starts_with(artifacts_dir)
+            .then(|| candidate.to_path_buf())
+    } else {
+        (!trimmed.starts_with(".."))
+            .then(|| artifacts_dir.join(candidate))
+            .filter(|path| path.starts_with(artifacts_dir))
+    }
 }
 
 fn fuzz_run_command(

--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -10,13 +10,14 @@ mod types;
 mod types_extra;
 mod workloads;
 
+pub(crate) use compare::compare_envelopes;
 pub use dispatch::run;
 pub use types::{
-    FuzzArgs, FuzzCampaignContract, FuzzContractOutput, FuzzCoverageCompletenessOutput,
-    FuzzCoverageSelectorSummaryOutput, FuzzDiscoverOutput, FuzzDiscoverSummary,
-    FuzzExecutionOutput, FuzzGateEvaluation, FuzzListOutput, FuzzOutput, FuzzPlanOutput,
-    FuzzReplayEnv, FuzzReplayOutput, FuzzReportOutput, FuzzRunArgs, FuzzRunOutput,
-    FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
+    FuzzArgs, FuzzCampaignContract, FuzzCompareHotspotPolicy, FuzzCompareOutput,
+    FuzzContractOutput, FuzzCoverageCompletenessOutput, FuzzCoverageSelectorSummaryOutput,
+    FuzzDiscoverOutput, FuzzDiscoverSummary, FuzzExecutionOutput, FuzzGateEvaluation,
+    FuzzListOutput, FuzzOutput, FuzzPlanOutput, FuzzReplayEnv, FuzzReplayOutput, FuzzReportOutput,
+    FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
 };
 
 #[cfg(test)]

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -26,7 +26,9 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             args: vec![],
         };
         let results_path = home.path().join("fuzz-results.json");
+        let artifacts_dir = home.path().join("fuzz-artifacts");
         std::fs::write(&results_path, "{}").expect("results file");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
 
         let persisted = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
             run_id: args.run_id.as_deref(),
@@ -39,8 +41,10 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             success: true,
             args: &args,
             results_path: &results_path,
+            artifacts_dir: &artifacts_dir,
             results: None,
             results_error: None,
+            missing_artifact_refs: &[],
         })
         .expect("persist fuzz run")
         .expect("run record");
@@ -63,10 +67,22 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             .unwrap_or_default()
             .contains("homeboy fuzz run component-a"));
         let artifacts = store.list_artifacts("proof-1").expect("artifacts");
-        assert_eq!(artifacts.len(), 1);
-        assert_eq!(artifacts[0].kind, "fuzz_results");
-        assert_eq!(artifacts[0].artifact_type, "file");
-        assert!(std::path::Path::new(&artifacts[0].path).is_file());
+        assert_eq!(artifacts.len(), 2);
+        let results_artifact = artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "fuzz_results")
+            .expect("fuzz results artifact");
+        assert_eq!(results_artifact.artifact_type, "file");
+        assert!(std::path::Path::new(&results_artifact.path).is_file());
+        let dir_artifact = artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "fuzz_artifacts")
+            .expect("fuzz artifacts directory");
+        assert_eq!(dir_artifact.artifact_type, "directory");
+        assert_eq!(
+            dir_artifact.metadata_json["source"],
+            "HOMEBOY_FUZZ_ARTIFACTS_DIR"
+        );
     });
 }
 
@@ -76,7 +92,9 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
         let mut args = fuzz_run_args_with_run_id("ignored");
         args.run_id = None;
         let results_path = home.path().join("fuzz-results.json");
+        let artifacts_dir = home.path().join("fuzz-artifacts");
         std::fs::write(&results_path, "{}").expect("results file");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
 
         let persisted = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
             run_id: args.run_id.as_deref(),
@@ -89,8 +107,10 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
             success: true,
             args: &args,
             results_path: &results_path,
+            artifacts_dir: &artifacts_dir,
             results: None,
             results_error: None,
+            missing_artifact_refs: &[],
         })
         .expect("persist fuzz run")
         .expect("run record");
@@ -103,7 +123,7 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
                 .list_artifacts(&persisted.id)
                 .expect("artifacts")
                 .len(),
-            1
+            2
         );
     });
 }
@@ -141,6 +161,7 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_open_finding() {
         seed_id: None,
         fingerprint: None,
         artifact_ids: Vec::new(),
+        source_refs: Vec::new(),
         metadata: serde_json::Value::Null,
         extra: std::collections::BTreeMap::new(),
     }];
@@ -281,11 +302,13 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             args: vec![],
         };
         let results_path = home.path().join("fuzz-results.json");
+        let artifacts_dir = home.path().join("fuzz-artifacts");
         std::fs::write(
             &results_path,
             r#"{"schema":"unsupported/fuzz-result/v1","id":"raw-output"}"#,
         )
         .expect("results file");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
 
         let persisted = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
             run_id: args.run_id.as_deref(),
@@ -298,10 +321,12 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             success: false,
             args: &args,
             results_path: &results_path,
+            artifacts_dir: &artifacts_dir,
             results: None,
             results_error: Some(
                 "fuzz results schema must be homeboy/fuzz-campaign/v1, got unsupported/fuzz-result/v1",
             ),
+            missing_artifact_refs: &[],
         })
         .expect("persist fuzz run")
         .expect("run record");
@@ -321,12 +346,61 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
         let artifacts = store
             .list_artifacts("proof-bad-results")
             .expect("artifacts");
-        assert_eq!(artifacts.len(), 1);
-        assert_eq!(artifacts[0].kind, "fuzz_results");
-        assert_eq!(artifacts[0].mime.as_deref(), Some("application/json"));
-        assert!(std::path::Path::new(&artifacts[0].path).is_file());
-        let raw = std::fs::read_to_string(&artifacts[0].path).expect("raw artifact");
+        let results_artifact = artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "fuzz_results")
+            .expect("fuzz results artifact");
+        assert_eq!(results_artifact.mime.as_deref(), Some("application/json"));
+        assert!(std::path::Path::new(&results_artifact.path).is_file());
+        let raw = std::fs::read_to_string(&results_artifact.path).expect("raw artifact");
         assert!(raw.contains("unsupported/fuzz-result/v1"));
+    });
+}
+
+#[test]
+fn fuzz_artifact_ref_validation_reports_missing_local_refs() {
+    with_isolated_home(|home| {
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
+        std::fs::write(artifacts_dir.join("present.json"), "{}").expect("present artifact");
+        let mut campaign = empty_fuzz_campaign();
+        campaign.artifacts.push(homeboy::core::fuzz::FuzzArtifact {
+            schema: homeboy::core::fuzz::FUZZ_ARTIFACT_SCHEMA.to_string(),
+            id: "case-log".to_string(),
+            kind: "case_log".to_string(),
+            artifact: Some(homeboy::core::artifact_contract::ArtifactContract {
+                schema: homeboy::core::artifact_contract::ARTIFACT_CONTRACT_SCHEMA.to_string(),
+                kind: "case_log".to_string(),
+                artifact_type: "file".to_string(),
+                path: Some("missing.json".to_string()),
+                url: None,
+                public_url: None,
+                role: None,
+                label: None,
+                semantic_key: None,
+                size_bytes: None,
+                sha256: None,
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            }),
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        });
+        campaign.metadata = serde_json::json!({
+            "artifact_refs": ["present.json", "also-missing.json", "https://example.test/remote.json"]
+        });
+
+        let validation = fuzz_artifact_ref_validation(Some(&campaign), &artifacts_dir);
+
+        assert_eq!(
+            validation.missing_refs,
+            vec!["also-missing.json".to_string(), "missing.json".to_string()]
+        );
+        assert!(validation
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("HOMEBOY_FUZZ_ARTIFACTS_DIR"));
     });
 }
 

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -2,8 +2,8 @@
 
 use super::super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
 use super::execution::{
-    default_runner_contract, fuzz_campaign_contract, fuzz_evidence_followups,
-    fuzz_run_artifact_validation_error, fuzz_run_outcome, fuzz_runner_env,
+    default_runner_contract, fuzz_artifact_ref_validation, fuzz_campaign_contract,
+    fuzz_evidence_followups, fuzz_run_artifact_validation_error, fuzz_run_outcome, fuzz_runner_env,
     persist_fuzz_run_evidence, FuzzRunEvidenceInput,
 };
 use super::planning::plan_inventory_selection;

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -320,7 +320,7 @@ pub(crate) struct FuzzCompareArgs {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
-pub(crate) enum FuzzCompareHotspotPolicy {
+pub enum FuzzCompareHotspotPolicy {
     /// Measure and report hotspot regressions without failing the compare.
     Advisory,
     /// Treat relative hotspot regressions as blocking compare regressions.

--- a/src/commands/runs/dispatch.rs
+++ b/src/commands/runs/dispatch.rs
@@ -7,8 +7,8 @@ use homeboy::core::Error;
 
 use super::types::{RunsArgs, RunsArtifactArgs, RunsArtifactCommand, RunsCommand, RunsOutput};
 use super::{
-    bench, compare, distribution, drift, evidence, findings, handlers, hotspots, latest, loop_sync,
-    query, reconcile, refs,
+    bench, compare, distribution, drift, evidence, findings, fuzz_compare, handlers, hotspots,
+    latest, loop_sync, query, reconcile, refs,
 };
 use super::{CmdResult, GlobalArgs};
 
@@ -109,6 +109,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::LatestRun(args) => latest::latest_run(args),
         RunsCommand::Compare(args) => compare::compare_runs(args),
         RunsCommand::BenchCompare(args) => bench::bench_compare_from_args(args),
+        RunsCommand::FuzzCompare(args) => fuzz_compare::fuzz_compare_from_args(args),
         RunsCommand::Hotspots(args) => hotspots::runs_hotspots(args),
         RunsCommand::Reconcile(args) => reconcile::reconcile_runs(args),
         RunsCommand::Show { run_id, json: _ } => handlers::show_run(&run_id),

--- a/src/commands/runs/fuzz_compare.rs
+++ b/src/commands/runs/fuzz_compare.rs
@@ -1,0 +1,255 @@
+//! Exact run-id fuzz comparison over persisted run artifacts.
+
+use std::fs::File;
+use std::path::Path;
+
+use clap::Args;
+use serde_json::Value;
+
+use homeboy::core::fuzz::{FuzzResultEnvelope, FUZZ_RESULT_ENVELOPE_SCHEMA};
+use homeboy::core::observation::runs_service;
+use homeboy::core::observation::{ArtifactRecord, ObservationStore};
+use homeboy::core::Error;
+
+use crate::commands::fuzz::{compare_envelopes, FuzzCompareHotspotPolicy};
+
+use super::{CmdResult, RunsOutput};
+
+#[derive(Args, Clone)]
+pub struct RunsFuzzCompareArgs {
+    /// Baseline fuzz run id.
+    #[arg(long = "from-run", value_name = "RUN_ID")]
+    pub from_run: String,
+
+    /// Candidate fuzz run id.
+    #[arg(long = "to-run", value_name = "RUN_ID")]
+    pub to_run: String,
+
+    /// How relative hotspot regressions affect the blocking compare status.
+    #[arg(long = "hotspot-policy", value_enum, default_value_t = FuzzCompareHotspotPolicy::Advisory)]
+    pub hotspot_policy: FuzzCompareHotspotPolicy,
+}
+
+pub fn fuzz_compare_from_args(args: RunsFuzzCompareArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let baseline = resolve_run_fuzz_envelope(&store, &args.from_run)?;
+    let candidate = resolve_run_fuzz_envelope(&store, &args.to_run)?;
+    let output = compare_envelopes(
+        baseline.envelope,
+        candidate.envelope,
+        args.hotspot_policy,
+        baseline.source_ref,
+        candidate.source_ref,
+        "runs.fuzz-compare",
+    )?;
+    Ok((RunsOutput::FuzzCompare(output), 0))
+}
+
+struct RunFuzzEnvelope {
+    envelope: FuzzResultEnvelope,
+    source_ref: String,
+}
+
+fn resolve_run_fuzz_envelope(
+    store: &ObservationStore,
+    run_id: &str,
+) -> homeboy::core::Result<RunFuzzEnvelope> {
+    let _run = runs_service::require_run(store, run_id)?;
+    let artifacts = runs_service::list_artifacts_for_run(store, run_id)?;
+    let mut candidates = artifacts
+        .iter()
+        .filter(|artifact| artifact.artifact_type == "file")
+        .filter(|artifact| is_fuzz_envelope_candidate(artifact))
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|artifact| fuzz_envelope_candidate_rank(artifact));
+
+    for artifact in candidates {
+        let Ok(mut envelope) = read_fuzz_envelope_artifact(artifact) else {
+            continue;
+        };
+        attach_related_fuzz_artifacts(&mut envelope, &artifacts);
+        return Ok(RunFuzzEnvelope {
+            envelope,
+            source_ref: format!("homeboy://run/{run_id}/artifact/{}", artifact.id),
+        });
+    }
+
+    Err(Error::validation_invalid_argument(
+        "run_id",
+        format!("fuzz result envelope artifact not found for run: {run_id}"),
+        Some(run_id.to_string()),
+        Some(vec![
+            format!("Run `homeboy runs artifacts {run_id}` to inspect recorded artifacts."),
+            "Persist a result envelope with `homeboy fuzz report <campaign> --run-id <run-id>`, or ensure the runner writes a homeboy/fuzz-result-envelope/v1 JSON artifact.".to_string(),
+        ]),
+    ))
+}
+
+fn is_fuzz_envelope_candidate(artifact: &ArtifactRecord) -> bool {
+    artifact.kind == "fuzz_result_envelope"
+        || artifact.metadata_json.get("schema").and_then(Value::as_str)
+            == Some(FUZZ_RESULT_ENVELOPE_SCHEMA)
+        || artifact.kind == "fuzz_results"
+}
+
+fn fuzz_envelope_candidate_rank(artifact: &ArtifactRecord) -> u8 {
+    if artifact.kind == "fuzz_result_envelope" {
+        0
+    } else if artifact.metadata_json.get("schema").and_then(Value::as_str)
+        == Some(FUZZ_RESULT_ENVELOPE_SCHEMA)
+    {
+        1
+    } else {
+        2
+    }
+}
+
+fn read_fuzz_envelope_artifact(
+    artifact: &ArtifactRecord,
+) -> homeboy::core::Result<FuzzResultEnvelope> {
+    let path = Path::new(&artifact.path);
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(artifact.path.clone())))?;
+    let envelope: FuzzResultEnvelope = serde_json::from_str(&contents).map_err(|error| {
+        Error::validation_invalid_json(
+            error,
+            Some(format!(
+                "parse fuzz result envelope artifact {}",
+                artifact.id
+            )),
+            Some(contents),
+        )
+    })?;
+    if envelope.schema != FUZZ_RESULT_ENVELOPE_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "schema",
+            format!(
+                "fuzz result envelope schema must be {FUZZ_RESULT_ENVELOPE_SCHEMA}, got {}",
+                envelope.schema
+            ),
+            Some(envelope.schema),
+            None,
+        ));
+    }
+    Ok(envelope)
+}
+
+fn attach_related_fuzz_artifacts(envelope: &mut FuzzResultEnvelope, artifacts: &[ArtifactRecord]) {
+    let values = artifacts
+        .iter()
+        .filter(|artifact| artifact.artifact_type == "file")
+        .filter(|artifact| artifact.kind != "fuzz_result_envelope")
+        .filter_map(read_related_fuzz_artifact_json)
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        return;
+    }
+    let mut metadata = match std::mem::take(&mut envelope.metadata) {
+        Value::Object(object) => object,
+        value if value.is_null() => serde_json::Map::new(),
+        value => {
+            let mut object = serde_json::Map::new();
+            object.insert("original".to_string(), value);
+            object
+        }
+    };
+    metadata.insert("resolved_run_artifacts".to_string(), Value::Array(values));
+    envelope.metadata = Value::Object(metadata);
+}
+
+fn read_related_fuzz_artifact_json(artifact: &ArtifactRecord) -> Option<Value> {
+    let path = Path::new(&artifact.path);
+    let file = File::open(path).ok()?;
+    let json = serde_json::from_reader::<_, Value>(file).ok()?;
+    is_related_fuzz_json(&json).then(|| json)
+}
+
+fn is_related_fuzz_json(value: &Value) -> bool {
+    value
+        .get("schema")
+        .and_then(Value::as_str)
+        .is_some_and(|schema| {
+            schema.contains("fuzz-hotspot") || schema.contains("fuzz-observation")
+        })
+        || value.get("hotspots").is_some()
+        || value.get("observation_set").is_some()
+        || value.get("observations").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+    use homeboy::test_support::with_isolated_home;
+
+    use super::*;
+
+    fn sample_run() -> NewRunRecord {
+        NewRunRecord::builder("fuzz")
+            .component_id("homeboy")
+            .command("homeboy fuzz run homeboy")
+            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+            .homeboy_version("test-version")
+            .metadata(serde_json::json!({}))
+            .build()
+    }
+
+    fn envelope(id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "schema": "homeboy/fuzz-result-envelope/v1",
+            "version": 1,
+            "id": id,
+            "status": "passed",
+            "request": {
+                "schema": "homeboy/fuzz-execution-request/v1",
+                "version": 1,
+                "id": format!("{id}-request"),
+                "component": "homeboy"
+            }
+        })
+    }
+
+    #[test]
+    fn fuzz_compare_resolves_envelopes_from_run_artifacts() {
+        with_isolated_home(|home| {
+            homeboy::core::set_artifact_root_override(Some(home.path().join("artifacts")));
+            let store = ObservationStore::open_initialized().expect("store");
+            let baseline = store.start_run(sample_run()).expect("baseline run");
+            store
+                .finish_run(&baseline.id, RunStatus::Pass, None)
+                .expect("finish baseline");
+            let candidate = store.start_run(sample_run()).expect("candidate run");
+            store
+                .finish_run(&candidate.id, RunStatus::Pass, None)
+                .expect("finish candidate");
+
+            let baseline_path = home.path().join("baseline-envelope.json");
+            let candidate_path = home.path().join("candidate-envelope.json");
+            std::fs::write(
+                &baseline_path,
+                serde_json::to_string(&envelope("baseline")).unwrap(),
+            )
+            .expect("baseline envelope");
+            std::fs::write(
+                &candidate_path,
+                serde_json::to_string(&envelope("candidate")).unwrap(),
+            )
+            .expect("candidate envelope");
+            store
+                .record_artifact(&baseline.id, "fuzz_result_envelope", &baseline_path)
+                .expect("baseline artifact");
+            store
+                .record_artifact(&candidate.id, "fuzz_result_envelope", &candidate_path)
+                .expect("candidate artifact");
+
+            let (_, exit_code) = fuzz_compare_from_args(RunsFuzzCompareArgs {
+                from_run: baseline.id.clone(),
+                to_run: candidate.id.clone(),
+                hotspot_policy: FuzzCompareHotspotPolicy::Advisory,
+            })
+            .expect("fuzz compare");
+
+            assert_eq!(exit_code, 0);
+            homeboy::core::set_artifact_root_override(None);
+        });
+    }
+}

--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -22,6 +22,7 @@ mod distribution;
 mod drift;
 mod evidence;
 mod findings;
+mod fuzz_compare;
 mod gh_actions;
 mod handlers;
 mod hotspots;

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -25,6 +25,7 @@ use super::drift::{RunsDriftArgs, RunsDriftOutput};
 use super::evidence::RunsEvidenceOutput;
 use super::findings;
 use super::findings::{RunsFindingOutput, RunsFindingsOutput};
+use super::fuzz_compare::RunsFuzzCompareArgs;
 use super::gh_actions::GhActionsImportOutput;
 use super::hotspots::{RunsHotspotsArgs, RunsHotspotsOutput};
 use super::latest::{RunsLatestFindingOutput, RunsLatestRunArgs, RunsLatestRunOutput};
@@ -32,6 +33,7 @@ use super::loop_sync::{RunsLoopSyncArgs, RunsLoopSyncOutput};
 use super::query::{RunsQueryArgs, RunsQueryOutput};
 use super::reconcile::{RunsReconcileArgs, RunsReconcileOutput};
 use super::refs::{RunsRefsArgs, RunsRefsOutput};
+use crate::commands::fuzz::FuzzCompareOutput;
 
 pub(super) const DEFAULT_LIMIT: i64 = 20;
 
@@ -65,6 +67,8 @@ pub(super) enum RunsCommand {
     Compare(RunsCompareArgs),
     /// Compare two persisted benchmark runs by exact run id; canonical replacement for `bench compare`
     BenchCompare(RunsBenchCompareArgs),
+    /// Compare two persisted fuzz runs by exact run id
+    FuzzCompare(RunsFuzzCompareArgs),
     /// Aggregate hotspot rankings across persisted fuzz run artifacts
     Hotspots(RunsHotspotsArgs),
     /// Mark orphaned running observation records stale
@@ -154,6 +158,7 @@ pub enum RunsOutput {
     Finding(RunsFindingOutput),
     LatestFinding(RunsLatestFindingOutput),
     BenchCompare(BenchCompareOutput),
+    FuzzCompare(FuzzCompareOutput),
     Hotspots(RunsHotspotsOutput),
     Reconcile(RunsReconcileOutput),
     Export(RunsExportOutput),

--- a/src/core/fuzz/contract.rs
+++ b/src/core/fuzz/contract.rs
@@ -164,7 +164,7 @@ pub fn canonical_operation_family(kind: &str) -> Option<FuzzOperationFamily> {
         "list" => Some(FuzzOperationFamily::List),
         "search" => Some(FuzzOperationFamily::Search),
         "navigate" => Some(FuzzOperationFamily::Navigate),
-        "render" | "block_render" => Some(FuzzOperationFamily::Render),
+        "render" => Some(FuzzOperationFamily::Render),
         "query" => Some(FuzzOperationFamily::Query),
         "load" => Some(FuzzOperationFamily::Load),
         "submit" => Some(FuzzOperationFamily::Submit),

--- a/src/core/fuzz/coverage.rs
+++ b/src/core/fuzz/coverage.rs
@@ -126,6 +126,8 @@ pub struct FuzzFinding {
     pub fingerprint: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_refs: Vec<String>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/src/core/fuzz/hotspots.rs
+++ b/src/core/fuzz/hotspots.rs
@@ -79,6 +79,8 @@ pub struct FuzzHotspot {
     pub evidence_refs: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_refs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_refs: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<FuzzProvenance>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
@@ -110,6 +112,7 @@ impl FuzzHotspot {
         self.labels = normalize_string_vec(std::mem::take(&mut self.labels));
         self.evidence_refs = normalize_string_vec(std::mem::take(&mut self.evidence_refs));
         self.artifact_refs = normalize_string_vec(std::mem::take(&mut self.artifact_refs));
+        self.source_refs = normalize_string_vec(std::mem::take(&mut self.source_refs));
         Ok(())
     }
 }

--- a/src/core/fuzz/tests/campaign_tests.rs
+++ b/src/core/fuzz/tests/campaign_tests.rs
@@ -27,8 +27,10 @@ fn campaign_serializes_seeds_coverage_findings_artifacts_thresholds_and_provenan
                 target_id: Some("target-1".to_string()),
                 label: None,
                 tags: Vec::new(),
+                source_refs: Vec::new(),
             }],
             metadata: Value::Null,
+            source_refs: Vec::new(),
             extra: BTreeMap::new(),
         }],
         workloads: vec![FuzzWorkload {
@@ -160,6 +162,7 @@ fn campaign_serializes_seeds_coverage_findings_artifacts_thresholds_and_provenan
             seed_id: Some("seed-1".to_string()),
             fingerprint: Some("abc123".to_string()),
             artifact_ids: vec!["artifact-1".to_string()],
+            source_refs: Vec::new(),
             metadata: Value::Null,
             extra: BTreeMap::new(),
         }],

--- a/src/core/fuzz/tests/surface_tests.rs
+++ b/src/core/fuzz/tests/surface_tests.rs
@@ -64,7 +64,7 @@ fn operation_normalizes_canonical_families_from_kind() {
             { "id": "create-1", "kind": "post" },
             { "id": "update-1", "kind": "PATCH" },
             { "id": "delete-1", "kind": "delete" },
-            { "id": "block-render-1", "kind": "block-render" },
+            { "id": "render-1", "kind": "render" },
             { "id": "performance-1", "kind": "performance probe" }
         ]
     }))
@@ -106,30 +106,5 @@ fn operation_preserves_declared_canonical_family() {
     assert_eq!(
         surface.operations[0].family,
         Some(FuzzOperationFamily::Search)
-    );
-}
-
-#[test]
-fn operation_reads_legacy_block_render_family_as_render() {
-    let surface = FuzzSurface::from_value(json!({
-        "id": "surface-1",
-        "kind": "renderer",
-        "safety_class": "read_only",
-        "operations": [
-            { "id": "render-specialized-unit", "kind": "block_render", "family": "block_render" }
-        ]
-    }))
-    .expect("surface contract");
-
-    assert_eq!(surface.operations[0].kind, "block_render");
-    assert_eq!(
-        surface.operations[0].family,
-        Some(FuzzOperationFamily::Render)
-    );
-
-    let serialized = serde_json::to_value(&surface).expect("serialized surface");
-    assert_eq!(
-        serialized["operations"][0]["family"],
-        serde_json::json!("render")
     );
 }

--- a/src/core/fuzz/types.rs
+++ b/src/core/fuzz/types.rs
@@ -84,6 +84,8 @@ pub struct FuzzOperation {
     pub label: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_refs: Vec<String>,
 }
 
 impl FuzzOperation {
@@ -96,6 +98,7 @@ impl FuzzOperation {
         self.target_id = normalize_optional_string(self.target_id.take());
         self.label = normalize_optional_string(self.label.take());
         self.tags = normalize_string_vec(std::mem::take(&mut self.tags));
+        self.source_refs = normalize_string_vec(std::mem::take(&mut self.source_refs));
         Ok(())
     }
 }
@@ -114,6 +117,8 @@ pub struct FuzzTarget {
     pub operations: Vec<FuzzOperation>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_refs: Vec<String>,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, Value>,
 }
@@ -126,6 +131,7 @@ impl FuzzTarget {
         self.kind = required_trimmed("target.kind", &self.kind)?;
         self.label = normalize_optional_string(self.label.take());
         self.locator = normalize_optional_string(self.locator.take());
+        self.source_refs = normalize_string_vec(std::mem::take(&mut self.source_refs));
         for operation in &mut self.operations {
             operation.normalize()?;
         }


### PR DESCRIPTION
## Summary
- Persist HOMEBOY_FUZZ_ARTIFACTS_DIR as fuzz run artifacts.
- Validate local fuzz artifact refs from campaign artifacts and metadata.
- Add run-based fuzz comparison over persisted result/hotspot/observation artifacts.
- Add optional generic source refs and remove the block_render core alias.

## Verification
- cargo test fuzz::tests::execution_tests --lib
- cargo test runs::fuzz_compare --lib
- cargo test core::fuzz --lib
- cargo test commands::fuzz::compare::tests --lib
- cargo test command_surface --test command_surface_test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Auditing the fuzzing infrastructure gaps, drafting the implementation, adding focused tests, and preparing the PR.