### PR TITLE
Add runs env provenance output

### DIFF
--- a/src/commands/runs/dispatch.rs
+++ b/src/commands/runs/dispatch.rs
@@ -81,6 +81,7 @@ impl RunsArgs {
             RunsCommand::Show { run_id, .. }
             | RunsCommand::ResumePlan { run_id }
             | RunsCommand::Evidence { run_id }
+            | RunsCommand::Env { run_id }
             | RunsCommand::Artifacts { run_id } => (
                 format!(
                     "Lab-offloaded run records are mirrored locally; inspect run `{run_id}` with `homeboy runs show {run_id}` without --runner."
@@ -124,6 +125,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Show { run_id, json: _ } => handlers::show_run(&run_id),
         RunsCommand::ResumePlan { run_id } => handlers::resume_plan(&run_id),
         RunsCommand::Evidence { run_id } => evidence::evidence(&run_id),
+        RunsCommand::Env { run_id } => handlers::env(&run_id),
         RunsCommand::Artifacts { run_id } => handlers::artifacts(&run_id),
         RunsCommand::Artifact(args) => handlers::artifact_command(args),
         RunsCommand::Findings(args) => findings::findings(args),

--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -18,8 +18,8 @@ use super::bench::run_contains_scenario;
 use super::common::{run_summaries_with_artifact_indexes, RunSummary};
 use super::types::{
     RunDetail, RunsArtifactArgs, RunsArtifactCommand, RunsArtifactGetArgs, RunsArtifactGetOutput,
-    RunsArtifactsOutput, RunsListArgs, RunsListOutput, RunsOutput, RunsResumePlanOutput,
-    RunsShowOutput,
+    RunsArtifactsOutput, RunsEnvKeyOutput, RunsEnvOutput, RunsEnvSourceLayerOutput, RunsEnvSummary,
+    RunsListArgs, RunsListOutput, RunsOutput, RunsResumePlanOutput, RunsShowOutput,
 };
 use super::{reconcile, remote, remote_artifact, CmdResult};
 
@@ -173,6 +173,155 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
         }),
         0,
     ))
