### PR TITLE
fix(test): complete #6705 runtime->tool rename (unbreak main test build)

### DIFF
--- a/src/commands/runner/tests/redaction.rs
+++ b/src/commands/runner/tests/redaction.rs
@@ -71,7 +71,7 @@ fn runner_env_output_redacts_values_by_default() {
         diagnostics: RunnerEnvDiagnostics {
             server_shell_env: "shell".to_string(),
             runner_job_env: "runner".to_string(),
-            selected_runtime: None,
+            selected_tool: None,
         },
     };
 
@@ -108,7 +108,7 @@ fn runner_env_output_reports_secret_env_refs_without_values() {
         diagnostics: RunnerEnvDiagnostics {
             server_shell_env: "shell".to_string(),
             runner_job_env: "runner".to_string(),
-            selected_runtime: None,
+            selected_tool: None,
         },
     };
 
@@ -150,7 +150,7 @@ fn runner_env_output_reports_secret_store_refs_without_values() {
         diagnostics: RunnerEnvDiagnostics {
             server_shell_env: "shell".to_string(),
             runner_job_env: "runner".to_string(),
-            selected_runtime: None,
+            selected_tool: None,
         },
     };
 

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -12,7 +12,7 @@ use homeboy::core::runners::{self as runner, RunnerSession, RunnerStatusReport, 
 use super::super::jobs::format_job_event;
 use super::super::status::{
     declared_executable_requirement_diagnostics, declared_run_followups_for_legacy,
-    declared_runtime_diagnostics, declared_runtime_diagnostics_for_legacy,
+    declared_runtime_diagnostics,
     declared_runtime_source_diagnostics, declared_tool_diagnostics, lab_runner_homeboy_output,
     runner_artifact_feature_diagnostics, runner_status_operator_commands,
 };
@@ -257,39 +257,6 @@ fn declared_runtime_reports_generic_package_paths_probe_and_mixed_source_warning
         .any(|diagnostic| diagnostic.id == "selected_runtime.mixed_core_source"));
 }
 
-#[test]
-fn declared_runtime_legacy_projection_preserves_selected_runtime_status_shape() {
-    let runtime = declared_runtime_diagnostics_for_legacy(
-        "sample_runtime",
-        Some("homeboy-lab"),
-        &BTreeMap::from([(
-            "HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR".to_string(),
-            "/home/chubes/.cache/homeboy/sample-runtime".to_string(),
-        )]),
-    );
-
-    let runtime = runtime.expect("catalog declares legacy sample runtime projection");
-    assert_eq!(runtime.tool, "sample-runtime");
-    assert_eq!(
-        runtime.playground_package.package,
-        "@automattic/sample-runtime-playground"
-    );
-    assert_eq!(runtime.source_git_sha.source, "runtime_probe_command");
-
-    let generic = declared_runtime_diagnostics(
-        &sample_runtime_declaration(),
-        Some("homeboy-lab"),
-        &BTreeMap::from([(
-            "HOMEBOY_SAMPLE_RUNTIME_INSTALL_DIR".to_string(),
-            "/home/chubes/.cache/homeboy/sample-runtime".to_string(),
-        )]),
-    );
-    let serialized = serde_json::to_string(&generic).expect("serialize generic diagnostics");
-
-    assert!(serialized.contains("\"runtime\":\"sample-runtime\""));
-    assert!(serialized.contains("\"packages\""));
-    assert!(!serialized.contains("\"playground_package\":{"));
-}
 
 #[test]
 fn sample_runtime_diagnostics_accept_single_managed_checkout() {


### PR DESCRIPTION
PR #6705 renamed RunnerEnvDiagnostics.selected_runtime -> selected_tool and removed declared_runtime_diagnostics_for_legacy, but left broken test references that FAIL the test build (cargo build --lib --tests). Fixes: redaction.rs 3x selected_runtime->selected_tool; status.rs removes the orphaned legacy-projection test (referenced the deleted helper) + unused import. Verified cargo build --lib --tests (exit 0). Unbreaks main test build for the whole fleet. Behavior-neutral test cleanup.