### PR TITLE
fix(runner): support directory exec artifacts

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -642,8 +642,9 @@ mod tests {
 
     #[test]
     fn sync_is_runner_source_management() {
-        let cli = TestCli::try_parse_from(["homeboy", "sync", "static-site-importer-fixture-matrix"])
-            .expect("rig sync should parse");
+        let cli =
+            TestCli::try_parse_from(["homeboy", "sync", "static-site-importer-fixture-matrix"])
+                .expect("rig sync should parse");
 
         assert!(cli.rig.is_runner_source_management_command());
     }

--- a/src/commands/runner/exec.rs
+++ b/src/commands/runner/exec.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
 
+use homeboy::core::engine::shell;
 use homeboy::core::observation::{ArtifactRecord, ObservationStore};
 use homeboy::core::runners::{self as runner, RunnerExecOutput, RunnerKind};
 use homeboy::core::stream_capture::StreamCaptureMetadata;
@@ -360,6 +361,34 @@ fn copy_runner_exec_artifact_source(
             }
             let server = server::load(server_id)?;
             let client = server::SshClient::from_server(&server, server_id)?;
+            if remote_runner_exec_artifact_type(&client, path)?
+                == RunnerExecArtifactSourceType::Directory
+            {
+                if client.is_local {
+                    copy_dir_all(path, &temp_path)?;
+                } else {
+                    let output = server::transfer::transfer(&server::transfer::TransferConfig {
+                        source: format!("{server_id}:{path_string}"),
+                        destination: temp_path.display().to_string(),
+                        recursive: true,
+                        compress: true,
+                        dry_run: false,
+                        exclude: Vec::new(),
+                    })?;
+                    if output.1 != 0 || !output.0.success {
+                        return Err(Error::validation_invalid_argument(
+                            "path",
+                            format!(
+                                "failed to download runner exec artifact directory: {}",
+                                output.0.error.unwrap_or_else(|| "scp failed".to_string())
+                            ),
+                            Some(path_string),
+                            None,
+                        ));
+                    }
+                }
+                return Ok(temp_path);
+            }
             let output = client.download_file(&path_string, &temp_path.display().to_string());
             if !output.success {
                 return Err(Error::validation_invalid_argument(
@@ -375,6 +404,65 @@ fn copy_runner_exec_artifact_source(
             Ok(temp_path)
         }
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RunnerExecArtifactSourceType {
+    File,
+    Directory,
+}
+
+fn remote_runner_exec_artifact_type(
+    client: &server::SshClient,
+    path: &Path,
+) -> homeboy::core::Result<RunnerExecArtifactSourceType> {
+    let path_string = path.display().to_string();
+    let quoted = shell::quote_path(&path_string);
+    if client.execute(&format!("test -d {quoted}")).success {
+        return Ok(RunnerExecArtifactSourceType::Directory);
+    }
+    if client.execute(&format!("test -f {quoted}")).success {
+        return Ok(RunnerExecArtifactSourceType::File);
+    }
+    Err(Error::validation_invalid_argument(
+        "path",
+        "runner exec artifact path is not a file or directory",
+        Some(path_string),
+        None,
+    ))
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> homeboy::core::Result<()> {
+    fs::create_dir_all(to).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("create {}", to.display())))
+    })?;
+    for entry in fs::read_dir(from).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("read {}", from.display())))
+    })? {
+        let entry = entry.map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("read {}", from.display())))
+        })?;
+        let source = entry.path();
+        let destination = to.join(entry.file_name());
+        let metadata = entry.metadata().map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("stat {}", source.display())))
+        })?;
+        if metadata.is_dir() {
+            copy_dir_all(&source, &destination)?;
+        } else if metadata.is_file() {
+            fs::copy(&source, &destination).map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some(format!(
+                        "copy {} to {}",
+                        source.display(),
+                        destination.display()
+                    )),
+                )
+            })?;
+        }
+    }
+    Ok(())
 }
 
 fn validate_runner_exec_artifact_path(

--- a/src/commands/runner/tests/exec.rs
+++ b/src/commands/runner/tests/exec.rs
@@ -292,6 +292,66 @@ fn runner_exec_promotes_offloaded_artifacts_from_runner_path() {
 }
 
 #[test]
+fn runner_exec_promotes_offloaded_directory_artifacts_from_runner_path() {
+    homeboy::test_support::with_isolated_home(|home| {
+        let artifact_root = home.path().join("artifacts");
+        homeboy::core::set_artifact_root_override(Some(artifact_root));
+        let workspace = tempfile::tempdir().expect("workspace");
+        let site = workspace.path().join("site");
+        std::fs::create_dir_all(&site).expect("create site");
+        std::fs::write(site.join("index.html"), "<h1>Preview</h1>").expect("write index");
+        server::create(
+            r#"{"id":"local-ssh","host":"localhost","user":"user"}"#,
+            false,
+        )
+        .expect("create local ssh server");
+        runner::create(
+            &format!(
+                r#"{{"id":"local-ssh","kind":"ssh","server_id":"local-ssh","workspace_root":"{}"}}"#,
+                workspace.path().display()
+            ),
+            false,
+        )
+        .expect("create ssh runner");
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                NewRunRecord::builder("runner-exec")
+                    .command("homeboy runner exec lab-ssh".to_string())
+                    .cwd_path(workspace.path())
+                    .metadata(serde_json::json!({}))
+                    .build(),
+            )
+            .expect("run");
+        let output = runner_exec_output(
+            "local-ssh",
+            RunnerExecMode::ReverseBroker,
+            &workspace.path().display().to_string(),
+        );
+
+        promote_runner_exec_artifacts(&run.id, &output, &["site".to_string()])
+            .expect("promote offloaded directory artifact");
+
+        let artifacts = store.list_artifacts(&run.id).expect("artifacts");
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].kind, "site");
+        assert_eq!(artifacts[0].artifact_type, "directory");
+        assert_eq!(artifacts[0].metadata_json["source"], "runner_path_attach");
+        assert_eq!(artifacts[0].metadata_json["runner_id"], "local-ssh");
+        assert_eq!(
+            artifacts[0].metadata_json["runner_path"],
+            site.display().to_string()
+        );
+        assert!(std::path::Path::new(&artifacts[0].path)
+            .join("index.html")
+            .is_file());
+        let entrypoints = homeboy::core::artifacts::html_preview_entrypoints(&artifacts[0]);
+        assert_eq!(entrypoints.len(), 1);
+        assert_eq!(entrypoints[0].path, "index.html");
+    });
+}
+
+#[test]
 fn runner_exec_rejects_artifacts_without_run_id() {
     let err = exec(
         "lab-local",


### PR DESCRIPTION
## Summary

- Fix `runner exec --artifact <directory>` for offloaded runner paths by detecting runner-side directories before using file download logic.
- Reuse recursive transfer for real SSH runners and local recursive copy for localhost-backed SSH test runners.
- Add focused coverage for offloaded directory artifact promotion and static HTML preview entrypoint discovery.

Closes #6502

## Verification

- `cargo fmt --check`
- `cargo test commands::runner::tests::exec`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the validation failure, implementing the runner exec directory artifact fix, adding tests, and preparing the PR.