+}
+
+pub fn env(run_id: &str) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let run = runs_service::require_run(&store, run_id)?;
+    let Some(envelope) = run.metadata_json.get("env_resolution").cloned() else {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!("run `{run_id}` does not contain Lab environment provenance metadata"),
+            Some(run_id.to_string()),
+            Some(vec![
+                "Environment provenance is recorded for Lab-offloaded runs that include `homeboy/env-resolution/v1` metadata.".to_string(),
+                "Run `homeboy runs show <run-id> --json` to inspect available metadata keys.".to_string(),
+            ]),
+        ));
+    };
+
+    let schema = envelope
+        .get("schema")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if schema != "homeboy/env-resolution/v1" {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!("run `{run_id}` contains unsupported environment provenance schema `{schema}`"),
+            Some(run_id.to_string()),
+            Some(vec![
+                "Expected `homeboy/env-resolution/v1`.".to_string(),
+                "Run `homeboy runs show <run-id> --json` to inspect the raw metadata shape."
+                    .to_string(),
+            ]),
+        ));
+    }
+
+    let values_redacted = envelope
+        .get("values_redacted")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !values_redacted {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!("run `{run_id}` environment provenance is not marked redacted"),
+            Some(run_id.to_string()),
+            Some(vec![
+                "Homeboy refuses to print unredacted environment provenance.".to_string(),
+                "Capture a fresh Lab run with `homeboy/env-resolution/v1` redacted provenance metadata.".to_string(),
+            ]),
+        ));
+    }
+    let keys = envelope
+        .get("keys")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(env_key_output)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let summary = RunsEnvSummary {
+        key_count: keys.len(),
+        secret_key_count: keys
+            .iter()
+            .filter(|entry| entry.classification == "secret")
+            .count(),
+        public_key_count: keys
+            .iter()
+            .filter(|entry| entry.classification == "public")
+            .count(),
+        shadowed_key_count: keys
+            .iter()
+            .filter(|entry| !entry.shadowed_source_layers.is_empty())
+            .count(),
+    };
+
+    Ok((
+        RunsOutput::Env(RunsEnvOutput {
+            command: "runs.env",
+            run_id: run_id.to_string(),
+            schema: schema.to_string(),
+            values_redacted,
+            summary,
+            keys,
+        }),
+        0,
+    ))
+}
+
+fn env_key_output(value: &Value) -> Option<RunsEnvKeyOutput> {
+    Some(RunsEnvKeyOutput {
+        key: value.get("key")?.as_str()?.to_string(),
+        classification: value
+            .get("classification")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string(),
+        value_status: value
+            .get("value_status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string(),
+        value_preview: value
+            .get("value_preview")
+            .and_then(Value::as_str)
+            .unwrap_or("<redacted>")
+            .to_string(),
+        winning_source_layer: value
+            .get("winning_source_layer")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string(),
+        shadowed_source_layers: value
+            .get("shadowed_source_layers")
+            .and_then(Value::as_array)
+            .map(|layers| {
+                layers
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        source_layers: value
+            .get("source_layers")
+            .and_then(Value::as_array)
+            .map(|layers| layers.iter().filter_map(env_source_layer_output).collect())
+            .unwrap_or_default(),
+    })
+}
+
+fn env_source_layer_output(value: &Value) -> Option<RunsEnvSourceLayerOutput> {
+    Some(RunsEnvSourceLayerOutput {
+        source: value.get("source")?.as_str()?.to_string(),
+        status: value
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string(),
+        classification: value
+            .get("classification")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string(),
+        value_status: value
+            .get("value_status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string(),
+    })
 }
 
 pub fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {

--- a/src/commands/runs/tests/mod.rs
+++ b/src/commands/runs/tests/mod.rs
@@ -2,7 +2,7 @@
 
 mod export_import;
 
-use super::handlers::{artifact_get, artifacts, show_run};
+use super::handlers::{artifact_get, artifacts, env, show_run};
 use super::{
     bench_compare, dead_owned_run, findings, latest, list_runs, RunsArtifactGetArgs, RunsListArgs,
     RunsOutput, WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER,
@@ -204,6 +204,126 @@ fn run_show_reconciles_owned_dead_running_run_before_displaying() {
             output.run.metadata["homeboy_reconciled"]["reason"],
             "owner_process_not_running"
         );
+    });
+}
+
+#[test]
+fn runs_env_explains_redacted_lab_env_resolution() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run(
+                "bench",
+                "homeboy",
+                "studio",
+                serde_json::json!({
+                    "env_resolution": {
+                        "schema": "homeboy/env-resolution/v1",
+                        "values_redacted": true,
+                        "keys": [
+                            {
+                                "key": "API_TOKEN",
+                                "classification": "secret",
+                                "value_status": "secret_redacted",
+                                "value_preview": "<redacted>",
+                                "winning_source_layer": "secret_env_plan_env_delta",
+                                "shadowed_source_layers": ["env_delta"],
+                                "source_layers": [
+                                    {
+                                        "source": "env_delta",
+                                        "status": "shadowed",
+                                        "classification": "secret",
+                                        "value_status": "secret_redacted"
+                                    },
+                                    {
+                                        "source": "secret_env_plan_env_delta",
+                                        "status": "winner",
+                                        "classification": "secret",
+                                        "value_status": "secret_redacted"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "HOMEBOY_RUNTIME_DIR",
+                                "classification": "public",
+                                "value_status": "redacted",
+                                "value_preview": "<redacted>",
+                                "winning_source_layer": "runtime_overlay",
+                                "shadowed_source_layers": [],
+                                "source_layers": [
+                                    {
+                                        "source": "runtime_overlay",
+                                        "status": "winner",
+                                        "classification": "public",
+                                        "value_status": "redacted"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }),
+            ))
+            .expect("run");
+
+        let (output, _) = env(&run.id).expect("runs env");
+        let RunsOutput::Env(output) = output else {
+            panic!("expected env output");
+        };
+
+        assert_eq!(output.command, "runs.env");
+        assert_eq!(output.run_id, run.id);
+        assert_eq!(output.schema, "homeboy/env-resolution/v1");
+        assert!(output.values_redacted);
+        assert_eq!(output.summary.key_count, 2);
+        assert_eq!(output.summary.secret_key_count, 1);
+        assert_eq!(output.summary.public_key_count, 1);
+        assert_eq!(output.summary.shadowed_key_count, 1);
+        let secret = output
+            .keys
+            .iter()
+            .find(|entry| entry.key == "API_TOKEN")
+            .expect("secret entry");
+        assert_eq!(secret.winning_source_layer, "secret_env_plan_env_delta");
+        assert_eq!(secret.shadowed_source_layers, vec!["env_delta"]);
+        assert_eq!(secret.value_preview, "<redacted>");
+        assert_eq!(secret.source_layers.len(), 2);
+        let serialized = serde_json::to_string(&output).expect("serialize output");
+        assert!(serialized.contains("secret_redacted"));
+        assert!(!serialized.contains("super-secret"));
+    });
+}
+
+#[test]
+fn runs_env_refuses_unredacted_env_resolution() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run(
+                "bench",
+                "homeboy",
+                "studio",
+                serde_json::json!({
+                    "env_resolution": {
+                        "schema": "homeboy/env-resolution/v1",
+                        "values_redacted": false,
+                        "keys": [{
+                            "key": "API_TOKEN",
+                            "value_preview": "super-secret"
+                        }]
+                    }
+                }),
+            ))
+            .expect("run");
+
+        let error = match env(&run.id) {
+            Ok(_) => panic!("unredacted env must fail"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(message.contains("not marked redacted"));
+        assert!(!message.contains("super-secret"));
     });
 }
 

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -87,6 +87,8 @@ pub(super) enum RunsCommand {
     ResumePlan { run_id: String },
     /// Show stable evidence registry data for one run; start here for reviewer-facing evidence
     Evidence { run_id: String },
+    /// Explain redacted Lab environment provenance for one run
+    Env { run_id: String },
     /// List artifacts recorded for one run
     Artifacts { run_id: String },
     /// Retrieve or sync recorded run artifacts
@@ -150,6 +152,7 @@ pub enum RunsOutput {
     Show(RunsShowOutput),
     ResumePlan(RunsResumePlanOutput),
     Evidence(RunsEvidenceOutput),
+    Env(RunsEnvOutput),
     Artifacts(RunsArtifactsOutput),
     ArtifactAttach(RunsArtifactAttachOutput),
     ArtifactGet(RunsArtifactGetOutput),
@@ -208,6 +211,43 @@ pub struct RunsResumePlanOutput {
     pub active_command: Option<ValidationCommandSummary>,
     pub next_command: Option<ValidationCommandSummary>,
     pub hints: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct RunsEnvOutput {
+    pub command: &'static str,
+    pub run_id: String,
+    pub schema: String,
+    pub values_redacted: bool,
+    pub summary: RunsEnvSummary,
+    pub keys: Vec<RunsEnvKeyOutput>,
+}
+
+#[derive(Serialize)]
+pub struct RunsEnvSummary {
+    pub key_count: usize,
+    pub secret_key_count: usize,
+    pub public_key_count: usize,
+    pub shadowed_key_count: usize,
+}
+
+#[derive(Serialize)]
+pub struct RunsEnvKeyOutput {
+    pub key: String,
+    pub classification: String,
+    pub value_status: String,
+    pub value_preview: String,
+    pub winning_source_layer: String,
+    pub shadowed_source_layers: Vec<String>,
+    pub source_layers: Vec<RunsEnvSourceLayerOutput>,
+}
+
+#[derive(Serialize)]
+pub struct RunsEnvSourceLayerOutput {
+    pub source: String,
+    pub status: String,
+    pub classification: String,
+    pub value_status: String,
 }
 
 #[derive(Args, Clone)]


### PR DESCRIPTION
## Summary
- Add `homeboy runs env <run-id>` to explain redacted `homeboy/env-resolution/v1` Lab environment provenance from run metadata.
- Return a sanitized projection with key summary counts, winning/shadowed source layers, source-layer status, and secret/public classification.
- Refuse to print provenance envelopes that are not marked redacted.

## Tests
- `cargo fmt`
- `cargo test commands::runs::tests::runs_env --lib`
- `cargo test command_surface --test command_surface_test`
- `cargo test commands::golden_contract_tests --lib`
- `cargo test command_contract --lib`
- `cargo test commands::runs --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implemented the CLI plumbing, tests, and PR description.