### PR TITLE
Gate high-risk safety manifest metadata

### DIFF
--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -35,6 +35,9 @@ homeboy extension run <extension_id> [-p|--project <project_id>] [-c|--component
 - `--no-stream` disables streaming and captures output.
 - By default, Homeboy auto-detects streaming behavior based on TTY.
 - Trailing `<args...>` are passed to CLI-type extensions.
+- Safety manifest metadata marks `extension run` as an operator command because
+  extension-owned runtime commands and forwarded arguments may mutate the target
+  system.
 
 ### `set`
 
@@ -134,7 +137,7 @@ Executes an action defined in the extension manifest.
 homeboy extension exec <extension_id> [-c|--component <component_id>] -- <command...>
 ```
 
-Runs a tool from the extension's vendor/runtime directory. When `--component` is provided, the command runs with that component's path as the working directory.
+Runs a tool from the extension's vendor/runtime directory. When `--component` is provided, the command runs with that component's path as the working directory. Safety manifest metadata marks `extension exec` as an operator command because forwarded commands may mutate the target system.
 
 ## Settings
 

--- a/docs/commands/manifest.md
+++ b/docs/commands/manifest.md
@@ -11,7 +11,13 @@ homeboy manifest
 Prints the recursive command manifest as the standard Homeboy JSON envelope. The
 payload includes visible and hidden command paths, aliases, mutation/operator
 safety metadata, dry-run flags, output-contract notes, Lab routing metadata,
-dangerous flags, and command docs paths.
+dangerous flags, risk exemptions, and command docs paths.
+
+`risk_exemption` marks mutating commands whose action is explicit in the command
+shape even though they do not yet expose a dry-run/apply guard. The manifest audit
+helper reports visible mutating commands that lack dry-run, apply/dangerous flag,
+or risk-exemption metadata; the initial gate enforces this for the first
+high-risk command set while the broader audit remains report-only.
 
 Use this command for automation that needs a machine-readable view of the CLI
 surface. Human command discovery should use `homeboy --help`, command-specific

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -127,6 +127,10 @@ The JSON payload uses `command: "runner.doctor"` and includes `runner_id`,
 Use `doctor` before `connect` when you need to know whether Homeboy, Git, SSH,
 and the configured workspace root are usable on the target machine.
 
+Safety manifest metadata marks `runner connect` and `runner work` as explicit
+operator lifecycle actions. They do not currently expose dry-run contracts; use
+`runner doctor` for preflight diagnostics before changing runner lifecycle state.
+
 Use `--scope lab-offload` before serious Lab evidence runs. It adds checks for
 the configured runner Homeboy command, bare `homeboy` PATH resolution, preferred
 runner binaries, connected daemon exec readiness, and Sample Runtime runner-path

--- a/docs/commands/stack.md
+++ b/docs/commands/stack.md
@@ -85,6 +85,10 @@ homeboy stack apply <stack-id>
 
 Fetches the base, recreates the local target branch from the base, then cherry-picks every PR head in order. `apply` stops on the first conflict, aborts the in-progress pick, and prints a manual-resolution hint. It does not push.
 
+Safety manifest metadata marks `apply` and `rebase` as explicit branch-mutation
+actions. Use `status` for read-only inspection and `sync --dry-run` for the
+available planning path before mutating a stack branch.
+
 ### `status`
 
 ```sh
@@ -113,6 +117,9 @@ Spec-less inspection of the current branch as a stack of commits over a base ref
 ## GitHub dependency
 
 `apply`, `status`, `sync`, and `inspect` PR lookup paths call the GitHub CLI (`gh`). Authenticate `gh` for private repositories before relying on stack reports.
+
+`push` is classified as an explicit remote publication action in the safety
+manifest. It does not currently expose a dry-run contract.
 
 ## Related
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -227,6 +227,24 @@ pub struct CommandSafetyManifest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommandSafetyAuditReport {
+    pub report_only: bool,
+    pub missing_action_metadata: Vec<CommandSafetyAuditFinding>,
+}
+
+impl CommandSafetyAuditReport {
+    pub fn has_findings(&self) -> bool {
+        !self.missing_action_metadata.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommandSafetyAuditFinding {
+    pub path: Vec<String>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandSurfaceDoctorReport {
     pub agrees: bool,
     pub source_registry_commands: Vec<String>,
@@ -263,6 +281,8 @@ pub struct CommandSafetyEntry {
     pub output: CommandOutputMetadata,
     pub lab: CommandLabMetadata,
     pub docs: CommandDocsMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_exemption: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extension: Option<ExtensionCommandManifest>,
     pub dangerous_flags: Vec<String>,
@@ -606,8 +626,8 @@ fn push_drift_note(notes: &mut Vec<String>, commands: &[String], label: &str) {
 // entry points here so existing call sites keep importing them from
 // `crate::cli_surface` unchanged while this module leans toward clap shapes.
 pub use crate::command_contract::safety_manifest::{
-    command_safety_manifest_from, command_safety_manifest_from_dynamic,
-    current_command_safety_manifest,
+    command_safety_manifest_audit, command_safety_manifest_from,
+    command_safety_manifest_from_dynamic, current_command_safety_manifest,
 };
 
 fn visible_subcommands(command: &Command, remaining_depth: usize) -> Vec<CommandSurfaceEntry> {

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -13,8 +13,8 @@
 
 use crate::cli_surface::{
     current_command_surface, CommandDocsMetadata, CommandDryRunMetadata, CommandLabMetadata,
-    CommandOutputMetadata, CommandSafetyEntry, CommandSafetyManifest, CommandSurface,
-    CommandSurfaceEntry, DynamicCommandDescriptor,
+    CommandOutputMetadata, CommandSafetyAuditFinding, CommandSafetyAuditReport, CommandSafetyEntry,
+    CommandSafetyManifest, CommandSurface, CommandSurfaceEntry, DynamicCommandDescriptor,
 };
 use crate::command_contract::registered_command;
 
@@ -36,6 +36,24 @@ pub fn command_safety_manifest_from_dynamic(
             .iter()
             .map(|entry| command_safety_entry(entry, &[], dynamic_commands))
             .collect(),
+    }
+}
+
+pub fn command_safety_manifest_audit(manifest: &CommandSafetyManifest) -> CommandSafetyAuditReport {
+    let mut missing_action_metadata = Vec::new();
+
+    for entry in flatten_manifest_entries(&manifest.commands) {
+        if !entry.hidden && entry.mutates && !entry_has_action_metadata(entry) {
+            missing_action_metadata.push(CommandSafetyAuditFinding {
+                path: entry.path.clone(),
+                reason: "visible mutating command lacks dry-run, dangerous/apply flag, or risk exemption metadata".to_string(),
+            });
+        }
+    }
+
+    CommandSafetyAuditReport {
+        report_only: true,
+        missing_action_metadata,
     }
 }
 
@@ -79,6 +97,7 @@ fn command_safety_entry(
         docs: CommandDocsMetadata {
             path: docs_path(&path, dynamic_commands),
         },
+        risk_exemption: safety.risk_exemption.map(str::to_string),
         extension: dynamic_command.and_then(|command| command.extension.clone()),
         dangerous_flags: safety
             .dangerous_flags
@@ -101,6 +120,7 @@ struct CommandSafetyMetadata {
     output_notes: &'static str,
     lab_supported: bool,
     lab_notes: &'static str,
+    risk_exemption: Option<&'static str>,
     dangerous_flags: Vec<&'static str>,
 }
 
@@ -114,9 +134,29 @@ impl Default for CommandSafetyMetadata {
             output_notes: "standard CLI output contract",
             lab_supported: false,
             lab_notes: "not declared as Lab-routable in the safety manifest",
+            risk_exemption: None,
             dangerous_flags: Vec::new(),
         }
     }
+}
+
+fn flatten_manifest_entries(entries: &[CommandSafetyEntry]) -> Vec<&CommandSafetyEntry> {
+    let mut flattened = Vec::new();
+
+    for entry in entries {
+        flattened.push(entry);
+        flattened.extend(flatten_manifest_entries(&entry.subcommands));
+    }
+
+    flattened
+}
+
+fn entry_has_action_metadata(entry: &CommandSafetyEntry) -> bool {
+    entry.dry_run.supported
+        || !entry.dangerous_flags.is_empty()
+        || entry.risk_exemption.is_some()
+        || entry.output.notes.contains("--apply")
+        || entry.output.notes.contains("--dry-run")
 }
 
 fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
@@ -329,6 +369,14 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.output_notes = "removes one stored agent-task prompt";
         }
+        ["agent-task", "fanout", "cook-batch"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.dry_run_flag = Some("--dry-run");
+            metadata.output_notes =
+                "creates/reuses DMC worktrees and can run the generated fanout unless --dry-run is passed";
+            metadata.dangerous_flags = vec!["--run-plan"];
+        }
         ["fuzz", "replay"] => {
             metadata.mutates = true;
             metadata.output_notes =
@@ -385,6 +433,9 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.output_notes = "mutates GitHub issue state through the configured repository";
+            metadata.risk_exemption = Some(
+                "the issue subcommand is the explicit GitHub write action; no dry-run contract exists yet",
+            );
         }
         ["git", "pr", "create"]
         | ["git", "pr", "edit"]
@@ -394,6 +445,9 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.output_notes = "mutates GitHub pull request state or branch state";
+            metadata.risk_exemption = Some(
+                "the PR subcommand is the explicit GitHub write action; no dry-run contract exists yet",
+            );
         }
         ["git", "pr", "fleet"] | ["git", "pr", "land"] => {
             metadata.mutates = true;
@@ -460,14 +514,20 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         | ["runner", "trust"]
         | ["runner", "pair"]
         | ["runner", "remove"]
-        | ["runner", "connect"]
         | ["runner", "disconnect"]
-        | ["runner", "refresh-homeboy"]
-        | ["runner", "work"] => {
+        | ["runner", "refresh-homeboy"] => {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.output_notes =
                 "mutates runner configuration, trust policy, or runner lifecycle state";
+        }
+        ["runner", "connect"] | ["runner", "work"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.output_notes = "mutates runner lifecycle state";
+            metadata.risk_exemption = Some(
+                "runner lifecycle command name is the explicit operator action; no dry-run contract exists yet",
+            );
         }
         ["runner", "doctor"] => {
             metadata.mutates = true;
@@ -564,6 +624,9 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.output_notes = "mutates the configured stack target branch";
+            metadata.risk_exemption = Some(
+                "stack command name is the explicit branch mutation action; status/sync --dry-run are the planning paths",
+            );
         }
         ["stack", "sync"] => {
             metadata.mutates = true;
@@ -575,6 +638,15 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.output_notes = "pushes the configured stack target branch to its remote";
+            metadata.risk_exemption = Some(
+                "push is the explicit remote publication action; no dry-run contract exists yet",
+            );
+        }
+        ["extension", "run"] | ["extension", "exec"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.output_notes = "executes extension-owned runtime commands with forwarded arguments that may mutate the target system";
+            metadata.dangerous_flags = vec!["extension runtime command", "passthrough args"];
         }
         ["undo"] => {
             metadata.mutates = true;
@@ -713,6 +785,15 @@ mod tests {
             || entry.operator
             || entry.dry_run.supported
             || !entry.dangerous_flags.is_empty()
+            || entry.risk_exemption.is_some()
+            || entry.output.notes.contains("--apply")
+            || entry.output.notes.contains("--dry-run")
+    }
+
+    fn entry_has_action_metadata(entry: &CommandSafetyEntry) -> bool {
+        entry.dry_run.supported
+            || !entry.dangerous_flags.is_empty()
+            || entry.risk_exemption.is_some()
             || entry.output.notes.contains("--apply")
             || entry.output.notes.contains("--dry-run")
     }
@@ -800,6 +881,8 @@ mod tests {
             ["extension", "install"].as_slice(),
             ["extension", "update"].as_slice(),
             ["extension", "uninstall"].as_slice(),
+            ["extension", "run"].as_slice(),
+            ["extension", "exec"].as_slice(),
             ["config", "set"].as_slice(),
             ["config", "remove"].as_slice(),
             ["project", "set"].as_slice(),
@@ -813,6 +896,20 @@ mod tests {
             ["api", "patch"].as_slice(),
             ["api", "delete"].as_slice(),
             ["http", "request"].as_slice(),
+            ["git", "issue", "create"].as_slice(),
+            ["git", "issue", "comment"].as_slice(),
+            ["git", "issue", "close"].as_slice(),
+            ["git", "issue", "edit"].as_slice(),
+            ["git", "pr", "create"].as_slice(),
+            ["git", "pr", "edit"].as_slice(),
+            ["git", "pr", "comment"].as_slice(),
+            ["git", "pr", "refresh"].as_slice(),
+            ["git", "pr", "policy", "open"].as_slice(),
+            ["runner", "connect"].as_slice(),
+            ["runner", "work"].as_slice(),
+            ["stack", "apply"].as_slice(),
+            ["stack", "rebase"].as_slice(),
+            ["stack", "push"].as_slice(),
         ] {
             let entry = manifest_path(&manifest, path);
 
@@ -894,6 +991,62 @@ mod tests {
             agent_task_promote.dry_run.flag.as_deref(),
             Some("--dry-run")
         );
+
+        let extension_run = manifest_path(&manifest, &["extension", "run"]);
+        assert!(extension_run.operator);
+        assert!(extension_run
+            .dangerous_flags
+            .contains(&"passthrough args".to_string()));
+
+        let stack_push = manifest_path(&manifest, &["stack", "push"]);
+        assert!(stack_push.risk_exemption.is_some());
+    }
+
+    #[test]
+    fn manifest_audit_reports_mutating_commands_without_action_metadata() {
+        let manifest = current_command_safety_manifest();
+        let report = command_safety_manifest_audit(&manifest);
+
+        assert!(report.report_only);
+
+        let findings = report
+            .missing_action_metadata
+            .iter()
+            .map(|finding| finding.path.join(" "))
+            .collect::<Vec<_>>();
+        assert!(findings.contains(&"config set".to_string()));
+        assert!(findings.contains(&"project set".to_string()));
+    }
+
+    #[test]
+    fn high_risk_action_commands_have_explicit_action_metadata() {
+        let manifest = current_command_safety_manifest();
+
+        for path in [
+            ["git", "issue", "create"].as_slice(),
+            ["git", "issue", "comment"].as_slice(),
+            ["git", "issue", "close"].as_slice(),
+            ["git", "issue", "edit"].as_slice(),
+            ["git", "pr", "create"].as_slice(),
+            ["git", "pr", "edit"].as_slice(),
+            ["git", "pr", "comment"].as_slice(),
+            ["git", "pr", "refresh"].as_slice(),
+            ["git", "pr", "policy", "open"].as_slice(),
+            ["stack", "apply"].as_slice(),
+            ["stack", "rebase"].as_slice(),
+            ["stack", "push"].as_slice(),
+            ["runner", "connect"].as_slice(),
+            ["runner", "work"].as_slice(),
+            ["extension", "run"].as_slice(),
+            ["extension", "exec"].as_slice(),
+        ] {
+            let entry = manifest_path(&manifest, path);
+            assert!(entry.mutates, "{path:?} should be marked mutating");
+            assert!(
+                entry_has_action_metadata(entry),
+                "{path:?} should have dry-run, dangerous/apply, or risk exemption metadata"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a report-only safety manifest audit helper for visible mutating commands that lack dry-run/apply/dangerous/risk-exemption metadata.
- Add risk-exemption/action metadata for the initial high-risk command set: git issue/pr writes, stack apply/rebase/push, runner connect/work, and extension run/exec.
- Enforce the first high-risk set with focused manifest tests and document the new manifest metadata.

## Tests
- cargo fmt
- cargo test --test command_surface_test
- cargo test command_contract::safety_manifest
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the safety manifest audit helper, metadata updates, tests, docs, and verification.