### PR TITLE
Fix runner workspace discovery for manual exec (#6417)

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -570,6 +570,15 @@ Runner metrics:
 - On Linux runners, metrics are sampled from `/proc` for the command process tree and include `peak_rss_bytes`, `child_process_count_peak`, `cpu_user_ms`, and `cpu_system_ms`.
 - CPU accounting is sampled and can miss very short-lived child processes between samples; duration is always recorded, and non-Linux runners report `source: "duration_only"`.
 
+### `workspace list`
+
+```sh
+homeboy runner workspace list <runner-id>
+homeboy runner workspace list <runner-id> --limit 5
+```
+
+`workspace list` shows recent runner-side Lab workspace directories under the runner's configured `workspace_root` and includes a reusable `runner exec --cwd <remote-path>` command for each entry. Use it after a manual or matrix session when the previous `remote_path` scrolled out of view and you need to run another command against the same runner-side checkout.
+
 ### `workspace sync`
 
 ```sh

--- a/src/command_contract/public_variants.rs
+++ b/src/command_contract/public_variants.rs
@@ -445,6 +445,13 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
     },
     PublicOutputVariantContract {
         command: "runner",
+        variant: "workspace_list",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("workspace_list"),
+        golden_fixture: None,
+    },
+    PublicOutputVariantContract {
+        command: "runner",
         variant: "workspace_sync",
         discriminator_field: Some("variant"),
         discriminator_value: Some("workspace_sync"),

--- a/src/commands/runner/workspace/mod.rs
+++ b/src/commands/runner/workspace/mod.rs
@@ -2,7 +2,8 @@ use clap::{Subcommand, ValueEnum};
 use serde::Serialize;
 
 use homeboy::core::runners::{
-    self as runner, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOutput,
+    self as runner, RunnerWorkspaceApplyOutput, RunnerWorkspaceListOutput, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOutput,
 };
 
 use super::CmdResult;
@@ -10,12 +11,22 @@ use super::CmdResult;
 #[derive(Debug, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum RunnerWorkspaceOutput {
+    List(RunnerWorkspaceListOutput),
     Sync(RunnerWorkspaceSyncOutput),
     Apply(RunnerWorkspaceApplyOutput),
 }
 
 #[derive(Subcommand)]
 pub(super) enum RunnerWorkspaceCommand {
+    /// List recent runner-side Lab workspaces and reusable exec commands
+    List {
+        /// Runner ID
+        runner_id: String,
+
+        /// Maximum number of workspaces to return
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+    },
     /// Materialize a controller-side worktree into the runner workspace root
     Sync {
         /// Runner ID
@@ -54,6 +65,10 @@ pub(super) enum RunnerWorkspaceSyncModeArg {
 
 pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceOutput> {
     match command {
+        RunnerWorkspaceCommand::List { runner_id, limit } => {
+            runner::list_workspaces(&runner_id, limit)
+                .map(|(output, exit_code)| (RunnerWorkspaceOutput::List(output), exit_code))
+        }
         RunnerWorkspaceCommand::Sync {
             runner_id,
             path,

--- a/src/core/runner/execution/redaction.rs
+++ b/src/core/runner/execution/redaction.rs
@@ -120,19 +120,53 @@ pub(super) fn runner_exec_diagnostics(
     source_snapshot: Option<&SourceSnapshot>,
     required_paths: &[String],
 ) -> Option<RunnerExecDiagnostics> {
-    if required_paths.is_empty() {
+    if required_paths.is_empty()
+        && source_snapshot
+            .and_then(|snapshot| snapshot.remote_path.as_ref())
+            .is_none()
+    {
         return None;
+    }
+    let mut hints = Vec::new();
+    if let Some(remote_path) = source_snapshot.and_then(|snapshot| snapshot.remote_path.as_ref()) {
+        hints.push(format!(
+            "Reuse this runner workspace with `homeboy runner exec {} --cwd {} -- <command>`.",
+            shell_arg(&runner.id),
+            shell_arg(remote_path)
+        ));
+        hints.push(format!(
+            "Discover recent runner workspaces with `homeboy runner workspace list {}`.",
+            shell_arg(&runner.id)
+        ));
+    }
+    if !required_paths.is_empty() {
+        hints.push(
+            "Use the generated _lab_workspaces/... snapshot path when the controller worktree path was synced into a lab snapshot."
+                .to_string(),
+        );
+        hints.push(
+            "Use --require-path to preflight paths that a command will reference before running it."
+                .to_string(),
+        );
     }
 
     Some(RunnerExecDiagnostics {
         runner_workspace_root: runner.workspace_root.clone(),
-        source_snapshot_remote_path: source_snapshot.and_then(|snapshot| snapshot.remote_path.clone()),
+        source_snapshot_remote_path: source_snapshot
+            .and_then(|snapshot| snapshot.remote_path.clone()),
         required_paths: required_paths.to_vec(),
-        hints: vec![
-            "Use the generated _lab_workspaces/... snapshot path when the controller worktree path was synced into a lab snapshot.".to_string(),
-            "Use --require-path to preflight paths that a command will reference before running it.".to_string(),
-        ],
+        hints,
     })
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 pub(super) fn runner_result(

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -121,7 +121,8 @@ pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerTransport};
 pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
 pub use workspace::{
-    sync_workspace, ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceSyncMode,
+    list_workspaces, sync_workspace, ByteFileCounts, RunnerWorkspaceCurrentSummary,
+    RunnerWorkspaceListEntry, RunnerWorkspaceListOutput, RunnerWorkspaceSyncMode,
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -12,10 +12,12 @@ mod sync;
 mod types;
 mod util;
 
+pub use sync::list_workspaces;
 pub use sync::sync_workspace;
 pub use types::{
-    ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry,
+    RunnerWorkspaceListOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    RunnerWorkspaceSyncOutput,
 };
 
 pub(crate) use snapshot::{

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::core::engine::temp;
 use crate::core::error::{Error, Result};
@@ -14,10 +14,12 @@ use super::snapshot::{
 };
 use super::types::{
     canonical_workspace_path, ByteFileCounts, LocalGitState, RunnerWorkspaceCurrentSummary,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
-    DEFAULT_EXCLUDES,
+    RunnerWorkspaceListEntry, RunnerWorkspaceListOutput, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput, DEFAULT_EXCLUDES,
 };
 use super::util::{deterministic_remote_path, git_output, validate_absolute_path};
+use crate::core::engine::shell;
+use crate::core::server::{self, SshClient};
 
 pub fn sync_workspace(
     runner_id: &str,
@@ -198,6 +200,125 @@ pub fn sync_workspace(
             ))
         }
     }
+}
+
+pub fn list_workspaces(runner_id: &str, limit: usize) -> Result<(RunnerWorkspaceListOutput, i32)> {
+    let runner = load(runner_id)?;
+    let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace_root",
+            "runner workspace list requires workspace_root",
+            Some(runner.id.clone()),
+            Some(vec![
+                "Set runner.workspace_root to the remote workspace directory.".to_string(),
+            ]),
+        )
+    })?;
+    validate_absolute_path("workspace_root", workspace_root)?;
+    let lab_workspaces_root = format!("{}/_lab_workspaces", workspace_root.trim_end_matches('/'));
+    let remote_paths = match runner.kind {
+        RunnerKind::Local => list_local_lab_workspaces(Path::new(&lab_workspaces_root), limit)?,
+        RunnerKind::Ssh => list_ssh_lab_workspaces(&runner, &lab_workspaces_root, limit)?,
+    };
+    let workspaces = remote_paths
+        .into_iter()
+        .map(|remote_path| RunnerWorkspaceListEntry {
+            exec_command: format!(
+                "homeboy runner exec {} --cwd {} -- <command>",
+                shell_arg(&runner.id),
+                shell_arg(&remote_path)
+            ),
+            remote_path,
+        })
+        .collect();
+
+    Ok((
+        RunnerWorkspaceListOutput {
+            variant: "workspace_list",
+            command: "runner.workspace.list",
+            runner_id: runner.id,
+            workspace_root: workspace_root.to_string(),
+            lab_workspaces_root,
+            workspaces,
+        },
+        0,
+    ))
+}
+
+fn list_local_lab_workspaces(root: &Path, limit: usize) -> Result<Vec<String>> {
+    if !root.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut entries = std::fs::read_dir(root)
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("list runner workspaces".to_string()))
+        })?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let file_type = entry.file_type().ok()?;
+            if !file_type.is_dir() {
+                return None;
+            }
+            let modified = entry
+                .metadata()
+                .ok()
+                .and_then(|metadata| metadata.modified().ok());
+            Some((entry.path(), modified))
+        })
+        .collect::<Vec<(PathBuf, Option<std::time::SystemTime>)>>();
+    entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    Ok(entries
+        .into_iter()
+        .take(limit)
+        .map(|(path, _)| path.display().to_string())
+        .collect())
+}
+
+fn list_ssh_lab_workspaces(
+    runner: &super::super::Runner,
+    lab_workspaces_root: &str,
+    limit: usize,
+) -> Result<Vec<String>> {
+    let server_id = runner.server_id.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "server_id",
+            "SSH runner workspace list requires server_id",
+            Some(runner.id.clone()),
+            None,
+        )
+    })?;
+    let server = server::load(server_id)?;
+    let mut client = SshClient::from_server(&server, server_id)?;
+    client.env.extend(runner.env.clone());
+    let command = format!(
+        "root={}; if [ -d \"$root\" ]; then ls -1td \"$root\"/*/ 2>/dev/null | sed 's#/$##'; fi",
+        shell::quote_arg(lab_workspaces_root)
+    );
+    let output = client.execute(&command);
+    if output.exit_code != 0 {
+        return Err(Error::internal_unexpected(format!(
+            "runner workspace list failed on {server_id}: {}",
+            output.stderr.trim()
+        )));
+    }
+    let paths = output
+        .stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    Ok(paths.into_iter().take(limit).collect())
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn workspace_lease(

--- a/src/core/runner/workspace/tests/snapshot.rs
+++ b/src/core/runner/workspace/tests/snapshot.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use crate::core::runner::workspace::snapshot::{
     snapshot_archive_command, snapshot_install_command,
 };
-use crate::core::runner::workspace::sync::sync_workspace;
+use crate::core::runner::workspace::sync::{list_workspaces, sync_workspace};
 use crate::core::runner::workspace::types::{RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
 use crate::core::runner::workspace::util::git_output;
 
@@ -237,6 +237,54 @@ fn snapshot_sync_uses_unique_clean_workspace_for_same_snapshot() {
         assert!(second_remote_path.join("Cargo.toml").exists());
         assert!(!second_remote_path.join("sentinel.txt").exists());
         assert!(remote_path.join("sentinel.txt").exists());
+    });
+}
+
+#[test]
+fn workspace_list_reports_recent_lab_workspaces_with_exec_commands() {
+    crate::test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source tempdir");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        fs::write(source.path().join("Cargo.toml"), "[package]\nname='app'\n").expect("manifest");
+
+        crate::core::runner::create(
+            &format!(
+                r#"{{"id":"lab-local-list","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let (sync, _) = sync_workspace(
+            "lab-local-list",
+            RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                controller_routed_git: false,
+                changed_since_base: None,
+                git_fetch_refs: Vec::new(),
+                snapshot_includes: Vec::new(),
+                allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
+            },
+        )
+        .expect("sync workspace");
+
+        let (list, exit_code) = list_workspaces("lab-local-list", 10).expect("list workspaces");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(list.command, "runner.workspace.list");
+        assert_eq!(
+            list.lab_workspaces_root,
+            format!("{}/_lab_workspaces", runner_root.path().display())
+        );
+        assert_eq!(list.workspaces.len(), 1);
+        assert_eq!(list.workspaces[0].remote_path, sync.remote_path);
+        assert!(list.workspaces[0]
+            .exec_command
+            .contains("homeboy runner exec lab-local-list --cwd"));
+        assert!(list.workspaces[0].exec_command.contains("-- <command>"));
     });
 }
 

--- a/src/core/runner/workspace/types.rs
+++ b/src/core/runner/workspace/types.rs
@@ -94,6 +94,22 @@ pub struct RunnerWorkspaceSyncOutput {
     pub validation_dependencies: Vec<RunnerValidationDependencySyncOutput>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerWorkspaceListOutput {
+    pub variant: &'static str,
+    pub command: &'static str,
+    pub runner_id: String,
+    pub workspace_root: String,
+    pub lab_workspaces_root: String,
+    pub workspaces: Vec<RunnerWorkspaceListEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerWorkspaceListEntry {
+    pub remote_path: String,
+    pub exec_command: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct RunnerWorkspaceCurrentSummary {
     pub local_path: String,

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -35,7 +35,7 @@ pub use super::runner::{
     evaluate_lab_runner_capabilities_for_runner, exec, execute_lab_offload,
     is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
     is_retrievable_runner_artifact, lab_offload_changed_since_ref, lab_offload_metadata,
-    lab_offload_metadata_with_workspace_mapping, mirror_connected_runner_run,
+    lab_offload_metadata_with_workspace_mapping, list_workspaces, mirror_connected_runner_run,
     mirrored_runner_job_identity, plan_managed_runner_source_sync,
     plan_managed_runner_source_syncs, preflight_lab_offload_changed_since,
     preflight_remote_argv_path_translation, prepare_git_lab_offload_changed_since,
@@ -56,7 +56,8 @@ pub use super::runner::{
     RunnerSpec, RunnerStaleDaemonWarning, RunnerStatusReport, RunnerToolRegistry, RunnerToolSpec,
     RunnerTunnelMode, RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput,
     RunnerWorkspaceApplyStatus, RunnerWorkspaceLease, RunnerWorkspaceLeaseSet,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    RunnerWorkspaceListEntry, RunnerWorkspaceListOutput, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
 // Registry CRUD entry points (re-exported at the root for ergonomics; also
@@ -105,9 +106,10 @@ pub mod execution {
 /// Workspace sync and patch application contracts.
 pub mod workspace {
     pub use super::super::runner::{
-        apply_change_artifact, apply_workspace_patch, plan_managed_runner_source_sync,
-        plan_managed_runner_source_syncs, sync_workspace, ManagedRunnerSourceSyncPlan,
-        RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
+        apply_change_artifact, apply_workspace_patch, list_workspaces,
+        plan_managed_runner_source_sync, plan_managed_runner_source_syncs, sync_workspace,
+        ManagedRunnerSourceSyncPlan, RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput,
+        RunnerWorkspaceApplyStatus, RunnerWorkspaceListEntry, RunnerWorkspaceListOutput,
         RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
     };
 }


### PR DESCRIPTION
## Summary
- Add `homeboy runner workspace list <runner-id>` to surface recent runner-side Lab workspace paths and reusable `runner exec --cwd` commands.
- Include workspace reuse and discovery hints in runner exec diagnostics.
- Document the manual workspace discovery workflow and register the new public output variant.

## Verification
- `cargo fmt`
- `cargo test workspace_list_reports_recent_lab_workspaces_with_exec_commands`
- `cargo test test_exec_reports_required_path_diagnostics`
- `cargo check`
- `cargo test --test command_surface_test` (31 passed, 1 existing broad safety-manifest allowlist failure unrelated to this change)

Closes #6417

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the issue fix, tests, and PR preparation.