### PR TITLE
Port controller from-spec loop primitives

### DIFF
--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -60,6 +60,22 @@ pub struct AgentTaskControllerFromSpecArgs {
     #[arg(long)]
     pub resume: bool,
 
+    /// Explicit controller run inputs JSON, @file, or - for stdin. Supports `inputs` and `metadata` objects.
+    #[arg(long, value_name = "JSON")]
+    pub inputs: Option<String>,
+
+    /// Declarative policy result JSON, @file, or - for stdin. Repeatable.
+    #[arg(long = "policy-result", value_name = "JSON")]
+    pub policy_results: Vec<String>,
+
+    /// Maximum controller actions to execute when --resume is supplied.
+    #[arg(
+        long = "max-actions",
+        visible_alias = "max-iterations",
+        value_name = "N"
+    )]
+    pub max_actions: Option<u32>,
+
     /// On --resume, discard stale persisted controller state and re-create it from this spec.
     #[arg(long, conflicts_with_all = ["fork", "resume_existing"])]
     pub replace: bool,

--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -616,20 +616,39 @@ fn resume_state_resolution(
 }
 
 pub(super) fn controller_from_spec(args: AgentTaskControllerFromSpecArgs) -> CmdResult<Value> {
-    let raw = config::read_json_spec_to_string(&args.spec)?;
-    let mut spec: AgentTaskRepoLoopSpec = serde_json::from_str(&raw).map_err(|error| {
-        homeboy::core::Error::validation_invalid_argument(
-            "spec",
-            error.to_string(),
-            Some(args.spec.clone()),
-            None,
-        )
-    })?;
-    agent_task_controller_service::apply_spec_dispatch_defaults(&mut spec, &args.spec);
     let defaults = ControllerDispatchDefaults::from_from_spec_args(&args);
-    defaults.apply_to_spec(&mut spec);
+    let spec = if args.inputs.is_some() || !args.policy_results.is_empty() {
+        materialize_controller_spec(
+            &args.spec,
+            args.inputs.as_deref(),
+            &args.policy_results,
+            Some(&defaults),
+        )?
+        .spec
+    } else {
+        let raw = config::read_json_spec_to_string(&args.spec)?;
+        let mut spec: AgentTaskRepoLoopSpec = serde_json::from_str(&raw).map_err(|error| {
+            homeboy::core::Error::validation_invalid_argument(
+                "spec",
+                error.to_string(),
+                Some(args.spec.clone()),
+                None,
+            )
+        })?;
+        agent_task_controller_service::apply_spec_dispatch_defaults(&mut spec, &args.spec);
+        defaults.apply_to_spec(&mut spec);
+        spec
+    };
     if args.doctor {
         return controller_from_spec_doctor(spec, &args);
+    }
+    if args.max_actions == Some(0) {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "max-actions",
+            "agent-task controller from-spec --resume requires --max-actions greater than zero",
+            Some(args.spec),
+            None,
+        ));
     }
     let report = if args.resume {
         init_from_spec_for_resume_with_resolution(
@@ -643,16 +662,25 @@ pub(super) fn controller_from_spec(args: AgentTaskControllerFromSpecArgs) -> Cmd
         return Ok((command_json_value(report)?, 0));
     }
 
-    let (resume_report, exit_code) = controller_resume_with_executor(
-        report.loop_id.clone(),
-        ExtensionProviderAgentTaskExecutor::discover(),
+    let dispatch = CliDispatchHook {
+        executor: ExtensionProviderAgentTaskExecutor::discover(),
         defaults,
+    };
+    let resume_result = agent_task_controller_service::resume_with_options(
+        &report.loop_id,
+        ExtensionProviderAgentTaskExecutor::discover(),
+        &dispatch,
+        agent_task_controller_service::ControllerResumeOptions {
+            max_actions: args.max_actions.unwrap_or(100) as usize,
+            stop_on_terminal: true,
+        },
     )?;
+    let exit_code = resume_result.exit_code;
     Ok((
         serde_json::json!({
             "schema": "homeboy/agent-task-loop-controller-from-spec-and-resume-result/v1",
             "from_spec": report,
-            "resume": resume_report,
+            "resume": resume_result.value,
         }),
         exit_code,
     ))

--- a/src/commands/agent_task/tests/loop_compile.rs
+++ b/src/commands/agent_task/tests/loop_compile.rs
@@ -711,6 +711,9 @@ fn controller_from_spec_doctor_reports_missing_provider_before_resume() {
         }))
         .expect("spec json"),
         resume: false,
