### PR TITLE
Support rig workload env providers

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -796,6 +796,18 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
             passthrough_args,
             scenario_ids: args.scenario_ids.clone(),
             extra_workloads,
+            env_provider_extensions: rig_spec
+                .as_ref()
+                .and_then(|spec| {
+                    ctx.extension_id.as_deref().map(|id| {
+                        rig::env_provider_extensions_for_extension_workloads(
+                            spec,
+                            rig::RigWorkloadKind::Bench,
+                            id,
+                        )
+                    })
+                })
+                .unwrap_or_default(),
             rig_package: rig_context
                 .as_ref()
                 .and_then(|context| rig::package_evidence(&context.spec.id)),

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -614,7 +614,7 @@ fn run_component_with_rig_context(
         effective_id
     )));
 
-    let (extra_workloads, invocation_requirements) =
+    let (extra_workloads, env_provider_extensions, invocation_requirements) =
         rig_workload_runtime_inputs(rig_context, rig_spec, ctx.extension_id.as_deref());
 
     let selected_scenarios = selected_scenario_ids(args, rig_spec)?;
@@ -658,6 +658,7 @@ fn run_component_with_rig_context(
             rig_id: rig_id.clone(),
             shared_state: shared_state_override.or_else(|| args.shared_state.clone()),
             extra_workloads,
+            env_provider_extensions,
             rig_package: rig_id
                 .as_deref()
                 .and_then(homeboy::core::rig::package_evidence),
@@ -729,12 +730,12 @@ fn rig_workload_runtime_inputs(
     rig_context: Option<&RigBenchContext>,
     rig_spec: Option<&RigSpec>,
     extension_id: Option<&str>,
-) -> (Vec<PathBuf>, InvocationRequirements) {
+) -> (Vec<PathBuf>, Vec<String>, InvocationRequirements) {
     let Some(spec) = rig_spec else {
-        return (Vec::new(), InvocationRequirements::default());
+        return (Vec::new(), Vec::new(), InvocationRequirements::default());
     };
     let Some(extension_id) = extension_id else {
-        return (Vec::new(), InvocationRequirements::default());
+        return (Vec::new(), Vec::new(), InvocationRequirements::default());
     };
 
     let package_root = rig_context.and_then(|context| context.package_root());
@@ -743,6 +744,11 @@ fn rig_workload_runtime_inputs(
             spec,
             rig::RigWorkloadKind::Bench,
             package_root,
+            extension_id,
+        ),
+        rig::env_provider_extensions_for_extension_workloads(
+            spec,
+            rig::RigWorkloadKind::Bench,
             extension_id,
         ),
         rig::invocation_requirements_for_extension_workloads(

--- a/src/commands/fuzz/workloads.rs
+++ b/src/commands/fuzz/workloads.rs
@@ -302,6 +302,7 @@ fn fuzz_rig_workload_inputs(
     let Some((context, extension_id)) = rig_context.zip(extension_id) else {
         return rig::RigExtensionWorkloadInputs {
             workload_paths: Vec::new(),
+            env_provider_extensions: Vec::new(),
             invocation_requirements: InvocationRequirements::default(),
         };
     };

--- a/src/commands/report/bench_coverage.rs
+++ b/src/commands/report/bench_coverage.rs
@@ -143,6 +143,7 @@ fn component_report(
             passthrough_args: Vec::new(),
             scenario_ids: Vec::new(),
             extra_workloads: Vec::new(),
+            env_provider_extensions: Vec::new(),
             rig_package: None,
         },
         &run_dir,

--- a/src/core/extension/bench/failure_diagnostic.rs
+++ b/src/core/extension/bench/failure_diagnostic.rs
@@ -147,6 +147,7 @@ mod tests {
             rig_id: Some("studio-bfb".to_string()),
             shared_state: None,
             extra_workloads: Vec::new(),
+            env_provider_extensions: Vec::new(),
             rig_package: None,
             invocation_requirements:
                 crate::core::engine::invocation::InvocationRequirements::default(),

--- a/src/core/extension/bench/run/list.rs
+++ b/src/core/extension/bench/run/list.rs
@@ -79,6 +79,7 @@ pub fn run_bench_list_workflow(
             rig_id: None,
             shared_state: None,
             extra_workloads: args.extra_workloads,
+            env_provider_extensions: args.env_provider_extensions,
             rig_package: args.rig_package.clone(),
             invocation_requirements: InvocationRequirements::default(),
         },

--- a/src/core/extension/bench/run/mod.rs
+++ b/src/core/extension/bench/run/mod.rs
@@ -158,6 +158,7 @@ mod tests {
                 rig_id: None,
                 shared_state: None,
                 extra_workloads: Vec::new(),
+                env_provider_extensions: Vec::new(),
                 rig_package: None,
                 invocation_requirements: InvocationRequirements::default(),
             },
@@ -254,6 +255,7 @@ mod tests {
             rig_id: None,
             shared_state: None,
             extra_workloads: Vec::new(),
+            env_provider_extensions: Vec::new(),
             rig_package: None,
             invocation_requirements: InvocationRequirements::default(),
         }
@@ -273,6 +275,7 @@ mod tests {
             passthrough_args: Vec::new(),
             scenario_ids: Vec::new(),
             extra_workloads: Vec::new(),
+            env_provider_extensions: Vec::new(),
             rig_package: None,
         })
         .expect("component-script list env");
@@ -610,6 +613,7 @@ printf '{}' > "$(dirname "$HOMEBOY_BENCH_RESULTS_FILE")/bench-report.json"
                     rig_id: None,
                     shared_state: None,
                     extra_workloads: Vec::new(),
+                    env_provider_extensions: Vec::new(),
                     rig_package: None,
                     invocation_requirements: InvocationRequirements::default(),
                 },
@@ -854,6 +858,7 @@ printf '{}' > "$(dirname "$HOMEBOY_BENCH_RESULTS_FILE")/bench-report.json"
                 rig_id: None,
                 shared_state: None,
                 extra_workloads: Vec::new(),
+                env_provider_extensions: Vec::new(),
                 rig_package: None,
                 invocation_requirements: InvocationRequirements::default(),
             },

--- a/src/core/extension/bench/run/runner.rs
+++ b/src/core/extension/bench/run/runner.rs
@@ -168,6 +168,7 @@ pub(crate) fn build_runner(
             &args.extra_workloads,
             "bench_workloads",
         )),
+        env_provider_extensions: &args.env_provider_extensions,
         invocation_requirements: args.invocation_requirements.clone(),
     })?
     .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())

