### PR TITLE
Add typed fuzz evidence refs

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use homeboy::core::artifact_ref::EvidenceRef;
 use homeboy::core::artifacts::{
     record_artifact_postprocess_outputs, run_artifact_postprocess_steps, ArtifactPostprocessContext,
 };
@@ -16,7 +17,8 @@ use uuid::Uuid;
 
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,
-    fuzz_result_envelope_from_campaign, gate_status, persist_fuzz_run_result_envelope,
+    fuzz_result_envelope_evidence_ref, fuzz_result_envelope_from_campaign, gate_status,
+    persist_fuzz_run_result_envelope,
 };
 use super::types::{
     FuzzArtifactPostprocessOutput, FuzzCampaignContract, FuzzExecutionOutput, FuzzRunArgs,
@@ -133,7 +135,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         .map(|workload| workload.id.clone())
         .or_else(|| args.workload_id.clone());
     let workload_path = selected_workload.and_then(|workload| workload.manifest_path.clone());
-    persist_fuzz_run_evidence(FuzzRunEvidenceInput {
+    let persisted_evidence = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
         run_id: args.run_id.as_deref(),
         component_id: &ctx.component_id,
         rig_id: rig_id.as_deref(),
@@ -192,6 +194,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
             results,
             campaign_contract,
             runner_contract: default_runner_contract(),
+            evidence_refs: persisted_evidence.evidence_refs,
             evidence_followups,
         },
         exit_code,
@@ -659,9 +662,15 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) postprocess: &'a [FuzzArtifactPostprocessOutput],
 }
 
