### PR TITLE
Declare runner workload followups

### DIFF
--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -458,45 +458,7 @@ fn lab_runner_homeboy_refresh_commands(runner_id: &str) -> Vec<String> {
 }
 
 pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
-    let mut followups = vec![
-        LabFollowup {
-            label: "recent_runs".to_string(),
-            command: "homeboy runs list --limit 5".to_string(),
-            purpose: "Find recent persisted run records before digging into runner state."
-                .to_string(),
-        },
-        LabFollowup {
-            label: "latest_bench_run".to_string(),
-            command: "homeboy runs latest-run --kind bench".to_string(),
-            purpose: "Resolve the latest benchmark run id for evidence inspection.".to_string(),
-        },
-        LabFollowup {
-            label: "latest_fuzz_run".to_string(),
-            command: "homeboy runs latest-run --kind fuzz".to_string(),
-            purpose: "Resolve the latest fuzz run id for evidence inspection.".to_string(),
-        },
-        LabFollowup {
-            label: "run_artifacts".to_string(),
-            command: "homeboy runs artifacts <run-id>".to_string(),
-            purpose: "List recorded run artifacts through Homeboy.".to_string(),
-        },
-        LabFollowup {
-            label: "run_evidence".to_string(),
-            command: "homeboy runs evidence <run-id>".to_string(),
-            purpose: "Show stable evidence summary and reviewer-facing commands for one run."
-                .to_string(),
-        },
-        LabFollowup {
-            label: "run_refs".to_string(),
-            command: "homeboy runs refs --kind bench --limit 10".to_string(),
-            purpose: "List recent benchmark run and artifact refs.".to_string(),
-        },
-        LabFollowup {
-            label: "fuzz_run_refs".to_string(),
-            command: "homeboy runs refs --kind fuzz --limit 10".to_string(),
-            purpose: "List recent fuzz run and artifact refs.".to_string(),
-        },
-    ];
+    let mut followups = declared_run_followups_for_legacy("managed_followups", None, runner_id);
     let Some(runner_id) = runner_id else {
         return followups;
     };
@@ -537,6 +499,7 @@ pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
     ]);
     followups.extend(declared_followups_for_legacy(
         "managed_followups",
+        None,
         Some(runner_id),
     ));
     if let Ok(path) = std::env::current_dir() {
@@ -552,13 +515,111 @@ pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
     followups
 }
 
