### PR TITLE
feat(fuzz): run artifact postprocess steps

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use homeboy::core::engine::execution_context;
 use homeboy::core::engine::invocation::InvocationRequirements;
@@ -12,8 +13,8 @@ use uuid::Uuid;
 
 use super::report::{evaluate_fuzz_gates, fuzz_coverage_completeness};
 use super::types::{
-    FuzzCampaignContract, FuzzExecutionOutput, FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract,
-    FuzzWorkloadOutput,
+    FuzzArtifactPostprocessOutput, FuzzCampaignContract, FuzzExecutionOutput, FuzzRunArgs,
+    FuzzRunOutput, FuzzRunnerContract, FuzzWorkloadOutput,
 };
 use super::workloads::{
     build_target_inventory, fuzz_invocation_requirements, fuzz_workloads, load_rig,
@@ -82,6 +83,15 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         &run_dir,
     )?;
     let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
+    let artifacts_dir =
+        run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_ARTIFACTS_DIR);
+    let postprocess = run_fuzz_artifact_postprocess(
+        rig_context.as_ref(),
+        extension_id.as_deref(),
+        selected_workload,
+        &results_path,
+        &artifacts_dir,
+    )?;
     let (results, results_error) = if results_path.exists() {
         match parse_fuzz_results_file(&results_path) {
             Ok(results) => (Some(results), None),
@@ -90,12 +100,12 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     } else {
         (None, None)
     };
-    let artifacts_dir =
-        run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_ARTIFACTS_DIR);
     let artifact_ref_validation = fuzz_artifact_ref_validation(results.as_ref(), &artifacts_dir);
     let artifact_validation_error = fuzz_run_artifact_validation_error(&args, results.as_ref());
+    let postprocess_error = fuzz_postprocess_error(&postprocess);
     let combined_results_error = results_error
         .as_deref()
+        .or(postprocess_error.as_deref())
         .or(artifact_validation_error.as_deref())
         .or(artifact_ref_validation.error.as_deref());
     let outcome = fuzz_run_outcome(
@@ -162,6 +172,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
                 stdout: runner_output.stdout,
                 stderr: runner_output.stderr,
             }),
+            postprocess,
             results,
             campaign_contract,
             runner_contract: default_runner_contract(),
@@ -267,6 +278,249 @@ fn fuzz_prepare_failure_message(prepare: &FuzzPrepareReport) -> String {
             failed_steps.join("; ")
         )
     }
