### PR TITLE
Add lab refresh workspace mapping contract

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -463,6 +463,7 @@ fn execution_envelope_plan(
     docs: &[String],
 ) -> RunnerExecutionEnvelope {
     let handoff_id = format!("lab-refresh:{}:{}", args.runner, args.run_id);
+    let mapping = workspace_mapping(args);
 
     RunnerExecutionEnvelope::planned(&handoff_id, "lab_refresh_plan")
         .with_source_ref(&args.run_id)
@@ -490,7 +491,7 @@ fn execution_envelope_plan(
                 "controller_path": args.workspace,
                 "runner_cwd": args.runner_cwd,
                 "sync_mode": args.sync_mode,
-                "mapping": handoff.workspace.mapping,
+                "mapping": mapping,
             },
             "runtime": {
                 "command": args.command,

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -94,7 +94,7 @@ pub struct LabRefreshPlanHandoff {
     pub runner: LabRefreshPlanRunnerHandoff,
     pub workspace: LabRefreshPlanWorkspaceHandoff,
     pub env_plan: LabRefreshPlanEnvPlan,
-    pub secret_plan: LabRefreshPlanSecretPlan,
+    pub secret_plan: SecretEnvPlan,
     pub runtime_refs: LabRefreshPlanRuntimeRefs,
     pub lifecycle: LabRefreshPlanLifecycle,
     pub artifact: LabRefreshPlanArtifactPlan,
@@ -121,17 +121,30 @@ pub struct LabRefreshPlanWorkspaceHandoff {
     pub controller_path: String,
     pub runner_cwd: String,
     pub sync_mode: String,
+    pub mapping: LabRefreshPlanWorkspaceMapping,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct LabRefreshPlanWorkspaceMapping {
+    pub schema: &'static str,
+    pub ref_id: String,
+    pub controller_path: String,
+    pub runner_path: String,
+    pub sync_mode: String,
+    pub lease: LabRefreshPlanWorkspaceLease,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct LabRefreshPlanWorkspaceLease {
+    pub lease_id: String,
+    pub owner_run_id: String,
+    pub cleanup_policy: &'static str,
+    pub ttl: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct LabRefreshPlanEnvPlan {
     pub vars: Vec<String>,
-    pub unknown: bool,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub struct LabRefreshPlanSecretPlan {
-    pub refs: Vec<String>,
     pub unknown: bool,
 }
 
@@ -361,6 +374,7 @@ fn handoff_plan(
         .filter(|command| matches!(command.label, "inspect-artifacts" | "inspect-evidence"))
         .cloned()
         .collect();
+    let workspace_mapping = workspace_mapping(args);
 
     LabRefreshPlanHandoff {
         schema: "homeboy/lab-refresh-handoff/v1",
@@ -381,15 +395,13 @@ fn handoff_plan(
             controller_path: args.workspace.clone(),
             runner_cwd: args.runner_cwd.clone(),
             sync_mode: args.sync_mode.clone(),
+            mapping: workspace_mapping,
         },
         env_plan: LabRefreshPlanEnvPlan {
             vars: execution_envelope_env_vars(execution_envelope),
             unknown: false,
         },
-        secret_plan: LabRefreshPlanSecretPlan {
-            refs: execution_envelope_secret_refs(execution_envelope),
-            unknown: false,
-        },
+        secret_plan: execution_envelope_secret_plan(execution_envelope),
         runtime_refs: LabRefreshPlanRuntimeRefs {
             command: args.command.clone(),
             docs: docs.to_vec(),
@@ -422,6 +434,27 @@ fn handoff_plan(
             unknown: false,
         },
     }
+}
+
+fn workspace_mapping(args: &RefreshPlanArgs) -> LabRefreshPlanWorkspaceMapping {
+    let ref_id = workspace_mapping_ref(&args.runner, &args.run_id);
+    LabRefreshPlanWorkspaceMapping {
+        schema: "homeboy/runner-workspace-mapping/v1",
+        ref_id: ref_id.clone(),
+        controller_path: args.workspace.clone(),
+        runner_path: args.runner_cwd.clone(),
+        sync_mode: args.sync_mode.clone(),
+        lease: LabRefreshPlanWorkspaceLease {
+            lease_id: format!("{ref_id}:lease"),
+            owner_run_id: args.run_id.clone(),
+            cleanup_policy: "operator_retains_until_evidence_verified",
+            ttl: None,
+        },
+    }
+}
+
+fn workspace_mapping_ref(runner: &str, run_id: &str) -> String {
+    format!("runner:{runner}:workspace:{run_id}")
 }
 
 fn execution_envelope_plan(
@@ -457,6 +490,7 @@ fn execution_envelope_plan(
                 "controller_path": args.workspace,
                 "runner_cwd": args.runner_cwd,
                 "sync_mode": args.sync_mode,
+                "mapping": handoff.workspace.mapping,
             },
             "runtime": {
                 "command": args.command,
@@ -479,11 +513,11 @@ fn execution_envelope_env_vars(envelope: &RunnerExecutionEnvelope) -> Vec<String
         .unwrap_or_default()
 }
 
-fn execution_envelope_secret_refs(envelope: &RunnerExecutionEnvelope) -> Vec<String> {
+fn execution_envelope_secret_plan(envelope: &RunnerExecutionEnvelope) -> SecretEnvPlan {
     envelope
         .secret_env
         .as_ref()
-        .map(SecretEnvPlan::secret_env_names)
+        .map(SecretEnvPlan::redacted)
         .unwrap_or_default()
 }
 
@@ -618,6 +652,7 @@ fn shell_quote(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA;
 
     #[test]
     fn plan_commands_include_existing_runner_artifact_primitives() {
@@ -713,10 +748,19 @@ mod tests {
         assert_eq!(handoff.workspace.controller_path, "/workspace/source");
         assert_eq!(handoff.workspace.runner_cwd, "/runner/source");
         assert_eq!(handoff.workspace.sync_mode, "snapshot-git");
+        assert_eq!(
+            handoff.workspace.mapping.ref_id,
+            "runner:lab-runner:workspace:matrix-refresh-1"
+        );
+        assert_eq!(
+            handoff.workspace.mapping.lease.cleanup_policy,
+            "operator_retains_until_evidence_verified"
+        );
+        assert_eq!(handoff.workspace.mapping.lease.ttl, None);
         assert_eq!(handoff.env_plan.vars, Vec::<String>::new());
         assert!(!handoff.env_plan.unknown);
-        assert_eq!(handoff.secret_plan.refs, Vec::<String>::new());
-        assert!(!handoff.secret_plan.unknown);
+        assert_eq!(handoff.secret_plan.schema, SECRET_ENV_PLAN_SCHEMA);
+        assert_eq!(handoff.secret_plan.secret_env_names(), Vec::<String>::new());
         assert_eq!(handoff.runtime_refs.command, vec!["cargo", "test"]);
         assert_eq!(handoff.artifact.paths, vec!["artifacts/matrix"]);
         assert_eq!(handoff.evidence.paths, evidence);
@@ -790,9 +834,34 @@ mod tests {
         );
         assert_eq!(envelope.metadata["runner"]["id"], "lab-runner");
         assert_eq!(
+            envelope.metadata["workspace"]["mapping"]["ref_id"],
+            "runner:lab-runner:workspace:matrix-refresh-1"
+        );
+        assert_eq!(
+            envelope.metadata["workspace"]["mapping"]["lease"]["owner_run_id"],
+            "matrix-refresh-1"
+        );
+        assert_eq!(
             envelope.metadata["runtime"]["command"],
             serde_json::json!(["cargo", "test"])
         );
+    }
+
+    #[test]
+    fn refresh_plan_secret_plan_uses_redacted_canonical_shape() {
+        let secret_plan =
+            SecretEnvPlan::from_secret_env_names(["B_SECRET".to_string(), "A_SECRET".to_string()]);
+
+        let redacted = serde_json::to_value(secret_plan.redacted()).expect("redacted json");
+        let rendered = serde_json::to_string(&redacted).expect("redacted json string");
+
+        assert_eq!(redacted["schema"], SECRET_ENV_PLAN_SCHEMA);
+        assert_eq!(
+            redacted["secret_env_names"],
+            serde_json::json!(["A_SECRET", "B_SECRET"])
+        );
+        assert!(!rendered.contains("super-secret-value"));
+        assert_eq!(secret_plan.redacted_env()["A_SECRET"], "[REDACTED]");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a typed `homeboy/runner-workspace-mapping/v1` object to lab refresh handoff workspace metadata.
- Include lease metadata in the refresh plan and runner execution envelope metadata.
- Reuse canonical `SecretEnvPlan` for the lab refresh secret plan instead of a parallel `refs/unknown` shape.
- Preserve the runner execution envelope handoff fields that landed in #6685 while resolving the original #6691 conflict.
- Add focused tests for workspace mapping metadata and redacted canonical secret plan output.

Replaces #6691, which conflicted after #6685 landed. This branch avoids force-pushing the original PR branch.

## Follow-up issues
- #6689
- #6688
- #6687

## Tests
- `cargo fmt --check`
- `cargo test commands::lab::tests`
- Prior #6691 broad `cargo test --lib` failed with documented pre-existing/unrelated failures outside this change area.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting code changes, resolving merge conflicts, focused tests, issue filing, and PR preparation.