### PR TITLE
Move top-level safety metadata into CommandSpec

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -46,7 +46,8 @@ pub use output::{
 pub use public_variants::{PublicOutputVariantContract, PUBLIC_OUTPUT_VARIANT_CONTRACTS};
 pub use spec::{
     registered_command, registered_command_dispatch_family, registered_command_json_family,
-    CommandLabSupportSummary, CommandRegistryEntry, CommandSpec, COMMAND_REGISTRY, COMMAND_SPECS,
+    CommandLabSupportSummary, CommandRegistryEntry, CommandSafetySpec, CommandSpec,
+    COMMAND_REGISTRY, COMMAND_SPECS,
 };
 pub(crate) use spec::{
     AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REVIEW_LAB_LABEL,

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -168,6 +168,14 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         metadata.output_notes = top_level.output_notes;
         metadata.lab_supported = top_level.lab_supported;
         metadata.lab_notes = top_level.lab_notes;
+
+        if path.len() == 1 {
+            metadata.mutates = top_level.safety.mutates;
+            metadata.operator = top_level.safety.operator;
+            metadata.dry_run_flag = top_level.safety.dry_run_flag;
+            metadata.risk_exemption = top_level.safety.risk_exemption;
+            metadata.dangerous_flags = top_level.safety.dangerous_flags.to_vec();
+        }
     }
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
@@ -179,37 +187,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
                 "default JSON output is non-mutating; pass --write to write markdown docs to disk";
             metadata.dangerous_flags = vec!["--write"];
         }
-        ["deploy"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec!["--head", "--force"];
-        }
-        ["release"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec![
-                "--apply",
-                "--deploy",
-                "--recover",
-                "--retag",
-                "--head",
-                "--skip-checks",
-                "--force-lower-bump",
-            ];
-        }
-        ["upgrade"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.dangerous_flags = vec!["--force", "--upgrade-runner"];
-        }
-        ["trace"] => {
-            metadata.mutates = true;
-        }
-        ["lint"] => {
-            metadata.dangerous_flags = vec!["--fix", "--force"];
-        }
         ["deps", "install"] | ["deps", "update"] | ["deps", "stack", "apply"] => {
             metadata.mutates = true;
             metadata.output_notes =
@@ -219,10 +196,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.output_notes = "commits and pushes prepared CI autofix changes";
-        }
-        ["cleanup"] => {
-            metadata.mutates = true;
-            metadata.dangerous_flags = vec!["--apply"];
         }
         ["cleanup", "artifacts"] => {
             metadata.mutates = true;
@@ -399,11 +372,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         | ["file", "sync"] => {
             metadata.mutates = true;
         }
-        ["triage"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.dangerous_flags = vec!["--auto-merge"];
-        }
         ["fleet", "exec"] => {
             metadata.mutates = true;
             metadata.operator = true;
@@ -468,10 +436,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.output_notes =
                 "mutates persisted audit baseline data in component configuration";
-        }
-        ["refactor"] => {
-            metadata.mutates = true;
-            metadata.dangerous_flags = vec!["--write", "--commit"];
         }
         ["refactor", "rename"]
         | ["refactor", "add"]
@@ -647,9 +611,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.operator = true;
             metadata.output_notes = "executes extension-owned runtime commands with forwarded arguments that may mutate the target system";
             metadata.dangerous_flags = vec!["extension runtime command", "passthrough args"];
-        }
-        ["undo"] => {
-            metadata.mutates = true;
         }
         ["undo", "delete"] => {
             metadata.mutates = true;

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -13,6 +13,7 @@ pub struct CommandSpec {
     pub name: &'static str,
     pub json_family: CommandJsonFamily,
     pub docs_slug: Option<&'static str>,
+    pub safety: CommandSafetySpec,
     pub output_notes: &'static str,
     pub lab_supported: bool,
     pub lab_notes: &'static str,
@@ -26,6 +27,27 @@ pub struct CommandLabSupportSummary {
     pub contract_labels: &'static [&'static str],
     pub message_label: &'static str,
     pub hint_label: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandSafetySpec {
+    pub mutates: bool,
+    pub operator: bool,
+    pub dry_run_flag: Option<&'static str>,
+    pub risk_exemption: Option<&'static str>,
+    pub dangerous_flags: &'static [&'static str],
+}
+
+impl CommandSafetySpec {
+    pub const fn read_only() -> Self {
+        Self {
+            mutates: false,
+            operator: false,
+            dry_run_flag: None,
+            risk_exemption: None,
+            dangerous_flags: &[],
+        }
+    }
 }
 
 pub const DEFAULT_LAB_UNSUPPORTED_NOTES: &str =
@@ -77,10 +99,34 @@ const fn command_spec(name: &'static str, json_family: CommandJsonFamily) -> Com
         name,
         json_family,
         docs_slug: Some(name),
+        safety: CommandSafetySpec::read_only(),
         output_notes: "standard CLI output contract",
         lab_supported: false,
         lab_notes: DEFAULT_LAB_UNSUPPORTED_NOTES,
         lab_support_summary: &[],
+    }
+}
+
+const fn command_spec_with_safety(
+    name: &'static str,
+    json_family: CommandJsonFamily,
+    safety: CommandSafetySpec,
+) -> CommandSpec {
+    CommandSpec {
+        safety,
+        ..command_spec(name, json_family)
+    }
+}
+
+const fn command_spec_with_output_notes_and_safety(
+    name: &'static str,
+    json_family: CommandJsonFamily,
+    output_notes: &'static str,
+    safety: CommandSafetySpec,
+) -> CommandSpec {
+    CommandSpec {
+        safety,
+        ..command_spec_with_output_notes(name, json_family, output_notes)
     }
 }
 
