### PR TITLE
fix(runner): bind lab agent-task run ids

### DIFF
--- a/src/core/runner/execution/broker.rs
+++ b/src/core/runner/execution/broker.rs
@@ -1,14 +1,12 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use reqwest::blocking::Client;
-use serde_json::json;
-
 use crate::command_contract::RunnerWorkload;
 use crate::core::api_jobs::{Job, JobStatus, RemoteRunnerJobRequest};
 use crate::core::error::{Error, Result};
 use crate::core::redaction::redact_argv;
 use crate::core::source_snapshot::SourceSnapshot;
+use reqwest::blocking::Client;
 
 use super::super::broker_http;
 use super::super::evidence::mirror_reverse_broker_evidence;
@@ -53,9 +51,10 @@ pub(super) fn exec_via_reverse_broker(
         capture_patch,
         source_snapshot: Some(source_snapshot.clone()),
         runner_workload: runner_workload.clone(),
-        metadata: Some(json!({
-            "transport": "reverse_broker",
-        })),
+        metadata: Some(runner_exec_request_metadata(
+            run_id.as_deref(),
+            "reverse_broker",
+        )),
         require_paths: require_paths.clone(),
     };
     let broker_token = super::super::broker_auth::broker_token_from_env();

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -61,6 +61,7 @@ pub(super) fn exec_via_daemon(
         "source_snapshot": source_snapshot.clone(),
         "require_paths": require_paths.clone(),
         "runner_workload": runner_workload,
+        "metadata": runner_exec_request_metadata(run_id.as_deref(), "daemon"),
     });
     let (status_code, response_body) = daemon_loopback_post_json(local_url, "/exec", &payload)
         .map_err(|err| daemon_exec_loopback_transport_error(&runner.id, err))?;

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -433,6 +433,17 @@ fn apply_explicit_runner_exec_run_id_env(
     })
 }
 
+fn runner_exec_request_metadata(run_id: Option<&str>, transport: &str) -> Value {
+    let mut metadata = serde_json::json!({
+        "transport": transport,
+    });
+    if let Some(run_id) = run_id.filter(|id| !id.trim().is_empty()) {
+        metadata["durable_run_id"] = serde_json::json!(run_id);
+        metadata["run_id"] = serde_json::json!(run_id);
+    }
+    metadata
+}
+
 fn ambient_env_is_present(name: &str) -> bool {
     std::env::var_os(name).is_some()
 }

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -36,7 +36,7 @@ fn timeout_mirrors_remote_job_without_cancelling() {
             "runner daemon job",
             true,
         );
-        let run_id = format!("runner-exec-lab-{job_id}");
+        let run_id = format!("runner-exec-bench-lab-{job_id}");
 
         assert!(err.message.contains("runner daemon job"));
         assert!(err.message.contains(job_id.to_string().as_str()));
@@ -236,6 +236,7 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
         });
         let broker_url = format!("http://{addr}");
 
+        let stable_run_id = "agent-task-run-123";
         let (output, exit_code) = exec_via_reverse_broker(
             &ssh_runner(),
             &broker_url,
@@ -248,7 +249,7 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
             None,
             Vec::new(),
             None,
-            None,
+            Some(stable_run_id.to_string()),
             true,
         )
         .expect("reverse broker detached exec");
@@ -257,7 +258,7 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
         assert_eq!(output.mode, RunnerExecMode::ReverseBroker);
         let job_id = output.job_id.as_deref().expect("job id");
         let mirror_run_id = output.mirror_run_id.as_deref().expect("mirror run id");
-        assert_eq!(mirror_run_id, format!("runner-exec-test-lab-{job_id}"));
+        assert_eq!(mirror_run_id, stable_run_id);
         assert_eq!(
             output
                 .runner_result
@@ -278,6 +279,20 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
         assert_eq!(stdout["persisted_run_id"].as_str(), Some(mirror_run_id));
         assert_eq!(stdout["mirror_run_id"].as_str(), Some(mirror_run_id));
         assert_eq!(stdout["job_id"].as_str(), Some(job_id));
+
+        let jobs: Value = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .expect("client")
+            .get(format!("{broker_url}/jobs"))
+            .send()
+            .expect("jobs response")
+            .json()
+            .expect("jobs json");
+        assert_eq!(
+            jobs["data"]["body"]["active_runner_jobs"][0]["durable_run_id"].as_str(),
+            Some(stable_run_id)
+        );
 
         let store = crate::core::observation::ObservationStore::open_initialized()
             .expect("observation store");

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -655,7 +655,7 @@ pub(crate) fn run_lab_offload_inner(
             required_extensions: contract.required_extensions.clone(),
             require_paths: Vec::new(),
             runner_workload: Some(runner_workload),
-            run_id: None,
+            run_id: agent_task_run_id.clone(),
             detach_after_handoff: request.detach_after_handoff,
         },
     );

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -68,6 +68,10 @@ pub(crate) fn run_runner_resident_lab_offload(
         request.normalized_args,
         remote_output_file.as_deref(),
     );
+    let run_isolation_token = agent_task_dispatch_run_isolation_token(request.normalized_args);
+    let (remapped_args, agent_task_run_id) =
+        ensure_agent_task_dispatch_run_id_with(&remapped_args, run_isolation_token.as_deref())
+            .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
     let mut command = vec![homeboy_path.to_string()];
     if remote_output_file.is_some() && !args_contain_output_file(request.normalized_args) {
         command.push("--output".to_string());
@@ -146,7 +150,7 @@ pub(crate) fn run_runner_resident_lab_offload(
             required_extensions: contract.required_extensions.clone(),
             require_paths: Vec::new(),
             runner_workload: None,
-            run_id: None,
+            run_id: agent_task_run_id,
             detach_after_handoff: false,
         },
     )?;


### PR DESCRIPTION
## Summary
- Pass the Lab agent-task run ID into runner exec for normal and runner-resident offloads.
- Attach the durable run ID to runner exec request metadata so active runner job/status follow-ups expose the stable ID.
- Cover detached reverse-broker handoff and active runner job metadata using the stable run ID.

## Tests
- cargo fmt --check
- cargo test core::runner::execution::tests::handoff -- --nocapture --test-threads=1
- cargo test core::runner::lab::offload::tests::durable_fallbacks -- --nocapture
- cargo test core::runner::lab::offload::tests::workspace_sync -- --nocapture
- cargo test -- --test-threads=1 (timed out after 10 minutes while still passing; no failures observed before timeout)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and verified the runner lifecycle fix.
