### PR TITLE
Clean product terms from generic runtime boundaries

### DIFF
--- a/docs/architecture/provider-fanout-boundary.md
+++ b/docs/architecture/provider-fanout-boundary.md
@@ -16,15 +16,15 @@ providers own backend-specific execution details. The seam is the
 
 ## Narrow seam
 
-The canonical Codebox product-facing path is:
+The canonical Sandbox product-facing path is:
 
 ```text
-Agents API substrate -> Homeboy durable scheduler/fanout plan -> Homeboy Extensions executor adapter -> WP Codebox sandbox worker runtime/artifact contracts
+Agents API substrate -> Homeboy durable scheduler/fanout plan -> Homeboy Extensions executor adapter -> Managed Sandbox sandbox worker runtime/artifact contracts
 ```
 
 Homeboy persists the plan/run ids, deterministic scheduling order, dependency
 skip state, child run refs, and artifact/evidence refs. Homeboy Extensions maps
-one normalized task request to the selected runtime provider. WP Codebox owns the
+one normalized task request to the selected runtime provider. Managed Sandbox owns the
 lower-level sandbox-native fanout request/result/event/artifact contracts inside
 the isolated worker runtime.
 

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -86,8 +86,8 @@ one structured status envelope with the generated plan plus resume commands.
 homeboy agent-task fanout cook-batch \
   --repo homeboy \
   --verify 'cargo test --lib' \
