### PR TITLE
Fail closed on materialized runtime ref readiness

### DIFF
--- a/src/core/agent_task_config_materialization.rs
+++ b/src/core/agent_task_config_materialization.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use serde_json::{Map, Value};
 
@@ -14,6 +15,9 @@ struct ConfiguredRef {
     repo: String,
     ref_name: String,
     path_in_repo: Option<String>,
+    setup: Vec<String>,
+    readiness: Vec<ConfiguredRefPathProbe>,
+    conflicts: Vec<ConfiguredRefPathProbe>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,6 +26,30 @@ struct MaterializedRef {
     repo: String,
     ref_name: String,
     path_in_repo: Option<String>,
+    setup: Vec<MaterializedRefSetupEvidence>,
+    readiness: Vec<MaterializedRefPathEvidence>,
+    conflicts: Vec<MaterializedRefPathEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConfiguredRefPathProbe {
+    path: String,
+    label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MaterializedRefSetupEvidence {
+    command: String,
+    status: i32,
+    stdout: String,
+    stderr: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MaterializedRefPathEvidence {
+    path: String,
+    label: Option<String>,
+    exists: bool,
 }
 
 pub(crate) fn materialize_provider_config_refs(config: Value) -> Result<Value> {
@@ -65,6 +93,22 @@ fn materialize_object(mut map: Map<String, Value>) -> Result<Value> {
                 "ref": materialized.ref_name,
                 "path_in_repo": materialized.path_in_repo,
                 "path": materialized.path,
+                "setup": materialized.setup.into_iter().map(|evidence| serde_json::json!({
+                    "command": evidence.command,
+                    "status": evidence.status,
+                    "stdout": evidence.stdout,
+                    "stderr": evidence.stderr,
+                })).collect::<Vec<_>>(),
+                "readiness": materialized.readiness.into_iter().map(|evidence| serde_json::json!({
+                    "path": evidence.path,
+                    "label": evidence.label,
+                    "exists": evidence.exists,
+                })).collect::<Vec<_>>(),
+                "conflicts": materialized.conflicts.into_iter().map(|evidence| serde_json::json!({
+                    "path": evidence.path,
+                    "label": evidence.label,
+                    "exists": evidence.exists,
+                })).collect::<Vec<_>>(),
             }),
         );
     }
@@ -85,11 +129,17 @@ fn configured_ref_from_map(map: &Map<String, Value>) -> Result<Option<Configured
         .filter(|value| !value.trim().is_empty())
         .map(validate_relative_path)
         .transpose()?;
+    let setup = string_array_from_map(map, "setup")?;
+    let readiness = path_probes_from_map(map, "readiness")?;
+    let conflicts = path_probes_from_map(map, "conflicts")?;
 
     Ok(Some(ConfiguredRef {
         repo: non_empty(repo, "repo")?,
         ref_name: non_empty(ref_name, "ref")?,
         path_in_repo,
+        setup,
+        readiness,
+        conflicts,
     }))
 }
 
@@ -146,12 +196,122 @@ fn materialize_configured_ref(configured_ref: &ConfiguredRef) -> Result<Material
         ));
     }
 
+    let setup = run_setup_commands(configured_ref, &path)?;
+    let readiness = collect_path_evidence(&path, &configured_ref.readiness);
+    let missing_readiness: Vec<_> = readiness
+        .iter()
+        .filter(|evidence| !evidence.exists)
+        .collect();
+    if !missing_readiness.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "provider_config",
+            format!(
+                "materialized provider/runtime ref '{}' is missing {} declared readiness path(s)",
+                configured_ref.repo,
+                missing_readiness.len()
+            ),
+            Some(configured_ref.ref_name.clone()),
+            Some(
+                missing_readiness
+                    .iter()
+                    .map(|evidence| evidence.path.clone())
+                    .collect(),
+            ),
+        ));
+    }
+
+    let conflicts = collect_path_evidence(&path, &configured_ref.conflicts);
+    let present_conflicts: Vec<_> = conflicts
+        .iter()
+        .filter(|evidence| evidence.exists)
+        .collect();
+    if !present_conflicts.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "provider_config",
+            format!(
+                "materialized provider/runtime ref '{}' contains {} declared conflict path(s)",
+                configured_ref.repo,
+                present_conflicts.len()
+            ),
+            Some(configured_ref.ref_name.clone()),
+            Some(
+                present_conflicts
+                    .iter()
+                    .map(|evidence| evidence.path.clone())
+                    .collect(),
+            ),
+        ));
+    }
+
     Ok(MaterializedRef {
         path: path.display().to_string(),
         repo: configured_ref.repo.clone(),
         ref_name: configured_ref.ref_name.clone(),
         path_in_repo: configured_ref.path_in_repo.clone(),
+        setup,
+        readiness,
+        conflicts,
     })
