### PR TITLE
Fix fanout runner workspace materialization

### DIFF
--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -55,6 +55,7 @@ fn submit_batch_cook_fanout(args: AgentTaskFanoutSubmitArgs) -> CmdResult<Value>
                 "run_id": cook.run_id(),
                 "worktree": cook.to_worktree,
                 "head": cook.head,
+                "workspace_materialization": cook.workspace_materialization,
                 "title": cook.title,
                 "command": cook_command(&plan, cook),
             })
@@ -131,6 +132,7 @@ fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
             "run_id": cook.run_id(),
             "worktree": cook.to_worktree,
             "head": cook.head,
+            "workspace_materialization": cook.workspace_materialization,
             "exit_code": exit_code,
             "result": value,
         }));
@@ -229,6 +231,8 @@ struct BatchCookSpec {
     cwd: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     workspace: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    workspace_materialization: Vec<BatchCookWorkspaceMaterialization>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     repo: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -276,6 +280,18 @@ struct BatchCookSpec {
     ai_tool: String,
     #[serde(default = "default_ai_used_for")]
     ai_used_for: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct BatchCookWorkspaceMaterialization {
+    field: String,
+    controller_path: String,
+    runner_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    branch: Option<String>,
+    #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
+    ref_name: Option<String>,
+    sync_status: String,
 }
 
 #[derive(Debug, Clone)]
@@ -402,19 +418,6 @@ fn default_cook_commit_message(cook: &BatchCookSpec) -> String {
     format!("fix: cook {target}")
 }
 
-fn client_context(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> String {
-    serde_json::json!({
-        "fanout": {
-            "id": plan.fanout_id,
-            "semantics": "batch_cook",
-            "cook_id": cook.cook_id,
-            "to_worktree": cook.to_worktree,
-            "head": cook.head,
-        }
-    })
-    .to_string()
-}
-
 fn merged_client_context(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> String {
     let mut context = serde_json::from_str::<Value>(cook.client_context.as_deref().unwrap_or("{}"))
         .unwrap_or(Value::Null);
@@ -430,6 +433,7 @@ fn merged_client_context(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> St
                 "cook_id": cook.cook_id,
                 "to_worktree": cook.to_worktree,
                 "head": cook.head,
+                "workspace_materialization": cook.workspace_materialization,
             }),
         );
     }
@@ -535,6 +539,15 @@ mod tests {
                         "cook_id": "5929-docs",
                         "prompt": "fix docs",
                         "repo": "homeboy",
+                        "cwd": "/runner/workspaces/homeboy@5929-docs",
+                        "workspace_materialization": [{
+                            "field": "cwd",
+                            "controller_path": "/Users/user/Developer/homeboy@5929-docs",
+                            "runner_path": "/runner/workspaces/homeboy@5929-docs",
+                            "branch": "fix/5929-docs",
+                            "ref": "fix/5929-docs",
+                            "sync_status": "materialized"
+                        }],
                         "to_worktree": "homeboy@fix-5929-docs",
                         "head": "fix/5929-docs",
                         "verify": ["homeboy test homeboy"]
@@ -563,6 +576,10 @@ mod tests {
         assert_eq!(invocation.options.to_worktree, "homeboy@fix-5929-docs");
         assert_eq!(invocation.options.head.as_deref(), Some("fix/5929-docs"));
         assert_eq!(
+            invocation.dispatch.cwd.as_deref(),
+            Some("/runner/workspaces/homeboy@5929-docs")
+        );
+        assert_eq!(
             invocation.dispatch.run_id.as_deref(),
             Some("cook-5929-docs")
         );
@@ -577,6 +594,13 @@ mod tests {
             .as_deref()
             .expect("client context")
             .contains("batch_cook"));
+        assert!(invocation
+            .dispatch
+            .core
+            .client_context
+            .as_deref()
+            .expect("client context")
+            .contains("/Users/user/Developer/homeboy@5929-docs"));
     }
 
     #[test]

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -81,12 +81,12 @@ use super::super::lab_selection::{
     LabRunnerSelectionSource,
 };
 use super::super::lab_workspaces::{
-    agent_task_plan_extra_workspaces, agent_task_provider_runtime_component_extra_workspaces,
-    lab_extra_workspaces, lab_runtime_overlay_metadata, lab_runtime_overlays,
-    lab_workspace_mapping_metadata, path_setting_extra_workspaces,
-    preflight_provider_config_source_cli_dependencies, provider_config_extra_workspaces,
-    rig_component_path_env_extra_workspaces, runtime_overlay_env_overrides,
-    sync_extra_lab_workspaces, sync_lab_runtime_overlays,
+    agent_task_fanout_extra_workspaces, agent_task_plan_extra_workspaces,
+    agent_task_provider_runtime_component_extra_workspaces, lab_extra_workspaces,
+    lab_runtime_overlay_metadata, lab_runtime_overlays, lab_workspace_mapping_metadata,
+    path_setting_extra_workspaces, preflight_provider_config_source_cli_dependencies,
+    provider_config_extra_workspaces, rig_component_path_env_extra_workspaces,
+    runtime_overlay_env_overrides, sync_extra_lab_workspaces, sync_lab_runtime_overlays,
     workspace_mapping_entries_for_git_dependency, workspace_mapping_entry,
     workspace_mapping_entry_for_validation_dependency, LabWorkspaceMappingEntry,
 };

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -118,6 +118,10 @@ fn prepare_lab_offload_workspace_stage_inner(
         &offload_args,
         source_path,
     )?);
+    extra_workspaces.extend(agent_task_fanout_extra_workspaces(
+        &offload_args,
+        source_path,
+    )?);
     extra_workspaces.extend(agent_task_provider_runtime_component_extra_workspaces(
         &offload_args,
         source_path,

--- a/src/core/runner/lab_args/agent_task_specs.rs
+++ b/src/core/runner/lab_args/agent_task_specs.rs
@@ -42,6 +42,8 @@ pub(in crate::core::runner) fn materialize_agent_task_specs_in_args<T>(
     mut sync_inline_json: impl FnMut(AgentTaskInlineJsonSpec<'_>) -> Result<Option<(String, T)>>,
 ) -> Result<AgentTaskSpecMaterialization<T>> {
     let remapped_args = remap_agent_task_plan_in_args(args, mappings, source_path)?;
+    let remapped_args =
+        remap_agent_task_fanout_input_in_args(&remapped_args, mappings, source_path)?;
     let remapped_args = inline_agent_task_prompt_files_in_args(&remapped_args, source_path)?;
     let (argv, workspace_entries) =
         materialize_inline_agent_task_json_specs_in_args(&remapped_args, |spec| {
@@ -51,6 +53,40 @@ pub(in crate::core::runner) fn materialize_agent_task_specs_in_args<T>(
     Ok(AgentTaskSpecMaterialization {
         argv,
         workspace_entries,
+    })
+}
+
+fn remap_agent_task_fanout_input_in_args(
+    args: &[String],
+    mappings: &[LabPathRemap],
+    source_path: &Path,
+) -> Result<Vec<String>> {
+    if !agent_task_subcommand_is(args, &["fanout", "run-plan"]) {
+        return Ok(args.to_vec());
+    }
+    let ordered = order_mappings_by_specificity(mappings);
+
+    try_rewrite_flag_value_args(args, |arg, iter, out| {
+        if arg == "--input" {
+            out.push(arg.to_string());
+            if let Some(spec) = iter.next() {
+                out.push(remap_agent_task_fanout_input_spec(
+                    spec,
+                    &ordered,
+                    source_path,
+                )?);
+            }
+            return Ok(());
+        }
+        if let Some(spec) = arg.strip_prefix("--input=") {
+            out.push(format!(
+                "--input={}",
+                remap_agent_task_fanout_input_spec(spec, &ordered, source_path)?
+            ));
+            return Ok(());
+        }
+        out.push(arg.to_string());
+        Ok(())
     })
 }
 
@@ -144,6 +180,98 @@ fn remap_agent_task_plan_spec(
             err.to_string(),
             Some("serialize remapped agent-task plan".to_string()),
         )
+    })
+}
+
+fn remap_agent_task_fanout_input_spec(
+    spec: &str,
+    mappings: &[&LabPathRemap],
+    source_path: &Path,
+) -> Result<String> {
+    if spec == "-" {
+        return Ok(spec.to_string());
+    }
+
+    let raw = read_agent_task_plan_spec_to_string(spec, source_path)?;
+    let mut value: Value = serde_json::from_str(&raw).map_err(|err| {
+        Error::validation_invalid_json(
+            err,
+            Some(format!("parse agent-task fanout run-plan --input {spec}")),
+            None,
+        )
+    })?;
+    let original_value = value.clone();
+    remap_paths_in_value(&mut value, mappings);
+    rewrite_fanout_cook_workspaces(&mut value, &original_value, mappings);
+    serde_json::to_string(&value).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("serialize remapped agent-task fanout input".to_string()),
+        )
+    })
+}
+
+fn rewrite_fanout_cook_workspaces(
+    value: &mut Value,
+    original_value: &Value,
+    mappings: &[&LabPathRemap],
+) {
+    let original_cooks = original_value
+        .get("cooks")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let Some(cooks) = value.get_mut("cooks").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for (index, cook) in cooks.iter_mut().enumerate() {
+        let Some(object) = cook.as_object_mut() else {
+            continue;
+        };
+        let original_object = original_cooks.get(index).and_then(Value::as_object);
+        let mut materializations = Vec::new();
+        for field in ["cwd", "workspace"] {
+            let Some(controller_value) = original_object
+                .and_then(|object| object.get(field))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+            else {
+                continue;
+            };
+            let resolved_controller_path = crate::core::worktree::resolve(&controller_value)
+                .ok()
+                .map(|record| record.worktree_path)
+                .unwrap_or_else(|| controller_value.clone());
+            let Some(runner_path) = rewrite_path_with_mappings(&resolved_controller_path, mappings)
+            else {
+                continue;
+            };
+            object.insert(field.to_string(), Value::String(runner_path.clone()));
+            materializations.push(serde_json::json!({
+                "field": field,
+                "controller_path": resolved_controller_path,
+                "runner_path": runner_path,
+                "branch": object.get("head").and_then(Value::as_str).or_else(|| object.get("base").and_then(Value::as_str)),
+                "ref": object.get("head").and_then(Value::as_str).or_else(|| object.get("base").and_then(Value::as_str)),
+                "sync_status": "materialized",
+            }));
+        }
+        if !materializations.is_empty() {
+            object.insert(
+                "workspace_materialization".to_string(),
+                Value::Array(materializations),
+            );
+        }
+    }
+}
+
+fn rewrite_path_with_mappings(path: &str, mappings: &[&LabPathRemap]) -> Option<String> {
+    mappings.iter().find_map(|mapping| {
+        if path == mapping.local {
+            return Some(mapping.remote.clone());
+        }
+        path.strip_prefix(&format!("{}/", mapping.local))
+            .map(|suffix| format!("{}/{suffix}", mapping.remote))
     })
 }
 

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1207,6 +1207,57 @@ fn materialize_agent_task_specs_syncs_inline_and_file_tasks_json() {
 }
 
 #[test]
+fn materialize_agent_task_specs_rewrites_fanout_child_cwd_to_runner_path() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let controller = temp.path().join("homeboy@cook-one");
+    std::fs::create_dir_all(&controller).expect("controller workspace");
+    let mappings = vec![LabPathRemap {
+        local: controller.display().to_string(),
+        remote: "/runner/workspaces/homeboy@cook-one".to_string(),
+    }];
+    let fanout = serde_json::json!({
+        "schema": "homeboy/agent-task-batch-cook-fanout-plan/v1",
+        "fanout_id": "fanout/test",
+        "cooks": [{
+            "cook_id": "one",
+            "prompt": "fix it",
+            "cwd": controller,
+            "to_worktree": "homeboy@fix-one",
+            "head": "fix/one",
+            "verify": ["cargo test -p homeboy"]
+        }]
+    })
+    .to_string();
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "fanout".to_string(),
+        "run-plan".to_string(),
+        "--input".to_string(),
+        fanout,
+    ];
+
+    let out = materialize_agent_task_specs_in_args(&args, &mappings, temp.path(), |_| {
+        Ok(None::<(String, &'static str)>)
+    })
+    .expect("materialize fanout input");
+    let rewritten: serde_json::Value = serde_json::from_str(&out.argv[5]).expect("rewritten json");
+
+    assert_eq!(
+        rewritten["cooks"][0]["cwd"],
+        serde_json::json!("/runner/workspaces/homeboy@cook-one")
+    );
+    assert_eq!(
+        rewritten["cooks"][0]["workspace_materialization"][0]["controller_path"],
+        serde_json::json!(temp.path().join("homeboy@cook-one").display().to_string())
+    );
+    assert_eq!(
+        rewritten["cooks"][0]["workspace_materialization"][0]["sync_status"],
+        serde_json::json!("materialized")
+    );
+}
+
+#[test]
 fn remap_path_settings_rewrites_local_path_values() {
     let mappings = vec![LabPathRemap {
         local: "/Users/user/Developer/tool-runner".to_string(),

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -644,6 +644,55 @@ pub(super) fn agent_task_plan_extra_workspaces(
     Ok(workspaces)
 }
 
+/// Discover controller-local workspaces embedded in a batch-cook fanout input
+/// before the offloaded `agent-task fanout run-plan` command reaches the runner.
+/// Child cooks often carry controller paths in `cwd` or `workspace`; syncing
+/// them here lets the later argument remapper rewrite the JSON to runner paths.
+pub(super) fn agent_task_fanout_extra_workspaces(
+    args: &[String],
+    source_path: &Path,
+) -> Result<Vec<ExtraLabWorkspace>> {
+    let Some(spec) = agent_task_fanout_input_spec(args) else {
+        return Ok(Vec::new());
+    };
+    let raw = match read_fanout_input_spec_to_string(&spec, source_path) {
+        Ok(raw) => raw,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let Some(cooks) = value.get("cooks").and_then(serde_json::Value::as_array) else {
+        return Ok(Vec::new());
+    };
+
+    let source_canon = source_path
+        .canonicalize()
+        .unwrap_or_else(|_| source_path.to_path_buf());
+    let mut seen = BTreeSet::new();
+    let mut workspaces = Vec::new();
+    for cook in cooks {
+        for field in ["cwd", "workspace"] {
+            let Some(candidate) = cook.get(field).and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            let Some(path) = fanout_workspace_candidate_path(candidate, source_path) else {
+                continue;
+            };
+            add_candidate_extra_workspace(
+                &path.display().to_string(),
+                "agent_task_fanout_cook_workspace",
+                &source_canon,
+                &mut seen,
+                &mut workspaces,
+            )?;
+        }
+    }
+
+    Ok(workspaces)
+}
+
 /// Resolve runtime components declared by the selected agent-task provider and
 /// add their controller-local checkouts to the Lab workspace handoff.
 pub(super) fn agent_task_provider_runtime_component_extra_workspaces(
@@ -871,6 +920,30 @@ fn agent_task_plan_spec(args: &[String]) -> Option<String> {
     None
 }
 
+fn agent_task_fanout_input_spec(args: &[String]) -> Option<String> {
+    let fanout_index = subcommand_index(args, "agent-task").and_then(|index| {
+        args.get(index + 1)
+            .filter(|arg| arg.as_str() == "fanout")
+            .and_then(|_| args.get(index + 2))
+            .filter(|arg| arg.as_str() == "run-plan")
+            .map(|_| index + 2)
+    })?;
+
+    let mut iter = args.iter().skip(fanout_index + 1).peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--input" {
+            return iter.next().cloned();
+        }
+        if let Some(value) = arg.strip_prefix("--input=") {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
 fn agent_task_plan_file_path(spec: &str, source_path: &Path) -> Option<PathBuf> {
     let path = spec.strip_prefix('@')?;
     if path.trim().is_empty() || path.contains("://") {
@@ -903,6 +976,38 @@ fn read_agent_task_plan_spec_to_string(spec: &str, source_path: &Path) -> Result
             Some(format!("read agent-task plan {}", path.display())),
         )
     })
+}
+
+fn read_fanout_input_spec_to_string(spec: &str, source_path: &Path) -> Result<String> {
+    let Some(_) = spec.strip_prefix('@') else {
+        return crate::core::config::read_json_spec_to_string(spec);
+    };
+    let Some(path) = agent_task_plan_file_path(spec, source_path) else {
+        return crate::core::config::read_json_spec_to_string(spec);
+    };
+    std::fs::read_to_string(&path).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("read agent-task fanout input {}", path.display())),
+        )
+    })
+}
+
+fn fanout_workspace_candidate_path(value: &str, source_path: &Path) -> Option<PathBuf> {
+    let path = PathBuf::from(shellexpand::tilde(value).to_string());
+    if path.is_dir() {
+        return Some(path);
+    }
+    if path.is_relative() {
+        let source_relative = source_path.join(&path);
+        if source_relative.is_dir() {
+            return Some(source_relative);
+        }
+    }
+    crate::core::worktree::resolve(value)
+        .ok()
+        .map(|record| PathBuf::from(record.worktree_path))
+        .filter(|path| path.is_dir())
 }
 
 fn path_setting_values(args: &[String]) -> Vec<String> {
@@ -952,9 +1057,10 @@ mod provider_config_candidate_paths_tests {
     use std::process::Command;
 
     use super::{
-        agent_task_plan_extra_workspaces, agent_task_plan_spec, path_setting_extra_workspaces,
-        preflight_provider_config_source_cli_dependencies, provider_config_candidate_paths,
-        provider_config_extra_workspaces, rig_component_path_env_extra_workspaces_from_entries,
+        agent_task_fanout_extra_workspaces, agent_task_plan_extra_workspaces, agent_task_plan_spec,
+        path_setting_extra_workspaces, preflight_provider_config_source_cli_dependencies,
+        provider_config_candidate_paths, provider_config_extra_workspaces,
+        rig_component_path_env_extra_workspaces_from_entries,
         workspace_mapping_entries_for_git_dependency,
     };
     use crate::core::runner::{
@@ -1210,6 +1316,48 @@ mod provider_config_candidate_paths_tests {
             .snapshot_includes
             .contains(&"packages/cli/dist/**".to_string()));
         assert!(workspaces[1].bootstrap_node_dependencies);
+    }
+
+    #[test]
+    fn agent_task_fanout_extra_workspaces_syncs_child_cook_paths() {
+        let controller = tempfile::tempdir().expect("controller");
+        let source = controller.path().join("primary");
+        let child = controller.path().join("homeboy@cook-one");
+        let spec = source.join("fanout.json");
+        std::fs::create_dir_all(&source).expect("source dir");
+        std::fs::create_dir_all(&child).expect("child dir");
+        std::fs::write(
+            &spec,
+            serde_json::json!({
+                "schema": "homeboy/agent-task-batch-cook-fanout-plan/v1",
+                "fanout_id": "fanout/test",
+                "cooks": [{
+                    "cook_id": "one",
+                    "prompt": "fix it",
+                    "cwd": child,
+                    "to_worktree": "homeboy@fix-one",
+                    "head": "fix/one",
+                    "verify": ["cargo test -p homeboy"]
+                }]
+            })
+            .to_string(),
+        )
+        .expect("fanout spec");
+
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "fanout".to_string(),
+            "run-plan".to_string(),
+            "--input".to_string(),
+            format!("@{}", spec.display()),
+        ];
+
+        let workspaces = agent_task_fanout_extra_workspaces(&args, &source).expect("workspaces");
+
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].role, "agent_task_fanout_cook_workspace");
+        assert_eq!(workspaces[0].path, child.canonicalize().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Materialize controller-local child cook workspaces referenced by batch-cook fanout specs during Lab offload.
- Rewrite offloaded fanout `--input` payloads so child cook `cwd`/`workspace` values resolve on the runner.
- Record controller path, runner path, branch/ref, and sync status in child cook output/client context.

Fixes #6452

## Verification
- `cargo test materialize_agent_task_specs_rewrites_fanout_child_cwd_to_runner_path --lib`
- `cargo test agent_task_fanout_extra_workspaces_syncs_child_cook_paths --lib`
- `cargo test batch_cook_plan_requires_independent_cooks_with_worktrees --lib`
- `cargo fmt --all`
- `cargo test --lib` started twice and showed only passing tests before timing out locally after 20m/30m; CI is the full-suite authority for this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Implementing the fanout runner workspace materialization fix, focused tests, and verification.