### PR TITLE
Add Lab runner availability preflight

### DIFF
--- a/src/core/runner/lab/offload/execute.rs
+++ b/src/core/runner/lab/offload/execute.rs
@@ -115,6 +115,9 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     )?;
     selection_timer.finish();
     let Some(selection) = selection else {
+        if !request.force_hot {
+            fail_if_no_default_runner_accepts_jobs(&contract)?;
+        }
         let reason = if request.force_hot && request.local_policy.allow_local_hot() {
             "force_hot_local_override"
         } else if request.force_hot {
@@ -195,6 +198,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     prepare_timer.finish();
     match preparation {
         LabRunnerPreparation::Ready => {
+            preflight_lab_runner_availability(&contract, &selection)?;
             plan = with_step(
                 plan,
                 PlanStep::ready("lab.connect_runner", "lab.connect_runner").build(),

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -75,6 +75,7 @@ use super::super::lab_env::{
 };
 use super::super::lab_plan::{base_lab_plan, disabled_select_runner_plan, with_step};
 use super::super::lab_selection::{
+    fail_if_no_default_runner_accepts_jobs, preflight_lab_runner_availability,
     prepare_lab_runner_for_offload, release_gate_local_hot_denied_error,
     resolve_lab_runner_selection, status_tunnel_mode, LabRunnerPreparation, LabRunnerSelection,
     LabRunnerSelectionSource,

--- a/src/core/runner/lab/offload/tests/mod.rs
+++ b/src/core/runner/lab/offload/tests/mod.rs
@@ -3,7 +3,9 @@
 pub(super) use super::super::super::lab_capabilities::lab_runner_capability_contract;
 pub(super) use super::super::super::lab_env::build_lab_offload_env;
 pub(super) use super::super::super::lab_plan::base_lab_plan;
-pub(super) use super::super::super::lab_selection::resolve_lab_runner_selection_from_default;
+pub(super) use super::super::super::lab_selection::{
+    lab_runner_availability_error, resolve_lab_runner_selection_from_default,
+};
 pub(super) use super::super::super::lab_workspaces::{
     workspace_mapping_entry, LAB_WORKSPACE_MAPPING_SCHEMA,
 };
@@ -12,9 +14,9 @@ pub(super) use crate::core::engine::command::{CaptureMetadata, CommandCaptureMet
 pub(super) use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
 pub(super) use crate::core::plan::PlanKind;
 pub(super) use crate::core::runner::{
-    RunnerActiveJobSource, RunnerActiveJobState, RunnerExecMode, RunnerExecOutput,
-    RunnerRequiredTool, RunnerSession, RunnerSessionState, RunnerStaleDaemonWarning,
-    RunnerTunnelMode, RunnerWorkspaceSyncOutput,
+    RunnerActiveJobSource, RunnerActiveJobState, RunnerAvailability, RunnerExecMode,
+    RunnerExecOutput, RunnerRequiredTool, RunnerSession, RunnerSessionState,
+    RunnerStaleDaemonWarning, RunnerTunnelMode, RunnerWorkspaceSyncOutput,
 };
 
 mod capability_metadata;

--- a/src/core/runner/lab/offload/tests/selection.rs
+++ b/src/core/runner/lab/offload/tests/selection.rs
@@ -58,6 +58,74 @@ fn lab_runner_selection_uses_default_for_supported_commands() {
 }
 
 #[test]
+fn lab_runner_availability_error_reports_busy_selected_runner() {
+    let selected = RunnerAvailability {
+        runner_id: "lab-busy".to_string(),
+        connected: true,
+        accepts_jobs: false,
+        active_job_count: 2,
+        capacity: Some(2),
+        reasons: vec!["capacity_reached".to_string()],
+    };
+
+    let err = lab_runner_availability_error("bench", Some(&selected), vec![selected.clone()]);
+
+    assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    assert!(err.message.contains("lab-busy"));
+    assert_eq!(err.details["field"], "runner");
+    assert_eq!(err.details["id"], "lab-busy");
+    assert_eq!(
+        err.details["runner_availability"]["selected"],
+        serde_json::json!(selected)
+    );
+    assert_eq!(
+        err.details["runner_availability"]["reasons"],
+        serde_json::json!(["capacity_reached"])
+    );
+    assert!(err.details["tried"].as_array().is_some_and(|tried| tried
+        .iter()
+        .any(|hint| hint.as_str().is_some_and(|hint| hint.contains("--runner")))));
+}
+
+#[test]
+fn lab_runner_availability_error_reports_no_available_runner_json_shape() {
+    let eligible = vec![
+        RunnerAvailability {
+            runner_id: "lab-a".to_string(),
+            connected: true,
+            accepts_jobs: false,
+            active_job_count: 1,
+            capacity: Some(1),
+            reasons: vec!["capacity_reached".to_string()],
+        },
+        RunnerAvailability {
+            runner_id: "lab-b".to_string(),
+            connected: true,
+            accepts_jobs: false,
+            active_job_count: 1,
+            capacity: None,
+            reasons: vec!["capacity_unknown".to_string()],
+        },
+    ];
+
+    let err = lab_runner_availability_error("test", None, eligible.clone());
+
+    assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    assert!(err.message.contains("none can accept jobs"));
+    assert_eq!(err.details["field"], "runner");
+    assert!(err.details["id"].is_null());
+    assert!(err.details["runner_availability"]["selected"].is_null());
+    assert_eq!(
+        err.details["runner_availability"]["eligible"],
+        serde_json::json!(eligible)
+    );
+    assert_eq!(
+        err.details["runner_availability"]["reasons"],
+        serde_json::json!(["capacity_reached", "capacity_unknown"])
+    );
+}
+
+#[test]
 fn lab_runner_selection_ignores_default_when_auto_offload_is_disabled() {
     let mut command = portable_lab_command("extension update");
     command.routing_policy.default_lab_offload = false;

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -3,11 +3,11 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use crate::command_contract::{lab_runner_unsupported_hint, lab_runner_unsupported_message};
-use crate::core::{Error, Result};
+use crate::core::{Error, ErrorCode, Result};
 
 use super::{
-    load, status, LabOffloadCommand, LabRunnerGateMode, RunnerConnectReport, RunnerStatusReport,
-    RunnerTunnelMode,
+    default_lab_runner_availability, load, status, LabOffloadCommand, LabRunnerGateMode,
+    RunnerAvailability, RunnerConnectReport, RunnerStatusReport, RunnerTunnelMode,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +63,107 @@ pub(super) fn prepare_lab_runner_for_offload(
     prepare_lab_runner_for_offload_with(selection, status, |runner_id| {
         connect_runner_for_offload(runner_id, selection.source)
     })
+}
+
+pub(super) fn preflight_lab_runner_availability(
+    command: &LabOffloadCommand,
+    selection: &LabRunnerSelection,
+) -> Result<()> {
+    let availability = preflight_lab_runner_availability_with(selection, status)?;
+    if availability.accepts_jobs {
+        return Ok(());
+    }
+
+    let eligible = if matches!(selection.source, LabRunnerSelectionSource::Default) {
+        default_lab_runner_availability().unwrap_or_else(|_| vec![availability.clone()])
+    } else {
+        vec![availability.clone()]
+    };
+    Err(lab_runner_availability_error(
+        command.hot_label,
+        Some(&availability),
+        eligible,
+    ))
+}
+
+fn preflight_lab_runner_availability_with(
+    selection: &LabRunnerSelection,
+    status_fn: impl Fn(&str) -> Result<RunnerStatusReport>,
+) -> Result<RunnerAvailability> {
+    let status = status_fn(&selection.runner_id)?;
+    Ok(RunnerAvailability::from_status_parts(
+        selection.runner_id.clone(),
+        status.connected,
+        status.stale_daemon.is_some(),
+        status.active_jobs.len(),
+        &status.active_job_state,
+        load(&selection.runner_id)?.settings.concurrency_limit,
+    ))
+}
+
+pub(super) fn fail_if_no_default_runner_accepts_jobs(command: &LabOffloadCommand) -> Result<()> {
+    if !command.portable || !command.routing_policy.default_lab_offload {
+        return Ok(());
+    }
+    let eligible = default_lab_runner_availability()?;
+    if eligible.is_empty()
+        || eligible
+            .iter()
+            .any(|availability| availability.accepts_jobs)
+    {
+        return Ok(());
+    }
+
+    Err(lab_runner_availability_error(
+        command.hot_label,
+        None,
+        eligible,
+    ))
+}
+
+pub(super) fn lab_runner_availability_error(
+    command_label: &str,
+    selected: Option<&RunnerAvailability>,
+    eligible: Vec<RunnerAvailability>,
+) -> Error {
+    let selected_runner_id = selected.map(|availability| availability.runner_id.clone());
+    let reasons: Vec<String> = selected
+        .map(|availability| availability.reasons.clone())
+        .unwrap_or_else(|| {
+            eligible
+                .iter()
+                .flat_map(|availability| availability.reasons.iter().cloned())
+                .collect()
+        });
+    let message = if let Some(runner_id) = selected_runner_id.as_deref() {
+        format!(
+            "Lab offload selected runner `{runner_id}` for `{command_label}`, but that runner cannot accept jobs"
+        )
+    } else {
+        format!(
+            "Lab offload found eligible runners for `{command_label}`, but none can accept jobs"
+        )
+    };
+
+    Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!("Invalid argument 'runner': {message}"),
+        serde_json::json!({
+            "field": "runner",
+            "problem": message,
+            "id": selected_runner_id,
+            "runner_availability": {
+                "selected": selected,
+                "eligible": eligible,
+                "reasons": reasons,
+            },
+            "tried": [
+                "Wait for an active Lab runner job to finish, then retry.",
+                "Choose another available runner with --runner <runner-id>.",
+                "Inspect availability with `homeboy runner status <runner-id> --json`.",
+            ],
+        }),
+    )
 }
 
 fn connect_runner_for_offload(

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -369,7 +369,6 @@ struct DefaultLabRunnerReadiness {
 }
 
 impl DefaultLabRunnerCandidate {
-    #[cfg(test)]
     fn availability(&self) -> RunnerAvailability {
         RunnerAvailability::from_status_parts(
             self.id.clone(),
@@ -417,6 +416,38 @@ impl DefaultLabRunnerCandidate {
             score,
         }
     }
+}
+
+pub(crate) fn default_lab_runner_availability() -> Result<Vec<RunnerAvailability>> {
+    let mut availability: Vec<RunnerAvailability> = list()?
+        .into_iter()
+        .filter_map(|runner| {
+            if runner.kind != RunnerKind::Ssh {
+                return None;
+            }
+            let status = status(&runner.id).ok()?;
+            let mode = status
+                .session
+                .as_ref()
+                .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
+            let candidate = DefaultLabRunnerCandidate {
+                id: runner.id,
+                mode,
+                connected: status.connected,
+                capacity: runner.settings.concurrency_limit,
+                stale_daemon: status.stale_daemon.is_some(),
+                active_jobs: status.active_jobs.len(),
+                active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
+                capabilities_ready: true,
+            };
+            candidate
+                .readiness()
+                .eligible
+                .then(|| candidate.availability())
+        })
+        .collect();
+    availability.sort_by(|a, b| a.runner_id.cmp(&b.runner_id));
+    Ok(availability)
 }
 
 fn resolve_default_lab_runner_from_candidates(


### PR DESCRIPTION
## Summary
- add a Lab runner availability preflight after existing runner prepare/connect and before workspace sync or job submission
- surface typed RunnerAvailability diagnostics for selected/default-eligible runners when no runner can accept jobs
- add focused unit coverage for busy selected runner diagnostics and no-available-runner JSON shape

## Tests
- cargo fmt
- cargo test lab_runner_availability_error --lib
- cargo test core::runner::lab::offload::tests::selection --lib
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the runner availability preflight slice, adding tests, and preparing this PR description.