+}
+
+fn run_setup_commands(
+    configured_ref: &ConfiguredRef,
+    path: &Path,
+) -> Result<Vec<MaterializedRefSetupEvidence>> {
+    let mut evidence = Vec::new();
+    for command in &configured_ref.setup {
+        let output = Command::new("sh")
+            .arg("-lc")
+            .arg(command)
+            .current_dir(path)
+            .output()
+            .map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some(format!("run provider/runtime ref setup: {command}")),
+                )
+            })?;
+        let status = output.status.code().unwrap_or(1);
+        let setup_evidence = MaterializedRefSetupEvidence {
+            command: command.clone(),
+            status,
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        };
+        if !output.status.success() {
+            return Err(Error::validation_invalid_argument(
+                "provider_config",
+                format!(
+                    "materialized provider/runtime ref '{}' setup command failed",
+                    configured_ref.repo
+                ),
+                Some(command.clone()),
+                Some(vec![format!(
+                    "status={} stdout={} stderr={}",
+                    setup_evidence.status, setup_evidence.stdout, setup_evidence.stderr
+                )]),
+            ));
+        }
+        evidence.push(setup_evidence);
+    }
+    Ok(evidence)
+}
+
+fn collect_path_evidence(
+    root: &Path,
+    probes: &[ConfiguredRefPathProbe],
+) -> Vec<MaterializedRefPathEvidence> {
+    probes
+        .iter()
+        .map(|probe| {
+            let path = root.join(&probe.path);
+            MaterializedRefPathEvidence {
+                path: path.display().to_string(),
+                label: probe.label.clone(),
+                exists: path.exists(),
+            }
+        })
+        .collect()
 }
 
 fn resolve_repo_remote(repo: &str) -> Result<String> {
@@ -236,6 +396,90 @@ fn validate_relative_path(value: &str) -> Result<String> {
         ));
     }
     Ok(value.to_string())
