### PR TITLE
Fail fuzz proofs on expected metric mismatch

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -12,7 +12,9 @@ use homeboy::core::observation::{ObservationStore, RunRecord, RunStatus};
 use homeboy::core::rig::{self, FuzzPrepareReport, RigSpec};
 use uuid::Uuid;
 
-use super::report::{evaluate_fuzz_gates, fuzz_coverage_completeness};
+use super::report::{
+    evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness, gate_status,
+};
 use super::types::{
     FuzzArtifactPostprocessOutput, FuzzCampaignContract, FuzzExecutionOutput, FuzzRunArgs,
     FuzzRunOutput, FuzzRunnerContract, FuzzWorkloadOutput,
@@ -104,10 +106,14 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     let artifact_ref_validation = fuzz_artifact_ref_validation(results.as_ref(), &artifacts_dir);
     let artifact_validation_error = fuzz_run_artifact_validation_error(&args, results.as_ref());
     let postprocess_error = fuzz_postprocess_error(&postprocess);
+    let expected_metric_gates =
+        evaluate_expected_metric_gates(results.as_ref(), &args.expect_metric);
+    let expected_metric_error = fuzz_expected_metric_error(&expected_metric_gates);
     let combined_results_error = results_error
         .as_deref()
         .or(postprocess_error.as_deref())
         .or(artifact_validation_error.as_deref())
+        .or(expected_metric_error.as_deref())
         .or(artifact_ref_validation.error.as_deref());
     let outcome = fuzz_run_outcome(
         runner_output.exit_code,
@@ -137,6 +143,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         results_path: &results_path,
         artifacts_dir: &artifacts_dir,
         results: results.as_ref(),
+        expected_metric_gates: &expected_metric_gates,
         results_error: combined_results_error,
         missing_artifact_refs: &artifact_ref_validation.missing_refs,
     })?;
@@ -156,13 +163,16 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
             status,
             workload_id,
             workload_path,
-            run_id: args.run_id,
-            seed: args.seed,
+            run_id: args.run_id.clone(),
+            seed: args.seed.clone(),
             inventory_file: args
                 .inventory
+                .clone()
                 .map(|path| path.to_string_lossy().to_string()),
-            max_duration: args.max_duration,
-            passthrough_args: args.args,
+            max_duration: args.max_duration.clone(),
+            passthrough_args: args.args.clone(),
+            requested_settings: fuzz_requested_settings(&args),
+            gates: fuzz_run_gates(results.as_ref(), &expected_metric_gates),
             target_inventory: Some(target_inventory),
             execution: Some(FuzzExecutionOutput {
                 kind: "fuzz".to_string(),
@@ -228,6 +238,41 @@ pub(super) fn fuzz_run_artifact_validation_error(
             "strict fuzz artifact validation failed; missing required artifact(s): {}",
             missing.join(", ")
         )
+    })
+}
+
+pub(super) fn fuzz_expected_metric_error(
+    gates: &[super::types::FuzzGateEvaluation],
+) -> Option<String> {
+    let failed = gates
+        .iter()
+        .filter(|gate| gate.status != "passed")
+        .map(|gate| {
+            format!(
+                "{} expected {} observed {}",
+                gate.metric, gate.expected, gate.observed
+            )
+        })
+        .collect::<Vec<_>>();
+
+    (!failed.is_empty())
+        .then(|| format!("fuzz expected metric gate(s) failed: {}", failed.join("; ")))
+}
+
+fn fuzz_run_gates(
+    results: Option<&FuzzCampaign>,
+    expected_metric_gates: &[super::types::FuzzGateEvaluation],
+) -> Vec<super::types::FuzzGateEvaluation> {
+    let mut gates = results.map(evaluate_fuzz_gates).unwrap_or_default();
+    gates.extend(expected_metric_gates.iter().cloned());
+    gates
+}
+
+fn fuzz_requested_settings(args: &FuzzRunArgs) -> serde_json::Value {
+    serde_json::json!({
+        "setting": args.setting_args.setting,
+        "setting_json": args.setting_args.setting_json,
+        "expect_metric": args.expect_metric,
     })
 }
 
@@ -735,6 +780,7 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) results_path: &'a Path,
     pub(super) artifacts_dir: &'a Path,
     pub(super) results: Option<&'a FuzzCampaign>,
+    pub(super) expected_metric_gates: &'a [super::types::FuzzGateEvaluation],
     pub(super) results_error: Option<&'a str>,
     pub(super) missing_artifact_refs: &'a [String],
 }
