### PR TITLE
Add Lab refresh planning command

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -27,6 +27,7 @@
 - [git](git.md)
 - [http](http.md) — generic proxied authenticated HTTP requests
 - [issues](issues.md) — reconcile findings against issue trackers
+- [lab](lab.md) — read-only Lab runner refresh planning
 - [lint](lint.md)
 - [logs](logs.md)
 - [manifest](manifest.md) — recursive command safety, docs, output, and Lab metadata

--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -1,0 +1,34 @@
+# Lab
+
+Plan Lab-oriented runner workflows without executing the workload.
+
+## Refresh Plan
+
+`homeboy lab refresh-plan` validates the runner configuration and local source
+inputs for a matrix-style refresh, then prints the existing Homeboy commands to
+run next:
+
+```sh
+homeboy lab refresh-plan \
+  --runner lab-runner \
+  --workspace ./component \
+  --runner-cwd /workspace/component \
+  --run-id matrix-refresh-20260627 \
+  --source ./component/src \
+  --fixture ./component/fixtures \
+  --output artifacts/matrix \
+  --summary artifacts/matrix/matrix-summary.json \
+  -- \
+  sh -lc './scripts/run-matrix --out artifacts/matrix'
+```
+
+The plan is intentionally read-only. It composes the current primitives:
+
+- `homeboy runner doctor <runner> --scope lab-offload`
+- `homeboy runner workspace sync <runner> --path <workspace> --mode <mode>`
+- `homeboy runner exec <runner> --artifact <path> --summary <path> ...`
+- `homeboy runs artifacts <run-id>`
+- `homeboy runs evidence <run-id>`
+
+Use the artifact loop guide for the evidence shape expected from runner and
+matrix workflows: `docs/operators/artifact-loop-runner-matrix.md`.

--- a/docs/operators/artifact-loop-runner-matrix.md
+++ b/docs/operators/artifact-loop-runner-matrix.md
@@ -36,6 +36,10 @@ or public links.
 For ad hoc runner work, create a known output directory inside the runner
 workspace and pass a stable run id:
 
