### PR TITLE
Stamp canonical Codebox fanout ownership

### DIFF
--- a/docs/architecture/provider-fanout-boundary.md
+++ b/docs/architecture/provider-fanout-boundary.md
@@ -16,6 +16,18 @@ providers own backend-specific execution details. The seam is the
 
 ## Narrow seam
 
+The canonical Codebox product-facing path is:
+
+```text
+Agents API substrate -> Homeboy durable scheduler/fanout plan -> Homeboy Extensions executor adapter -> WP Codebox sandbox worker runtime/artifact contracts
+```
+
+Homeboy persists the plan/run ids, deterministic scheduling order, dependency
+skip state, child run refs, and artifact/evidence refs. Homeboy Extensions maps
+one normalized task request to the selected runtime provider. WP Codebox owns the
+lower-level sandbox-native fanout request/result/event/artifact contracts inside
+the isolated worker runtime.
+
 Homeboy submits provider-neutral `AgentTaskRequest` tasks to an executor provider.
 The provider may translate the task into any backend-specific single-task or
 fanout request, but Homeboy core does not depend on provider runtime field names.

--- a/src/core/agent_task_fanout.rs
+++ b/src/core/agent_task_fanout.rs
@@ -11,6 +11,7 @@ use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep};
 
 pub const AGENT_TASK_FANOUT_PLAN_SCHEMA: &str = "homeboy/agent-task-fanout-plan/v1";
 pub const AGENT_TASK_FANOUT_AGGREGATE_SCHEMA: &str = "homeboy/agent-task-fanout-aggregate/v1";
+pub const AGENT_TASK_FANOUT_CANONICAL_PATH: &str = "homeboy-durable-scheduler-to-runtime-executor";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskFanoutPlan {
@@ -119,6 +120,19 @@ impl AgentTaskFanoutPlan {
             "plane".to_string(),
             serde_json::to_value(self.plane).expect("fanout plane serializes"),
         );
+        plan.inputs.insert(
+            "canonical_path".to_string(),
+            Value::String(AGENT_TASK_FANOUT_CANONICAL_PATH.to_string()),
+        );
+        plan.inputs.insert(
+            "ownership".to_string(),
+            serde_json::json!({
+                "substrate": "agents-api",
+                "durable_scheduler": "homeboy",
+                "runtime_executor_adapter": "homeboy-extensions",
+                "sandbox_worker_runtime": "wp-codebox"
+            }),
+        );
         if let Some(group_key) = &self.group_key {
             plan.inputs
                 .insert("group_key".to_string(), Value::String(group_key.clone()));
@@ -138,6 +152,11 @@ impl AgentTaskFanoutPlan {
                 let mut builder =
                     PlanStep::ready(request.task_id.clone(), "agent_task.fanout.task")
                         .label(request.task_id.clone())
+                        .input_value(
+                            "canonical_path",
+                            Value::String(AGENT_TASK_FANOUT_CANONICAL_PATH.to_string()),
+                        )
+                        .input_value("owner", Value::String("homeboy".to_string()))
                         .input_value(
                             "request",
                             serde_json::to_value(request).expect("agent task request serializes"),
@@ -416,6 +435,18 @@ mod tests {
         assert_eq!(homeboy_plan.kind, PlanKind::AgentTaskFanout);
         assert_eq!(homeboy_plan.steps.len(), 2);
         assert_eq!(homeboy_plan.steps[1].needs, vec!["generate".to_string()]);
+        assert_eq!(
+            homeboy_plan.inputs["canonical_path"],
+            json!(AGENT_TASK_FANOUT_CANONICAL_PATH)
+        );
+        assert_eq!(
+            homeboy_plan.inputs["ownership"]["durable_scheduler"],
+            json!("homeboy")
+        );
+        assert!(homeboy_plan.steps.iter().all(|step| {
+            step.inputs["canonical_path"] == json!(AGENT_TASK_FANOUT_CANONICAL_PATH)
+                && step.inputs["owner"] == json!("homeboy")
+        }));
 
         let schedule = projected.to_schedule_plan();
         assert_eq!(schedule.plan_id, "fanout/site-workflow");


### PR DESCRIPTION
## Summary
- Document the canonical Codebox product-facing path through Homeboy durable scheduler state.
- Stamp durable Homeboy fanout plan projections and steps with canonical ownership metadata.
- Cover the projection in existing agent-task fanout tests.

## Tests
- cargo fmt
- cargo test agent_task_fanout

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fanout ownership metadata/docs and targeted test updates.