### PR TITLE
Clean up stale command contract tests

### DIFF
--- a/docs/commands/runtime.md
+++ b/docs/commands/runtime.md
@@ -1,6 +1,6 @@
 # `homeboy runtime`
 
-Inspect Homeboy core-owned runtime assets used by extension runners.
+Inspect Homeboy core-bundled runtime assets used by extension runners.
 
 ## Runtime Packages
 
@@ -12,18 +12,18 @@ Provider commands can use `{{runtime_path}}`, and Homeboy injects `HOMEBOY_RUNTI
 
 ## Helper Paths
 
-Resolve the materialized path for a bundled core runtime helper:
+Resolve the materialized path for a core-bundled runtime helper:
 
 ```bash
 homeboy runtime helper path runner-prelude.sh
 homeboy runtime helper path HOMEBOY_RUNTIME_COMMAND_CAPTURE
 ```
 
-The command accepts only known helper filenames or the corresponding injected
-`HOMEBOY_RUNTIME_*` environment variable names. It is not a general runtime
-package browser, extension asset resolver, or arbitrary config-path lookup.
-Normal extension execution receives these paths automatically in the runner
-environment.
+The command accepts only known helper filenames or their corresponding injected
+`HOMEBOY_RUNTIME_*` environment variable names. It resolves the same helper
+assets that Homeboy automatically materializes and injects into extension runner
+environments; it is not a runtime package browser, extension asset resolver, or
+arbitrary config-path lookup.
 
 Use `--plain` when a shell wrapper needs a sourceable path without parsing JSON:
 

--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -11,7 +11,7 @@ pub struct RuntimeArgs {
 
 #[derive(Subcommand)]
 enum RuntimeCommand {
-    /// Resolve core-owned runner runtime helper paths.
+    /// Inspect core-bundled runtime helper paths exposed to extension runners.
     Helper {
         #[command(subcommand)]
         command: RuntimeHelperCommand,
@@ -20,13 +20,13 @@ enum RuntimeCommand {
 
 #[derive(Subcommand)]
 enum RuntimeHelperCommand {
-    /// Print the materialized path for a runtime helper.
+    /// Print the materialized path for a known core runtime helper.
     Path {
         /// Print only the path, for shell bootstrap usage.
         #[arg(long)]
         plain: bool,
 
-        /// Helper filename or HOMEBOY_RUNTIME_* env var name.
+        /// Known helper filename or injected HOMEBOY_RUNTIME_* env var name.
         helper: String,
     },
 }

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -244,7 +244,7 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
                 "start",
                 "preview",
                 "--cwd",
-                "/home/user/Developer/_lab_workspaces/site",
+                "/runner/workspaces/site",
                 "--command",
                 "npm run dev",
             ]),
@@ -267,7 +267,6 @@ fn unsupported_lab_command_cases() -> Vec<Commands> {
         ]),
         parsed_command(&["homeboy", "status"]),
         parsed_command(&["homeboy", "bench", "list"]),
-        parsed_command(&["homeboy", "bench", "history", "homeboy"]),
     ]
 }
 
@@ -656,7 +655,7 @@ fn test_lab_command_contracts_cover_hot_commands() {
         "start",
         "preview",
         "--cwd",
-        "/home/user/Developer/_lab_workspaces/site",
+        "/runner/workspaces/site",
         "--command",
         "npm run dev",
     ])

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -145,63 +145,6 @@ fn agent_task_discovery_help_documents_typed_flags() {
 }
 
 #[test]
-fn deprecated_bench_reader_aliases_are_removed() {
-    assert!(Cli::try_parse_from(["homeboy", "bench", "history", "studio-web"]).is_err());
-    assert!(Cli::try_parse_from([
-        "homeboy",
-        "bench",
-        "distribution",
-        "studio-web",
-        "--field",
-        "results.total_elapsed_ms",
-    ])
-    .is_err());
-    assert!(Cli::try_parse_from([
-        "homeboy",
-        "bench",
-        "compare",
-        "--from-run",
-        "run-a",
-        "--to-run",
-        "run-b",
-    ])
-    .is_err());
-
-    Cli::try_parse_from([
-        "homeboy",
-        "runs",
-        "list",
-        "--kind",
-        "bench",
-        "--component",
-        "studio-web",
-    ])
-    .expect("bench runs list should remain parseable");
-    Cli::try_parse_from([
-        "homeboy",
-        "runs",
-        "distribution",
-        "--kind",
-        "bench",
-        "--component",
-        "studio-web",
-        "--field",
-        "results.total_elapsed_ms",
-    ])
-    .expect("bench runs distribution should remain parseable");
-    Cli::try_parse_from([
-        "homeboy",
-        "runs",
-        "bench-compare",
-        "--from-run",
-        "run-a",
-        "--to-run",
-        "run-b",
-    ])
-    .expect("runs bench-compare should remain parseable");
-}
-
-#[test]
 fn agent_task_tool_bridge_stays_hidden_but_parseable() {
     let surface = current_command_surface();
 
@@ -391,7 +334,7 @@ fn runner_exec_raw_command_parses_before_trailing_command() {
         "homeboy-lab",
         "--raw",
         "--cwd",
-        "/home/user/Developer",
+        "/runner/workspaces",
         "python3",
         "-c",
         "print('hello')",
@@ -409,7 +352,7 @@ fn runner_exec_run_id_parses_before_trailing_command() {
         "--run-id",
         "ssi-fixture-matrix-summary",
         "--cwd",
-        "/home/user/Developer",
+        "/runner/workspaces",
         "homeboy",
         "trace",
         "matrix",
@@ -430,7 +373,7 @@ fn runner_exec_artifact_parses_before_trailing_command() {
         "--artifact",
         "output/report.json",
         "--cwd",
-        "/home/user/Developer",
+        "/runner/workspaces",
         "homeboy",
         "trace",
         "matrix",
@@ -451,7 +394,7 @@ fn runner_exec_artifact_dir_parses_before_trailing_command() {
         "--artifact-dir",
         "output",
         "--cwd",
-        "/home/user/Developer",
+        "/runner/workspaces",
         "homeboy",
         "trace",
         "matrix",

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -364,9 +364,9 @@ fn routes_remote_runner_job_broker_lifecycle() {
         "/runner/jobs",
         Some(serde_json::json!({
             "runner_id": "homeboy-lab",
-            "project_id": "extrachill",
-            "command": ["homeboy", "test", "sample-plugin"],
-            "cwd": "/home/user/Developer/sample-plugin"
+            "project_id": "sample-project",
+            "command": ["homeboy", "test", "sample-component"],
+            "cwd": "/runner/workspaces/sample-component"
         })),
         &store,
     );
@@ -384,7 +384,7 @@ fn routes_remote_runner_job_broker_lifecycle() {
         "/runner/jobs/claim",
         Some(serde_json::json!({
             "runner_id": "homeboy-lab",
-            "project_id": "extrachill",
+            "project_id": "sample-project",
             "lease_ms": 30000
         })),
         &store,
@@ -402,7 +402,7 @@ fn routes_remote_runner_job_broker_lifecycle() {
         .expect("claim expiry");
     assert_eq!(
         claim.body["body"]["claim"]["request"]["command"],
-        serde_json::json!(["homeboy", "test", "sample-plugin"])
+        serde_json::json!(["homeboy", "test", "sample-component"])
     );
 
     let heartbeat = route_with_job_store_and_body(
@@ -471,9 +471,9 @@ fn remote_runner_broker_redacts_secret_env_from_public_surfaces() {
         "/runner/jobs",
         Some(serde_json::json!({
             "runner_id": "homeboy-lab",
-            "project_id": "extrachill",
-            "command": ["homeboy", "test", "sample-plugin"],
-            "cwd": "/home/user/Developer/sample-plugin",
+            "project_id": "sample-project",
+            "command": ["homeboy", "test", "sample-component"],
+            "cwd": "/runner/workspaces/sample-component",
             "env": {
                 "PUBLIC_FLAG": "1",
                 "RUNNER_SECRET_TOKEN": sentinel
@@ -511,7 +511,7 @@ fn remote_runner_broker_redacts_secret_env_from_public_surfaces() {
         "/runner/jobs/claim",
         Some(serde_json::json!({
             "runner_id": "homeboy-lab",
-            "project_id": "extrachill",
+            "project_id": "sample-project",
             "lease_ms": 30000
         })),
         &store,
@@ -531,7 +531,7 @@ fn routes_remote_runner_job_updates_require_live_matching_claim_id() {
         "/runner/jobs",
         Some(serde_json::json!({
             "runner_id": "homeboy-lab",
-            "command": ["homeboy", "test", "sample-plugin"]
+            "command": ["homeboy", "test", "sample-component"]
         })),
         &store,
     );
@@ -577,7 +577,7 @@ fn routes_remote_runner_job_updates_require_live_matching_claim_id() {
         "/runner/jobs",
         Some(serde_json::json!({
             "runner_id": "homeboy-lab",
-            "command": ["homeboy", "test", "sample-plugin"]
+            "command": ["homeboy", "test", "sample-component"]
         })),
         &store,
     );
@@ -631,7 +631,7 @@ fn broker_reconcile_route_owns_expired_reverse_runner_claims() {
         "/runner/jobs",
         Some(serde_json::json!({
             "runner_id": "homeboy-lab",
-            "command": ["homeboy", "test", "sample-plugin"]
+            "command": ["homeboy", "test", "sample-component"]
         })),
         &store,
     );
@@ -711,7 +711,7 @@ fn daemon_http_error_envelope_includes_error_payload() {
 fn routes_remote_runner_session_registration() {
     let _home = HomeGuard::new();
     crate::core::runner::create(
-        r#"{"id":"homeboy-lab","kind":"local","workspace_root":"/home/user/Developer"}"#,
+        r#"{"id":"homeboy-lab","kind":"local","workspace_root":"/runner/workspaces"}"#,
         false,
     )
     .expect("create runner");


### PR DESCRIPTION
## Summary
- remove obsolete deleted bench alias absence coverage
- drop stale lab command contract case
- replace product/local fixture strings with neutral samples
- clarify runtime helper command docs

## Testing
- cargo check
- cargo test --test command_surface_test
- cargo test test_lab_command_contracts_cover_hot_commands

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, cleanup edits, test updates, and verification.