+Use `homeboy lab refresh-plan` first when you want a read-only preflight that
+checks the runner/workspace/source inputs and prints the next `runner doctor`,
+`runner workspace sync`, `runner exec`, and `runs evidence` commands.
+
 ```sh
 run_id="review-static-html-$(date -u +%Y%m%dT%H%M%SZ)"
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -6,9 +6,9 @@ use std::path::PathBuf;
 use crate::commands::{
     agent_task, api, audit, audit_baseline, auth, bench, build, changelog, changes, ci, cleanup,
     component, config, daemon, db, deploy, deps, doctor, extension, file, fleet, fuzz, git, http,
-    issues, lint, logs, manifest, observe, project, refactor, refs, release, report, review, rig,
-    runner, runs, runtime, self_cmd, server, ssh, stack, status, test, trace, triage, tunnel, undo,
-    upgrade, version, worktree,
+    issues, lab, lint, logs, manifest, observe, project, refactor, refs, release, report, review,
+    rig, runner, runs, runtime, self_cmd, server, ssh, stack, status, test, trace, triage, tunnel,
+    undo, upgrade, version, worktree,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -165,6 +165,8 @@ pub enum Commands {
     Rig(rig::RigArgs),
     /// Manage local and SSH execution runners
     Runner(runner::RunnerArgs),
+    /// Discover Lab routing and runner refresh planning commands
+    Lab(lab::LabArgs),
     /// Inspect core-owned runtime helper assets
     Runtime(runtime::RuntimeArgs),
     /// Manage component-backed task worktrees
@@ -430,6 +432,7 @@ mod entry_command_impls {
                 Commands::Refs(_) => "refs",
                 Commands::Rig(_) => "rig",
                 Commands::Runner(_) => "runner",
+                Commands::Lab(_) => "lab",
                 Commands::Runtime(_) => "runtime",
                 Commands::Worktree(_) => "worktree",
                 Commands::Tunnel(_) => "tunnel",

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -239,6 +239,7 @@ impl Commands {
             | Commands::Release(_)
             | Commands::Report(_)
             | Commands::Runner(_)
+            | Commands::Lab(_)
             | Commands::Runtime(_)
             | Commands::Worktree(_)
             | Commands::Tunnel(_)

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -496,6 +496,11 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         RIG_LAB_SUPPORT,
     ),
     command_spec("runner", CommandJsonFamily::Workspace),
+    command_spec_with_output_notes(
+        "lab",
+        CommandJsonFamily::Workspace,
+        "Lab planning commands compose existing runner/workspace/run artifact primitives without executing workloads",
+    ),
     command_spec("runtime", CommandJsonFamily::Workspace),
     command_spec("worktree", CommandJsonFamily::Workspace),
     lab_command_spec_with_summary(

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -2,9 +2,9 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    agent_task, build, changelog, changes, cleanup, component, config, docs, extension, manifest,
-    project, refactor, refs, release, report, rig, runner, runs, runtime, stack, tunnel, undo,
-    worktree, GlobalArgs,
+    agent_task, build, changelog, changes, cleanup, component, config, docs, extension, lab,
+    manifest, project, refactor, refs, release, report, rig, runner, runs, runtime, stack, tunnel,
+    undo, worktree, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -26,6 +26,7 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Refs(args) => map(refs::run(args, global)),
         Commands::Rig(args) => map(rig::run(args, global)),
         Commands::Runner(args) => map(runner::run(args, global)),
+        Commands::Lab(args) => map(lab::run(args, global)),
         Commands::Runtime(args) => map(runtime::run(args, global)),
         Commands::Worktree(args) => map(worktree::run(args, global)),
         Commands::Tunnel(args) => map(tunnel::run(args, global)),

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -1,0 +1,369 @@
+use std::path::Path;
+
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use homeboy::core::runners;
+
+use super::{CmdResult, GlobalArgs};
+
+#[derive(Args)]
+pub struct LabArgs {
+    #[command(subcommand)]
+    command: LabCommand,
+}
+
+#[derive(Subcommand)]
+enum LabCommand {
+    /// Plan a runner-backed refresh loop before dispatching matrix-style work
+    RefreshPlan(RefreshPlanArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct RefreshPlanArgs {
+    /// Runner ID that will execute the workload
+    #[arg(long)]
+    runner: String,
+
+    /// Controller-side workspace or worktree to sync to the runner
+    #[arg(long = "workspace")]
+    workspace: String,
+
+    /// Runner-side cwd for the eventual runner exec command
+    #[arg(long = "runner-cwd")]
+    runner_cwd: String,
+
+    /// Stable run id to use for the produced evidence
+    #[arg(long = "run-id")]
+    run_id: String,
+
+    /// Produced output directory or file. Relative paths are resolved from --runner-cwd.
+    #[arg(long = "output", value_name = "PATH")]
+    outputs: Vec<String>,
+
+    /// Produced summary directory or file. Relative paths are resolved from --runner-cwd.
+    #[arg(long = "summary", value_name = "PATH")]
+    summaries: Vec<String>,
+
+    /// Source path that must exist before the refresh is dispatched. Repeat for multiple paths.
+    #[arg(long = "source", value_name = "PATH")]
+    sources: Vec<String>,
+
+    /// Fixture path that must exist before the refresh is dispatched. Repeat for multiple paths.
+    #[arg(long = "fixture", value_name = "PATH")]
+    fixtures: Vec<String>,
+
+    /// Runner workspace sync mode to use in the planned sync command.
+    #[arg(long = "sync-mode", default_value = "snapshot")]
+    sync_mode: String,
+
+    /// Command and arguments to run after the plan checks pass.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    command: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct LabRefreshPlanOutput {
+    pub variant: &'static str,
+    pub runner: String,
+    pub workspace: String,
+    pub runner_cwd: String,
+    pub run_id: String,
+    pub checks: Vec<LabRefreshPlanCheck>,
+    pub evidence_paths: Vec<LabRefreshPlanEvidencePath>,
+    pub next_commands: Vec<LabRefreshPlanCommand>,
+    pub docs: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct LabRefreshPlanCheck {
+    pub name: String,
+    pub status: &'static str,
+    pub detail: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct LabRefreshPlanEvidencePath {
+    pub kind: &'static str,
+    pub path: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct LabRefreshPlanCommand {
+    pub label: &'static str,
+    pub command: String,
+    pub purpose: &'static str,
+}
+
+pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabRefreshPlanOutput> {
+    match args.command {
+        LabCommand::RefreshPlan(args) => refresh_plan(args).map(|output| (output, 0)),
+    }
+}
+
+fn refresh_plan(args: RefreshPlanArgs) -> homeboy::core::Result<LabRefreshPlanOutput> {
+    if args.command.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "command",
+            "refresh-plan requires a command after --",
+            None,
+            Some(vec![
+                "Example: homeboy lab refresh-plan --runner lab --workspace . --runner-cwd /workspace/app --run-id run-1 --output artifacts/review -- npm test".to_string(),
+            ]),
+        ));
+    }
+
+    let mut checks = Vec::new();
+    add_runner_check(&mut checks, &args.runner)?;
+    add_path_check(&mut checks, "workspace", &args.workspace)?;
+    for source in &args.sources {
+        add_path_check(&mut checks, "source", source)?;
+    }
+    for fixture in &args.fixtures {
+        add_path_check(&mut checks, "fixture", fixture)?;
+    }
+
+    let evidence_paths = evidence_paths(&args);
+    let next_commands = next_commands(&args, &evidence_paths);
+
+    Ok(LabRefreshPlanOutput {
+        variant: "refresh_plan",
+        runner: args.runner,
+        workspace: args.workspace,
+        runner_cwd: args.runner_cwd,
+        run_id: args.run_id,
+        checks,
+        evidence_paths,
+        next_commands,
+        docs: vec![
+            "docs/operators/artifact-loop-runner-matrix.md".to_string(),
+            "docs/commands/lab.md".to_string(),
+        ],
+    })
+}
+
+fn add_runner_check(
+    checks: &mut Vec<LabRefreshPlanCheck>,
+    runner_id: &str,
+) -> homeboy::core::Result<()> {
+    let runner = runners::load(runner_id)?;
+    let configured_homeboy = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
+    let workspace_root = runner
+        .workspace_root
+        .as_deref()
+        .unwrap_or("runner has no default workspace_root");
+
+    checks.push(LabRefreshPlanCheck {
+        name: "runner".to_string(),
+        status: "ok",
+        detail: format!(
+            "configured runner `{runner_id}` uses Homeboy `{configured_homeboy}` with workspace root `{workspace_root}`"
+        ),
+    });
+    checks.push(LabRefreshPlanCheck {
+        name: "runner_homeboy_capability".to_string(),
+        status: "planned",
+        detail: format!(
+            "verify with `{}` before dispatching the refresh workload",
+            shell_join(&[
+                "homeboy",
+                "runner",
+                "doctor",
+                runner_id,
+                "--scope",
+                "lab-offload",
+            ])
+        ),
+    });
+
+    Ok(())
+}
+
+fn add_path_check(
+    checks: &mut Vec<LabRefreshPlanCheck>,
+    label: &str,
+    path: &str,
+) -> homeboy::core::Result<()> {
+    if !Path::new(path).exists() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            label,
+            format!("{label} path does not exist: {path}"),
+            None,
+            None,
+        ));
+    }
+
+    checks.push(LabRefreshPlanCheck {
+        name: label.to_string(),
+        status: "ok",
+        detail: path.to_string(),
+    });
+    Ok(())
+}
+
+fn evidence_paths(args: &RefreshPlanArgs) -> Vec<LabRefreshPlanEvidencePath> {
+    args.outputs
+        .iter()
+        .map(|path| LabRefreshPlanEvidencePath {
+            kind: "artifact",
+            path: path.clone(),
+        })
+        .chain(
+            args.summaries
+                .iter()
+                .map(|path| LabRefreshPlanEvidencePath {
+                    kind: "summary",
+                    path: path.clone(),
+                }),
+        )
+        .collect()
+}
+
+fn next_commands(
+    args: &RefreshPlanArgs,
+    evidence_paths: &[LabRefreshPlanEvidencePath],
+) -> Vec<LabRefreshPlanCommand> {
+    let mut runner_exec = vec![
+        "homeboy".to_string(),
+        "runner".to_string(),
+        "exec".to_string(),
+        args.runner.clone(),
+        "--cwd".to_string(),
+        args.runner_cwd.clone(),
+        "--run-id".to_string(),
+        args.run_id.clone(),
+    ];
+    for evidence_path in evidence_paths {
+        match evidence_path.kind {
+            "artifact" => runner_exec.push("--artifact".to_string()),
+            "summary" => runner_exec.push("--summary".to_string()),
+            _ => continue,
+        }
+        runner_exec.push(evidence_path.path.clone());
+    }
+    runner_exec.push("--".to_string());
+    runner_exec.extend(args.command.clone());
+
+    vec![
+        LabRefreshPlanCommand {
+            label: "verify-runner",
+            command: shell_join(&[
+                "homeboy",
+                "runner",
+                "doctor",
+                &args.runner,
+                "--scope",
+                "lab-offload",
+            ]),
+            purpose: "verify runner Homeboy binary, daemon, and Lab offload capability",
+        },
+        LabRefreshPlanCommand {
+            label: "sync-workspace",
+            command: shell_join(&[
+                "homeboy",
+                "runner",
+                "workspace",
+                "sync",
+                &args.runner,
+                "--path",
+                &args.workspace,
+                "--mode",
+                &args.sync_mode,
+            ]),
+            purpose: "materialize the fresh controller workspace on the runner",
+        },
+        LabRefreshPlanCommand {
+            label: "run-refresh",
+            command: shell_join_owned(&runner_exec),
+            purpose: "execute the workload and declare produced evidence paths",
+        },
+        LabRefreshPlanCommand {
+            label: "inspect-artifacts",
+            command: shell_join(&["homeboy", "runs", "artifacts", &args.run_id]),
+            purpose: "confirm the produced files are attached to the persisted run",
+        },
+        LabRefreshPlanCommand {
+            label: "inspect-evidence",
+            command: shell_join(&["homeboy", "runs", "evidence", &args.run_id]),
+            purpose: "get reviewer-facing artifact refs or fetch commands",
+        },
+    ]
+}
+
+fn shell_join(args: &[&str]) -> String {
+    args.iter()
+        .map(|arg| shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_join_owned(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_commands_include_existing_runner_artifact_primitives() {
+        let args = RefreshPlanArgs {
+            runner: "lab-runner".to_string(),
+            workspace: "/workspace/source".to_string(),
+            runner_cwd: "/runner/source".to_string(),
+            run_id: "matrix-refresh-1".to_string(),
+            outputs: vec!["artifacts/matrix".to_string()],
+            summaries: vec!["artifacts/matrix/matrix-summary.json".to_string()],
+            sources: Vec::new(),
+            fixtures: Vec::new(),
+            sync_mode: "snapshot".to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-lc".to_string(),
+                "./run matrix".to_string(),
+            ],
+        };
+        let evidence = evidence_paths(&args);
+        let commands = next_commands(&args, &evidence);
+
+        assert_eq!(commands[0].label, "verify-runner");
+        assert_eq!(
+            commands[1].command,
+            "homeboy runner workspace sync lab-runner --path /workspace/source --mode snapshot"
+        );
+        assert_eq!(commands[2].label, "run-refresh");
+        assert!(commands[2].command.contains(
+            "--artifact artifacts/matrix --summary artifacts/matrix/matrix-summary.json"
+        ));
+        assert!(commands[2].command.contains("-- sh -lc './run matrix'"));
+        assert_eq!(
+            commands[3].command,
+            "homeboy runs artifacts matrix-refresh-1"
+        );
+        assert_eq!(
+            commands[4].command,
+            "homeboy runs evidence matrix-refresh-1"
+        );
+    }
+
+    #[test]
+    fn shell_quote_handles_spaces_and_single_quotes() {
+        assert_eq!(shell_quote("simple/path"), "simple/path");
+        assert_eq!(shell_quote("two words"), "'two words'");
+        assert_eq!(shell_quote("it's ok"), "'it'\\''s ok'");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -215,6 +215,7 @@ pub mod git;
 pub mod http;
 pub mod issues;
 pub mod json_output;
+pub mod lab;
 pub mod lint;
 pub mod logs;
 pub mod manifest;

--- a/src/core/observation/store/artifacts.rs
+++ b/src/core/observation/store/artifacts.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use uuid::Uuid;
 
 use super::*;

--- a/src/core/observation/store/runs.rs
+++ b/src/core/observation/store/runs.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use uuid::Uuid;
 
 use super::*;


### PR DESCRIPTION
## Summary
- Adds `homeboy lab refresh-plan`, a read-only planner for runner-backed matrix/refresh loops.
- Validates configured runner plus local workspace/source/fixture paths before dispatch.
- Outputs next commands that compose existing primitives: `runner doctor`, `runner workspace sync`, `runner exec --artifact/--summary`, `runs artifacts`, and `runs evidence`.
- Documents the new command and links it from the runner/matrix artifact loop guide.
- Includes a narrow compile fix for missing `rusqlite::OptionalExtension` imports in observation store modules, required for `cargo check` on this branch.

Fixes #6629.

## Verification
- `cargo fmt`
- `cargo check`
- `cargo test commands::lab::tests`
- `cargo test cli_surface::tests::command_registry_docs_paths_exist_and_are_indexed`
- `cargo test` was run; it passed 6167 tests and failed 11 existing/unrelated tests documented during PR creation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, documentation, verification, and PR preparation.
