### PR TITLE
Fix generated controller next commands

### DIFF
--- a/src/core/agent_task_controller_service/run_failure_summary.rs
+++ b/src/core/agent_task_controller_service/run_failure_summary.rs
@@ -254,19 +254,26 @@ fn collect_evidence_refs(
         &mut refs,
         ControllerRunEvidenceRef {
             kind: "run_evidence".to_string(),
-            uri: format!("homeboy agent-task controller status {loop_id} --json"),
+            uri: format!("homeboy agent-task controller status {loop_id}"),
             label: Some("persisted controller run evidence".to_string()),
         },
     );
 
     if let Some(action) = failed_action {
         // Runner job logs.
+        let runner_id = find_all_strings(action, &["runner_id"])
+            .into_iter()
+            .next()
+            .or_else(|| find_all_strings(status, &["runner_id"]).into_iter().next());
         for job_id in find_all_strings(action, &["runner_job_id", "job_id"]) {
             push_ref(
                 &mut refs,
                 ControllerRunEvidenceRef {
                     kind: "runner_job_log".to_string(),
-                    uri: format!("homeboy logs runner-job {job_id}"),
+                    uri: runner_id
+                        .as_ref()
+                        .map(|runner_id| format!("homeboy runner job logs {runner_id} {job_id}"))
+                        .unwrap_or_else(|| format!("runner-job://{job_id}")),
                     label: Some(format!("runner job {job_id} log")),
                 },
             );
@@ -278,7 +285,7 @@ fn collect_evidence_refs(
                 &mut refs,
                 ControllerRunEvidenceRef {
                     kind: "run_evidence".to_string(),
-                    uri: format!("homeboy agent-task show {run_id} --json"),
+                    uri: format!("homeboy agent-task status {run_id} --full"),
                     label: Some(format!("agent-task run {run_id} evidence")),
                 },
             );
@@ -362,17 +369,19 @@ fn next_command(loop_id: &str, owner: OwnerSurface, action_status: Option<&str>)
         .unwrap_or(false)
     {
         return format!(
-            "homeboy agent-task controller status {loop_id} --json  # resolve the runner block, then re-run with --resume"
+            "homeboy agent-task controller status {loop_id}  # resolve the runner block, then re-run with --resume"
         );
     }
     match owner {
         OwnerSurface::LabRunner => {
-            format!("homeboy runner status  # then `homeboy agent-task controller status {loop_id} --json`")
+            format!(
+                "homeboy runner status  # then `homeboy agent-task controller status {loop_id}`"
+            )
         }
         OwnerSurface::WpCodebox | OwnerSurface::WordPressRuntime | OwnerSurface::ProviderPlugin => {
-            format!("homeboy agent-task controller status {loop_id} --json  # inspect provider/runtime evidence refs above")
+            format!("homeboy agent-task controller status {loop_id}  # inspect provider/runtime evidence refs above")
         }
-        _ => format!("homeboy agent-task controller status {loop_id} --json"),
+        _ => format!("homeboy agent-task controller status {loop_id}"),
     }
 }
 

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -14,6 +14,7 @@ use crate::core::agent_task_loop_controller::{
 };
 use crate::core::agent_task_scheduler::AgentTaskExecutionContext;
 use crate::test_support::with_isolated_home;
+use clap::Parser;
 use serde_json::json;
 use std::sync::{Arc, Mutex};
 
@@ -3334,6 +3335,7 @@ fn run_failure_summary_normalizes_nested_provider_failure() {
             "diagnostic": "PHP fatal: Uncaught Error: Class 'Foo' not found",
         },
         "execution": {
+            "runner_id": "homeboy-lab",
             "runner_job_id": "job-77",
             "diagnostics": [
                 { "message": "PHP fatal: Uncaught Error: Class 'Foo' not found" }
@@ -3361,6 +3363,7 @@ fn run_failure_summary_normalizes_nested_provider_failure() {
     assert_eq!(summary.provider.as_deref(), Some("wp-codebox"));
     assert_eq!(summary.failure_phase.as_deref(), Some("plugin_activation"));
     assert!(summary.next_command.contains("loop-9"));
+    assert_homeboy_command_parses(&summary.next_command);
 
     // Durable evidence refs: persisted run evidence, runner job log, per-run
     // evidence, and the declared provider artifact bundle.
@@ -3375,11 +3378,12 @@ fn run_failure_summary_normalizes_nested_provider_failure() {
     assert!(summary
         .evidence_refs
         .iter()
-        .any(|reference| reference.uri.contains("job-77")));
+        .any(|reference| reference.uri == "homeboy runner job logs homeboy-lab job-77"));
     assert!(summary
         .evidence_refs
         .iter()
         .any(|reference| reference.uri == "file:///runs/run-42/codebox.log"));
+    assert_emitted_homeboy_evidence_commands_parse(&summary);
 }
 
 #[test]
@@ -3400,11 +3404,13 @@ fn run_failure_summary_handles_runner_block_without_diagnostic_message() {
     assert_eq!(summary.owner_surface, "lab_runner");
     assert!(summary.root_blocker.contains("runner"));
     assert!(summary.next_command.contains("--resume"));
+    assert_homeboy_command_parses(&summary.next_command);
     // Still always surfaces the persisted run-evidence ref.
     assert!(summary
         .evidence_refs
         .iter()
         .any(|reference| reference.kind == "run_evidence"));
+    assert_emitted_homeboy_evidence_commands_parse(&summary);
 }
 
 #[test]
@@ -3421,6 +3427,28 @@ fn run_failure_summary_falls_back_to_stopped_reason() {
     assert!(summary.root_blocker.contains("max-actions"));
     assert_eq!(summary.phase.as_deref(), Some("plan"));
     assert!(!summary.evidence_refs.is_empty());
+    assert_homeboy_command_parses(&summary.next_command);
+    assert_emitted_homeboy_evidence_commands_parse(&summary);
+}
+
+fn assert_emitted_homeboy_evidence_commands_parse(summary: &ControllerRunFailureSummary) {
+    for reference in &summary.evidence_refs {
+        if reference.uri.starts_with("homeboy ") {
+            assert_homeboy_command_parses(&reference.uri);
+        }
+    }
+}
+
+fn assert_homeboy_command_parses(command: &str) {
+    let command = command.split('#').next().unwrap_or(command).trim();
+    let argv: Vec<&str> = command.split_whitespace().collect();
+    assert!(
+        !argv.is_empty(),
+        "expected non-empty emitted Homeboy command: {command:?}"
+    );
+    crate::cli_surface::Cli::try_parse_from(argv).unwrap_or_else(|error| {
+        panic!("emitted Homeboy command did not parse: {command}\n{error}")
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace stale controller failure-summary commands that used unsupported `--json` flags.
- Replace nonexistent `homeboy agent-task show` evidence refs with `homeboy agent-task status --full`.
- Emit current runner job log commands when a runner id is available, and avoid fake Homeboy commands when only the job id is known.
- Add parser-backed regression assertions for generated next commands and Homeboy evidence refs.

Fixes #6527.

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo test run_failure_summary --lib`
- `cargo test --test command_surface_test`
- `cargo test --lib` (fails: 6088 passed, 11 failed, 18 ignored; failures are outside this change area: Lab command contracts/env setup, process termination timing, release proxy formatting, workspace materialization, and related existing environment-sensitive tests)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the command-generation fix, adding regression tests, and running verification.