### PR TITLE
Fix cook-batch workspace materialization initialization

### DIFF
--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -638,6 +638,7 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
             tasks: Vec::new(),
             cwd: None,
             workspace: None,
+            workspace_materialization: Vec::new(),
             repo: Some(args.repo.clone()),
             task_url: Some(issue_url.clone()),
             backend: args.backend.clone(),


### PR DESCRIPTION
## Summary
- Initialize `workspace_materialization` for cook-batch generated `BatchCookSpec` values.
- Restores Homeboy compilation after the cook-batch and fanout workspace materialization changes landed.

## Testing
- `cargo test commands::agent_task::fanout --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosed the compile failure, drafted the minimal fix, and ran focused verification.
