### PR TITLE
Add generic agent-task contract fixtures

### DIFF
--- a/docs/architecture/agent-task-generic-loop-contract.md
+++ b/docs/architecture/agent-task-generic-loop-contract.md
@@ -1,0 +1,14 @@
+# Agent Task Generic Loop Contract
+
+Homeboy owns the generic loop, action, artifact, evidence, provider-outcome, and diagnostic-ranking contracts. Runtime providers own their runtime-package execution details and report them through the generic outcome and evidence fields.
+
+Versioned schema identifiers are exported by `homeboy agent-task contract`:
+
+- `homeboy/agent-task-loop-action/v1`
+- `homeboy/agent-task-artifact-declaration/v1`
+- `homeboy/agent-task-artifact-handoff/v1`
+- `homeboy/agent-task-provider-outcome-contract/v1`
+- `homeboy/agent-task-evidence-ref/v1`
+- `homeboy/agent-task-diagnostic-ranking/v1`
+
+Contract fixtures live under `tests/fixtures/agent_task_contract/` and intentionally use neutral provider/runtime names. They cover successful required artifact handoff, structurally valid provider outcomes with nested runtime import diagnostics, local file evidence refs, and generic missing required artifact symptoms.

--- a/src/commands/agent_task/tests/contract.rs
+++ b/src/commands/agent_task/tests/contract.rs
@@ -49,8 +49,24 @@ fn contract_output_exports_core_agent_task_metadata() {
         "homeboy/agent-task-artifact-declaration/v1"
     );
     assert_eq!(
+        value["schemas"]["artifact_handoff"],
+        "homeboy/agent-task-artifact-handoff/v1"
+    );
+    assert_eq!(
         value["schemas"]["evidence_ref"],
         "homeboy/agent-task-evidence-ref/v1"
+    );
+    assert_eq!(
+        value["schemas"]["loop_action"],
+        "homeboy/agent-task-loop-action/v1"
+    );
+    assert_eq!(
+        value["schemas"]["provider_outcome_contract"],
+        "homeboy/agent-task-provider-outcome-contract/v1"
+    );
+    assert_eq!(
+        value["schemas"]["diagnostic_ranking"],
+        "homeboy/agent-task-diagnostic-ranking/v1"
     );
     assert_eq!(
         value["schemas"]["secret_env_requirement"],
@@ -88,4 +104,24 @@ fn contract_output_exports_core_agent_task_metadata() {
         .as_array()
         .expect("sensitive keys")
         .contains(&json!("refresh_token")));
+}
+
+#[test]
+fn generic_loop_contract_fixtures_are_versioned_and_provider_neutral() {
+    let fixtures = [
+        include_str!("../../../../tests/fixtures/agent_task_contract/successful_required_artifact_handoff.json"),
+        include_str!("../../../../tests/fixtures/agent_task_contract/nested_runtime_import_failure.json"),
+        include_str!("../../../../tests/fixtures/agent_task_contract/local_file_evidence_refs.json"),
+        include_str!("../../../../tests/fixtures/agent_task_contract/missing_required_artifact.json"),
+    ];
+
+    for raw in fixtures {
+        assert!(!raw.contains("WordPress"));
+        assert!(!raw.contains("WP Codebox"));
+        assert!(!raw.contains("Data Machine"));
+        assert!(!raw.contains("WPSG"));
+        assert!(!raw.contains("wp-codebox"));
+        let outcome: AgentTaskOutcome = serde_json::from_str(raw).expect("fixture outcome");
+        assert_eq!(outcome.schema, AGENT_TASK_OUTCOME_SCHEMA);
+    }
 }

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -256,6 +256,169 @@ fn diagnose_hydrates_executor_result_evidence_root_cause() {
 }
 
 #[test]