+        inputs: None,
+        policy_results: Vec::new(),
+        max_actions: None,
         replace: false,
         fork: false,
         resume_existing: false,
@@ -754,6 +757,9 @@ fn controller_from_spec_doctor_accepts_fixture_provider() {
         }))
         .expect("spec json"),
         resume: false,
+        inputs: None,
+        policy_results: Vec::new(),
+        max_actions: None,
         replace: false,
         fork: false,
         resume_existing: false,

--- a/src/core/agent_task_controller_service/actions.rs
+++ b/src/core/agent_task_controller_service/actions.rs
@@ -1,7 +1,9 @@
 //! Split from `agent_task_controller_service` god file (#5208). Structural move only.
 #![allow(unused_imports)]
 use super::*;
+use std::fs;
 use std::io::{self, Read};
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -389,6 +391,11 @@ where
             executor,
             dispatch,
         ),
+        AgentTaskLoopPolicyAction::RunCommand {
+            dedupe_key,
+            entity_id,
+            request,
+        } => execute_run_command_action(record, action, dedupe_key, entity_id.as_deref(), request),
         AgentTaskLoopPolicyAction::FanOut {
             dedupe_key,
             entity_ids,
@@ -534,6 +541,227 @@ where
     }
 }
 
+fn execute_run_command_action(
+    record: &mut AgentTaskLoopControllerRecord,
+    action: &AgentTaskLoopPolicyActionRecord,
+    dedupe_key: &str,
+    entity_id: Option<&str>,
+    request: &Value,
+) -> Result<(Value, i32)> {
+    let request = hydrate_consumed_artifacts(record, request);
+    let request = request_with_required_workflow_artifacts(record, &request);
+    let execution = request.get("execution").unwrap_or(&Value::Null);
+    let command = required_string(execution, "command")?;
+    let args = execution
+        .get("args")
+        .and_then(Value::as_array)
+        .map(|args| {
+            args.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let required_artifacts = request
+        .get("artifacts")
+        .and_then(Value::as_array)
+        .map(|artifacts| {
+            artifacts
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let io_dir = loop_action_io_dir(&record.loop_id, &action.action_id)?;
+    fs::create_dir_all(&io_dir).map_err(|error| Error::internal_io(error.to_string(), None))?;
+    let input_path = io_dir.join("input.json");
+    let output_path = io_dir.join("output.json");
+    let input = serde_json::json!({
+        "schema": "homeboy/agent-task-loop-command-input/v1",
+        "loop_id": record.loop_id,
+        "action_id": action.action_id,
+        "dedupe_key": dedupe_key,
+        "entity_id": entity_id,
+        "request": request,
+        "controller": &*record,
+    });
+    write_json_file(&input_path, &input)?;
+
+    let mut process = Command::new(&command);
+    process.args(&args);
+    if let Some(cwd) = execution
+        .get("cwd")
+        .and_then(Value::as_str)
+        .filter(|cwd| !cwd.is_empty())
+    {
+        process.current_dir(cwd);
+    }
+    process.env("HOMEBOY_LOOP_ACTION_INPUT", &input_path);
+    process.env("HOMEBOY_LOOP_ACTION_OUTPUT", &output_path);
+    process.env("HOMEBOY_LOOP_ID", &record.loop_id);
+    process.env("HOMEBOY_LOOP_ACTION_ID", &action.action_id);
+    process.env("HOMEBOY_LOOP_ACTION_DEDUPE_KEY", dedupe_key);
+
+    let output = process
+        .output()
+        .map_err(|error| Error::internal_io(error.to_string(), None))?;
+    let exit_code = output.status.code().unwrap_or(1);
+    let result = if output_path.exists() {
+        read_json_file(&output_path)?
+    } else {
+        serde_json::json!({})
+    };
+    let artifacts = result.get("artifacts").cloned().unwrap_or(Value::Null);
+    let missing = missing_required_command_artifacts(&required_artifacts, &artifacts);
+    let command_success = exit_code == 0 && missing.is_empty();
+    let effective_exit_code = if command_success { 0 } else { 1 };
+
+    if command_success {
+        record_run_command_outputs(record, action, dedupe_key, entity_id, &request, &artifacts)?;
+    }
+
+    Ok((
+        serde_json::json!({
+            "mode": "run_command",
+            "command": command,
+            "args": args,
+            "input_path": input_path,
+            "output_path": output_path,
+            "exit_code": exit_code,
+            "stdout": String::from_utf8_lossy(&output.stdout),
+            "stderr": String::from_utf8_lossy(&output.stderr),
+            "missing_artifacts": missing,
+            "result": result,
+        }),
+        effective_exit_code,
+    ))
+}
+
+fn loop_action_io_dir(loop_id: &str, action_id: &str) -> Result<PathBuf> {
+    Ok(crate::core::paths::homeboy_data()?
+        .join("agent-task-loop-actions")
+        .join(sanitize_loop_action_id(loop_id))
+        .join(action_id))
+}
+
+fn sanitize_loop_action_id(raw: &str) -> String {
+    raw.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn write_json_file(path: &PathBuf, value: &Value) -> Result<()> {
+    let payload = serde_json::to_string_pretty(value)
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    fs::write(path, format!("{payload}\n"))
+        .map_err(|error| Error::internal_io(error.to_string(), None))
+}
+
+fn read_json_file(path: &PathBuf) -> Result<Value> {
+    let payload =
+        fs::read_to_string(path).map_err(|error| Error::internal_io(error.to_string(), None))?;
+    serde_json::from_str(&payload).map_err(|error| Error::internal_json(error.to_string(), None))
+}
+
+fn missing_required_command_artifacts(required: &[String], artifacts: &Value) -> Vec<String> {
+    required
+        .iter()
+        .filter(|artifact| artifacts.get(artifact.as_str()).is_none_or(Value::is_null))
+        .cloned()
+        .collect()
+}
+
+fn record_run_command_outputs(
+    record: &mut AgentTaskLoopControllerRecord,
+    action: &AgentTaskLoopPolicyActionRecord,
+    dedupe_key: &str,
+    entity_id: Option<&str>,
+    request: &Value,
+    artifacts: &Value,
+) -> Result<()> {
+    let run_id = format!("{}:{}", record.loop_id, action.action_id);
+    let artifact_refs = artifact_refs_from_command_result(artifacts);
+    persist_controller_artifacts(&record.loop_id, &action.action_id, artifacts)?;
+    if let Some(entity_id) = entity_id {
+        if let Some(entity) = record.entities.get_mut(entity_id) {
+            entity.artifact_refs.extend(artifact_refs.clone());
+        }
+    }
+    if !record
+        .task_lineage
+        .iter()
+        .any(|lineage| lineage.run_id == run_id)
+    {
+        record.task_lineage.push(AgentTaskLoopTaskLineage {
+            run_id: run_id.clone(),
+            task_id: None,
+            parent_run_id: None,
+            parent_task_id: None,
+            entity_id: entity_id.map(str::to_string),
+            dedupe_key: Some(dedupe_key.to_string()),
+            artifact_refs,
+            inputs: request.clone(),
+            outputs: serde_json::json!({ "artifacts": artifacts }),
+        });
+    }
+    Ok(())
+}
+
+fn persist_controller_artifacts(loop_id: &str, action_id: &str, artifacts: &Value) -> Result<()> {
+    let Some(object) = artifacts.as_object() else {
+        return Ok(());
+    };
+    if object.is_empty() {
+        return Ok(());
+    }
+    let root = crate::core::paths::artifact_root()?
+        .join("agent-task-loop-controller")
+        .join(sanitize_loop_action_id(loop_id))
+        .join(action_id);
+    fs::create_dir_all(&root).map_err(|error| Error::internal_io(error.to_string(), None))?;
+    for (artifact_id, artifact) in object {
+        let path = root.join(format!("{}.json", sanitize_loop_action_id(artifact_id)));
+        write_json_file(&path, artifact)?;
+    }
+    Ok(())
+}
+
+fn artifact_refs_from_command_result(artifacts: &Value) -> Vec<AgentTaskLoopArtifactRef> {
+    let Some(object) = artifacts.as_object() else {
+        return Vec::new();
+    };
+    object
+        .iter()
+        .map(|(artifact_id, artifact)| {
+            let uri = artifact
+                .get("artifact_url")
+                .or_else(|| artifact.get("url"))
+                .or_else(|| artifact.get("path"))
+                .and_then(Value::as_str)
+                .unwrap_or(artifact_id)
+                .to_string();
+            AgentTaskLoopArtifactRef {
+                uri,
+                kind: artifact
+                    .get("schema")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                role: None,
+                label: Some(artifact_id.clone()),
+                semantic_key: None,
+            }
+        })
+        .collect()
+}
+
 pub(super) fn execute_retry_action(
     record: &mut AgentTaskLoopControllerRecord,
     action: &AgentTaskLoopPolicyActionRecord,
@@ -644,7 +872,8 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
-    let request = request_with_required_workflow_artifacts(record, request);
+    let request = hydrate_consumed_artifacts(record, request);
+    let request = request_with_required_workflow_artifacts(record, &request);
     let request = &request;
     let mode = request
         .get("mode")

--- a/src/core/agent_task_controller_service/artifacts.rs
+++ b/src/core/agent_task_controller_service/artifacts.rs
@@ -230,6 +230,218 @@ pub(super) fn request_with_required_workflow_artifacts(
     Value::Object(request)
 }
 
+pub(super) fn hydrate_consumed_artifacts(
+    record: &AgentTaskLoopControllerRecord,
+    request: &Value,
+) -> Value {
+    let consumed = consumed_artifact_ids(request);
+    if consumed.is_empty() {
+        return request.clone();
+    }
+
+    let mut artifacts = serde_json::Map::new();
+    for artifact_id in consumed {
+        if let Some(artifact) = find_controller_artifact(record, &artifact_id) {
+            artifacts.insert(artifact_id, artifact);
+        }
+    }
+    if artifacts.is_empty() {
+        return request.clone();
+    }
+
+    let mut hydrated = request.clone();
+    merge_request_input_artifacts(&mut hydrated, &artifacts);
+    merge_runtime_execution_input_artifacts(&mut hydrated, &artifacts);
+    merge_dispatch_context_artifacts(&mut hydrated, &artifacts);
+    hydrated
+}
+
+fn consumed_artifact_ids(request: &Value) -> Vec<String> {
+    let mut ids = Vec::new();
+    append_string_array(&mut ids, request.get("consumes"));
+    append_string_array(
+        &mut ids,
+        request
+            .get("inputs")
+            .and_then(|inputs| inputs.get("consumes")),
+    );
+    if let Some(context) = request
+        .get("dispatch")
+        .and_then(|dispatch| dispatch.get("client_context"))
+        .and_then(Value::as_str)
+        .and_then(|context| serde_json::from_str::<Value>(context).ok())
+    {
+        append_string_array(&mut ids, context.get("consumes"));
+        append_string_array(
+            &mut ids,
+            context
+                .get("inputs")
+                .and_then(|inputs| inputs.get("consumes")),
+        );
+    }
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+fn append_string_array(ids: &mut Vec<String>, value: Option<&Value>) {
+    let Some(values) = value.and_then(Value::as_array) else {
+        return;
+    };
+    ids.extend(
+        values
+            .iter()
+            .filter_map(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+    );
+}
+
+fn find_controller_artifact(
+    record: &AgentTaskLoopControllerRecord,
+    artifact_id: &str,
+) -> Option<Value> {
+    for lineage in record.task_lineage.iter().rev() {
+        if let Some(artifact) = artifact_from_outputs(&lineage.outputs, artifact_id) {
+            return Some(artifact);
+        }
+    }
+    for event in record.history.iter().rev() {
+        if let Some(artifact) = artifact_from_history_payload(&event.payload, artifact_id) {
+            return Some(artifact);
+        }
+    }
+    None
+}
+
+fn artifact_from_outputs(outputs: &Value, artifact_id: &str) -> Option<Value> {
+    outputs
+        .get("artifacts")
+        .and_then(|artifacts| artifacts.get(artifact_id))
+        .or_else(|| {
+            outputs
+                .get("typed_artifacts")
+                .and_then(|artifacts| artifacts.get(artifact_id))
+        })
+        .cloned()
+}
+
+fn artifact_from_history_payload(payload: &Value, artifact_id: &str) -> Option<Value> {
+    let result = payload.get("execution")?.get("result")?;
+    if let Some(artifact) = artifact_from_outputs(result, artifact_id) {
+        return Some(artifact);
+    }
+    let outcomes = result
+        .get("aggregate")
+        .and_then(|aggregate| aggregate.get("outcomes"))
+        .and_then(Value::as_array)?;
+    for outcome in outcomes.iter().rev() {
+        if let Some(artifact) =
+            artifact_from_outputs(outcome.get("outputs").unwrap_or(&Value::Null), artifact_id)
+        {
+            return Some(artifact);
+        }
+        if let Some(artifact) = outcome
+            .get("metadata")
+            .and_then(|metadata| metadata.get("typed_artifacts"))
+            .and_then(|artifacts| artifacts.get(artifact_id))
+            .cloned()
+        {
+            return Some(artifact);
+        }
+    }
+    None
+}
+
+fn merge_request_input_artifacts(request: &mut Value, artifacts: &serde_json::Map<String, Value>) {
+    let Some(object) = request.as_object_mut() else {
+        return;
+    };
+    let inputs = object
+        .entry("inputs".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(inputs) = inputs.as_object_mut() else {
+        return;
+    };
+    let artifact_inputs = inputs
+        .entry("artifacts".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(artifact_inputs) = artifact_inputs.as_object_mut() else {
+        return;
+    };
+    for (artifact_id, artifact) in artifacts {
+        artifact_inputs.insert(artifact_id.clone(), artifact.clone());
+    }
+    insert_artifact_aliases(inputs, artifacts);
+}
+
+fn merge_runtime_execution_input_artifacts(
+    request: &mut Value,
+    artifacts: &serde_json::Map<String, Value>,
+) {
+    let Some(runtime_input) = request
+        .get_mut("runtime_execution")
+        .and_then(|runtime_execution| runtime_execution.get_mut("input"))
+        .and_then(|input| input.get_mut("input"))
+    else {
+        return;
+    };
+    let Some(runtime_input) = runtime_input.as_object_mut() else {
+        return;
+    };
+    let artifact_inputs = runtime_input
+        .entry("artifacts".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(artifact_inputs) = artifact_inputs.as_object_mut() else {
+        return;
+    };
+    for (artifact_id, artifact) in artifacts {
+        artifact_inputs.insert(artifact_id.clone(), artifact.clone());
+    }
+    insert_artifact_aliases(runtime_input, artifacts);
+}
+
+fn merge_dispatch_context_artifacts(
+    request: &mut Value,
+    artifacts: &serde_json::Map<String, Value>,
+) {
+    let Some(context_value) = request
+        .get_mut("dispatch")
+        .and_then(|dispatch| dispatch.get_mut("client_context"))
+    else {
+        return;
+    };
+    let Some(context_string) = context_value.as_str() else {
+        return;
+    };
+    let Ok(mut context) = serde_json::from_str::<Value>(context_string) else {
+        return;
+    };
+    merge_request_input_artifacts(&mut context, artifacts);
+    merge_runtime_execution_input_artifacts(&mut context, artifacts);
+    *context_value = Value::String(context.to_string());
+}
+
+fn insert_artifact_aliases(
+    inputs: &mut serde_json::Map<String, Value>,
+    artifacts: &serde_json::Map<String, Value>,
+) {
+    for (artifact_id, artifact) in artifacts {
+        let should_insert = inputs
+            .get(artifact_id)
+            .is_none_or(|value| value.is_null() || value.as_str() == Some(""));
+        if should_insert {
+            inputs.insert(
+                artifact_id.clone(),
+                artifact
+                    .get("payload")
+                    .cloned()
+                    .unwrap_or_else(|| artifact.clone()),
+            );
+        }
+    }
+}
+
 pub(super) fn execution_with_request_workflow_artifacts(
     execution: Value,
     request: &Value,

--- a/src/core/agent_task_controller_service/spec.rs
+++ b/src/core/agent_task_controller_service/spec.rs
@@ -219,7 +219,7 @@ pub struct AgentTaskRepoLoopSpecWorkflow {
     pub gates: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub metrics: Vec<String>,
-    #[serde(default, skip_serializing_if = "Value::is_null")]
+    #[serde(default, alias = "execution", skip_serializing_if = "Value::is_null")]
     pub runtime_execution: Value,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub inputs: Value,

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -915,8 +915,21 @@ pub(super) fn compile_loop_spec_workflow(
     spec: &AgentTaskRepoLoopSpec,
     workflow: &AgentTaskRepoLoopSpecWorkflow,
 ) -> Result<AgentTaskLoopPolicyAction> {
-    let request = workflow_dispatch_request(spec, workflow)?;
     let dedupe_key = format!("workflow:{}", workflow.workflow_id);
+    if workflow
+        .runtime_execution
+        .get("kind")
+        .and_then(Value::as_str)
+        == Some("command")
+    {
+        return Ok(AgentTaskLoopPolicyAction::RunCommand {
+            dedupe_key,
+            entity_id: None,
+            request: workflow_command_request(workflow),
+        });
+    }
+
+    let request = workflow_dispatch_request(spec, workflow)?;
     let fan_out_entity_ids = workflow_fan_out_entity_ids(workflow)?;
     if fan_out_entity_ids.is_empty() {
         Ok(AgentTaskLoopPolicyAction::SpawnTask {
@@ -938,6 +951,18 @@ pub(super) fn compile_loop_spec_workflow(
             request_template: request,
         })
     }
+}
+
+fn workflow_command_request(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Value {
+    serde_json::json!({
+        "mode": "command",
+        "workflow_id": workflow.workflow_id,
+        "consumes": workflow.inputs.get("consumes").cloned().unwrap_or(Value::Null),
+        "artifacts": workflow.artifacts,
+        "execution": workflow.runtime_execution,
+        "runtime_execution": workflow.runtime_execution,
+        "inputs": workflow.inputs,
+    })
 }
 
 fn workflow_fan_out_entity_ids(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Result<Vec<String>> {

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -3377,6 +3377,96 @@ fn run_failure_summary_falls_back_to_stopped_reason() {
     assert!(!summary.evidence_refs.is_empty());
 }
 
+#[test]
+fn run_command_workflow_executes_deterministic_artifact_action() {
+    with_isolated_home(|home| {
+        let spec = AgentTaskRepoLoopSpec {
+            schema: None,
+            loop_id: "repo-loop-command".to_string(),
+            phase: "init".to_string(),
+            config_version: "v1".to_string(),
+            metadata: Value::Null,
+            entities: Vec::new(),
+            agents: Vec::new(),
+            tools: Vec::new(),
+            abilities: Vec::new(),
+            workflows: vec![AgentTaskRepoLoopSpecWorkflow {
+                workflow_id: "deterministic-validation".to_string(),
+                agent_id: None,
+                prompt: None,
+                tasks: vec!["Run deterministic validation.".to_string()],
+                entity_ids: Vec::new(),
+                fan_out: None,
+                tools: Vec::new(),
+                abilities: Vec::new(),
+                artifacts: vec!["validation_result".to_string()],
+                consumes: Vec::new(),
+                emits: Vec::new(),
+                dependencies: Vec::new(),
+                gates: Vec::new(),
+                metrics: Vec::new(),
+                runtime_execution: json!({
+                    "kind": "command",
+                    "command": "/bin/sh",
+                    "args": ["-c", "printf '%s\n' '{\"artifacts\":{\"validation_result\":{\"schema\":\"example/ValidationResult/v1\",\"artifact_url\":\"artifact://validation-result\"}}}' > \"$HOMEBOY_LOOP_ACTION_OUTPUT\""]
+                }),
+                inputs: Value::Null,
+            }],
+            artifacts: vec![AgentTaskRepoLoopSpecArtifact {
+                artifact_id: "validation_result".to_string(),
+                kind: "example/ValidationResult/v1".to_string(),
+                description: None,
+                required: true,
+            }],
+            artifact_graph: Vec::new(),
+            dependencies: Vec::new(),
+            gates: Vec::new(),
+            metrics: Vec::new(),
+            gate_bundles: Vec::new(),
+            policy: None,
+            phases: Vec::new(),
+            actions: Vec::new(),
+            initial_event: None,
+        };
+
+        let initialized = init_from_spec(ControllerFromSpecRequest { spec }).expect("init");
+        match &initialized.actions[0].action {
+            AgentTaskLoopPolicyAction::RunCommand { request, .. } => {
+                assert_eq!(request["execution"]["kind"], "command");
+            }
+            other => panic!("expected run_command action, got {other:?}"),
+        }
+
+        let result = run_next(
+            "repo-loop-command",
+            CapturingExecutor::default(),
+            &CapturingDispatchHook::default(),
+        )
+        .expect("run command action");
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.value.status.as_deref(), Some("completed"));
+        assert_eq!(
+            result.value.execution.as_ref().unwrap()["result"]["artifacts"]["validation_result"]
+                ["schema"],
+            "example/ValidationResult/v1"
+        );
+        assert_eq!(result.value.controller.task_lineage.len(), 1);
+        assert_eq!(
+            result.value.controller.task_lineage[0].outputs["artifacts"]["validation_result"]
+                ["artifact_url"],
+            "artifact://validation-result"
+        );
+        let persisted_artifact = home
+            .path()
+            .join(".local/share/homeboy/artifacts/agent-task-loop-controller/repo-loop-command/action-1/validation_result.json");
+        let persisted: Value = serde_json::from_str(
+            &std::fs::read_to_string(&persisted_artifact).expect("persisted controller artifact"),
+        )
+        .expect("persisted artifact json");
+        assert_eq!(persisted["schema"], "example/ValidationResult/v1");
+    });
+}
+
 fn plan_stage<'a>(plan: &'a HomeboyPlan, id: &str) -> &'a PlanStep {
     plan.steps
         .iter()

--- a/src/core/agent_task_loop_controller/helpers.rs
+++ b/src/core/agent_task_loop_controller/helpers.rs
@@ -7,6 +7,7 @@ use serde_json::{json, Value};
 pub(crate) fn action_dedupe_key(action: &AgentTaskLoopPolicyAction) -> Option<String> {
     match action {
         AgentTaskLoopPolicyAction::SpawnTask { dedupe_key, .. }
+        | AgentTaskLoopPolicyAction::RunCommand { dedupe_key, .. }
         | AgentTaskLoopPolicyAction::FanOut { dedupe_key, .. }
         | AgentTaskLoopPolicyAction::SpawnController { dedupe_key, .. }
         | AgentTaskLoopPolicyAction::SpawnSubloop { dedupe_key, .. }
@@ -63,6 +64,7 @@ pub(crate) fn jsonpath_match_is_truthy(value: &Value) -> bool {
 pub(crate) fn action_entity_id(action: &AgentTaskLoopPolicyAction) -> Option<String> {
     match action {
         AgentTaskLoopPolicyAction::SpawnTask { entity_id, .. }
+        | AgentTaskLoopPolicyAction::RunCommand { entity_id, .. }
         | AgentTaskLoopPolicyAction::SpawnController { entity_id, .. }
         | AgentTaskLoopPolicyAction::SpawnSubloop { entity_id, .. }
         | AgentTaskLoopPolicyAction::WaitForController { entity_id, .. }
@@ -77,6 +79,7 @@ pub(crate) fn action_entity_id(action: &AgentTaskLoopPolicyAction) -> Option<Str
 pub(crate) fn action_name(action: &AgentTaskLoopPolicyAction) -> &'static str {
     match action {
         AgentTaskLoopPolicyAction::SpawnTask { .. } => "spawn_task",
+        AgentTaskLoopPolicyAction::RunCommand { .. } => "run_command",
         AgentTaskLoopPolicyAction::FanOut { .. } => "fan_out",
         AgentTaskLoopPolicyAction::SpawnController { .. } => "spawn_controller",
         AgentTaskLoopPolicyAction::SpawnSubloop { .. } => "spawn_subloop",

--- a/src/core/agent_task_loop_controller/policy.rs
+++ b/src/core/agent_task_loop_controller/policy.rs
@@ -32,6 +32,13 @@ pub enum AgentTaskLoopPolicyAction {
         #[serde(default, skip_serializing_if = "Value::is_null")]
         request: Value,
     },
+    RunCommand {
+        dedupe_key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        entity_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Value::is_null")]
+        request: Value,
+    },
     FanOut {
         dedupe_key: String,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
## Summary

- Port the generic controller `from-spec --resume` inputs/policy/max-action surface onto current `main`.
- Add deterministic command workflow execution and controller artifact persistence.
- Preserve runtime execution and hydrate consumed artifacts into downstream runtime inputs.

Closes #6450

## Tests

- `cargo fmt --check`
- `cargo test core::agent_task_controller_service::tests`
- `cargo test commands::agent_task::tests::controller_run`
- `cargo test from_spec`
- `cargo test run_from_spec`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Porting and testing the controller from-spec primitives.
