### PR TITLE
Add lab runner execution envelope output

### DIFF
--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -5,8 +5,9 @@ Plan Lab-oriented runner workflows without executing the workload.
 ## Refresh Plan
 
 `homeboy lab refresh-plan` validates the runner configuration and local source
-inputs for a matrix-style refresh, then prints the existing Homeboy commands to
-run next:
+inputs for a matrix-style refresh, then prints a canonical
+`homeboy/runner-execution-envelope/v1` plus the existing Homeboy commands to run
+next:
 
 ```sh
 homeboy lab refresh-plan \
@@ -29,6 +30,12 @@ The plan is intentionally read-only. It composes the current primitives:
 - `homeboy runner exec <runner> --artifact <path> --summary <path> ...`
 - `homeboy runs artifacts <run-id>`
 - `homeboy runs evidence <run-id>`
+
+The `execution_envelope` field is the durable lab handoff shape. It includes the
+planned lifecycle gates, cleanup/retry guidance, artifact declarations derived
+from `--output` and `--summary`, an explicit secret env plan, result refs, and
+runner/workspace/runtime metadata. The older `handoff` object remains operator
+context for the same plan instead of the only contract.
 
 Use the artifact loop guide for the evidence shape expected from runner and
 matrix workflows: `docs/operators/artifact-loop-runner-matrix.md`.

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -151,12 +151,19 @@ It does not upgrade binaries, rewrite runner paths, or refresh Sample Runtime ca
 those remain explicit operator actions because they can be expensive or depend
 on environment-specific paths.
 
+`runner status` includes generic `selected_lab_runner.executable_requirements`
+from declared agent runtime manifests. Each entry names the runtime, requirement
+id, non-secret env vars, candidate executable names/paths, optional version
+arguments, and install hint. Homeboy owns the generic semantics: runtimes declare
+the executable they need; runner diagnostics expose the declaration without
+embedding product-specific checks in core.
+
 `runner status` also includes `selected_lab_runner.wp_codebox_runtime` for the
-runner job environment. That block shows the configured WP Codebox CLI, managed
-cache source/binary, expected `@automattic/wp-codebox-playground` and
-`@automattic/wp-codebox-core` paths, a runner-side probe command that prints the
-exact effective runtime and git SHA, and warnings when configured paths mix a
-stale checkout with the managed cache.
+legacy runner job environment projection. That block shows the configured WP
+Codebox CLI, managed cache source/binary, expected
+`@automattic/wp-codebox-playground` and `@automattic/wp-codebox-core` paths, a
+runner-side probe command that prints the exact effective runtime and git SHA,
+and warnings when configured paths mix a stale checkout with the managed cache.
 
 ### `refresh-homeboy`
 

--- a/docs/operators/artifact-loop-runner-matrix.md
+++ b/docs/operators/artifact-loop-runner-matrix.md
@@ -38,7 +38,10 @@ workspace and pass a stable run id:
 
 Use `homeboy lab refresh-plan` first when you want a read-only preflight that
 checks the runner/workspace/source inputs and prints the next `runner doctor`,
-`runner workspace sync`, `runner exec`, and `runs evidence` commands.
+`runner workspace sync`, `runner exec`, and `runs evidence` commands. Its
+`execution_envelope` field is the canonical runner handoff contract for the
+planned lifecycle, cleanup guidance, secret env plan, artifact declarations, and
+result refs.
 
 ```sh
 run_id="review-static-html-$(date -u +%Y%m%dT%H%M%SZ)"

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -3,8 +3,13 @@ use std::path::Path;
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
+use homeboy::core::runner_execution_envelope::{
+    RunnerExecutionArtifactDeclaration, RunnerExecutionEnvelope, RunnerExecutionLifecyclePolicy,
+    RunnerExecutionResultRefs,
+};
 use homeboy::core::runners;
 use homeboy::core::runners::RunnerWorkspaceSyncMode;
+use homeboy::core::secret_env_plan::SecretEnvPlan;
 
 use super::{CmdResult, GlobalArgs};
 
