### PR TITLE
Add generic artifact postprocess runner

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::Duration;
 
+use homeboy::core::artifacts::{
+    record_artifact_postprocess_outputs, run_artifact_postprocess_steps, ArtifactPostprocessContext,
+};
 use homeboy::core::engine::execution_context;
 use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
@@ -147,6 +149,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         expected_metric_gates: &expected_metric_gates,
         results_error: combined_results_error,
         missing_artifact_refs: &artifact_ref_validation.missing_refs,
+        postprocess: &postprocess,
     })?;
     let evidence_followups = fuzz_evidence_followups(
         args.run_id.as_deref(),
@@ -339,24 +342,20 @@ pub(super) fn run_fuzz_artifact_postprocess(
     if steps.is_empty() {
         return Ok(Vec::new());
     }
-    std::fs::create_dir_all(artifacts_dir).map_err(|error| {
-        homeboy::core::Error::internal_io(
-            error.to_string(),
-            Some(artifacts_dir.display().to_string()),
-        )
-    })?;
-
-    let mut outputs = Vec::new();
-    for (index, step) in steps.iter().enumerate() {
-        outputs.push(run_fuzz_artifact_postprocess_step(
-            index,
-            step,
-            rig_context,
-            results_path,
-            artifacts_dir,
-        )?);
-    }
-    Ok(outputs)
+    let expand =
+        |value: &str| expand_postprocess_path(value, rig_context, results_path, artifacts_dir);
+    let outputs = run_artifact_postprocess_steps(
+        &steps,
+        &ArtifactPostprocessContext {
+            artifact_root: artifacts_dir,
+            input_root: Some(results_path),
+            path_expander: Some(&expand),
+        },
+    )?;
+    Ok(outputs
+        .into_iter()
+        .map(FuzzArtifactPostprocessOutput::from)
+        .collect())
 }
 
 fn fuzz_artifact_postprocess_steps(
@@ -393,129 +392,6 @@ fn fuzz_artifact_postprocess_steps(
         .unwrap_or_default()
 }
 
-fn run_fuzz_artifact_postprocess_step(
-    index: usize,
-    step: &homeboy::core::rig::ArtifactPostprocessSpec,
-    rig_context: Option<&FuzzRigContext>,
-    results_path: &Path,
-    artifacts_dir: &Path,
-) -> homeboy::core::Result<FuzzArtifactPostprocessOutput> {
-    let id = step
-        .id
-        .clone()
-        .unwrap_or_else(|| format!("artifact-postprocess-{}", index + 1));
-    let output_path = resolve_postprocess_output_path(&step.output, artifacts_dir)?;
-    if let Some(parent) = output_path.parent() {
-        std::fs::create_dir_all(parent).map_err(|error| {
-            homeboy::core::Error::internal_io(error.to_string(), Some(parent.display().to_string()))
-        })?;
-    }
-    let input = step
-        .input
-        .as_ref()
-        .map(|input| expand_postprocess_path(input, rig_context, results_path, artifacts_dir));
-    let parameters_json = serde_json::to_string(&step.parameters).map_err(|error| {
-        homeboy::core::Error::internal_unexpected(format!(
-            "failed to serialize artifact postprocess parameters: {error}"
-        ))
-    })?;
-
-    let mut command = Command::new(&step.helper);
-    command.arg(&step.action);
-    if let Some(args) = step
-        .parameters
-        .get("args")
-        .and_then(serde_json::Value::as_array)
-    {
-        for arg in args.iter().filter_map(serde_json::Value::as_str) {
-            command.arg(arg);
-        }
-    }
-    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_ID", &id);
-    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_HELPER", &step.helper);
-    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_ACTION", &step.action);
-    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT", &output_path);
-    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT", artifacts_dir);
-    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_PARAMETERS", parameters_json);
-    if let Some(input) = input.as_ref() {
-        command.env("HOMEBOY_ARTIFACT_POSTPROCESS_INPUT", input);
-    }
-    for (key, value) in &step.parameters {
-        if let Some(value) = postprocess_parameter_env_value(value) {
-            command.env(postprocess_parameter_env_key(key), value);
-        }
-    }
-
-    let output = command.output().map_err(|error| {
-        homeboy::core::Error::internal_io(
-            format!(
-                "failed to run artifact postprocess `{}` via helper `{}`: {error}",
-                id, step.helper
-            ),
-            Some("fuzz.artifact_postprocess".to_string()),
-        )
-    })?;
-    let exit_code = output.status.code();
-    let mut success = output.status.success();
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    let mut error = (!success).then(|| {
-        format!(
-            "artifact postprocess `{id}` failed with exit code {}",
-            exit_code
-                .map(|code| code.to_string())
-                .unwrap_or_else(|| "unknown".to_string())
-        )
-    });
-    if success && !output_path.exists() {
-        success = false;
-        error = Some(format!(
-            "artifact postprocess `{id}` did not create required output {}",
-            output_path.display()
-        ));
-    }
-
-    Ok(FuzzArtifactPostprocessOutput {
-        id,
-        helper: step.helper.clone(),
-        action: step.action.clone(),
-        input: input.map(|path| path.to_string_lossy().to_string()),
-        output: output_path.to_string_lossy().to_string(),
-        required: step.required,
-        exit_code,
-        success,
-        stdout,
-        stderr,
-        error,
-    })
-}
-
-fn resolve_postprocess_output_path(
-    output: &str,
-    artifacts_dir: &Path,
-) -> homeboy::core::Result<PathBuf> {
-    let trimmed = output.trim();
-    let path = Path::new(trimmed);
-    if trimmed.is_empty() || path.is_absolute() || trimmed.starts_with("..") {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "artifact_postprocess.output",
-            "artifact postprocess output must be a non-empty path relative to HOMEBOY_FUZZ_ARTIFACTS_DIR",
-            Some(output.to_string()),
-            None,
-        ));
-    }
-    let resolved = artifacts_dir.join(path);
-    if !resolved.starts_with(artifacts_dir) {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "artifact_postprocess.output",
-            "artifact postprocess output must stay within HOMEBOY_FUZZ_ARTIFACTS_DIR",
-            Some(output.to_string()),
-            None,
-        ));
-    }
-    Ok(resolved)
-}
-
 fn expand_postprocess_path(
     value: &str,
     rig_context: Option<&FuzzRigContext>,
@@ -531,27 +407,23 @@ fn expand_postprocess_path(
     })
 }
 
