### PR TITLE
Surface agent task lifecycle events in runs evidence

### DIFF
--- a/src/commands/runs/evidence.rs
+++ b/src/commands/runs/evidence.rs
@@ -24,6 +24,8 @@ pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
     let failure = evidence_report::evidence_failure_summary(&run);
     let retention = evidence_report::evidence_retention(&artifact_root, &run.id);
     let evidence_links = evidence_report::evidence_links(&artifacts);
+    let agent_task_lifecycle_event =
+        evidence_report::evidence_agent_task_lifecycle_event(&run.metadata_json);
     let matrix_summary = evidence_report::evidence_matrix_summary(&run, &artifacts);
     let (evidence_manifest, evidence_manifest_errors) =
         evidence_report::evidence_manifest(&run, &artifacts);
@@ -50,6 +52,7 @@ pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
             failure,
             disk_budget,
             evidence_links,
+            agent_task_lifecycle_event,
             matrix_summary,
             evidence_manifest,
             evidence_manifest_errors,
@@ -158,7 +161,30 @@ mod tests {
                             }]
                         },
                         "scenario_metrics": [{"scenario_id":"cold","metrics":{"p95_ms":42.0}}],
-                        "resource_policy": {"hot_command":"bench"}
+                        "resource_policy": {"hot_command":"bench"},
+                        "lab": {
+                            "remote_events": [{
+                                "data": {
+                                    "data": {
+                                        "agent_task_lifecycle_event": {
+                                            "schema": "homeboy/agent-task-run-plan-lifecycle-event/v1",
+                                            "identity": {
+                                                "runner_id": "lab-default",
+                                                "runner_job_id": "job-1",
+                                                "run_id": "run-typed"
+                                            },
+                                            "aggregate": {
+                                                "schema": "homeboy/agent-task-aggregate/v1",
+                                                "plan_id": "plan-from-event",
+                                                "status": "succeeded",
+                                                "totals": {"skipped": 0, "succeeded": 1, "failed": 0},
+                                                "outcomes": []
+                                            }
+                                        }
+                                    }
+                                }
+                            }]
+                        }
                     }),
                 ))
                 .expect("run");
