### PR TITLE
Detect stale runner runtime paths

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -333,6 +333,16 @@ read `active_runner_jobs`, `runner_job`, `workspace_leases`, `runner_result`,
 `mutation_artifacts`, `artifact_ref`, and `handoff` so direct SSH and reverse
 broker implementations stay hidden behind the same lifecycle vocabulary.
 
+Connected daemon status also reports stale runtime-path signals. When the daemon
+started with configured `HOMEBOY_*_COMPONENT_PATH`, `HOMEBOY_*_PLUGIN_PATH`,
+`HOMEBOY_*_PROVIDER_PATH`, or `HOMEBOY_*_RUNTIME_PATH` values, `/version`
+captures start-time fingerprints and compares them with the current on-disk
+paths. `homeboy runner status <runner-id>` surfaces those differences in
+`stale_daemon.stale_runtime_paths`, and surfaces runner config path changes in
+`stale_daemon.changed_runtime_paths`. This is intentionally read-only: refresh a
+development runner with `homeboy runner disconnect <runner-id>` followed by
+`homeboy runner connect <runner-id>` after rebuilding runner-side runtime code.
+
 ```json
 {
   "success": true,

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+use std::time::UNIX_EPOCH;
 
 use crate::command_contract::RunnerWorkload;
 use crate::core::api_jobs::{JobStatus, JobStore};
@@ -36,6 +37,15 @@ use patch_capture::{capture_baseline, capture_patch_report};
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
 
 static DAEMON_JOB_STORE: OnceLock<JobStore> = OnceLock::new();
+static DAEMON_RUNTIME_SNAPSHOT: OnceLock<DaemonRuntimeSnapshot> = OnceLock::new();
+
+const RUNTIME_PATH_FILE_LIMIT: usize = 2_000;
+const RUNTIME_PATH_SUFFIXES: &[&str] = &[
+    "_COMPONENT_PATH",
+    "_PLUGIN_PATH",
+    "_PROVIDER_PATH",
+    "_RUNTIME_PATH",
+];
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DaemonState {
@@ -65,6 +75,19 @@ pub struct DaemonStopResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
     pub state_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct DaemonRuntimeSnapshot {
+    loaded_at: String,
+    paths: Vec<DaemonRuntimePathSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct DaemonRuntimePathSnapshot {
+    env: String,
+    path: String,
+    fingerprint: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -211,6 +234,7 @@ where
     })?;
     let state = write_state(local_addr)?;
     let job_store = JobStore::open(paths::daemon_jobs_file()?)?;
+    let _ = daemon_runtime_snapshot();
     let loopback_bind = local_addr.ip().is_loopback();
 
     for stream in listener.incoming() {
@@ -303,6 +327,7 @@ where
             body: json!({
                 "version": VERSION,
                 "build_identity": build_identity::current(),
+                "runtime_paths": daemon_runtime_paths_body(),
             }),
             artifact: None,
         },
@@ -531,6 +556,136 @@ fn enqueue_exec_job(
 
 fn daemon_job_store() -> &'static JobStore {
     DAEMON_JOB_STORE.get_or_init(JobStore::default)
+}
+
+fn daemon_runtime_snapshot() -> &'static DaemonRuntimeSnapshot {
+    DAEMON_RUNTIME_SNAPSHOT.get_or_init(capture_daemon_runtime_snapshot)
+}
+
+fn daemon_runtime_paths_body() -> serde_json::Value {
+    let snapshot = daemon_runtime_snapshot();
+    let current: Vec<_> = snapshot
+        .paths
+        .iter()
+        .map(|path| DaemonRuntimePathSnapshot {
+            env: path.env.clone(),
+            path: path.path.clone(),
+            fingerprint: runtime_path_fingerprint(Path::new(&path.path)),
+        })
+        .collect();
+    let stale: Vec<_> = snapshot
+        .paths
+        .iter()
+        .zip(current.iter())
+        .filter(|(loaded, current)| loaded.fingerprint != current.fingerprint)
+        .map(|(loaded, current)| {
+            json!({
+                "env": loaded.env,
+                "path": loaded.path,
+                "loaded_fingerprint": loaded.fingerprint,
+                "current_fingerprint": current.fingerprint,
+            })
+        })
+        .collect();
+
+    json!({
+        "loaded_at": snapshot.loaded_at,
+        "loaded": snapshot.paths,
+        "current": current,
+        "stale": stale,
+    })
+}
+
+fn capture_daemon_runtime_snapshot() -> DaemonRuntimeSnapshot {
+    let paths = runtime_path_env_values()
+        .into_iter()
+        .map(|(env, path)| DaemonRuntimePathSnapshot {
+            env,
+            fingerprint: runtime_path_fingerprint(Path::new(&path)),
+            path,
+        })
+        .collect();
+
+    DaemonRuntimeSnapshot {
+        loaded_at: chrono::Utc::now().to_rfc3339(),
+        paths,
+    }
+}
+
+fn runtime_path_env_values() -> BTreeMap<String, String> {
+    std::env::vars()
+        .filter(|(name, value)| is_runtime_path_env(name) && !value.trim().is_empty())
+        .collect()
+}
+
+fn is_runtime_path_env(name: &str) -> bool {
+    name.starts_with("HOMEBOY_")
+        && RUNTIME_PATH_SUFFIXES
+            .iter()
+            .any(|suffix| name.ends_with(suffix))
+}
+
+fn runtime_path_fingerprint(path: &Path) -> String {
+    let mut state = RuntimePathFingerprintState::default();
+    collect_runtime_path_fingerprint(path, &mut state);
+    format!(
+        "exists={};files={};dirs={};bytes={};mtime_ns={};truncated={}",
+        state.exists, state.files, state.dirs, state.bytes, state.latest_mtime_ns, state.truncated
+    )
+}
+
+#[derive(Default)]
+struct RuntimePathFingerprintState {
+    exists: bool,
+    files: usize,
+    dirs: usize,
+    bytes: u64,
+    latest_mtime_ns: u128,
+    truncated: bool,
+}
+
+fn collect_runtime_path_fingerprint(path: &Path, state: &mut RuntimePathFingerprintState) {
+    if state.files >= RUNTIME_PATH_FILE_LIMIT {
+        state.truncated = true;
+        return;
+    }
+    let Ok(metadata) = fs::metadata(path) else {
+        return;
+    };
+    state.exists = true;
+    if metadata.is_dir() {
+        state.dirs += 1;
+        let Ok(entries) = fs::read_dir(path) else {
+            return;
+        };
+        let mut entries: Vec<_> = entries.filter_map(|entry| entry.ok()).collect();
+        entries.sort_by_key(|entry| entry.path());
+        for entry in entries {
+            let path = entry.path();
+            if should_skip_runtime_fingerprint_path(&path) {
+                continue;
+            }
+            collect_runtime_path_fingerprint(&path, state);
+            if state.truncated {
+                return;
+            }
+        }
+    } else if metadata.is_file() {
+        state.files += 1;
+        state.bytes = state.bytes.saturating_add(metadata.len());
+    }
+    if let Ok(modified) = metadata.modified() {
+        if let Ok(duration) = modified.duration_since(UNIX_EPOCH) {
+            state.latest_mtime_ns = state.latest_mtime_ns.max(duration.as_nanos());
+        }
+    }
+}
+
+fn should_skip_runtime_fingerprint_path(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(".git" | "node_modules" | "vendor" | "target")
+    )
 }
 
 fn route_read_only_api(

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::thread;
@@ -16,9 +17,9 @@ use crate::core::server::{self, Server, ServerAuthMode, SshClient};
 
 use super::session::{
     ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
-    RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
-    RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
-    RunnerTunnelMode,
+    RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
+    RunnerStatusReport, RunnerTunnelMode,
 };
 use super::{broker_auth, broker_http};
 use super::{load, Runner, RunnerKind};
@@ -29,6 +30,7 @@ const REVERSE_RUNNER_HEARTBEAT_TTL: Duration = Duration::from_secs(90);
 mod connection_daemon;
 use connection_daemon::{connect_remote_daemon, daemon_http_version, versions_match};
 use connection_daemon::{daemon_http_identity, normalize_homeboy_version_owned};
+use connection_daemon::{daemon_http_runtime_loaded_paths, daemon_http_runtime_stale_paths};
 
 use super::daemon_http_get::daemon_get;
 
@@ -498,19 +500,76 @@ fn stale_daemon_warning(
         .and_then(|local_url| daemon_http_identity(local_url).ok())
         .filter(|identity| !identity.trim().is_empty());
     let session_identity = daemon_identity.or_else(|| session.homeboy_build_identity.clone());
+    let stale_runtime_paths = session
+        .local_url
+        .as_deref()
+        .and_then(|local_url| daemon_http_runtime_stale_paths(local_url).ok())
+        .unwrap_or_default();
+    let changed_runtime_paths = session
+        .local_url
+        .as_deref()
+        .and_then(|local_url| daemon_http_runtime_loaded_paths(local_url).ok())
+        .map(|loaded| changed_runtime_paths(&runner.env, &loaded))
+        .unwrap_or_default();
     if versions_match(&observed_session_version, &current_version)
         && versions_match(&session.homeboy_version, &current_version)
         && identities_match(session_identity.as_deref(), Some(&current_identity.display))
+        && stale_runtime_paths.is_empty()
+        && changed_runtime_paths.is_empty()
     {
         return None;
     }
-    Some(RunnerStaleDaemonWarning::new(
-        &runner.id,
-        observed_session_version,
-        current_version,
-        session_identity,
-        Some(current_identity.display),
-    ))
+    Some(
+        RunnerStaleDaemonWarning::new(
+            &runner.id,
+            observed_session_version,
+            current_version,
+            session_identity,
+            Some(current_identity.display),
+        )
+        .with_runtime_paths(&runner.id, stale_runtime_paths, changed_runtime_paths),
+    )
+}
+
+fn changed_runtime_paths(
+    runner_env: &std::collections::HashMap<String, String>,
+    loaded_paths: &BTreeMap<String, String>,
+) -> Vec<RunnerChangedRuntimePath> {
+    let current_paths: BTreeMap<String, String> = runner_env
+        .iter()
+        .filter(|(name, value)| is_runtime_path_env(name) && !value.trim().is_empty())
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect();
+    let mut names: std::collections::BTreeSet<String> = loaded_paths.keys().cloned().collect();
+    names.extend(current_paths.keys().cloned());
+    names
+        .into_iter()
+        .filter_map(|env| {
+            let loaded_path = loaded_paths.get(&env).cloned();
+            let configured_path = current_paths.get(&env).cloned();
+            if loaded_path == configured_path {
+                None
+            } else {
+                Some(RunnerChangedRuntimePath {
+                    env,
+                    loaded_path,
+                    configured_path,
+                })
+            }
+        })
+        .collect()
+}
+
+fn is_runtime_path_env(name: &str) -> bool {
+    name.starts_with("HOMEBOY_")
+        && [
+            "_COMPONENT_PATH",
+            "_PLUGIN_PATH",
+            "_PROVIDER_PATH",
+            "_RUNTIME_PATH",
+        ]
+        .iter()
+        .any(|suffix| name.ends_with(suffix))
 }
 
 pub fn statuses() -> Result<Vec<RunnerStatusReport>> {
@@ -1101,8 +1160,10 @@ pub(super) fn terminate_pid(pid: u32) {
 mod tests {
     use std::collections::HashMap;
 
+    use super::super::session::RunnerStaleRuntimePath;
     use super::connection_daemon::{
-        daemon_identity_from_body, daemon_version_from_body, versions_match,
+        daemon_identity_from_body, daemon_runtime_loaded_paths_from_body,
+        daemon_runtime_stale_paths_from_body, daemon_version_from_body, versions_match,
     };
     use super::*;
     use crate::test_support;
@@ -1201,6 +1262,87 @@ mod tests {
             warning.recovery_commands,
             vec![
                 "homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect".to_string(),
+                "homeboy runner disconnect homeboy-lab".to_string(),
+                "homeboy runner connect homeboy-lab".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_daemon_runtime_stale_paths_from_version_body() {
+        let paths = daemon_runtime_stale_paths_from_body(&serde_json::json!({
+            "version": "0.228.13",
+            "runtime_paths": {
+                "stale": [{
+                    "env": "HOMEBOY_WP_CODEBOX_COMPONENT_PATH",
+                    "path": "/home/chubes/Developer/wp-codebox",
+                    "loaded_fingerprint": "files=10",
+                    "current_fingerprint": "files=11"
+                }]
+            }
+        }));
+
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].env, "HOMEBOY_WP_CODEBOX_COMPONENT_PATH");
+        assert_eq!(paths[0].loaded_fingerprint, "files=10");
+        assert_eq!(paths[0].current_fingerprint, "files=11");
+    }
+
+    #[test]
+    fn changed_runtime_paths_reports_runner_config_changes_since_daemon_start() {
+        let mut runner_env = HashMap::new();
+        runner_env.insert(
+            "HOMEBOY_WP_CODEBOX_COMPONENT_PATH".to_string(),
+            "/home/chubes/Developer/wp-codebox@new".to_string(),
+        );
+        let loaded = daemon_runtime_loaded_paths_from_body(&serde_json::json!({
+            "runtime_paths": {
+                "loaded": [{
+                    "env": "HOMEBOY_WP_CODEBOX_COMPONENT_PATH",
+                    "path": "/home/chubes/Developer/wp-codebox@old",
+                    "fingerprint": "files=10"
+                }]
+            }
+        }));
+
+        let changed = changed_runtime_paths(&runner_env, &loaded);
+
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].env, "HOMEBOY_WP_CODEBOX_COMPONENT_PATH");
+        assert_eq!(
+            changed[0].loaded_path.as_deref(),
+            Some("/home/chubes/Developer/wp-codebox@old")
+        );
+        assert_eq!(
+            changed[0].configured_path.as_deref(),
+            Some("/home/chubes/Developer/wp-codebox@new")
+        );
+    }
+
+    #[test]
+    fn runtime_path_warning_uses_rebuild_specific_message() {
+        let warning = RunnerStaleDaemonWarning::new(
+            "homeboy-lab",
+            "0.228.13".to_string(),
+            "0.228.13".to_string(),
+            Some("homeboy 0.228.13+same".to_string()),
+            Some("homeboy 0.228.13+same".to_string()),
+        )
+        .with_runtime_paths(
+            "homeboy-lab",
+            vec![RunnerStaleRuntimePath {
+                env: "HOMEBOY_WP_CODEBOX_COMPONENT_PATH".to_string(),
+                path: "/home/chubes/Developer/wp-codebox".to_string(),
+                loaded_fingerprint: "files=10".to_string(),
+                current_fingerprint: "files=11".to_string(),
+            }],
+            Vec::new(),
+        );
+
+        assert!(warning.message.contains("runner-side rebuilds"));
+        assert_eq!(
+            warning.recovery_commands,
+            vec![
                 "homeboy runner disconnect homeboy-lab".to_string(),
                 "homeboy runner connect homeboy-lab".to_string(),
             ]

--- a/src/core/runner/connection_daemon.rs
+++ b/src/core/runner/connection_daemon.rs
@@ -2,15 +2,18 @@ use std::path::Path;
 use std::time::Duration;
 
 use reqwest::blocking::Client;
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::core::server::{Server, SshClient};
 
+use super::super::session::RunnerStaleRuntimePath;
 use super::{
     failed_connect, open_loopback_tunnel, parse_loopback_daemon_addr, remote_daemon_start,
     remote_daemon_stop, reserve_loopback_port, terminate_pid, wait_for_tcp, RemoteDaemon,
 };
 use crate::core::runner::{RunnerConnectReport, RunnerFailureKind};
+use std::collections::BTreeMap;
 
 pub(super) fn connect_remote_daemon(
     server: &Server,
@@ -174,6 +177,20 @@ pub(super) fn daemon_http_version(local_url: &str) -> std::result::Result<String
         .ok_or_else(|| "remote daemon version response did not include a version".to_string())
 }
 
+pub(super) fn daemon_http_runtime_stale_paths(
+    local_url: &str,
+) -> std::result::Result<Vec<RunnerStaleRuntimePath>, String> {
+    let body = daemon_http_body(local_url)?;
+    Ok(daemon_runtime_stale_paths_from_body(&body))
+}
+
+pub(super) fn daemon_http_runtime_loaded_paths(
+    local_url: &str,
+) -> std::result::Result<BTreeMap<String, String>, String> {
+    let body = daemon_http_body(local_url)?;
+    Ok(daemon_runtime_loaded_paths_from_body(&body))
+}
+
 fn daemon_http_body(local_url: &str) -> std::result::Result<Value, String> {
     let client = Client::builder()
         .timeout(Duration::from_secs(2))
@@ -211,6 +228,51 @@ pub(super) fn daemon_identity_from_body(body: &Value) -> Option<&str> {
             body.pointer("/data/build_identity/display")
                 .and_then(Value::as_str)
         })
+}
+
+#[derive(Debug, Deserialize)]
+struct RuntimeStalePathBody {
+    env: String,
+    path: String,
+    loaded_fingerprint: String,
+    current_fingerprint: String,
+}
+
+pub(super) fn daemon_runtime_stale_paths_from_body(body: &Value) -> Vec<RunnerStaleRuntimePath> {
+    let stale = body
+        .pointer("/runtime_paths/stale")
+        .or_else(|| body.pointer("/data/runtime_paths/stale"));
+    let Some(Value::Array(paths)) = stale else {
+        return Vec::new();
+    };
+    paths
+        .iter()
+        .filter_map(|value| serde_json::from_value::<RuntimeStalePathBody>(value.clone()).ok())
+        .map(|path| RunnerStaleRuntimePath {
+            env: path.env,
+            path: path.path,
+            loaded_fingerprint: path.loaded_fingerprint,
+            current_fingerprint: path.current_fingerprint,
+        })
+        .collect()
+}
+
+pub(super) fn daemon_runtime_loaded_paths_from_body(body: &Value) -> BTreeMap<String, String> {
+    let loaded = body
+        .pointer("/runtime_paths/loaded")
+        .or_else(|| body.pointer("/data/runtime_paths/loaded"));
+    let Some(Value::Array(paths)) = loaded else {
+        return BTreeMap::new();
+    };
+    paths
+        .iter()
+        .filter_map(|value| {
+            Some((
+                value.get("env")?.as_str()?.to_string(),
+                value.get("path")?.as_str()?.to_string(),
+            ))
+        })
+        .collect()
 }
 
 fn daemon_freshness_mismatch(

--- a/src/core/runner/lab/preparation_tests.rs
+++ b/src/core/runner/lab/preparation_tests.rs
@@ -6,7 +6,7 @@ use crate::core::runner::{
     RunnerActiveJobState, RunnerConnectReport, RunnerStatusReport, RunnerTunnelMode,
 };
 
-use super::super::session::RunnerStaleDaemonWarning;
+use super::super::session::{RunnerStaleDaemonWarning, RunnerStaleRuntimePath};
 
 #[test]
 fn lab_runner_preparation_falls_back_for_unreachable_default_runner() {
@@ -147,7 +147,50 @@ fn lab_runner_preparation_refreshes_stale_default_daemon_version() {
 }
 
 #[test]
-fn lab_runner_preparation_errors_when_explicit_stale_daemon_refresh_fails() {
+fn lab_runner_preparation_falls_back_for_stale_default_runtime_paths() {
+    let selection = LabRunnerSelection {
+        runner_id: "lab".to_string(),
+        source: LabRunnerSelectionSource::Default,
+        mode: RunnerTunnelMode::DirectSsh,
+    };
+
+    let prepared = prepare_lab_runner_for_offload_with(
+        &selection,
+        |runner_id| {
+            Ok(RunnerStatusReport {
+                runner_id: runner_id.to_string(),
+                connected: true,
+                state: super::super::RunnerSessionState::Connected,
+                session: Some(connected_direct_session(
+                    runner_id,
+                    Some("http://127.0.0.1:1234"),
+                )),
+                stale_daemon: Some(stale_runtime_path_warning(runner_id)),
+                active_jobs: Vec::new(),
+                active_runner_jobs: Vec::new(),
+                active_job_count: 0,
+                stale_runner_jobs: Vec::new(),
+                stale_runner_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
+                session_path: "/tmp/lab.json".to_string(),
+            })
+        },
+        |_| panic!("stale runtime daemon should not dispatch or reconnect automatically"),
+    )
+    .expect("prepared");
+
+    assert_eq!(
+        prepared,
+        LabRunnerPreparation::FallBackLocal {
+            reason: "connected runner `lab` daemon runtime is stale after runner-side rebuilds or path changes; restart the active daemon with `homeboy runner disconnect lab && homeboy runner connect lab`".to_string()
+        }
+    );
+}
+
+#[test]
+fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
     let selection = LabRunnerSelection {
         runner_id: "lab".to_string(),
         source: LabRunnerSelectionSource::Explicit,
@@ -519,5 +562,25 @@ fn stale_daemon_warning(runner_id: &str) -> RunnerStaleDaemonWarning {
         "homeboy 0.219.0".to_string(),
         Some("homeboy 0.218.0+old".to_string()),
         Some("homeboy 0.219.0+new".to_string()),
+    )
+}
+
+fn stale_runtime_path_warning(runner_id: &str) -> RunnerStaleDaemonWarning {
+    RunnerStaleDaemonWarning::new(
+        runner_id,
+        "homeboy 0.219.0".to_string(),
+        "homeboy 0.219.0".to_string(),
+        Some("homeboy 0.219.0+same".to_string()),
+        Some("homeboy 0.219.0+same".to_string()),
+    )
+    .with_runtime_paths(
+        runner_id,
+        vec![RunnerStaleRuntimePath {
+            env: "HOMEBOY_WP_CODEBOX_COMPONENT_PATH".to_string(),
+            path: "/home/chubes/Developer/wp-codebox".to_string(),
+            loaded_fingerprint: "files=10".to_string(),
+            current_fingerprint: "files=11".to_string(),
+        }],
+        Vec::new(),
     )
 }

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -193,7 +193,10 @@ pub(super) fn prepare_lab_runner_for_offload_with(
     let status = status_fn(&selection.runner_id)?;
     if status.connected {
         if let Some(reason) = connected_runner_not_ready_reason(&selection.runner_id, &status) {
-            if status.stale_daemon.is_some()
+            if status
+                .stale_daemon
+                .as_ref()
+                .is_some_and(|warning| !stale_daemon_runtime_paths_changed(warning))
                 && status_tunnel_mode(&status) == RunnerTunnelMode::DirectSsh
             {
                 eprintln!(
@@ -312,6 +315,11 @@ fn connected_runner_not_ready_reason(
 ) -> Option<String> {
     if let Some(warning) = status.stale_daemon.as_ref() {
         let restart = stale_daemon_repair_command(runner_id, status);
+        if !warning.stale_runtime_paths.is_empty() || !warning.changed_runtime_paths.is_empty() {
+            return Some(format!(
+                "connected runner `{runner_id}` daemon runtime is stale after runner-side rebuilds or path changes; restart the active daemon with `{restart}`"
+            ));
+        }
         return Some(format!(
             "connected runner `{runner_id}` daemon is stale: connected daemon reports {}, but the configured runner executable reports {}; stale runner runtimes can return malformed or misleading provider output; restart the active daemon with `{restart}`",
             warning.session_homeboy_version, warning.current_homeboy_version
@@ -332,6 +340,10 @@ fn connected_runner_not_ready_reason(
         }
         _ => None,
     }
+}
+
+fn stale_daemon_runtime_paths_changed(warning: &super::RunnerStaleDaemonWarning) -> bool {
+    !warning.stale_runtime_paths.is_empty() || !warning.changed_runtime_paths.is_empty()
 }
 
 fn stale_daemon_repair_command(runner_id: &str, status: &RunnerStatusReport) -> String {

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -116,11 +116,11 @@ pub use offload_metadata::{
 pub use resource_metrics::RunnerResourceMetrics;
 pub use session::{
     ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
-    RunnerArtifactRef, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
-    RunnerHandoff, RunnerJob, RunnerLifecycleOwner, RunnerMutationArtifacts,
+    RunnerArtifactRef, RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport,
+    RunnerFailureKind, RunnerHandoff, RunnerJob, RunnerLifecycleOwner, RunnerMutationArtifacts,
     RunnerNamedWorkspaceLease, RunnerResult, RunnerSession, RunnerSessionRole, RunnerSessionState,
-    RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceLease,
-    RunnerWorkspaceLeaseSet,
+    RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
+    RunnerWorkspaceLease, RunnerWorkspaceLeaseSet,
 };
 pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerTransport};

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -443,8 +443,29 @@ pub struct RunnerStaleDaemonWarning {
     pub session_homeboy_build_identity: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_homeboy_build_identity: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stale_runtime_paths: Vec<RunnerStaleRuntimePath>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_runtime_paths: Vec<RunnerChangedRuntimePath>,
     pub message: String,
     pub recovery_commands: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerStaleRuntimePath {
+    pub env: String,
+    pub path: String,
+    pub loaded_fingerprint: String,
+    pub current_fingerprint: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerChangedRuntimePath {
+    pub env: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loaded_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configured_path: Option<String>,
 }
 
 impl RunnerStaleDaemonWarning {
@@ -461,12 +482,32 @@ impl RunnerStaleDaemonWarning {
             session_homeboy_build_identity,
             current_homeboy_build_identity,
             message: "connected runner daemon was started by a different Homeboy build than the configured runner executable; run recovery_commands in order to restart the active daemon".to_string(),
+            stale_runtime_paths: Vec::new(),
+            changed_runtime_paths: Vec::new(),
             recovery_commands: vec![
                 format!("homeboy runner refresh-homeboy {} --ref main --reconnect", runner_id),
                 format!("homeboy runner disconnect {}", runner_id),
                 format!("homeboy runner connect {}", runner_id),
             ],
         }
+    }
+
+    pub fn with_runtime_paths(
+        mut self,
+        runner_id: &str,
+        stale_runtime_paths: Vec<RunnerStaleRuntimePath>,
+        changed_runtime_paths: Vec<RunnerChangedRuntimePath>,
+    ) -> Self {
+        self.stale_runtime_paths = stale_runtime_paths;
+        self.changed_runtime_paths = changed_runtime_paths;
+        if !self.stale_runtime_paths.is_empty() || !self.changed_runtime_paths.is_empty() {
+            self.message = "connected runner daemon runtime paths are stale; run recovery_commands in order to restart the active daemon after runner-side rebuilds or path changes".to_string();
+            self.recovery_commands = vec![
+                format!("homeboy runner disconnect {}", runner_id),
+                format!("homeboy runner connect {}", runner_id),
+            ];
+        }
+        self
     }
 }
 

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -50,16 +50,16 @@ pub use super::runner::{
     LabRunnerSelectionSource, ManagedRunnerSourceSyncPlan, PreparedLabRunnerCapability,
     RemoteArtifactDownload, ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions,
     ReverseRunnerWorkerOutput, Runner, RunnerActiveJobSource, RunnerActiveJobState,
-    RunnerArtifactRef, RunnerCapabilityPreflight, RunnerConnectReport, RunnerDisconnectReport,
-    RunnerExecDiagnostics, RunnerExecMode, RunnerExecOptions, RunnerExecOutput, RunnerFailureKind,
-    RunnerHandoff, RunnerJob, RunnerKind, RunnerLifecycleOwner, RunnerMutationArtifacts,
-    RunnerNamedWorkspaceLease, RunnerRequiredTool, RunnerResourceMetrics, RunnerResult,
-    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerSpec, RunnerStaleDaemonWarning,
-    RunnerStatusReport, RunnerToolRegistry, RunnerToolSpec, RunnerTunnelMode,
-    RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
-    RunnerWorkspaceLease, RunnerWorkspaceLeaseSet, RunnerWorkspaceListEntry,
-    RunnerWorkspaceListOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
-    RunnerWorkspaceSyncOutput,
+    RunnerArtifactRef, RunnerCapabilityPreflight, RunnerChangedRuntimePath, RunnerConnectReport,
+    RunnerDisconnectReport, RunnerExecDiagnostics, RunnerExecMode, RunnerExecOptions,
+    RunnerExecOutput, RunnerFailureKind, RunnerHandoff, RunnerJob, RunnerKind,
+    RunnerLifecycleOwner, RunnerMutationArtifacts, RunnerNamedWorkspaceLease, RunnerRequiredTool,
+    RunnerResourceMetrics, RunnerResult, RunnerSession, RunnerSessionRole, RunnerSessionState,
+    RunnerSpec, RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport,
+    RunnerToolRegistry, RunnerToolSpec, RunnerTunnelMode, RunnerWorkspaceApplyOptions,
+    RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus, RunnerWorkspaceLease,
+    RunnerWorkspaceLeaseSet, RunnerWorkspaceListEntry, RunnerWorkspaceListOutput,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
 // Registry CRUD entry points (re-exported at the root for ergonomics; also
@@ -91,9 +91,9 @@ pub mod connection {
     pub use super::super::runner::{
         connect, connect_reverse, disconnect, run_reverse_worker, status, statuses,
         ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput,
-        RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
-        RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
-        RunnerTunnelMode,
+        RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+        RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
+        RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
     };
 }
 


### PR DESCRIPTION
## Summary
- Capture runner daemon runtime path fingerprints at daemon start and expose stale/current comparisons from `/version`.
- Surface stale runtime path fingerprints and configured path changes in runner status.
- Block Lab offload dispatch to stale runtime daemons with safe disconnect/connect remediation.

Closes #6501.

## Testing
- `cargo test runner::connection::tests --lib`
- `cargo test runner::lab::preparation_tests --lib`
- `cargo fmt --check`
- `cargo check --lib`
- `git diff --check --cached`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Porting stale runner runtime detection to current `main`, resolving conflicts, and focused tests.
