### PR TITLE
Surface runtime evidence refs in controller results

### DIFF
--- a/src/core/agent_task_controller_service/actions.rs
+++ b/src/core/agent_task_controller_service/actions.rs
@@ -86,6 +86,7 @@ where
                         .to_string(),
                     ),
                     failure_summary,
+                    runtime_evidence: controller_action_runtime_evidence(&execution),
                     execution: Some(execution),
                     controller: record.clone(),
                 },
@@ -133,6 +134,7 @@ where
                 failure_summary: Some(controller_action_failure_summary(
                     record, action, &execution,
                 )),
+                runtime_evidence: controller_action_runtime_evidence(&execution),
                 execution: Some(execution),
                 controller: record.clone(),
             },
@@ -172,6 +174,7 @@ where
                 failure_summary: Some(controller_action_failure_summary(
                     record, action, &execution,
                 )),
+                runtime_evidence: controller_action_runtime_evidence(&execution),
                 execution: Some(execution),
                 controller: record.clone(),
             },

--- a/src/core/agent_task_controller_service/artifacts.rs
+++ b/src/core/agent_task_controller_service/artifacts.rs
@@ -829,6 +829,136 @@ where
     })
 }
 
+pub(super) fn controller_action_runtime_evidence(
+    execution: &Value,
+) -> Option<ControllerActionRuntimeEvidence> {
+    let mut evidence = ControllerActionRuntimeEvidence {
+        runtime_invocation_id: None,
+        provider_id: None,
+        runtime_id: None,
+        failure_classification: None,
+        phase: None,
+        artifact_refs: Vec::new(),
+        transcript_refs: Vec::new(),
+        result_refs: Vec::new(),
+        diagnostics_refs: Vec::new(),
+    };
+
+    collect_runtime_evidence(execution, &mut evidence);
+
+    (evidence.runtime_invocation_id.is_some()
+        || evidence.provider_id.is_some()
+        || evidence.runtime_id.is_some()
+        || evidence.failure_classification.is_some()
+        || evidence.phase.is_some()
+        || !evidence.artifact_refs.is_empty()
+        || !evidence.transcript_refs.is_empty()
+        || !evidence.result_refs.is_empty()
+        || !evidence.diagnostics_refs.is_empty())
+    .then_some(evidence)
+}
+
+fn collect_runtime_evidence(value: &Value, evidence: &mut ControllerActionRuntimeEvidence) {
+    match value {
+        Value::Object(object) => {
+            set_first_string(
+                &mut evidence.runtime_invocation_id,
+                object
+                    .get("runtime_invocation_id")
+                    .or_else(|| object.get("invocation_id"))
+                    .and_then(Value::as_str),
+            );
+            set_first_string(
+                &mut evidence.provider_id,
+                object
+                    .get("provider_id")
+                    .or_else(|| object.get("provider"))
+                    .and_then(Value::as_str),
+            );
+            set_first_string(
+                &mut evidence.runtime_id,
+                object.get("runtime_id").and_then(Value::as_str),
+            );
+            set_first_string(
+                &mut evidence.failure_classification,
+                object.get("failure_classification").and_then(Value::as_str),
+            );
+            set_first_string(
+                &mut evidence.phase,
+                object
+                    .get("phase")
+                    .or_else(|| object.get("failure_phase"))
+                    .and_then(Value::as_str),
+            );
+
+            if let Some(refs) = object.get("refs").and_then(Value::as_object) {
+                collect_ref_group(refs.get("artifact_bundles"), &mut evidence.artifact_refs);
+                collect_ref_group(refs.get("artifacts"), &mut evidence.artifact_refs);
+                collect_ref_group(refs.get("logs"), &mut evidence.artifact_refs);
+                collect_ref_group(refs.get("transcripts"), &mut evidence.transcript_refs);
+                collect_ref_group(refs.get("results"), &mut evidence.result_refs);
+                collect_ref_group(refs.get("diagnostics"), &mut evidence.diagnostics_refs);
+            }
+
+            collect_ref_field(object.get("artifact_bundle"), &mut evidence.artifact_refs);
+            collect_ref_field(
+                object.get("artifact_bundle_ref"),
+                &mut evidence.artifact_refs,
+            );
+            collect_ref_field(object.get("artifact_ref"), &mut evidence.artifact_refs);
+            collect_ref_field(object.get("artifact_path"), &mut evidence.artifact_refs);
+            collect_ref_field(object.get("transcript_ref"), &mut evidence.transcript_refs);
+            collect_ref_field(object.get("result_ref"), &mut evidence.result_refs);
+            collect_ref_field(
+                object.get("diagnostics_ref"),
+                &mut evidence.diagnostics_refs,
+            );
+
+            for child in object.values() {
+                collect_runtime_evidence(child, evidence);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_runtime_evidence(item, evidence);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn set_first_string(target: &mut Option<String>, value: Option<&str>) {
+    if target.is_none() {
+        if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
+            *target = Some(value.to_string());
+        }
+    }
+}
+
+fn collect_ref_group(value: Option<&Value>, target: &mut Vec<Value>) {
+    match value {
+        Some(Value::Array(items)) => {
+            for item in items {
+                push_ref_once(target, item.clone());
+            }
+        }
+        Some(value) => push_ref_once(target, value.clone()),
+        None => {}
+    }
+}
+
+fn collect_ref_field(value: Option<&Value>, target: &mut Vec<Value>) {
+    if let Some(value) = value.filter(|value| !value.is_null()) {
+        push_ref_once(target, value.clone());
+    }
+}
+
+fn push_ref_once(target: &mut Vec<Value>, value: Value) {
+    if !target.iter().any(|existing| existing == &value) {
+        target.push(value);
+    }
+}
+
 pub(super) fn first_pending_action_id(record: &AgentTaskLoopControllerRecord) -> Option<String> {
     if !matches!(record.state, AgentTaskLoopControllerState::Running) {
         return None;

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -571,6 +571,7 @@ where
                 action_id: None,
                 status: None,
                 failure_summary: None,
+                runtime_evidence: None,
                 execution: None,
                 controller: record,
             },

--- a/src/core/agent_task_controller_service/reports.rs
+++ b/src/core/agent_task_controller_service/reports.rs
@@ -117,8 +117,35 @@ pub struct ControllerActionReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_summary: Option<ControllerActionFailureSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_evidence: Option<ControllerActionRuntimeEvidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub execution: Option<Value>,
     pub controller: AgentTaskLoopControllerRecord,
+}
+
+/// Generic runtime evidence surfaced from runtime-backed controller action
+/// execution results. The controller preserves provider-neutral ids and refs
+/// already present in dispatch/runtime payloads without interpreting them.
+#[derive(Debug, Clone, Serialize)]
+pub struct ControllerActionRuntimeEvidence {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_invocation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_classification: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transcript_refs: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub result_refs: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics_refs: Vec<Value>,
 }
 
 /// Concise failed-action context for controller resume operators.

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -81,6 +81,7 @@ impl ControllerDispatchHook for FailingDispatchHook {
                     "outcomes": [{
                         "task_id": "task-overlay-prepare",
                         "status": "failed",
+                        "failure_classification": "provider",
                         "diagnostics": [{
                             "class": "provider.runtime_overlay",
                             "message": "Recipe runtime overlay preparation failed: download php-scoper timed out after 60004ms",
@@ -88,7 +89,25 @@ impl ControllerDispatchHook for FailingDispatchHook {
                                 "provider": "synthetic-runtime",
                                 "phase": "runtime_overlay_preparation"
                             }
-                        }]
+                        }],
+                        "outputs": {
+                            "provider_run_result": {
+                                "status": "failed",
+                                "failure_classification": "provider",
+                                "metadata": {
+                                    "provider_id": "synthetic-runtime",
+                                    "runtime_id": "runtime-abc",
+                                    "runtime_invocation_id": "invocation-123",
+                                    "phase": "runtime_overlay_preparation"
+                                },
+                                "refs": {
+                                    "artifact_bundles": [{"id": "bundle-1", "path": "artifacts/bundle.zip"}],
+                                    "transcripts": [{"uri": "artifacts/transcript.ndjson"}],
+                                    "results": [{"uri": "artifacts/result.json"}],
+                                    "diagnostics": [{"uri": "artifacts/diagnostics.json"}]
+                                }
+                            }
+                        }
                     }]
                 }
             }),
