### PR TITLE
refactor(cli): extract shared controller args via command(flatten) (field_patterns)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -662,7 +662,6 @@
         "dead_code::src/core/lab_routing.rs::UnreferencedExport",
         "docs::docs/commands/runtime.md::BrokenDocReference",
         "duplication::src/core/fuzz/types.rs::DuplicateFunction",
-        "field_patterns::src/commands/agent_task/args/controller.rs::RepeatedFieldPattern",
         "field_patterns::src/commands/report/performance_digest.rs::RepeatedFieldPattern",
         "field_patterns::src/commands/runs/gh_actions.rs::RepeatedFieldPattern",
         "field_patterns::src/commands/runs/types.rs::RepeatedFieldPattern",

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -704,15 +704,23 @@ mod agent_task_checkout {
                     agent_task::AgentTaskControllerCommand::FromSpec(
                         agent_task::AgentTaskControllerFromSpecArgs {
                             resume: true,
-                            dispatch_backend,
-                            dispatch_selector,
+                            dispatch:
+                                agent_task::AgentTaskControllerDispatchArgs {
+                                    dispatch_backend,
+                                    dispatch_selector,
+                                    ..
+                                },
                             ..
                         },
                     )
                     | agent_task::AgentTaskControllerCommand::RunFromSpec(
                         agent_task::AgentTaskControllerRunFromSpecArgs {
-                            dispatch_backend,
-                            dispatch_selector,
+                            dispatch:
+                                agent_task::AgentTaskControllerDispatchArgs {
+                                    dispatch_backend,
+                                    dispatch_selector,
+                                    ..
+                                },
                             ..
                         },
                     ),

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -25,7 +25,7 @@ pub mod tool;
 pub use args::{
     ActiveArgs, AgentTaskArgs, AgentTaskAuthArgs, AgentTaskAuthCommand, AgentTaskCommand,
     AgentTaskControllerApplyEventArgs, AgentTaskControllerArgs, AgentTaskControllerCommand,
-    AgentTaskControllerFromSpecArgs, AgentTaskControllerInitArgs,
+    AgentTaskControllerDispatchArgs, AgentTaskControllerFromSpecArgs, AgentTaskControllerInitArgs,
     AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerMaterializeArgs,
     AgentTaskControllerRunArgs, AgentTaskControllerRunFromSpecArgs, AgentTaskControllerRunNextArgs,
     AgentTaskControllerStatusArgs, AgentTaskControllerValidateProofArgs, AgentTaskCookArgs,

--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -44,6 +44,39 @@ pub enum AgentTaskControllerCommand {
     Proof(AgentTaskControllerProofArgs),
 }
 
+/// Shared dispatch overrides for controller subcommands that can spawn dispatch
+/// actions. Flattened into each controller args struct so the CLI surface is
+/// identical to declaring these fields inline.
+#[derive(Args, Debug, Clone)]
+pub struct AgentTaskControllerDispatchArgs {
+    /// Executor backend to use for controller-spawned dispatch actions when the action omits one.
+    #[arg(long = "dispatch-backend", value_name = "BACKEND")]
+    pub dispatch_backend: Option<String>,
+
+    /// Extension-provider selector: the Homeboy executor provider id (e.g.
+    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
+    /// dispatch actions when the action omits one. This is NOT a model or AI
+    /// runtime name (codex, opencode, claude-code) — pass those in
+    /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
+    #[arg(
+        long = "dispatch-selector",
+        visible_alias = "dispatch-provider-id",
+        value_name = "PROVIDER_ID"
+    )]
+    pub dispatch_selector: Option<String>,
+
+    /// Model override to use for controller-spawned dispatch actions when the action omits one.
+    #[arg(long = "dispatch-model", value_name = "MODEL")]
+    pub dispatch_model: Option<String>,
+
+    /// Agent/model provider config (JSON, @file, or -): the nested AI
+    /// runtime/provider/model the selected executor uses for controller-spawned
+    /// dispatch actions when the action omits one. Put AI runtime names like
+    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
+    #[arg(long = "dispatch-provider-config", value_name = "JSON")]
+    pub dispatch_provider_config: Option<String>,
+}
+
 #[derive(Args, Debug)]
 pub struct AgentTaskControllerInitArgs {
     /// Durable loop id. Unsafe path characters are normalized for storage.
@@ -100,32 +133,8 @@ pub struct AgentTaskControllerFromSpecArgs {
     #[arg(long)]
     pub doctor: bool,
 
-    /// Executor backend to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-backend", value_name = "BACKEND")]
-    pub dispatch_backend: Option<String>,
-
-    /// Extension-provider selector: the Homeboy executor provider id (e.g.
-    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
-    /// dispatch actions when the action omits one. This is NOT a model or AI
-    /// runtime name (codex, opencode, claude-code) — pass those in
-    /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
-    #[arg(
-        long = "dispatch-selector",
-        visible_alias = "dispatch-provider-id",
-        value_name = "PROVIDER_ID"
-    )]
-    pub dispatch_selector: Option<String>,
-
-    /// Model override to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-model", value_name = "MODEL")]
-    pub dispatch_model: Option<String>,
-
-    /// Agent/model provider config (JSON, @file, or -): the nested AI
-    /// runtime/provider/model the selected executor uses for controller-spawned
-    /// dispatch actions when the action omits one. Put AI runtime names like
-    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
-    #[arg(long = "dispatch-provider-config", value_name = "JSON")]
-    pub dispatch_provider_config: Option<String>,
+    #[command(flatten)]
+    pub dispatch: AgentTaskControllerDispatchArgs,
 }
 
 #[derive(Args, Debug)]
