### PR TITLE
Fix bench rig package freshness evidence

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -793,6 +793,9 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
             passthrough_args,
             scenario_ids: args.scenario_ids.clone(),
             extra_workloads,
+            rig_package: rig_context
+                .as_ref()
+                .and_then(|context| rig::package_evidence(&context.spec.id)),
         },
         &run_dir,
     );

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -652,6 +652,9 @@ fn run_component_with_rig_context(
             rig_id: rig_id.clone(),
             shared_state: shared_state_override.or_else(|| args.shared_state.clone()),
             extra_workloads,
+            rig_package: rig_id
+                .as_deref()
+                .and_then(homeboy::core::rig::package_evidence),
             invocation_requirements,
         },
         &run_dir,

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -182,6 +182,44 @@ fn write_rig(home: &TempDir, rig_id: &str, component_id: &str, path: &std::path:
     write_rig_with_profiles(home, rig_id, component_id, path, "{}");
 }
 
+fn install_rig_package(
+    home: &TempDir,
+    rig_id: &str,
+    component_id: &str,
+    path: &std::path::Path,
+) -> std::path::PathBuf {
+    let package_root = home.path().join(format!("{rig_id}-package"));
+    let rig_dir = package_root.join("rigs").join(rig_id);
+    let workload_dir = package_root.join("workloads");
+    fs::create_dir_all(&rig_dir).expect("mkdir package rig");
+    fs::create_dir_all(&workload_dir).expect("mkdir package workloads");
+    fs::write(workload_dir.join("package-extra.bench.js"), "// fixture\n")
+        .expect("write package workload");
+    fs::write(
+        rig_dir.join("rig.json"),
+        format!(
+            r#"{{
+                    "components": {{
+                        "{component_id}": {{
+                            "path": "{}",
+                            "extensions": {{ "fixture-bench": {{}} }}
+                        }}
+                    }},
+                    "bench": {{ "default_component": "{component_id}" }},
+                    "bench_workloads": {{ "fixture-bench": [
+                        {{ "path": "${{package.root}}/workloads/package-extra.bench.js" }}
+                    ] }}
+                }}"#,
+            path.display()
+        ),
+    )
+    .expect("write package rig");
+
+    homeboy::core::rig::install(package_root.to_string_lossy().as_ref(), Some(rig_id), false)
+        .expect("install rig package");
+    package_root
+}
+
 fn write_rig_with_component_script(
     home: &TempDir,
     rig_id: &str,
@@ -428,6 +466,73 @@ fn run_list_uses_rig_default_component_and_workloads() {
                 assert_eq!(result.scenarios[0].id, "rig-extra");
             }
             _ => panic!("expected list output"),
+        }
+    });
+}
+
+#[test]
+fn run_list_serializes_installed_rig_package_evidence() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        let package_root = install_rig_package(home, "studio-bfb", "studio", component_dir.path());
+
+        let (output, exit_code) = run_list(&list_args(None, vec!["studio-bfb".to_string()]))
+            .expect("rig bench list should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::List(result) => {
+                let package_root = package_root.to_string_lossy().to_string();
+                assert_eq!(result.scenarios[0].id, "package-extra");
+                let evidence = result.rig_package.expect("rig package evidence");
+                assert_eq!(evidence.rig_id, "studio-bfb");
+                assert_eq!(evidence.package_root, package_root);
+                assert_eq!(evidence.source, package_root);
+                assert!(!evidence.freshness_verified);
+                assert_eq!(
+                    evidence.freshness,
+                    homeboy::core::extension::bench::parsing::RigPackageFreshness::Unknown
+                );
+                assert!(evidence
+                    .refresh_command
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("homeboy rig install"));
+            }
+            _ => panic!("expected list output"),
+        }
+    });
+}
+
+#[test]
+fn single_rig_run_records_installed_rig_package_evidence_in_metadata() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        let package_root = install_rig_package(home, "studio-bfb", "studio", component_dir.path());
+
+        let (output, exit_code) = run(
+            run_args(None, vec!["studio-bfb".to_string()], Vec::new()),
+            &GlobalArgs {},
+        )
+        .expect("rig bench should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::Single(result) => {
+                let package_root = package_root.to_string_lossy().to_string();
+                let metadata = result
+                    .results
+                    .expect("bench results")
+                    .run_metadata
+                    .expect("run metadata");
+                let evidence = metadata.rig_package.expect("rig package evidence");
+                assert_eq!(evidence.package_root, package_root);
+                assert_eq!(evidence.rig_id, "studio-bfb");
+                assert_eq!(evidence.source_root.as_deref(), Some(package_root.as_str()));
+            }
+            _ => panic!("expected single output"),
         }
     });
 }

