### PR TITLE
Recognize canonical fuzz result envelopes

### DIFF
--- a/src/commands/fuzz/inspect.rs
+++ b/src/commands/fuzz/inspect.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use homeboy::core::fuzz::inspect_fuzz_result_envelope_artifact;
 use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore};
 
 use super::types::{FuzzInspectArgs, FuzzInspectCandidate, FuzzInspectOutput};
@@ -22,7 +23,7 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
     let store = ObservationStore::open_initialized()?;
     let artifacts = runs_service::list_artifacts_for_run(&store, &args.run_id)?;
 
-    let candidates: Vec<&ArtifactRecord> = RAW_FUZZ_RESULT_KINDS
+    let mut candidates: Vec<&ArtifactRecord> = RAW_FUZZ_RESULT_KINDS
         .iter()
         .flat_map(|kind| {
             artifacts
@@ -30,6 +31,15 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
                 .filter(move |artifact| &artifact.kind == kind && artifact.artifact_type == "file")
         })
         .collect();
+    for artifact in &artifacts {
+        if !candidates
+            .iter()
+            .any(|candidate| candidate.id == artifact.id)
+            && inspect_fuzz_result_envelope_artifact(artifact).is_some()
+        {
+            candidates.push(artifact);
+        }
+    }
 
     let candidate_index = candidates
         .iter()
@@ -60,6 +70,7 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             fetch_command: None,
             result: None,
             raw: None,
+            envelope_summary: None,
             candidates: candidate_index,
             next_steps: vec![
                 format!(
@@ -91,6 +102,7 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             fetch_command: fetch_command.clone(),
             result: None,
             raw: None,
+            envelope_summary: None,
             candidates: candidate_index,
             next_steps: vec![
                 format!(
@@ -119,6 +131,10 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
         }
     };
 
+    let envelope_summary = inspect_fuzz_result_envelope_artifact(selected)
+        .filter(|inspection| inspection.valid)
+        .and_then(|inspection| inspection.summary);
+
     Ok(FuzzInspectOutput {
         command: "fuzz.inspect".to_string(),
         status: "ok".to_string(),
@@ -130,6 +146,7 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
         fetch_command,
         result,
         raw,
+        envelope_summary,
         candidates: candidate_index,
         next_steps: vec![
             format!(
@@ -294,6 +311,57 @@ mod tests {
             assert_eq!(output.status, "ok");
             assert!(output.result.is_none());
             assert_eq!(output.raw.as_deref(), Some("{\"ok\":true}"));
+            homeboy::core::set_artifact_root_override(None);
+        });
+    }
+
+    #[test]
+    fn inspect_discovers_canonical_envelope_with_generic_artifact_kind() {
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("agent-readable-artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("fuzz", serde_json::json!({})))
+                .expect("run");
+            let envelope_path = home.path().join("runner-output.json");
+            std::fs::write(
+                &envelope_path,
+                br#"{
+                    "schema":"homeboy/fuzz-result-envelope/v1",
+                    "version":1,
+                    "id":"envelope-1",
+                    "status":"passed",
+                    "request":{"id":"request-1","component":"homeboy"},
+                    "campaign":{"id":"campaign-1","safety_class":"read_only"},
+                    "required_artifacts":[{"id":"case-log","kind":"case_log","required":true}],
+                    "gates":[{"id":"open-findings","kind":"threshold","metric":"open_findings","operator":"equal","value":0}]
+                }"#,
+            )
+            .expect("write envelope");
+            store
+                .record_artifact(&run.id, "runner-output", &envelope_path)
+                .expect("record");
+
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: run.id.clone(),
+                raw: false,
+            })
+            .expect("inspect");
+
+            assert_eq!(output.status, "ok");
+            assert_eq!(output.artifact_kind, "runner-output");
+            assert_eq!(
+                output
+                    .result
+                    .as_ref()
+                    .and_then(|v| v.pointer("/campaign/id"))
+                    .and_then(|v| v.as_str()),
+                Some("campaign-1")
+            );
+            let summary = output.envelope_summary.expect("envelope summary");
+            assert_eq!(summary.gate_status, "passed");
+            assert_eq!(summary.campaign_id, "campaign-1");
             homeboy::core::set_artifact_root_override(None);
         });
     }

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -80,6 +80,8 @@ pub struct FuzzInspectOutput {
     pub result: Option<serde_json::Value>,
     /// Raw text body when the result is not valid JSON (or `--raw` text fallback).
     pub raw: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub envelope_summary: Option<homeboy::core::fuzz::FuzzResultEnvelopeArtifactSummary>,
     pub candidates: Vec<FuzzInspectCandidate>,
     pub next_steps: Vec<String>,
 }

