### PR TITLE
Validate command workflow runtime kind

### DIFF
--- a/src/commands/agent_task/tests/controller_run.rs
+++ b/src/commands/agent_task/tests/controller_run.rs
@@ -417,6 +417,53 @@ fn controller_run_from_spec_rejects_unbounded_zero_max_actions() {
     });
 }
 
+#[test]
+fn controller_run_from_spec_rejects_command_runtime_without_command_kind() {
+    with_temp_home(|| {
+        let observed_request = Arc::new(Mutex::new(None));
+        let error = controller_run_from_spec_with_test_executor(
+            AgentTaskControllerRunFromSpecArgs {
+                spec: serde_json::to_string(&json!({
+                    "loop_id": "run-from-spec-command-missing-kind",
+                    "workflows": [{
+                        "workflow_id": "static-validation",
+                        "prompt": "Run static validation.",
+                        "runtime_execution": {
+                            "command": "/bin/sh",
+                            "args": ["-c", "printf ok"]
+                        }
+                    }]
+                }))
+                .expect("spec json"),
+                inputs: None,
+                policy_results: Vec::new(),
+                max_actions: 1,
+                reconcile_stale: false,
+                replace: false,
+                fork: false,
+                resume_existing: false,
+                dispatch_backend: Some("fixture".to_string()),
+                dispatch_selector: None,
+                dispatch_model: None,
+                dispatch_provider_config: None,
+            },
+            CapturingExecutor {
+                observed_request: Arc::clone(&observed_request),
+            },
+        )
+        .expect_err("command-shaped runtime execution is rejected before dispatch");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert_eq!(error.details["field"], "workflows[].runtime_execution.kind");
+        assert_eq!(error.details["id"], "static-validation");
+        assert!(error.message.contains("kind: command"), "{error}");
+        assert!(observed_request
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none());
+    });
+}
+
 fn run_from_spec_proof_args(
     loop_id: &str,
     prompt: &str,

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -916,6 +916,7 @@ pub(super) fn compile_loop_spec_workflow(
     workflow: &AgentTaskRepoLoopSpecWorkflow,
 ) -> Result<AgentTaskLoopPolicyAction> {
     let dedupe_key = format!("workflow:{}", workflow.workflow_id);
+    validate_workflow_runtime_execution(workflow)?;
     if workflow
         .runtime_execution
         .get("kind")
@@ -951,6 +952,26 @@ pub(super) fn compile_loop_spec_workflow(
             request_template: request,
         })
     }
+}
+
+fn validate_workflow_runtime_execution(workflow: &AgentTaskRepoLoopSpecWorkflow) -> Result<()> {
+    let Some(execution) = workflow.runtime_execution.as_object() else {
+        return Ok(());
+    };
+    if execution
+        .get("command")
+        .and_then(Value::as_str)
+        .is_some_and(|command| !command.trim().is_empty())
+        && execution.get("kind").and_then(Value::as_str) != Some("command")
+    {
+        return Err(Error::validation_invalid_argument(
+            "workflows[].runtime_execution.kind",
+            "workflow runtime_execution declares a command but is missing `kind: command`; deterministic command workflows must opt into command execution instead of falling through to agent dispatch",
+            Some(workflow.workflow_id.clone()),
+            Some(vec!["command".to_string()]),
+        ));
+    }
+    Ok(())
 }
 
 fn workflow_command_request(

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -2412,6 +2412,67 @@ mod run_command_workflow_tests {
     }
 
     #[test]
+    fn command_shaped_runtime_execution_requires_explicit_command_kind() {
+        with_isolated_home(|_| {
+            let spec = AgentTaskRepoLoopSpec {
+                schema: None,
+                loop_id: "repo-loop-command-missing-kind".to_string(),
+                phase: "init".to_string(),
+                config_version: "v1".to_string(),
+                metadata: Value::Null,
+                entities: Vec::new(),
+                agents: Vec::new(),
+                tools: Vec::new(),
+                abilities: Vec::new(),
+                workflows: vec![AgentTaskRepoLoopSpecWorkflow {
+                    workflow_id: "deterministic-validation".to_string(),
+                    agent_id: None,
+                    prompt: None,
+                    tasks: vec!["Run deterministic validation.".to_string()],
+                    entity_ids: Vec::new(),
+                    fan_out: None,
+                    tools: Vec::new(),
+                    abilities: Vec::new(),
+                    artifacts: vec!["validation_result".to_string()],
+                    consumes: Vec::new(),
+                    emits: Vec::new(),
+                    dependencies: Vec::new(),
+                    gates: Vec::new(),
+                    metrics: Vec::new(),
+                    runtime_execution: json!({
+                        "command": "/bin/sh",
+                        "args": ["-c", "printf ok"]
+                    }),
+                    inputs: Value::Null,
+                }],
+                artifacts: vec![AgentTaskRepoLoopSpecArtifact {
+                    artifact_id: "validation_result".to_string(),
+                    kind: "example/ValidationResult/v1".to_string(),
+                    description: None,
+                    required: true,
+                }],
+                artifact_graph: Vec::new(),
+                dependencies: Vec::new(),
+                gates: Vec::new(),
+                metrics: Vec::new(),
+                gate_bundles: Vec::new(),
+                policy: None,
+                phases: Vec::new(),
+                actions: Vec::new(),
+                initial_event: None,
+            };
+
+            let error = init_from_spec(ControllerFromSpecRequest { spec })
+                .expect_err("missing command kind is rejected before dispatch");
+
+            assert_eq!(error.code.as_str(), "validation.invalid_argument");
+            assert_eq!(error.details["field"], "workflows[].runtime_execution.kind");
+            assert_eq!(error.details["id"], "deterministic-validation");
+            assert!(error.message.contains("kind: command"), "{error}");
+        });
+    }
+
+    #[test]
     fn run_command_workflow_times_out_instead_of_blocking_controller() {
         with_isolated_home(|_| {
             let spec = AgentTaskRepoLoopSpec {


### PR DESCRIPTION
## Summary
- Add controller spec validation for runtime_execution.command entries missing kind: command.
- Fail with a Homeboy validation diagnostic before deterministic command-shaped workflows can fall through to agent dispatch.
- Cover both core init_from_spec compilation and controller run-from-spec behavior.

Fixes #6585.

## Tests
- cargo fmt --check
- CARGO_TARGET_DIR="/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-command-workflow-target" cargo test command_shaped_runtime_execution_requires_explicit_command_kind
- CARGO_TARGET_DIR="/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-command-workflow-target" cargo test controller_run_from_spec_rejects_command_runtime_without_command_kind
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the controller runtime validation, focused Rust tests, local verification, and PR drafting.