### PR TITLE
fix(rig): clear error when rig spec uses an unrecognized component schema

### DIFF
--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -123,6 +123,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         | ErrorCode::ValidationMissingArgument
         | ErrorCode::ValidationInvalidArgument
         | ErrorCode::ValidationInvalidJson
+        | ErrorCode::RigSchemaUnsupported
         | ErrorCode::ValidationMultipleErrors => 2,
 
         ErrorCode::ProjectNotFound

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -38,6 +38,7 @@ pub enum ErrorCode {
     RigPipelineFailed,
     RigServiceFailed,
     RigResourceConflict,
+    RigSchemaUnsupported,
     RunnerLabTransportFailure,
     StackNotFound,
     StackApplyConflict,
@@ -92,6 +93,7 @@ impl ErrorCode {
             ErrorCode::RigPipelineFailed => "rig.pipeline_failed",
             ErrorCode::RigServiceFailed => "rig.service_failed",
             ErrorCode::RigResourceConflict => "rig.resource_conflict",
+            ErrorCode::RigSchemaUnsupported => "rig.schema_unsupported",
             ErrorCode::RunnerLabTransportFailure => "runner.lab_transport_failure",
             ErrorCode::StackNotFound => "stack.not_found",
             ErrorCode::StackApplyConflict => "stack.apply_conflict",
@@ -354,6 +356,46 @@ impl Error {
         }
 
         Self::new(ErrorCode::ValidationInvalidJson, "Invalid JSON", details)
+    }
+
+    /// A rig spec parsed as valid JSON but its shape doesn't match this
+    /// binary's `RigSpec` schema — almost always a binary/spec version
+    /// mismatch (e.g. a rig declaring the `component_id`/`path_setting`
+    /// component schema against an older homeboy that only understood
+    /// top-level `path`). This is deliberately *not* `validation.invalid_json`:
+    /// the file isn't malformed, the running binary is just behind.
+    pub fn rig_schema_unsupported(
+        serde_error: impl Into<String>,
+        context: impl Into<String>,
+        component: Option<String>,
+    ) -> Self {
+        let active = env!("CARGO_PKG_VERSION");
+        let serde_error = serde_error.into();
+        let message = match &component {
+            Some(name) => format!(
+                "Rig component '{}' uses an unrecognized schema (expected `path` or `component_id`); \
+                 this rig may require a newer homeboy — active version is {}.",
+                name, active
+            ),
+            None => format!(
+                "Rig spec uses a schema this homeboy build does not recognize ({}); \
+                 this rig may require a newer homeboy — active version is {}.",
+                serde_error, active
+            ),
+        };
+        let mut details = serde_json::json!({
+            "error": serde_error,
+            "context": context.into(),
+            "active_version": active,
+        });
+        if let Some(name) = component {
+            details["component"] = serde_json::json!(name);
+        }
+        Self::new(ErrorCode::RigSchemaUnsupported, message, details).with_hint(
+            "Run 'homeboy upgrade' to get a build that understands this rig schema, then retry. \
+             If the binary is already current, the rig spec may genuinely be malformed — check the \
+             named field against the current rig schema.",
+        )
     }
 
     pub fn validation_multiple_errors(errors: Vec<ValidationErrorItem>) -> Self {

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -252,6 +252,52 @@ pub(crate) fn files_match(left: &Path, right: &Path) -> bool {
     }
 }
 
+/// Classify a serde error from rig-spec deserialization into an actionable
+/// error.
+///
+/// A `Category::Data` error means the JSON parsed fine but its shape doesn't
+/// match this binary's `RigSpec` schema — almost always a binary/spec version
+/// mismatch (e.g. a current rig declaring the `component_id`/`path_setting`
+/// component schema against an older homeboy that only understood top-level
+/// `path`). Those surface as `rig.schema_unsupported` with an upgrade hint
+/// instead of mislabeling a valid rig file as malformed JSON. Syntax/EOF
+/// errors stay `validation.invalid_json` because the file really is malformed.
+fn rig_spec_parse_error(
+    err: serde_json::Error,
+    path: &Path,
+    value: Option<&serde_json::Value>,
+    received: Option<String>,
+) -> Error {
+    let context = format!("parse rig spec {}", path.display());
+    if matches!(err.classify(), serde_json::error::Category::Data) {
+        let component = value.and_then(component_with_unrecognized_schema);
+        return Error::rig_schema_unsupported(err.to_string(), context, component);
+    }
+    Error::validation_invalid_json(err, Some(context), received)
+}
+
+/// Find the first component whose declaration matches neither the portable
+/// `path` schema nor the registry `component_id` schema — the shape an older
+/// binary rejects with `missing field `path``.
+fn component_with_unrecognized_schema(value: &serde_json::Value) -> Option<String> {
+    let components = value.get("components")?.as_object()?;
+    components
+        .iter()
+        .find(|(_, spec)| {
+            let Some(spec) = spec.as_object() else {
+                return false;
+            };
+            let has_path = spec
+                .get("path")
+                .and_then(|p| p.as_str())
+                .map(|p| !p.is_empty())
+                .unwrap_or(false);
+            let has_component_id = spec.contains_key("component_id");
+            !has_path && !has_component_id
+        })
+        .map(|(name, _)| name.clone())
+}
+
 fn read_config(id: &str) -> Result<(RigSpec, Option<String>)> {
     let path = paths::rig_config(id)?;
     if !path.exists() {
@@ -265,9 +311,11 @@ fn read_config(id: &str) -> Result<(RigSpec, Option<String>)> {
         Error::internal_unexpected(format!("Failed to read rig {}: {}", path.display(), e))
     })?;
     let mut spec: RigSpec = serde_json::from_str(&content).map_err(|e| {
-        Error::validation_invalid_json(
+        let value = serde_json::from_str::<serde_json::Value>(&content).ok();
+        rig_spec_parse_error(
             e,
-            Some(format!("parse rig spec {}", path.display())),
+            &path,
+            value.as_ref(),
             Some(content.chars().take(200).collect()),
         )
     })?;
@@ -297,9 +345,8 @@ fn read_spec_from_path(path: &Path, id_hint: Option<&str>, package_root: &Path) 
             })?
         }
     };