--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -68,6 +68,7 @@ fn bench_command_json_contract_matches_golden_fixture() {
                     component_id: "homeboy".to_string(),
                     scenarios: Vec::new(),
                     count: 0,
+                    rig_package: None,
                 })),
             ]
         }),

--- a/src/commands/report/bench_coverage.rs
+++ b/src/commands/report/bench_coverage.rs
@@ -143,6 +143,7 @@ fn component_report(
             passthrough_args: Vec::new(),
             scenario_ids: Vec::new(),
             extra_workloads: Vec::new(),
+            rig_package: None,
         },
         &run_dir,
     );

--- a/src/core/extension/bench/failure_diagnostic.rs
+++ b/src/core/extension/bench/failure_diagnostic.rs
@@ -147,6 +147,7 @@ mod tests {
             rig_id: Some("studio-bfb".to_string()),
             shared_state: None,
             extra_workloads: Vec::new(),
+            rig_package: None,
             invocation_requirements:
                 crate::core::engine::invocation::InvocationRequirements::default(),
         }

--- a/src/core/extension/bench/parsing/mod.rs
+++ b/src/core/extension/bench/parsing/mod.rs
@@ -83,6 +83,7 @@ pub use super::result_types::{
     BenchMemory, BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy, BenchMetrics,
     BenchProvenance, BenchProvenanceLink, BenchResults, BenchRunExecution, BenchRunMetadata,
     BenchRunSnapshot, BenchRunnerMetadata, BenchScenario, BenchWorkloadMetadata, RegressionTest,
+    RigPackageEvidence, RigPackageFreshness,
 };
 
 /// Read and parse a `$HOMEBOY_BENCH_RESULTS_FILE` written by an extension.

--- a/src/core/extension/bench/result_types.rs
+++ b/src/core/extension/bench/result_types.rs
@@ -98,9 +98,46 @@ pub struct BenchRunMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner: Option<BenchRunnerMetadata>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rig_package: Option<RigPackageEvidence>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lifecycle: Option<LifecycleResultMetadata>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<BenchDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RigPackageEvidence {
+    pub rig_id: String,
+    pub package_root: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovery_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub installed_source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_source_revision: Option<String>,
+    pub linked: bool,
+    pub materialized: bool,
+    pub freshness: RigPackageFreshness,
+    pub freshness_verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub freshness_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RigPackageFreshness {
+    Verified,
+    Stale,
+    Missing,
+    Unknown,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]

--- a/src/core/extension/bench/run/list.rs
+++ b/src/core/extension/bench/run/list.rs
@@ -41,7 +41,12 @@ pub fn run_bench_list_workflow(
             &output.stdout,
             &output.stderr,
         )?;
-        return bench_list_result(args.component_label, results_file, &args.scenario_ids);
+        return bench_list_result(
+            args.component_label,
+            results_file,
+            &args.scenario_ids,
+            args.rig_package,
+        );
     }
 
     let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;
@@ -74,6 +79,7 @@ pub fn run_bench_list_workflow(
             rig_id: None,
             shared_state: None,
             extra_workloads: args.extra_workloads,
+            rig_package: args.rig_package.clone(),
             invocation_requirements: InvocationRequirements::default(),
         },
         run_dir,
