### PR TITLE
Centralize top-level command specs

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -6,8 +6,10 @@
 //! `crate::command_contract::*` or `homeboy::command_contract::*` — and put
 //! implementation details in the matching submodule:
 //!
+//! - [`spec`] owns shared top-level command metadata consumed by output,
+//!   safety/docs manifests, and command lookup.
 //! - [`output`] owns response-mode, output-file, JSON-family,
-//!   command-registry, output-descriptor, aggregate-descriptor,
+//!   output-descriptor, aggregate-descriptor,
 //!   response-plan types, and the `Commands` impl that resolves them.
 //! - [`lab`] owns Lab portability contracts and the `Commands` accessors
 //!   that surface Lab fields on a descriptor.
@@ -19,6 +21,7 @@ mod lab;
 mod output;
 mod public_variants;
 pub mod safety_manifest;
+mod spec;
 
 pub use lab::{
     lab_runner_support_summary, lab_runner_supported_contract_labels, lab_runner_supported_labels,
@@ -40,9 +43,12 @@ pub(crate) use lab::{
     TUNNEL_SERVICE_START_LAB_LABEL,
 };
 pub use output::{
-    registered_command, registered_command_dispatch_family, registered_command_json_family,
     CommandDescriptor, CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind,
-    CommandOutputDescriptor, CommandOutputFileMode, CommandRawOutputMode, CommandRegistryEntry,
-    CommandResponseMode, CommandResponsePlan, CommandStdoutMode, COMMAND_REGISTRY,
+    CommandOutputDescriptor, CommandOutputFileMode, CommandRawOutputMode, CommandResponseMode,
+    CommandResponsePlan, CommandStdoutMode,
 };
 pub use public_variants::{PublicOutputVariantContract, PUBLIC_OUTPUT_VARIANT_CONTRACTS};
+pub use spec::{
+    registered_command, registered_command_dispatch_family, registered_command_json_family,
+    CommandRegistryEntry, CommandSpec, COMMAND_REGISTRY, COMMAND_SPECS,
+};

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -17,6 +17,7 @@ use crate::commands::{
 };
 
 use super::lab::apply_lab_contract_to_descriptor;
+use super::spec::registered_command_json_family;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandResponseMode {
@@ -84,171 +85,6 @@ pub struct CommandOutputDescriptor {
     pub output_file_mode: CommandOutputFileMode,
     pub json_family: CommandJsonFamily,
     pub output_contract: CommandOutputContractKind,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CommandRegistryEntry {
-    pub name: &'static str,
-    pub json_family: CommandJsonFamily,
-    pub docs_slug: Option<&'static str>,
-    pub output_notes: &'static str,
-    pub lab_supported: bool,
-    pub lab_notes: &'static str,
-}
-
-const DEFAULT_LAB_UNSUPPORTED_NOTES: &str = "not declared as Lab-routable in the command registry";
-
-impl CommandRegistryEntry {
-    pub fn docs_path(&self) -> Option<String> {
-        self.docs_slug
-            .map(|slug| format!("docs/commands/{slug}.md"))
-    }
-}
-
-const fn command_registry_entry(
-    name: &'static str,
-    json_family: CommandJsonFamily,
-) -> CommandRegistryEntry {
-    CommandRegistryEntry {
-        name,
-        json_family,
-        docs_slug: Some(name),
-        output_notes: "standard CLI output contract",
-        lab_supported: false,
-        lab_notes: DEFAULT_LAB_UNSUPPORTED_NOTES,
-    }
-}
-
-const fn lab_command_registry_entry(
-    name: &'static str,
-    json_family: CommandJsonFamily,
-    lab_notes: &'static str,
-) -> CommandRegistryEntry {
-    CommandRegistryEntry {
-        lab_supported: true,
-        lab_notes,
-        ..command_registry_entry(name, json_family)
-    }
-}
-
-const fn manifest_command_registry_entry() -> CommandRegistryEntry {
-    CommandRegistryEntry {
-        output_notes:
-            "recursive command safety, docs, output, and Lab metadata in the standard JSON envelope",
-        ..command_registry_entry("manifest", CommandJsonFamily::Workspace)
-    }
-}
-
-pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
-    lab_command_registry_entry(
-        "agent-task",
-        CommandJsonFamily::Workspace,
-        "Lab runner routing covers portable, explicit-runner, and runner-resident agent-task workflows",
-    ),
-    command_registry_entry("project", CommandJsonFamily::Workspace),
-    command_registry_entry("ssh", CommandJsonFamily::Ops),
-    command_registry_entry("server", CommandJsonFamily::Ops),
-    lab_command_registry_entry(
-        "test",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for test runs",
-    ),
-    lab_command_registry_entry(
-        "bench",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for benchmark runs",
-    ),
-    lab_command_registry_entry(
-        "fuzz",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for fuzz runs",
-    ),
-    lab_command_registry_entry(
-        "trace",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for trace runs",
-    ),
-    command_registry_entry("observe", CommandJsonFamily::Quality),
-    lab_command_registry_entry(
-        "lint",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for changed-scope lint runs",
-    ),
-    command_registry_entry("db", CommandJsonFamily::Ops),
-    command_registry_entry("deps", CommandJsonFamily::Ops),
-    command_registry_entry("ci", CommandJsonFamily::Ops),
-    command_registry_entry("doctor", CommandJsonFamily::Ops),
-    command_registry_entry("file", CommandJsonFamily::Ops),
-    command_registry_entry("fleet", CommandJsonFamily::Ops),
-    command_registry_entry("logs", CommandJsonFamily::Ops),
-    command_registry_entry("triage", CommandJsonFamily::Ops),
-    command_registry_entry("deploy", CommandJsonFamily::Ops),
-    command_registry_entry("component", CommandJsonFamily::Workspace),
-    command_registry_entry("config", CommandJsonFamily::Workspace),
-    command_registry_entry("daemon", CommandJsonFamily::Ops),
-    command_registry_entry("extension", CommandJsonFamily::Workspace),
-    command_registry_entry("status", CommandJsonFamily::Ops),
-    command_registry_entry("docs", CommandJsonFamily::Workspace),
-    manifest_command_registry_entry(),
-    command_registry_entry("changelog", CommandJsonFamily::Workspace),
-    command_registry_entry("cleanup", CommandJsonFamily::Workspace),
-    command_registry_entry("git", CommandJsonFamily::Ops),
-    command_registry_entry("issues", CommandJsonFamily::Ops),
-    command_registry_entry("version", CommandJsonFamily::Workspace),
-    command_registry_entry("build", CommandJsonFamily::Workspace),
-    command_registry_entry("changes", CommandJsonFamily::Workspace),
-    command_registry_entry("release", CommandJsonFamily::Workspace),
-    command_registry_entry("report", CommandJsonFamily::Workspace),
-    lab_command_registry_entry(
-        "review",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for release-gate review runs",
-    ),
-    lab_command_registry_entry(
-        "audit",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for audit source runs",
-    ),
-    command_registry_entry("audit-baseline", CommandJsonFamily::Quality),
-    lab_command_registry_entry(
-        "refactor",
-        CommandJsonFamily::Workspace,
-        "portable Lab offload is available for refactor source runs",
-    ),
-    command_registry_entry("refs", CommandJsonFamily::Workspace),
-    lab_command_registry_entry(
-        "rig",
-        CommandJsonFamily::Workspace,
-        "portable Lab offload is available for rig check workflows",
-    ),
-    command_registry_entry("runner", CommandJsonFamily::Workspace),
-    command_registry_entry("runtime", CommandJsonFamily::Workspace),
-    command_registry_entry("worktree", CommandJsonFamily::Workspace),
-    lab_command_registry_entry(
-        "tunnel",
-        CommandJsonFamily::Workspace,
-        "Lab runner routing covers tunnel preview and service workflows",
-    ),
-    command_registry_entry("runs", CommandJsonFamily::Workspace),
-    command_registry_entry("self", CommandJsonFamily::Ops),
-    command_registry_entry("stack", CommandJsonFamily::Workspace),
-    command_registry_entry("undo", CommandJsonFamily::Workspace),
-    command_registry_entry("auth", CommandJsonFamily::Ops),
-    command_registry_entry("api", CommandJsonFamily::Ops),
-    command_registry_entry("http", CommandJsonFamily::Ops),
-    command_registry_entry("upgrade", CommandJsonFamily::Ops),
-];
-
-pub fn registered_command(name: &str) -> Option<&'static CommandRegistryEntry> {
-    COMMAND_REGISTRY.iter().find(|entry| entry.name == name)
-}
-
-pub fn registered_command_json_family(name: &str) -> Option<CommandJsonFamily> {
-    registered_command(name).map(|entry| entry.json_family)
-}
-
-pub fn registered_command_dispatch_family(name: &str) -> Option<CommandDispatchFamily> {
-    registered_command_json_family(name).map(Into::into)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -511,6 +347,7 @@ fn registered_json_envelope_descriptor(
 
 #[cfg(test)]
 mod tests {
+    use super::super::spec::{COMMAND_REGISTRY, DEFAULT_LAB_UNSUPPORTED_NOTES};
     use super::*;
     use crate::cli_surface::{Cli, Commands};
     use clap::CommandFactory;

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -132,10 +132,7 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
     match path.as_slice() {
-        ["manifest"] => {
-            metadata.output_notes =
-                "recursive command safety, docs, output, and Lab metadata in the standard JSON envelope";
-        }
+        ["manifest"] => {}
         ["docs", "map"] => {
             metadata.mutates = true;
             metadata.output_notes =
@@ -152,7 +149,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.dry_run_flag = Some("--dry-run");
-            metadata.output_notes = "release execution mutates git tags/releases and may deploy; use --dry-run to plan and --apply for risky modes";
             metadata.dangerous_flags = vec![
                 "--apply",
                 "--deploy",
@@ -166,16 +162,12 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         ["upgrade"] => {
             metadata.mutates = true;
             metadata.operator = true;
-            metadata.output_notes = "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used";
             metadata.dangerous_flags = vec!["--force", "--upgrade-runner"];
         }
         ["trace"] => {
             metadata.mutates = true;
-            metadata.output_notes = "runs trace workflows and records observation artifacts unless using read-only subcommands";
         }
         ["lint"] => {
-            metadata.output_notes =
-                "runs lint workflows; pass --fix to apply auto-fixable findings in place";
             metadata.dangerous_flags = vec!["--fix", "--force"];
         }
         ["deps", "install"] | ["deps", "update"] | ["deps", "stack", "apply"] => {
@@ -190,8 +182,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         }
         ["cleanup"] => {
             metadata.mutates = true;
-            metadata.output_notes =
-                "cleanup subcommands report plans by default and require --apply for removals";
             metadata.dangerous_flags = vec!["--apply"];
         }
         ["cleanup", "artifacts"] => {
@@ -427,7 +417,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         }
         ["refactor"] => {
             metadata.mutates = true;
-            metadata.output_notes = "refactor subcommands can rewrite source files; use planning/dry-run modes where available";
             metadata.dangerous_flags = vec!["--write", "--commit"];
         }
         ["refactor", "rename"]
@@ -583,7 +572,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         }
         ["undo"] => {
             metadata.mutates = true;
-            metadata.output_notes = "restores files from the latest or selected undo snapshot";
         }
         ["undo", "delete"] => {
             metadata.mutates = true;

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -1,0 +1,216 @@
+//! Shared top-level command metadata.
+//!
+//! This is the first narrow `CommandSpec` slice: top-level metadata that is
+//! consumed by output routing, safety/docs manifest derivation, and command
+//! lookup without changing parsed CLI behavior.
+
+use super::output::{CommandDispatchFamily, CommandJsonFamily};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandSpec {
+    pub name: &'static str,
+    pub json_family: CommandJsonFamily,
+    pub docs_slug: Option<&'static str>,
+    pub output_notes: &'static str,
+    pub lab_supported: bool,
+    pub lab_notes: &'static str,
+}
+
+pub type CommandRegistryEntry = CommandSpec;
+
+pub const DEFAULT_LAB_UNSUPPORTED_NOTES: &str =
+    "not declared as Lab-routable in the command registry";
+
+impl CommandSpec {
+    pub fn docs_path(&self) -> Option<String> {
+        self.docs_slug
+            .map(|slug| format!("docs/commands/{slug}.md"))
+    }
+}
+
+const fn command_spec(name: &'static str, json_family: CommandJsonFamily) -> CommandSpec {
+    CommandSpec {
+        name,
+        json_family,
+        docs_slug: Some(name),
+        output_notes: "standard CLI output contract",
+        lab_supported: false,
+        lab_notes: DEFAULT_LAB_UNSUPPORTED_NOTES,
+    }
+}
+
+const fn command_spec_with_output_notes(
+    name: &'static str,
+    json_family: CommandJsonFamily,
+    output_notes: &'static str,
+) -> CommandSpec {
+    CommandSpec {
+        output_notes,
+        ..command_spec(name, json_family)
+    }
+}
+
+const fn lab_command_spec_with_output_notes(
+    name: &'static str,
+    json_family: CommandJsonFamily,
+    lab_notes: &'static str,
+    output_notes: &'static str,
+) -> CommandSpec {
+    CommandSpec {
+        output_notes,
+        ..lab_command_spec(name, json_family, lab_notes)
+    }
+}
+
+const fn lab_command_spec(
+    name: &'static str,
+    json_family: CommandJsonFamily,
+    lab_notes: &'static str,
+) -> CommandSpec {
+    CommandSpec {
+        lab_supported: true,
+        lab_notes,
+        ..command_spec(name, json_family)
+    }
+}
+
+const fn manifest_command_spec() -> CommandSpec {
+    CommandSpec {
+        output_notes:
+            "recursive command safety, docs, output, and Lab metadata in the standard JSON envelope",
+        ..command_spec("manifest", CommandJsonFamily::Workspace)
+    }
+}
+
+pub const COMMAND_SPECS: &[CommandSpec] = &[
+    lab_command_spec(
+        "agent-task",
+        CommandJsonFamily::Workspace,
+        "Lab runner routing covers portable, explicit-runner, and runner-resident agent-task workflows",
+    ),
+    command_spec("project", CommandJsonFamily::Workspace),
+    command_spec("ssh", CommandJsonFamily::Ops),
+    command_spec("server", CommandJsonFamily::Ops),
+    lab_command_spec(
+        "test",
+        CommandJsonFamily::Quality,
+        "portable Lab offload is available for test runs",
+    ),
+    lab_command_spec(
+        "bench",
+        CommandJsonFamily::Quality,
+        "portable Lab offload is available for benchmark runs",
+    ),
+    lab_command_spec(
+        "fuzz",
+        CommandJsonFamily::Quality,
+        "portable Lab offload is available for fuzz runs",
+    ),
+    lab_command_spec_with_output_notes(
+        "trace",
+        CommandJsonFamily::Quality,
+        "portable Lab offload is available for trace runs",
+        "runs trace workflows and records observation artifacts unless using read-only subcommands",
+    ),
+    command_spec("observe", CommandJsonFamily::Quality),
+    lab_command_spec_with_output_notes(
+        "lint",
+        CommandJsonFamily::Quality,
+        "portable Lab offload is available for changed-scope lint runs",
+        "runs lint workflows; pass --fix to apply auto-fixable findings in place",
+    ),
+    command_spec("db", CommandJsonFamily::Ops),
+    command_spec("deps", CommandJsonFamily::Ops),
+    command_spec("ci", CommandJsonFamily::Ops),
+    command_spec("doctor", CommandJsonFamily::Ops),
+    command_spec("file", CommandJsonFamily::Ops),
+    command_spec("fleet", CommandJsonFamily::Ops),
+    command_spec("logs", CommandJsonFamily::Ops),
+    command_spec("triage", CommandJsonFamily::Ops),
+    command_spec("deploy", CommandJsonFamily::Ops),
+    command_spec("component", CommandJsonFamily::Workspace),
+    command_spec("config", CommandJsonFamily::Workspace),
+    command_spec("daemon", CommandJsonFamily::Ops),
+    command_spec("extension", CommandJsonFamily::Workspace),
+    command_spec("status", CommandJsonFamily::Ops),
+    command_spec("docs", CommandJsonFamily::Workspace),
+    manifest_command_spec(),
+    command_spec("changelog", CommandJsonFamily::Workspace),
+    command_spec_with_output_notes(
+        "cleanup",
+        CommandJsonFamily::Workspace,
+        "cleanup subcommands report plans by default and require --apply for removals",
+    ),
+    command_spec("git", CommandJsonFamily::Ops),
+    command_spec("issues", CommandJsonFamily::Ops),
+    command_spec("version", CommandJsonFamily::Workspace),
+    command_spec("build", CommandJsonFamily::Workspace),
+    command_spec("changes", CommandJsonFamily::Workspace),
+    command_spec_with_output_notes(
+        "release",
+        CommandJsonFamily::Workspace,
+        "release execution mutates git tags/releases and may deploy; use --dry-run to plan and --apply for risky modes",
+    ),
+    command_spec("report", CommandJsonFamily::Workspace),
+    lab_command_spec(
+        "review",
+        CommandJsonFamily::Quality,
+        "portable Lab offload is available for release-gate review runs",
+    ),
+    lab_command_spec(
+        "audit",
+        CommandJsonFamily::Quality,
+        "portable Lab offload is available for audit source runs",
+    ),
+    command_spec("audit-baseline", CommandJsonFamily::Quality),
+    lab_command_spec_with_output_notes(
+        "refactor",
+        CommandJsonFamily::Workspace,
+        "portable Lab offload is available for refactor source runs",
+        "refactor subcommands can rewrite source files; use planning/dry-run modes where available",
+    ),
+    command_spec("refs", CommandJsonFamily::Workspace),
+    lab_command_spec(
+        "rig",
+        CommandJsonFamily::Workspace,
+        "portable Lab offload is available for rig check workflows",
+    ),
+    command_spec("runner", CommandJsonFamily::Workspace),
+    command_spec("runtime", CommandJsonFamily::Workspace),
+    command_spec("worktree", CommandJsonFamily::Workspace),
+    lab_command_spec(
+        "tunnel",
+        CommandJsonFamily::Workspace,
+        "Lab runner routing covers tunnel preview and service workflows",
+    ),
+    command_spec("runs", CommandJsonFamily::Workspace),
+    command_spec("self", CommandJsonFamily::Ops),
+    command_spec("stack", CommandJsonFamily::Workspace),
+    command_spec_with_output_notes(
+        "undo",
+        CommandJsonFamily::Workspace,
+        "restores files from the latest or selected undo snapshot",
+    ),
+    command_spec("auth", CommandJsonFamily::Ops),
+    command_spec("api", CommandJsonFamily::Ops),
+    command_spec("http", CommandJsonFamily::Ops),
+    command_spec_with_output_notes(
+        "upgrade",
+        CommandJsonFamily::Ops,
+        "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used",
+    ),
+];
+
+pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = COMMAND_SPECS;
+
+pub fn registered_command(name: &str) -> Option<&'static CommandSpec> {
+    COMMAND_SPECS.iter().find(|entry| entry.name == name)
+}
+
+pub fn registered_command_json_family(name: &str) -> Option<CommandJsonFamily> {
+    registered_command(name).map(|entry| entry.json_family)
+}
+
+pub fn registered_command_dispatch_family(name: &str) -> Option<CommandDispatchFamily> {
+    registered_command_json_family(name).map(Into::into)
+}

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -642,8 +642,9 @@ mod tests {
 
     #[test]
     fn sync_is_runner_source_management() {
-        let cli = TestCli::try_parse_from(["homeboy", "sync", "static-site-importer-fixture-matrix"])
-            .expect("rig sync should parse");
+        let cli =
+            TestCli::try_parse_from(["homeboy", "sync", "static-site-importer-fixture-matrix"])
+                .expect("rig sync should parse");
 
         assert!(cli.rig.is_runner_source_management_command());
     }

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -3,6 +3,7 @@ use homeboy::cli_surface::{
     command_surface_doctor_report, command_surface_from_with_depth,
     current_command_safety_manifest, current_command_surface, Cli, CommandSafetyManifest, Commands,
 };
+use homeboy::command_contract::{CommandJsonFamily, COMMAND_SPECS};
 use std::collections::BTreeSet;
 use std::sync::OnceLock;
 
@@ -228,6 +229,47 @@ fn manifest_command_exposes_recursive_safety_manifest() {
         .any(|entry| entry.get("mutates").is_some()
             && entry.get("operator").is_some()
             && entry.get("dangerous_flags").is_some()));
+}
+
+#[test]
+fn command_specs_drive_top_level_manifest_metadata() {
+    let manifest = command_safety_manifest();
+
+    for spec in COMMAND_SPECS {
+        let entry = manifest
+            .commands
+            .iter()
+            .find(|entry| entry.name == spec.name)
+            .unwrap_or_else(|| panic!("command spec `{}` missing from safety manifest", spec.name));
+
+        assert_eq!(
+            entry.output.structured,
+            spec.json_family != CommandJsonFamily::RawOnly,
+            "top-level manifest output structure drifted from CommandSpec for `{}`",
+            spec.name
+        );
+        assert_eq!(
+            entry.output.notes, spec.output_notes,
+            "top-level manifest output notes drifted from CommandSpec for `{}`",
+            spec.name
+        );
+        assert_eq!(
+            entry.lab.supported, spec.lab_supported,
+            "top-level manifest Lab support drifted from CommandSpec for `{}`",
+            spec.name
+        );
+        assert_eq!(
+            entry.lab.notes, spec.lab_notes,
+            "top-level manifest Lab notes drifted from CommandSpec for `{}`",
+            spec.name
+        );
+        assert_eq!(
+            entry.docs.path,
+            spec.docs_path(),
+            "top-level manifest docs path drifted from CommandSpec for `{}`",
+            spec.name
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a shared top-level CommandSpec table for command metadata.
- Move the existing command registry out of output routing so output, safety/docs manifest derivation, and command lookup use the same source.
- Move top-level safety output notes for trace/lint/release/cleanup/refactor/undo/upgrade into the shared spec.
- Add a command surface parity test that asserts top-level manifest metadata is generated from CommandSpec.
- Include one rustfmt-only line wrap on current main so cargo fmt --check passes.

## Tests
- cargo fmt --check
- cargo test command_registry --lib
- cargo test command_specs_drive_top_level_manifest_metadata
- cargo test --test command_surface_test before rebasing exposed a broad pre-existing failure in the now-removed mutating_safety_manifest_entries_advertise_apply_or_are_allowlisted test on the prior base.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the CommandSpec refactor slice, resolving rebase conflicts, updating tests, and running verification.