### PR TITLE
Make fuzz measurement profile non-blocking

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -9,14 +9,16 @@ use homeboy::core::engine::execution_context;
 use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner, FuzzConfig};
-use homeboy::core::fuzz::{parse_fuzz_results_file, FuzzArtifact, FuzzCampaign, FuzzFindingStatus};
+use homeboy::core::fuzz::{
+    parse_fuzz_results_file, FuzzArtifact, FuzzCampaign, FuzzFindingStatus, FuzzGateProfile,
+};
 use homeboy::core::lifecycle::LifecyclePhaseStatus;
 use homeboy::core::observation::{ObservationStore, RunRecord, RunStatus};
 use homeboy::core::rig::{self, FuzzPrepareReport, RigSpec};
 use uuid::Uuid;
 
 use super::report::{
-    evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,
+    evaluate_expected_metric_gates, evaluate_fuzz_gates_for_profile, fuzz_coverage_completeness,
     fuzz_result_envelope_evidence_ref, fuzz_result_envelope_from_campaign, gate_status,
     persist_fuzz_run_result_envelope,
 };
@@ -126,6 +128,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         runner_output.timed_out,
         results.as_ref(),
         combined_results_error,
+        args.gate_profile.as_core(),
     );
     let exit_code = outcome.exit_code;
     let success = outcome.success;
@@ -178,7 +181,11 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
             max_duration: args.max_duration.clone(),
             passthrough_args: args.args.clone(),
             requested_settings: fuzz_requested_settings(&args),
