### PR TITLE
fix(fuzz): enforce execution budgets

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use homeboy::core::engine::execution_context;
 use homeboy::core::engine::invocation::InvocationRequirements;
@@ -111,6 +112,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     let outcome = fuzz_run_outcome(
         runner_output.exit_code,
         runner_output.success,
+        runner_output.timed_out,
         results.as_ref(),
         combined_results_error,
     );
@@ -532,9 +534,30 @@ pub(super) struct FuzzRunOutcome {
 pub(super) fn fuzz_run_outcome(
     runner_exit_code: i32,
     runner_success: bool,
+    runner_timed_out: bool,
     results: Option<&FuzzCampaign>,
     results_error: Option<&str>,
 ) -> FuzzRunOutcome {
+    if runner_timed_out {
+        return FuzzRunOutcome {
+            status: "timeout",
+            success: false,
+            exit_code: 124,
+        };
+    }
+
+    if let Some(non_proof_status) = results.and_then(fuzz_campaign_non_proof_status) {
+        return FuzzRunOutcome {
+            status: non_proof_status,
+            success: false,
+            exit_code: if runner_exit_code == 0 {
+                1
+            } else {
+                runner_exit_code
+            },
+        };
+    }
+
     let campaign_failed = results.is_some_and(fuzz_campaign_reports_failure);
     let success = runner_success && !campaign_failed && results_error.is_none();
     FuzzRunOutcome {
@@ -547,6 +570,46 @@ pub(super) fn fuzz_run_outcome(
         } else {
             runner_exit_code
         },
+    }
+}
+
+fn fuzz_campaign_non_proof_status(campaign: &FuzzCampaign) -> Option<&'static str> {
+    if let Some(status) = fuzz_metadata_non_proof_status(&campaign.metadata) {
+        return Some(status);
+    }
+
+    if campaign.lifecycle.as_ref().is_some_and(|lifecycle| {
+        lifecycle
+            .phases
+            .iter()
+            .any(|phase| phase.status == LifecyclePhaseStatus::Skipped)
+    }) {
+        return Some("skipped");
+    }
+
+    None
+}
+
+fn fuzz_metadata_non_proof_status(value: &serde_json::Value) -> Option<&'static str> {
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(status) = object.get("status").and_then(|status| status.as_str()) {
+                let normalized = status.trim().to_ascii_lowercase();
+                if matches!(
+                    normalized.as_str(),
+                    "skipped" | "skip" | "unsupported" | "not_executed" | "not-executed"
+                ) {
+                    return Some(match normalized.as_str() {
+                        "unsupported" => "unsupported",
+                        "not_executed" | "not-executed" => "not_executed",
+                        _ => "skipped",
+                    });
+                }
+            }
+            object.values().find_map(fuzz_metadata_non_proof_status)
+        }
+        serde_json::Value::Array(values) => values.iter().find_map(fuzz_metadata_non_proof_status),
+        _ => None,
     }
 }
 
@@ -994,6 +1057,7 @@ fn run_fuzz_extension_script(
         .path_override(args.comp.path.clone())
         .with_run_dir(run_dir)
         .invocation_requirements(invocation_requirements)
+        .timeout(fuzz_max_duration(args.max_duration.as_deref())?)
         .script_args(&args.args);
 
     let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
@@ -1003,6 +1067,53 @@ fn run_fuzz_extension_script(
     }
 
     runner.run()
+}
+
+pub(super) fn fuzz_max_duration(raw: Option<&str>) -> homeboy::core::Result<Option<Duration>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+
+    let (amount, multiplier) = if let Some(amount) = raw.strip_suffix("ms") {
+        (amount, 0)
+    } else if let Some(amount) = raw.strip_suffix('s') {
+        (amount, 1)
+    } else if let Some(amount) = raw.strip_suffix('m') {
+        (amount, 60)
+    } else if let Some(amount) = raw.strip_suffix('h') {
+        (amount, 60 * 60)
+    } else {
+        (raw, 1)
+    };
+
+    let amount = amount.parse::<u64>().map_err(|_| {
+        homeboy::core::Error::validation_invalid_argument(
+            "max_duration",
+            format!(
+                "Invalid fuzz max duration '{raw}'. Use a positive duration such as 60s or 5m."
+            ),
+            Some(raw.to_string()),
+            None,
+        )
+    })?;
+    if amount == 0 {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "max_duration",
+            "Fuzz max duration must be greater than zero.",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+
+    Ok(Some(if multiplier == 0 {
+        Duration::from_millis(amount)
+    } else {
+        Duration::from_secs(amount.saturating_mul(multiplier))
+    }))
 }
 
 pub(super) fn fuzz_runner_env(

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -137,7 +137,7 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_failed_campaign() {
         "case_counts": { "passed": 2, "failed": 1, "errored": 0 }
     });
 
