### PR TITLE
Add trace profile compare-bundle metadata

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1,4 +1,4 @@
-use clap::Args;
+use clap::{Args, ValueEnum};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -925,6 +925,13 @@ fn resolve_trace_profile_args(args: &mut TraceArgs) -> homeboy::core::Result<()>
     if args.comp.component.is_none() {
         args.comp.component = resolved.profile.component.clone();
     }
+
+    validate_trace_profile_required_env(profile_id, &resolved.profile.required_env)?;
+
+    if args.comp.component.as_deref() == Some("compare-bundle") {
+        apply_trace_profile_compare_bundle_args(args, &resolved.profile)?;
+    }
+
     if args.scenario.is_none() && args.scenario_arg.is_none() {
         args.scenario = resolved.profile.scenario.clone();
     }
@@ -959,6 +966,76 @@ fn resolve_trace_profile_args(args: &mut TraceArgs) -> homeboy::core::Result<()>
     let mut variants = resolved.profile.variants.clone();
     variants.extend(args.variants.clone());
     args.variants = variants;
+    Ok(())
+}
+
+fn validate_trace_profile_required_env(
+    profile_id: &str,
+    required_env: &[String],
+) -> homeboy::core::Result<()> {
+    let missing = required_env
+        .iter()
+        .filter(|name| {
+            std::env::var(name.as_str())
+                .map(|value| value.is_empty())
+                .unwrap_or(true)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "--profile",
+        format!(
+            "trace profile '{}' requires environment variable{} {}",
+            profile_id,
+            if missing.len() == 1 { "" } else { "s" },
+            missing.join(", ")
+        ),
+        Some("export the required environment before running this trace profile".to_string()),
+        Some(missing),
+    ))
+}
+
+fn apply_trace_profile_compare_bundle_args(
+    args: &mut TraceArgs,
+    profile: &rig::TraceProfileSpec,
+) -> homeboy::core::Result<()> {
+    let Some(compare_bundle) = profile.compare_bundle.as_ref() else {
+        return Ok(());
+    };
+
+    if args.scenario.is_none() {
+        args.scenario = Some(compare_bundle.component.clone());
+    }
+    if args.scenario_arg.is_none()
+        && args.compare_after.is_none()
+        && !compare_bundle.scenarios.is_empty()
+    {
+        args.scenario_arg = Some(compare_bundle.scenarios.join(","));
+    }
+    if args.repeat == 1 {
+        if let Some(repeat) = compare_bundle.repeat {
+            args.repeat = repeat;
+        }
+    }
+    if args.schedule == TraceSchedule::Grouped {
+        if let Some(schedule) = compare_bundle.schedule.as_deref() {
+            args.schedule = TraceSchedule::from_str(schedule, true).map_err(|_| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "trace_profiles.compare_bundle.schedule",
+                    format!("unsupported trace compare-bundle schedule '{}'", schedule),
+                    Some("use grouped or interleaved".to_string()),
+                    None,
+                )
+            })?;
+        }
+    }
+    if compare_bundle.canonical {
+        args.canonical = true;
+    }
     Ok(())
 }
 

--- a/src/commands/trace/profile_tests.rs
+++ b/src/commands/trace/profile_tests.rs
@@ -150,6 +150,73 @@ fn trace_profile_cli_fields_override_profile_fields() {
 }
 
 #[test]
+fn trace_profile_required_env_fails_before_run() {
+    with_isolated_home(|home| {
+        let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+        fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+        fs::write(
+            rig_dir.join("wallet-rig.json"),
+            r#"{
+                "components": { "stripe": { "path": "/tmp/stripe" } },
+                "trace_profiles": {
+                    "wallet": {
+                        "component": "stripe",
+                        "scenario": "wallet",
+                        "required_env": ["HOMEBOY_PROFILE_TEST_MISSING_ENV"]
+                    }
+                }
+            }"#,
+        )
+        .expect("write rig");
+        std::env::remove_var("HOMEBOY_PROFILE_TEST_MISSING_ENV");
+
+        let err = resolve_trace_profile_args(&mut trace_args_for_profile("wallet"))
+            .expect_err("missing env should fail profile resolution");
+
+        assert!(err.to_string().contains("HOMEBOY_PROFILE_TEST_MISSING_ENV"));
+    });
+}
+
+#[test]
+fn trace_profile_resolves_compare_bundle_metadata() {
+    with_isolated_home(|home| {
+        let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+        fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+        fs::write(
+            rig_dir.join("stripe-rig.json"),
+            r#"{
+                "components": { "stripe": { "path": "/tmp/stripe" } },
+                "trace_profiles": {
+                    "wallet-compare": {
+                        "compare_bundle": {
+                            "component": "stripe",
+                            "scenarios": ["waterfall", "scroll"],
+                            "repeat": 5,
+                            "schedule": "interleaved",
+                            "canonical": true
+                        }
+                    }
+                }
+            }"#,
+        )
+        .expect("write rig");
+        let mut args = trace_args_for_profile("wallet-compare");
+        args.comp.component = Some("compare-bundle".to_string());
+        args.baseline_target = Some("origin/main".to_string());
+        args.candidate = Some("HEAD".to_string());
+
+        resolve_trace_profile_args(&mut args).expect("profile resolves");
+
+        assert_eq!(args.rig.as_deref(), Some("stripe-rig"));
+        assert_eq!(args.scenario.as_deref(), Some("stripe"));
+        assert_eq!(args.scenario_arg.as_deref(), Some("waterfall,scroll"));
+        assert_eq!(args.repeat, 5);
+        assert_eq!(args.schedule, TraceSchedule::Interleaved);
+        assert!(args.canonical);
+    });
+}
+
+#[test]
 fn trace_list_profiles_lists_rig_profiles() {
     with_isolated_home(|home| {
         let component_dir = tempfile::TempDir::new().expect("component dir");

--- a/src/core/rig/spec/trace.rs
+++ b/src/core/rig/spec/trace.rs
@@ -73,8 +73,32 @@ pub struct TraceProfileSpec {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub settings: BTreeMap<String, serde_json::Value>,
 
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_env: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compare_bundle: Option<TraceCompareBundleProfileSpec>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_preview: Option<TracePublicPreviewSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TraceCompareBundleProfileSpec {
+    pub component: String,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scenarios: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repeat: Option<usize>,
+
+    #[serde(default)]
+    pub canonical: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- add generic trace profile required environment validation
- add trace profile compare-bundle metadata for component, scenarios, repeat, schedule, and canonical defaults
- cover required-env and compare-bundle profile resolution with tests

## Tests
- cargo test trace_profile --quiet
- cargo fmt --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the profile metadata extension, tests, and PR preparation.