### PR TITLE
Recover Lab results after stream truncation

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -825,7 +825,10 @@ pub(crate) fn run_lab_offload_inner(
         "Lab offload host telemetry: {}",
         host_telemetry.to_metadata()
     );
-    ensure_lab_offload_streams_not_truncated(&exec_output, output_file_content.is_some())?;
+    ensure_lab_offload_streams_not_truncated(
+        &exec_output,
+        lab_offload_structured_result_available(&exec_output, output_file_content.as_deref()),
+    )?;
     mirror_agent_task_run_plan_lifecycle(
         request.normalized_args,
         &exec_output.stdout,
@@ -944,9 +947,17 @@ pub(crate) fn ensure_lab_offload_streams_not_truncated(
     error.details["runner_id"] = serde_json::json!(exec_output.runner_id);
     error.details["remote_cwd"] = serde_json::json!(exec_output.remote_cwd);
     error.details["job_id"] = serde_json::json!(exec_output.job_id);
+    error.details["reason"] = serde_json::json!("output_too_large");
     error.details["capture"] =
         serde_json::to_value(capture).unwrap_or_else(|_| serde_json::json!({}));
     Err(error)
+}
+
+pub(crate) fn lab_offload_structured_result_available(
+    exec_output: &super::super::super::RunnerExecOutput,
+    output_file_content: Option<&str>,
+) -> bool {
+    output_file_content.is_some() || exec_output.runner_result.is_some()
 }
 
 pub(crate) fn download_lab_output_file(runner_id: &str, remote_path: &str) -> Result<String> {

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -496,6 +496,7 @@ fn lab_stream_truncation_fails_without_structured_output_file() {
 
     assert_eq!(err.code, ErrorCode::InternalUnexpected);
     assert!(err.message.contains("retained stream limit"));
+    assert_eq!(err.details["reason"], "output_too_large");
 }
 
 #[test]
@@ -526,6 +527,42 @@ fn lab_stream_truncation_is_allowed_with_structured_output_file() {
     assert!(
         allowed.is_ok(),
         "structured output file must permit truncated streams, got: {allowed:?}"
+    );
+}
+
+#[test]
+fn lab_stream_truncation_is_allowed_with_structured_runner_result() {
+    let mut output = truncated_runner_exec_output();
+    output.runner_result = Some(crate::core::runner::RunnerResult {
+        exit_code: 0,
+        status: crate::core::api_jobs::JobStatus::Succeeded,
+        stdout_bytes: Some(5 * 1024 * 1024),
+        stderr_bytes: Some(0),
+        mirror_run_id: Some("fuzz-run-123".to_string()),
+        mutation_artifacts: None,
+        artifact_refs: vec![crate::core::runner::RunnerArtifactRef {
+            artifact_id: "artifact-123".to_string(),
+            name: Some("fuzz_results".to_string()),
+            path: Some("runner-artifact://homeboy-lab/fuzz-run-123/artifact-123".to_string()),
+            url: None,
+            mime: Some("application/json".to_string()),
+            size_bytes: Some(2048),
+            sha256: None,
+            transport: Some("runner_artifact".to_string()),
+        }],
+    });
+
+    let structured_result_available = lab_offload_structured_result_available(&output, None);
+    assert!(structured_result_available);
+    assert_eq!(
+        output.runner_result.as_ref().expect("runner result").status,
+        crate::core::api_jobs::JobStatus::Succeeded
+    );
+    let allowed = ensure_lab_offload_streams_not_truncated(&output, structured_result_available);
+
+    assert!(
+        allowed.is_ok(),
+        "structured runner result must permit truncated streams, got: {allowed:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Treat retained stream truncation as acceptable when Lab offload recovered a structured runner result, not only when a structured output file was downloaded.
- Preserve the existing failure path when no structured result can be recovered, and mark the details reason as `output_too_large`.
- Add coverage for truncated output with a structured runner result/artifact and for the explicit no-structured-result failure.

Fixes #6471

## Verification
- `cargo fmt`
- `cargo test core::runner::lab::offload::tests::exec_errors::lab_stream_truncation`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, tests, verification, and PR drafting.