### PR TITLE
Fix rig-owned bench setting warnings

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -334,8 +334,11 @@ pub enum BenchReportFormat {
 fn warn_unknown_setting_keys(
     ctx: &execution_context::ExecutionContext,
     setting_args: &SettingArgs,
+    rig_accepted_setting_keys: &[String],
 ) {
-    if let Some(message) = unknown_setting_keys_warning(ctx, setting_args) {
+    if let Some(message) =
+        unknown_setting_keys_warning(ctx, setting_args, rig_accepted_setting_keys)
+    {
         eprintln!("{message}");
     }
 }
@@ -348,23 +351,39 @@ fn warn_unknown_setting_keys(
 fn unknown_setting_keys_warning(
     ctx: &execution_context::ExecutionContext,
     setting_args: &SettingArgs,
+    rig_accepted_setting_keys: &[String],
 ) -> Option<String> {
     let unknown = ctx.unknown_setting_overrides(
         setting_args.setting.iter().map(|(k, _)| k.as_str()),
         setting_args.setting_json.iter().map(|(k, _)| k.as_str()),
     );
+    let rig_accepted: std::collections::HashSet<&str> = rig_accepted_setting_keys
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let unknown: Vec<String> = unknown
+        .into_iter()
+        .filter(|key| !rig_accepted.contains(key.as_str()))
+        .collect();
     if unknown.is_empty() {
         return None;
     }
 
     let mut accepted = ctx.accepted_setting_keys.clone();
+    accepted.extend(rig_accepted_setting_keys.iter().cloned());
     accepted.sort();
+    accepted.dedup();
     let extension = ctx.extension_id.as_deref().unwrap_or("<unknown>");
+    let owner_scope = if rig_accepted_setting_keys.is_empty() {
+        format!("extension '{extension}'")
+    } else {
+        format!("extension '{extension}' or active rig")
+    };
     Some(format!(
-        "warning: bench ignored {} unknown setting key(s) not declared by extension '{}': {}. \
+        "warning: bench ignored {} unknown setting key(s) not declared by {}: {}. \
          Accepted settings: {}. Check for a typo before relying on this run.",
         unknown.len(),
-        extension,
+        owner_scope,
         unknown.join(", "),
         if accepted.is_empty() {
             "<none declared>".to_string()
@@ -651,7 +670,15 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
         effective_extension_overrides(&args.extension_override.extensions, rig_spec.as_deref());
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
-    warn_unknown_setting_keys(&ctx, &args.setting_args);
+    warn_unknown_setting_keys(
+        &ctx,
+        &args.setting_args,
+        rig_spec
+            .as_ref()
+            .and_then(|spec| spec.bench.as_ref())
+            .map(|bench| bench.accepted_settings.as_slice())
+            .unwrap_or(&[]),
+    );
     let extra_workloads = rig_spec
         .as_ref()
         .and_then(|spec| {

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -587,7 +587,14 @@ fn run_component_with_rig_context(
         super::effective_extension_overrides(&args.extension_override.extensions, rig_spec);
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
-    super::warn_unknown_setting_keys(&ctx, &args.setting_args);
+    super::warn_unknown_setting_keys(
+        &ctx,
+        &args.setting_args,
+        rig_spec
+            .and_then(|spec| spec.bench.as_ref())
+            .map(|bench| bench.accepted_settings.as_slice())
+            .unwrap_or(&[]),
+    );
     homeboy::core::hygiene::require_dependency_hygiene_for_source_with_settings(
         &ctx.source_path,
         ctx.extension_path.as_deref(),

--- a/src/commands/bench/tests/settings_tests.rs
+++ b/src/commands/bench/tests/settings_tests.rs
@@ -10,7 +10,7 @@ fn unknown_setting_key_warns_before_run() {
     };
 
     let warning =
-        unknown_setting_keys_warning(&ctx, &setting_args).expect("unknown key should warn");
+        unknown_setting_keys_warning(&ctx, &setting_args, &[]).expect("unknown key should warn");
     assert!(
         warning.contains("bench_env"),
         "warning names the typo: {warning}"
@@ -33,5 +33,38 @@ fn declared_setting_key_does_not_warn() {
         setting_json: Vec::new(),
     };
 
-    assert!(unknown_setting_keys_warning(&ctx, &setting_args).is_none());
+    assert!(unknown_setting_keys_warning(&ctx, &setting_args, &[]).is_none());
+}
+
+#[test]
+fn declared_rig_setting_key_does_not_warn_as_extension_unknown() {
+    let ctx = ctx_with_accepted_setting_keys(&["workflow_bench_env"]);
+    let setting_args = SettingArgs {
+        setting: vec![(
+            "fixture_matrix_namespace".to_string(),
+            "nightly".to_string(),
+        )],
+        setting_json: Vec::new(),
+    };
+    let rig_accepted = vec!["fixture_matrix_namespace".to_string()];
+
+    assert!(unknown_setting_keys_warning(&ctx, &setting_args, &rig_accepted).is_none());
+}
+
+#[test]
+fn unknown_setting_still_warns_when_not_declared_by_extension_or_rig() {
+    let ctx = ctx_with_accepted_setting_keys(&["workflow_bench_env"]);
+    let setting_args = SettingArgs {
+        setting: vec![(
+            "unexpected_fixture_input".to_string(),
+            "nightly".to_string(),
+        )],
+        setting_json: Vec::new(),
+    };
+    let rig_accepted = vec!["fixture_matrix_namespace".to_string()];
+
+    let warning = unknown_setting_keys_warning(&ctx, &setting_args, &rig_accepted)
+        .expect("unknown key should warn");
+    assert!(warning.contains("unexpected_fixture_input"));
+    assert!(warning.contains("fixture_matrix_namespace"));
 }

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -400,6 +400,13 @@ pub struct BenchSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub warmup_iterations: Option<u64>,
 
+    /// Setting keys accepted by rig-owned bench orchestration, such as
+    /// `bench_prepare` pipelines or out-of-tree workloads. These keys are
+    /// validated alongside extension manifest settings so rig inputs do not
+    /// warn as extension-ignored typos.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accepted_settings: Vec<String>,
+
     /// Optional matrix axes for cross-rig bench comparison reporting.
     ///
     /// Example: `{ "runtime": "sdk", "substrate": "bfb" }`. When


### PR DESCRIPTION
## Summary
- Add generic rig bench `accepted_settings` declarations for rig-owned setting keys.
- Treat those declared rig keys as accepted when bench validates `--setting` / `--setting-json` overrides.
- Keep extension manifest setting validation intact: truly unknown keys still warn, and accepted settings include both extension and rig declarations in rig runs.

Fixes #6697

## Tests
- `cargo test settings_tests --lib`
- `cargo fmt --check`
- `git diff --check`

## Risks
- This is the smallest contract slice and does not yet add structured accepted/ignored/rejected setting provenance to bench output.
- Existing rig specs must opt into suppressing rig-owned keys by declaring `bench.accepted_settings`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the focused rig-owned bench settings validation contract, tests, and PR preparation.
