### PR TITLE
runs artifacts: add --pull to retrieve a run's artifact bytes to the local artifact root

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -15,7 +15,7 @@ homeboy runs show <run-id> [--json]
 homeboy runs dossier <run-id> [--json]
 homeboy runs resume-plan <run-id>
 homeboy runs evidence <run-id>
-homeboy runs artifacts <run-id> [--runner <runner-id>]
+homeboy runs artifacts <run-id> [--runner <runner-id>] [--pull] [--pull-dir <dir>]
 homeboy runs refs [--kind bench] [--component <id>] [--rig <id>] [--status <status>] [--since 24h] [--artifact-kind <kind>] [--aggregate-artifact-kind <kind>]
 homeboy runs artifact attach <run-id> --runner <runner-id> --path <runner-path> --name <artifact-name>
 homeboy runs artifact get <run-id> <artifact-id> [--runner <runner-id>] [--output <path>]
@@ -65,6 +65,8 @@ then promote or attach artifacts through the command-specific surface when it is
 available. See
 [Artifact loop for runner and matrix workflows](../operators/artifact-loop-runner-matrix.md)
 for generic runner, static HTML, and matrix examples.
+
+`homeboy runs artifacts <run-id> --pull` retrieves every retrievable artifact's bytes for a run to the operator-local artifact root in one pass, so a completed run is self-contained instead of pointing only at runner-resident paths or non-resolving tunnel URLs. The retrieval is best-effort and per-artifact: the listing still prints, and the JSON output gains a `pull` summary where each artifact reports `already_local` (file/directory already on the controller), `pulled` (bytes copied from a runner/remote store), `skipped` (metadata-only or non-file artifacts), or `failed` (with the error message) — so it is clear exactly which diagnostics are unreachable and why. Pass `--pull-dir <dir>` to write pulled bytes into a chosen directory instead of the default run-scoped path under the artifact root. `--pull` operates on the local mirrored observation store and is mutually exclusive with `--runner`.
 
 `homeboy runs artifacts <run-id> --runner <runner-id>` queries a connected runner daemon for the run's artifact records from the controller machine. `homeboy runs artifact get <run-id> <artifact-id> --runner <runner-id>` pulls selected runner-side artifact bytes through that connection into the local artifact cache, or into `--output` when provided, and reports the runner id plus source content path in JSON output. Use these commands when a controller-side agent has a run id and artifact id but should not SSH into the runner or know runner filesystem paths.
 

--- a/src/commands/runs/dispatch.rs
+++ b/src/commands/runs/dispatch.rs
@@ -103,6 +103,7 @@ impl RunsArgs {
                 ),
                 vec![
                     format!("Run `homeboy runs artifacts {}` to list mirrored artifact records.", args.run_id),
+                    format!("Run `homeboy runs artifacts {} --pull` to retrieve runner/remote artifact bytes to the operator-local artifact root.", args.run_id),
                     format!("Run `homeboy runs artifacts {} --runner {runner_id}` to query the connected runner daemon directly.", args.run_id),
                     "Use `homeboy runs artifact get <run-id> <artifact-id> --runner <id>` to pull selected runner-side artifact bytes.".to_string(),
                 ],

--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -18,9 +18,9 @@ use super::bench::run_contains_scenario;
 use super::common::{run_summaries_with_artifact_indexes, RunSummary};
 use super::types::{
     RunDetail, RunsArtifactArgs, RunsArtifactCommand, RunsArtifactGetArgs, RunsArtifactGetOutput,
-    RunsArtifactPathGuide, RunsArtifactsArgs, RunsArtifactsOutput, RunsEnvKeyOutput, RunsEnvOutput,
-    RunsEnvSourceLayerOutput, RunsEnvSummary, RunsListArgs, RunsListOutput, RunsOutput,
-    RunsResumePlanOutput, RunsShowOutput,
+    RunsArtifactPathGuide, RunsArtifactPullEntry, RunsArtifactPullSummary, RunsArtifactsArgs,
+    RunsArtifactsOutput, RunsEnvKeyOutput, RunsEnvOutput, RunsEnvSourceLayerOutput, RunsEnvSummary,
+    RunsListArgs, RunsListOutput, RunsOutput, RunsResumePlanOutput, RunsShowOutput,
 };
 use super::{reconcile, remote, remote_artifact, CmdResult};
 