+}
+
+pub(super) fn run_fuzz_artifact_postprocess(
+    rig_context: Option<&FuzzRigContext>,
+    extension_id: Option<&str>,
+    workload: Option<&FuzzWorkloadOutput>,
+    results_path: &Path,
+    artifacts_dir: &Path,
+) -> homeboy::core::Result<Vec<FuzzArtifactPostprocessOutput>> {
+    let steps = fuzz_artifact_postprocess_steps(rig_context, extension_id, workload);
+    if steps.is_empty() {
+        return Ok(Vec::new());
+    }
+    std::fs::create_dir_all(artifacts_dir).map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some(artifacts_dir.display().to_string()),
+        )
+    })?;
+
+    let mut outputs = Vec::new();
+    for (index, step) in steps.iter().enumerate() {
+        outputs.push(run_fuzz_artifact_postprocess_step(
+            index,
+            step,
+            rig_context,
+            results_path,
+            artifacts_dir,
+        )?);
+    }
+    Ok(outputs)
+}
+
+fn fuzz_artifact_postprocess_steps(
+    rig_context: Option<&FuzzRigContext>,
+    extension_id: Option<&str>,
+    workload: Option<&FuzzWorkloadOutput>,
+) -> Vec<homeboy::core::rig::ArtifactPostprocessSpec> {
+    let Some((context, extension_id, workload)) =
+        rig_context
+            .zip(extension_id)
+            .and_then(|(context, extension_id)| {
+                workload.map(|workload| (context, extension_id, workload))
+            })
+    else {
+        return Vec::new();
+    };
+    let Some(manifest_path) = workload.manifest_path.as_deref() else {
+        return Vec::new();
+    };
+    let expanded = rig::workload_path_expansions_for_extension(
+        &context.spec,
+        rig::RigWorkloadKind::Fuzz,
+        context.package_root.as_deref(),
+        extension_id,
+    );
+    let Some(entries) = context.spec.fuzz_workloads.get(extension_id) else {
+        return Vec::new();
+    };
+    entries
+        .iter()
+        .zip(expanded.iter())
+        .find(|(_, expansion)| expansion.expanded_path == Path::new(manifest_path))
+        .map(|(entry, _)| entry.artifact_postprocess().to_vec())
+        .unwrap_or_default()
+}
+
+fn run_fuzz_artifact_postprocess_step(
+    index: usize,
+    step: &homeboy::core::rig::ArtifactPostprocessSpec,
+    rig_context: Option<&FuzzRigContext>,
+    results_path: &Path,
+    artifacts_dir: &Path,
+) -> homeboy::core::Result<FuzzArtifactPostprocessOutput> {
+    let id = step
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("artifact-postprocess-{}", index + 1));
+    let output_path = resolve_postprocess_output_path(&step.output, artifacts_dir)?;
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            homeboy::core::Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+        })?;
+    }
+    let input = step
+        .input
+        .as_ref()
+        .map(|input| expand_postprocess_path(input, rig_context, results_path, artifacts_dir));
+    let parameters_json = serde_json::to_string(&step.parameters).map_err(|error| {
+        homeboy::core::Error::internal_unexpected(format!(
+            "failed to serialize artifact postprocess parameters: {error}"
+        ))
+    })?;
+
+    let mut command = Command::new(&step.helper);
+    command.arg(&step.action);
+    if let Some(args) = step
+        .parameters
+        .get("args")
+        .and_then(serde_json::Value::as_array)
+    {
+        for arg in args.iter().filter_map(serde_json::Value::as_str) {
+            command.arg(arg);
+        }
+    }
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_ID", &id);
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_HELPER", &step.helper);
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_ACTION", &step.action);
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT", &output_path);
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT", artifacts_dir);
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_PARAMETERS", parameters_json);
+    if let Some(input) = input.as_ref() {
+        command.env("HOMEBOY_ARTIFACT_POSTPROCESS_INPUT", input);
+    }
+    for (key, value) in &step.parameters {
+        if let Some(value) = postprocess_parameter_env_value(value) {
+            command.env(postprocess_parameter_env_key(key), value);
+        }
+    }
+
+    let output = command.output().map_err(|error| {
+        homeboy::core::Error::internal_io(
+            format!(
+                "failed to run artifact postprocess `{}` via helper `{}`: {error}",
+                id, step.helper
+            ),
+            Some("fuzz.artifact_postprocess".to_string()),
+        )
+    })?;
+    let exit_code = output.status.code();
+    let mut success = output.status.success();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let mut error = (!success).then(|| {
+        format!(
+            "artifact postprocess `{id}` failed with exit code {}",
+            exit_code
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        )
+    });
+    if success && !output_path.exists() {
+        success = false;
+        error = Some(format!(
+            "artifact postprocess `{id}` did not create required output {}",
+            output_path.display()
+        ));
+    }
+
+    Ok(FuzzArtifactPostprocessOutput {
+        id,
+        helper: step.helper.clone(),
+        action: step.action.clone(),
+        input: input.map(|path| path.to_string_lossy().to_string()),
+        output: output_path.to_string_lossy().to_string(),
+        required: step.required,
+        exit_code,
+        success,
+        stdout,
+        stderr,
+        error,
+    })
+}
+
+fn resolve_postprocess_output_path(
+    output: &str,
+    artifacts_dir: &Path,
+) -> homeboy::core::Result<PathBuf> {
+    let trimmed = output.trim();
+    let path = Path::new(trimmed);
+    if trimmed.is_empty() || path.is_absolute() || trimmed.starts_with("..") {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "artifact_postprocess.output",
+            "artifact postprocess output must be a non-empty path relative to HOMEBOY_FUZZ_ARTIFACTS_DIR",
+            Some(output.to_string()),
+            None,
+        ));
+    }
+    let resolved = artifacts_dir.join(path);
+    if !resolved.starts_with(artifacts_dir) {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "artifact_postprocess.output",
+            "artifact postprocess output must stay within HOMEBOY_FUZZ_ARTIFACTS_DIR",
+            Some(output.to_string()),
+            None,
+        ));
+    }
+    Ok(resolved)
+}
+
+fn expand_postprocess_path(
+    value: &str,
+    rig_context: Option<&FuzzRigContext>,
+    results_path: &Path,
+    artifacts_dir: &Path,
+) -> PathBuf {
+    let expanded = value
+        .replace("${run.fuzz_results}", &results_path.to_string_lossy())
+        .replace("${run.fuzz_artifacts}", &artifacts_dir.to_string_lossy());
+    PathBuf::from(match rig_context {
+        Some(context) => rig::expand::expand_vars(&context.spec, &expanded),
+        None => expanded,
+    })
+}
+
+fn postprocess_parameter_env_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn postprocess_parameter_env_key(key: &str) -> String {
+    let suffix = key
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!("HOMEBOY_ARTIFACT_POSTPROCESS_PARAMETER_{suffix}")
+}
+
+pub(super) fn fuzz_postprocess_error(outputs: &[FuzzArtifactPostprocessOutput]) -> Option<String> {
+    let failed = outputs
+        .iter()
+        .filter(|output| output.required && !output.success)
+        .map(|output| match output.error.as_deref() {
+            Some(error) => error.to_string(),
+            None => format!("artifact postprocess `{}` failed", output.id),
+        })
+        .collect::<Vec<_>>();
+    (!failed.is_empty()).then(|| {
+        format!(
+            "required fuzz artifact postprocess step(s) failed: {}",
+            failed.join("; ")
+        )
+    })
 }
 
 pub(super) struct FuzzRunOutcome {
@@ -698,6 +952,13 @@ pub(super) fn default_runner_contract() -> FuzzRunnerContract {
             "HOMEBOY_FUZZ_INVENTORY_FILE",
             "HOMEBOY_FUZZ_MAX_DURATION",
             "HOMEBOY_FUZZ_GATE_PROFILE",
+            "HOMEBOY_ARTIFACT_POSTPROCESS_ID",
+            "HOMEBOY_ARTIFACT_POSTPROCESS_HELPER",
+            "HOMEBOY_ARTIFACT_POSTPROCESS_ACTION",
+            "HOMEBOY_ARTIFACT_POSTPROCESS_INPUT",
+            "HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT",
+            "HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT",
+            "HOMEBOY_ARTIFACT_POSTPROCESS_PARAMETERS",
         ],
     }
 }

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -405,6 +405,128 @@ fn fuzz_artifact_ref_validation_reports_missing_local_refs() {
 }
 
 #[test]
