### PR TITLE
Apply controller cwd defaults to command workflows

### DIFF
--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -925,7 +925,7 @@ pub(super) fn compile_loop_spec_workflow(
         return Ok(AgentTaskLoopPolicyAction::RunCommand {
             dedupe_key,
             entity_id: None,
-            request: workflow_command_request(workflow),
+            request: workflow_command_request(spec, workflow),
         });
     }
 
@@ -953,13 +953,31 @@ pub(super) fn compile_loop_spec_workflow(
     }
 }
 
-fn workflow_command_request(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Value {
+fn workflow_command_request(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+) -> Value {
+    let mut execution = workflow.runtime_execution.clone();
+    if execution.get("cwd").and_then(Value::as_str).is_none() {
+        if let Some(cwd) = spec
+            .metadata
+            .get("dispatch_defaults")
+            .and_then(Value::as_object)
+            .and_then(|defaults| defaults.get("cwd"))
+            .and_then(Value::as_str)
+            .filter(|cwd| !cwd.is_empty())
+        {
+            if let Value::Object(execution) = &mut execution {
+                execution.insert("cwd".to_string(), Value::String(cwd.to_string()));
+            }
+        }
+    }
     serde_json::json!({
         "mode": "command",
         "workflow_id": workflow.workflow_id,
         "consumes": workflow.inputs.get("consumes").cloned().unwrap_or(Value::Null),
         "artifacts": workflow.artifacts,
-        "execution": workflow.runtime_execution,
+        "execution": execution,
         "runtime_execution": workflow.runtime_execution,
         "inputs": workflow.inputs,
     })

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -3542,6 +3542,86 @@ fn run_command_workflow_executes_deterministic_artifact_action() {
 }
 
 #[test]
+fn run_command_workflow_inherits_dispatch_default_cwd() {
+    let repo = tempfile::tempdir().expect("repo tempdir");
+    std::fs::write(repo.path().join("repo-marker"), "ok").expect("repo marker");
+    with_isolated_home(|_| {
+        let spec = AgentTaskRepoLoopSpec {
+            schema: None,
+            loop_id: "repo-loop-command-cwd".to_string(),
+            phase: "init".to_string(),
+            config_version: "v1".to_string(),
+            metadata: json!({
+                "dispatch_defaults": {
+                    "cwd": repo.path().display().to_string()
+                }
+            }),
+            entities: Vec::new(),
+            agents: Vec::new(),
+            tools: Vec::new(),
+            abilities: Vec::new(),
+            workflows: vec![AgentTaskRepoLoopSpecWorkflow {
+                workflow_id: "deterministic-validation".to_string(),
+                agent_id: None,
+                prompt: None,
+                tasks: vec!["Run deterministic validation.".to_string()],
+                entity_ids: Vec::new(),
+                fan_out: None,
+                tools: Vec::new(),
+                abilities: Vec::new(),
+                artifacts: vec!["validation_result".to_string()],
+                consumes: Vec::new(),
+                emits: Vec::new(),
+                dependencies: Vec::new(),
+                gates: Vec::new(),
+                metrics: Vec::new(),
+                runtime_execution: json!({
+                    "kind": "command",
+                    "command": "/bin/sh",
+                    "args": ["-c", "test -f repo-marker && printf '%s\n' '{\"artifacts\":{\"validation_result\":{\"schema\":\"example/ValidationResult/v1\"}}}' > \"$HOMEBOY_LOOP_ACTION_OUTPUT\""]
+                }),
+                inputs: Value::Null,
+            }],
+            artifacts: vec![AgentTaskRepoLoopSpecArtifact {
+                artifact_id: "validation_result".to_string(),
+                kind: "example/ValidationResult/v1".to_string(),
+                description: None,
+                required: true,
+            }],
+            artifact_graph: Vec::new(),
+            dependencies: Vec::new(),
+            gates: Vec::new(),
+            metrics: Vec::new(),
+            gate_bundles: Vec::new(),
+            policy: None,
+            phases: Vec::new(),
+            actions: Vec::new(),
+            initial_event: None,
+        };
+
+        let initialized = init_from_spec(ControllerFromSpecRequest { spec }).expect("init");
+        match &initialized.actions[0].action {
+            AgentTaskLoopPolicyAction::RunCommand { request, .. } => {
+                assert_eq!(
+                    request["execution"]["cwd"].as_str(),
+                    Some(repo.path().to_string_lossy().as_ref())
+                );
+            }
+            other => panic!("expected run_command action, got {other:?}"),
+        }
+
+        let result = run_next(
+            "repo-loop-command-cwd",
+            CapturingExecutor::default(),
+            &CapturingDispatchHook::default(),
+        )
+        .expect("run command action");
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.value.status.as_deref(), Some("completed"));
+    });
+}
+
+#[test]
 fn run_command_workflow_times_out_instead_of_blocking_controller() {
     with_isolated_home(|_| {
         let spec = AgentTaskRepoLoopSpec {


### PR DESCRIPTION
## Summary
- Apply repo-derived controller cwd defaults to command workflow execution when the command does not set an explicit cwd
- Preserve the original runtime_execution snapshot while running the effective execution with cwd
- Add coverage proving command workflows execute from the dispatch-default repo cwd

## Verification
- cargo fmt
- cargo test run_command_workflow
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing Lab command cwd loss and drafting/verifying the generic controller fix.