### PR TITLE
Fix runner exec artifact paths after offload (#6459)

### DIFF
--- a/src/commands/runner/exec.rs
+++ b/src/commands/runner/exec.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Read};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use homeboy::core::observation::{ArtifactRecord, ObservationStore};
 use homeboy::core::runners::{self as runner, RunnerExecOutput, RunnerKind};
 use homeboy::core::stream_capture::StreamCaptureMetadata;
+use homeboy::core::{server, Error};
 
 use super::super::CmdResult;
 use super::types::RUNNER_EXEC_SCRIPT_ENV;
@@ -86,8 +87,8 @@ pub(super) fn exec(
         },
     )?;
     if let Some(run_id) = validated_run_id.as_deref() {
-        promote_runner_exec_artifacts(run_id, &output.remote_cwd, &artifact_outputs)?;
-        promote_runner_exec_summaries(run_id, &output.remote_cwd, &summary_outputs)?;
+        promote_runner_exec_artifacts(run_id, &output, &artifact_outputs)?;
+        promote_runner_exec_summaries(run_id, &output, &summary_outputs)?;
     }
     Ok((output, exit_code))
 }
@@ -241,12 +242,12 @@ pub(super) fn prepare_runner_exec_env(
 
 pub(super) fn promote_runner_exec_artifacts(
     run_id: &str,
-    remote_cwd: &str,
+    output: &RunnerExecOutput,
     artifact_outputs: &[String],
 ) -> homeboy::core::Result<Vec<ArtifactRecord>> {
     promote_runner_exec_outputs(
         run_id,
-        remote_cwd,
+        output,
         artifact_outputs,
         RunnerExecEvidenceRole::Artifact,
     )
@@ -254,12 +255,12 @@ pub(super) fn promote_runner_exec_artifacts(
 
 pub(super) fn promote_runner_exec_summaries(
     run_id: &str,
-    remote_cwd: &str,
+    output: &RunnerExecOutput,
     summary_outputs: &[String],
 ) -> homeboy::core::Result<Vec<ArtifactRecord>> {
     promote_runner_exec_outputs(
         run_id,
-        remote_cwd,
+        output,
         summary_outputs,
         RunnerExecEvidenceRole::Summary,
     )
@@ -289,7 +290,7 @@ impl RunnerExecEvidenceRole {
 
 fn promote_runner_exec_outputs(
     run_id: &str,
-    remote_cwd: &str,
+    output: &RunnerExecOutput,
     output_paths: &[String],
     role: RunnerExecEvidenceRole,
 ) -> homeboy::core::Result<Vec<ArtifactRecord>> {
@@ -298,23 +299,156 @@ fn promote_runner_exec_outputs(
     }
 
     let store = ObservationStore::open_initialized()?;
+    let runner = match output.mode {
+        runner::RunnerExecMode::Local => None,
+        runner::RunnerExecMode::Daemon
+        | runner::RunnerExecMode::ReverseBroker
+        | runner::RunnerExecMode::DiagnosticSsh => Some(runner::load(&output.runner_id)?),
+    };
     output_paths
         .iter()
         .map(|declared| {
-            let path = resolve_runner_exec_artifact_path(remote_cwd, declared);
+            let runner_path = resolve_runner_exec_artifact_path(&output.remote_cwd, declared);
             let kind = role.kind(declared);
-            let metadata = serde_json::json!({
+            let mut metadata = serde_json::json!({
                 "declared_path": declared,
                 "evidence_role": role.as_str(),
                 "promoted_by": "runner.exec",
             });
-            if path.is_dir() {
-                store.record_directory_artifact_with_metadata(run_id, &kind, &path, metadata)
+            let record_path = if let Some(runner) = runner.as_ref() {
+                metadata["source"] = serde_json::json!("runner_path_attach");
+                metadata["runner_id"] = serde_json::json!(runner.id.clone());
+                metadata["runner_path"] = serde_json::json!(runner_path.display().to_string());
+                copy_runner_exec_artifact_source(runner, &runner_path)?
             } else {
-                store.record_artifact_with_metadata(run_id, &kind, &path, metadata)
+                runner_path.clone()
+            };
+            if record_path.is_dir() {
+                store.record_directory_artifact_with_metadata(run_id, &kind, &record_path, metadata)
+            } else {
+                store.record_artifact_with_metadata(run_id, &kind, &record_path, metadata)
             }
         })
         .collect()
+}
+
+fn copy_runner_exec_artifact_source(
+    runner: &runner::Runner,
+    path: &Path,
+) -> homeboy::core::Result<PathBuf> {
+    let path_string = path.display().to_string();
+    match runner.kind {
+        RunnerKind::Local => Ok(path.to_path_buf()),
+        RunnerKind::Ssh => {
+            validate_runner_exec_artifact_path(runner, path)?;
+            let server_id = runner.server_id.as_deref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "runner",
+                    "SSH runner is missing server_id",
+                    Some(runner.id.clone()),
+                    None,
+                )
+            })?;
+            let temp_path = runner_exec_attach_download_path(&runner.id, path)?;
+            if let Some(parent) = temp_path.parent() {
+                fs::create_dir_all(parent).map_err(|err| {
+                    Error::internal_io(
+                        err.to_string(),
+                        Some(format!("create {}", parent.display())),
+                    )
+                })?;
+            }
+            let server = server::load(server_id)?;
+            let client = server::SshClient::from_server(&server, server_id)?;
+            let output = client.download_file(&path_string, &temp_path.display().to_string());
+            if !output.success {
+                return Err(Error::validation_invalid_argument(
+                    "path",
+                    format!(
+                        "failed to download runner exec artifact: {}",
+                        output.stderr.trim()
+                    ),
+                    Some(path_string),
+                    None,
+                ));
+            }
+            Ok(temp_path)
+        }
+    }
+}
+
+fn validate_runner_exec_artifact_path(
+    runner: &runner::Runner,
+    path: &Path,
+) -> homeboy::core::Result<()> {
+    if !path.is_absolute() {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "runner exec artifact path must resolve to an absolute runner-side path",
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "runner exec artifact path must not contain parent directory components",
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+
+    let roots = allowed_runner_exec_artifact_roots(runner);
+    if roots.iter().any(|root| path_is_within_root(path, root)) {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "path",
+        "runner exec artifact path must be under an allowed runner workspace/output root",
+        Some(path.display().to_string()),
+        Some(vec![format!(
+            "Allowed roots: {}",
+            roots
+                .iter()
+                .map(|root| root.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )]),
+    ))
+}
+
+fn allowed_runner_exec_artifact_roots(runner: &runner::Runner) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    roots.extend(runner.workspace_root.as_deref().map(PathBuf::from));
+    roots.extend(runner.policy.workspace_roots.iter().map(PathBuf::from));
+    roots.extend(runner.env.get("HOMEBOY_ARTIFACT_ROOT").map(PathBuf::from));
+    roots.retain(|root| root.is_absolute());
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+fn path_is_within_root(path: &Path, root: &Path) -> bool {
+    path == root || path.starts_with(root)
+}
+
+fn runner_exec_attach_download_path(
+    runner_id: &str,
+    path: &Path,
+) -> homeboy::core::Result<PathBuf> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("artifact");
+    Ok(homeboy::core::artifact_root()?
+        .join("runner-exec-attach")
+        .join(runner_id)
+        .join(format!("{}-{file_name}", uuid::Uuid::new_v4())))
 }
 
 fn resolve_runner_exec_artifact_path(remote_cwd: &str, declared: &str) -> PathBuf {

--- a/src/commands/runner/tests/exec.rs
+++ b/src/commands/runner/tests/exec.rs
@@ -1,12 +1,13 @@
 use super::super::dispatch::raw_exec_command_run;
 use super::super::exec::{
-    exec, prepare_runner_exec_command, prepare_runner_exec_env, read_bounded,
-    read_runner_exec_script, RUNNER_EXEC_SCRIPT_LIMIT_BYTES,
+    exec, prepare_runner_exec_command, prepare_runner_exec_env, promote_runner_exec_artifacts,
+    read_bounded, read_runner_exec_script, RUNNER_EXEC_SCRIPT_LIMIT_BYTES,
 };
 use super::super::types::RUNNER_EXEC_SCRIPT_ENV;
 
 use homeboy::core::observation::{NewRunRecord, ObservationStore};
-use homeboy::core::runners::{self as runner, RunnerExecOutput};
+use homeboy::core::runners::{self as runner, RunnerExecMode, RunnerExecOutput};
+use homeboy::core::server;
 
 #[test]
 fn raw_exec_command_run_keeps_structured_output_and_presentation_streams() {
@@ -236,6 +237,61 @@ fn runner_exec_promotes_declared_summaries_as_typed_evidence() {
 }
 
 #[test]
+fn runner_exec_promotes_offloaded_artifacts_from_runner_path() {
+    homeboy::test_support::with_isolated_home(|home| {
+        let artifact_root = home.path().join("artifacts");
+        homeboy::core::set_artifact_root_override(Some(artifact_root));
+        let workspace = tempfile::tempdir().expect("workspace");
+        let report = workspace.path().join("report.txt");
+        std::fs::write(&report, "runner output").expect("write runner output");
+        server::create(
+            r#"{"id":"local-ssh","host":"localhost","user":"user"}"#,
+            false,
+        )
+        .expect("create local ssh server");
+        runner::create(
+            &format!(
+                r#"{{"id":"local-ssh","kind":"ssh","server_id":"local-ssh","workspace_root":"{}"}}"#,
+                workspace.path().display()
+            ),
+            false,
+        )
+        .expect("create ssh runner");
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                NewRunRecord::builder("runner-exec")
+                    .command("homeboy runner exec lab-ssh".to_string())
+                    .cwd_path(workspace.path())
+                    .metadata(serde_json::json!({}))
+                    .build(),
+            )
+            .expect("run");
+        let output = runner_exec_output(
+            "local-ssh",
+            RunnerExecMode::ReverseBroker,
+            &workspace.path().display().to_string(),
+        );
+
+        promote_runner_exec_artifacts(&run.id, &output, &["report.txt".to_string()])
+            .expect("promote offloaded artifact");
+
+        let artifacts = store.list_artifacts(&run.id).expect("artifacts");
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].metadata_json["source"], "runner_path_attach");
+        assert_eq!(artifacts[0].metadata_json["runner_id"], "local-ssh");
+        assert_eq!(
+            artifacts[0].metadata_json["runner_path"],
+            report.display().to_string()
+        );
+        assert_eq!(
+            std::fs::read_to_string(&artifacts[0].path).unwrap(),
+            "runner output"
+        );
+    });
+}
+
+#[test]
 fn runner_exec_rejects_artifacts_without_run_id() {
     let err = exec(
         "lab-local",
@@ -256,6 +312,35 @@ fn runner_exec_rejects_artifacts_without_run_id() {
 
     assert_eq!(err.code.as_str(), "validation.invalid_argument");
     assert_eq!(err.details["field"], "run_id");
+}
+
+fn runner_exec_output(runner_id: &str, mode: RunnerExecMode, remote_cwd: &str) -> RunnerExecOutput {
+    RunnerExecOutput {
+        variant: "exec",
+        command: "runner.exec",
+        runner_id: runner_id.to_string(),
+        dry_run: false,
+        mode,
+        argv: vec!["sh".to_string(), "-c".to_string(), "true".to_string()],
+        remote_cwd: remote_cwd.to_string(),
+        exit_code: 0,
+        stdout: String::new(),
+        stderr: String::new(),
+        source_snapshot: None,
+        job: None,
+        runner_job: None,
+        job_id: None,
+        job_events: None,
+        mirror_run_id: None,
+        patch: None,
+        mutation_artifacts: None,
+        artifacts: Vec::new(),
+        metrics: None,
+        capture: None,
+        runner_result: None,
+        handoff: None,
+        diagnostics: None,
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Resolve `runner exec --artifact` and `--summary` paths against the runner execution context after offloaded runs.
- Copy SSH runner outputs back through the runner/server path before recording run artifacts, while keeping local runner capture local.
- Validate offloaded artifact paths against configured runner workspace/output roots.

## Verification
- `cargo fmt --check`
- `cargo test commands::runner::tests::exec`
- `cargo check`

Closes #6459

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the issue fix, tests, and PR preparation.