### PR TITLE
Add fuzz observation hotspot ranker

### DIFF
--- a/src/commands/fuzz/compare.rs
+++ b/src/commands/fuzz/compare.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use homeboy::core::fuzz::{
     parse_fuzz_hotspot_set_value, parse_fuzz_observation_set_value,
-    parse_fuzz_result_envelope_file, FuzzHotspot, FuzzObservationFamily, FuzzResultEnvelope,
+    parse_fuzz_result_envelope_file, rank_fuzz_observation_set_hotspots, FuzzHotspot,
+    FuzzResultEnvelope,
 };
 
 use super::report::{
@@ -312,42 +313,8 @@ fn collect_hotspots_from_value(
         return;
     }
     if let Some(set) = parse_fuzz_observation_set_value(value) {
-        hotspots.extend(set.observations.into_iter().map(|observation| {
-            let dimension = match observation.family {
-                FuzzObservationFamily::Action => "action",
-                FuzzObservationFamily::Query => "query",
-                FuzzObservationFamily::Resource => "resource",
-                FuzzObservationFamily::Timing => "timing",
-                FuzzObservationFamily::Counter => "counter",
-            }
-            .to_string();
-            let id = observation.fingerprint.clone().unwrap_or_else(|| {
-                [
-                    Some(dimension.as_str()),
-                    Some(observation.subject.as_str()),
-                    Some(observation.metric.as_str()),
-                    observation.operation_id.as_deref(),
-                    observation.case_id.as_deref(),
-                ]
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>()
-                .join(":")
-            });
-            FuzzCompareHotspotSnapshot {
-                id,
-                dimension,
-                kind: Some("observation".to_string()),
-                metric: observation.metric,
-                value: observation.value,
-                unit: observation.unit,
-                basis: Some("fuzz_observation_set".to_string()),
-                sample_count: observation.sample_count,
-                rank: None,
-                relative_score: Some(observation.value.abs()),
-                label: Some(observation.subject),
-            }
-        }));
+        let ranked = rank_fuzz_observation_set_hotspots(&set);
+        hotspots.extend(ranked.items.into_iter().map(hotspot_snapshot));
         return;
     }
 
@@ -872,7 +839,8 @@ mod tests {
         assert_eq!(snapshot.hotspots[0].id, "page-load:duration");
         assert_eq!(snapshot.hotspots[0].dimension, "timing");
         assert_eq!(snapshot.hotspots[0].kind.as_deref(), Some("observation"));
-        assert_eq!(snapshot.hotspots[0].relative_score, Some(123.0));
+        assert_eq!(snapshot.hotspots[0].rank, Some(1));
+        assert_eq!(snapshot.hotspots[0].relative_score, Some(1.0));
     }
 
     #[test]

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 
 use homeboy::core::fuzz::{
     default_fuzz_gates, fuzz_gate_profile_contract, parse_fuzz_case_log_file,
-    parse_fuzz_results_file, parse_fuzz_target_inventory_file, FuzzCampaign, FuzzExecutionRequest,
+    parse_fuzz_observation_set_value, parse_fuzz_results_file, parse_fuzz_target_inventory_file,
+    rank_fuzz_observation_set_hotspots, FuzzCampaign, FuzzExecutionRequest, FuzzHotspotSet,
     FuzzProvenance, FuzzResultEnvelope, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
     FUZZ_RESULT_ENVELOPE_SCHEMA,
 };
@@ -28,6 +29,7 @@ pub(super) fn run_validate(args: FuzzValidateArgs) -> homeboy::core::Result<Fuzz
     let gates = evaluate_fuzz_gates(&campaign);
     let coverage_completeness = fuzz_coverage_completeness(&campaign);
     let performance_hotspots = fuzz_performance_hotspots(&campaign);
+    let observation_hotspots = fuzz_observation_hotspots(&campaign);
 
     Ok(FuzzValidateOutput {
         command: "fuzz.validate".to_string(),
@@ -44,6 +46,7 @@ pub(super) fn run_validate(args: FuzzValidateArgs) -> homeboy::core::Result<Fuzz
         artifacts: campaign.artifacts.len(),
         coverage_completeness,
         performance_hotspots,
+        observation_hotspots,
         gates,
     })
 }
