### PR TITLE
Move Lab support summaries into CommandSpec

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -36,12 +36,7 @@ pub use lab::{
     RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS,
     RUNNER_WORKLOAD_SCHEMA,
 };
-pub(crate) use lab::{
-    AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LAB_NO_EXTRA_TOOLS, LINT_LAB_LABEL,
-    REVIEW_LAB_LABEL, RIG_CHECK_LAB_LABEL, RIG_UP_LAB_UNSUPPORTED_REASON, TEST_LAB_LABEL,
-    TRACE_LAB_LABEL, TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL, TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
-    TUNNEL_SERVICE_START_LAB_LABEL,
-};
+pub(crate) use lab::{LAB_NO_EXTRA_TOOLS, RIG_UP_LAB_UNSUPPORTED_REASON};
 pub use output::{
     CommandDescriptor, CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind,
     CommandOutputDescriptor, CommandOutputFileMode, CommandRawOutputMode, CommandResponseMode,
@@ -50,5 +45,10 @@ pub use output::{
 pub use public_variants::{PublicOutputVariantContract, PUBLIC_OUTPUT_VARIANT_CONTRACTS};
 pub use spec::{
     registered_command, registered_command_dispatch_family, registered_command_json_family,
-    CommandRegistryEntry, CommandSpec, COMMAND_REGISTRY, COMMAND_SPECS,
+    CommandLabSupportSummary, CommandRegistryEntry, CommandSpec, COMMAND_REGISTRY, COMMAND_SPECS,
+};
+pub(crate) use spec::{
+    AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REVIEW_LAB_LABEL,
+    RIG_CHECK_LAB_LABEL, TEST_LAB_LABEL, TRACE_LAB_LABEL, TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
+    TUNNEL_SERVICE_EXPOSE_LAB_LABEL, TUNNEL_SERVICE_START_LAB_LABEL,
 };

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -16,6 +16,16 @@ use crate::core::engine::execution_context::{self, ResolveOptions};
 use crate::core::extension::ExtensionCapability;
 use std::collections::BTreeSet;
 
+use super::spec::{
+    CommandLabSupportSummary, AGENT_TASK_AUTH_STATUS_LAB_LABEL,
+    AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL, AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL,
+    AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL, AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
+    AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL,
+    AGENT_TASK_RUN_LAB_LABEL, AGENT_TASK_STATUS_LAB_LABEL, AUDIT_LAB_LABEL, BENCH_LAB_LABEL,
+    COMMAND_SPECS, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REFACTOR_LAB_LABEL, REVIEW_LAB_LABEL,
+    RIG_CHECK_LAB_LABEL, TEST_LAB_LABEL, TRACE_LAB_LABEL,
+};
+
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
 
 /// Routing-policy flags shared by every Lab command representation
@@ -302,35 +312,6 @@ pub(crate) const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
 pub(crate) const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
 const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
-const AGENT_TASK_RUN_LAB_LABEL: &str = "agent-task cook/run-plan/retry --run";
-const AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL: &str =
-    "agent-task controller from-spec --resume/run-from-spec/materialize";
-const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task controller resume";
-const AGENT_TASK_STATUS_LAB_LABEL: &str =
-    "agent-task run/run-next/status/logs/artifacts/review/list/active/latest";
-const AGENT_TASK_PROVIDERS_LAB_LABEL: &str = "agent-task providers";
-const AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL: &str = "agent-task fanout run-plan";
-const AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL: &str = "agent-task fanout submit-batch";
-const AGENT_TASK_FANOUT_STATUS_LAB_LABEL: &str = "agent-task fanout status/artifacts";
-const AGENT_TASK_AUTH_STATUS_LAB_LABEL: &str = "agent-task auth status";
-pub(crate) const LINT_LAB_LABEL: &str = "lint";
-pub(crate) const TEST_LAB_LABEL: &str = "test";
-pub(crate) const AUDIT_LAB_LABEL: &str = "audit";
-pub(crate) const REVIEW_LAB_LABEL: &str = "review";
-pub(crate) const BENCH_LAB_LABEL: &str = "bench";
-pub(crate) const FUZZ_LAB_LABEL: &str = "fuzz";
-pub(crate) const TRACE_LAB_LABEL: &str = "trace";
-const REFACTOR_LAB_LABEL: &str = "refactor";
-pub(crate) const RIG_CHECK_LAB_LABEL: &str = "rig check";
-pub(crate) const TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL: &str = "tunnel preview-consumer run";
-pub(crate) const TUNNEL_SERVICE_EXPOSE_LAB_LABEL: &str = "tunnel service expose";
-pub(crate) const TUNNEL_SERVICE_START_LAB_LABEL: &str = "tunnel service start";
-
-struct LabSupportedCommandSummary {
-    contract_labels: &'static [&'static str],
-    message_label: &'static str,
-    hint_label: &'static str,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabRunnerSupportSummary {
@@ -339,118 +320,14 @@ pub struct LabRunnerSupportSummary {
     pub hint: String,
 }
 
-const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
-    LabSupportedCommandSummary {
-        contract_labels: &[AGENT_TASK_RUN_LAB_LABEL],
-        message_label: "agent-task cook/run-plan",
-        hint_label: "agent-task cook/run-plan",
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[
-            AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL,
-            AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL,
-        ],
-        message_label: "agent-task controller from-spec --resume/run-from-spec/materialize/resume",
-        hint_label: "agent-task controller from-spec --resume/run-from-spec/materialize/resume",
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[AGENT_TASK_RUN_LAB_LABEL],
-        message_label: "agent-task retry --run",
-        hint_label: "agent-task retry --run",
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[AGENT_TASK_STATUS_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL],
-        message_label:
-            "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
-        hint_label:
-            "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[
-            AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
-            AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
-            AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
-        ],
-        message_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
-        hint_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[AGENT_TASK_AUTH_STATUS_LAB_LABEL],
-        message_label: AGENT_TASK_AUTH_STATUS_LAB_LABEL,
-        hint_label: AGENT_TASK_AUTH_STATUS_LAB_LABEL,
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[LINT_LAB_LABEL],
-        message_label: LINT_LAB_LABEL,
-        hint_label: LINT_LAB_LABEL,
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[TEST_LAB_LABEL],
-        message_label: TEST_LAB_LABEL,
-        hint_label: TEST_LAB_LABEL,
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[AUDIT_LAB_LABEL],
-        message_label: AUDIT_LAB_LABEL,
-        hint_label: AUDIT_LAB_LABEL,
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[REVIEW_LAB_LABEL],
-        message_label: REVIEW_LAB_LABEL,
-        hint_label: REVIEW_LAB_LABEL,
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[BENCH_LAB_LABEL],
-        message_label: BENCH_LAB_LABEL,
-        hint_label: "bench run",
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[FUZZ_LAB_LABEL],
-        message_label: FUZZ_LAB_LABEL,
-        hint_label: "fuzz run",
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[TRACE_LAB_LABEL],
-        message_label: TRACE_LAB_LABEL,
-        hint_label: TRACE_LAB_LABEL,
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[REFACTOR_LAB_LABEL],
-        message_label: "refactor source runs",
-        hint_label: "refactor source runs",
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[RIG_CHECK_LAB_LABEL],
-        message_label: RIG_CHECK_LAB_LABEL,
-        hint_label: RIG_CHECK_LAB_LABEL,
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL],
-        message_label: TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
-        hint_label: TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[TUNNEL_SERVICE_EXPOSE_LAB_LABEL],
-        message_label: TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
-        hint_label: TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
-    },
-    LabSupportedCommandSummary {
-        contract_labels: &[TUNNEL_SERVICE_START_LAB_LABEL],
-        message_label: TUNNEL_SERVICE_START_LAB_LABEL,
-        hint_label: TUNNEL_SERVICE_START_LAB_LABEL,
-    },
-];
-
 pub fn lab_runner_supported_labels() -> Vec<&'static str> {
