### PR TITLE
Block Lab offload on runner version drift

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -283,7 +283,7 @@ pub(crate) fn run_lab_offload_inner(
         PlanStep::builder(
             "lab.runner_homeboy",
             "lab.runner_homeboy",
-            if runner_status.stale_daemon.is_some() {
+            if lab_runner_homeboy_has_blocking_drift(&runner_status) {
                 PlanStepStatus::Failed
             } else {
                 PlanStepStatus::Ready
@@ -314,7 +314,7 @@ pub(crate) fn run_lab_offload_inner(
                 shell::quote_arg(runner_id)
             ))
     );
-    if runner_status.stale_daemon.is_some() {
+    if lab_runner_homeboy_has_blocking_drift(&runner_status) {
         return Err(stale_runner_homeboy_error(
             runner_id,
             homeboy_path,

--- a/src/core/runner/lab/offload/metadata.rs
+++ b/src/core/runner/lab/offload/metadata.rs
@@ -195,6 +195,8 @@ pub(crate) fn lab_runner_homeboy_metadata(
     configured_executable: &str,
     status: &RunnerStatusReport,
 ) -> serde_json::Value {
+    let controller_version = env!("CARGO_PKG_VERSION");
+    let controller_build_identity = crate::core::build_identity::current().display;
     let refresh_commands = vec![
         format!(
             "homeboy runner refresh-homeboy {} --ref main --reconnect",
@@ -206,13 +208,29 @@ pub(crate) fn lab_runner_homeboy_metadata(
     serde_json::json!({
         "schema": "homeboy/lab-runner-homeboy/v1",
         "runner_id": runner_id,
+        "controller_version": controller_version,
+        "controller_build_identity": controller_build_identity,
         "configured_executable": configured_executable,
         "active_daemon_version": status.session.as_ref().map(|session| session.homeboy_version.clone()),
         "active_daemon_build_identity": status.session.as_ref().and_then(|session| session.homeboy_build_identity.clone()),
         "stale_daemon": status.stale_daemon,
+        "version_drift": lab_runner_homeboy_version_drift(status),
         "refresh_commands": refresh_commands,
         "upgrade_command": format!("homeboy upgrade --force --upgrade-runner {}", shell::quote_arg(runner_id)),
     })
+}
+
+pub(crate) fn lab_runner_homeboy_has_blocking_drift(status: &RunnerStatusReport) -> bool {
+    status.stale_daemon.is_some() || lab_runner_homeboy_version_drift(status)
+}
+
+fn lab_runner_homeboy_version_drift(status: &RunnerStatusReport) -> bool {
+    let controller_version = env!("CARGO_PKG_VERSION");
+    status
+        .session
+        .as_ref()
+        .map(|session| session.homeboy_version.as_str())
+        .is_some_and(|version| version != controller_version)
 }
 
 pub(crate) fn lab_source_checkout_metadata(source_path: &Path) -> serde_json::Value {
@@ -341,7 +359,15 @@ pub(crate) fn stale_runner_homeboy_error(
         .as_ref()
         .map(|warning| warning.message.clone())
         .unwrap_or_else(|| {
-            "connected runner daemon was started by a different Homeboy runtime".to_string()
+            format!(
+                "connected runner daemon reports Homeboy version `{}` while the controller is `{}`",
+                status
+                    .session
+                    .as_ref()
+                    .map(|session| session.homeboy_version.as_str())
+                    .unwrap_or("<unknown>"),
+                env!("CARGO_PKG_VERSION")
+            )
         });
     let refresh = refresh_commands.join(" && ");
     Error::validation_invalid_argument(

--- a/src/core/runner/lab/offload/tests/capability_metadata.rs
+++ b/src/core/runner/lab/offload/tests/capability_metadata.rs
@@ -245,6 +245,10 @@ fn lab_runner_homeboy_metadata_names_binary_and_refresh_path() {
 
     assert_eq!(metadata["schema"], "homeboy/lab-runner-homeboy/v1");
     assert_eq!(metadata["runner_id"], "homeboy lab");
+    assert_eq!(metadata["controller_version"], env!("CARGO_PKG_VERSION"));
+    assert!(metadata["controller_build_identity"]
+        .as_str()
+        .is_some_and(|identity| identity.starts_with("homeboy ")));
     assert_eq!(
         metadata["configured_executable"],
         "/tmp/_lab_workspaces/homeboy/target/debug/homeboy"
@@ -254,6 +258,7 @@ fn lab_runner_homeboy_metadata_names_binary_and_refresh_path() {
         metadata["active_daemon_build_identity"],
         "homeboy 0.0.0+test"
     );
+    assert_eq!(metadata["version_drift"], true);
     assert_eq!(
         metadata["refresh_commands"],
         serde_json::json!([
@@ -266,6 +271,32 @@ fn lab_runner_homeboy_metadata_names_binary_and_refresh_path() {
         metadata["upgrade_command"],
         "homeboy upgrade --force --upgrade-runner 'homeboy lab'"
     );
+}
+
+#[test]
+fn runner_homeboy_version_drift_blocks_offload_with_upgrade_guidance() {
+    let status = reverse_status("homeboy-lab");
+
+    assert!(lab_runner_homeboy_has_blocking_drift(&status));
+
+    let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
+
+    assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+    assert!(err
+        .message
+        .contains("Lab offload refused runner `homeboy-lab`"));
+    assert!(err
+        .message
+        .contains("connected runner daemon reports Homeboy version `homeboy 0.0.0`"));
+    assert!(err.message.contains(env!("CARGO_PKG_VERSION")));
+    let tried = err.details["tried"].as_array().expect("tried hints");
+    assert!(tried
+        .iter()
+        .any(|hint| hint.as_str().is_some_and(|hint| hint
+            .contains("homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect"))));
+    assert!(tried.iter().any(|hint| hint
+        .as_str()
+        .is_some_and(|hint| hint.contains("refresh or select a clean runner binary"))));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- block Lab offload when the selected runner active Homeboy daemon version drifts from the controller
- include controller identity and version_drift in Lab runner Homeboy metadata
- add coverage for version-drift remediation guidance

Closes #6564

## Tests
- cargo fmt --check
- cargo test core::runner::lab::offload::tests::capability_metadata
- cargo test core::runner::lab::offload::tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Root-cause inspection, code/test changes, verification, and PR preparation.