+pub(super) struct FuzzRunPersistedEvidence {
+    #[allow(dead_code)]
+    pub(super) run: Option<RunRecord>,
+    pub(super) evidence_refs: Vec<EvidenceRef>,
+}
+
 pub(super) fn persist_fuzz_run_evidence(
     input: FuzzRunEvidenceInput<'_>,
-) -> homeboy::core::Result<Option<RunRecord>> {
+) -> homeboy::core::Result<FuzzRunPersistedEvidence> {
     let run_id = input
         .run_id
         .filter(|run_id| !run_id.trim().is_empty())
@@ -714,6 +723,7 @@ pub(super) fn persist_fuzz_run_evidence(
         metadata_json: metadata,
     };
     store.upsert_imported_run(&run)?;
+    let mut evidence_refs = Vec::new();
     if input.results_path.is_file() {
         store.record_artifact(&run_id, "fuzz_results", input.results_path)?;
     }
@@ -721,7 +731,9 @@ pub(super) fn persist_fuzz_run_evidence(
         let mut envelope =
             fuzz_result_envelope_from_campaign(input.args, input.component_id, campaign, None)?;
         envelope.status = gate_status(&evaluate_fuzz_gates(campaign));
-        persist_fuzz_run_result_envelope(Some(&run_id), &envelope)?;
+        if let Some(artifact) = persist_fuzz_run_result_envelope(Some(&run_id), &envelope)? {
+            evidence_refs.push(fuzz_result_envelope_evidence_ref(&artifact));
+        }
     }
     if input.artifacts_dir.is_dir() {
         store.record_directory_artifact_with_metadata(
@@ -755,7 +767,10 @@ pub(super) fn persist_fuzz_run_evidence(
         )
         .collect::<Vec<_>>();
     record_artifact_postprocess_outputs(&store, &run_id, &generic_postprocess_outputs)?;
-    Ok(Some(run))
+    Ok(FuzzRunPersistedEvidence {
+        run: Some(run),
+        evidence_refs,
+    })
 }
 
 #[derive(Default)]

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
+use homeboy::core::artifact_ref::EvidenceRef;
 use homeboy::core::engine::execution_context;
 use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
@@ -14,7 +15,8 @@ use uuid::Uuid;
 
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,
-    fuzz_result_envelope_from_campaign, gate_status, persist_fuzz_run_result_envelope,
+    fuzz_result_envelope_evidence_ref, fuzz_result_envelope_from_campaign, gate_status,
+    persist_fuzz_run_result_envelope,
 };
 use super::types::{
     FuzzArtifactPostprocessOutput, FuzzCampaignContract, FuzzExecutionOutput, FuzzRunArgs,
@@ -131,7 +133,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         .map(|workload| workload.id.clone())
         .or_else(|| args.workload_id.clone());
     let workload_path = selected_workload.and_then(|workload| workload.manifest_path.clone());
-    persist_fuzz_run_evidence(FuzzRunEvidenceInput {
+    let persisted_evidence = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
         run_id: args.run_id.as_deref(),
         component_id: &ctx.component_id,
         rig_id: rig_id.as_deref(),
@@ -189,6 +191,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
             results,
             campaign_contract,
             runner_contract: default_runner_contract(),
+            evidence_refs: persisted_evidence.evidence_refs,
             evidence_followups,
         },
         exit_code,
@@ -786,9 +789,15 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) missing_artifact_refs: &'a [String],
 }
 
+pub(super) struct FuzzRunPersistedEvidence {
+    #[allow(dead_code)]
+    pub(super) run: Option<RunRecord>,
+    pub(super) evidence_refs: Vec<EvidenceRef>,
+}
+
 pub(super) fn persist_fuzz_run_evidence(
     input: FuzzRunEvidenceInput<'_>,
-) -> homeboy::core::Result<Option<RunRecord>> {
+) -> homeboy::core::Result<FuzzRunPersistedEvidence> {
     let run_id = input
         .run_id
         .filter(|run_id| !run_id.trim().is_empty())
@@ -841,6 +850,7 @@ pub(super) fn persist_fuzz_run_evidence(
         metadata_json: metadata,
     };
     store.upsert_imported_run(&run)?;
+    let mut evidence_refs = Vec::new();
     if input.results_path.is_file() {
         store.record_artifact(&run_id, "fuzz_results", input.results_path)?;
     }
@@ -848,7 +858,9 @@ pub(super) fn persist_fuzz_run_evidence(
         let mut envelope =
             fuzz_result_envelope_from_campaign(input.args, input.component_id, campaign, None)?;
         envelope.status = gate_status(&evaluate_fuzz_gates(campaign));
-        persist_fuzz_run_result_envelope(Some(&run_id), &envelope)?;
+        if let Some(artifact) = persist_fuzz_run_result_envelope(Some(&run_id), &envelope)? {
+            evidence_refs.push(fuzz_result_envelope_evidence_ref(&artifact));
+        }
     }
     if input.artifacts_dir.is_dir() {
         store.record_directory_artifact_with_metadata(
@@ -861,7 +873,10 @@ pub(super) fn persist_fuzz_run_evidence(
             }),
         )?;
     }
-    Ok(Some(run))
+    Ok(FuzzRunPersistedEvidence {
+        run: Some(run),
+        evidence_refs,
+    })
 }
 
 #[derive(Default)]

--- a/src/commands/fuzz/inspect.rs
+++ b/src/commands/fuzz/inspect.rs
@@ -1,8 +1,10 @@
 use std::path::Path;
 
+use homeboy::core::artifact_ref::{artifact_uri, EvidenceRef};
 use homeboy::core::fuzz::inspect_fuzz_result_envelope_artifact;
 use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore};
 
+use super::report::fuzz_result_envelope_evidence_ref;
 use super::types::{FuzzInspectArgs, FuzzInspectCandidate, FuzzInspectOutput};
 
 /// Artifact kinds that hold the raw fuzz runner input/result pair, ordered by
@@ -49,6 +51,7 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             kind: artifact.kind.clone(),
             artifact_type: artifact.artifact_type.clone(),
             path: artifact.path.clone(),
+            canonical_ref: artifact_uri(&artifact.run_id, &artifact.id),
             exists: Path::new(&artifact.path).is_file(),
         })
         .collect::<Vec<_>>();
