### PR TITLE
Add typed runner handoff envelope

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -29,11 +29,12 @@ pub use lab::{
     lab_runner_unsupported_message, CommandPortabilityContract, LabCommandContract,
     LabCommandPortability, LabCommandRequiredTool, LabCommandRouteContract,
     LabLocalExecutionPolicy, LabLocalHotPolicy, LabRoutingPolicy, LabRunnerSupportSummary,
-    LabSelectedRunnerFallbackPolicy, LabSourcePathMode, LabWorkspaceModePolicy, RunnerWorkload,
-    RunnerWorkloadArtifactRef, RunnerWorkloadAssignment, RunnerWorkloadCapability,
-    RunnerWorkloadCommandFamily, RunnerWorkloadExtensionRevision, RunnerWorkloadKind,
-    RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
-    RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS,
+    LabSelectedRunnerFallbackPolicy, LabSourcePathMode, LabWorkspaceModePolicy,
+    RunnerHandoffEnvelope, RunnerHandoffFollowCommands, RunnerWorkload, RunnerWorkloadArtifactRef,
+    RunnerWorkloadAssignment, RunnerWorkloadCapability, RunnerWorkloadCommandFamily,
+    RunnerWorkloadExtensionRevision, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
+    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
+    RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS, RUNNER_HANDOFF_ENVELOPE_SCHEMA,
     RUNNER_WORKLOAD_SCHEMA,
 };
 pub(crate) use lab::{

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -17,6 +17,7 @@ use crate::core::extension::ExtensionCapability;
 use std::collections::BTreeSet;
 
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
+pub const RUNNER_HANDOFF_ENVELOPE_SCHEMA: &str = "homeboy/runner-exec-handoff/v1";
 
 /// Routing-policy flags shared by every Lab command representation
 /// (`LabCommandContract`, `LabRoutePlan`, `LabOffloadCommand`). These four
@@ -214,6 +215,67 @@ pub struct RunnerWorkloadArtifactRef {
     pub path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerHandoffEnvelope {
+    pub schema: String,
+    pub status: String,
+    pub execution_location: String,
+    pub runner_id: String,
+    pub job_id: String,
+    pub durable_run_id: Option<String>,
+    pub persisted_run_id: Option<String>,
+    pub mirror_run_id: Option<String>,
+    pub remote_cwd: String,
+    pub follow_commands: RunnerHandoffFollowCommands,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerHandoffFollowCommands {
+    pub job_logs: String,
+    pub job_cancel: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logs: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<String>,
+}
+
+impl RunnerHandoffEnvelope {
+    pub fn detached_lab_offload(
+        runner_id: &str,
+        job_id: &str,
+        remote_cwd: String,
+        mirror_run_id: Option<String>,
+    ) -> Self {
+        let follow_commands = RunnerHandoffFollowCommands {
+            job_logs: format!("homeboy runner job logs {runner_id} {job_id} --follow"),
+            job_cancel: format!("homeboy runner job cancel {runner_id} {job_id}"),
+            status: mirror_run_id
+                .as_ref()
+                .map(|run_id| format!("homeboy agent-task status {run_id}")),
+            logs: mirror_run_id
+                .as_ref()
+                .map(|run_id| format!("homeboy agent-task logs {run_id}")),
+            artifacts: mirror_run_id
+                .as_ref()
+                .map(|run_id| format!("homeboy agent-task artifacts {run_id}")),
+        };
+        Self {
+            schema: RUNNER_HANDOFF_ENVELOPE_SCHEMA.to_string(),
+            status: "handoff_complete".to_string(),
+            execution_location: format!("runner:{runner_id}"),
+            runner_id: runner_id.to_string(),
+            job_id: job_id.to_string(),
+            durable_run_id: mirror_run_id.clone(),
+            persisted_run_id: mirror_run_id.clone(),
+            mirror_run_id,
+            remote_cwd,
+            follow_commands,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -362,28 +362,13 @@ pub(super) fn detached_handoff_output(
         mirror_run_id.as_deref(),
         DaemonJobHandoffState::InFlight,
     );
-    let mut follow_commands = json!({
-        "job_logs": format!("homeboy runner job logs {} {} --follow", runner.id, job.id),
-        "job_cancel": format!("homeboy runner job cancel {} {}", runner.id, job.id),
-    });
-    if let Some(run_id) = mirror_run_id.as_deref() {
-        follow_commands["status"] = json!(format!("homeboy agent-task status {run_id}"));
-        follow_commands["logs"] = json!(format!("homeboy agent-task logs {run_id}"));
-        follow_commands["artifacts"] = json!(format!("homeboy agent-task artifacts {run_id}"));
-    }
-    let stdout = serde_json::to_string_pretty(&json!({
-        "schema": "homeboy/runner-exec-handoff/v1",
-        "status": "handoff_complete",
-        "execution_location": format!("runner:{}", runner.id),
-        "runner_id": runner.id.clone(),
-        "job_id": job_id,
-        "durable_run_id": mirror_run_id.as_deref(),
-        "persisted_run_id": mirror_run_id.as_deref(),
-        "mirror_run_id": mirror_run_id.as_deref(),
-        "remote_cwd": cwd.clone(),
-        "follow_commands": follow_commands,
-    }))
-    .unwrap_or_else(|_| "{}".to_string());
+    let envelope = crate::command_contract::RunnerHandoffEnvelope::detached_lab_offload(
+        &runner.id,
+        &job_id,
+        cwd.clone(),
+        mirror_run_id.clone(),
+    );
+    let stdout = serde_json::to_string_pretty(&envelope).unwrap_or_else(|_| "{}".to_string());
     let transport = match mode {
         RunnerExecMode::ReverseBroker => "reverse_broker",
         _ => "daemon",

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -333,6 +333,29 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
         assert_eq!(output.job_id.as_deref(), Some(job_id.as_str()));
         assert_eq!(output.mirror_run_id.as_deref(), Some("agent-task-run-6454"));
         let json: Value = serde_json::from_str(&output.stdout).expect("handoff JSON");
+        let envelope: crate::command_contract::RunnerHandoffEnvelope =
+            serde_json::from_value(json.clone()).expect("typed handoff envelope");
+        assert_eq!(
+            envelope.schema,
+            crate::command_contract::RUNNER_HANDOFF_ENVELOPE_SCHEMA
+        );
+        assert_eq!(envelope.status, "handoff_complete");
+        assert_eq!(envelope.execution_location, "runner:lab");
+        assert_eq!(envelope.runner_id, "lab");
+        assert_eq!(envelope.job_id, job_id);
+        assert_eq!(envelope.remote_cwd, "/srv/homeboy/project");
+        assert_eq!(
+            envelope.durable_run_id.as_deref(),
+            Some("agent-task-run-6454")
+        );
+        assert_eq!(
+            envelope.persisted_run_id.as_deref(),
+            Some("agent-task-run-6454")
+        );
+        assert_eq!(
+            envelope.mirror_run_id.as_deref(),
+            Some("agent-task-run-6454")
+        );
         assert_eq!(json["status"], "handoff_complete");
         assert_eq!(json["job_id"], job_id);
         assert_eq!(json["durable_run_id"], "agent-task-run-6454");
@@ -349,6 +372,38 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             format!("homeboy runner job logs lab {job_id} --follow")
         );
     });
+}
+
+#[test]
+fn runner_handoff_envelope_omits_agent_task_followups_without_run_id() {
+    let envelope = crate::command_contract::RunnerHandoffEnvelope::detached_lab_offload(
+        "lab",
+        "job-123",
+        "/srv/homeboy/project".to_string(),
+        None,
+    );
+    let json = serde_json::to_value(&envelope).expect("serialize handoff envelope");
+
+    assert_eq!(
+        json["schema"],
+        crate::command_contract::RUNNER_HANDOFF_ENVELOPE_SCHEMA
+    );
+    assert_eq!(json["status"], "handoff_complete");
+    assert_eq!(json["execution_location"], "runner:lab");
+    assert_eq!(json["durable_run_id"], Value::Null);
+    assert_eq!(json["persisted_run_id"], Value::Null);
+    assert_eq!(json["mirror_run_id"], Value::Null);
+    assert_eq!(
+        json["follow_commands"]["job_logs"],
+        "homeboy runner job logs lab job-123 --follow"
+    );
+    assert_eq!(
+        json["follow_commands"]["job_cancel"],
+        "homeboy runner job cancel lab job-123"
+    );
+    assert!(json["follow_commands"].get("status").is_none());
+    assert!(json["follow_commands"].get("logs").is_none());
+    assert!(json["follow_commands"].get("artifacts").is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a typed RunnerHandoffEnvelope and follow-up command contract for detached Lab runner handoffs.
- Serialize the existing detached handoff stdout through the typed envelope while preserving current JSON keys and human stderr hints.
- Add focused tests for envelope shape and optional follow-up command behavior.

## Tests
- cargo fmt
- cargo test core::runner::execution::tests::handoff
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the typed handoff envelope, wiring it into detached handoff output, adding focused tests, and preparing this PR.