### PR TITLE
Add runner diagnostic declarations

### DIFF
--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -9,7 +9,7 @@ use homeboy::core::project::{self, Project};
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use crate::commands::runner::{wp_codebox_tool_diagnostics, RunnerToolDiagnostics};
+use crate::commands::runner::{declared_tool_diagnostics_for_legacy, RunnerToolDiagnostics};
 use crate::commands::CmdResult;
 
 #[derive(Args)]
@@ -796,7 +796,7 @@ fn setup_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {
 }
 
 fn extension_wp_codebox_diagnostics(extension_id: &str) -> Option<RunnerToolDiagnostics> {
-    if extension_id != "wordpress" {
+    if load_extension(extension_id).is_err() {
         return None;
     }
     let env = [
@@ -812,7 +812,7 @@ fn extension_wp_codebox_diagnostics(extension_id: &str) -> Option<RunnerToolDiag
     })
     .collect::<BTreeMap<_, _>>();
 
-    Some(wp_codebox_tool_diagnostics(None, &env))
+    declared_tool_diagnostics_for_legacy("wp_codebox", None, &env)
 }
 
 fn run_action(

--- a/src/commands/runner/env.rs
+++ b/src/commands/runner/env.rs
@@ -4,7 +4,7 @@ use homeboy::core::runners::{self as runner};
 use homeboy::core::server::RunnerSecretEnvRef;
 
 use super::super::CmdResult;
-use super::status::wp_codebox_tool_diagnostics;
+use super::status::declared_tool_diagnostics_for_legacy;
 use super::types::{
     RunnerEnvDiagnostics, RunnerEnvOutput, RunnerSecretEnvReferenceOutput, REDACTED_ENV_VALUE,
 };
@@ -19,10 +19,8 @@ pub(super) fn env(runner_id: &str) -> CmdResult<RunnerEnvOutput> {
         .map(|key| (key, REDACTED_ENV_VALUE.to_string()))
         .collect();
 
-    let wp_codebox = Some(wp_codebox_tool_diagnostics(
-        Some(runner_id),
-        &diagnostic_env,
-    ));
+    let wp_codebox =
+        declared_tool_diagnostics_for_legacy("wp_codebox", Some(runner_id), &diagnostic_env);
 
     let secret_env = runner
         .secret_env

--- a/src/commands/runner/mod.rs
+++ b/src/commands/runner/mod.rs
@@ -23,5 +23,5 @@ mod tests;
 
 pub use cli::RunnerArgs;
 pub use dispatch::{run, run_command_output};
-pub(crate) use status::wp_codebox_tool_diagnostics;
+pub(crate) use status::declared_tool_diagnostics_for_legacy;
 pub use types::RunnerToolDiagnostics;

--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -1,5 +1,10 @@
 use std::collections::BTreeMap;
 
+use homeboy::core::agent_runtime_manifest::{
+    discover_agent_runtime_catalog, AgentRuntimeDiagnosticFollowup,
+    AgentRuntimeDiagnosticsContract, AgentRuntimeRuntimeDiagnosticDeclaration,
+    AgentRuntimeSourceConsistencyDiagnostic, AgentRuntimeToolDiagnosticDeclaration,
+};
 use homeboy::core::runner::RunnerActiveJobState;
 use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, RunnerTunnelMode};
 
@@ -91,7 +96,11 @@ fn selected_lab_runner_status(
         kind: format!("{:?}", runner_config.kind).to_ascii_lowercase(),
         configured_executable: configured_executable.clone(),
         runner_homeboy: lab_runner_homeboy_output(runner_id, &configured_executable, &status),
-        wp_codebox_runtime: wp_codebox_runtime_output(Some(runner_id), &effective_env),
+        wp_codebox_runtime: declared_runtime_diagnostics_for_legacy(
+            "wp_codebox_runtime",
+            Some(runner_id),
+            &effective_env,
+        ),
         daemon_enabled: runner_config.settings.daemon,
         workspace_root: runner_config.workspace_root.clone(),
         readiness_state: format!("{:?}", status.state).to_ascii_lowercase(),
@@ -143,153 +152,236 @@ fn lab_runner_homeboy_output(
     }
 }
 
-pub(crate) fn wp_codebox_tool_diagnostics(
+pub(crate) fn declared_tool_diagnostics_for_legacy(
+    legacy_output: &str,
+    runner_id: Option<&str>,
+    env: &BTreeMap<String, String>,
+) -> Option<RunnerToolDiagnostics> {
+    declared_diagnostics_contracts()
+        .iter()
+        .flat_map(|contract| contract.tools.iter())
+        .find(|declaration| declaration.legacy_output.as_deref() == Some(legacy_output))
+        .map(|declaration| declared_tool_diagnostics(declaration, runner_id, env))
+}
+
+pub(crate) fn declared_runtime_diagnostics_for_legacy(
+    legacy_output: &str,
+    runner_id: Option<&str>,
+    env: &BTreeMap<String, String>,
+) -> Option<WpCodeboxRuntimeOutput> {
+    declared_diagnostics_contracts()
+        .iter()
+        .flat_map(|contract| contract.runtimes.iter())
+        .find(|declaration| declaration.legacy_output.as_deref() == Some(legacy_output))
+        .map(|declaration| declared_runtime_diagnostics(declaration, runner_id, env))
+}
+
+pub(crate) fn declared_tool_diagnostics(
+    declaration: &AgentRuntimeToolDiagnosticDeclaration,
     runner_id: Option<&str>,
     env: &BTreeMap<String, String>,
 ) -> RunnerToolDiagnostics {
-    let configured = env
-        .get("HOMEBOY_WP_CODEBOX_BIN")
-        .cloned()
-        .or_else(|| env.get("HOMEBOY_SETTINGS_WP_CODEBOX_BIN").cloned());
-    let configured_binary_source = if env.contains_key("HOMEBOY_WP_CODEBOX_BIN") {
-        "HOMEBOY_WP_CODEBOX_BIN"
-    } else if env.contains_key("HOMEBOY_SETTINGS_WP_CODEBOX_BIN") {
-        "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"
-    } else {
-        "unset"
-    };
-    let install_dir = env
-        .get("HOMEBOY_WP_CODEBOX_INSTALL_DIR")
-        .cloned()
-        .unwrap_or_else(|| "${HOME}/.cache/homeboy/wp-codebox".to_string());
-    let managed_cache_source = format!("{}/source", install_dir.trim_end_matches('/'));
-    let managed_cache_binary = format!("{managed_cache_source}/packages/cli/dist/index.js");
+    let (configured, configured_binary_source) =
+        configured_value(env, &declaration.configured_binary_env);
+    let install_dir = install_dir(
+        env,
+        declaration.install_dir_env.as_deref(),
+        declaration.default_install_dir.as_deref(),
+    );
+    let managed_cache_source =
+        render_diagnostic_template(&declaration.managed_cache_source, &install_dir, "");
+    let managed_cache_binary = render_diagnostic_template(
+        &declaration.managed_cache_binary,
+        &install_dir,
+        &managed_cache_source,
+    );
     RunnerToolDiagnostics {
-        tool: "wp-codebox",
+        tool: declaration.tool.clone(),
         configured_binary: configured,
         configured_binary_source,
         managed_cache_source,
         managed_cache_binary,
-        effective_binary_rule:
-            "managed cache binary wins when executable; otherwise configured binary, then PATH",
-        diagnostic_command: wp_codebox_effective_binary_command(runner_id),
+        effective_binary_rule: declaration.effective_binary_rule.clone(),
+        diagnostic_command: diagnostic_command(runner_id, &declaration.diagnostic_script),
     }
 }
 
-pub(crate) fn wp_codebox_runtime_output(
+pub(crate) fn declared_runtime_diagnostics(
+    declaration: &AgentRuntimeRuntimeDiagnosticDeclaration,
     runner_id: Option<&str>,
     env: &BTreeMap<String, String>,
 ) -> WpCodeboxRuntimeOutput {
-    let configured = env
-        .get("HOMEBOY_WP_CODEBOX_BIN")
-        .cloned()
-        .or_else(|| env.get("HOMEBOY_SETTINGS_WP_CODEBOX_BIN").cloned());
-    let configured_binary_source = if env.contains_key("HOMEBOY_WP_CODEBOX_BIN") {
-        "HOMEBOY_WP_CODEBOX_BIN"
-    } else if env.contains_key("HOMEBOY_SETTINGS_WP_CODEBOX_BIN") {
-        "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"
-    } else {
-        "unset"
-    };
-    let install_dir = env
-        .get("HOMEBOY_WP_CODEBOX_INSTALL_DIR")
-        .cloned()
-        .unwrap_or_else(|| "${HOME}/.cache/homeboy/wp-codebox".to_string());
-    let managed_cache_source = format!("{}/source", install_dir.trim_end_matches('/'));
-    let managed_cache_binary = format!("{managed_cache_source}/packages/cli/dist/index.js");
-    let expected_playground_path = format!("{managed_cache_source}/packages/playground");
-    let expected_core_path = env
-        .get("HOMEBOY_WP_CODEBOX_CORE_MODULE")
-        .cloned()
-        .unwrap_or_else(|| format!("{managed_cache_source}/packages/core"));
-    let diagnostics = wp_codebox_runtime_diagnostics(
-        configured.as_deref(),
+    let (configured, configured_binary_source) =
+        configured_value(env, &declaration.configured_binary_env);
+    let install_dir = install_dir(
+        env,
+        declaration.install_dir_env.as_deref(),
+        declaration.default_install_dir.as_deref(),
+    );
+    let managed_cache_source =
+        render_diagnostic_template(&declaration.managed_cache_source, &install_dir, "");
+    let managed_cache_binary = render_diagnostic_template(
+        &declaration.managed_cache_binary,
+        &install_dir,
         &managed_cache_source,
-        &expected_core_path,
+    );
+    let packages = declared_runtime_packages(declaration, env, &install_dir, &managed_cache_source);
+    let diagnostics = declared_runtime_source_diagnostics(
+        &declaration.source_consistency,
+        env,
+        configured.as_deref(),
+        &install_dir,
+        &managed_cache_source,
     );
 
     WpCodeboxRuntimeOutput {
-        tool: "wp-codebox",
+        tool: declaration.tool.clone(),
         configured_binary: configured,
         configured_binary_source,
         managed_cache_source: managed_cache_source.clone(),
         managed_cache_binary,
-        effective_binary_rule:
-            "managed cache binary wins when executable; otherwise configured binary, then PATH",
-        playground_package: WpCodeboxPackageRuntimeOutput {
-            package: "@automattic/wp-codebox-playground",
-            expected_path: expected_playground_path,
-            resolution: WpCodeboxProbeValue {
-                value: None,
-                source: "runtime_probe_command",
-            },
-        },
-        core_package: WpCodeboxPackageRuntimeOutput {
-            package: "@automattic/wp-codebox-core",
-            expected_path: expected_core_path,
-            resolution: WpCodeboxProbeValue {
-                value: None,
-                source: "runtime_probe_command",
-            },
-        },
-        source_git_sha: WpCodeboxProbeValue {
-            value: None,
-            source: "runtime_probe_command",
-        },
-        dist_build_freshness: WpCodeboxProbeValue {
-            value: None,
-            source: "runtime_probe_command",
-        },
-        runtime_probe_command: wp_codebox_runtime_probe_command(runner_id),
+        effective_binary_rule: declaration.effective_binary_rule.clone(),
+        playground_package: packages.first().cloned().unwrap_or_else(empty_package),
+        core_package: packages.get(1).cloned().unwrap_or_else(empty_package),
+        source_git_sha: declared_probe_value(declaration, "source_git_sha"),
+        dist_build_freshness: declared_probe_value(declaration, "dist_build_freshness"),
+        runtime_probe_command: diagnostic_command(runner_id, &declaration.runtime_probe_script),
         diagnostics,
     }
 }
 
-pub(crate) fn wp_codebox_runtime_diagnostics(
+pub(crate) fn declared_runtime_source_diagnostics(
+    declarations: &[AgentRuntimeSourceConsistencyDiagnostic],
+    env: &BTreeMap<String, String>,
     configured_binary: Option<&str>,
+    install_dir: &str,
     managed_cache_source: &str,
-    core_path: &str,
 ) -> Vec<WpCodeboxRuntimeDiagnostic> {
     let mut diagnostics = Vec::new();
-    if let Some(configured_binary) = configured_binary {
-        if !configured_binary.starts_with(managed_cache_source) {
+    for declaration in declarations {
+        let path = match declaration.path.as_str() {
+            "configured_binary" => configured_binary.map(str::to_string),
+            other => env.get(other).cloned(),
+        }
+        .unwrap_or_else(|| {
+            render_diagnostic_template(&declaration.path, install_dir, managed_cache_source)
+        });
+        let root = render_diagnostic_template(&declaration.root, install_dir, managed_cache_source);
+        if !path.starts_with(&root) {
             diagnostics.push(WpCodeboxRuntimeDiagnostic {
-                id: "wp_codebox.mixed_cli_source",
-                severity: "warning",
-                message: format!(
-                    "Configured WP Codebox CLI `{configured_binary}` is outside managed cache `{managed_cache_source}`; runner jobs may mix a stale CLI with managed package sources."
-                ),
-                remediation: "Unset HOMEBOY_WP_CODEBOX_BIN/HOMEBOY_SETTINGS_WP_CODEBOX_BIN or point it at the managed cache binary reported here.".to_string(),
+                id: declaration.id.clone(),
+                severity: declaration.severity.clone(),
+                message: render_path_message(&declaration.message, &path, &root),
+                remediation: declaration.remediation.clone(),
             });
         }
-    }
-    if !core_path.starts_with(managed_cache_source) {
-        diagnostics.push(WpCodeboxRuntimeDiagnostic {
-            id: "wp_codebox.mixed_core_source",
-            severity: "warning",
-            message: format!(
-                "Resolved WP Codebox core path `{core_path}` is outside managed cache `{managed_cache_source}`; runner jobs may mix core and playground builds."
-            ),
-            remediation: "Refresh the WordPress extension setup/runtime env so HOMEBOY_WP_CODEBOX_CORE_MODULE resolves from the same managed WP Codebox checkout used by the CLI.".to_string(),
-        });
     }
     diagnostics
 }
 
-pub(crate) fn wp_codebox_effective_binary_command(runner_id: Option<&str>) -> String {
-    let script = "configured=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}; install_dir=${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v wp-codebox 2>/dev/null || true); source=path; fi; revision=$(git -C \"$managed_source\" rev-parse --short HEAD 2>/dev/null || true); printf 'configured_binary=%s\nmanaged_cache_source=%s\nmanaged_cache_binary=%s\neffective_binary=%s\neffective_source=%s\nmanaged_cache_revision=%s\n' \"${configured:-}\" \"$managed_source\" \"$managed_binary\" \"${effective:-}\" \"$source\" \"${revision:-}\"";
-    match runner_id {
-        Some(runner_id) => format!(
-            "homeboy runner exec {} --raw -- bash -lc {}",
-            shell_arg(runner_id),
-            shell_arg(script)
-        ),
-        None => format!("bash -lc {}", shell_arg(script)),
+fn declared_diagnostics_contracts() -> Vec<AgentRuntimeDiagnosticsContract> {
+    discover_agent_runtime_catalog()
+        .manifests
+        .into_iter()
+        .map(|manifest| manifest.materialization.diagnostics)
+        .filter(|contract| !contract.is_empty())
+        .collect()
+}
+
+fn configured_value(env: &BTreeMap<String, String>, keys: &[String]) -> (Option<String>, String) {
+    for key in keys {
+        if let Some(value) = env.get(key) {
+            return (Some(value.clone()), key.clone());
+        }
+    }
+    (None, "unset".to_string())
+}
+
+fn install_dir(
+    env: &BTreeMap<String, String>,
+    key: Option<&str>,
+    default_value: Option<&str>,
+) -> String {
+    key.and_then(|key| env.get(key).cloned())
+        .or_else(|| default_value.map(str::to_string))
+        .unwrap_or_default()
+}
+
+fn render_diagnostic_template(
+    template: &str,
+    install_dir: &str,
+    managed_cache_source: &str,
+) -> String {
+    template
+        .replace("${install_dir}", install_dir.trim_end_matches('/'))
+        .replace(
+            "${managed_cache_source}",
+            managed_cache_source.trim_end_matches('/'),
+        )
+}
+
+fn render_path_message(template: &str, path: &str, root: &str) -> String {
+    template.replace("${path}", path).replace("${root}", root)
+}
+
+fn declared_runtime_packages(
+    declaration: &AgentRuntimeRuntimeDiagnosticDeclaration,
+    env: &BTreeMap<String, String>,
+    install_dir: &str,
+    managed_cache_source: &str,
+) -> Vec<WpCodeboxPackageRuntimeOutput> {
+    declaration
+        .packages
+        .iter()
+        .map(|package| WpCodeboxPackageRuntimeOutput {
+            package: package.package.clone(),
+            expected_path: package
+                .env_override
+                .as_deref()
+                .and_then(|key| env.get(key).cloned())
+                .unwrap_or_else(|| {
+                    render_diagnostic_template(
+                        &package.expected_path,
+                        install_dir,
+                        managed_cache_source,
+                    )
+                }),
+            resolution: WpCodeboxProbeValue {
+                value: None,
+                source: "runtime_probe_command".to_string(),
+            },
+        })
+        .collect()
+}
+
+fn empty_package() -> WpCodeboxPackageRuntimeOutput {
+    WpCodeboxPackageRuntimeOutput {
+        package: String::new(),
+        expected_path: String::new(),
+        resolution: WpCodeboxProbeValue {
+            value: None,
+            source: "runtime_probe_command".to_string(),
+        },
     }
 }
 
-pub(crate) fn wp_codebox_runtime_probe_command(runner_id: Option<&str>) -> String {
-    let script = "configured=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}; install_dir=${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v wp-codebox 2>/dev/null || true); source=path; fi; resolve_pkg() { node -e 'const path=require(\"path\"); try { const p=require.resolve(process.argv[2] + \"/package.json\", { paths: [process.argv[1]] }); process.stdout.write(path.dirname(p)); } catch (error) {}' \"$managed_source\" \"$1\" 2>/dev/null || true; }; playground=$(resolve_pkg @automattic/wp-codebox-playground); core=$(resolve_pkg @automattic/wp-codebox-core); if [ -z \"$core\" ] && [ -n \"${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}\" ]; then core=$HOMEBOY_WP_CODEBOX_CORE_MODULE; fi; revision=$(git -C \"$managed_source\" rev-parse HEAD 2>/dev/null || true); if [ ! -e \"$managed_binary\" ]; then dist_state=missing; elif find \"$managed_source/packages/cli/src\" -type f -newer \"$managed_binary\" 2>/dev/null | read newer; then dist_state=stale; else dist_state=fresh; fi; printf 'cli_binary=%s\ncli_binary_source=%s\nmanaged_cache_source=%s\nmanaged_cache_binary=%s\nplayground_path=%s\ncore_path=%s\nsource_git_sha=%s\ndist_build_freshness=%s\n' \"${effective:-}\" \"$source\" \"$managed_source\" \"$managed_binary\" \"${playground:-}\" \"${core:-}\" \"${revision:-}\" \"$dist_state\"";
+fn declared_probe_value(
+    declaration: &AgentRuntimeRuntimeDiagnosticDeclaration,
+    field: &str,
+) -> WpCodeboxProbeValue {
+    let source = declaration
+        .probes
+        .iter()
+        .find(|probe| probe.field == field)
+        .map(|probe| probe.source.clone())
+        .unwrap_or_else(|| "runtime_probe_command".to_string());
+    WpCodeboxProbeValue {
+        value: None,
+        source,
+    }
+}
+
+fn diagnostic_command(runner_id: Option<&str>, script: &str) -> String {
     match runner_id {
         Some(runner_id) => format!(
             "homeboy runner exec {} --raw -- bash -lc {}",
@@ -368,39 +460,41 @@ fn lab_runner_homeboy_refresh_commands(runner_id: &str) -> Vec<String> {
 pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
     let mut followups = vec![
         LabFollowup {
-            label: "recent_runs",
+            label: "recent_runs".to_string(),
             command: "homeboy runs list --limit 5".to_string(),
-            purpose: "Find recent persisted run records before digging into runner state.",
+            purpose: "Find recent persisted run records before digging into runner state."
+                .to_string(),
         },
         LabFollowup {
-            label: "latest_bench_run",
+            label: "latest_bench_run".to_string(),
             command: "homeboy runs latest-run --kind bench".to_string(),
-            purpose: "Resolve the latest benchmark run id for evidence inspection.",
+            purpose: "Resolve the latest benchmark run id for evidence inspection.".to_string(),
         },
         LabFollowup {
-            label: "latest_fuzz_run",
+            label: "latest_fuzz_run".to_string(),
             command: "homeboy runs latest-run --kind fuzz".to_string(),
-            purpose: "Resolve the latest fuzz run id for evidence inspection.",
+            purpose: "Resolve the latest fuzz run id for evidence inspection.".to_string(),
         },
         LabFollowup {
-            label: "run_artifacts",
+            label: "run_artifacts".to_string(),
             command: "homeboy runs artifacts <run-id>".to_string(),
-            purpose: "List recorded run artifacts through Homeboy.",
+            purpose: "List recorded run artifacts through Homeboy.".to_string(),
         },
         LabFollowup {
-            label: "run_evidence",
+            label: "run_evidence".to_string(),
             command: "homeboy runs evidence <run-id>".to_string(),
-            purpose: "Show stable evidence summary and reviewer-facing commands for one run.",
+            purpose: "Show stable evidence summary and reviewer-facing commands for one run."
+                .to_string(),
         },
         LabFollowup {
-            label: "run_refs",
+            label: "run_refs".to_string(),
             command: "homeboy runs refs --kind bench --limit 10".to_string(),
-            purpose: "List recent benchmark run and artifact refs.",
+            purpose: "List recent benchmark run and artifact refs.".to_string(),
         },
         LabFollowup {
-            label: "fuzz_run_refs",
+            label: "fuzz_run_refs".to_string(),
             command: "homeboy runs refs --kind fuzz --limit 10".to_string(),
-            purpose: "List recent fuzz run and artifact refs.",
+            purpose: "List recent fuzz run and artifact refs.".to_string(),
         },
     ];
     let Some(runner_id) = runner_id else {
@@ -409,54 +503,73 @@ pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
     let runner_arg = shell_arg(runner_id);
     followups.extend([
         LabFollowup {
-            label: "doctor",
+            label: "doctor".to_string(),
             command: format!("homeboy runner doctor {runner_arg} --scope lab-offload"),
-            purpose: "Probe runner tools, workspace writability, artifact storage, and Lab offload readiness.",
+            purpose: "Probe runner tools, workspace writability, artifact storage, and Lab offload readiness.".to_string(),
         },
         LabFollowup {
-            label: "refresh_homeboy",
+            label: "refresh_homeboy".to_string(),
             command: format!("homeboy runner refresh-homeboy {runner_arg} --ref main --reconnect"),
-            purpose: "Materialize a clean runner-side Homeboy binary, select it for Lab jobs, and refresh the daemon session.",
+            purpose: "Materialize a clean runner-side Homeboy binary, select it for Lab jobs, and refresh the daemon session.".to_string(),
         },
         LabFollowup {
-            label: "env",
+            label: "env".to_string(),
             command: format!("homeboy runner env {runner_arg}"),
-            purpose: "Show the redacted environment Homeboy injects into runner jobs.",
+            purpose: "Show the redacted environment Homeboy injects into runner jobs.".to_string(),
         },
         LabFollowup {
-            label: "homeboy_binary_refresh",
+            label: "homeboy_binary_refresh".to_string(),
             command: format!(
                 "homeboy runner disconnect {runner_arg} && homeboy runner connect {runner_arg}"
             ),
-            purpose: "Restart the runner daemon so offload uses the currently configured Homeboy binary.",
+            purpose: "Restart the runner daemon so offload uses the currently configured Homeboy binary.".to_string(),
         },
         LabFollowup {
-            label: "homeboy_binary_upgrade",
+            label: "homeboy_binary_upgrade".to_string(),
             command: format!("homeboy upgrade --force --upgrade-runner {runner_arg}"),
-            purpose: "Upgrade the Homeboy binary configured for this runner before reconnecting stale runs.",
+            purpose: "Upgrade the Homeboy binary configured for this runner before reconnecting stale runs.".to_string(),
         },
         LabFollowup {
-            label: "wp_codebox_effective_binary",
-            command: wp_codebox_effective_binary_command(Some(runner_id)),
-            purpose: "Print the configured WP Codebox binary, managed cache binary/source, effective binary/source, and managed cache revision used by runner workloads.",
-        },
-        LabFollowup {
-            label: "exec",
+            label: "exec".to_string(),
             command: format!("homeboy runner exec {runner_arg} -- <command>"),
-            purpose: "Run a managed follow-up command through Homeboy instead of opening an ad-hoc shell.",
+            purpose: "Run a managed follow-up command through Homeboy instead of opening an ad-hoc shell.".to_string(),
         },
     ]);
+    followups.extend(declared_followups_for_legacy(
+        "managed_followups",
+        Some(runner_id),
+    ));
     if let Ok(path) = std::env::current_dir() {
         followups.push(LabFollowup {
-            label: "workspace_sync",
+            label: "workspace_sync".to_string(),
             command: format!(
                 "homeboy runner workspace sync {runner_arg} --path {} --mode snapshot",
                 shell_arg(&path.display().to_string())
             ),
-            purpose: "Materialize the current checkout into the runner workspace before a replay or follow-up run.",
+            purpose: "Materialize the current checkout into the runner workspace before a replay or follow-up run.".to_string(),
         });
     }
     followups
+}
+
+fn declared_followups_for_legacy(legacy_output: &str, runner_id: Option<&str>) -> Vec<LabFollowup> {
+    declared_diagnostics_contracts()
+        .iter()
+        .flat_map(|contract| contract.followups.iter())
+        .filter(|followup| followup.legacy_output.as_deref() == Some(legacy_output))
+        .map(|followup| declared_followup(followup, runner_id))
+        .collect()
+}
+
+fn declared_followup(
+    declaration: &AgentRuntimeDiagnosticFollowup,
+    runner_id: Option<&str>,
+) -> LabFollowup {
+    LabFollowup {
+        label: declaration.label.clone(),
+        command: diagnostic_command(runner_id, &declaration.command_script),
+        purpose: declaration.purpose.clone(),
+    }
 }
 
 fn shell_arg(value: &str) -> String {

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -1,13 +1,18 @@
 use std::collections::BTreeMap;
 
+use homeboy::core::agent_runtime_manifest::{
+    AgentRuntimePackageDiagnosticDeclaration, AgentRuntimeProbeDiagnosticDeclaration,
+    AgentRuntimeRuntimeDiagnosticDeclaration, AgentRuntimeSourceConsistencyDiagnostic,
+    AgentRuntimeToolDiagnosticDeclaration,
+};
 use homeboy::core::api_jobs::{JobEvent, JobStatus};
 use homeboy::core::runner::{RunnerActiveJobSource, RunnerActiveJobState};
 use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, RunnerTunnelMode};
 
 use super::super::jobs::format_job_event;
 use super::super::status::{
+    declared_runtime_diagnostics, declared_runtime_source_diagnostics, declared_tool_diagnostics,
     runner_artifact_feature_diagnostics, runner_status_operator_commands,
-    wp_codebox_runtime_diagnostics, wp_codebox_runtime_output, wp_codebox_tool_diagnostics,
 };
 
 #[test]
@@ -126,7 +131,9 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
 
 #[test]
 fn wp_codebox_diagnostics_distinguish_configured_managed_and_effective() {
-    let diagnostics = wp_codebox_tool_diagnostics(
+    let declaration = wp_codebox_tool_declaration();
+    let diagnostics = declared_tool_diagnostics(
+        &declaration,
         Some("homeboy-lab"),
         &BTreeMap::from([
             (
@@ -167,7 +174,9 @@ fn wp_codebox_diagnostics_distinguish_configured_managed_and_effective() {
 
 #[test]
 fn wp_codebox_runtime_reports_package_paths_probe_and_mixed_source_warnings() {
-    let runtime = wp_codebox_runtime_output(
+    let declaration = wp_codebox_runtime_declaration();
+    let runtime = declared_runtime_diagnostics(
+        &declaration,
         Some("homeboy-lab"),
         &BTreeMap::from([
             (
@@ -223,13 +232,42 @@ fn wp_codebox_runtime_reports_package_paths_probe_and_mixed_source_warnings() {
 
 #[test]
 fn wp_codebox_runtime_diagnostics_accept_single_managed_checkout() {
-    let diagnostics = wp_codebox_runtime_diagnostics(
+    let diagnostics = declared_runtime_source_diagnostics(
+        &wp_codebox_runtime_declaration().source_consistency,
+        &BTreeMap::from([(
+            "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
+            "/cache/wp-codebox/source/packages/core/dist/index.js".to_string(),
+        )]),
         Some("/cache/wp-codebox/source/packages/cli/dist/index.js"),
+        "/cache/wp-codebox",
         "/cache/wp-codebox/source",
-        "/cache/wp-codebox/source/packages/core/dist/index.js",
     );
 
     assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn unknown_runtime_declaration_does_not_emit_wp_specific_guidance() {
+    let declaration = AgentRuntimeToolDiagnosticDeclaration {
+        tool: "other-runtime".to_string(),
+        legacy_output: None,
+        configured_binary_env: vec!["OTHER_RUNTIME_BIN".to_string()],
+        install_dir_env: Some("OTHER_RUNTIME_INSTALL_DIR".to_string()),
+        default_install_dir: Some("${HOME}/.cache/homeboy/other-runtime".to_string()),
+        managed_cache_source: "${install_dir}/source".to_string(),
+        managed_cache_binary: "${managed_cache_source}/bin/other-runtime".to_string(),
+        effective_binary_rule: "declared runtime rule".to_string(),
+        diagnostic_script: "printf other_runtime".to_string(),
+        extra: BTreeMap::new(),
+    };
+
+    let diagnostics =
+        declared_tool_diagnostics(&declaration, Some("homeboy-lab"), &BTreeMap::new());
+    let serialized = serde_json::to_string(&diagnostics).expect("serialize diagnostics");
+
+    assert!(serialized.contains("other-runtime"));
+    assert!(!serialized.contains("wp-codebox"));
+    assert!(!serialized.contains("HOMEBOY_WP_CODEBOX"));
 }
 
 #[test]
@@ -288,4 +326,86 @@ fn runner_status_artifact_diagnostics_surface_controller_runner_checks_and_drift
     assert!(serialized
         .contains("homeboy runner exec homeboy-lab -- homeboy runs artifact attach --help"));
     assert!(serialized.contains("version/build drift"));
+}
+
+fn wp_codebox_tool_declaration() -> AgentRuntimeToolDiagnosticDeclaration {
+    AgentRuntimeToolDiagnosticDeclaration {
+        tool: "wp-codebox".to_string(),
+        legacy_output: Some("wp_codebox".to_string()),
+        configured_binary_env: vec![
+            "HOMEBOY_WP_CODEBOX_BIN".to_string(),
+            "HOMEBOY_SETTINGS_WP_CODEBOX_BIN".to_string(),
+        ],
+        install_dir_env: Some("HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string()),
+        default_install_dir: Some("${HOME}/.cache/homeboy/wp-codebox".to_string()),
+        managed_cache_source: "${install_dir}/source".to_string(),
+        managed_cache_binary: "${managed_cache_source}/packages/cli/dist/index.js".to_string(),
+        effective_binary_rule:
+            "managed cache binary wins when executable; otherwise configured binary, then PATH"
+                .to_string(),
+        diagnostic_script: "configured=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}; install_dir=${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v wp-codebox 2>/dev/null || true); source=path; fi; revision=$(git -C \"$managed_source\" rev-parse --short HEAD 2>/dev/null || true); printf 'configured_binary=%s\nmanaged_cache_source=%s\nmanaged_cache_binary=%s\neffective_binary=%s\neffective_source=%s\nmanaged_cache_revision=%s\n' \"${configured:-}\" \"$managed_source\" \"$managed_binary\" \"${effective:-}\" \"$source\" \"${revision:-}\"".to_string(),
+        extra: BTreeMap::new(),
+    }
+}
+
+fn wp_codebox_runtime_declaration() -> AgentRuntimeRuntimeDiagnosticDeclaration {
+    AgentRuntimeRuntimeDiagnosticDeclaration {
+        tool: "wp-codebox".to_string(),
+        legacy_output: Some("wp_codebox_runtime".to_string()),
+        configured_binary_env: vec![
+            "HOMEBOY_WP_CODEBOX_BIN".to_string(),
+            "HOMEBOY_SETTINGS_WP_CODEBOX_BIN".to_string(),
+        ],
+        install_dir_env: Some("HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string()),
+        default_install_dir: Some("${HOME}/.cache/homeboy/wp-codebox".to_string()),
+        managed_cache_source: "${install_dir}/source".to_string(),
+        managed_cache_binary: "${managed_cache_source}/packages/cli/dist/index.js".to_string(),
+        effective_binary_rule:
+            "managed cache binary wins when executable; otherwise configured binary, then PATH"
+                .to_string(),
+        packages: vec![
+            AgentRuntimePackageDiagnosticDeclaration {
+                field: "playground_package".to_string(),
+                package: "@automattic/wp-codebox-playground".to_string(),
+                expected_path: "${managed_cache_source}/packages/playground".to_string(),
+                env_override: None,
+            },
+            AgentRuntimePackageDiagnosticDeclaration {
+                field: "core_package".to_string(),
+                package: "@automattic/wp-codebox-core".to_string(),
+                expected_path: "${managed_cache_source}/packages/core".to_string(),
+                env_override: Some("HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string()),
+            },
+        ],
+        probes: vec![
+            AgentRuntimeProbeDiagnosticDeclaration {
+                field: "source_git_sha".to_string(),
+                source: "runtime_probe_command".to_string(),
+            },
+            AgentRuntimeProbeDiagnosticDeclaration {
+                field: "dist_build_freshness".to_string(),
+                source: "runtime_probe_command".to_string(),
+            },
+        ],
+        runtime_probe_script: "configured=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}; install_dir=${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v wp-codebox 2>/dev/null || true); source=path; fi; resolve_pkg() { node -e 'const path=require(\"path\"); try { const p=require.resolve(process.argv[2] + \"/package.json\", { paths: [process.argv[1]] }); process.stdout.write(path.dirname(p)); } catch (error) {}' \"$managed_source\" \"$1\" 2>/dev/null || true; }; playground=$(resolve_pkg @automattic/wp-codebox-playground); core=$(resolve_pkg @automattic/wp-codebox-core); if [ -z \"$core\" ] && [ -n \"${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}\" ]; then core=$HOMEBOY_WP_CODEBOX_CORE_MODULE; fi; revision=$(git -C \"$managed_source\" rev-parse HEAD 2>/dev/null || true); if [ ! -e \"$managed_binary\" ]; then dist_state=missing; elif find \"$managed_source/packages/cli/src\" -type f -newer \"$managed_binary\" 2>/dev/null | read newer; then dist_state=stale; else dist_state=fresh; fi; printf 'cli_binary=%s\ncli_binary_source=%s\nmanaged_cache_source=%s\nmanaged_cache_binary=%s\nplayground_path=%s\ncore_path=%s\nsource_git_sha=%s\ndist_build_freshness=%s\n' \"${effective:-}\" \"$source\" \"$managed_source\" \"$managed_binary\" \"${playground:-}\" \"${core:-}\" \"${revision:-}\" \"$dist_state\"".to_string(),
+        source_consistency: vec![
+            AgentRuntimeSourceConsistencyDiagnostic {
+                id: "wp_codebox.mixed_cli_source".to_string(),
+                severity: "warning".to_string(),
+                path: "configured_binary".to_string(),
+                root: "${managed_cache_source}".to_string(),
+                message: "Configured WP Codebox CLI `${path}` is outside managed cache `${root}`; runner jobs may mix a stale CLI with managed package sources.".to_string(),
+                remediation: "Unset HOMEBOY_WP_CODEBOX_BIN/HOMEBOY_SETTINGS_WP_CODEBOX_BIN or point it at the managed cache binary reported here.".to_string(),
+            },
+            AgentRuntimeSourceConsistencyDiagnostic {
+                id: "wp_codebox.mixed_core_source".to_string(),
+                severity: "warning".to_string(),
+                path: "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
+                root: "${managed_cache_source}".to_string(),
+                message: "Resolved WP Codebox core path `${path}` is outside managed cache `${root}`; runner jobs may mix core and playground builds.".to_string(),
+                remediation: "Refresh the WordPress extension setup/runtime env so HOMEBOY_WP_CODEBOX_CORE_MODULE resolves from the same managed WP Codebox checkout used by the CLI.".to_string(),
+            },
+        ],
+        extra: BTreeMap::new(),
+    }
 }

--- a/src/commands/runner/types.rs
+++ b/src/commands/runner/types.rs
@@ -49,9 +49,9 @@ impl Default for RunnerExtra {
 
 #[derive(Debug, Serialize)]
 pub struct LabFollowup {
-    pub label: &'static str,
+    pub label: String,
     pub command: String,
-    pub purpose: &'static str,
+    pub purpose: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -60,7 +60,8 @@ pub struct LabSelectedRunnerOutput {
     pub kind: String,
     pub configured_executable: String,
     pub runner_homeboy: LabRunnerHomeboyOutput,
-    pub wp_codebox_runtime: WpCodeboxRuntimeOutput,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wp_codebox_runtime: Option<WpCodeboxRuntimeOutput>,
     pub daemon_enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_root: Option<String>,
@@ -98,25 +99,25 @@ pub struct RunnerArtifactFeatureDiagnostics {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RunnerToolDiagnostics {
-    pub tool: &'static str,
+    pub tool: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub configured_binary: Option<String>,
-    pub configured_binary_source: &'static str,
+    pub configured_binary_source: String,
     pub managed_cache_source: String,
     pub managed_cache_binary: String,
-    pub effective_binary_rule: &'static str,
+    pub effective_binary_rule: String,
     pub diagnostic_command: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct WpCodeboxRuntimeOutput {
-    pub tool: &'static str,
+    pub tool: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub configured_binary: Option<String>,
-    pub configured_binary_source: &'static str,
+    pub configured_binary_source: String,
     pub managed_cache_source: String,
     pub managed_cache_binary: String,
-    pub effective_binary_rule: &'static str,
+    pub effective_binary_rule: String,
     pub playground_package: WpCodeboxPackageRuntimeOutput,
     pub core_package: WpCodeboxPackageRuntimeOutput,
     pub source_git_sha: WpCodeboxProbeValue,
@@ -128,7 +129,7 @@ pub struct WpCodeboxRuntimeOutput {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct WpCodeboxPackageRuntimeOutput {
-    pub package: &'static str,
+    pub package: String,
     pub expected_path: String,
     pub resolution: WpCodeboxProbeValue,
 }
@@ -136,13 +137,13 @@ pub struct WpCodeboxPackageRuntimeOutput {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct WpCodeboxProbeValue {
     pub value: Option<String>,
-    pub source: &'static str,
+    pub source: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct WpCodeboxRuntimeDiagnostic {
-    pub id: &'static str,
-    pub severity: &'static str,
+    pub id: String,
+    pub severity: String,
     pub message: String,
     pub remediation: String,
 }

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -66,6 +66,11 @@ pub struct AgentRuntimeMaterializationContract {
     pub executable_requirements: Vec<AgentRuntimeExecutableRequirement>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub readiness_checks: Vec<AgentTaskProviderRunnerReadiness>,
+    #[serde(
+        default,
+        skip_serializing_if = "AgentRuntimeDiagnosticsContract::is_empty"
+    )]
+    pub diagnostics: AgentRuntimeDiagnosticsContract,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub env_passthrough: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -80,10 +85,115 @@ impl AgentRuntimeMaterializationContract {
             && self.dependencies.is_empty()
             && self.executable_requirements.is_empty()
             && self.readiness_checks.is_empty()
+            && self.diagnostics.is_empty()
             && self.env_passthrough.is_empty()
             && self.workspace.is_none()
             && self.extra.is_empty()
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentRuntimeDiagnosticsContract {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<AgentRuntimeToolDiagnosticDeclaration>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtimes: Vec<AgentRuntimeRuntimeDiagnosticDeclaration>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub followups: Vec<AgentRuntimeDiagnosticFollowup>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl AgentRuntimeDiagnosticsContract {
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+            && self.runtimes.is_empty()
+            && self.followups.is_empty()
+            && self.extra.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentRuntimeToolDiagnosticDeclaration {
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_output: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub configured_binary_env: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_dir_env: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_install_dir: Option<String>,
+    pub managed_cache_source: String,
+    pub managed_cache_binary: String,
+    pub effective_binary_rule: String,
+    pub diagnostic_script: String,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentRuntimeRuntimeDiagnosticDeclaration {
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_output: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub configured_binary_env: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_dir_env: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_install_dir: Option<String>,
+    pub managed_cache_source: String,
+    pub managed_cache_binary: String,
+    pub effective_binary_rule: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub packages: Vec<AgentRuntimePackageDiagnosticDeclaration>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub probes: Vec<AgentRuntimeProbeDiagnosticDeclaration>,
+    pub runtime_probe_script: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_consistency: Vec<AgentRuntimeSourceConsistencyDiagnostic>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentRuntimePackageDiagnosticDeclaration {
+    pub field: String,
+    pub package: String,
+    pub expected_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env_override: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentRuntimeProbeDiagnosticDeclaration {
+    pub field: String,
+    #[serde(default = "default_runtime_probe_source")]
+    pub source: String,
+}
+
+fn default_runtime_probe_source() -> String {
+    "runtime_probe_command".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentRuntimeSourceConsistencyDiagnostic {
+    pub id: String,
+    pub severity: String,
+    pub path: String,
+    pub root: String,
+    pub message: String,
+    pub remediation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentRuntimeDiagnosticFollowup {
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_output: Option<String>,
+    pub command_script: String,
+    pub purpose: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -583,6 +693,25 @@ mod tests {
                         "label": "Example Runtime Ready",
                         "secret_env": ["EXAMPLE_RUNTIME_TOKEN"]
                     }],
+                    "diagnostics": {
+                        "tools": [{
+                            "tool": "example-runtime",
+                            "legacy_output": "example_runtime",
+                            "configured_binary_env": ["EXAMPLE_RUNTIME_BIN"],
+                            "install_dir_env": "EXAMPLE_RUNTIME_INSTALL_DIR",
+                            "default_install_dir": "${HOME}/.cache/homeboy/example-runtime",
+                            "managed_cache_source": "${install_dir}/source",
+                            "managed_cache_binary": "${managed_cache_source}/bin/example-runtime",
+                            "effective_binary_rule": "managed cache binary wins",
+                            "diagnostic_script": "printf example-runtime"
+                        }],
+                        "followups": [{
+                            "label": "example_runtime_binary",
+                            "legacy_output": "managed_followups",
+                            "command_script": "printf example-runtime",
+                            "purpose": "Inspect the declared runtime binary."
+                        }]
+                    },
                     "env_passthrough": ["EXAMPLE_RUNTIME_BIN", "EXAMPLE_RUNTIME_TOKEN", "EXAMPLE_RUNTIME_BIN"],
                     "workspace": {
                         "cwd": "git_checkout",
@@ -626,6 +755,19 @@ mod tests {
                 "EXAMPLE_RUNTIME_BIN".to_string(),
                 "EXAMPLE_RUNTIME_TOKEN".to_string()
             ]
+        );
+        assert_eq!(
+            manifests[0].materialization.diagnostics.tools[0].tool,
+            "example-runtime"
+        );
+        assert_eq!(
+            manifests[0].materialization.diagnostics.followups[0].label,
+            "example_runtime_binary"
+        );
+        assert_eq!(
+            serde_json::to_value(&manifests[0]).expect("runtime export")["materialization"]
+                ["diagnostics"]["tools"][0]["managed_cache_binary"],
+            "${managed_cache_source}/bin/example-runtime"
         );
         assert_eq!(
             materialization_plan


### PR DESCRIPTION
## Summary
- add runtime-owned runner diagnostics declarations to agent runtime materialization contracts
- route runner status/env WP Codebox compatibility output through declared diagnostics instead of hardcoded helper branches
- add focused tests for declared WP Codebox diagnostics and unknown runtime behavior

## Tests
- cargo test commands::runner::tests::status
- cargo test core::agent_runtime_manifest::tests::discovers_first_class_agent_runtime_manifests_from_extensions
- cargo test --test architecture_core_agnostic_test
- git diff --check

## Notes
- 
running 1 test
test core_files_do_not_name_extension_owned_runtime_products ... FAILED

failures:

---- core_files_do_not_name_extension_owned_runtime_products stdout ----

thread 'core_files_do_not_name_extension_owned_runtime_products' (283027133) panicked at tests/runtime_product_boundary_test.rs:21:5:
Homeboy core must keep extension-owned runtime product knowledge in extensions/adapters:
src/core/api_jobs/mod.rs
src/core/extension/setup_env.rs
src/core/extension/execution.rs
src/core/agent_task_fanout.rs
src/core/agent_task_dispatch_plan.rs
src/core/deploy/generated_artifacts.rs
src/core/runner/lab/preparation_tests.rs
src/core/runner/connection.rs
src/core/agent_task_provider/tests/selection_tests.rs
src/core/agent_task_provider/tests/outcome_tests.rs
src/core/agent_task_provider/runtime_types.rs
src/core/agent_task_provider/staging_reconciliation.rs
src/core/agent_task_executor_evidence.rs
src/core/rig/pipeline/command_step.rs
src/core/agent_task_runtime_dependency_graph.rs
src/core/worktree.rs
src/core/agent_task_controller_service/run_failure_summary.rs
src/core/agent_task_controller_service/spec_compile.rs
src/core/agent_task_controller_service/mod.rs
src/core/agent_task_controller_service/tests.rs
src/core/git/github/body_file.rs
src/core/observation/run_failure_causes.rs
src/commands/agent_task/review.rs
src/commands/agent_task/fanout.rs
src/commands/agent_task/args/controller.rs
src/commands/agent_task/args/mod.rs
src/commands/runs_summary.rs
src/commands/route.rs
src/commands/runner/types.rs
src/commands/runner/env.rs
src/commands/runner/doctor/tests/managed_source.rs
src/commands/runner/tests/redaction.rs
src/commands/runner/tests/status.rs
src/commands/runner/status.rs
src/commands/extension.rs
tests/agent_tool_dispatch.rs
docs/architecture/provider-fanout-boundary.md
docs/commands/bench.md
docs/commands/agent-task.md
docs/commands/runner.md
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    core_files_do_not_name_extension_owned_runtime_products

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.84s currently fails on broad pre-existing product-name references across many untouched files; this PR does not use that as proof.
- The remaining bench/fuzz runner followups stay in core for this staged migration. WP Codebox binary/cache diagnostics and the effective-binary followup now come from declared data.
- A homeboy-extensions manifest PR is needed after this lands to declare the WP Codebox diagnostics data for the WordPress runtime.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and verified runner diagnostic contract cleanup.