@@ -67,6 +70,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             artifact_id: String::new(),
             artifact_kind: String::new(),
             artifact_path: String::new(),
+            canonical_ref: None,
+            evidence_ref: None,
             fetch_command: None,
             result: None,
             raw: None,
@@ -88,6 +93,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
         "homeboy runs artifact get {} {} -o <path>",
         selected.run_id, selected.id
     ));
+    let canonical_ref = Some(artifact_uri(&selected.run_id, &selected.id));
+    let evidence_ref = fuzz_inspect_evidence_ref(selected);
 
     let path = Path::new(&selected.path);
     if !path.is_file() {
@@ -99,6 +106,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             artifact_id: selected.id.clone(),
             artifact_kind: selected.kind.clone(),
             artifact_path: selected.path.clone(),
+            canonical_ref,
+            evidence_ref,
             fetch_command: fetch_command.clone(),
             result: None,
             raw: None,
@@ -143,6 +152,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
         artifact_id: selected.id.clone(),
         artifact_kind: selected.kind.clone(),
         artifact_path: selected.path.clone(),
+        canonical_ref,
+        evidence_ref,
         fetch_command,
         result,
         raw,
@@ -159,6 +170,12 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             ),
         ],
     })
+}
+
+fn fuzz_inspect_evidence_ref(artifact: &ArtifactRecord) -> Option<EvidenceRef> {
+    inspect_fuzz_result_envelope_artifact(artifact)
+        .is_some()
+        .then(|| fuzz_result_envelope_evidence_ref(artifact))
 }
 
 #[cfg(test)]
@@ -351,6 +368,15 @@ mod tests {
 
             assert_eq!(output.status, "ok");
             assert_eq!(output.artifact_kind, "runner-output");
+            assert!(output
+                .canonical_ref
+                .as_deref()
+                .expect("canonical ref")
+                .starts_with("homeboy://run/"));
+            let evidence_ref = output.evidence_ref.as_ref().expect("evidence ref");
+            assert_eq!(evidence_ref.role.as_deref(), Some("result"));
+            assert_eq!(evidence_ref.semantic_key.as_deref(), Some("fuzz.result_envelope"));
+            assert_eq!(Some(evidence_ref.canonical_uri()), output.canonical_ref.as_deref());
             assert_eq!(
                 output
                     .result

--- a/src/commands/fuzz/inspect.rs
+++ b/src/commands/fuzz/inspect.rs
@@ -1,8 +1,10 @@
 use std::path::Path;
 
+use homeboy::core::artifact_ref::{artifact_uri, EvidenceRef};
 use homeboy::core::fuzz::inspect_fuzz_result_envelope_artifact;
 use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore};
 
+use super::report::fuzz_result_envelope_evidence_ref;
 use super::types::{FuzzInspectArgs, FuzzInspectCandidate, FuzzInspectOutput};
 
 /// Artifact kinds that hold the raw fuzz runner input/result pair, ordered by
@@ -49,6 +51,7 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             kind: artifact.kind.clone(),
             artifact_type: artifact.artifact_type.clone(),
             path: artifact.path.clone(),
+            canonical_ref: artifact_uri(&artifact.run_id, &artifact.id),
             exists: Path::new(&artifact.path).is_file(),
         })
         .collect::<Vec<_>>();
@@ -67,6 +70,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             artifact_id: String::new(),
             artifact_kind: String::new(),
             artifact_path: String::new(),
+            canonical_ref: None,
+            evidence_ref: None,
             fetch_command: None,
             result: None,
             raw: None,
@@ -88,6 +93,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
         "homeboy runs artifact get {} {} -o <path>",
         selected.run_id, selected.id
     ));