-    let outcome = fuzz_run_outcome(0, true, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
 
     assert_eq!(outcome.status, "failed");
     assert!(!outcome.success);
@@ -166,7 +166,7 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_open_finding() {
         extra: std::collections::BTreeMap::new(),
     }];
 
-    let outcome = fuzz_run_outcome(0, true, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
 
     assert_eq!(outcome.status, "failed");
     assert!(!outcome.success);
@@ -192,7 +192,7 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_failed_lifecycle_phase
         metadata: std::collections::BTreeMap::new(),
     });
 
-    let outcome = fuzz_run_outcome(0, true, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
 
     assert_eq!(outcome.status, "failed");
     assert!(!outcome.success);
@@ -225,11 +225,89 @@ fn fuzz_run_outcome_fails_when_workload_reports_invariant_failure_count() {
         }
     });
 
-    let outcome = fuzz_run_outcome(0, true, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
 
     assert_eq!(outcome.status, "failed");
     assert!(!outcome.success);
     assert_eq!(outcome.exit_code, 1);
+}
+
+#[test]
+fn fuzz_run_outcome_reports_timeout_as_non_pass() {
+    let outcome = fuzz_run_outcome(0, true, true, None, None);
+
+    assert_eq!(outcome.status, "timeout");
+    assert!(!outcome.success);
+    assert_eq!(outcome.exit_code, 124);
+}
+
+#[test]
+fn fuzz_run_outcome_reports_skipped_lifecycle_as_non_proof() {
+    let mut campaign = empty_fuzz_campaign();
+    campaign.lifecycle = Some(LifecycleResultMetadata {
+        schema: LIFECYCLE_RESULT_SCHEMA.to_string(),
+        version: LIFECYCLE_CONTRACT_VERSION,
+        phases: vec![LifecyclePhaseResult {
+            id: "execute".to_string(),
+            phase: LifecyclePhaseKind::Snapshot,
+            status: LifecyclePhaseStatus::Skipped,
+            snapshot_ref: None,
+            started_at: None,
+            finished_at: None,
+            message: Some("runner skipped unsupported workload".to_string()),
+        }],
+        snapshot_refs: Vec::new(),
+        metadata: std::collections::BTreeMap::new(),
+    });
+
+    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
+
+    assert_eq!(outcome.status, "skipped");
+    assert!(!outcome.success);
+    assert_eq!(outcome.exit_code, 1);
+}
+
+#[test]
+fn fuzz_run_outcome_reports_unsupported_metadata_as_non_proof() {
+    let mut campaign = empty_fuzz_campaign();
+    campaign.metadata = serde_json::json!({
+        "wordpress_fuzz_result": {
+            "status": "unsupported",
+            "success": true
+        }
+    });
+
+    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
+
+    assert_eq!(outcome.status, "unsupported");
+    assert!(!outcome.success);
+    assert_eq!(outcome.exit_code, 1);
+}
+
+#[test]
+fn fuzz_max_duration_accepts_supported_units() {
+    assert_eq!(
+        fuzz_max_duration(Some("250ms")).expect("duration"),
+        Some(std::time::Duration::from_millis(250))
+    );
+    assert_eq!(
+        fuzz_max_duration(Some("60s")).expect("duration"),
+        Some(std::time::Duration::from_secs(60))
+    );
+    assert_eq!(
+        fuzz_max_duration(Some("5m")).expect("duration"),
+        Some(std::time::Duration::from_secs(300))
+    );
+    assert_eq!(
+        fuzz_max_duration(Some("1h")).expect("duration"),
+        Some(std::time::Duration::from_secs(3600))
+    );
+}
+
+#[test]
+fn fuzz_max_duration_rejects_zero_and_unknown_units() {
+    assert!(fuzz_max_duration(Some("0s")).is_err());
+    assert!(fuzz_max_duration(Some("10x")).is_err());
 }
 
 #[test]

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -3,9 +3,9 @@
 use super::super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
 use super::execution::{
     default_runner_contract, fuzz_artifact_ref_validation, fuzz_campaign_contract,
-    fuzz_evidence_followups, fuzz_postprocess_error, fuzz_run_artifact_validation_error,
-    fuzz_run_outcome, fuzz_runner_env, persist_fuzz_run_evidence, run_fuzz_artifact_postprocess,
-    FuzzRunEvidenceInput,
+    fuzz_evidence_followups, fuzz_max_duration, fuzz_postprocess_error,
+    fuzz_run_artifact_validation_error, fuzz_run_outcome, fuzz_runner_env,
+    persist_fuzz_run_evidence, run_fuzz_artifact_postprocess, FuzzRunEvidenceInput,
 };
 use super::planning::plan_inventory_selection;
 use super::replay::run_replay;

