### PR TITLE
Expose runtime bundle budgets in controller evidence

### DIFF
--- a/src/core/agent_task_controller_service/artifacts.rs
+++ b/src/core/agent_task_controller_service/artifacts.rs
@@ -234,16 +234,217 @@ pub(super) fn execution_with_request_workflow_artifacts(
     execution: Value,
     request: &Value,
 ) -> Value {
-    let Some(workflow_artifacts) = request
+    let runtime_bundle = runtime_bundle_evidence(request, &execution);
+    let workflow_artifacts = request
         .get("workflow_artifacts")
         .and_then(Value::as_array)
-        .filter(|artifacts| !artifacts.is_empty())
-    else {
+        .filter(|artifacts| !artifacts.is_empty());
+
+    if workflow_artifacts.is_none() && runtime_bundle.is_none() {
         return execution;
-    };
+    }
+
     let mut execution = execution.as_object().cloned().unwrap_or_default();
-    merge_workflow_artifacts(&mut execution, workflow_artifacts);
+    if let Some(workflow_artifacts) = workflow_artifacts {
+        merge_workflow_artifacts(&mut execution, workflow_artifacts);
+    }
+    if let Some(runtime_bundle) = runtime_bundle {
+        execution.insert("runtime_bundle".to_string(), runtime_bundle);
+    }
     Value::Object(execution)
+}
+
+fn runtime_bundle_evidence(request: &Value, execution: &Value) -> Option<Value> {
+    let configured = runtime_bundle_configurations(request);
+    let observed = runtime_bundle_observations(execution);
+    if configured.is_empty() && observed.is_empty() {
+        return None;
+    }
+
+    let mut evidence = serde_json::Map::new();
+    if !configured.is_empty() {
+        evidence.insert(
+            "configured".to_string(),
+            serde_json::json!({ "tasks": configured }),
+        );
+    }
+    if !observed.is_empty() {
+        evidence.insert(
+            "observed".to_string(),
+            serde_json::json!({ "results": observed }),
+        );
+    }
+    Some(Value::Object(evidence))
+}
+
+fn runtime_bundle_configurations(value: &Value) -> Vec<Value> {
+    let mut tasks = Vec::new();
+    collect_runtime_bundle_configurations(value, &mut tasks, 0);
+    tasks
+}
+
+fn collect_runtime_bundle_configurations(value: &Value, tasks: &mut Vec<Value>, depth: usize) {
+    if depth > 12 {
+        return;
+    }
+    match value {
+        Value::Object(object) => {
+            if let Some(runtime_task) = object.get("runtime_task") {
+                push_runtime_bundle_configuration(runtime_task, tasks);
+            }
+            push_runtime_bundle_configuration(value, tasks);
+            for child in object.values() {
+                collect_runtime_bundle_configurations(child, tasks, depth + 1);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                collect_runtime_bundle_configurations(child, tasks, depth + 1);
+            }
+        }
+        Value::String(raw) => {
+            let trimmed = raw.trim_start();
+            if (trimmed.starts_with('{') || trimmed.starts_with('[')) && raw.len() < 128 * 1024 {
+                if let Ok(parsed) = serde_json::from_str::<Value>(raw) {
+                    collect_runtime_bundle_configurations(&parsed, tasks, depth + 1);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_runtime_bundle_configuration(runtime_task: &Value, tasks: &mut Vec<Value>) {
+    let Some(object) = runtime_task.as_object() else {
+        return;
+    };
+    let ability = object.get("ability").and_then(Value::as_str);
+    let kind = object.get("kind").and_then(Value::as_str);
+    let input = object.get("input");
+    let is_bundle = kind == Some("bundle")
+        || ability.is_some_and(|ability| ability.contains("runtime-package/"))
+        || input.and_then(|input| input.get("package")).is_some();
+    if !is_bundle {
+        return;
+    }
+
+    let mut task = serde_json::Map::new();
+    if let Some(ability) = ability {
+        task.insert("ability".to_string(), Value::String(ability.to_string()));
+    }
+    if let Some(kind) = kind {
+        task.insert("kind".to_string(), Value::String(kind.to_string()));
+    }
+    if let Some(input) = input {
+        let budgets = runtime_budget_fields(input);
+        if !budgets.is_empty() {
+            task.insert("budgets".to_string(), Value::Object(budgets));
+        }
+    }
+    let task = Value::Object(task);
+    if !tasks.iter().any(|existing| existing == &task) {
+        tasks.push(task);
+    }
+}
+
+fn runtime_budget_fields(value: &Value) -> serde_json::Map<String, Value> {
+    let mut fields = serde_json::Map::new();
+    collect_runtime_budget_fields(value, &mut fields, 0);
+    fields
+}
+
+fn collect_runtime_budget_fields(
+    value: &Value,
+    fields: &mut serde_json::Map<String, Value>,
+    depth: usize,
+) {
+    if depth > 8 {
+        return;
+    }
+    match value {
+        Value::Object(object) => {
+            for (key, child) in object {
+                if is_runtime_budget_key(key) && !child.is_null() {
+                    fields.entry(key.clone()).or_insert_with(|| child.clone());
+                }
+                collect_runtime_budget_fields(child, fields, depth + 1);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                collect_runtime_budget_fields(child, fields, depth + 1);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_runtime_budget_key(key: &str) -> bool {
+    key == "time_budget_ms"
+        || key == "step_budget"
+        || key == "wait_budget_ms"
+        || key == "drain_budget_ms"
+        || key == "wait_timeout_ms"
+        || key == "drain_timeout_ms"
+}
+
+fn runtime_bundle_observations(value: &Value) -> Vec<Value> {
+    let mut observations = Vec::new();
+    collect_runtime_bundle_observations(value, &mut observations, 0);
+    observations
+}
+
+fn collect_runtime_bundle_observations(value: &Value, observations: &mut Vec<Value>, depth: usize) {
+    if depth > 16 {
+        return;
+    }
+    match value {
+        Value::Object(object) => {
+            let mut observed = serde_json::Map::new();
+            for (key, child) in object {
+                if is_runtime_observation_key(key) && !child.is_null() {
+                    observed.insert(key.clone(), child.clone());
+                }
+            }
+            if !observed.is_empty() {
+                let observed = Value::Object(observed);
+                if !observations.iter().any(|existing| existing == &observed) {
+                    observations.push(observed);
+                }
+            }
+            for child in object.values() {
+                collect_runtime_bundle_observations(child, observations, depth + 1);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                collect_runtime_bundle_observations(child, observations, depth + 1);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_runtime_observation_key(key: &str) -> bool {
+    matches!(
+        key,
+        "wait_result"
+            | "job_status"
+            | "steps_drained"
+            | "actions_drained"
+            | "drained_steps"
+            | "drained_actions"
+            | "elapsed_ms"
+            | "elapsed_time_ms"
+            | "wall_time_ms"
+            | "wall_time"
+            | "completion_outcome"
+            | "completion_status"
+            | "terminal_state"
+            | "error_type"
+            | "classification"
+            | "error_classification"
+    )
 }
 
 fn matching_completed_workflow_artifacts(

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -46,6 +46,9 @@ struct CountingFailingDispatchHook {
 }
 
 #[derive(Clone, Default)]
+struct RuntimeBudgetDispatchHook;
+
+#[derive(Clone, Default)]
 struct EvidenceExecutor;
 
 impl ControllerDispatchHook for CapturingDispatchHook {
@@ -167,6 +170,38 @@ impl ControllerDispatchHook for CountingFailingDispatchHook {
                 }]
             }),
             1,
+        ))
+    }
+}
+
+impl ControllerDispatchHook for RuntimeBudgetDispatchHook {
+    fn dispatch(&self, _request: &Value) -> Result<(Value, i32)> {
+        Ok((
+            json!({
+                "schema": "homeboy/test-generic-dispatch-result/v1",
+                "run_id": "generic-run-runtime-budget",
+                "aggregate": {
+                    "outcomes": [{
+                        "task_id": "task-runtime-bundle",
+                        "status": "succeeded",
+                        "outputs": {
+                            "provider_run_result": {
+                                "wait_result": {
+                                    "terminal_state": "timeout",
+                                    "steps_drained": 12,
+                                    "actions_drained": 7,
+                                    "elapsed_ms": 300123
+                                },
+                                "job_status": "running",
+                                "completion_outcome": "wait_budget_expired",
+                                "error_type": "runtime_wait_timeout",
+                                "classification": "runtime_incomplete"
+                            }
+                        }
+                    }]
+                }
+            }),
+            0,
         ))
     }
 }
@@ -2135,6 +2170,113 @@ fn resume_failed_action_result_includes_top_level_failure_summary() {
         assert_eq!(
             failed["execution"]["result"]["aggregate"]["outcomes"][0]["diagnostics"][0]["message"],
             failed["failure_summary"]["diagnostic"]
+        );
+    });
+}
+
+#[test]
+fn runtime_bundle_action_result_exposes_budgets_and_observed_wait_outcome() {
+    with_isolated_home(|_| {
+        let mut record = init(ControllerInitRequest {
+            loop_id: "loop-service-runtime-budget-evidence".to_string(),
+            phase: "generate".to_string(),
+            config_version: "v1".to_string(),
+        })
+        .expect("controller initialized");
+        let workflow_context = json!({
+            "schema": "homeboy/repo-loop-workflow-context/v1",
+            "workflow_id": "bundle-generation",
+            "runtime_task": {
+                "kind": "bundle",
+                "ability": "runtime-package/run",
+                "input": {
+                    "package": { "source": "bundles/site-generator" },
+                    "time_budget_ms": 900000,
+                    "step_budget": 42,
+                    "input": {
+                        "wait_for_completion": true,
+                        "drain_budget_ms": 300000
+                    }
+                }
+            },
+            "plan": {
+                "schema": "homeboy/repo-loop-workflow-plan/v1",
+                "artifacts": [{
+                    "id": "generated_candidate",
+                    "artifact_type": "runtime-candidate",
+                    "data": {
+                        "kind": "runtime-candidate",
+                        "required": true
+                    }
+                }]
+            }
+        });
+        record.record_action(
+            AgentTaskLoopPolicyAction::SpawnTask {
+                dedupe_key: "workflow:bundle-generation".to_string(),
+                entity_id: None,
+                request: json!({
+                    "mode": "dispatch",
+                    "run_id": "controller-service-runtime-budget",
+                    "dispatch": {
+                        "client_context": workflow_context.to_string()
+                    }
+                }),
+            },
+            "run runtime bundle",
+        );
+        controller::write_controller(&record).expect("controller written");
+
+        let result = resume(
+            "loop-service-runtime-budget-evidence",
+            CapturingExecutor::default(),
+            &RuntimeBudgetDispatchHook,
+        )
+        .expect("controller resumed");
+
+        assert_eq!(result.exit_code, 1);
+        let failed = &result.value.results[0];
+        assert_eq!(failed["status"], json!("failed"));
+        assert_eq!(
+            failed["execution"]["runtime_bundle"]["configured"]["tasks"][0]["budgets"]
+                ["time_budget_ms"],
+            json!(900000)
+        );
+        assert_eq!(
+            failed["execution"]["runtime_bundle"]["configured"]["tasks"][0]["budgets"]
+                ["step_budget"],
+            json!(42)
+        );
+        assert_eq!(
+            failed["execution"]["runtime_bundle"]["configured"]["tasks"][0]["budgets"]
+                ["drain_budget_ms"],
+            json!(300000)
+        );
+        let observed = &failed["execution"]["runtime_bundle"]["observed"]["results"];
+        assert!(observed
+            .as_array()
+            .expect("observed results")
+            .iter()
+            .any(|entry| {
+                entry["wait_result"]["terminal_state"] == json!("timeout")
+                    && entry["wait_result"]["steps_drained"] == json!(12)
+                    && entry["wait_result"]["actions_drained"] == json!(7)
+                    && entry["wait_result"]["elapsed_ms"] == json!(300123)
+            }));
+        assert!(observed
+            .as_array()
+            .expect("observed results")
+            .iter()
+            .any(|entry| {
+                entry["job_status"] == json!("running")
+                    && entry["completion_outcome"] == json!("wait_budget_expired")
+                    && entry["error_type"] == json!("runtime_wait_timeout")
+                    && entry["classification"] == json!("runtime_incomplete")
+            }));
+        assert_eq!(
+            failed["execution"]["result"]["aggregate"]["outcomes"][0]["outputs"]
+                ["provider_run_result"]["wait_result"]["terminal_state"],
+            json!("timeout")
         );
     });
 }


### PR DESCRIPTION
## Summary

- Surface runtime bundle budget configuration in controller action execution evidence.
- Capture observed runtime wait/drain outcomes from dispatch results when present.
- Add regression coverage for a bundle action that fails after the runtime wait budget expires.

Closes #6411

## Tests

- `cargo fmt --check`
- `cargo test core::agent_task_controller_service::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and testing the controller evidence implementation.
