### PR TITLE
Decouple artifact browser capture providers

### DIFF
--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fs;
 use std::net::TcpListener;
 use std::path::{Component, Path, PathBuf};
@@ -213,7 +214,7 @@ pub fn capture(args: RunsArtifactCaptureArgs) -> CmdResult<RunsOutput> {
     let base_url = format!("http://127.0.0.1:{port}/");
     let mut child = start_static_artifact_server(&artifact_path, port)?;
     let _ = wait_for_static_server(&base_url);
-    let browser = detect_playwright();
+    let browser = resolve_capture_provider();
     let viewport = RunsArtifactCaptureViewport {
         width: args.viewport_width,
         height: args.viewport_height,
@@ -246,7 +247,9 @@ pub fn capture(args: RunsArtifactCaptureArgs) -> CmdResult<RunsOutput> {
             if let Some(browser_error) = browser.error.as_ref() {
                 status = "failed".to_string();
                 error = Some(browser_error.clone());
-            } else if let Err(err) = capture_screenshot(&page_url, &screenshot_path, &viewport) {
+            } else if let Err(err) =
+                capture_screenshot(&browser, &page_url, &screenshot_path, &viewport)
+            {
                 status = "failed".to_string();
                 error = Some(err.to_string());
             }
@@ -344,53 +347,48 @@ fn wait_for_static_server(base_url: &str) -> bool {
     false
 }
 
-fn detect_playwright() -> RunsArtifactCaptureBrowser {
-    match Command::new("playwright")
-        .arg("--version")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-    {
-        Ok(status) if status.success() => RunsArtifactCaptureBrowser {
-            command: "playwright".to_string(),
+fn resolve_capture_provider() -> RunsArtifactCaptureBrowser {
+    match env::var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND") {
+        Ok(command) if !command.trim().is_empty() => RunsArtifactCaptureBrowser {
+            command,
             available: true,
             error: None,
         },
-        Ok(status) => RunsArtifactCaptureBrowser {
-            command: "playwright".to_string(),
+        _ => RunsArtifactCaptureBrowser {
+            command: "HOMEBOY_ARTIFACT_CAPTURE_COMMAND".to_string(),
             available: false,
-            error: Some(format!("playwright --version exited with status {status}")),
-        },
-        Err(err) => RunsArtifactCaptureBrowser {
-            command: "playwright".to_string(),
-            available: false,
-            error: Some(format!(
-                "playwright CLI is not available: {err}. Install Playwright and browser binaries to capture screenshots."
-            )),
+            error: Some(
+                "no browser capture provider configured; set HOMEBOY_ARTIFACT_CAPTURE_COMMAND to a command that writes HOMEBOY_ARTIFACT_CAPTURE_OUTPUT"
+                    .to_string(),
+            ),
         },
     }
 }
 
 fn capture_screenshot(
+    provider: &RunsArtifactCaptureBrowser,
     page_url: &str,
     screenshot_path: &Path,
     viewport: &RunsArtifactCaptureViewport,
 ) -> homeboy::core::Result<()> {
-    let viewport_arg = format!("{},{}", viewport.width, viewport.height);
-    let output = Command::new("playwright")
-        .arg("screenshot")
-        .arg("--browser=chromium")
-        .arg("--viewport-size")
-        .arg(&viewport_arg)
-        .arg(page_url)
-        .arg(screenshot_path)
+    let output = Command::new("sh")
+        .args(["-c", &provider.command])
+        .env("HOMEBOY_ARTIFACT_CAPTURE_URL", page_url)
+        .env("HOMEBOY_ARTIFACT_CAPTURE_OUTPUT", screenshot_path)
+        .env(
+            "HOMEBOY_ARTIFACT_CAPTURE_VIEWPORT_WIDTH",
+            viewport.width.to_string(),
+        )
+        .env(
+            "HOMEBOY_ARTIFACT_CAPTURE_VIEWPORT_HEIGHT",
+            viewport.height.to_string(),
+        )
         .stdin(Stdio::null())
         .output()
         .map_err(|err| {
             Error::internal_io(
                 err.to_string(),
-                Some("run playwright screenshot".to_string()),
+                Some("run artifact capture provider".to_string()),
             )
         })?;
     if output.status.success() {
@@ -399,9 +397,9 @@ fn capture_screenshot(
 
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     Err(Error::validation_invalid_argument(
-        "playwright",
+        "HOMEBOY_ARTIFACT_CAPTURE_COMMAND",
         format!(
-            "playwright screenshot failed with status {}{}",
+            "artifact capture provider failed with status {}{}",
             output.status,
             if stderr.is_empty() {
                 "".to_string()
@@ -409,8 +407,10 @@ fn capture_screenshot(
                 format!(": {stderr}")
             }
         ),
-        Some(page_url.to_string()),
-        None,
+        Some(provider.command.clone()),
+        Some(vec![
+            "Provider commands receive HOMEBOY_ARTIFACT_CAPTURE_URL, HOMEBOY_ARTIFACT_CAPTURE_OUTPUT, HOMEBOY_ARTIFACT_CAPTURE_VIEWPORT_WIDTH, and HOMEBOY_ARTIFACT_CAPTURE_VIEWPORT_HEIGHT.".to_string(),
+        ]),
     ))
 }
 
@@ -1137,26 +1137,29 @@ mod tests {
     }
 
     #[test]
-    fn capture_records_manifest_with_fake_playwright() {
+    fn capture_records_manifest_with_configured_provider() {
         let _guard = artifact_root_test_lock();
         with_isolated_home(|home| {
             let artifact_root = home.path().join("artifacts");
             homeboy::core::set_artifact_root_override(Some(artifact_root));
             let bin = home.path().join("bin");
             fs::create_dir_all(&bin).expect("bin");
-            let fake_playwright = bin.join("playwright");
+            let fake_provider = bin.join("capture-provider");
             fs::write(
-                &fake_playwright,
-                b"#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then exit 0; fi\nif [ \"$1\" = \"screenshot\" ]; then printf fake-screenshot > \"$6\"; exit 0; fi\nexit 2\n",
+                &fake_provider,
+                b"#!/bin/sh\nprintf fake-screenshot > \"$HOMEBOY_ARTIFACT_CAPTURE_OUTPUT\"\n",
             )
-            .expect("fake playwright");
-            let mut perms = fs::metadata(&fake_playwright)
+            .expect("fake provider");
+            let mut perms = fs::metadata(&fake_provider)
                 .expect("metadata")
                 .permissions();
             perms.set_mode(0o755);
-            fs::set_permissions(&fake_playwright, perms).expect("chmod");
-            let old_path = env::var("PATH").unwrap_or_default();
-            env::set_var("PATH", format!("{}:{old_path}", bin.display()));
+            fs::set_permissions(&fake_provider, perms).expect("chmod");
+            let old_provider = env::var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND").ok();
+            env::set_var(
+                "HOMEBOY_ARTIFACT_CAPTURE_COMMAND",
+                fake_provider.display().to_string(),
+            );
 
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
@@ -1184,7 +1187,10 @@ mod tests {
                 viewport_height: 844,
             })
             .expect("capture");
-            env::set_var("PATH", old_path);
+            match old_provider {
+                Some(value) => env::set_var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND", value),
+                None => env::remove_var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND"),
+            }
             assert_eq!(result.1, 0);
             let RunsOutput::ArtifactCapture(output) = result.0 else {
                 panic!("unexpected output");
@@ -1202,6 +1208,57 @@ mod tests {
             let manifest = fs::read_to_string(&output.manifest_path).expect("manifest");
             assert!(manifest.contains("runs.artifact.capture"));
             assert!(manifest.contains("fse-pilot-build-theme/index.html"));
+        });
+    }
+
+    #[test]
+    fn capture_reports_missing_provider_without_browser_assumptions() {
+        let _guard = artifact_root_test_lock();
+        with_isolated_home(|home| {
+            let old_provider = env::var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND").ok();
+            env::remove_var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND");
+            let artifact_root = home.path().join("artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("runner-exec").build())
+                .expect("run");
+            let site = home.path().join("site");
+            fs::create_dir_all(&site).expect("site");
+            fs::write(site.join("index.html"), b"<html>Generated</html>").expect("html");
+            let artifact = store
+                .record_directory_artifact(&run.id, "generated_site", &site)
+                .expect("artifact");
+
+            let result = capture(RunsArtifactCaptureArgs {
+                run_id: run.id,
+                artifact_id: artifact.id,
+                entrypoints: vec!["index.html".to_string()],
+                output_dir: home.path().join("captures"),
+                port: None,
+                viewport_width: 390,
+                viewport_height: 844,
+            })
+            .expect("capture manifest");
+            match old_provider {
+                Some(value) => env::set_var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND", value),
+                None => env::remove_var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND"),
+            }
+            assert_eq!(result.1, 1);
+            let RunsOutput::ArtifactCapture(output) = result.0 else {
+                panic!("unexpected output");
+            };
+            assert!(!output.browser.available);
+            assert!(output
+                .browser
+                .command
+                .contains("HOMEBOY_ARTIFACT_CAPTURE_COMMAND"));
+            assert!(output
+                .browser
+                .error
+                .unwrap()
+                .contains("no browser capture provider configured"));
         });
     }
 

--- a/src/core/artifact_dom_boxes.rs
+++ b/src/core/artifact_dom_boxes.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::env;
 use std::io::ErrorKind;
 use std::net::TcpListener;
 use std::path::{Component, Path, PathBuf};
@@ -254,23 +255,32 @@ fn run_browser_capture(
     page_paths: &[String],
     text_sample_limit: usize,
 ) -> Result<BrowserReport> {
-    let output = Command::new("node")
-        .arg("-e")
-        .arg(browser_script())
-        .arg(base_url)
-        .arg(serde_json::to_string(page_paths).map_err(|err| {
-            Error::internal_json(err.to_string(), Some("serialize DOM box page paths".into()))
-        })?)
-        .arg(text_sample_limit.to_string())
+    let provider = env::var("HOMEBOY_DOM_BOX_CAPTURE_COMMAND")
+        .ok()
+        .filter(|command| !command.trim().is_empty())
+        .ok_or_else(missing_browser_error)?;
+    let page_paths_json = serde_json::to_string(page_paths).map_err(|err| {
+        Error::internal_json(err.to_string(), Some("serialize DOM box page paths".into()))
+    })?;
+    let output = Command::new("sh")
+        .args(["-c", &provider])
+        .env("HOMEBOY_DOM_BOX_BASE_URL", base_url)
+        .env("HOMEBOY_DOM_BOX_PAGE_PATHS_JSON", page_paths_json)
+        .env(
+            "HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT",
+            text_sample_limit.to_string(),
+        )
         .output()
-        .map_err(|err| missing_browser_error(format!("failed to start node: {err}")))?;
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("run DOM box capture provider".to_string()),
+            )
+        })?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        if output.status.code() == Some(42) || stderr.contains("playwright install") {
-            return Err(missing_browser_error(stderr.trim().to_string()));
-        }
         return Err(Error::internal_unexpected(format!(
-            "DOM box browser capture failed: {}",
+            "DOM box capture provider failed: {}",
             stderr.trim()
         )));
     }
@@ -287,16 +297,16 @@ fn run_browser_capture(
     })
 }
 
-fn missing_browser_error(problem: String) -> Error {
+fn missing_browser_error() -> Error {
     Error::validation_invalid_argument(
-        "browser",
-        format!("browser automation dependency is unavailable: {problem}"),
+        "HOMEBOY_DOM_BOX_CAPTURE_COMMAND",
+        "no DOM box capture provider configured",
         None,
         Some(vec![
-            "Install Node.js and Playwright for this checkout: npm install -D playwright && npx playwright install chromium".to_string(),
+            "Set HOMEBOY_DOM_BOX_CAPTURE_COMMAND to a command that writes a browser DOM-box JSON payload to stdout.".to_string(),
+            "Provider commands receive HOMEBOY_DOM_BOX_BASE_URL, HOMEBOY_DOM_BOX_PAGE_PATHS_JSON, and HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT.".to_string(),
         ]),
     )
-    .with_hint("Homeboy DOM box capture runs a local Chromium browser through Playwright.".to_string())
 }
 
 fn write_report(path: &Path, report: &DomBoxReport) -> Result<()> {
@@ -312,70 +322,13 @@ fn write_report(path: &Path, report: &DomBoxReport) -> Result<()> {
         .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))
 }
 
-fn browser_script() -> &'static str {
-    r#"
-const [baseUrl, pathsJson, limitRaw] = process.argv.slice(1);
-let chromium;
-try {
-  chromium = require('playwright').chromium;
-} catch (error) {
-  console.error('Playwright is not installed or cannot be loaded: ' + error.message);
-  process.exit(42);
-}
-const paths = JSON.parse(pathsJson);
-const limit = Number.parseInt(limitRaw, 10) || 160;
-(async () => {
-  const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 1 });
-  const entrypoints = [];
-  for (const pagePath of paths) {
-    const page = await context.newPage();
-    const pageUrl = new URL(pagePath, baseUrl).toString();
-    await page.goto(pageUrl, { waitUntil: 'networkidle' });
-    const viewport = page.viewportSize() || { width: 1440, height: 900 };
-    const elements = await page.evaluate((sampleLimit) => Array.from(document.querySelectorAll('[data-figma-node-id]')).map((element) => {
-      const rect = element.getBoundingClientRect();
-      const nodeId = element.getAttribute('data-figma-node-id') || '';
-      const rawText = (element.innerText || element.textContent || '').replace(/\s+/g, ' ').trim();
-      const tag = element.tagName.toLowerCase();
-      return {
-        node_id: nodeId,
-        node_name: element.getAttribute('data-figma-node-name') || null,
-        selector: `${tag}[data-figma-node-id="${nodeId.replace(/"/g, '\\"')}"]`,
-        tag,
-        text_sample: rawText.slice(0, sampleLimit),
-        boundingClientRect: {
-          x: rect.x,
-          y: rect.y,
-          width: rect.width,
-          height: rect.height,
-          top: rect.top,
-          right: rect.right,
-          bottom: rect.bottom,
-          left: rect.left,
-        },
-      };
-    }), limit);
-    entrypoints.push({
-      page_path: pagePath,
-      page_url: pageUrl,
-      viewport: { width: viewport.width, height: viewport.height, device_scale_factor: 1 },
-      elements,
-    });
-    await page.close();
-  }
-  await browser.close();
-  process.stdout.write(JSON.stringify({ entrypoints }));
-})().catch((error) => {
-  console.error(error && error.stack ? error.stack : String(error));
-  process.exit(1);
-});
-"#
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::Mutex;
+
+    static PROVIDER_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn rect() -> DomRect {
         DomRect {
@@ -444,5 +397,59 @@ mod tests {
         .expect("plan");
 
         assert_eq!(planned, vec!["/index.html", "/nested/page.html"]);
+    }
+
+    #[test]
+    fn browser_capture_uses_configured_provider_command() {
+        let _guard = PROVIDER_ENV_LOCK.lock().expect("provider env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = dir.path().join("dom-provider");
+        std::fs::write(
+            &provider,
+            r#"#!/bin/sh
+printf '%s' '{"entrypoints":[{"page_path":"/index.html","page_url":"http://127.0.0.1/index.html","viewport":{"width":1440,"height":900,"device_scale_factor":1},"elements":[{"node_id":"12:34","node_name":"Hero","selector":"div[data-figma-node-id=\"12:34\"]","tag":"div","text_sample":"Hello world","boundingClientRect":{"x":1,"y":2,"width":3,"height":4,"top":2,"right":4,"bottom":6,"left":1}}]}]}'
+"#,
+        )
+        .expect("provider");
+        let mut perms = std::fs::metadata(&provider)
+            .expect("metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&provider, perms).expect("chmod");
+
+        let previous = env::var("HOMEBOY_DOM_BOX_CAPTURE_COMMAND").ok();
+        env::set_var(
+            "HOMEBOY_DOM_BOX_CAPTURE_COMMAND",
+            provider.display().to_string(),
+        );
+        let report = run_browser_capture("http://127.0.0.1/", &["/index.html".to_string()], 160)
+            .expect("capture");
+        match previous {
+            Some(value) => env::set_var("HOMEBOY_DOM_BOX_CAPTURE_COMMAND", value),
+            None => env::remove_var("HOMEBOY_DOM_BOX_CAPTURE_COMMAND"),
+        }
+
+        assert_eq!(report.entrypoints.len(), 1);
+        assert_eq!(report.entrypoints[0].elements[0].node_id, "12:34");
+    }
+
+    #[test]
+    fn browser_capture_reports_missing_provider_without_browser_assumption() {
+        let _guard = PROVIDER_ENV_LOCK.lock().expect("provider env lock");
+        let previous = env::var("HOMEBOY_DOM_BOX_CAPTURE_COMMAND").ok();
+        env::remove_var("HOMEBOY_DOM_BOX_CAPTURE_COMMAND");
+        let error = run_browser_capture("http://127.0.0.1/", &["/index.html".to_string()], 160)
+            .expect_err("missing provider");
+        match previous {
+            Some(value) => env::set_var("HOMEBOY_DOM_BOX_CAPTURE_COMMAND", value),
+            None => env::remove_var("HOMEBOY_DOM_BOX_CAPTURE_COMMAND"),
+        }
+
+        assert!(error
+            .to_string()
+            .contains("HOMEBOY_DOM_BOX_CAPTURE_COMMAND"));
+        assert!(error
+            .to_string()
+            .contains("no DOM box capture provider configured"));
     }
 }


### PR DESCRIPTION
## Summary
- Replace implicit Playwright screenshot capture with an explicit HOMEBOY_ARTIFACT_CAPTURE_COMMAND provider contract.
- Replace embedded DOM-box browser automation with an explicit HOMEBOY_DOM_BOX_CAPTURE_COMMAND provider contract.
- Keep Homeboy responsible for artifact serving, validation, manifest/report shaping, and provider orchestration instead of owning a browser runtime.

## Tests
- cargo test artifact_dom_boxes
- cargo test remote_artifact::tests::capture

## Notes
- Addresses #6541 by removing Homeboy's hardcoded browser runtime assumption rather than resolving a specific local browser CLI.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Refactoring the Homeboy artifact capture seams, updating tests, running verification, and drafting this PR description.