@@ -257,6 +283,13 @@ mod tests {
             assert_eq!(manifest.tracker_refs[0].id, "Extra-Chill/homeboy#123");
             assert_eq!(manifest.blocking_conditions[0].kind, "review_needed");
             assert!(output.evidence_manifest_errors.is_empty());
+            let lifecycle_event = output
+                .agent_task_lifecycle_event
+                .expect("agent task lifecycle event");
+            assert_eq!(
+                lifecycle_event["aggregate"]["plan_id"].as_str(),
+                Some("plan-from-event")
+            );
             assert!(
                 output.disk_budget.available_bytes.is_some()
                     || output.disk_budget.warning.is_some()

--- a/src/core/observation/evidence_report.rs
+++ b/src/core/observation/evidence_report.rs
@@ -51,6 +51,8 @@ pub struct RunEvidenceReport<S: Serialize> {
     pub disk_budget: DiskBudget,
     pub evidence_links: Vec<EvidenceLink>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_task_lifecycle_event: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub matrix_summary: Option<GenericMatrixSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence_manifest: Option<EvidenceManifest>,
@@ -161,6 +163,38 @@ pub fn evidence_metadata(metadata: &Value) -> EvidenceMetadata {
         ),
         runtime: pick_metadata(metadata, &["runtime", "runner", "ci_context", "rig_state"]),
     }
+}
+
+pub fn evidence_agent_task_lifecycle_event(metadata: &Value) -> Option<Value> {
+    agent_task_lifecycle_event_value(metadata).cloned()
+}
+
+fn agent_task_lifecycle_event_value(value: &Value) -> Option<&Value> {
+    if value.get("schema").and_then(Value::as_str)
+        == Some("homeboy/agent-task-run-plan-lifecycle-event/v1")
+    {
+        return Some(value);
+    }
+    if let Some(event) = value
+        .get("agent_task_lifecycle_event")
+        .and_then(agent_task_lifecycle_event_value)
+    {
+        return Some(event);
+    }
+    if let Some(event) = value.get("data").and_then(agent_task_lifecycle_event_value) {
+        return Some(event);
+    }
+    value
+        .get("lab")
+        .and_then(|lab| lab.get("remote_events"))
+        .and_then(Value::as_array)
+        .and_then(|events| {
+            events
+                .iter()
+                .rev()
+                .filter_map(|event| event.get("data"))
+                .find_map(agent_task_lifecycle_event_value)
+        })
 }
 
 fn pick_metadata(metadata: &Value, keys: &[&str]) -> Value {

--- a/src/core/runner/agent_task_lifecycle_event.rs
+++ b/src/core/runner/agent_task_lifecycle_event.rs
@@ -1,5 +1,6 @@
 use crate::command_contract::AgentTaskDispatchIdentity;
 use crate::core::agent_tasks::scheduler::AgentTaskAggregate;
+use crate::core::api_jobs::{JobEvent, JobEventKind};
 use crate::core::{Error, Result};
 
 pub(crate) const AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA: &str =
@@ -82,4 +83,34 @@ pub(crate) fn is_agent_task_run_plan_envelope(value: &serde_json::Value) -> bool
             .get("data")
             .and_then(|data| data.get("plan_id"))
             .is_some()
+}
+
+pub(crate) fn agent_task_run_plan_lifecycle_event_from_job_events(
+    job_events: Option<&[JobEvent]>,
+) -> Option<AgentTaskRunPlanLifecycleEvent> {
+    job_events?.iter().rev().find_map(|event| {
+        if event.kind != JobEventKind::Result && event.kind != JobEventKind::Progress {
+            return None;
+        }
+        agent_task_run_plan_lifecycle_event_from_value(event.data.as_ref()?)
+    })
+}
+
+pub(crate) fn agent_task_run_plan_lifecycle_event_from_value(
+    value: &serde_json::Value,
+) -> Option<AgentTaskRunPlanLifecycleEvent> {
+    if value.get("schema").and_then(serde_json::Value::as_str)
+        == Some(AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA)
+    {
+        return serde_json::from_value(value.clone()).ok();
+    }
+    if let Some(event) = value
+        .get("agent_task_lifecycle_event")
+        .and_then(agent_task_run_plan_lifecycle_event_from_value)
+    {
+        return Some(event);
+    }
+    value
+        .get("data")
+        .and_then(agent_task_run_plan_lifecycle_event_from_value)
 }

--- a/src/core/runner/evidence/mirror.rs
+++ b/src/core/runner/evidence/mirror.rs
@@ -7,6 +7,10 @@ use crate::core::error::{Error, Result};
 use crate::core::execution_contract::{encode_uri_component, EXECUTION_CONTRACT};
 use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::core::redaction::redact_argv_display;
+use crate::core::runner::agent_task_lifecycle_event::{
+    agent_task_run_plan_lifecycle_event_from_job_events,
+    agent_task_run_plan_lifecycle_event_from_value,
+};
 
 use super::super::execution::{canonical_daemon_body, daemon_api_get, result_event_data};
 use super::super::{load, Runner};
@@ -255,6 +259,21 @@ pub(super) fn mirror_job_run(
     run_id: Option<&str>,
 ) -> Result<RunRecord> {
     let inferred_label = runner_exec_run_label(command);
+    let agent_task_lifecycle_event = agent_task_run_plan_lifecycle_event_from_value(result)
+        .or_else(|| agent_task_run_plan_lifecycle_event_from_job_events(Some(events)))
+        .and_then(|event| serde_json::to_value(event).ok());
+    let mut lab = json!({
+        "runner": runner_metadata(runner),
+        "remote_job": job,
+        "remote_events": events,
+        "result_summary": result_summary(result),
+        "source_snapshot": source_snapshot_from_result(result),
+        "run_label": inferred_label,
+        "explicit_run_id": run_id,
+    });
+    if let Some(event) = agent_task_lifecycle_event {
+        lab["agent_task_lifecycle_event"] = event;
+    }
     let run = RunRecord {
         id: run_id
             .map(str::to_string)
@@ -269,17 +288,7 @@ pub(super) fn mirror_job_run(
         homeboy_version: None,
         git_sha: None,
         rig_id: None,
-        metadata_json: json!({
-            "lab": {
-                "runner": runner_metadata(runner),
-                "remote_job": job,
-                "remote_events": events,
-                "result_summary": result_summary(result),
-                "source_snapshot": source_snapshot_from_result(result),
-                "run_label": inferred_label,
-                "explicit_run_id": run_id,
-            }
-        }),
+        metadata_json: json!({ "lab": lab }),
     };
     import_run_if_absent(store, &run)?;
     store.get_run(&run.id)?.ok_or_else(|| {

--- a/src/core/runner/evidence/tests/mod.rs
+++ b/src/core/runner/evidence/tests/mod.rs
@@ -4,7 +4,7 @@ use reqwest::header;
 use serde_json::json;
 use uuid::Uuid;
 
-use crate::core::api_jobs::{Job, JobArtifactMetadata, JobStatus};
+use crate::core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobEventKind, JobStatus};
 use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::core::runner::{Runner, RunnerKind};
 use crate::core::server::{RunnerPolicy, RunnerSettings};
@@ -118,13 +118,40 @@ fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
             claim_expires_at_ms: None,
             artifacts: Vec::new(),
         };
+        let lifecycle_event = json!({
+            "schema": "homeboy/agent-task-run-plan-lifecycle-event/v1",
+            "identity": {
+                "runner_id": "lab",
+                "runner_job_id": job_id.to_string(),
+                "run_id": "run-typed"
+            },
+            "aggregate": {
+                "schema": "homeboy/agent-task-aggregate/v1",
+                "plan_id": "plan-from-result",
+                "status": "succeeded",
+                "totals": {"skipped": 0, "succeeded": 1, "failed": 0},
+                "outcomes": []
+            }
+        });
+        let events = vec![JobEvent {
+            sequence: 1,
+            job_id,
+            kind: JobEventKind::Result,
+            timestamp_ms: 1_700_000_001_000,
+            message: None,
+            data: Some(json!({
+                "data": {
+                    "agent_task_lifecycle_event": lifecycle_event
+                }
+            })),
+        }];
         let run = mirror_job_run(
             &store,
             &ssh_runner(),
             "/srv/homeboy/project",
             &["homeboy".to_string(), "bench".to_string()],
             &job,
-            &[],
+            &events,
             &json!({"exit_code":0,"output":{"command":"bench"}}),
             None,
         )
@@ -139,6 +166,10 @@ fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
         assert_eq!(
             run.metadata_json["lab"]["remote_job"]["id"].as_str(),
             Some(job_id.to_string().as_str())
+        );
+        assert_eq!(
+            run.metadata_json["lab"]["agent_task_lifecycle_event"]["aggregate"]["plan_id"].as_str(),
+            Some("plan-from-result")
         );
     });
 }

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -21,10 +21,12 @@ use crate::core::agent_tasks::provider::{
 use crate::core::agent_tasks::scheduler::{
     AgentTaskAggregate, AgentTaskAggregateTotals, AgentTaskPlan,
 };
-use crate::core::api_jobs::{JobEvent, JobEventKind};
+use crate::core::api_jobs::JobEvent;
+#[cfg(test)]
+use crate::core::api_jobs::JobEventKind;
 use crate::core::runner::agent_task_lifecycle_event::{
-    is_agent_task_run_plan_envelope, parse_offloaded_run_plan_envelope,
-    AgentTaskRunPlanLifecycleEvent, AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA,
+    agent_task_run_plan_lifecycle_event_from_job_events, is_agent_task_run_plan_envelope,
+    parse_offloaded_run_plan_envelope,
 };
 use crate::core::{config, Error, Result};
 use serde::{Deserialize, Serialize};
@@ -114,7 +116,7 @@ pub(super) fn mirror_agent_task_run_plan_lifecycle(
     if plan_spec == "-" {
         return Ok(());
     }
-    let aggregate = match typed_agent_task_lifecycle_event_from_job_events(job_events) {
+    let aggregate = match agent_task_run_plan_lifecycle_event_from_job_events(job_events) {
         Some(event) => event.aggregate,
         None => {
             let envelope = parse_offloaded_run_plan_envelope(
@@ -145,36 +147,6 @@ pub(super) fn mirror_agent_task_run_plan_lifecycle(
     agent_task_lifecycle::mark_running(&run_id)?;
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(())
-}
-
-fn typed_agent_task_lifecycle_event_from_job_events(
-    job_events: Option<&[JobEvent]>,
-) -> Option<AgentTaskRunPlanLifecycleEvent> {
-    job_events?.iter().rev().find_map(|event| {
-        if event.kind != JobEventKind::Result && event.kind != JobEventKind::Progress {
-            return None;
-        }
-        typed_agent_task_lifecycle_event_from_value(event.data.as_ref()?)
-    })
-}
-
-fn typed_agent_task_lifecycle_event_from_value(
-    value: &serde_json::Value,
-) -> Option<AgentTaskRunPlanLifecycleEvent> {
-    if value.get("schema").and_then(serde_json::Value::as_str)
-        == Some(AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA)
-    {
-        return serde_json::from_value(value.clone()).ok();
-    }
-    if let Some(event) = value
-        .get("agent_task_lifecycle_event")
-        .and_then(typed_agent_task_lifecycle_event_from_value)
-    {
-        return Some(event);
-    }
-    value
-        .get("data")
-        .and_then(typed_agent_task_lifecycle_event_from_value)
 }
 
 fn agent_task_run_plan_lifecycle_output<'a>(
@@ -834,7 +806,7 @@ mod tests {
             })),
         }];
 
-        let event = typed_agent_task_lifecycle_event_from_job_events(Some(&events))
+        let event = agent_task_run_plan_lifecycle_event_from_job_events(Some(&events))
             .expect("typed lifecycle event");
 
         assert_eq!(event.identity.runner_id, "lab-default");


### PR DESCRIPTION
## Summary
- Persist typed agent-task run-plan lifecycle events into mirrored runner observation metadata when runner results or job events carry them.
- Reuse the typed lifecycle-event parser from the Lab agent-task bridge instead of keeping bridge-local extraction logic.
- Surface the event as an optional `agent_task_lifecycle_event` field in structured `homeboy runs evidence` output without removing existing metadata output.

## Testing
- `cargo fmt`
- `cargo test test_mirror_daemon_evidence_persists_runner_exec_observation`
- `cargo test run_plan_lifecycle_event_is_extracted_from_result_metadata`
- `cargo test evidence_command_reports_registry_artifacts_retention_and_failure_summary`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the code change, adding focused tests, running verification, and drafting this PR description.