@@ -169,32 +178,8 @@ pub struct AgentTaskControllerRunFromSpecArgs {
     #[arg(long = "resume-existing", conflicts_with_all = ["replace", "fork", "reconcile_stale"])]
     pub resume_existing: bool,
 
-    /// Executor backend to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-backend", value_name = "BACKEND")]
-    pub dispatch_backend: Option<String>,
-
-    /// Extension-provider selector: the Homeboy executor provider id (e.g.
-    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
-    /// dispatch actions when the action omits one. This is NOT a model or AI
-    /// runtime name (codex, opencode, claude-code) — pass those in
-    /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
-    #[arg(
-        long = "dispatch-selector",
-        visible_alias = "dispatch-provider-id",
-        value_name = "PROVIDER_ID"
-    )]
-    pub dispatch_selector: Option<String>,
-
-    /// Model override to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-model", value_name = "MODEL")]
-    pub dispatch_model: Option<String>,
-
-    /// Agent/model provider config (JSON, @file, or -): the nested AI
-    /// runtime/provider/model the selected executor uses for controller-spawned
-    /// dispatch actions when the action omits one. Put AI runtime names like
-    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
-    #[arg(long = "dispatch-provider-config", value_name = "JSON")]
-    pub dispatch_provider_config: Option<String>,
+    #[command(flatten)]
+    pub dispatch: AgentTaskControllerDispatchArgs,
 }
 
 #[derive(Args, Debug)]
@@ -263,32 +248,8 @@ pub struct AgentTaskControllerRunNextArgs {
     /// Durable loop id returned by `agent-task controller init`.
     pub loop_id: String,
 
-    /// Executor backend to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-backend", value_name = "BACKEND")]
-    pub dispatch_backend: Option<String>,
-
-    /// Extension-provider selector: the Homeboy executor provider id (e.g.
-    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
-    /// dispatch actions when the action omits one. This is NOT a model or AI
-    /// runtime name (codex, opencode, claude-code) — pass those in
-    /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
-    #[arg(
-        long = "dispatch-selector",
-        visible_alias = "dispatch-provider-id",
-        value_name = "PROVIDER_ID"
-    )]
-    pub dispatch_selector: Option<String>,
-
-    /// Model override to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-model", value_name = "MODEL")]
-    pub dispatch_model: Option<String>,
-
-    /// Agent/model provider config (JSON, @file, or -): the nested AI
-    /// runtime/provider/model the selected executor uses for controller-spawned
-    /// dispatch actions when the action omits one. Put AI runtime names like
-    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
-    #[arg(long = "dispatch-provider-config", value_name = "JSON")]
-    pub dispatch_provider_config: Option<String>,
+    #[command(flatten)]
+    pub dispatch: AgentTaskControllerDispatchArgs,
 }
 
 #[derive(Args, Debug)]