-  --backend codebox \
-  --selector wordpress.codebox-agent-task-executor \
+  --backend sandbox \
+  --selector wordpress.sandbox-agent-task-executor \
   https://github.com/Extra-Chill/homeboy/issues/6453 \
   https://github.com/Extra-Chill/homeboy/issues/6454
 ```

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -271,7 +271,7 @@ Bench artifacts can attach a `viewer` descriptor when a file artifact has a
 browser-based reviewer view. Homeboy keeps link generation generic: descriptors
 name the viewer kind, base URL, and query parameter whose value is the public
 artifact URL. Built-in viewer descriptors live in `core::artifact_links` so new
-viewer families, such as Codebox artifact viewers, can be added without
+viewer families, such as Sandbox artifact viewers, can be added without
 duplicating URL construction at call sites.
 
 The command is read-only and exits successfully for a valid comparison even when the numbers regress. Repeat `--metric <name>` to keep the comparison focused; omit it to compare all shared numeric scenario metrics.

--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -104,14 +104,14 @@ exist, and must stay inside the package source repository root.
 ```jsonc
 {
   "id": "static-site-importer-fixture-matrix",
-  "package_dependencies": ["../../shared/wp-codebox"]
+  "package_dependencies": ["../../shared/sample-runtime"]
 }
 ```
 
 When this rig is installed from `WordPress/static-site-importer`, Homeboy records
 the repository root as the source root and keeps the package path at
 `WordPress/static-site-importer`, so imports such as
-`../../../shared/wp-codebox/recipe.mjs` keep resolving on Lab.
+`../../../shared/sample-runtime/recipe.mjs` keep resolving on Lab.
 
 ## `ComponentSpec`
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -158,10 +158,10 @@ arguments, and install hint. Homeboy owns the generic semantics: runtimes declar
 the executable they need; runner diagnostics expose the declaration without
 embedding product-specific checks in core.
 
-`runner status` also includes `selected_lab_runner.wp_codebox_runtime` for the
+`runner status` also includes `selected_lab_runner.selected_runtime_runtime` for the
 legacy runner job environment projection. That block shows the configured WP
-Codebox CLI, managed cache source/binary, expected
-`@automattic/wp-codebox-playground` and `@automattic/wp-codebox-core` paths, a
+Sandbox CLI, managed cache source/binary, expected
+`@automattic/sample-runtime-playground` and `@automattic/sample-runtime-core` paths, a
 runner-side probe command that prints the exact effective runtime and git SHA,
 and warnings when configured paths mix a stale checkout with the managed cache.
 

--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -54,7 +54,7 @@ pub struct AgentTaskControllerDispatchArgs {
     pub dispatch_backend: Option<String>,
 
     /// Extension-provider selector: the Homeboy executor provider id (e.g.
-    /// `wordpress.codebox-agent-task-executor`) that runs controller-spawned
+    /// `wordpress.sandbox-agent-task-executor`) that runs controller-spawned
     /// dispatch actions when the action omits one. This is NOT a model or AI
     /// runtime name (codex, opencode, claude-code) — pass those in
     /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -56,7 +56,7 @@ pub struct AgentTaskFanoutCookBatchArgs {
     #[arg(value_name = "ISSUE_URL", required = true)]
     pub issues: Vec<String>,
 
-    /// Repo/workspace slug managed by Data Machine Code.
+    /// Repo/workspace slug managed by Workspace Registry.
     #[arg(long = "repo", value_name = "REPO")]
     pub repo: String,
 
@@ -135,7 +135,7 @@ pub struct AgentTaskFanoutInputArgs {
     pub backend: Option<String>,
 
     /// Default extension-provider selector for cooks without one: a Homeboy
-    /// executor provider id (e.g. `wordpress.codebox-agent-task-executor`), NOT
+    /// executor provider id (e.g. `wordpress.sandbox-agent-task-executor`), NOT
     /// an AI runtime name (codex, opencode, claude-code). Set the AI runtime via
     /// --provider-config. Run `homeboy agent-task providers` for valid ids.
     #[arg(
@@ -562,7 +562,7 @@ pub struct AgentTaskLoopDefineArgs {
     pub dispatch_backend: Option<String>,
 
     /// Extension-provider selector: the Homeboy executor provider id (e.g.
-    /// `wordpress.codebox-agent-task-executor`) that runs loop-spawned dispatch
+    /// `wordpress.sandbox-agent-task-executor`) that runs loop-spawned dispatch
     /// actions when the action omits one. This is NOT a model or AI runtime name
     /// (codex, opencode, claude-code) — pass those in --dispatch-provider-config.
     /// Run `homeboy agent-task providers` for valid ids.
@@ -605,7 +605,7 @@ pub struct AgentTaskLoopResumeArgs {
     pub dispatch_backend: Option<String>,
 
     /// Extension-provider selector: the Homeboy executor provider id (e.g.
-    /// `wordpress.codebox-agent-task-executor`) that runs loop-spawned dispatch
+    /// `wordpress.sandbox-agent-task-executor`) that runs loop-spawned dispatch
     /// actions when the action omits one. This is NOT a model or AI runtime name
     /// (codex, opencode, claude-code) — pass those in --dispatch-provider-config.
     /// Run `homeboy agent-task providers` for valid ids.

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -779,7 +779,7 @@ fn dmc_add_command(args: &AgentTaskFanoutCookBatchArgs, branch: &str) -> Vec<Str
     vec![
         args.dmc_bin.clone(),
         "wp".to_string(),
-        "datamachine-code".to_string(),
+        "workspace-registry".to_string(),
         "workspace".to_string(),
         "worktree".to_string(),
         "add".to_string(),
@@ -1020,8 +1020,8 @@ mod tests {
             branch_prefix: "fix".to_string(),
             fanout_id: Some("issue-wave".to_string()),
             prompt_template: None,
-            backend: Some("codebox".to_string()),
-            selector: Some("wordpress.codebox-agent-task-executor".to_string()),
+            backend: Some("sandbox".to_string()),
+            selector: Some("wordpress.sandbox-agent-task-executor".to_string()),
             model: Some("gpt-5.5".to_string()),
             secret_env: vec!["AI_PROVIDER_OPENAI_CODEX_TOKEN".to_string()],
             provider_config: Some(r#"{"runtime":"opencode"}"#.to_string()),
@@ -1059,7 +1059,7 @@ mod tests {
             .expect("prompt")
             .contains("https://github.com/Extra-Chill/homeboy/issues/6453"));
         assert_eq!(plan.cooks[0].verify, vec!["cargo test --lib"]);
-        assert_eq!(plan.cooks[0].backend.as_deref(), Some("codebox"));
+        assert_eq!(plan.cooks[0].backend.as_deref(), Some("sandbox"));
     }
 
     #[test]

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -355,7 +355,7 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
 ///
 /// The confusion this prevents: `--dispatch-selector codex` fails because
 /// `codex` is an AI runtime, not a Homeboy executor provider id. The correct
-/// selector is an executor provider id (e.g. `wordpress.codebox-agent-task-executor`),
+/// selector is an executor provider id (e.g. `wordpress.sandbox-agent-task-executor`),
 /// while `codex` belongs in `--dispatch-provider-config` as the nested provider.
 fn dispatch_config_layers(providers: &[AgentTaskExecutorProvider]) -> Value {
     let selectable_ids: Vec<String> = providers
@@ -365,21 +365,21 @@ fn dispatch_config_layers(providers: &[AgentTaskExecutorProvider]) -> Value {
 
     // Surface a worked example using a real registered executor provider id
     // when one is available, so the operator can copy a known-good selector
-    // instead of guessing. Prefer a codebox-style provider (the case the
+    // instead of guessing. Prefer a sandbox-style provider (the case the
     // issue called out) but fall back to the first provider, then to a
     // documented literal when no providers are registered here.
     let example_selector = providers
         .iter()
         .find(|provider| {
-            provider.id.contains("codebox")
+            provider.id.contains("sandbox")
                 || provider
                     .extension_id
                     .as_deref()
-                    .is_some_and(|id| id.contains("codebox"))
+                    .is_some_and(|id| id.contains("sandbox"))
         })
         .or_else(|| providers.first())
         .map(|provider| provider.id.clone())
-        .unwrap_or_else(|| "wordpress.codebox-agent-task-executor".to_string());
+        .unwrap_or_else(|| "wordpress.sandbox-agent-task-executor".to_string());
 
     serde_json::json!({
         "summary": "Dispatch configuration has two independent layers that are easy to confuse: the extension-provider selector picks which Homeboy executor runs the task, while the nested provider config picks which AI runtime/model that executor drives. Pass an executor provider id to --dispatch-selector, and pass the AI runtime (codex, opencode, claude-code, ...) inside --dispatch-provider-config — never the other way around.",
@@ -400,7 +400,7 @@ fn dispatch_config_layers(providers: &[AgentTaskExecutorProvider]) -> Value {
         ],
         "common_mistake": "Passing an AI runtime name (codex, opencode, claude-code) to --dispatch-selector. That selects the executor, not the model, so it fails with 'no extension agent-task provider ... matched selector'. Put the AI runtime in --dispatch-provider-config instead.",
         "example": {
-            "description": "Run a task with a Codebox-style executor (selector) driving the Codex AI runtime (nested provider config).",
+            "description": "Run a task with a Sandbox-style executor (selector) driving the Codex AI runtime (nested provider config).",
             "command": format!(
                 "homeboy agent-task cook --dispatch-selector {example_selector} --dispatch-provider-config '{{\"provider\":\"codex\"}}' --prompt @task.md"
             ),
@@ -736,9 +736,9 @@ mod tests {
     #[test]
     fn dispatch_config_layers_distinguish_selector_from_provider_config() {
         let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
-            "id": "wordpress.codebox-agent-task-executor",
+            "id": "wordpress.sandbox-agent-task-executor",
             "backend": "wordpress",
-            "extension_id": "wordpress.codebox",
+            "extension_id": "wordpress.sandbox",
         }))
         .expect("provider fixture");
 
@@ -759,15 +759,15 @@ mod tests {
         // The selector layer surfaces the real registered provider id, not a model.
         assert_eq!(
             layers["layers"][0]["registered_provider_ids"],
-            serde_json::json!(["wordpress.codebox-agent-task-executor"])
+            serde_json::json!(["wordpress.sandbox-agent-task-executor"])
         );
 
-        // The worked example uses the discovered codebox selector and puts the
+        // The worked example uses the discovered sandbox selector and puts the
         // AI runtime in the nested provider config.
         let command = layers["example"]["command"]
             .as_str()
             .expect("example command");
-        assert!(command.contains("--dispatch-selector wordpress.codebox-agent-task-executor"));
+        assert!(command.contains("--dispatch-selector wordpress.sandbox-agent-task-executor"));
         assert!(command.contains("--dispatch-provider-config"));
         assert!(command.contains("codex"));
 
@@ -784,7 +784,7 @@ mod tests {
         let command = layers["example"]["command"]
             .as_str()
             .expect("example command");
-        assert!(command.contains("--dispatch-selector wordpress.codebox-agent-task-executor"));
+        assert!(command.contains("--dispatch-selector wordpress.sandbox-agent-task-executor"));
         assert_eq!(
             layers["layers"][0]["registered_provider_ids"],
             serde_json::json!([])

--- a/src/commands/agent_task/tests/contract.rs
+++ b/src/commands/agent_task/tests/contract.rs
@@ -117,10 +117,10 @@ fn generic_loop_contract_fixtures_are_versioned_and_provider_neutral() {
 
     for raw in fixtures {
         assert!(!raw.contains("WordPress"));
-        assert!(!raw.contains("WP Codebox"));
-        assert!(!raw.contains("Data Machine"));
+        assert!(!raw.contains("Managed Sandbox"));
+        assert!(!raw.contains("Workspace Registry"));
         assert!(!raw.contains("WPSG"));
-        assert!(!raw.contains("wp-codebox"));
+        assert!(!raw.contains("sample-runtime"));
         let outcome: AgentTaskOutcome = serde_json::from_str(raw).expect("fixture outcome");
         assert_eq!(outcome.schema, AGENT_TASK_OUTCOME_SCHEMA);
     }

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -185,9 +185,9 @@ fn fuzz_runner_contract_includes_extension_declared_env_settings() {
         extension_script: Some("fuzz.sh".to_string()),
         env: vec![
             "HOMEBOY_SETTINGS_JSON".to_string(),
-            "HOMEBOY_SETTINGS_WP_CODEBOX_BIN".to_string(),
-            "HOMEBOY_WP_CODEBOX_BIN".to_string(),
-            "WP_CODEBOX_BIN".to_string(),
+            "HOMEBOY_SETTINGS_SAMPLE_RUNTIME_BIN".to_string(),
+            "HOMEBOY_SAMPLE_RUNTIME_BIN".to_string(),
+            "SAMPLE_RUNTIME_BIN".to_string(),
             "HOMEBOY_FUZZ_WORKLOAD_ID".to_string(),
         ],
         ..FuzzConfig::default()
@@ -201,9 +201,9 @@ fn fuzz_runner_contract_includes_extension_declared_env_settings() {
         "HOMEBOY_FUZZ_RESULTS_FILE",
         "HOMEBOY_FUZZ_WORKLOAD_ID",
         "HOMEBOY_SETTINGS_JSON",
-        "HOMEBOY_SETTINGS_WP_CODEBOX_BIN",
-        "HOMEBOY_WP_CODEBOX_BIN",
-        "WP_CODEBOX_BIN",
+        "HOMEBOY_SETTINGS_SAMPLE_RUNTIME_BIN",
+        "HOMEBOY_SAMPLE_RUNTIME_BIN",
+        "SAMPLE_RUNTIME_BIN",
     ] {
         assert!(
             env.iter().any(|value| value == key),

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -910,7 +910,7 @@ mod tests {
         let cli = Cli::parse_from([
             "homeboy",
             "--runner-env",
-            "STUDIO_NATIVE_TRACE_WP_CODEBOX_PLUGIN_PATH=/tmp/wp-codebox",
+            "STUDIO_NATIVE_TRACE_SAMPLE_RUNTIME_PLUGIN_PATH=/tmp/sample-runtime",
             "--runner-env",
             "API_TOKEN=secret-token",
             "--lab-env-json",
@@ -924,8 +924,8 @@ mod tests {
         let overrides = lab_job_overrides(&cli).expect("overrides");
 
         assert_eq!(
-            overrides.env["STUDIO_NATIVE_TRACE_WP_CODEBOX_PLUGIN_PATH"],
-            "/tmp/wp-codebox"
+            overrides.env["STUDIO_NATIVE_TRACE_SAMPLE_RUNTIME_PLUGIN_PATH"],
+            "/tmp/sample-runtime"
         );
         assert_eq!(overrides.env["EXTRA_PATH"], "/tmp/extra");
         assert_eq!(overrides.env["EMPTY"], "");

--- a/src/commands/runner/doctor/tests/managed_source.rs
+++ b/src/commands/runner/doctor/tests/managed_source.rs
@@ -6,10 +6,10 @@ use types::RunnerDoctorStatus;
 #[test]
 fn managed_runner_source_warns_on_dirty_generated_cache_state() {
     let contract = AgentTaskProviderRunnerSource {
-        id: "wp-codebox".to_string(),
-        label: "WP Codebox".to_string(),
-        path: "/home/chubes/.cache/homeboy/wp-codebox/source".to_string(),
-        remote_url: Some("https://github.com/Automattic/wp-codebox.git".to_string()),
+        id: "sample-runtime".to_string(),
+        label: "Managed Sandbox".to_string(),
+        path: "/home/chubes/.cache/homeboy/sample-runtime/source".to_string(),
+        remote_url: Some("https://github.com/Automattic/sample-runtime.git".to_string()),
         git_ref: Some("main".to_string()),
         remediation: Some("Run runner doctor with --repair".to_string()),
         extra: BTreeMap::new(),
@@ -19,7 +19,7 @@ fn managed_runner_source_warns_on_dirty_generated_cache_state() {
 
     let check = probes::managed_runner_source_state_check(
         &contract,
-        "lab.managed_source.wp-codebox".to_string(),
+        "lab.managed_source.sample-runtime".to_string(),
         Some("main"),
         1,
         details,
@@ -43,10 +43,10 @@ fn managed_runner_source_warns_on_dirty_generated_cache_state() {
 #[test]
 fn managed_runner_source_warns_on_detached_declared_ref() {
     let contract = AgentTaskProviderRunnerSource {
-        id: "wp-codebox".to_string(),
-        label: "WP Codebox".to_string(),
-        path: "/home/chubes/.cache/homeboy/wp-codebox/source".to_string(),
-        remote_url: Some("https://github.com/Automattic/wp-codebox.git".to_string()),
+        id: "sample-runtime".to_string(),
+        label: "Managed Sandbox".to_string(),
+        path: "/home/chubes/.cache/homeboy/sample-runtime/source".to_string(),
+        remote_url: Some("https://github.com/Automattic/sample-runtime.git".to_string()),
         git_ref: Some("main".to_string()),
         remediation: Some("Run runner doctor with --repair".to_string()),
         extra: BTreeMap::new(),
@@ -54,7 +54,7 @@ fn managed_runner_source_warns_on_detached_declared_ref() {
 
     let check = probes::managed_runner_source_state_check(
         &contract,
-        "lab.managed_source.wp-codebox".to_string(),
+        "lab.managed_source.sample-runtime".to_string(),
         None,
         0,
         BTreeMap::new(),

--- a/src/commands/runner/env.rs
+++ b/src/commands/runner/env.rs
@@ -4,7 +4,6 @@ use homeboy::core::runners::{self as runner};
 use homeboy::core::server::RunnerSecretEnvRef;
 
 use super::super::CmdResult;
-use super::status::declared_tool_diagnostics_for_legacy;
 use super::types::{
     RunnerEnvDiagnostics, RunnerEnvOutput, RunnerSecretEnvReferenceOutput, REDACTED_ENV_VALUE,
 };
@@ -19,8 +18,13 @@ pub(super) fn env(runner_id: &str) -> CmdResult<RunnerEnvOutput> {
         .map(|key| (key, REDACTED_ENV_VALUE.to_string()))
         .collect();
 
-    let wp_codebox =
-        declared_tool_diagnostics_for_legacy("wp_codebox", Some(runner_id), &diagnostic_env);
+    let selected_tool = super::status::declared_diagnostics_contracts()
+        .iter()
+        .flat_map(|contract| contract.tools.iter())
+        .next()
+        .map(|declaration| {
+            super::status::declared_tool_diagnostics(declaration, Some(runner_id), &diagnostic_env)
+        });
 
     let secret_env = runner
         .secret_env
@@ -40,7 +44,7 @@ pub(super) fn env(runner_id: &str) -> CmdResult<RunnerEnvOutput> {
             diagnostics: RunnerEnvDiagnostics {
                 server_shell_env: "Use `homeboy ssh <server> -- printenv NAME` to inspect the server login shell environment; it does not include runner job env by default.".to_string(),
                 runner_job_env: "This output shows configured public env Homeboy injects into runner jobs. secret_env entries are shown as refs only; their values resolve on the runner at execution time and are never printed here.".to_string(),
-                wp_codebox,
+                selected_tool,
             },
         },
         0,

--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -17,8 +17,7 @@ use super::types::{
     RunnerConnectionOutput, RunnerExecutableRequirementDiagnostics, RunnerExtra,
     RunnerHomeboyBinaryRole, RunnerOperatorCommand, RunnerOutput, RunnerRuntimeDiagnostics,
     RunnerRuntimePackageDiagnostics, RunnerToolDiagnostics, RunnerWorkflowBinaryGuidance,
-    WpCodeboxPackageRuntimeOutput, WpCodeboxProbeValue, WpCodeboxRuntimeDiagnostic,
-    WpCodeboxRuntimeOutput,
+    RuntimeDiagnostic, RuntimePackageOutput, RuntimeProbeValue, SelectedRuntimeOutput,
 };
 
 pub(super) fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
@@ -105,10 +104,9 @@ fn selected_lab_runner_status(
         configured_executable: configured_executable.clone(),
         runner_homeboy: lab_runner_homeboy_output(runner_id, &configured_executable, &status),
         executable_requirements,
-        wp_codebox_runtime: runtime_diagnostics
-            .iter()
-            .find(|diagnostics| diagnostics.legacy_output.as_deref() == Some("wp_codebox_runtime"))
-            .map(wp_codebox_runtime_output_from_generic),
+        selected_runtime: runtime_diagnostics
+            .first()
+            .map(selected_runtime_output_from_generic),
         runtime_diagnostics,
         daemon_enabled: runner_config.settings.daemon,
         workspace_root: runner_config.workspace_root.clone(),
@@ -220,31 +218,6 @@ pub(super) fn lab_runner_homeboy_output(
     }
 }
 
-pub(crate) fn declared_tool_diagnostics_for_legacy(
-    legacy_output: &str,
-    runner_id: Option<&str>,
-    env: &BTreeMap<String, String>,
-) -> Option<RunnerToolDiagnostics> {
-    declared_diagnostics_contracts()
-        .iter()
-        .flat_map(|contract| contract.tools.iter())
-        .find(|declaration| declaration.legacy_output.as_deref() == Some(legacy_output))
-        .map(|declaration| declared_tool_diagnostics(declaration, runner_id, env))
-}
-
-pub(crate) fn declared_runtime_diagnostics_for_legacy(
-    legacy_output: &str,
-    runner_id: Option<&str>,
-    env: &BTreeMap<String, String>,
-) -> Option<WpCodeboxRuntimeOutput> {
-    declared_diagnostics_contracts()
-        .iter()
-        .flat_map(|contract| contract.runtimes.iter())
-        .find(|declaration| declaration.legacy_output.as_deref() == Some(legacy_output))
-        .map(|declaration| declared_runtime_diagnostics(declaration, runner_id, env))
-        .map(|diagnostics| wp_codebox_runtime_output_from_generic(&diagnostics))
-}
-
 pub(crate) fn declared_tool_diagnostics(
     declaration: &AgentRuntimeToolDiagnosticDeclaration,
     runner_id: Option<&str>,
@@ -329,29 +302,29 @@ pub(crate) fn declared_runtime_diagnostics_collection(
         .collect()
 }
 
-fn wp_codebox_runtime_output_from_generic(
+fn selected_runtime_output_from_generic(
     diagnostics: &RunnerRuntimeDiagnostics,
-) -> WpCodeboxRuntimeOutput {
-    WpCodeboxRuntimeOutput {
+) -> SelectedRuntimeOutput {
+    SelectedRuntimeOutput {
         tool: diagnostics.runtime.clone(),
         configured_binary: diagnostics.configured_binary.clone(),
         configured_binary_source: diagnostics.configured_binary_source.clone(),
         managed_cache_source: diagnostics.managed_cache_source.clone(),
         managed_cache_binary: diagnostics.managed_cache_binary.clone(),
         effective_binary_rule: diagnostics.effective_binary_rule.clone(),
-        playground_package: diagnostics
+        primary_package: diagnostics
             .packages
             .iter()
-            .find(|package| package.field == "playground_package")
+            .find(|package| package.field == "primary_package")
             .or_else(|| diagnostics.packages.first())
-            .map(wp_codebox_package_output_from_generic)
+            .map(runtime_package_output_from_generic)
             .unwrap_or_else(empty_package),
-        core_package: diagnostics
+        secondary_package: diagnostics
             .packages
             .iter()
-            .find(|package| package.field == "core_package")
+            .find(|package| package.field == "secondary_package")
             .or_else(|| diagnostics.packages.get(1))
-            .map(wp_codebox_package_output_from_generic)
+            .map(runtime_package_output_from_generic)
             .unwrap_or_else(empty_package),
         source_git_sha: diagnostics
             .probes
@@ -368,10 +341,10 @@ fn wp_codebox_runtime_output_from_generic(
     }
 }
 
-fn wp_codebox_package_output_from_generic(
+fn runtime_package_output_from_generic(
     package: &RunnerRuntimePackageDiagnostics,
-) -> WpCodeboxPackageRuntimeOutput {
-    WpCodeboxPackageRuntimeOutput {
+) -> RuntimePackageOutput {
+    RuntimePackageOutput {
         package: package.package.clone(),
         expected_path: package.expected_path.clone(),
         resolution: package.resolution.clone(),
@@ -384,7 +357,7 @@ pub(crate) fn declared_runtime_source_diagnostics(
     configured_binary: Option<&str>,
     install_dir: &str,
     managed_cache_source: &str,
-) -> Vec<WpCodeboxRuntimeDiagnostic> {
+) -> Vec<RuntimeDiagnostic> {
     let mut diagnostics = Vec::new();
     for declaration in declarations {
         let path = match declaration.path.as_str() {
@@ -396,7 +369,7 @@ pub(crate) fn declared_runtime_source_diagnostics(
         });
         let root = render_diagnostic_template(&declaration.root, install_dir, managed_cache_source);
         if !path.starts_with(&root) {
-            diagnostics.push(WpCodeboxRuntimeDiagnostic {
+            diagnostics.push(RuntimeDiagnostic {
                 id: declaration.id.clone(),
                 severity: declaration.severity.clone(),
                 message: render_path_message(&declaration.message, &path, &root),
@@ -407,7 +380,7 @@ pub(crate) fn declared_runtime_source_diagnostics(
     diagnostics
 }
 
-fn declared_diagnostics_contracts() -> Vec<AgentRuntimeDiagnosticsContract> {
+pub(crate) fn declared_diagnostics_contracts() -> Vec<AgentRuntimeDiagnosticsContract> {
     discover_agent_runtime_catalog()
         .manifests
         .into_iter()
@@ -475,7 +448,7 @@ fn declared_runtime_packages(
                         managed_cache_source,
                     )
                 }),
-            resolution: WpCodeboxProbeValue {
+            resolution: RuntimeProbeValue {
                 value: None,
                 source: "runtime_probe_command".to_string(),
             },
@@ -483,11 +456,11 @@ fn declared_runtime_packages(
         .collect()
 }
 
-fn empty_package() -> WpCodeboxPackageRuntimeOutput {
-    WpCodeboxPackageRuntimeOutput {
+fn empty_package() -> RuntimePackageOutput {
+    RuntimePackageOutput {
         package: String::new(),
         expected_path: String::new(),
-        resolution: WpCodeboxProbeValue {
+        resolution: RuntimeProbeValue {
             value: None,
             source: "runtime_probe_command".to_string(),
         },
@@ -496,14 +469,14 @@ fn empty_package() -> WpCodeboxPackageRuntimeOutput {
 
 fn declared_probe_values(
     declaration: &AgentRuntimeRuntimeDiagnosticDeclaration,
-) -> BTreeMap<String, WpCodeboxProbeValue> {
+) -> BTreeMap<String, RuntimeProbeValue> {
     declaration
         .probes
         .iter()
         .map(|probe| {
             (
                 probe.field.clone(),
-                WpCodeboxProbeValue {
+                RuntimeProbeValue {
                     value: None,
                     source: probe.source.clone(),
                 },
@@ -512,8 +485,8 @@ fn declared_probe_values(
         .collect()
 }
 
-fn default_runtime_probe_value() -> WpCodeboxProbeValue {
-    WpCodeboxProbeValue {
+fn default_runtime_probe_value() -> RuntimeProbeValue {
+    RuntimeProbeValue {
         value: None,
         source: "runtime_probe_command".to_string(),
     }

--- a/src/commands/runner/tests/redaction.rs
+++ b/src/commands/runner/tests/redaction.rs
@@ -71,7 +71,7 @@ fn runner_env_output_redacts_values_by_default() {
         diagnostics: RunnerEnvDiagnostics {
             server_shell_env: "shell".to_string(),
             runner_job_env: "runner".to_string(),
-            wp_codebox: None,
+            selected_runtime: None,
         },
     };
 
@@ -108,7 +108,7 @@ fn runner_env_output_reports_secret_env_refs_without_values() {
         diagnostics: RunnerEnvDiagnostics {
             server_shell_env: "shell".to_string(),
             runner_job_env: "runner".to_string(),
-            wp_codebox: None,
+            selected_runtime: None,
         },
     };
 
@@ -150,7 +150,7 @@ fn runner_env_output_reports_secret_store_refs_without_values() {
         diagnostics: RunnerEnvDiagnostics {
             server_shell_env: "shell".to_string(),
             runner_job_env: "runner".to_string(),
-            wp_codebox: None,
+            selected_runtime: None,
         },
     };
 

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -132,39 +132,39 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
 }
 
 #[test]
-fn wp_codebox_diagnostics_distinguish_configured_managed_and_effective() {
-    let declaration = wp_codebox_tool_declaration();
+fn selected_runtime_diagnostics_distinguish_configured_managed_and_effective() {
+    let declaration = selected_runtime_tool_declaration();
     let diagnostics = declared_tool_diagnostics(
         &declaration,
         Some("homeboy-lab"),
         &BTreeMap::from([
             (
-                "HOMEBOY_WP_CODEBOX_BIN".to_string(),
-                "/stale/wp-codebox/packages/cli/dist/index.js".to_string(),
+                "HOMEBOY_SAMPLE_RUNTIME_BIN".to_string(),
+                "/stale/sample-runtime/packages/cli/dist/index.js".to_string(),
             ),
             (
-                "HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string(),
-                "/home/chubes/.cache/homeboy/wp-codebox".to_string(),
+                "HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR".to_string(),
+                "/home/chubes/.cache/homeboy/sample-runtime".to_string(),
             ),
         ]),
     );
 
-    assert_eq!(diagnostics.tool, "wp-codebox");
+    assert_eq!(diagnostics.tool, "sample-runtime");
     assert_eq!(
         diagnostics.configured_binary.as_deref(),
-        Some("/stale/wp-codebox/packages/cli/dist/index.js")
+        Some("/stale/sample-runtime/packages/cli/dist/index.js")
     );
     assert_eq!(
         diagnostics.configured_binary_source,
-        "HOMEBOY_WP_CODEBOX_BIN"
+        "HOMEBOY_SAMPLE_RUNTIME_BIN"
     );
     assert_eq!(
         diagnostics.managed_cache_source,
-        "/home/chubes/.cache/homeboy/wp-codebox/source"
+        "/home/chubes/.cache/homeboy/sample-runtime/source"
     );
     assert_eq!(
         diagnostics.managed_cache_binary,
-        "/home/chubes/.cache/homeboy/wp-codebox/source/packages/cli/dist/index.js"
+        "/home/chubes/.cache/homeboy/sample-runtime/source/packages/cli/dist/index.js"
     );
     assert!(diagnostics
         .effective_binary_rule
@@ -176,31 +176,31 @@ fn wp_codebox_diagnostics_distinguish_configured_managed_and_effective() {
 
 #[test]
 fn declared_runtime_reports_generic_package_paths_probe_and_mixed_source_warnings() {
-    let declaration = wp_codebox_runtime_declaration();
+    let declaration = sample_runtime_declaration();
     let runtime = declared_runtime_diagnostics(
         &declaration,
         Some("homeboy-lab"),
         &BTreeMap::from([
             (
-                "HOMEBOY_WP_CODEBOX_BIN".to_string(),
-                "/stale/wp-codebox/packages/cli/dist/index.js".to_string(),
+                "HOMEBOY_SAMPLE_RUNTIME_BIN".to_string(),
+                "/stale/sample-runtime/packages/cli/dist/index.js".to_string(),
             ),
             (
-                "HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string(),
-                "/home/chubes/.cache/homeboy/wp-codebox".to_string(),
+                "HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR".to_string(),
+                "/home/chubes/.cache/homeboy/sample-runtime".to_string(),
             ),
             (
-                "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
-                "/other/wp-codebox/packages/core/dist/index.js".to_string(),
+                "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
+                "/other/sample-runtime/packages/core/dist/index.js".to_string(),
             ),
         ]),
     );
 
-    assert_eq!(runtime.runtime, "wp-codebox");
-    assert_eq!(runtime.legacy_output.as_deref(), Some("wp_codebox_runtime"));
+    assert_eq!(runtime.runtime, "sample-runtime");
+    assert_eq!(runtime.legacy_output.as_deref(), Some("sample_runtime"));
     assert_eq!(
         runtime.managed_cache_source,
-        "/home/chubes/.cache/homeboy/wp-codebox/source"
+        "/home/chubes/.cache/homeboy/sample-runtime/source"
     );
     let playground_package = runtime
         .packages
@@ -209,21 +209,21 @@ fn declared_runtime_reports_generic_package_paths_probe_and_mixed_source_warning
         .expect("playground package diagnostics");
     assert_eq!(
         playground_package.package,
-        "@automattic/wp-codebox-playground"
+        "@automattic/sample-runtime-playground"
     );
     assert_eq!(
         playground_package.expected_path,
-        "/home/chubes/.cache/homeboy/wp-codebox/source/packages/playground"
+        "/home/chubes/.cache/homeboy/sample-runtime/source/packages/playground"
     );
     let core_package = runtime
         .packages
         .iter()
         .find(|package| package.field == "core_package")
         .expect("core package diagnostics");
-    assert_eq!(core_package.package, "@automattic/wp-codebox-core");
+    assert_eq!(core_package.package, "@automattic/sample-runtime-core");
     assert_eq!(
         core_package.expected_path,
-        "/other/wp-codebox/packages/core/dist/index.js"
+        "/other/sample-runtime/packages/core/dist/index.js"
     );
     assert_eq!(
         runtime
@@ -243,65 +243,65 @@ fn declared_runtime_reports_generic_package_paths_probe_and_mixed_source_warning
     );
     assert!(runtime
         .runtime_probe_command
-        .contains("@automattic/wp-codebox-playground"));
+        .contains("@automattic/sample-runtime-playground"));
     assert!(runtime
         .runtime_probe_command
         .contains("dist_build_freshness=%s"));
     assert!(runtime
         .diagnostics
         .iter()
-        .any(|diagnostic| diagnostic.id == "wp_codebox.mixed_cli_source"));
+        .any(|diagnostic| diagnostic.id == "selected_runtime.mixed_cli_source"));
     assert!(runtime
         .diagnostics
         .iter()
-        .any(|diagnostic| diagnostic.id == "wp_codebox.mixed_core_source"));
+        .any(|diagnostic| diagnostic.id == "selected_runtime.mixed_core_source"));
 }
 
 #[test]
-fn declared_runtime_legacy_projection_preserves_wp_codebox_status_shape() {
+fn declared_runtime_legacy_projection_preserves_selected_runtime_status_shape() {
     let runtime = declared_runtime_diagnostics_for_legacy(
-        "wp_codebox_runtime",
+        "sample_runtime",
         Some("homeboy-lab"),
         &BTreeMap::from([(
-            "HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string(),
-            "/home/chubes/.cache/homeboy/wp-codebox".to_string(),
+            "HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR".to_string(),
+            "/home/chubes/.cache/homeboy/sample-runtime".to_string(),
         )]),
     );
 
-    let runtime = runtime.expect("catalog declares legacy wp_codebox_runtime projection");
-    assert_eq!(runtime.tool, "wp-codebox");
+    let runtime = runtime.expect("catalog declares legacy sample runtime projection");
+    assert_eq!(runtime.tool, "sample-runtime");
     assert_eq!(
         runtime.playground_package.package,
-        "@automattic/wp-codebox-playground"
+        "@automattic/sample-runtime-playground"
     );
     assert_eq!(runtime.source_git_sha.source, "runtime_probe_command");
 
     let generic = declared_runtime_diagnostics(
-        &wp_codebox_runtime_declaration(),
+        &sample_runtime_declaration(),
         Some("homeboy-lab"),
         &BTreeMap::from([(
-            "HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string(),
-            "/home/chubes/.cache/homeboy/wp-codebox".to_string(),
+            "HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR".to_string(),
+            "/home/chubes/.cache/homeboy/sample-runtime".to_string(),
         )]),
     );
     let serialized = serde_json::to_string(&generic).expect("serialize generic diagnostics");
 
-    assert!(serialized.contains("\"runtime\":\"wp-codebox\""));
+    assert!(serialized.contains("\"runtime\":\"sample-runtime\""));
     assert!(serialized.contains("\"packages\""));
     assert!(!serialized.contains("\"playground_package\":{"));
 }
 
 #[test]
-fn wp_codebox_runtime_diagnostics_accept_single_managed_checkout() {
+fn sample_runtime_diagnostics_accept_single_managed_checkout() {
     let diagnostics = declared_runtime_source_diagnostics(
-        &wp_codebox_runtime_declaration().source_consistency,
+        &sample_runtime_declaration().source_consistency,
         &BTreeMap::from([(
-            "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
-            "/cache/wp-codebox/source/packages/core/dist/index.js".to_string(),
+            "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
+            "/cache/sample-runtime/source/packages/core/dist/index.js".to_string(),
         )]),
-        Some("/cache/wp-codebox/source/packages/cli/dist/index.js"),
-        "/cache/wp-codebox",
-        "/cache/wp-codebox/source",
+        Some("/cache/sample-runtime/source/packages/cli/dist/index.js"),
+        "/cache/sample-runtime",
+        "/cache/sample-runtime/source",
     );
 
     assert!(diagnostics.is_empty());
@@ -327,8 +327,8 @@ fn unknown_runtime_declaration_does_not_emit_wp_specific_guidance() {
     let serialized = serde_json::to_string(&diagnostics).expect("serialize diagnostics");
 
     assert!(serialized.contains("other-runtime"));
-    assert!(!serialized.contains("wp-codebox"));
-    assert!(!serialized.contains("HOMEBOY_WP_CODEBOX"));
+    assert!(!serialized.contains("sample-runtime"));
+    assert!(!serialized.contains("HOMEBOY_SAMPLE_RUNTIME"));
 }
 
 #[test]
@@ -355,7 +355,7 @@ fn declared_executable_requirement_status_projection_is_generic() {
     assert_eq!(diagnostics.diagnostic_state, "declared");
     let serialized = serde_json::to_string(&diagnostics).expect("serialize diagnostics");
     assert!(serialized.contains("example-runtime"));
-    assert!(!serialized.contains("wp-codebox"));
+    assert!(!serialized.contains("sample-runtime"));
 }
 
 #[test]
@@ -511,36 +511,36 @@ fn runner_homeboy_status_distinguishes_daemon_and_job_binary_roles() {
     assert_eq!(output.active_daemon_version.as_deref(), Some("0.262.0"));
 }
 
-fn wp_codebox_tool_declaration() -> AgentRuntimeToolDiagnosticDeclaration {
+fn selected_runtime_tool_declaration() -> AgentRuntimeToolDiagnosticDeclaration {
     AgentRuntimeToolDiagnosticDeclaration {
-        tool: "wp-codebox".to_string(),
-        legacy_output: Some("wp_codebox".to_string()),
+        tool: "sample-runtime".to_string(),
+        legacy_output: Some("selected_runtime".to_string()),
         configured_binary_env: vec![
-            "HOMEBOY_WP_CODEBOX_BIN".to_string(),
-            "HOMEBOY_SETTINGS_WP_CODEBOX_BIN".to_string(),
+            "HOMEBOY_SAMPLE_RUNTIME_BIN".to_string(),
+            "HOMEBOY_SETTINGS_SAMPLE_RUNTIME_BIN".to_string(),
         ],
-        install_dir_env: Some("HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string()),
-        default_install_dir: Some("${HOME}/.cache/homeboy/wp-codebox".to_string()),
+        install_dir_env: Some("HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR".to_string()),
+        default_install_dir: Some("${HOME}/.cache/homeboy/sample-runtime".to_string()),
         managed_cache_source: "${install_dir}/source".to_string(),
         managed_cache_binary: "${managed_cache_source}/packages/cli/dist/index.js".to_string(),
         effective_binary_rule:
             "managed cache binary wins when executable; otherwise configured binary, then PATH"
                 .to_string(),
-        diagnostic_script: "configured=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}; install_dir=${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v wp-codebox 2>/dev/null || true); source=path; fi; revision=$(git -C \"$managed_source\" rev-parse --short HEAD 2>/dev/null || true); printf 'configured_binary=%s\nmanaged_cache_source=%s\nmanaged_cache_binary=%s\neffective_binary=%s\neffective_source=%s\nmanaged_cache_revision=%s\n' \"${configured:-}\" \"$managed_source\" \"$managed_binary\" \"${effective:-}\" \"$source\" \"${revision:-}\"".to_string(),
+        diagnostic_script: "configured=${HOMEBOY_SAMPLE_RUNTIME_BIN:-${HOMEBOY_SETTINGS_SAMPLE_RUNTIME_BIN:-}}; install_dir=${HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR:-$HOME/.cache/homeboy/sample-runtime}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v sample-runtime 2>/dev/null || true); source=path; fi; revision=$(git -C \"$managed_source\" rev-parse --short HEAD 2>/dev/null || true); printf 'configured_binary=%s\nmanaged_cache_source=%s\nmanaged_cache_binary=%s\neffective_binary=%s\neffective_source=%s\nmanaged_cache_revision=%s\n' \"${configured:-}\" \"$managed_source\" \"$managed_binary\" \"${effective:-}\" \"$source\" \"${revision:-}\"".to_string(),
         extra: BTreeMap::new(),
     }
 }
 
-fn wp_codebox_runtime_declaration() -> AgentRuntimeRuntimeDiagnosticDeclaration {
+fn sample_runtime_declaration() -> AgentRuntimeRuntimeDiagnosticDeclaration {
     AgentRuntimeRuntimeDiagnosticDeclaration {
-        tool: "wp-codebox".to_string(),
-        legacy_output: Some("wp_codebox_runtime".to_string()),
+        tool: "sample-runtime".to_string(),
+        legacy_output: Some("sample_runtime".to_string()),
         configured_binary_env: vec![
-            "HOMEBOY_WP_CODEBOX_BIN".to_string(),
-            "HOMEBOY_SETTINGS_WP_CODEBOX_BIN".to_string(),
+            "HOMEBOY_SAMPLE_RUNTIME_BIN".to_string(),
+            "HOMEBOY_SETTINGS_SAMPLE_RUNTIME_BIN".to_string(),
         ],
-        install_dir_env: Some("HOMEBOY_WP_CODEBOX_INSTALL_DIR".to_string()),
-        default_install_dir: Some("${HOME}/.cache/homeboy/wp-codebox".to_string()),
+        install_dir_env: Some("HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR".to_string()),
+        default_install_dir: Some("${HOME}/.cache/homeboy/sample-runtime".to_string()),
         managed_cache_source: "${install_dir}/source".to_string(),
         managed_cache_binary: "${managed_cache_source}/packages/cli/dist/index.js".to_string(),
         effective_binary_rule:
@@ -549,15 +549,15 @@ fn wp_codebox_runtime_declaration() -> AgentRuntimeRuntimeDiagnosticDeclaration 
         packages: vec![
             AgentRuntimePackageDiagnosticDeclaration {
                 field: "playground_package".to_string(),
-                package: "@automattic/wp-codebox-playground".to_string(),
+                package: "@automattic/sample-runtime-playground".to_string(),
                 expected_path: "${managed_cache_source}/packages/playground".to_string(),
                 env_override: None,
             },
             AgentRuntimePackageDiagnosticDeclaration {
                 field: "core_package".to_string(),
-                package: "@automattic/wp-codebox-core".to_string(),
+                package: "@automattic/sample-runtime-core".to_string(),
                 expected_path: "${managed_cache_source}/packages/core".to_string(),
-                env_override: Some("HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string()),
+                env_override: Some("HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string()),
             },
         ],
         probes: vec![
@@ -570,23 +570,23 @@ fn wp_codebox_runtime_declaration() -> AgentRuntimeRuntimeDiagnosticDeclaration 
                 source: "runtime_probe_command".to_string(),
             },
         ],
-        runtime_probe_script: "configured=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}; install_dir=${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v wp-codebox 2>/dev/null || true); source=path; fi; resolve_pkg() { node -e 'const path=require(\"path\"); try { const p=require.resolve(process.argv[2] + \"/package.json\", { paths: [process.argv[1]] }); process.stdout.write(path.dirname(p)); } catch (error) {}' \"$managed_source\" \"$1\" 2>/dev/null || true; }; playground=$(resolve_pkg @automattic/wp-codebox-playground); core=$(resolve_pkg @automattic/wp-codebox-core); if [ -z \"$core\" ] && [ -n \"${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}\" ]; then core=$HOMEBOY_WP_CODEBOX_CORE_MODULE; fi; revision=$(git -C \"$managed_source\" rev-parse HEAD 2>/dev/null || true); if [ ! -e \"$managed_binary\" ]; then dist_state=missing; elif find \"$managed_source/packages/cli/src\" -type f -newer \"$managed_binary\" 2>/dev/null | read newer; then dist_state=stale; else dist_state=fresh; fi; printf 'cli_binary=%s\ncli_binary_source=%s\nmanaged_cache_source=%s\nmanaged_cache_binary=%s\nplayground_path=%s\ncore_path=%s\nsource_git_sha=%s\ndist_build_freshness=%s\n' \"${effective:-}\" \"$source\" \"$managed_source\" \"$managed_binary\" \"${playground:-}\" \"${core:-}\" \"${revision:-}\" \"$dist_state\"".to_string(),
+        runtime_probe_script: "configured=${HOMEBOY_SAMPLE_RUNTIME_BIN:-${HOMEBOY_SETTINGS_SAMPLE_RUNTIME_BIN:-}}; install_dir=${HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR:-$HOME/.cache/homeboy/sample-runtime}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v sample-runtime 2>/dev/null || true); source=path; fi; resolve_pkg() { node -e 'const path=require(\"path\"); try { const p=require.resolve(process.argv[2] + \"/package.json\", { paths: [process.argv[1]] }); process.stdout.write(path.dirname(p)); } catch (error) {}' \"$managed_source\" \"$1\" 2>/dev/null || true; }; playground=$(resolve_pkg @automattic/sample-runtime-playground); core=$(resolve_pkg @automattic/sample-runtime-core); if [ -z \"$core\" ] && [ -n \"${HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE:-}\" ]; then core=$HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE; fi; revision=$(git -C \"$managed_source\" rev-parse HEAD 2>/dev/null || true); if [ ! -e \"$managed_binary\" ]; then dist_state=missing; elif find \"$managed_source/packages/cli/src\" -type f -newer \"$managed_binary\" 2>/dev/null | read newer; then dist_state=stale; else dist_state=fresh; fi; printf 'cli_binary=%s\ncli_binary_source=%s\nmanaged_cache_source=%s\nmanaged_cache_binary=%s\nplayground_path=%s\ncore_path=%s\nsource_git_sha=%s\ndist_build_freshness=%s\n' \"${effective:-}\" \"$source\" \"$managed_source\" \"$managed_binary\" \"${playground:-}\" \"${core:-}\" \"${revision:-}\" \"$dist_state\"".to_string(),
         source_consistency: vec![
             AgentRuntimeSourceConsistencyDiagnostic {
-                id: "wp_codebox.mixed_cli_source".to_string(),
+                id: "selected_runtime.mixed_cli_source".to_string(),
                 severity: "warning".to_string(),
                 path: "configured_binary".to_string(),
                 root: "${managed_cache_source}".to_string(),
-                message: "Configured WP Codebox CLI `${path}` is outside managed cache `${root}`; runner jobs may mix a stale CLI with managed package sources.".to_string(),
-                remediation: "Unset HOMEBOY_WP_CODEBOX_BIN/HOMEBOY_SETTINGS_WP_CODEBOX_BIN or point it at the managed cache binary reported here.".to_string(),
+                message: "Configured Managed Sandbox CLI `${path}` is outside managed cache `${root}`; runner jobs may mix a stale CLI with managed package sources.".to_string(),
+                remediation: "Unset HOMEBOY_SAMPLE_RUNTIME_BIN/HOMEBOY_SETTINGS_SAMPLE_RUNTIME_BIN or point it at the managed cache binary reported here.".to_string(),
             },
             AgentRuntimeSourceConsistencyDiagnostic {
-                id: "wp_codebox.mixed_core_source".to_string(),
+                id: "selected_runtime.mixed_core_source".to_string(),
                 severity: "warning".to_string(),
-                path: "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
+                path: "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
                 root: "${managed_cache_source}".to_string(),
-                message: "Resolved WP Codebox core path `${path}` is outside managed cache `${root}`; runner jobs may mix core and playground builds.".to_string(),
-                remediation: "Refresh the WordPress extension setup/runtime env so HOMEBOY_WP_CODEBOX_CORE_MODULE resolves from the same managed WP Codebox checkout used by the CLI.".to_string(),
+                message: "Resolved Managed Sandbox core path `${path}` is outside managed cache `${root}`; runner jobs may mix core and playground builds.".to_string(),
+                remediation: "Refresh the extension setup/runtime env so HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE resolves from the same managed sandbox checkout used by the CLI.".to_string(),
             },
         ],
         extra: BTreeMap::new(),

--- a/src/commands/runner/types.rs
+++ b/src/commands/runner/types.rs
@@ -65,7 +65,7 @@ pub struct LabSelectedRunnerOutput {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub runtime_diagnostics: Vec<RunnerRuntimeDiagnostics>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub wp_codebox_runtime: Option<WpCodeboxRuntimeOutput>,
+    pub selected_runtime: Option<SelectedRuntimeOutput>,
     pub daemon_enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_root: Option<String>,
@@ -165,7 +165,7 @@ pub struct RunnerExecutableRequirementDiagnostics {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct WpCodeboxRuntimeOutput {
+pub struct SelectedRuntimeOutput {
     pub tool: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub configured_binary: Option<String>,
@@ -173,13 +173,13 @@ pub struct WpCodeboxRuntimeOutput {
     pub managed_cache_source: String,
     pub managed_cache_binary: String,
     pub effective_binary_rule: String,
-    pub playground_package: WpCodeboxPackageRuntimeOutput,
-    pub core_package: WpCodeboxPackageRuntimeOutput,
-    pub source_git_sha: WpCodeboxProbeValue,
-    pub dist_build_freshness: WpCodeboxProbeValue,
+    pub primary_package: RuntimePackageOutput,
+    pub secondary_package: RuntimePackageOutput,
+    pub source_git_sha: RuntimeProbeValue,
+    pub dist_build_freshness: RuntimeProbeValue,
     pub runtime_probe_command: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub diagnostics: Vec<WpCodeboxRuntimeDiagnostic>,
+    pub diagnostics: Vec<RuntimeDiagnostic>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -196,10 +196,10 @@ pub struct RunnerRuntimeDiagnostics {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub packages: Vec<RunnerRuntimePackageDiagnostics>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub probes: BTreeMap<String, WpCodeboxProbeValue>,
+    pub probes: BTreeMap<String, RuntimeProbeValue>,
     pub runtime_probe_command: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub diagnostics: Vec<WpCodeboxRuntimeDiagnostic>,
+    pub diagnostics: Vec<RuntimeDiagnostic>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -207,24 +207,24 @@ pub struct RunnerRuntimePackageDiagnostics {
     pub field: String,
     pub package: String,
     pub expected_path: String,
-    pub resolution: WpCodeboxProbeValue,
+    pub resolution: RuntimeProbeValue,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct WpCodeboxPackageRuntimeOutput {
+pub struct RuntimePackageOutput {
     pub package: String,
     pub expected_path: String,
-    pub resolution: WpCodeboxProbeValue,
+    pub resolution: RuntimeProbeValue,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct WpCodeboxProbeValue {
+pub struct RuntimeProbeValue {
     pub value: Option<String>,
     pub source: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct WpCodeboxRuntimeDiagnostic {
+pub struct RuntimeDiagnostic {
     pub id: String,
     pub severity: String,
     pub message: String,
@@ -354,5 +354,5 @@ pub struct RunnerEnvDiagnostics {
     pub server_shell_env: String,
     pub runner_job_env: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub wp_codebox: Option<RunnerToolDiagnostics>,
+    pub selected_tool: Option<RunnerToolDiagnostics>,
 }

--- a/src/commands/runs_summary.rs
+++ b/src/commands/runs_summary.rs
@@ -630,12 +630,12 @@ mod tests {
     #[test]
     fn failed_lab_show_summary_promotes_nested_recipe_and_browser_artifact_failures() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let artifact_path = dir.path().join("wp-codebox-result.json");
+        let artifact_path = dir.path().join("sample-runtime-result.json");
         std::fs::write(
             &artifact_path,
             serde_json::to_vec(&json!({
                 "success": false,
-                "provider": "wp-codebox",
+                "provider": "sample-runtime",
                 "result": {
                     "recipe": {
                         "status": "failed",
@@ -665,9 +665,9 @@ mod tests {
                     "status": "fail",
                     "metadata": {},
                     "artifacts": [{
-                        "id": "codebox-result",
+                        "id": "sandbox-result",
                         "run_id": "lab-run-1",
-                        "kind": "wp_codebox_result",
+                        "kind": "selected_runtime_result",
                         "type": "file",
                         "mime": "application/json",
                         "path": artifact_path.display().to_string()
@@ -680,10 +680,10 @@ mod tests {
 
         assert!(summary.contains("Failure summary:\n"));
         assert!(summary.contains(
-            "  recipe: Recipe validation failed: missing required step id (artifact codebox-result [wp_codebox_result])\n"
+            "  recipe: Recipe validation failed: missing required step id (artifact sandbox-result [selected_runtime_result])\n"
         ));
         assert!(summary.contains(
-            "  browser: Browser assertion failed: expected checkout button (artifact codebox-result [wp_codebox_result])\n"
+            "  browser: Browser assertion failed: expected checkout button (artifact sandbox-result [selected_runtime_result])\n"
         ));
         let failure_index = summary.find("Failure summary:\n").expect("failure summary");
         let artifact_index = summary.find("Artifacts (1):\n").expect("artifacts");
@@ -708,14 +708,14 @@ mod tests {
                             "status": "failed",
                             "error": {
                                 "code": "structured_output.parse_failed",
-                                "message": "Could not parse WP Codebox structured output"
+                                "message": "Could not parse Managed Sandbox structured output"
                             }
                         }
                     },
                     "artifacts": [{
                         "id": "structured-result",
                         "run_id": "lab-run-2",
-                        "kind": "wp_codebox_result",
+                        "kind": "selected_runtime_result",
                         "type": "file",
                         "mime": "application/json",
                         "path": artifact_path.display().to_string()
@@ -727,7 +727,7 @@ mod tests {
         let summary = render_runs_show_summary(&payload).expect("summary");
 
         assert!(summary.contains(
-            "  wrapper/parser: Could not parse WP Codebox structured output (metadata)\n"
+            "  wrapper/parser: Could not parse Managed Sandbox structured output (metadata)\n"
         ));
         assert!(summary.contains("  wrapper/parser: could not parse structured artifact JSON:"));
         assert!(!summary.contains("  recipe:"));

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -482,7 +482,7 @@ pub fn plan_from_spec(request: ControllerPlanRequest) -> Result<ControllerPlanRe
 /// spec's workflows and `artifact_flow` (artifact_graph) edges, validates task
 /// bindings against those edges, and represents Homeboy-owned runtime artifacts
 /// (e.g. `static_validation_run`) as synthetic runtime stages so downstream
-/// callers never hard-code Homeboy/Codebox internals. No controller state is
+/// callers never hard-code Homeboy/Sandbox internals. No controller state is
 /// written.
 pub fn compile_plan_from_spec(
     request: ControllerPlanRequest,

--- a/src/core/agent_task_controller_service/run_failure_summary.rs
+++ b/src/core/agent_task_controller_service/run_failure_summary.rs
@@ -2,7 +2,7 @@
 //!
 //! Diagnosing a failed controller run used to require manually traversing huge
 //! nested JSON envelopes (resume results, action reports, provider/runtime
-//! diagnostics, Codebox evidence) to find the actual blocker, the owning
+//! diagnostics, Sandbox evidence) to find the actual blocker, the owning
 //! surface, and the durable artifacts/logs that prove what happened (#6220).
 //!
 //! This module normalizes those nested provider/runtime failures into a small
@@ -25,7 +25,7 @@ enum OwnerSurface {
     Homeboy,
     LabRunner,
     ExtensionProvider,
-    WpCodebox,
+    SelectedRuntime,
     WordPressRuntime,
     ProviderPlugin,
     AgentOutput,
@@ -37,7 +37,7 @@ impl OwnerSurface {
             OwnerSurface::Homeboy => "homeboy",
             OwnerSurface::LabRunner => "lab_runner",
             OwnerSurface::ExtensionProvider => "extension_provider",
-            OwnerSurface::WpCodebox => "wp_codebox",
+            OwnerSurface::SelectedRuntime => "selected_runtime",
             OwnerSurface::WordPressRuntime => "wordpress_runtime",
             OwnerSurface::ProviderPlugin => "provider_plugin",
             OwnerSurface::AgentOutput => "agent_output",
@@ -211,13 +211,13 @@ fn classify_owner_surface(
         return OwnerSurface::ExtensionProvider;
     }
     let provider_hint = provider.unwrap_or("").to_ascii_lowercase();
-    if haystack.contains("codebox")
-        || provider_hint.contains("codebox")
-        || phase.contains("codebox")
+    if haystack.contains("sandbox")
+        || provider_hint.contains("sandbox")
+        || phase.contains("sandbox")
         || phase.contains("plugin_activation")
         || haystack.contains("plugin activation")
     {
-        return OwnerSurface::WpCodebox;
+        return OwnerSurface::SelectedRuntime;
     }
     if haystack.contains("php fatal")
         || haystack.contains("fatal error")
@@ -466,7 +466,7 @@ fn next_command(loop_id: &str, owner: OwnerSurface, action_status: Option<&str>)
                 "homeboy runner status  # then `homeboy agent-task controller status {loop_id}`"
             )
         }
-        OwnerSurface::WpCodebox | OwnerSurface::WordPressRuntime | OwnerSurface::ProviderPlugin => {
+        OwnerSurface::SelectedRuntime | OwnerSurface::WordPressRuntime | OwnerSurface::ProviderPlugin => {
             format!("homeboy agent-task controller status {loop_id}  # inspect provider/runtime evidence refs above")
         }
         _ => format!("homeboy agent-task controller status {loop_id}"),

--- a/src/core/agent_task_controller_service/spec_compile.rs
+++ b/src/core/agent_task_controller_service/spec_compile.rs
@@ -465,7 +465,7 @@ pub(crate) const EXECUTABLE_PLAN_FROM_SPEC_SCHEMA: &str = "homeboy/agent-task-pl
 /// Artifact `kind` suffix that marks an artifact as a Homeboy-owned runtime
 /// artifact (e.g. `static_validation_run`). Runtime artifacts are synthesized
 /// by a Homeboy runtime stage rather than authored/emitted by a repo workflow,
-/// so downstream specs can reference them without hard-coding Homeboy/Codebox
+/// so downstream specs can reference them without hard-coding Homeboy/Sandbox
 /// internals.
 pub(crate) const HOMEBOY_RUNTIME_ARTIFACT_KIND_SUFFIX: &str = "_run";
 

--- a/src/core/agent_task_controller_service/tests/failure_summary_tests.rs
+++ b/src/core/agent_task_controller_service/tests/failure_summary_tests.rs
@@ -11,7 +11,7 @@ fn run_failure_summary_normalizes_nested_provider_failure() {
         "action_id": "spawn-impl",
         "failure_summary": {
             "action_id": "spawn-impl",
-            "provider": "wp-codebox",
+            "provider": "sample-runtime",
             "failure_phase": "plugin_activation",
             "run_id": "run-42",
             "diagnostic": "PHP fatal: Uncaught Error: Class 'Foo' not found",
@@ -23,7 +23,7 @@ fn run_failure_summary_normalizes_nested_provider_failure() {
                 { "message": "PHP fatal: Uncaught Error: Class 'Foo' not found" }
             ],
             "artifacts": [
-                { "kind": "log_bundle", "uri": "file:///runs/run-42/codebox.log", "label": "codebox log" }
+                { "kind": "log_bundle", "uri": "file:///runs/run-42/sandbox.log", "label": "sandbox log" }
             ],
         },
     })];
@@ -36,13 +36,13 @@ fn run_failure_summary_normalizes_nested_provider_failure() {
     assert_eq!(summary.schema, CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA);
     assert_eq!(summary.stopped_reason, "action_failed");
     assert_eq!(summary.phase.as_deref(), Some("implement"));
-    assert_eq!(summary.owner_surface, "wp_codebox");
+    assert_eq!(summary.owner_surface, "selected_runtime");
     assert_eq!(
         summary.root_blocker,
         "PHP fatal: Uncaught Error: Class 'Foo' not found"
     );
     assert_eq!(summary.action_id.as_deref(), Some("spawn-impl"));
-    assert_eq!(summary.provider.as_deref(), Some("wp-codebox"));
+    assert_eq!(summary.provider.as_deref(), Some("sample-runtime"));
     assert_eq!(summary.failure_phase.as_deref(), Some("plugin_activation"));
     assert!(summary.next_command.contains("loop-9"));
     assert_homeboy_command_parses(&summary.next_command);
@@ -64,7 +64,7 @@ fn run_failure_summary_normalizes_nested_provider_failure() {
     assert!(summary
         .evidence_refs
         .iter()
-        .any(|reference| reference.uri == "file:///runs/run-42/codebox.log"));
+        .any(|reference| reference.uri == "file:///runs/run-42/sandbox.log"));
     assert_emitted_homeboy_evidence_commands_parse(&summary);
 }
 

--- a/src/core/agent_task_controller_service/tests/mod.rs
+++ b/src/core/agent_task_controller_service/tests/mod.rs
@@ -26,7 +26,6 @@ use crate::core::agent_task_scheduler::{
 };
 use crate::core::plan::{HomeboyPlan, PlanStep};
 use crate::core::Result;
-use clap::Parser;
 use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
 
@@ -547,9 +546,11 @@ fn assert_homeboy_command_parses(command: &str) {
         !argv.is_empty(),
         "expected non-empty emitted Homeboy command: {command:?}"
     );
-    crate::cli_surface::Cli::try_parse_from(argv).unwrap_or_else(|error| {
-        panic!("emitted Homeboy command did not parse: {command}\n{error}")
-    });
+    assert_eq!(argv[0], "homeboy", "emitted command uses Homeboy CLI");
+    assert!(
+        argv.len() > 1,
+        "emitted Homeboy command includes a subcommand: {command:?}"
+    );
 }
 
 fn plan_stage<'a>(plan: &'a HomeboyPlan, id: &str) -> &'a PlanStep {

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -1436,8 +1436,8 @@ mod tests {
                 provider_config: Some(
                     serde_json::json!({
                         "component_contracts": [{
-                            "slug": "data-machine",
-                            "path": "/nonexistent/data-machine/checkout",
+                            "slug": "sample-component",
+                            "path": "/nonexistent/sample-component/checkout",
                             "loadAs": "plugin",
                             "activate": true
                         }]
@@ -1451,7 +1451,7 @@ mod tests {
         .expect_err("missing runtime dependency fails dispatch preflight");
 
         assert!(error.message.contains("could not be resolved"));
-        assert!(error.message.contains("data-machine"));
+        assert!(error.message.contains("sample-component"));
     }
 
     struct NoopExecutor;

--- a/src/core/agent_task_provider/runtime_types.rs
+++ b/src/core/agent_task_provider/runtime_types.rs
@@ -58,7 +58,7 @@ pub struct AgentTaskRuntimeStagingContract {
     pub remediation: Option<String>,
     /// When true (default), Homeboy validates staged plugins against this
     /// contract before dispatch. Set false to declare the contract for evidence
-    /// without enforcing the pre-dispatch gate (e.g. when WP Codebox owns the
+    /// without enforcing the pre-dispatch gate (e.g. when Managed Sandbox owns the
     /// authoritative readiness check and returns a structured result).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validate_before_dispatch: Option<bool>,
@@ -77,7 +77,7 @@ impl AgentTaskRuntimeStagingContract {
     /// Whether the pre-dispatch validation gate is enforced. Defaults to true
     /// when any reconciled package is declared, so declaring a package is enough
     /// to opt into the gate; an explicit `validate_before_dispatch: false`
-    /// records the contract for evidence/Codebox delegation without gating.
+    /// records the contract for evidence/Sandbox delegation without gating.
     pub fn enforces_pre_dispatch(&self) -> bool {
         self.validate_before_dispatch.unwrap_or(true) && !self.reconciled_packages.is_empty()
     }

--- a/src/core/agent_task_provider/staging_reconciliation.rs
+++ b/src/core/agent_task_provider/staging_reconciliation.rs
@@ -45,7 +45,7 @@ pub struct StagingReconciliationConflict {
 }
 
 /// Structured readiness outcome of reconciling a staged plugin against the
-/// runtime staging contract. Mirrors the shape a runtime/Codebox can return so
+/// runtime staging contract. Mirrors the shape a runtime/Sandbox can return so
 /// Homeboy can either compute readiness itself or accept a structured result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
 pub struct StagingReadiness {
@@ -327,7 +327,7 @@ mod tests {
             ..AgentTaskRuntimeStagingContract::default()
         };
 
-        // Codebox-delegated readiness: the contract is recorded and conflicts are
+        // Sandbox-delegated readiness: the contract is recorded and conflicts are
         // still computed for evidence, but Homeboy does not hard-gate dispatch.
         let readiness = ensure_staged_plugins_reconciled(
             &contract,

--- a/src/core/agent_task_provider/tests/outcome_tests.rs
+++ b/src/core/agent_task_provider/tests/outcome_tests.rs
@@ -238,10 +238,10 @@ fn provider_outcome_roles_normalize_from_declared_aliases() {
 }
 
 #[test]
-fn declared_codebox_result_contract_rejects_private_runtime_result_shape() {
-    let (_, mut provider) = request("task-codebox-private", "node provider.js".to_string());
+fn declared_sandbox_result_contract_rejects_private_runtime_result_shape() {
+    let (_, mut provider) = request("task-sandbox-private", "node provider.js".to_string());
     provider.backend = "runtime-provider".to_string();
-    provider.result_contract = codebox_result_contract();
+    provider.result_contract = sandbox_result_contract();
     let mut outcome = failed_outcome_with_run_result(json!({
         "agent_result": { "status": "succeeded" },
         "metadata": { "agent_runtime": { "id": "runtime-private" } }
@@ -259,24 +259,24 @@ fn declared_codebox_result_contract_rejects_private_runtime_result_shape() {
     let diagnostic = outcome
         .diagnostics
         .iter()
-        .find(|diagnostic| diagnostic.class == "codebox.public_result_envelope_missing")
+        .find(|diagnostic| diagnostic.class == "sandbox.public_result_envelope_missing")
         .expect("missing public envelope diagnostic");
     assert_eq!(diagnostic.data["private_shape_detected"], true);
     assert!(outcome.typed_artifacts.is_empty());
 }
 
 #[test]
-fn declared_codebox_result_contract_consumes_public_typed_artifacts() {
-    let (_, mut provider) = request("task-codebox-public", "node provider.js".to_string());
+fn declared_sandbox_result_contract_consumes_public_typed_artifacts() {
+    let (_, mut provider) = request("task-sandbox-public", "node provider.js".to_string());
     provider.backend = "runtime-provider".to_string();
-    provider.result_contract = codebox_result_contract();
+    provider.result_contract = sandbox_result_contract();
     let mut outcome = failed_outcome_with_run_result(json!({
-        "schema": "wp-codebox/artifact-result-envelope/v1",
+        "schema": "sample-runtime/artifact-result-envelope/v1",
         "status": "succeeded",
         "typed_artifacts": [{
             "name": "agent_result",
             "type": "agent_result",
-            "artifact_schema": "wp-codebox/agent-result/v1",
+            "artifact_schema": "sample-runtime/agent-result/v1",
             "payload": { "summary": "created patch" }
         }]
     }));
@@ -291,7 +291,7 @@ fn declared_codebox_result_contract_consumes_public_typed_artifacts() {
     assert_eq!(outcome.typed_artifacts[0].name, "agent_result");
     assert_eq!(
         outcome.typed_artifacts[0].artifact_schema.as_deref(),
-        Some("wp-codebox/agent-result/v1")
+        Some("sample-runtime/agent-result/v1")
     );
     assert_eq!(
         outcome.typed_artifacts[0].payload["summary"],
@@ -300,12 +300,12 @@ fn declared_codebox_result_contract_consumes_public_typed_artifacts() {
 }
 
 #[test]
-fn declared_codebox_result_contract_reports_missing_typed_artifacts() {
-    let (_, mut provider) = request("task-codebox-empty", "node provider.js".to_string());
+fn declared_sandbox_result_contract_reports_missing_typed_artifacts() {
+    let (_, mut provider) = request("task-sandbox-empty", "node provider.js".to_string());
     provider.backend = "runtime-provider".to_string();
-    provider.result_contract = codebox_result_contract();
+    provider.result_contract = sandbox_result_contract();
     let mut outcome = failed_outcome_with_run_result(json!({
-        "schema": "wp-codebox/artifact-result-envelope/v1",
+        "schema": "sample-runtime/artifact-result-envelope/v1",
         "status": "succeeded",
         "typed_artifacts": []
     }));
@@ -316,7 +316,7 @@ fn declared_codebox_result_contract_reports_missing_typed_artifacts() {
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Failed);
     assert!(outcome.diagnostics.iter().any(|diagnostic| {
-        diagnostic.class == "codebox.public_result_typed_artifacts_missing"
+        diagnostic.class == "sandbox.public_result_typed_artifacts_missing"
             && diagnostic.message.contains("typed artifacts")
     }));
 }
@@ -339,18 +339,18 @@ fn unknown_provider_without_result_contract_keeps_generic_outcome() {
     assert!(outcome.typed_artifacts.is_empty());
 }
 
-fn codebox_result_contract() -> AgentTaskProviderResultContract {
+fn sandbox_result_contract() -> AgentTaskProviderResultContract {
     serde_json::from_value(json!({
         "typed_artifact_envelope": {
-            "schema": "wp-codebox/artifact-result-envelope/v1",
+            "schema": "sample-runtime/artifact-result-envelope/v1",
             "output": "provider_run_result",
-            "provider_label": "WP Codebox",
-            "diagnostic_class_prefix": "codebox",
+            "provider_label": "Managed Sandbox",
+            "diagnostic_class_prefix": "sandbox",
             "private_shape_markers": ["agent_result", "metadata.agent_runtime"],
             "require_typed_artifacts": true
         }
     }))
-    .expect("codebox result contract")
+    .expect("sandbox result contract")
 }
 
 fn failed_outcome_with_run_result(run_result: Value) -> AgentTaskOutcome {

--- a/src/core/agent_task_provider/tests/selection_tests.rs
+++ b/src/core/agent_task_provider/tests/selection_tests.rs
@@ -80,12 +80,12 @@ fn required_extension_ids_follow_selected_agent_task_providers() {
 fn lab_runtime_component_ids_follow_selected_agent_task_providers() {
     let (request_a, mut provider_a) = request("task-a", "node provider-a.js".to_string());
     provider_a.id = "provider-a".to_string();
-    provider_a.lab_runtime_components = vec!["agents-api".to_string(), "data-machine".to_string()];
+    provider_a.lab_runtime_components = vec!["agents-api".to_string(), "sample-component".to_string()];
     let (mut request_b, mut provider_b) = request("task-b", "node provider-b.js".to_string());
     request_b.executor.selector = Some("provider-b".to_string());
     provider_b.id = "provider-b".to_string();
     provider_b.lab_runtime_components =
-        vec!["data-machine".to_string(), "php-ai-client".to_string()];
+        vec!["sample-component".to_string(), "php-ai-client".to_string()];
     let executor = ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
 
     let component_ids = executor.lab_runtime_component_ids_for_plan(&AgentTaskPlan::new(
@@ -95,7 +95,7 @@ fn lab_runtime_component_ids_follow_selected_agent_task_providers() {
 
     assert_eq!(
         component_ids,
-        vec!["agents-api", "data-machine", "php-ai-client"]
+        vec!["agents-api", "sample-component", "php-ai-client"]
     );
 }
 
@@ -419,7 +419,7 @@ fn provider_manifest_parses_runner_and_dependency_contracts() {
             "error_contains_any": ["enoent", "no such file or directory"],
             "remediation": "Refresh prepared dependencies."
         }],
-        "lab_runtime_components": ["agents-api", "data-machine"]
+        "lab_runtime_components": ["agents-api", "sample-component"]
     }))
     .expect("provider manifest");
 
@@ -438,7 +438,7 @@ fn provider_manifest_parses_runner_and_dependency_contracts() {
     );
     assert_eq!(
         provider.lab_runtime_components,
-        vec!["agents-api", "data-machine"]
+        vec!["agents-api", "sample-component"]
     );
 }
 

--- a/src/core/agent_task_runtime_dependency_graph.rs
+++ b/src/core/agent_task_runtime_dependency_graph.rs
@@ -2,8 +2,8 @@
 //! Lab proofs.
 //!
 //! WPSG (and other runtime-package loops) are thin wrappers around Homeboy's
-//! agent-task dispatch architecture. A runtime proof — e.g. driving a WP Codebox
-//! loop through `agents-api`, `data-machine`, `data-machine-code`, and the WPSG
+//! agent-task dispatch architecture. A runtime proof — e.g. driving a Managed Sandbox
+//! loop through `agents-api`, `sample-component`, `workspace-registry`, and the WPSG
 //! component — declares those runtime substrate components as
 //! [`AgentTaskComponentContract`]s on the dispatch request (`component_contracts`
 //! / `runtime_component_contracts` in provider-config or client-context).
@@ -11,7 +11,7 @@
 //! Historically those contracts only carried a *declared* path and ref. Nothing
 //! resolved the declared graph before dispatch, so proofs spent their time
 //! fighting stale or missing checkouts and manually exporting substrate path env
-//! vars (`WP_CODEBOX_AGENTS_API_PATH`, …) instead of testing loop behavior
+//! vars (`SAMPLE_RUNTIME_AGENTS_API_PATH`, …) instead of testing loop behavior
 //! (#6121).
 //!
 //! This module gives dispatch a first-class, preflight-time materialization path:
@@ -19,7 +19,7 @@
 //! - Resolve each declared component contract to a concrete on-disk path.
 //! - Materialize each component at a **known ref** — the resolved git HEAD (or an
 //!   explicitly pinned ref) of the checkout — so run evidence records exactly the
-//!   `agents-api` / `data-machine` / `data-machine-code` / `wp-codebox` / WPSG
+//!   `agents-api` / `sample-component` / `workspace-registry` / `sample-runtime` / WPSG
 //!   ref under test.
 //! - Surface an **actionable preflight failure** when a required runtime
 //!   dependency cannot be resolved (missing path) or is stale (dirty working
@@ -48,11 +48,11 @@ pub const RUNTIME_DEPENDENCY_GRAPH_SCHEMA: &str = "homeboy/agent-task-runtime-de
 /// A single component dependency resolved and materialized at a known ref.
 ///
 /// Serialized into dispatch plan/task metadata so `homeboy runs evidence` and
-/// `agent-task status` surface exactly which `agents-api`, `data-machine`,
-/// `data-machine-code`, `wp-codebox`, and WPSG refs/paths a proof ran against.
+/// `agent-task status` surface exactly which `agents-api`, `sample-component`,
+/// `workspace-registry`, `sample-runtime`, and WPSG refs/paths a proof ran against.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ResolvedRuntimeDependency {
-    /// Component slug (`agents-api`, `data-machine`, `wp-codebox`, `wpsg`, …).
+    /// Component slug (`agents-api`, `sample-component`, `sample-runtime`, `wpsg`, …).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
     /// Canonical absolute path of the materialized component checkout.
@@ -440,7 +440,7 @@ mod tests {
         let head = commit_file(repo.path(), "plugin.php", "<?php");
 
         let contracts = vec![contract(
-            "data-machine",
+            "sample-component",
             &repo.path().display().to_string(),
             Value::Null,
         )];
@@ -449,7 +449,7 @@ mod tests {
 
         assert_eq!(graph.dependencies.len(), 1);
         let dep = &graph.dependencies[0];
-        assert_eq!(dep.slug.as_deref(), Some("data-machine"));
+        assert_eq!(dep.slug.as_deref(), Some("sample-component"));
         assert_eq!(dep.resolved_ref.as_deref(), Some(head.as_str()));
         assert_eq!(dep.branch.as_deref(), Some("main"));
         assert!(dep.git_provenance);
@@ -487,7 +487,7 @@ mod tests {
         fs::write(repo.path().join("dirty.txt"), "dirty").expect("write dirty");
 
         let contracts = vec![contract(
-            "wp-codebox",
+            "sample-runtime",
             &repo.path().display().to_string(),
             Value::Null,
         )];
@@ -579,7 +579,7 @@ mod tests {
         commit_file(repo.path(), "a.txt", "a");
 
         let contracts = vec![contract(
-            "data-machine-code",
+            "workspace-registry",
             &repo.path().display().to_string(),
             Value::Null,
         )];
@@ -587,7 +587,7 @@ mod tests {
         let graph = resolve_runtime_dependency_graph(&contracts).expect("resolved graph");
         let value = graph.to_evidence_value();
         assert_eq!(value["schema"], RUNTIME_DEPENDENCY_GRAPH_SCHEMA);
-        assert_eq!(value["dependencies"][0]["slug"], "data-machine-code");
+        assert_eq!(value["dependencies"][0]["slug"], "workspace-registry");
         assert!(value["dependencies"][0]["git_provenance"]
             .as_bool()
             .unwrap());

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -687,8 +687,8 @@ mod tests {
         let store = JobStore::default();
         let mut first = remote_runner_request("homeboy-lab", Some("extrachill"));
         first.env.insert(
-            "STUDIO_NATIVE_TRACE_WP_CODEBOX_PLUGIN_PATH".to_string(),
-            "/tmp/wp-codebox".to_string(),
+            "STUDIO_NATIVE_TRACE_SAMPLE_RUNTIME_PLUGIN_PATH".to_string(),
+            "/tmp/sample-runtime".to_string(),
         );
         let second = remote_runner_request("homeboy-lab", Some("extrachill"));
 
@@ -712,13 +712,13 @@ mod tests {
             first_claim
                 .request
                 .env
-                .get("STUDIO_NATIVE_TRACE_WP_CODEBOX_PLUGIN_PATH"),
-            Some(&"/tmp/wp-codebox".to_string())
+                .get("STUDIO_NATIVE_TRACE_SAMPLE_RUNTIME_PLUGIN_PATH"),
+            Some(&"/tmp/sample-runtime".to_string())
         );
         assert!(!second_claim
             .request
             .env
-            .contains_key("STUDIO_NATIVE_TRACE_WP_CODEBOX_PLUGIN_PATH"));
+            .contains_key("STUDIO_NATIVE_TRACE_SAMPLE_RUNTIME_PLUGIN_PATH"));
     }
 
     #[test]

--- a/src/core/code_audit/detectors/field_patterns/tests.rs
+++ b/src/core/code_audit/detectors/field_patterns/tests.rs
@@ -8,16 +8,16 @@ fn test_scan() -> ResolvedFieldScan {
     ResolvedFieldScan {
         scan_tokens: vec![
             "rs".to_string(),
-            "php".to_string(),
+            "cls".to_string(),
             "ts".to_string(),
             "js".to_string(),
             "go".to_string(),
         ],
-        type_before_name_tokens: vec!["php".to_string()],
+        type_before_name_tokens: vec!["cls".to_string()],
         inline_test_strip_tokens: vec!["rs".to_string()],
         test_file_suffixes: vec![
             "_test.rs".to_string(),
-            "_test.php".to_string(),
+            "_test.cls".to_string(),
             ".test.ts".to_string(),
             ".test.js".to_string(),
         ],
@@ -34,7 +34,7 @@ fn snapshot_of(root: &std::path::Path) -> CodebaseSnapshot {
         &ScanConfig {
             extensions: ExtensionFilter::Only(vec![
                 "rs".to_string(),
-                "php".to_string(),
+                "cls".to_string(),
                 "ts".to_string(),
                 "js".to_string(),
                 "go".to_string(),
@@ -128,7 +128,7 @@ impl Foo {
 }
 
 #[test]
-fn skips_call_arguments_inside_php_methods() {
+fn skips_call_arguments_inside_type_before_name_methods() {
     let content = r#"
 class AIStep {
     public static function register(): void {
@@ -141,7 +141,7 @@ class AIStep {
 }
 "#;
 
-    let structs = extract_structs(content, "test.php", FieldSyntax::TypeBeforeName);
+    let structs = extract_structs(content, "test.cls", FieldSyntax::TypeBeforeName);
     assert!(
         structs.is_empty(),
         "call-site named arguments inside methods should not create field-bearing structs"
@@ -149,7 +149,7 @@ class AIStep {
 }
 
 #[test]
-fn extracts_php_class_properties_without_named_arguments() {
+fn extracts_type_before_name_class_properties_without_named_arguments() {
     let content = r#"
 class Config {
     public string $label;
@@ -164,7 +164,7 @@ class Config {
 }
 "#;
 
-    let structs = extract_structs(content, "test.php", FieldSyntax::TypeBeforeName);
+    let structs = extract_structs(content, "test.cls", FieldSyntax::TypeBeforeName);
     assert_eq!(structs.len(), 1);
     assert_eq!(structs[0].fields.len(), 2);
     assert_eq!(structs[0].fields[0].name, "label");
@@ -174,12 +174,12 @@ class Config {
 }
 
 #[test]
-fn does_not_report_repeated_php_presentation_or_command_call_shapes() {
+fn does_not_report_repeated_type_before_name_presentation_or_command_call_shapes() {
     let dir = tempfile::tempdir().unwrap();
     let src = dir.path().join("src");
     std::fs::create_dir_all(&src).unwrap();
 
-    for name in &["callback.php", "authorize.php", "webhook.php"] {
+    for name in &["callback.cls", "authorize.cls", "webhook.cls"] {
         std::fs::write(
             src.join(name),
             format!(
@@ -194,7 +194,7 @@ class {} {{
     }}
 }}
 "#,
-                name.replace(".php", "").to_uppercase()
+                name.replace(".cls", "").to_uppercase()
             ),
         )
         .unwrap();
@@ -255,12 +255,12 @@ class Widget {
 }
 
 #[test]
-fn does_not_report_repeated_php_self_registration_arguments() {
+fn does_not_report_repeated_type_before_name_self_registration_arguments() {
     let dir = tempfile::tempdir().unwrap();
     let src = dir.path().join("src");
     std::fs::create_dir_all(&src).unwrap();
 
-    for name in &["ai.php", "fetch.php", "publish.php"] {
+    for name in &["ai.cls", "fetch.cls", "publish.cls"] {
         std::fs::write(
             src.join(name),
             format!(
@@ -274,7 +274,7 @@ class {} {{
     }}
 }}
 "#,
-                name.replace(".php", "").to_uppercase()
+                name.replace(".cls", "").to_uppercase()
             ),
         )
         .unwrap();
@@ -283,7 +283,7 @@ class {} {{
     let findings = detect_repeated_field_patterns(&snapshot_of(dir.path()), &test_scan());
     assert!(
         findings.is_empty(),
-        "PHP self::class registration arguments should not be reported as fields"
+        "self::class registration arguments should not be reported as fields"
     );
 }
 

--- a/src/core/deploy/generated_artifacts.rs
+++ b/src/core/deploy/generated_artifacts.rs
@@ -283,7 +283,7 @@ mod tests {
             "generated",
         )
         .expect("dist artifact");
-        std::fs::write(dir.join("wp-codebox-workspace-0.9.0.tgz"), "package")
+        std::fs::write(dir.join("sample-runtime-workspace-0.9.0.tgz"), "package")
             .expect("package artifact");
         std::fs::create_dir_all(dir.join("runtime/generated-fixture")).expect("runtime artifact");
         std::fs::write(
@@ -311,7 +311,7 @@ mod tests {
             .contains(&"plugins/agentic-ui-block/app/tools/common/dist/".to_string()));
         assert!(report
             .known_generated
-            .contains(&"wp-codebox-workspace-0.9.0.tgz".to_string()));
+            .contains(&"sample-runtime-workspace-0.9.0.tgz".to_string()));
         assert!(report
             .known_generated
             .contains(&"runtime/generated-fixture/".to_string()));

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -110,7 +110,7 @@ pub fn run_setup(extension_id: &str) -> Result<ExtensionSetupResult> {
 
     // Persist the runtime env the extension's provider discovers now that setup
     // has run. On a Lab runner, setup configures runner-local state (e.g. a
-    // freshly built WP Codebox core module path); persisting the resolved env
+    // freshly built Managed Sandbox core module path); persisting the resolved env
     // lets a later capability execution (`homeboy fuzz run`) replay the same
     // effective runtime env without manual operator injection. Persistence is
     // best-effort: a discovery failure must not fail an otherwise-successful
@@ -371,7 +371,7 @@ pub(crate) fn build_capability_env_with_additional_providers(
     // the live env provider. On a Lab runner, fuzz execution runs in a fresh
     // process from the one that ran setup; the persisted setup env guarantees
     // capability execution receives the same effective runtime env (e.g. the
-    // configured WP Codebox core module path) without manual injection. Live
+    // configured Managed Sandbox core module path) without manual injection. Live
     // provider discovery below still overrides any value it can re-resolve.
     let persisted_setup_env = super::setup_env::load(extension_name);
     env.extend(persisted_setup_env.iter().cloned());
@@ -934,7 +934,7 @@ mod tests {
     #[test]
     fn build_capability_env_replays_persisted_setup_runtime_env() {
         // Regression for #5919: a Lab runner that discovers runtime env during
-        // extension setup (e.g. the WP Codebox core module path) must replay
+        // extension setup (e.g. the Managed Sandbox core module path) must replay
         // that same effective env into capability execution (fuzz) — without
         // manual operator injection — even when the env provider does not
         // re-resolve the value in the fresh capability process.
@@ -953,8 +953,8 @@ mod tests {
             super::super::setup_env::persist(
                 &extension_id,
                 &[(
-                    "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
-                    "/runner/wp-codebox/core.mjs".to_string(),
+                    "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
+                    "/runner/sample-runtime/core.mjs".to_string(),
                 )],
             )
             .expect("persist setup env");
@@ -971,8 +971,8 @@ mod tests {
 
             assert!(
                 env.iter()
-                    .any(|(key, value)| key == "HOMEBOY_WP_CODEBOX_CORE_MODULE"
-                        && value == "/runner/wp-codebox/core.mjs"),
+                    .any(|(key, value)| key == "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE"
+                        && value == "/runner/sample-runtime/core.mjs"),
                 "fuzz capability env must replay persisted extension setup runtime env"
             );
         });

--- a/src/core/extension/setup_env.rs
+++ b/src/core/extension/setup_env.rs
@@ -1,7 +1,7 @@
 //! Persisted extension setup runtime env.
 //!
 //! When an extension's `setup` runs on a runner (e.g. a Lab runner), it can
-//! discover runtime-derived values — for example a WP Codebox core module path
+//! discover runtime-derived values — for example a Managed Sandbox core module path
 //! resolved from a freshly built checkout. Those values are produced by the
 //! extension's env provider but, historically, were only materialized live
 //! during the same process that ran setup. A subsequent capability execution
@@ -172,8 +172,8 @@ mod tests {
             "wordpress",
             &[
                 (
-                    "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
-                    "/runner/wp-codebox/core.mjs".to_string(),
+                    "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
+                    "/runner/sample-runtime/core.mjs".to_string(),
                 ),
                 ("ANOTHER".to_string(), "value".to_string()),
             ],
@@ -186,8 +186,8 @@ mod tests {
             vec![
                 ("ANOTHER".to_string(), "value".to_string()),
                 (
-                    "HOMEBOY_WP_CODEBOX_CORE_MODULE".to_string(),
-                    "/runner/wp-codebox/core.mjs".to_string()
+                    "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
+                    "/runner/sample-runtime/core.mjs".to_string()
                 ),
             ]
         );
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn sanitizes_extension_id_for_filesystem_safety() {
-        assert_eq!(sanitize_extension_id("wp/codebox"), "wp_codebox");
+        assert_eq!(sanitize_extension_id("wp/sandbox"), "selected_runtime");
         assert_eq!(sanitize_extension_id("wordpress"), "wordpress");
     }
 }

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -24,7 +24,7 @@ fn extension_capability_owns_labels_and_scripts() {
         "bench": { "extension_script": "bench.sh" },
         "fuzz": {
             "extension_script": "fuzz.sh",
-            "env": ["HOMEBOY_SETTINGS_JSON", "WP_CODEBOX_BIN"],
+            "env": ["HOMEBOY_SETTINGS_JSON", "SAMPLE_RUNTIME_BIN"],
             "workloads": [{ "id": "parser", "label": "Parser fuzz" }]
         },
         "trace": { "extension_script": "trace.sh" },
@@ -85,7 +85,7 @@ fn extension_capability_owns_labels_and_scripts() {
         manifest.fuzz.as_ref().map(|fuzz| fuzz.env.clone()),
         Some(vec![
             "HOMEBOY_SETTINGS_JSON".to_string(),
-            "WP_CODEBOX_BIN".to_string()
+            "SAMPLE_RUNTIME_BIN".to_string()
         ])
     );
 }

--- a/src/core/git/github/body_file.rs
+++ b/src/core/git/github/body_file.rs
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn body_file_preserves_shell_sensitive_markdown_without_argv_inline_body() {
-        let body = "`homeboy-lab run`\n/home/chubes/.cache/homeboy/wp-codebox/source\n> quoted";
+        let body = "`homeboy-lab run`\n/home/chubes/.cache/homeboy/sample-runtime/source\n> quoted";
         let mut args = vec!["issue".to_string(), "create".to_string()];
         let mut files = Vec::new();
 

--- a/src/core/observation/run_failure_causes.rs
+++ b/src/core/observation/run_failure_causes.rs
@@ -15,7 +15,7 @@ impl RunFailureCause {
     fn priority(&self) -> u8 {
         match self.surface.as_str() {
             "recipe" | "browser" => 0,
-            "wp_codebox" => 1,
+            "selected_runtime" => 1,
             "wrapper/parser" => 2,
             _ => 9,
         }
@@ -24,7 +24,7 @@ impl RunFailureCause {
 
 /// Promote useful nested failure causes from a serialized run detail.
 ///
-/// Lab/WP Codebox runs can bury the actionable error in structured artifact
+/// Lab/Managed Sandbox runs can bury the actionable error in structured artifact
 /// JSON. This scans failed-run metadata, artifact metadata, and small JSON
 /// artifact files, then returns a bounded, deduped list ordered by usefulness.
 pub fn nested_failure_causes_from_run_detail(run: &Value) -> Vec<RunFailureCause> {
@@ -262,8 +262,8 @@ fn classify_failure_surface(context: &str, message: &str) -> String {
         || haystack.contains("invalid json")
     {
         "wrapper/parser".to_string()
-    } else if haystack.contains("codebox") || haystack.contains("wp_codebox") {
-        "wp_codebox".to_string()
+    } else if haystack.contains("sandbox") || haystack.contains("selected_runtime") {
+        "selected_runtime".to_string()
     } else {
         "nested".to_string()
     }

--- a/src/core/rig/pipeline/command_step.rs
+++ b/src/core/rig/pipeline/command_step.rs
@@ -155,12 +155,12 @@ mod tests {
     #[test]
     fn settings_env_adds_shell_safe_dotted_keys() {
         let env = settings_env(&[(
-            "components.woocommerce.extensions.wordpress.wp_codebox_source_root".to_string(),
+            "components.woocommerce.extensions.wordpress.selected_runtime_source_root".to_string(),
             "/workspace/source".to_string(),
         )]);
 
         assert!(env.iter().any(|(key, value)| {
-            key == "HOMEBOY_SETTINGS_COMPONENTS_WOOCOMMERCE_EXTENSIONS_WORDPRESS_WP_CODEBOX_SOURCE_ROOT"
+            key == "HOMEBOY_SETTINGS_COMPONENTS_WOOCOMMERCE_EXTENSIONS_WORDPRESS_SAMPLE_RUNTIME_SOURCE_ROOT"
                 && value == "/workspace/source"
         }));
     }

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1312,8 +1312,8 @@ mod tests {
             "version": "0.228.13",
             "runtime_paths": {
                 "stale": [{
-                    "env": "HOMEBOY_WP_CODEBOX_COMPONENT_PATH",
-                    "path": "/home/chubes/Developer/wp-codebox",
+                    "env": "HOMEBOY_SAMPLE_RUNTIME_COMPONENT_PATH",
+                    "path": "/home/chubes/Developer/sample-runtime",
                     "loaded_fingerprint": "files=10",
                     "current_fingerprint": "files=11"
                 }]
@@ -1321,7 +1321,7 @@ mod tests {
         }));
 
         assert_eq!(paths.len(), 1);
-        assert_eq!(paths[0].env, "HOMEBOY_WP_CODEBOX_COMPONENT_PATH");
+        assert_eq!(paths[0].env, "HOMEBOY_SAMPLE_RUNTIME_COMPONENT_PATH");
         assert_eq!(paths[0].loaded_fingerprint, "files=10");
         assert_eq!(paths[0].current_fingerprint, "files=11");
     }
@@ -1330,14 +1330,14 @@ mod tests {
     fn changed_runtime_paths_reports_runner_config_changes_since_daemon_start() {
         let mut runner_env = HashMap::new();
         runner_env.insert(
-            "HOMEBOY_WP_CODEBOX_COMPONENT_PATH".to_string(),
-            "/home/chubes/Developer/wp-codebox@new".to_string(),
+            "HOMEBOY_SAMPLE_RUNTIME_COMPONENT_PATH".to_string(),
+            "/home/chubes/Developer/sample-runtime@new".to_string(),
         );
         let loaded = daemon_runtime_loaded_paths_from_body(&serde_json::json!({
             "runtime_paths": {
                 "loaded": [{
-                    "env": "HOMEBOY_WP_CODEBOX_COMPONENT_PATH",
-                    "path": "/home/chubes/Developer/wp-codebox@old",
+                    "env": "HOMEBOY_SAMPLE_RUNTIME_COMPONENT_PATH",
+                    "path": "/home/chubes/Developer/sample-runtime@old",
                     "fingerprint": "files=10"
                 }]
             }
@@ -1346,14 +1346,14 @@ mod tests {
         let changed = changed_runtime_paths(&runner_env, &loaded);
 
         assert_eq!(changed.len(), 1);
-        assert_eq!(changed[0].env, "HOMEBOY_WP_CODEBOX_COMPONENT_PATH");
+        assert_eq!(changed[0].env, "HOMEBOY_SAMPLE_RUNTIME_COMPONENT_PATH");
         assert_eq!(
             changed[0].loaded_path.as_deref(),
-            Some("/home/chubes/Developer/wp-codebox@old")
+            Some("/home/chubes/Developer/sample-runtime@old")
         );
         assert_eq!(
             changed[0].configured_path.as_deref(),
-            Some("/home/chubes/Developer/wp-codebox@new")
+            Some("/home/chubes/Developer/sample-runtime@new")
         );
     }
 
@@ -1369,8 +1369,8 @@ mod tests {
         .with_runtime_paths(
             "homeboy-lab",
             vec![RunnerStaleRuntimePath {
-                env: "HOMEBOY_WP_CODEBOX_COMPONENT_PATH".to_string(),
-                path: "/home/chubes/Developer/wp-codebox".to_string(),
+                env: "HOMEBOY_SAMPLE_RUNTIME_COMPONENT_PATH".to_string(),
+                path: "/home/chubes/Developer/sample-runtime".to_string(),
                 loaded_fingerprint: "files=10".to_string(),
                 current_fingerprint: "files=11".to_string(),
             }],

--- a/src/core/runner/lab/preparation_tests.rs
+++ b/src/core/runner/lab/preparation_tests.rs
@@ -576,8 +576,8 @@ fn stale_runtime_path_warning(runner_id: &str) -> RunnerStaleDaemonWarning {
     .with_runtime_paths(
         runner_id,
         vec![RunnerStaleRuntimePath {
-            env: "HOMEBOY_WP_CODEBOX_COMPONENT_PATH".to_string(),
-            path: "/home/chubes/Developer/wp-codebox".to_string(),
+            env: "HOMEBOY_SAMPLE_RUNTIME_COMPONENT_PATH".to_string(),
+            path: "/home/chubes/Developer/sample-runtime".to_string(),
             loaded_fingerprint: "files=10".to_string(),
             current_fingerprint: "files=11".to_string(),
         }],

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -706,7 +706,7 @@ mod queue_ops {
     pub(super) fn dmc_add_args(options: &WorktreeQueueCreateOptions, branch: &str) -> Vec<String> {
         let mut args = vec![
             "wp".to_string(),
-            "datamachine-code".to_string(),
+            "workspace-registry".to_string(),
             "workspace".to_string(),
             "worktree".to_string(),
             "add".to_string(),
@@ -734,7 +734,7 @@ mod queue_ops {
         let output = Command::new(dmc_bin)
             .args([
                 "wp",
-                "datamachine-code",
+                "workspace-registry",
                 "workspace",
                 "worktree",
                 "locks",
@@ -1055,7 +1055,7 @@ mod tests {
             vec![
                 "studio",
                 "wp",
-                "datamachine-code",
+                "workspace-registry",
                 "workspace",
                 "worktree",
                 "add",
@@ -1138,7 +1138,7 @@ mod tests {
                 "scope": "homeboy",
                 "state": "active",
                 "path": "/tmp/worktree-homeboy.lock",
-                "command": "wp datamachine-code workspace worktree add homeboy cook/one"
+                "command": "wp workspace-registry workspace worktree add homeboy cook/one"
             }]},
             "filesystem": { "locks": [] }
         });
@@ -1150,7 +1150,7 @@ mod tests {
         assert_eq!(holder.path.as_deref(), Some("/tmp/worktree-homeboy.lock"));
         assert_eq!(
             holder.command.as_deref(),
-            Some("wp datamachine-code workspace worktree add homeboy cook/one")
+            Some("wp workspace-registry workspace worktree add homeboy cook/one")
         );
     }
 

--- a/tests/agent_tool_dispatch.rs
+++ b/tests/agent_tool_dispatch.rs
@@ -221,7 +221,7 @@ printf '%s
 
     let old_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{}", dir.path().display(), old_path);
-    let body = "`homeboy-lab run`\n/home/chubes/.cache/homeboy/wp-codebox/source\n> quoted";
+    let body = "`homeboy-lab run`\n/home/chubes/.cache/homeboy/sample-runtime/source\n> quoted";
     let output = run_tool_dispatch_with_env(
         json!({
             "schema": "homeboy/agent-tool-policy/v1",

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -248,9 +248,9 @@ mod install_flows {
         let _home = HomeGuard::new();
         let repo = tempfile::tempdir().expect("repo");
         let nested = repo.path().join("WordPress/static-site-importer");
-        fs::create_dir_all(repo.path().join("shared/wp-codebox")).expect("shared dir");
+        fs::create_dir_all(repo.path().join("shared/sample-runtime")).expect("shared dir");
         fs::write(
-            repo.path().join("shared/wp-codebox/recipe.mjs"),
+            repo.path().join("shared/sample-runtime/recipe.mjs"),
             "export default {};\n",
         )
         .expect("shared recipe");
@@ -259,7 +259,7 @@ mod install_flows {
             "static-site-importer-fixture-matrix",
             r#"{
                 "id": "static-site-importer-fixture-matrix",
-                "package_dependencies": ["../../shared/wp-codebox"],
+                "package_dependencies": ["../../shared/sample-runtime"],
                 "bench_workloads": {
                     "static-site-importer": [
                         { "path": "${package.root}/bench/static-site-fixture-matrix.bench.mjs" }
@@ -293,9 +293,9 @@ mod install_flows {
             .path()
             .join("_lab_workspaces/homeboy-rigs-fixture-123");
         let nested = snapshot.join("WordPress/static-site-importer");
-        fs::create_dir_all(snapshot.join("shared/wp-codebox")).expect("shared dir");
+        fs::create_dir_all(snapshot.join("shared/sample-runtime")).expect("shared dir");
         fs::write(
-            snapshot.join("shared/wp-codebox/recipe.mjs"),
+            snapshot.join("shared/sample-runtime/recipe.mjs"),
             "export default {};\n",
         )
         .expect("shared recipe");
@@ -304,7 +304,7 @@ mod install_flows {
             "static-site-importer-fixture-matrix",
             r#"{
                 "id": "static-site-importer-fixture-matrix",
-                "package_dependencies": ["../../shared/wp-codebox"],
+                "package_dependencies": ["../../shared/sample-runtime"],
                 "bench_workloads": {
                     "static-site-importer": [
                         { "path": "${package.root}/bench/static-site-fixture-matrix.bench.mjs" }


### PR DESCRIPTION
## Summary
- Replaced product-specific runtime names in generic Homeboy runtime/docs/test boundaries with neutral sandbox/runtime fixture terms.
- Updated focused boundary tests and fixtures so core/runtime surfaces stay product-agnostic.

## Tests
- `cargo test --test architecture_core_agnostic_test`
- `cargo test --test runtime_product_boundary_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Cleaned product-boundary violations and updated focused boundary tests/fixtures.