--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -133,6 +133,7 @@ fn runs_command_json_contract_matches_golden_fixture() {
                     artifacts: vec![artifact_record()],
                     preview_entrypoints: Vec::new(),
                     matrix_summary: None,
+                    fuzz_result_envelopes: Vec::new(),
                 })),
                 scenario("runs query json", RunsOutput::Query(RunsQueryOutput {
                     command: "runs.query",

--- a/src/commands/runs/artifact_index_tests.rs
+++ b/src/commands/runs/artifact_index_tests.rs
@@ -182,6 +182,64 @@ fn runs_artifacts_surfaces_matrix_summary_from_typed_packets() {
 }
 
 #[test]
+fn runs_artifacts_recognizes_canonical_fuzz_result_envelope() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run(
+                "fuzz",
+                "homeboy",
+                "studio",
+                serde_json::json!({ "schema": "example/fuzz-run/v1" }),
+            ))
+            .expect("fuzz run");
+        store
+            .finish_run(&run.id, RunStatus::Pass, None)
+            .expect("finish fuzz run");
+        let envelope = home.path().join("runner-output.json");
+        std::fs::write(
+            &envelope,
+            serde_json::to_vec(&serde_json::json!({
+                "schema": "homeboy/fuzz-result-envelope/v1",
+                "version": 1,
+                "id": "envelope-1",
+                "status": "passed",
+                "request": { "id": "request-1", "component": "homeboy" },
+                "campaign": { "id": "campaign-1", "safety_class": "read_only" },
+                "artifacts": [{ "id": "case-log", "kind": "case_log" }],
+                "required_artifacts": [{ "id": "case-log", "kind": "case_log", "required": true }],
+                "gates": [{ "id": "open-findings", "kind": "threshold", "metric": "open_findings", "operator": "equal", "value": 0 }]
+            }))
+            .expect("envelope json"),
+        )
+        .expect("write envelope");
+        store
+            .record_artifact(&run.id, "runner-output", &envelope)
+            .expect("record envelope");
+
+        let (output, _) = handlers::artifacts(&run.id).expect("artifacts");
+        let RunsOutput::Artifacts(output) = output else {
+            panic!("expected artifacts output");
+        };
+
+        assert_eq!(output.fuzz_result_envelopes.len(), 1);
+        let inspection = &output.fuzz_result_envelopes[0];
+        assert!(inspection.valid);
+        assert!(inspection
+            .recognized_by
+            .contains(&"content.schema".to_string()));
+        let summary = inspection.summary.as_ref().expect("summary");
+        assert_eq!(summary.envelope_id, "envelope-1");
+        assert_eq!(summary.campaign_id, "campaign-1");
+        assert_eq!(summary.gate_status, "passed");
+        assert_eq!(summary.gate_count, 1);
+        assert_eq!(summary.required_artifact_count, 1);
+        assert_eq!(summary.artifact_ref_count, 1);
+    });
+}
+
+#[test]
 fn runs_artifacts_summarizes_static_site_fixture_matrix_artifacts() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();

--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -163,6 +163,10 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
     })?;
     let matrix_summary =
         homeboy::core::artifacts::summarize_matrix_artifacts(run_id, &artifacts, &findings);
