### PR TITLE
Fix #6415 runner artifact capability discovery

### DIFF
--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -5,8 +5,9 @@ use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, 
 
 use super::super::CmdResult;
 use super::types::{
-    LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerConnectionOutput,
-    RunnerExtra, RunnerOperatorCommand, RunnerOutput, RunnerToolDiagnostics,
+    LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
+    RunnerConnectionOutput, RunnerExtra, RunnerOperatorCommand, RunnerOutput,
+    RunnerToolDiagnostics,
 };
 
 pub(super) fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
@@ -100,6 +101,7 @@ fn lab_runner_homeboy_output(
     status: &RunnerStatusReport,
 ) -> LabRunnerHomeboyOutput {
     let controller_version = env!("CARGO_PKG_VERSION").to_string();
+    let controller_build_identity = homeboy::core::build_identity::current().display;
     let active_daemon_version = status
         .session
         .as_ref()
@@ -109,6 +111,7 @@ fn lab_runner_homeboy_output(
         .is_some_and(|version| version != &controller_version);
     LabRunnerHomeboyOutput {
         controller_version,
+        controller_build_identity,
         configured_executable: configured_executable.to_string(),
         active_daemon_version,
         active_daemon_build_identity: status
@@ -121,6 +124,12 @@ fn lab_runner_homeboy_output(
             .and_then(|warning| serde_json::to_value(warning).ok()),
         version_drift,
         command_availability_checks: lab_command_availability_checks(configured_executable),
+        artifact_features: runner_artifact_feature_diagnostics(
+            runner_id,
+            configured_executable,
+            status,
+            version_drift,
+        ),
         refresh_commands: lab_runner_homeboy_refresh_commands(runner_id),
         upgrade_command: format!(
             "homeboy upgrade --force --upgrade-runner {}",
@@ -178,10 +187,56 @@ fn lab_command_availability_checks(homeboy_path: &str) -> Vec<String> {
     let binary = shell_arg(homeboy_path);
     vec![
         format!("{binary} --version"),
+        format!("{binary} runner exec --help"),
+        format!("{binary} runs artifact --help"),
         format!("{binary} fuzz --help"),
         format!("{binary} runs evidence --help"),
         format!("{binary} extension list"),
     ]
+}
+
+pub(super) fn runner_artifact_feature_diagnostics(
+    runner_id: &str,
+    homeboy_path: &str,
+    status: &RunnerStatusReport,
+    version_drift: bool,
+) -> RunnerArtifactFeatureDiagnostics {
+    let binary = shell_arg(homeboy_path);
+    let runner_arg = shell_arg(runner_id);
+    let mut hints = Vec::new();
+    if version_drift || status.stale_daemon.is_some() {
+        hints.push(format!(
+            "Runner `{runner_id}` reports Homeboy version/build drift. If artifact commands are missing on runner jobs, restart the active daemon with `homeboy runner disconnect {runner_arg}` then `homeboy runner connect {runner_arg}`."
+        ));
+    }
+    if status.connected
+        && status
+            .session
+            .as_ref()
+            .and_then(|session| session.local_url.as_ref())
+            .is_none()
+    {
+        hints.push(format!(
+            "Runner `{runner_id}` has no direct daemon URL in the active session; verify artifact command support through managed exec instead of assuming the controller binary matches the runner binary."
+        ));
+    }
+
+    RunnerArtifactFeatureDiagnostics {
+        required_features: vec!["runner_exec_artifact_output", "runs_artifact_attach"],
+        controller_commands: vec![
+            "homeboy runner exec <runner-id> --run-id <run-id> --artifact <path> -- <command>"
+                .to_string(),
+            "homeboy runs artifact attach <run-id> --runner <runner-id> --path <path> --name <name>"
+                .to_string(),
+        ],
+        runner_command_checks: vec![
+            format!("{binary} runner exec --help"),
+            format!("{binary} runs artifact attach --help"),
+            format!("homeboy runner exec {runner_arg} -- {binary} runner exec --help"),
+            format!("homeboy runner exec {runner_arg} -- {binary} runs artifact attach --help"),
+        ],
+        hints,
+    }
 }
 
 fn lab_runner_homeboy_refresh_commands(runner_id: &str) -> Vec<String> {

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -5,7 +5,10 @@ use homeboy::core::runner::{RunnerActiveJobSource, RunnerActiveJobState};
 use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, RunnerTunnelMode};
 
 use super::super::jobs::format_job_event;
-use super::super::status::{runner_status_operator_commands, wp_codebox_tool_diagnostics};
+use super::super::status::{
+    runner_artifact_feature_diagnostics, runner_status_operator_commands,
+    wp_codebox_tool_diagnostics,
+};
 
 #[test]
 fn runner_job_event_format_includes_sequence_kind_message_and_data() {
@@ -158,4 +161,62 @@ fn wp_codebox_diagnostics_distinguish_configured_managed_and_effective() {
     assert!(diagnostics
         .diagnostic_command
         .contains("effective_source=%s"));
+}
+
+#[test]
+fn runner_status_artifact_diagnostics_surface_controller_runner_checks_and_drift_hint() {
+    let report = RunnerStatusReport {
+        runner_id: "homeboy-lab".to_string(),
+        connected: true,
+        state: runner::RunnerSessionState::Connected,
+        session: Some(RunnerSession {
+            runner_id: "homeboy-lab".to_string(),
+            mode: RunnerTunnelMode::Reverse,
+            role: runner::RunnerSessionRole::Controller,
+            server_id: None,
+            controller_id: Some("controller".to_string()),
+            broker_url: Some("https://broker.example.test/".to_string()),
+            remote_daemon_address: None,
+            local_port: None,
+            local_url: None,
+            tunnel_pid: None,
+            remote_daemon_pid: None,
+            homeboy_version: "old".to_string(),
+            homeboy_build_identity: None,
+            connected_at: "2026-06-19T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: Some("2026-06-19T00:00:01Z".to_string()),
+        }),
+        stale_daemon: None,
+        active_jobs: Vec::new(),
+        active_runner_jobs: Vec::new(),
+        active_job_count: 0,
+        stale_runner_jobs: Vec::new(),
+        stale_runner_job_count: 0,
+        active_job_state: RunnerActiveJobState::Available,
+        active_job_source: Some(RunnerActiveJobSource::ReverseBroker),
+        active_job_error: None,
+        session_path: "/tmp/session.json".to_string(),
+    };
+
+    let diagnostics = runner_artifact_feature_diagnostics("homeboy-lab", "homeboy", &report, true);
+    let serialized = serde_json::to_string(&diagnostics).expect("serialize diagnostics");
+
+    assert!(diagnostics
+        .required_features
+        .contains(&"runner_exec_artifact_output"));
+    assert!(diagnostics
+        .required_features
+        .contains(&"runs_artifact_attach"));
+    assert!(serialized.contains(
+        "homeboy runner exec <runner-id> --run-id <run-id> --artifact <path> -- <command>"
+    ));
+    assert!(serialized.contains(
+        "homeboy runs artifact attach <run-id> --runner <runner-id> --path <path> --name <name>"
+    ));
+    assert!(serialized.contains("homeboy runner exec homeboy-lab -- homeboy runner exec --help"));
+    assert!(serialized
+        .contains("homeboy runner exec homeboy-lab -- homeboy runs artifact attach --help"));
+    assert!(serialized.contains("version/build drift"));
 }

--- a/src/commands/runner/types.rs
+++ b/src/commands/runner/types.rs
@@ -71,6 +71,7 @@ pub struct LabSelectedRunnerOutput {
 #[derive(Debug, Serialize)]
 pub struct LabRunnerHomeboyOutput {
     pub controller_version: String,
+    pub controller_build_identity: String,
     pub configured_executable: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_daemon_version: Option<String>,
@@ -80,8 +81,18 @@ pub struct LabRunnerHomeboyOutput {
     pub stale_daemon: Option<Value>,
     pub version_drift: bool,
     pub command_availability_checks: Vec<String>,
+    pub artifact_features: RunnerArtifactFeatureDiagnostics,
     pub refresh_commands: Vec<String>,
     pub upgrade_command: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerArtifactFeatureDiagnostics {
+    pub required_features: Vec<&'static str>,
+    pub controller_commands: Vec<String>,
+    pub runner_command_checks: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- Add controller build identity and artifact feature diagnostics to runner status output.
- Surface exact controller/runner checks for `runner exec --artifact` and `runs artifact attach` support.
- Add targeted drift hints for stale or mismatched runner sessions and focused status test coverage.

## Verification
- `cargo fmt --check`
- `cargo test commands::runner::tests::status`
- `cargo test --test output_contracts_test`
- `cargo test --test command_surface_test` currently has one unrelated existing failure in `mutating_safety_manifest_entries_advertise_apply_or_are_allowlisted` listing many pre-existing safety manifest entries.

Closes #6415

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the issue fix, tests, and PR preparation.