--- a/src/core/engine/executor.rs
+++ b/src/core/engine/executor.rs
@@ -164,6 +164,7 @@ fn try_execute_direct(
         stderr: String::from_utf8_lossy(&out.stderr).to_string(),
         success: out.status.success(),
         exit_code: out.status.code().unwrap_or(-1),
+        timed_out: false,
         child_resource: None,
     })
 }

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -16,6 +16,7 @@ pub struct ComponentScriptOutput {
     pub success: bool,
     pub stdout: String,
     pub stderr: String,
+    pub timed_out: bool,
     pub child_resource: Option<ExtensionChildResourceSummary>,
     pub extension_phase_timings: Vec<ExtensionPhaseTiming>,
 }
@@ -27,6 +28,7 @@ impl From<RunnerOutput> for ComponentScriptOutput {
             success: output.success,
             stdout: output.stdout,
             stderr: output.stderr,
+            timed_out: output.timed_out,
             child_resource: output.child_resource,
             extension_phase_timings: output.extension_phase_timings,
         }
@@ -40,6 +42,7 @@ impl From<ComponentScriptOutput> for RunnerOutput {
             success: output.success,
             stdout: output.stdout,
             stderr: output.stderr,
+            timed_out: output.timed_out,
             child_resource: output.child_resource,
             extension_phase_timings: output.extension_phase_timings,
         }
@@ -79,6 +82,7 @@ pub(crate) fn run_component_scripts_with_env(
 
     let mut stdout = String::new();
     let mut stderr = String::new();
+    let mut timed_out = false;
     let mut child_resource = None;
     let env = component_script_env(component, source_path, extra_env)?;
 
@@ -104,11 +108,13 @@ pub(crate) fn run_component_scripts_with_env(
             super::execution::CapabilityScriptOptions {
                 passthrough,
                 stderr_passthrough: false,
+                timeout: None,
             },
         )?;
 
         stdout.push_str(&output.stdout);
         stderr.push_str(&output.stderr);
+        timed_out |= output.timed_out;
         child_resource = output.child_resource.clone();
 
         if !output.success {
@@ -117,6 +123,7 @@ pub(crate) fn run_component_scripts_with_env(
                 success: false,
                 stdout,
                 stderr,
+                timed_out,
                 child_resource,
                 extension_phase_timings: Vec::new(),
             });
@@ -128,6 +135,7 @@ pub(crate) fn run_component_scripts_with_env(
         success: true,
         stdout,
         stderr,
+        timed_out,
         child_resource,
         extension_phase_timings: Vec::new(),
     })

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -6,11 +6,14 @@ use crate::core::error::{Error, Result};
 use crate::core::project::{self, Project};
 use crate::core::rig::toolchain;
 use crate::core::server::{
-    execute_local_command_in_dir, execute_local_command_interactive,
-    execute_local_command_passthrough, execute_local_command_stderr_passthrough, CommandOutput,
+    execute_local_command_in_dir, execute_local_command_in_dir_with_timeout,
+    execute_local_command_interactive, execute_local_command_passthrough,
+    execute_local_command_passthrough_with_timeout, execute_local_command_stderr_passthrough,
+    execute_local_command_stderr_passthrough_with_timeout, CommandOutput,
 };
 use std::collections::HashMap;
 use std::path::Path;
+use std::time::Duration;
 
 mod action;
 mod readiness;
@@ -401,25 +404,39 @@ pub(crate) fn execute_capability_script(
     let current_dir = working_dir;
 
     if options.passthrough {
-        Ok(execute_local_command_passthrough(
-            &command,
-            current_dir,
-            env_opt,
-        ))
+        Ok(match options.timeout {
+            Some(timeout) => execute_local_command_passthrough_with_timeout(
+                &command,
+                current_dir,
+                env_opt,
+                timeout,
+            ),
+            None => execute_local_command_passthrough(&command, current_dir, env_opt),
+        })
     } else if options.stderr_passthrough {
-        Ok(execute_local_command_stderr_passthrough(
-            &command,
-            current_dir,
-            env_opt,
-        ))
+        Ok(match options.timeout {
+            Some(timeout) => execute_local_command_stderr_passthrough_with_timeout(
+                &command,
+                current_dir,
+                env_opt,
+                timeout,
+            ),
+            None => execute_local_command_stderr_passthrough(&command, current_dir, env_opt),
+        })
     } else {
-        Ok(execute_local_command_in_dir(&command, current_dir, env_opt))
+        Ok(match options.timeout {
+            Some(timeout) => {
+                execute_local_command_in_dir_with_timeout(&command, current_dir, env_opt, timeout)
+            }
+            None => execute_local_command_in_dir(&command, current_dir, env_opt),
+        })
     }
 }
 
 pub(crate) struct CapabilityScriptOptions {
     pub passthrough: bool,
     pub stderr_passthrough: bool,
+    pub timeout: Option<Duration>,
 }
 
 pub(crate) struct PreparedCapabilityRun {
@@ -1164,6 +1181,7 @@ mod tests {
             CapabilityScriptOptions {
                 passthrough: false,
                 stderr_passthrough: true,
+                timeout: None,
             },
         )
         .expect("script should run");
@@ -1171,5 +1189,30 @@ mod tests {
         assert!(output.success);
         assert_eq!(output.stdout, "{\"ok\":true}\n");
         assert_eq!(output.stderr, "progress turn=1\n");
+    }
+
+    #[test]
+    fn execute_capability_script_timeout_returns_partial_output() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = execute_capability_script(
+            dir.path(),
+            "unused.sh",
+            &[],
+            &[],
+            None,
+            Some("printf 'started\\n'; sleep 2"),
+            CapabilityScriptOptions {
+                passthrough: false,
+                stderr_passthrough: false,
+                timeout: Some(Duration::from_millis(50)),
+            },
+        )
+        .expect("script should run until timeout");
+
+        assert!(!output.success);
+        assert!(output.timed_out);
+        assert_eq!(output.exit_code, 124);
+        assert_eq!(output.stdout, "started\n");
+        assert!(output.stderr.contains("Homeboy command timed out"));
     }
 }

