### PR TITLE
Clarify runner Homeboy binary roles

### DIFF
--- a/src/commands/runner/exec.rs
+++ b/src/commands/runner/exec.rs
@@ -640,6 +640,7 @@ fn runner_exec_dry_run(
                 runner_workspace_root: runner.workspace_root,
                 source_snapshot_remote_path: None,
                 required_paths: require_paths,
+                homeboy_binaries: None,
                 hints: vec!["dry run only; no runner command was executed".to_string()],
             }),
         },

--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -13,8 +13,8 @@ use homeboy::core::runners::{
 use super::super::CmdResult;
 use super::types::{
     LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
-    RunnerConnectionOutput, RunnerExtra, RunnerOperatorCommand, RunnerOutput,
-    RunnerToolDiagnostics, WpCodeboxPackageRuntimeOutput, WpCodeboxProbeValue,
+    RunnerConnectionOutput, RunnerExtra, RunnerHomeboyBinaryRole, RunnerOperatorCommand,
+    RunnerOutput, RunnerToolDiagnostics, WpCodeboxPackageRuntimeOutput, WpCodeboxProbeValue,
     WpCodeboxRuntimeDiagnostic, WpCodeboxRuntimeOutput,
 };
 
@@ -119,7 +119,7 @@ fn selected_lab_runner_status(
     }))
 }
 