@@ -759,11 +805,13 @@ pub(super) fn persist_fuzz_run_evidence(
         "exit_code": input.exit_code,
         "success": input.success,
         "status": input.status,
+        "requested_settings": fuzz_requested_settings(input.args),
         "campaign_id": input.results.map(|campaign| campaign.id.as_str()),
         "results_error": input.results_error,
         "missing_artifact_refs": input.missing_artifact_refs,
         "coverage_completeness": input.results.map(fuzz_coverage_completeness),
-        "gates": input.results.map(evaluate_fuzz_gates),
+        "gates": fuzz_run_gates(input.results, input.expected_metric_gates),
+        "gate_status": gate_status(&fuzz_run_gates(input.results, input.expected_metric_gates)),
     });
     let run = RunRecord {
         id: run_id.clone(),
@@ -965,6 +1013,12 @@ fn fuzz_run_command(
     }
     if args.require_result_envelope {
         parts.push("--require-result-envelope".to_string());
+    }
+    for (metric, expected) in &args.expect_metric {
+        parts.extend([
+            "--expect-metric".to_string(),
+            format!("{metric}={expected}"),
+        ]);
     }
     if !args.args.is_empty() {
         parts.push("--".to_string());

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -252,6 +252,115 @@ pub(super) fn evaluate_fuzz_gates(campaign: &FuzzCampaign) -> Vec<FuzzGateEvalua
         .collect()
 }
 
+pub(super) fn evaluate_expected_metric_gates(
+    campaign: Option<&FuzzCampaign>,
+    expectations: &[(String, String)],
+) -> Vec<FuzzGateEvaluation> {
+    expectations
+        .iter()
+        .map(|(metric, expected)| {
+            let expected_value = expected.trim().parse::<f64>().unwrap_or(f64::NAN);
+            let observed = campaign.and_then(|campaign| fuzz_campaign_metric(campaign, metric));
+            let passed = expected_value.is_finite()
+                && observed
+                    .is_some_and(|observed| (observed - expected_value).abs() < f64::EPSILON);
+            FuzzGateEvaluation {
+                gate_id: format!("expected-metric-{metric}"),
+                status: if passed { "passed" } else { "failed" }.to_string(),
+                metric: metric.clone(),
+                observed: observed.unwrap_or(0.0),
+                expected: if expected_value.is_finite() {
+                    expected_value
+                } else {
+                    0.0
+                },
+            }
+        })
+        .collect()
+}
+
+pub(super) fn fuzz_campaign_metric(campaign: &FuzzCampaign, metric: &str) -> Option<f64> {
+    let mut metrics = BTreeMap::new();
+    collect_value_metrics(None, &campaign.metadata, &mut metrics);
+    for (key, value) in &campaign.extra {
+        collect_value_metrics(Some(key), value, &mut metrics);
+    }
+    for artifact in &campaign.artifacts {
+        collect_value_metrics(
+            Some(&format!("artifact.{}.metadata", artifact.id)),
+            &artifact.metadata,
+            &mut metrics,
+        );
+        for (key, value) in &artifact.extra {
+            collect_value_metrics(
+                Some(&format!("artifact.{}.extra.{key}", artifact.id)),
+                value,
+                &mut metrics,
+            );
+        }
+    }
+    if let Some(summary) = campaign.coverage_summary.as_ref() {
+        collect_value_metrics(
+            Some("coverage_summary.metadata"),
+            &summary.metadata,
+            &mut metrics,
+        );
+        for (key, value) in &summary.extra {
+            collect_value_metrics(
+                Some(&format!("coverage_summary.extra.{key}")),
+                value,
+                &mut metrics,
+            );
+        }
+    }
+
+    metrics.get(metric).copied().or_else(|| {
+        metrics
+            .iter()
+            .find_map(|(key, value)| key.ends_with(&format!(".{metric}")).then_some(*value))
+    })
+}
+
+fn collect_value_metrics(
+    prefix: Option<&str>,
+    value: &serde_json::Value,
+    metrics: &mut BTreeMap<String, f64>,
+) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for (key, value) in object {
+                let metric = prefix
+                    .map(|prefix| format!("{prefix}.{key}"))
+                    .unwrap_or_else(|| key.clone());
+                collect_value_metrics(Some(&metric), value, metrics);
+            }
+        }
+        serde_json::Value::Number(number) => {
+            if let (Some(prefix), Some(value)) =
+                (prefix, number.as_f64().filter(|value| value.is_finite()))
+            {
+                metrics.insert(prefix.to_string(), value);
+            }
+        }
+        serde_json::Value::String(raw) => {
+            if let (Some(prefix), Ok(value)) = (prefix, raw.parse::<f64>()) {
+                if value.is_finite() {
+                    metrics.insert(prefix.to_string(), value);
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for (index, value) in values.iter().enumerate() {
+                let metric = prefix
+                    .map(|prefix| format!("{prefix}.{index}"))
+                    .unwrap_or_else(|| index.to_string());
+                collect_value_metrics(Some(&metric), value, metrics);
+            }
+        }
+        _ => {}
+    }
+}
+
 pub(super) fn evaluate_fuzz_result_envelope_gates(
     envelope: &FuzzResultEnvelope,
 ) -> Vec<FuzzGateEvaluation> {

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -23,6 +23,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             require_result_envelope: false,
             max_duration: None,
             gate_profile: FuzzGateProfileArg::Measurement,
+            expect_metric: vec![],
             args: vec![],
         };
         let results_path = home.path().join("fuzz-results.json");