--- a/src/core/extension/lint/run/workflow.rs
+++ b/src/core/extension/lint/run/workflow.rs
@@ -301,6 +301,7 @@ fn run_scoped_lint_runs(
         success,
         stdout,
         stderr,
+        timed_out: false,
         child_resource: None,
         extension_phase_timings,
     })

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::core::component::Component;
 use crate::core::engine::invocation::{InvocationGuard, InvocationRequirements};
@@ -20,6 +21,7 @@ pub struct RunnerOutput {
     pub success: bool,
     pub stdout: String,
     pub stderr: String,
+    pub timed_out: bool,
     pub child_resource: Option<ExtensionChildResourceSummary>,
     pub extension_phase_timings: Vec<ExtensionPhaseTiming>,
 }
@@ -52,6 +54,8 @@ pub struct ExtensionRunner {
     passthrough: bool,
     /// Tee only runner stderr to the terminal while capturing stdout/stderr.
     stderr_passthrough: bool,
+    /// Optional wall-clock budget enforced by the parent process.
+    timeout: Option<Duration>,
     /// Run directory path for recording machine-local child process evidence.
     run_dir_path: Option<PathBuf>,
     invocation_requirements: InvocationRequirements,
@@ -81,6 +85,7 @@ impl ExtensionRunner {
             command_override: None,
             passthrough: true,
             stderr_passthrough: false,
+            timeout: None,
             run_dir_path: None,
             invocation_requirements: InvocationRequirements::default(),
         }
@@ -190,6 +195,11 @@ impl ExtensionRunner {
         self
     }
 
+    pub(crate) fn timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
     /// Execute the extension runner script.
     ///
     /// Performs the full orchestration:
@@ -267,6 +277,7 @@ impl ExtensionRunner {
             success: output.success,
             stdout: output.stdout,
             stderr: output.stderr,
+            timed_out: output.timed_out,
             child_resource: output.child_resource,
             extension_phase_timings: self
                 .run_dir_path
@@ -324,6 +335,7 @@ impl ExtensionRunner {
             super::execution::CapabilityScriptOptions {
                 passthrough: self.passthrough,
                 stderr_passthrough: self.stderr_passthrough,
+                timeout: self.timeout,
             },
         )
     }
@@ -652,6 +664,7 @@ mod tests {
             stderr: "fatal setup error".to_string(),
             success: false,
             exit_code: 2,
+            timed_out: false,
             child_resource: None,
         };
 
@@ -685,6 +698,7 @@ mod tests {
             stderr: "formatter missing".to_string(),
             success: false,
             exit_code: 127,
+            timed_out: false,
             child_resource: None,
         };
 

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -622,6 +622,7 @@ fn run_declared_result_parser(
         crate::core::extension::execution::CapabilityScriptOptions {
             passthrough: false,
             stderr_passthrough: false,
+            timeout: None,
         },
     )?;
     if !output.success {

--- a/src/core/extension/trace/generic_runner.rs
+++ b/src/core/extension/trace/generic_runner.rs
@@ -42,6 +42,7 @@ pub(super) fn run_generic_trace_runner(
             success: true,
             stdout,
             stderr: String::new(),
+            timed_out: false,
             child_resource: None,
             extension_phase_timings: Vec::new(),
         });
@@ -56,6 +57,7 @@ pub(super) fn run_generic_trace_runner(
             success: false,
             stdout: String::new(),
             stderr: format!("unknown trace scenario {}", args.scenario_id),
+            timed_out: false,
             child_resource: None,
             extension_phase_timings: Vec::new(),
         });
