### PR TITLE
Propagate run IDs to claimed runner jobs

### DIFF
--- a/src/core/runner/execution/worker.rs
+++ b/src/core/runner/execution/worker.rs
@@ -38,7 +38,7 @@ pub(super) fn exec_worker_local_with_process_output(
     let mut runner = load(runner_id)?;
     runner.kind = RunnerKind::Local;
     runner.server_id = None;
-    let plan = prepare_daemon_local_process(RunnerProcessRequest {
+    let mut plan = prepare_daemon_local_process(RunnerProcessRequest {
         runner_id: runner_id.to_string(),
         runner: Some(runner),
         cwd: options.cwd.clone(),
@@ -52,6 +52,8 @@ pub(super) fn exec_worker_local_with_process_output(
         require_paths: options.require_paths.clone(),
         validate_require_paths_on_host: true,
     })?;
+    let run_id_hint =
+        apply_explicit_runner_exec_run_id_env(&mut plan.env, options.run_id.as_deref());
     super::super::workload::validate_runner_workload_dispatch(
         options.runner_workload.as_ref(),
         runner_id,
@@ -84,7 +86,7 @@ pub(super) fn exec_worker_local_with_process_output(
     )?;
     preflight_worker_local_capability_plan(&plan.runner, capability_preflight.as_ref(), &plan.env)?;
     let output = execute(&plan)?;
-    Ok(exec_output(
+    let (mut output, exit_code) = exec_output(
         &plan.runner,
         RunnerExecMode::Local,
         plan.cwd,
@@ -94,7 +96,9 @@ pub(super) fn exec_worker_local_with_process_output(
         plan.require_paths,
         &plan.env,
         &[],
-    ))
+    );
+    append_runner_exec_diagnostic_hint(&mut output, run_id_hint);
+    Ok((output, exit_code))
 }
 
 pub(super) fn preflight_worker_local_capability_plan(

--- a/src/core/runner/worker/run.rs
+++ b/src/core/runner/worker/run.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use reqwest::blocking::Client;
 use serde_json::json;
 
-use crate::core::api_jobs::RemoteRunnerJobResult;
+use crate::core::api_jobs::{RemoteRunnerJobRequest, RemoteRunnerJobResult};
 use crate::core::error::{Error, Result};
 
 use super::super::execution::{exec_worker_local_until_cancelled, RunnerExecOptions};
@@ -277,6 +277,7 @@ fn run_once_output(
     };
     let mut cancel_seen = false;
     let mut last_cancel_poll = Instant::now();
+    let claimed_run_id = claimed_job_run_id(&claim.request);
     let exec_result = exec_worker_local_until_cancelled(
         &options.runner_id,
         RunnerExecOptions {
@@ -293,7 +294,7 @@ fn run_once_output(
             required_extensions: claim.request.required_extensions(),
             require_paths: claim.request.require_paths.clone(),
             runner_workload: claim.request.runner_workload.clone(),
-            run_id: None,
+            run_id: claimed_run_id,
             detach_after_handoff: false,
         },
         || {
@@ -378,4 +379,25 @@ fn run_once_output(
         ),
         exit_code,
     ))
+}
+
+fn claimed_job_run_id(request: &RemoteRunnerJobRequest) -> Option<String> {
+    request
+        .lifecycle
+        .as_ref()
+        .and_then(|lifecycle| non_empty_run_id(lifecycle.durable_run_id.as_deref()))
+        .or_else(|| {
+            request
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("run_id"))
+                .and_then(|run_id| non_empty_run_id(run_id.as_str()))
+        })
+}
+
+fn non_empty_run_id(run_id: Option<&str>) -> Option<String> {
+    run_id
+        .map(str::trim)
+        .filter(|run_id| !run_id.is_empty())
+        .map(ToString::to_string)
 }

--- a/src/core/runner/worker/tests/support.rs
+++ b/src/core/runner/worker/tests/support.rs
@@ -12,6 +12,41 @@ pub(super) fn spawn_mock_broker(
     spawn_mock_broker_with_paths(store, expected_requests, None)
 }
 
+pub(super) fn spawn_mock_broker_until_finish(
+    store: JobStore,
+    max_requests: usize,
+) -> (String, std::thread::JoinHandle<()>) {
+    spawn_mock_broker_until_finish_with_paths(store, max_requests, None)
+}
+
+pub(super) fn spawn_mock_broker_until_finish_with_paths(
+    store: JobStore,
+    max_requests: usize,
+    seen_paths: Option<Arc<std::sync::Mutex<Vec<String>>>>,
+) -> (String, std::thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+    let addr = listener.local_addr().expect("addr");
+    let handle = std::thread::spawn(move || {
+        for _ in 0..max_requests {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let request = read_request(&mut stream);
+            if let Some(seen_paths) = &seen_paths {
+                seen_paths
+                    .lock()
+                    .expect("record request path")
+                    .push(request.path.clone());
+            }
+            let finished = request.path.ends_with("/finish");
+            let response = handle_request(&store, &request);
+            write_response(&mut stream, response);
+            if finished {
+                break;
+            }
+        }
+    });
+    (format!("http://{addr}"), handle)
+}
+
 pub(super) fn spawn_mock_broker_with_paths(
     store: JobStore,
     expected_requests: usize,

--- a/src/core/runner/worker/tests/worker_tests.rs
+++ b/src/core/runner/worker/tests/worker_tests.rs
@@ -4,15 +4,17 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore, RemoteRunnerJobRequest};
+use crate::core::api_jobs::{
+    JobEventKind, JobStatus, JobStore, RemoteRunnerJobRequest, RunnerJobLifecycleMetadata,
+};
 use crate::core::server::RunnerPolicy;
 use crate::test_support;
 
 use super::super::run::{run_loop, run_reverse_worker};
 use super::support::{
     spawn_cancelling_after_claim_broker, spawn_cancelling_on_second_snapshot_broker,
-    spawn_failing_broker, spawn_mock_broker, spawn_mock_broker_with_paths,
-    write_reverse_controller_session,
+    spawn_failing_broker, spawn_mock_broker, spawn_mock_broker_until_finish,
+    spawn_mock_broker_until_finish_with_paths, write_reverse_controller_session,
 };
 use super::worker_options;
 
@@ -62,7 +64,7 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
             .expect("submit job");
         let seen_paths = Arc::new(std::sync::Mutex::new(Vec::new()));
         let (broker_url, handle) =
-            spawn_mock_broker_with_paths(store.clone(), 5, Some(seen_paths.clone()));
+            spawn_mock_broker_until_finish_with_paths(store.clone(), 8, Some(seen_paths.clone()));
         write_reverse_controller_session(&broker_url);
 
         let (output, exit_code) =
@@ -107,6 +109,80 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
             );
             assert!(result["metrics"]["sample_count"].as_u64().is_some());
         }
+    });
+}
+
+#[test]
+fn reverse_worker_injects_lifecycle_run_id_into_claimed_job_env() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let store = JobStore::default();
+        let mut request = run_id_echo_request();
+        request.env.insert(
+            "HOMEBOY_ACTIVE_RUN_ID".to_string(),
+            "conflicting-active".to_string(),
+        );
+        request.env.insert(
+            "HOMEBOY_RUN_ID".to_string(),
+            "conflicting-homeboy".to_string(),
+        );
+        request.env.insert(
+            "HOMEBOY_BENCH_RUN_ID".to_string(),
+            "conflicting-bench".to_string(),
+        );
+        request.env.insert(
+            "WORKFLOW_BENCH_RUN_ID".to_string(),
+            "conflicting-workflow".to_string(),
+        );
+        request.lifecycle = Some(RunnerJobLifecycleMetadata {
+            source: None,
+            kind: None,
+            durable_run_id: Some("durable-run-123".to_string()),
+            active_child_count: None,
+            active_cell_count: None,
+        });
+        store.submit_remote_runner_job(request).expect("submit job");
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+
+        let (output, exit_code) =
+            run_reverse_worker(worker_options(broker_url)).expect("run worker");
+
+        assert_eq!(exit_code, 0);
+        let job = output.job.expect("job");
+        assert_eq!(job.status, JobStatus::Succeeded);
+        handle.join().expect("mock broker joins");
+        let result = result_event_data(&store, job.id);
+        assert_eq!(
+            result["stdout"],
+            serde_json::json!("durable-run-123|durable-run-123|durable-run-123|unset")
+        );
+    });
+}
+
+#[test]
+fn reverse_worker_uses_metadata_run_id_for_claimed_job_env() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let store = JobStore::default();
+        let mut request = run_id_echo_request();
+        request.metadata = Some(serde_json::json!({
+            "run_id": "metadata-run-456",
+        }));
+        store.submit_remote_runner_job(request).expect("submit job");
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+
+        let (output, exit_code) =
+            run_reverse_worker(worker_options(broker_url)).expect("run worker");
+
+        assert_eq!(exit_code, 0);
+        let job = output.job.expect("job");
+        assert_eq!(job.status, JobStatus::Succeeded);
+        handle.join().expect("mock broker joins");
+        let result = result_event_data(&store, job.id);
+        assert_eq!(
+            result["stdout"],
+            serde_json::json!("metadata-run-456|metadata-run-456|metadata-run-456|unset")
+        );
     });
 }
 