+    let canonical_ref = Some(artifact_uri(&selected.run_id, &selected.id));
+    let evidence_ref = fuzz_inspect_evidence_ref(selected);
 
     let path = Path::new(&selected.path);
     if !path.is_file() {
@@ -99,6 +106,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             artifact_id: selected.id.clone(),
             artifact_kind: selected.kind.clone(),
             artifact_path: selected.path.clone(),
+            canonical_ref,
+            evidence_ref,
             fetch_command: fetch_command.clone(),
             result: None,
             raw: None,
@@ -143,6 +152,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
         artifact_id: selected.id.clone(),
         artifact_kind: selected.kind.clone(),
         artifact_path: selected.path.clone(),
+        canonical_ref,
+        evidence_ref,
         fetch_command,
         result,
         raw,
@@ -159,6 +170,12 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             ),
         ],
     })
+}
+
+fn fuzz_inspect_evidence_ref(artifact: &ArtifactRecord) -> Option<EvidenceRef> {
+    inspect_fuzz_result_envelope_artifact(artifact)
+        .is_some()
+        .then(|| fuzz_result_envelope_evidence_ref(artifact))
 }
 
 #[cfg(test)]
@@ -351,6 +368,21 @@ mod tests {
 
             assert_eq!(output.status, "ok");
             assert_eq!(output.artifact_kind, "runner-output");
+            assert!(output
+                .canonical_ref
+                .as_deref()
+                .expect("canonical ref")
+                .starts_with("homeboy://run/"));
+            let evidence_ref = output.evidence_ref.as_ref().expect("evidence ref");
+            assert_eq!(evidence_ref.role.as_deref(), Some("result"));
+            assert_eq!(
+                evidence_ref.semantic_key.as_deref(),
+                Some("fuzz.result_envelope")
+            );
+            assert_eq!(
+                Some(evidence_ref.canonical_uri()),
+                output.canonical_ref.as_deref()
+            );
             assert_eq!(
                 output
                     .result

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use homeboy::core::artifact_ref::EvidenceRef;
 use homeboy::core::fuzz::{
     default_fuzz_gates, fuzz_gate_profile_contract, parse_fuzz_case_log_file,
     parse_fuzz_observation_set_value, parse_fuzz_results_file, parse_fuzz_target_inventory_file,
@@ -73,11 +74,16 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
             homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
         })?;
     }
