### PR TITLE
Preserve rig package source metadata

### DIFF
--- a/src/commands/bench/tests/mod.rs
+++ b/src/commands/bench/tests/mod.rs
@@ -6,6 +6,7 @@ use homeboy::core::extension::bench::aggregate_comparison;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 use tempfile::TempDir;
 
@@ -219,6 +220,67 @@ fn install_rig_package(
     homeboy::core::rig::install(package_root.to_string_lossy().as_ref(), Some(rig_id), false)
         .expect("install rig package");
     package_root
+}
+
+fn install_git_rig_package(
+    home: &TempDir,
+    rig_id: &str,
+    component_id: &str,
+    path: &std::path::Path,
+) -> (std::path::PathBuf, String) {
+    let package_root = home.path().join(format!("{rig_id}-git-package"));
+    let rig_dir = package_root.join("rigs").join(rig_id);
+    fs::create_dir_all(&rig_dir).expect("mkdir package rig");
+    fs::write(
+        rig_dir.join("rig.json"),
+        format!(
+            r#"{{
+                    "components": {{
+                        "{component_id}": {{
+                            "path": "{}",
+                            "extensions": {{ "fixture-bench": {{}} }}
+                        }}
+                    }},
+                    "bench": {{ "default_component": "{component_id}" }}
+                }}"#,
+            path.display()
+        ),
+    )
+    .expect("write package rig");
+
+    git(&package_root, &["init", "-b", "main"]);
+    git(&package_root, &["config", "user.name", "Test User"]);
+    git(&package_root, &["config", "user.email", "test@example.com"]);
+    git(&package_root, &["add", "."]);
+    git(&package_root, &["commit", "-m", "Initial rig package"]);
+    let revision = git_output(&package_root, &["rev-parse", "--short", "HEAD"]);
+    fs::write(package_root.join("untracked.txt"), "dirty\n").expect("dirty package");
+
+    homeboy::core::rig::install(package_root.to_string_lossy().as_ref(), Some(rig_id), false)
+        .expect("install rig package");
+    (package_root, revision)
+}
+
+fn git(repo: &std::path::Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {:?} failed", args);
+}
+
+fn git_output(repo: &std::path::Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+    assert!(output.status.success(), "git {:?} failed", args);
+    String::from_utf8(output.stdout)
+        .expect("git output utf8")
+        .trim()
+        .to_string()
 }
 
 fn write_local_rig_package(

--- a/src/commands/bench/tests/scenario_run_tests.rs
+++ b/src/commands/bench/tests/scenario_run_tests.rs
@@ -33,6 +33,46 @@ fn single_rig_run_records_installed_rig_package_evidence_in_metadata() {
 }
 
 #[test]
+fn local_git_rig_package_evidence_records_source_identity() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        let (_package_root, revision) =
+            install_git_rig_package(home, "studio-bfb", "studio", component_dir.path());
+
+        let (output, exit_code) = run(
+            run_args(None, vec!["studio-bfb".to_string()], Vec::new()),
+            &GlobalArgs {},
+        )
+        .expect("rig bench should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::Single(result) => {
+                let metadata = result
+                    .results
+                    .expect("bench results")
+                    .run_metadata
+                    .expect("run metadata");
+                let evidence = metadata.rig_package.expect("rig package evidence");
+                assert_eq!(
+                    evidence.installed_source_revision.as_deref(),
+                    Some(revision.as_str())
+                );
+                assert_eq!(
+                    evidence.current_source_revision.as_deref(),
+                    Some(revision.as_str())
+                );
+                assert_eq!(evidence.source_ref.as_deref(), Some("main"));
+                assert!(evidence.source_dirty);
+                assert!(evidence.freshness_verified);
+            }
+            _ => panic!("expected single output"),
+        }
+    });
+}
+
+#[test]
 fn run_selects_single_scenario() {
     with_isolated_home(|home| {
         write_bench_extension(home);

--- a/src/core/extension/bench/result_types.rs
+++ b/src/core/extension/bench/result_types.rs
@@ -121,6 +121,10 @@ pub struct RigPackageEvidence {
     pub installed_source_revision: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub source_dirty: bool,
     pub linked: bool,
     pub materialized: bool,
     pub freshness: RigPackageFreshness,

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -35,6 +35,8 @@ pub(crate) struct PreparedSource {
     pub discovery_path: PathBuf,
     pub linked: bool,
     pub source_revision: Option<String>,
+    pub source_ref: Option<String>,
+    pub source_dirty: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -69,6 +71,10 @@ pub struct RigSourceMetadata {
     pub materialized: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub source_dirty: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -141,6 +147,8 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
             linked: prepared.linked,
             materialized,
             source_revision: prepared.source_revision.clone(),
+            source_ref: prepared.source_ref.clone(),
+            source_dirty: prepared.source_dirty,
         };
         write_source_metadata(&rig.id, &metadata)?;
 
@@ -666,6 +674,9 @@ fn prepare_git_source(source: &str) -> Result<PreparedSource> {
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rig packages dir".into())))?;
     git::clone_repo(root_source, &package_path)?;
     let source_revision = git::short_head_revision(&package_path);
+    let source_ref = git::current_branch(&package_path).filter(|branch| !branch.is_empty());
+    let source_dirty =
+        git::status_porcelain_bytes(&package_path).is_some_and(|status| !status.is_empty());
     let discovery_path = match subpath {
         Some(subpath) => package_path.join(subpath),
         None => package_path.clone(),
@@ -692,6 +703,8 @@ fn prepare_git_source(source: &str) -> Result<PreparedSource> {
         discovery_path,
         linked: false,
         source_revision,
+        source_ref,
+        source_dirty,
     })
 }
 
@@ -730,13 +743,20 @@ fn prepare_local_source(source: &str) -> Result<PreparedSource> {
             None,
         ));
     }
+    let source_revision = git::short_head_revision_at(&package_path);
+    let source_ref = git::current_branch(&package_path).filter(|branch| !branch.is_empty());
+    let source_dirty =
+        git::status_porcelain_bytes(&package_path).is_some_and(|status| !status.is_empty());
+
     Ok(PreparedSource {
         source: package_path.to_string_lossy().to_string(),
         source_root: package_path.clone(),
         discovery_path: package_path.clone(),
         package_path,
         linked: true,
-        source_revision: None,
+        source_revision,
+        source_ref,
+        source_dirty,
     })
 }
 

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -136,6 +136,9 @@ pub fn package_evidence(id: &str) -> Option<RigPackageEvidence> {
 fn local_package_evidence(id: &str, package_root: PathBuf) -> RigPackageEvidence {
     let source = package_root.to_string_lossy().to_string();
     let current_source_revision = git::short_head_revision_at(&package_root);
+    let source_ref = git::current_branch(&package_root).filter(|branch| !branch.is_empty());
+    let source_dirty =
+        git::status_porcelain_bytes(&package_root).is_some_and(|status| !status.is_empty());
     RigPackageEvidence {
         rig_id: id.to_string(),
         package_root: source.clone(),
@@ -152,6 +155,8 @@ fn local_package_evidence(id: &str, package_root: PathBuf) -> RigPackageEvidence
         discovery_path: Some(package_root.to_string_lossy().to_string()),
         installed_source_revision: current_source_revision.clone(),
         current_source_revision,
+        source_ref,
+        source_dirty,
         linked: true,
         materialized: false,
         freshness: RigPackageFreshness::Verified,
@@ -215,6 +220,8 @@ fn package_evidence_from_metadata(id: &str, metadata: RigSourceMetadata) -> RigP
         discovery_path: metadata.discovery_path,
         installed_source_revision: metadata.source_revision,
         current_source_revision,
+        source_ref: metadata.source_ref,
+        source_dirty: metadata.source_dirty,
         linked: metadata.linked,
         materialized: metadata.materialized,
         freshness,

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -295,6 +295,9 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
     let previous_revision = git::short_head_revision(&source_root);
     git::pull_repo(&source_root)?;
     let source_revision = git::short_head_revision(&source_root);
+    let source_ref = git::current_branch(&source_root).filter(|branch| !branch.is_empty());
+    let source_dirty =
+        git::status_porcelain_bytes(&source_root).is_some_and(|status| !status.is_empty());
 
     let mut updated = Vec::new();
     let mut updated_stacks = Vec::new();
@@ -337,6 +340,8 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
             linked: false,
             materialized,
             source_revision: source_revision.clone(),
+            source_ref: source_ref.clone(),
+            source_dirty,
         };
         write_source_metadata(&rig.id, &metadata)?;
 

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -58,6 +58,10 @@ pub(super) struct LabOffloadRigPackageSource {
     pub source_revision: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub source_dirty: bool,
     pub freshness_verified: bool,
     pub freshness_status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -117,6 +121,8 @@ pub(super) fn sync_lab_offload_rigs(
                         discovery_path: None,
                         source_revision: primary.source_snapshot.git_sha.clone(),
                         current_source_revision: primary.source_snapshot.git_sha.clone(),
+                        source_ref: primary.source_snapshot.git_branch.clone(),
+                        source_dirty: primary.source_snapshot.dirty,
                         freshness_verified: primary.source_snapshot.git_sha.is_some(),
                         freshness_status: if primary.source_snapshot.git_sha.is_some() {
                             "verified".to_string()
@@ -186,8 +192,20 @@ pub(super) fn sync_lab_offload_rigs(
                     install_source: install_source.clone(),
                     rig_path: Some(metadata.rig_path),
                     discovery_path: metadata.discovery_path,
-                    source_revision: metadata.source_revision,
-                    current_source_revision: source_snapshot.git_sha.clone(),
+                    source_revision: metadata.source_revision.clone(),
+                    current_source_revision: source_snapshot
+                        .git_sha
+                        .clone()
+                        .or_else(|| metadata.source_revision.clone()),
+                    source_ref: source_snapshot
+                        .git_branch
+                        .clone()
+                        .or_else(|| metadata.source_ref.clone()),
+                    source_dirty: source_snapshot
+                        .git_sha
+                        .is_some()
+                        .then_some(source_snapshot.dirty)
+                        .unwrap_or(metadata.source_dirty),
                     linked: metadata.linked,
                     materialized: metadata.materialized,
                     freshness_verified: false,
@@ -295,6 +313,10 @@ fn with_lab_package_freshness(
     rig_id: &str,
     mut package_source: LabOffloadRigPackageSource,
 ) -> LabOffloadRigPackageSource {
+    if package_source.current_source_revision.is_none() {
+        package_source.current_source_revision = package_source.source_revision.clone();
+    }
+
     match (
         package_source.source_revision.as_deref(),
         package_source.current_source_revision.as_deref(),
@@ -1065,6 +1087,8 @@ mod tests {
                         .to_string(),
                     discovery_path: Some(checkout.display().to_string()),
                     source_revision: None,
+                    source_ref: None,
+                    source_dirty: false,
                     linked: true,
                     materialized: false,
                 },
@@ -1114,6 +1138,8 @@ mod tests {
                 discovery_path: Some("/controller/homeboy-rigs".to_string()),
                 source_revision: Some("abc1234".to_string()),
                 current_source_revision: Some("def5678".to_string()),
+                source_ref: Some("main".to_string()),
+                source_dirty: false,
                 freshness_verified: false,
                 freshness_status: String::new(),
                 freshness_message: None,
@@ -1134,6 +1160,38 @@ mod tests {
             package.refresh_command.as_deref(),
             Some("homeboy rig install /runner/_lab_workspaces/homeboy-rigs --id studio-web-product-matrix --reinstall")
         );
+    }
+
+    #[test]
+    fn lab_package_source_freshness_uses_controller_metadata_when_snapshot_has_no_git() {
+        let package = with_lab_package_freshness(
+            "ssi-matrix-run-latest",
+            LabOffloadRigPackageSource {
+                source: "/controller/homeboy-rigs".to_string(),
+                source_root: "/controller/homeboy-rigs".to_string(),
+                package_path: "/controller/homeboy-rigs".to_string(),
+                install_source: "/runner/_lab_workspaces/homeboy-rigs".to_string(),
+                rig_path: Some("/controller/homeboy-rigs/rigs/ssi/rig.json".to_string()),
+                discovery_path: Some("/controller/homeboy-rigs".to_string()),
+                source_revision: Some("abc1234".to_string()),
+                current_source_revision: None,
+                source_ref: Some("main".to_string()),
+                source_dirty: true,
+                freshness_verified: false,
+                freshness_status: String::new(),
+                freshness_message: None,
+                refresh_command: None,
+                linked: true,
+                materialized: false,
+            },
+        );
+
+        assert!(package.freshness_verified);
+        assert_eq!(package.freshness_status, "verified");
+        assert_eq!(package.source_ref.as_deref(), Some("main"));
+        assert!(package.source_dirty);
+        assert!(package.freshness_message.is_none());
+        assert!(package.refresh_command.is_none());
     }
 
     #[test]

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -312,6 +312,8 @@ fn write_rig_source_metadata(rig_id: &str) {
             linked: false,
             materialized: false,
             source_revision: Some("abc123".to_string()),
+            source_ref: Some("main".to_string()),
+            source_dirty: false,
         })
         .expect("serialize source metadata"),
     )


### PR DESCRIPTION
## Summary
- record git revision, ref, and dirty state when rig package sources are selected or refreshed
- carry source identity into rig package evidence and Lab rig materialization metadata
- use controller-captured source revision when Lab runner snapshots omit .git, avoiding unknown freshness for materialized rig packages

Closes #6604

## Tests
- cargo fmt --all
- cargo test local_git_rig_package_evidence_records_source_identity --lib
- cargo test lab_package_source_freshness --lib
- cargo test rig_package_evidence --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementation, tests, formatting, and PR preparation