@@ -43,6 +44,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             results_path: &results_path,
             artifacts_dir: &artifacts_dir,
             results: None,
+            expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
         })
@@ -109,6 +111,7 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
             results_path: &results_path,
             artifacts_dir: &artifacts_dir,
             results: None,
+            expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
         })
@@ -168,6 +171,39 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_open_finding() {
 
     let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
 
+    assert_eq!(outcome.status, "failed");
+    assert!(!outcome.success);
+    assert_eq!(outcome.exit_code, 1);
+}
+
+#[test]
+fn fuzz_run_expected_metric_gate_fails_when_observed_metric_differs() {
+    let mut campaign = empty_fuzz_campaign();
+    campaign.metadata = serde_json::json!({
+        "metrics": {
+            "side_effect_grouped_created_count": 25,
+            "simple_created": 25,
+            "grouped_created": 25,
+            "variation_created": 25
+        }
+    });
+    let expectations = vec![(
+        "side_effect_grouped_created_count".to_string(),
+        "2".to_string(),
+    )];
+
+    let gates = evaluate_expected_metric_gates(Some(&campaign), &expectations);
+    let error = fuzz_expected_metric_error(&gates).expect("expected metric failure");
+    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), Some(&error));
+
+    assert_eq!(gate_status(&gates), "failed");
+    assert!(gates.iter().any(|gate| {
+        gate.gate_id == "expected-metric-side_effect_grouped_created_count"
+            && gate.status == "failed"
+            && gate.observed == 25.0
+            && gate.expected == 2.0
+    }));
+    assert!(error.contains("side_effect_grouped_created_count expected 2 observed 25"));
     assert_eq!(outcome.status, "failed");
     assert!(!outcome.success);
     assert_eq!(outcome.exit_code, 1);
@@ -377,6 +413,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             require_result_envelope: false,
             max_duration: None,
             gate_profile: FuzzGateProfileArg::Measurement,
+            expect_metric: vec![],
             args: vec![],
         };
         let results_path = home.path().join("fuzz-results.json");
@@ -401,6 +438,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             results_path: &results_path,
             artifacts_dir: &artifacts_dir,
             results: None,
