### PR TITLE
Add one-command issue cook batch fanout

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -66,12 +66,51 @@ ordering and output bindings belong in the existing single-run `fanout submit` /
 | Subcommand | Purpose |
 |---|---|
 | `cook` | Run one workspace task through the patch-artifact handoff workflow. |
+| `fanout cook-batch <issue-url>... --repo <repo>` | One-command multi-issue cook setup: derive prompts, create/reuse DMC worktrees, generate PR metadata, and return status/resume commands. |
 | `fanout plan\|submit\|run-plan` | Normalize, inspect, or run a batch of independent cooks, each with its own worktree/branch/PR. |
 | `fanout submit-batch\|status\|artifacts` | Submit and inspect durable batches of independent `AgentTaskPlan` tasks. |
 | `review <run-id>` | Build a durable aggregate review envelope from run state, logs, artifacts, and promotion hints. |
 | `promote <source>` | Promote a completed generic patch artifact into a managed worktree. |
 | `finalize-pr` | Finalize a green cook run into a review-ready pull request. |
 | `gate-feedback` | Convert deterministic gate results into a cook retry or stop decision. |
+
+#### Multi-Issue Cook Batch
+
+Use `agent-task fanout cook-batch` when an operator has a set of GitHub issues
+that should each get an isolated branch, worktree, cook run, deterministic gates,
+and PR finalization defaults. The command accepts issue URLs directly, derives
+the batch-cook plan, queues DMC worktree creation from `origin/main`, and returns
+one structured status envelope with the generated plan plus resume commands.
+
+```bash
+homeboy agent-task fanout cook-batch \
+  --repo homeboy \
+  --verify 'cargo test --lib' \
+  --backend codebox \
+  --selector wordpress.codebox-agent-task-executor \
+  https://github.com/Extra-Chill/homeboy/issues/6453 \
+  https://github.com/Extra-Chill/homeboy/issues/6454
+```
+
+Add `--dry-run` to inspect the derived branch/worktree names and batch-cook spec
+without creating worktrees. Add `--run-plan` after reviewing provider readiness
+to execute the generated batch immediately. When DMC worktree creation is blocked
+by an active lock or another queue issue, the output reports `status: blocked`,
+lists the exact worktree rows and retry commands, and exits non-zero before any
+provider process starts.
+
+The generated plan uses the existing
+`homeboy/agent-task-batch-cook-fanout-plan/v1` contract. That means operators can
+save the returned `plan` object and resume with:
+
+```bash
+homeboy agent-task fanout run-plan --input @batch-cook-plan.json
+```
+
+Prompt templates can be customized with `--prompt-template`; placeholders are
+`{issue_url}`, `{issue_ref}`, `{repo}`, `{branch}`, and `{worktree}`. PR titles,
+commit messages, source refs, and AI disclosure defaults are derived per issue
+unless the generated plan is edited before `fanout run-plan`.
 
 ## Lab Guardrails
 

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -559,7 +559,9 @@ impl Commands {
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
-                        command: agent_task::AgentTaskFanoutCommand::RunPlan(_),
+                        command:
+                            agent_task::AgentTaskFanoutCommand::RunPlan(_)
+                            | agent_task::AgentTaskFanoutCommand::CookBatch(_),
                     }),
             }) => LabCommandContract::portable(
                 AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -30,12 +30,13 @@ pub use args::{
     AgentTaskControllerRunArgs, AgentTaskControllerRunFromSpecArgs, AgentTaskControllerRunNextArgs,
     AgentTaskControllerStatusArgs, AgentTaskControllerValidateProofArgs, AgentTaskCookArgs,
     AgentTaskDoctorArgs, AgentTaskFanoutArgs, AgentTaskFanoutBatchStatusArgs,
-    AgentTaskFanoutCommand, AgentTaskFanoutInputArgs, AgentTaskFanoutPlanArgs,
-    AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs, AgentTaskFanoutSubmitBatchArgs,
-    AgentTaskLoopArgs, AgentTaskLoopCommand, AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs,
-    AgentTaskLoopStatusArgs, CancelArgs, CompileLoopArgs, ContractArgs, ContractFormat,
-    FinalizePrArgs, GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs, ProvidersArgs, RetryArgs,
-    ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    AgentTaskFanoutCommand, AgentTaskFanoutCookBatchArgs, AgentTaskFanoutInputArgs,
+    AgentTaskFanoutPlanArgs, AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs,
+    AgentTaskFanoutSubmitBatchArgs, AgentTaskLoopArgs, AgentTaskLoopCommand,
+    AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs, AgentTaskLoopStatusArgs, CancelArgs,
+    CompileLoopArgs, ContractArgs, ContractFormat, FinalizePrArgs, GateFeedbackArgs, LatestArgs,
+    ListArgs, PromoteArgs, ProvidersArgs, RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs,
+    SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -34,6 +34,8 @@ pub struct AgentTaskFanoutArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum AgentTaskFanoutCommand {
+    /// Build an operator-ready batch-cook fanout from issue URLs and create/reuse DMC worktrees.
+    CookBatch(AgentTaskFanoutCookBatchArgs),
     /// Normalize a batch-cook fanout plan with independent cooks, worktrees, and PR targets.
     Plan(AgentTaskFanoutPlanArgs),
     /// Return the independent cook commands for a batch-cook fanout plan.
@@ -46,6 +48,76 @@ pub enum AgentTaskFanoutCommand {
     Artifacts(AgentTaskFanoutBatchStatusArgs),
     /// Run each independent cook and let each cook open/update its own PR.
     RunPlan(AgentTaskFanoutRunPlanArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskFanoutCookBatchArgs {
+    /// Issue URLs to cook. Each URL becomes one branch, worktree, prompt, and PR target.
+    #[arg(value_name = "ISSUE_URL", required = true)]
+    pub issues: Vec<String>,
+
+    /// Repo/workspace slug managed by Data Machine Code.
+    #[arg(long = "repo", value_name = "REPO")]
+    pub repo: String,
+
+    /// Git ref used when creating worktrees.
+    #[arg(long = "from", default_value = "origin/main", value_name = "REF")]
+    pub from: String,
+
+    /// Pull request base branch used by cook finalization.
+    #[arg(long = "base", default_value = "main", value_name = "BRANCH")]
+    pub base: String,
+
+    /// Prefix for generated branches.
+    #[arg(long = "branch-prefix", default_value = "fix", value_name = "PREFIX")]
+    pub branch_prefix: String,
+
+    /// Batch fanout id. Defaults to cook-batch-<repo>-<first-issue>-<count>.
+    #[arg(long = "fanout-id", value_name = "ID")]
+    pub fanout_id: Option<String>,
+
+    /// Prompt template. Supports {issue_url}, {issue_ref}, {repo}, {branch}, and {worktree}.
+    #[arg(long = "prompt-template", value_name = "TEXT")]
+    pub prompt_template: Option<String>,
+
+    /// Default executor backend for all generated cooks.
+    #[arg(long = "backend", value_name = "BACKEND")]
+    pub backend: Option<String>,
+
+    /// Provider id for all generated cooks.
+    #[arg(
+        long = "selector",
+        visible_alias = "provider-id",
+        value_name = "PROVIDER_ID"
+    )]
+    pub selector: Option<String>,
+
+    /// Optional model override passed through to the provider and PR disclosure.
+    #[arg(long = "model", value_name = "MODEL")]
+    pub model: Option<String>,
+
+    /// Secret environment variable name to hydrate for the provider. Repeatable.
+    #[arg(long = "secret-env", value_name = "ENV")]
+    pub secret_env: Vec<String>,
+
+    /// Provider config JSON object, @file, or - for stdin. Reused by every cook.
+    #[arg(long = "provider-config", value_name = "JSON")]
+    pub provider_config: Option<String>,
+
+    #[command(flatten)]
+    pub gates: VerifyGateArgs,
+
+    /// Report commands/spec without creating worktrees.
+    #[arg(long = "dry-run")]
+    pub dry_run: bool,
+
+    /// Run the generated batch-cook plan immediately after worktree creation succeeds.
+    #[arg(long = "run-plan")]
+    pub run_plan: bool,
+
+    /// Path to the `studio`/DMC wrapper binary.
+    #[arg(long = "dmc-bin", default_value = "studio", value_name = "BIN")]
+    pub dmc_bin: String,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashSet;
 
 use homeboy::core::agent_tasks::batch;
 use homeboy::core::agent_tasks::dispatch_service::{
@@ -16,18 +17,19 @@ use homeboy::core::agent_tasks::{
     AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA, AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA,
     AGENT_TASK_BATCH_COOK_FANOUT_SUBMIT_SCHEMA,
 };
-use homeboy::core::{config, Error, Result};
+use homeboy::core::{config, worktree, Error, Result};
 
 use super::super::CmdResult;
 use super::args::{
     AgentTaskFanoutArgs, AgentTaskFanoutBatchStatusArgs, AgentTaskFanoutCommand,
-    AgentTaskFanoutInputArgs, AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs,
-    AgentTaskFanoutSubmitBatchArgs,
+    AgentTaskFanoutCookBatchArgs, AgentTaskFanoutInputArgs, AgentTaskFanoutRunPlanArgs,
+    AgentTaskFanoutSubmitArgs, AgentTaskFanoutSubmitBatchArgs,
 };
 use super::command_json_value;
 
 pub(super) fn fanout(args: AgentTaskFanoutArgs) -> CmdResult<Value> {
     match args.command {
+        AgentTaskFanoutCommand::CookBatch(cook_batch_args) => cook_batch(cook_batch_args),
         AgentTaskFanoutCommand::Plan(plan_args) => {
             let plan = load_batch_cook_fanout_plan(&plan_args.input)?;
             Ok((command_json_value(plan)?, 0))
@@ -102,6 +104,10 @@ fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
     if let Some(record_run_id) = args.record_run_id {
         plan.fanout_id = record_run_id;
     }
+    run_batch_cook_fanout_plan(plan)
+}
+
+fn run_batch_cook_fanout_plan(plan: BatchCookFanoutPlan) -> CmdResult<Value> {
     let executor = provider::ExtensionProviderAgentTaskExecutor::discover();
     let mut results = Vec::new();
     let mut failed = 0usize;
@@ -150,6 +156,155 @@ fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
         }),
         if failed == 0 { 0 } else { 1 },
     ))
+}
+
+fn cook_batch(args: AgentTaskFanoutCookBatchArgs) -> CmdResult<Value> {
+    if !args.gates.has_deterministic_gate() {
+        return Err(invalid_fanout(
+            "agent-task fanout cook-batch requires --verify or --private-verify",
+        ));
+    }
+    let plan = build_cook_batch_plan(&args)?;
+    let branches = plan
+        .cooks
+        .iter()
+        .map(|cook| {
+            let branch = cook.head.clone().expect("generated cooks have heads");
+            (branch, cook.to_worktree.clone())
+        })
+        .collect::<Vec<_>>();
+    let worktrees = queue_or_reuse_worktrees(&args, &branches)?;
+    let blocked = worktrees
+        .rows
+        .iter()
+        .filter(|row| {
+            !matches!(
+                row.status,
+                worktree::WorktreeQueueCreateStatus::Created
+                    | worktree::WorktreeQueueCreateStatus::Queued
+            )
+        })
+        .count();
+    let can_run = !args.dry_run
+        && blocked == 0
+        && worktrees
+            .rows
+            .iter()
+            .all(|row| matches!(row.status, worktree::WorktreeQueueCreateStatus::Created));
+    let run_result = if args.run_plan && can_run {
+        let (value, exit_code) = run_batch_cook_fanout_plan(plan.clone())?;
+        Some(serde_json::json!({ "exit_code": exit_code, "result": value }))
+    } else {
+        None
+    };
+    let status = if args.run_plan && run_result.is_some() {
+        run_result
+            .as_ref()
+            .and_then(|value| value["result"]["status"].as_str())
+            .unwrap_or("completed")
+    } else if blocked > 0 {
+        "blocked"
+    } else if args.dry_run {
+        "planned"
+    } else {
+        "ready"
+    };
+    let exit_code = if blocked == 0 { 0 } else { 1 };
+
+    Ok((
+        serde_json::json!({
+            "schema": "homeboy/agent-task-cook-batch/v1",
+            "fanout_id": plan.fanout_id,
+            "status": status,
+            "dry_run": args.dry_run,
+            "summary": {
+                "issues": plan.cooks.len(),
+                "worktrees_total": worktrees.rows.len(),
+                "worktrees_blocked": blocked,
+            },
+            "preflight": {
+                "provider_readiness_command": provider_readiness_command(&args),
+                "deterministic_gates": {
+                    "verify": args.gates.verify,
+                    "private_verify": args.gates.private_verify,
+                }
+            },
+            "worktrees": worktrees,
+            "plan": plan,
+            "run_result": run_result,
+            "commands": cook_batch_commands(&args),
+            "next_actions": cook_batch_next_actions(status, args.run_plan, blocked),
+        }),
+        exit_code,
+    ))
+}
+
+fn queue_or_reuse_worktrees(
+    args: &AgentTaskFanoutCookBatchArgs,
+    branches: &[(String, String)],
+) -> Result<worktree::WorktreeQueueCreateOutput> {
+    if args.dry_run {
+        return worktree::queue_create(worktree::WorktreeQueueCreateOptions {
+            repo: args.repo.clone(),
+            branches: branches.iter().map(|(branch, _)| branch.clone()).collect(),
+            from: args.from.clone(),
+            task_url: None,
+            task_ref: None,
+            dry_run: true,
+            retry_after_seconds: 30,
+            dmc_bin: args.dmc_bin.clone(),
+        });
+    }
+
+    let mut reused = Vec::new();
+    let mut to_create = Vec::new();
+    for (branch, handle) in branches {
+        match worktree::status(handle) {
+            Ok(status)
+                if status.record.state == worktree::TaskWorktreeState::Active
+                    && !status.safety.worktree_missing =>
+            {
+                reused.push(worktree::WorktreeQueueCreateRow {
+                    branch: branch.clone(),
+                    handle: handle.clone(),
+                    status: worktree::WorktreeQueueCreateStatus::Created,
+                    command: dmc_add_command(args, branch),
+                    retry_after_seconds: None,
+                    active_lock_holder: None,
+                    path: Some(status.record.worktree_path),
+                    error: None,
+                });
+            }
+            _ => to_create.push(branch.clone()),
+        }
+    }
+
+    let created = worktree::queue_create(worktree::WorktreeQueueCreateOptions {
+        repo: args.repo.clone(),
+        branches: to_create,
+        from: args.from.clone(),
+        task_url: None,
+        task_ref: None,
+        dry_run: false,
+        retry_after_seconds: 30,
+        dmc_bin: args.dmc_bin.clone(),
+    })?;
+    let mut rows = Vec::new();
+    for (branch, handle) in branches {
+        if let Some(row) = reused.iter().find(|row| row.handle == *handle) {
+            rows.push(row.clone());
+        } else if let Some(row) = created.rows.iter().find(|row| row.branch == *branch) {
+            rows.push(row.clone());
+        }
+    }
+
+    Ok(worktree::WorktreeQueueCreateOutput {
+        schema: "homeboy/worktree-queue-create/v1",
+        repo: args.repo.clone(),
+        base_ref: args.from.clone(),
+        dry_run: false,
+        rows,
+    })
 }
 
 fn load_fanout_agent_task_plan(
@@ -402,19 +557,6 @@ fn default_cook_commit_message(cook: &BatchCookSpec) -> String {
     format!("fix: cook {target}")
 }
 
-fn client_context(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> String {
-    serde_json::json!({
-        "fanout": {
-            "id": plan.fanout_id,
-            "semantics": "batch_cook",
-            "cook_id": cook.cook_id,
-            "to_worktree": cook.to_worktree,
-            "head": cook.head,
-        }
-    })
-    .to_string()
-}
-
 fn merged_client_context(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec) -> String {
     let mut context = serde_json::from_str::<Value>(cook.client_context.as_deref().unwrap_or("{}"))
         .unwrap_or(Value::Null);
@@ -447,6 +589,235 @@ fn cook_command(plan: &BatchCookFanoutPlan, _cook: &BatchCookSpec) -> Vec<String
         "--record-run-id".to_string(),
         plan.fanout_id.clone(),
     ]
+}
+
+fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCookFanoutPlan> {
+    let mut seen = HashSet::new();
+    let mut cooks = Vec::with_capacity(args.issues.len());
+    for issue_url in &args.issues {
+        let issue = IssueRef::parse(issue_url)?;
+        if !seen.insert(issue.key.clone()) {
+            return Err(invalid_fanout(
+                "duplicate issue URLs are not allowed in one cook-batch",
+            ));
+        }
+        let branch = format!(
+            "{}/issue-{}-{}",
+            trim_slashes(&args.branch_prefix),
+            issue.number,
+            slugify(&issue.repo)
+        );
+        let worktree = format!("{}@{}", args.repo, slugify(&branch));
+        let prompt = render_prompt(
+            args.prompt_template.as_deref(),
+            &issue,
+            &args.repo,
+            &branch,
+            &worktree,
+        );
+        cooks.push(BatchCookSpec {
+            cook_id: format!("issue-{}", issue.number),
+            prompt: Some(prompt),
+            tasks: Vec::new(),
+            cwd: None,
+            workspace: None,
+            repo: Some(args.repo.clone()),
+            task_url: Some(issue_url.clone()),
+            backend: args.backend.clone(),
+            selector: args.selector.clone(),
+            model: args.model.clone(),
+            secret_env: args.secret_env.clone(),
+            attempts: 1,
+            concurrency: 1,
+            provider_config: args.provider_config.clone(),
+            client_context: Some(
+                serde_json::json!({
+                    "issue_url": issue_url,
+                    "issue_ref": issue.key,
+                    "operator_workflow": "agent-task fanout cook-batch"
+                })
+                .to_string(),
+            ),
+            to_worktree: worktree,
+            provider_command: None,
+            verify: args.gates.verify.clone(),
+            private_verify: args.gates.private_verify.clone(),
+            private_gate_reveal: args.gates.private_gate_reveal,
+            max_attempts: default_max_attempts(),
+            no_finalize: false,
+            base: args.base.clone(),
+            head: Some(branch),
+            title: Some(format!("Fix {}", issue.key)),
+            commit_message: Some(format!("fix: address {}", issue.key)),
+            protected_branches: super::review::default_protected_branches(),
+            ai_tool: default_ai_tool(),
+            ai_used_for: default_ai_used_for(),
+        });
+    }
+    let first = cooks
+        .first()
+        .map(|cook| cook.cook_id.clone())
+        .unwrap_or_else(|| "empty".to_string());
+    Ok(BatchCookFanoutPlan {
+        schema: batch_cook_fanout_plan_schema(),
+        fanout_id: args
+            .fanout_id
+            .clone()
+            .unwrap_or_else(|| format!("cook-batch-{}-{}-{}", args.repo, first, cooks.len())),
+        cooks,
+        metadata: serde_json::json!({
+            "source": "agent-task fanout cook-batch",
+            "issue_count": args.issues.len(),
+            "repo": args.repo,
+            "base": args.base,
+            "from": args.from,
+        }),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IssueRef {
+    url: String,
+    owner: String,
+    repo: String,
+    number: String,
+    key: String,
+}
+
+impl IssueRef {
+    fn parse(url: &str) -> Result<Self> {
+        let trimmed = url.trim();
+        let marker = "/issues/";
+        let Some((prefix, number_part)) = trimmed.split_once(marker) else {
+            return Err(invalid_fanout(
+                "cook-batch issue inputs must be GitHub issue URLs",
+            ));
+        };
+        let number = number_part
+            .split(|c| matches!(c, '/' | '?' | '#'))
+            .next()
+            .unwrap_or_default();
+        if number.is_empty() || !number.chars().all(|c| c.is_ascii_digit()) {
+            return Err(invalid_fanout(
+                "GitHub issue URL is missing a numeric issue number",
+            ));
+        }
+        let mut segments = prefix.trim_end_matches('/').rsplit('/');
+        let repo = segments.next().unwrap_or_default();
+        let owner = segments.next().unwrap_or_default();
+        if owner.is_empty() || repo.is_empty() {
+            return Err(invalid_fanout(
+                "GitHub issue URL must include owner and repo",
+            ));
+        }
+        let key = format!("{owner}/{repo}#{number}");
+        Ok(Self {
+            url: trimmed.to_string(),
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            number: number.to_string(),
+            key,
+        })
+    }
+}
+
+fn render_prompt(
+    template: Option<&str>,
+    issue: &IssueRef,
+    repo: &str,
+    branch: &str,
+    worktree: &str,
+) -> String {
+    let template = template.unwrap_or(
+        "Fix {issue_url}. Inspect the issue, implement the smallest correct change in {repo}, run the requested verification gates, push {branch}, and open/update the PR with reviewer-ready evidence.",
+    );
+    template
+        .replace("{issue_url}", &issue.url)
+        .replace("{issue_ref}", &issue.key)
+        .replace("{repo}", repo)
+        .replace("{branch}", branch)
+        .replace("{worktree}", worktree)
+}
+
+fn provider_readiness_command(args: &AgentTaskFanoutCookBatchArgs) -> Vec<String> {
+    let mut command = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "providers".to_string(),
+    ];
+    if let Some(backend) = &args.backend {
+        command.push(format!("--backend={backend}"));
+    }
+    if let Some(selector) = &args.selector {
+        command.push(format!("--selector={selector}"));
+    }
+    for secret in &args.secret_env {
+        command.push(format!("--secret-env={secret}"));
+    }
+    command.push("--validate-readiness".to_string());
+    command
+}
+
+fn dmc_add_command(args: &AgentTaskFanoutCookBatchArgs, branch: &str) -> Vec<String> {
+    vec![
+        args.dmc_bin.clone(),
+        "wp".to_string(),
+        "datamachine-code".to_string(),
+        "workspace".to_string(),
+        "worktree".to_string(),
+        "add".to_string(),
+        args.repo.clone(),
+        branch.to_string(),
+        format!("--from={}", args.from),
+    ]
+}
+
+fn cook_batch_commands(args: &AgentTaskFanoutCookBatchArgs) -> Value {
+    let issues = args.issues.join(" ");
+    serde_json::json!({
+        "plan": format!("homeboy agent-task fanout cook-batch --repo {} --dry-run {}", args.repo, issues),
+        "run": format!("homeboy agent-task fanout cook-batch --repo {} --run-plan {}", args.repo, issues),
+        "status": "inspect each cook result under plan.cooks and use agent-task status <run-id>",
+        "retry": "rerun this cook-batch after fixing provider/worktree blockers, or rerun the blocked issue URL only",
+        "resume_from_plan": "save .plan to JSON and run homeboy agent-task fanout run-plan --input @batch-cook-plan.json",
+    })
+}
+
+fn cook_batch_next_actions(status: &str, run_plan: bool, blocked: usize) -> Vec<String> {
+    if blocked > 0 {
+        return vec![
+            "repair worktree queue blockers reported under worktrees.rows".to_string(),
+            "rerun the same cook-batch command; created worktrees are recorded and blocked rows carry retry commands".to_string(),
+        ];
+    }
+    if run_plan {
+        return vec![format!(
+            "batch execution {status}; inspect run_result.result.cooks for PR/finalization outcomes"
+        )];
+    }
+    vec![
+        "review plan.cooks and provider_readiness_command before execution".to_string(),
+        "rerun with --run-plan or save plan to JSON and run homeboy agent-task fanout run-plan --input @batch-cook-plan.json".to_string(),
+    ]
+}
+
+fn trim_slashes(value: &str) -> String {
+    value.trim_matches('/').to_string()
+}
+
+fn slugify(value: &str) -> String {
+    let mut slug = String::new();
+    let mut last_dash = false;
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash {
+            slug.push('-');
+            last_dash = true;
+        }
+    }
+    slug.trim_matches('-').to_string()
 }
 
 fn reject_generic_fanout_inputs(value: &Value) -> Result<()> {
@@ -512,6 +883,9 @@ fn batch_commands(batch_id: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli_surface::{Cli, Commands};
+    use crate::commands::agent_task::{AgentTaskCommand, AgentTaskFanoutCommand};
+    use clap::Parser;
     use serde_json::json;
 
     fn args() -> AgentTaskFanoutInputArgs {
@@ -595,5 +969,105 @@ mod tests {
         assert!(error
             .to_string()
             .contains("accepts only batch cook plans with independent cooks"));
+    }
+
+    fn cook_batch_args() -> AgentTaskFanoutCookBatchArgs {
+        AgentTaskFanoutCookBatchArgs {
+            issues: vec![
+                "https://github.com/Extra-Chill/homeboy/issues/6453".to_string(),
+                "https://github.com/Extra-Chill/homeboy/issues/6454".to_string(),
+            ],
+            repo: "homeboy".to_string(),
+            from: "origin/main".to_string(),
+            base: "main".to_string(),
+            branch_prefix: "fix".to_string(),
+            fanout_id: Some("issue-wave".to_string()),
+            prompt_template: None,
+            backend: Some("codebox".to_string()),
+            selector: Some("wordpress.codebox-agent-task-executor".to_string()),
+            model: Some("gpt-5.5".to_string()),
+            secret_env: vec!["AI_PROVIDER_OPENAI_CODEX_TOKEN".to_string()],
+            provider_config: Some(r#"{"runtime":"opencode"}"#.to_string()),
+            gates: super::super::args::VerifyGateArgs {
+                verify: vec!["cargo test --lib".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,
+            },
+            dry_run: true,
+            run_plan: false,
+            dmc_bin: "studio".to_string(),
+        }
+    }
+
+    #[test]
+    fn cook_batch_builds_batch_cook_plan_from_issue_urls() {
+        let args = cook_batch_args();
+        let plan = build_cook_batch_plan(&args).expect("cook batch plan");
+
+        assert_eq!(plan.fanout_id, "issue-wave");
+        assert_eq!(plan.cooks.len(), 2);
+        assert_eq!(plan.cooks[0].cook_id, "issue-6453");
+        assert_eq!(plan.cooks[0].to_worktree, "homeboy@fix-issue-6453-homeboy");
+        assert_eq!(
+            plan.cooks[0].head.as_deref(),
+            Some("fix/issue-6453-homeboy")
+        );
+        assert_eq!(
+            plan.cooks[0].title.as_deref(),
+            Some("Fix Extra-Chill/homeboy#6453")
+        );
+        assert!(plan.cooks[0]
+            .prompt
+            .as_deref()
+            .expect("prompt")
+            .contains("https://github.com/Extra-Chill/homeboy/issues/6453"));
+        assert_eq!(plan.cooks[0].verify, vec!["cargo test --lib"]);
+        assert_eq!(plan.cooks[0].backend.as_deref(), Some("codebox"));
+    }
+
+    #[test]
+    fn cook_batch_dry_run_returns_status_and_resume_commands() {
+        let (value, exit_code) = cook_batch(cook_batch_args()).expect("cook batch dry run");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["schema"], "homeboy/agent-task-cook-batch/v1");
+        assert_eq!(value["status"], "planned");
+        assert_eq!(value["summary"]["issues"], 2);
+        assert_eq!(value["worktrees"]["dry_run"], true);
+        assert_eq!(value["worktrees"]["rows"][0]["status"], "queued");
+        assert!(value["commands"]["resume_from_plan"]
+            .as_str()
+            .expect("resume command")
+            .contains("fanout run-plan"));
+    }
+
+    #[test]
+    fn cook_batch_cli_parses_multiple_issues_and_gates() {
+        let cli = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "homeboy",
+            "--verify",
+            "cargo test --lib",
+            "https://github.com/Extra-Chill/homeboy/issues/6453",
+            "https://github.com/Extra-Chill/homeboy/issues/6454",
+        ])
+        .expect("cook-batch parses");
+
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let AgentTaskCommand::Fanout(fanout) = agent_task.command else {
+            panic!("fanout command");
+        };
+        let AgentTaskFanoutCommand::CookBatch(args) = fanout.command else {
+            panic!("cook-batch command");
+        };
+        assert_eq!(args.issues.len(), 2);
+        assert_eq!(args.gates.verify, vec!["cargo test --lib"]);
+        assert_eq!(args.from, "origin/main");
     }
 }


### PR DESCRIPTION
## Summary
- Add `homeboy agent-task fanout cook-batch` to turn issue URLs into batch-cook fanout plans.
- Create or reuse DMC worktrees for generated issue branches and return status/resume commands.
- Include provider readiness guidance, deterministic gate enforcement, PR metadata defaults, lab portability classification, and docs.

Fixes #6453

## Verification
- `cargo test commands::agent_task::fanout --lib`
- `cargo test command_contract::lab --lib` currently exposes an unrelated baseline failure for plain `bench` lab support in this checkout.
- `cargo test --lib` was attempted twice and exceeded local timeouts after long passing output; CI is the full-suite gate.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Implementation, tests, docs, and local verification.