-fn lab_runner_homeboy_output(
+pub(super) fn lab_runner_homeboy_output(
     runner_id: &str,
     configured_executable: &str,
     status: &RunnerStatusReport,
@@ -137,6 +137,11 @@ fn lab_runner_homeboy_output(
         controller_version,
         controller_build_identity,
         configured_executable: configured_executable.to_string(),
+        binary_roles: runner_homeboy_binary_roles(
+            configured_executable,
+            &status.session,
+            &active_daemon_version,
+        ),
         active_daemon_version,
         active_daemon_build_identity: status
             .session
@@ -408,9 +413,50 @@ fn lab_command_availability_checks(homeboy_path: &str) -> Vec<String> {
         format!("{binary} --version"),
         format!("{binary} runner exec --help"),
         format!("{binary} runs artifact --help"),
+        format!("{binary} tunnel artifact-origin dom-boxes --help"),
         format!("{binary} fuzz --help"),
         format!("{binary} runs evidence --help"),
         format!("{binary} extension list"),
+    ]
+}
+
+fn runner_homeboy_binary_roles(
+    configured_executable: &str,
+    session: &Option<RunnerSession>,
+    active_daemon_version: &Option<String>,
+) -> Vec<RunnerHomeboyBinaryRole> {
+    let controller_identity = homeboy::core::build_identity::current();
+    vec![
+        RunnerHomeboyBinaryRole {
+            role: "controller_cli",
+            owner: "operator_command",
+            path: std::env::current_exe()
+                .ok()
+                .map(|path| path.display().to_string()),
+            version: Some(controller_identity.version),
+            build_identity: Some(controller_identity.display),
+            purpose: "Renders this status output and submits runner jobs; it does not prove what the runner daemon or job command binary supports.",
+        },
+        RunnerHomeboyBinaryRole {
+            role: "active_daemon",
+            owner: "runner_session",
+            path: session
+                .as_ref()
+                .and_then(|session| session.remote_daemon_address.clone()),
+            version: active_daemon_version.clone(),
+            build_identity: session
+                .as_ref()
+                .and_then(|session| session.homeboy_build_identity.clone()),
+            purpose: "Accepts connected daemon jobs until the runner is disconnected/reconnected; it can lag behind the configured job binary after refresh-homeboy.",
+        },
+        RunnerHomeboyBinaryRole {
+            role: "job_command_binary",
+            owner: "runner_config.settings.homeboy_path",
+            path: Some(configured_executable.to_string()),
+            version: None,
+            build_identity: None,
+            purpose: "Binary path selected for runner-side Homeboy subcommands and capability checks; use command_availability_checks to verify required subcommands on the runner.",
+        },
     ]
 }
 

--- a/src/commands/runner/tests/exec.rs
+++ b/src/commands/runner/tests/exec.rs
@@ -144,7 +144,7 @@ fn runner_exec_promotes_declared_artifacts_to_run_store() {
             )
             .expect("run");
 
-        let (_output, exit_code) = exec(
+        let (output, exit_code) = exec(
             "lab-local",
             Some(workspace.path().display().to_string()),
             None,
@@ -167,6 +167,19 @@ fn runner_exec_promotes_declared_artifacts_to_run_store() {
         .expect("runner exec");
 
         assert_eq!(exit_code, 0);
+        let binaries = output
+            .diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.homeboy_binaries.as_ref())
+            .expect("runner exec reports Homeboy binary role diagnostics");
+        assert_eq!(binaries.controller_cli.owner, "operator_command");
+        assert_eq!(
+            binaries.job_command_binary.owner,
+            "runner_config.settings.homeboy_path"
+        );
+        assert!(binaries
+            .guidance
+            .contains("verify job_command_binary on the runner"));
         let artifacts = store.list_artifacts(&run.id).expect("artifacts");
         assert_eq!(artifacts.len(), 2);
         assert_eq!(artifacts[0].kind, "out_txt");

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -12,7 +12,7 @@ use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, 
 use super::super::jobs::format_job_event;
 use super::super::status::{
     declared_run_followups_for_legacy, declared_runtime_diagnostics,
-    declared_runtime_source_diagnostics, declared_tool_diagnostics,
+    declared_runtime_source_diagnostics, declared_tool_diagnostics, lab_runner_homeboy_output,
     runner_artifact_feature_diagnostics, runner_status_operator_commands,
 };
 
@@ -366,6 +366,54 @@ fn runner_status_artifact_diagnostics_surface_controller_runner_checks_and_drift
     assert!(serialized
         .contains("homeboy runner exec homeboy-lab -- homeboy runs artifact attach --help"));
     assert!(serialized.contains("version/build drift"));
+}
+
+#[test]
+fn runner_homeboy_status_distinguishes_daemon_and_job_binary_roles() {
+    let report = RunnerStatusReport {
+        runner_id: "homeboy-lab".to_string(),
+        connected: true,
+        state: runner::RunnerSessionState::Connected,
+        session: Some(RunnerSession {
+            runner_id: "homeboy-lab".to_string(),
+            mode: RunnerTunnelMode::DirectSsh,
+            role: runner::RunnerSessionRole::Controller,
+            server_id: Some("homeboy-lab".to_string()),
+            controller_id: None,
+            broker_url: None,
+            remote_daemon_address: Some("127.0.0.1:7357".to_string()),
+            local_port: Some(7357),
+            local_url: Some("http://127.0.0.1:7357".to_string()),
+            tunnel_pid: Some(123),
+            remote_daemon_pid: Some(456),
+            homeboy_version: "0.262.0".to_string(),
+            homeboy_build_identity: Some("0.262.0 old-build".to_string()),
+            connected_at: "2026-06-19T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+        }),
+        stale_daemon: None,
+        active_jobs: Vec::new(),
+        active_runner_jobs: Vec::new(),
+        active_job_count: 0,
+        stale_runner_jobs: Vec::new(),
+        stale_runner_job_count: 0,
+        active_job_state: RunnerActiveJobState::Available,
+        active_job_source: Some(RunnerActiveJobSource::DirectDaemon),
+        active_job_error: None,
+        session_path: "/tmp/session.json".to_string(),
+    };
+
+    let output = lab_runner_homeboy_output("homeboy-lab", "/opt/homeboy/bin/homeboy", &report);
+    let serialized = serde_json::to_string(&output).expect("serialize runner homeboy output");
+
+    assert!(serialized.contains("controller_cli"));
+    assert!(serialized.contains("active_daemon"));
+    assert!(serialized.contains("job_command_binary"));
+    assert!(serialized.contains("runner_config.settings.homeboy_path"));
+    assert!(serialized.contains("/opt/homeboy/bin/homeboy tunnel artifact-origin dom-boxes --help"));
+    assert_eq!(output.active_daemon_version.as_deref(), Some("0.262.0"));
 }
 
 fn wp_codebox_tool_declaration() -> AgentRuntimeToolDiagnosticDeclaration {

--- a/src/commands/runner/types.rs
+++ b/src/commands/runner/types.rs
@@ -76,6 +76,7 @@ pub struct LabRunnerHomeboyOutput {
     pub controller_version: String,
     pub controller_build_identity: String,
     pub configured_executable: String,
+    pub binary_roles: Vec<RunnerHomeboyBinaryRole>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_daemon_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -87,6 +88,19 @@ pub struct LabRunnerHomeboyOutput {
     pub artifact_features: RunnerArtifactFeatureDiagnostics,
     pub refresh_commands: Vec<String>,
     pub upgrade_command: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerHomeboyBinaryRole {
+    pub role: &'static str,
+    pub owner: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_identity: Option<String>,
+    pub purpose: &'static str,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -19,7 +19,7 @@ use crate::core::source_snapshot::SourceSnapshot;
 use super::resource_metrics::RunnerResourceMetrics;
 use super::{
     connect, select_runner_transport, status, Runner, RunnerCapabilityPreflight, RunnerHandoff,
-    RunnerJob, RunnerKind, RunnerMutationArtifacts, RunnerResult, RunnerTransport,
+    RunnerJob, RunnerKind, RunnerMutationArtifacts, RunnerResult, RunnerSession, RunnerTransport,
 };
 
 const DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS: u64 = 20 * 60;
@@ -189,8 +189,29 @@ pub struct RunnerExecDiagnostics {
     pub source_snapshot_remote_path: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub required_paths: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub homeboy_binaries: Option<RunnerExecHomeboyBinaries>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub hints: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerExecHomeboyBinaries {
+    pub controller_cli: RunnerExecHomeboyBinary,
+    pub active_daemon: RunnerExecHomeboyBinary,
+    pub job_command_binary: RunnerExecHomeboyBinary,
+    pub guidance: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerExecHomeboyBinary {
+    pub owner: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_identity: Option<String>,
 }
 
 const RUNNER_EXEC_RUN_ID_ENV_NAMES: &[&str] = &[
@@ -391,7 +412,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
         RunnerTransport::Unavailable => Err(Error::validation_invalid_argument(
             "runner",
             "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` or pass `--ssh` for explicit SSH diagnostics",
-            Some(runner.id),
+            Some(runner.id.clone()),
             Some(vec![
                 "Daemon-backed execution preserves job metadata and artifact discovery.".to_string(),
                 "SSH execution is intended for MVP diagnostics and must be explicit.".to_string(),
@@ -399,6 +420,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
         )),
     };
     result.map(|(mut output, exit_code)| {
+        append_runner_exec_binary_diagnostics(&mut output, &runner, connected.session.as_ref());
         append_runner_exec_diagnostic_hint(&mut output, run_id_hint);
         (output, exit_code)
     })
@@ -459,9 +481,62 @@ fn append_runner_exec_diagnostic_hint(output: &mut RunnerExecOutput, hint: Optio
             runner_workspace_root: None,
             source_snapshot_remote_path: None,
             required_paths: Vec::new(),
+            homeboy_binaries: None,
             hints: Vec::new(),
         });
     diagnostics.hints.push(hint);
+}
+
+fn append_runner_exec_binary_diagnostics(
+    output: &mut RunnerExecOutput,
+    runner: &Runner,
+    session: Option<&RunnerSession>,
+) {
+    let diagnostics = output
+        .diagnostics
+        .get_or_insert_with(|| RunnerExecDiagnostics {
+            runner_workspace_root: runner.workspace_root.clone(),
+            source_snapshot_remote_path: None,
+            required_paths: Vec::new(),
+            homeboy_binaries: None,
+            hints: Vec::new(),
+        });
+    diagnostics.homeboy_binaries = Some(runner_exec_homeboy_binaries(runner, session));
+}
+
+fn runner_exec_homeboy_binaries(
+    runner: &Runner,
+    session: Option<&RunnerSession>,
+) -> RunnerExecHomeboyBinaries {
+    let controller_identity = crate::core::build_identity::current();
+    let configured_executable = runner
+        .settings
+        .homeboy_path
+        .clone()
+        .unwrap_or_else(|| "homeboy".to_string());
+    RunnerExecHomeboyBinaries {
+        controller_cli: RunnerExecHomeboyBinary {
+            owner: "operator_command",
+            path: std::env::current_exe()
+                .ok()
+                .map(|path| path.display().to_string()),
+            version: Some(controller_identity.version),
+            build_identity: Some(controller_identity.display),
+        },
+        active_daemon: RunnerExecHomeboyBinary {
+            owner: "runner_session",
+            path: session.and_then(|session| session.remote_daemon_address.clone()),
+            version: session.map(|session| session.homeboy_version.clone()),
+            build_identity: session.and_then(|session| session.homeboy_build_identity.clone()),
+        },
+        job_command_binary: RunnerExecHomeboyBinary {
+            owner: "runner_config.settings.homeboy_path",
+            path: Some(configured_executable),
+            version: None,
+            build_identity: None,
+        },
+        guidance: "For Homeboy subcommands executed inside runner jobs, verify job_command_binary on the runner, not only this controller CLI. If active_daemon differs after refreshing homeboy_path, reconnect the runner daemon.".to_string(),
+    }
 }
 
 fn should_force_diagnostic_ssh(runner: &Runner, options: &RunnerExecOptions) -> bool {

--- a/src/core/runner/execution/redaction.rs
+++ b/src/core/runner/execution/redaction.rs
@@ -155,6 +155,7 @@ pub(super) fn runner_exec_diagnostics(
         source_snapshot_remote_path: source_snapshot
             .and_then(|snapshot| snapshot.remote_path.clone()),
         required_paths: required_paths.to_vec(),
+        homeboy_binaries: None,
         hints,
     })
 }


### PR DESCRIPTION
## Summary
- Add explicit runner Homeboy binary role metadata to runner status: controller CLI, active daemon, and configured job command binary.
- Add runner exec diagnostics that identify the controller CLI, active daemon session build/version, and job command binary ownership.
- Include a runner-side capability check for `tunnel artifact-origin dom-boxes --help` so operators can verify the selected job binary supports artifact DOM box workflows.

Fixes #6473.

## Verification
- `cargo test runner_homeboy_status_distinguishes_daemon_and_job_binary_roles`
- `cargo test runner_exec_promotes_declared_artifacts_to_run_store`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, implementation, tests, and PR preparation.