-            gates: fuzz_run_gates(results.as_ref(), &expected_metric_gates),
+            gates: fuzz_run_gates(
+                results.as_ref(),
+                args.gate_profile.as_core(),
+                &expected_metric_gates,
+            ),
             target_inventory: Some(target_inventory),
             execution: Some(FuzzExecutionOutput {
                 kind: "fuzz".to_string(),
@@ -268,9 +275,12 @@ pub(super) fn fuzz_expected_metric_error(
 
 fn fuzz_run_gates(
     results: Option<&FuzzCampaign>,
+    gate_profile: FuzzGateProfile,
     expected_metric_gates: &[super::types::FuzzGateEvaluation],
 ) -> Vec<super::types::FuzzGateEvaluation> {
-    let mut gates = results.map(evaluate_fuzz_gates).unwrap_or_default();
+    let mut gates = results
+        .map(|results| evaluate_fuzz_gates_for_profile(results, gate_profile))
+        .unwrap_or_default();
     gates.extend(expected_metric_gates.iter().cloned());
     gates
 }
@@ -458,6 +468,7 @@ pub(super) fn fuzz_run_outcome(
     runner_timed_out: bool,
     results: Option<&FuzzCampaign>,
     results_error: Option<&str>,
+    gate_profile: FuzzGateProfile,
 ) -> FuzzRunOutcome {
     if runner_timed_out {
         return FuzzRunOutcome {
@@ -479,7 +490,8 @@ pub(super) fn fuzz_run_outcome(
         };
     }
 
-    let campaign_failed = results.is_some_and(fuzz_campaign_reports_failure);
+    let campaign_failed = gate_profile != FuzzGateProfile::Measurement
+        && results.is_some_and(fuzz_campaign_reports_failure);
     let success = runner_success && !campaign_failed && results_error.is_none();
     FuzzRunOutcome {
         status: if success { "passed" } else { "failed" },
@@ -694,8 +706,16 @@ pub(super) fn persist_fuzz_run_evidence(
         "results_error": input.results_error,
         "missing_artifact_refs": input.missing_artifact_refs,
         "coverage_completeness": input.results.map(fuzz_coverage_completeness),
-        "gates": fuzz_run_gates(input.results, input.expected_metric_gates),
-        "gate_status": gate_status(&fuzz_run_gates(input.results, input.expected_metric_gates)),
+        "gates": fuzz_run_gates(
+            input.results,
+            input.args.gate_profile.as_core(),
+            input.expected_metric_gates
+        ),
+        "gate_status": gate_status(&fuzz_run_gates(
+            input.results,
+            input.args.gate_profile.as_core(),
+            input.expected_metric_gates
+        )),
     });
     let run = RunRecord {
         id: run_id.clone(),
@@ -730,7 +750,10 @@ pub(super) fn persist_fuzz_run_evidence(
     if let Some(campaign) = input.results {
         let mut envelope =
             fuzz_result_envelope_from_campaign(input.args, input.component_id, campaign, None)?;
-        envelope.status = gate_status(&evaluate_fuzz_gates(campaign));
+        envelope.status = gate_status(&evaluate_fuzz_gates_for_profile(
+            campaign,
+            input.args.gate_profile.as_core(),
+        ));
         if let Some(artifact) = persist_fuzz_run_result_envelope(Some(&run_id), &envelope)? {
             evidence_refs.push(fuzz_result_envelope_evidence_ref(&artifact));
         }

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 
 use homeboy::core::artifact_ref::EvidenceRef;
 use homeboy::core::fuzz::{
-    default_fuzz_gates, fuzz_gate_profile_contract, parse_fuzz_case_log_file,
-    parse_fuzz_observation_set_value, parse_fuzz_results_file, parse_fuzz_target_inventory_file,
-    rank_fuzz_observation_set_hotspots, FuzzCampaign, FuzzExecutionRequest, FuzzHotspotSet,
-    FuzzProvenance, FuzzResultEnvelope, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
+    fuzz_gate_profile_contract, parse_fuzz_case_log_file, parse_fuzz_observation_set_value,
+    parse_fuzz_results_file, parse_fuzz_target_inventory_file, rank_fuzz_observation_set_hotspots,
+    FuzzCampaign, FuzzExecutionRequest, FuzzGateProfile, FuzzHotspotSet, FuzzProvenance,
+    FuzzResultEnvelope, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
     FUZZ_RESULT_ENVELOPE_SCHEMA,
 };
 use homeboy::core::observation::{ArtifactRecord, ObservationStore};
@@ -27,7 +27,7 @@ pub(super) fn run_validate(args: FuzzValidateArgs) -> homeboy::core::Result<Fuzz
     for path in &args.case_logs {
         case_log_entries += parse_fuzz_case_log_file(path)?.len();
     }
-    let gates = evaluate_fuzz_gates(&campaign);
+    let gates = evaluate_fuzz_gates_for_profile(&campaign, args.gate_profile.as_core());
     let coverage_completeness = fuzz_coverage_completeness(&campaign);
     let performance_hotspots = fuzz_performance_hotspots(&campaign);
     let observation_hotspots = fuzz_observation_hotspots(&campaign);
@@ -281,11 +281,20 @@ pub(super) fn fuzz_provenance(run_id: Option<String>) -> FuzzProvenance {
     }
 }
 
+#[cfg(test)]
 pub(super) fn evaluate_fuzz_gates(campaign: &FuzzCampaign) -> Vec<FuzzGateEvaluation> {
-    let profile = FuzzGateEvaluationProfile::default();
-    let metrics = FuzzGateMetrics::from_campaign(campaign, &profile);
+    evaluate_fuzz_gates_for_profile(campaign, FuzzGateProfile::Strict)
+}
 
-    default_fuzz_gates()
+pub(super) fn evaluate_fuzz_gates_for_profile(
+    campaign: &FuzzCampaign,
+    profile: FuzzGateProfile,
+) -> Vec<FuzzGateEvaluation> {
+    let evaluation_profile = FuzzGateEvaluationProfile::default();
+    let metrics = FuzzGateMetrics::from_campaign(campaign, &evaluation_profile);
+    let (_, gates) = fuzz_gate_profile_contract(profile);
+
+    gates
         .into_iter()
         .map(|gate| {
             let observed = match gate.metric.as_str() {

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -232,7 +232,14 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_failed_campaign() {
         "case_counts": { "passed": 2, "failed": 1, "errored": 0 }
     });
 
-    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Strict,
+    );
 
     assert_eq!(outcome.status, "failed");
     assert!(!outcome.success);
@@ -261,11 +268,54 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_open_finding() {
         extra: std::collections::BTreeMap::new(),
     }];
 
-    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Strict,
+    );
 
     assert_eq!(outcome.status, "failed");
     assert!(!outcome.success);
     assert_eq!(outcome.exit_code, 1);
+}
+
+#[test]
+fn fuzz_run_outcome_measurement_profile_records_open_findings_without_failing() {
+    let mut campaign = empty_fuzz_campaign();
+    campaign.findings = vec![FuzzFinding {
+        schema: homeboy::core::fuzz::FUZZ_FINDING_SCHEMA.to_string(),
+        id: "finding-1".to_string(),
+        title: "runner surfaced a failing case".to_string(),
+        severity: "high".to_string(),
+        status: FuzzFindingStatus::Open,
+        surface_id: None,
+        target_id: None,
+        operation_id: None,
+        case_id: Some("case-1".to_string()),
+        workload_id: None,
+        seed_id: None,
+        fingerprint: None,
+        artifact_ids: Vec::new(),
+        source_refs: Vec::new(),
+        metadata: serde_json::Value::Null,
+        extra: std::collections::BTreeMap::new(),
+    }];
+
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Measurement,
+    );
+
+    assert_eq!(outcome.status, "passed");
+    assert!(outcome.success);
+    assert_eq!(outcome.exit_code, 0);
 }
 
 #[test]
@@ -286,7 +336,14 @@ fn fuzz_run_expected_metric_gate_fails_when_observed_metric_differs() {
 
     let gates = evaluate_expected_metric_gates(Some(&campaign), &expectations);
     let error = fuzz_expected_metric_error(&gates).expect("expected metric failure");
-    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), Some(&error));
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        Some(&campaign),
+        Some(&error),
+        homeboy::core::fuzz::FuzzGateProfile::Measurement,
+    );
 
     assert_eq!(gate_status(&gates), "failed");
     assert!(gates.iter().any(|gate| {
@@ -320,7 +377,14 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_failed_lifecycle_phase
         metadata: std::collections::BTreeMap::new(),
     });
 
-    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Strict,
+    );
 
     assert_eq!(outcome.status, "failed");
     assert!(!outcome.success);
@@ -353,7 +417,14 @@ fn fuzz_run_outcome_fails_when_workload_reports_invariant_failure_count() {
         }
     });
 
-    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Strict,
+    );
 
     assert_eq!(outcome.status, "failed");
     assert!(!outcome.success);
