### PR TITLE
upgrade: warn loudly when a configured runner stays version-degraded

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -85,6 +85,11 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     let json = serde_json::to_value(&result)
         .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
 
+    // Surface any runner left version-degraded by the upgrade with a prominent
+    // warning and its exact remediation command, instead of burying the drift in
+    // the JSON payload (only ever rediscovered via `homeboy self status`).
+    warn_degraded_runners(&result);
+
     // If upgrade succeeded and restart is needed, do it
     if result.upgraded && result.restart_required && !args.no_restart {
         // Print the result first so the user sees it
@@ -106,6 +111,67 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     }
 
     Ok((json, upgrade_exit_code(&result, !args.runners.is_empty())))
+}
+
+/// Configured runners that the upgrade left version-degraded (PATH/version drift
+/// relative to the upgraded controller). Reuses the drift detection already
+/// captured on each entry's `path_drift` — the same signal `homeboy self status`
+/// reports — so this stays a presentation-only surface.
+fn degraded_runners(result: &upgrade::UpgradeResult) -> Vec<&upgrade::RunnerUpgradeEntry> {
+    result
+        .runners_updated
+        .iter()
+        .chain(result.runners_skipped.iter())
+        .filter(|entry| entry.path_drift.is_some())
+        .collect()
+}
+
+/// Human-readable warning lines for any runner left version-degraded after the
+/// upgrade. Empty when every configured runner is aligned with the controller.
+fn degraded_runner_warning_lines(result: &upgrade::UpgradeResult) -> Vec<String> {
+    let degraded = degraded_runners(result);
+    if degraded.is_empty() {
+        return Vec::new();
+    }
+
+    let controller_version = result
+        .new_version
+        .as_deref()
+        .unwrap_or(result.previous_version.as_str());
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "DEGRADED: {} configured runner(s) remain version-degraded after upgrading the controller to {}",
+        degraded.len(),
+        controller_version
+    ));
+    for entry in degraded {
+        lines.push(format!(
+            "  {}: {}",
+            entry.runner_id,
+            entry
+                .path_drift
+                .as_deref()
+                .unwrap_or("runner version drift detected")
+        ));
+        let remediation = if entry.recovery_commands.is_empty() {
+            format!(
+                "homeboy upgrade --force --upgrade-runner {}",
+                entry.runner_id
+            )
+        } else {
+            entry.recovery_commands.join(" && ")
+        };
+        lines.push(format!("    remediate: {}", remediation));
+    }
+    lines
+}
+
+/// Emit the post-upgrade degraded-runner warning to the upgrade status channel.
+fn warn_degraded_runners(result: &upgrade::UpgradeResult) {
+    for line in degraded_runner_warning_lines(result) {
+        homeboy::log_status!("upgrade", "{}", line);
+    }
 }
 
 fn upgrade_exit_code(result: &upgrade::UpgradeResult, targeted_runner_upgrade: bool) -> i32 {
@@ -173,6 +239,66 @@ mod tests {
         });
 
         assert_eq!(upgrade_exit_code(&result, false), 0);
+    }
+
+    #[test]
+    fn degraded_runner_emits_warning_with_remediation() {
+        let mut result = base_upgrade_result();
+        result.new_version = Some("0.265.2".to_string());
+        result.runners_skipped.push(upgrade::RunnerUpgradeEntry {
+            runner_id: "homeboy-lab".to_string(),
+            homeboy_path: "/home/user/homeboy-main/target/release/homeboy".to_string(),
+            success: false,
+            upgraded: false,
+            previous_version: Some("0.265.2".to_string()),
+            new_version: Some("0.265.2".to_string()),
+            bare_homeboy_version: Some("0.255.8".to_string()),
+            path_drift: Some(
+                "configured runner executable reports 0.265.2, but bare `homeboy` reports 0.255.8"
+                    .to_string(),
+            ),
+            recovery_commands: vec![
+                "homeboy upgrade --force --upgrade-runner homeboy-lab".to_string(),
+            ],
+            extensions_synced: Vec::new(),
+            extensions_skipped: Vec::new(),
+            extensions_failed: Vec::new(),
+            stale_daemon: None,
+            exit_code: 0,
+            detail: "runner remains degraded".to_string(),
+        });
+
+        let lines = degraded_runner_warning_lines(&result);
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains("DEGRADED"));
+        assert!(lines[0].contains("0.265.2"));
+        assert!(lines[1].contains("homeboy-lab"));
+        assert!(lines[2].contains("remediate"));
+        assert!(lines[2].contains("homeboy upgrade --force --upgrade-runner homeboy-lab"));
+    }
+
+    #[test]
+    fn aligned_runners_emit_no_degraded_warning() {
+        let mut result = base_upgrade_result();
+        result.runners_updated.push(upgrade::RunnerUpgradeEntry {
+            runner_id: "homeboy-lab".to_string(),
+            homeboy_path: "homeboy".to_string(),
+            success: true,
+            upgraded: true,
+            previous_version: Some("0.265.1".to_string()),
+            new_version: Some("0.265.2".to_string()),
+            bare_homeboy_version: Some("0.265.2".to_string()),
+            path_drift: None,
+            recovery_commands: Vec::new(),
+            extensions_synced: Vec::new(),
+            extensions_skipped: Vec::new(),
+            extensions_failed: Vec::new(),
+            stale_daemon: None,
+            exit_code: 0,
+            detail: "upgraded".to_string(),
+        });
+
+        assert!(degraded_runner_warning_lines(&result).is_empty());
     }
 
     fn base_upgrade_result() -> upgrade::UpgradeResult {


### PR DESCRIPTION
## Problem

`Closes #6735`

After `homeboy upgrade` brings the controller to a new version, a configured runner can stay on a PATH-shadowed older binary (`path_drift`, e.g. controller `0.265.2` vs runner `0.255.8`). The upgrade reported overall success and listed `recovery_commands` in the JSON payload, but never surfaced the degradation to the operator. The drift was only discoverable by separately running `homeboy self status`, and remediation was fully manual — so a subsequent bench could route to a stale runner.

## Change

Add a prominent post-upgrade warning to the `upgrade` command:

- After the upgrade completes, scan `runners_updated` + `runners_skipped` for any entry that still carries `path_drift` (the **same** drift signal `self status` reports — no reimplementation).
- Emit a clear `DEGRADED:` callout naming the controller version, each affected runner with its drift detail, and the exact `remediate:` command (from the entry's existing `recovery_commands`, falling back to `homeboy upgrade --force --upgrade-runner <id>`).
- Routed through the existing `log_status!("upgrade", ...)` channel, consistent with the rest of the upgrade flow.

This is presentation-only: drift detection, remediation, and exit codes are unchanged. It just makes existing degradation impossible to miss interactively.

## Tests

Targeted unit tests in `src/commands/upgrade.rs`:
- `degraded_runner_emits_warning_with_remediation` — degraded runner produces a DEGRADED warning + remediation command.
- `aligned_runners_emit_no_degraded_warning` — aligned runners produce nothing.

`cargo test --lib commands::upgrade` → 4 passed.

## Follow-ups

- Optional auto-remediation: have `homeboy upgrade` offer/auto-run `--upgrade-runner` for degraded configured runners (intentionally out of scope here — auto-mutation is riskier and larger).
- Pre-bench guard: warn/error (with override) when a selected runner is version-degraded before dispatching a run to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)