### PR TITLE
Clarify runner workflow binary status

### DIFF
--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -14,8 +14,9 @@ use super::super::CmdResult;
 use super::types::{
     LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
     RunnerConnectionOutput, RunnerExtra, RunnerHomeboyBinaryRole, RunnerOperatorCommand,
-    RunnerOutput, RunnerToolDiagnostics, WpCodeboxPackageRuntimeOutput, WpCodeboxProbeValue,
-    WpCodeboxRuntimeDiagnostic, WpCodeboxRuntimeOutput,
+    RunnerOutput, RunnerToolDiagnostics, RunnerWorkflowBinaryGuidance,
+    WpCodeboxPackageRuntimeOutput, WpCodeboxProbeValue, WpCodeboxRuntimeDiagnostic,
+    WpCodeboxRuntimeOutput,
 };
 
 pub(super) fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
@@ -133,15 +134,23 @@ pub(super) fn lab_runner_homeboy_output(
     let version_drift = active_daemon_version
         .as_ref()
         .is_some_and(|version| version != &controller_version);
+    let binary_roles = runner_homeboy_binary_roles(
+        configured_executable,
+        &status.session,
+        &active_daemon_version,
+    );
+    let controller_cli = binary_roles[0].clone();
+    let active_daemon = binary_roles[1].clone();
+    let configured_job_binary = binary_roles[2].clone();
     LabRunnerHomeboyOutput {
         controller_version,
         controller_build_identity,
         configured_executable: configured_executable.to_string(),
-        binary_roles: runner_homeboy_binary_roles(
-            configured_executable,
-            &status.session,
-            &active_daemon_version,
-        ),
+        controller_cli,
+        active_daemon,
+        configured_job_binary,
+        binary_roles,
+        workflow_binary_guidance: runner_workflow_binary_guidance(),
         active_daemon_version,
         active_daemon_build_identity: status
             .session
@@ -450,7 +459,7 @@ fn runner_homeboy_binary_roles(
             purpose: "Accepts connected daemon jobs until the runner is disconnected/reconnected; it can lag behind the configured job binary after refresh-homeboy.",
         },
         RunnerHomeboyBinaryRole {
-            role: "job_command_binary",
+            role: "configured_job_binary",
             owner: "runner_config.settings.homeboy_path",
             path: Some(configured_executable.to_string()),
             version: None,
@@ -458,6 +467,14 @@ fn runner_homeboy_binary_roles(
             purpose: "Binary path selected for runner-side Homeboy subcommands and capability checks; use command_availability_checks to verify required subcommands on the runner.",
         },
     ]
+}
+
+fn runner_workflow_binary_guidance() -> RunnerWorkflowBinaryGuidance {
+    RunnerWorkflowBinaryGuidance {
+        recent_workflows: "Recent or already-queued runner workflows may still be owned by the active_daemon session shown here until the runner reconnects.",
+        explicit_workflows: "Explicit runner workflow commands and capability checks use configured_job_binary unless the workflow overrides the command binary itself.",
+        capability_checks: "Use command_availability_checks or artifact_features.runner_command_checks to verify the configured_job_binary on the runner before assuming controller_cli features are available remotely.",
+    }
 }
 
 pub(super) fn runner_artifact_feature_diagnostics(

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -410,9 +410,17 @@ fn runner_homeboy_status_distinguishes_daemon_and_job_binary_roles() {
 
     assert!(serialized.contains("controller_cli"));
     assert!(serialized.contains("active_daemon"));
-    assert!(serialized.contains("job_command_binary"));
+    assert!(serialized.contains("configured_job_binary"));
     assert!(serialized.contains("runner_config.settings.homeboy_path"));
     assert!(serialized.contains("/opt/homeboy/bin/homeboy tunnel artifact-origin dom-boxes --help"));
+    assert!(serialized.contains("Recent or already-queued runner workflows"));
+    assert_eq!(output.controller_cli.role, "controller_cli");
+    assert_eq!(output.active_daemon.role, "active_daemon");
+    assert_eq!(output.configured_job_binary.role, "configured_job_binary");
+    assert_eq!(
+        output.configured_job_binary.path.as_deref(),
+        Some("/opt/homeboy/bin/homeboy")
+    );
     assert_eq!(output.active_daemon_version.as_deref(), Some("0.262.0"));
 }
 

--- a/src/commands/runner/types.rs
+++ b/src/commands/runner/types.rs
@@ -76,7 +76,11 @@ pub struct LabRunnerHomeboyOutput {
     pub controller_version: String,
     pub controller_build_identity: String,
     pub configured_executable: String,
+    pub controller_cli: RunnerHomeboyBinaryRole,
+    pub active_daemon: RunnerHomeboyBinaryRole,
+    pub configured_job_binary: RunnerHomeboyBinaryRole,
     pub binary_roles: Vec<RunnerHomeboyBinaryRole>,
+    pub workflow_binary_guidance: RunnerWorkflowBinaryGuidance,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_daemon_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -90,7 +94,7 @@ pub struct LabRunnerHomeboyOutput {
     pub upgrade_command: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct RunnerHomeboyBinaryRole {
     pub role: &'static str,
     pub owner: &'static str,
@@ -101,6 +105,13 @@ pub struct RunnerHomeboyBinaryRole {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_identity: Option<String>,
     pub purpose: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerWorkflowBinaryGuidance {
+    pub recent_workflows: &'static str,
+    pub explicit_workflows: &'static str,
+    pub capability_checks: &'static str,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/core/observation/store/artifacts.rs
+++ b/src/core/observation/store/artifacts.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use uuid::Uuid;
 
 use super::*;

--- a/src/core/observation/store/runs.rs
+++ b/src/core/observation/store/runs.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use uuid::Uuid;
 
 use super::*;


### PR DESCRIPTION
## Summary
- Add explicit runner Homeboy role fields for controller_cli, active_daemon, and configured_job_binary alongside the existing binary_roles array.
- Add workflow_binary_guidance so operators can distinguish recent daemon-owned workflows from explicit configured job binary checks.
- Import rusqlite::OptionalExtension in split observation store modules so fresh origin/main compiles.

Fixes #6628.

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test runner_homeboy_status_distinguishes_daemon_and_job_binary_roles`
- `cargo run -- runner status homeboy-lab`
- `cargo test` was run and failed only in existing/unrelated tests documented during PR creation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, implementation, tests, verification, and PR preparation.