-fn postprocess_parameter_env_value(value: &serde_json::Value) -> Option<String> {
-    match value {
-        serde_json::Value::String(value) => Some(value.clone()),
-        serde_json::Value::Bool(value) => Some(value.to_string()),
-        serde_json::Value::Number(value) => Some(value.to_string()),
-        _ => None,
+impl From<homeboy::core::artifacts::ArtifactPostprocessOutput> for FuzzArtifactPostprocessOutput {
+    fn from(output: homeboy::core::artifacts::ArtifactPostprocessOutput) -> Self {
+        Self {
+            id: output.id,
+            helper: output.helper,
+            action: output.action,
+            input: output.input,
+            output: output.output,
+            required: output.required,
+            exit_code: output.exit_code,
+            success: output.success,
+            stdout: output.stdout,
+            stderr: output.stderr,
+            error: output.error,
+            artifacts: output.artifacts,
+        }
     }
-}
-
-fn postprocess_parameter_env_key(key: &str) -> String {
-    let suffix = key
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_uppercase()
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    format!("HOMEBOY_ARTIFACT_POSTPROCESS_PARAMETER_{suffix}")
 }
 
 pub(super) fn fuzz_postprocess_error(outputs: &[FuzzArtifactPostprocessOutput]) -> Option<String> {
@@ -784,6 +656,7 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) expected_metric_gates: &'a [super::types::FuzzGateEvaluation],
     pub(super) results_error: Option<&'a str>,
     pub(super) missing_artifact_refs: &'a [String],
+    pub(super) postprocess: &'a [FuzzArtifactPostprocessOutput],
 }
 
 pub(super) fn persist_fuzz_run_evidence(
@@ -861,6 +734,27 @@ pub(super) fn persist_fuzz_run_evidence(
             }),
         )?;
     }