-    LAB_SUPPORTED_COMMAND_SUMMARIES
-        .iter()
+    lab_support_summaries()
         .map(|summary| summary.message_label)
         .collect()
 }
 
 pub fn lab_runner_supported_contract_labels() -> Vec<&'static str> {
-    LAB_SUPPORTED_COMMAND_SUMMARIES
-        .iter()
+    lab_support_summaries()
         .flat_map(|summary| summary.contract_labels.iter().copied())
         .collect::<BTreeSet<_>>()
         .into_iter()
@@ -458,9 +335,7 @@ pub fn lab_runner_supported_contract_labels() -> Vec<&'static str> {
 }
 
 pub fn lab_runner_supports_contract_label(contract_label: &str) -> bool {
-    LAB_SUPPORTED_COMMAND_SUMMARIES
-        .iter()
-        .any(|summary| summary.contract_labels.contains(&contract_label))
+    lab_support_summaries().any(|summary| summary.contract_labels.contains(&contract_label))
 }
 
 pub fn lab_runner_support_summary() -> LabRunnerSupportSummary {
@@ -486,10 +361,15 @@ pub fn lab_runner_unsupported_hint() -> String {
 }
 
 fn lab_runner_supported_hint_labels() -> Vec<&'static str> {
-    LAB_SUPPORTED_COMMAND_SUMMARIES
-        .iter()
+    lab_support_summaries()
         .map(|summary| summary.hint_label)
         .collect()
+}
+
+fn lab_support_summaries() -> impl Iterator<Item = &'static CommandLabSupportSummary> {
+    COMMAND_SPECS
+        .iter()
+        .flat_map(|spec| spec.lab_support_summary.iter())
 }
 
 #[cfg(test)]

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -14,12 +14,43 @@ pub struct CommandSpec {
     pub output_notes: &'static str,
     pub lab_supported: bool,
     pub lab_notes: &'static str,
+    pub lab_support_summary: &'static [CommandLabSupportSummary],
 }
 
 pub type CommandRegistryEntry = CommandSpec;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandLabSupportSummary {
+    pub contract_labels: &'static [&'static str],
+    pub message_label: &'static str,
+    pub hint_label: &'static str,
+}
+
 pub const DEFAULT_LAB_UNSUPPORTED_NOTES: &str =
     "not declared as Lab-routable in the command registry";
