### PR TITLE
Sync worktree snapshots for runner exec

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -592,6 +592,7 @@ homeboy runner remove <id>
 ```sh
 homeboy runner exec <runner-id> -- <command...>
 homeboy runner exec <runner-id> --project <project-id> --cwd /runner/workspace/project -- <command...>
+homeboy runner exec <runner-id> --sync-workspace /local/project@patch --require-path /runner/resources/input -- <command...>
 homeboy runner exec <runner-id> --ssh --cwd /runner/workspace/project -- <command...>
 homeboy runner exec <runner-id> --run-id ssi-fixture-matrix-summary -- <command...>
 homeboy runner exec <runner-id> --cwd /runner/workspace/project --require-path /runner/workspace/project -- <command...>
@@ -606,6 +607,7 @@ Path rules:
 - SSH runners require `workspace_root` so local paths are not silently reused remotely.
 - SSH `--cwd` must be an absolute path under the configured `workspace_root`.
 - Omitting `--cwd` on an SSH runner uses the runner `workspace_root`.
+- `--sync-workspace <local-worktree>` snapshots a controller-side worktree first, including dirty edits allowed by the normal snapshot safety excludes, then executes from the returned runner `remote_path`. It is mutually exclusive with `--cwd` because Homeboy owns the execution cwd for that one command.
 - `--require-path <path>` preflights one or more runner-side paths before execution. Use it when a command references a lab worktree path so missing controller-only paths fail with a structured `require_path` error instead of an empty command failure.
 - `--project <id>` feeds the runner trust policy project allowlist check.
 - `--run-id <id>` sets the persisted controller-side runner-exec run id for ad hoc evidence commands. When omitted, Homeboy derives a run id prefix from the command domain, such as `trace-matrix-summary`.
@@ -616,6 +618,18 @@ Path rules:
   `mutation_artifacts.patch_ref` when a patch artifact is available. Direct
   daemon and reverse broker results use the same field; callers should not branch
   on transport mode to find returned mutations.
+
+Dirty local worktree against runner-side resources:
+
+```sh
+homeboy runner exec <runner-id> \
+  --sync-workspace /local/project@patch \
+  --require-path /runner/resources/input \
+  --capture-patch \
+  -- ./run-workload --input /runner/resources/input
+```
+
+This is the generic one-command form for “run my local patch on the runner”: Homeboy snapshots the local source, runs the command from the materialized runner copy, preflights any runner-owned resource paths the caller declares, and attaches source snapshot metadata to patch capture output. The resource path meaning remains caller-owned; Homeboy only checks that the path exists on the runner.
 
 Runner job environment:
 

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -248,6 +248,10 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         cwd: Option<String>,
 
+        /// Snapshot a local worktree to the runner first and execute from the materialized remote path.
+        #[arg(long = "sync-workspace")]
+        sync_workspace: Option<String>,
+
         /// Project ID used for runner trust policy checks
         #[arg(long)]
         project: Option<String>,

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -154,6 +154,7 @@ pub fn run(
         RunnerCommand::Exec {
             id,
             cwd,
+            sync_workspace,
             project,
             ssh,
             capture_patch,
@@ -170,6 +171,7 @@ pub fn run(
         } => map_execution(exec(
             &id,
             cwd,
+            sync_workspace,
             project,
             ssh,
             capture_patch,
@@ -230,6 +232,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
         RunnerCommand::Exec {
             id,
             cwd,
+            sync_workspace,
             project,
             ssh,
             capture_patch,
@@ -246,6 +249,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
         } => run_raw_exec(
             id,
             cwd,
+            sync_workspace,
             project,
             ssh,
             capture_patch,
@@ -274,6 +278,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
 fn run_raw_exec(
     id: String,
     cwd: Option<String>,
+    sync_workspace: Option<String>,
     project: Option<String>,
     ssh: bool,
     capture_patch: bool,
@@ -290,6 +295,7 @@ fn run_raw_exec(
     match exec(
         &id,
         cwd,
+        sync_workspace,
         project,
         ssh,
         capture_patch,

--- a/src/commands/runner/exec.rs
+++ b/src/commands/runner/exec.rs
@@ -9,6 +9,7 @@ use homeboy::core::runners::{
     self as runner, RunnerExecOutput, RunnerExecPromotedOutput, RunnerExecStructuredSummary,
     RunnerKind,
 };
+use homeboy::core::source_snapshot::SourceSnapshot;
 use homeboy::core::stream_capture::StreamCaptureMetadata;
 use homeboy::core::{server, Error};
 
@@ -19,6 +20,7 @@ use super::types::RUNNER_EXEC_SCRIPT_ENV;
 pub(super) fn exec(
     runner_id: &str,
     cwd: Option<String>,
+    sync_workspace: Option<String>,
     project_id: Option<String>,
     allow_diagnostic_ssh: bool,
     capture_patch: bool,
@@ -53,6 +55,7 @@ pub(super) fn exec(
     }
 
     if dry_run {
+        let (cwd, _) = exec_workspace_context(runner_id, cwd, sync_workspace, true)?;
         return runner_exec_dry_run(
             runner_id,
             cwd,
@@ -64,6 +67,7 @@ pub(super) fn exec(
     }
 
     let validated_run_id = validate_runner_exec_run_id(run_id)?;
+    let (cwd, source_snapshot) = exec_workspace_context(runner_id, cwd, sync_workspace, false)?;
 
     let (mut output, exit_code) = runner::exec(
         runner_id,
@@ -80,7 +84,7 @@ pub(super) fn exec(
                 .collect(),
             capture_patch,
             raw_exec: true,
-            source_snapshot: None,
+            source_snapshot,
             capability_preflight: Some(runner::RunnerCapabilityPreflight {
                 command: "runner.exec".to_string(),
                 required_commands,
@@ -122,6 +126,55 @@ pub(super) fn exec(
         output.promoted_outputs.extend(promoted_summaries);
     }
     Ok((output, exit_code))
+}
+
+pub(super) fn exec_workspace_context(
+    runner_id: &str,
+    cwd: Option<String>,
+    sync_workspace: Option<String>,
+    dry_run: bool,
+) -> homeboy::core::Result<(Option<String>, Option<SourceSnapshot>)> {
+    let Some(local_path) = sync_workspace else {
+        return Ok((cwd, None));
+    };
+
+    if cwd.is_some() {
+        return Err(Error::validation_invalid_argument(
+            "cwd",
+            "--cwd and --sync-workspace are mutually exclusive; --sync-workspace executes from the materialized runner path",
+            None,
+            Some(vec![
+                "Use --sync-workspace <local-worktree> when the command should run from that worktree snapshot.".to_string(),
+                "Use --cwd <runner-path> when the runner-side path already exists.".to_string(),
+            ]),
+        ));
+    }
+
+    if dry_run {
+        return Ok((None, None));
+    }
+
+    let (synced, _) = runner::sync_workspace(
+        runner_id,
+        runner::RunnerWorkspaceSyncOptions {
+            path: local_path,
+            mode: runner::RunnerWorkspaceSyncMode::Snapshot,
+            controller_routed_git: false,
+            changed_since_base: None,
+            git_fetch_refs: Vec::new(),
+            snapshot_includes: Vec::new(),
+            allow_dirty_lab_workspace: false,
+            run_isolation_token: None,
+        },
+    )?;
+    let source_snapshot = SourceSnapshot::collect_local(
+        runner_id,
+        Path::new(&synced.local_path),
+        Some(&synced.remote_path),
+        synced.sync_mode.label(),
+    );
+
+    Ok((Some(synced.remote_path), Some(source_snapshot)))
 }
 
 fn validate_runner_exec_run_id(run_id: Option<String>) -> homeboy::core::Result<Option<String>> {

--- a/src/commands/runner/tests/exec.rs
+++ b/src/commands/runner/tests/exec.rs
@@ -1,8 +1,8 @@
 use super::super::dispatch::raw_exec_command_run;
 use super::super::exec::{
-    exec, prepare_runner_exec_command, prepare_runner_exec_env, promote_runner_exec_artifact_dirs,
-    promote_runner_exec_artifacts, read_bounded, read_runner_exec_script,
-    RUNNER_EXEC_SCRIPT_LIMIT_BYTES,
+    exec, exec_workspace_context, prepare_runner_exec_command, prepare_runner_exec_env,
+    promote_runner_exec_artifact_dirs, promote_runner_exec_artifacts, read_bounded,
+    read_runner_exec_script, RUNNER_EXEC_SCRIPT_LIMIT_BYTES,
 };
 use super::super::types::RUNNER_EXEC_SCRIPT_ENV;
 
@@ -54,6 +54,21 @@ fn raw_exec_command_run_keeps_structured_output_and_presentation_streams() {
     assert_eq!(value["stdout"], "hello\n");
     assert_eq!(value["stderr"], "warn\n");
     assert_eq!(value["job_id"], "job-123");
+}
+
+#[test]
+fn sync_workspace_exec_rejects_explicit_cwd() {
+    let err = exec_workspace_context(
+        "lab",
+        Some("/runner/workspace/project".to_string()),
+        Some("/local/project".to_string()),
+        false,
+    )
+    .expect_err("cwd and sync-workspace must conflict");
+
+    assert!(err
+        .to_string()
+        .contains("--cwd and --sync-workspace are mutually exclusive"));
 }
 
 #[test]
@@ -151,6 +166,7 @@ fn runner_exec_promotes_declared_artifacts_to_run_store() {
             "lab-local",
             Some(workspace.path().display().to_string()),
             None,
+            None,
             false,
             false,
             Vec::new(),
@@ -223,6 +239,7 @@ fn runner_exec_promotes_declared_summaries_as_typed_evidence() {
         let (output, exit_code) = exec(
             "lab-local",
             Some(workspace.path().display().to_string()),
+            None,
             None,
             false,
             false,
@@ -299,6 +316,7 @@ fn runner_exec_structured_summary_is_independent_of_large_stdout() {
         let (output, exit_code) = exec(
             "lab-local",
             Some(workspace.path().display().to_string()),
+            None,
             None,
             false,
             false,
@@ -502,6 +520,7 @@ fn runner_exec_rejects_artifacts_without_run_id() {
         "lab-local",
         None,
         None,
+        None,
         false,
         false,
         Vec::new(),
@@ -555,6 +574,7 @@ fn runner_exec_output(runner_id: &str, mode: RunnerExecMode, remote_cwd: &str) -
 fn runner_exec_rejects_summaries_without_run_id() {
     let err = exec(
         "lab-local",
+        None,
         None,
         None,
         false,


### PR DESCRIPTION
## Summary
- add `homeboy runner exec --sync-workspace <local-worktree>` for one-command dirty worktree snapshot execution on a runner
- reject `--cwd` with `--sync-workspace` to avoid ambiguous execution location
- document the generic runner-side resource workflow in the current runner command layout

## Testing
- `cargo fmt --check`
- `cargo test sync_workspace_exec_rejects_explicit_cwd`
- `cargo test core_agnostic`
- `cargo test command_surface`
- `cargo run -- runner exec --help`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode, plus OpenCode subagents
- **Used for:** implementation, conflict repair, test execution, and PR description drafting