@@ -436,6 +512,60 @@ fn reverse_worker_interrupts_running_job_when_broker_cancel_is_observed() {
             .iter()
             .any(|event| event.kind == JobEventKind::Result));
     });
+}
+
+fn create_shell_runner() {
+    crate::core::runner::create(
+        r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+        false,
+    )
+    .expect("create runner");
+    crate::core::runner::merge(
+        Some("lab"),
+        &serde_json::json!({
+            "policy": RunnerPolicy {
+                allow_raw_exec: Some(true),
+                workspace_roots: vec!["/tmp".to_string()],
+                allowed_commands: vec!["sh".to_string()],
+                ..Default::default()
+            }
+        })
+        .to_string(),
+        &[],
+    )
+    .expect("set policy");
+}
+
+fn run_id_echo_request() -> RemoteRunnerJobRequest {
+    RemoteRunnerJobRequest {
+        runner_id: "lab".to_string(),
+        project_id: None,
+        operation: "runner.exec".to_string(),
+        command: vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf '%s|%s|%s|%s' \"$HOMEBOY_ACTIVE_RUN_ID\" \"$HOMEBOY_RUN_ID\" \"$HOMEBOY_BENCH_RUN_ID\" \"${WORKFLOW_BENCH_RUN_ID-unset}\"".to_string(),
+        ],
+        cwd: Some("/tmp".to_string()),
+        env: Default::default(),
+        secret_env_names: Vec::new(),
+        capture_patch: false,
+        source_snapshot: None,
+        require_paths: Vec::new(),
+        runner_workload: None,
+        lifecycle: None,
+        metadata: None,
+    }
+}
+
+fn result_event_data(store: &JobStore, job_id: uuid::Uuid) -> serde_json::Value {
+    store
+        .events(job_id)
+        .expect("events")
+        .into_iter()
+        .find(|event| event.kind == JobEventKind::Result)
+        .and_then(|event| event.data)
+        .expect("result event data")
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Propagate claimed reverse-runner job lifecycle `durable_run_id` or metadata `run_id` into `RunnerExecOptions.run_id`.
- Apply explicit run-id env injection in the worker-local execution path so claimed jobs receive `HOMEBOY_RUN_ID`/related env and conflicting run-id env is scrubbed.
- Add focused worker tests for lifecycle and metadata run IDs, including conflicting env behavior.

## Local verification
- `cargo fmt`
- `git diff --check`
- `cargo test core::runner::worker::tests::worker_tests::reverse_worker_injects_lifecycle_run_id_into_claimed_job_env -- --test-threads=1`
- `cargo test core::runner::worker::tests::worker_tests::reverse_worker_uses_metadata_run_id_for_claimed_job_env -- --test-threads=1`
- `cargo test core::runner::execution::tests::exec::runner_exec_explicit_run_id_overrides_conflicting_run_id_env`

Actions are rate limited, so I documented local verification and did not wait for GitHub Actions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code change, focused test additions, local verification, and PR description drafting.