### PR TITLE
Support adopted workspace refs

### DIFF
--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -5,9 +5,9 @@ use homeboy::core::cleanup::{
     self as artifact_cleanup, ArtifactCleanupOptions, ArtifactCleanupOutput,
 };
 use homeboy::core::worktree::{
-    self, CleanupPolicy, WorktreeCleanupOutput, WorktreeCreateOptions, WorktreeCreateOutput,
-    WorktreeListOutput, WorktreeQueueCreateOptions, WorktreeQueueCreateOutput,
-    WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeStatusOutput,
+    self, CleanupPolicy, WorktreeAdoptOptions, WorktreeAdoptOutput, WorktreeCleanupOutput,
+    WorktreeCreateOptions, WorktreeCreateOutput, WorktreeListOutput, WorktreeQueueCreateOptions,
+    WorktreeQueueCreateOutput, WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeStatusOutput,
 };
 
 use super::CmdResult;
@@ -39,6 +39,19 @@ enum WorktreeCommand {
         /// Cleanup policy for lifecycle cleanup
         #[arg(long, value_enum)]
         cleanup_policy: Option<CliCleanupPolicy>,
+    },
+    /// Adopt an existing local workspace path for @workspace:<handle> refs
+    Adopt {
+        /// Workspace handle resolved by @workspace:<handle>
+        handle: String,
+        /// Existing local directory to resolve for this handle
+        path: String,
+        /// Optional generic kind label recorded as provenance
+        #[arg(long)]
+        kind: Option<String>,
+        /// Optional JSON provenance payload recorded with the adopted path
+        #[arg(long)]
+        provenance_json: Option<String>,
     },
     /// Create multiple DMC worktrees one-at-a-time with lock-aware queue status JSON
     QueueCreate {
@@ -111,6 +124,7 @@ impl From<CliCleanupPolicy> for CleanupPolicy {
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum WorktreeOutput {
     Create(WorktreeCreateOutput),
+    Adopt(WorktreeAdoptOutput),
     QueueCreate(WorktreeQueueCreateOutput),
     List(WorktreeListOutput),
     Status(WorktreeStatusOutput),
@@ -142,6 +156,29 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
             run_id,
             cleanup_policy: cleanup_policy.map(Into::into),
         })?),
+        WorktreeCommand::Adopt {
+            handle,
+            path,
+            kind,
+            provenance_json,
+        } => {
+            let provenance = provenance_json
+                .map(|value| serde_json::from_str(&value))
+                .transpose()
+                .map_err(|err| {
+                    homeboy::core::Error::validation_invalid_json(
+                        err,
+                        Some("provenance_json".to_string()),
+                        None,
+                    )
+                })?;
+            WorktreeOutput::Adopt(worktree::adopt(WorktreeAdoptOptions {
+                handle,
+                path,
+                kind,
+                provenance,
+            })?)
+        }
         WorktreeCommand::QueueCreate {
             repo,
             branches,

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -82,6 +82,8 @@ pub(super) struct WorkspaceRefResolution {
     pub(super) raw_ref: String,
     pub(super) handle: String,
     pub(super) subpath: Option<String>,
+    pub(super) source_kind: String,
+    pub(super) source_provenance: Option<serde_json::Value>,
     pub(super) workspace_path: PathBuf,
     pub(super) resolved_path: PathBuf,
 }
@@ -853,6 +855,8 @@ fn add_candidate_workspace_ref_extra_workspace(
             "ref": resolution.raw_ref,
             "handle": resolution.handle,
             "subpath": resolution.subpath,
+            "workspace_source": resolution.source_kind,
+            "workspace_provenance": resolution.source_provenance,
             "workspace_path": resolution.workspace_path.display().to_string(),
             "resolved_path": resolution.resolved_path.display().to_string(),
         })),
