### PR TITLE
Fix rig install schema compatibility errors

### DIFF
--- a/src/core/rig/discovery.rs
+++ b/src/core/rig/discovery.rs
@@ -165,13 +165,7 @@ fn discovered_from_path(
 ) -> Result<DiscoveredRig> {
     let content = fs::read_to_string(path)
         .map_err(|e| Error::internal_io(e.to_string(), Some("read rig spec".into())))?;
-    let mut spec: super::RigSpec = serde_json::from_str(&content).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some(format!("parse rig spec {}", path.display())),
-            Some(content.chars().take(200).collect()),
-        )
-    })?;
+    let mut spec = parse_discovered_rig_spec(path, &content)?;
     if spec.id.is_empty() {
         spec.id = fallback_name
             .and_then(|name| name.to_str())
@@ -189,6 +183,29 @@ fn discovered_from_path(
         id: extension::slugify_id(&spec.id)?,
         description: spec.description,
         rig_path: path.to_path_buf(),
+    })
+}
+
+fn parse_discovered_rig_spec(path: &Path, content: &str) -> Result<super::RigSpec> {
+    let value: serde_json::Value = serde_json::from_str(content).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse rig spec {}", path.display())),
+            Some(content.chars().take(200).collect()),
+        )
+    })?;
+
+    serde_json::from_value(value).map_err(|e| {
+        Error::validation_invalid_argument(
+            "rig_spec",
+            format!(
+                "Rig spec schema is not compatible with this Homeboy binary: {}",
+                e
+            ),
+            Some(path.to_string_lossy().to_string()),
+            None,
+        )
+        .with_hint("Upgrade Homeboy, or update the rig spec to fields supported by this binary")
     })
 }
 

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -4,6 +4,7 @@ use crate::core::rig::{
     declared_id, discover_rigs, install, list, list_ids, load, load_local_source,
     read_source_metadata, read_stack_source_metadata, run_check,
 };
+use crate::core::ErrorCode;
 use crate::test_support::HomeGuard;
 use std::fs;
 use std::path::Path;
@@ -424,6 +425,63 @@ mod install_flows {
                 .expect("metadata")
                 .materialized
         );
+    }
+
+    #[test]
+    fn install_accepts_registry_backed_component_specs() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        write_rig(
+            package.path(),
+            "registry-backed",
+            r#"{
+            "id": "registry-backed",
+            "components": {
+                "app": {
+                    "component_id": "registry-app",
+                    "default_ref": "origin/main",
+                    "path_setting": "HOMEBOY_RIG_COMPONENT_PATH__REGISTRY_BACKED__APP",
+                    "branch": "main"
+                }
+            }
+        }"#,
+        );
+
+        let result = install(package.path().to_str().unwrap(), None, false)
+            .expect("install registry-backed component rig");
+
+        assert_eq!(result.installed.len(), 1);
+        let rig = load("registry-backed").expect("load registry-backed rig");
+        let component = &rig.components["app"];
+        assert!(component.path.is_empty());
+        assert_eq!(component.component_id.as_deref(), Some("registry-app"));
+        assert_eq!(component.default_ref.as_deref(), Some("origin/main"));
+        assert_eq!(component.branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn install_reports_schema_errors_separately_from_invalid_json() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        fs::create_dir_all(package.path().join("rigs/schema-bad")).expect("rig dir");
+        fs::write(
+            package.path().join("rigs/schema-bad/rig.json"),
+            r#"{
+            "id": "schema-bad",
+            "app_launcher": {
+                "platform": "macos"
+            }
+        }"#,
+        )
+        .expect("rig json");
+
+        let err = install(package.path().to_str().unwrap(), None, false)
+            .expect_err("schema error should fail install discovery");
+
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.details["field"], "rig_spec");
+        assert!(err.message.contains("schema"));
+        assert!(err.message.contains("missing field"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep registry-backed rig component specs accepted during rig install
- classify syntactically valid but schema-incompatible rig specs as schema compatibility errors instead of invalid JSON
- add install regression coverage for registry-backed component specs

Closes #6565

## Tests
- cargo +stable fmt --check
- cargo +stable test install_flows

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating rig install parsing, implementing the parser/error classification fix, and adding regression tests.