### PR TITLE
Make PR checks direct and actionable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 # PR quality pipeline.
 #
-# Homeboy Action owns the CI DAG so command failures aggregate instead of
-# skipping later quality checks. Ordinary PR quality gates use the action-provided
-# Homeboy binary instead of compiling a release binary on every pull request.
+# Keep these checks direct in this repository so PRs do not depend on an extra
+# reusable-workflow planning job before actionable Audit/Lint/Test checks exist.
 
 name: CI
 
@@ -23,13 +22,55 @@ permissions:
 
 jobs:
   homeboy:
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
-    with:
-      component: homeboy
-      commands: audit,lint,test
-      differential-gating: true
-      # Autofix is explicitly disabled on PRs: an on-failure autofix push
-      # lands a bot commit mid-review and supersedes in-flight CI runs,
-      # which reads as a spurious failure (see #3819). Require manual fixes.
-      autofix: 'false'
-    secrets: inherit
+    name: homeboy / ${{ matrix.title }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - command: audit
+            title: Audit
+            section_key: audit
+            section_title: Audit
+          - command: lint
+            title: Lint
+            section_key: lint
+            section_title: Lint
+          - command: test
+            title: Test
+            section_key: test
+            section_title: Test
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Check out Homeboy Action
+        uses: actions/checkout@v6
+        with:
+          repository: Extra-Chill/homeboy-action
+          ref: v2
+          path: .homeboy-action
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+
+      - uses: ./.homeboy-action
+        with:
+          component: homeboy
+          commands: ${{ matrix.command }}
+          expected-commands: audit,lint,test
+          differential-gating: true
+          # Autofix is explicitly disabled on PRs: an on-failure autofix push
+          # lands a bot commit mid-review and supersedes in-flight CI runs,
+          # which reads as a spurious failure (see #3819). Require manual fixes.
+          autofix: 'false'
+          app-token: ${{ steps.app-token.outputs.token || github.token }}
+          comment-section-key: ${{ matrix.section_key }}
+          comment-section-title: ${{ matrix.section_title }}


### PR DESCRIPTION
## Summary
- Replace the reusable Homeboy CI workflow call with direct PR jobs for Audit, Lint, and Test.
- Remove the always-skipped optional Build check from normal PRs.
- Remove the separate reusable Plan scheduler hop so actionable command checks are created directly.

Fixes #6495.

## Root cause
Homeboy's PR workflow delegated the full DAG to `Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2`. That reusable workflow always emitted a `Build` job, but the Homeboy caller did not pass `build-command`, so `homeboy / Build` completed as skipped on every PR. It also emitted a separate `homeboy / Plan` job before Audit/Lint/Test could be materialized; when GitHub left that scheduler job queued with no runner, steps, or logs, the whole PR stayed `UNSTABLE` with no actionable command-level check.

Evidence from affected runs:
- #6515 run `28238049087`: `homeboy / Plan` queued with no runner/steps/logs; `homeboy / Build` skipped.
- #6517 run `28238415202`: same shape.
- `main` has no branch protection required-status setting forcing the old Plan/Build names.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'`\n- `git diff --check`\n- `gh workflow view CI --repo Extra-Chill/homeboy --yaml` confirmed the currently deployed workflow still uses the reusable Plan/Build shape this PR replaces.\n\n`actionlint` is not installed in this local environment, so GitHub Actions semantic validation is deferred to the PR run.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** gpt-5.5 via OpenCode\n- **Used for:** Investigating stuck Homeboy PR checks, editing the GitHub Actions workflow, and preparing validation/PR evidence.\n