@@ -361,8 +432,54 @@ fn fuzz_run_outcome_fails_when_workload_reports_invariant_failure_count() {
 }
 
 #[test]
+fn fuzz_run_outcome_measurement_profile_records_failure_metadata_without_failing() {
+    let mut campaign = empty_fuzz_campaign();
+    campaign.metadata = serde_json::json!({
+        "status": "failed",
+        "success": false,
+        "case_counts": { "passed": 2, "failed": 1, "errored": 0 },
+        "nested": { "invariant_failure_count": 1 }
+    });
+    campaign.lifecycle = Some(LifecycleResultMetadata {
+        schema: LIFECYCLE_RESULT_SCHEMA.to_string(),
+        version: LIFECYCLE_CONTRACT_VERSION,
+        phases: vec![LifecyclePhaseResult {
+            id: "execute".to_string(),
+            phase: LifecyclePhaseKind::Snapshot,
+            status: LifecyclePhaseStatus::Failed,
+            snapshot_ref: None,
+            started_at: None,
+            finished_at: None,
+            message: Some("runner recorded a failing case".to_string()),
+        }],
+        snapshot_refs: Vec::new(),
+        metadata: std::collections::BTreeMap::new(),
+    });
+
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Measurement,
+    );
+
+    assert_eq!(outcome.status, "passed");
+    assert!(outcome.success);
+    assert_eq!(outcome.exit_code, 0);
+}
+
+#[test]
 fn fuzz_run_outcome_reports_timeout_as_non_pass() {
-    let outcome = fuzz_run_outcome(0, true, true, None, None);
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        true,
+        None,
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Measurement,
+    );
 
     assert_eq!(outcome.status, "timeout");
     assert!(!outcome.success);