@@ -300,32 +261,8 @@ pub struct AgentTaskControllerRunArgs {
     #[arg(long = "action-id", value_name = "ID")]
     pub action_id: String,
 
-    /// Executor backend to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-backend", value_name = "BACKEND")]
-    pub dispatch_backend: Option<String>,
-
-    /// Extension-provider selector: the Homeboy executor provider id (e.g.
-    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
-    /// dispatch actions when the action omits one. This is NOT a model or AI
-    /// runtime name (codex, opencode, claude-code) — pass those in
-    /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
-    #[arg(
-        long = "dispatch-selector",
-        visible_alias = "dispatch-provider-id",
-        value_name = "PROVIDER_ID"
-    )]
-    pub dispatch_selector: Option<String>,
-
-    /// Model override to use for controller-spawned dispatch actions when the action omits one.
-    #[arg(long = "dispatch-model", value_name = "MODEL")]
-    pub dispatch_model: Option<String>,
-
-    /// Agent/model provider config (JSON, @file, or -): the nested AI
-    /// runtime/provider/model the selected executor uses for controller-spawned
-    /// dispatch actions when the action omits one. Put AI runtime names like
-    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
-    #[arg(long = "dispatch-provider-config", value_name = "JSON")]
-    pub dispatch_provider_config: Option<String>,
+    #[command(flatten)]
+    pub dispatch: AgentTaskControllerDispatchArgs,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -193,10 +193,11 @@ pub struct AgentTaskFanoutRunPlanArgs {
 }
 
 pub use controller::{
-    AgentTaskControllerApplyEventArgs, AgentTaskControllerCommand, AgentTaskControllerFromSpecArgs,
-    AgentTaskControllerInitArgs, AgentTaskControllerMarkHumanReadyArgs,
-    AgentTaskControllerMaterializeArgs, AgentTaskControllerPlanArgs, AgentTaskControllerProofArgs,
-    AgentTaskControllerRunArgs, AgentTaskControllerRunFromSpecArgs, AgentTaskControllerRunNextArgs,
+    AgentTaskControllerApplyEventArgs, AgentTaskControllerCommand, AgentTaskControllerDispatchArgs,
+    AgentTaskControllerFromSpecArgs, AgentTaskControllerInitArgs,
+    AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerMaterializeArgs,
+    AgentTaskControllerPlanArgs, AgentTaskControllerProofArgs, AgentTaskControllerRunArgs,
+    AgentTaskControllerRunFromSpecArgs, AgentTaskControllerRunNextArgs,
     AgentTaskControllerStatusArgs, AgentTaskControllerValidateProofArgs,
 };
 

--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -28,9 +28,9 @@ use homeboy::core::agent_tasks::loop_controller::AgentTaskLoopPolicyAction;
 use super::super::CmdResult;
 use super::args::{
     AgentTaskControllerApplyEventArgs, AgentTaskControllerArgs, AgentTaskControllerCommand,
-    AgentTaskControllerFromSpecArgs, AgentTaskControllerMaterializeArgs,
-    AgentTaskControllerPlanArgs, AgentTaskControllerProofArgs, AgentTaskControllerRunArgs,
-    AgentTaskControllerRunFromSpecArgs, AgentTaskControllerRunNextArgs,
+    AgentTaskControllerDispatchArgs, AgentTaskControllerFromSpecArgs,
+    AgentTaskControllerMaterializeArgs, AgentTaskControllerPlanArgs, AgentTaskControllerProofArgs,
+    AgentTaskControllerRunArgs, AgentTaskControllerRunFromSpecArgs, AgentTaskControllerRunNextArgs,
     AgentTaskControllerValidateProofArgs, AgentTaskLoopArgs, AgentTaskLoopCommand,
     AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs, AgentTaskLoopStatusArgs,
 };
@@ -366,10 +366,12 @@ where
         replace: false,
         fork: false,
         resume_existing: false,
