### PR TITLE
Decouple runtime diagnostics from WP Codebox status

### DIFF
--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -14,9 +14,9 @@ use super::super::CmdResult;
 use super::types::{
     LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
     RunnerConnectionOutput, RunnerExtra, RunnerHomeboyBinaryRole, RunnerOperatorCommand,
-    RunnerOutput, RunnerToolDiagnostics, RunnerWorkflowBinaryGuidance,
-    WpCodeboxPackageRuntimeOutput, WpCodeboxProbeValue, WpCodeboxRuntimeDiagnostic,
-    WpCodeboxRuntimeOutput,
+    RunnerOutput, RunnerRuntimeDiagnostics, RunnerRuntimePackageDiagnostics, RunnerToolDiagnostics,
+    RunnerWorkflowBinaryGuidance, WpCodeboxPackageRuntimeOutput, WpCodeboxProbeValue,
+    WpCodeboxRuntimeDiagnostic, WpCodeboxRuntimeOutput,
 };
 
 pub(super) fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
@@ -94,16 +94,18 @@ fn selected_lab_runner_status(
     let effective_env = runner::effective_env(runner_id)?
         .into_iter()
         .collect::<BTreeMap<_, _>>();
+    let runtime_diagnostics =
+        declared_runtime_diagnostics_collection(Some(runner_id), &effective_env);
     Ok(Some(LabSelectedRunnerOutput {
         runner_id: runner_id.to_string(),
         kind: format!("{:?}", runner_config.kind).to_ascii_lowercase(),
         configured_executable: configured_executable.clone(),
         runner_homeboy: lab_runner_homeboy_output(runner_id, &configured_executable, &status),
-        wp_codebox_runtime: declared_runtime_diagnostics_for_legacy(
-            "wp_codebox_runtime",
-            Some(runner_id),
-            &effective_env,
-        ),
+        wp_codebox_runtime: runtime_diagnostics
+            .iter()
+            .find(|diagnostics| diagnostics.legacy_output.as_deref() == Some("wp_codebox_runtime"))
+            .map(wp_codebox_runtime_output_from_generic),
+        runtime_diagnostics,
         daemon_enabled: runner_config.settings.daemon,
         workspace_root: runner_config.workspace_root.clone(),
         readiness_state: format!("{:?}", status.state).to_ascii_lowercase(),
@@ -198,6 +200,7 @@ pub(crate) fn declared_runtime_diagnostics_for_legacy(
         .flat_map(|contract| contract.runtimes.iter())
         .find(|declaration| declaration.legacy_output.as_deref() == Some(legacy_output))
         .map(|declaration| declared_runtime_diagnostics(declaration, runner_id, env))
+        .map(|diagnostics| wp_codebox_runtime_output_from_generic(&diagnostics))
 }
 
 pub(crate) fn declared_tool_diagnostics(
@@ -234,7 +237,7 @@ pub(crate) fn declared_runtime_diagnostics(
     declaration: &AgentRuntimeRuntimeDiagnosticDeclaration,
     runner_id: Option<&str>,
     env: &BTreeMap<String, String>,
-) -> WpCodeboxRuntimeOutput {
+) -> RunnerRuntimeDiagnostics {
     let (configured, configured_binary_source) =
         configured_value(env, &declaration.configured_binary_env);
     let install_dir = install_dir(
@@ -258,19 +261,78 @@ pub(crate) fn declared_runtime_diagnostics(
         &managed_cache_source,
     );
 
-    WpCodeboxRuntimeOutput {
-        tool: declaration.tool.clone(),
+    RunnerRuntimeDiagnostics {
+        runtime: declaration.tool.clone(),
+        legacy_output: declaration.legacy_output.clone(),
         configured_binary: configured,
         configured_binary_source,
         managed_cache_source: managed_cache_source.clone(),
         managed_cache_binary,
         effective_binary_rule: declaration.effective_binary_rule.clone(),
-        playground_package: packages.first().cloned().unwrap_or_else(empty_package),
-        core_package: packages.get(1).cloned().unwrap_or_else(empty_package),
-        source_git_sha: declared_probe_value(declaration, "source_git_sha"),
-        dist_build_freshness: declared_probe_value(declaration, "dist_build_freshness"),
+        packages,
+        probes: declared_probe_values(declaration),
         runtime_probe_command: diagnostic_command(runner_id, &declaration.runtime_probe_script),
         diagnostics,
+    }
+}
+
+pub(crate) fn declared_runtime_diagnostics_collection(
+    runner_id: Option<&str>,
+    env: &BTreeMap<String, String>,
+) -> Vec<RunnerRuntimeDiagnostics> {
+    declared_diagnostics_contracts()
+        .iter()
+        .flat_map(|contract| contract.runtimes.iter())
+        .map(|declaration| declared_runtime_diagnostics(declaration, runner_id, env))
+        .collect()
+}
+
+fn wp_codebox_runtime_output_from_generic(
+    diagnostics: &RunnerRuntimeDiagnostics,
+) -> WpCodeboxRuntimeOutput {
+    WpCodeboxRuntimeOutput {
+        tool: diagnostics.runtime.clone(),
+        configured_binary: diagnostics.configured_binary.clone(),
+        configured_binary_source: diagnostics.configured_binary_source.clone(),
+        managed_cache_source: diagnostics.managed_cache_source.clone(),
+        managed_cache_binary: diagnostics.managed_cache_binary.clone(),
+        effective_binary_rule: diagnostics.effective_binary_rule.clone(),
+        playground_package: diagnostics
+            .packages
+            .iter()
+            .find(|package| package.field == "playground_package")
+            .or_else(|| diagnostics.packages.first())
+            .map(wp_codebox_package_output_from_generic)
+            .unwrap_or_else(empty_package),
+        core_package: diagnostics
+            .packages
+            .iter()
+            .find(|package| package.field == "core_package")
+            .or_else(|| diagnostics.packages.get(1))
+            .map(wp_codebox_package_output_from_generic)
+            .unwrap_or_else(empty_package),
+        source_git_sha: diagnostics
+            .probes
+            .get("source_git_sha")
+            .cloned()
+            .unwrap_or_else(default_runtime_probe_value),
+        dist_build_freshness: diagnostics
+            .probes
+            .get("dist_build_freshness")
+            .cloned()
+            .unwrap_or_else(default_runtime_probe_value),
+        runtime_probe_command: diagnostics.runtime_probe_command.clone(),
+        diagnostics: diagnostics.diagnostics.clone(),
+    }
+}
+
+fn wp_codebox_package_output_from_generic(
+    package: &RunnerRuntimePackageDiagnostics,
+) -> WpCodeboxPackageRuntimeOutput {
+    WpCodeboxPackageRuntimeOutput {
+        package: package.package.clone(),
+        expected_path: package.expected_path.clone(),
+        resolution: package.resolution.clone(),
     }
 }
 
@@ -353,11 +415,12 @@ fn declared_runtime_packages(
     env: &BTreeMap<String, String>,
     install_dir: &str,
     managed_cache_source: &str,
-) -> Vec<WpCodeboxPackageRuntimeOutput> {
+) -> Vec<RunnerRuntimePackageDiagnostics> {
     declaration
         .packages
         .iter()
-        .map(|package| WpCodeboxPackageRuntimeOutput {
+        .map(|package| RunnerRuntimePackageDiagnostics {
+            field: package.field.clone(),
             package: package.package.clone(),
             expected_path: package
                 .env_override
@@ -389,19 +452,28 @@ fn empty_package() -> WpCodeboxPackageRuntimeOutput {
     }
 }
 
-fn declared_probe_value(
+fn declared_probe_values(
     declaration: &AgentRuntimeRuntimeDiagnosticDeclaration,
-    field: &str,
-) -> WpCodeboxProbeValue {
-    let source = declaration
+) -> BTreeMap<String, WpCodeboxProbeValue> {
+    declaration
         .probes
         .iter()
-        .find(|probe| probe.field == field)
-        .map(|probe| probe.source.clone())
-        .unwrap_or_else(|| "runtime_probe_command".to_string());
+        .map(|probe| {
+            (
+                probe.field.clone(),
+                WpCodeboxProbeValue {
+                    value: None,
+                    source: probe.source.clone(),
+                },
+            )
+        })
+        .collect()
+}
+
+fn default_runtime_probe_value() -> WpCodeboxProbeValue {
     WpCodeboxProbeValue {
         value: None,
-        source,
+        source: "runtime_probe_command".to_string(),
     }
 }
 

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -12,8 +12,9 @@ use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, 
 use super::super::jobs::format_job_event;
 use super::super::status::{
     declared_run_followups_for_legacy, declared_runtime_diagnostics,
-    declared_runtime_source_diagnostics, declared_tool_diagnostics, lab_runner_homeboy_output,
-    runner_artifact_feature_diagnostics, runner_status_operator_commands,
+    declared_runtime_diagnostics_for_legacy, declared_runtime_source_diagnostics,
+    declared_tool_diagnostics, lab_runner_homeboy_output, runner_artifact_feature_diagnostics,
+    runner_status_operator_commands,
 };
 
 #[test]
@@ -174,7 +175,7 @@ fn wp_codebox_diagnostics_distinguish_configured_managed_and_effective() {
 }
 
 #[test]
-fn wp_codebox_runtime_reports_package_paths_probe_and_mixed_source_warnings() {
+fn declared_runtime_reports_generic_package_paths_probe_and_mixed_source_warnings() {
     let declaration = wp_codebox_runtime_declaration();
     let runtime = declared_runtime_diagnostics(
         &declaration,
@@ -195,26 +196,51 @@ fn wp_codebox_runtime_reports_package_paths_probe_and_mixed_source_warnings() {
         ]),
     );
 
-    assert_eq!(runtime.tool, "wp-codebox");
+    assert_eq!(runtime.runtime, "wp-codebox");
+    assert_eq!(runtime.legacy_output.as_deref(), Some("wp_codebox_runtime"));
     assert_eq!(
         runtime.managed_cache_source,
         "/home/chubes/.cache/homeboy/wp-codebox/source"
     );
+    let playground_package = runtime
+        .packages
+        .iter()
+        .find(|package| package.field == "playground_package")
+        .expect("playground package diagnostics");
     assert_eq!(
-        runtime.playground_package.package,
+        playground_package.package,
         "@automattic/wp-codebox-playground"
     );
     assert_eq!(
-        runtime.playground_package.expected_path,
+        playground_package.expected_path,
         "/home/chubes/.cache/homeboy/wp-codebox/source/packages/playground"
     );
-    assert_eq!(runtime.core_package.package, "@automattic/wp-codebox-core");
+    let core_package = runtime
+        .packages
+        .iter()
+        .find(|package| package.field == "core_package")
+        .expect("core package diagnostics");
+    assert_eq!(core_package.package, "@automattic/wp-codebox-core");
     assert_eq!(
-        runtime.core_package.expected_path,
+        core_package.expected_path,
         "/other/wp-codebox/packages/core/dist/index.js"
     );
-    assert_eq!(runtime.source_git_sha.source, "runtime_probe_command");
-    assert_eq!(runtime.dist_build_freshness.source, "runtime_probe_command");
+    assert_eq!(
+        runtime
+            .probes
+            .get("source_git_sha")
+            .expect("source git sha probe")
+            .source,
+        "runtime_probe_command"
+    );
+    assert_eq!(
+        runtime
+            .probes
+            .get("dist_build_freshness")
+            .expect("dist freshness probe")
+            .source,
+        "runtime_probe_command"
+    );
     assert!(runtime
         .runtime_probe_command
         .contains("@automattic/wp-codebox-playground"));
@@ -229,6 +255,40 @@ fn wp_codebox_runtime_reports_package_paths_probe_and_mixed_source_warnings() {
         .diagnostics
         .iter()
         .any(|diagnostic| diagnostic.id == "wp_codebox.mixed_core_source"));
+}
+
+#[test]
+fn declared_runtime_legacy_projection_preserves_wp_codebox_status_shape() {
+    let runtime = declared_runtime_diagnostics_for_legacy(
+        "wp_codebox_runtime",
+        Some("homeboy-lab"),
+        &BTreeMap::from([(
+            "HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string(),
+            "/home/chubes/.cache/homeboy/wp-codebox".to_string(),
+        )]),
+    );
+
+    let runtime = runtime.expect("catalog declares legacy wp_codebox_runtime projection");
+    assert_eq!(runtime.tool, "wp-codebox");
+    assert_eq!(
+        runtime.playground_package.package,
+        "@automattic/wp-codebox-playground"
+    );
+    assert_eq!(runtime.source_git_sha.source, "runtime_probe_command");
+
+    let generic = declared_runtime_diagnostics(
+        &wp_codebox_runtime_declaration(),
+        Some("homeboy-lab"),
+        &BTreeMap::from([(
+            "HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string(),
+            "/home/chubes/.cache/homeboy/wp-codebox".to_string(),
+        )]),
+    );
+    let serialized = serde_json::to_string(&generic).expect("serialize generic diagnostics");
+
+    assert!(serialized.contains("\"runtime\":\"wp-codebox\""));
+    assert!(serialized.contains("\"packages\""));
+    assert!(!serialized.contains("\"playground_package\":{"));
 }
 
 #[test]

--- a/src/commands/runner/types.rs
+++ b/src/commands/runner/types.rs
@@ -60,6 +60,8 @@ pub struct LabSelectedRunnerOutput {
     pub kind: String,
     pub configured_executable: String,
     pub runner_homeboy: LabRunnerHomeboyOutput,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub runtime_diagnostics: Vec<RunnerRuntimeDiagnostics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wp_codebox_runtime: Option<WpCodeboxRuntimeOutput>,
     pub daemon_enabled: bool,
@@ -151,6 +153,34 @@ pub struct WpCodeboxRuntimeOutput {
     pub runtime_probe_command: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<WpCodeboxRuntimeDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerRuntimeDiagnostics {
+    pub runtime: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legacy_output: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configured_binary: Option<String>,
+    pub configured_binary_source: String,
+    pub managed_cache_source: String,
+    pub managed_cache_binary: String,
+    pub effective_binary_rule: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub packages: Vec<RunnerRuntimePackageDiagnostics>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub probes: BTreeMap<String, WpCodeboxProbeValue>,
+    pub runtime_probe_command: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<WpCodeboxRuntimeDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerRuntimePackageDiagnostics {
+    pub field: String,
+    pub package: String,
+    pub expected_path: String,
+    pub resolution: WpCodeboxProbeValue,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/core/agent_task_fanout.rs
+++ b/src/core/agent_task_fanout.rs
@@ -12,6 +12,7 @@ use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep};
 pub const AGENT_TASK_FANOUT_PLAN_SCHEMA: &str = "homeboy/agent-task-fanout-plan/v1";
 pub const AGENT_TASK_FANOUT_AGGREGATE_SCHEMA: &str = "homeboy/agent-task-fanout-aggregate/v1";
 pub const AGENT_TASK_FANOUT_CANONICAL_PATH: &str = "homeboy-durable-scheduler-to-runtime-executor";
+pub const AGENT_TASK_FANOUT_RUNTIME_BOUNDARY: &str = "manifest_declared_runtime_executor";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskFanoutPlan {
@@ -125,12 +126,12 @@ impl AgentTaskFanoutPlan {
             Value::String(AGENT_TASK_FANOUT_CANONICAL_PATH.to_string()),
         );
         plan.inputs.insert(
-            "ownership".to_string(),
+            "runtime_boundary".to_string(),
             serde_json::json!({
-                "substrate": "agents-api",
+                "boundary": AGENT_TASK_FANOUT_RUNTIME_BOUNDARY,
                 "durable_scheduler": "homeboy",
-                "runtime_executor_adapter": "homeboy-extensions",
-                "sandbox_worker_runtime": "wp-codebox"
+                "executor": "declared_by_task_executor",
+                "runtime": "declared_by_task_runtime"
             }),
         );
         if let Some(group_key) = &self.group_key {
@@ -440,9 +441,14 @@ mod tests {
             json!(AGENT_TASK_FANOUT_CANONICAL_PATH)
         );
         assert_eq!(
-            homeboy_plan.inputs["ownership"]["durable_scheduler"],
+            homeboy_plan.inputs["runtime_boundary"]["durable_scheduler"],
             json!("homeboy")
         );
+        assert_eq!(
+            homeboy_plan.inputs["runtime_boundary"]["runtime"],
+            json!("declared_by_task_runtime")
+        );
+        assert!(!homeboy_plan.inputs.contains_key("ownership"));
         assert!(homeboy_plan.steps.iter().all(|step| {
             step.inputs["canonical_path"] == json!(AGENT_TASK_FANOUT_CANONICAL_PATH)
                 && step.inputs["owner"] == json!("homeboy")

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -543,16 +543,50 @@ fn validate_required_extensions_fails_with_missing_module() {
     assert_eq!(err.code, crate::core::error::ErrorCode::ExtensionNotFound);
     assert!(err.message.contains("nonexistent-extension-abc123"));
     assert!(err.message.contains("test-component"));
-    // Should have install hint + browse hint
+    // Should have install hint + source guidance hint.
     assert!(err.hints.len() >= 2);
     assert!(err
         .hints
         .iter()
         .any(|h| h.message.contains("homeboy extension install")));
-    assert!(err
+    assert!(!err
         .hints
         .iter()
-        .any(|h| h.message.contains("homeboy-extensions")));
+        .any(|h| h.message.contains("Extra-Chill/homeboy-extensions")));
+    assert!(err.hints.iter().any(|h| h.message.contains("<source>")));
+}
+
+#[test]
+fn validate_required_extensions_uses_declared_extension_source_hint() {
+    let mut extensions = HashMap::new();
+    extensions.insert(
+        "nonexistent-extension-abc123".to_string(),
+        ScopedExtensionConfig {
+            version: None,
+            settings: HashMap::from([(
+                "source".to_string(),
+                serde_json::Value::String("https://example.test/extensions.git".to_string()),
+            )]),
+        },
+    );
+    let comp = Component {
+        id: "test-component".to_string(),
+        extensions: Some(extensions),
+        ..Default::default()
+    };
+
+    let err = validate_required_extensions(&comp).unwrap_err();
+    let hints = err
+        .hints
+        .iter()
+        .map(|hint| hint.message.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(hints.contains(
+        "homeboy extension install https://example.test/extensions.git --id nonexistent-extension-abc123"
+    ));
+    assert!(!hints.contains("Extra-Chill/homeboy-extensions"));
 }
 
 #[test]

--- a/src/core/extension/validation.rs
+++ b/src/core/extension/validation.rs
@@ -14,10 +14,10 @@ pub fn validate_required_extensions(component: &crate::core::component::Componen
         _ => return Ok(()),
     };
 
-    let mut missing: Vec<String> = Vec::new();
-    for extension_id in extensions.keys() {
+    let mut missing: Vec<(&String, &crate::core::component::ScopedExtensionConfig)> = Vec::new();
+    for (extension_id, ext_config) in extensions {
         if load_extension(extension_id).is_err() {
-            missing.push(extension_id.clone());
+            missing.push((extension_id, ext_config));
         }
     }
 
@@ -25,23 +25,19 @@ pub fn validate_required_extensions(component: &crate::core::component::Componen
         return Ok(());
     }
 
-    missing.sort();
+    missing.sort_by(|(left, _), (right, _)| left.cmp(right));
 
-    let extension_list = missing.join(", ");
+    let missing_ids: Vec<String> = missing.iter().map(|(id, _)| (*id).clone()).collect();
+    let extension_list = missing_ids.join(", ");
     let install_hints: Vec<String> = missing
         .iter()
-        .map(|id| {
-            format!(
-                "homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id {}",
-                id
-            )
-        })
+        .map(|(id, ext_config)| extension_install_hint(id, ext_config))
         .collect();
 
     let message = if missing.len() == 1 {
         format!(
             "Component '{}' requires extension '{}' which is not installed",
-            component.id, missing[0]
+            component.id, missing_ids[0]
         )
     } else {
         format!(
@@ -55,7 +51,7 @@ pub fn validate_required_extensions(component: &crate::core::component::Componen
         message,
         serde_json::json!({
             "component_id": component.id,
-            "missing_extensions": missing,
+            "missing_extensions": missing_ids,
         }),
     );
 
@@ -64,7 +60,7 @@ pub fn validate_required_extensions(component: &crate::core::component::Componen
     }
 
     err = err.with_hint(
-        "Browse available extensions: https://github.com/Extra-Chill/homeboy-extensions"
+        "Provide an extension source with `homeboy extension install <source> --id <extension-id>` or add `source`/`source_url` to the component extension settings."
             .to_string(),
     );
 
@@ -126,10 +122,7 @@ pub fn validate_extension_requirements(
             },
             Err(_) => {
                 errors.push(format!("Extension '{}' is not installed", extension_id));
-                hints.push(format!(
-                    "homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id {}",
-                    extension_id
-                ));
+                hints.push(extension_install_hint(extension_id, ext_config));
             }
         }
     }
@@ -166,6 +159,31 @@ pub fn validate_extension_requirements(
     }
 
     Err(err)
+}
+
+fn extension_install_hint(
+    extension_id: &str,
+    ext_config: &crate::core::component::ScopedExtensionConfig,
+) -> String {
+    match extension_source(ext_config) {
+        Some(source) => format!("homeboy extension install {} --id {}", source, extension_id),
+        None => format!(
+            "homeboy extension install <source> --id {} (declare `source` or `source_url` in this component's extension settings to make this command exact)",
+            extension_id
+        ),
+    }
+}
+
+fn extension_source(ext_config: &crate::core::component::ScopedExtensionConfig) -> Option<&str> {
+    ["source", "source_url", "install_source"]
+        .iter()
+        .find_map(|key| {
+            ext_config
+                .settings
+                .get(*key)
+                .and_then(|value| value.as_str())
+        })
+        .filter(|value| !value.trim().is_empty())
 }
 
 /// Check if any of the component's linked extensions provide build configuration.


### PR DESCRIPTION
## Summary
- Replace hardcoded agent-task fanout downstream ownership names with a generic runtime boundary projection.
- Add manifest-driven generic runner runtime diagnostics while preserving the legacy `wp_codebox_runtime` status shape as a presentation alias.
- Make missing-extension remediation source-aware and generic instead of pointing every component at `Extra-Chill/homeboy-extensions`.

## Tests
- `cargo test commands::runner::tests::status --lib`
- `cargo test core::extension --lib`
- `cargo test agent_task_fanout --lib`
- `cargo test commands::bench::tests::bench_default_baseline_output_test::default_baseline_expansion_records_metadata_on_comparison_output --lib`

## Notes
- `cargo test --lib` was attempted and timed out after starting the 6204-test suite. Before timeout it showed `command_contract::lab::tests::test_supports_lab_runner` failing independently with an existing CLI parse error around `bench ... homeboy`; the same test fails when run by itself.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the runtime-boundary cleanup, updating tests, running verification, and drafting this PR description.