### PR TITLE
Improve cleanup artifacts operator summary

### DIFF
--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 use homeboy::core::cleanup::{self, ArtifactCleanupOptions, ArtifactCleanupOutput};
+use serde_json::Value;
 
 use super::CmdResult;
 
@@ -51,5 +52,172 @@ pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<Artifact
             merged_only: args.merged_only,
         })
         .map(|output| (output, 0)),
+    }
+}
+
+pub(crate) fn render_artifact_cleanup_summary(payload: &Value) -> Option<String> {
+    if payload.get("command").and_then(Value::as_str)? != "cleanup.artifacts" {
+        return None;
+    }
+
+    let mode = payload.get("mode").and_then(Value::as_str)?;
+    let root = payload.get("root").and_then(Value::as_str).unwrap_or(".");
+    let candidate_count = payload
+        .get("candidate_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let applied_count = payload
+        .get("applied_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let skipped_count = payload
+        .get("skipped_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let estimated_bytes = payload
+        .get("estimated_bytes")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let reclaimed_bytes = payload
+        .get("reclaimed_bytes")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let remaining_candidates = candidate_count.saturating_sub(applied_count);
+
+    let mut lines = vec![
+        "Artifact cleanup summary".to_string(),
+        format!(
+            "Mode: {}",
+            if mode == "apply" { "apply" } else { "dry run" }
+        ),
+        format!("Root: {root}"),
+        format!("Candidates: {candidate_count}"),
+        format!("Applied: {applied_count}"),
+        format!("Remaining candidates: {remaining_candidates}"),
+        format!("Estimated reclaimable: {}", format_bytes(estimated_bytes)),
+        format!("Reclaimed: {}", format_bytes(reclaimed_bytes)),
+        format!("Skipped: {skipped_count}"),
+    ];
+
+    for (reason, count) in skipped_counts_by_reason(payload) {
+        lines.push(format!("  - {reason}: {count}"));
+    }
+
+    let next = if mode == "apply" {
+        format!("homeboy cleanup artifacts --path {}", shell_quote(root))
+    } else {
+        format!(
+            "homeboy cleanup artifacts --path {} --apply",
+            shell_quote(root)
+        )
+    };
+    lines.push(format!("Next safe command: {next}"));
+    lines.push(String::new());
+
+    Some(lines.join("\n"))
+}
+
+fn skipped_counts_by_reason(payload: &Value) -> Vec<(String, u64)> {
+    let mut counts = std::collections::BTreeMap::new();
+    if let Some(skipped) = payload.get("skipped").and_then(Value::as_array) {
+        for row in skipped {
+            if let Some(reason) = row.get("reason").and_then(Value::as_str) {
+                *counts.entry(reason.to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+    counts.into_iter().collect()
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+
+    match bytes {
+        0..=1023 => format!("{bytes} B"),
+        _ if (bytes as f64) < MIB => format!("{:.1} KiB", bytes as f64 / KIB),
+        _ if (bytes as f64) < GIB => format!("{:.1} MiB", bytes as f64 / MIB),
+        _ => format!("{:.1} GiB", bytes as f64 / GIB),
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | ':'))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn cleanup_artifacts_summary_emphasizes_operator_counts() {
+        let payload = json!({
+            "command": "cleanup.artifacts",
+            "mode": "dry_run",
+            "root": "/tmp/homeboy repo",
+            "worktree_count": 2,
+            "candidate_count": 3,
+            "skipped_count": 2,
+            "applied_count": 0,
+            "estimated_bytes": 1572864,
+            "reclaimed_bytes": 0,
+            "candidates": [],
+            "skipped": [
+                { "reason": "artifact path contains tracked or staged source changes" },
+                { "reason": "artifact path contains tracked or staged source changes" }
+            ],
+            "applied": []
+        });
+
+        let summary = render_artifact_cleanup_summary(&payload).expect("summary");
+
+        assert!(summary.contains("Artifact cleanup summary\n"));
+        assert!(summary.contains("Candidates: 3\n"));
+        assert!(summary.contains("Applied: 0\n"));
+        assert!(summary.contains("Remaining candidates: 3\n"));
+        assert!(summary.contains("Estimated reclaimable: 1.5 MiB\n"));
+        assert!(summary.contains("Reclaimed: 0 B\n"));
+        assert!(
+            summary.contains("  - artifact path contains tracked or staged source changes: 2\n")
+        );
+        assert!(summary.contains(
+            "Next safe command: homeboy cleanup artifacts --path '/tmp/homeboy repo' --apply\n"
+        ));
+    }
+
+    #[test]
+    fn cleanup_artifacts_apply_summary_reports_remaining_after_applied() {
+        let payload = json!({
+            "command": "cleanup.artifacts",
+            "mode": "apply",
+            "root": "/tmp/homeboy",
+            "candidate_count": 4,
+            "skipped_count": 1,
+            "applied_count": 3,
+            "estimated_bytes": 4096,
+            "reclaimed_bytes": 3072,
+            "skipped": [
+                { "reason": "worktree branch is not merged into its upstream" }
+            ]
+        });
+
+        let summary = render_artifact_cleanup_summary(&payload).expect("summary");
+
+        assert!(summary.contains("Mode: apply\n"));
+        assert!(summary.contains("Remaining candidates: 1\n"));
+        assert!(summary.contains("Reclaimed: 3.0 KiB\n"));
+        assert!(
+            summary.contains("Next safe command: homeboy cleanup artifacts --path /tmp/homeboy\n")
+        );
     }
 }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -91,6 +91,25 @@ pub fn run_command_output(
                 },
             )
         }
+        Commands::Cleanup(args) => {
+            let summarize = cleanup_summary_eligible(&args);
+            let (stdout_result, exit_code) = dispatch(Commands::Cleanup(args), global);
+            let summary_stdout = summarize
+                .then(|| {
+                    stdout_result
+                        .as_ref()
+                        .ok()
+                        .and_then(super::cleanup::render_artifact_cleanup_summary)
+                })
+                .flatten();
+
+            JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                CommandPresentation {
+                    stdout: summary_stdout,
+                    stderr: None,
+                },
+            )
+        }
         Commands::Runs(args) => {
             let summarize = runs_show_summary_eligible(&args);
             let (stdout_result, exit_code) = dispatch(Commands::Runs(args), global);
@@ -253,6 +272,13 @@ fn bench_summary_eligible(args: &crate::commands::bench::BenchArgs) -> bool {
         && !homeboy::core::lab_routing::is_lab_offload_subprocess()
 }
 
+fn cleanup_summary_eligible(args: &crate::commands::cleanup::CleanupArgs) -> bool {
+    matches!(
+        args.command,
+        crate::commands::cleanup::CleanupCommand::Artifacts(_)
+    ) && !homeboy::core::lab_routing::is_lab_offload_subprocess()
+}
+
 fn agent_task_summary_kind_for_output(
     args: &crate::commands::agent_task::AgentTaskArgs,
 ) -> Option<super::agent_task_summary::AgentTaskSummaryKind> {
@@ -342,6 +368,23 @@ mod tests {
 
         assert!(agent_task_summary_kind_for_output_mode(&args, false).is_some());
         assert!(agent_task_summary_kind_for_output_mode(&args, true).is_none());
+    }
+
+    #[test]
+    fn cleanup_artifacts_summary_is_eligible_for_operator_stdout() {
+        let args = crate::commands::cleanup::CleanupArgs {
+            command: crate::commands::cleanup::CleanupCommand::Artifacts(
+                crate::commands::cleanup::CleanupArtifactsArgs {
+                    apply: false,
+                    self_artifacts: false,
+                    path: None,
+                    temp_root: Vec::new(),
+                    merged_only: false,
+                },
+            ),
+        };
+
+        assert!(cleanup_summary_eligible(&args));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a compact operator summary for `homeboy cleanup artifacts` stdout.
- Preserve the existing full machine-readable JSON payload for output files and structured consumers.
- Summarize candidates, applied removals, reclaimed bytes, remaining candidates, skipped reasons, and next safe command.

Fixes #6602

## Tests
- `cargo fmt --check`
- `cargo test cleanup_artifacts_summary --lib`
- `cargo test cleanup_artifacts_apply_summary --lib`
- `cargo test cleanup_artifacts_summary_is_eligible --lib`
- CLI verification: `cargo run --quiet -- cleanup artifacts --path <fixture> --output <file>` and `jq -r '.success, .data.command, (.data.candidates | length)' <file>`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implementing the cleanup artifacts operator summary, tests, focused verification, and PR drafting.