### PR TITLE
Preflight Lab secret env handoff

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -636,6 +636,7 @@ pub(crate) fn run_lab_offload_inner(
     // The remaining pre-dispatch checks (secret-env, provider, path translation)
     // are still runner setup overhead before the workload executes.
     let pre_dispatch_started = std::time::Instant::now();
+    preflight_lab_secret_env_handoff(runner_id, Some(&runner), &env, &secret_env_handoff)?;
     preflight_agent_task_runner_secret_env_plan(
         runner_id,
         &runner,

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -115,6 +115,7 @@ use super::fallback::{
 use super::provider_preflight::preflight_agent_task_provider_on_runner;
 use super::secrets::{
     build_lab_secret_env_handoff_plan, preflight_agent_task_runner_secret_env_plan,
+    preflight_lab_secret_env_handoff,
 };
 use super::trace_fetch_refs::lab_offload_git_fetch_refs;
 use super::workspace_plan::{lab_workspace_sync_mode, preflight_required_git_checkout_workspace};

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -142,7 +142,7 @@ pub(crate) fn run_runner_resident_lab_offload(
         },
     ]);
     let mut env = build_lab_offload_env_with_passthroughs(&lab_metadata);
-    env.extend(secret_env_handoff.env_delta);
+    env.extend(secret_env_handoff.env_delta.clone());
     for (name, value) in &request.job_overrides.env {
         env.insert(name.clone(), value.clone());
     }
@@ -150,6 +150,7 @@ pub(crate) fn run_runner_resident_lab_offload(
     secret_env_names.extend(request.job_overrides.secret_env_names.clone());
     secret_env_names.sort();
     secret_env_names.dedup();
+    preflight_lab_secret_env_handoff(runner_id, None, &env, &secret_env_handoff)?;
 
     let exec_timer = overhead.phase(LabOffloadPhase::RemoteExec);
     let (exec_output, exit_code) = exec(

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -33,6 +33,7 @@ const LAB_SECRET_ENV_HANDOFF_SCHEMA: &str = "homeboy/lab-secret-env-handoff/v1";
 pub(super) struct LabSecretEnvHandoffPlan {
     pub(super) env_delta: HashMap<String, String>,
     pub(super) diagnostics: serde_json::Value,
+    pub(super) entries: Vec<SecretEnvHandoffEntry>,
     pub(super) secret_env_plan: SecretEnvPlan,
     pub(super) secret_env_names: Vec<String>,
     pub(super) runner_deferred_secret_env: Vec<String>,
@@ -87,6 +88,7 @@ pub(super) fn build_lab_secret_env_handoff_plan(
     Ok(LabSecretEnvHandoffPlan {
         env_delta,
         diagnostics,
+        entries,
         secret_env_plan,
         secret_env_names,
         runner_deferred_secret_env,
@@ -386,6 +388,74 @@ pub(super) fn preflight_agent_task_runner_secret_env_plan(
         );
     }
     Err(error)
+}
+
+pub(super) fn preflight_lab_secret_env_handoff(
+    runner_id: &str,
+    runner: Option<&Runner>,
+    env: &HashMap<String, String>,
+    handoff: &LabSecretEnvHandoffPlan,
+) -> Result<()> {
+    let mut missing = Vec::new();
+    for entry in &handoff.entries {
+        let configured = match entry.owner.as_str() {
+            "controller" => env.contains_key(&entry.name),
+            "runner" => runner
+                .map(|runner| runner.secret_env.contains_key(&entry.name))
+                .unwrap_or(true),
+            _ => true,
+        };
+        if configured {
+            continue;
+        }
+
+        let mut missing_entry = entry.clone();
+        missing_entry.status = "missing".to_string();
+        missing_entry.remediation = Some(secret_env_handoff_remediation(entry));
+        missing.push(missing_entry);
+    }
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let names = missing
+        .iter()
+        .map(|entry| entry.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut error = Error::validation_invalid_argument(
+        "secret-env",
+        format!(
+            "missing required Lab secret env before dispatch on runner `{}`: {}",
+            runner_id, names
+        ),
+        Some(runner_id.to_string()),
+        Some(vec![
+            "Configure controller-forwarded secrets in the controller environment or Homeboy agent-task secret config before Lab dispatch.".to_string(),
+            "Configure runner-deferred secrets with the selected runner secret_env references before Lab dispatch.".to_string(),
+            "Use `homeboy runner env <runner>` to inspect redacted runner secret_env refs without printing values.".to_string(),
+        ]),
+    );
+    if let serde_json::Value::Object(details) = &mut error.details {
+        details.insert(
+            "missing_required_secret_env_handoff".to_string(),
+            serde_json::to_value(&missing).unwrap_or_else(|_| serde_json::Value::Array(Vec::new())),
+        );
+        details.insert(
+            "secret_env_handoff".to_string(),
+            handoff.diagnostics.clone(),
+        );
+    }
+    Err(error)
+}
+
+fn secret_env_handoff_remediation(entry: &SecretEnvHandoffEntry) -> String {
+    match entry.owner.as_str() {
+        "controller" => "Configure this secret in the controller environment or Homeboy agent-task secret config so Lab can forward it without exposing the value.".to_string(),
+        "runner" => "Configure this name in the selected runner secret_env references before Lab dispatch.".to_string(),
+        _ => "Configure the required secret env name before Lab dispatch.".to_string(),
+    }
 }
 
 fn declared_agent_task_controller_secret_env(args: &[String]) -> Vec<String> {
@@ -1084,6 +1154,78 @@ mod tests {
             .as_deref()
             .expect("remediation")
             .contains("runner secret_env references"));
+    }
+
+    #[test]
+    fn preflight_lab_secret_env_handoff_reports_missing_runner_deferred_secret() {
+        let args = vec![
+            "homeboy".to_string(),
+            "tunnel".to_string(),
+            "preview-client".to_string(),
+            "start".to_string(),
+            "--ingress".to_string(),
+            "https://preview-broker.example.test".to_string(),
+            "--token-env=HOMEBOY_RUNNER_PREFLIGHT_TOKEN".to_string(),
+        ];
+        let handoff = build_lab_secret_env_handoff_plan(&args, HashMap::new()).expect("handoff");
+        let runner = fixture_runner(HashMap::new());
+
+        let err =
+            preflight_lab_secret_env_handoff("lab-a", Some(&runner), &HashMap::new(), &handoff)
+                .expect_err("missing runner-deferred secret should fail before dispatch");
+
+        assert!(err.message.contains("HOMEBOY_RUNNER_PREFLIGHT_TOKEN"));
+        let rendered = err.details.to_string();
+        assert!(rendered.contains("runner-deferred secrets"));
+        assert!(rendered.contains("runner secret_env references"));
+        assert!(rendered.contains("\"status\":\"missing\""));
+    }
+
+    #[test]
+    fn preflight_lab_secret_env_handoff_preserves_unknown_runner_side_status() {
+        let args = vec![
+            "homeboy".to_string(),
+            "tunnel".to_string(),
+            "preview-client".to_string(),
+            "start".to_string(),
+            "--ingress".to_string(),
+            "https://preview-broker.example.test".to_string(),
+            "--token-env=HOMEBOY_UNKNOWN_RUNNER_TOKEN".to_string(),
+        ];
+        let handoff = build_lab_secret_env_handoff_plan(&args, HashMap::new()).expect("handoff");
+
+        preflight_lab_secret_env_handoff("lab-a", None, &HashMap::new(), &handoff)
+            .expect("unknown runner-side secret status should remain runner-deferred");
+    }
+
+    #[test]
+    fn preflight_lab_secret_env_handoff_reports_redacted_controller_forwarded_secret() {
+        let args = vec![
+            "homeboy".to_string(),
+            "trace".to_string(),
+            "compare".to_string(),
+            "woocommerce-gateway-stripe".to_string(),
+            "real-wallet".to_string(),
+            "--secret-env=HOMEBOY_CONTROLLER_PREFLIGHT_SECRET".to_string(),
+        ];
+        std::env::set_var(
+            "HOMEBOY_CONTROLLER_PREFLIGHT_SECRET",
+            "controller-secret-value-must-not-leak",
+        );
+        let handoff = build_lab_secret_env_handoff_plan(&args, HashMap::new()).expect("handoff");
+        let runner = fixture_runner(HashMap::new());
+
+        let err =
+            preflight_lab_secret_env_handoff("lab-a", Some(&runner), &HashMap::new(), &handoff)
+                .expect_err("missing forwarded controller secret should fail before dispatch");
+
+        let rendered = err.details.to_string();
+        assert!(rendered.contains("HOMEBOY_CONTROLLER_PREFLIGHT_SECRET"));
+        assert!(rendered.contains("controller-forwarded secrets"));
+        assert!(rendered.contains("controller environment"));
+        assert!(!rendered.contains("controller-secret-value-must-not-leak"));
+
+        std::env::remove_var("HOMEBOY_CONTROLLER_PREFLIGHT_SECRET");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Retain typed Lab secret env handoff entries alongside redacted diagnostics.
- Add a pre-dispatch handoff preflight for knowable missing controller-forwarded and runner-deferred secrets.
- Preserve unknown runner-side secret status when the runner config is not available, and keep diagnostics value-redacted.

## Tests
- cargo fmt
- cargo test core::runner::lab::secrets::tests
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the handoff preflight, focused tests, formatting/checks, and PR preparation.