@@ -63,13 +68,14 @@ pub struct RefreshPlanArgs {
     command: Vec<String>,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, PartialEq)]
 pub struct LabRefreshPlanOutput {
     pub variant: &'static str,
     pub runner: String,
     pub workspace: String,
     pub runner_cwd: String,
     pub run_id: String,
+    pub execution_envelope: RunnerExecutionEnvelope,
     pub handoff: LabRefreshPlanHandoff,
     pub checks: Vec<LabRefreshPlanCheck>,
     pub evidence_paths: Vec<LabRefreshPlanEvidencePath>,
@@ -215,6 +221,7 @@ fn refresh_plan(args: RefreshPlanArgs) -> homeboy::core::Result<LabRefreshPlanOu
         "docs/commands/lab.md".to_string(),
     ];
     let handoff = handoff_plan(&args, &evidence_paths, &next_commands, &docs);
+    let execution_envelope = execution_envelope_plan(&args, &handoff, &evidence_paths, &docs);
 
     Ok(LabRefreshPlanOutput {
         variant: "refresh_plan",
@@ -222,6 +229,7 @@ fn refresh_plan(args: RefreshPlanArgs) -> homeboy::core::Result<LabRefreshPlanOu
         workspace: args.workspace,
         runner_cwd: args.runner_cwd,
         run_id: args.run_id,
+        execution_envelope,
         handoff,
         checks,
         evidence_paths,
@@ -392,6 +400,78 @@ fn handoff_plan(
             unknown: false,
         },
     }
+}
+
+fn execution_envelope_plan(
+    args: &RefreshPlanArgs,
+    handoff: &LabRefreshPlanHandoff,
+    evidence_paths: &[LabRefreshPlanEvidencePath],
+    docs: &[String],
+) -> RunnerExecutionEnvelope {
+    RunnerExecutionEnvelope::planned(&handoff.handoff_id, "lab_refresh_plan")
+        .with_source_ref(&args.run_id)
+        .with_secret_env(SecretEnvPlan::default())
+        .with_lifecycle_policy(RunnerExecutionLifecyclePolicy {
+            cleanup: Some("operator_retains_runner_workspace_until_evidence_verified".to_string()),
+            retry: Some("rerun_refresh_plan_then_runner_exec".to_string()),
+            gates: vec![
+                "runner_doctor_lab_offload".to_string(),
+                "workspace_sync".to_string(),
+                "evidence_inspection".to_string(),
+            ],
+        })
+        .with_artifact_declarations(artifact_declarations(evidence_paths))
+        .with_result_refs(RunnerExecutionResultRefs {
+            plan_id: Some(handoff.handoff_id.clone()),
+            run_id: Some(args.run_id.clone()),
+            ..RunnerExecutionResultRefs::default()
+        })
+        .with_metadata(serde_json::json!({
+            "runner": {
+                "id": args.runner,
+            },
+            "workspace": {
+                "controller_path": args.workspace,
+                "runner_cwd": args.runner_cwd,
+                "sync_mode": args.sync_mode,
+            },
+            "runtime": {
+                "command": args.command,
+            },
+            "docs": docs,
+        }))
+}
+
+fn artifact_declarations(
+    evidence_paths: &[LabRefreshPlanEvidencePath],
+) -> Vec<RunnerExecutionArtifactDeclaration> {
+    evidence_paths
+        .iter()
+        .enumerate()
+        .map(
+            |(index, evidence_path)| RunnerExecutionArtifactDeclaration {
+                name: artifact_name(evidence_path, index),
+                artifact_type: Some(evidence_path.kind.to_string()),
+                artifact_schema: None,
+                path: Some(evidence_path.path.clone()),
+                required: true,
+                description: Some(format!(
+                    "{} produced by the lab refresh workload",
+                    evidence_path.kind
+                )),
+                metadata: serde_json::Value::Null,
+            },
+        )
+        .collect()
+}
+
+fn artifact_name(evidence_path: &LabRefreshPlanEvidencePath, index: usize) -> String {
+    Path::new(&evidence_path.path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("{}-{}", evidence_path.kind, index + 1))
 }
 
 fn next_commands(
@@ -576,6 +656,82 @@ mod tests {
         assert_eq!(handoff.evidence.paths, evidence);
         assert_eq!(handoff.result.status, "planned");
         assert_eq!(handoff.inspection.commands.len(), 2);
+    }
+
+    #[test]
+    fn refresh_plan_compiles_canonical_execution_envelope() {
+        let args = RefreshPlanArgs {
+            runner: "lab-runner".to_string(),
+            workspace: "/workspace/source".to_string(),
+            runner_cwd: "/runner/source".to_string(),
+            run_id: "matrix-refresh-1".to_string(),
+            outputs: vec!["artifacts/matrix".to_string()],
+            summaries: vec!["artifacts/matrix/matrix-summary.json".to_string()],
+            sources: Vec::new(),
+            fixtures: Vec::new(),
+            sync_mode: "snapshot".to_string(),
+            command: vec!["cargo".to_string(), "test".to_string()],
+        };
+        let evidence = evidence_paths(&args);
+        let commands = next_commands(&args, &evidence);
+        let docs = vec!["docs/commands/lab.md".to_string()];
+        let handoff = handoff_plan(&args, &evidence, &commands, &docs);
+
+        let envelope = execution_envelope_plan(&args, &handoff, &evidence, &docs);
+
+        assert_eq!(
+            envelope.schema,
+            homeboy::core::runner_execution_envelope::RUNNER_EXECUTION_ENVELOPE_SCHEMA
+        );
+        assert_eq!(
+            envelope.envelope_id,
+            "lab-refresh:lab-runner:matrix-refresh-1"
+        );
+        assert_eq!(envelope.source.kind, "lab_refresh_plan");
+        assert_eq!(envelope.source.ref_id.as_deref(), Some("matrix-refresh-1"));
+        assert_eq!(
+            envelope.result_refs.plan_id.as_deref(),
+            Some(handoff.handoff_id.as_str())
+        );
+        assert_eq!(
+            envelope.result_refs.run_id.as_deref(),
+            Some("matrix-refresh-1")
+        );
+        assert_eq!(
+            envelope.lifecycle_policy.cleanup.as_deref(),
+            Some("operator_retains_runner_workspace_until_evidence_verified")
+        );
+        assert_eq!(
+            envelope
+                .secret_env
+                .expect("secret env plan")
+                .secret_env_names(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            envelope
+                .artifact_declarations
+                .iter()
+                .map(|artifact| (
+                    artifact.name.as_str(),
+                    artifact.artifact_type.as_deref(),
+                    artifact.path.as_deref()
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("matrix", Some("artifact"), Some("artifacts/matrix")),
+                (
+                    "matrix-summary.json",
+                    Some("summary"),
+                    Some("artifacts/matrix/matrix-summary.json")
+                ),
+            ]
+        );
+        assert_eq!(envelope.metadata["runner"]["id"], "lab-runner");
+        assert_eq!(
+            envelope.metadata["runtime"]["command"],
+            serde_json::json!(["cargo", "test"])
+        );
     }
 
     #[test]

--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeMap;
 
 use homeboy::core::agent_runtime_manifest::{
     discover_agent_runtime_catalog, AgentRuntimeDiagnosticFollowup,
-    AgentRuntimeDiagnosticsContract, AgentRuntimeRuntimeDiagnosticDeclaration,
-    AgentRuntimeSourceConsistencyDiagnostic, AgentRuntimeToolDiagnosticDeclaration,
+    AgentRuntimeDiagnosticsContract, AgentRuntimeExecutableRequirement,
+    AgentRuntimeRuntimeDiagnosticDeclaration, AgentRuntimeSourceConsistencyDiagnostic,
+    AgentRuntimeToolDiagnosticDeclaration,
 };
 use homeboy::core::runners::{
     self as runner, RunnerActiveJobState, RunnerAvailability, RunnerSession, RunnerStatusReport,
@@ -13,10 +14,11 @@ use homeboy::core::runners::{
 use super::super::CmdResult;
 use super::types::{
     LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
-    RunnerConnectionOutput, RunnerExtra, RunnerHomeboyBinaryRole, RunnerOperatorCommand,
-    RunnerOutput, RunnerRuntimeDiagnostics, RunnerRuntimePackageDiagnostics, RunnerToolDiagnostics,
-    RunnerWorkflowBinaryGuidance, WpCodeboxPackageRuntimeOutput, WpCodeboxProbeValue,
-    WpCodeboxRuntimeDiagnostic, WpCodeboxRuntimeOutput,
+    RunnerConnectionOutput, RunnerExecutableRequirementDiagnostics, RunnerExtra,
+    RunnerHomeboyBinaryRole, RunnerOperatorCommand, RunnerOutput, RunnerRuntimeDiagnostics,
+    RunnerRuntimePackageDiagnostics, RunnerToolDiagnostics, RunnerWorkflowBinaryGuidance,
+    WpCodeboxPackageRuntimeOutput, WpCodeboxProbeValue, WpCodeboxRuntimeDiagnostic,
+    WpCodeboxRuntimeOutput,
 };
 
 pub(super) fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
@@ -96,11 +98,13 @@ fn selected_lab_runner_status(
         .collect::<BTreeMap<_, _>>();
     let runtime_diagnostics =
         declared_runtime_diagnostics_collection(Some(runner_id), &effective_env);
+    let executable_requirements = declared_executable_requirement_diagnostics_collection();
     Ok(Some(LabSelectedRunnerOutput {
         runner_id: runner_id.to_string(),
         kind: format!("{:?}", runner_config.kind).to_ascii_lowercase(),
         configured_executable: configured_executable.clone(),
         runner_homeboy: lab_runner_homeboy_output(runner_id, &configured_executable, &status),
+        executable_requirements,
         wp_codebox_runtime: runtime_diagnostics
             .iter()
             .find(|diagnostics| diagnostics.legacy_output.as_deref() == Some("wp_codebox_runtime"))
@@ -120,6 +124,40 @@ fn selected_lab_runner_status(
         ),
         status,
     }))
+}
+
+pub(super) fn declared_executable_requirement_diagnostics_collection(
+) -> Vec<RunnerExecutableRequirementDiagnostics> {
+    discover_agent_runtime_catalog()
+        .manifests
+        .into_iter()
+        .flat_map(|manifest| {
+            let runtime = manifest.id;
+            manifest
+                .materialization
+                .executable_requirements
+                .into_iter()
+                .map(move |requirement| {
+                    declared_executable_requirement_diagnostics(&runtime, requirement)
+                })
+        })
+        .collect()
+}
+
+pub(super) fn declared_executable_requirement_diagnostics(
+    runtime: &str,
+    requirement: AgentRuntimeExecutableRequirement,
+) -> RunnerExecutableRequirementDiagnostics {
+    RunnerExecutableRequirementDiagnostics {
+        runtime: runtime.to_string(),
+        id: requirement.id,
+        label: requirement.label,
+        env: requirement.env,
+        candidates: requirement.candidates,
+        version_command: requirement.version_command,
+        install_hint: requirement.install_hint,
+        diagnostic_state: "declared",
+    }
 }
 
 pub(super) fn lab_runner_homeboy_output(

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
 use homeboy::core::agent_runtime_manifest::{
-    AgentRuntimePackageDiagnosticDeclaration, AgentRuntimeProbeDiagnosticDeclaration,
-    AgentRuntimeRuntimeDiagnosticDeclaration, AgentRuntimeSourceConsistencyDiagnostic,
-    AgentRuntimeToolDiagnosticDeclaration,
+    AgentRuntimeExecutableRequirement, AgentRuntimePackageDiagnosticDeclaration,
+    AgentRuntimeProbeDiagnosticDeclaration, AgentRuntimeRuntimeDiagnosticDeclaration,
+    AgentRuntimeSourceConsistencyDiagnostic, AgentRuntimeToolDiagnosticDeclaration,
 };
 use homeboy::core::api_jobs::{JobEvent, JobStatus};
 use homeboy::core::runner::{RunnerActiveJobSource, RunnerActiveJobState};
@@ -11,10 +11,10 @@ use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, 
 
 use super::super::jobs::format_job_event;
 use super::super::status::{
-    declared_run_followups_for_legacy, declared_runtime_diagnostics,
-    declared_runtime_diagnostics_for_legacy, declared_runtime_source_diagnostics,
-    declared_tool_diagnostics, lab_runner_homeboy_output, runner_artifact_feature_diagnostics,
-    runner_status_operator_commands,
+    declared_executable_requirement_diagnostics, declared_run_followups_for_legacy,
+    declared_runtime_diagnostics, declared_runtime_diagnostics_for_legacy,
+    declared_runtime_source_diagnostics, declared_tool_diagnostics, lab_runner_homeboy_output,
+    runner_artifact_feature_diagnostics, runner_status_operator_commands,
 };
 
 #[test]
@@ -329,6 +329,33 @@ fn unknown_runtime_declaration_does_not_emit_wp_specific_guidance() {
     assert!(serialized.contains("other-runtime"));
     assert!(!serialized.contains("wp-codebox"));
     assert!(!serialized.contains("HOMEBOY_WP_CODEBOX"));
+}
+
+#[test]
+fn declared_executable_requirement_status_projection_is_generic() {
+    let diagnostics = declared_executable_requirement_diagnostics(
+        "example-runtime",
+        AgentRuntimeExecutableRequirement {
+            id: "example-runtime-cli".to_string(),
+            label: Some("Example Runtime CLI".to_string()),
+            env: vec!["EXAMPLE_RUNTIME_BIN".to_string()],
+            candidates: vec!["example-runtime".to_string()],
+            version_command: vec!["--version".to_string()],
+            install_hint: Some("Install example-runtime on the runner PATH.".to_string()),
+            extra: BTreeMap::new(),
+        },
+    );
+
+    assert_eq!(diagnostics.runtime, "example-runtime");
+    assert_eq!(diagnostics.id, "example-runtime-cli");
+    assert_eq!(diagnostics.label.as_deref(), Some("Example Runtime CLI"));
+    assert_eq!(diagnostics.env, vec!["EXAMPLE_RUNTIME_BIN".to_string()]);
+    assert_eq!(diagnostics.candidates, vec!["example-runtime".to_string()]);
+    assert_eq!(diagnostics.version_command, vec!["--version".to_string()]);
+    assert_eq!(diagnostics.diagnostic_state, "declared");
+    let serialized = serde_json::to_string(&diagnostics).expect("serialize diagnostics");
+    assert!(serialized.contains("example-runtime"));
+    assert!(!serialized.contains("wp-codebox"));
 }
 
 #[test]

--- a/src/commands/runner/types.rs
+++ b/src/commands/runner/types.rs
@@ -61,6 +61,8 @@ pub struct LabSelectedRunnerOutput {
     pub configured_executable: String,
     pub runner_homeboy: LabRunnerHomeboyOutput,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub executable_requirements: Vec<RunnerExecutableRequirementDiagnostics>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub runtime_diagnostics: Vec<RunnerRuntimeDiagnostics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wp_codebox_runtime: Option<WpCodeboxRuntimeOutput>,
@@ -135,6 +137,23 @@ pub struct RunnerToolDiagnostics {
     pub managed_cache_binary: String,
     pub effective_binary_rule: String,
     pub diagnostic_command: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerExecutableRequirementDiagnostics {
+    pub runtime: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub version_command: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_hint: Option<String>,
+    pub diagnostic_state: &'static str,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/core/agent_task_controller_service/artifacts.rs
+++ b/src/core/agent_task_controller_service/artifacts.rs
@@ -192,11 +192,7 @@ mod required_artifacts {
         }
     }
 
-    pub fn execution_contains_artifact(
-        value: &Value,
-        artifact_id: &str,
-        kind: &str,
-    ) -> bool {
+    pub fn execution_contains_artifact(value: &Value, artifact_id: &str, kind: &str) -> bool {
         match value {
             Value::Object(object) => {
                 let id_matches = object
@@ -341,10 +337,7 @@ mod hydration {
             .cloned()
     }
 
-    pub fn artifact_from_history_payload(
-        payload: &Value,
-        artifact_id: &str,
-    ) -> Option<Value> {
+    pub fn artifact_from_history_payload(payload: &Value, artifact_id: &str) -> Option<Value> {
         let result = payload.get("execution")?.get("result")?;
         if let Some(artifact) = artifact_from_outputs(result, artifact_id) {
             return Some(artifact);
@@ -468,10 +461,7 @@ pub(super) use hydration::*;
 mod runtime_bundle {
     use super::*;
 
-    pub fn execution_with_request_workflow_artifacts(
-        execution: Value,
-        request: &Value,
-    ) -> Value {
+    pub fn execution_with_request_workflow_artifacts(execution: Value, request: &Value) -> Value {
         let runtime_bundle = runtime_bundle_evidence(request, &execution);
         let workflow_artifacts = request
             .get("workflow_artifacts")
@@ -954,9 +944,7 @@ mod evidence_index {
         })
     }
 
-    pub fn artifact_ref_from_artifact(
-        artifact: &AgentTaskArtifact,
-    ) -> AgentTaskLoopArtifactRef {
+    pub fn artifact_ref_from_artifact(artifact: &AgentTaskArtifact) -> AgentTaskLoopArtifactRef {
         AgentTaskLoopArtifactRef {
             uri: artifact
                 .url
@@ -1120,10 +1108,7 @@ mod runtime_evidence {
         .then_some(evidence)
     }
 
-    pub fn collect_runtime_evidence(
-        value: &Value,
-        evidence: &mut ControllerActionRuntimeEvidence,
-    ) {
+    pub fn collect_runtime_evidence(value: &Value, evidence: &mut ControllerActionRuntimeEvidence) {
         match value {
             Value::Object(object) => {
                 set_first_string(
@@ -1224,9 +1209,7 @@ mod runtime_evidence {
         }
     }
 
-    pub fn first_pending_action_id(
-        record: &AgentTaskLoopControllerRecord,
-    ) -> Option<String> {
+    pub fn first_pending_action_id(record: &AgentTaskLoopControllerRecord) -> Option<String> {
         if !matches!(record.state, AgentTaskLoopControllerState::Running) {
             return None;
         }

--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -181,7 +181,10 @@ mod run_lookup {
         missing_run_guidance_for_runner_ids(run_id, connected)
     }
 
-    pub(crate) fn missing_run_guidance_for_runner_ids(run_id: &str, runner_ids: Vec<String>) -> Vec<String> {
+    pub(crate) fn missing_run_guidance_for_runner_ids(
+        run_id: &str,
+        runner_ids: Vec<String>,
+    ) -> Vec<String> {
         let mut hints = Vec::new();
         for runner_id in runner_ids {
             hints.push(format!(

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -122,6 +122,65 @@ pub struct RunnerExecutionResultRefs {
 }
 
 impl RunnerExecutionEnvelope {
+    pub fn planned(envelope_id: impl Into<String>, source_kind: impl Into<String>) -> Self {
+        let envelope_id = envelope_id.into();
+
+        Self {
+            schema: RUNNER_EXECUTION_ENVELOPE_SCHEMA.to_string(),
+            envelope_id: envelope_id.clone(),
+            source: RunnerExecutionSource {
+                kind: source_kind.into(),
+                ref_id: Some(envelope_id),
+            },
+            runner_workload: None,
+            agent_task: None,
+            secret_env: None,
+            lifecycle_policy: RunnerExecutionLifecyclePolicy::default(),
+            artifact_declarations: Vec::new(),
+            loop_policy: RunnerExecutionLoopPolicy::default(),
+            mutation_policy: RunnerExecutionMutationPolicy::default(),
+            publication_intent: RunnerExecutionPublicationIntent::default(),
+            result_refs: RunnerExecutionResultRefs::default(),
+            metadata: Value::Null,
+        }
+    }
+
+    pub fn with_source_ref(mut self, ref_id: impl Into<String>) -> Self {
+        self.source.ref_id = Some(ref_id.into());
+        self
+    }
+
+    pub fn with_secret_env(mut self, secret_env: SecretEnvPlan) -> Self {
+        self.secret_env = Some(secret_env);
+        self
+    }
+
+    pub fn with_lifecycle_policy(
+        mut self,
+        lifecycle_policy: RunnerExecutionLifecyclePolicy,
+    ) -> Self {
+        self.lifecycle_policy = lifecycle_policy;
+        self
+    }
+
+    pub fn with_artifact_declarations(
+        mut self,
+        artifact_declarations: impl IntoIterator<Item = RunnerExecutionArtifactDeclaration>,
+    ) -> Self {
+        self.artifact_declarations = artifact_declarations.into_iter().collect();
+        self
+    }
+
+    pub fn with_result_refs(mut self, result_refs: RunnerExecutionResultRefs) -> Self {
+        self.result_refs = result_refs;
+        self
+    }
+
+    pub fn with_metadata(mut self, metadata: Value) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
     pub fn from_runner_workload(workload: RunnerWorkload) -> Self {
         let mutation_policy = RunnerExecutionMutationPolicy {
             capture_patch: workload.mutation_policy.capture_patch,


### PR DESCRIPTION
## Summary
- emit canonical execution_envelope from lab refresh-plan
- add RunnerExecutionEnvelope builder helpers and lab artifact/result metadata
- surface generic executable requirement diagnostics in runner status

## Testing
- cargo check
- cargo test runner_execution_envelope
- cargo test commands::lab
- cargo test commands::runner::tests::status --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, code changes, test updates, and verification.