### PR TITLE
Add runner workspace pull recovery

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -922,6 +922,21 @@ mod tests {
             ["homeboy", "runner", "disconnect", "homeboy-lab"].as_slice(),
             [
                 "homeboy",
+                "runner",
+                "workspace",
+                "pull",
+                "homeboy-lab",
+                "--remote-path",
+                "/srv/homeboy/workspace",
+                "--include",
+                "fixtures/*.fig",
+                "--to",
+                "fixtures",
+                "--dry-run",
+            ]
+            .as_slice(),
+            [
+                "homeboy",
                 "db",
                 "delete-row",
                 "mysite",

--- a/src/command_contract/public_variants.rs
+++ b/src/command_contract/public_variants.rs
@@ -466,6 +466,13 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
     },
     PublicOutputVariantContract {
         command: "runner",
+        variant: "workspace_pull",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("workspace_pull"),
+        golden_fixture: None,
+    },
+    PublicOutputVariantContract {
+        command: "runner",
         variant: "workspace_apply",
         discriminator_field: Some("variant"),
         discriminator_value: Some("workspace_apply"),

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -512,6 +512,13 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.output_notes = "materializes a local worktree into runner workspace state";
             metadata.dangerous_flags = vec!["--allow-dirty-lab-workspace"];
         }
+        ["runner", "workspace", "pull"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.dry_run_flag = Some("--dry-run");
+            metadata.output_notes =
+                "copies selected files from runner workspace state to a local destination";
+        }
         ["runner", "workspace", "apply"] => {
             metadata.mutates = true;
             metadata.operator = true;

--- a/src/commands/runner/workspace/mod.rs
+++ b/src/commands/runner/workspace/mod.rs
@@ -3,7 +3,8 @@ use serde::Serialize;
 
 use homeboy::core::runners::{
     self as runner, RunnerWorkspaceApplyOutput, RunnerWorkspaceListOutput,
-    RunnerWorkspacePruneOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOutput,
+    RunnerWorkspacePruneOutput, RunnerWorkspacePullOutput, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOutput,
 };
 
 use super::CmdResult;
@@ -13,6 +14,7 @@ use super::CmdResult;
 pub enum RunnerWorkspaceOutput {
     List(RunnerWorkspaceListOutput),
     Sync(RunnerWorkspaceSyncOutput),
+    Pull(RunnerWorkspacePullOutput),
     Apply(RunnerWorkspaceApplyOutput),
     Prune(RunnerWorkspacePruneOutput),
 }
@@ -44,6 +46,27 @@ pub(super) enum RunnerWorkspaceCommand {
         /// Permit git sync to overwrite a dirty runner-side workspace.
         #[arg(long)]
         allow_dirty_lab_workspace: bool,
+    },
+    /// Copy selected files from a runner workspace back to the controller
+    Pull {
+        /// Runner ID
+        runner_id: String,
+
+        /// Absolute runner-side workspace or snapshot path to pull from
+        #[arg(long)]
+        remote_path: String,
+
+        /// Relative glob to copy from the remote path. Repeat for multiple globs.
+        #[arg(long = "include")]
+        includes: Vec<String>,
+
+        /// Local destination directory on the controller
+        #[arg(long)]
+        to: String,
+
+        /// Validate and print the copy plan without transferring files
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Apply a Lab-generated patch/delta back to its local source worktree
     Apply {
@@ -94,6 +117,22 @@ pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceO
             allow_dirty_lab_workspace,
         } => sync(&runner_id, path, mode, allow_dirty_lab_workspace)
             .map(|(output, exit_code)| (RunnerWorkspaceOutput::Sync(output), exit_code)),
+        RunnerWorkspaceCommand::Pull {
+            runner_id,
+            remote_path,
+            includes,
+            to,
+            dry_run,
+        } => runner::pull_workspace(
+            &runner_id,
+            runner::RunnerWorkspacePullOptions {
+                remote_path,
+                includes,
+                to,
+                dry_run,
+            },
+        )
+        .map(|(output, exit_code)| (RunnerWorkspaceOutput::Pull(output), exit_code)),
         RunnerWorkspaceCommand::Apply { input, force } => {
             runner::apply_workspace_patch(runner::RunnerWorkspaceApplyOptions { input, force })
                 .map(|(output, exit_code)| (RunnerWorkspaceOutput::Apply(output), exit_code))

--- a/src/core/observation/store/artifacts.rs
+++ b/src/core/observation/store/artifacts.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use uuid::Uuid;
 
 use super::*;

--- a/src/core/observation/store/runs.rs
+++ b/src/core/observation/store/runs.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use uuid::Uuid;
 
 use super::*;

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -128,11 +128,12 @@ pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerFileTransfer, RunnerTransport};
 pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
 pub use workspace::{
-    list_workspaces, prune_workspaces, sync_workspace, ByteFileCounts,
-    RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry, RunnerWorkspaceListOutput,
-    RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput,
-    RunnerWorkspacePruneSkippedEntry, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
-    RunnerWorkspaceSyncOutput,
+    list_workspaces, plan_workspace_pull, prune_workspaces, pull_workspace, sync_workspace,
+    ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry,
+    RunnerWorkspaceListOutput, RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions,
+    RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry, RunnerWorkspacePullOptions,
+    RunnerWorkspacePullOutput, RunnerWorkspacePullPlan, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -7,17 +7,20 @@
 //! runner subsystem so the historical `workspace::*` paths keep resolving.
 
 mod git;
+mod pull;
 mod snapshot;
 mod sync;
 mod types;
 mod util;
 
+pub use pull::{plan_workspace_pull, pull_workspace};
 pub use sync::sync_workspace;
 pub use sync::{list_workspaces, prune_workspaces};
 pub use types::{
     ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry,
     RunnerWorkspaceListOutput, RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions,
-    RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry, RunnerWorkspaceSyncMode,
+    RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry, RunnerWorkspacePullOptions,
+    RunnerWorkspacePullOutput, RunnerWorkspacePullPlan, RunnerWorkspaceSyncMode,
     RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 

--- a/src/core/runner/workspace/pull.rs
+++ b/src/core/runner/workspace/pull.rs
@@ -1,0 +1,432 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use crate::core::error::{Error, Result};
+use crate::core::server;
+
+use super::super::{load, Runner, RunnerKind};
+use super::types::{
+    ByteFileCounts, RunnerWorkspacePullOptions, RunnerWorkspacePullOutput, RunnerWorkspacePullPlan,
+};
+
+pub fn pull_workspace(
+    runner_id: &str,
+    options: RunnerWorkspacePullOptions,
+) -> Result<(RunnerWorkspacePullOutput, i32)> {
+    let runner = load(runner_id)?;
+    let plan = plan_workspace_pull(&runner, &options)?;
+
+    if !options.dry_run {
+        fs::create_dir_all(&plan.local_destination).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("create {}", plan.local_destination)),
+            )
+        })?;
+    }
+    let before = if options.dry_run {
+        BTreeMap::new()
+    } else {
+        local_file_stats(Path::new(&plan.local_destination))?
+    };
+
+    if !options.dry_run {
+        match runner.kind {
+            RunnerKind::Local => pull_local(&plan)?,
+            RunnerKind::Ssh => pull_ssh(&runner, &plan)?,
+        }
+    }
+
+    let counts = if options.dry_run {
+        ByteFileCounts::default()
+    } else {
+        changed_local_file_counts(Path::new(&plan.local_destination), &before)?
+    };
+
+    Ok((
+        RunnerWorkspacePullOutput {
+            variant: "workspace_pull",
+            command: "runner.workspace.pull",
+            runner_id: plan.runner_id,
+            remote_path: plan.remote_path,
+            includes: plan.includes,
+            local_destination: plan.local_destination,
+            remote_sources: plan.remote_sources,
+            allowed_roots: plan.allowed_roots,
+            dry_run: options.dry_run,
+            files: counts.files,
+            bytes: counts.bytes,
+        },
+        0,
+    ))
+}
+
+pub fn plan_workspace_pull(
+    runner: &Runner,
+    options: &RunnerWorkspacePullOptions,
+) -> Result<RunnerWorkspacePullPlan> {
+    let remote_path = normalize_remote_path(&options.remote_path)?;
+    let includes = normalize_includes(&options.includes)?;
+    let local_destination = normalize_local_destination(&options.to)?;
+    let allowed_roots = allowed_runner_workspace_roots(runner)?;
+
+    if !allowed_roots
+        .iter()
+        .any(|root| path_is_within_root(&remote_path, root))
+    {
+        return Err(Error::validation_invalid_argument(
+            "remote_path",
+            "runner workspace pull path must be under an allowed runner workspace root",
+            Some(remote_path),
+            Some(vec![format!("Allowed roots: {}", allowed_roots.join(", "))]),
+        ));
+    }
+
+    let remote_sources = includes
+        .iter()
+        .map(|include| join_remote_path(&remote_path, include))
+        .collect();
+
+    Ok(RunnerWorkspacePullPlan {
+        runner_id: runner.id.clone(),
+        remote_path,
+        includes,
+        local_destination,
+        remote_sources,
+        allowed_roots,
+    })
+}
+
+fn pull_local(plan: &RunnerWorkspacePullPlan) -> Result<()> {
+    for include in &plan.includes {
+        let pattern = join_remote_path(&plan.remote_path, include);
+        let entries = glob::glob(&pattern).map_err(|err| {
+            Error::validation_invalid_argument(
+                "include",
+                format!("invalid include glob: {err}"),
+                Some(include.clone()),
+                None,
+            )
+        })?;
+        for entry in entries {
+            let source = entry.map_err(|err| {
+                Error::internal_io(err.to_string(), Some(format!("glob {pattern}")))
+            })?;
+            if source.is_file() {
+                let relative = source.strip_prefix(&plan.remote_path).unwrap_or(&source);
+                let destination = Path::new(&plan.local_destination).join(relative);
+                if let Some(parent) = destination.parent() {
+                    fs::create_dir_all(parent).map_err(|err| {
+                        Error::internal_io(
+                            err.to_string(),
+                            Some(format!("create {}", parent.display())),
+                        )
+                    })?;
+                }
+                fs::copy(&source, &destination).map_err(|err| {
+                    Error::internal_io(
+                        err.to_string(),
+                        Some(format!(
+                            "copy {} to {}",
+                            source.display(),
+                            destination.display()
+                        )),
+                    )
+                })?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn pull_ssh(runner: &Runner, plan: &RunnerWorkspacePullPlan) -> Result<()> {
+    let server_id = runner.server_id.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runner",
+            "SSH runner is missing server_id",
+            Some(runner.id.clone()),
+            None,
+        )
+    })?;
+
+    for source in &plan.remote_sources {
+        let output = server::transfer::transfer(&server::transfer::TransferConfig {
+            source: format!("{server_id}:{source}"),
+            destination: plan.local_destination.clone(),
+            recursive: true,
+            compress: true,
+            dry_run: false,
+            exclude: Vec::new(),
+        })?;
+        if output.1 != 0 || !output.0.success {
+            return Err(Error::validation_invalid_argument(
+                "remote_path",
+                format!(
+                    "failed to pull runner workspace files: {}",
+                    output.0.error.unwrap_or_else(|| "scp failed".to_string())
+                ),
+                Some(source.clone()),
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn normalize_remote_path(path: &str) -> Result<String> {
+    let path = path.trim_end_matches('/');
+    let parsed = Path::new(path);
+    if !parsed.is_absolute() {
+        return Err(Error::validation_invalid_argument(
+            "remote_path",
+            "runner workspace pull path must be absolute",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+    if has_parent_dir(parsed) {
+        return Err(Error::validation_invalid_argument(
+            "remote_path",
+            "runner workspace pull path must not contain parent directory components",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+    Ok(if path.is_empty() {
+        "/".to_string()
+    } else {
+        path.to_string()
+    })
+}
+
+fn normalize_includes(includes: &[String]) -> Result<Vec<String>> {
+    let mut normalized = if includes.is_empty() {
+        vec!["**/*".to_string()]
+    } else {
+        includes.to_vec()
+    };
+    for include in &mut normalized {
+        *include = include.trim_start_matches('/').to_string();
+        let path = Path::new(include);
+        if include.is_empty() || path.is_absolute() || has_parent_dir(path) {
+            return Err(Error::validation_invalid_argument(
+                "include",
+                "include glob must be a non-empty relative path without parent directory components",
+                Some(include.clone()),
+                None,
+            ));
+        }
+    }
+    normalized.sort();
+    normalized.dedup();
+    Ok(normalized)
+}
+
+fn normalize_local_destination(path: &str) -> Result<String> {
+    let expanded = shellexpand::tilde(path).to_string();
+    if expanded.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "to",
+            "local destination must not be empty",
+            None,
+            None,
+        ));
+    }
+    Ok(expanded)
+}
+
+fn allowed_runner_workspace_roots(runner: &Runner) -> Result<Vec<String>> {
+    let mut roots = Vec::new();
+    if let Some(root) = runner.workspace_root.as_deref() {
+        roots.push(normalize_root(root));
+    }
+    roots.extend(
+        runner
+            .policy
+            .workspace_roots
+            .iter()
+            .map(|root| normalize_root(root)),
+    );
+    roots.sort();
+    roots.dedup();
+    roots.retain(|root| Path::new(root).is_absolute());
+    if roots.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "runner",
+            "runner has no configured workspace roots for workspace pull",
+            Some(runner.id.clone()),
+            Some(vec![
+                "Set runner.workspace_root or policy.workspace_roots before pulling workspace files."
+                    .to_string(),
+            ]),
+        ));
+    }
+    Ok(roots)
+}
+
+fn normalize_root(path: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn path_is_within_root(path: &str, root: &str) -> bool {
+    let root = normalize_root(root);
+    path == root || path.starts_with(&format!("{root}/"))
+}
+
+fn join_remote_path(base: &str, include: &str) -> String {
+    if base == "/" {
+        format!("/{include}")
+    } else {
+        format!("{base}/{include}")
+    }
+}
+
+fn has_parent_dir(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
+
+fn local_file_stats(
+    root: &Path,
+) -> Result<BTreeMap<PathBuf, (u64, Option<std::time::SystemTime>)>> {
+    let mut stats = BTreeMap::new();
+    collect_local_file_stats(root, root, &mut stats)?;
+    Ok(stats)
+}
+
+fn collect_local_file_stats(
+    root: &Path,
+    path: &Path,
+    stats: &mut BTreeMap<PathBuf, (u64, Option<std::time::SystemTime>)>,
+) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(path).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
+    })? {
+        let entry = entry.map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
+        })?;
+        let child = entry.path();
+        let metadata = entry.metadata().map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("stat {}", child.display())))
+        })?;
+        if metadata.is_dir() {
+            collect_local_file_stats(root, &child, stats)?;
+        } else if metadata.is_file() {
+            let relative = child.strip_prefix(root).unwrap_or(&child).to_path_buf();
+            stats.insert(relative, (metadata.len(), metadata.modified().ok()));
+        }
+    }
+    Ok(())
+}
+
+fn changed_local_file_counts(
+    root: &Path,
+    before: &BTreeMap<PathBuf, (u64, Option<std::time::SystemTime>)>,
+) -> Result<ByteFileCounts> {
+    let after = local_file_stats(root)?;
+    let mut counts = ByteFileCounts::default();
+    for (path, stat) in after {
+        if before.get(&path) != Some(&stat) {
+            counts.files += 1;
+            counts.bytes += stat.0;
+        }
+    }
+    Ok(counts)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::core::runner::{Runner, RunnerKind};
+    use crate::core::server::{RunnerPolicy, RunnerSettings};
+
+    use super::*;
+
+    fn runner() -> Runner {
+        Runner {
+            id: "lab".to_string(),
+            kind: RunnerKind::Ssh,
+            server_id: Some("lab-server".to_string()),
+            workspace_root: Some("/srv/homeboy".to_string()),
+            settings: RunnerSettings::default(),
+            env: HashMap::new(),
+            secret_env: HashMap::new(),
+            resources: HashMap::new(),
+            policy: RunnerPolicy::default(),
+        }
+    }
+
+    #[test]
+    fn pull_plan_accepts_path_under_workspace_root() {
+        let plan = plan_workspace_pull(
+            &runner(),
+            &RunnerWorkspacePullOptions {
+                remote_path: "/srv/homeboy/snapshots/run-1".to_string(),
+                includes: vec!["fixtures/*.fig".to_string()],
+                to: "./fixtures".to_string(),
+                dry_run: true,
+            },
+        )
+        .expect("plan");
+
+        assert_eq!(plan.runner_id, "lab");
+        assert_eq!(
+            plan.remote_sources,
+            vec!["/srv/homeboy/snapshots/run-1/fixtures/*.fig"]
+        );
+        assert_eq!(plan.allowed_roots, vec!["/srv/homeboy"]);
+    }
+
+    #[test]
+    fn pull_plan_rejects_path_outside_workspace_root() {
+        let err = plan_workspace_pull(
+            &runner(),
+            &RunnerWorkspacePullOptions {
+                remote_path: "/etc".to_string(),
+                includes: vec!["*.conf".to_string()],
+                to: ".".to_string(),
+                dry_run: true,
+            },
+        )
+        .expect_err("outside root should fail");
+
+        assert!(err.to_string().contains("allowed runner workspace root"));
+    }
+
+    #[test]
+    fn pull_plan_rejects_parent_components() {
+        let err = plan_workspace_pull(
+            &runner(),
+            &RunnerWorkspacePullOptions {
+                remote_path: "/srv/homeboy/../secret".to_string(),
+                includes: vec!["*.fig".to_string()],
+                to: ".".to_string(),
+                dry_run: true,
+            },
+        )
+        .expect_err("parent remote path should fail");
+        assert!(err.to_string().contains("parent directory"));
+
+        let err = plan_workspace_pull(
+            &runner(),
+            &RunnerWorkspacePullOptions {
+                remote_path: "/srv/homeboy/work".to_string(),
+                includes: vec!["../*.fig".to_string()],
+                to: ".".to_string(),
+                dry_run: true,
+            },
+        )
+        .expect_err("parent include should fail");
+        assert!(err.to_string().contains("relative path"));
+    }
+}

