### PR TITLE
Fix controller fork run isolation

### DIFF
--- a/src/commands/agent_task/tests/controller_run.rs
+++ b/src/commands/agent_task/tests/controller_run.rs
@@ -517,6 +517,49 @@ fn controller_run_from_spec_reconcile_stale_recovers_without_manual_cleanup() {
     });
 }
 
+#[test]
+fn controller_run_from_spec_fork_isolates_repeated_replays_from_stale_child_runs() {
+    with_temp_home(|| {
+        controller_run_from_spec_with_test_executor(
+            run_from_spec_proof_args("run-from-spec-fork-isolation", "Draft the brief.", false),
+            ArtifactCapturingExecutor::default(),
+        )
+        .expect("base proof run");
+
+        let mut first_fork_args =
+            run_from_spec_proof_args("run-from-spec-fork-isolation", "Rewrite the brief.", false);
+        first_fork_args.fork = true;
+        let mut second_fork_args =
+            run_from_spec_proof_args("run-from-spec-fork-isolation", "Rewrite the brief.", false);
+        second_fork_args.fork = true;
+
+        let (first, first_exit_code) = controller_run_from_spec_with_test_executor(
+            first_fork_args,
+            ArtifactCapturingExecutor::default(),
+        )
+        .expect("first fork run");
+        let (second, second_exit_code) = controller_run_from_spec_with_test_executor(
+            second_fork_args,
+            ArtifactCapturingExecutor::default(),
+        )
+        .expect("second fork run");
+
+        assert_eq!(first_exit_code, 0, "{first:#}");
+        assert_eq!(second_exit_code, 0, "{second:#}");
+        assert_ne!(first["loop_id"], second["loop_id"]);
+        assert_eq!(first["from_spec"]["resume_state"]["action"], "forking");
+        assert_eq!(second["from_spec"]["resume_state"]["action"], "forking");
+        assert_eq!(first["results"][0]["claimed"], true);
+        assert_eq!(second["results"][0]["claimed"], true);
+        assert_ne!(
+            first["results"][0]["execution"]["result"]["run_id"],
+            second["results"][0]["execution"]["result"]["run_id"]
+        );
+        assert_eq!(first["status"]["controller"]["loop_id"], first["loop_id"]);
+        assert_eq!(second["status"]["controller"]["loop_id"], second["loop_id"]);
+    });
+}
+
 #[derive(Clone, Default)]
 struct ArtifactCapturingExecutor {
     observed_request: Arc<Mutex<Option<AgentTaskRequest>>>,

--- a/src/core/agent_task_controller_service/actions.rs
+++ b/src/core/agent_task_controller_service/actions.rs
@@ -989,7 +989,8 @@ where
     match mode {
         "run_plan" => {
             let plan = plan_from_controller_request(request)?;
-            let run_id = controller_request_run_id(request, dedupe_key, &action.action_id);
+            let run_id =
+                controller_request_run_id(request, &record.loop_id, dedupe_key, &action.action_id);
             let submitted = if lifecycle::run_record_exists(&run_id)? {
                 lifecycle::status(&run_id)?
             } else {
@@ -1027,7 +1028,8 @@ where
         }
         "submit" => {
             let plan = plan_from_controller_request(request)?;
-            let run_id = controller_request_run_id(request, dedupe_key, &action.action_id);
+            let run_id =
+                controller_request_run_id(request, &record.loop_id, dedupe_key, &action.action_id);
             let submitted = lifecycle::submit_plan(&plan, Some(&run_id))?;
             record_controller_spawn(
                 record,
@@ -1184,7 +1186,7 @@ where
     let mut results = Vec::new();
     let mut exit_code = 0;
     for entity_id in entity_ids.iter().take(max_items) {
-        let request = materialize_fan_out_request(request_template, entity_id);
+        let request = materialize_fan_out_request(request_template, &record.loop_id, entity_id);
         let child_dedupe_key = format!("{dedupe_key}:{entity_id}");
         let child_action = AgentTaskLoopPolicyActionRecord {
             action_id: format!("{}:{entity_id}", action.action_id),

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -12,6 +12,7 @@ use serde::de::{self, DeserializeOwned};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 use crate::core::agent_task::{
     AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskTypedArtifact, AgentTaskWorkflowEvidence,
@@ -379,11 +380,11 @@ pub fn init_from_spec_for_resume_with_resolution(
     }
 }
 
-/// Derive a deterministic fork loop id from the requested id and spec fingerprint.
+/// Derive an isolated fork loop id from the requested id and spec fingerprint.
 ///
-/// Using the fingerprint keeps reruns of the same changed spec collapsing onto a
-/// single fork instead of multiplying controllers, while still isolating the
-/// fork from the original loop id's stale state.
+/// Forks are operator-requested fresh runs. Include a nonce so repeated forks of
+/// the same spec cannot collapse onto an earlier fork controller and inherit its
+/// terminal child outcomes.
 fn derive_fork_loop_id(requested_loop_id: &str, spec_fingerprint: &str) -> String {
     let short = spec_fingerprint
         .strip_prefix("sha256:")
@@ -391,10 +392,12 @@ fn derive_fork_loop_id(requested_loop_id: &str, spec_fingerprint: &str) -> Strin
         .chars()
         .take(12)
         .collect::<String>();
+    let nonce = Uuid::new_v4().simple().to_string();
+    let nonce = &nonce[..12];
     // Use a sanitization-stable separator: the loop_id becomes a single path
     // segment (slashes are collapsed to `_` by sanitize_path_segment), so the
     // persisted `record.loop_id` would otherwise diverge from the derived id.
-    format!("{requested_loop_id}-fork-{short}")
+    format!("{requested_loop_id}-fork-{short}-{nonce}")
 }
 
 /// Remove a persisted controller record (and its directory) so a replace

--- a/src/core/agent_task_controller_service/request.rs
+++ b/src/core/agent_task_controller_service/request.rs
@@ -85,7 +85,11 @@ pub fn plan_from_controller_request(request: &Value) -> Result<AgentTaskPlan> {
     })
 }
 
-pub(super) fn materialize_fan_out_request(template: &Value, entity_id: &str) -> Value {
+pub(super) fn materialize_fan_out_request(
+    template: &Value,
+    loop_id: &str,
+    entity_id: &str,
+) -> Value {
     let mut request = template.clone();
     if let Some(object) = request.as_object_mut() {
         object.insert(
@@ -94,7 +98,8 @@ pub(super) fn materialize_fan_out_request(template: &Value, entity_id: &str) -> 
         );
         object.entry("run_id".to_string()).or_insert_with(|| {
             Value::String(format!(
-                "controller-{}",
+                "controller-{}-{}",
+                sanitize_controller_identity_part(loop_id),
                 entity_id.replace([':', '/', '#'], "_")
             ))
         });
@@ -104,16 +109,22 @@ pub(super) fn materialize_fan_out_request(template: &Value, entity_id: &str) -> 
 
 pub(super) fn controller_request_run_id(
     request: &Value,
+    loop_id: &str,
     dedupe_key: &str,
     action_id: &str,
 ) -> String {
     optional_string(request, "run_id").unwrap_or_else(|| {
         format!(
-            "controller-{}-{}",
+            "controller-{}-{}-{}",
+            sanitize_controller_identity_part(loop_id),
             action_id,
             dedupe_key.replace([':', '/', '#', ' '], "_")
         )
     })
+}
+
+fn sanitize_controller_identity_part(value: &str) -> String {
+    value.replace([':', '/', '#', ' '], "_")
 }
 
 pub(super) fn required_string(value: &Value, key: &str) -> Result<String> {

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -390,6 +390,16 @@ mod init_from_spec_resume_tests {
             assert_ne!(report.loop_id, "repo-loop-resume-fork");
             assert!(report.loop_id.starts_with("repo-loop-resume-fork-fork-"));
 
+            let second_report = init_from_spec_for_resume_with_resolution(
+                ControllerFromSpecRequest { spec: changed },
+                ControllerResumeStateResolution::Fork,
+            )
+            .expect("a second fork gets a fresh controller");
+            assert_ne!(second_report.loop_id, report.loop_id);
+            assert!(second_report
+                .loop_id
+                .starts_with("repo-loop-resume-fork-fork-"));
+
             // The original controller still carries the base fingerprint, untouched.
             let original = status("repo-loop-resume-fork").expect("original controller intact");
             assert_eq!(


### PR DESCRIPTION
## Summary

- give `agent-task controller run-from-spec --fork` a fresh fork controller id per invocation instead of reusing the same spec-fingerprint-derived fork
- include the controller loop id in default child run IDs for run-plan/submit/fan-out actions so lifecycle lookup does not reuse child runs from another controller
- add focused coverage for repeated fork replays staying isolated from stale child outcomes

Closes #6587.

## Tests

- `CARGO_TARGET_DIR="/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-controller-fork-target" cargo test controller_run_from_spec_fork_isolates_repeated_replays_from_stale_child_runs`
- `CARGO_TARGET_DIR="/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-controller-fork-target" cargo test init_from_spec_for_resume_fork_isolates_under_derived_loop_id`
- `cargo fmt --check`
- `git diff --check`

Note: the first local `cargo test` attempt used the shared `target/` dir after a parallel Cargo invocation and failed with a transient `.fingerprint` write error. Retried with an isolated `CARGO_TARGET_DIR`; focused tests passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, implementation, tests, and PR drafting.