### PR TITLE
Prefer local rig packages for bench runs

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -738,6 +738,9 @@ fn validate_report_selection_for_single_run(args: &BenchRunArgs) -> homeboy::cor
 fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
     let passthrough_args = filter_homeboy_flags(&args.args);
     let rig_context = load_list_rig(args)?;
+    if let Some(context) = rig_context.as_ref() {
+        report_list_rig_source(context);
+    }
     let rig_spec = rig_context.as_ref().map(|context| &context.spec);
     let effective_id = resolve_list_component_id(args, rig_spec)?;
     let path_override = args.comp.path.clone().or_else(|| {
@@ -805,6 +808,15 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
     Ok((BenchOutput::List(output), 0))
 }
 
+fn report_list_rig_source(context: &ListRigContext) {
+    if let Some(evidence) = rig::package_evidence(&context.spec.id) {
+        eprintln!(
+            "bench rig source: rig={} package_root={} freshness={:?}",
+            evidence.rig_id, evidence.package_root, evidence.freshness
+        );
+    }
+}
+
 fn effective_extension_overrides(
     explicit_overrides: &[String],
     rig_spec: Option<&rig::RigSpec>,
@@ -830,7 +842,7 @@ type ListRigContext = rig::RigSourceContext;
 fn load_list_rig(args: &BenchListArgs) -> homeboy::core::Result<Option<ListRigContext>> {
     match args.rig.as_slice() {
         [] => Ok(None),
-        [rig_id] => Ok(Some(rig::RigSourceContext::load(rig_id)?)),
+        [rig_id] => Ok(Some(rig::RigSourceContext::load_for_invocation(rig_id)?)),
         _ => Err(homeboy::core::Error::validation_invalid_argument(
             "--rig",
             "bench list accepts exactly one rig id",

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -40,9 +40,12 @@ fn prepare_rig_bench_context(
     rig_id: &str,
     args: &BenchRunArgs,
 ) -> homeboy::core::Result<RigBenchContext> {
-    let mut spec = rig::load(rig_id)?;
+    let mut source = rig::RigSourceContext::load_for_invocation(rig_id)?;
+    report_rig_source(&source);
+    let mut spec = source.spec.clone();
     let declared_spec = spec.clone();
     apply_bench_path_override(&mut spec, args);
+    source.spec = spec.clone();
     let lease = rig::lease::acquire_active_run_lease(&spec, "bench")?;
     let prepare_settings = bench_prepare_settings(args);
     if let Some(prepare) = rig::run_bench_prepare(&spec, &prepare_settings)? {
@@ -58,10 +61,19 @@ fn prepare_rig_bench_context(
     let id = spec.id.clone();
     Ok(RigBenchContext {
         id,
-        source: rig::RigSourceContext::from_spec(spec),
+        source,
         snapshot,
         _lease: lease,
     })
+}
+
+fn report_rig_source(source: &rig::RigSourceContext) {
+    if let Some(evidence) = rig::package_evidence(&source.spec.id) {
+        eprintln!(
+            "bench rig source: rig={} package_root={} freshness={:?}",
+            evidence.rig_id, evidence.package_root, evidence.freshness
+        );
+    }
 }
 
 fn bench_prepare_failure_message(prepare: &BenchPrepareReport) -> String {

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -6,6 +6,7 @@ use homeboy::core::extension::bench::aggregate_comparison;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::sync::{Mutex, OnceLock};
 use tempfile::TempDir;
 
 /// Minimal CLI wrapper to exercise clap parsing of `BenchArgs`.
@@ -218,6 +219,48 @@ fn install_rig_package(
     homeboy::core::rig::install(package_root.to_string_lossy().as_ref(), Some(rig_id), false)
         .expect("install rig package");
     package_root
+}
+
+fn write_local_rig_package(
+    root: &std::path::Path,
+    rig_id: &str,
+    component_id: &str,
+    path: &std::path::Path,
+    workload_stem: &str,
+) {
+    let rig_dir = root.join("rigs").join(rig_id);
+    let workload_dir = root.join("workloads");
+    fs::create_dir_all(&rig_dir).expect("mkdir local package rig");
+    fs::create_dir_all(&workload_dir).expect("mkdir local package workloads");
+    fs::write(
+        workload_dir.join(format!("{workload_stem}.bench.js")),
+        "// fixture\n",
+    )
+    .expect("write local package workload");
+    fs::write(
+        rig_dir.join("rig.json"),
+        format!(
+            r#"{{
+                    "components": {{
+                        "{component_id}": {{
+                            "path": "{}",
+                            "extensions": {{ "fixture-bench": {{}} }}
+                        }}
+                    }},
+                    "bench": {{ "default_component": "{component_id}" }},
+                    "bench_workloads": {{ "fixture-bench": [
+                        {{ "path": "${{package.root}}/workloads/{workload_stem}.bench.js" }}
+                    ] }}
+                }}"#,
+            path.display()
+        ),
+    )
+    .expect("write local package rig");
+}
+
+fn current_dir_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 fn write_rig_with_component_script(
@@ -503,6 +546,53 @@ fn run_list_serializes_installed_rig_package_evidence() {
             _ => panic!("expected list output"),
         }
     });
+}
+
+#[test]
+fn run_list_prefers_enclosing_local_rig_package_over_installed_package() {
+    let _guard = current_dir_lock().lock().expect("lock current dir");
+    let original_dir = std::env::current_dir().expect("current dir");
+
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        install_rig_package(home, "studio-bfb", "studio", component_dir.path());
+
+        let local_package = tempfile::TempDir::new().expect("local package");
+        write_local_rig_package(
+            local_package.path(),
+            "studio-bfb",
+            "studio",
+            component_dir.path(),
+            "fresh-checkout-extra",
+        );
+        std::env::set_current_dir(local_package.path()).expect("enter local package");
+
+        let result = run_list(&list_args(None, vec!["studio-bfb".to_string()]));
+        std::env::set_current_dir(&original_dir).expect("restore current dir");
+        let (output, exit_code) = result.expect("rig bench list should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::List(result) => {
+                assert_eq!(result.scenarios[0].id, "fresh-checkout-extra");
+                let evidence = result.rig_package.expect("rig package evidence");
+                assert_eq!(
+                    std::path::PathBuf::from(evidence.package_root)
+                        .canonicalize()
+                        .expect("canonical evidence root"),
+                    local_package
+                        .path()
+                        .canonicalize()
+                        .expect("canonical local package")
+                );
+                assert!(evidence.freshness_verified);
+            }
+            _ => panic!("expected list output"),
+        }
+    });
+
+    std::env::set_current_dir(original_dir).expect("restore current dir");
 }
 
 #[test]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -125,8 +125,39 @@ pub(crate) fn local_package_root(id: &str) -> Option<PathBuf> {
 }
 
 pub fn package_evidence(id: &str) -> Option<RigPackageEvidence> {
+    if let Some(package_root) = local_package_root(id) {
+        return Some(local_package_evidence(id, package_root));
+    }
     let metadata = read_source_metadata(id)?;
     Some(package_evidence_from_metadata(id, metadata))
+}
+
+fn local_package_evidence(id: &str, package_root: PathBuf) -> RigPackageEvidence {
+    let source = package_root.to_string_lossy().to_string();
+    let current_source_revision = git::short_head_revision_at(&package_root);
+    RigPackageEvidence {
+        rig_id: id.to_string(),
+        package_root: source.clone(),
+        source: source.clone(),
+        source_root: Some(source),
+        rig_path: Some(
+            package_root
+                .join("rigs")
+                .join(id)
+                .join("rig.json")
+                .to_string_lossy()
+                .to_string(),
+        ),
+        discovery_path: Some(package_root.to_string_lossy().to_string()),
+        installed_source_revision: current_source_revision.clone(),
+        current_source_revision,
+        linked: true,
+        materialized: false,
+        freshness: RigPackageFreshness::Verified,
+        freshness_verified: true,
+        freshness_message: None,
+        refresh_command: None,
+    }
 }
 
 fn package_evidence_from_metadata(id: &str, metadata: RigSourceMetadata) -> RigPackageEvidence {
@@ -457,8 +488,10 @@ impl RigSourceContext {
     /// Build a source context from an already-loaded spec, resolving the
     /// package root from the rig's recorded source metadata.
     pub fn from_spec(spec: RigSpec) -> Self {
-        let package_root = read_source_metadata(&spec.id)
-            .map(|metadata| std::path::PathBuf::from(metadata.package_path));
+        let package_root = local_package_root(&spec.id).or_else(|| {
+            read_source_metadata(&spec.id)
+                .map(|metadata| std::path::PathBuf::from(metadata.package_path))
+        });
         Self { spec, package_root }
     }
 
@@ -466,6 +499,36 @@ impl RigSourceContext {
     pub fn load(id: &str) -> Result<Self> {
         Ok(Self::from_spec(load(id)?))
     }
+
+    /// Load a rig for a command invocation, preferring an enclosing local rig
+    /// package checkout that contains the requested rig ID over the globally
+    /// installed rig registry.
+    pub fn load_for_invocation(id: &str) -> Result<Self> {
+        if let Some(package_root) = enclosing_local_package_for_rig(id)? {
+            return Ok(Self::from_spec(load_local_source(
+                package_root.to_string_lossy().as_ref(),
+                Some(id),
+            )?));
+        }
+        Self::load(id)
+    }
+}
+
+fn enclosing_local_package_for_rig(id: &str) -> Result<Option<PathBuf>> {
+    let current_dir = std::env::current_dir()
+        .map_err(|e| Error::internal_io(e.to_string(), Some("get current dir".into())))?;
+    for candidate in current_dir.ancestors() {
+        if candidate.join("rigs").join(id).join("rig.json").is_file() {
+            return Ok(Some(candidate.to_path_buf()));
+        }
+        if candidate.join("rig.json").is_file() {
+            let rigs = discover_rigs_for_install(candidate, Some(id), false)?;
+            if !rigs.is_empty() {
+                return Ok(Some(candidate.to_path_buf()));
+            }
+        }
+    }
+    Ok(None)
 }
 
 /// Return the JSON-declared rig ID when it differs from the installed ID.


### PR DESCRIPTION
## Summary
- Prefer an enclosing local rig package checkout for `homeboy bench --rig <id>` and `homeboy bench list --rig <id>` when that checkout contains the requested rig.
- Preserve installed-package fallback when no local checkout is present.
- Print selected rig source package root/freshness before bench workload execution.
- Add regression coverage for stale installed package vs fresh local checkout selection.

Closes #6563

## Tests
- `cargo fmt --check`
- `cargo test commands::bench::tests::run_list_prefers_enclosing_local_rig_package_over_installed_package`
- `cargo test commands::bench::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause inspection, implementation, regression test, and PR drafting.