@@ -1284,28 +1288,31 @@ fn maybe_resolve_workspace_ref(
     let Some((handle, subpath)) = parse_workspace_ref(value) else {
         return Ok(None);
     };
-    let record = worktree::resolve(&handle).map_err(|_| {
+    let record = worktree::resolve_workspace_ref(&handle).map_err(|_| {
         Error::validation_invalid_argument(
             "workspace_ref",
-            format!("Lab offload workspace ref `{value}` does not match a known Homeboy worktree"),
+            format!("Lab offload workspace ref `{value}` does not match a known workspace handle"),
             Some(value.to_string()),
             Some(vec![
-                "Create or list Homeboy task worktrees with `homeboy worktree create` and `homeboy worktree list`.".to_string(),
+                "Create a Homeboy task worktree or adopt an existing path with `homeboy worktree adopt <handle> <path>`.".to_string(),
             ]),
         )
     })?;
-    if record.state != TaskWorktreeState::Active {
+    if record.state() != &TaskWorktreeState::Active {
         return Err(Error::validation_invalid_argument(
             "workspace_ref",
-            format!("Lab offload workspace ref `{value}` points at a stale Homeboy worktree"),
-            Some(record.id),
+            format!(
+                "Lab offload workspace ref `{value}` points at a stale {}",
+                record.source_kind()
+            ),
+            Some(record.handle().to_string()),
             Some(vec![
-                "Use an active worktree handle or create a fresh worktree before Lab offload."
+                "Use an active workspace handle or adopt an existing path before Lab offload."
                     .to_string(),
             ]),
         ));
     }
-    let workspace_path = PathBuf::from(&record.worktree_path);
+    let workspace_path = PathBuf::from(record.path());
     let mut resolved = workspace_path.clone();
     if let Some(subpath) = subpath.as_deref() {
         resolved.push(subpath);
@@ -1325,6 +1332,8 @@ fn maybe_resolve_workspace_ref(
         raw_ref: value.to_string(),
         handle,
         subpath,
+        source_kind: record.source_kind().to_string(),
+        source_provenance: record.provenance().cloned(),
         workspace_path,
         resolved_path: resolved.clone(),
     });
@@ -1368,6 +1377,7 @@ mod provider_config_candidate_paths_tests {
     use crate::core::runner::{
         ByteFileCounts, RunnerGitDependencyMaterializationOutput, RunnerWorkspaceSyncMode,
     };
+    use crate::core::worktree;
 
     fn git(path: &Path, args: &[&str]) {
         let output = Command::new("git")
@@ -1958,6 +1968,98 @@ mod provider_config_candidate_paths_tests {
     }
 
     #[test]
+    fn path_setting_workspace_ref_resolves_adopted_workspace() {
+        crate::test_support::with_isolated_home(|home| {
+            let source = home.path().join("primary");
+            let workspace = home.path().join("external-workspace");
+            let nested = workspace.join("fixtures/input.json");
+            std::fs::create_dir_all(&source).expect("source dir");
+            std::fs::create_dir_all(nested.parent().unwrap()).expect("nested dir");
+            std::fs::write(&nested, "{}\n").expect("nested file");
+            worktree::adopt(worktree::WorktreeAdoptOptions {
+                handle: "external".to_string(),
+                path: workspace.display().to_string(),
+                kind: Some("local_checkout".to_string()),
+                provenance: Some(serde_json::json!({
+                    "source": "test-harness",
+                    "note": "opaque caller metadata"
+                })),
+            })
+            .expect("adopt workspace");
+            let args = vec![
+                "homeboy".to_string(),
+                "trace".to_string(),
+                "--setting".to_string(),
+                "fixture=@workspace:external/fixtures/input.json".to_string(),
+            ];
+
+            let (rewritten, resolutions) =
+                resolve_path_setting_workspace_refs_in_args(&args).expect("resolve refs");
+            let expected = format!(
+                "fixture={}",
+                workspace
+                    .canonicalize()
+                    .unwrap()
+                    .join("fixtures/input.json")
+                    .display()
+            );
+
+            assert_eq!(rewritten[3], expected);
+            assert_eq!(resolutions.len(), 1);
+            assert_eq!(resolutions[0].handle, "external");
+            assert_eq!(resolutions[0].source_kind, "adopted_workspace");
+            assert_eq!(
+                resolutions[0].source_provenance.as_ref().unwrap()["source"],
+                "test-harness"
+            );
+            assert_eq!(
+                resolutions[0].subpath.as_deref(),
+                Some("fixtures/input.json")
+            );
+
+            let workspaces =
+                workspace_ref_extra_workspaces(&resolutions, &source).expect("extra workspaces");
+            assert_eq!(workspaces.len(), 1);
+            assert_eq!(workspaces[0].path, workspace.canonicalize().unwrap());
+            let provenance = workspaces[0].source_provenance.as_ref().unwrap();
+            assert_eq!(provenance["workspace_source"], "adopted_workspace");
+            assert_eq!(
+                provenance["workspace_provenance"]["note"],
+                "opaque caller metadata"
+            );
+        });
+    }
+
+    #[test]
+    fn path_setting_workspace_ref_missing_adopted_path_fails_locally() {
+        crate::test_support::with_isolated_home(|home| {
+            let workspace = home.path().join("external-workspace");
+            std::fs::create_dir_all(&workspace).expect("workspace dir");
+            worktree::adopt(worktree::WorktreeAdoptOptions {
+                handle: "external".to_string(),
+                path: workspace.display().to_string(),
+                kind: None,
+                provenance: None,
+            })
+            .expect("adopt workspace");
+            std::fs::remove_dir_all(&workspace).expect("remove adopted workspace");
+            let args = vec![
+                "homeboy".to_string(),
+                "trace".to_string(),
+                "--setting=fixture=@workspace:external".to_string(),
+            ];
+
+            let err = resolve_path_setting_workspace_refs_in_args(&args)
+                .expect_err("missing adopted workspace path should fail");
+
+            assert_eq!(err.details["field"], "workspace_ref");
+            assert!(err
+                .message
+                .contains("resolved to a missing controller path"));
+        });
+    }
+
+    #[test]
     fn path_setting_workspace_ref_missing_handle_fails_locally() {
         crate::test_support::with_isolated_home(|_| {
             let args = vec![
@@ -1972,7 +2074,7 @@ mod provider_config_candidate_paths_tests {
             assert_eq!(err.details["field"], "workspace_ref");
             assert!(err
                 .message
-                .contains("does not match a known Homeboy worktree"));
+                .contains("does not match a known workspace handle"));
         });
     }
 
@@ -2012,7 +2114,7 @@ mod provider_config_candidate_paths_tests {
                 .expect_err("removed workspace ref should fail");
 
             assert_eq!(err.details["field"], "workspace_ref");
-            assert!(err.message.contains("stale Homeboy worktree"));
+            assert!(err.message.contains("stale task_worktree"));
         });
     }
 

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -53,6 +53,61 @@ mod types {
         pub state: TaskWorktreeState,
     }
 
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct AdoptedWorkspaceRecord {
+        pub handle: String,
+        pub path: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub kind: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub provenance: Option<serde_json::Value>,
+        pub created_at: String,
+        pub state: TaskWorktreeState,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum WorkspaceRefRecord {
+        Task(TaskWorktreeRecord),
+        Adopted(AdoptedWorkspaceRecord),
+    }
+
+    impl WorkspaceRefRecord {
+        pub fn handle(&self) -> &str {
+            match self {
+                WorkspaceRefRecord::Task(record) => &record.id,
+                WorkspaceRefRecord::Adopted(record) => &record.handle,
+            }
+        }
+
+        pub fn path(&self) -> &str {
+            match self {
+                WorkspaceRefRecord::Task(record) => &record.worktree_path,
+                WorkspaceRefRecord::Adopted(record) => &record.path,
+            }
+        }
+
+        pub fn state(&self) -> &TaskWorktreeState {
+            match self {
+                WorkspaceRefRecord::Task(record) => &record.state,
+                WorkspaceRefRecord::Adopted(record) => &record.state,
+            }
+        }
+
+        pub fn source_kind(&self) -> &'static str {
+            match self {
+                WorkspaceRefRecord::Task(_) => "task_worktree",
+                WorkspaceRefRecord::Adopted(_) => "adopted_workspace",
+            }
+        }
+
+        pub fn provenance(&self) -> Option<&serde_json::Value> {
+            match self {
+                WorkspaceRefRecord::Task(_) => None,
+                WorkspaceRefRecord::Adopted(record) => record.provenance.as_ref(),
+            }
+        }
+    }
+
     #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
     pub struct WorktreeSafetyReport {
         pub dirty: bool,
@@ -67,6 +122,11 @@ mod types {
     #[derive(Debug, Clone, Serialize)]
     pub struct WorktreeCreateOutput {
         pub record: TaskWorktreeRecord,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct WorktreeAdoptOutput {
+        pub record: AdoptedWorkspaceRecord,
     }
 
     #[derive(Debug, Clone, Serialize)]
@@ -100,6 +160,14 @@ mod types {
         pub task_url: Option<String>,
         pub run_id: Option<String>,
         pub cleanup_policy: Option<CleanupPolicy>,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct WorktreeAdoptOptions {
+        pub handle: String,
+        pub path: String,
+        pub kind: Option<String>,
+        pub provenance: Option<serde_json::Value>,
     }
 
     #[derive(Debug, Clone)]
@@ -166,7 +234,8 @@ mod types {
 }
 
 pub use types::{
-    CleanupPolicy, TaskWorktreeRecord, TaskWorktreeState, WorktreeCleanupOutput,
+    AdoptedWorkspaceRecord, CleanupPolicy, TaskWorktreeRecord, TaskWorktreeState,
+    WorkspaceRefRecord, WorktreeAdoptOptions, WorktreeAdoptOutput, WorktreeCleanupOutput,
     WorktreeCreateOptions, WorktreeCreateOutput, WorktreeListOutput, WorktreeQueueCreateOptions,
     WorktreeQueueCreateOutput, WorktreeQueueCreateRow, WorktreeQueueCreateStatus,
     WorktreeQueueLockHolder, WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeSafetyReport,
@@ -175,6 +244,10 @@ pub use types::{
 
 pub fn create(options: WorktreeCreateOptions) -> Result<WorktreeCreateOutput> {
     create_with_store(options, &metadata_dir()?)
+}
+
+pub fn adopt(options: WorktreeAdoptOptions) -> Result<WorktreeAdoptOutput> {
+    adopt_with_store(options, &adopted_metadata_dir()?)
 }
 
 pub fn list() -> Result<WorktreeListOutput> {
@@ -189,6 +262,13 @@ pub fn resolve(id: &str) -> Result<TaskWorktreeRecord> {
     read_record(&metadata_dir()?, id)
 }
 
+pub fn resolve_workspace_ref(handle: &str) -> Result<WorkspaceRefRecord> {
+    if let Ok(record) = read_record(&metadata_dir()?, handle) {
+        return Ok(WorkspaceRefRecord::Task(record));
+    }
+    read_adopted_record(&adopted_metadata_dir()?, handle).map(WorkspaceRefRecord::Adopted)
+}
+
 pub fn remove(options: WorktreeRemoveOptions) -> Result<WorktreeRemoveOutput> {
     remove_with_store(options, &metadata_dir()?)
 }
@@ -200,6 +280,48 @@ pub fn cleanup(force: bool) -> Result<WorktreeCleanupOutput> {
 
 mod store_ops {
     use super::*;
+
+    pub(super) fn adopt_with_store(
+        options: WorktreeAdoptOptions,
+        store_dir: &Path,
+    ) -> Result<WorktreeAdoptOutput> {
+        if options.handle.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "handle",
+                "Adopted workspace handle must not be empty",
+                Some(options.handle),
+                None,
+            ));
+        }
+        let path = PathBuf::from(&options.path).canonicalize().map_err(|err| {
+            Error::validation_invalid_argument(
+                "path",
+                "Adopted workspace path must exist on the controller",
+                Some(format!("{} ({err})", options.path)),
+                Some(vec![
+                    "Pass an existing local checkout or workspace path.".to_string()
+                ]),
+            )
+        })?;
+        if !path.is_dir() {
+            return Err(Error::validation_invalid_argument(
+                "path",
+                "Adopted workspace path must be a directory",
+                Some(path.display().to_string()),
+                None,
+            ));
+        }
+        let record = AdoptedWorkspaceRecord {
+            handle: options.handle,
+            path: path.display().to_string(),
+            kind: options.kind,
+            provenance: options.provenance,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            state: TaskWorktreeState::Active,
+        };
+        write_adopted_record(store_dir, &record)?;
+        Ok(WorktreeAdoptOutput { record })
+    }
 
     pub(super) fn cleanup_with_store(force: bool, store: &Path) -> Result<WorktreeCleanupOutput> {
         let mut candidates = Vec::new();
@@ -485,6 +607,18 @@ mod store_ops {
         Ok(data_root.join("task-worktrees"))
     }
 
+    pub(super) fn adopted_metadata_dir() -> Result<PathBuf> {
+        let observation_db = paths::observation_db()?;
+        let data_root = observation_db.parent().ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "observation database path `{}` has no parent directory",
+                observation_db.display()
+            ))
+        })?;
+
+        Ok(data_root.join("adopted-workspaces"))
+    }
+
     pub(super) fn record_path(store_dir: &Path, id: &str) -> PathBuf {
         store_dir.join(format!("{}.json", paths::sanitize_path_segment(id)))
     }
@@ -509,12 +643,51 @@ mod store_ops {
         Ok(())
     }
 
+    pub(super) fn write_adopted_record(
+        store_dir: &Path,
+        record: &AdoptedWorkspaceRecord,
+    ) -> Result<()> {
+        let store_owner = ownership::owner_for_path_or_ancestor(store_dir)?;
+        fs::create_dir_all(store_dir).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(store_dir.display().to_string()))
+        })?;
+        let json = serde_json::to_string_pretty(record)
+            .map_err(|err| Error::internal_json(err.to_string(), Some(record.handle.clone())))?;
+        let path = record_path(store_dir, &record.handle);
+        fs::write(&path, format!("{json}\n"))
+            .map_err(|err| Error::internal_io(err.to_string(), Some(record.handle.clone())))?;
+        ownership::normalize_created_path(
+            store_dir,
+            store_owner,
+            false,
+            "write adopted workspace metadata",
+        )?;
+        ownership::normalize_created_path(
+            &path,
+            store_owner,
+            false,
+            "write adopted workspace metadata",
+        )?;
+        Ok(())
+    }
+
     pub(super) fn read_record(store_dir: &Path, id: &str) -> Result<TaskWorktreeRecord> {
         read_record_path(&record_path(store_dir, id))
     }
 
     pub(super) fn read_record_path(path: &Path) -> Result<TaskWorktreeRecord> {
         let raw = fs::read_to_string(path)
+            .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+        serde_json::from_str(&raw)
+            .map_err(|err| Error::internal_json(err.to_string(), Some(path.display().to_string())))
+    }
+
+    pub(super) fn read_adopted_record(
+        store_dir: &Path,
+        handle: &str,
+    ) -> Result<AdoptedWorkspaceRecord> {
+        let path = record_path(store_dir, handle);
+        let raw = fs::read_to_string(&path)
             .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
         serde_json::from_str(&raw)
             .map_err(|err| Error::internal_json(err.to_string(), Some(path.display().to_string())))


### PR DESCRIPTION
## Summary
- Add a generic Homeboy-owned adopted workspace registry for `handle -> path` records.
- Expose `homeboy worktree adopt <handle> <path>` with optional generic `--kind` and opaque `--provenance-json`.
- Resolve `@workspace:<handle>/subpath` from task worktrees first, then adopted workspaces, preserving stale/missing local errors and workspace mapping provenance for Lab sync/remapping.

Fixes #6712.

## Tests
- `cargo test path_setting_workspace_ref --lib`
- `cargo check`
- `git diff --check`
- `HOME=<isolated temp> RUSTUP_HOME=/Users/chubes/.rustup CARGO_HOME=/Users/chubes/.cargo cargo run --quiet -- worktree adopt external <temp-workspace> --kind generic --provenance-json '{"source":"cli-test"}'`

## Notes
- `cargo fmt --check` still reports pre-existing formatting drift in unrelated base-branch files (`src/commands/runner/tests/status.rs`, `src/core/agent_task_controller_service/run_failure_summary.rs`, `src/core/agent_task_provider/tests/selection_tests.rs`). I formatted only the files touched by this PR to avoid unrelated churn.

## Risks
- Adopted workspace records intentionally persist machine-local controller paths; stale path validation fails locally before Lab offload.
- If a task worktree and adopted workspace share a handle, the task worktree continues to take precedence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementation, focused tests, verification, and PR drafting.