### PR TITLE
Parse runner refresh identity JSON payload

### DIFF
--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -638,6 +638,7 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
             tasks: Vec::new(),
             cwd: None,
             workspace: None,
+            workspace_materialization: Vec::new(),
             repo: Some(args.repo.clone()),
             task_url: Some(issue_url.clone()),
             backend: args.backend.clone(),

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -240,13 +240,14 @@ fn identity_probe_script(binary_path: &str) -> String {
 }
 
 fn parse_identity(stdout: &str) -> Result<Value> {
-    let Some(line) = stdout.lines().rev().find(|line| !line.trim().is_empty()) else {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
         return Err(Error::internal_json(
             "refresh-homeboy produced no identity output".to_string(),
             None,
         ));
-    };
-    serde_json::from_str(line).map_err(|err| {
+    }
+    serde_json::from_str(trimmed).map_err(|err| {
         Error::internal_json(
             err.to_string(),
             Some("parse runner Homeboy identity output".to_string()),


### PR DESCRIPTION
## Summary
- Parse the full pretty-printed `homeboy self identity` JSON output in `runner refresh-homeboy`.
- Fixes `internal.json_error` when refreshing a runner Homeboy binary.

## Testing
- `cargo test homeboy_refresh --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosed the runner refresh parse failure, drafted the minimal fix, and ran focused verification.