@@ -388,7 +505,14 @@ fn fuzz_run_outcome_reports_skipped_lifecycle_as_non_proof() {
         metadata: std::collections::BTreeMap::new(),
     });
 
-    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Measurement,
+    );
 
     assert_eq!(outcome.status, "skipped");
     assert!(!outcome.success);
@@ -405,7 +529,14 @@ fn fuzz_run_outcome_reports_unsupported_metadata_as_non_proof() {
         }
     });
 
-    let outcome = fuzz_run_outcome(0, true, false, Some(&campaign), None);
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Measurement,
+    );
 
     assert_eq!(outcome.status, "unsupported");
     assert!(!outcome.success);

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -307,6 +307,7 @@ fn fuzz_validate_accepts_case_log_artifact() {
 
     let output = run_validate(FuzzValidateArgs {
         results_file,
+        gate_profile: FuzzGateProfileArg::Measurement,
         case_logs: vec![case_log.clone()],
     })
     .expect("validate fuzz campaign and case log");
@@ -342,6 +343,7 @@ fn fuzz_validate_rejects_invalid_case_log_artifact() {
 
     let err = match run_validate(FuzzValidateArgs {
         results_file,
+        gate_profile: FuzzGateProfileArg::Measurement,
         case_logs: vec![case_log],
     }) {
         Ok(_) => panic!("invalid case log should fail validation"),
@@ -349,6 +351,53 @@ fn fuzz_validate_rejects_invalid_case_log_artifact() {
     };
 
     assert!(err.message.contains("skip_reason"));
+}
+
+#[test]
+fn fuzz_validate_measurement_profile_is_non_blocking_but_strict_profile_blocks() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let results_file = dir.path().join("fuzz-results.json");
+    std::fs::write(
+        &results_file,
+        serde_json::json!({
+            "schema": homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA,
+            "id": "campaign-1",
+            "safety_class": "read_only",
+            "findings": [{
+                "id": "finding-1",
+                "title": "open finding",
+                "severity": "high",
+                "status": "open"
+            }],
+            "metadata": {
+                "status": "failed",
+                "case_counts": { "passed": 1, "failed": 1 }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write campaign");
+
+    let measurement = run_validate(FuzzValidateArgs {
+        results_file: results_file.clone(),
+        gate_profile: FuzzGateProfileArg::Measurement,
+        case_logs: Vec::new(),
+    })
+    .expect("validate measurement campaign");
+    let strict = run_validate(FuzzValidateArgs {
+        results_file,
+        gate_profile: FuzzGateProfileArg::Strict,
+        case_logs: Vec::new(),
+    })
+    .expect("validate strict campaign");
+
+    assert_eq!(measurement.status, "passed");
+    assert_eq!(measurement.open_findings, 1);
+    assert!(measurement.gates.is_empty());
+    assert_eq!(strict.status, "failed");
+    assert!(strict.gates.iter().any(|gate| {
+        gate.gate_id == "no-open-findings" && gate.status == "failed" && gate.observed == 1.0
+    }));
 }
 
 #[test]

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -279,6 +279,10 @@ pub(crate) struct FuzzValidateArgs {
     #[arg(value_name = "RESULTS_FILE")]
     pub(crate) results_file: PathBuf,
 
+    /// Gate profile to evaluate while validating the campaign.
+    #[arg(long = "gate-profile", value_enum, default_value_t = FuzzGateProfileArg::Measurement)]
+    pub(crate) gate_profile: FuzzGateProfileArg,
+
     /// Canonical fuzz case log JSONL/JSON artifact to validate.
     #[arg(long = "case-log", value_name = "PATH")]
     pub(crate) case_logs: Vec<PathBuf>,


### PR DESCRIPTION
## Summary
- Make the fuzz measurement gate profile record findings and failure metadata without failing the run.
- Keep strict fuzz gate behavior blocking for open findings and failed campaign signals.
- Add focused validation and run-outcome coverage for measurement-first semantics.

## Tests
- `cargo test commands::fuzz::tests`
- `cargo fmt && cargo test fuzz`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implemented fuzz measurement-first semantics and focused tests.