### PR TITLE
fix(bench): run rig workloads over native scripts

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -747,7 +747,8 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
         args.setting_args.setting.clone(),
         args.setting_args.setting_json.clone(),
     );
-    resolve_options.extension_overrides = args.extension_override.extensions.clone();
+    resolve_options.extension_overrides =
+        effective_extension_overrides(&args.extension_override.extensions, rig_spec.as_deref());
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
     warn_unknown_setting_keys(&ctx, &args.setting_args);
@@ -790,6 +791,26 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
     let output = output?;
 
     Ok((BenchOutput::List(output), 0))
+}
+
+fn effective_extension_overrides(
+    explicit_overrides: &[String],
+    rig_spec: Option<&rig::RigSpec>,
+) -> Vec<String> {
+    if !explicit_overrides.is_empty() {
+        return explicit_overrides.to_vec();
+    }
+
+    let Some(spec) = rig_spec else {
+        return Vec::new();
+    };
+
+    let workload_extension_ids =
+        rig::extension_ids_for_workloads(spec, rig::RigWorkloadKind::Bench);
+    match workload_extension_ids.as_slice() {
+        [extension_id] => vec![extension_id.clone()],
+        _ => Vec::new(),
+    }
 }
 
 type ListRigContext = rig::RigSourceContext;

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -577,7 +577,8 @@ fn run_component_with_rig_context(
         args.setting_args.setting.clone(),
         args.setting_args.setting_json.clone(),
     );
-    resolve_options.extension_overrides = args.extension_override.extensions.clone();
+    resolve_options.extension_overrides =
+        super::effective_extension_overrides(&args.extension_override.extensions, rig_spec);
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
     super::warn_unknown_setting_keys(&ctx, &args.setting_args);

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -182,6 +182,61 @@ fn write_rig(home: &TempDir, rig_id: &str, component_id: &str, path: &std::path:
     write_rig_with_profiles(home, rig_id, component_id, path, "{}");
 }
 
+fn write_rig_with_component_script(
+    home: &TempDir,
+    rig_id: &str,
+    component_id: &str,
+    path: &std::path::Path,
+) {
+    let script_path = path.join("native-bench.sh");
+    fs::write(
+        &script_path,
+        r#"#!/bin/sh
+cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
+{
+  "component_id": "$HOMEBOY_COMPONENT_ID",
+  "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0},
+  "scenarios": [
+    { "id": "native-script", "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0}, "metrics": {} }
+  ]
+}
+JSON
+"#,
+    )
+    .expect("write native bench script");
+
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&script_path)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod script");
+    }
+
+    let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+    fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+    fs::write(
+        rig_dir.join(format!("{}.json", rig_id)),
+        format!(
+            r#"{{
+                    "components": {{
+                        "{component_id}": {{
+                            "path": "{}",
+                            "scripts": {{ "bench": ["./native-bench.sh"] }}
+                        }}
+                    }},
+                    "bench": {{ "default_component": "{component_id}" }},
+                    "bench_workloads": {{ "fixture-bench": [
+                        {{ "path": "${{components.{component_id}.path}}/rig-extra.bench.js" }}
+                    ] }}
+                }}"#,
+            path.display()
+        ),
+    )
+    .expect("write rig");
+}
+
 fn write_rig_with_profiles(
     home: &TempDir,
     rig_id: &str,
@@ -370,6 +425,27 @@ fn run_list_uses_rig_default_component_and_workloads() {
                 assert_eq!(result.component, "studio");
                 assert_eq!(result.component_id, "studio");
                 assert_eq!(result.count, 2);
+                assert_eq!(result.scenarios[0].id, "rig-extra");
+            }
+            _ => panic!("expected list output"),
+        }
+    });
+}
+
+#[test]
+fn run_list_prefers_rig_workloads_over_component_bench_script() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_rig_with_component_script(home, "studio-bfb", "studio", component_dir.path());
+
+        let (output, exit_code) = run_list(&list_args(None, vec!["studio-bfb".to_string()]))
+            .expect("rig bench list should use rig workloads");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::List(result) => {
+                assert_eq!(result.count, 1);
                 assert_eq!(result.scenarios[0].id, "rig-extra");
             }
             _ => panic!("expected list output"),
@@ -805,6 +881,31 @@ fn rig_bench_component_expands_extension_settings() {
             .and_then(|value| value.as_str()),
         Some(expected_mount_source.as_str())
     );
+}
+
+#[test]
+fn run_prefers_rig_workloads_over_component_bench_script() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_rig_with_component_script(home, "studio-bfb", "studio", component_dir.path());
+
+        let (output, exit_code) = run(
+            run_args(None, vec!["studio-bfb".to_string()], Vec::new()),
+            &GlobalArgs {},
+        )
+        .expect("rig bench should use rig workloads");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::Single(result) => {
+                let scenarios = result.results.expect("results").scenarios;
+                assert_eq!(scenarios.len(), 1);
+                assert_eq!(scenarios[0].id, "rig-extra");
+            }
+            _ => panic!("expected single output"),
+        }
+    });
 }
 
 #[test]

--- a/src/core/extension/bench/run/list.rs
+++ b/src/core/extension/bench/run/list.rs
@@ -20,7 +20,7 @@ pub fn run_bench_list_workflow(
     run_dir: &RunDir,
 ) -> Result<BenchListWorkflowResult> {
     let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
-    if component.has_script(ExtensionCapability::Bench) {
+    if component.has_script(ExtensionCapability::Bench) && args.extra_workloads.is_empty() {
         let list_env = bench_component_script_list_env(&args)?;
         let source_path = crate::core::extension::component_script::source_path(
             component,

--- a/src/core/extension/bench/run/workflow.rs
+++ b/src/core/extension/bench/run/workflow.rs
@@ -103,7 +103,7 @@ pub fn run_main_bench_workflow(
         })?;
     }
 
-    if component.has_script(ExtensionCapability::Bench) {
+    if component.has_script(ExtensionCapability::Bench) && args.extra_workloads.is_empty() {
         clear_responsiveness_file(run_dir)?;
         let component_env = bench_component_script_env(&args, run_dir)?;
         let script_output =


### PR DESCRIPTION
## Summary
- Prefer rig-declared bench workloads over component-native bench scripts when a rig supplies workloads.
- Infer the sole rig bench workload extension as the effective extension when the caller did not pass --extension.
- Add list/run coverage for rigs whose component also declares a native bench script.

## Context
This unblocks the Static Site Importer fixture matrix rig. The canonical Blocks Engine fixture root currently has 71 top-level fixture directories, not 49; earlier references to 49 were stale.

## Verification
- cargo fmt
- cargo test prefers_rig_workloads_over_component_bench_script
- cargo build
- ./target/debug/homeboy bench list static-site-importer --rig static-site-importer-fixture-matrix --path /Users/chubes/Developer/static-site-importer@fix-dropped-images-materialization

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Debugging Homeboy bench routing, implementing the fix, adding focused tests, and drafting this PR description.