-    let mut spec: RigSpec = serde_json::from_value(value).map_err(|e| {
-        Error::validation_invalid_json(e, Some(format!("parse rig spec {}", path.display())), None)
-    })?;
+    let mut spec: RigSpec = serde_json::from_value(value.clone())
+        .map_err(|e| rig_spec_parse_error(e, path, Some(&value), None))?;
     if spec.id.is_empty() {
         spec.id = id_hint.unwrap_or_default().to_string();
     }
@@ -575,4 +622,87 @@ pub fn list_ids() -> Result<Vec<String>> {
             .map(|entry| entry.id)
             .collect()
     })
+}
+
+#[cfg(test)]
+mod schema_error_tests {
+    use super::*;
+    use crate::core::error::ErrorCode;
+
+    /// A rig declaring the `component_id` component schema, with one component
+    /// that uses neither `path` nor `component_id` — the shape an older binary
+    /// rejects with `missing field `path``.
+    fn rig_value_with_unrecognized_component() -> serde_json::Value {
+        serde_json::from_str(
+            r#"{
+                "id": "static-site-importer-fixture-matrix",
+                "components": {
+                    "importer": { "component_id": "static-site-importer", "branch": "trunk" },
+                    "legacy": { "branch": "trunk" }
+                }
+            }"#,
+        )
+        .expect("fixture value")
+    }
+
+    #[test]
+    fn data_shape_error_surfaces_schema_unsupported_with_component() {
+        // A serde `Category::Data` error: valid JSON, wrong shape — exactly
+        // what an older binary's stricter parser produces (`missing field path`).
+        let err = serde_json::from_str::<WorkloadSpec>("{}").unwrap_err();
+        assert!(matches!(err.classify(), serde_json::error::Category::Data));
+
+        let value = rig_value_with_unrecognized_component();
+        let path = Path::new("/tmp/static-site-importer-fixture-matrix/rig.json");
+        let error = rig_spec_parse_error(err, path, Some(&value), None);
+
+        assert_eq!(error.code, ErrorCode::RigSchemaUnsupported);
+        assert!(
+            error.message.contains("legacy"),
+            "message should name the offending component: {}",
+            error.message
+        );
+        assert!(
+            error.message.contains(env!("CARGO_PKG_VERSION")),
+            "message should report the active version: {}",
+            error.message
+        );
+        assert!(
+            error.hints.iter().any(|h| h.message.contains("homeboy upgrade")),
+            "should hint to upgrade"
+        );
+    }
+
+    #[test]
+    fn syntax_error_stays_invalid_json() {
+        let err = serde_json::from_str::<serde_json::Value>("{ not json").unwrap_err();
+        assert!(matches!(err.classify(), serde_json::error::Category::Syntax));
+
+        let path = Path::new("/tmp/broken/rig.json");
+        let error = rig_spec_parse_error(err, path, None, Some("{ not json".to_string()));
+        assert_eq!(error.code, ErrorCode::ValidationInvalidJson);
+    }
+
+    #[test]
+    fn component_detection_skips_recognized_schemas() {
+        let value: serde_json::Value = serde_json::from_str(
+            r#"{
+                "components": {
+                    "with_path": { "path": "~/dev/foo" },
+                    "with_id": { "component_id": "foo" }
+                }
+            }"#,
+        )
+        .expect("value");
+        assert_eq!(component_with_unrecognized_schema(&value), None);
+    }
+
+    #[test]
+    fn component_detection_finds_unrecognized_schema() {
+        let value = rig_value_with_unrecognized_component();
+        assert_eq!(
+            component_with_unrecognized_schema(&value),
+            Some("legacy".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`homeboy rig install` (and any rig load) failed with an opaque, misleading error when a rig's `rig.json` used the `component_id` / `path_setting` / `branch` component schema against a binary whose parser predated it:

```
{"code":"validation.invalid_json","message":"Invalid JSON",
 "details":{"context":"parse rig spec .../rig.json","error":"missing field `path` at line 11 column 5"}}
```

The JSON was valid and the rig was current — the running binary was just stale (a dirty `0.259.0` build; `0.265.2`+ parse it fine). But the error read like a malformed rig file and sent the operator debugging the wrong thing.

## Root cause

The parse path classified *every* serde failure as `validation.invalid_json`, including `serde_json::Category::Data` errors — valid JSON whose shape doesn't match this binary's `RigSpec` schema. A schema/version mismatch is not a malformed file.

## What changed

- New `ErrorCode::RigSchemaUnsupported` (`rig.schema_unsupported`) plus an `Error::rig_schema_unsupported(...)` constructor that reports the active homeboy version (`CARGO_PKG_VERSION`) and hints `homeboy upgrade`.
- New `rig_spec_parse_error()` classifier in `src/core/rig/mod.rs`: serde `Category::Data` errors become `rig.schema_unsupported`; `Category::Syntax`/`Eof` stay `validation.invalid_json` (the file really is malformed).
- When the offending shape is a component, the message names it: *"Rig component '<name>' uses an unrecognized schema (expected `path` or `component_id`); this rig may require a newer homeboy — active version is X.Y.Z."*
- Wired into both rig-spec deserialize sites (`read_config`, `read_spec_from_path`); added the new code to the exit-code mapping (exit 2, validation class).
- Added 4 unit tests covering Data→schema_unsupported (with component naming + version + upgrade hint), syntax→invalid_json, and the component-detection helper (recognized vs unrecognized shapes).

## Test/build

- `cargo build` — clean (pre-existing unrelated warnings only).
- `cargo test --lib schema_error_tests` — 4 passed.
- `cargo test --lib rig::spec` — 60 passed (no regressions).

## Follow-ups (out of scope for this PR)

- Full schema-version negotiation: embed an explicit rig-spec schema version in `rig.json` and a `requires_homeboy >= X.Y.Z` field so the message can name the *exact* minimum version rather than just advising an upgrade.
- The `from_str → serde_json::Value` parse in `install.rs::read_json_value` only ever yields syntax errors (it deserializes to `Value`), so it was intentionally left on the `validation.invalid_json` path.

Closes #6734

🤖 Generated with [Claude Code](https://claude.com/claude-code)