### PR TITLE
Add runner availability diagnostics

### DIFF
--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -5,8 +5,10 @@ use homeboy::core::agent_runtime_manifest::{
     AgentRuntimeDiagnosticsContract, AgentRuntimeRuntimeDiagnosticDeclaration,
     AgentRuntimeSourceConsistencyDiagnostic, AgentRuntimeToolDiagnosticDeclaration,
 };
-use homeboy::core::runner::RunnerActiveJobState;
-use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, RunnerTunnelMode};
+use homeboy::core::runners::{
+    self as runner, RunnerActiveJobState, RunnerAvailability, RunnerSession, RunnerStatusReport,
+    RunnerTunnelMode,
+};
 
 use super::super::CmdResult;
 use super::types::{
@@ -105,6 +107,14 @@ fn selected_lab_runner_status(
         workspace_root: runner_config.workspace_root.clone(),
         readiness_state: format!("{:?}", status.state).to_ascii_lowercase(),
         connected: status.connected,
+        availability: RunnerAvailability::from_status_parts(
+            runner_id,
+            status.connected,
+            status.stale_daemon.is_some(),
+            status.active_job_count,
+            &status.active_job_state,
+            runner_config.settings.concurrency_limit,
+        ),
         status,
     }))
 }

--- a/src/commands/runner/types.rs
+++ b/src/commands/runner/types.rs
@@ -3,8 +3,8 @@ use serde_json::Value;
 
 use homeboy::core::api_jobs::{Job, JobEvent};
 use homeboy::core::runners::{
-    ReverseRunnerWorkerOutput, Runner, RunnerConnectReport, RunnerDisconnectReport,
-    RunnerExecOutput, RunnerStatusReport,
+    ReverseRunnerWorkerOutput, Runner, RunnerAvailability, RunnerConnectReport,
+    RunnerDisconnectReport, RunnerExecOutput, RunnerStatusReport,
 };
 use homeboy::core::EntityCrudOutput;
 
@@ -67,6 +67,7 @@ pub struct LabSelectedRunnerOutput {
     pub workspace_root: Option<String>,
     pub readiness_state: String,
     pub connected: bool,
+    pub availability: RunnerAvailability,
     pub status: RunnerStatusReport,
 }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -116,11 +116,11 @@ pub use offload_metadata::{
 pub use resource_metrics::RunnerResourceMetrics;
 pub use session::{
     ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
-    RunnerArtifactRef, RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport,
-    RunnerFailureKind, RunnerHandoff, RunnerJob, RunnerLifecycleOwner, RunnerMutationArtifacts,
-    RunnerNamedWorkspaceLease, RunnerResult, RunnerSession, RunnerSessionRole, RunnerSessionState,
-    RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
-    RunnerWorkspaceLease, RunnerWorkspaceLeaseSet,
+    RunnerArtifactRef, RunnerAvailability, RunnerChangedRuntimePath, RunnerConnectReport,
+    RunnerDisconnectReport, RunnerFailureKind, RunnerHandoff, RunnerJob, RunnerLifecycleOwner,
+    RunnerMutationArtifacts, RunnerNamedWorkspaceLease, RunnerResult, RunnerSession,
+    RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStaleRuntimePath,
+    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceLease, RunnerWorkspaceLeaseSet,
 };
 pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerFileTransfer, RunnerTransport};