-fn declared_followups_for_legacy(legacy_output: &str, runner_id: Option<&str>) -> Vec<LabFollowup> {
+pub(crate) fn declared_run_followups_for_legacy(
+    legacy_output: &str,
+    run_kind: Option<&str>,
+    _runner_id: Option<&str>,
+) -> Vec<LabFollowup> {
+    default_run_followup_declarations()
+        .iter()
+        .filter(|followup| followup_matches(followup, legacy_output, run_kind))
+        .map(declared_run_followup)
+        .collect()
+}
+
+fn declared_followups_for_legacy(
+    legacy_output: &str,
+    run_kind: Option<&str>,
+    runner_id: Option<&str>,
+) -> Vec<LabFollowup> {
     declared_diagnostics_contracts()
         .iter()
         .flat_map(|contract| contract.followups.iter())
-        .filter(|followup| followup.legacy_output.as_deref() == Some(legacy_output))
+        .filter(|followup| followup_matches(followup, legacy_output, run_kind))
         .map(|followup| declared_followup(followup, runner_id))
         .collect()
+}
+
+fn followup_matches(
+    followup: &AgentRuntimeDiagnosticFollowup,
+    legacy_output: &str,
+    run_kind: Option<&str>,
+) -> bool {
+    if followup.legacy_output.as_deref() != Some(legacy_output) {
+        return false;
+    }
+    let declared_kind = followup
+        .run_kind
+        .as_deref()
+        .or(followup.workload.as_deref());
+    match (run_kind, declared_kind) {
+        (None, _) => true,
+        (Some(_), None) => true,
+        (Some(run_kind), Some(declared_kind)) => run_kind == declared_kind,
+    }
+}
+
+fn default_run_followup_declarations() -> Vec<AgentRuntimeDiagnosticFollowup> {
+    vec![
+        run_followup(
+            "recent_runs",
+            None,
+            "homeboy runs list --limit 5",
+            "Find recent persisted run records before digging into runner state.",
+        ),
+        run_followup(
+            "latest_bench_run",
+            Some("bench"),
+            "homeboy runs latest-run --kind bench",
+            "Resolve the latest benchmark run id for evidence inspection.",
+        ),
+        run_followup(
+            "latest_fuzz_run",
+            Some("fuzz"),
+            "homeboy runs latest-run --kind fuzz",
+            "Resolve the latest fuzz run id for evidence inspection.",
+        ),
+        run_followup(
+            "run_artifacts",
+            None,
+            "homeboy runs artifacts <run-id>",
+            "List recorded run artifacts through Homeboy.",
+        ),
+        run_followup(
+            "run_evidence",
+            None,
+            "homeboy runs evidence <run-id>",
+            "Show stable evidence summary and reviewer-facing commands for one run.",
+        ),
+        run_followup(
+            "run_refs",
+            Some("bench"),
+            "homeboy runs refs --kind bench --limit 10",
+            "List recent benchmark run and artifact refs.",
+        ),
+        run_followup(
+            "fuzz_run_refs",
+            Some("fuzz"),
+            "homeboy runs refs --kind fuzz --limit 10",
+            "List recent fuzz run and artifact refs.",
+        ),
+    ]
+}
+
+fn run_followup(
+    label: &str,
+    run_kind: Option<&str>,
+    command_script: &str,
+    purpose: &str,
+) -> AgentRuntimeDiagnosticFollowup {
+    AgentRuntimeDiagnosticFollowup {
+        label: label.to_string(),
+        legacy_output: Some("managed_followups".to_string()),
+        run_kind: run_kind.map(str::to_string),
+        workload: None,
+        command_script: command_script.to_string(),
+        purpose: purpose.to_string(),
+    }
 }
 
 fn declared_followup(
@@ -568,6 +629,14 @@ fn declared_followup(
     LabFollowup {
         label: declaration.label.clone(),
         command: diagnostic_command(runner_id, &declaration.command_script),
+        purpose: declaration.purpose.clone(),
+    }
+}
+
+fn declared_run_followup(declaration: &AgentRuntimeDiagnosticFollowup) -> LabFollowup {
+    LabFollowup {
+        label: declaration.label.clone(),
+        command: declaration.command_script.clone(),
         purpose: declaration.purpose.clone(),
     }
 }

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -11,7 +11,8 @@ use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, 
 
 use super::super::jobs::format_job_event;
 use super::super::status::{
-    declared_runtime_diagnostics, declared_runtime_source_diagnostics, declared_tool_diagnostics,
+    declared_run_followups_for_legacy, declared_runtime_diagnostics,
+    declared_runtime_source_diagnostics, declared_tool_diagnostics,
     runner_artifact_feature_diagnostics, runner_status_operator_commands,
 };
 
@@ -268,6 +269,45 @@ fn unknown_runtime_declaration_does_not_emit_wp_specific_guidance() {
     assert!(serialized.contains("other-runtime"));
     assert!(!serialized.contains("wp-codebox"));
     assert!(!serialized.contains("HOMEBOY_WP_CODEBOX"));
+}
+
+#[test]
+fn declared_bench_followups_preserve_existing_status_guidance() {
+    let followups = declared_run_followups_for_legacy("managed_followups", Some("bench"), None);
+    let serialized = serde_json::to_string(&followups).expect("serialize followups");
+
+    assert!(serialized.contains("latest_bench_run"));
+    assert!(serialized.contains("homeboy runs latest-run --kind bench"));
+    assert!(serialized.contains("homeboy runs refs --kind bench --limit 10"));
+    assert!(serialized.contains("homeboy runs artifacts <run-id>"));
+    assert!(!serialized.contains("latest_fuzz_run"));
+    assert!(!serialized.contains("homeboy runs refs --kind fuzz --limit 10"));
+}
+
+#[test]
+fn declared_fuzz_followups_preserve_existing_status_guidance() {
+    let followups = declared_run_followups_for_legacy("managed_followups", Some("fuzz"), None);
+    let serialized = serde_json::to_string(&followups).expect("serialize followups");
+
+    assert!(serialized.contains("latest_fuzz_run"));
+    assert!(serialized.contains("homeboy runs latest-run --kind fuzz"));
+    assert!(serialized.contains("homeboy runs refs --kind fuzz --limit 10"));
+    assert!(serialized.contains("homeboy runs evidence <run-id>"));
+    assert!(!serialized.contains("latest_bench_run"));
+    assert!(!serialized.contains("homeboy runs refs --kind bench --limit 10"));
+}
+
+#[test]
+fn unknown_workload_does_not_emit_declared_bench_or_fuzz_followups() {
+    let followups = declared_run_followups_for_legacy("managed_followups", Some("unknown"), None);
+    let serialized = serde_json::to_string(&followups).expect("serialize followups");
+
+    assert!(serialized.contains("recent_runs"));
+    assert!(serialized.contains("run_artifacts"));
+    assert!(!serialized.contains("latest_bench_run"));
+    assert!(!serialized.contains("latest_fuzz_run"));
+    assert!(!serialized.contains("--kind bench"));
+    assert!(!serialized.contains("--kind fuzz"));
 }
 
 #[test]

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -192,6 +192,10 @@ pub struct AgentRuntimeDiagnosticFollowup {
     pub label: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub legacy_output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workload: Option<String>,
     pub command_script: String,
     pub purpose: String,
 }


### PR DESCRIPTION
## Summary
- add run-kind/workload selectors to agent runtime diagnostic followups
- render bench/fuzz runner status followups from default run-kind declarations instead of direct LabFollowup literals
- add focused coverage for bench, fuzz, and unknown workload followup filtering

## Tests
- cargo fmt
- cargo test commands::runner::tests::status
- cargo test agent_runtime_manifest
- cargo test runner_status_includes_lab_diagnostics

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the manifest selector surface, runner status rendering changes, tests, and PR preparation.