@@ -52,6 +55,7 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
     let campaign = parse_fuzz_results_file(&args.results_file)?;
     let coverage_completeness = fuzz_coverage_completeness(&campaign);
     let performance_hotspots = fuzz_performance_hotspots(&campaign);
+    let observation_hotspots = fuzz_observation_hotspots(&campaign);
     let component = args.run.comp.id().unwrap_or("unknown");
     let mut envelope = fuzz_result_envelope_from_campaign(
         &args.run,
@@ -85,8 +89,14 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
         envelope,
         coverage_completeness,
         performance_hotspots,
+        observation_hotspots,
         gates,
     })
+}
+
+pub(super) fn fuzz_observation_hotspots(campaign: &FuzzCampaign) -> Option<FuzzHotspotSet> {
+    parse_fuzz_observation_set_value(&campaign.metadata)
+        .map(|set| rank_fuzz_observation_set_hotspots(&set))
 }
 
 pub(super) fn fuzz_result_envelope_from_campaign(

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -11,7 +11,7 @@ use super::planning::plan_inventory_selection;
 use super::replay::run_replay;
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,
-    fuzz_performance_hotspots, gate_status, run_report, run_validate,
+    fuzz_observation_hotspots, fuzz_performance_hotspots, gate_status, run_report, run_validate,
     FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
 };
 use super::types::{

--- a/src/commands/fuzz/tests/report_tests.rs
+++ b/src/commands/fuzz/tests/report_tests.rs
@@ -188,6 +188,46 @@ fn fuzz_performance_hotspots_extracts_generic_metadata_metrics() {
 }
 
 #[test]
+fn fuzz_observation_hotspots_rank_observation_set_metrics() {
+    let mut campaign = empty_fuzz_campaign();
+    campaign.metadata = serde_json::json!({
+        "observation_set": {
+            "schema": homeboy::core::fuzz::FUZZ_OBSERVATION_SET_SCHEMA,
+            "version": 1,
+            "id": "report-observations",
+            "observations": [
+                {
+                    "id": "low",
+                    "family": "timing",
+                    "subject": "case-low",
+                    "metric": "duration",
+                    "value": 10,
+                    "unit": "ms"
+                },
+                {
+                    "id": "high",
+                    "family": "timing",
+                    "subject": "case-high",
+                    "metric": "duration",
+                    "value": 40,
+                    "unit": "ms"
+                }
+            ]
+        }
+    });
+
+    let hotspots = fuzz_observation_hotspots(&campaign).expect("observation hotspots");
+
+    assert_eq!(hotspots.id, "report-observations-hotspots");
+    assert_eq!(hotspots.items[0].id, "timing:case-high:duration");
+    assert_eq!(hotspots.items[0].rank, Some(1));
+    assert_eq!(hotspots.items[0].relative_score, Some(1.0));
+    assert_eq!(hotspots.items[1].id, "timing:case-low:duration");
+    assert_eq!(hotspots.items[1].rank, Some(2));
+    assert_eq!(hotspots.items[1].relative_score, Some(0.25));
+}
+
+#[test]
 fn select_workload_requires_explicit_id_for_ambiguous_fuzz_workloads() {
     let workloads = vec![
         FuzzWorkloadOutput {

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -2,8 +2,8 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 
 use homeboy::core::fuzz::{
-    FuzzCampaign, FuzzExecutionRequest, FuzzGate, FuzzReplayMetadata, FuzzRequiredArtifact,
-    FuzzResultEnvelope, FuzzTargetInventory,
+    FuzzCampaign, FuzzExecutionRequest, FuzzGate, FuzzHotspotSet, FuzzReplayMetadata,
+    FuzzRequiredArtifact, FuzzResultEnvelope, FuzzTargetInventory,
 };
 use homeboy::core::performance_hotspots::PerformanceHotspotSummary;
 
@@ -202,6 +202,8 @@ pub struct FuzzValidateOutput {
     pub artifacts: usize,
     pub coverage_completeness: FuzzCoverageCompletenessOutput,
     pub performance_hotspots: PerformanceHotspotSummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observation_hotspots: Option<FuzzHotspotSet>,
     pub gates: Vec<FuzzGateEvaluation>,
 }
 
@@ -214,6 +216,8 @@ pub struct FuzzReportOutput {
     pub envelope: FuzzResultEnvelope,
     pub coverage_completeness: FuzzCoverageCompletenessOutput,
     pub performance_hotspots: PerformanceHotspotSummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observation_hotspots: Option<FuzzHotspotSet>,
     pub gates: Vec<FuzzGateEvaluation>,
 }
 

--- a/src/core/fuzz/hotspots.rs
+++ b/src/core/fuzz/hotspots.rs
@@ -9,7 +9,7 @@ use super::normalize::{
 };
 use super::schema_defaults::{fuzz_contract_version, fuzz_hotspot_set_schema};
 use super::schemas::{FUZZ_CONTRACT_VERSION, FUZZ_HOTSPOT_SET_SCHEMA};
-use super::FuzzProvenance;
+use super::{FuzzObservation, FuzzObservationFamily, FuzzObservationSet, FuzzProvenance};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FuzzHotspotSet {
@@ -130,4 +130,95 @@ pub fn parse_fuzz_hotspot_set_value(value: &Value) -> Option<FuzzHotspotSet> {
             .cloned()
     }?;
     FuzzHotspotSet::from_value(candidate).ok()
+}
+
+pub fn rank_fuzz_observation_set_hotspots(observation_set: &FuzzObservationSet) -> FuzzHotspotSet {
+    let mut items = observation_set
+        .observations
+        .iter()
+        .map(hotspot_from_observation)
+        .collect::<Vec<_>>();
+    let max_score = items
+        .iter()
+        .map(|item| item.value.abs())
+        .fold(0.0_f64, f64::max);
+
+    items.sort_by(|a, b| {
+        b.value
+            .abs()
+            .total_cmp(&a.value.abs())
+            .then_with(|| a.dimension.cmp(&b.dimension))
+            .then_with(|| a.metric.cmp(&b.metric))
+            .then_with(|| a.unit.cmp(&b.unit))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
+    for (index, item) in items.iter_mut().enumerate() {
+        item.rank = Some(index as u64 + 1);
+        item.relative_score = Some(if max_score == 0.0 {
+            0.0
+        } else {
+            item.value.abs() / max_score
+        });
+    }
+
+    FuzzHotspotSet {
+        schema: FUZZ_HOTSPOT_SET_SCHEMA.to_string(),
+        version: FUZZ_CONTRACT_VERSION,
+        id: format!("{}-hotspots", observation_set.id),
+        label: observation_set.label.clone(),
+        items,
+        provenance: None,
+        metadata: serde_json::json!({
+            "basis": "fuzz_observation_set",
+            "source_observation_set_id": observation_set.id,
+        }),
+        extra: BTreeMap::new(),
+    }
+}
+
+fn hotspot_from_observation(observation: &FuzzObservation) -> FuzzHotspot {
+    let dimension = observation_family_dimension(observation.family).to_string();
+    FuzzHotspot {
+        id: observation.fingerprint.clone().unwrap_or_else(|| {
+            [
+                Some(dimension.as_str()),
+                Some(observation.subject.as_str()),
+                Some(observation.metric.as_str()),
+                observation.operation_id.as_deref(),
+                observation.case_id.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join(":")
+        }),
+        dimension,
+        kind: Some("observation".to_string()),
+        metric: observation.metric.clone(),
+        value: observation.value,
+        unit: observation.unit.clone(),
+        basis: Some("fuzz_observation_set".to_string()),
+        sample_count: observation.sample_count,
+        rank: None,
+        relative_score: None,
+        label: Some(observation.subject.clone()),
+        labels: Vec::new(),
+        evidence_refs: vec![observation.id.clone()],
+        artifact_refs: Vec::new(),
+        source_refs: Vec::new(),
+        provenance: None,
+        metadata: observation.metadata.clone(),
+        extra: observation.extra.clone(),
+    }
+}
+
+fn observation_family_dimension(family: FuzzObservationFamily) -> &'static str {
+    match family {
+        FuzzObservationFamily::Action => "action",
+        FuzzObservationFamily::Query => "query",
+        FuzzObservationFamily::Resource => "resource",
+        FuzzObservationFamily::Timing => "timing",
+        FuzzObservationFamily::Counter => "counter",
+    }
 }

--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -39,7 +39,9 @@ pub use defaults::{
 pub use envelope::{
     FuzzExecutionRequest, FuzzGate, FuzzRequiredArtifact, FuzzResultEnvelope, FuzzTargetInventory,
 };
-pub use hotspots::{parse_fuzz_hotspot_set_value, FuzzHotspot, FuzzHotspotSet};
+pub use hotspots::{
+    parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots, FuzzHotspot, FuzzHotspotSet,
+};
 pub use observations::{
     parse_fuzz_observation_set_value, FuzzObservation, FuzzObservationFamily, FuzzObservationSet,
 };

--- a/src/core/fuzz/tests/hotspot_tests.rs
+++ b/src/core/fuzz/tests/hotspot_tests.rs
@@ -1,6 +1,9 @@
 use serde_json::json;
 
-use crate::core::fuzz::{parse_fuzz_hotspot_set_value, FUZZ_HOTSPOT_SET_SCHEMA};
+use crate::core::fuzz::{
+    parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots, FuzzObservationSet,
+    FUZZ_HOTSPOT_SET_SCHEMA, FUZZ_OBSERVATION_SET_SCHEMA,
+};
 
 #[test]
 fn parses_typed_hotspot_set_from_result_envelope_metadata() {
@@ -80,4 +83,57 @@ fn rejects_unsupported_hotspot_set_versions() {
     });
 
     assert!(parse_fuzz_hotspot_set_value(&invalid).is_none());
+}
+
+#[test]
+fn ranks_observation_set_hotspots_deterministically() {
+    let observations = FuzzObservationSet::from_value(json!({
+        "schema": FUZZ_OBSERVATION_SET_SCHEMA,
+        "version": 1,
+        "id": "candidate-observations",
+        "observations": [
+            {
+                "id": "slow-query",
+                "family": "query",
+                "subject": "query-a",
+                "metric": "duration",
+                "value": 25.0,
+                "unit": "ms",
+                "fingerprint": "query-a:duration"
+            },
+            {
+                "id": "counter-spike",
+                "family": "counter",
+                "subject": "counter-a",
+                "metric": "count",
+                "value": -50.0,
+                "unit": "count"
+            },
+            {
+                "id": "same-score-action",
+                "family": "action",
+                "subject": "action-a",
+                "metric": "duration",
+                "value": 25.0,
+                "unit": "ms"
+            }
+        ]
+    }))
+    .expect("observation set");
+
+    let hotspots = rank_fuzz_observation_set_hotspots(&observations);
+
+    assert_eq!(hotspots.schema, FUZZ_HOTSPOT_SET_SCHEMA);
+    assert_eq!(hotspots.id, "candidate-observations-hotspots");
+    assert_eq!(hotspots.items.len(), 3);
+    assert_eq!(hotspots.items[0].id, "counter:counter-a:count");
+    assert_eq!(hotspots.items[0].rank, Some(1));
+    assert_eq!(hotspots.items[0].relative_score, Some(1.0));
+    assert_eq!(hotspots.items[1].id, "action:action-a:duration");
+    assert_eq!(hotspots.items[1].rank, Some(2));
+    assert_eq!(hotspots.items[1].relative_score, Some(0.5));
+    assert_eq!(hotspots.items[2].id, "query-a:duration");
+    assert_eq!(hotspots.items[2].rank, Some(3));
+    assert_eq!(hotspots.items[2].relative_score, Some(0.5));
+    assert_eq!(hotspots.items[2].evidence_refs, vec!["slow-query"]);
 }


### PR DESCRIPTION
## Summary
- Add a generic observation-set-to-hotspot-set ranker for fuzz observation sets.
- Use ranked observation hotspots in fuzz compare instead of inline unranked snapshots.
- Surface optional ranked observation hotspots in fuzz validate/report output without mutating persisted envelopes.

## Tests
- cargo test fuzz::tests && cargo test commands::fuzz::tests::report_tests && cargo test commands::fuzz::compare::tests
- cargo test commands::fuzz::compare::tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fuzz observation hotspot ranker, updating report/compare plumbing, and adding focused tests.