### PR TITLE
Declare provider result contracts

### DIFF
--- a/src/core/agent_task_provider/outcome_normalization.rs
+++ b/src/core/agent_task_provider/outcome_normalization.rs
@@ -6,62 +6,70 @@ pub(super) fn normalize_provider_outcome_roles(
 ) {
     normalize_provider_artifact_roles(&mut outcome.artifacts, &provider.role_aliases);
     normalize_provider_run_result_output(outcome, &provider.role_aliases);
-    let codebox_public_envelope_valid = normalize_codebox_public_result_envelope(outcome, provider);
+    let result_contract_valid = normalize_provider_result_contract(outcome, provider);
     normalize_provider_runtime_contract(outcome, provider);
-    if codebox_public_envelope_valid {
+    if result_contract_valid {
         surface_provider_run_result_diagnostics(outcome);
     }
 }
 
-const CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA: &str =
-    "wp-codebox/artifact-result-envelope/v1";
-
-fn normalize_codebox_public_result_envelope(
+fn normalize_provider_result_contract(
     outcome: &mut AgentTaskOutcome,
     provider: &AgentTaskExecutorProvider,
 ) -> bool {
-    if provider.backend != "codebox" {
+    let Some(contract) = provider.result_contract.typed_artifact_envelope.as_ref() else {
         return true;
-    }
+    };
 
-    let envelope = output_value(&outcome.outputs, "provider_run_result").cloned();
+    let envelope = output_value(&outcome.outputs, &contract.output).cloned();
     let Some(envelope) = envelope else {
-        fail_codebox_public_envelope_boundary(
+        fail_typed_artifact_envelope_boundary(
             outcome,
-            "codebox.public_result_envelope_missing",
-            "WP Codebox provider result did not include the public artifact result envelope.",
+            contract,
+            "public_result_envelope_missing",
+            format!(
+                "{} provider result did not include the declared artifact result envelope.",
+                typed_artifact_envelope_provider_label(provider, contract)
+            ),
             json!({
-                "expected_schema": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+                "expected_schema": contract.schema,
+                "output": contract.output,
                 "provider_backend": provider.backend,
             }),
         );
         return false;
     };
 
-    if envelope.get("schema").and_then(Value::as_str)
-        != Some(CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA)
-    {
-        fail_codebox_public_envelope_boundary(
+    if envelope.get("schema").and_then(Value::as_str) != Some(contract.schema.as_str()) {
+        fail_typed_artifact_envelope_boundary(
             outcome,
-            "codebox.public_result_envelope_missing",
-            "WP Codebox provider result used a non-public result shape; Homeboy only consumes the public artifact result envelope.",
+            contract,
+            "public_result_envelope_missing",
+            format!(
+                "{} provider result used a non-public result shape; Homeboy only consumes the declared artifact result envelope.",
+                typed_artifact_envelope_provider_label(provider, contract)
+            ),
             json!({
-                "expected_schema": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+                "expected_schema": contract.schema,
                 "actual_schema": envelope.get("schema").and_then(Value::as_str),
-                "private_shape_detected": codebox_private_result_shape_detected(&envelope),
+                "private_shape_detected": private_result_shape_detected(&envelope, contract),
             }),
         );
         return false;
     }
 
-    let typed_artifacts = codebox_public_typed_artifacts(&envelope);
-    if typed_artifacts.is_empty() {
-        fail_codebox_public_envelope_boundary(
+    let typed_artifacts = public_typed_artifacts(&envelope, &contract.schema);
+    if typed_artifacts.is_empty() && contract.require_typed_artifacts.unwrap_or(false) {
+        fail_typed_artifact_envelope_boundary(
             outcome,
-            "codebox.public_result_typed_artifacts_missing",
-            "WP Codebox public artifact result envelope did not include any typed artifacts.",
+            contract,
+            "public_result_typed_artifacts_missing",
+            format!(
+                "{} artifact result envelope did not include any typed artifacts.",
+                typed_artifact_envelope_provider_label(provider, contract)
+            ),
             json!({
-                "expected_schema": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+                "expected_schema": contract.schema,
                 "envelope_status": envelope.get("status").and_then(Value::as_str),
             }),
         );
@@ -82,31 +90,52 @@ fn normalize_codebox_public_result_envelope(
     true
 }
 
-fn fail_codebox_public_envelope_boundary(
+fn fail_typed_artifact_envelope_boundary(
     outcome: &mut AgentTaskOutcome,
-    class: &str,
-    message: &str,
+    contract: &AgentTaskProviderTypedArtifactEnvelopeContract,
+    class_suffix: &str,
+    message: String,
     data: Value,
 ) {
     outcome.status = AgentTaskOutcomeStatus::Failed;
     outcome.failure_classification = Some(AgentTaskFailureClassification::Provider);
     push_unique_diagnostic(
         &mut outcome.diagnostics,
-        class.to_string(),
-        message.to_string(),
+        format!(
+            "{}.{}",
+            contract
+                .diagnostic_class_prefix
+                .as_deref()
+                .unwrap_or("provider.result_contract"),
+            class_suffix
+        ),
+        message,
         data,
     );
 }
 
-fn codebox_private_result_shape_detected(value: &Value) -> bool {
-    value.get("agent_result").is_some()
-        || value
-            .get("metadata")
-            .and_then(|metadata| metadata.get("agent_runtime"))
-            .is_some()
+fn typed_artifact_envelope_provider_label(
+    provider: &AgentTaskExecutorProvider,
+    contract: &AgentTaskProviderTypedArtifactEnvelopeContract,
+) -> String {
+    contract
+        .provider_label
+        .clone()
+        .or_else(|| provider.label.clone())
+        .unwrap_or_else(|| provider.id.clone())
 }
 
-fn codebox_public_typed_artifacts(envelope: &Value) -> Vec<AgentTaskTypedArtifact> {
+fn private_result_shape_detected(
+    value: &Value,
+    contract: &AgentTaskProviderTypedArtifactEnvelopeContract,
+) -> bool {
+    contract
+        .private_shape_markers
+        .iter()
+        .any(|path| value_at_path(value, path).is_some())
+}
+
+fn public_typed_artifacts(envelope: &Value, envelope_schema: &str) -> Vec<AgentTaskTypedArtifact> {
     let Some(value) = envelope
         .get("typed_artifacts")
         .or_else(|| envelope.get("typedArtifacts"))
@@ -117,12 +146,12 @@ fn codebox_public_typed_artifacts(envelope: &Value) -> Vec<AgentTaskTypedArtifac
     match value {
         Value::Array(items) => items
             .iter()
-            .filter_map(codebox_public_typed_artifact_from_value)
+            .filter_map(|value| public_typed_artifact_from_value(value, envelope_schema))
             .collect(),
         Value::Object(map) => map
             .iter()
             .filter_map(|(name, payload)| {
-                codebox_public_typed_artifact_from_value(payload).or_else(|| {
+                public_typed_artifact_from_value(payload, envelope_schema).or_else(|| {
                     Some(AgentTaskTypedArtifact {
                         name: name.clone(),
                         artifact_type: payload
@@ -137,7 +166,7 @@ fn codebox_public_typed_artifacts(envelope: &Value) -> Vec<AgentTaskTypedArtifac
                             .map(str::to_string),
                         payload: payload.clone(),
                         artifact: None,
-                        metadata: json!({ "source": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA }),
+                        metadata: json!({ "source": envelope_schema }),
                     })
                 })
             })
@@ -146,7 +175,10 @@ fn codebox_public_typed_artifacts(envelope: &Value) -> Vec<AgentTaskTypedArtifac
     }
 }
 
-fn codebox_public_typed_artifact_from_value(value: &Value) -> Option<AgentTaskTypedArtifact> {
+fn public_typed_artifact_from_value(
+    value: &Value,
+    envelope_schema: &str,
+) -> Option<AgentTaskTypedArtifact> {
     let name = value
         .get("name")
         .and_then(Value::as_str)
@@ -173,8 +205,15 @@ fn codebox_public_typed_artifact_from_value(value: &Value) -> Option<AgentTaskTy
         metadata: value
             .get("metadata")
             .cloned()
-            .unwrap_or_else(|| json!({ "source": CODEBOX_PUBLIC_ARTIFACT_RESULT_ENVELOPE_SCHEMA })),
+            .unwrap_or_else(|| json!({ "source": envelope_schema })),
     })
+}
+
+fn value_at_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    path.split('.')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .try_fold(value, |current, part| current.get(part))
 }
 
 /// Whether an outcome status represents a failure for which we want to mine the

--- a/src/core/agent_task_provider/tests/common.rs
+++ b/src/core/agent_task_provider/tests/common.rs
@@ -36,6 +36,7 @@ pub(super) fn request(
         lab_runtime_components: Vec::new(),
         timeout_artifact_discovery: AgentTaskProviderTimeoutArtifactDiscovery::default(),
         role_aliases: AgentTaskProviderRoleAliases::default(),
+        result_contract: AgentTaskProviderResultContract::default(),
         runtime_contract: AgentTaskRuntimeContract::default(),
         extension_id: None,
         extension_path: None,

--- a/src/core/agent_task_provider/tests/manifest_tests.rs
+++ b/src/core/agent_task_provider/tests/manifest_tests.rs
@@ -131,6 +131,16 @@ fn provider_manifest_preserves_unknown_metadata_on_export() {
             "outputs": { "patch": ["diff"] },
             "provider_alias_policy": "strict"
         },
+        "result_contract": {
+            "typed_artifact_envelope": {
+                "schema": "provider/artifact-result-envelope/v1",
+                "output": "provider_run_result",
+                "provider_label": "Provider Runtime",
+                "diagnostic_class_prefix": "provider_runtime",
+                "private_shape_markers": ["private_result"],
+                "require_typed_artifacts": true
+            }
+        },
         "runtime_contract": {
             "capabilities": ["sandbox", "artifacts"],
             "lifecycle_states": {
@@ -197,6 +207,25 @@ fn provider_manifest_preserves_unknown_metadata_on_export() {
         provider.role_aliases.extra["provider_alias_policy"],
         "strict"
     );
+    let result_contract = provider
+        .result_contract
+        .typed_artifact_envelope
+        .as_ref()
+        .expect("typed artifact envelope contract");
+    assert_eq!(
+        result_contract.schema,
+        "provider/artifact-result-envelope/v1"
+    );
+    assert_eq!(result_contract.output, "provider_run_result");
+    assert_eq!(
+        result_contract.diagnostic_class_prefix.as_deref(),
+        Some("provider_runtime")
+    );
+    assert_eq!(
+        result_contract.private_shape_markers,
+        vec!["private_result"]
+    );
+    assert_eq!(result_contract.require_typed_artifacts, Some(true));
     assert_eq!(
         provider.runtime_contract.capabilities,
         vec!["sandbox".to_string(), "artifacts".to_string()]
@@ -245,6 +274,14 @@ fn provider_manifest_preserves_unknown_metadata_on_export() {
         "diagnostic"
     );
     assert_eq!(exported["role_aliases"]["provider_alias_policy"], "strict");
+    assert_eq!(
+        exported["result_contract"]["typed_artifact_envelope"]["schema"],
+        "provider/artifact-result-envelope/v1"
+    );
+    assert_eq!(
+        exported["result_contract"]["typed_artifact_envelope"]["private_shape_markers"][0],
+        "private_result"
+    );
     assert_eq!(exported["runtime_contract"]["capabilities"][0], "sandbox");
     assert_eq!(
         exported["runtime_contract"]["normalization"]["output_artifacts"][0]["name"],

--- a/src/core/agent_task_provider/tests/outcome_tests.rs
+++ b/src/core/agent_task_provider/tests/outcome_tests.rs
@@ -238,9 +238,10 @@ fn provider_outcome_roles_normalize_from_declared_aliases() {
 }
 
 #[test]
-fn codebox_provider_rejects_private_runtime_result_shape() {
+fn declared_codebox_result_contract_rejects_private_runtime_result_shape() {
     let (_, mut provider) = request("task-codebox-private", "node provider.js".to_string());
-    provider.backend = "codebox".to_string();
+    provider.backend = "runtime-provider".to_string();
+    provider.result_contract = codebox_result_contract();
     let mut outcome = failed_outcome_with_run_result(json!({
         "agent_result": { "status": "succeeded" },
         "metadata": { "agent_runtime": { "id": "runtime-private" } }
@@ -265,9 +266,10 @@ fn codebox_provider_rejects_private_runtime_result_shape() {
 }
 
 #[test]
-fn codebox_provider_consumes_public_typed_artifacts() {
+fn declared_codebox_result_contract_consumes_public_typed_artifacts() {
     let (_, mut provider) = request("task-codebox-public", "node provider.js".to_string());
-    provider.backend = "codebox".to_string();
+    provider.backend = "runtime-provider".to_string();
+    provider.result_contract = codebox_result_contract();
     let mut outcome = failed_outcome_with_run_result(json!({
         "schema": "wp-codebox/artifact-result-envelope/v1",
         "status": "succeeded",
@@ -298,9 +300,10 @@ fn codebox_provider_consumes_public_typed_artifacts() {
 }
 
 #[test]
-fn codebox_public_envelope_reports_missing_typed_artifacts() {
+fn declared_codebox_result_contract_reports_missing_typed_artifacts() {
     let (_, mut provider) = request("task-codebox-empty", "node provider.js".to_string());
-    provider.backend = "codebox".to_string();
+    provider.backend = "runtime-provider".to_string();
+    provider.result_contract = codebox_result_contract();
     let mut outcome = failed_outcome_with_run_result(json!({
         "schema": "wp-codebox/artifact-result-envelope/v1",
         "status": "succeeded",
@@ -316,6 +319,38 @@ fn codebox_public_envelope_reports_missing_typed_artifacts() {
         diagnostic.class == "codebox.public_result_typed_artifacts_missing"
             && diagnostic.message.contains("typed artifacts")
     }));
+}
+
+#[test]
+fn unknown_provider_without_result_contract_keeps_generic_outcome() {
+    let (_, provider) = request("task-generic-provider", "node provider.js".to_string());
+    let mut outcome = failed_outcome_with_run_result(json!({
+        "agent_result": { "status": "succeeded" },
+        "metadata": { "agent_runtime": { "id": "runtime-private" } }
+    }));
+    outcome.status = AgentTaskOutcomeStatus::Succeeded;
+    outcome.failure_classification = None;
+
+    normalize_provider_outcome_roles(&mut outcome, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    assert_eq!(outcome.failure_classification, None);
+    assert!(outcome.diagnostics.is_empty());
+    assert!(outcome.typed_artifacts.is_empty());
+}
+
+fn codebox_result_contract() -> AgentTaskProviderResultContract {
+    serde_json::from_value(json!({
+        "typed_artifact_envelope": {
+            "schema": "wp-codebox/artifact-result-envelope/v1",
+            "output": "provider_run_result",
+            "provider_label": "WP Codebox",
+            "diagnostic_class_prefix": "codebox",
+            "private_shape_markers": ["agent_result", "metadata.agent_runtime"],
+            "require_typed_artifacts": true
+        }
+    }))
+    .expect("codebox result contract")
 }
 
 fn failed_outcome_with_run_result(run_result: Value) -> AgentTaskOutcome {

--- a/src/core/agent_task_provider/types.rs
+++ b/src/core/agent_task_provider/types.rs
@@ -75,6 +75,11 @@ pub struct AgentTaskExecutorProvider {
         skip_serializing_if = "AgentTaskProviderRoleAliases::is_empty"
     )]
     pub role_aliases: AgentTaskProviderRoleAliases,
+    #[serde(
+        default,
+        skip_serializing_if = "AgentTaskProviderResultContract::is_empty"
+    )]
+    pub result_contract: AgentTaskProviderResultContract,
     #[serde(default, skip_serializing_if = "AgentTaskRuntimeContract::is_empty")]
     pub runtime_contract: AgentTaskRuntimeContract,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -87,6 +92,50 @@ pub struct AgentTaskExecutorProvider {
     pub runtime_path: Option<String>,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentTaskProviderResultContract {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub typed_artifact_envelope: Option<AgentTaskProviderTypedArtifactEnvelopeContract>,
+}
+
+impl AgentTaskProviderResultContract {
+    pub(super) fn is_empty(&self) -> bool {
+        self.typed_artifact_envelope.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskProviderTypedArtifactEnvelopeContract {
+    pub schema: String,
+    #[serde(default = "default_provider_run_result_output")]
+    pub output: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic_class_prefix: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub private_shape_markers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_typed_artifacts: Option<bool>,
+}
+
+impl Default for AgentTaskProviderTypedArtifactEnvelopeContract {
+    fn default() -> Self {
+        Self {
+            schema: String::new(),
+            output: default_provider_run_result_output(),
+            provider_label: None,
+            diagnostic_class_prefix: None,
+            private_shape_markers: Vec::new(),
+            require_typed_artifacts: None,
+        }
+    }
+}
+
+fn default_provider_run_result_output() -> String {
+    "provider_run_result".to_string()
 }
 
 fn default_provider_schema() -> String {

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -1861,6 +1861,7 @@ HOMEBOY_SHARED_MISSING_SECRET_TEST, HOMEBOY_OTHER_MISSING_SECRET_TEST"
             lab_runtime_components: Vec::new(),
             timeout_artifact_discovery: Default::default(),
             role_aliases: Default::default(),
+            result_contract: Default::default(),
             runtime_contract: Default::default(),
             extension_id: None,
             extension_path: None,


### PR DESCRIPTION
## Summary
- add a provider-declared result contract for typed-artifact result envelopes
- route artifact-envelope normalization through the declared contract instead of a Codebox backend branch
- preserve current Codebox behavior in tests via manifest-style contract data and keep unknown providers generic

## Tests
- `cargo fmt`
- `cargo test declared_codebox_result_contract`
- `cargo test unknown_provider_without_result_contract`
- `cargo test provider_manifest_preserves_unknown_metadata_on_export`
- `cargo test --test architecture_core_agnostic_test`

Note: `cargo test core::agent_task_provider::tests` was also run; it compiled and passed 79/80 provider tests, with the existing environment-sensitive `default_backend_ignores_provider_manifest_default_backend` failing because this checkout homeboy.json declares default backend `codebox`.

## Follow-ups
- Move runner status WP Codebox binary/cache diagnostics behind provider-declared diagnostic/runtime contracts.
- Add the matching Codebox `result_contract` declaration in homeboy-extensions provider manifests before depending on the new core contract in production.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, focused tests, formatting/test runs, and PR drafting.