### PR TITLE
Support rig package dependencies

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -36,6 +36,7 @@ For git sources, `repo.git//subpath` clones the repository root but discovers sp
 | `services` | object | No | Map of service ID to `ServiceSpec`. |
 | `symlinks` | array | No | List of `SymlinkSpec` entries. |
 | `shared_paths` | array | No | List of dependency paths the rig may borrow from another checkout. |
+| `package_dependencies` | array | No | Install-time package-relative paths that must materialize with the package, for nested package imports that cross the selected package root. |
 | `resources` | object | No | Resource declarations used by active-run leases. |
 | `pipeline` | object | No | Map of pipeline name to `PipelineStep[]`. |
 | `bench` | object | No | Rig-pinned benchmark component/default-baseline settings. |
@@ -92,6 +93,25 @@ Example:
 ```
 
 The installed rig keeps the base `pipeline.check` and `components.app.branch`, while replacing `components.app.path`.
+
+## Package Dependencies
+
+Nested package rigs can declare sibling files/directories that must travel with
+the selected package when Lab materializes the package source. Entries are
+resolved relative to the selected package root, must be relative paths, must
+exist, and must stay inside the package source repository root.
+
+```jsonc
+{
+  "id": "static-site-importer-fixture-matrix",
+  "package_dependencies": ["../../shared/wp-codebox"]
+}
+```
+
+When this rig is installed from `WordPress/static-site-importer`, Homeboy records
+the repository root as the source root and keeps the package path at
+`WordPress/static-site-importer`, so imports such as
+`../../../shared/wp-codebox/recipe.mjs` keep resolving on Lab.
 
 ## `ComponentSpec`
 

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -84,10 +84,20 @@ pub struct StackSourceMetadata {
     pub source_revision: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct RigPackageMetadata {
+    #[serde(default)]
+    package_dependencies: Vec<String>,
+}
+
 pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallResult> {
-    let prepared = prepare_source(source)?;
+    let mut prepared = prepare_source(source)?;
     let discovered = discover_rigs_for_install(&prepared.discovery_path, id, all)?;
     let selected = select_rigs(discovered, id, all, source)?;
+    let dependency_roots = package_source_roots_for_dependencies(&prepared, &selected)?;
+    prepared.source_root = dependency_roots.source_root;
+    prepared.package_path = dependency_roots.package_path;
+    prepared.discovery_path = dependency_roots.discovery_path;
     let discovered_stacks = if id.is_some() && !all {
         Vec::new()
     } else {
@@ -349,6 +359,124 @@ fn remove_extends(value: &mut serde_json::Value) {
     if let Some(object) = value.as_object_mut() {
         object.remove(EXTENDS_FIELD);
     }
+}
+
+struct PackageDependencySourceRoots {
+    source_root: PathBuf,
+    package_path: PathBuf,
+    discovery_path: PathBuf,
+}
+
+fn package_source_roots_for_dependencies(
+    prepared: &PreparedSource,
+    rigs: &[DiscoveredRig],
+) -> Result<PackageDependencySourceRoots> {
+    let mut dependency_paths = Vec::new();
+    for rig in rigs {
+        let value = read_json_value(&rig.rig_path)?;
+        let spec: RigPackageMetadata = serde_json::from_value(value).map_err(|e| {
+            Error::validation_invalid_argument(
+                "rig_spec",
+                format!(
+                    "Rig spec schema is not compatible with this Homeboy binary: {}",
+                    e
+                ),
+                Some(rig.rig_path.to_string_lossy().to_string()),
+                None,
+            )
+        })?;
+        for dependency in spec.package_dependencies {
+            dependency_paths.push((rig.id.clone(), dependency));
+        }
+    }
+
+    if dependency_paths.is_empty() {
+        return Ok(PackageDependencySourceRoots {
+            source_root: prepared.source_root.clone(),
+            package_path: prepared.package_path.clone(),
+            discovery_path: prepared.discovery_path.clone(),
+        });
+    }
+
+    let repo_root =
+        git::repo_root(&prepared.package_path).unwrap_or_else(|| prepared.source_root.clone());
+    let repo_root = repo_root.canonicalize().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!(
+                "resolve rig package source root {}",
+                repo_root.display()
+            )),
+        )
+    })?;
+    let package_root = prepared.package_path.canonicalize().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!(
+                "resolve rig package path {}",
+                prepared.package_path.display()
+            )),
+        )
+    })?;
+    if !package_root.starts_with(&repo_root) {
+        return Err(Error::validation_invalid_argument(
+            "package_dependencies",
+            "Rig package dependencies require the selected package path to stay inside the package source root",
+            Some(prepared.package_path.to_string_lossy().to_string()),
+            Some(vec![format!("source root: {}", repo_root.display())]),
+        ));
+    }
+
+    for (rig_id, dependency) in dependency_paths {
+        validate_package_dependency_path(&rig_id, &dependency, &package_root, &repo_root)?;
+    }
+
+    Ok(PackageDependencySourceRoots {
+        source_root: repo_root,
+        package_path: package_root.clone(),
+        discovery_path: package_root,
+    })
+}
+
+fn validate_package_dependency_path(
+    rig_id: &str,
+    dependency: &str,
+    package_root: &Path,
+    source_root: &Path,
+) -> Result<PathBuf> {
+    let dependency = dependency.trim();
+    if dependency.is_empty() || Path::new(dependency).is_absolute() {
+        return Err(Error::validation_invalid_argument(
+            "package_dependencies",
+            "Rig package dependency paths must be non-empty relative paths",
+            Some(dependency.to_string()),
+            Some(vec![format!("rig: {rig_id}")]),
+        ));
+    }
+
+    let candidate = package_root.join(dependency);
+    let canonical = candidate.canonicalize().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!(
+                "resolve rig package dependency {} for {}",
+                candidate.display(),
+                rig_id
+            )),
+        )
+    })?;
+    if !canonical.starts_with(source_root) {
+        return Err(Error::validation_invalid_argument(
+            "package_dependencies",
+            "Rig package dependency paths must stay inside the package source root",
+            Some(dependency.to_string()),
+            Some(vec![
+                format!("rig: {rig_id}"),
+                format!("source root: {}", source_root.display()),
+            ]),
+        ));
+    }
+    Ok(canonical)
 }
 
 fn merge_json(target: &mut serde_json::Value, overlay: serde_json::Value) {

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -244,6 +244,97 @@ mod install_flows {
     }
 
     #[test]
+    fn local_nested_package_dependency_records_repo_source_root() {
+        let _home = HomeGuard::new();
+        let repo = tempfile::tempdir().expect("repo");
+        let nested = repo.path().join("WordPress/static-site-importer");
+        fs::create_dir_all(repo.path().join("shared/wp-codebox")).expect("shared dir");
+        fs::write(
+            repo.path().join("shared/wp-codebox/recipe.mjs"),
+            "export default {};\n",
+        )
+        .expect("shared recipe");
+        write_single_rig(
+            &nested,
+            "static-site-importer-fixture-matrix",
+            r#"{
+                "id": "static-site-importer-fixture-matrix",
+                "package_dependencies": ["../../shared/wp-codebox"],
+                "bench_workloads": {
+                    "static-site-importer": [
+                        { "path": "${package.root}/bench/static-site-fixture-matrix.bench.mjs" }
+                    ]
+                }
+            }"#,
+        );
+        GitFixture::init(repo.path()).commit("nested package with shared dependency");
+
+        let result =
+            install(nested.to_str().unwrap(), None, false).expect("install nested package");
+        let metadata =
+            read_source_metadata("static-site-importer-fixture-matrix").expect("metadata");
+        let repo_root = repo.path().canonicalize().expect("canonical repo root");
+        let package_root = nested.canonicalize().expect("canonical package root");
+
+        assert_eq!(result.source_root, repo_root);
+        assert_eq!(result.package_path, package_root);
+        assert_eq!(
+            metadata.source_root.as_deref(),
+            Some(repo_root.to_str().unwrap())
+        );
+        assert_eq!(metadata.package_path, package_root.to_string_lossy());
+    }
+
+    #[test]
+    fn package_dependency_outside_source_root_is_rejected() {
+        let _home = HomeGuard::new();
+        let parent = tempfile::tempdir().expect("parent");
+        let repo = parent.path().join("repo");
+        let outside = parent.path().join("outside-shared");
+        let nested = repo.join("packages/app");
+        fs::create_dir_all(&outside).expect("outside dir");
+        write_single_rig(
+            &nested,
+            "bad-rig",
+            r#"{
+                "id": "bad-rig",
+                "package_dependencies": ["../../../outside-shared"]
+            }"#,
+        );
+        GitFixture::init(&repo).commit("bad dependency");
+
+        let err = install(nested.to_str().unwrap(), None, false)
+            .expect_err("dependency outside repo should fail");
+
+        assert!(err
+            .message
+            .contains("package dependency paths must stay inside"));
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+    }
+
+    #[test]
+    fn absolute_package_dependency_is_rejected() {
+        let _home = HomeGuard::new();
+        let repo = tempfile::tempdir().expect("repo");
+        let nested = repo.path().join("packages/app");
+        write_single_rig(
+            &nested,
+            "bad-rig",
+            r#"{
+                "id": "bad-rig",
+                "package_dependencies": ["/tmp/shared"]
+            }"#,
+        );
+        GitFixture::init(repo.path()).commit("bad dependency");
+
+        let err = install(nested.to_str().unwrap(), None, false)
+            .expect_err("absolute dependency should fail");
+
+        assert!(err.message.contains("non-empty relative paths"));
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+    }
+
+    #[test]
     fn install_git_source_missing_subpath_reports_source_and_package_roots() {
         let _home = HomeGuard::new();
         let repo = tempfile::tempdir().expect("repo");


### PR DESCRIPTION
## Summary
- Add install-time `package_dependencies` support for rig package specs
- Validate dependency paths are relative, exist, and stay inside the package source repository root
- Preserve nested package paths while recording the repo root as source root so Lab snapshots include shared dependencies
- Document the field and cover nested/out-of-root/absolute dependency cases

Closes #6574.

## Tests
- `cargo fmt --check`
- `cargo test install_test -- --nocapture`
- Isolated install verification against Homeboy Rigs SSI package: `HOME="$tmp" XDG_DATA_HOME="$tmp/.local/share" ./target/debug/homeboy rig install /Users/chubes/Developer/homeboy-rigs@fix-ssi-matrix-package-dependencies/WordPress/static-site-importer --id static-site-importer-fixture-matrix && HOME="$tmp" XDG_DATA_HOME="$tmp/.local/share" ./target/debug/homeboy rig sources list`
- `git diff --check`

Actions credits are exhausted; local targeted tests passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigating rig package materialization, implementing install-time dependency support, adding targeted tests/docs, and preparing this PR.