+    let generic_postprocess_outputs = input
+        .postprocess
+        .iter()
+        .map(
+            |output| homeboy::core::artifacts::ArtifactPostprocessOutput {
+                id: output.id.clone(),
+                helper: output.helper.clone(),
+                action: output.action.clone(),
+                input: output.input.clone(),
+                output: output.output.clone(),
+                required: output.required,
+                exit_code: output.exit_code,
+                success: output.success,
+                stdout: output.stdout.clone(),
+                stderr: output.stderr.clone(),
+                error: output.error.clone(),
+                artifacts: output.artifacts.clone(),
+            },
+        )
+        .collect::<Vec<_>>();
+    record_artifact_postprocess_outputs(&store, &run_id, &generic_postprocess_outputs)?;
     Ok(Some(run))
 }
 

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -54,6 +54,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
+            postprocess: &[],
         })
         .expect("persist fuzz run")
         .expect("run record");
@@ -126,6 +127,7 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
             expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
+            postprocess: &[],
         })
         .expect("persist fuzz run")
         .expect("run record");
@@ -173,6 +175,7 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
             expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
+            postprocess: &[],
         })
         .expect("persist fuzz run");
 
@@ -516,6 +519,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
                 "fuzz results schema must be homeboy/fuzz-campaign/v1, got unsupported/fuzz-result/v1",
             ),
             missing_artifact_refs: &[],
+            postprocess: &[],
         })
         .expect("persist fuzz run")
         .expect("run record");

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -178,6 +178,8 @@ pub struct FuzzArtifactPostprocessOutput {
     pub stdout: String,
     pub stderr: String,
     pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<homeboy::core::artifacts::ArtifactPostprocessProducedArtifact>,
 }
 
 #[derive(Serialize)]

