### PR TITLE
Consolidate command spec descriptor routing

### DIFF
--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -17,7 +17,7 @@ use crate::commands::{
 };
 
 use super::lab::apply_lab_contract_to_descriptor;
-use super::spec::registered_command_json_family;
+use super::spec::registered_command;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandResponseMode {
@@ -326,23 +326,13 @@ fn markdown_or_json_response(markdown: bool) -> CommandResponseMode {
     }
 }
 
-/// Builds the common JSON-envelope descriptor: a JSON response mode paired with
-/// the [`CommandOutputContractKind::JsonEnvelope`] contract, varying only by
-/// [`CommandJsonFamily`] and output-file mode.
-fn json_envelope_descriptor(
-    json_family: CommandJsonFamily,
-    output_file_mode: CommandOutputFileMode,
-) -> CommandOutputDescriptor {
-    CommandOutputDescriptor::json_envelope(json_family, output_file_mode)
-}
-
 fn registered_json_envelope_descriptor(
     command: &Commands,
     output_file_mode: CommandOutputFileMode,
 ) -> CommandOutputDescriptor {
-    let json_family = registered_command_json_family(command.top_level_name())
-        .expect("top-level command should be registered");
-    json_envelope_descriptor(json_family, output_file_mode)
+    registered_command(command.top_level_name())
+        .expect("top-level command should be registered")
+        .output_descriptor(output_file_mode)
 }
 
 #[cfg(test)]
@@ -568,16 +558,15 @@ mod tests {
     }
 
     #[test]
-    fn json_envelope_descriptor_uses_shared_contract_shape() {
+    fn command_spec_output_descriptor_uses_shared_contract_shape() {
+        let spec = crate::command_contract::registered_command("status")
+            .expect("status command should be registered");
+
         assert_eq!(
+            spec.output_descriptor(CommandOutputFileMode::GenericEnvelope),
             CommandOutputDescriptor::json_envelope(
-                CommandJsonFamily::Workspace,
+                CommandJsonFamily::Ops,
                 CommandOutputFileMode::GenericEnvelope,
-            ),
-            workspace_descriptor(
-                CommandResponseMode::Json,
-                CommandOutputFileMode::GenericEnvelope,
-                CommandOutputContractKind::JsonEnvelope,
             )
         );
     }

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -4,7 +4,9 @@
 //! consumed by output routing, safety/docs manifest derivation, and command
 //! lookup without changing parsed CLI behavior.
 
-use super::output::{CommandDispatchFamily, CommandJsonFamily};
+use super::output::{
+    CommandDispatchFamily, CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CommandSpec {
@@ -25,6 +27,17 @@ impl CommandSpec {
     pub fn docs_path(&self) -> Option<String> {
         self.docs_slug
             .map(|slug| format!("docs/commands/{slug}.md"))
+    }
+
+    pub const fn output_descriptor(
+        &self,
+        output_file_mode: CommandOutputFileMode,
+    ) -> CommandOutputDescriptor {
+        CommandOutputDescriptor::json_envelope(self.json_family, output_file_mode)
+    }
+
+    pub fn dispatch_family(&self) -> CommandDispatchFamily {
+        self.json_family.into()
     }
 }
 
@@ -212,5 +225,5 @@ pub fn registered_command_json_family(name: &str) -> Option<CommandJsonFamily> {
 }
 
 pub fn registered_command_dispatch_family(name: &str) -> Option<CommandDispatchFamily> {
-    registered_command_json_family(name).map(Into::into)
+    registered_command(name).map(CommandSpec::dispatch_family)
 }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use crate::cli_surface::Commands;
-use crate::command_contract::{registered_command_dispatch_family, CommandDispatchFamily};
+use crate::command_contract::{registered_command, CommandDispatchFamily};
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
 use super::output_runtime::{CommandPresentation, JsonCommandRun};
@@ -293,7 +293,8 @@ fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Va
 }
 
 fn dispatch_family(command: &Commands) -> CommandDispatchFamily {
-    registered_command_dispatch_family(command.top_level_name())
+    registered_command(command.top_level_name())
+        .map(|spec| spec.dispatch_family())
         .expect("top-level command should be registered")
 }
 


### PR DESCRIPTION
## Summary
- Add command-spec helpers for output descriptors and dispatch family derivation.
- Route registered JSON envelope descriptors and JSON dispatch family lookup through the shared command spec.
- Remove the redundant local JSON envelope helper while preserving existing command output behavior.

## Testing
- cargo fmt --check
- cargo test --lib command_spec_output_descriptor_uses_shared_contract_shape
- cargo test --lib json_dispatch_family_comes_from_command_registry
- cargo test --lib manifest_dispatches_as_json_workspace_output
- cargo test --lib command_registry_manifest_and_docs_metadata_align
- cargo check

## Caveats
- cargo test command_contract --lib currently fails in existing Lab contract fixture tests: command_contract::lab::tests::test_lab_command_contracts_cover_hot_commands and command_contract::lab::tests::test_supports_lab_runner.
- cargo test --lib exceeded the 120s tool timeout and also showed unrelated failures in fuzz replay/routing/trace repeat tests before timeout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the command descriptor/dispatch surfaces, implementing this small consolidation, running verification, and drafting this PR description.