-        dispatch_backend: preparation.profile.dispatch_backend.clone(),
-        dispatch_selector: preparation.profile.dispatch_selector.clone(),
-        dispatch_model: None,
-        dispatch_provider_config: preparation.profile.dispatch_provider_config.clone(),
+        dispatch: AgentTaskControllerDispatchArgs {
+            dispatch_backend: preparation.profile.dispatch_backend.clone(),
+            dispatch_selector: preparation.profile.dispatch_selector.clone(),
+            dispatch_model: None,
+            dispatch_provider_config: preparation.profile.dispatch_provider_config.clone(),
+        },
     };
 
     let (run_value, exit_code) = controller_run_from_spec_with_executor(run_args, executor)?;
@@ -959,37 +961,37 @@ struct ControllerDispatchDefaults {
 impl ControllerDispatchDefaults {
     fn from_from_spec_args(args: &AgentTaskControllerFromSpecArgs) -> Self {
         Self {
-            backend: args.dispatch_backend.clone(),
-            selector: args.dispatch_selector.clone(),
-            model: args.dispatch_model.clone(),
-            provider_config: args.dispatch_provider_config.clone(),
+            backend: args.dispatch.dispatch_backend.clone(),
+            selector: args.dispatch.dispatch_selector.clone(),
+            model: args.dispatch.dispatch_model.clone(),
+            provider_config: args.dispatch.dispatch_provider_config.clone(),
         }
     }
 
     fn from_run_from_spec_args(args: &AgentTaskControllerRunFromSpecArgs) -> Self {
         Self {
-            backend: args.dispatch_backend.clone(),
-            selector: args.dispatch_selector.clone(),
-            model: args.dispatch_model.clone(),
-            provider_config: args.dispatch_provider_config.clone(),
+            backend: args.dispatch.dispatch_backend.clone(),
+            selector: args.dispatch.dispatch_selector.clone(),
+            model: args.dispatch.dispatch_model.clone(),
+            provider_config: args.dispatch.dispatch_provider_config.clone(),
         }
     }
 
     fn from_run_next_args(args: &AgentTaskControllerRunNextArgs) -> Self {
         Self {
-            backend: args.dispatch_backend.clone(),
-            selector: args.dispatch_selector.clone(),
-            model: args.dispatch_model.clone(),
-            provider_config: args.dispatch_provider_config.clone(),
+            backend: args.dispatch.dispatch_backend.clone(),
+            selector: args.dispatch.dispatch_selector.clone(),
+            model: args.dispatch.dispatch_model.clone(),
+            provider_config: args.dispatch.dispatch_provider_config.clone(),
         }
     }
 
     fn from_run_args(args: &AgentTaskControllerRunArgs) -> Self {
         Self {
-            backend: args.dispatch_backend.clone(),
-            selector: args.dispatch_selector.clone(),
-            model: args.dispatch_model.clone(),
-            provider_config: args.dispatch_provider_config.clone(),
+            backend: args.dispatch.dispatch_backend.clone(),
+            selector: args.dispatch.dispatch_selector.clone(),
+            model: args.dispatch.dispatch_model.clone(),
+            provider_config: args.dispatch.dispatch_provider_config.clone(),
         }
     }
 

--- a/src/commands/agent_task/tests/controller_run.rs
+++ b/src/commands/agent_task/tests/controller_run.rs
@@ -180,10 +180,12 @@ fn controller_run_from_spec_materializes_runs_bounded_actions_and_returns_status
                 replace: false,
                 fork: false,
                 resume_existing: false,
-                dispatch_backend: Some("fixture".to_string()),
-                dispatch_selector: None,
-                dispatch_model: None,
-                dispatch_provider_config: None,
+                dispatch: AgentTaskControllerDispatchArgs {
+                    dispatch_backend: Some("fixture".to_string()),
+                    dispatch_selector: None,
+                    dispatch_model: None,
+                    dispatch_provider_config: None,
+                },
             },
             ArtifactCapturingExecutor::default(),
         )