+pub(crate) const AGENT_TASK_RUN_LAB_LABEL: &str = "agent-task cook/run-plan/retry --run";
+pub(crate) const AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL: &str =
+    "agent-task controller from-spec --resume/run-from-spec/materialize";
+pub(crate) const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task controller resume";
+pub(crate) const AGENT_TASK_STATUS_LAB_LABEL: &str =
+    "agent-task run/run-next/status/logs/artifacts/review/list/active/latest";
+pub(crate) const AGENT_TASK_PROVIDERS_LAB_LABEL: &str = "agent-task providers";
+pub(crate) const AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL: &str = "agent-task fanout run-plan";
+pub(crate) const AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL: &str = "agent-task fanout submit-batch";
+pub(crate) const AGENT_TASK_FANOUT_STATUS_LAB_LABEL: &str = "agent-task fanout status/artifacts";
+pub(crate) const AGENT_TASK_AUTH_STATUS_LAB_LABEL: &str = "agent-task auth status";
+pub(crate) const LINT_LAB_LABEL: &str = "lint";
+pub(crate) const TEST_LAB_LABEL: &str = "test";
+pub(crate) const AUDIT_LAB_LABEL: &str = "audit";
+pub(crate) const REVIEW_LAB_LABEL: &str = "review";
+pub(crate) const BENCH_LAB_LABEL: &str = "bench";
+pub(crate) const FUZZ_LAB_LABEL: &str = "fuzz";
+pub(crate) const TRACE_LAB_LABEL: &str = "trace";
+pub(crate) const REFACTOR_LAB_LABEL: &str = "refactor";
+pub(crate) const RIG_CHECK_LAB_LABEL: &str = "rig check";
+pub(crate) const TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL: &str = "tunnel preview-consumer run";
+pub(crate) const TUNNEL_SERVICE_EXPOSE_LAB_LABEL: &str = "tunnel service expose";
+pub(crate) const TUNNEL_SERVICE_START_LAB_LABEL: &str = "tunnel service start";
 
 impl CommandSpec {
     pub fn docs_path(&self) -> Option<String> {
@@ -36,6 +67,7 @@ const fn command_spec(name: &'static str, json_family: CommandJsonFamily) -> Com
         output_notes: "standard CLI output contract",
         lab_supported: false,
         lab_notes: DEFAULT_LAB_UNSUPPORTED_NOTES,
+        lab_support_summary: &[],
     }
 }
 
@@ -74,6 +106,31 @@ const fn lab_command_spec(
     }
 }
 