+fn fuzz_artifact_postprocess_collects_declared_output_under_artifact_root() {
+    with_isolated_home(|home| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workload_path = temp.path().join("parser.json");
+        std::fs::write(&workload_path, "{}").expect("workload");
+        let spec: RigSpec = serde_json::from_value(serde_json::json!({
+            "id": "package-fuzz",
+            "fuzz_workloads": {
+                "generic": [
+                    {
+                        "path": "${package.root}/parser.json",
+                        "artifact_postprocess": [
+                            {
+                                "id": "coverage-summary",
+                                "helper": "sh",
+                                "action": "-c",
+                                "input": "${run.fuzz_results}",
+                                "output": "coverage/summary.json",
+                                "parameters": {
+                                    "args": ["cp \"$HOMEBOY_ARTIFACT_POSTPROCESS_INPUT\" \"$HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT\""]
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }))
+        .expect("parse rig spec");
+        let context = FuzzRigContext {
+            spec,
+            package_root: Some(temp.path().to_path_buf()),
+        };
+        let workload = FuzzWorkloadOutput {
+            id: "parser".to_string(),
+            label: None,
+            description: None,
+            source: format!("rig_workloads:generic:{}", workload_path.display()),
+            manifest_path: Some(workload_path.to_string_lossy().to_string()),
+        };
+        let results_path = home.path().join("fuzz-results.json");
+        std::fs::write(&results_path, r#"{"status":"ok"}"#).expect("results");
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+
+        let outputs = run_fuzz_artifact_postprocess(
+            Some(&context),
+            Some("generic"),
+            Some(&workload),
+            &results_path,
+            &artifacts_dir,
+        )
+        .expect("postprocess");
+
+        assert_eq!(outputs.len(), 1);
+        assert!(outputs[0].success);
+        let collected = artifacts_dir.join("coverage/summary.json");
+        assert!(collected.is_file());
+        assert_eq!(
+            std::fs::read_to_string(collected).expect("collected"),
+            r#"{"status":"ok"}"#
+        );
+    });
+}
+
+#[test]
+fn required_fuzz_artifact_postprocess_fails_when_output_is_missing() {
+    with_isolated_home(|home| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workload_path = temp.path().join("parser.json");
+        std::fs::write(&workload_path, "{}").expect("workload");
+        let spec: RigSpec = serde_json::from_value(serde_json::json!({
+            "id": "package-fuzz",
+            "fuzz_workloads": {
+                "generic": [
+                    {
+                        "path": "${package.root}/parser.json",
+                        "artifact_postprocess": [
+                            {
+                                "id": "gap-report",
+                                "helper": "sh",
+                                "action": "-c",
+                                "output": "gaps/report.json",
+                                "parameters": { "args": ["true"] }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }))
+        .expect("parse rig spec");
+        let context = FuzzRigContext {
+            spec,
+            package_root: Some(temp.path().to_path_buf()),
+        };
+        let workload = FuzzWorkloadOutput {
+            id: "parser".to_string(),
+            label: None,
+            description: None,
+            source: format!("rig_workloads:generic:{}", workload_path.display()),
+            manifest_path: Some(workload_path.to_string_lossy().to_string()),
+        };
+        let results_path = home.path().join("fuzz-results.json");
+        std::fs::write(&results_path, "{}").expect("results");
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+
+        let outputs = run_fuzz_artifact_postprocess(
+            Some(&context),
+            Some("generic"),
+            Some(&workload),
+            &results_path,
+            &artifacts_dir,
+        )
+        .expect("postprocess");
+
+        assert_eq!(outputs.len(), 1);
+        assert!(!outputs[0].success);
+        let error = fuzz_postprocess_error(&outputs).expect("required failure");
+        assert!(error.contains("gap-report"));
+        assert!(error.contains("did not create required output"));
+    });
+}
+
+#[test]
 fn fuzz_report_persists_result_envelope_artifact_for_run_id() {
     with_isolated_home(|home| {
         let artifact_root = home.path().join("agent-readable-artifacts");

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -3,8 +3,9 @@
 use super::super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
 use super::execution::{
     default_runner_contract, fuzz_artifact_ref_validation, fuzz_campaign_contract,
-    fuzz_evidence_followups, fuzz_run_artifact_validation_error, fuzz_run_outcome, fuzz_runner_env,
-    persist_fuzz_run_evidence, FuzzRunEvidenceInput,
+    fuzz_evidence_followups, fuzz_postprocess_error, fuzz_run_artifact_validation_error,
+    fuzz_run_outcome, fuzz_runner_env, persist_fuzz_run_evidence, run_fuzz_artifact_postprocess,
+    FuzzRunEvidenceInput,
 };
 use super::planning::plan_inventory_selection;
 use super::replay::run_replay;

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -386,6 +386,7 @@ fn fuzz_output_contract_has_stable_variant_discriminators() {
         passthrough_args: Vec::new(),
         target_inventory: None,
         execution: None,
+        postprocess: Vec::new(),
         results: None,
         campaign_contract: fuzz_campaign_contract(None, None),
         runner_contract: FuzzRunnerContract {

--- a/src/commands/fuzz/tests/report_tests.rs
+++ b/src/commands/fuzz/tests/report_tests.rs
@@ -48,6 +48,7 @@ fn fuzz_output_contract_includes_results_file_and_parsed_campaign() {
             stdout: String::new(),
             stderr: String::new(),
         }),
+        postprocess: Vec::new(),
         results: Some(results),
         campaign_contract: fuzz_campaign_contract(None, Some("seed-1")),
         runner_contract: FuzzRunnerContract {

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -42,6 +42,45 @@ fn fuzz_workloads_include_rig_declared_paths() {
 }
 
 #[test]
+fn fuzz_workload_parses_artifact_postprocess_metadata() {
+    let spec: RigSpec = serde_json::from_value(serde_json::json!({
+        "id": "package-fuzz",
+        "fuzz_workloads": {
+            "generic": [
+                {
+                    "path": "fuzz/parser.json",
+                    "artifact_postprocess": [
+                        {
+                            "id": "coverage-summary",
+                            "helper": "fuzz-helper",
+                            "action": "summarize-coverage",
+                            "input": "${run.fuzz_results}",
+                            "output": "coverage/summary.json",
+                            "parameters": {
+                                "format": "json",
+                                "threshold": 1
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }))
+    .expect("parse rig spec");
+
+    let postprocess = spec.fuzz_workloads["generic"][0].artifact_postprocess();
+
+    assert_eq!(postprocess.len(), 1);
+    assert_eq!(postprocess[0].id.as_deref(), Some("coverage-summary"));
+    assert_eq!(postprocess[0].helper, "fuzz-helper");
+    assert_eq!(postprocess[0].action, "summarize-coverage");
+    assert_eq!(postprocess[0].input.as_deref(), Some("${run.fuzz_results}"));
+    assert_eq!(postprocess[0].output, "coverage/summary.json");
+    assert!(postprocess[0].required);
+    assert_eq!(postprocess[0].parameters["format"], "json");
+}
+
+#[test]
 fn resolve_component_id_uses_fuzz_default_component() {
     let spec: RigSpec = serde_json::from_value(serde_json::json!({
         "id": "package-fuzz",

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -385,12 +385,12 @@ pub(crate) struct FuzzReplayArgs {
 }
 
 pub use super::types_extra::{
-    FuzzCampaignContract, FuzzCompareDeltas, FuzzCompareHotspotDelta, FuzzCompareHotspotSnapshot,
-    FuzzCompareHotspotSummary, FuzzCompareOutput, FuzzCompareSnapshot,
-    FuzzContractGateProfileOutput, FuzzContractOutput, FuzzCoverageCompletenessOutput,
-    FuzzCoverageSelectorSummaryOutput, FuzzDiscoverOutput, FuzzDiscoverSummary,
-    FuzzExecutionOutput, FuzzGateEvaluation, FuzzGateStatusChange, FuzzInspectCandidate,
-    FuzzInspectOutput, FuzzListOutput, FuzzOutput, FuzzPlanOutput, FuzzReplayEnv,
-    FuzzReplayExecution, FuzzReplayOutput, FuzzReportOutput, FuzzRunOutput, FuzzRunnerContract,
-    FuzzValidateOutput, FuzzWorkloadOutput,
+    FuzzArtifactPostprocessOutput, FuzzCampaignContract, FuzzCompareDeltas,
+    FuzzCompareHotspotDelta, FuzzCompareHotspotSnapshot, FuzzCompareHotspotSummary,
+    FuzzCompareOutput, FuzzCompareSnapshot, FuzzContractGateProfileOutput, FuzzContractOutput,
+    FuzzCoverageCompletenessOutput, FuzzCoverageSelectorSummaryOutput, FuzzDiscoverOutput,
+    FuzzDiscoverSummary, FuzzExecutionOutput, FuzzGateEvaluation, FuzzGateStatusChange,
+    FuzzInspectCandidate, FuzzInspectOutput, FuzzListOutput, FuzzOutput, FuzzPlanOutput,
+    FuzzReplayEnv, FuzzReplayExecution, FuzzReplayOutput, FuzzReportOutput, FuzzRunOutput,
+    FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
 };

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -154,10 +154,26 @@ pub struct FuzzRunOutput {
     pub passthrough_args: Vec<String>,
     pub target_inventory: Option<FuzzTargetInventory>,
     pub execution: Option<FuzzExecutionOutput>,
+    pub postprocess: Vec<FuzzArtifactPostprocessOutput>,
     pub results: Option<FuzzCampaign>,
     pub campaign_contract: FuzzCampaignContract,
     pub runner_contract: FuzzRunnerContract,
     pub evidence_followups: Vec<String>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct FuzzArtifactPostprocessOutput {
+    pub id: String,
+    pub helper: String,
+    pub action: String,
+    pub input: Option<String>,
+    pub output: String,
+    pub required: bool,
+    pub exit_code: Option<i32>,
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+    pub error: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -66,8 +66,8 @@ pub use source::{
     SkippedRigSourceStack, SkippedRigSourceUpdate,
 };
 pub use spec::{
-    AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, BenchSpec, CheckSpec,
-    ComponentSpec, DiscoverSpec, ExecutableRequirementSpec, FilesystemAssertionKind,
+    AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, ArtifactPostprocessSpec, BenchSpec,
+    CheckSpec, ComponentSpec, DiscoverSpec, ExecutableRequirementSpec, FilesystemAssertionKind,
     FilesystemAssertionSpec, NewerThanSpec, PatchOp, PipelineStep, RigRequirementsSpec,
     RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp,
     SymlinkSpec, TimeSource, TraceConfig, TraceDependencySpec, TraceExperimentArtifactSpec,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -487,6 +487,9 @@ pub struct TraceConfig {
 pub struct WorkloadSpec {
     pub path: String,
 
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_postprocess: Vec<ArtifactPostprocessSpec>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trace_phase_template: Option<String>,
 
@@ -524,8 +527,36 @@ pub struct WorkloadSpec {
     pub lifecycle: Option<LifecycleContract>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactPostprocessSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    pub helper: String,
+
+    pub action: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input: Option<String>,
+
+    pub output: String,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub parameters: BTreeMap<String, serde_json::Value>,
+
+    #[serde(default = "default_artifact_postprocess_required")]
+    pub required: bool,
+}
+
+fn default_artifact_postprocess_required() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct WorkloadDefaultsSpec {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_postprocess: Vec<ArtifactPostprocessSpec>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trace_phase_template: Option<String>,
 
@@ -586,6 +617,10 @@ impl WorkloadSpec {
         }
 
         prepend_missing(&mut self.named_leases, &defaults.named_leases);
+        prepend_missing(
+            &mut self.artifact_postprocess,
+            &defaults.artifact_postprocess,
+        );
         prepend_missing(&mut self.trace_guardrails, &defaults.trace_guardrails);
         prepend_missing(&mut self.trace_probes, &defaults.trace_probes);
         prepend_missing(&mut self.dependencies, &defaults.dependencies);
@@ -679,6 +714,7 @@ mod tests {
     fn test_trace_phase_preset() {
         let workload = WorkloadSpec {
             path: "trace.mjs".to_string(),
+            artifact_postprocess: Vec::new(),
             trace_phase_template: None,
             public_preview: None,
             check_groups: None,
@@ -851,6 +887,7 @@ mod tests {
     fn test_trace_default_phase_preset() {
         let workload = WorkloadSpec {
             path: "trace.mjs".to_string(),
+            artifact_postprocess: Vec::new(),
             trace_phase_template: None,
             public_preview: None,
             check_groups: None,
@@ -879,6 +916,7 @@ mod tests {
     fn test_port_range_size() {
         let workload = WorkloadSpec {
             path: "bench.mjs".to_string(),
+            artifact_postprocess: Vec::new(),
             trace_phase_template: None,
             public_preview: None,
             check_groups: None,
@@ -907,6 +945,7 @@ mod tests {
     fn test_named_leases() {
         let workload = WorkloadSpec {
             path: "bench.mjs".to_string(),
+            artifact_postprocess: Vec::new(),
             trace_phase_template: None,
             public_preview: None,
             check_groups: None,

--- a/src/core/rig/spec/workload.rs
+++ b/src/core/rig/spec/workload.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use crate::core::extension::trace::{TraceProbeConfig, TraceSpanMetadata};
 
 use super::{
-    TraceDependencySpec, TraceGuardrailSpec, TracePublicPreviewSpec, TraceVariantSpec, WorkloadSpec,
+    ArtifactPostprocessSpec, TraceDependencySpec, TraceGuardrailSpec, TracePublicPreviewSpec,
+    TraceVariantSpec, WorkloadSpec,
 };
 
 impl WorkloadSpec {
@@ -25,6 +26,10 @@ impl WorkloadSpec {
 
     pub fn named_leases(&self) -> &[String] {
         &self.named_leases
+    }
+
+    pub fn artifact_postprocess(&self) -> &[ArtifactPostprocessSpec] {
+        &self.artifact_postprocess
     }
 
     pub fn trace_phase_preset(&self, name: &str) -> Option<&[String]> {

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -481,6 +481,7 @@ fn test_trace_variants() {
 fn workload_with_trace_metadata() -> WorkloadSpec {
     WorkloadSpec {
         path: "/tmp/scoped.trace.mjs".to_string(),
+        artifact_postprocess: Vec::new(),
         trace_phase_template: None,
         public_preview: None,
         check_groups: Some(vec!["desktop-app".to_string()]),


### PR DESCRIPTION
## Summary
- Add generic rig workload artifact_postprocess support for fuzz runs.
- Execute postprocess steps after runner output and before artifact validation/persistence.
- Support helper/action/input/output/parameters metadata and fail closed when required outputs are missing.
- Add focused parsing, execution, and missing-output tests.

## Verification
- cargo fmt --check
- cargo test fuzz_artifact_postprocess --lib
- cargo test fuzz_workload_parses_artifact_postprocess_metadata --lib
- cargo test fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_contract --lib
- cargo test test_trace_default_phase_preset --lib
- cargo test test_port_range_size --lib
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Auditing the artifact postprocess gap, drafting the generic fuzz postprocess runner binding, adding focused tests, and preparing the PR.