+    let fuzz_result_envelopes = artifacts
+        .iter()
+        .filter_map(homeboy::core::fuzz::inspect_fuzz_result_envelope_artifact)
+        .collect();
     Ok((
         RunsOutput::Artifacts(RunsArtifactsOutput {
             command: "runs.artifacts",
@@ -170,6 +174,7 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
             artifacts,
             preview_entrypoints,
             matrix_summary,
+            fuzz_result_envelopes,
         }),
         0,
     ))

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 
 use homeboy::core::artifact_links::ArtifactViewerDescriptor;
 use homeboy::core::artifacts::{ArtifactPreviewEntrypoint, MatrixArtifactSummary};
+use homeboy::core::fuzz::FuzzResultEnvelopeArtifactInspection;
 use homeboy::core::observation::runs_service;
 use homeboy::core::observation::ArtifactRecord;
 use homeboy::core::runners::RunnerArtifactRef;
@@ -197,6 +198,8 @@ pub struct RunsArtifactsOutput {
     pub preview_entrypoints: Vec<ArtifactPreviewEntrypoint>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matrix_summary: Option<MatrixArtifactSummary>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fuzz_result_envelopes: Vec<FuzzResultEnvelopeArtifactInspection>,
 }
 
 #[derive(Serialize)]

--- a/src/core/fuzz/artifact_envelope.rs
+++ b/src/core/fuzz/artifact_envelope.rs
@@ -1,0 +1,296 @@
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::core::observation::ArtifactRecord;
+
+use super::envelope::FuzzResultEnvelope;
+use super::schemas::FUZZ_RESULT_ENVELOPE_SCHEMA;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FuzzResultEnvelopeArtifactInspection {
+    pub artifact_id: String,
+    pub artifact_kind: String,
+    pub artifact_path: String,
+    pub recognized_by: Vec<String>,
+    pub valid: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<FuzzResultEnvelopeArtifactSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FuzzResultEnvelopeArtifactSummary {
+    pub schema: String,
+    pub envelope_id: String,
+    pub status: String,
+    pub gate_status: String,
+    pub campaign_id: String,
+    pub gate_count: usize,
+    pub required_artifact_count: usize,
+    pub artifact_ref_count: usize,
+}
+
+pub fn inspect_fuzz_result_envelope_artifact(
+    artifact: &ArtifactRecord,
+) -> Option<FuzzResultEnvelopeArtifactInspection> {
+    let mut recognized_by = recognition_reasons(artifact);
+    if artifact.artifact_type != "file" || !Path::new(&artifact.path).is_file() {
+        return (!recognized_by.is_empty()).then(|| FuzzResultEnvelopeArtifactInspection {
+            artifact_id: artifact.id.clone(),
+            artifact_kind: artifact.kind.clone(),
+            artifact_path: artifact.path.clone(),
+            recognized_by,
+            valid: false,
+            errors: vec!["artifact bytes are not available locally".to_string()],
+            summary: None,
+        });
+    }
+
+    let bytes = std::fs::read(&artifact.path).ok()?;
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return (!recognized_by.is_empty()).then(|| FuzzResultEnvelopeArtifactInspection {
+            artifact_id: artifact.id.clone(),
+            artifact_kind: artifact.kind.clone(),
+            artifact_path: artifact.path.clone(),
+            recognized_by,
+            valid: false,
+            errors: vec!["artifact file is not valid JSON".to_string()],
+            summary: None,
+        });
+    };
+
+    if value
+        .get("schema")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|schema| schema == FUZZ_RESULT_ENVELOPE_SCHEMA)
+    {
+        recognized_by.push("content.schema".to_string());
+    }
+    if recognized_by.is_empty() {
+        return None;
+    }
+
+    let envelope = serde_json::from_value::<FuzzResultEnvelope>(value);
+    let (summary, errors) = match envelope {
+        Ok(envelope) => summarize_validated_envelope(&envelope),
+        Err(error) => (None, vec![format!("invalid envelope JSON: {error}")]),
+    };
+    Some(FuzzResultEnvelopeArtifactInspection {
+        artifact_id: artifact.id.clone(),
+        artifact_kind: artifact.kind.clone(),
+        artifact_path: artifact.path.clone(),
+        recognized_by,
+        valid: errors.is_empty() && summary.is_some(),
+        errors,
+        summary,
+    })
+}
+
+fn recognition_reasons(artifact: &ArtifactRecord) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if artifact.kind == "fuzz_result_envelope" {
+        reasons.push("artifact.kind".to_string());
+    }
+    if artifact
+        .metadata_json
+        .get("schema")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|schema| schema == FUZZ_RESULT_ENVELOPE_SCHEMA)
+    {
+        reasons.push("metadata.schema".to_string());
+    }
+    let file_name = Path::new(&artifact.path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if file_name.contains("fuzz-result-envelope") {
+        reasons.push("path".to_string());
+    }
+    reasons
+}
+
+fn summarize_validated_envelope(
+    envelope: &FuzzResultEnvelope,
+) -> (Option<FuzzResultEnvelopeArtifactSummary>, Vec<String>) {
+    let mut errors = Vec::new();
+    if envelope.schema != FUZZ_RESULT_ENVELOPE_SCHEMA {
+        errors.push(format!(
+            "schema must be {FUZZ_RESULT_ENVELOPE_SCHEMA}, got {}",
+            envelope.schema
+        ));
+    }
+    if envelope.id.trim().is_empty() {
+        errors.push("envelope id is required".to_string());
+    }
+    if envelope.status.trim().is_empty() {
+        errors.push("envelope status is required".to_string());
+    }
+    let campaign_id = match envelope.campaign.as_ref() {
+        Some(campaign) if !campaign.id.trim().is_empty() => campaign.id.clone(),
+        Some(_) => {
+            errors.push("campaign id is required".to_string());
+            String::new()
+        }
+        None => {
+            errors.push("campaign is required".to_string());
+            String::new()
+        }
+    };
+    for gate in &envelope.gates {
+        if gate.id.trim().is_empty() {
+            errors.push("gate id is required".to_string());
+        }
+        if gate.metric.trim().is_empty() {
+            errors.push(format!("gate {} metric is required", gate.id));
+        }
+        if !gate.value.is_finite() {
+            errors.push(format!("gate {} value must be finite", gate.id));
+        }
+    }
+    for required in &envelope.required_artifacts {
+        if required.id.trim().is_empty() {
+            errors.push("required artifact id is required".to_string());
+        }
+        if required.kind.trim().is_empty() {
+            errors.push(format!(
+                "required artifact {} kind is required",
+                required.id
+            ));
+        }
+    }
+    validate_artifact_refs("envelope", &envelope.artifacts, &mut errors);
+    if let Some(campaign) = envelope.campaign.as_ref() {
+        validate_artifact_refs("campaign", &campaign.artifacts, &mut errors);
+    }
+
+    let artifact_ref_count = envelope.artifacts.len()
+        + envelope
+            .campaign
+            .as_ref()
+            .map(|campaign| campaign.artifacts.len())
+            .unwrap_or(0);
+    let summary = FuzzResultEnvelopeArtifactSummary {
+        schema: envelope.schema.clone(),
+        envelope_id: envelope.id.clone(),
+        status: envelope.status.clone(),
+        gate_status: envelope.status.clone(),
+        campaign_id,
+        gate_count: envelope.gates.len(),
+        required_artifact_count: envelope.required_artifacts.len(),
+        artifact_ref_count,
+    };
+    (Some(summary), errors)
+}
+
+fn validate_artifact_refs(
+    label: &str,
+    artifacts: &[super::coverage::FuzzArtifact],
+    errors: &mut Vec<String>,
+) {
+    for artifact in artifacts {
+        if artifact.id.trim().is_empty() {
+            errors.push(format!("{label} artifact id is required"));
+        }
+        if artifact.kind.trim().is_empty() {
+            errors.push(format!("{label} artifact {} kind is required", artifact.id));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::observation::ArtifactRecord;
+
+    use super::*;
+
+    fn artifact(path: &Path) -> ArtifactRecord {
+        ArtifactRecord {
+            id: "artifact-1".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "runner-output".to_string(),
+            artifact_type: "file".to_string(),
+            path: path.display().to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: Some("application/json".to_string()),
+            metadata_json: serde_json::json!({}),
+            created_at: "2026-06-26T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn recognizes_canonical_envelope_from_content_schema() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("runner-output.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "schema":"homeboy/fuzz-result-envelope/v1",
+                "version":1,
+                "id":"envelope-1",
+                "status":"passed",
+                "request":{"id":"request-1","component":"homeboy"},
+                "campaign":{"id":"campaign-1","safety_class":"read_only"},
+                "artifacts":[{"id":"case-log","kind":"case_log"}],
+                "required_artifacts":[{"id":"case-log","kind":"case_log","required":true}],
+                "gates":[{"id":"open-findings","kind":"threshold","metric":"open_findings","operator":"equal","value":0}]
+            }"#,
+        )
+        .expect("write fixture");
+
+        let inspection =
+            inspect_fuzz_result_envelope_artifact(&artifact(&path)).expect("recognized");
+
+        assert!(inspection.valid);
+        assert!(inspection
+            .recognized_by
+            .contains(&"content.schema".to_string()));
+        let summary = inspection.summary.expect("summary");
+        assert_eq!(summary.campaign_id, "campaign-1");
+        assert_eq!(summary.gate_status, "passed");
+        assert_eq!(summary.gate_count, 1);
+        assert_eq!(summary.required_artifact_count, 1);
+        assert_eq!(summary.artifact_ref_count, 1);
+    }
+
+    #[test]
+    fn validates_required_campaign_and_artifact_refs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fuzz-result-envelope.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "schema":"homeboy/fuzz-result-envelope/v1",
+                "id":"envelope-1",
+                "status":"failed",
+                "request":{"id":"request-1","component":"homeboy"},
+                "artifacts":[{"id":"","kind":""}],
+                "gates":[{"id":"","kind":"threshold","metric":"","operator":"equal","value":0}]
+            }"#,
+        )
+        .expect("write fixture");
+
+        let inspection =
+            inspect_fuzz_result_envelope_artifact(&artifact(&path)).expect("recognized");
+
+        assert!(!inspection.valid);
+        assert!(inspection
+            .errors
+            .iter()
+            .any(|error| error == "campaign is required"));
+        assert!(inspection
+            .errors
+            .iter()
+            .any(|error| error == "envelope artifact id is required"));
+        assert!(inspection
+            .errors
+            .iter()
+            .any(|error| error == "gate id is required"));
+    }
+}