+const fn lab_command_spec_with_summary(
+    name: &'static str,
+    json_family: CommandJsonFamily,
+    lab_notes: &'static str,
+    lab_support_summary: &'static [CommandLabSupportSummary],
+) -> CommandSpec {
+    CommandSpec {
+        lab_support_summary,
+        ..lab_command_spec(name, json_family, lab_notes)
+    }
+}
+
+const fn lab_command_spec_with_output_notes_and_summary(
+    name: &'static str,
+    json_family: CommandJsonFamily,
+    lab_notes: &'static str,
+    output_notes: &'static str,
+    lab_support_summary: &'static [CommandLabSupportSummary],
+) -> CommandSpec {
+    CommandSpec {
+        lab_support_summary,
+        ..lab_command_spec_with_output_notes(name, json_family, lab_notes, output_notes)
+    }
+}
+
 const fn manifest_command_spec() -> CommandSpec {
     CommandSpec {
         output_notes:
@@ -82,42 +139,162 @@ const fn manifest_command_spec() -> CommandSpec {
     }
 }
 
+const AGENT_TASK_LAB_SUPPORT: &[CommandLabSupportSummary] = &[
+    CommandLabSupportSummary {
+        contract_labels: &[AGENT_TASK_RUN_LAB_LABEL],
+        message_label: "agent-task cook/run-plan",
+        hint_label: "agent-task cook/run-plan",
+    },
+    CommandLabSupportSummary {
+        contract_labels: &[
+            AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL,
+            AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL,
+        ],
+        message_label: "agent-task controller from-spec --resume/run-from-spec/materialize/resume",
+        hint_label: "agent-task controller from-spec --resume/run-from-spec/materialize/resume",
+    },
+    CommandLabSupportSummary {
+        contract_labels: &[AGENT_TASK_RUN_LAB_LABEL],
+        message_label: "agent-task retry --run",
+        hint_label: "agent-task retry --run",
+    },
+    CommandLabSupportSummary {
+        contract_labels: &[AGENT_TASK_STATUS_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL],
+        message_label:
+            "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
+        hint_label:
+            "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
+    },
+    CommandLabSupportSummary {
+        contract_labels: &[
+            AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
+            AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
+            AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
+        ],
+        message_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
+        hint_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
+    },
+    CommandLabSupportSummary {
+        contract_labels: &[AGENT_TASK_AUTH_STATUS_LAB_LABEL],
+        message_label: AGENT_TASK_AUTH_STATUS_LAB_LABEL,
+        hint_label: AGENT_TASK_AUTH_STATUS_LAB_LABEL,
+    },
+];
+
+const LINT_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[LINT_LAB_LABEL],
+    message_label: LINT_LAB_LABEL,
+    hint_label: LINT_LAB_LABEL,
+}];
+
+const TEST_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[TEST_LAB_LABEL],
+    message_label: TEST_LAB_LABEL,
+    hint_label: TEST_LAB_LABEL,
+}];
+
+const AUDIT_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[AUDIT_LAB_LABEL],
+    message_label: AUDIT_LAB_LABEL,
+    hint_label: AUDIT_LAB_LABEL,
+}];
+
+const REVIEW_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[REVIEW_LAB_LABEL],
+    message_label: REVIEW_LAB_LABEL,
+    hint_label: REVIEW_LAB_LABEL,
+}];
+
+const BENCH_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[BENCH_LAB_LABEL],
+    message_label: BENCH_LAB_LABEL,
+    hint_label: "bench run",
+}];
+
+const FUZZ_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[FUZZ_LAB_LABEL],
+    message_label: FUZZ_LAB_LABEL,
+    hint_label: "fuzz run",
+}];
+
+const TRACE_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[TRACE_LAB_LABEL],
+    message_label: TRACE_LAB_LABEL,
+    hint_label: TRACE_LAB_LABEL,
+}];
+
+const REFACTOR_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[REFACTOR_LAB_LABEL],
+    message_label: "refactor source runs",
+    hint_label: "refactor source runs",
+}];
+
+const RIG_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[RIG_CHECK_LAB_LABEL],
+    message_label: RIG_CHECK_LAB_LABEL,
+    hint_label: RIG_CHECK_LAB_LABEL,
+}];
+
+const TUNNEL_LAB_SUPPORT: &[CommandLabSupportSummary] = &[
+    CommandLabSupportSummary {
+        contract_labels: &[TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL],
+        message_label: TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
+        hint_label: TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
+    },
+    CommandLabSupportSummary {
+        contract_labels: &[TUNNEL_SERVICE_EXPOSE_LAB_LABEL],
+        message_label: TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
+        hint_label: TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
+    },
+    CommandLabSupportSummary {
+        contract_labels: &[TUNNEL_SERVICE_START_LAB_LABEL],
+        message_label: TUNNEL_SERVICE_START_LAB_LABEL,
+        hint_label: TUNNEL_SERVICE_START_LAB_LABEL,
+    },
+];
+
 pub const COMMAND_SPECS: &[CommandSpec] = &[
-    lab_command_spec(
+    lab_command_spec_with_summary(
         "agent-task",
         CommandJsonFamily::Workspace,
         "Lab runner routing covers portable, explicit-runner, and runner-resident agent-task workflows",
+        AGENT_TASK_LAB_SUPPORT,
     ),
     command_spec("project", CommandJsonFamily::Workspace),
     command_spec("ssh", CommandJsonFamily::Ops),
     command_spec("server", CommandJsonFamily::Ops),
-    lab_command_spec(
+    lab_command_spec_with_summary(
         "test",
         CommandJsonFamily::Quality,
         "portable Lab offload is available for test runs",
+        TEST_LAB_SUPPORT,
     ),
-    lab_command_spec(
+    lab_command_spec_with_summary(
         "bench",
         CommandJsonFamily::Quality,
         "portable Lab offload is available for benchmark runs",
+        BENCH_LAB_SUPPORT,
     ),
-    lab_command_spec(
+    lab_command_spec_with_summary(
         "fuzz",
         CommandJsonFamily::Quality,
         "portable Lab offload is available for fuzz runs",
+        FUZZ_LAB_SUPPORT,
     ),
-    lab_command_spec_with_output_notes(
+    lab_command_spec_with_output_notes_and_summary(
         "trace",
         CommandJsonFamily::Quality,
         "portable Lab offload is available for trace runs",
         "runs trace workflows and records observation artifacts unless using read-only subcommands",
+        TRACE_LAB_SUPPORT,
     ),
     command_spec("observe", CommandJsonFamily::Quality),
-    lab_command_spec_with_output_notes(
+    lab_command_spec_with_output_notes_and_summary(
         "lint",
         CommandJsonFamily::Quality,
         "portable Lab offload is available for changed-scope lint runs",
         "runs lint workflows; pass --fix to apply auto-fixable findings in place",
+        LINT_LAB_SUPPORT,
     ),
     command_spec("db", CommandJsonFamily::Ops),
     command_spec("deps", CommandJsonFamily::Ops),
@@ -152,36 +329,41 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         "release execution mutates git tags/releases and may deploy; use --dry-run to plan and --apply for risky modes",
     ),
     command_spec("report", CommandJsonFamily::Workspace),
-    lab_command_spec(
+    lab_command_spec_with_summary(
         "review",
         CommandJsonFamily::Quality,
         "portable Lab offload is available for release-gate review runs",
+        REVIEW_LAB_SUPPORT,
     ),
-    lab_command_spec(
+    lab_command_spec_with_summary(
         "audit",
         CommandJsonFamily::Quality,
         "portable Lab offload is available for audit source runs",
+        AUDIT_LAB_SUPPORT,
     ),
     command_spec("audit-baseline", CommandJsonFamily::Quality),
-    lab_command_spec_with_output_notes(
+    lab_command_spec_with_output_notes_and_summary(
         "refactor",
         CommandJsonFamily::Workspace,
         "portable Lab offload is available for refactor source runs",
         "refactor subcommands can rewrite source files; use planning/dry-run modes where available",
+        REFACTOR_LAB_SUPPORT,
     ),
     command_spec("refs", CommandJsonFamily::Workspace),
-    lab_command_spec(
+    lab_command_spec_with_summary(
         "rig",
         CommandJsonFamily::Workspace,
         "portable Lab offload is available for rig check workflows",
+        RIG_LAB_SUPPORT,
     ),
     command_spec("runner", CommandJsonFamily::Workspace),
     command_spec("runtime", CommandJsonFamily::Workspace),
     command_spec("worktree", CommandJsonFamily::Workspace),
-    lab_command_spec(
+    lab_command_spec_with_summary(
         "tunnel",
         CommandJsonFamily::Workspace,
         "Lab runner routing covers tunnel preview and service workflows",
+        TUNNEL_LAB_SUPPORT,
     ),
     command_spec("runs", CommandJsonFamily::Workspace),
     command_spec("self", CommandJsonFamily::Ops),

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -38,10 +38,6 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
             ]),
             "bench",
         ),
-        (
-            parsed_command(&["homeboy", "bench", "history", "homeboy"]),
-            "bench",
-        ),
         (parsed_command(&["homeboy", "fuzz"]), "fuzz"),
         (parsed_command(&["homeboy", "fuzz", "run"]), "fuzz"),
         // `fuzz list` offloads (unlike `bench list`) because fuzz workloads are
@@ -267,34 +263,38 @@ fn unsupported_lab_command_cases() -> Vec<Commands> {
         ]),
         parsed_command(&["homeboy", "status"]),
         parsed_command(&["homeboy", "bench", "list"]),
+        parsed_command(&["homeboy", "bench", "history", "homeboy"]),
     ]
 }
 
 #[test]
 fn test_lab_runner_supported_labels_are_contract_owned() {
+    let spec_labels = crate::command_contract::COMMAND_SPECS
+        .iter()
+        .flat_map(|spec| spec.lab_support_summary.iter())
+        .map(|summary| summary.message_label)
+        .collect::<Vec<_>>();
+
     assert_eq!(
         lab_runner_supported_labels().as_slice(),
-        &[
-            "agent-task cook/run-plan",
-            "agent-task controller from-spec --resume/run-from-spec/materialize/resume",
-            "agent-task retry --run",
-            "agent-task run/run-next/status/logs/artifacts/review/list/active/latest/providers",
-            "agent-task fanout run-plan/submit-batch/status/artifacts",
-            "agent-task auth status",
-            "lint",
-            "test",
-            "audit",
-            "review",
-            "bench",
-            "fuzz",
-            "trace",
-            "refactor source runs",
-            "rig check",
-            "tunnel preview-consumer run",
-            "tunnel service expose",
-            "tunnel service start",
-        ]
+        spec_labels.as_slice(),
+        "Lab support labels should be generated from CommandSpec summary rows"
     );
+
+    let spec_contract_labels = crate::command_contract::COMMAND_SPECS
+        .iter()
+        .flat_map(|spec| spec.lab_support_summary.iter())
+        .flat_map(|summary| summary.contract_labels.iter().copied())
+        .collect::<std::collections::BTreeSet<_>>();
+
+    for (command, expected_label) in supported_lab_command_cases() {
+        let contract = command.lab_contract().expect("hot contract");
+        assert!(
+            spec_contract_labels.contains(contract.hot_label),
+            "CommandSpec Lab support summaries should include contract `{}` for `{expected_label}`",
+            contract.hot_label
+        );
+    }
     for label in lab_runner_supported_labels() {
         assert!(lab_runner_unsupported_message().contains(label));
         assert!(lab_runner_unsupported_hint().contains(label));
@@ -356,8 +356,11 @@ fn local_execution_policy_names_legacy_flag_combinations() {
 
 #[test]
 fn test_supports_lab_runner() {
-    for (command, _) in supported_lab_command_cases() {
-        assert!(command.supports_lab_runner());
+    for (command, expected_label) in supported_lab_command_cases() {
+        assert!(
+            command.supports_lab_runner(),
+            "expected `{expected_label}` to support Lab runner"
+        );
     }
     for command in unsupported_lab_command_cases() {
         assert!(!command.supports_lab_runner());
@@ -432,8 +435,10 @@ fn fuzz_run_and_list_offload_but_other_subcommands_stay_local() {
 
 #[test]
 fn test_lab_command_contracts_cover_hot_commands() {
-    for (command, _) in supported_lab_command_cases() {
-        let contract = command.lab_contract().expect("hot contract");
+    for (command, expected_label) in supported_lab_command_cases() {
+        let contract = command
+            .lab_contract()
+            .unwrap_or_else(|| panic!("expected `{expected_label}` to expose a hot contract"));
         assert!(
             lab_runner_summary_covers_contract_label(contract.hot_label),
             "Lab support summary omitted `{}`",


### PR DESCRIPTION
## Summary
- Add CommandSpec-owned Lab support summary rows and hot-label constants.
- Derive Lab runner support labels/contracts from COMMAND_SPECS instead of a duplicate lab.rs table.
- Replace the brittle hard-coded Lab summary label test with parity assertions against CommandSpec and actual parsed command contracts.
- Correct the stale bench history Lab-support test case to match current BenchArgs lab contract behavior.

## Tests
- cargo fmt --check
- cargo test command_contract
- cargo test command_surface

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the CommandSpec Lab summary metadata slice, updating tests, running verification, and preparing this PR description.