@@ -153,11 +153,23 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
     artifacts_from_args(RunsArtifactsArgs {
         run_id: run_id.to_string(),
         runner: None,
+        pull: false,
+        pull_dir: None,
     })
 }
 
 pub fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutput> {
     if let Some(runner_id) = args.runner.as_deref() {
+        if args.pull {
+            return Err(Error::validation_invalid_argument(
+                "pull",
+                "`--pull` operates on the local mirrored observation store; drop `--runner` to retrieve runner artifact bytes to the operator-local artifact root",
+                Some(runner_id.to_string()),
+                Some(vec![
+                    format!("Run `homeboy runs artifacts {} --pull` (without --runner) to pull mirrored runner artifacts locally.", args.run_id),
+                ]),
+            ));
+        }
         return remote::runner_artifacts(runner_id, &args.run_id);
     }
 
@@ -180,6 +192,11 @@ pub fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutput> {
         .iter()
         .filter_map(homeboy::core::fuzz::inspect_fuzz_result_envelope_artifact)
         .collect();
+    let pull = if args.pull {
+        Some(pull_artifacts_to_local(&artifacts, args.pull_dir.as_deref())?)
+    } else {
+        None
+    };
     Ok((
         RunsOutput::Artifacts(RunsArtifactsOutput {
             command: "runs.artifacts",
@@ -190,9 +207,161 @@ pub fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutput> {
             preview_entrypoints,
             matrix_summary,
             fuzz_result_envelopes,
+            pull,
         }),
         0,
     ))
+}
+
+/// Best-effort retrieval of each artifact's bytes to the operator-local
+/// artifact root so a completed run is self-contained.
+///
+/// Local-file (and locally-present directory) artifacts are already operator
+/// readable and reported as `already_local`. Remote runner artifacts are
+/// downloaded; metadata-only / url artifacts are skipped with a reason. A
+/// single artifact's failure never aborts the pass — it is recorded so the
+/// operator sees exactly which diagnostics are unreachable and why.
+fn pull_artifacts_to_local(
+    artifacts: &[homeboy::core::observation::ArtifactRecord],
+    pull_dir: Option<&std::path::Path>,
+) -> homeboy::core::Result<RunsArtifactPullSummary> {
+    let pull_root = match pull_dir {
+        Some(dir) => dir.display().to_string(),
+        None => homeboy::core::artifact_root()?.display().to_string(),
+    };
+    let mut entries = Vec::with_capacity(artifacts.len());
+    let (mut pulled_count, mut already_local_count, mut skipped_count, mut failed_count) =
+        (0, 0, 0, 0);
+
+    for artifact in artifacts {
+        let entry = match runs_service::classify_artifact_storage(artifact) {
+            runs_service::ArtifactStorage::LocalFile => {
+                already_local_count += 1;
+                RunsArtifactPullEntry {
+                    artifact_id: artifact.id.clone(),
+                    storage: "local_file",
+                    status: "already_local",
+                    output_path: Some(artifact.path.clone()),
+                    size_bytes: artifact.size_bytes,
+                    content_type: artifact.mime.clone(),
+                    sha256: artifact.sha256.clone(),
+                    error: None,
+                }
+            }
+            runs_service::ArtifactStorage::Remote => {
+                let output = pull_dir.map(|dir| dir.join(sanitize_artifact_filename(&artifact.id)));
+                match runs_service::download_remote_artifact(artifact.clone(), output) {
+                    Ok(outcome) => {
+                        pulled_count += 1;
+                        RunsArtifactPullEntry {
+                            artifact_id: artifact.id.clone(),
+                            storage: "remote",
+                            status: "pulled",
+                            output_path: Some(outcome.output_path.display().to_string()),
+                            size_bytes: outcome.size_bytes,
+                            content_type: outcome.content_type,
+                            sha256: outcome.sha256,
+                            error: None,
+                        }
+                    }
+                    Err(err) => {
+                        failed_count += 1;
+                        RunsArtifactPullEntry {
+                            artifact_id: artifact.id.clone(),
+                            storage: "remote",
+                            status: "failed",
+                            output_path: None,
+                            size_bytes: None,
+                            content_type: None,
+                            sha256: None,
+                            error: Some(err.message),
+                        }
+                    }
+                }
+            }
+            runs_service::ArtifactStorage::MetadataOnly => {
+                skipped_count += 1;
+                RunsArtifactPullEntry {
+                    artifact_id: artifact.id.clone(),
+                    storage: "metadata_only",
+                    status: "skipped",
+                    output_path: None,
+                    size_bytes: None,
+                    content_type: None,
+                    sha256: None,
+                    error: Some(
+                        "artifact was imported as metadata only; bytes are not available"
+                            .to_string(),
+                    ),
+                }
+            }
+            runs_service::ArtifactStorage::Other => {
+                // A locally-present directory artifact is already self-contained.
+                if artifact.artifact_type == "directory"
+                    && std::path::Path::new(&artifact.path).is_dir()
+                {
+                    already_local_count += 1;
+                    RunsArtifactPullEntry {
+                        artifact_id: artifact.id.clone(),
+                        storage: "other",
+                        status: "already_local",
+                        output_path: Some(artifact.path.clone()),
+                        size_bytes: artifact.size_bytes,
+                        content_type: artifact.mime.clone(),
+                        sha256: artifact.sha256.clone(),
+                        error: None,
+                    }
+                } else {
+                    skipped_count += 1;
+                    RunsArtifactPullEntry {
+                        artifact_id: artifact.id.clone(),
+                        storage: "other",
+                        status: "skipped",
+                        output_path: None,
+                        size_bytes: None,
+                        content_type: None,
+                        sha256: None,
+                        error: Some(format!(
+                            "artifact type `{}` is not a pullable file",
+                            artifact.artifact_type
+                        )),
+                    }
+                }
+            }
+        };
+        entries.push(entry);
+    }
+
+    Ok(RunsArtifactPullSummary {
+        pull_root,
+        pulled_count,
+        already_local_count,
+        skipped_count,
+        failed_count,
+        entries,
+    })
+}
+
+/// Derive a filesystem-safe filename from an artifact id for `--pull-dir`
+/// targets. Mirrors the conservative substitution used elsewhere for derived
+/// artifact paths so unusual ids cannot escape the target directory.
+fn sanitize_artifact_filename(artifact_id: &str) -> String {
+    let sanitized = artifact_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let trimmed = sanitized.trim_matches(['.', '_']).to_string();
+    if trimmed.is_empty() {
+        "artifact".to_string()
+    } else {
+        trimmed
+    }
 }
 
 pub fn env(run_id: &str) -> CmdResult<RunsOutput> {
@@ -439,5 +608,164 @@ pub(crate) fn run_summary(run: RunRecord) -> RunSummary {
         cwd: run.cwd,
         status_note,
         artifact_index: None,
+    }
+}
+
+#[cfg(test)]
+mod pull_tests {
+    use std::fs;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    use homeboy::core::observation::{ArtifactRecord, NewRunRecord, ObservationStore};
+    use homeboy::test_support::with_isolated_home;
+
+    use super::*;
+
+    fn artifact_root_test_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    fn metadata_only_record(run_id: &str, id: &str) -> ArtifactRecord {
+        ArtifactRecord {
+            id: id.to_string(),
+            run_id: run_id.to_string(),
+            kind: "finding-packets".to_string(),
+            artifact_type: "metadata-only".to_string(),
+            path: format!("metadata://{id}"),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: None,
+            metadata_json: serde_json::json!({}),
+            created_at: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+
+    #[test]
+    fn sanitize_artifact_filename_is_path_safe() {
+        assert_eq!(sanitize_artifact_filename("finding-packets.json"), "finding-packets.json");
+        assert_eq!(sanitize_artifact_filename("../../etc/passwd"), "etc_passwd");
+        assert_eq!(sanitize_artifact_filename("a/b\\c"), "a_b_c");
+        assert_eq!(sanitize_artifact_filename("..."), "artifact");
+        assert_eq!(sanitize_artifact_filename(""), "artifact");
+    }
+
+    #[test]
+    fn pull_reports_local_file_as_already_local() {
+        let _guard = artifact_root_test_lock();
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("bench").build())
+                .expect("run");
+            let source = home.path().join("finding-packets.json");
+            fs::write(&source, br#"{"findings":[]}"#).expect("source");
+            let artifact = store
+                .record_artifact(&run.id, "finding-packets", &source)
+                .expect("artifact");
+
+            let summary = pull_artifacts_to_local(&[artifact.clone()], None).expect("pull summary");
+
+            assert_eq!(summary.already_local_count, 1);
+            assert_eq!(summary.pulled_count, 0);
+            assert_eq!(summary.failed_count, 0);
+            assert_eq!(summary.entries.len(), 1);
+            assert_eq!(summary.entries[0].status, "already_local");
+            assert_eq!(summary.entries[0].storage, "local_file");
+            assert_eq!(summary.entries[0].output_path.as_deref(), Some(artifact.path.as_str()));
+        });
+    }
+
+    #[test]
+    fn pull_skips_metadata_only_artifacts_with_reason() {
+        let _guard = artifact_root_test_lock();
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+
+            let record = metadata_only_record("run-1", "finding-packets");
+            let summary = pull_artifacts_to_local(&[record], None).expect("pull summary");
+
+            assert_eq!(summary.skipped_count, 1);
+            assert_eq!(summary.entries[0].status, "skipped");
+            assert_eq!(summary.entries[0].storage, "metadata_only");
+            assert!(summary.entries[0]
+                .error
+                .as_deref()
+                .unwrap()
+                .contains("metadata only"));
+        });
+    }
+
+    #[test]
+    fn pull_records_per_artifact_failure_without_aborting() {
+        let _guard = artifact_root_test_lock();
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+
+            // A remote runner-artifact ref for a runner that does not exist must
+            // be reported as a failed entry, not panic or abort the pass.
+            let remote = ArtifactRecord {
+                id: "matrix-json".to_string(),
+                run_id: "run-1".to_string(),
+                kind: "matrix".to_string(),
+                artifact_type: "remote_file".to_string(),
+                path: "runner-artifact://does-not-exist/run-1/matrix-json".to_string(),
+                url: None,
+                public_url: None,
+                viewer_url: None,
+                viewer_links: Vec::new(),
+                sha256: None,
+                size_bytes: None,
+                mime: None,
+                metadata_json: serde_json::json!({}),
+                created_at: chrono::Utc::now().to_rfc3339(),
+            };
+            let local_source = home.path().join("summary.json");
+            fs::write(&local_source, b"{}").expect("source");
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("bench").build())
+                .expect("run");
+            let local = store
+                .record_artifact(&run.id, "summary", &local_source)
+                .expect("artifact");
+
+            let summary =
+                pull_artifacts_to_local(&[remote, local], None).expect("pull summary");
+
+            assert_eq!(summary.entries.len(), 2);
+            assert_eq!(summary.failed_count, 1);
+            assert_eq!(summary.already_local_count, 1);
+            let remote_entry = summary
+                .entries
+                .iter()
+                .find(|entry| entry.artifact_id == "matrix-json")
+                .expect("remote entry");
+            assert_eq!(remote_entry.status, "failed");
+            assert!(remote_entry.error.is_some());
+        });
+    }
+
+    #[test]
+    fn artifacts_from_args_pull_with_runner_is_rejected() {
+        let result = artifacts_from_args(RunsArtifactsArgs {
+            run_id: "run-1".to_string(),
+            runner: Some("lab".to_string()),
+            pull: true,
+            pull_dir: None,
+        });
+        let Err(err) = result else {
+            panic!("--pull with --runner should fail");
+        };
+        assert!(err.to_string().contains("local mirrored observation store"));
     }
 }

