### PR TITLE
Make Composer installs deterministic

### DIFF
--- a/src/extensions/deps_provider.rs
+++ b/src/extensions/deps_provider.rs
@@ -306,7 +306,7 @@ impl ComposerDependencyProvider {
         _component: &Component,
         path: &Path,
     ) -> Result<Option<DependencyCommandResult>> {
-        let args = vec!["install".to_string(), "--no-interaction".to_string()];
+        let args = composer_install_command_args();
         let output = Command::new("composer")
             .args(&args)
             .current_dir(path)
@@ -347,6 +347,14 @@ impl ComposerDependencyProvider {
             stderr,
         }))
     }
+}
+
+pub fn composer_install_command_args() -> Vec<String> {
+    vec![
+        "install".to_string(),
+        "--no-interaction".to_string(),
+        "--no-progress".to_string(),
+    ]
 }
 
 pub(crate) struct ComponentScriptDependencyProvider;

--- a/tests/deps_test.rs
+++ b/tests/deps_test.rs
@@ -178,6 +178,14 @@ fn test_composer_command_args() {
 }
 
 #[test]
+fn composer_install_command_args_are_runtime_prep_safe() {
+    assert_eq!(
+        deps_provider::composer_install_command_args(),
+        vec!["install", "--no-interaction", "--no-progress"]
+    );
+}
+
+#[test]
 fn stack_plan_walks_declared_downstream_edges_in_order() {
     let components = vec![
         stack_component(


### PR DESCRIPTION
## Summary
- centralize Composer install args for dependency-provider installs
- add --no-progress to provider-owned Composer installs for deterministic runtime prep
- cover the generated install command shape in deps tests

## Tests
- cargo test --test deps_test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, tests, and PR preparation