@@ -237,12 +239,14 @@ fn controller_run_from_spec_persists_dispatch_defaults_for_generated_actions() {
                 replace: false,
                 fork: false,
                 resume_existing: false,
-                dispatch_backend: Some("fixture".to_string()),
-                dispatch_selector: None,
-                dispatch_model: Some("gpt-test".to_string()),
-                dispatch_provider_config: Some(
-                    r#"{"runtime_wordpress_version":"6.9"}"#.to_string(),
-                ),
+                dispatch: AgentTaskControllerDispatchArgs {
+                    dispatch_backend: Some("fixture".to_string()),
+                    dispatch_selector: None,
+                    dispatch_model: Some("gpt-test".to_string()),
+                    dispatch_provider_config: Some(
+                        r#"{"runtime_wordpress_version":"6.9"}"#.to_string(),
+                    ),
+                },
             },
             CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
@@ -328,17 +332,19 @@ fn controller_run_from_spec_preserves_runtime_execution_and_components() {
                 replace: false,
                 fork: false,
                 resume_existing: false,
-                dispatch_backend: Some("fixture".to_string()),
-                dispatch_selector: None,
-                dispatch_model: Some("gpt-cli".to_string()),
-                dispatch_provider_config: Some(
-                    json!({
-                        "provider": "codex",
-                        "model": "gpt-config",
-                        "options": { "reasoning_effort": "high" }
-                    })
-                    .to_string(),
-                ),
+                dispatch: AgentTaskControllerDispatchArgs {
+                    dispatch_backend: Some("fixture".to_string()),
+                    dispatch_selector: None,
+                    dispatch_model: Some("gpt-cli".to_string()),
+                    dispatch_provider_config: Some(
+                        json!({
+                            "provider": "codex",
+                            "model": "gpt-config",
+                            "options": { "reasoning_effort": "high" }
+                        })
+                        .to_string(),
+                    ),
+                },
             },
             CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
@@ -403,10 +409,12 @@ fn controller_run_from_spec_rejects_unbounded_zero_max_actions() {
                 replace: false,
                 fork: false,
                 resume_existing: false,
-                dispatch_backend: Some("fixture".to_string()),
-                dispatch_selector: None,
-                dispatch_model: None,
-                dispatch_provider_config: None,
+                dispatch: AgentTaskControllerDispatchArgs {
+                    dispatch_backend: Some("fixture".to_string()),
+                    dispatch_selector: None,
+                    dispatch_model: None,
+                    dispatch_provider_config: None,
+                },
             },
             CapturingExecutor::default(),
         )
@@ -442,10 +450,12 @@ fn controller_run_from_spec_rejects_command_runtime_without_command_kind() {
                 replace: false,
                 fork: false,
                 resume_existing: false,
-                dispatch_backend: Some("fixture".to_string()),
-                dispatch_selector: None,
-                dispatch_model: None,
-                dispatch_provider_config: None,
+                dispatch: AgentTaskControllerDispatchArgs {
+                    dispatch_backend: Some("fixture".to_string()),
+                    dispatch_selector: None,
+                    dispatch_model: None,
+                    dispatch_provider_config: None,
+                },
             },
             CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
@@ -482,10 +492,12 @@ fn run_from_spec_proof_args(
         replace: false,
         fork: false,
         resume_existing: false,
-        dispatch_backend: Some("fixture".to_string()),
-        dispatch_selector: None,
-        dispatch_model: None,
-        dispatch_provider_config: None,
+        dispatch: AgentTaskControllerDispatchArgs {
+            dispatch_backend: Some("fixture".to_string()),
+            dispatch_selector: None,
+            dispatch_model: None,
+            dispatch_provider_config: None,
+        },
     }
 }
 

--- a/src/commands/agent_task/tests/dispatch.rs
+++ b/src/commands/agent_task/tests/dispatch.rs
@@ -352,8 +352,11 @@ fn controller_dispatch_provider_id_alias_maps_to_dispatch_selector() {
         panic!("expected controller from-spec command");
     };
 
-    assert_eq!(args.dispatch_selector.as_deref(), Some("sample-provider"));
-    assert_eq!(args.dispatch_model, None);
+    assert_eq!(
+        args.dispatch.dispatch_selector.as_deref(),
+        Some("sample-provider")
+    );
+    assert_eq!(args.dispatch.dispatch_model, None);
 }
 
 #[test]