--- a/src/commands/runs/remote.rs
+++ b/src/commands/runs/remote.rs
@@ -58,6 +58,7 @@ pub fn runner_artifacts(runner_id: &str, run_id: &str) -> CmdResult<RunsOutput> 
             preview_entrypoints: Vec::new(),
             matrix_summary: None,
             fuzz_result_envelopes: Vec::new(),
+            pull: None,
         }),
         0,
     ))

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -212,6 +212,46 @@ pub struct RunsArtifactsOutput {
     pub matrix_summary: Option<MatrixArtifactSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fuzz_result_envelopes: Vec<FuzzResultEnvelopeArtifactInspection>,
+    /// Present only when `--pull` was requested. Summarizes the best-effort
+    /// retrieval of each artifact's bytes to the operator-local artifact root.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pull: Option<RunsArtifactPullSummary>,
+}
+
+/// Result of a `runs artifacts <run-id> --pull` retrieval pass.
+#[derive(Serialize)]
+pub struct RunsArtifactPullSummary {
+    /// Operator-local artifact root that retrieved bytes are written under.
+    pub pull_root: String,
+    /// Artifacts copied from a runner/remote store to the local root this run.
+    pub pulled_count: usize,
+    /// Artifacts that were already operator-local and self-contained.
+    pub already_local_count: usize,
+    /// Artifacts that could not be pulled (metadata-only, directories, urls).
+    pub skipped_count: usize,
+    /// Artifacts whose retrieval was attempted but failed.
+    pub failed_count: usize,
+    pub entries: Vec<RunsArtifactPullEntry>,
+}
+
+/// Per-artifact outcome for a `--pull` retrieval pass.
+#[derive(Serialize)]
+pub struct RunsArtifactPullEntry {
+    pub artifact_id: String,
+    /// Storage class observed for the artifact (local_file, remote, metadata_only, other).
+    pub storage: &'static str,
+    /// Retrieval status: pulled, already_local, skipped, or failed.
+    pub status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -256,6 +296,15 @@ pub struct RunsArtifactsArgs {
     /// Query artifacts from a connected execution runner daemon
     #[arg(long)]
     pub runner: Option<String>,
+    /// Pull runner/remote artifact bytes to the operator-local artifact root so
+    /// the completed run is self-contained. Best-effort and per-artifact: the
+    /// listing still prints, and each artifact reports a pull status.
+    #[arg(long)]
+    pub pull: bool,
+    /// Optional directory to write pulled artifact bytes into. Defaults to a
+    /// run-scoped path under the operator-local artifact root.
+    #[arg(long, requires = "pull")]
+    pub pull_dir: Option<PathBuf>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary

Resolves the highest-value, self-contained slice of #6736: a completed run (e.g. the static-site-importer fixture matrix) advertised `artifact_urls` on the artifact tunnel that **404 immediately**, while the structured `finding-packets.json` / `matrix.json` / `summary.json` lived only on the runner. There was no first-class "pull artifacts to local" path, so the operator finished a run with diagnostics they couldn't open.

This adds:

```
homeboy runs artifacts <run-id> --pull [--pull-dir <dir>]
```

`--pull` retrieves every retrievable artifact's bytes for a run to the operator-local artifact root in one pass, so a completed run is self-contained instead of pointing only at runner-resident paths or non-resolving tunnel URLs. It builds on the existing `runs_service` retrieval machinery (`classify_artifact_storage` + `download_remote_artifact` + local file detection).

Retrieval is **best-effort and per-artifact**: the listing still prints, and the JSON output gains a `pull` summary where each artifact reports:

- `already_local` — file/directory already on the controller (self-contained)
- `pulled` — bytes copied from a runner/remote store to the local root
- `skipped` — metadata-only or non-file (url/directory-without-bytes) artifact, with a reason
- `failed` — retrieval attempted but failed, with the error message

So it is clear exactly which diagnostics are unreachable and why — directly addressing the "diagnostics you can't open" papercut. A single artifact's failure never aborts the pass. `--pull` operates on the local mirrored observation store and is mutually exclusive with `--runner` (returns a clear validation error pointing at the correct invocation). `--pull-dir` writes pulled bytes into a chosen directory; otherwise a run-scoped path under the artifact root is used.

## Changes
- `src/commands/runs/types.rs` — `--pull` / `--pull-dir` args; `RunsArtifactPullSummary` / `RunsArtifactPullEntry` output (serialized only when `--pull` is used, so existing output is unchanged).
- `src/commands/runs/handlers.rs` — `pull_artifacts_to_local` retrieval pass + path-safe filename sanitization; `--pull` + `--runner` guard. Plus 5 unit tests.
- `src/commands/runs/dispatch.rs` / `remote.rs` — wire `pull: None` and add a `--pull` operator hint.
- `docs/commands/runs.md` — document `--pull` / `--pull-dir`.

## Tests
- `cargo build -p homeboy --lib` — clean (no new warnings).
- `cargo test -p homeboy --lib commands::runs` — 133 passed.
- New `commands::runs::handlers::pull_tests` — 5 passed (already_local, metadata-only skip, per-artifact failure isolation, runner-guard rejection, filename path-safety).
- `cargo test -p homeboy --test output_contracts_test` — 4 passed (golden contracts unaffected).

## Follow-ups (remaining parts of #6736)
- [ ] Make the operator/bench summary stop advertising tunnel `artifact_urls` that 404, or make those URLs durable for the run's lifetime.
- [ ] Surface the resolved execution host in the summary (the default "local" runner ran under Linux `/home/chubes` while the controller was macOS `/Users/chubes`, which made "where are my artifacts" worse).
- [ ] Optionally inline `finding-packets` contents (or a local-copy path) directly into the `*.homeboy-bench.json` output so the bench file alone is self-contained.
- [ ] Companion: the degraded runner (`homeboy runner exec ... --ssh` returned nothing) is tracked separately.

Refs #6736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)