@@ -87,6 +89,7 @@ pub(super) fn run_generic_trace_runner(
         success: output.status.success(),
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        timed_out: false,
         child_resource: None,
         extension_phase_timings: super::super::runner::read_extension_phase_timings(
             run_dir.path(),

--- a/src/core/extension/trace/run/tests/extension.rs
+++ b/src/core/extension/trace/run/tests/extension.rs
@@ -297,6 +297,7 @@ fn test_run_trace_workflow() {
             .map(|i| format!("line {i}"))
             .collect::<Vec<_>>()
             .join("\n"),
+        timed_out: false,
         child_resource: None,
         extension_phase_timings: Vec::new(),
     };

--- a/src/core/extension/trace/run/tests/workflow.rs
+++ b/src/core/extension/trace/run/tests/workflow.rs
@@ -94,6 +94,7 @@ fn trace_failure_records_child_cleanup_context() {
         success: false,
         stdout: String::new(),
         stderr: "Homeboy interrupted by signal 15".to_string(),
+        timed_out: false,
         child_resource: Some(
             crate::core::engine::resource::ExtensionChildResourceSummary {
                 child: crate::core::engine::resource::ChildProcessIdentity {

--- a/src/core/project/files.rs
+++ b/src/core/project/files.rs
@@ -730,6 +730,7 @@ mod tests {
             stderr: String::new(),
             success: false,
             exit_code: 126,
+            timed_out: false,
             child_resource: None,
         };
 
@@ -752,6 +753,7 @@ mod tests {
             stderr: "permission denied\n".to_string(),
             success: false,
             exit_code: 2,
+            timed_out: false,
             child_resource: None,
         };
 

--- a/src/core/release/planning_quality.rs
+++ b/src/core/release/planning_quality.rs
@@ -328,6 +328,7 @@ mod tests {
             success: exit_code == 0,
             stdout: stdout.to_string(),
             stderr: stderr.to_string(),
+            timed_out: false,
             child_resource: None,
             extension_phase_timings: Vec::new(),
         }

--- a/src/core/server/client/local_exec.rs
+++ b/src/core/server/client/local_exec.rs
@@ -1,4 +1,5 @@
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use crate::core::engine::invocation;
 
@@ -26,13 +27,23 @@ pub fn execute_local_command_in_dir(
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
 ) -> CommandOutput {
-    execute_local_command_in_dir_impl(command, current_dir, env)
+    execute_local_command_in_dir_impl(command, current_dir, env, None)
+}
+
+pub(crate) fn execute_local_command_in_dir_with_timeout(
+    command: &str,
+    current_dir: Option<&str>,
+    env: Option<&[(&str, &str)]>,
+    timeout: Duration,
+) -> CommandOutput {
+    execute_local_command_in_dir_impl(command, current_dir, env, Some(timeout))
 }
 
 fn execute_local_command_in_dir_impl(
     command: &str,
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
+    timeout: Option<Duration>,
 ) -> CommandOutput {
     use std::io::Read;
     use std::thread;
@@ -71,6 +82,7 @@ fn execute_local_command_in_dir_impl(
                 stderr: format!("Command error: {}", e),
                 success: false,
                 exit_code: -1,
+                timed_out: false,
                 child_resource: None,
             };
         }
@@ -106,8 +118,8 @@ fn execute_local_command_in_dir_impl(
         .take()
         .map(|pipe| thread::spawn(move || read_all(pipe)));
 
-    let (status, delegated_failure) =
-        wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard);
+    let (status, delegated_failure, timed_out) =
+        wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard, timeout);
     let interrupted_signal = active_cleanup_signal();
 
     let stdout = stdout_handle
@@ -121,26 +133,43 @@ fn execute_local_command_in_dir_impl(
         Ok(status) => CommandOutput {
             stdout,
             stderr: stderr_with_delegated_failure(
-                stderr_with_interruption(stderr, interrupted_signal),
+                stderr_with_timeout(
+                    stderr_with_interruption(stderr, interrupted_signal),
+                    timed_out,
+                    timeout,
+                ),
                 delegated_failure.as_ref(),
             ),
             success: status.success()
                 && interrupted_signal.is_none()
-                && delegated_failure.is_none(),
-            exit_code: interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
+                && delegated_failure.is_none()
+                && !timed_out,
+            exit_code: timed_out_exit_code(
+                timed_out,
+                interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
+            ),
+            timed_out,
             child_resource: Some(monitor.finish()),
         },
         Err(e) => CommandOutput {
             stdout,
             stderr: stderr_with_delegated_failure(
                 stderr_with_interruption(
-                    format!("{stderr}\nCommand error: {}", e),
+                    stderr_with_timeout(
+                        format!("{stderr}\nCommand error: {}", e),
+                        timed_out,
+                        timeout,
+                    ),
                     interrupted_signal,
                 ),
                 delegated_failure.as_ref(),
             ),
             success: false,
-            exit_code: interrupted_exit_code(interrupted_signal, -1),
+            exit_code: timed_out_exit_code(
+                timed_out,
+                interrupted_exit_code(interrupted_signal, -1),
+            ),
+            timed_out,
             child_resource: Some(monitor.finish()),
         },
     };
@@ -202,13 +231,23 @@ pub fn execute_local_command_passthrough(
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
 ) -> CommandOutput {
-    execute_local_command_passthrough_impl(command, current_dir, env)
+    execute_local_command_passthrough_impl(command, current_dir, env, None)
+}
+
+pub(crate) fn execute_local_command_passthrough_with_timeout(
+    command: &str,
+    current_dir: Option<&str>,
+    env: Option<&[(&str, &str)]>,
+    timeout: Duration,
+) -> CommandOutput {
+    execute_local_command_passthrough_impl(command, current_dir, env, Some(timeout))
 }
 
 fn execute_local_command_passthrough_impl(
     command: &str,
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
+    timeout: Option<Duration>,
 ) -> CommandOutput {
     use std::io::{Read, Write};
     use std::thread;
@@ -247,6 +286,7 @@ fn execute_local_command_passthrough_impl(
                 stderr: format!("Command error: {}", e),
                 success: false,
                 exit_code: -1,
+                timed_out: false,
                 child_resource: None,
             };
         }
@@ -293,8 +333,8 @@ fn execute_local_command_passthrough_impl(
         .take()
         .map(|pipe| thread::spawn(move || tee_to(pipe, std::io::stderr())));
 
-    let (status, delegated_failure) =
-        wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard);
+    let (status, delegated_failure, timed_out) =
+        wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard, timeout);
     let interrupted_signal = active_cleanup_signal();
 
     let stdout = stdout_handle
@@ -308,26 +348,43 @@ fn execute_local_command_passthrough_impl(
         Ok(status) => CommandOutput {
             stdout,
             stderr: stderr_with_delegated_failure(
-                stderr_with_interruption(stderr, interrupted_signal),
+                stderr_with_timeout(
+                    stderr_with_interruption(stderr, interrupted_signal),
+                    timed_out,
+                    timeout,
+                ),
                 delegated_failure.as_ref(),
             ),
             success: status.success()
                 && interrupted_signal.is_none()
-                && delegated_failure.is_none(),
-            exit_code: interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
+                && delegated_failure.is_none()
+                && !timed_out,
+            exit_code: timed_out_exit_code(
+                timed_out,
+                interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
+            ),
+            timed_out,
             child_resource: Some(monitor.finish()),
         },
         Err(e) => CommandOutput {
             stdout,
             stderr: stderr_with_delegated_failure(
                 stderr_with_interruption(
-                    format!("{stderr}\nCommand error: {}", e),
+                    stderr_with_timeout(
+                        format!("{stderr}\nCommand error: {}", e),
+                        timed_out,
+                        timeout,
+                    ),
                     interrupted_signal,
                 ),
                 delegated_failure.as_ref(),
             ),
             success: false,
-            exit_code: interrupted_exit_code(interrupted_signal, -1),
+            exit_code: timed_out_exit_code(
+                timed_out,
+                interrupted_exit_code(interrupted_signal, -1),
+            ),
+            timed_out,
             child_resource: Some(monitor.finish()),
         },
     };
@@ -341,6 +398,24 @@ pub(crate) fn execute_local_command_stderr_passthrough(
     command: &str,
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
+) -> CommandOutput {
+    execute_local_command_stderr_passthrough_impl(command, current_dir, env, None)
+}
+
+pub(crate) fn execute_local_command_stderr_passthrough_with_timeout(
+    command: &str,
+    current_dir: Option<&str>,
+    env: Option<&[(&str, &str)]>,
+    timeout: Duration,
+) -> CommandOutput {
+    execute_local_command_stderr_passthrough_impl(command, current_dir, env, Some(timeout))
+}
+
+fn execute_local_command_stderr_passthrough_impl(
+    command: &str,
+    current_dir: Option<&str>,
+    env: Option<&[(&str, &str)]>,
+    timeout: Option<Duration>,
 ) -> CommandOutput {
     use std::io::{Read, Write};
     use std::thread;
@@ -379,6 +454,7 @@ pub(crate) fn execute_local_command_stderr_passthrough(
                 stderr: format!("Command error: {}", e),
                 success: false,
                 exit_code: -1,
+                timed_out: false,
                 child_resource: None,
             };
         }
@@ -432,8 +508,8 @@ pub(crate) fn execute_local_command_stderr_passthrough(
         .take()
         .map(|pipe| thread::spawn(move || tee_to_stderr(pipe)));
 
-    let (status, delegated_failure) =
-        wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard);
+    let (status, delegated_failure, timed_out) =
+        wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard, timeout);
     let interrupted_signal = active_cleanup_signal();
 
     let stdout = stdout_handle
@@ -447,26 +523,43 @@ pub(crate) fn execute_local_command_stderr_passthrough(
         Ok(status) => CommandOutput {
             stdout,
             stderr: stderr_with_delegated_failure(
-                stderr_with_interruption(stderr, interrupted_signal),
+                stderr_with_timeout(
+                    stderr_with_interruption(stderr, interrupted_signal),
+                    timed_out,
+                    timeout,
+                ),
                 delegated_failure.as_ref(),
             ),
             success: status.success()
                 && interrupted_signal.is_none()
-                && delegated_failure.is_none(),
-            exit_code: interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
+                && delegated_failure.is_none()
+                && !timed_out,
+            exit_code: timed_out_exit_code(
+                timed_out,
+                interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
+            ),
+            timed_out,
             child_resource: Some(monitor.finish()),
         },
         Err(e) => CommandOutput {
             stdout,
             stderr: stderr_with_delegated_failure(
                 stderr_with_interruption(
-                    format!("{stderr}\nCommand error: {}", e),
+                    stderr_with_timeout(
+                        format!("{stderr}\nCommand error: {}", e),
+                        timed_out,
+                        timeout,
+                    ),
                     interrupted_signal,
                 ),
                 delegated_failure.as_ref(),
             ),
             success: false,
-            exit_code: interrupted_exit_code(interrupted_signal, -1),
+            exit_code: timed_out_exit_code(
+                timed_out,
+                interrupted_exit_code(interrupted_signal, -1),
+            ),
+            timed_out,
             child_resource: Some(monitor.finish()),
         },
     };
@@ -474,6 +567,32 @@ pub(crate) fn execute_local_command_stderr_passthrough(
         cleanup_guard.cleanup();
     }
     output
+}
+
+fn timed_out_exit_code(timed_out: bool, fallback: i32) -> i32 {
+    if timed_out {
+        124
+    } else {
+        fallback
+    }
+}
+
+fn stderr_with_timeout(mut stderr: String, timed_out: bool, timeout: Option<Duration>) -> String {
+    if timed_out {
+        if !stderr.is_empty() && !stderr.ends_with('\n') {
+            stderr.push('\n');
+        }
+        match timeout {
+            Some(timeout) => stderr.push_str(&format!(
+                "Homeboy command timed out after {}ms; terminated child process group before returning failure evidence.",
+                timeout.as_millis()
+            )),
+            None => stderr.push_str(
+                "Homeboy command timed out; terminated child process group before returning failure evidence.",
+            ),
+        }
+    }
+    stderr
 }
 
 fn invocation_child_guard(
@@ -496,28 +615,45 @@ fn wait_for_child_or_delegated_failure(
     child: &mut std::process::Child,
     env: Option<&[(&str, &str)]>,
     cleanup_guard: &mut Option<ProcessGroupCleanupGuard>,
+    timeout: Option<Duration>,
 ) -> (
     std::io::Result<std::process::ExitStatus>,
     Option<DelegatedRunTerminalFailure>,
+    bool,
 ) {
-    let Some(monitor) = DelegatedRunFailureMonitor::from_env(env) else {
-        return (child.wait(), None);
-    };
+    let monitor = DelegatedRunFailureMonitor::from_env(env);
+    let deadline = timeout.map(|timeout| Instant::now() + timeout);
 
     loop {
         match child.try_wait() {
-            Ok(Some(status)) => return (Ok(status), None),
+            Ok(Some(status)) => return (Ok(status), None, false),
             Ok(None) => {}
-            Err(error) => return (Err(error), None),
+            Err(error) => return (Err(error), None, false),
         }
 
-        if let Some(failure) = monitor.terminal_failure() {
+        if let Some(failure) = monitor
+            .as_ref()
+            .and_then(|monitor| monitor.terminal_failure())
+        {
             if let Some(cleanup_guard) = cleanup_guard.take() {
                 cleanup_guard.cleanup();
             }
-            return (child.wait(), Some(failure));
+            return (child.wait(), Some(failure), false);
         }
 
-        std::thread::sleep(monitor.poll_interval);
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            if let Some(cleanup_guard) = cleanup_guard.take() {
+                cleanup_guard.cleanup();
+            } else {
+                let _ = child.kill();
+            }
+            return (child.wait(), None, true);
+        }
+
+        let poll_interval = monitor
+            .as_ref()
+            .map(|monitor| monitor.poll_interval)
+            .unwrap_or_else(|| Duration::from_millis(50));
+        std::thread::sleep(poll_interval);
     }
 }

--- a/src/core/server/client/mod.rs
+++ b/src/core/server/client/mod.rs
@@ -13,10 +13,14 @@ mod ssh_client;
 mod tests;
 
 pub(crate) use delegated::DELEGATED_RUN_STATUS_FILE_ENV;
-pub(crate) use local_exec::execute_local_command_stderr_passthrough;
 pub use local_exec::{
     execute_local_command, execute_local_command_in_dir, execute_local_command_interactive,
     execute_local_command_passthrough,
+};
+pub(crate) use local_exec::{
+    execute_local_command_in_dir_with_timeout, execute_local_command_passthrough_with_timeout,
+    execute_local_command_stderr_passthrough,
+    execute_local_command_stderr_passthrough_with_timeout,
 };
 
 pub struct SshClient {
@@ -38,5 +42,6 @@ pub struct CommandOutput {
     pub stderr: String,
     pub success: bool,
     pub exit_code: i32,
+    pub timed_out: bool,
     pub child_resource: Option<ExtensionChildResourceSummary>,
 }

--- a/src/core/server/client/ssh_client.rs
+++ b/src/core/server/client/ssh_client.rs
@@ -303,6 +303,7 @@ impl SshClient {
                     stderr: String::new(),
                     success: true,
                     exit_code: 0,
+                    timed_out: false,
                     child_resource: None,
                 },
                 Err(err) => CommandOutput {
@@ -313,6 +314,7 @@ impl SshClient {
                     ),
                     success: false,
                     exit_code: -1,
+                    timed_out: false,
                     child_resource: None,
                 },
             };
@@ -326,6 +328,7 @@ impl SshClient {
                     stderr: format!("failed to create download target '{}': {}", local_path, err),
                     success: false,
                     exit_code: -1,
+                    timed_out: false,
                     child_resource: None,
                 };
             }
@@ -343,6 +346,7 @@ impl SshClient {
                 stderr: String::from_utf8_lossy(&out.stderr).to_string(),
                 success: out.status.success(),
                 exit_code: out.status.code().unwrap_or(-1),
+                timed_out: false,
                 child_resource: None,
             },
             Err(err) => CommandOutput {
@@ -350,6 +354,7 @@ impl SshClient {
                 stderr: format!("SSH download error: {}", err),
                 success: false,
                 exit_code: -1,
+                timed_out: false,
                 child_resource: None,
             },
         }
@@ -392,6 +397,7 @@ impl SshClient {
             stderr: "SSH retry exhausted".to_string(),
             success: false,
             exit_code: -1,
+            timed_out: false,
             child_resource: None,
         }
     }
@@ -423,6 +429,7 @@ impl SshClient {
                         stderr: format!("Failed to open stdin file: {}", err),
                         success: false,
                         exit_code: -1,
+                        timed_out: false,
                         child_resource: None,
                     };
                 }
