### PR TITLE
Fix detached Lab handoff output

### DIFF
--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -237,6 +237,9 @@ fn daemon_loopback_post_json(
     let body = serde_json::to_string(payload)
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
     let mut stream = TcpStream::connect(address)?;
+    let timeout = Duration::from_secs(10);
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
     write!(
         stream,
         "POST {path} HTTP/1.1\r\nHost: {address}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -350,19 +353,26 @@ pub(super) fn detached_handoff_output(
         mirror_run_id.as_deref(),
         DaemonJobHandoffState::InFlight,
     );
+    let mut follow_commands = json!({
+        "job_logs": format!("homeboy runner job logs {} {} --follow", runner.id, job.id),
+        "job_cancel": format!("homeboy runner job cancel {} {}", runner.id, job.id),
+    });
+    if let Some(run_id) = mirror_run_id.as_deref() {
+        follow_commands["status"] = json!(format!("homeboy agent-task status {run_id}"));
+        follow_commands["logs"] = json!(format!("homeboy agent-task logs {run_id}"));
+        follow_commands["artifacts"] = json!(format!("homeboy agent-task artifacts {run_id}"));
+    }
     let stdout = serde_json::to_string_pretty(&json!({
         "schema": "homeboy/runner-exec-handoff/v1",
         "status": "handoff_complete",
         "execution_location": format!("runner:{}", runner.id),
         "runner_id": runner.id.clone(),
         "job_id": job_id,
+        "durable_run_id": mirror_run_id.as_deref(),
         "persisted_run_id": mirror_run_id.as_deref(),
         "mirror_run_id": mirror_run_id.as_deref(),
         "remote_cwd": cwd.clone(),
-        "follow_commands": {
-            "job_logs": format!("homeboy runner job logs {} {} --follow", runner.id, job.id),
-            "job_cancel": format!("homeboy runner job cancel {} {}", runner.id, job.id),
-        }
+        "follow_commands": follow_commands,
     }))
     .unwrap_or_else(|_| "{}".to_string());
     let transport = match mode {

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -36,7 +36,7 @@ fn timeout_mirrors_remote_job_without_cancelling() {
             "runner daemon job",
             true,
         );
-        let run_id = format!("runner-exec-lab-{job_id}");
+        let run_id = format!("runner-exec-bench-lab-{job_id}");
 
         assert!(err.message.contains("runner daemon job"));
         assert!(err.message.contains(job_id.to_string().as_str()));
@@ -288,6 +288,50 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
         assert_eq!(
             run.metadata_json["lab"]["remote_job"]["id"].as_str(),
             Some(job_id)
+        );
+    });
+}
+
+#[test]
+fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner = ssh_runner();
+        let job = running_job();
+        let job_id = job.id.to_string();
+
+        let (output, exit_code) = detached_handoff_output(
+            &runner,
+            RunnerExecMode::Daemon,
+            "/srv/homeboy/project".to_string(),
+            vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ],
+            SourceSnapshot::existing_remote("lab", "/srv/homeboy/project", Some("/srv/homeboy")),
+            job,
+            Vec::new(),
+            Some("agent-task-run-6454".to_string()),
+        );
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.job_id.as_deref(), Some(job_id.as_str()));
+        assert_eq!(output.mirror_run_id.as_deref(), Some("agent-task-run-6454"));
+        let json: Value = serde_json::from_str(&output.stdout).expect("handoff JSON");
+        assert_eq!(json["status"], "handoff_complete");
+        assert_eq!(json["job_id"], job_id);
+        assert_eq!(json["durable_run_id"], "agent-task-run-6454");
+        assert_eq!(
+            json["follow_commands"]["status"],
+            "homeboy agent-task status agent-task-run-6454"
+        );
+        assert_eq!(
+            json["follow_commands"]["logs"],
+            "homeboy agent-task logs agent-task-run-6454"
+        );
+        assert_eq!(
+            json["follow_commands"]["job_logs"],
+            format!("homeboy runner job logs lab {job_id} --follow")
         );
     });
 }
@@ -667,4 +711,26 @@ fn daemon_exec_empty_envelope_over_http_is_actionable_not_null() {
         .hints
         .iter()
         .any(|hint| hint.message.contains("homeboy runner connect")));
+}
+
+fn running_job() -> Job {
+    Job {
+        id: uuid::Uuid::new_v4(),
+        operation: "runner.exec".to_string(),
+        status: JobStatus::Running,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: None,
+        event_count: 0,
+        source_snapshot: None,
+        stale_reason: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+    }
 }

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -656,7 +656,11 @@ pub(crate) fn run_lab_offload_inner(
             required_extensions: contract.required_extensions.clone(),
             require_paths: Vec::new(),
             runner_workload: Some(runner_workload),
-            run_id: None,
+            run_id: if request.detach_after_handoff {
+                agent_task_run_id.clone()
+            } else {
+                None
+            },
             detach_after_handoff: request.detach_after_handoff,
         },
     );
@@ -743,6 +747,21 @@ pub(crate) fn run_lab_offload_inner(
     plan = add_success_step(plan, "lab.exec");
     if exec_output.mirror_run_id.is_some() {
         plan = add_success_step(plan, "lab.mirror_evidence");
+    }
+    if request.detach_after_handoff {
+        let mut stderr = String::new();
+        for message in messages {
+            stderr.push_str(&message);
+            stderr.push('\n');
+        }
+        stderr.push_str(&exec_output.stderr);
+        return Ok(LabOffloadOutcome::Offloaded {
+            plan,
+            stdout: exec_output.stdout.clone(),
+            stderr,
+            exit_code,
+            output_file_content: Some(exec_output.stdout),
+        });
     }
     // Parsing/applying the remote command output (patch extraction) is post-
     // workload overhead, not workload time.


### PR DESCRIPTION
## Summary
- return immediately after detached runner daemon/broker handoff instead of importing remote structured output while the job is still running
- propagate the durable agent-task run id into detached handoff output
- include runner job and agent-task follow-up commands in detached handoff JSON
- bound daemon loopback socket reads/writes during exec acceptance

Fixes #6454.

## Verification
- cargo fmt --check
- git diff --check
- cargo test core::runner::execution::tests::handoff --lib
- cargo test --lib (timed out after 20 minutes with no reported failures before timeout; CI is the full-suite authority)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Investigation, implementation, focused tests, and verification