+            expected_metric_gates: &[],
             results_error: Some(
                 "fuzz results schema must be homeboy/fuzz-campaign/v1, got unsupported/fuzz-result/v1",
             ),

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -3,15 +3,16 @@
 use super::super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
 use super::execution::{
     default_runner_contract, fuzz_artifact_ref_validation, fuzz_campaign_contract,
-    fuzz_evidence_followups, fuzz_max_duration, fuzz_postprocess_error,
+    fuzz_evidence_followups, fuzz_expected_metric_error, fuzz_max_duration, fuzz_postprocess_error,
     fuzz_run_artifact_validation_error, fuzz_run_outcome, fuzz_runner_env,
     persist_fuzz_run_evidence, run_fuzz_artifact_postprocess, FuzzRunEvidenceInput,
 };
 use super::planning::plan_inventory_selection;
 use super::replay::run_replay;
 use super::report::{
-    evaluate_fuzz_gates, fuzz_coverage_completeness, fuzz_performance_hotspots, gate_status,
-    run_report, run_validate, FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
+    evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,
+    fuzz_performance_hotspots, gate_status, run_report, run_validate,
+    FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
 };
 use super::types::{
     FuzzCommand, FuzzDiscoverArgs, FuzzExecutionOutput, FuzzGateProfileArg, FuzzListOutput,
@@ -89,6 +90,7 @@ fn planner_args() -> FuzzPlanArgs {
             require_result_envelope: false,
             max_duration: None,
             gate_profile: FuzzGateProfileArg::Measurement,
+            expect_metric: vec![],
             args: Vec::new(),
         },
         request_id: None,
@@ -210,6 +212,7 @@ fn fuzz_run_args_with_run_id(run_id: &str) -> FuzzRunArgs {
         require_result_envelope: false,
         max_duration: None,
         gate_profile: FuzzGateProfileArg::Measurement,
+        expect_metric: vec![],
         args: vec![],
     }
 }

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -216,6 +216,8 @@ fn fuzz_run_parses_generic_contract_flags() {
         "--require-result-envelope",
         "--max-duration",
         "60s",
+        "--expect-metric",
+        "side_effect_grouped_created_count=2",
         "--",
         "--engine",
         "libfuzzer",
@@ -236,6 +238,13 @@ fn fuzz_run_parses_generic_contract_flags() {
             assert!(run.require_coverage_summary);
             assert!(run.require_result_envelope);
             assert_eq!(run.max_duration.as_deref(), Some("60s"));
+            assert_eq!(
+                run.expect_metric,
+                vec![(
+                    "side_effect_grouped_created_count".to_string(),
+                    "2".to_string()
+                )]
+            );
             assert_eq!(run.args, vec!["--engine", "libfuzzer"]);
         }
         _ => panic!("expected fuzz run command"),
@@ -384,6 +393,8 @@ fn fuzz_output_contract_has_stable_variant_discriminators() {
         inventory_file: None,
         max_duration: None,
         passthrough_args: Vec::new(),
+        requested_settings: serde_json::Value::Null,
+        gates: Vec::new(),
         target_inventory: None,
         execution: None,
         postprocess: Vec::new(),

--- a/src/commands/fuzz/tests/report_tests.rs
+++ b/src/commands/fuzz/tests/report_tests.rs
@@ -37,6 +37,8 @@ fn fuzz_output_contract_includes_results_file_and_parsed_campaign() {
         inventory_file: None,
         max_duration: None,
         passthrough_args: Vec::new(),
+        requested_settings: serde_json::Value::Null,
+        gates: Vec::new(),
         target_inventory: None,
         execution: Some(FuzzExecutionOutput {
             kind: "fuzz".to_string(),

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -122,6 +122,7 @@ fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_cont
         require_result_envelope: false,
         max_duration: Some("60s".to_string()),
         gate_profile: FuzzGateProfileArg::Measurement,
+        expect_metric: vec![],
         args: vec![],
     };
     let workload = FuzzWorkloadOutput {
@@ -220,6 +221,7 @@ fn fuzz_runner_env_expands_rig_workload_and_injects_runtime_context() {
         require_result_envelope: false,
         max_duration: None,
         gate_profile: FuzzGateProfileArg::Measurement,
+        expect_metric: vec![],
         args: vec![],
     };
     let workload = FuzzWorkloadOutput {

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -189,6 +189,11 @@ pub struct FuzzRunArgs {
     #[arg(long = "gate-profile", value_enum, default_value_t = FuzzGateProfileArg::Measurement)]
     pub(crate) gate_profile: FuzzGateProfileArg,
 
+    /// Require a numeric metric emitted by the fuzz campaign to equal this value.
+    /// Repeatable. Format: `--expect-metric metric_name=2`.
+    #[arg(long = "expect-metric", value_name = "METRIC=VALUE", value_parser = crate::commands::parse_key_val)]
+    pub(crate) expect_metric: Vec<(String, String)>,
+
     /// Additional runner arguments reserved for the fuzz extension script.
     #[arg(last = true)]
     pub(crate) args: Vec<String>,

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -152,6 +152,8 @@ pub struct FuzzRunOutput {
     pub inventory_file: Option<String>,
     pub max_duration: Option<String>,
     pub passthrough_args: Vec<String>,
+    pub requested_settings: serde_json::Value,
+    pub gates: Vec<FuzzGateEvaluation>,
     pub target_inventory: Option<FuzzTargetInventory>,
     pub execution: Option<FuzzExecutionOutput>,
     pub postprocess: Vec<FuzzArtifactPostprocessOutput>,


### PR DESCRIPTION
## Summary
- Add repeatable `homeboy fuzz run --expect-metric METRIC=VALUE` assertions for normalized fuzz campaign metrics.
- Fail fuzz proof outcome and persisted run status when an expected metric is missing or differs from the requested value.
- Persist requested settings and gate evaluations in fuzz run output/evidence so reviewer-facing proof surfaces requested vs observed values.

Fixes #6510.

## Tests
- `cargo test commands::fuzz::tests`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the expected metric proof gate, adding regression coverage, and preparing this PR.