--- a/src/core/artifact_postprocess.rs
+++ b/src/core/artifact_postprocess.rs
@@ -1,0 +1,402 @@
+//! Generic artifact postprocess runner binding.
+//!
+//! Workload owners declare helper/action/input/output/parameters. Core executes
+//! that portable contract and records produced files without interpreting the
+//! workload domain.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Serialize;
+
+use crate::core::artifact_manifest::{self, ARTIFACT_MANIFEST_FILE};
+use crate::core::error::{Error, Result};
+use crate::core::observation::{ArtifactRecord, ObservationStore};
+use crate::core::rig::ArtifactPostprocessSpec;
+
+#[derive(Clone)]
+pub struct ArtifactPostprocessContext<'a> {
+    pub artifact_root: &'a Path,
+    pub input_root: Option<&'a Path>,
+    pub path_expander: Option<&'a dyn Fn(&str) -> PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactPostprocessOutput {
+    pub id: String,
+    pub helper: String,
+    pub action: String,
+    pub input: Option<String>,
+    pub output: String,
+    pub required: bool,
+    pub exit_code: Option<i32>,
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<ArtifactPostprocessProducedArtifact>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactPostprocessProducedArtifact {
+    pub kind: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "serde_json_value_is_empty")]
+    pub metadata: serde_json::Value,
+}
+
+pub fn run_artifact_postprocess_steps(
+    steps: &[ArtifactPostprocessSpec],
+    context: &ArtifactPostprocessContext<'_>,
+) -> Result<Vec<ArtifactPostprocessOutput>> {
+    if steps.is_empty() {
+        return Ok(Vec::new());
+    }
+    std::fs::create_dir_all(context.artifact_root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(context.artifact_root.display().to_string()),
+        )
+    })?;
+
+    steps
+        .iter()
+        .enumerate()
+        .map(|(index, step)| run_artifact_postprocess_step(index, step, context))
+        .collect()
+}
+
+pub fn record_artifact_postprocess_outputs(
+    store: &ObservationStore,
+    run_id: &str,
+    outputs: &[ArtifactPostprocessOutput],
+) -> Result<Vec<ArtifactRecord>> {
+    let mut records = Vec::new();
+    for output in outputs {
+        for artifact in &output.artifacts {
+            let mut metadata = artifact.metadata.clone();
+            merge_object_metadata(
+                &mut metadata,
+                serde_json::json!({
+                    "source": "homeboy.artifact-postprocess",
+                    "postprocess_id": output.id,
+                    "helper": output.helper,
+                    "action": output.action,
+                    "declared_artifact_id": artifact.id,
+                    "declared_path": artifact.path,
+                }),
+            );
+            records.push(store.record_artifact_with_metadata(
+                run_id,
+                &artifact.kind,
+                &artifact.path,
+                metadata,
+            )?);
+        }
+    }
+    Ok(records)
+}
+
+fn run_artifact_postprocess_step(
+    index: usize,
+    step: &ArtifactPostprocessSpec,
+    context: &ArtifactPostprocessContext<'_>,
+) -> Result<ArtifactPostprocessOutput> {
+    let id = step
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("artifact-postprocess-{}", index + 1));
+    let output_path = resolve_postprocess_output_path(&step.output, context.artifact_root)?;
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+        })?;
+    }
+    let input = step
+        .input
+        .as_ref()
+        .map(|input| expand_postprocess_path(input, context));
+    let parameters_json = serde_json::to_string(&step.parameters).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize artifact postprocess parameters".to_string()),
+        )
+    })?;
+
+    let mut command = Command::new(&step.helper);
+    command.arg(&step.action);
+    if let Some(args) = step
+        .parameters
+        .get("args")
+        .and_then(serde_json::Value::as_array)
+    {
+        for arg in args.iter().filter_map(serde_json::Value::as_str) {
+            command.arg(arg);
+        }
+    }
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_ID", &id);
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_HELPER", &step.helper);
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_ACTION", &step.action);
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT", &output_path);
+    command.env(
+        "HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT",
+        context.artifact_root,
+    );
+    command.env("HOMEBOY_ARTIFACT_POSTPROCESS_PARAMETERS", parameters_json);
+    if let Some(input) = input.as_ref() {
+        command.env("HOMEBOY_ARTIFACT_POSTPROCESS_INPUT", input);
+    }
+    for (key, value) in &step.parameters {
+        if let Some(value) = postprocess_parameter_env_value(value) {
+            command.env(postprocess_parameter_env_key(key), value);
+        }
+    }
+
+    let output = command.output().map_err(|error| {
+        Error::internal_io(
+            format!(
+                "failed to run artifact postprocess `{}` via helper `{}`: {error}",
+                id, step.helper
+            ),
+            Some("homeboy.artifact-postprocess".to_string()),
+        )
+    })?;
+    let exit_code = output.status.code();
+    let mut success = output.status.success();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let mut error = (!success).then(|| {
+        format!(
+            "artifact postprocess `{id}` failed with exit code {}",
+            exit_code
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        )
+    });
+    if success && step.required && !output_path.exists() {
+        success = false;
+        error = Some(format!(
+            "artifact postprocess `{id}` did not create required output {}",
+            output_path.display()
+        ));
+    }
+
+    let artifacts = if output_path.exists() {
+        produced_artifacts(&id, &output_path)?
+    } else {
+        Vec::new()
+    };
+
+    Ok(ArtifactPostprocessOutput {
+        id,
+        helper: step.helper.clone(),
+        action: step.action.clone(),
+        input: input.map(|path| path.to_string_lossy().to_string()),
+        output: output_path.to_string_lossy().to_string(),
+        required: step.required,
+        exit_code,
+        success,
+        stdout,
+        stderr,
+        error,
+        artifacts,
+    })
+}
+
+fn produced_artifacts(
+    postprocess_id: &str,
+    output_path: &Path,
+) -> Result<Vec<ArtifactPostprocessProducedArtifact>> {
+    if output_path.is_file() {
+        return Ok(vec![ArtifactPostprocessProducedArtifact {
+            kind: postprocess_id.to_string(),
+            path: output_path.to_string_lossy().to_string(),
+            id: None,
+            metadata: serde_json::json!({}),
+        }]);
+    }
+
+    if !output_path.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let manifest_path = output_path.join(ARTIFACT_MANIFEST_FILE);
+    let manifest = if manifest_path.is_file() {
+        artifact_manifest::read_manifest_from_root(output_path)?
+    } else {
+        artifact_manifest::manifest_for_existing_files(output_path)?
+    };
+    manifest
+        .validate_under(output_path)?
+        .into_iter()
+        .map(|validated| {
+            let mut metadata = validated.entry.metadata.clone();
+            merge_object_metadata(
+                &mut metadata,
+                serde_json::json!({
+                    "manifest_path": manifest_path.is_file().then(|| manifest_path.to_string_lossy().to_string()),
+                    "manifest_entry_path": validated.entry.path,
+                    "role": validated.entry.role,
+                    "label": validated.entry.label,
+                    "semantic_key": validated.entry.semantic_key,
+                }),
+            );
+            Ok(ArtifactPostprocessProducedArtifact {
+                kind: validated.entry.kind,
+                path: validated.absolute_path.to_string_lossy().to_string(),
+                id: validated.entry.id,
+                metadata,
+            })
+        })
+        .collect()
+}
+
+fn resolve_postprocess_output_path(output: &str, artifact_root: &Path) -> Result<PathBuf> {
+    let trimmed = output.trim();
+    let path = Path::new(trimmed);
+    if trimmed.is_empty() || path.is_absolute() || trimmed.starts_with("..") {
+        return Err(Error::validation_invalid_argument(
+            "artifact_postprocess.output",
+            "artifact postprocess output must be a non-empty path relative to HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT",
+            Some(output.to_string()),
+            None,
+        ));
+    }
+    let resolved = artifact_root.join(path);
+    if !resolved.starts_with(artifact_root) {
+        return Err(Error::validation_invalid_argument(
+            "artifact_postprocess.output",
+            "artifact postprocess output must stay within HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT",
+            Some(output.to_string()),
+            None,
+        ));
+    }
+    Ok(resolved)
+}
+
+fn expand_postprocess_path(value: &str, context: &ArtifactPostprocessContext<'_>) -> PathBuf {
+    let expanded = match context.input_root {
+        Some(input_root) => value.replace("${run.input}", &input_root.to_string_lossy()),
+        None => value.to_string(),
+    }
+    .replace("${run.artifacts}", &context.artifact_root.to_string_lossy());
+    context
+        .path_expander
+        .map(|expand| expand(&expanded))
+        .unwrap_or_else(|| PathBuf::from(expanded))
+}
+
+fn postprocess_parameter_env_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn postprocess_parameter_env_key(key: &str) -> String {
+    let suffix: String = key
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("HOMEBOY_ARTIFACT_POSTPROCESS_PARAM_{suffix}")
+}
+
+fn merge_object_metadata(target: &mut serde_json::Value, extra: serde_json::Value) {
+    if !target.is_object() {
+        *target = serde_json::json!({});
+    }
+    let Some(target) = target.as_object_mut() else {
+        return;
+    };
+    let Some(extra) = extra.as_object() else {
+        return;
+    };
+    for (key, value) in extra {
+        if !value.is_null() {
+            target.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn serde_json_value_is_empty(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Null => true,
+        serde_json::Value::Object(map) => map.is_empty(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::observation::NewRunRecord;
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn executes_generic_helper_and_records_manifest_artifact() {
+        with_isolated_home(|home| {
+            let input = home.path().join("input.json");
+            std::fs::write(&input, r#"{"status":"ok"}"#).expect("input");
+            let artifact_root = home.path().join("artifacts");
+            let step: ArtifactPostprocessSpec = serde_json::from_value(serde_json::json!({
+                "id": "generic-report",
+                "helper": "sh",
+                "action": "-c",
+                "input": "${run.input}",
+                "output": "reports",
+                "parameters": {
+                    "args": ["mkdir -p \"$HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT\" && cp \"$HOMEBOY_ARTIFACT_POSTPROCESS_INPUT\" \"$HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT/report.json\" && printf '{\"schema\":\"homeboy/artifact-manifest/v1\",\"artifacts\":[{\"id\":\"report\",\"path\":\"report.json\",\"kind\":\"proof_report\",\"metadata\":{\"custom\":\"yes\"}}]}\n' > \"$HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT/homeboy-artifact-manifest.json\""]
+                }
+            }))
+            .expect("step");
+
+            let outputs = run_artifact_postprocess_steps(
+                &[step],
+                &ArtifactPostprocessContext {
+                    artifact_root: &artifact_root,
+                    input_root: Some(&input),
+                    path_expander: None,
+                },
+            )
+            .expect("postprocess");
+
+            assert_eq!(outputs.len(), 1);
+            assert!(outputs[0].success);
+            assert_eq!(outputs[0].artifacts.len(), 1);
+            assert_eq!(outputs[0].artifacts[0].kind, "proof_report");
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(
+                    NewRunRecord::builder("test")
+                        .command("test")
+                        .metadata(serde_json::json!({}))
+                        .build(),
+                )
+                .expect("run");
+            let records =
+                record_artifact_postprocess_outputs(&store, &run.id, &outputs).expect("records");
+
+            assert_eq!(records.len(), 1);
+            assert_eq!(records[0].kind, "proof_report");
+            assert_eq!(
+                records[0].metadata_json["source"],
+                "homeboy.artifact-postprocess"
+            );
+            assert_eq!(records[0].metadata_json["postprocess_id"], "generic-report");
+            assert_eq!(records[0].metadata_json["declared_artifact_id"], "report");
+            assert_eq!(records[0].metadata_json["custom"], "yes");
+        });
+    }
+}

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -31,6 +31,10 @@ pub use super::artifact_origin::{
     inspect, serve, status, status_with_command, ArtifactOriginInspect, ArtifactOriginServeSpec,
     ArtifactOriginStatus,
 };
+pub use super::artifact_postprocess::{
+    record_artifact_postprocess_outputs, run_artifact_postprocess_steps,
+    ArtifactPostprocessContext, ArtifactPostprocessOutput, ArtifactPostprocessProducedArtifact,
+};
 pub use super::artifact_preview::{html_preview_entrypoints, ArtifactPreviewEntrypoint};
 pub use super::artifact_ref::{
     ArtifactReference, METADATA_ONLY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -52,6 +52,7 @@ pub mod artifact_links;
 pub mod artifact_manifest;
 pub(crate) mod artifact_metadata;
 pub mod artifact_origin;
+pub mod artifact_postprocess;
 pub mod artifact_preview;
 pub mod artifact_ref;
 pub mod browser_evidence;


### PR DESCRIPTION
## Summary
- Add a product-neutral artifact postprocess runner for declared helper/action/input/output/parameters steps.
- Collect produced output files from a declared artifact manifest, or from existing files under the output directory, and register them in run artifacts.
- Route fuzz workload postprocess execution through the generic binding while preserving existing fuzz path substitutions.

## Tests
- cargo test artifact_postprocess --lib
- cargo test fuzz --lib
- cargo test artifact_index --lib
- cargo test runs_artifacts --lib
- cargo test evidence --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the generic runner binding, adapting fuzz postprocess wiring, adding tests, and running local verification.