@@ -437,6 +444,7 @@ impl SshClient {
                 stderr: String::from_utf8_lossy(&out.stderr).to_string(),
                 success: out.status.success(),
                 exit_code: out.status.code().unwrap_or(-1),
+                timed_out: false,
                 child_resource: None,
             },
             Err(e) => CommandOutput {
@@ -444,6 +452,7 @@ impl SshClient {
                 stderr: format!("SSH error: {}", e),
                 success: false,
                 exit_code: -1,
+                timed_out: false,
                 child_resource: None,
             },
         }

--- a/src/core/server/client/tests.rs
+++ b/src/core/server/client/tests.rs
@@ -327,6 +327,7 @@ fn managed_session_connect_reports_per_command_fallback() {
             stderr: String::new(),
             success: true,
             exit_code: 0,
+            timed_out: false,
             child_resource: None,
         },
     );

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -10,11 +10,15 @@ mod process_cleanup;
 mod session;
 pub mod transfer;
 
-pub(crate) use client::execute_local_command_stderr_passthrough;
 pub(crate) use client::DELEGATED_RUN_STATUS_FILE_ENV;
 pub use client::{
     execute_local_command, execute_local_command_in_dir, execute_local_command_interactive,
     execute_local_command_passthrough, CommandOutput, SshClient,
+};
+pub(crate) use client::{
+    execute_local_command_in_dir_with_timeout, execute_local_command_passthrough_with_timeout,
+    execute_local_command_stderr_passthrough,
+    execute_local_command_stderr_passthrough_with_timeout,
 };
 pub use connection::{resolve_context, SshResolveArgs, SshResolveResult};
 pub use keys::{


### PR DESCRIPTION
## Summary
- Enforce fuzz `--max-duration` as a parent-side execution timeout around extension runner processes.
- Preserve captured stdout/stderr and run-dir artifacts on timeout while returning typed `timeout` status.
- Classify skipped, unsupported, and not_executed fuzz outcomes as non-proof terminal states instead of pass.

## Tests
- `cargo fmt`
- `cargo check`
- `cargo test commands::fuzz::tests::execution_tests`
- `cargo test core::extension::execution::tests::execute_capability_script_timeout_returns_partial_output`
- `cargo test core::extension::execution::tests::test_execute_capability_script_supports_stderr_only_passthrough`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, focused tests, formatting/test command execution, and PR description drafting.