### PR TITLE
Add Lab runner file transfer abstraction

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -43,17 +43,9 @@ pub(crate) fn ensure_remote_lab_artifact_dir(runner_id: &str, output_file: &str)
         .rsplit_once('/')
         .map(|(parent, _)| if parent.is_empty() { "/" } else { parent })
         .unwrap_or(".");
-    let client = ssh_client_for_lab_runner(runner_id)?;
-    let mkdir = client.execute(&format!("mkdir -p {}", shell::quote_arg(parent)));
-    if !mkdir.success {
-        return Err(Error::internal_unexpected(format!(
-            "Lab offload could not create Homeboy-owned artifact directory `{parent}` on runner `{runner_id}`: {}",
-            mkdir.stderr.trim()
-        ))
-        .with_hint(
-            "Lab structured output is written outside the synced checkout so it does not dirty the runner workspace; the runner workspace parent must be writable.".to_string(),
-        ));
-    }
+    lab_runner_file_transfer(runner_id)?
+        .ensure_directory(parent)
+        .map_err(|err| lab_artifact_directory_error(runner_id, parent, err))?;
     Ok(())
 }
 
@@ -79,50 +71,54 @@ pub(crate) fn materialize_lab_at_files_on_runner(
         return Ok(());
     }
 
-    let client = ssh_client_for_lab_runner(runner_id)?;
+    let transfer = lab_runner_file_transfer(runner_id)?;
     for spec in specs {
         let parent = spec
             .remote_path
             .rsplit_once('/')
             .map(|(parent, _)| if parent.is_empty() { "/" } else { parent })
             .unwrap_or(".");
-        let mkdir = client.execute(&format!("mkdir -p {}", shell::quote_arg(parent)));
-        if !mkdir.success {
-            return Err(lab_at_file_materialization_error(
+        transfer.ensure_directory(parent).map_err(|err| {
+            lab_at_file_materialization_error(
                 runner_id,
                 spec,
-                format!("failed to create remote parent directory: {}", mkdir.stderr),
-            ));
-        }
-        let upload = client.upload_file(&spec.local_path.display().to_string(), &spec.remote_path);
-        if !upload.success {
-            return Err(lab_at_file_materialization_error(
-                runner_id,
-                spec,
-                format!("failed to upload file: {}", upload.stderr),
-            ));
-        }
+                format!("failed to create remote parent directory: {}", err.message),
+            )
+        })?;
+        transfer
+            .upload_file(&spec.local_path.display().to_string(), &spec.remote_path)
+            .map_err(|err| {
+                lab_at_file_materialization_error(
+                    runner_id,
+                    spec,
+                    format!("failed to upload file: {}", err.message),
+                )
+            })?;
     }
 
     Ok(())
 }
 
