### PR TITLE
Add typed agent-task runner lifecycle events

### DIFF
--- a/src/core/runner/agent_task_lifecycle_event.rs
+++ b/src/core/runner/agent_task_lifecycle_event.rs
@@ -1,0 +1,85 @@
+use crate::command_contract::AgentTaskDispatchIdentity;
+use crate::core::agent_tasks::scheduler::AgentTaskAggregate;
+use crate::core::{Error, Result};
+
+pub(crate) const AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA: &str =
+    "homeboy/agent-task-run-plan-lifecycle-event/v1";
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub(crate) struct AgentTaskRunPlanLifecycleEvent {
+    #[serde(default = "agent_task_run_plan_lifecycle_event_schema")]
+    pub schema: String,
+    #[serde(default)]
+    pub identity: AgentTaskDispatchIdentity,
+    pub aggregate: AgentTaskAggregate,
+}
+
+fn agent_task_run_plan_lifecycle_event_schema() -> String {
+    AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA.to_string()
+}
+
+pub(crate) fn agent_task_run_plan_lifecycle_event_from_output(
+    identity: AgentTaskDispatchIdentity,
+    output: &str,
+) -> Result<Option<AgentTaskRunPlanLifecycleEvent>> {
+    let envelope = parse_offloaded_run_plan_envelope(output)?;
+    if !is_agent_task_run_plan_envelope(&envelope) {
+        return Ok(None);
+    }
+    let Some(aggregate_value) = envelope.get("data").cloned() else {
+        return Ok(None);
+    };
+    let aggregate: AgentTaskAggregate =
+        serde_json::from_value(aggregate_value).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse offloaded agent-task aggregate".to_string()),
+            )
+        })?;
+    Ok(Some(AgentTaskRunPlanLifecycleEvent {
+        schema: AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA.to_string(),
+        identity,
+        aggregate,
+    }))
+}
+
+pub(crate) fn parse_offloaded_run_plan_envelope(stdout: &str) -> Result<serde_json::Value> {
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout) {
+        return Ok(value);
+    }
+
+    let mut first_json = None;
+    for (index, _) in stdout.match_indices('{') {
+        let mut stream = serde_json::Deserializer::from_str(&stdout[index..]).into_iter();
+        if let Some(Ok(value)) = stream.next() {
+            if is_agent_task_run_plan_envelope(&value) {
+                return Ok(value);
+            }
+            if first_json.is_none() {
+                first_json = Some(value);
+            }
+        }
+    }
+    if let Some(value) = first_json {
+        return Ok(value);
+    }
+
+    serde_json::from_str(stdout).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse offloaded agent-task run-plan output".to_string()),
+        )
+    })
+}
+
+pub(crate) fn is_agent_task_run_plan_envelope(value: &serde_json::Value) -> bool {
+    value
+        .get("data")
+        .and_then(|data| data.get("schema"))
+        .and_then(serde_json::Value::as_str)
+        == Some("homeboy/agent-task-aggregate/v1")
+        || value
+            .get("data")
+            .and_then(|data| data.get("plan_id"))
+            .is_some()
+}

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -21,6 +21,11 @@ use crate::core::agent_tasks::provider::{
 use crate::core::agent_tasks::scheduler::{
     AgentTaskAggregate, AgentTaskAggregateTotals, AgentTaskPlan,
 };
+use crate::core::api_jobs::{JobEvent, JobEventKind};
+use crate::core::runner::agent_task_lifecycle_event::{
+    is_agent_task_run_plan_envelope, parse_offloaded_run_plan_envelope,
+    AgentTaskRunPlanLifecycleEvent, AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA,
+};
 use crate::core::{config, Error, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -101,6 +106,7 @@ pub(super) fn mirror_agent_task_run_plan_lifecycle(
     args: &[String],
     stdout: &str,
     output_file_content: Option<&str>,
+    job_events: Option<&[JobEvent]>,
 ) -> Result<()> {
     let Some((plan_spec, run_id)) = agent_task_run_plan_recording_args(args) else {
         return Ok(());
@@ -108,15 +114,25 @@ pub(super) fn mirror_agent_task_run_plan_lifecycle(
     if plan_spec == "-" {
         return Ok(());
     }
-    let envelope = parse_offloaded_run_plan_envelope(agent_task_run_plan_lifecycle_output(
-        stdout,
-        output_file_content,
-    ))?;
-    if !is_agent_task_run_plan_envelope(&envelope) {
-        return Ok(());
-    }
-    let Some(aggregate_value) = envelope.get("data").cloned() else {
-        return Ok(());
+    let aggregate = match typed_agent_task_lifecycle_event_from_job_events(job_events) {
+        Some(event) => event.aggregate,
+        None => {
+            let envelope = parse_offloaded_run_plan_envelope(
+                agent_task_run_plan_lifecycle_output(stdout, output_file_content),
+            )?;
+            if !is_agent_task_run_plan_envelope(&envelope) {
+                return Ok(());
+            }
+            let Some(aggregate_value) = envelope.get("data").cloned() else {
+                return Ok(());
+            };
+            serde_json::from_value(aggregate_value).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse offloaded agent-task aggregate".to_string()),
+                )
+            })?
+        }
     };
     let raw_plan = config::read_json_spec_to_string(&plan_spec)?;
     let plan: AgentTaskPlan = serde_json::from_str(&raw_plan).map_err(|error| {
@@ -125,18 +141,40 @@ pub(super) fn mirror_agent_task_run_plan_lifecycle(
             Some(format!("read agent-task plan {plan_spec}")),
         )
     })?;
-    let aggregate: AgentTaskAggregate =
-        serde_json::from_value(aggregate_value).map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("parse offloaded agent-task aggregate".to_string()),
-            )
-        })?;
-
     agent_task_lifecycle::submit_plan(&plan, Some(&run_id))?;
     agent_task_lifecycle::mark_running(&run_id)?;
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(())
+}
+
+fn typed_agent_task_lifecycle_event_from_job_events(
+    job_events: Option<&[JobEvent]>,
+) -> Option<AgentTaskRunPlanLifecycleEvent> {
+    job_events?.iter().rev().find_map(|event| {
+        if event.kind != JobEventKind::Result && event.kind != JobEventKind::Progress {
+            return None;
+        }
+        typed_agent_task_lifecycle_event_from_value(event.data.as_ref()?)
+    })
+}
+
+fn typed_agent_task_lifecycle_event_from_value(
+    value: &serde_json::Value,
+) -> Option<AgentTaskRunPlanLifecycleEvent> {
+    if value.get("schema").and_then(serde_json::Value::as_str)
+        == Some(AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA)
+    {
+        return serde_json::from_value(value.clone()).ok();
+    }
+    if let Some(event) = value
+        .get("agent_task_lifecycle_event")
+        .and_then(typed_agent_task_lifecycle_event_from_value)
+    {
+        return Some(event);
+    }
+    value
+        .get("data")
+        .and_then(typed_agent_task_lifecycle_event_from_value)
 }
 
 fn agent_task_run_plan_lifecycle_output<'a>(
