### PR TITLE
Add runner handoff identity contract

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -26,8 +26,8 @@ mod spec;
 pub use lab::{
     lab_runner_support_summary, lab_runner_supported_contract_labels, lab_runner_supported_labels,
     lab_runner_supports_contract_label, lab_runner_unsupported_hint,
-    lab_runner_unsupported_message, CommandPortabilityContract, LabCommandContract,
-    LabCommandPortability, LabCommandRequiredTool, LabCommandRouteContract,
+    lab_runner_unsupported_message, AgentTaskDispatchIdentity, CommandPortabilityContract,
+    LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabCommandRouteContract,
     LabLocalExecutionPolicy, LabLocalHotPolicy, LabRoutingPolicy, LabRunnerSupportSummary,
     LabSelectedRunnerFallbackPolicy, LabSourcePathMode, LabWorkspaceModePolicy,
     RunnerHandoffEnvelope, RunnerHandoffFollowCommands, RunnerWorkload, RunnerWorkloadArtifactRef,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -232,6 +232,8 @@ pub struct RunnerHandoffEnvelope {
     pub schema: String,
     pub status: String,
     pub execution_location: String,
+    #[serde(default)]
+    pub identity: AgentTaskDispatchIdentity,
     pub runner_id: String,
     pub job_id: String,
     pub durable_run_id: Option<String>,
@@ -239,6 +241,18 @@ pub struct RunnerHandoffEnvelope {
     pub mirror_run_id: Option<String>,
     pub remote_cwd: String,
     pub follow_commands: RunnerHandoffFollowCommands,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AgentTaskDispatchIdentity {
+    pub runner_id: String,
+    pub runner_job_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persisted_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handoff_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -277,6 +291,13 @@ impl RunnerHandoffEnvelope {
             schema: RUNNER_HANDOFF_ENVELOPE_SCHEMA.to_string(),
             status: "handoff_complete".to_string(),
             execution_location: format!("runner:{runner_id}"),
+            identity: AgentTaskDispatchIdentity {
+                runner_id: runner_id.to_string(),
+                runner_job_id: job_id.to_string(),
+                persisted_run_id: mirror_run_id.clone(),
+                run_id: mirror_run_id.clone(),
+                handoff_id: Some(format!("runner:{runner_id}:job:{job_id}")),
+            },
             runner_id: runner_id.to_string(),
             job_id: job_id.to_string(),
             durable_run_id: mirror_run_id.clone(),

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -341,6 +341,20 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
         );
         assert_eq!(envelope.status, "handoff_complete");
         assert_eq!(envelope.execution_location, "runner:lab");
+        assert_eq!(envelope.identity.runner_id, "lab");
+        assert_eq!(envelope.identity.runner_job_id, job_id);
+        assert_eq!(
+            envelope.identity.persisted_run_id.as_deref(),
+            Some("agent-task-run-6454")
+        );
+        assert_eq!(
+            envelope.identity.run_id.as_deref(),
+            Some("agent-task-run-6454")
+        );
+        assert_eq!(
+            envelope.identity.handoff_id.as_deref(),
+            Some(format!("runner:lab:job:{job_id}").as_str())
+        );
         assert_eq!(envelope.runner_id, "lab");
         assert_eq!(envelope.job_id, job_id);
         assert_eq!(envelope.remote_cwd, "/srv/homeboy/project");
@@ -357,6 +371,14 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             Some("agent-task-run-6454")
         );
         assert_eq!(json["status"], "handoff_complete");
+        assert_eq!(json["identity"]["runner_id"], "lab");
+        assert_eq!(json["identity"]["runner_job_id"], job_id);
+        assert_eq!(json["identity"]["persisted_run_id"], "agent-task-run-6454");
+        assert_eq!(json["identity"]["run_id"], "agent-task-run-6454");
+        assert_eq!(
+            json["identity"]["handoff_id"],
+            format!("runner:lab:job:{job_id}")
+        );
         assert_eq!(json["job_id"], job_id);
         assert_eq!(json["durable_run_id"], "agent-task-run-6454");
         assert_eq!(
@@ -390,6 +412,11 @@ fn runner_handoff_envelope_omits_agent_task_followups_without_run_id() {
     );
     assert_eq!(json["status"], "handoff_complete");
     assert_eq!(json["execution_location"], "runner:lab");
+    assert_eq!(json["identity"]["runner_id"], "lab");
+    assert_eq!(json["identity"]["runner_job_id"], "job-123");
+    assert_eq!(json["identity"]["handoff_id"], "runner:lab:job:job-123");
+    assert!(json["identity"].get("persisted_run_id").is_none());
+    assert!(json["identity"].get("run_id").is_none());
     assert_eq!(json["durable_run_id"], Value::Null);
     assert_eq!(json["persisted_run_id"], Value::Null);
     assert_eq!(json["mirror_run_id"], Value::Null);


### PR DESCRIPTION
## Summary
- Add a typed `AgentTaskDispatchIdentity` to the runner handoff envelope.
- Populate identity from locally available detached handoff fields while preserving existing top-level JSON keys and follow commands.
- Cover populated identity serialization and omitted optional run-id fields.

## Tests
- `cargo fmt`
- `cargo test core::runner::execution::tests::handoff`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the typed handoff identity slice, focused test updates, formatting, verification, commit, push, and PR creation.