-    persist_fuzz_result_envelope(
+    let persisted_envelope = persist_fuzz_result_envelope(
         args.run.run_id.as_deref(),
         &envelope,
         args.output_envelope.as_deref(),
     )?;
+    let evidence_refs = persisted_envelope
+        .as_ref()
+        .map(fuzz_result_envelope_evidence_ref)
+        .into_iter()
+        .collect();
 
     Ok(FuzzReportOutput {
         command: "fuzz.report".to_string(),
@@ -86,6 +92,7 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
         envelope_file: args
             .output_envelope
             .map(|path| path.to_string_lossy().to_string()),
+        evidence_refs,
         envelope,
         coverage_completeness,
         performance_hotspots,
@@ -214,20 +221,29 @@ fn record_fuzz_result_envelope_artifact(
     envelope: &FuzzResultEnvelope,
     source: &str,
 ) -> homeboy::core::Result<Option<ArtifactRecord>> {
+    let metadata = serde_json::json!({
+        "schema": envelope.schema.as_str(),
+        "envelope_id": envelope.id.as_str(),
+        "status": envelope.status.as_str(),
+        "campaign_id": envelope.campaign.as_ref().map(|campaign| campaign.id.as_str()),
+        "source": source,
+        "evidence": {
+            "role": "result",
+            "semantic_key": "fuzz.result_envelope",
+        },
+    });
     store
-        .record_artifact_with_metadata(
-            run_id,
-            FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
-            path,
-            serde_json::json!({
-                "schema": envelope.schema.as_str(),
-                "envelope_id": envelope.id.as_str(),
-                "status": envelope.status.as_str(),
-                "campaign_id": envelope.campaign.as_ref().map(|campaign| campaign.id.as_str()),
-                "source": source,
-            }),
-        )
+        .record_artifact_with_metadata(run_id, FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND, path, metadata)
         .map(Some)
+}
+
+pub(super) fn fuzz_result_envelope_evidence_ref(artifact: &ArtifactRecord) -> EvidenceRef {
+    EvidenceRef::for_artifact(
+        artifact,
+        "Fuzz result envelope",
+        Some("result".to_string()),
+        Some("fuzz.result_envelope".to_string()),
+    )
 }
 
 fn fuzz_result_envelope_json(envelope: &FuzzResultEnvelope) -> homeboy::core::Result<String> {

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use homeboy::core::artifact_ref::EvidenceRef;
 use homeboy::core::fuzz::{
     default_fuzz_gates, fuzz_gate_profile_contract, parse_fuzz_case_log_file,
     parse_fuzz_results_file, parse_fuzz_target_inventory_file, FuzzCampaign, FuzzExecutionRequest,
@@ -69,11 +70,16 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
             homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
         })?;
     }
-    persist_fuzz_result_envelope(
+    let persisted_envelope = persist_fuzz_result_envelope(
         args.run.run_id.as_deref(),
         &envelope,
         args.output_envelope.as_deref(),
     )?;
+    let evidence_refs = persisted_envelope
+        .as_ref()
+        .map(fuzz_result_envelope_evidence_ref)
+        .into_iter()
+        .collect();
 
     Ok(FuzzReportOutput {
         command: "fuzz.report".to_string(),
@@ -82,6 +88,7 @@ pub(super) fn run_report(args: FuzzReportArgs) -> homeboy::core::Result<FuzzRepo
         envelope_file: args
             .output_envelope
             .map(|path| path.to_string_lossy().to_string()),
+        evidence_refs,
         envelope,
         coverage_completeness,
         performance_hotspots,
@@ -204,20 +211,29 @@ fn record_fuzz_result_envelope_artifact(
     envelope: &FuzzResultEnvelope,
     source: &str,
 ) -> homeboy::core::Result<Option<ArtifactRecord>> {
+    let metadata = serde_json::json!({
+        "schema": envelope.schema.as_str(),
+        "envelope_id": envelope.id.as_str(),
+        "status": envelope.status.as_str(),
+        "campaign_id": envelope.campaign.as_ref().map(|campaign| campaign.id.as_str()),
+        "source": source,
+        "evidence": {
+            "role": "result",
+            "semantic_key": "fuzz.result_envelope",
+        },
+    });
     store
-        .record_artifact_with_metadata(
-            run_id,
-            FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
-            path,
-            serde_json::json!({
-                "schema": envelope.schema.as_str(),
-                "envelope_id": envelope.id.as_str(),
-                "status": envelope.status.as_str(),
-                "campaign_id": envelope.campaign.as_ref().map(|campaign| campaign.id.as_str()),
-                "source": source,
-            }),
-        )
+        .record_artifact_with_metadata(run_id, FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND, path, metadata)
         .map(Some)
+}
+
+pub(super) fn fuzz_result_envelope_evidence_ref(artifact: &ArtifactRecord) -> EvidenceRef {
+    EvidenceRef::for_artifact(
+        artifact,
+        "Fuzz result envelope",
+        Some("result".to_string()),
+        Some("fuzz.result_envelope".to_string()),
+    )
 }
 
 fn fuzz_result_envelope_json(envelope: &FuzzResultEnvelope) -> homeboy::core::Result<String> {

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -56,6 +56,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             missing_artifact_refs: &[],
         })
         .expect("persist fuzz run")
+        .run
         .expect("run record");
 
         assert_eq!(persisted.id, "proof-1");
@@ -128,6 +129,7 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
             missing_artifact_refs: &[],
         })
         .expect("persist fuzz run")
+        .run
         .expect("run record");
 
         assert!(persisted.id.starts_with("fuzz-"));
@@ -157,7 +159,7 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
         .expect("results file");
         std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
 
-        persist_fuzz_run_evidence(FuzzRunEvidenceInput {
+        let persisted = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
             run_id: args.run_id.as_deref(),
             component_id: "component-a",
             rig_id: args.rig.as_deref(),
@@ -176,6 +178,17 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
         })
         .expect("persist fuzz run");
 
+        assert_eq!(persisted.evidence_refs.len(), 1);
+        assert_eq!(
+            persisted.evidence_refs[0].canonical_uri(),
+            persisted.evidence_refs[0]
+                .artifact
+                .as_ref()
+                .expect("artifact ref")
+                .canonical_uri()
+        );
+        assert_eq!(persisted.evidence_refs[0].role.as_deref(), Some("result"));
+
         let store = ObservationStore::open_initialized().expect("store");
         let artifacts = store.list_artifacts("proof-envelope").expect("artifacts");
         let envelope_artifact = artifacts
@@ -190,6 +203,10 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
         assert_eq!(
             envelope_artifact.metadata_json["source"],
             "homeboy fuzz run"
+        );
+        assert_eq!(
+            envelope_artifact.metadata_json["evidence"]["semantic_key"],
+            "fuzz.result_envelope"
         );
 
         let envelope: serde_json::Value = serde_json::from_str(
@@ -518,6 +535,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             missing_artifact_refs: &[],
         })
         .expect("persist fuzz run")
+        .run
         .expect("run record");
 
         assert_eq!(persisted.id, "proof-bad-results");

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -57,6 +57,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             postprocess: &[],
         })
         .expect("persist fuzz run")
