### PR TITLE
Infer runtime provider secret env for runner jobs

### DIFF
--- a/src/core/api_jobs/remote_runner.rs
+++ b/src/core/api_jobs/remote_runner.rs
@@ -147,6 +147,7 @@ impl JobStore {
             &request.command,
             None,
             &request.secret_env_names,
+            &request.env,
         );
         crate::core::runner::workload::validate_runner_workload_dispatch(
             request.runner_workload.as_ref(),

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -385,6 +385,7 @@ fn enqueue_exec_job(
         &request.command,
         None,
         &request.secret_env_names,
+        &request.env,
     );
     crate::core::runner::workload::validate_runner_workload_dispatch(
         request.runner_workload.as_ref(),

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -262,6 +262,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
         &options.command,
         options.capability_preflight.as_ref(),
         &options.secret_env_names,
+        &options.env,
     );
     let mut plan = prepare_runner_process(RunnerProcessRequest {
         runner_id: runner_id.to_string(),

--- a/src/core/runner/execution/secrets.rs
+++ b/src/core/runner/execution/secrets.rs
@@ -321,14 +321,16 @@ pub(crate) fn runner_exec_secret_env_names(
     command: &[String],
     preflight: Option<&RunnerCapabilityPreflight>,
     explicit_names: &[String],
+    env: &HashMap<String, String>,
 ) -> Vec<String> {
-    runner_exec_secret_env_plan(command, preflight, explicit_names).secret_env_names()
+    runner_exec_secret_env_plan(command, preflight, explicit_names, env).secret_env_names()
 }
 
 pub(crate) fn runner_exec_secret_env_plan(
     command: &[String],
     preflight: Option<&RunnerCapabilityPreflight>,
     explicit_names: &[String],
+    env: &HashMap<String, String>,
 ) -> SecretEnvPlan {
     let mut names = Vec::new();
     names.extend(explicit_names.iter().cloned());
@@ -344,5 +346,47 @@ pub(crate) fn runner_exec_secret_env_plan(
     names.extend(super::super::lab::secrets::declared_tunnel_secret_env(
         command,
     ));
+    names.extend(declared_runtime_provider_secret_env(env));
     SecretEnvPlan::from_secret_env_names(names)
+}
+
+fn declared_runtime_provider_secret_env(env: &HashMap<String, String>) -> Vec<String> {
+    let explicit = env
+        .get("HOMEBOY_AGENT_RUNTIME_SECRET_ENV")
+        .into_iter()
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if !explicit.is_empty() {
+        return explicit;
+    }
+
+    match env
+        .get("HOMEBOY_AGENT_RUNTIME_PROVIDER")
+        .map(String::as_str)
+        .map(str::trim)
+    {
+        Some("codex") => [
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect(),
+        Some("openai") => vec!["OPENAI_API_KEY".to_string()],
+        Some("claude-code") => [
+            "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN",
+            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN",
+            "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect(),
+        _ => Vec::new(),
+    }
 }

--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -227,9 +227,58 @@ fn runner_exec_secret_env_names_include_tunnel_preview_client_token() {
         ],
         None,
         &[],
+        &HashMap::new(),
     );
 
     assert_eq!(names, vec!["HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string()]);
+}
+
+#[test]
+fn runner_exec_secret_env_names_include_runtime_provider_defaults() {
+    let names = runner_exec_secret_env_names(
+        &["node".to_string(), "run-headless-loop.cjs".to_string()],
+        None,
+        &[],
+        &HashMap::from([(
+            "HOMEBOY_AGENT_RUNTIME_PROVIDER".to_string(),
+            "codex".to_string(),
+        )]),
+    );
+
+    assert_eq!(
+        names,
+        vec![
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID".to_string(),
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT".to_string(),
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP".to_string(),
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn runner_exec_secret_env_names_prefer_explicit_runtime_secret_env() {
+    let names = runner_exec_secret_env_names(
+        &["node".to_string(), "run-headless-loop.cjs".to_string()],
+        None,
+        &[],
+        &HashMap::from([
+            (
+                "HOMEBOY_AGENT_RUNTIME_PROVIDER".to_string(),
+                "codex".to_string(),
+            ),
+            (
+                "HOMEBOY_AGENT_RUNTIME_SECRET_ENV".to_string(),
+                "CUSTOM_REFRESH,CUSTOM_ACCESS".to_string(),
+            ),
+        ]),
+    );
+
+    assert_eq!(
+        names,
+        vec!["CUSTOM_ACCESS".to_string(), "CUSTOM_REFRESH".to_string()]
+    );
 }
 
 #[test]

--- a/src/core/runner/execution/worker.rs
+++ b/src/core/runner/execution/worker.rs
@@ -33,6 +33,7 @@ pub(super) fn exec_worker_local_with_process_output(
         &options.command,
         options.capability_preflight.as_ref(),
         &options.secret_env_names,
+        &options.env,
     );
     let mut runner = load(runner_id)?;
     runner.kind = RunnerKind::Local;


### PR DESCRIPTION
## Summary
- infer runner secret env names from HOMEBOY_AGENT_RUNTIME_PROVIDER when dispatching runner jobs
- preserve HOMEBOY_AGENT_RUNTIME_SECRET_ENV as an explicit override
- apply the same secret planning to direct runner exec, daemon jobs, local worker execution, and remote runner API jobs

## Verification
- cargo test runner_exec_secret_env_names --lib
- cargo fmt --check
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing runner secret-env propagation, implementing provider-default inference, and focused verification.