### PR TITLE
refactor: prune stale field_patterns baseline row (batch 3)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -673,7 +673,6 @@
         "field_patterns::src/core/api_jobs/remote_runner.rs::RepeatedFieldPattern",
         "field_patterns::src/core/ci_failure_log_triage.rs::RepeatedFieldPattern",
         "field_patterns::src/core/engine/resource.rs::RepeatedFieldPattern",
-        "field_patterns::src/core/extension/bench/metric_policy_preset.rs::RepeatedFieldPattern",
         "field_patterns::src/core/extension/bench/responsiveness.rs::RepeatedFieldPattern",
         "field_patterns::src/core/extension/trace/report.rs::RepeatedFieldPattern",
         "field_patterns::src/core/fuzz/types.rs::RepeatedFieldPattern",


### PR DESCRIPTION
## Summary
Prunes one **verified-stale** `field_patterns` baseline row. The other candidates in this batch were investigated and deliberately NOT changed because doing so would break CI or required risky out-of-scope multi-file refactors.

## Pruned (verified stale)
- **`src/core/extension/bench/metric_policy_preset.rs`** — its repeated-field group (`regression_threshold_percent`, `regression_threshold_absolute`, `variance_aware`, `min_iterations_for_variance`, `regression_test`) co-occurs in only **2** structs (`BenchMetricPolicyPreset` + `BenchMetricPolicy` in `result_types.rs`), below the detector's `MIN_OCCURRENCES = 3`. `regression_test` alone hits 3 structs but a single field is not a group (`MIN_GROUP_SIZE = 2`), and no 2+ field group spans those 3 structs. No finding is emitted → row is stale.

## NOT pruned (NOT stale — would break CI)
- **`src/core/git/github_types.rs`** — the `^pub struct` count is 0 only because all 25 structs live inside `mod outputs {}` / `mod options {}` submodules (indented). The field-pattern detector uses brace-depth line scanning, not AST, so it fully scans these. `{component_id, owner, repo, action, success}` genuinely co-occurs across 5+ output structs. Real finding — kept.

## Skipped (genuine but too tangled — cross-file, kept rows)
- **`responsiveness.rs`** — finding is cross-file: `{sampled_peak_rss_bytes, sampled_peak_cpu_percent}` spans `responsiveness.rs`, `engine/resource.rs`, and `commands/report/performance_digest.rs` (each with its own baseline row).
- **`api_jobs/types.rs`** — `{claim_id, claimed_by_runner_id, claimed_at_ms, claim_expires_at_ms}` spans `api_jobs/types.rs` (2 structs) + `runner/session.rs`; ~144 field references across 12 files.
- **`server/mod.rs`** — repeated groups are cross-file across runner/server modules.

These three require multi-file shared-struct extraction + flatten across files that have their own baseline rows; out of scope for a surgical pass and risks wire-format round-trips. Left intact.

## Verification
- Wire format preserved: only a baseline-data row was removed; **no Rust code changed**, so no serialization can shift.
- `homeboy.json` validated as well-formed JSON.
- No heavy local build (per VPS rules); CI re-runs the audit detector and will confirm the pruned finding no longer surfaces, plus normal build/test.
- `cargo fmt` produced only unrelated diffs which were reverted (`git checkout --`).