+        .run
         .expect("run record");
 
         assert_eq!(persisted.id, "proof-1");
@@ -130,6 +131,7 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
             postprocess: &[],
         })
         .expect("persist fuzz run")
+        .run
         .expect("run record");
 
         assert!(persisted.id.starts_with("fuzz-"));
@@ -159,7 +161,7 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
         .expect("results file");
         std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
 
-        persist_fuzz_run_evidence(FuzzRunEvidenceInput {
+        let persisted = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
             run_id: args.run_id.as_deref(),
             component_id: "component-a",
             rig_id: args.rig.as_deref(),
@@ -179,6 +181,17 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
         })
         .expect("persist fuzz run");
 
+        assert_eq!(persisted.evidence_refs.len(), 1);
+        assert_eq!(
+            persisted.evidence_refs[0].canonical_uri(),
+            persisted.evidence_refs[0]
+                .artifact
+                .as_ref()
+                .expect("artifact ref")
+                .canonical_uri()
+        );
+        assert_eq!(persisted.evidence_refs[0].role.as_deref(), Some("result"));
+
         let store = ObservationStore::open_initialized().expect("store");
         let artifacts = store.list_artifacts("proof-envelope").expect("artifacts");
         let envelope_artifact = artifacts
@@ -193,6 +206,10 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
         assert_eq!(
             envelope_artifact.metadata_json["source"],
             "homeboy fuzz run"
+        );
+        assert_eq!(
+            envelope_artifact.metadata_json["evidence"]["semantic_key"],
+            "fuzz.result_envelope"
         );
 
         let envelope: serde_json::Value = serde_json::from_str(
@@ -522,6 +539,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             postprocess: &[],
         })
         .expect("persist fuzz run")
+        .run
         .expect("run record");
 
         assert_eq!(persisted.id, "proof-bad-results");

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -414,6 +414,7 @@ fn fuzz_output_contract_has_stable_variant_discriminators() {
             extension_script_required: true,
             env: Vec::new(),
         },
+        evidence_refs: Vec::new(),
         evidence_followups: Vec::new(),
     }))
     .unwrap();

--- a/src/commands/fuzz/tests/report_tests.rs
+++ b/src/commands/fuzz/tests/report_tests.rs
@@ -58,6 +58,7 @@ fn fuzz_output_contract_includes_results_file_and_parsed_campaign() {
             extension_script_required: true,
             env: vec!["HOMEBOY_FUZZ_RESULTS_FILE"],
         },