@@ -144,47 +182,6 @@ fn agent_task_run_plan_lifecycle_output<'a>(
     output_file_content: Option<&'a str>,
 ) -> &'a str {
     output_file_content.unwrap_or(stdout)
-}
-
-pub(super) fn parse_offloaded_run_plan_envelope(stdout: &str) -> Result<serde_json::Value> {
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout) {
-        return Ok(value);
-    }
-
-    let mut first_json = None;
-    for (index, _) in stdout.match_indices('{') {
-        let mut stream = serde_json::Deserializer::from_str(&stdout[index..]).into_iter();
-        if let Some(Ok(value)) = stream.next() {
-            if is_agent_task_run_plan_envelope(&value) {
-                return Ok(value);
-            }
-            if first_json.is_none() {
-                first_json = Some(value);
-            }
-        }
-    }
-    if let Some(value) = first_json {
-        return Ok(value);
-    }
-
-    serde_json::from_str(stdout).map_err(|error| {
-        Error::internal_json(
-            error.to_string(),
-            Some("parse offloaded agent-task run-plan output".to_string()),
-        )
-    })
-}
-
-fn is_agent_task_run_plan_envelope(value: &serde_json::Value) -> bool {
-    value
-        .get("data")
-        .and_then(|data| data.get("schema"))
-        .and_then(serde_json::Value::as_str)
-        == Some("homeboy/agent-task-aggregate/v1")
-        || value
-            .get("data")
-            .and_then(|data| data.get("plan_id"))
-            .is_some()
 }
 
 pub(super) fn parse_offloaded_dispatch_envelope(stdout: &str) -> Result<Option<serde_json::Value>> {
@@ -802,8 +799,46 @@ mod tests {
         ];
         let stdout = "{\"success\":true,\"data\":{\"command\":\"extension.setup\"}}";
 
-        mirror_agent_task_run_plan_lifecycle(&args, stdout, None)
+        mirror_agent_task_run_plan_lifecycle(&args, stdout, None, None)
             .expect("ignore non-aggregate output");
+    }
+
+    #[test]
+    fn run_plan_lifecycle_event_is_extracted_from_result_metadata() {
+        let aggregate = serde_json::json!({
+            "schema": "homeboy/agent-task-run-plan-lifecycle-event/v1",
+            "identity": {
+                "runner_id": "lab-default",
+                "runner_job_id": "job-1",
+                "run_id": "run-typed"
+            },
+            "aggregate": {
+                "schema":"homeboy/agent-task-aggregate/v1",
+                "plan_id":"plan-from-event",
+                "status":"succeeded",
+                "totals":{"skipped":0,"succeeded":1,"failed":0},
+                "outcomes":[]
+            }
+        });
+        let events = vec![JobEvent {
+            sequence: 1,
+            job_id: uuid::Uuid::nil(),
+            kind: JobEventKind::Result,
+            timestamp_ms: 1,
+            message: None,
+            data: Some(serde_json::json!({
+                "exit_code": 0,
+                "data": {
+                    "agent_task_lifecycle_event": aggregate
+                }
+            })),
+        }];
+
+        let event = typed_agent_task_lifecycle_event_from_job_events(Some(&events))
+            .expect("typed lifecycle event");
+
+        assert_eq!(event.identity.runner_id, "lab-default");
+        assert_eq!(event.aggregate.plan_id, "plan-from-event");
     }
 
     #[test]

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -829,6 +829,7 @@ pub(crate) fn run_lab_offload_inner(
         request.normalized_args,
         &exec_output.stdout,
         output_file_content.as_deref(),
+        exec_output.job_events.as_deref(),
     )?;
 
     let mut stderr = String::new();

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -10,6 +10,7 @@ use crate::core::error::{Error, Result};
 use crate::core::output::{BatchResult, CreateOutput, CreateResult, MergeOutput, MergeResult};
 use crate::core::server::{self, RunnerPolicy, RunnerSecretEnvRef, RunnerSettings, ServerRunner};
 