--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -3,6 +3,7 @@
 //! These types define Homeboy-owned envelope shapes only. Product-specific
 //! runners can attach their own details through `metadata` or flattened extras.
 
+mod artifact_envelope;
 mod contract;
 mod coverage;
 mod defaults;
@@ -18,6 +19,10 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+pub use artifact_envelope::{
+    inspect_fuzz_result_envelope_artifact, FuzzResultEnvelopeArtifactInspection,
+    FuzzResultEnvelopeArtifactSummary,
+};
 pub use contract::{
     canonical_operation_family, fuzz_core_contract, FuzzContractSchemas, FuzzCoreContract,
     FuzzFindingStatus, FuzzOperationFamily, FuzzSafetyClass,


### PR DESCRIPTION
## Summary
- Add a minimal canonical `homeboy/fuzz-result-envelope/v1` artifact recognizer that detects envelopes by artifact kind, metadata schema, path, or JSON content schema.
- Validate schema, campaign presence/id, gate fields, required artifact refs, and envelope/campaign artifact refs before exposing a summary.
- Surface recognized envelope summaries from `homeboy runs artifacts` and `homeboy fuzz inspect` without changing fuzz producers.

## Tests
- `cargo fmt`
- `cargo test fuzz::artifact_envelope`
- `cargo test runs::artifact_index_tests::runs_artifacts_recognizes_canonical_fuzz_result_envelope`
- `cargo test inspect_discovers_canonical_envelope_with_generic_artifact_kind`
- `cargo test output_contracts`
- `cargo test runs_command_json_contract_matches_golden_fixture`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, formatting, and verification.