@@ -339,6 +339,7 @@ pub fn resolve_default_lab_runner() -> Result<Option<String>> {
                 id: runner.id,
                 mode,
                 connected: status.connected,
+                capacity: runner.settings.concurrency_limit,
                 stale_daemon: status.stale_daemon.is_some(),
                 active_jobs: status.active_jobs.len(),
                 active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
@@ -353,6 +354,7 @@ struct DefaultLabRunnerCandidate {
     id: String,
     mode: RunnerTunnelMode,
     connected: bool,
+    capacity: Option<usize>,
     stale_daemon: bool,
     active_jobs: usize,
     active_jobs_available: bool,
@@ -366,6 +368,22 @@ struct DefaultLabRunnerReadiness {
 }
 
 impl DefaultLabRunnerCandidate {
+    #[cfg(test)]
+    fn availability(&self) -> RunnerAvailability {
+        RunnerAvailability::from_status_parts(
+            self.id.clone(),
+            self.connected,
+            self.stale_daemon,
+            self.active_jobs,
+            if self.active_jobs_available {
+                &RunnerActiveJobState::Available
+            } else {
+                &RunnerActiveJobState::Unavailable
+            },
+            self.capacity,
+        )
+    }
+
     fn readiness(&self) -> DefaultLabRunnerReadiness {
         if !self.capabilities_ready || self.stale_daemon {
             return DefaultLabRunnerReadiness {
@@ -755,6 +773,7 @@ mod tests {
             id: id.to_string(),
             mode,
             connected,
+            capacity: None,
             stale_daemon: false,
             active_jobs: 0,
             active_jobs_available: true,
@@ -1312,6 +1331,64 @@ mod tests {
         );
 
         assert_eq!(selected.as_deref(), Some("lab-b"));
+    }
+
+    #[test]
+    fn runner_availability_reports_unavailable_runner_reasons() {
+        let mut unavailable = default_lab_candidate("lab-a", RunnerTunnelMode::Reverse, false);
+        unavailable.active_jobs_available = false;
+
+        assert_eq!(
+            unavailable.availability(),
+            RunnerAvailability {
+                runner_id: "lab-a".to_string(),
+                connected: false,
+                accepts_jobs: false,
+                active_job_count: 0,
+                capacity: None,
+                reasons: vec![
+                    "not_connected".to_string(),
+                    "active_jobs_unavailable".to_string()
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn runner_availability_reports_busy_runner_at_capacity() {
+        let mut busy = default_lab_candidate("lab-a", RunnerTunnelMode::DirectSsh, true);
+        busy.capacity = Some(2);
+        busy.active_jobs = 2;
+
+        assert_eq!(
+            busy.availability(),
+            RunnerAvailability {
+                runner_id: "lab-a".to_string(),
+                connected: true,
+                accepts_jobs: false,
+                active_job_count: 2,
+                capacity: Some(2),
+                reasons: vec!["capacity_reached".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn runner_availability_reports_ambiguous_unknown_capacity() {
+        let mut ambiguous = default_lab_candidate("lab-a", RunnerTunnelMode::DirectSsh, true);
+        ambiguous.active_jobs = 1;
+
+        assert_eq!(
+            ambiguous.availability(),
+            RunnerAvailability {
+                runner_id: "lab-a".to_string(),
+                connected: true,
+                accepts_jobs: false,
+                active_job_count: 1,
+                capacity: None,
+                reasons: vec!["capacity_unknown".to_string()],
+            }
+        );
     }
 
     #[test]

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -87,6 +87,65 @@ pub enum RunnerActiveJobSource {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerAvailability {
+    pub runner_id: String,
+    pub connected: bool,
+    pub accepts_jobs: bool,
+    pub active_job_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capacity: Option<usize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+}
+
+impl RunnerAvailability {
+    pub fn from_status_parts(
+        runner_id: impl Into<String>,
+        connected: bool,
+        stale_daemon: bool,
+        active_job_count: usize,
+        active_job_state: &RunnerActiveJobState,
+        capacity: Option<usize>,
+    ) -> Self {
+        let mut reasons = Vec::new();
+        if !connected {
+            reasons.push("not_connected".to_string());
+        }
+        if stale_daemon {
+            reasons.push("stale_daemon".to_string());
+        }
+        if *active_job_state != RunnerActiveJobState::Available {
+            reasons.push(
+                match active_job_state {
+                    RunnerActiveJobState::Unavailable => "active_jobs_unavailable",
+                    RunnerActiveJobState::NotQueried => "active_jobs_not_queried",
+                    RunnerActiveJobState::Available => unreachable!(),
+                }
+                .to_string(),
+            );
+        }
+        match capacity {
+            Some(capacity) if active_job_count >= capacity => {
+                reasons.push("capacity_reached".to_string());
+            }
+            None if active_job_count > 0 => {
+                reasons.push("capacity_unknown".to_string());
+            }
+            _ => {}
+        }
+        let accepts_jobs = reasons.is_empty();
+        Self {
+            runner_id: runner_id.into(),
+            connected,
+            accepts_jobs,
+            active_job_count,
+            capacity,
+            reasons,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerActiveJobError {
     pub code: String,
     pub message: String,

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -50,18 +50,18 @@ pub use super::runner::{
     LabRunnerGateMode, LabRunnerSelectionSource, ManagedRunnerSourceSyncPlan,
     PreparedLabRunnerCapability, RemoteArtifactDownload, ReverseRunnerConnectOptions,
     ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner, RunnerActiveJobSource,
-    RunnerActiveJobState, RunnerArtifactRef, RunnerCapabilityPreflight, RunnerChangedRuntimePath,
-    RunnerConnectReport, RunnerDisconnectReport, RunnerExecDiagnostics, RunnerExecMode,
-    RunnerExecOptions, RunnerExecOutput, RunnerFailureKind, RunnerHandoff, RunnerJob, RunnerKind,
-    RunnerLifecycleOwner, RunnerMutationArtifacts, RunnerNamedWorkspaceLease, RunnerRequiredTool,
-    RunnerResourceMetrics, RunnerResult, RunnerSession, RunnerSessionRole, RunnerSessionState,
-    RunnerSpec, RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport,
-    RunnerToolRegistry, RunnerToolSpec, RunnerTunnelMode, RunnerWorkspaceApplyOptions,
-    RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus, RunnerWorkspaceLease,
-    RunnerWorkspaceLeaseSet, RunnerWorkspaceListEntry, RunnerWorkspaceListOutput,
-    RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput,
-    RunnerWorkspacePruneSkippedEntry, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
-    RunnerWorkspaceSyncOutput,
+    RunnerActiveJobState, RunnerArtifactRef, RunnerAvailability, RunnerCapabilityPreflight,
+    RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerExecDiagnostics,
+    RunnerExecMode, RunnerExecOptions, RunnerExecOutput, RunnerFailureKind, RunnerHandoff,
+    RunnerJob, RunnerKind, RunnerLifecycleOwner, RunnerMutationArtifacts,
+    RunnerNamedWorkspaceLease, RunnerRequiredTool, RunnerResourceMetrics, RunnerResult,
+    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerSpec, RunnerStaleDaemonWarning,
+    RunnerStaleRuntimePath, RunnerStatusReport, RunnerToolRegistry, RunnerToolSpec,
+    RunnerTunnelMode, RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput,
+    RunnerWorkspaceApplyStatus, RunnerWorkspaceLease, RunnerWorkspaceLeaseSet,
+    RunnerWorkspaceListEntry, RunnerWorkspaceListOutput, RunnerWorkspacePruneEntry,
+    RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
 // Registry CRUD entry points (re-exported at the root for ergonomics; also
@@ -93,9 +93,9 @@ pub mod connection {
     pub use super::super::runner::{
         connect, connect_reverse, disconnect, run_reverse_worker, status, statuses,
         ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput,
-        RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
-        RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
-        RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
+        RunnerAvailability, RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport,
+        RunnerFailureKind, RunnerSession, RunnerSessionRole, RunnerSessionState,
+        RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
     };
 }
 


### PR DESCRIPTION
## Summary
- add a typed RunnerAvailability contract for runner connectivity, capacity, active jobs, and reason codes
- surface availability on selected Lab runner status diagnostics
- cover unavailable, full-capacity, and unknown-capacity availability reporting without changing default runner selection semantics

## Tests
- cargo fmt
- cargo test core::runner::tests::runner_availability --lib
- cargo test core::runner::tests::default_lab_runner --lib
- cargo test commands::runner::tests::status --lib
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the runner availability diagnostics slice, tests, formatting, and PR preparation.