+        evidence_refs: Vec::new(),
         evidence_followups: Vec::new(),
     }))
     .unwrap();

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use std::collections::BTreeMap;
 
+use homeboy::core::artifact_ref::EvidenceRef;
 use homeboy::core::fuzz::{
     FuzzCampaign, FuzzExecutionRequest, FuzzGate, FuzzHotspotSet, FuzzReplayMetadata,
     FuzzRequiredArtifact, FuzzResultEnvelope, FuzzTargetInventory,
@@ -75,6 +76,10 @@ pub struct FuzzInspectOutput {
     pub artifact_id: String,
     pub artifact_kind: String,
     pub artifact_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_ref: Option<EvidenceRef>,
     pub fetch_command: Option<String>,
     /// Parsed JSON body when the raw result is valid JSON; otherwise null.
     pub result: Option<serde_json::Value>,
@@ -94,6 +99,7 @@ pub struct FuzzInspectCandidate {
     pub kind: String,
     pub artifact_type: String,
     pub path: String,
+    pub canonical_ref: String,
     pub exists: bool,
 }
 
@@ -162,6 +168,7 @@ pub struct FuzzRunOutput {
     pub results: Option<FuzzCampaign>,
     pub campaign_contract: FuzzCampaignContract,
     pub runner_contract: FuzzRunnerContract,
+    pub evidence_refs: Vec<EvidenceRef>,
     pub evidence_followups: Vec<String>,
 }
 
@@ -215,6 +222,7 @@ pub struct FuzzReportOutput {
     pub status: String,
     pub results_file: String,
     pub envelope_file: Option<String>,
+    pub evidence_refs: Vec<EvidenceRef>,
     pub envelope: FuzzResultEnvelope,
     pub coverage_completeness: FuzzCoverageCompletenessOutput,
     pub performance_hotspots: PerformanceHotspotSummary,

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use std::collections::BTreeMap;
 
+use homeboy::core::artifact_ref::EvidenceRef;
 use homeboy::core::fuzz::{
     FuzzCampaign, FuzzExecutionRequest, FuzzGate, FuzzReplayMetadata, FuzzRequiredArtifact,
     FuzzResultEnvelope, FuzzTargetInventory,
@@ -75,6 +76,10 @@ pub struct FuzzInspectOutput {
     pub artifact_id: String,
     pub artifact_kind: String,
     pub artifact_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_ref: Option<EvidenceRef>,
     pub fetch_command: Option<String>,
     /// Parsed JSON body when the raw result is valid JSON; otherwise null.
     pub result: Option<serde_json::Value>,
@@ -94,6 +99,7 @@ pub struct FuzzInspectCandidate {
     pub kind: String,
     pub artifact_type: String,
     pub path: String,
+    pub canonical_ref: String,
     pub exists: bool,
 }
 
@@ -162,6 +168,7 @@ pub struct FuzzRunOutput {
     pub results: Option<FuzzCampaign>,
     pub campaign_contract: FuzzCampaignContract,
     pub runner_contract: FuzzRunnerContract,
+    pub evidence_refs: Vec<EvidenceRef>,
     pub evidence_followups: Vec<String>,
 }
 
@@ -211,6 +218,7 @@ pub struct FuzzReportOutput {
     pub status: String,
     pub results_file: String,
     pub envelope_file: Option<String>,
+    pub evidence_refs: Vec<EvidenceRef>,
     pub envelope: FuzzResultEnvelope,
     pub coverage_completeness: FuzzCoverageCompletenessOutput,
     pub performance_hotspots: PerformanceHotspotSummary,

--- a/src/core/artifact_ref.rs
+++ b/src/core/artifact_ref.rs
@@ -2,11 +2,12 @@ use std::fmt;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::core::execution_contract::decode_uri_component;
+use crate::core::execution_contract::{decode_uri_component, encode_uri_component};
 use crate::core::observation::ArtifactRecord;
 
 pub const ARTIFACT_REF_SCHEMA: &str = "homeboy/artifact-ref/v1";
 pub const EVIDENCE_REF_SCHEMA: &str = "homeboy/evidence-ref/v1";
+pub const HOMEBOY_REF_SCHEME: &str = "homeboy://";
 pub const RUNNER_ARTIFACT_REF_SCHEME: &str = "runner-artifact://";
 pub const METADATA_ONLY_REF_SCHEME: &str = "metadata-only:";
 
@@ -129,6 +130,10 @@ impl ArtifactRef {
             semantic_key: None,
         }
     }
+
+    pub fn canonical_uri(&self) -> String {
+        artifact_uri(&self.run_id, &self.id)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -161,6 +166,39 @@ impl EvidenceRef {
             artifact: None,
         }
     }
+
+    pub fn for_artifact(
+        artifact: &ArtifactRecord,
+        label: impl Into<String>,
+        role: Option<String>,
+        semantic_key: Option<String>,
+    ) -> Self {
+        let mut artifact_ref = ArtifactRef::from_record(artifact);
+        artifact_ref.role = role.clone();
+        artifact_ref.semantic_key = semantic_key.clone();
+        Self {
+            schema: EVIDENCE_REF_SCHEMA.to_string(),
+            kind: "artifact".to_string(),
+            target: artifact_ref.canonical_uri(),
+            label: label.into(),
+            role,
+            semantic_key,
+            artifact: Some(artifact_ref),
+        }
+    }
+
+    pub fn canonical_uri(&self) -> &str {
+        &self.target
+    }
+}
+
+pub fn artifact_uri(run_id: &str, artifact_id: &str) -> String {
+    format!(
+        "{}run/{}/artifact/{}",
+        HOMEBOY_REF_SCHEME,
+        encode_uri_component(run_id),
+        encode_uri_component(artifact_id)
+    )
 }
 
 #[cfg(test)]
@@ -236,6 +274,43 @@ mod tests {
                 "role": "summary",
                 "semantic_key": "run.summary"
             })
+        );
+    }
+
+    #[test]
+    fn evidence_ref_builds_generic_homeboy_artifact_uri() {
+        let artifact = ArtifactRecord {
+            id: "artifact 1".to_string(),
+            run_id: "run/1".to_string(),
+            kind: "fuzz_result_envelope".to_string(),
+            artifact_type: "file".to_string(),
+            path: "summary.json".to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: None,
+            metadata_json: json!({}),
+            created_at: "2026-06-27T00:00:00Z".to_string(),
+        };
+
+        let reference = EvidenceRef::for_artifact(
+            &artifact,
+            "Fuzz result envelope",
+            Some("result".to_string()),
+            Some("fuzz.result_envelope".to_string()),
+        );
+
+        assert_eq!(
+            reference.canonical_uri(),
+            "homeboy://run/run%2F1/artifact/artifact%201"
+        );
+        assert_eq!(reference.kind, "artifact");
+        assert_eq!(
+            reference.artifact.expect("artifact").role.as_deref(),
+            Some("result")
         );
     }
 }


### PR DESCRIPTION
## Summary
- add generic `homeboy://run/<run-id>/artifact/<artifact-id>` artifact URIs to the typed artifact/evidence ref primitives
- surface fuzz result envelope evidence refs from `fuzz run`, `fuzz report`, and `fuzz inspect`
- annotate persisted fuzz result envelope artifacts with generic evidence metadata

Closes #6651

## Tests
- `cargo test artifact_ref`
- `cargo test fuzz::tests`
- `cargo test` (fails in unrelated existing tests; 6,181 passed, 11 failed)
- `cargo clippy --all-targets -- -D warnings` (blocked by existing lint debt outside this slice)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing typed evidence refs, fuzz wiring, tests, and PR preparation.
