### PR TITLE
Remove deprecated bench reader aliases

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -9,9 +9,6 @@ deltas against a stored baseline.
 homeboy bench <component> [options] [-- <runner-args>]
 homeboy bench matrix [<component>] --setting-matrix <key=value[,value...]> [options] [-- <runner-args>]
 homeboy bench list <component> [options] [-- <runner-args>]
-homeboy bench history <component> [--scenario <id>] [--rig <id>] [--limit 20]
-homeboy bench distribution <component> --field <metadata.path> [--scenario <id>] [--rig <id>] [--status <status>] [--limit 20]
-homeboy bench compare --from-run <run-id> --to-run <run-id> [--metric <name>]
 ```
 
 ## Description

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -118,13 +118,11 @@ Metric lookup supports top-level run metadata such as `results.total_elapsed_ms`
 ## Related Readers
 
 ```bash
-homeboy bench history <component> [--scenario <id>] [--rig <id>] [--limit 20]
-homeboy bench distribution <component> --field <metadata.path> [--scenario <id>] [--rig <id>] [--status <status>] [--limit 20]
-homeboy bench compare --from-run <run-id> --to-run <run-id>
+homeboy runs list --kind bench --component <component> [--scenario <id>] [--rig <id>] [--limit 20]
+homeboy runs distribution --kind bench --component <component> --field <metadata.path> [--scenario <id>] [--rig <id>] [--status <status>] [--limit 20]
+homeboy runs bench-compare --from-run <run-id> --to-run <run-id>
 homeboy rig runs <id> [--limit 20]
 ```
-
-These commands are thin read-only compatibility wrappers over the same observation-store records. Prefer `runs` readers for new automation: `bench history` returns the `runs.list` payload, `bench distribution` returns `runs.distribution`, and `bench compare` returns `runs.bench-compare`.
 
 ## Portable Bundles
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -19,7 +19,7 @@ use super::utils::args::{
     filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, PassthroughCommand,
     PositionalComponentArgs, SettingArgs,
 };
-use super::{runs, CmdResult, GlobalArgs};
+use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
     CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, CommandPortabilityContract,
     LabCommandContract, BENCH_LAB_LABEL,
@@ -62,8 +62,7 @@ impl BenchArgs {
 
     /// Whether this invocation is a bench *run* (the variants that emit the
     /// large `BenchCommandOutput`/comparison envelopes the compact summary
-    /// targets). Subcommands like `list`, `history`, `distribution`, and
-    /// `compare` keep their existing output.
+    /// targets). Subcommands like `list` keep their existing output.
     pub fn is_run_invocation(&self) -> bool {
         matches!(self.command, None | Some(BenchCommand::Matrix(_)))
     }
@@ -110,10 +109,7 @@ impl BenchArgs {
         match &self.command {
             None => Some(&self.run),
             Some(BenchCommand::Matrix(args)) => Some(args.run_args()),
-            Some(BenchCommand::History(_)) => None,
-            Some(BenchCommand::List(_))
-            | Some(BenchCommand::Distribution(_))
-            | Some(BenchCommand::Compare(_)) => None,
+            Some(BenchCommand::List(_)) => None,
         }
     }
 }
@@ -125,64 +121,6 @@ enum BenchCommand {
     Matrix(settings_matrix::BenchMatrixArgs),
     /// List declared benchmark scenarios without executing them
     List(BenchListArgs),
-    /// Deprecated compatibility alias for `homeboy runs list --kind bench --component <component>`
-    #[command(hide = true)]
-    History(BenchHistoryArgs),
-    /// Deprecated compatibility alias for `homeboy runs distribution --kind bench --component <component>`
-    #[command(hide = true)]
-    Distribution(BenchDistributionArgs),
-    /// Deprecated compatibility alias for `homeboy runs bench-compare --from-run <id> --to-run <id>`
-    #[command(hide = true)]
-    Compare(BenchCompareArgs),
-}
-
-#[derive(Args)]
-struct BenchHistoryArgs {
-    /// Component ID
-    component: String,
-    /// Scenario ID
-    #[arg(long = "scenario")]
-    scenario_id: Option<String>,
-    /// Rig ID
-    #[arg(long)]
-    rig: Option<String>,
-    /// Maximum runs to return
-    #[arg(long, default_value_t = 20)]
-    limit: i64,
-}
-
-#[derive(Args)]
-struct BenchDistributionArgs {
-    /// Component ID
-    component: String,
-    /// Scenario ID
-    #[arg(long = "scenario")]
-    scenario_id: Option<String>,
-    /// Rig ID
-    #[arg(long)]
-    rig: Option<String>,
-    /// Run status
-    #[arg(long)]
-    status: Option<String>,
-    /// Dot-separated metadata path to aggregate
-    #[arg(long = "field", required = true)]
-    fields: Vec<String>,
-    /// Maximum runs to inspect before scenario filtering
-    #[arg(long, default_value_t = 20)]
-    limit: i64,
-}
-
-#[derive(Args)]
-struct BenchCompareArgs {
-    /// Earlier run ID
-    #[arg(long = "from-run")]
-    from_run: String,
-    /// Later run ID
-    #[arg(long = "to-run")]
-    to_run: String,
-    /// Metric to include. Repeat to compare multiple metrics. Defaults to all shared numeric metrics.
-    #[arg(long = "metric")]
-    metrics: Vec<String>,
 }
 
 #[derive(Args)]
@@ -457,7 +395,6 @@ pub enum BenchOutput {
     MatrixFanout(fanout::BenchMatrixFanoutOutput),
     SettingsMatrix(settings_matrix::BenchSettingsMatrixOutput),
     List(BenchListWorkflowResult),
-    Observation(runs::RunsOutput),
 }
 
 pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
@@ -469,55 +406,6 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
                 Ok((BenchOutput::SettingsMatrix(output), exit))
             }
             BenchCommand::List(list_args) => run_list(list_args),
-            BenchCommand::History(history_args) => {
-                eprintln!(
-                    "warning: `homeboy bench history` is deprecated; use `homeboy runs list --kind bench --component <component>`"
-                );
-                let (output, exit_code) = runs::list_runs(
-                    runs::RunsListArgs {
-                        runner: None,
-                        kind: Some("bench".to_string()),
-                        component_id: Some(history_args.component.clone()),
-                        rig: history_args.rig.clone(),
-                        scenario_id: history_args.scenario_id.clone(),
-                        status: None,
-                        limit: history_args.limit,
-                        include_active_runner_jobs: false,
-                    },
-                    "runs.list",
-                )?;
-                Ok((BenchOutput::Observation(output), exit_code))
-            }
-            BenchCommand::Distribution(distribution_args) => {
-                eprintln!(
-                    "warning: `homeboy bench distribution` is deprecated; use `homeboy runs distribution --kind bench --component <component>`"
-                );
-                let (output, exit_code) = runs::runs_distribution(
-                    runs::RunsDistributionArgs {
-                        kind: Some("bench".to_string()),
-                        component_id: Some(distribution_args.component.clone()),
-                        rig: distribution_args.rig.clone(),
-                        scenario_id: distribution_args.scenario_id.clone(),
-                        status: distribution_args.status.clone(),
-                        fields: distribution_args.fields.clone(),
-                        limit: distribution_args.limit,
-                    },
-                    "runs.distribution",
-                )?;
-                Ok((BenchOutput::Observation(output), exit_code))
-            }
-            BenchCommand::Compare(compare_args) => {
-                eprintln!(
-                    "warning: `homeboy bench compare` is deprecated; use `homeboy runs bench-compare`"
-                );
-                let (output, exit_code) =
-                    runs::bench_compare_from_args(runs::RunsBenchCompareArgs {
-                        from_run: compare_args.from_run.clone(),
-                        to_run: compare_args.to_run.clone(),
-                        metrics: compare_args.metrics.clone(),
-                    })?;
-                Ok((BenchOutput::Observation(output), exit_code))
-            }
         };
     }
 

--- a/src/commands/bench/settings_matrix.rs
+++ b/src/commands/bench/settings_matrix.rs
@@ -317,7 +317,7 @@ fn settings_matrix_parent_metadata(
                 .collect::<Vec<_>>(),
             "compare_children": if child_run_ids.len() >= 2 {
                 Some(format!(
-                    "homeboy bench compare --from-run {} --to-run {}",
+                    "homeboy runs bench-compare --from-run {} --to-run {}",
                     child_run_ids[0], child_run_ids[1]
                 ))
             } else {
@@ -661,7 +661,7 @@ mod tests {
         );
         assert_eq!(
             metadata["inspect"]["compare_children"],
-            "homeboy bench compare --from-run run-a --to-run run-b"
+            "homeboy runs bench-compare --from-run run-a --to-run run-b"
         );
     }
 

--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -60,7 +60,6 @@ pub(crate) use types::RunsArtifactGetArgs;
 use types::DEFAULT_LIMIT;
 pub(crate) use types::{RunsListArgs, RunsListOutput};
 
-pub(crate) use bench::bench_compare_from_args;
 pub use bench::{bench_compare, BenchCompareOutput, RunsBenchCompareArgs};
 pub(super) use bench::{bench_numeric_metrics, run_contains_scenario};
 pub use distribution::{runs_distribution, RunsDistributionArgs, RunsDistributionOutput};

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -58,15 +58,15 @@ pub struct RunsArgs {
 
 #[derive(Subcommand, Clone)]
 pub(super) enum RunsCommand {
-    /// List persisted observation runs; canonical replacement for `bench history` and `rig runs`
+    /// List persisted observation runs
     List(RunsListArgs),
-    /// Aggregate persisted run metadata; canonical replacement for `bench distribution`
+    /// Aggregate persisted run metadata
     Distribution(RunsDistributionArgs),
     /// Show the latest persisted observation run matching filters
     LatestRun(RunsLatestRunArgs),
     /// Compare selected metrics across persisted run history
     Compare(RunsCompareArgs),
-    /// Compare two persisted benchmark runs by exact run id; canonical replacement for `bench compare`
+    /// Compare two persisted benchmark runs by exact run id
     BenchCompare(RunsBenchCompareArgs),
     /// Compare two persisted fuzz runs by exact run id
     FuzzCompare(RunsFuzzCompareArgs),

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -146,6 +146,63 @@ fn agent_task_discovery_help_documents_typed_flags() {
 }
 
 #[test]
+fn deprecated_bench_reader_aliases_are_removed() {
+    assert!(Cli::try_parse_from(["homeboy", "bench", "history", "studio-web"]).is_err());
+    assert!(Cli::try_parse_from([
+        "homeboy",
+        "bench",
+        "distribution",
+        "studio-web",
+        "--field",
+        "results.total_elapsed_ms",
+    ])
+    .is_err());
+    assert!(Cli::try_parse_from([
+        "homeboy",
+        "bench",
+        "compare",
+        "--from-run",
+        "run-a",
+        "--to-run",
+        "run-b",
+    ])
+    .is_err());
+
+    Cli::try_parse_from([
+        "homeboy",
+        "runs",
+        "list",
+        "--kind",
+        "bench",
+        "--component",
+        "studio-web",
+    ])
+    .expect("bench runs list should remain parseable");
+    Cli::try_parse_from([
+        "homeboy",
+        "runs",
+        "distribution",
+        "--kind",
+        "bench",
+        "--component",
+        "studio-web",
+        "--field",
+        "results.total_elapsed_ms",
+    ])
+    .expect("bench runs distribution should remain parseable");
+    Cli::try_parse_from([
+        "homeboy",
+        "runs",
+        "bench-compare",
+        "--from-run",
+        "run-a",
+        "--to-run",
+        "run-b",
+    ])
+    .expect("runs bench-compare should remain parseable");
+}
+
+#[test]
 fn agent_task_tool_bridge_stays_hidden_but_parseable() {
     let surface = current_command_surface();
 


### PR DESCRIPTION
## Summary
- Canonicalize settings-matrix child compare follow-up commands to `homeboy runs bench-compare`.
- Remove hidden deprecated `homeboy bench history`, `homeboy bench distribution`, and `homeboy bench compare` aliases.
- Update bench/runs docs and command-surface coverage for the canonical `runs` readers.

## Local verification
- `cargo fmt`
- `cargo test settings_matrix`
- `cargo test deprecated_bench_reader_aliases_are_removed`
- `git diff --check`

## GitHub Actions
- Not run locally and not used for verification. This PR intentionally relies on local Rust verification to avoid GitHub Actions/rate-limit usage.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the alias cleanup, updating docs/tests, running local verification, and drafting this PR description.