-pub(crate) fn ssh_client_for_lab_runner(runner_id: &str) -> Result<SshClient> {
+pub(crate) fn lab_runner_file_transfer(runner_id: &str) -> Result<RunnerFileTransfer> {
     let runner = load(runner_id)?;
-    let server_id = runner.server_id.as_deref().ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "runner",
-            "Lab offload @file materialization requires an SSH runner with server_id",
-            Some(runner_id.to_string()),
-            Some(vec![
-                "Register a direct SSH runner or configure a reverse-connected runner before Lab offload.".to_string(),
-            ]),
-        )
-    })?;
-    let server = server::load(server_id)?;
-    let mut client = SshClient::from_server(&server, server_id)?;
-    client.env.extend(runner.env);
-    Ok(client)
+    let runner_status = status(runner_id).ok();
+    RunnerFileTransfer::for_runner(&runner, runner_status.as_ref())
+}
+
+pub(crate) fn lab_artifact_directory_error(runner_id: &str, parent: &str, err: Error) -> Error {
+    let mut error = Error::new(
+        err.code,
+        format!(
+            "Lab offload could not create Homeboy-owned artifact directory `{parent}` on runner `{runner_id}`: {}",
+            err.message
+        ),
+        err.details,
+    );
+    error.retryable = err.retryable;
+    error.hints = err.hints;
+    error.with_hint(
+        "Lab structured output is written outside the synced checkout so it does not dirty the runner workspace; the runner workspace parent must be writable.".to_string(),
+    )
 }
 
 pub(crate) fn lab_at_file_materialization_error(
@@ -922,15 +918,9 @@ pub(crate) fn ensure_lab_offload_streams_not_truncated(
 pub(crate) fn download_lab_output_file(runner_id: &str, remote_path: &str) -> Result<String> {
     let temp = local_lab_output_temp_path(runner_id, remote_path);
     let temp_text = temp.display().to_string();
-    let client = ssh_client_for_lab_runner(runner_id)?;
-    let output = client.download_file(remote_path, &temp_text);
-    if !output.success {
-        return Err(Error::internal_unexpected(format!(
-            "Lab offload could not retrieve remote structured output `{remote_path}` from runner `{runner_id}`: {}",
-            output.stderr.trim()
-        ))
-        .with_hint("The remote command was invoked with --output, but the runner-side file was not readable after execution.".to_string()));
-    }
+    lab_runner_file_transfer(runner_id)?
+        .download_file(remote_path, &temp_text)
+        .map_err(|err| lab_output_download_error(runner_id, remote_path, err))?;
     let content = std::fs::read_to_string(&temp).map_err(|err| {
         Error::internal_io(
             err.to_string(),
@@ -939,6 +929,20 @@ pub(crate) fn download_lab_output_file(runner_id: &str, remote_path: &str) -> Re
     })?;
     let _ = std::fs::remove_file(&temp);
     Ok(content)
+}
+
+pub(crate) fn lab_output_download_error(runner_id: &str, remote_path: &str, err: Error) -> Error {
+    let mut error = Error::new(
+        err.code,
+        format!(
+            "Lab offload could not retrieve remote structured output `{remote_path}` from runner `{runner_id}`: {}",
+            err.message
+        ),
+        err.details,
+    );
+    error.retryable = err.retryable;
+    error.hints = err.hints;
+    error.with_hint("The remote command was invoked with --output, but the runner-side file was not readable after execution.".to_string())
 }
 
 pub(crate) fn local_lab_output_temp_path(runner_id: &str, remote_path: &str) -> PathBuf {

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -48,7 +48,6 @@ use crate::core::agent_tasks::provider::provider_runner_source_contracts;
 use crate::core::engine::shell;
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::redaction::{redact_argv, redact_argv_display, RedactionPolicy};
-use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, ErrorCode, Result};
 
@@ -97,7 +96,7 @@ use super::super::{
     plan_managed_runner_source_syncs, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since, prepare_lab_runner_capability, rig_materialization,
     status, sync_workspace, LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions,
-    RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
+    RunnerFileTransfer, RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -123,7 +123,7 @@ pub use session::{
     RunnerWorkspaceLease, RunnerWorkspaceLeaseSet,
 };
 pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
-pub(crate) use transport::{select_runner_transport, RunnerTransport};
+pub(crate) use transport::{select_runner_transport, RunnerFileTransfer, RunnerTransport};
 pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
 pub use workspace::{
     list_workspaces, prune_workspaces, sync_workspace, ByteFileCounts,

--- a/src/core/runner/transport.rs
+++ b/src/core/runner/transport.rs
@@ -1,3 +1,9 @@
+use serde_json::json;
+
+use crate::core::engine::shell;
+use crate::core::error::{Error, ErrorCode, Result};
+use crate::core::server::{self, SshClient};
+
 use super::session::{RunnerSession, RunnerStatusReport, RunnerTunnelMode};
 use super::{Runner, RunnerKind};
 
@@ -27,6 +33,134 @@ pub(crate) enum RunnerTransport {
     Local,
     DiagnosticSsh,
     Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RunnerFileTransferCapability {
+    DirectSsh {
+        server_id: String,
+    },
+    Unsupported {
+        transport: &'static str,
+        reason: &'static str,
+        broker_url: Option<String>,
+    },
+}
+
+pub(crate) struct RunnerFileTransfer {
+    runner_id: String,
+    client: SshClient,
+}
+
+impl RunnerFileTransferCapability {
+    pub(crate) fn for_runner(
+        runner: &Runner,
+        status: Option<&RunnerStatusReport>,
+    ) -> RunnerFileTransferCapability {
+        match select_runner_transport(runner, status, false) {
+            RunnerTransport::ReverseBroker(handle) => RunnerFileTransferCapability::Unsupported {
+                transport: "reverse_broker",
+                reason: "Lab runner file transfer over the reverse broker is not implemented yet",
+                broker_url: Some(handle.endpoint_url().to_string()),
+            },
+            RunnerTransport::Local => RunnerFileTransferCapability::Unsupported {
+                transport: "local",
+                reason: "Lab runner file transfer requires a remote runner transport",
+                broker_url: None,
+            },
+            RunnerTransport::DirectDaemon(_)
+            | RunnerTransport::DiagnosticSsh
+            | RunnerTransport::Unavailable => match (runner.kind.clone(), runner.server_id.clone()) {
+                (RunnerKind::Ssh, Some(server_id)) => {
+                    RunnerFileTransferCapability::DirectSsh { server_id }
+                }
+                (RunnerKind::Ssh, None) => RunnerFileTransferCapability::Unsupported {
+                    transport: "direct_daemon",
+                    reason: "Lab runner file transfer over the direct daemon API is not implemented yet and no SSH server_id is configured",
+                    broker_url: None,
+                },
+                (RunnerKind::Local, _) => RunnerFileTransferCapability::Unsupported {
+                    transport: "local",
+                    reason: "Lab runner file transfer requires a remote runner transport",
+                    broker_url: None,
+                },
+            },
+        }
+    }
+
+    pub(crate) fn ensure_supported(&self, runner_id: &str) -> Result<&str> {
+        match self {
+            RunnerFileTransferCapability::DirectSsh { server_id } => Ok(server_id.as_str()),
+            RunnerFileTransferCapability::Unsupported {
+                transport,
+                reason,
+                broker_url,
+            } => Err(unsupported_file_transfer_error(
+                runner_id,
+                transport,
+                reason,
+                broker_url.as_deref(),
+            )),
+        }
+    }
+}
+
+impl RunnerFileTransfer {
+    pub(crate) fn for_runner(
+        runner: &Runner,
+        status: Option<&RunnerStatusReport>,
+    ) -> Result<RunnerFileTransfer> {
+        let capability = RunnerFileTransferCapability::for_runner(runner, status);
+        let server_id = capability.ensure_supported(&runner.id)?;
+        let server = server::load(server_id)?;
+        let mut client = SshClient::from_server(&server, server_id)?;
+        client.env.extend(runner.env.clone());
+        Ok(RunnerFileTransfer {
+            runner_id: runner.id.clone(),
+            client,
+        })
+    }
+
+    pub(crate) fn ensure_directory(&self, remote_dir: &str) -> Result<()> {
+        let mkdir = self
+            .client
+            .execute(&format!("mkdir -p {}", shell::quote_arg(remote_dir)));
+        if !mkdir.success {
+            return Err(file_transfer_operation_error(
+                &self.runner_id,
+                "mkdir",
+                remote_dir,
+                mkdir.stderr,
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn upload_file(&self, local_path: &str, remote_path: &str) -> Result<()> {
+        let upload = self.client.upload_file(local_path, remote_path);
+        if !upload.success {
+            return Err(file_transfer_operation_error(
+                &self.runner_id,
+                "upload",
+                remote_path,
+                upload.stderr,
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn download_file(&self, remote_path: &str, local_path: &str) -> Result<()> {
+        let download = self.client.download_file(remote_path, local_path);
+        if !download.success {
+            return Err(file_transfer_operation_error(
+                &self.runner_id,
+                "download",
+                remote_path,
+                download.stderr,
+            ));
+        }
+        Ok(())
+    }
 }
 
 pub(crate) fn select_runner_transport(
@@ -64,6 +198,55 @@ pub(crate) fn select_runner_transport(
     } else {
         RunnerTransport::Unavailable
     }
+}
+
+fn unsupported_file_transfer_error(
+    runner_id: &str,
+    transport: &str,
+    reason: &str,
+    broker_url: Option<&str>,
+) -> Error {
+    let mut error = Error::new(
+        ErrorCode::RunnerLabTransportFailure,
+        format!(
+            "Lab offload runner `{runner_id}` does not currently support controller file transfer over `{transport}`: {reason}"
+        ),
+        json!({
+            "runner_id": runner_id,
+            "transport": transport,
+            "broker_url": broker_url,
+            "missing_capability": "runner_file_transfer",
+            "supported_transports": ["direct_ssh"],
+        }),
+    );
+    error.retryable = Some(false);
+    error
+        .with_hint("Use a direct SSH runner for Lab @file arguments and structured-output download until the reverse broker exposes a file-transfer API.".to_string())
+        .with_hint("Next transport implementation should provide mkdir/upload/download through the selected runner transport instead of calling SSH directly.".to_string())
+}
+
+fn file_transfer_operation_error(
+    runner_id: &str,
+    operation: &str,
+    remote_path: &str,
+    stderr: String,
+) -> Error {
+    let mut error = Error::new(
+        ErrorCode::RunnerLabTransportFailure,
+        format!(
+            "Lab runner file transfer `{operation}` failed on runner `{runner_id}` for `{remote_path}`: {}",
+            stderr.trim()
+        ),
+        json!({
+            "runner_id": runner_id,
+            "operation": operation,
+            "remote_path": remote_path,
+            "stderr": stderr,
+            "transport": "direct_ssh",
+        }),
+    );
+    error.retryable = Some(true);
+    error
 }
 
 #[cfg(test)]
@@ -160,5 +343,37 @@ mod tests {
             }
             transport => panic!("expected reverse broker, got {transport:?}"),
         }
+    }
+
+    #[test]
+    fn file_transfer_selects_direct_ssh_when_server_id_exists() {
+        let mut runner = runner(RunnerKind::Ssh);
+        runner.server_id = Some("srv".to_string());
+
+        assert_eq!(
+            RunnerFileTransferCapability::for_runner(&runner, None),
+            RunnerFileTransferCapability::DirectSsh {
+                server_id: "srv".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn file_transfer_errors_for_reverse_broker_with_actionable_metadata() {
+        let runner = runner(RunnerKind::Ssh);
+        let mut session = session(RunnerTunnelMode::Reverse);
+        session.broker_url = Some("https://broker.example".to_string());
+        let capability = RunnerFileTransferCapability::for_runner(&runner, Some(&status(session)));
+        let err = capability
+            .ensure_supported("test-runner")
+            .expect_err("reverse broker file transfer should be unsupported");
+
+        assert_eq!(err.code, ErrorCode::RunnerLabTransportFailure);
+        assert_eq!(err.details["transport"], "reverse_broker");
+        assert_eq!(err.details["broker_url"], "https://broker.example");
+        assert_eq!(err.details["missing_capability"], "runner_file_transfer");
+        assert!(err
+            .message
+            .contains("does not currently support controller file transfer"));
     }
 }


### PR DESCRIPTION
## Summary
- Add a transport-owned Lab runner file-transfer capability and concrete direct SSH implementation.
- Route Lab @file materialization, artifact directory creation, and structured-output download through the abstraction instead of direct SSH helper calls.
- Return actionable runner.lab_transport_failure metadata for reverse broker runners until a broker file API lands.

## Tests
- cargo test core::runner::transport
- cargo test core::runner::lab::offload
- cargo test (timed out after 300s locally; unrelated failures appeared outside this change, including command contract/process/workspace tests)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the scoped runner file-transfer abstraction, tests, and PR preparation.