### PR TITLE
Improve controller failure diagnostics

### DIFF
--- a/src/core/agent_task_controller_service/run_failure_summary.rs
+++ b/src/core/agent_task_controller_service/run_failure_summary.rs
@@ -134,14 +134,19 @@ pub fn build_run_failure_summary(
 
     let action_status = failed_action.and_then(|result| string_field(result, "status"));
 
-    let root_blocker = failure_summary
-        .and_then(|summary| string_field(summary, "diagnostic"))
-        .or_else(|| deep_diagnostic_message(failed_action))
-        .or_else(|| stopped_reason_blocker(stopped_reason, action_status.as_deref()))
-        .unwrap_or_else(|| "controller run failed".to_string());
+    let explicit_diagnostic =
+        failure_summary.and_then(|summary| string_field(summary, "diagnostic"));
+    let deep_diagnostic = best_diagnostic_message(failed_action);
+    let root_blocker = best_root_blocker(
+        explicit_diagnostic.as_deref(),
+        deep_diagnostic.as_deref(),
+        stopped_reason_blocker(stopped_reason, action_status.as_deref()).as_deref(),
+    )
+    .unwrap_or_else(|| "controller run failed".to_string());
 
-    let first_diagnostic =
-        deep_diagnostic_message(failed_action).filter(|diagnostic| *diagnostic != root_blocker);
+    let first_diagnostic = deep_diagnostic
+        .or(explicit_diagnostic)
+        .filter(|diagnostic| *diagnostic != root_blocker);
 
     let owner_surface = classify_owner_surface(
         provider.as_deref(),
@@ -295,10 +300,16 @@ fn collect_evidence_refs(
         for evidence in collect_declared_refs(action) {
             push_ref(&mut refs, evidence);
         }
+        for evidence in collect_source_like_refs(action) {
+            push_ref(&mut refs, evidence);
+        }
     }
 
     // Evidence index recorded on the controller status (artifact bundles).
     for evidence in collect_declared_refs(status) {
+        push_ref(&mut refs, evidence);
+    }
+    for evidence in collect_source_like_refs(status) {
         push_ref(&mut refs, evidence);
     }
 
@@ -362,6 +373,83 @@ fn declared_ref_from_item(container_key: &str, item: &Value) -> Option<Controlle
     Some(ControllerRunEvidenceRef { kind, uri, label })
 }
 
+fn collect_source_like_refs(value: &Value) -> Vec<ControllerRunEvidenceRef> {
+    let mut out = Vec::new();
+    collect_source_like_refs_into(value, &mut out);
+    out
+}
+
+fn collect_source_like_refs_into(value: &Value, out: &mut Vec<ControllerRunEvidenceRef>) {
+    match value {
+        Value::Object(map) => {
+            for (key, nested) in map {
+                if let Some(kind) = source_like_ref_kind(key) {
+                    collect_source_like_ref_value(kind, key, nested, out);
+                }
+                collect_source_like_refs_into(nested, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_source_like_refs_into(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn source_like_ref_kind(key: &str) -> Option<&'static str> {
+    let lower = key.to_ascii_lowercase();
+    if lower.contains("provider") && lower.contains("path") {
+        Some("provider_source")
+    } else if lower.contains("prepared") && lower.contains("source") {
+        Some("prepared_source")
+    } else if (lower.contains("runtime") || lower.contains("overlay"))
+        && (lower.contains("source") || lower.contains("ref"))
+    {
+        Some("runtime_overlay_source")
+    } else {
+        None
+    }
+}
+
+fn collect_source_like_ref_value(
+    kind: &str,
+    key: &str,
+    value: &Value,
+    out: &mut Vec<ControllerRunEvidenceRef>,
+) {
+    match value {
+        Value::String(text) if !text.trim().is_empty() => out.push(ControllerRunEvidenceRef {
+            kind: kind.to_string(),
+            uri: text.trim().to_string(),
+            label: Some(key.to_string()),
+        }),
+        Value::Object(map) => {
+            if let Some(uri) = string_field(value, "uri")
+                .or_else(|| string_field(value, "url"))
+                .or_else(|| string_field(value, "path"))
+                .or_else(|| string_field(value, "ref"))
+            {
+                out.push(ControllerRunEvidenceRef {
+                    kind: kind.to_string(),
+                    uri,
+                    label: string_field(value, "label").or_else(|| Some(key.to_string())),
+                });
+            }
+            for nested in map.values() {
+                collect_source_like_ref_value(kind, key, nested, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_source_like_ref_value(kind, key, item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Next recommended Homeboy command, tailored to the owning surface.
 fn next_command(loop_id: &str, owner: OwnerSurface, action_status: Option<&str>) -> String {
     if action_status
@@ -401,29 +489,81 @@ fn stopped_reason_blocker(stopped_reason: &str, action_status: Option<&str>) -> 
     }
 }
 
-/// Find the deepest/first diagnostic message inside a result's nested
-/// `diagnostics` arrays (provider/runtime envelopes bury these).
-fn deep_diagnostic_message(value: Option<&Value>) -> Option<String> {
-    let value = value?;
-    find_diagnostic_message(value)
+fn best_root_blocker(
+    explicit: Option<&str>,
+    nested: Option<&str>,
+    fallback: Option<&str>,
+) -> Option<String> {
+    [explicit, nested, fallback]
+        .into_iter()
+        .flatten()
+        .filter(|message| !message.trim().is_empty())
+        .min_by_key(|message| diagnostic_message_priority(message))
+        .map(str::to_string)
 }
 
-fn find_diagnostic_message(value: &Value) -> Option<String> {
+fn diagnostic_message_priority(message: &str) -> u8 {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("fatal") || lower.contains("exception") || lower.contains("uncaught") {
+        0
+    } else if lower.contains("stale")
+        || lower.contains("not found")
+        || lower.contains("missing path")
+        || lower.contains("required ability")
+        || lower.contains("unavailable")
+    {
+        1
+    } else if lower.contains("missing required")
+        || lower.contains("required typed artifact")
+        || lower.contains("typed artifact")
+        || lower.contains("artifact")
+    {
+        8
+    } else {
+        4
+    }
+}
+
+fn best_diagnostic_message(value: Option<&Value>) -> Option<String> {
+    let value = value?;
+    let mut candidates = Vec::new();
+    collect_diagnostic_messages(value, 0, &mut candidates);
+    candidates
+        .into_iter()
+        .min_by_key(|candidate| {
+            (
+                diagnostic_message_priority(&candidate.message),
+                candidate.depth,
+            )
+        })
+        .map(|candidate| candidate.message)
+}
+
+struct DiagnosticCandidate {
+    message: String,
+    depth: usize,
+}
+
+fn collect_diagnostic_messages(value: &Value, depth: usize, out: &mut Vec<DiagnosticCandidate>) {
     match value {
         Value::Object(map) => {
             if let Some(Value::Array(diagnostics)) = map.get("diagnostics") {
                 for diagnostic in diagnostics {
                     if let Some(message) = string_field(diagnostic, "message") {
-                        if !message.trim().is_empty() {
-                            return Some(message);
-                        }
+                        out.push(DiagnosticCandidate { message, depth });
                     }
                 }
             }
-            map.values().find_map(find_diagnostic_message)
+            for nested in map.values() {
+                collect_diagnostic_messages(nested, depth + 1, out);
+            }
         }
-        Value::Array(items) => items.iter().find_map(find_diagnostic_message),
-        _ => None,
+        Value::Array(items) => {
+            for nested in items {
+                collect_diagnostic_messages(nested, depth + 1, out);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -3185,6 +3185,63 @@ mod failure_summary_tests {
     }
 
     #[test]
+    fn run_failure_summary_prefers_nested_actionable_diagnostic_over_generic_artifact_blocker() {
+        let results = vec![serde_json::json!({
+            "schema": ACTION_RESULT_SCHEMA,
+            "status": "failed",
+            "action_id": "generate-site",
+            "failure_summary": {
+                "action_id": "generate-site",
+                "provider": "runtime-provider",
+                "failure_phase": "runtime_execution",
+                "run_id": "run-99",
+                "diagnostic": "Missing required typed artifact: static_site_pull_request",
+            },
+            "execution": {
+                "diagnostics": [{
+                    "class": "required_typed_artifacts_missing",
+                    "message": "Missing required typed artifact: static_site_pull_request"
+                }],
+                "provider_result": {
+                    "runtime": {
+                        "diagnostics": [{
+                            "class": "provider_runtime_fatal",
+                            "message": "Fatal error: ProviderMetadata::getDescription() must be compatible with RuntimeMetadata::getDescription()"
+                        }],
+                        "selected_provider_plugin_path": "/workspace/plugins/provider/current",
+                        "prepared_plugin_source": {
+                            "uri": "git+https://example.invalid/provider.git#abc123",
+                            "label": "prepared provider plugin"
+                        },
+                        "runtime_overlay_ref": "git+https://example.invalid/runtime.git#def456"
+                    }
+                }
+            }
+        })];
+        let status = serde_json::json!({ "controller": { "phase": "generate" } });
+
+        let summary = build_run_failure_summary("loop-99", "action_failed", &results, &status);
+
+        assert_eq!(
+            summary.root_blocker,
+            "Fatal error: ProviderMetadata::getDescription() must be compatible with RuntimeMetadata::getDescription()"
+        );
+        assert_eq!(summary.owner_surface, "wordpress_runtime");
+        assert!(summary.evidence_refs.iter().any(|reference| {
+            reference.kind == "provider_source"
+                && reference.uri == "/workspace/plugins/provider/current"
+        }));
+        assert!(summary.evidence_refs.iter().any(|reference| {
+            reference.kind == "prepared_source"
+                && reference.uri == "git+https://example.invalid/provider.git#abc123"
+        }));
+        assert!(summary.evidence_refs.iter().any(|reference| {
+            reference.kind == "runtime_overlay_source"
+                && reference.uri == "git+https://example.invalid/runtime.git#def456"
+        }));
+    }
+
+    #[test]
     fn run_failure_summary_handles_runner_block_without_diagnostic_message() {
         let results = vec![serde_json::json!({
             "schema": ACTION_RESULT_SCHEMA,


### PR DESCRIPTION
## Summary

- Rank nested actionable diagnostics ahead of generic missing-artifact blockers in controller run failure summaries.
- Preserve generic source/ref/path evidence from nested payloads as typed evidence refs.
- Add focused coverage for nested fatal diagnostics and source evidence refs.

Fixes #6586.

## Tests

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-target-fix-loop cargo test core::agent_task_controller_service::tests::failure_summary_tests`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementation, focused Rust test, and PR preparation.