@@ -88,7 +94,12 @@ pub fn run_bench_list_workflow(
         &runner_output.stdout,
         &runner_output.stderr,
     )?;
-    bench_list_result(args.component_label, results_file, &args.scenario_ids)
+    bench_list_result(
+        args.component_label,
+        results_file,
+        &args.scenario_ids,
+        args.rig_package,
+    )
 }
 
 pub(crate) fn ensure_bench_list_success(
@@ -113,6 +124,7 @@ pub(crate) fn bench_list_result(
     component_label: String,
     results_file: PathBuf,
     scenario_ids: &[String],
+    rig_package: Option<crate::core::extension::bench::parsing::RigPackageEvidence>,
 ) -> Result<BenchListWorkflowResult> {
     let mut parsed = parsing::parse_bench_results_file_with_artifact_context(&results_file, None)?;
     normalize_workload_json_scenario_ids(&mut parsed);
@@ -124,6 +136,7 @@ pub(crate) fn bench_list_result(
         component_id: parsed.component_id,
         scenarios: parsed.scenarios,
         count,
+        rig_package,
     })
 }
 

--- a/src/core/extension/bench/run/mod.rs
+++ b/src/core/extension/bench/run/mod.rs
@@ -158,6 +158,7 @@ mod tests {
                 rig_id: None,
                 shared_state: None,
                 extra_workloads: Vec::new(),
+                rig_package: None,
                 invocation_requirements: InvocationRequirements::default(),
             },
             &run_dir,
@@ -253,6 +254,7 @@ mod tests {
             rig_id: None,
             shared_state: None,
             extra_workloads: Vec::new(),
+            rig_package: None,
             invocation_requirements: InvocationRequirements::default(),
         }
     }
@@ -271,6 +273,7 @@ mod tests {
             passthrough_args: Vec::new(),
             scenario_ids: Vec::new(),
             extra_workloads: Vec::new(),
+            rig_package: None,
         })
         .expect("component-script list env");
 
@@ -607,6 +610,7 @@ printf '{}' > "$(dirname "$HOMEBOY_BENCH_RESULTS_FILE")/bench-report.json"
                     rig_id: None,
                     shared_state: None,
                     extra_workloads: Vec::new(),
+                    rig_package: None,
                     invocation_requirements: InvocationRequirements::default(),
                 },
                 &run_dir,
@@ -783,6 +787,7 @@ printf '{}' > "$(dirname "$HOMEBOY_BENCH_RESULTS_FILE")/bench-report.json"
             component: "homeboy".to_string(),
             component_id: "homeboy".to_string(),
             count: 1,
