### PR TITLE
Fix #6416 portable rig matrix planning

### DIFF
--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -80,6 +80,18 @@ is advisory only; use global `--force-hot` when the extra pressure is expected.
 services, leases, ports, and declared filesystem paths that are not portable
 through the current single-workspace runner snapshot.
 
+For command-only rigs, agents can ask Homeboy for a portable runner plan instead
+of materializing the rig locally:
+
+```sh
+homeboy --runner homeboy-lab rig up script-matrix --dry-run
+```
+
+The plan emits equivalent `homeboy runner exec <runner-id> ...` commands for each
+`kind: "command"` step. It refuses rigs with services, declared resources,
+symlinks, shared paths, or typed pipeline steps so local service stacks still stay
+on the local `rig up` path.
+
 The pipeline can start services, run typed `git` / `build` / `extension` / `stack` steps, apply idempotent local patches, create symlinks/shared paths, and run checks.
 
 ### `check`

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -441,11 +441,13 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
                 "reports a plan by default; pass --write to rewrite source files";
             metadata.dangerous_flags = vec!["--write"];
         }
-        ["rig", "up"]
-        | ["rig", "down"]
-        | ["rig", "repair"]
-        | ["rig", "install"]
-        | ["rig", "update"] => {
+        ["rig", "up"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.dry_run_flag = Some("--dry-run");
+            metadata.output_notes = "mutates local rig runtime state unless --dry-run is passed with --runner to emit a runner exec plan";
+        }
+        ["rig", "down"] | ["rig", "repair"] | ["rig", "install"] | ["rig", "update"] => {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.output_notes = "mutates local rig runtime state or installed rig packages";

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -12,7 +12,8 @@ use homeboy::core::rig;
 use self::output::{
     RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledStackSummary,
     RigInstalledSummary, RigListOutput, RigRepairOutput, RigShowOutput, RigSourceSummary,
-    RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput, RigUpdateOutput,
+    RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput, RigUpPlanOutput, RigUpPlanStep,
+    RigUpdateOutput,
 };
 use super::CmdResult;
 use crate::command_contract::{
@@ -43,6 +44,16 @@ impl RigArgs {
             self.command,
             RigCommand::Install { .. } | RigCommand::Sources { .. }
         )
+    }
+
+    pub(crate) fn up_dry_run_rig_id(&self) -> Option<&str> {
+        match &self.command {
+            RigCommand::Up {
+                rig_id,
+                dry_run: true,
+            } => Some(rig_id),
+            _ => None,
+        }
     }
 
     pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
@@ -94,6 +105,9 @@ enum RigCommand {
     Up {
         /// Rig ID
         rig_id: String,
+        /// Build an execution plan without running the rig.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Run a rig's `check` pipeline and report health
     Check {
@@ -200,7 +214,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
     match args.command {
         RigCommand::List => list(),
         RigCommand::Show { rig_id } => show(&rig_id),
-        RigCommand::Up { rig_id } => up(&rig_id),
+        RigCommand::Up { rig_id, dry_run } => up(&rig_id, dry_run),
         RigCommand::Check { target, id } => check(&target, id.as_deref()),
         RigCommand::Down { rig_id } => down(&rig_id),
         RigCommand::Repair { rig_id } => repair(&rig_id),
@@ -350,8 +364,16 @@ fn show(rig_id: &str) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn up(rig_id: &str) -> CmdResult<RigCommandOutput> {
+fn up(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
     let rig = rig::load(rig_id)?;
+    if dry_run {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "dry_run",
+            "rig up --dry-run requires --runner <runner-id> so Homeboy can emit a portable runner exec plan",
+            Some(rig_id.to_string()),
+            None,
+        ));
+    }
     let report = rig::run_up(&rig)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
@@ -361,6 +383,118 @@ fn up(rig_id: &str) -> CmdResult<RigCommandOutput> {
         }),
         exit_code,
     ))
+}
+
+pub(crate) fn up_runner_exec_plan(rig_id: &str, runner_id: &str) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(rig_id)?;
+    let steps = command_only_up_steps(&rig, runner_id)?;
+    let commands = steps
+        .iter()
+        .map(|step| step.runner_exec_command.clone())
+        .collect();
+    Ok((
+        RigCommandOutput::UpPlan(RigUpPlanOutput {
+            command: "rig.up.plan",
+            rig_id: rig.id,
+            runner_id: runner_id.to_string(),
+            portable: true,
+            steps,
+            commands,
+        }),
+        0,
+    ))
+}
+
+fn command_only_up_steps(
+    rig: &rig::RigSpec,
+    runner_id: &str,
+) -> homeboy::core::Result<Vec<RigUpPlanStep>> {
+    if !rig.services.is_empty()
+        || !rig.resources.is_empty()
+        || !rig.symlinks.is_empty()
+        || !rig.shared_paths.is_empty()
+    {
+        return Err(non_portable_up_error(&rig.id));
+    }
+
+    let Some(steps) = rig.pipeline.get("up") else {
+        return Ok(Vec::new());
+    };
+    steps
+        .iter()
+        .enumerate()
+        .map(|(index, step)| match step {
+            rig::PipelineStep::Command {
+                cmd,
+                cwd,
+                env,
+                label,
+                ..
+            } => {
+                let mut env_pairs = env
+                    .iter()
+                    .map(|(key, value)| format!("{key}={value}"))
+                    .collect::<Vec<_>>();
+                env_pairs.sort();
+                let mut argv = vec![
+                    "homeboy".to_string(),
+                    "runner".to_string(),
+                    "exec".to_string(),
+                    runner_id.to_string(),
+                ];
+                if let Some(cwd) = cwd {
+                    argv.push("--cwd".to_string());
+                    argv.push(cwd.clone());
+                }
+                for pair in &env_pairs {
+                    argv.push("--env".to_string());
+                    argv.push(pair.clone());
+                }
+                argv.extend([
+                    "--".to_string(),
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    cmd.clone(),
+                ]);
+                Ok(RigUpPlanStep {
+                    label: label
+                        .clone()
+                        .unwrap_or_else(|| format!("command[{}]", index + 1)),
+                    command: cmd.clone(),
+                    cwd: cwd.clone(),
+                    env: env_pairs,
+                    runner_exec_command: shell_join(&argv),
+                })
+            }
+            _ => Err(non_portable_up_error(&rig.id)),
+        })
+        .collect()
+}
+
+fn non_portable_up_error(rig_id: &str) -> homeboy::core::Error {
+    homeboy::core::Error::validation_invalid_argument(
+        "rig_id",
+        "rig up --dry-run --runner only plans command-only rigs; service, resource, symlink, shared-path, and typed pipeline steps still run locally through rig up",
+        Some(rig_id.to_string()),
+        None,
+    )
+}
+
+fn shell_join(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn check(target: &str, id: Option<&str>) -> CmdResult<RigCommandOutput> {
@@ -487,6 +621,7 @@ fn app_uninstall(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
 mod tests {
     use super::*;
     use clap::Parser;
+    use std::fs;
 
     #[derive(Parser)]
     struct TestCli {
@@ -503,5 +638,92 @@ mod tests {
             panic!("expected rig sources command");
         };
         assert!(command.is_none());
+    }
+
+    #[test]
+    fn up_dry_run_runner_plan_emits_command_only_runner_exec_steps() {
+        crate::test_support::with_isolated_home(|home| {
+            write_rig(
+                home.path(),
+                "script-matrix",
+                serde_json::json!({
+                    "id": "script-matrix",
+                    "description": "script matrix",
+                    "pipeline": {
+                        "up": [
+                            {
+                                "kind": "command",
+                                "command": "./scripts/run-one.sh --axis a",
+                                "cwd": "packages/tooling",
+                                "env": { "MATRIX_AXIS": "a" },
+                                "label": "axis a"
+                            },
+                            {
+                                "kind": "command",
+                                "command": "./scripts/run-one.sh --axis b",
+                                "label": "axis b"
+                            }
+                        ]
+                    }
+                }),
+            );
+
+            let (output, exit_code) = up_runner_exec_plan("script-matrix", "homeboy-lab")
+                .expect("command-only rig should plan");
+
+            assert_eq!(exit_code, 0);
+            let json = serde_json::to_value(output).expect("serialize plan");
+            assert_eq!(json["variant"], "up_plan");
+            assert_eq!(json["payload"]["portable"], true);
+            assert_eq!(json["payload"]["steps"].as_array().unwrap().len(), 2);
+            assert_eq!(
+                json["payload"]["steps"][0]["runner_exec_command"],
+                "homeboy runner exec homeboy-lab --cwd packages/tooling --env MATRIX_AXIS=a -- sh -c './scripts/run-one.sh --axis a'"
+            );
+            assert_eq!(
+                json["payload"]["commands"][1],
+                "homeboy runner exec homeboy-lab -- sh -c './scripts/run-one.sh --axis b'"
+            );
+        });
+    }
+
+    #[test]
+    fn up_dry_run_runner_plan_refuses_resource_rigs() {
+        crate::test_support::with_isolated_home(|home| {
+            write_rig(
+                home.path(),
+                "resource-rig",
+                serde_json::json!({
+                    "id": "resource-rig",
+                    "description": "resource rig",
+                    "resources": {
+                        "ports": [8888]
+                    },
+                    "pipeline": {
+                        "up": [
+                            { "kind": "command", "command": "npm run matrix" }
+                        ]
+                    }
+                }),
+            );
+
+            let err = match up_runner_exec_plan("resource-rig", "homeboy-lab") {
+                Ok(_) => panic!("resource rig should not plan"),
+                Err(err) => err,
+            };
+
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("command-only rigs"));
+        });
+    }
+
+    fn write_rig(home: &std::path::Path, rig_id: &str, value: serde_json::Value) {
+        let dir = home.join(".config/homeboy/rigs");
+        fs::create_dir_all(&dir).expect("create rigs dir");
+        fs::write(
+            dir.join(format!("{rig_id}.json")),
+            serde_json::to_string_pretty(&value).expect("serialize rig"),
+        )
+        .expect("write rig");
     }
 }

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -15,6 +15,7 @@ pub enum RigCommandOutput {
     List(RigListOutput),
     Show(RigShowOutput),
     Up(RigUpOutput),
+    UpPlan(RigUpPlanOutput),
     Check(RigCheckOutput),
     Down(RigDownOutput),
     Repair(RigRepairOutput),
@@ -69,6 +70,27 @@ pub struct RigUpOutput {
     pub command: &'static str,
     #[serde(flatten)]
     pub report: rig::UpReport,
+}
+
+#[derive(Serialize)]
+pub struct RigUpPlanOutput {
+    pub command: &'static str,
+    pub rig_id: String,
+    pub runner_id: String,
+    pub portable: bool,
+    pub steps: Vec<RigUpPlanStep>,
+    pub commands: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct RigUpPlanStep {
+    pub label: String,
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<String>,
+    pub runner_exec_command: String,
 }
 
 #[derive(Serialize)]

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -33,6 +33,20 @@ pub fn route_after_parse(
     }
 
     if let (Some(runner_id), Commands::Rig(args)) = (cli.runner.as_deref(), &cli.command) {
+        if let Some(rig_id) = args.up_dry_run_rig_id() {
+            let (output, exit_code) = crate::commands::rig::up_runner_exec_plan(rig_id, runner_id)?;
+            let stdout = serde_json::to_string_pretty(&output).map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some("serialize rig up runner exec plan".to_string()),
+                )
+            })?;
+            if let Some(path) = output_file {
+                write_output_file(path, &stdout)?;
+            }
+            println!("{stdout}");
+            return Ok(Some(exit_code));
+        }
         if args.is_runner_source_management_command() {
             let (stdout, stderr, exit_code) =
                 run_rig_source_management_on_runner(runner_id, normalized_args, output_file)?;
@@ -732,6 +746,31 @@ mod tests {
         .expect("write rig source metadata");
     }
 
+    fn write_command_only_rig(home: &Path, rig_id: &str) {
+        let rigs_dir = home.join(".config").join("homeboy").join("rigs");
+        fs::create_dir_all(&rigs_dir).expect("create rigs dir");
+        let spec = serde_json::json!({
+            "id": rig_id,
+            "description": "command-only rig",
+            "pipeline": {
+                "up": [
+                    {
+                        "kind": "command",
+                        "command": "./scripts/run-matrix.sh",
+                        "cwd": "tools",
+                        "env": { "MATRIX": "portable" },
+                        "label": "run matrix"
+                    }
+                ]
+            }
+        });
+        fs::write(
+            rigs_dir.join(format!("{rig_id}.json")),
+            serde_json::to_string_pretty(&spec).expect("serialize rig"),
+        )
+        .expect("write rig");
+    }
+
     #[test]
     fn non_lab_command_continues_local_dispatch() {
         let cli = Cli::parse_from(["homeboy", "status"]);
@@ -769,6 +808,38 @@ mod tests {
         assert_eq!(command.hot_label, "test");
         assert!(command.portable);
         assert!(command.unsupported_reason.is_none());
+    }
+
+    #[test]
+    fn rig_up_dry_run_with_runner_emits_runner_exec_plan() {
+        crate::test_support::with_isolated_home(|home| {
+            write_command_only_rig(home.path(), "script-matrix");
+            let output = home.path().join("plan.json");
+            let normalized = vec![
+                "homeboy".to_string(),
+                "--runner".to_string(),
+                "homeboy-lab".to_string(),
+                "rig".to_string(),
+                "up".to_string(),
+                "script-matrix".to_string(),
+                "--dry-run".to_string(),
+            ];
+            let cli = Cli::parse_from(&normalized);
+
+            let outcome = route_after_parse(&cli, &normalized, Some(&output.to_string_lossy()))
+                .expect("route rig up plan");
+
+            assert_eq!(outcome, Some(0));
+            let plan: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(output).expect("read output plan"))
+                    .expect("parse output plan");
+            assert_eq!(plan["variant"], "up_plan");
+            assert_eq!(plan["payload"]["runner_id"], "homeboy-lab");
+            assert_eq!(
+                plan["payload"]["commands"][0],
+                "homeboy runner exec homeboy-lab --cwd tools --env MATRIX=portable -- sh -c ./scripts/run-matrix.sh"
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `rig up --dry-run` planning for command-only rigs when a global `--runner` is selected.
- Emit structured `rig.up.plan` output with equivalent `homeboy runner exec <runner-id> ...` commands.
- Refuse service/resource/symlink/shared-path/typed-step rigs so local service stacks remain local-only, and document the operator path.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test commands::rig::tests::up_dry_run_runner_plan`
- `cargo test commands::route::tests::rig_up_dry_run_with_runner_emits_runner_exec_plan`
- `cargo test --test output_contracts_test`
- `cargo check`

Closes #6416

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the issue fix, tests, and PR preparation.