### PR TITLE
Improve cleanup artifacts non-git error

### DIFF
--- a/src/core/cleanup.rs
+++ b/src/core/cleanup.rs
@@ -461,7 +461,20 @@ fn remove_artifact_path(path: &Path) -> Result<()> {
 }
 
 fn git_root(path: &Path) -> Result<PathBuf> {
-    let output = git::run_git(path, &["rev-parse", "--show-toplevel"], "git root")?;
+    let output = git::run_git(path, &["rev-parse", "--show-toplevel"], "git root").map_err(|_| {
+        Error::validation_invalid_argument(
+            "path",
+            format!(
+                "{} is not inside a git checkout; run `homeboy cleanup artifacts` from a checkout or pass `--path <PATH>`",
+                path.display()
+            ),
+            Some(path.to_string_lossy().to_string()),
+            None,
+        )
+        .with_hint(
+            "Run from a git checkout or pass `--path <PATH>`, for example: `homeboy cleanup artifacts --path /path/to/checkout`.",
+        )
+    })?;
     Ok(PathBuf::from(output.trim()))
 }
 
@@ -555,6 +568,27 @@ mod tests {
         .expect_err("reject ambiguous cleanup root");
 
         assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
+    }
+
+    #[test]
+    fn cleanup_artifacts_outside_git_checkout_suggests_path_override() {
+        let tmp = TempDir::new().expect("tempdir");
+        let err = resolve_root(&ArtifactCleanupOptions {
+            path: Some(tmp.path().to_path_buf()),
+            apply: false,
+            self_artifacts: false,
+            temp_roots: Vec::new(),
+            merged_only: false,
+        })
+        .expect_err("reject non-git cleanup root");
+
+        assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
+        assert!(err.message.contains("not inside a git checkout"));
+        assert!(err.message.contains("--path <PATH>"));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("Run from a git checkout")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Return a cleanup-specific validation error when `cleanup artifacts` resolves a non-git directory.
- Add guidance to run from a git checkout or pass `--path <PATH>`, including an example invocation.
- Add a focused regression test for the non-git cleanup root case.

Closes https://github.com/Extra-Chill/homeboy/issues/6600

## Tests
- `cargo fmt --check`
- `cargo test --lib cleanup_artifacts_outside_git_checkout_suggests_path_override`
- `cargo run --manifest-path /path/to/homeboy/Cargo.toml -- cleanup artifacts --merged-only` from a non-git directory

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the focused CLI error improvement, adding the regression test, and drafting this PR description.