### PR TITLE
fix(lab): mirror downloaded agent-task output

### DIFF
--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -97,14 +97,21 @@ pub(super) fn sync_inline_agent_task_file(
     Ok(Some((remote_spec, entry)))
 }
 
-pub(super) fn mirror_agent_task_run_plan_lifecycle(args: &[String], stdout: &str) -> Result<()> {
+pub(super) fn mirror_agent_task_run_plan_lifecycle(
+    args: &[String],
+    stdout: &str,
+    output_file_content: Option<&str>,
+) -> Result<()> {
     let Some((plan_spec, run_id)) = agent_task_run_plan_recording_args(args) else {
         return Ok(());
     };
     if plan_spec == "-" {
         return Ok(());
     }
-    let envelope = parse_offloaded_run_plan_envelope(stdout)?;
+    let envelope = parse_offloaded_run_plan_envelope(agent_task_run_plan_lifecycle_output(
+        stdout,
+        output_file_content,
+    ))?;
     if !is_agent_task_run_plan_envelope(&envelope) {
         return Ok(());
     }
@@ -130,6 +137,13 @@ pub(super) fn mirror_agent_task_run_plan_lifecycle(args: &[String], stdout: &str
     agent_task_lifecycle::mark_running(&run_id)?;
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(())
+}
+
+fn agent_task_run_plan_lifecycle_output<'a>(
+    stdout: &'a str,
+    output_file_content: Option<&'a str>,
+) -> &'a str {
+    output_file_content.unwrap_or(stdout)
 }
 
 pub(super) fn parse_offloaded_run_plan_envelope(stdout: &str) -> Result<serde_json::Value> {
@@ -788,7 +802,27 @@ mod tests {
         ];
         let stdout = "{\"success\":true,\"data\":{\"command\":\"extension.setup\"}}";
 
-        mirror_agent_task_run_plan_lifecycle(&args, stdout).expect("ignore non-aggregate output");
+        mirror_agent_task_run_plan_lifecycle(&args, stdout, None)
+            .expect("ignore non-aggregate output");
+    }
+
+    #[test]
+    fn run_plan_lifecycle_prefers_downloaded_output_file_content() {
+        let stdout = "{\"success\":true,\"data\":{\"command\":\"agent-task.run-plan\"}}";
+        let downloaded_output = concat!(
+            "{\"success\":true,\"data\":{",
+            "\"schema\":\"homeboy/agent-task-aggregate/v1\",",
+            "\"plan_id\":\"plan-from-file\",",
+            "\"status\":\"succeeded\",",
+            "\"totals\":{\"skipped\":0,\"succeeded\":1,\"failed\":0},",
+            "\"outcomes\":[]}}"
+        );
+
+        let selected = agent_task_run_plan_lifecycle_output(stdout, Some(downloaded_output));
+        let envelope = parse_offloaded_run_plan_envelope(selected).expect("parse selected output");
+
+        assert!(is_agent_task_run_plan_envelope(&envelope));
+        assert_eq!(envelope["data"]["plan_id"], "plan-from-file");
     }
 
     #[test]

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -797,7 +797,11 @@ pub(crate) fn run_lab_offload_inner(
         host_telemetry.to_metadata()
     );
     ensure_lab_offload_streams_not_truncated(&exec_output, output_file_content.is_some())?;
-    mirror_agent_task_run_plan_lifecycle(request.normalized_args, &exec_output.stdout)?;
+    mirror_agent_task_run_plan_lifecycle(
+        request.normalized_args,
+        &exec_output.stdout,
+        output_file_content.as_deref(),
+    )?;
 
     let mut stderr = String::new();
     for message in messages {


### PR DESCRIPTION
## Summary
- Use downloaded structured output content for offloaded agent-task run-plan lifecycle mirroring when --output was used.
- Keep stdout as the fallback when no output file was imported.
- Add a focused regression test for selecting downloaded aggregate content over stdout.

## Tests
- cargo fmt --check
- cargo test run_plan_lifecycle_prefers_downloaded_output_file_content
- cargo test core::runner::lab::agent_task_bridge
- cargo test core::runner::lab::offload

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the offloaded Lab lifecycle mirror path, implementing the bugfix, adding the focused regression test, and running local verification.