### PR TITLE
Fix runner exec summary evidence for #6418

### DIFF
--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -258,6 +258,11 @@ pub(super) enum RunnerCommand {
         #[arg(long = "artifact", value_name = "PATH")]
         artifact_outputs: Vec<String>,
 
+        /// Summary file or directory produced by the runner command to persist as typed run evidence.
+        /// Relative paths are resolved from the runner exec cwd. Repeat for multiple summaries.
+        #[arg(long = "summary", value_name = "PATH")]
+        summary_outputs: Vec<String>,
+
         /// Print remote stdout/stderr directly instead of the structured JSON envelope.
         /// Use global --output to still write the full structured envelope to a file.
         #[arg(long)]

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -141,6 +141,7 @@ pub fn run(
             dry_run,
             run_id,
             artifact_outputs,
+            summary_outputs,
             raw: _,
             command,
         } => map_execution(exec(
@@ -155,6 +156,7 @@ pub fn run(
             dry_run,
             run_id,
             artifact_outputs,
+            summary_outputs,
             command,
         )),
         RunnerCommand::Env { id } => map_env(env_mod::env(&id)),
@@ -213,6 +215,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             dry_run,
             run_id,
             artifact_outputs,
+            summary_outputs,
             raw: true,
             command,
         } => run_raw_exec(
@@ -227,6 +230,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             dry_run,
             run_id,
             artifact_outputs,
+            summary_outputs,
             command,
         ),
         command => {
@@ -253,6 +257,7 @@ fn run_raw_exec(
     dry_run: bool,
     run_id: Option<String>,
     artifact_outputs: Vec<String>,
+    summary_outputs: Vec<String>,
     command: Vec<String>,
 ) -> JsonCommandRun {
     match exec(
@@ -267,6 +272,7 @@ fn run_raw_exec(
         dry_run,
         run_id,
         artifact_outputs,
+        summary_outputs,
         command,
     ) {
         Ok((output, exit_code)) => raw_exec_command_run(output, exit_code),

--- a/src/commands/runner/exec.rs
+++ b/src/commands/runner/exec.rs
@@ -23,6 +23,7 @@ pub(super) fn exec(
     dry_run: bool,
     run_id: Option<String>,
     artifact_outputs: Vec<String>,
+    summary_outputs: Vec<String>,
     command: Vec<String>,
 ) -> CmdResult<RunnerExecOutput> {
     let script = script_file
@@ -32,11 +33,12 @@ pub(super) fn exec(
     let prepared_command = prepare_runner_exec_command(script.as_ref(), command)?;
     let env = prepare_runner_exec_env(env, script.as_deref())?;
     let required_commands = prepared_command.first().cloned().into_iter().collect();
+    let has_declared_outputs = !artifact_outputs.is_empty() || !summary_outputs.is_empty();
 
-    if !dry_run && !artifact_outputs.is_empty() && run_id.is_none() {
+    if !dry_run && has_declared_outputs && run_id.is_none() {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "run_id",
-            "runner exec --artifact requires --run-id so artifacts can be attached to a persisted run",
+            "runner exec --artifact/--summary requires --run-id so evidence can be attached to a persisted run",
             None,
             None,
         ));
@@ -85,6 +87,7 @@ pub(super) fn exec(
     )?;
     if let Some(run_id) = validated_run_id.as_deref() {
         promote_runner_exec_artifacts(run_id, &output.remote_cwd, &artifact_outputs)?;
+        promote_runner_exec_summaries(run_id, &output.remote_cwd, &summary_outputs)?;
     }
     Ok((output, exit_code))
 }
@@ -241,18 +244,68 @@ pub(super) fn promote_runner_exec_artifacts(
     remote_cwd: &str,
     artifact_outputs: &[String],
 ) -> homeboy::core::Result<Vec<ArtifactRecord>> {
-    if artifact_outputs.is_empty() {
+    promote_runner_exec_outputs(
+        run_id,
+        remote_cwd,
+        artifact_outputs,
+        RunnerExecEvidenceRole::Artifact,
+    )
+}
+
+pub(super) fn promote_runner_exec_summaries(
+    run_id: &str,
+    remote_cwd: &str,
+    summary_outputs: &[String],
+) -> homeboy::core::Result<Vec<ArtifactRecord>> {
+    promote_runner_exec_outputs(
+        run_id,
+        remote_cwd,
+        summary_outputs,
+        RunnerExecEvidenceRole::Summary,
+    )
+}
+
+#[derive(Clone, Copy)]
+enum RunnerExecEvidenceRole {
+    Artifact,
+    Summary,
+}
+
+impl RunnerExecEvidenceRole {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Artifact => "artifact",
+            Self::Summary => "summary",
+        }
+    }
+
+    fn kind(self, declared: &str) -> String {
+        match self {
+            Self::Artifact => runner_exec_artifact_kind(declared),
+            Self::Summary => runner_exec_summary_kind(declared),
+        }
+    }
+}
+
+fn promote_runner_exec_outputs(
+    run_id: &str,
+    remote_cwd: &str,
+    output_paths: &[String],
+    role: RunnerExecEvidenceRole,
+) -> homeboy::core::Result<Vec<ArtifactRecord>> {
+    if output_paths.is_empty() {
         return Ok(Vec::new());
     }
 
     let store = ObservationStore::open_initialized()?;
-    artifact_outputs
+    output_paths
         .iter()
         .map(|declared| {
             let path = resolve_runner_exec_artifact_path(remote_cwd, declared);
-            let kind = runner_exec_artifact_kind(declared);
+            let kind = role.kind(declared);
             let metadata = serde_json::json!({
                 "declared_path": declared,
+                "evidence_role": role.as_str(),
                 "promoted_by": "runner.exec",
             });
             if path.is_dir() {
@@ -278,6 +331,23 @@ fn runner_exec_artifact_kind(declared: &str) -> String {
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("runner_exec_artifact");
+    sanitize_runner_exec_kind(name, "runner_exec_artifact")
+}
+
+fn runner_exec_summary_kind(declared: &str) -> String {
+    let name = Path::new(declared)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("runner_exec_summary");
+    let kind = sanitize_runner_exec_kind(name, "runner_exec_summary");
+    if kind.ends_with("summary") {
+        kind
+    } else {
+        format!("{kind}_summary")
+    }
+}
+
+fn sanitize_runner_exec_kind(name: &str, fallback: &str) -> String {
     let kind: String = name
         .chars()
         .map(|ch| {
@@ -289,7 +359,7 @@ fn runner_exec_artifact_kind(declared: &str) -> String {
         })
         .collect();
     if kind.is_empty() {
-        "runner_exec_artifact".to_string()
+        fallback.to_string()
     } else {
         kind
     }

--- a/src/commands/runner/tests/exec.rs
+++ b/src/commands/runner/tests/exec.rs
@@ -155,6 +155,7 @@ fn runner_exec_promotes_declared_artifacts_to_run_store() {
             false,
             Some(run.id.clone()),
             vec!["out.txt".to_string(), "reports".to_string()],
+            Vec::new(),
             vec![
                 "sh".to_string(),
                 "-c".to_string(),
@@ -179,6 +180,62 @@ fn runner_exec_promotes_declared_artifacts_to_run_store() {
 }
 
 #[test]
+fn runner_exec_promotes_declared_summaries_as_typed_evidence() {
+    homeboy::test_support::with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        runner::create(
+            &format!(
+                r#"{{"id":"lab-local","kind":"local","workspace_root":"{}"}}"#,
+                workspace.path().display()
+            ),
+            false,
+        )
+        .expect("create local runner");
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                NewRunRecord::builder("runner-exec")
+                    .command("homeboy runner exec lab-local".to_string())
+                    .cwd_path(workspace.path())
+                    .metadata(serde_json::json!({}))
+                    .build(),
+            )
+            .expect("run");
+
+        let (_output, exit_code) = exec(
+            "lab-local",
+            Some(workspace.path().display().to_string()),
+            None,
+            false,
+            false,
+            Vec::new(),
+            None,
+            Vec::new(),
+            false,
+            Some(run.id.clone()),
+            Vec::new(),
+            vec!["summary.json".to_string()],
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                r#"printf '{"matrix":{"passed":1}}' > summary.json"#.to_string(),
+            ],
+        )
+        .expect("runner exec");
+
+        assert_eq!(exit_code, 0);
+        let artifacts = store.list_artifacts(&run.id).expect("artifacts");
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].kind, "summary");
+        assert_eq!(artifacts[0].artifact_type, "file");
+        assert_eq!(artifacts[0].metadata_json["declared_path"], "summary.json");
+        assert_eq!(artifacts[0].metadata_json["evidence_role"], "summary");
+        assert_eq!(artifacts[0].metadata_json["promoted_by"], "runner.exec");
+        assert!(std::path::Path::new(&artifacts[0].path).is_file());
+    });
+}
+
+#[test]
 fn runner_exec_rejects_artifacts_without_run_id() {
     let err = exec(
         "lab-local",
@@ -192,9 +249,33 @@ fn runner_exec_rejects_artifacts_without_run_id() {
         false,
         None,
         vec!["out.txt".to_string()],
+        Vec::new(),
         vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
     )
     .expect_err("artifact requires run id");
+
+    assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    assert_eq!(err.details["field"], "run_id");
+}
+
+#[test]
+fn runner_exec_rejects_summaries_without_run_id() {
+    let err = exec(
+        "lab-local",
+        None,
+        None,
+        false,
+        false,
+        Vec::new(),
+        None,
+        Vec::new(),
+        false,
+        None,
+        Vec::new(),
+        vec!["summary.json".to_string()],
+        vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
+    )
+    .expect_err("summary requires run id");
 
     assert_eq!(err.code.as_str(), "validation.invalid_argument");
     assert_eq!(err.details["field"], "run_id");


### PR DESCRIPTION
## Summary
- Add repeatable `homeboy runner exec --summary <path>` for summary files/directories produced by runner commands.
- Promote declared summaries into the persisted run artifact store with `evidence_role: summary` metadata, avoiding stdout JSON parsing.
- Cover summary promotion and missing `--run-id` validation in runner exec tests.

## Verification
- `cargo fmt --check`
- `cargo test commands::runner::tests`

Closes #6418

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the issue fix, tests, and PR preparation.