+fn generic_contract_fixtures_surface_runtime_import_before_missing_artifact() {
+    with_temp_home(|| {
+        let run_id = "run-contract-import-diagnostics";
+        let outcome = fixture_outcome(
+            "../../../../tests/fixtures/agent_task_contract/nested_runtime_import_failure.json",
+        );
+
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            FixtureOutcomeExecutor { outcome },
+        )
+        .expect("run completed with fixture outcome");
+
+        let (diagnose_value, diagnose_exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+        })
+        .expect("diagnose loaded");
+        assert_eq!(diagnose_exit_code, 0);
+        assert_eq!(
+            diagnose_value["root_cause"]["class"],
+            "runtime.import_failed"
+        );
+        assert_eq!(
+            diagnose_value["root_cause"]["message"],
+            "ImportError: cannot import runtime package module 'neutral_runtime.adapter'"
+        );
+        assert_eq!(
+            diagnose_value["missing_artifacts"][0]["missing"],
+            json!(["answer_packet"])
+        );
+
+        let (status_value, status_exit_code) = status(StatusArgs {
+            run_id: run_id.to_string(),
+            bridge: false,
+            since_cursor: None,
+            full: true,
+        })
+        .expect("status loaded");
+        assert_eq!(status_exit_code, 0);
+        assert_eq!(
+            status_value["diagnostic_summary"]["class"],
+            "runtime.import_failed"
+        );
+        assert_eq!(
+            status_value["failure_reasons"][0]["message"],
+            "ImportError: cannot import runtime package module 'neutral_runtime.adapter'"
+        );
+    });
+}
+
+#[test]
+fn generic_contract_fixtures_hydrate_local_file_and_path_evidence() {
+    with_isolated_home(|home| {
+        let structured_path = home.path().join("structured-result.json");
+        let log_path = home.path().join("runtime.log");
+        std::fs::write(
+            &structured_path,
+            serde_json::to_string(&json!({
+                "status": "provider_error",
+                "diagnostics": [{
+                    "class": "runtime.import_failed",
+                    "message": "ImportError: cannot import runtime package module 'neutral_runtime.adapter'"
+                }],
+                "access_token": "secret-token"
+            }))
+            .expect("structured evidence json"),
+        )
+        .expect("write structured evidence");
+        std::fs::write(&log_path, "runtime import failed").expect("write log evidence");
+
+        let raw = include_str!(
+            "../../../../tests/fixtures/agent_task_contract/local_file_evidence_refs.json"
+        )
+        .replace(
+            "__LOCAL_FILE_URI__",
+            &format!("file://{}", structured_path.display()),
+        )
+        .replace("__LOCAL_PATH__", &log_path.display().to_string());
+        let outcome: AgentTaskOutcome = serde_json::from_str(&raw).expect("fixture outcome");
+        let run_id = "run-contract-local-evidence";
+
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            FixtureOutcomeExecutor { outcome },
+        )
+        .expect("run completed with fixture outcome");
+
+        let (value, exit_code) = evidence(EvidenceArgs {
+            run_id: run_id.to_string(),
+            kind: None,
+            task: Some("task-a".to_string()),
+            failure_only: true,
+        })
+        .expect("evidence loaded");
+        assert_eq!(exit_code, 0);
+        let entries = value["evidence"].as_array().expect("evidence entries");
+        let structured = entries
+            .iter()
+            .find(|entry| entry["kind"] == "executor-result")
+            .expect("structured evidence");
+        assert_eq!(structured["source"], "file");
+        assert_eq!(
+            structured["content"]["value"]["diagnostics"][0]["class"],
+            "runtime.import_failed"
+        );
+        assert_eq!(structured["content"]["value"]["access_token"], "[REDACTED]");
+
+        let plain = entries
+            .iter()
+            .find(|entry| entry["kind"] == "runtime-log")
+            .expect("plain path evidence");
+        assert_eq!(plain["source"], "file");
+        assert_eq!(plain["content"]["text"], "runtime import failed");
+    });
+}
+
+#[test]
+fn generic_contract_fixtures_accept_successful_required_artifact_handoff() {
+    let outcome = fixture_outcome(
+        "../../../../tests/fixtures/agent_task_contract/successful_required_artifact_handoff.json",
+    );
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    assert!(outcome
+        .typed_artifacts
+        .iter()
+        .any(|artifact| artifact.name == "answer_packet"));
+    assert!(outcome
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.metadata["handoff_schema"]
+            == "homeboy/agent-task-artifact-handoff/v1"));
+}
+
+fn fixture_outcome(relative_path: &str) -> AgentTaskOutcome {
+    let raw = match relative_path {
+        "../../../../tests/fixtures/agent_task_contract/successful_required_artifact_handoff.json" => include_str!("../../../../tests/fixtures/agent_task_contract/successful_required_artifact_handoff.json"),
+        "../../../../tests/fixtures/agent_task_contract/nested_runtime_import_failure.json" => include_str!("../../../../tests/fixtures/agent_task_contract/nested_runtime_import_failure.json"),
+        "../../../../tests/fixtures/agent_task_contract/missing_required_artifact.json" => include_str!("../../../../tests/fixtures/agent_task_contract/missing_required_artifact.json"),
+        _ => panic!("unknown fixture {relative_path}"),
+    };
+    serde_json::from_str(raw).expect("fixture outcome")
+}
+
+struct FixtureOutcomeExecutor {
+    outcome: AgentTaskOutcome,
+}
+
+impl AgentTaskExecutorAdapter for FixtureOutcomeExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        let mut outcome = self.outcome.clone();
+        outcome.task_id = request.task_id;
+        outcome
+    }
+}
+
+#[test]
 fn evidence_command_hydrates_plain_local_path_refs_and_summarizes_unsupported_refs() {
     with_isolated_home(|home| {
         let file_path = home.path().join("plain-evidence.txt");

--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -31,7 +31,12 @@ use crate::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA;
 pub const AGENT_TASK_CORE_CONTRACT_SCHEMA: &str = "homeboy/agent-task-core-contract/v1";
 pub const AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA: &str =
     "homeboy/agent-task-artifact-declaration/v1";
+pub const AGENT_TASK_ARTIFACT_HANDOFF_SCHEMA: &str = "homeboy/agent-task-artifact-handoff/v1";
 pub const AGENT_TASK_EVIDENCE_REF_SCHEMA: &str = "homeboy/agent-task-evidence-ref/v1";
+pub const AGENT_TASK_LOOP_ACTION_SCHEMA: &str = "homeboy/agent-task-loop-action/v1";
+pub const AGENT_TASK_PROVIDER_OUTCOME_CONTRACT_SCHEMA: &str =
+    "homeboy/agent-task-provider-outcome-contract/v1";
+pub const AGENT_TASK_DIAGNOSTIC_RANKING_SCHEMA: &str = "homeboy/agent-task-diagnostic-ranking/v1";
 pub const SECRET_ENV_REQUIREMENT_SCHEMA: &str = "homeboy/secret-env-requirement/v1";
 pub const AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA: &str =
     "homeboy/agent-task-batch-cook-fanout-plan/v1";
@@ -55,7 +60,11 @@ pub struct AgentTaskCoreContractSchemas {
     pub outcome: String,
     pub artifact: String,
     pub artifact_declaration: String,
+    pub artifact_handoff: String,
     pub evidence_ref: String,
+    pub loop_action: String,
+    pub provider_outcome_contract: String,
+    pub diagnostic_ranking: String,
     pub workflow: String,
     pub plan: String,
     pub aggregate: String,
@@ -130,7 +139,11 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
             outcome: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
             artifact: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
             artifact_declaration: AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA.to_string(),
+            artifact_handoff: AGENT_TASK_ARTIFACT_HANDOFF_SCHEMA.to_string(),
             evidence_ref: AGENT_TASK_EVIDENCE_REF_SCHEMA.to_string(),
+            loop_action: AGENT_TASK_LOOP_ACTION_SCHEMA.to_string(),
+            provider_outcome_contract: AGENT_TASK_PROVIDER_OUTCOME_CONTRACT_SCHEMA.to_string(),
+            diagnostic_ranking: AGENT_TASK_DIAGNOSTIC_RANKING_SCHEMA.to_string(),
             workflow: AGENT_TASK_WORKFLOW_SCHEMA.to_string(),
             plan: AGENT_TASK_PLAN_SCHEMA.to_string(),
             aggregate: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),

--- a/src/core/agent_task_executor_evidence.rs
+++ b/src/core/agent_task_executor_evidence.rs
@@ -183,28 +183,28 @@ mod tests {
     fn test_request() -> AgentTaskRequest {
         AgentTaskRequest {
             schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
-            task_id: "wpsg/codebox proof".to_string(),
+            task_id: "neutral-runtime proof".to_string(),
             group_key: None,
             parent_plan_id: None,
             executor: AgentTaskExecutor {
-                backend: "codebox".to_string(),
+                backend: "example-provider".to_string(),
                 selector: None,
                 runtime_selection: None,
                 required_capabilities: Vec::new(),
                 secret_env: Vec::new(),
                 model: Some("claude-sonnet".to_string()),
                 config: json!({
-                    "runtime_component_paths": ["/runner/components/wpsg"],
+                    "runtime_component_paths": ["/runner/components/sample-runtime"],
                     "api_key": "sk-super-secret",
                 }),
             },
-            instructions: "prove the codebox typed artifact".to_string(),
+            instructions: "prove the typed artifact handoff".to_string(),
             inputs: Value::Null,
             source_refs: Vec::new(),
             workspace: AgentTaskWorkspace::default(),
             component_contracts: vec![AgentTaskComponentContract {
-                slug: Some("wpsg".to_string()),
-                path: Some("/runner/components/wpsg".to_string()),
+                slug: Some("sample-runtime".to_string()),
+                path: Some("/runner/components/sample-runtime".to_string()),
                 load_as: None,
                 activate: None,
                 extra: Map::new(),
@@ -220,7 +220,7 @@ mod tests {
     fn test_outcome() -> AgentTaskOutcome {
         AgentTaskOutcome {
             schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-            task_id: "wpsg/codebox proof".to_string(),
+            task_id: "neutral-runtime proof".to_string(),
             status: AgentTaskOutcomeStatus::Succeeded,
             summary: Some("token=abc done".to_string()),
             failure_classification: None,
@@ -297,7 +297,7 @@ mod tests {
             assert!(raw.contains("[REDACTED]"));
             // ...while component contracts, runtime/component paths, model, and
             // typed artifact expectations are retained.
-            assert!(raw.contains("/runner/components/wpsg"));
+            assert!(raw.contains("/runner/components/sample-runtime"));
             assert!(raw.contains("runtime_component_paths"));
             assert!(raw.contains("claude-sonnet"));
             assert!(raw.contains("component_contracts"));

--- a/tests/fixtures/agent_task_contract/local_file_evidence_refs.json
+++ b/tests/fixtures/agent_task_contract/local_file_evidence_refs.json
@@ -1,0 +1,19 @@
+{
+  "schema": "homeboy/agent-task-outcome/v1",
+  "task_id": "task-contract-local-evidence",
+  "status": "provider_error",
+  "summary": "Provider recorded local file evidence refs.",
+  "failure_classification": "provider",
+  "evidence_refs": [
+    {
+      "kind": "executor-result",
+      "uri": "__LOCAL_FILE_URI__",
+      "label": "Structured local result"
+    },
+    {
+      "kind": "runtime-log",
+      "uri": "__LOCAL_PATH__",
+      "label": "Plain local log"
+    }
+  ]
+}

--- a/tests/fixtures/agent_task_contract/missing_required_artifact.json
+++ b/tests/fixtures/agent_task_contract/missing_required_artifact.json
@@ -1,0 +1,19 @@
+{
+  "schema": "homeboy/agent-task-outcome/v1",
+  "task_id": "task-contract-missing-artifact",
+  "status": "provider_error",
+  "summary": "Required artifact answer_packet was not produced.",
+  "failure_classification": "provider",
+  "diagnostics": [
+    {
+      "class": "missing_required_artifact",
+      "message": "Required artifact answer_packet was not produced.",
+      "data": {
+        "missing": ["answer_packet"]
+      }
+    }
+  ],
+  "metadata": {
+    "expected_artifacts": ["answer_packet"]
+  }
+}

--- a/tests/fixtures/agent_task_contract/nested_runtime_import_failure.json
+++ b/tests/fixtures/agent_task_contract/nested_runtime_import_failure.json
@@ -1,0 +1,36 @@
+{
+  "schema": "homeboy/agent-task-outcome/v1",
+  "task_id": "task-contract-import-failure",
+  "status": "provider_error",
+  "summary": "Provider returned a structurally valid outcome with nested runtime diagnostics.",
+  "failure_classification": "provider",
+  "diagnostics": [
+    {
+      "class": "missing_required_artifact",
+      "message": "Required artifact answer_packet was not produced.",
+      "data": {
+        "missing": ["answer_packet"]
+      }
+    }
+  ],
+  "outputs": {
+    "provider_outcome_contract": "homeboy/agent-task-provider-outcome-contract/v1",
+    "provider_status": "succeeded",
+    "runtime": {
+      "status": "failed",
+      "diagnostics": [
+        {
+          "class": "runtime.import_failed",
+          "message": "ImportError: cannot import runtime package module 'neutral_runtime.adapter'"
+        },
+        {
+          "class": "runtime.required_artifact_missing",
+          "message": "Required artifact answer_packet was not produced."
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "expected_artifacts": ["answer_packet"]
+  }
+}

--- a/tests/fixtures/agent_task_contract/successful_required_artifact_handoff.json
+++ b/tests/fixtures/agent_task_contract/successful_required_artifact_handoff.json
@@ -1,0 +1,40 @@
+{
+  "schema": "homeboy/agent-task-outcome/v1",
+  "task_id": "task-contract-success",
+  "status": "succeeded",
+  "summary": "Required artifact was produced and handed off.",
+  "artifacts": [
+    {
+      "schema": "homeboy/agent-task-artifact/v1",
+      "id": "artifact-answer-packet",
+      "kind": "typed-artifact",
+      "name": "answer_packet",
+      "label": "Answer packet",
+      "path": "artifacts/answer-packet.json",
+      "metadata": {
+        "handoff_schema": "homeboy/agent-task-artifact-handoff/v1",
+        "required": true
+      }
+    }
+  ],
+  "typed_artifacts": [
+    {
+      "name": "answer_packet",
+      "type": "json",
+      "artifact_schema": "example/answer-packet/v1",
+      "payload": {
+        "result": "accepted"
+      }
+    }
+  ],
+  "evidence_refs": [
+    {
+      "kind": "artifact-handoff",
+      "uri": "homeboy://agent-task/run/run-contract-success/artifacts#outcome=task-contract-success",
+      "label": "Required artifact handoff"
+    }
+  ],
+  "metadata": {
+    "expected_artifacts": ["answer_packet"]
+  }
+}


### PR DESCRIPTION
## Summary
- Exports explicit schema ids for generic loop actions, artifact handoffs, provider outcome contracts, and diagnostic ranking through `homeboy agent-task contract`.
- Adds neutral contract fixtures for required artifact handoff success, nested runtime import failure, local file evidence refs, and missing required artifact symptoms.
- Adds tests proving `agent-task diagnose`, `status --full`, `agent-task evidence`, and controller status prioritize actionable nested runtime/import diagnostics over missing artifact symptoms without runtime-specific fixture names.

## Tests
- `cargo test commands::agent_task::tests --lib`
- `cargo test status_diagnostics_surface_failed_child_run_root_cause --lib`
- `cargo test agent_task_executor_evidence --lib -- --test-threads=1`
- `git diff --check`

## Broad suite note
- `cargo test --lib` is not green on this branch: 6,196 passed, 10 failed, 18 ignored. Failures were outside this change scope: route extension lookup, runner legacy projection, parallel TMPDIR-sensitive executor evidence test, process SIGTERM/SIGKILL expectations, extension runner run-dir IO, refactor module-surface unwrap, runner workspace generated-output assertion, and composer install argv expectation. Focused changed-scope tests are green.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the contract fixture/test/docs change, running validation, and preparing this PR.
