### PR TITLE
Persist bench URL artifacts from run files

### DIFF
--- a/src/commands/bench/observation/artifacts.rs
+++ b/src/commands/bench/observation/artifacts.rs
@@ -126,40 +126,64 @@ fn persist_bench_artifact(
     let kind = artifact.kind.clone().unwrap_or_else(|| name.to_string());
     let metadata = bench_artifact_metadata(scenario_id, run_index, name, artifact);
 
-    if let Some(url) = artifact.url.clone() {
-        return match observation.0.store().record_url_artifact_with_metadata(
-            observation.run_id(),
-            &kind,
-            &url,
-            metadata,
-        ) {
-            Ok(record) => {
-                apply_recorded_bench_artifact_links(scenario_id, run_index, name, artifact, &record)
-            }
-            Err(error) => Some(bench_artifact_diagnostic(
+    let original_path = artifact.path.clone();
+    if let Some(original_path) = original_path.as_deref() {
+        if bench_artifact_path_is_blocked(original_path) {
+            return Some(bench_artifact_diagnostic(
                 scenario_id,
                 run_index,
                 name,
-                "bench_artifact_url_record_failed",
-                format!("failed to record bench URL artifact `{name}`: {error}"),
-                serde_json::json!({ "url": url }),
-            )),
-        };
+                "bench_artifact_path_blocked",
+                format!("blocked bench artifact path `{original_path}` for `{name}`"),
+                serde_json::json!({ "path": original_path }),
+            ));
+        }
     }
 
-    let original_path = artifact.path.clone()?;
-    if bench_artifact_path_is_blocked(&original_path) {
+    let Some(path) = resolve_bench_artifact_file_pointer(
+        original_path.as_deref(),
+        artifact.url.as_deref(),
+        run_dir,
+        shared_state,
+    ) else {
+        if let Some(url) = artifact.url.clone() {
+            return match observation.0.store().record_url_artifact_with_metadata(
+                observation.run_id(),
+                &kind,
+                &url,
+                metadata,
+            ) {
+                Ok(record) => apply_recorded_bench_artifact_links(
+                    scenario_id,
+                    run_index,
+                    name,
+                    artifact,
+                    &record,
+                ),
+                Err(error) => Some(bench_artifact_diagnostic(
+                    scenario_id,
+                    run_index,
+                    name,
+                    "bench_artifact_url_record_failed",
+                    format!("failed to record bench URL artifact `{name}`: {error}"),
+                    serde_json::json!({ "url": url }),
+                )),
+            };
+        }
+
+        let original_path = original_path?;
         return Some(bench_artifact_diagnostic(
             scenario_id,
             run_index,
             name,
-            "bench_artifact_path_blocked",
-            format!("blocked bench artifact path `{original_path}` for `{name}`"),
-            serde_json::json!({ "path": original_path }),
+            "bench_artifact_path_missing",
+            format!("bench artifact path for `{name}` was not found: {original_path}"),
+            serde_json::json!({
+                "path": original_path,
+                "resolved_path": resolve_bench_artifact_path(&original_path, run_dir, shared_state).to_string_lossy().to_string(),
+            }),
         ));
-    }
-
-    let path = resolve_bench_artifact_path(&original_path, run_dir, shared_state);
+    };
     let record = if path.is_file() {
         observation.0.store().record_artifact_with_metadata(
             observation.run_id(),
@@ -178,17 +202,7 @@ fn persist_bench_artifact(
                 metadata,
             )
     } else {
-        return Some(bench_artifact_diagnostic(
-            scenario_id,
-            run_index,
-            name,
-            "bench_artifact_path_missing",
-            format!("bench artifact path for `{name}` was not found: {original_path}"),
-            serde_json::json!({
-                "path": original_path,
-                "resolved_path": path.to_string_lossy().to_string(),
-            }),
-        ));
+        unreachable!("resolved bench artifact file pointers must be files or directories");
     };
 
     match record {
@@ -338,6 +352,40 @@ fn resolve_bench_artifact_path(
         return run_dir_path;
     }
     artifact_path
+}
+
+fn resolve_bench_artifact_file_pointer(
+    path: Option<&str>,
+    url: Option<&str>,
+    run_dir: &RunDir,
+    shared_state: Option<&str>,
+) -> Option<PathBuf> {
+    if let Some(path) = path {
+        let resolved = resolve_bench_artifact_path(path, run_dir, shared_state);
+        if resolved.is_file() || resolved.is_dir() {
+            return Some(resolved);
+        }
+    }
+
+    let filename = url.and_then(artifact_filename_from_url)?;
+    for candidate in [
+        run_dir.path().join("artifacts").join(&filename),
+        run_dir.path().join(&filename),
+    ] {
+        if candidate.is_file() || candidate.is_dir() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn artifact_filename_from_url(url: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    parsed
+        .path_segments()?
+        .next_back()
+        .filter(|segment| !segment.is_empty() && !bench_artifact_path_is_blocked(segment))
+        .map(str::to_string)
 }
 
 fn resolve_shared_state_artifact(path: &Path, shared_state: Option<&str>) -> Option<PathBuf> {

--- a/src/commands/bench/observation/tests.rs
+++ b/src/commands/bench/observation/tests.rs
@@ -552,6 +552,96 @@ fn bench_observation_rewrites_invocation_artifacts_to_persisted_paths() {
 }
 
 #[test]
+fn bench_observation_mirrors_url_artifact_from_run_artifacts_dir() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let run_dir = RunDir::create().expect("run dir");
+        fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+        let runtime_artifact = run_dir.path().join("artifacts/finding-packets.json");
+        fs::create_dir_all(runtime_artifact.parent().expect("artifact parent")).expect("mkdir");
+        fs::write(
+            &runtime_artifact,
+            b"{\"finding_packets\":[{\"diagnostic_kind\":\"missing_block\"}]}",
+        )
+        .expect("artifact");
+
+        let mut results = bench_results("homeboy", "cold", 42.0);
+        results.scenarios[0].artifacts.insert(
+            "finding_packets".to_string(),
+            BenchArtifact {
+                path: None,
+                url: Some(
+                    "https://homeboy-artifacts.example.test/finding-packets.json".to_string(),
+                ),
+                artifact_type: Some("url".to_string()),
+                kind: Some("finding_packets".to_string()),
+                label: Some("Finding packets".to_string()),
+                observation_artifact_id: None,
+                ..BenchArtifact::default()
+            },
+        );
+        let mut workflow = BenchRunWorkflowResult {
+            status: "passed".to_string(),
+            component: "homeboy".to_string(),
+            exit_code: 0,
+            iterations: 10,
+            results: Some(results),
+            gate_results: Vec::new(),
+            gate_failures: Vec::new(),
+            baseline_comparison: None,
+            hints: None,
+            failure: None,
+            diagnostics: Vec::new(),
+        };
+
+        let args = bench_args();
+        let observation = start(BenchObservationStart {
+            component_id: "homeboy",
+            component_label: "homeboy",
+            source_path: home.path(),
+            args: &args,
+            selected_scenarios: &["cold".to_string()],
+            rig_id: None,
+            rig_snapshot: None,
+            run_dir: &run_dir,
+        })
+        .expect("start observation");
+        let run_id = observation.run_id().to_string();
+
+        finish_success(Some(observation), &mut workflow, &run_dir).expect("observation summary");
+        run_dir.cleanup();
+
+        let artifact =
+            &workflow.results.as_ref().unwrap().scenarios[0].artifacts["finding_packets"];
+        let persisted_path = artifact.path.as_deref().expect("persisted artifact path");
+        assert!(PathBuf::from(persisted_path).is_file());
+        assert_eq!(
+            fs::read_to_string(persisted_path).expect("read persisted"),
+            "{\"finding_packets\":[{\"diagnostic_kind\":\"missing_block\"}]}"
+        );
+
+        let store = ObservationStore::open_initialized().expect("store");
+        let artifacts = store.list_artifacts(&run_id).expect("artifacts");
+        let observation_artifact_id = artifact
+            .observation_artifact_id
+            .as_deref()
+            .expect("observation artifact id");
+        let record = artifacts
+            .iter()
+            .find(|artifact| artifact.id == observation_artifact_id)
+            .expect("artifact record");
+        assert_eq!(record.artifact_type, "file");
+        assert_eq!(record.url, None);
+        assert_eq!(record.metadata_json["source"], "bench");
+        assert_eq!(record.metadata_json["name"], "finding_packets");
+        assert_eq!(
+            record.metadata_json["url"],
+            "https://homeboy-artifacts.example.test/finding-packets.json"
+        );
+    });
+}
+
+#[test]
 fn bench_observation_rewrites_cleaned_short_invocation_artifact_paths() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();

--- a/src/commands/runs/artifact_index_tests.rs
+++ b/src/commands/runs/artifact_index_tests.rs
@@ -182,6 +182,58 @@ fn runs_artifacts_surfaces_matrix_summary_from_typed_packets() {
 }
 
 #[test]
+fn runs_artifacts_classifies_persisted_bench_artifact_from_metadata() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run(
+                "bench",
+                "homeboy",
+                "matrix-rig",
+                serde_json::json!({ "scenario_id": "fixture-matrix" }),
+            ))
+            .expect("matrix run");
+        store
+            .finish_run(&run.id, RunStatus::Pass, None)
+            .expect("finish matrix run");
+        let packets = home.path().join("finding-packets.json");
+        std::fs::write(
+            &packets,
+            serde_json::to_vec(&serde_json::json!({
+                "finding_packets": [
+                    { "diagnostic_kind": "missing_block", "fixture_id": "home" }
+                ]
+            }))
+            .expect("packet json"),
+        )
+        .expect("write packets");
+        store
+            .record_artifact_with_metadata(
+                &run.id,
+                "bench_artifact",
+                &packets,
+                serde_json::json!({
+                    "source": "bench",
+                    "name": "finding_packets",
+                    "url": "https://homeboy-artifacts.example.test/finding-packets.json"
+                }),
+            )
+            .expect("record packets");
+
+        let (output, _) = handlers::artifacts(&run.id).expect("artifacts");
+        let RunsOutput::Artifacts(output) = output else {
+            panic!("expected artifacts output");
+        };
+        let summary = output.matrix_summary.expect("matrix summary");
+
+        assert_eq!(summary.finding_count, 1);
+        assert_eq!(summary.finding_packet_refs.len(), 1);
+        assert!(summary.parse_diagnostics.is_empty());
+    });
+}
+
+#[test]
 fn runs_artifacts_recognizes_canonical_fuzz_result_envelope() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();

--- a/src/core/matrix_artifact_summary.rs
+++ b/src/core/matrix_artifact_summary.rs
@@ -344,7 +344,15 @@ fn classify_artifact(artifact: &ArtifactRecord) -> ArtifactClass {
         artifact.path.as_str(),
         artifact.id.as_str(),
     ];
-    for key in ["role", "semantic_key", "schema", "kind"] {
+    for key in [
+        "role",
+        "semantic_key",
+        "schema",
+        "kind",
+        "name",
+        "original_path",
+        "url",
+    ] {
         if let Some(value) = artifact.metadata_json.get(key).and_then(Value::as_str) {
             tokens.push(value);
         }


### PR DESCRIPTION
## Summary
- Mirror bench URL/path artifacts from Homeboy-owned run artifact files before falling back to URL-only records.
- Infer URL artifact filenames from the run artifacts directory so JSON outputs like finding packets and matrix summaries become durable observation artifacts.
- Keep matrix artifact summaries classified after persisted storage moves files under UUID paths.

Closes #6603

## Tests
- `cargo fmt`
- `cargo test commands::bench::observation::tests --lib`
- `cargo test commands::runs::artifact_index_tests --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, tests, and PR preparation.