+            rig_package: None,
             scenarios: vec![BenchScenario {
                 id: "audit-self".to_string(),
                 file: Some("src/bin/bench-audit-self.rs".to_string()),
@@ -849,6 +854,7 @@ printf '{}' > "$(dirname "$HOMEBOY_BENCH_RESULTS_FILE")/bench-report.json"
                 rig_id: None,
                 shared_state: None,
                 extra_workloads: Vec::new(),
+                rig_package: None,
                 invocation_requirements: InvocationRequirements::default(),
             },
             &run_dir,

--- a/src/core/extension/bench/run/types.rs
+++ b/src/core/extension/bench/run/types.rs
@@ -8,6 +8,7 @@ use crate::core::engine::baseline::BaselineFlags;
 use crate::core::engine::invocation::InvocationRequirements;
 use crate::core::extension::bench::baseline::BenchBaselineComparison;
 use crate::core::extension::bench::diagnostic::BenchDiagnostic;
+use crate::core::extension::bench::parsing::RigPackageEvidence;
 use crate::core::extension::bench::parsing::{BenchResults, BenchRunExecution, BenchScenario};
 use crate::core::extension::bench::phase_events::BenchPhaseFailureClassification;
 use crate::core::extension::bench::responsiveness::{
@@ -61,6 +62,7 @@ pub struct BenchRunWorkflowArgs {
     /// Rig-declared out-of-tree workloads to run alongside in-tree discovery.
     /// Exported to dispatchers as `HOMEBOY_BENCH_EXTRA_WORKLOADS`.
     pub extra_workloads: Vec<PathBuf>,
+    pub rig_package: Option<RigPackageEvidence>,
     /// Generic Homeboy isolation requirements for each child workload
     /// invocation. Rigs can use this for browser/server/wasm benchmarks without
     /// runner-specific namespace logic.
@@ -124,6 +126,7 @@ pub struct BenchListWorkflowArgs {
     pub passthrough_args: Vec<String>,
     pub scenario_ids: Vec<String>,
     pub extra_workloads: Vec<PathBuf>,
+    pub rig_package: Option<RigPackageEvidence>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -132,4 +135,6 @@ pub struct BenchListWorkflowResult {
     pub component_id: String,
     pub scenarios: Vec<BenchScenario>,
     pub count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig_package: Option<RigPackageEvidence>,
 }

--- a/src/core/extension/bench/run/workflow.rs
+++ b/src/core/extension/bench/run/workflow.rs
@@ -148,6 +148,7 @@ pub fn run_main_bench_workflow(
                     path: source_path.to_string_lossy().to_string(),
                     source_revision: None,
                 }),
+                rig_package: args.rig_package.clone(),
                 lifecycle: None,
                 diagnostics: Vec::new(),
             });

--- a/src/core/extension/bench/run_metadata.rs
+++ b/src/core/extension/bench/run_metadata.rs
@@ -42,6 +42,7 @@ pub(crate) fn stamp_run_metadata(
                 .to_string(),
             source_revision: source_revision_at(&execution_context.extension_path),
         }),
+        rig_package: args.rig_package.clone(),
         lifecycle: None,
         diagnostics: Vec::new(),
     });
