### PR TITLE
Route fanout run-plan through Lab

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -309,6 +309,7 @@ const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task controller resu
 const AGENT_TASK_STATUS_LAB_LABEL: &str =
     "agent-task run/run-next/status/logs/artifacts/review/list/active/latest";
 const AGENT_TASK_PROVIDERS_LAB_LABEL: &str = "agent-task providers";
+const AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL: &str = "agent-task fanout run-plan";
 const AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL: &str = "agent-task fanout submit-batch";
 const AGENT_TASK_FANOUT_STATUS_LAB_LABEL: &str = "agent-task fanout status/artifacts";
 const AGENT_TASK_AUTH_STATUS_LAB_LABEL: &str = "agent-task auth status";
@@ -366,11 +367,12 @@ const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
     },
     LabSupportedCommandSummary {
         contract_labels: &[
+            AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
             AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
             AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
         ],
-        message_label: "agent-task fanout submit-batch/status/artifacts",
-        hint_label: "agent-task fanout submit-batch/status/artifacts",
+        message_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
+        hint_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
     },
     LabSupportedCommandSummary {
         contract_labels: &[AGENT_TASK_AUTH_STATUS_LAB_LABEL],
@@ -554,6 +556,17 @@ impl Commands {
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command: agent_task::AgentTaskCommand::Providers(_),
             }) => LabCommandContract::explicit_runner_simple(AGENT_TASK_PROVIDERS_LAB_LABEL),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command:
+                    agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
+                        command: agent_task::AgentTaskFanoutCommand::RunPlan(_),
+                    }),
+            }) => LabCommandContract::portable(
+                AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
+                None,
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -1331,6 +1331,36 @@ mod tests {
     }
 
     #[test]
+    fn agent_task_fanout_run_plan_supports_lab_runner_routing() {
+        let normalized = vec![
+            "homeboy".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "--lab-only".to_string(),
+            "agent-task".to_string(),
+            "fanout".to_string(),
+            "run-plan".to_string(),
+            "--input".to_string(),
+            "fanout.json".to_string(),
+        ];
+        let cli = Cli::parse_from(&normalized);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+        let local_policy = runners::LabLocalExecutionPolicy::from_flags(
+            cli.allow_local_hot,
+            cli.allow_local_fallback,
+            cli.lab_only,
+        );
+
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        assert!(local_policy.deny_local_execution());
+        assert_eq!(command.hot_label, "agent-task fanout run-plan");
+        assert!(command.portable);
+        assert!(command.routing_policy.default_lab_offload);
+        assert!(command.routing_policy.requires_extension_parity);
+    }
+
+    #[test]
     fn agent_task_fanout_state_reads_are_runner_resident() {
         for args in [
             [


### PR DESCRIPTION
## Summary
- Register `agent-task fanout run-plan` as a portable Lab-routable command.
- Include the command in the supported `--runner` help/validation summary.
- Add route coverage for `fanout run-plan --runner ... --lab-only`.

Fixes #6433.

## Testing
- `cargo test agent_task_fanout_run_plan_supports_lab_runner_routing`
- `cargo build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosed the route-contract gap, drafted the focused fix and test, and ran verification commands.
