### PR TITLE
chore: clear duplicate-function tech debt

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -662,8 +662,6 @@
         "dead_code::src/core/lab_routing.rs::UnreferencedExport",
         "docs::docs/commands/runtime.md::BrokenDocReference",
         "duplication::src/core/artifact_contract.rs::DuplicateFunction",
-        "duplication::src/core/extension/runner.rs::DuplicateFunction",
-        "duplication::src/core/extension/test/run.rs::DuplicateFunction",
         "duplication::src/core/fuzz/types.rs::DuplicateFunction",
         "field_patterns::src/commands/agent_task/args/controller.rs::RepeatedFieldPattern",
         "field_patterns::src/commands/report/performance_digest.rs::RepeatedFieldPattern",

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -487,7 +487,7 @@ fn parsed_detail(output: &str) -> Option<serde_json::Value> {
     })
 }
 
-fn tail_lines(s: &str, max_lines: usize) -> (String, bool) {
+pub(in crate::core::extension) fn tail_lines(s: &str, max_lines: usize) -> (String, bool) {
     let lines: Vec<&str> = s.lines().collect();
     if lines.len() <= max_lines {
         (s.to_string(), false)

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -4,6 +4,7 @@ use crate::core::engine::local_files;
 use crate::core::engine::output_parse::ParseSpec;
 use crate::core::engine::run_dir::{self, RunDir};
 use crate::core::error::{Error, ErrorCode};
+use crate::core::extension::runner::tail_lines;
 use crate::core::extension::test::analyze::{analyze, TestAnalysis, TestAnalysisInput};
 use crate::core::extension::test::baseline::{self, TestBaselineComparison, TestCounts};
 use crate::core::extension::test::{
@@ -106,16 +107,6 @@ pub struct RawTestOutput {
 const RAW_OUTPUT_TAIL_LINES: usize = 80;
 const PHPUNIT_NO_DISCOVERY_MARKER: &str = "NO PHPUNIT TEST FILES DISCOVERED";
 const REQUIRE_PHPUNIT_TESTS_SETTING: &str = "require_phpunit_tests";
-
-fn tail_lines(s: &str, max_lines: usize) -> (String, bool) {
-    let lines: Vec<&str> = s.lines().collect();
-    if lines.len() <= max_lines {
-        (s.to_string(), false)
-    } else {
-        let start = lines.len() - max_lines;
-        (lines[start..].join("\n"), true)
-    }
-}
 
 fn test_run_status(
     runner_success: bool,


### PR DESCRIPTION
Consolidates duplicate/near-duplicate functions into shared helpers/canonical fns to clear duplication::DuplicateFunction and ::NearDuplicate findings, removing their homeboy.json baseline rows. Behavior-preserving in-place refactors. Verified with cargo build --lib --tests.

## Fixed
- **tail_lines** (DuplicateFunction): identical fn defined in both `src/core/extension/runner.rs` and `src/core/extension/test/run.rs`. Kept the canonical copy in `runner.rs` (now `pub(in crate::core::extension)`), removed the duplicate in `test/run.rs`, and imported the canonical one. Removed baseline rows `duplication::src/core/extension/runner.rs::DuplicateFunction` and `duplication::src/core/extension/test/run.rs::DuplicateFunction`.

## Skipped (intentionally separate / fleet-owned)
- **src/core/artifact_contract.rs** (DuplicateFunction + NearDuplicate): the duplicate/near-duplicate partners live in `src/core/fuzz/normalize.rs` and `src/core/fuzz/observations.rs` (fleet-owned, off-limits). Helpers are module-private serde-default / validation one-liners deliberately scoped to each subsystem; consolidating would require editing fuzz/* or raising fuzz visibility. Baseline rows left in place.