@@ -266,6 +312,55 @@ const TUNNEL_LAB_SUPPORT: &[CommandLabSupportSummary] = &[
     },
 ];
 
+const DEPLOY_DANGEROUS_FLAGS: &[&str] = &["--head", "--force"];
+const RELEASE_DANGEROUS_FLAGS: &[&str] = &[
+    "--apply",
+    "--deploy",
+    "--recover",
+    "--retag",
+    "--head",
+    "--skip-checks",
+    "--force-lower-bump",
+];
+const UPGRADE_DANGEROUS_FLAGS: &[&str] = &["--force", "--upgrade-runner"];
+const LINT_DANGEROUS_FLAGS: &[&str] = &["--fix", "--force"];
+const CLEANUP_DANGEROUS_FLAGS: &[&str] = &["--apply"];
+const TRIAGE_DANGEROUS_FLAGS: &[&str] = &["--auto-merge"];
+const REFACTOR_DANGEROUS_FLAGS: &[&str] = &["--write", "--commit"];
+
+const fn mutating_safety() -> CommandSafetySpec {
+    CommandSafetySpec {
+        mutates: true,
+        operator: false,
+        dry_run_flag: None,
+        risk_exemption: None,
+        dangerous_flags: &[],
+    }
+}
+
+const fn operator_safety(
+    dry_run_flag: Option<&'static str>,
+    dangerous_flags: &'static [&'static str],
+) -> CommandSafetySpec {
+    CommandSafetySpec {
+        mutates: true,
+        operator: true,
+        dry_run_flag,
+        risk_exemption: None,
+        dangerous_flags,
+    }
+}
+
+const fn guarded_safety(dangerous_flags: &'static [&'static str]) -> CommandSafetySpec {
+    CommandSafetySpec {
+        mutates: false,
+        operator: false,
+        dry_run_flag: None,
+        risk_exemption: None,
+        dangerous_flags,
+    }
+}
+
 pub const COMMAND_SPECS: &[CommandSpec] = &[
     lab_command_spec_with_summary(
         "agent-task",
@@ -294,21 +389,27 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         "portable Lab offload is available for fuzz runs",
         FUZZ_LAB_SUPPORT,
     ),
-    lab_command_spec_with_output_notes_and_summary(
-        "trace",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for trace runs",
-        "runs trace workflows and records observation artifacts unless using read-only subcommands",
-        TRACE_LAB_SUPPORT,
-    ),
+    CommandSpec {
+        safety: mutating_safety(),
+        ..lab_command_spec_with_output_notes_and_summary(
+            "trace",
+            CommandJsonFamily::Quality,
+            "portable Lab offload is available for trace runs",
+            "runs trace workflows and records observation artifacts unless using read-only subcommands",
+            TRACE_LAB_SUPPORT,
+        )
+    },
     command_spec("observe", CommandJsonFamily::Quality),
-    lab_command_spec_with_output_notes_and_summary(
-        "lint",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for changed-scope lint runs",
-        "runs lint workflows; pass --fix to apply auto-fixable findings in place",
-        LINT_LAB_SUPPORT,
-    ),
+    CommandSpec {
+        safety: guarded_safety(LINT_DANGEROUS_FLAGS),
+        ..lab_command_spec_with_output_notes_and_summary(
+            "lint",
+            CommandJsonFamily::Quality,
+            "portable Lab offload is available for changed-scope lint runs",
+            "runs lint workflows; pass --fix to apply auto-fixable findings in place",
+            LINT_LAB_SUPPORT,
+        )
+    },
     command_spec("db", CommandJsonFamily::Ops),
     command_spec("deps", CommandJsonFamily::Ops),
     command_spec("ci", CommandJsonFamily::Ops),
@@ -316,8 +417,16 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     command_spec("file", CommandJsonFamily::Ops),
     command_spec("fleet", CommandJsonFamily::Ops),
     command_spec("logs", CommandJsonFamily::Ops),
-    command_spec("triage", CommandJsonFamily::Ops),
-    command_spec("deploy", CommandJsonFamily::Ops),
+    command_spec_with_safety(
+        "triage",
+        CommandJsonFamily::Ops,
+        operator_safety(None, TRIAGE_DANGEROUS_FLAGS),
+    ),
+    command_spec_with_safety(
+        "deploy",
+        CommandJsonFamily::Ops,
+        operator_safety(Some("--dry-run"), DEPLOY_DANGEROUS_FLAGS),
+    ),
     command_spec("component", CommandJsonFamily::Workspace),
     command_spec("config", CommandJsonFamily::Workspace),
     command_spec("daemon", CommandJsonFamily::Ops),
@@ -326,20 +435,28 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     command_spec("docs", CommandJsonFamily::Workspace),
     manifest_command_spec(),
     command_spec("changelog", CommandJsonFamily::Workspace),
-    command_spec_with_output_notes(
+    command_spec_with_output_notes_and_safety(
         "cleanup",
         CommandJsonFamily::Workspace,
         "cleanup subcommands report plans by default and require --apply for removals",
+        CommandSafetySpec {
+            mutates: true,
+            operator: false,
+            dry_run_flag: None,
+            risk_exemption: None,
+            dangerous_flags: CLEANUP_DANGEROUS_FLAGS,
+        },
     ),
     command_spec("git", CommandJsonFamily::Ops),
     command_spec("issues", CommandJsonFamily::Ops),
     command_spec("version", CommandJsonFamily::Workspace),
     command_spec("build", CommandJsonFamily::Workspace),
     command_spec("changes", CommandJsonFamily::Workspace),
-    command_spec_with_output_notes(
+    command_spec_with_output_notes_and_safety(
         "release",
         CommandJsonFamily::Workspace,
         "release execution mutates git tags/releases and may deploy; use --dry-run to plan and --apply for risky modes",
+        operator_safety(Some("--dry-run"), RELEASE_DANGEROUS_FLAGS),
     ),
     command_spec("report", CommandJsonFamily::Workspace),
     lab_command_spec_with_summary(
@@ -355,13 +472,22 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         AUDIT_LAB_SUPPORT,
     ),
     command_spec("audit-baseline", CommandJsonFamily::Quality),
-    lab_command_spec_with_output_notes_and_summary(
-        "refactor",
-        CommandJsonFamily::Workspace,
-        "portable Lab offload is available for refactor source runs",
-        "refactor subcommands can rewrite source files; use planning/dry-run modes where available",
-        REFACTOR_LAB_SUPPORT,
-    ),
+    CommandSpec {
+        safety: CommandSafetySpec {
+            mutates: true,
+            operator: false,
+            dry_run_flag: None,
+            risk_exemption: None,
+            dangerous_flags: REFACTOR_DANGEROUS_FLAGS,
+        },
+        ..lab_command_spec_with_output_notes_and_summary(
+            "refactor",
+            CommandJsonFamily::Workspace,
+            "portable Lab offload is available for refactor source runs",
+            "refactor subcommands can rewrite source files; use planning/dry-run modes where available",
+            REFACTOR_LAB_SUPPORT,
+        )
+    },
     command_spec("refs", CommandJsonFamily::Workspace),
     lab_command_spec_with_summary(
         "rig",
@@ -381,18 +507,20 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     command_spec("runs", CommandJsonFamily::Workspace),
     command_spec("self", CommandJsonFamily::Ops),
     command_spec("stack", CommandJsonFamily::Workspace),
-    command_spec_with_output_notes(
+    command_spec_with_output_notes_and_safety(
         "undo",
         CommandJsonFamily::Workspace,
         "restores files from the latest or selected undo snapshot",
+        mutating_safety(),
     ),
     command_spec("auth", CommandJsonFamily::Ops),
     command_spec("api", CommandJsonFamily::Ops),
     command_spec("http", CommandJsonFamily::Ops),
-    command_spec_with_output_notes(
+    command_spec_with_output_notes_and_safety(
         "upgrade",
         CommandJsonFamily::Ops,
         "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used",
+        operator_safety(None, UPGRADE_DANGEROUS_FLAGS),
     ),
 ];
 

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -264,6 +264,38 @@ fn command_specs_drive_top_level_manifest_metadata() {
             spec.name
         );
         assert_eq!(
+            entry.mutates, spec.safety.mutates,
+            "top-level manifest mutation metadata drifted from CommandSpec for `{}`",
+            spec.name
+        );
+        assert_eq!(
+            entry.operator, spec.safety.operator,
+            "top-level manifest operator metadata drifted from CommandSpec for `{}`",
+            spec.name
+        );
+        assert_eq!(
+            entry.dry_run.flag.as_deref(),
+            spec.safety.dry_run_flag,
+            "top-level manifest dry-run metadata drifted from CommandSpec for `{}`",
+            spec.name
+        );
+        assert_eq!(
+            entry.risk_exemption.as_deref(),
+            spec.safety.risk_exemption,
+            "top-level manifest risk metadata drifted from CommandSpec for `{}`",
+            spec.name
+        );
+        assert_eq!(
+            entry.dangerous_flags,
+            spec.safety
+                .dangerous_flags
+                .iter()
+                .map(|flag| flag.to_string())
+                .collect::<Vec<_>>(),
+            "top-level manifest dangerous flag metadata drifted from CommandSpec for `{}`",
+            spec.name
+        );
+        assert_eq!(
             entry.docs.path,
             spec.docs_path(),
             "top-level manifest docs path drifted from CommandSpec for `{}`",


### PR DESCRIPTION
## Summary
- Add top-level safety metadata to CommandSpec.
- Derive top-level safety manifest action flags from CommandSpec instead of safety_manifest match arms.
- Extend CommandSpec manifest parity assertions to cover safety fields.

## Tests
- cargo fmt --check
- cargo test command_safety_manifest
- cargo test --test command_surface_test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and verified CommandSpec safety metadata cleanup.