--- a/src/core/extension/bench/run/types.rs
+++ b/src/core/extension/bench/run/types.rs
@@ -62,6 +62,9 @@ pub struct BenchRunWorkflowArgs {
     /// Rig-declared out-of-tree workloads to run alongside in-tree discovery.
     /// Exported to dispatchers as `HOMEBOY_BENCH_EXTRA_WORKLOADS`.
     pub extra_workloads: Vec<PathBuf>,
+    /// Additional installed extensions whose generic env providers should be
+    /// merged into the bench runner env before caller overrides.
+    pub env_provider_extensions: Vec<String>,
     pub rig_package: Option<RigPackageEvidence>,
     /// Generic Homeboy isolation requirements for each child workload
     /// invocation. Rigs can use this for browser/server/wasm benchmarks without
@@ -126,6 +129,7 @@ pub struct BenchListWorkflowArgs {
     pub passthrough_args: Vec<String>,
     pub scenario_ids: Vec<String>,
     pub extra_workloads: Vec<PathBuf>,
+    pub env_provider_extensions: Vec<String>,
     pub rig_package: Option<RigPackageEvidence>,
 }
 

--- a/src/core/extension/bench/run_metadata.rs
+++ b/src/core/extension/bench/run_metadata.rs
@@ -220,6 +220,7 @@ mod tests {
             rig_id: Some("studio".to_string()),
             shared_state: Some(component_dir.path().join("shared")),
             extra_workloads: Vec::new(),
+            env_provider_extensions: Vec::new(),
             rig_package: None,
             invocation_requirements: InvocationRequirements::default(),
         };

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -125,6 +125,7 @@ pub struct ScenarioRunnerOptions<'a> {
     pub artifact_env: Option<(&'a str, &'a Path)>,
     pub list_only_env: Option<(&'a str, bool)>,
     pub extra_workloads_env: Option<(&'a str, &'a [PathBuf], &'a str)>,
+    pub env_provider_extensions: &'a [String],
     pub invocation_requirements: crate::core::engine::invocation::InvocationRequirements,
 }
 
@@ -135,6 +136,7 @@ pub fn build_scenario_runner(options: ScenarioRunnerOptions<'_>) -> Result<Exten
         .settings(options.settings)
         .settings_json(options.settings_json)
         .with_run_dir(options.run_dir)
+        .env_provider_extensions(options.env_provider_extensions)
         .invocation_requirements(options.invocation_requirements);
 
     if let Some((key, path)) = options.results_env {

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -336,6 +336,26 @@ pub(crate) fn build_capability_env(
     settings_json: &str,
     extra_env: &[(String, String)],
 ) -> Result<Vec<(String, String)>> {
+    build_capability_env_with_additional_providers(
+        extension_name,
+        component_id,
+        extension_path,
+        component_path,
+        settings_json,
+        &[],
+        extra_env,
+    )
+}
+
+pub(crate) fn build_capability_env_with_additional_providers(
+    extension_name: &str,
+    component_id: &str,
+    extension_path: &Path,
+    component_path: &Path,
+    settings_json: &str,
+    additional_env_provider_paths: &[(String, std::path::PathBuf)],
+    extra_env: &[(String, String)],
+) -> Result<Vec<(String, String)>> {
     let component_path_value = component_path.to_string_lossy();
     let mut env = build_exec_env(
         extension_name,
@@ -364,6 +384,15 @@ pub(crate) fn build_capability_env(
             component_path,
             &provider_env,
         )?);
+    }
+    for (_extension_id, provider_path) in additional_env_provider_paths {
+        if let Ok(extension) = env_provider::load_manifest_from_dir(provider_path) {
+            env.extend(env_provider::env_vars(
+                &extension,
+                component_path,
+                &provider_env,
+            )?);
+        }
     }
     env.extend(extra_env.iter().cloned());
     Ok(env)

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -40,6 +40,7 @@ pub struct ExtensionRunner {
     /// conflict — strictly more expressive). See SettingArgs docstring.
     settings_json_overrides: Vec<(String, serde_json::Value)>,
     env_vars: Vec<(String, String)>,
+    env_provider_extensions: Vec<String>,
     script_args: Vec<String>,
     path_override: Option<String>,
     pre_loaded_component: Option<Component>,
@@ -78,6 +79,7 @@ impl ExtensionRunner {
             settings_overrides: Vec::new(),
             settings_json_overrides: Vec::new(),
             env_vars: Vec::new(),
+            env_provider_extensions: Vec::new(),
             script_args: Vec::new(),
             path_override: None,
             pre_loaded_component: None,
@@ -118,6 +120,14 @@ impl ExtensionRunner {
     /// Add an environment variable.
     pub fn env(mut self, key: &str, value: &str) -> Self {
         self.env_vars.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    pub fn env_provider_extensions(mut self, extension_ids: &[String]) -> Self {
+        self.env_provider_extensions
+            .extend(extension_ids.iter().filter(|id| !id.is_empty()).cloned());
+        self.env_provider_extensions.sort();
+        self.env_provider_extensions.dedup();
         self
     }
 
@@ -310,14 +320,29 @@ impl ExtensionRunner {
         extension_name: &str,
         extra_env_vars: &[(String, String)],
     ) -> Result<Vec<(String, String)>> {
-        super::execution::build_capability_env(
+        let additional_env_provider_paths = self.additional_env_provider_paths()?;
+        super::execution::build_capability_env_with_additional_providers(
             extension_name,
             &self.execution_context.component.id,
             extension_path,
             project_path,
             settings_json,
+            &additional_env_provider_paths,
             extra_env_vars,
         )
+    }
+
+    fn additional_env_provider_paths(&self) -> Result<Vec<(String, PathBuf)>> {
+        self.env_provider_extensions
+            .iter()
+            .filter(|extension_id| extension_id.as_str() != self.execution_context.extension_id)
+            .map(|extension_id| {
+                Ok((
+                    extension_id.clone(),
+                    super::registry::extension_path(extension_id),
+                ))
+            })
+            .collect()
     }
 
     fn execute_script(

--- a/src/core/extension/trace/run/runner.rs
+++ b/src/core/extension/trace/run/runner.rs
@@ -66,6 +66,7 @@ pub(crate) fn build_trace_runner(
             &args.runner_inputs.workload_paths,
             "trace_workloads",
         )),
+        env_provider_extensions: &[],
         invocation_requirements: args.runner_inputs.invocation_requirements.clone(),
     })?;
 

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -86,7 +86,8 @@ pub use state::{
     ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot, ServiceState,
 };
 pub use workloads::{
-    check_groups_for_extension_workloads, extension_ids_for_workloads, extension_workload_inputs,
+    check_groups_for_extension_workloads, env_provider_extensions_for_extension_workloads,
+    extension_ids_for_workloads, extension_workload_inputs,
     invocation_requirements_for_extension_workloads, runner_capabilities_for_extension,
     trace_dependencies_for_extension, workload_path_expansions_for_extension,
     workloads_for_extension, RigExtensionWorkloadInputs, RigWorkloadKind, RigWorkloadPathExpansion,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -488,6 +488,9 @@ pub struct WorkloadSpec {
     pub path: String,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_provider_extensions: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_postprocess: Vec<ArtifactPostprocessSpec>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -714,6 +717,7 @@ mod tests {
     fn test_trace_phase_preset() {
         let workload = WorkloadSpec {
             path: "trace.mjs".to_string(),
+            env_provider_extensions: Vec::new(),
             artifact_postprocess: Vec::new(),
             trace_phase_template: None,
             public_preview: None,
@@ -887,6 +891,7 @@ mod tests {
     fn test_trace_default_phase_preset() {
         let workload = WorkloadSpec {
             path: "trace.mjs".to_string(),
+            env_provider_extensions: Vec::new(),
             artifact_postprocess: Vec::new(),
             trace_phase_template: None,
             public_preview: None,
@@ -916,6 +921,7 @@ mod tests {
     fn test_port_range_size() {
         let workload = WorkloadSpec {
             path: "bench.mjs".to_string(),
+            env_provider_extensions: Vec::new(),
             artifact_postprocess: Vec::new(),
             trace_phase_template: None,
             public_preview: None,
@@ -945,6 +951,7 @@ mod tests {
     fn test_named_leases() {
         let workload = WorkloadSpec {
             path: "bench.mjs".to_string(),
+            env_provider_extensions: Vec::new(),
             artifact_postprocess: Vec::new(),
             trace_phase_template: None,
             public_preview: None,

--- a/src/core/rig/spec/workload.rs
+++ b/src/core/rig/spec/workload.rs
@@ -12,6 +12,10 @@ impl WorkloadSpec {
         &self.path
     }
 
+    pub fn env_provider_extensions(&self) -> &[String] {
+        &self.env_provider_extensions
+    }
+
     pub fn public_preview(&self) -> Option<&TracePublicPreviewSpec> {
         self.public_preview.as_ref()
     }

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -23,6 +23,7 @@ pub struct RigWorkloadPathExpansion {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RigExtensionWorkloadInputs {
     pub workload_paths: Vec<PathBuf>,
+    pub env_provider_extensions: Vec<String>,
     pub invocation_requirements: InvocationRequirements,
 }
 
@@ -56,6 +57,11 @@ pub fn extension_workload_inputs(
 ) -> RigExtensionWorkloadInputs {
     RigExtensionWorkloadInputs {
         workload_paths: workloads_for_extension(rig_spec, kind, package_root, extension_id),
+        env_provider_extensions: env_provider_extensions_for_extension_workloads(
+            rig_spec,
+            kind,
+            extension_id,
+        ),
         invocation_requirements: invocation_requirements_for_extension_workloads(
             rig_spec,
             kind,
@@ -85,6 +91,34 @@ pub fn workload_path_expansions_for_extension(
             expanded_path: expand_workload_path(rig_spec, package_root, workload.path()),
         })
         .collect()
+}
+
+pub fn env_provider_extensions_for_extension_workloads(
+    rig_spec: &RigSpec,
+    kind: RigWorkloadKind,
+    extension_id: &str,
+) -> Vec<String> {
+    let workloads = match kind {
+        RigWorkloadKind::Bench => &rig_spec.bench_workloads,
+        RigWorkloadKind::Fuzz => &rig_spec.fuzz_workloads,
+        RigWorkloadKind::Trace => &rig_spec.trace_workloads,
+    };
+    let Some(entries) = workloads.get(extension_id) else {
+        return Vec::new();
+    };
+
+    let mut extensions = BTreeSet::new();
+    for entry in entries {
+        extensions.extend(
+            entry
+                .env_provider_extensions()
+                .iter()
+                .filter(|extension| !extension.is_empty())
+                .cloned(),
+        );
+    }
+
+    extensions.into_iter().collect()
 }
 
 pub fn trace_dependencies_for_extension(

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -481,6 +481,7 @@ fn test_trace_variants() {
 fn workload_with_trace_metadata() -> WorkloadSpec {
     WorkloadSpec {
         path: "/tmp/scoped.trace.mjs".to_string(),
+        env_provider_extensions: Vec::new(),
         artifact_postprocess: Vec::new(),
         trace_phase_template: None,
         public_preview: None,

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -2,9 +2,10 @@ use std::path::PathBuf;
 
 use crate::core::rig::spec::RigSpec;
 use crate::core::rig::{
-    check_groups_for_extension_workloads, extension_ids_for_workloads, extension_workload_inputs,
-    runner_capabilities_for_extension, trace_dependencies_for_extension,
-    workload_path_expansions_for_extension, workloads_for_extension, RigWorkloadKind,
+    check_groups_for_extension_workloads, env_provider_extensions_for_extension_workloads,
+    extension_ids_for_workloads, extension_workload_inputs, runner_capabilities_for_extension,
+    trace_dependencies_for_extension, workload_path_expansions_for_extension,
+    workloads_for_extension, RigWorkloadKind,
 };
 
 #[test]
@@ -38,6 +39,37 @@ fn test_bench_workloads_for_extension_filters_and_expands_paths() {
     );
     assert!(
         workloads_for_extension(&rig_spec, RigWorkloadKind::Bench, None, "extension-c").is_empty()
+    );
+}
+
+#[test]
+fn test_env_provider_extensions_for_extension_workloads_are_deduplicated() {
+    let rig_spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "fixture-bench",
+            "bench_workloads": {
+                "nodejs": [
+                    {
+                        "path": "/tmp/one.bench.mjs",
+                        "env_provider_extensions": ["fixture-runtime", "fixture-runtime"]
+                    },
+                    {
+                        "path": "/tmp/two.bench.mjs",
+                        "env_provider_extensions": ["artifact-helper", ""]
+                    }
+                ]
+            }
+        }"#,
+    )
+    .expect("parse rig spec");
+
+    assert_eq!(
+        env_provider_extensions_for_extension_workloads(
+            &rig_spec,
+            RigWorkloadKind::Bench,
+            "nodejs",
+        ),
+        vec!["artifact-helper".to_string(), "fixture-runtime".to_string()]
     );
 }
 


### PR DESCRIPTION
## Summary
- Add generic `env_provider_extensions` metadata to rig workload specs.
- Merge declared extension env provider output into extension runner env before explicit caller overrides.
- Thread the generic provider IDs through bench rig workload inputs and keep trace/fuzz defaults empty.

## Tests
- `cargo fmt --check`
- `cargo test package_dependency -- --nocapture`
- `cargo test build_capability_env -- --nocapture`
- `cargo test env_provider_extensions -- --nocapture`

Closes #6584

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing generic rig workload env provider plumbing, tests, and PR description.