### PR TITLE
Label artifact path scope in runs output

### DIFF
--- a/src/commands/runs/artifact_index_tests.rs
+++ b/src/commands/runs/artifact_index_tests.rs
@@ -169,6 +169,19 @@ fn runs_artifacts_surfaces_matrix_summary_from_typed_packets() {
         let RunsOutput::Artifacts(output) = output else {
             panic!("expected artifacts output");
         };
+        assert_eq!(
+            output.path_guide.listing_source,
+            "operator_local_persisted_store"
+        );
+        assert!(output
+            .path_guide
+            .operator_local_path_fields
+            .iter()
+            .any(|field| field.contains("artifacts[].path")));
+        assert!(output
+            .path_guide
+            .runner_path_scope
+            .contains("not operator-local filesystem paths"));
         let summary = output.matrix_summary.expect("matrix summary");
 
         assert_eq!(summary.fixture_count, 2);

--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -18,7 +18,7 @@ use super::bench::run_contains_scenario;
 use super::common::{run_summaries_with_artifact_indexes, RunSummary};
 use super::types::{
     RunDetail, RunsArtifactArgs, RunsArtifactCommand, RunsArtifactGetArgs, RunsArtifactGetOutput,
-    RunsArtifactsArgs, RunsArtifactsOutput, RunsEnvKeyOutput, RunsEnvOutput,
+    RunsArtifactPathGuide, RunsArtifactsArgs, RunsArtifactsOutput, RunsEnvKeyOutput, RunsEnvOutput,
     RunsEnvSourceLayerOutput, RunsEnvSummary, RunsListArgs, RunsListOutput, RunsOutput,
     RunsResumePlanOutput, RunsShowOutput,
 };
@@ -183,8 +183,9 @@ pub fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutput> {
     Ok((
         RunsOutput::Artifacts(RunsArtifactsOutput {
             command: "runs.artifacts",
-            run_id: args.run_id,
+            run_id: args.run_id.clone(),
             runner_id: None,
+            path_guide: RunsArtifactPathGuide::for_listing(&args.run_id, None),
             artifacts,
             preview_entrypoints,
             matrix_summary,

--- a/src/commands/runs/remote.rs
+++ b/src/commands/runs/remote.rs
@@ -3,7 +3,7 @@ use homeboy::core::observation::ArtifactRecord;
 use homeboy::core::runners as runner;
 use homeboy::core::Error;
 
-use super::types::{RunsArtifactGetArgs, RunsArtifactsOutput};
+use super::types::{RunsArtifactGetArgs, RunsArtifactPathGuide, RunsArtifactsOutput};
 use super::{remote_artifact, CmdResult, RunsListArgs, RunsListOutput, RunsOutput};
 
 pub fn list_runner_runs(
@@ -53,6 +53,7 @@ pub fn runner_artifacts(runner_id: &str, run_id: &str) -> CmdResult<RunsOutput> 
             command: "runs.artifacts",
             run_id: run_id.to_string(),
             runner_id: Some(runner_id.to_string()),
+            path_guide: RunsArtifactPathGuide::for_listing(run_id, Some(runner_id)),
             artifacts,
             preview_entrypoints: Vec::new(),
             matrix_summary: None,
@@ -162,5 +163,20 @@ mod tests {
         assert_eq!(artifacts[0].id, "report-json");
         assert_eq!(artifacts[0].run_id, "run-123");
         assert_eq!(artifacts[0].mime.as_deref(), Some("application/json"));
+    }
+
+    #[test]
+    fn connected_runner_path_guide_labels_runner_resident_refs() {
+        let guide = RunsArtifactPathGuide::for_listing("run-a", Some("runner-a"));
+
+        assert_eq!(guide.listing_source, "connected_runner:runner-a");
+        assert!(guide
+            .runner_path_fields
+            .iter()
+            .any(|field| field.contains("runner-artifact://")));
+        assert!(guide
+            .runner_path_scope
+            .contains("not operator-local filesystem paths"));
+        assert!(guide.fetch_hint.contains("--runner <runner-id>"));
     }
 }

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -204,6 +204,7 @@ pub struct RunsArtifactsOutput {
     pub run_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_id: Option<String>,
+    pub path_guide: RunsArtifactPathGuide,
     pub artifacts: Vec<ArtifactRecord>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub preview_entrypoints: Vec<ArtifactPreviewEntrypoint>,
@@ -211,6 +212,41 @@ pub struct RunsArtifactsOutput {
     pub matrix_summary: Option<MatrixArtifactSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fuzz_result_envelopes: Vec<FuzzResultEnvelopeArtifactInspection>,
+}
+
+#[derive(Serialize)]
+pub struct RunsArtifactPathGuide {
+    pub listing_source: String,
+    pub operator_local_path_fields: Vec<&'static str>,
+    pub runner_path_fields: Vec<&'static str>,
+    pub local_path_scope: &'static str,
+    pub runner_path_scope: &'static str,
+    pub fetch_hint: String,
+}
+
+impl RunsArtifactPathGuide {
+    pub fn for_listing(run_id: &str, runner_id: Option<&str>) -> Self {
+        let listing_source = runner_id
+            .map(|runner_id| format!("connected_runner:{runner_id}"))
+            .unwrap_or_else(|| "operator_local_persisted_store".to_string());
+
+        Self {
+            listing_source,
+            operator_local_path_fields: vec![
+                "artifacts[].path when artifacts[].type is file or directory",
+                "preview_entrypoints[].public_url when present",
+            ],
+            runner_path_fields: vec![
+                "artifacts[].path when artifacts[].type is remote_file",
+                "artifacts[].path values using runner-artifact://",
+            ],
+            local_path_scope: "Operator-local paths are readable by the Homeboy process that printed this output.",
+            runner_path_scope: "Runner paths and runner-artifact:// refs are runner-resident references, not operator-local filesystem paths.",
+            fetch_hint: format!(
+                "Use `homeboy runs artifact get {run_id} <artifact-id>` to copy an artifact to an operator-local output path. Add `--runner <runner-id>` when fetching directly from a connected runner daemon."
+            ),
+        }
+    }
 }
 
 #[derive(Args, Clone)]


### PR DESCRIPTION
## Summary
- add a generic `path_guide` to `homeboy runs artifacts` output
- distinguish operator-local persisted paths from runner-resident paths and `runner-artifact://` refs
- include the generic `runs artifact get` hint for copying artifacts locally

## Testing
- `cargo check` passed
- `git diff --check` passed
- `cargo test commands::runs::artifact_index_tests` currently fails before these tests run because of unrelated existing runner test drift: missing `declared_runtime_diagnostics_for_legacy` and `RunnerEnvDiagnostics.selected_runtime` fixtures
- `cargo fmt --check` reports unrelated formatting drift in files outside this PR: `src/core/agent_task_controller_service/run_failure_summary.rs` and `src/core/agent_task_provider/tests/selection_tests.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode, plus OpenCode subagents
- **Used for:** implementation, test execution, and PR description drafting