--- a/src/commands/agent_task/tests/loop_compile.rs
+++ b/src/commands/agent_task/tests/loop_compile.rs
@@ -718,10 +718,12 @@ fn controller_from_spec_doctor_reports_missing_provider_before_resume() {
         fork: false,
         resume_existing: false,
         doctor: true,
-        dispatch_backend: Some("missing-provider".to_string()),
-        dispatch_selector: None,
-        dispatch_model: None,
-        dispatch_provider_config: None,
+        dispatch: AgentTaskControllerDispatchArgs {
+            dispatch_backend: Some("missing-provider".to_string()),
+            dispatch_selector: None,
+            dispatch_model: None,
+            dispatch_provider_config: None,
+        },
     })
     .expect("doctor report");
 
@@ -764,10 +766,12 @@ fn controller_from_spec_doctor_accepts_fixture_provider() {
         fork: false,
         resume_existing: false,
         doctor: true,
-        dispatch_backend: Some("fixture".to_string()),
-        dispatch_selector: None,
-        dispatch_model: None,
-        dispatch_provider_config: None,
+        dispatch: AgentTaskControllerDispatchArgs {
+            dispatch_backend: Some("fixture".to_string()),
+            dispatch_selector: None,
+            dispatch_model: None,
+            dispatch_provider_config: None,
+        },
     })
     .expect("doctor report");
 

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -9,9 +9,9 @@ pub(in crate::commands::agent_task) use super::super::super::agent_task_dispatch
     DispatchArgs, DispatchCoreArgs,
 };
 pub(in crate::commands::agent_task) use super::super::args::{
-    AgentTaskControllerApplyEventArgs, AgentTaskControllerFromSpecArgs,
-    AgentTaskControllerMaterializeArgs, AgentTaskControllerProofArgs,
-    AgentTaskControllerRunFromSpecArgs,
+    AgentTaskControllerApplyEventArgs, AgentTaskControllerDispatchArgs,
+    AgentTaskControllerFromSpecArgs, AgentTaskControllerMaterializeArgs,
+    AgentTaskControllerProofArgs, AgentTaskControllerRunFromSpecArgs,
 };
 pub(in crate::commands::agent_task) use super::super::args::{
     AgentTaskCookArgs, CompileLoopArgs, DiagnoseArgs, EvidenceArgs, ReviewArgs, StatusArgs,

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -345,7 +345,7 @@ mod tests {
     use crate::command_contract::CommandDispatchFamily;
     use crate::commands::agent_task::{
         AgentTaskArgs, AgentTaskCommand, AgentTaskControllerArgs, AgentTaskControllerCommand,
-        AgentTaskControllerRunFromSpecArgs, StatusArgs,
+        AgentTaskControllerDispatchArgs, AgentTaskControllerRunFromSpecArgs, StatusArgs,
     };
 
     #[test]
@@ -467,10 +467,12 @@ mod tests {
                         replace: false,
                         fork: false,
                         resume_existing: false,
-                        dispatch_backend: None,
-                        dispatch_selector: None,
-                        dispatch_model: None,
-                        dispatch_provider_config: None,
+                        dispatch: AgentTaskControllerDispatchArgs {
+                            dispatch_backend: None,
+                            dispatch_selector: None,
+                            dispatch_model: None,
+                            dispatch_provider_config: None,
+                        },
                     },
                 ),
             }),


### PR DESCRIPTION
Extracts the four dispatch override fields (dispatch_backend, dispatch_selector, dispatch_model, dispatch_provider_config) repeated across AgentTaskControllerFromSpecArgs / RunFromSpecArgs / RunNextArgs / RunArgs into a shared clap::Args sub-struct (AgentTaskControllerDispatchArgs) used via #[command(flatten)], clearing the field_patterns RepeatedFieldPattern finding for src/commands/agent_task/args/controller.rs.

CLI surface IDENTICAL (clap flatten is transparent — every #[arg(long=..., value_name=..., visible_alias=...)] attribute preserved exactly). Call sites updated to access via .dispatch.<field>; struct literals and lab.rs pattern matches updated to nest under the flattened struct. Baseline row removed from homeboy.json.

Verified: cargo build --lib --tests (exit 0).