### PR TITLE
Fix rig reinstall over stale registry specs

### DIFF
--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -413,6 +413,12 @@ fn ensure_stack_refreshable(stack: &DiscoveredStack, target: &Path) -> Result<()
         return Ok(());
     }
 
+    if read_stack_source_metadata(&stack.id)
+        .is_some_and(|metadata| config_matches_source(target, Path::new(&metadata.stack_path)))
+    {
+        return Ok(());
+    }
+
     if config_matches_source(target, &stack.stack_path) {
         return Ok(());
     }

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -378,17 +378,19 @@ fn ensure_rig_refreshable(rig: &DiscoveredRig, target: &Path) -> Result<()> {
             ));
         }
     };
-    let mut spec: super::RigSpec = serde_json::from_str(&content).map_err(|e| {
+    let value: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
         Error::validation_invalid_json(
             e,
             Some(format!("parse existing rig spec {}", target.display())),
             Some(content.chars().take(200).collect()),
         )
     })?;
-    if spec.id.is_empty() {
-        spec.id = rig.id.clone();
-    }
-    let existing_id = extension::slugify_id(&spec.id)?;
+    let existing_id = value
+        .get("id")
+        .and_then(|id| id.as_str())
+        .filter(|id| !id.is_empty())
+        .unwrap_or(&rig.id);
+    let existing_id = extension::slugify_id(existing_id)?;
     if existing_id == rig.id {
         return Ok(());
     }
@@ -407,6 +409,10 @@ fn ensure_rig_refreshable(rig: &DiscoveredRig, target: &Path) -> Result<()> {
 }
 
 fn ensure_stack_refreshable(stack: &DiscoveredStack, target: &Path) -> Result<()> {
+    if !target.exists() && fs::symlink_metadata(target).is_ok() {
+        return Ok(());
+    }
+
     if config_matches_source(target, &stack.stack_path) {
         return Ok(());
     }

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -112,6 +112,54 @@ mod install_flows {
     }
 
     #[test]
+    fn reinstall_replaces_broken_owned_stack_link() {
+        let _home = HomeGuard::new();
+        let stale_package = tempfile::tempdir().expect("stale package");
+        write_rig(stale_package.path(), "studio", &minimal_rig("studio"));
+        write_stack(stale_package.path(), "studio-combined", "studio");
+        install(stale_package.path().to_str().unwrap(), None, false).expect("install stale");
+        fs::remove_dir_all(stale_package.path()).expect("remove stale source");
+
+        let package = tempfile::tempdir().expect("package");
+        write_rig(package.path(), "studio", &minimal_rig("studio"));
+        let stack_path = write_stack(package.path(), "studio-combined", "studio");
+
+        let result = install(package.path().to_str().unwrap(), None, false)
+            .expect("reinstall replaces broken stack link");
+
+        assert_eq!(result.installed_stacks.len(), 1);
+        let installed = crate::core::paths::stack_config("studio-combined").expect("stack path");
+        assert!(installed.exists());
+        #[cfg(unix)]
+        assert_eq!(fs::read_link(&installed).expect("symlink"), stack_path);
+    }
+
+    #[test]
+    fn reinstall_replaces_same_id_legacy_rig_schema() {
+        let _home = HomeGuard::new();
+        let config = crate::core::paths::rig_config("legacy-rig").expect("rig path");
+        fs::create_dir_all(config.parent().expect("rig dir")).expect("rig dir");
+        fs::write(
+            &config,
+            r#"{
+                "id": "legacy-rig",
+                "bench_workloads": { "app": ["legacy-string-workload.mjs"] }
+            }"#,
+        )
+        .expect("legacy rig config");
+
+        let package = tempfile::tempdir().expect("package");
+        let rig_path = write_rig(package.path(), "legacy-rig", &minimal_rig("legacy-rig"));
+
+        let result = install(package.path().to_str().unwrap(), None, false)
+            .expect("reinstall replaces same-id legacy schema");
+
+        assert_eq!(result.installed.len(), 1);
+        #[cfg(unix)]
+        assert_eq!(fs::read_link(&config).expect("symlink"), rig_path);
+    }
+
+    #[test]
     fn install_git_source_subpath_records_nested_package_root() {
         let _home = HomeGuard::new();
         let repo = tempfile::tempdir().expect("repo");

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -160,6 +160,33 @@ mod install_flows {
     }
 
     #[test]
+    fn reinstall_replaces_owned_stack_with_updated_content() {
+        let _home = HomeGuard::new();
+        let first_package = tempfile::tempdir().expect("first package");
+        write_rig(first_package.path(), "studio", &minimal_rig("studio"));
+        write_stack(first_package.path(), "studio-combined", "studio");
+        install(first_package.path().to_str().unwrap(), None, false).expect("install first");
+
+        let second_package = tempfile::tempdir().expect("second package");
+        write_rig(second_package.path(), "studio", &minimal_rig("studio"));
+        let stack_path = write_stack(second_package.path(), "studio-combined", "studio");
+        fs::write(
+            &stack_path,
+            minimal_stack("studio-combined", "studio")
+                .replace("studio-combined stack", "updated stack"),
+        )
+        .expect("update stack content");
+
+        let result = install(second_package.path().to_str().unwrap(), None, false)
+            .expect("reinstall replaces owned stack with updated content");
+
+        assert_eq!(result.installed_stacks.len(), 1);
+        let installed = crate::core::paths::stack_config("studio-combined").expect("stack path");
+        #[cfg(unix)]
+        assert_eq!(fs::read_link(&installed).expect("symlink"), stack_path);
+    }
+
+    #[test]
     fn install_git_source_subpath_records_nested_package_root() {
         let _home = HomeGuard::new();
         let repo = tempfile::tempdir().expect("repo");


### PR DESCRIPTION
## Summary
- Allows rig reinstall to replace same-id legacy rig configs without deserializing the old full schema.
- Allows stack reinstall to replace broken installed stack links from stale source metadata.
- Allows owned installed stack specs to refresh when a rig package reinstall brings updated stack content.
- Adds regression coverage for stale stack links, legacy same-id rig schema refresh, and owned stack content refresh.

## Verification
- `cargo test reinstall_replaces`
- Canonical `homeboy rig install --all <studio rig package> --reinstall` against PR 469 merged state: passed with this branch.
- Canonical `homeboy rig check studio-canonical-loop-proof --runner homeboy-lab`: passed before PR 469 merge-conflict resolution with this branch; proof run id `ca89aae6-9f99-4835-9f95-8b7d568d9f54`.
- Final PR 469 offloaded run is blocked until this fix is merged and the runner Homeboy binary is refreshed; failed runner install run `runner-exec-rig-install-studio-5f4593febf33-29c25056-d9a2-4e2b-b84a-d7e88ca6d436-1782450810878135000-homeboy-lab-2a60cfb2-fb19-451a-a185-303837999d5c` shows the old binary refusing owned stack refresh.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the canonical rig install blocker, implementing the reinstall fix, and adding regression tests.