@@ -219,6 +220,7 @@ mod tests {
             rig_id: Some("studio".to_string()),
             shared_state: Some(component_dir.path().join("shared")),
             extra_workloads: Vec::new(),
+            rig_package: None,
             invocation_requirements: InvocationRequirements::default(),
         };
         let mut results = BenchResults {

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -91,7 +91,8 @@ pub use workloads::{
 };
 
 use crate::core::error::{Error, Result};
-use crate::core::paths;
+use crate::core::extension::bench::parsing::{RigPackageEvidence, RigPackageFreshness};
+use crate::core::{git, paths};
 use discovery::discover_rigs_for_install;
 use std::collections::HashMap;
 use std::fs;
@@ -119,6 +120,84 @@ pub(crate) fn local_package_root(id: &str) -> Option<PathBuf> {
     LOCAL_PACKAGE_ROOTS
         .get()
         .and_then(|roots| roots.lock().ok()?.get(id).cloned())
+}
+
+pub fn package_evidence(id: &str) -> Option<RigPackageEvidence> {
+    let metadata = read_source_metadata(id)?;
+    Some(package_evidence_from_metadata(id, metadata))
+}
+
+fn package_evidence_from_metadata(id: &str, metadata: RigSourceMetadata) -> RigPackageEvidence {
+    let package_root = metadata.package_path.clone();
+    let source_root = metadata
+        .source_root
+        .clone()
+        .unwrap_or_else(|| metadata.package_path.clone());
+    let current_source_revision = git::short_head_revision_at(Path::new(&source_root));
+    let root_present = Path::new(&source_root).is_dir();
+    let (freshness, freshness_message) = if !root_present {
+        (
+            RigPackageFreshness::Missing,
+            Some("installed rig package source path is missing".to_string()),
+        )
+    } else if let (Some(installed), Some(current)) = (
+        metadata.source_revision.as_deref(),
+        current_source_revision.as_deref(),
+    ) {
+        if installed == current {
+            (RigPackageFreshness::Verified, None)
+        } else {
+            (
+                RigPackageFreshness::Stale,
+                Some(format!(
+                    "installed source revision {installed} differs from current source revision {current}"
+                )),
+            )
+        }
+    } else {
+        (
+            RigPackageFreshness::Unknown,
+            Some(
+                "source freshness could not be verified because a git revision was unavailable"
+                    .to_string(),
+            ),
+        )
+    };
+    let freshness_verified = freshness == RigPackageFreshness::Verified;
+    let refresh_command = (!freshness_verified).then(|| {
+        format!(
+            "homeboy rig install {} --id {} --reinstall",
+            shell_arg(&metadata.source),
+            shell_arg(id)
+        )
+    });
+
+    RigPackageEvidence {
+        rig_id: id.to_string(),
+        package_root,
+        source: metadata.source,
+        source_root: Some(source_root),
+        rig_path: Some(metadata.rig_path),
+        discovery_path: metadata.discovery_path,
+        installed_source_revision: metadata.source_revision,
+        current_source_revision,
+        linked: metadata.linked,
+        materialized: metadata.materialized,
+        freshness,
+        freshness_verified,
+        freshness_message,
+        refresh_command,
+    }
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 /// Byte-compare the contents of two files.

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -56,6 +56,14 @@ pub(super) struct LabOffloadRigPackageSource {
     pub discovery_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_source_revision: Option<String>,
+    pub freshness_verified: bool,
+    pub freshness_status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub freshness_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_command: Option<String>,
     pub linked: bool,
     pub materialized: bool,
 }
@@ -108,6 +116,17 @@ pub(super) fn sync_lab_offload_rigs(
                         rig_path: None,
                         discovery_path: None,
                         source_revision: primary.source_snapshot.git_sha.clone(),
+                        current_source_revision: primary.source_snapshot.git_sha.clone(),
+                        freshness_verified: primary.source_snapshot.git_sha.is_some(),
+                        freshness_status: if primary.source_snapshot.git_sha.is_some() {
+                            "verified".to_string()
+                        } else {
+                            "unknown".to_string()
+                        },
+                        freshness_message: primary.source_snapshot.git_sha.is_none().then(|| {
+                            "primary rig source freshness could not be verified because a git revision was unavailable".to_string()
+                        }),
+                        refresh_command: None,
                         linked: true,
                         materialized: false,
                     },
@@ -160,20 +179,27 @@ pub(super) fn sync_lab_offload_rigs(
                     Some(&synced.remote_path),
                     "lab_rig_source",
                 );
+                let package_source = LabOffloadRigPackageSource {
+                    source: metadata.source,
+                    source_root,
+                    package_path: metadata.package_path,
+                    install_source: install_source.clone(),
+                    rig_path: Some(metadata.rig_path),
+                    discovery_path: metadata.discovery_path,
+                    source_revision: metadata.source_revision,
+                    current_source_revision: source_snapshot.git_sha.clone(),
+                    linked: metadata.linked,
+                    materialized: metadata.materialized,
+                    freshness_verified: false,
+                    freshness_status: String::new(),
+                    freshness_message: None,
+                    refresh_command: None,
+                };
+                let package_source = with_lab_package_freshness(rig_id, package_source);
                 (
                     install_source.clone(),
                     LabOffloadRigSyncSource::InstalledMetadata,
-                    LabOffloadRigPackageSource {
-                        source: metadata.source,
-                        source_root,
-                        package_path: metadata.package_path,
-                        install_source,
-                        rig_path: Some(metadata.rig_path),
-                        discovery_path: metadata.discovery_path,
-                        source_revision: metadata.source_revision,
-                        linked: metadata.linked,
-                        materialized: metadata.materialized,
-                    },
+                    package_source,
                     LabOffloadRigWorkloadHashes {
                         source_snapshot_hash: source_snapshot.snapshot_hash.clone(),
                         workspace_snapshot_identity: synced.snapshot_identity,
@@ -263,6 +289,43 @@ pub(super) fn sync_lab_offload_rigs(
     }
 
     Ok(synced_rigs)
+}
+
+fn with_lab_package_freshness(
+    rig_id: &str,
+    mut package_source: LabOffloadRigPackageSource,
+) -> LabOffloadRigPackageSource {
+    match (
+        package_source.source_revision.as_deref(),
+        package_source.current_source_revision.as_deref(),
+    ) {
+        (Some(installed), Some(current)) if installed == current => {
+            package_source.freshness_verified = true;
+            package_source.freshness_status = "verified".to_string();
+        }
+        (Some(installed), Some(current)) => {
+            package_source.freshness_status = "stale".to_string();
+            package_source.freshness_message = Some(format!(
+                "installed source revision {installed} differs from current source revision {current}"
+            ));
+            package_source.refresh_command = Some(format!(
+                "homeboy rig install {} --id {} --reinstall",
+                package_source.install_source, rig_id
+            ));
+        }
+        _ => {
+            package_source.freshness_status = "unknown".to_string();
+            package_source.freshness_message = Some(
+                "runner rig source freshness could not be verified because a git revision was unavailable"
+                    .to_string(),
+            );
+            package_source.refresh_command = Some(format!(
+                "homeboy rig install {} --id {} --reinstall",
+                package_source.install_source, rig_id
+            ));
+        }
+    }
+    package_source
 }
 
 fn installed_rig_path_from_stdout(stdout: &str, rig_id: &str) -> Option<String> {
@@ -1034,6 +1097,41 @@ mod tests {
                 .remote_checkout_root
                 .contains("${package.root}"));
         });
+    }
+
+    #[test]
+    fn lab_package_source_freshness_reports_stale_revision_and_refresh_command() {
+        let package = with_lab_package_freshness(
+            "studio-web-product-matrix",
+            LabOffloadRigPackageSource {
+                source: "/controller/homeboy-rigs".to_string(),
+                source_root: "/controller/homeboy-rigs".to_string(),
+                package_path: "/controller/homeboy-rigs".to_string(),
+                install_source: "/runner/_lab_workspaces/homeboy-rigs".to_string(),
+                rig_path: Some("/controller/homeboy-rigs/rigs/studio/rig.json".to_string()),
+                discovery_path: Some("/controller/homeboy-rigs".to_string()),
+                source_revision: Some("abc1234".to_string()),
+                current_source_revision: Some("def5678".to_string()),
+                freshness_verified: false,
+                freshness_status: String::new(),
+                freshness_message: None,
+                refresh_command: None,
+                linked: true,
+                materialized: false,
+            },
+        );
+
+        assert!(!package.freshness_verified);
+        assert_eq!(package.freshness_status, "stale");
+        assert!(package
+            .freshness_message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("abc1234"));
+        assert_eq!(
+            package.refresh_command.as_deref(),
+            Some("homeboy rig install /runner/_lab_workspaces/homeboy-rigs --id studio-web-product-matrix --reinstall")
+        );
     }
 
     #[test]

--- a/tests/commands/bench/observation_artifact_test.rs
+++ b/tests/commands/bench/observation_artifact_test.rs
@@ -118,6 +118,7 @@ fn bench_observation_resolves_shared_state_mount_artifacts() {
             workloads: Vec::new(),
             provenance: Default::default(),
             runner: None,
+            rig_package: None,
             lifecycle: None,
             diagnostics: Vec::new(),
         });


### PR DESCRIPTION
## Summary
- Surface installed rig package evidence in bench list output and bench run metadata.
- Include package root, source paths, source revisions, freshness status, and refresh command hints.
- Add Lab rig package freshness fields to rig sync metadata.
- Add focused bench output and Lab metadata contract tests.

Fixes #6430.

## Verification
- cargo test installed_rig_package_evidence --lib
- cargo test lab_package_source_freshness_reports_stale_revision_and_refresh_command --lib
- cargo test commands::bench --lib
- cargo test core::extension::bench --lib
- cargo test core::runner::rig_materialization --lib
- cargo test --lib compiled and ran for 20 minutes but hit the local tool timeout before completing the full 6k+ test suite.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Implementing rig package evidence metadata, focused tests, verification, and PR preparation.