### PR TITLE
Install agent task contracts with extension assets

### DIFF
--- a/src/core/extension/lifecycle/install_sources.rs
+++ b/src/core/extension/lifecycle/install_sources.rs
@@ -213,7 +213,12 @@ fn install_shared_assets_from_root(source_root: &Path, extension_dir: &Path) -> 
         return Ok(());
     };
 
-    for shared_dir in ["scripts/lib", "agent-runtimes", "runtime-agent-ci"] {
+    for shared_dir in [
+        "scripts/lib",
+        "agent-runtimes",
+        "runtime-agent-ci",
+        "agent-task-contracts",
+    ] {
         let source = source_root.join(shared_dir);
         if !source.is_dir() {
             continue;
@@ -221,7 +226,7 @@ fn install_shared_assets_from_root(source_root: &Path, extension_dir: &Path) -> 
 
         let target = match shared_dir {
             "agent-runtimes" => paths::agent_runtimes()?,
-            "runtime-agent-ci" => paths::homeboy()?.join(shared_dir),
+            "runtime-agent-ci" | "agent-task-contracts" => paths::homeboy()?.join(shared_dir),
             // Shared extension libraries install under the extensions root so
             // installed wrappers can source `../../../scripts/lib/...`.
             _ => extensions_dir.join(shared_dir),

--- a/src/core/extension/lifecycle/mod.rs
+++ b/src/core/extension/lifecycle/mod.rs
@@ -357,6 +357,19 @@ mod tests {
             "module.exports = { schema: 'fixture' };\n",
         )
         .expect("runtime agent ci helper");
+
+        let agent_task_contract = root.join("agent-task-contracts/agent-task-provider-contract.js");
+        fs::create_dir_all(
+            agent_task_contract
+                .parent()
+                .expect("agent task contract parent"),
+        )
+        .expect("agent task contract dir");
+        fs::write(
+            &agent_task_contract,
+            "module.exports = { contract: 'fixture' };\n",
+        )
+        .expect("agent task contract");
     }
 
     fn run_git(dir: &Path, args: &[&str]) -> bool {
@@ -785,6 +798,9 @@ exec '{}' "$@"
             assert!(home
                 .join(".config/homeboy/runtime-agent-ci/lib/agent-task-provider-contract.js")
                 .exists());
+            assert!(home
+                .join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js")
+                .exists());
         });
     }
 
@@ -817,6 +833,9 @@ exec '{}' "$@"
                 .exists());
             assert!(home
                 .join(".config/homeboy/runtime-agent-ci/lib/agent-task-provider-contract.js")
+                .exists());
+            assert!(home
+                .join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js")
                 .exists());
         });
     }
@@ -873,6 +892,9 @@ exec '{}' "$@"
             assert!(home
                 .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
                 .exists());
+            assert!(home
+                .join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js")
+                .exists());
         });
     }
 
@@ -893,6 +915,9 @@ exec '{}' "$@"
                 .exists());
             assert!(home
                 .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
+                .exists());
+            assert!(home
+                .join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js")
                 .exists());
         });
     }


### PR DESCRIPTION
## Summary
- Install shared agent-task-contracts from extension monorepos into the Homeboy config directory
- Cover linked, cloned, and extracted monorepo installs so agent runtimes can require the contract package at runtime

## Verification
- cargo fmt --check
- cargo test extension::lifecycle::tests::
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the installer/test change.