--- a/src/core/runner/workspace/types.rs
+++ b/src/core/runner/workspace/types.rs
@@ -94,6 +94,39 @@ pub struct RunnerWorkspaceSyncOutput {
     pub validation_dependencies: Vec<RunnerValidationDependencySyncOutput>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct RunnerWorkspacePullOptions {
+    pub remote_path: String,
+    pub includes: Vec<String>,
+    pub to: String,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerWorkspacePullPlan {
+    pub runner_id: String,
+    pub remote_path: String,
+    pub includes: Vec<String>,
+    pub local_destination: String,
+    pub remote_sources: Vec<String>,
+    pub allowed_roots: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerWorkspacePullOutput {
+    pub variant: &'static str,
+    pub command: &'static str,
+    pub runner_id: String,
+    pub remote_path: String,
+    pub includes: Vec<String>,
+    pub local_destination: String,
+    pub remote_sources: Vec<String>,
+    pub allowed_roots: Vec<String>,
+    pub dry_run: bool,
+    pub files: usize,
+    pub bytes: u64,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RunnerWorkspaceListOutput {
     pub variant: &'static str,

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -37,9 +37,9 @@ pub use super::runner::{
     is_retrievable_runner_artifact, lab_offload_changed_since_ref, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping, list_workspaces, mirror_connected_runner_run,
     mirrored_runner_job_identity, plan_homeboy_binary_refresh, plan_managed_runner_source_sync,
-    plan_managed_runner_source_syncs, preflight_lab_offload_changed_since,
+    plan_managed_runner_source_syncs, plan_workspace_pull, preflight_lab_offload_changed_since,
     preflight_remote_argv_path_translation, prepare_git_lab_offload_changed_since,
-    prepare_lab_runner_capability, prune_workspaces, refresh_homeboy_binary,
+    prepare_lab_runner_capability, prune_workspaces, pull_workspace, refresh_homeboy_binary,
     refresh_mirrored_daemon_evidence, reportable_artifact_evidence_path,
     resolve_default_lab_runner, run_reverse_worker, runner_artifact_store_token,
     runner_exec_failure_error, runner_job_cancel, runner_job_log_snapshot, status, statuses,
@@ -61,7 +61,8 @@ pub use super::runner::{
     RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus, RunnerWorkspaceLease,
     RunnerWorkspaceLeaseSet, RunnerWorkspaceListEntry, RunnerWorkspaceListOutput,
     RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput,
-    RunnerWorkspacePruneSkippedEntry, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    RunnerWorkspacePruneSkippedEntry, RunnerWorkspacePullOptions, RunnerWorkspacePullOutput,
+    RunnerWorkspacePullPlan, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
     RunnerWorkspaceSyncOutput,
 };
 
@@ -113,12 +114,13 @@ pub mod execution {
 pub mod workspace {
     pub use super::super::runner::{
         apply_change_artifact, apply_workspace_patch, list_workspaces,
-        plan_managed_runner_source_sync, plan_managed_runner_source_syncs, prune_workspaces,
-        sync_workspace, ManagedRunnerSourceSyncPlan, RunnerWorkspaceApplyOptions,
-        RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus, RunnerWorkspaceListEntry,
-        RunnerWorkspaceListOutput, RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions,
-        RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry, RunnerWorkspaceSyncMode,
-        RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+        plan_managed_runner_source_sync, plan_managed_runner_source_syncs, plan_workspace_pull,
+        prune_workspaces, pull_workspace, sync_workspace, ManagedRunnerSourceSyncPlan,
+        RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
+        RunnerWorkspaceListEntry, RunnerWorkspaceListOutput, RunnerWorkspacePruneEntry,
+        RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry,
+        RunnerWorkspacePullOptions, RunnerWorkspacePullOutput, RunnerWorkspacePullPlan,
+        RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
     };
 }
 


### PR DESCRIPTION
## Summary
- Add `homeboy runner workspace pull <runner> --remote-path <path> --include <glob> --to <dir>` for runner-to-controller workspace recovery.
- Validate runner-side paths against configured `workspace_root` / `policy.workspace_roots`, reject parent directory components, and support `--dry-run` planning.
- Emit provenance and copy counts in structured output: runner id, remote path, includes, local destination, remote sources, allowed roots, files, and bytes.
- Fix missing `rusqlite::OptionalExtension` imports that blocked `cargo check` on `origin/main`.

Fixes #6626

## Verification
- `cargo fmt`
- `cargo check`
- `cargo test workspace::pull`
- `cargo test documented_command_forms_parse`
- `cargo test suspicious_command_paths_require_safety_classification`
- `cargo test` was run; unrelated existing/environment-sensitive failures remain:
  - `command_contract::lab::tests::test_supports_lab_runner`
  - `commands::route::tests::explicit_runner_for_changed_scope_test_is_lab_portable`
  - `core::agent_task_lifecycle::tests::cancel_run_signals_live_running_record`
  - `core::process::process_tree_tests::terminate_process_tree_escalates_to_sigkill_on_sigterm_resistant_child`
  - `core::process::process_tree_tests::terminate_process_tree_uses_sigterm_for_cooperative_child`
  - `core::refactor::plan::generate::module_surface::tests::build_uses_snapshot_content_for_module_surfaces`
  - `core::release::executor::github_release::tests::repair_tests::repair_commands_include_configured_enterprise_proxy_env`
  - `core::runner::workspace::tests::git::git_materialization_ignores_generated_homeboy_output_but_refuses_source_dirty_state`
  - `extensions::deps_provider::tests::composer_install_runs_full_dependency_install_lifecycle`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the runner workspace pull command, safety/path planning tests, contract wiring, verification, and PR preparation.