+mod agent_task_lifecycle_event;
 mod apply;
 mod broker_auth;
 mod broker_http;

--- a/src/core/runner/worker/result.rs
+++ b/src/core/runner/worker/result.rs
@@ -1,9 +1,11 @@
 use base64::Engine;
 use serde_json::json;
 
+use crate::command_contract::AgentTaskDispatchIdentity;
 use crate::core::api_jobs::{
     Job, JobArtifactMetadata, RemoteRunnerJobRequest, RemoteRunnerJobResult,
 };
+use crate::core::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_output;
 
 use super::super::capabilities::RunnerCapabilityPreflight;
 use super::types::{ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
@@ -28,6 +30,25 @@ pub(super) fn remote_runner_result_from_exec_output(
     }
     if let Some(mirror_run_id) = exec_output.mirror_run_id.clone() {
         data["mirror_run_id"] = json!(mirror_run_id);
+    }
+    if let Some(lifecycle_event) = agent_task_run_plan_lifecycle_event_from_output(
+        AgentTaskDispatchIdentity {
+            runner_id: exec_output.runner_id.clone(),
+            runner_job_id: exec_output.job_id.clone().unwrap_or_default(),
+            persisted_run_id: exec_output.mirror_run_id.clone(),
+            run_id: exec_output.mirror_run_id.clone(),
+            handoff_id: exec_output
+                .job_id
+                .as_ref()
+                .map(|job_id| format!("runner:{}:job:{job_id}", exec_output.runner_id)),
+        },
+        &exec_output.stdout,
+    )
+    .ok()
+    .flatten()
+    {
+        data["agent_task_lifecycle_event"] =
+            serde_json::to_value(lifecycle_event).unwrap_or(serde_json::Value::Null);
     }
     if let Some(runner_workload) = runner_workload {
         data["runner_workload"] =

--- a/src/core/runner/worker/tests/result_tests.rs
+++ b/src/core/runner/worker/tests/result_tests.rs
@@ -136,3 +136,56 @@ fn reverse_worker_result_mirrors_file_artifact_bytes() {
         Some("d29ya2VyIGFydGlmYWN0IGJ5dGVz")
     );
 }
+
+#[test]
+fn reverse_worker_result_attaches_typed_agent_task_lifecycle_event() {
+    let result = remote_runner_result_from_exec_output(
+        RunnerExecOutput {
+            variant: "exec",
+            command: "runner.exec",
+            runner_id: "lab-default".to_string(),
+            dry_run: false,
+            mode: RunnerExecMode::Local,
+            argv: vec!["homeboy".to_string(), "agent-task".to_string()],
+            remote_cwd: "/srv/workspace".to_string(),
+            exit_code: 0,
+            stdout: concat!(
+                "runner chatter\n",
+                "{\"success\":true,\"data\":{",
+                "\"schema\":\"homeboy/agent-task-aggregate/v1\",",
+                "\"plan_id\":\"plan-typed\",",
+                "\"status\":\"succeeded\",",
+                "\"totals\":{\"skipped\":0,\"succeeded\":1,\"failed\":0},",
+                "\"outcomes\":[]}}"
+            )
+            .to_string(),
+            stderr: String::new(),
+            source_snapshot: None,
+            job: None,
+            runner_job: None,
+            job_id: Some("job-typed".to_string()),
+            job_events: None,
+            mirror_run_id: Some("run-typed".to_string()),
+            patch: None,
+            mutation_artifacts: None,
+            artifacts: Vec::new(),
+            metrics: None,
+            capture: None,
+            runner_result: None,
+            handoff: None,
+            diagnostics: None,
+        },
+        0,
+        None,
+    );
+
+    let event = &result.data.as_ref().expect("data")["agent_task_lifecycle_event"];
+    assert_eq!(
+        event["schema"],
+        "homeboy/agent-task-run-plan-lifecycle-event/v1"
+    );
+    assert_eq!(event["identity"]["runner_id"], "lab-default");
+    assert_eq!(event["identity"]["runner_job_id"], "job-typed");
+    assert_eq!(event["identity"]["run_id"], "run-typed");
+    assert_eq!(event["aggregate"]["plan_id"], "plan-typed");
+}


### PR DESCRIPTION
## Summary
- Add a typed homeboy/agent-task-run-plan-lifecycle-event/v1 payload for runner job metadata, bound to AgentTaskDispatchIdentity plus the run-plan aggregate.
- Attach that payload to reverse runner job result metadata when agent-task aggregate output is detected.
- Make Lab agent-task lifecycle mirroring prefer typed job event metadata and preserve the existing stdout/output-file fallback.

## Tests
- cargo fmt
- cargo test reverse_worker_result_attaches_typed_agent_task_lifecycle_event
- cargo test run_plan_lifecycle_event_is_extracted_from_result_metadata
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, focused tests, formatting/check execution, and PR preparation.