+}
+
+fn string_array_from_map(map: &Map<String, Value>, key: &str) -> Result<Vec<String>> {
+    let Some(value) = map.get(key) else {
+        return Ok(Vec::new());
+    };
+    let Some(items) = value.as_array() else {
+        return Err(Error::validation_invalid_argument(
+            key,
+            "provider/runtime ref field must be an array",
+            None,
+            None,
+        ));
+    };
+    items
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        key,
+                        "provider/runtime ref setup entries must be strings",
+                        None,
+                        None,
+                    )
+                })
+                .and_then(|value| non_empty(value, key))
+        })
+        .collect()
+}
+
+fn path_probes_from_map(
+    map: &Map<String, Value>,
+    key: &str,
+) -> Result<Vec<ConfiguredRefPathProbe>> {
+    let Some(value) = map.get(key) else {
+        return Ok(Vec::new());
+    };
+    let Some(items) = value.as_array() else {
+        return Err(Error::validation_invalid_argument(
+            key,
+            "provider/runtime ref path probe field must be an array",
+            None,
+            None,
+        ));
+    };
+    items
+        .iter()
+        .map(|item| path_probe_from_value(item, key))
+        .collect()
+}
+
+fn path_probe_from_value(value: &Value, key: &str) -> Result<ConfiguredRefPathProbe> {
+    if let Some(path) = value.as_str() {
+        return Ok(ConfiguredRefPathProbe {
+            path: validate_relative_path(&non_empty(path, key)?)?,
+            label: None,
+        });
+    }
+    let Some(map) = value.as_object() else {
+        return Err(Error::validation_invalid_argument(
+            key,
+            "provider/runtime ref path probes must be strings or objects",
+            None,
+            None,
+        ));
+    };
+    let Some(path) = map.get("path").and_then(Value::as_str) else {
+        return Err(Error::validation_invalid_argument(
+            key,
+            "provider/runtime ref path probe objects must include a path string",
+            None,
+            None,
+        ));
+    };
+    Ok(ConfiguredRefPathProbe {
+        path: validate_relative_path(&non_empty(path, key)?)?,
+        label: map
+            .get("label")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+            .map(str::to_string),
+    })
 }
 
 fn non_empty(value: &str, field: &str) -> Result<String> {
@@ -324,6 +568,115 @@ mod tests {
             let path = overlay["path"].as_str().expect("path");
             assert_eq!(overlay["materialized_path"], path);
             assert!(Path::new(path).join("bootstrap.php").is_file());
+        });
+    }
+
+    #[test]
+    fn ref_setup_materializes_declared_readiness_evidence() {
+        with_isolated_home(|_| {
+            let repo = tempfile::tempdir().expect("repo");
+            init_repo(repo.path());
+            fs::create_dir_all(repo.path().join("runtime")).expect("runtime dir");
+            fs::write(
+                repo.path().join("runtime/setup.sh"),
+                "printf ready > ready.txt",
+            )
+            .expect("setup script");
+            commit_all(repo.path());
+            let head = git::run_git(repo.path(), &["rev-parse", "HEAD"], "head")
+                .expect("head")
+                .trim()
+                .to_string();
+
+            let config = serde_json::json!({
+                "runtime_overlays": [{
+                    "name": "runtime-client",
+                    "repo": repo.path().display().to_string(),
+                    "ref": head,
+                    "path_in_repo": "runtime",
+                    "setup": ["sh setup.sh"],
+                    "readiness": [{ "path": "ready.txt", "label": "setup marker" }],
+                    "conflicts": ["vendor/stale-runtime-copy"]
+                }]
+            });
+
+            let materialized = materialize_provider_config_refs(config).expect("materialized");
+            let overlay = &materialized["runtime_overlays"][0];
+            let path = overlay["path"].as_str().expect("path");
+            assert_eq!(
+                fs::read_to_string(Path::new(path).join("ready.txt")).unwrap(),
+                "ready"
+            );
+            let materialized_ref = &overlay["materialized_ref"];
+            assert_eq!(materialized_ref["setup"][0]["command"], "sh setup.sh");
+            assert_eq!(materialized_ref["setup"][0]["status"], 0);
+            assert_eq!(materialized_ref["readiness"][0]["label"], "setup marker");
+            assert_eq!(materialized_ref["readiness"][0]["exists"], true);
+            assert_eq!(materialized_ref["conflicts"][0]["exists"], false);
+        });
+    }
+
+    #[test]
+    fn missing_readiness_probe_fails_closed() {
+        with_isolated_home(|_| {
+            let repo = tempfile::tempdir().expect("repo");
+            init_repo(repo.path());
+            fs::create_dir_all(repo.path().join("runtime")).expect("runtime dir");
+            fs::write(repo.path().join("runtime/bootstrap.txt"), "runtime").expect("runtime file");
+            commit_all(repo.path());
+            let head = git::run_git(repo.path(), &["rev-parse", "HEAD"], "head")
+                .expect("head")
+                .trim()
+                .to_string();
+
+            let err = materialize_provider_config_refs(serde_json::json!({
+                "runtime_overlays": [{
+                    "repo": repo.path().display().to_string(),
+                    "ref": head,
+                    "path_in_repo": "runtime",
+                    "readiness": ["vendor/autoload.php"]
+                }]
+            }))
+            .expect_err("missing readiness should fail");
+
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("missing 1 declared readiness path"));
+            assert!(err.message.contains(repo.path().to_string_lossy().as_ref()));
+        });
+    }
+
+    #[test]
+    fn present_conflict_probe_fails_closed() {
+        with_isolated_home(|_| {
+            let repo = tempfile::tempdir().expect("repo");
+            init_repo(repo.path());
+            fs::create_dir_all(repo.path().join("runtime/vendor/stale-runtime-copy"))
+                .expect("conflict dir");
+            fs::write(
+                repo.path()
+                    .join("runtime/vendor/stale-runtime-copy/package.txt"),
+                "conflict",
+            )
+            .expect("conflict file");
+            fs::write(repo.path().join("runtime/bootstrap.txt"), "runtime").expect("runtime file");
+            commit_all(repo.path());
+            let head = git::run_git(repo.path(), &["rev-parse", "HEAD"], "head")
+                .expect("head")
+                .trim()
+                .to_string();
+
+            let err = materialize_provider_config_refs(serde_json::json!({
+                "runtime_overlays": [{
+                    "repo": repo.path().display().to_string(),
+                    "ref": head,
+                    "path_in_repo": "runtime",
+                    "conflicts": ["vendor/stale-runtime-copy"]
+                }]
+            }))
+            .expect_err("present conflict should fail");
+
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("contains 1 declared conflict path"));
         });
     }
 


### PR DESCRIPTION
## Summary
- extend generic provider/runtime ref declarations with `setup`, `readiness`, and `conflicts` probes
- run declared setup commands during ref materialization and attach setup/readiness/conflict evidence to `materialized_ref`
- fail closed before dispatch when declared readiness paths are missing or declared conflict paths are present

Closes #6567.

## Tests
- `cargo fmt --check`
- `CARGO_TARGET_DIR="/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-6567-target" cargo test core::agent_task_config_materialization::tests --lib`
- `git diff --check`
- `cargo test --lib core::agent_task_config_materialization::tests`

Note: the default worktree `target/` directory was removed during an initial build, causing rustc temp-file errors before tests executed. The focused test was rerun successfully with an isolated `CARGO_TARGET_DIR` before merge. Post-merge verification also passed in the worktree with the normal target directory.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Debugging runtime dependency readiness, editing tests/code, and verification.