### PR TITLE
Add runs dossier command

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -12,6 +12,7 @@ homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario 
 homeboy runs bench-compare --from-run <run-id> --to-run <run-id> [--metric <name>]
 homeboy runs fuzz-compare --from-run <run-id> --to-run <run-id> [--hotspot-policy <advisory|blocking|off>]
 homeboy runs show <run-id> [--json]
+homeboy runs dossier <run-id> [--json]
 homeboy runs resume-plan <run-id>
 homeboy runs evidence <run-id>
 homeboy runs artifacts <run-id> [--runner <runner-id>]
@@ -42,6 +43,8 @@ homeboy runs loop-sync <archive-root> [--component <id>] [--rig <id>] [--label <
 The JSON output includes stable run fields: run id, kind, status, timestamps, component id, rig id, git SHA, command, cwd, metadata, and artifact records where relevant.
 
 `homeboy runs show <run-id>` prints a compact human summary by default: run identity, status, component/rig/SHA, timestamps, bench hotspots, generic coverage summaries when present, key case artifacts, and each recorded artifact's locator with a concise `homeboy runs artifact get <run-id> <artifact-id>` command to inspect it. This makes bench artifacts, scenario outputs, slow/hot metric families, and fuzzer coverage gaps/case artifacts easy to find without spelunking temp directories. Coverage rendering is schema-blind and only uses generic metadata fields such as `coverage_summary`, `coverage_gaps`, `surface_count`, `operation_count`, `exercised_count`, `skipped_count`, `failed_count`, `declared_count`, `executable_count`, `proven_count`, `skipped_reason_counts`, and `skipped_reasons`; key case artifact detection uses generic artifact id/kind/name markers such as `key_case`, `fuzz_case`, `failing_case`, `case_artifact`, and `repro_case`. Pass `--json` for the full structured payload on stdout; it is also always written to `--output <file>`.
+
+`homeboy runs dossier <run-id>` aggregates the existing read-only run inspection surfaces into one actionable report. It includes status and stale/failure category, failure/gate data when recorded, run/job/handoff/result refs when present in generic metadata, redacted environment provenance counts, artifact/evidence refs with reviewer-visible versus operator-local hints, inspection commands, and repair/next commands only when existing data supports them. The command reads the observation store and artifact registry; it does not mutate runs, artifacts, or external systems. Pass `--json` for the full structured payload.
 
 For full-coverage claims, prefer persisted evidence that distinguishes declared, executable, and proven states. A declared surface/workload is inventory, an executable surface/workload has a runnable command or manifest path, and a proven surface/workload has a persisted run plus reviewer-visible coverage/case artifacts or fetch commands. `runs show`, `runs artifacts`, and `runs evidence` surface those cues generically; missing proven counts or missing artifacts should be treated as incomplete proof.
 
@@ -121,6 +124,7 @@ Metric lookup supports top-level run metadata such as `results.total_elapsed_ms`
 
 ```bash
 homeboy runs list --kind bench --component <component> [--scenario <id>] [--rig <id>] [--limit 20]
+homeboy runs dossier <run-id>
 homeboy runs distribution --kind bench --component <component> --field <metadata.path> [--scenario <id>] [--rig <id>] [--status <status>] [--limit 20]
 homeboy runs bench-compare --from-run <run-id> --to-run <run-id>
 homeboy rig runs <id> [--limit 20]

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -111,16 +111,18 @@ pub fn run_command_output(
             )
         }
         Commands::Runs(args) => {
-            let summarize = runs_show_summary_eligible(&args);
+            let summarize_show = runs_show_summary_eligible(&args);
+            let summarize_dossier = runs_dossier_summary_eligible(&args);
             let (stdout_result, exit_code) = dispatch(Commands::Runs(args), global);
-            let summary_stdout = summarize
-                .then(|| {
-                    stdout_result
-                        .as_ref()
-                        .ok()
-                        .and_then(super::runs_summary::render_runs_show_summary)
-                })
-                .flatten();
+            let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
+                if summarize_show {
+                    super::runs_summary::render_runs_show_summary(payload)
+                } else if summarize_dossier {
+                    super::runs_dossier_summary::render_runs_dossier_summary(payload)
+                } else {
+                    None
+                }
+            });
 
             JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
                 CommandPresentation {
@@ -248,6 +250,10 @@ fn controller_evidence_refs(controller: &Value) -> Vec<Value> {
 /// lab-offload subprocesses whose stdout must remain machine-readable.
 fn runs_show_summary_eligible(args: &crate::commands::runs::RunsArgs) -> bool {
     args.show_summary_eligible() && !homeboy::core::lab_routing::is_lab_offload_subprocess()
+}
+
+fn runs_dossier_summary_eligible(args: &crate::commands::runs::RunsArgs) -> bool {
+    args.dossier_summary_eligible() && !homeboy::core::lab_routing::is_lab_offload_subprocess()
 }
 
 fn ci_triage_summary_eligible(args: &crate::commands::ci::CiArgs) -> bool {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -233,6 +233,7 @@ pub mod rig;
 pub mod route;
 pub mod runner;
 pub mod runs;
+pub(crate) mod runs_dossier_summary;
 pub(crate) mod runs_summary;
 pub mod runtime;
 pub mod self_cmd;

--- a/src/commands/runs/dispatch.rs
+++ b/src/commands/runs/dispatch.rs
@@ -7,8 +7,8 @@ use homeboy::core::Error;
 
 use super::types::{RunsArgs, RunsArtifactArgs, RunsArtifactCommand, RunsCommand, RunsOutput};
 use super::{
-    bench, compare, distribution, drift, evidence, findings, fuzz_compare, handlers, hotspots,
-    latest, loop_sync, query, reconcile, refs,
+    bench, compare, distribution, dossier, drift, evidence, findings, fuzz_compare, handlers,
+    hotspots, latest, loop_sync, query, reconcile, refs,
 };
 use super::{CmdResult, GlobalArgs};
 
@@ -17,6 +17,10 @@ impl RunsArgs {
     /// compact human summary (i.e. the caller did not pass `--json`).
     pub fn show_summary_eligible(&self) -> bool {
         matches!(self.command, RunsCommand::Show { json: false, .. })
+    }
+
+    pub fn dossier_summary_eligible(&self) -> bool {
+        matches!(self.command, RunsCommand::Dossier { json: false, .. })
     }
 
     pub fn absorb_global_runner_for_list(&mut self, runner: Option<String>) -> Option<String> {
@@ -79,6 +83,7 @@ impl RunsArgs {
                 ],
             ),
             RunsCommand::Show { run_id, .. }
+            | RunsCommand::Dossier { run_id, .. }
             | RunsCommand::ResumePlan { run_id }
             | RunsCommand::Evidence { run_id }
             | RunsCommand::Env { run_id } => (
@@ -133,6 +138,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Hotspots(args) => hotspots::runs_hotspots(args),
         RunsCommand::Reconcile(args) => reconcile::reconcile_runs(args),
         RunsCommand::Show { run_id, json: _ } => handlers::show_run(&run_id),
+        RunsCommand::Dossier { run_id, json: _ } => dossier::runs_dossier(&run_id),
         RunsCommand::ResumePlan { run_id } => handlers::resume_plan(&run_id),
         RunsCommand::Evidence { run_id } => evidence::evidence(&run_id),
         RunsCommand::Env { run_id } => handlers::env(&run_id),

--- a/src/commands/runs/dossier.rs
+++ b/src/commands/runs/dossier.rs
@@ -1,0 +1,403 @@
+use serde::Serialize;
+use serde_json::Value;
+
+use homeboy::core::observation::evidence_report;
+use homeboy::core::observation::{runs_service, ObservationStore, RunEvidenceCommands, RunRecord};
+use homeboy::core::validation_progress::ValidationProgressLedger;
+
+use super::common::RunSummary;
+use super::{reconcile, run_summary, CmdResult, RunsOutput};
+
+#[derive(Serialize)]
+pub struct RunsDossierOutput {
+    pub command: &'static str,
+    pub run_id: String,
+    pub run_ref: String,
+    pub status: RunsDossierStatus,
+    pub run: RunSummary,
+    pub refs: RunsDossierRefs,
+    pub failure: evidence_report::EvidenceFailureSummary,
+    pub env: RunsDossierEnvSummary,
+    pub artifacts: RunsDossierArtifactSummary,
+    pub inspection_commands: Vec<RunsDossierCommandHint>,
+    pub repair_commands: Vec<RunsDossierCommandHint>,
+    pub next_commands: Vec<RunsDossierCommandHint>,
+}
+
+#[derive(Serialize)]
+pub struct RunsDossierStatus {
+    pub status: String,
+    pub stale: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RunsDossierRefs {
+    pub show_command: String,
+    #[serde(flatten)]
+    pub evidence_commands: RunEvidenceCommands,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handoff_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_ref: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RunsDossierEnvSummary {
+    pub available: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    pub values_redacted: bool,
+    pub key_count: usize,
+    pub secret_key_count: usize,
+    pub public_key_count: usize,
+    pub shadowed_key_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    pub note: String,
+}
+
+#[derive(Serialize)]
+pub struct RunsDossierArtifactSummary {
+    pub count: usize,
+    pub file_count: usize,
+    pub directory_count: usize,
+    pub url_count: usize,
+    pub missing_count: usize,
+    pub reviewer_visible_count: usize,
+    pub fetchable_count: usize,
+    pub artifacts: Vec<RunsDossierArtifactRef>,
+}
+
+#[derive(Serialize)]
+pub struct RunsDossierArtifactRef {
+    pub artifact_id: String,
+    pub kind: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub ref_id: String,
+    pub reviewer_visible: bool,
+    pub visibility_hint: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fetch_command: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RunsDossierCommandHint {
+    pub label: String,
+    pub command: String,
+    pub reason: String,
+}
+
+pub fn runs_dossier(run_id: &str) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
+    runs_service::refresh_mirrored_daemon_evidence_best_effort(run_id);
+    let run = runs_service::require_run(&store, run_id)?;
+    let artifacts = runs_service::list_artifacts_for_run(&store, run_id)?;
+    let artifact_index = evidence_report::evidence_artifact_index(&artifacts);
+    let failure = evidence_report::evidence_failure_summary(&run);
+    let stale_reason = reconcile::running_status_note(&run);
+    let env = env_summary(&run);
+    let validation_progress = ValidationProgressLedger::from_run(&run);
+
+    Ok((
+        RunsOutput::Dossier(RunsDossierOutput {
+            command: "runs.dossier",
+            run_id: run.id.clone(),
+            run_ref: format!("homeboy://run/{}", run.id),
+            status: RunsDossierStatus {
+                status: run.status.clone(),
+                stale: stale_reason.is_some(),
+                stale_reason,
+                category: status_category(&run, &failure),
+                finished_at: run.finished_at.clone(),
+            },
+            run: run_summary(run.clone()),
+            refs: refs(&run),
+            failure,
+            env,
+            artifacts: artifact_summary(artifact_index),
+            inspection_commands: inspection_commands(&run),
+            repair_commands: repair_commands(&run, &validation_progress),
+            next_commands: next_commands(&run, validation_progress.as_ref()),
+        }),
+        0,
+    ))
+}
+
+fn status_category(
+    run: &RunRecord,
+    failure: &evidence_report::EvidenceFailureSummary,
+) -> Option<String> {
+    if !failure.gate_failures.is_empty() {
+        return Some("gate_failure".to_string());
+    }
+    if failure.error.is_some() || !failure.failure.is_null() {
+        return Some("execution_failure".to_string());
+    }
+    matches!(run.status.as_str(), "stale").then(|| "stale_running_record".to_string())
+}
+
+fn refs(run: &RunRecord) -> RunsDossierRefs {
+    RunsDossierRefs {
+        show_command: format!("homeboy runs show {}", shell_arg(&run.id)),
+        evidence_commands: RunEvidenceCommands::for_run_id(&shell_arg(&run.id)),
+        job_ref: first_string_at_any(
+            &run.metadata_json,
+            &[
+                &["job_ref"],
+                &["runner_job_id"],
+                &["job", "id"],
+                &["identity", "runner_job_id"],
+            ],
+        ),
+        handoff_ref: first_string_at_any(
+            &run.metadata_json,
+            &[
+                &["handoff_ref"],
+                &["handoff", "ref"],
+                &["handoff", "id"],
+                &["plan_id"],
+            ],
+        ),
+        result_ref: first_string_at_any(
+            &run.metadata_json,
+            &[
+                &["result_ref"],
+                &["result", "ref"],
+                &["result", "id"],
+                &["output_ref"],
+            ],
+        ),
+    }
+}
+
+fn env_summary(run: &RunRecord) -> RunsDossierEnvSummary {
+    let Some(envelope) = run.metadata_json.get("env_resolution") else {
+        return RunsDossierEnvSummary {
+            available: false,
+            schema: None,
+            values_redacted: true,
+            key_count: 0,
+            secret_key_count: 0,
+            public_key_count: 0,
+            shadowed_key_count: 0,
+            command: None,
+            note: "No redacted environment provenance metadata recorded for this run.".to_string(),
+        };
+    };
+    let keys = envelope
+        .get("keys")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let values_redacted = envelope
+        .get("values_redacted")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    RunsDossierEnvSummary {
+        available: true,
+        schema: envelope
+            .get("schema")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        values_redacted,
+        key_count: keys.len(),
+        secret_key_count: keys
+            .iter()
+            .filter(|key| key.get("classification").and_then(Value::as_str) == Some("secret"))
+            .count(),
+        public_key_count: keys
+            .iter()
+            .filter(|key| key.get("classification").and_then(Value::as_str) == Some("public"))
+            .count(),
+        shadowed_key_count: keys
+            .iter()
+            .filter(|key| {
+                key.get("shadowed_source_layers")
+                    .and_then(Value::as_array)
+                    .is_some_and(|layers| !layers.is_empty())
+            })
+            .count(),
+        command: values_redacted.then(|| format!("homeboy runs env {}", shell_arg(&run.id))),
+        note: if values_redacted {
+            "Redacted environment provenance is available.".to_string()
+        } else {
+            "Environment provenance exists but is not marked redacted; Homeboy will not print values."
+                .to_string()
+        },
+    }
+}
+
+fn artifact_summary(index: evidence_report::EvidenceArtifactIndex) -> RunsDossierArtifactSummary {
+    let mut reviewer_visible_count = 0;
+    let mut fetchable_count = 0;
+    let artifacts = index
+        .artifacts
+        .into_iter()
+        .map(|artifact| {
+            let reviewer_visible = artifact.address.reviewer_visible;
+            if reviewer_visible {
+                reviewer_visible_count += 1;
+            }
+            if artifact.fetch_command.is_some() {
+                fetchable_count += 1;
+            }
+            let target = artifact
+                .public_url
+                .clone()
+                .or_else(|| artifact.fetch_command.clone());
+            RunsDossierArtifactRef {
+                artifact_id: artifact.id,
+                kind: artifact.kind,
+                artifact_type: artifact.artifact_type,
+                ref_id: format!(
+                    "homeboy://run/{}/artifact/{}",
+                    artifact.reference.run_id, artifact.reference.id
+                ),
+                reviewer_visible,
+                visibility_hint: if reviewer_visible {
+                    "reviewer-visible".to_string()
+                } else if artifact.fetch_command.is_some() {
+                    "operator-local; fetch before sharing with reviewers".to_string()
+                } else {
+                    "not reviewer-visible from the recorded address".to_string()
+                },
+                target,
+                fetch_command: artifact.fetch_command,
+            }
+        })
+        .collect();
+
+    RunsDossierArtifactSummary {
+        count: index.count,
+        file_count: index.file_count,
+        directory_count: index.directory_count,
+        url_count: index.url_count,
+        missing_count: index.missing_count,
+        reviewer_visible_count,
+        fetchable_count,
+        artifacts,
+    }
+}
+
+fn inspection_commands(run: &RunRecord) -> Vec<RunsDossierCommandHint> {
+    let run_id = shell_arg(&run.id);
+    let mut commands = vec![
+        command_hint(
+            "show",
+            format!("homeboy runs show {run_id}"),
+            "Inspect compact run metadata and artifacts.",
+        ),
+        command_hint(
+            "show-json",
+            format!("homeboy runs show {run_id} --json"),
+            "Inspect the full persisted run payload.",
+        ),
+        command_hint(
+            "evidence",
+            format!("homeboy runs evidence {run_id}"),
+            "Inspect reviewer-facing evidence, artifact addresses, failure summary, and retention hints.",
+        ),
+        command_hint(
+            "artifacts",
+            format!("homeboy runs artifacts {run_id}"),
+            "List all recorded artifact rows.",
+        ),
+    ];
+    if run.metadata_json.get("env_resolution").is_some() {
+        commands.push(command_hint(
+            "env",
+            format!("homeboy runs env {run_id}"),
+            "Inspect redacted environment provenance when available.",
+        ));
+    }
+    commands
+}
+
+fn repair_commands(
+    run: &RunRecord,
+    validation_progress: &Option<ValidationProgressLedger>,
+) -> Vec<RunsDossierCommandHint> {
+    let run_id = shell_arg(&run.id);
+    let mut commands = Vec::new();
+    if run.status == "running" {
+        commands.push(command_hint(
+            "reconcile-running",
+            "homeboy runs reconcile".to_string(),
+            "Mark orphaned running records stale after owner-process checks.",
+        ));
+    }
+    if validation_progress.is_some() {
+        commands.push(command_hint(
+            "resume-plan",
+            format!("homeboy runs resume-plan {run_id}"),
+            "Inspect the generic validation-progress ledger before resuming work.",
+        ));
+    }
+    commands
+}
+
+fn next_commands(
+    run: &RunRecord,
+    validation_progress: Option<&ValidationProgressLedger>,
+) -> Vec<RunsDossierCommandHint> {
+    let run_id = shell_arg(&run.id);
+    let mut commands = vec![command_hint(
+        "export",
+        format!("homeboy runs export --run {run_id} --output <dir>"),
+        "Create a portable metadata bundle for handoff or review.",
+    )];
+    if validation_progress
+        .and_then(|ledger| ledger.next_command.as_ref())
+        .is_some()
+    {
+        commands.push(command_hint(
+            "resume-plan",
+            format!("homeboy runs resume-plan {run_id}"),
+            "A next validation command is recorded in the ledger.",
+        ));
+    }
+    commands
+}
+
+fn command_hint(label: &str, command: String, reason: &str) -> RunsDossierCommandHint {
+    RunsDossierCommandHint {
+        label: label.to_string(),
+        command,
+        reason: reason.to_string(),
+    }
+}
+
+fn first_string_at_any(value: &Value, paths: &[&[&str]]) -> Option<String> {
+    paths.iter().find_map(|path| string_at(value, path))
+}
+
+fn string_at(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str().map(str::to_string)
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':'))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}

--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -19,6 +19,7 @@ mod corpus_tests;
 mod disk;
 mod dispatch;
 mod distribution;
+mod dossier;
 mod drift;
 mod evidence;
 mod findings;
@@ -63,6 +64,7 @@ pub(crate) use types::{RunsListArgs, RunsListOutput};
 pub use bench::{bench_compare, BenchCompareOutput, RunsBenchCompareArgs};
 pub(super) use bench::{bench_numeric_metrics, run_contains_scenario};
 pub use distribution::{runs_distribution, RunsDistributionArgs, RunsDistributionOutput};
+pub use dossier::{runs_dossier, RunsDossierOutput};
 
 // Test-only helpers consumed by sibling test modules via `super::runs::*` / `super::*`.
 #[cfg(test)]

--- a/src/commands/runs/tests/mod.rs
+++ b/src/commands/runs/tests/mod.rs
@@ -4,8 +4,8 @@ mod export_import;
 
 use super::handlers::{artifact_get, artifacts, env, show_run};
 use super::{
-    bench_compare, dead_owned_run, findings, latest, list_runs, RunsArtifactGetArgs, RunsListArgs,
-    RunsOutput, WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER,
+    bench_compare, dead_owned_run, findings, latest, list_runs, runs_dossier, RunsArtifactGetArgs,
+    RunsListArgs, RunsOutput, WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER,
 };
 
 use homeboy::core::observation::runs_service;
@@ -184,6 +184,96 @@ fn run_show_includes_metadata_and_artifacts() {
         );
         assert_eq!(output.run.artifacts.len(), 1);
         assert_eq!(output.run.artifacts[0].kind, "bench_results");
+    });
+}
+
+#[test]
+fn runs_dossier_aggregates_failure_env_refs_artifacts_and_commands() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run(
+                "bench",
+                "homeboy",
+                "studio",
+                serde_json::json!({
+                    "exit_code": 1,
+                    "error": "budget exceeded",
+                    "gate_failures": ["p95_ms exceeded"],
+                    "runner_job_id": "job-123",
+                    "handoff": { "ref": "handoff-123" },
+                    "result": { "ref": "result-123" },
+                    "env_resolution": {
+                        "schema": "homeboy/env-resolution/v1",
+                        "values_redacted": true,
+                        "keys": [
+                            {
+                                "key": "TOKEN",
+                                "classification": "secret",
+                                "shadowed_source_layers": ["env"]
+                            },
+                            {
+                                "key": "HOMEBOY_RUNTIME_DIR",
+                                "classification": "public",
+                                "shadowed_source_layers": []
+                            }
+                        ]
+                    }
+                }),
+            ))
+            .expect("run");
+        store
+            .finish_run(&run.id, RunStatus::Fail, None)
+            .expect("finish run");
+        let artifact_path = home.path().join("report.json");
+        std::fs::write(&artifact_path, b"{}").expect("artifact");
+        store
+            .record_artifact(&run.id, "report", &artifact_path)
+            .expect("record artifact");
+        store
+            .record_url_artifact(&run.id, "review", "https://example.test/evidence")
+            .expect("record url");
+
+        let (output, _) = runs_dossier(&run.id).expect("dossier");
+        let RunsOutput::Dossier(output) = output else {
+            panic!("expected dossier output");
+        };
+
+        assert_eq!(output.command, "runs.dossier");
+        assert_eq!(output.run_id, run.id);
+        assert_eq!(output.run_ref, format!("homeboy://run/{}", run.id));
+        assert_eq!(output.status.status, "fail");
+        assert_eq!(output.status.category.as_deref(), Some("gate_failure"));
+        assert_eq!(output.failure.error.as_deref(), Some("budget exceeded"));
+        assert_eq!(output.failure.gate_failures, vec!["p95_ms exceeded"]);
+        assert_eq!(output.refs.job_ref.as_deref(), Some("job-123"));
+        assert_eq!(output.refs.handoff_ref.as_deref(), Some("handoff-123"));
+        assert_eq!(output.refs.result_ref.as_deref(), Some("result-123"));
+        assert_eq!(
+            output.env.schema.as_deref(),
+            Some("homeboy/env-resolution/v1")
+        );
+        assert!(output.env.values_redacted);
+        assert_eq!(output.env.key_count, 2);
+        assert_eq!(output.env.secret_key_count, 1);
+        assert_eq!(output.env.public_key_count, 1);
+        assert_eq!(output.env.shadowed_key_count, 1);
+        assert_eq!(output.artifacts.count, 2);
+        assert_eq!(output.artifacts.reviewer_visible_count, 1);
+        assert_eq!(output.artifacts.fetchable_count, 1);
+        assert!(output
+            .artifacts
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.visibility_hint
+                == "operator-local; fetch before sharing with reviewers"));
+        assert!(output
+            .inspection_commands
+            .iter()
+            .any(|command| command.command == format!("homeboy runs evidence {}", run.id)));
+        assert!(output.next_commands.iter().any(|command| command.command
+            == format!("homeboy runs export --run {} --output <dir>", run.id)));
     });
 }
 

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -22,6 +22,7 @@ use super::bundle::{RunsExportArgs, RunsExportOutput, RunsImportArgs, RunsImport
 use super::common::RunSummary;
 use super::compare::{RunsCompareArgs, RunsCompareOutput};
 use super::distribution::{RunsDistributionArgs, RunsDistributionOutput};
+use super::dossier::RunsDossierOutput;
 use super::drift::{RunsDriftArgs, RunsDriftOutput};
 use super::evidence::RunsEvidenceOutput;
 use super::findings;
@@ -81,6 +82,13 @@ pub(super) enum RunsCommand {
         /// The compact summary surfaces status, key metadata, and artifact
         /// pointers with inspect commands; the full payload is unchanged and
         /// always available with this flag or via `--output <file>`.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Aggregate the actionable read-only dossier for one persisted run
+    Dossier {
+        run_id: String,
+        /// Print the full JSON output instead of the compact human dossier.
         #[arg(long)]
         json: bool,
     },
@@ -151,6 +159,7 @@ pub enum RunsOutput {
     LatestRun(RunsLatestRunOutput),
     Compare(RunsCompareOutput),
     Show(RunsShowOutput),
+    Dossier(RunsDossierOutput),
     ResumePlan(RunsResumePlanOutput),
     Evidence(RunsEvidenceOutput),
     Env(RunsEnvOutput),

--- a/src/commands/runs_dossier_summary.rs
+++ b/src/commands/runs_dossier_summary.rs
@@ -1,0 +1,178 @@
+//! Compact human-readable summary for `homeboy runs dossier`.
+
+use serde_json::Value;
+
+use super::summary_json::{string_value, usize_value, value_at};
+
+pub(crate) fn render_runs_dossier_summary(payload: &Value) -> Option<String> {
+    if payload.get("variant").and_then(Value::as_str)? != "dossier" {
+        return None;
+    }
+    let dossier = value_at(payload, &["payload"])?;
+    Some(render_dossier(dossier))
+}
+
+fn render_dossier(dossier: &Value) -> String {
+    let run_id = string_value(dossier, &["run_id"]).unwrap_or("<unknown>");
+    let kind = string_value(dossier, &["run", "kind"]).unwrap_or("run");
+    let status = string_value(dossier, &["status", "status"]).unwrap_or("unknown");
+    let mut lines = vec![
+        format!("Run Dossier {run_id} ({kind})"),
+        format!("Status: {status}"),
+    ];
+
+    if let Some(category) = string_value(dossier, &["status", "category"]) {
+        lines.push(format!("Category: {category}"));
+    }
+    if let Some(reason) = string_value(dossier, &["status", "stale_reason"]) {
+        lines.push(format!("Stale reason: {reason}"));
+    }
+    if let Some(error) = string_value(dossier, &["failure", "error"]) {
+        lines.push(format!("Error: {error}"));
+    }
+    if let Some(gates) = value_at(dossier, &["failure", "gate_failures"]).and_then(Value::as_array)
+    {
+        if !gates.is_empty() {
+            lines.push("Gate failures:".to_string());
+            for gate in gates.iter().filter_map(Value::as_str) {
+                lines.push(format!("  {gate}"));
+            }
+        }
+    }
+
+    lines.extend(ref_lines(dossier));
+    lines.extend(env_lines(dossier));
+    lines.extend(artifact_lines(dossier));
+    lines.extend(command_lines(dossier, "Inspection", "inspection_commands"));
+    lines.extend(command_lines(dossier, "Repair", "repair_commands"));
+    lines.extend(command_lines(dossier, "Next", "next_commands"));
+    lines.push(format!("Full output: homeboy runs dossier {run_id} --json"));
+
+    let mut output = lines.join("\n");
+    output.push('\n');
+    output
+}
+
+fn ref_lines(dossier: &Value) -> Vec<String> {
+    let mut lines = vec!["Refs:".to_string()];
+    if let Some(run_ref) = string_value(dossier, &["run_ref"]) {
+        lines.push(format!("  run: {run_ref}"));
+    }
+    for (label, path) in [
+        ("job", &["refs", "job_ref"][..].as_ref()),
+        ("handoff", &["refs", "handoff_ref"][..].as_ref()),
+        ("result", &["refs", "result_ref"][..].as_ref()),
+    ] {
+        if let Some(value) = string_value(dossier, path) {
+            lines.push(format!("  {label}: {value}"));
+        }
+    }
+    lines
+}
+
+fn env_lines(dossier: &Value) -> Vec<String> {
+    let Some(env) = value_at(dossier, &["env"]) else {
+        return Vec::new();
+    };
+    let available = env
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !available {
+        return vec!["Env provenance: not recorded".to_string()];
+    }
+    let keys = usize_value(env, &["key_count"]).unwrap_or(0);
+    let secret = usize_value(env, &["secret_key_count"]).unwrap_or(0);
+    let public = usize_value(env, &["public_key_count"]).unwrap_or(0);
+    let shadowed = usize_value(env, &["shadowed_key_count"]).unwrap_or(0);
+    let mut lines = vec![format!(
+        "Env provenance: {keys} keys ({secret} secret, {public} public, {shadowed} shadowed)"
+    )];
+    if let Some(command) = string_value(env, &["command"]) {
+        lines.push(format!("  inspect: {command}"));
+    }
+    lines
+}
+
+fn artifact_lines(dossier: &Value) -> Vec<String> {
+    let count = usize_value(dossier, &["artifacts", "count"]).unwrap_or(0);
+    let reviewer_visible =
+        usize_value(dossier, &["artifacts", "reviewer_visible_count"]).unwrap_or(0);
+    let fetchable = usize_value(dossier, &["artifacts", "fetchable_count"]).unwrap_or(0);
+    let missing = usize_value(dossier, &["artifacts", "missing_count"]).unwrap_or(0);
+    let mut lines = vec![format!(
+        "Artifacts: {count} recorded, {reviewer_visible} reviewer-visible, {fetchable} fetchable, {missing} missing"
+    )];
+    if let Some(artifacts) =
+        value_at(dossier, &["artifacts", "artifacts"]).and_then(Value::as_array)
+    {
+        for artifact in artifacts.iter().take(8) {
+            let id = string_value(artifact, &["artifact_id"]).unwrap_or("artifact");
+            let kind = string_value(artifact, &["kind"]).unwrap_or("");
+            let hint = string_value(artifact, &["visibility_hint"]).unwrap_or("unknown visibility");
+            lines.push(format!("  {id} [{kind}]: {hint}"));
+            if let Some(target) = string_value(artifact, &["target"]) {
+                lines.push(format!("    target: {target}"));
+            }
+        }
+    }
+    lines
+}
+
+fn command_lines(dossier: &Value, title: &str, key: &str) -> Vec<String> {
+    let Some(commands) = value_at(dossier, &[key]).and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    if commands.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = vec![format!("{title} commands:")];
+    for command in commands {
+        if let Some(value) = string_value(command, &["command"]) {
+            lines.push(format!("  {value}"));
+        }
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn renders_actionable_dossier_summary() {
+        let payload = json!({
+            "variant": "dossier",
+            "payload": {
+                "run_id": "run-1",
+                "run_ref": "homeboy://run/run-1",
+                "run": { "kind": "bench" },
+                "status": { "status": "fail", "category": "gate_failure" },
+                "failure": { "error": "boom", "gate_failures": ["budget exceeded"] },
+                "refs": { "job_ref": "job-1" },
+                "env": { "available": true, "key_count": 2, "secret_key_count": 1, "public_key_count": 1, "shadowed_key_count": 1, "command": "homeboy runs env run-1" },
+                "artifacts": {
+                    "count": 1,
+                    "reviewer_visible_count": 0,
+                    "fetchable_count": 1,
+                    "missing_count": 0,
+                    "artifacts": [{ "artifact_id": "a1", "kind": "report", "visibility_hint": "operator-local; fetch before sharing with reviewers", "target": "homeboy runs artifact get run-1 a1 -o <path>" }]
+                },
+                "inspection_commands": [{ "command": "homeboy runs evidence run-1" }],
+                "repair_commands": [],
+                "next_commands": [{ "command": "homeboy runs export --run run-1 --output <dir>" }]
+            }
+        });
+
+        let summary = render_runs_dossier_summary(&payload).expect("summary");
+        assert!(summary.contains("Run Dossier run-1 (bench)\n"));
+        assert!(summary.contains("Category: gate_failure\n"));
+        assert!(summary.contains("job: job-1\n"));
+        assert!(summary.contains("Env provenance: 2 keys (1 secret, 1 public, 1 shadowed)\n"));
+        assert!(
+            summary.contains("Artifacts: 1 recorded, 0 reviewer-visible, 1 fetchable, 0 missing\n")
+        );
+        assert!(summary.contains("Full output: homeboy runs dossier run-1 --json\n"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add read-only `homeboy runs dossier <run-id>` to aggregate status, failure category, run refs, env provenance summary, artifact/evidence visibility hints, and follow-up commands.
- Reuse existing observation store, run service, evidence report, artifact index, and validation-progress helpers.
- Add compact human presentation, command docs, and focused tests.

## Tests
- `cargo fmt`
- `cargo test dossier --lib`
- `cargo test commands::runs:: --lib`
- `cargo test --bin homeboy --no-run`
- `cargo run --quiet -- runs dossier --help`

## Known unrelated test failures
- `cargo test runs --lib` fails in `extensions::deps_provider::tests::composer_install_runs_full_dependency_install_lifecycle`: expected `["composer", "install", "--no-interaction"]`, got `["composer", "install", "--no-interaction", "--no-progress"]`.
- `cargo test command_contract --lib` fails in `command_contract::lab::tests::test_supports_lab_runner` while parsing an existing `homeboy bench ...` fixture.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the command, tests, docs, and verification workflow.