@@ -2158,6 +2177,42 @@ fn resume_failed_action_result_includes_top_level_failure_summary() {
         assert_eq!(
             failed["failure_summary"]["provider"],
             json!("synthetic-runtime")
+        );
+        assert_eq!(
+            failed["runtime_evidence"]["runtime_invocation_id"],
+            json!("invocation-123")
+        );
+        assert_eq!(
+            failed["runtime_evidence"]["runtime_id"],
+            json!("runtime-abc")
+        );
+        assert_eq!(
+            failed["runtime_evidence"]["provider_id"],
+            json!("synthetic-runtime")
+        );
+        assert_eq!(
+            failed["runtime_evidence"]["failure_classification"],
+            json!("provider")
+        );
+        assert_eq!(
+            failed["runtime_evidence"]["phase"],
+            json!("runtime_overlay_preparation")
+        );
+        assert_eq!(
+            failed["runtime_evidence"]["artifact_refs"][0]["path"],
+            json!("artifacts/bundle.zip")
+        );
+        assert_eq!(
+            failed["runtime_evidence"]["transcript_refs"][0]["uri"],
+            json!("artifacts/transcript.ndjson")
+        );
+        assert_eq!(
+            failed["runtime_evidence"]["result_refs"][0]["uri"],
+            json!("artifacts/result.json")
+        );
+        assert_eq!(
+            failed["runtime_evidence"]["diagnostics_refs"][0]["uri"],
+            json!("artifacts/diagnostics.json")
         );
         assert_eq!(
             failed["failure_summary"]["failure_phase"],


### PR DESCRIPTION
## Summary

- Add provider-neutral `runtime_evidence` to controller action results.
- Extract runtime ids, failure classification, phase, and transcript/result/diagnostic/artifact refs from existing runtime payloads.
- Extend failure-summary coverage so failed runtime-backed actions point directly to their evidence refs.

Closes #6412

## Tests

- `cargo fmt --check`
- `cargo test core::agent_task_controller_service::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and testing the controller evidence implementation.
