### PR TITLE
Add fuzz artifact hotspot cohorts

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -72,6 +72,21 @@ validates local refs that point inside it when possible. Homeboy core owns the
 path contract; extensions own artifact meaning and any runner/offload upload
 implementation beyond the persisted fuzz result envelope.
 
+When a runner or extension promotes an artifact directory through `runner exec
+--artifact-dir`, Homeboy records each direct file or directory child as a generic
+run artifact. A child JSON file with a Homeboy fuzz schema is recognized as typed
+evidence: `homeboy/fuzz-result-envelope/v1` becomes `fuzz_result_envelope`,
+`homeboy/fuzz-observation-set/v1` becomes `fuzz_observation_set`, and
+`homeboy/fuzz-hotspot-set/v1` becomes `fuzz_hotspot_set`. Result envelopes with
+an embedded observation set also derive persisted observation and hotspot
+artifacts for `runs hotspots` and `runs fuzz-compare`.
+
+Runner-specific schemas such as mutation-isolation or delete-boundary reports are
+not Homeboy core schemas. Store them as generic artifacts, or wrap their neutral
+measurements in `homeboy/fuzz-observation-set/v1` / `homeboy/fuzz-hotspot-set/v1`
+when downstream agents need portable hotspot comparison. The producer owns the
+schema meaning; Homeboy core stores the bytes, metadata, and typed fuzz contracts.
+
 Runners that collect action, query, resource, timing, or counter measurements can
 emit a `homeboy/fuzz-observation-set/v1` artifact. Each observation includes a
 generic `family`, optional `case_id` / `target_id` / `operation_id`, `phase`,
@@ -294,6 +309,17 @@ hotspots. Individual `deltas.hotspot_deltas[]` entries include
 `classification` values such as `advisory_regression`, `blocking_regression`,
 `measured_regression`, `advisory_improvement`, `blocking_improvement`,
 `measured_improvement`, and `unchanged`.
+
+Persisted run artifacts can be compared without local artifact paths:
+
+```bash
+homeboy runs fuzz-compare --from-run fuzz-baseline --to-run fuzz-candidate \
+  --hotspot-policy advisory
+homeboy runs hotspots --baseline-run fuzz-baseline --candidate-run fuzz-candidate
+```
+
+`runs hotspots` consumes persisted typed fuzz observation and hotspot artifacts
+and returns a cohort comparison without threshold or gate semantics.
 
 Fuzz workloads do not have a benchmark fallback. If `homeboy fuzz run` cannot
 execute the selected workload, fix the fuzz runner, rig declaration, or Lab

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -11,6 +11,8 @@ homeboy runs latest-run [--kind bench|rig|trace] [--component <id>] [--rig <id>]
 homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
 homeboy runs bench-compare --from-run <run-id> --to-run <run-id> [--metric <name>]
 homeboy runs fuzz-compare --from-run <run-id> --to-run <run-id> [--hotspot-policy <advisory|blocking|off>]
+homeboy runs hotspots <run-id>... [--limit <count>]
+homeboy runs hotspots --baseline-run <run-id> --candidate-run <run-id> [--limit <count>]
 homeboy runs show <run-id> [--json]
 homeboy runs dossier <run-id> [--json]
 homeboy runs resume-plan <run-id>
@@ -119,6 +121,22 @@ Metric lookup supports top-level run metadata such as `results.total_elapsed_ms`
 `homeboy runs bench-compare --from-run <baseline-run-id> --to-run <candidate-run-id>` compares numeric metrics recorded in two exact benchmark runs. It captures both run IDs, component state, shared benchmark context, selected metric deltas, and a Markdown table under `reports.markdown` in the JSON payload.
 
 `homeboy runs fuzz-compare --from-run <baseline-run-id> --to-run <candidate-run-id>` compares persisted fuzz result envelope artifacts for two exact runs. It resolves `fuzz_result_envelope` artifacts from the observation store, folds in related persisted fuzz hotspot/observation artifacts for hotspot analysis, and returns the same `homeboy/fuzz-compare/v1` payload as `homeboy fuzz compare` without requiring local file paths.
+
+`homeboy runs hotspots <run-id>...` ranks generic fuzz hotspots from persisted fuzz artifacts. It reads typed `homeboy/fuzz-hotspot-set/v1` artifacts directly, ranks typed `homeboy/fuzz-observation-set/v1` artifacts into hotspot points, and falls back to generic finding or coverage-gap signals only when typed hotspot data is absent:
+
+```bash
+homeboy runs hotspots fuzz-run-1 fuzz-run-2 --limit 10
+```
+
+For threshold-free cohort comparison, pass one or more baseline and candidate runs. The comparison reports new, resolved, increased, decreased, and unchanged hotspot movement without adding gate, pass/fail, or product-specific threshold semantics:
+
+```bash
+homeboy runs hotspots \
+  --baseline-run fuzz-baseline-1 \
+  --baseline-run fuzz-baseline-2 \
+  --candidate-run fuzz-candidate-1 \
+  --limit 20
+```
 
 ## Related Readers
 

--- a/src/commands/bench/observation/tests.rs
+++ b/src/commands/bench/observation/tests.rs
@@ -82,7 +82,7 @@ fn recorded_bench_artifact_reports_unreachable_public_viewer_url() {
         size_bytes: None,
         mime: Some("application/json".to_string()),
         metadata_json: serde_json::json!({
-            "viewer": crate::commands::runs::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None),
+            "viewer": crate::commands::runs::HOSTED_BLUEPRINT_VIEWER.to_metadata(None),
             "public_url_validation": {
                 "url": "https://artifacts.example.test/homeboy/runs/run-1/artifacts/artifact-1",
                 "reachable": false,
@@ -192,9 +192,7 @@ fn bench_observation_persists_success_with_metrics_and_artifacts() {
                 kind: Some("json".to_string()),
                 label: Some("Transcript".to_string()),
                 observation_artifact_id: None,
-                viewer: Some(
-                    crate::commands::runs::WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None),
-                ),
+                viewer: Some(crate::commands::runs::HOSTED_BLUEPRINT_VIEWER.to_metadata(None)),
                 ..BenchArtifact::default()
             },
         );
@@ -355,7 +353,7 @@ fn bench_observation_persists_success_with_metrics_and_artifacts() {
             .starts_with("https://playground.wordpress.net/?blueprint-url="));
         assert_eq!(
             transcript_artifact.viewer_refs.viewer_links[0].kind,
-            "wordpress-playground-blueprint"
+            "hosted-blueprint"
         );
         assert!(
             workflow.results.as_ref().unwrap().scenarios[0].artifacts["admin"]

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -395,7 +395,7 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_failed_lifecycle_phase
 fn fuzz_run_outcome_fails_when_workload_reports_invariant_failure_count() {
     let mut campaign = empty_fuzz_campaign();
     campaign.metadata = serde_json::json!({
-        "wordpress_fuzz_result": {
+        "runner_fuzz_result": {
             "status": "passed",
             "success": true,
             "cases": [
@@ -523,7 +523,7 @@ fn fuzz_run_outcome_reports_skipped_lifecycle_as_non_proof() {
 fn fuzz_run_outcome_reports_unsupported_metadata_as_non_proof() {
     let mut campaign = empty_fuzz_campaign();
     campaign.metadata = serde_json::json!({
-        "wordpress_fuzz_result": {
+        "runner_fuzz_result": {
             "status": "unsupported",
             "success": true
         }

--- a/src/commands/runner/exec.rs
+++ b/src/commands/runner/exec.rs
@@ -4,6 +4,10 @@ use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
 
 use homeboy::core::engine::shell;
+use homeboy::core::fuzz::{
+    parse_fuzz_observation_set_value, rank_fuzz_observation_set_hotspots, FUZZ_HOTSPOT_SET_SCHEMA,
+    FUZZ_OBSERVATION_SET_SCHEMA, FUZZ_RESULT_ENVELOPE_SCHEMA,
+};
 use homeboy::core::observation::{ArtifactRecord, ObservationStore};
 use homeboy::core::runners::{
     self as runner, RunnerExecOutput, RunnerExecPromotedOutput, RunnerExecStructuredSummary,
@@ -412,7 +416,7 @@ pub(super) fn promote_runner_exec_artifact_dirs(
                 artifact_metadata["source"] = serde_json::json!("runner_path_attach");
                 artifact_metadata["runner_id"] = serde_json::json!(runner.id.clone());
             }
-            records.push(record_runner_exec_output(
+            records.extend(record_runner_exec_output(
                 &store,
                 run_id,
                 &runner_exec_artifact_kind(&name),
@@ -495,10 +499,10 @@ fn promote_runner_exec_outputs(
             } else {
                 runner_path.clone()
             };
-            let record = record_runner_exec_output(&store, run_id, &kind, &record_path, metadata)?;
-            Ok(record)
+            record_runner_exec_output(&store, run_id, &kind, &record_path, metadata)
         })
-        .collect()
+        .collect::<homeboy::core::Result<Vec<_>>>()
+        .map(|records| records.into_iter().flatten().collect())
 }
 
 fn record_runner_exec_output(
@@ -507,12 +511,125 @@ fn record_runner_exec_output(
     kind: &str,
     record_path: &Path,
     metadata: serde_json::Value,
-) -> homeboy::core::Result<ArtifactRecord> {
+) -> homeboy::core::Result<Vec<ArtifactRecord>> {
     if record_path.is_dir() {
-        store.record_directory_artifact_with_metadata(run_id, kind, record_path, metadata)
-    } else {
-        store.record_artifact_with_metadata(run_id, kind, record_path, metadata)
+        return store
+            .record_directory_artifact_with_metadata(run_id, kind, record_path, metadata)
+            .map(|record| vec![record]);
     }
+
+    let (kind, metadata) = fuzz_typed_artifact_metadata(kind, record_path, metadata);
+    let record = store.record_artifact_with_metadata(run_id, &kind, record_path, metadata)?;
+    let mut records = vec![record.clone()];
+    records.extend(persist_derived_fuzz_artifacts(store, run_id, &record)?);
+    Ok(records)
+}
+
+fn fuzz_typed_artifact_metadata(
+    kind: &str,
+    record_path: &Path,
+    mut metadata: serde_json::Value,
+) -> (String, serde_json::Value) {
+    let Some(json) = read_json_file(record_path) else {
+        return (kind.to_string(), metadata);
+    };
+    let Some(schema) = json.get("schema").and_then(serde_json::Value::as_str) else {
+        return (kind.to_string(), metadata);
+    };
+
+    let canonical_kind = match schema {
+        FUZZ_RESULT_ENVELOPE_SCHEMA => Some("fuzz_result_envelope"),
+        FUZZ_OBSERVATION_SET_SCHEMA => Some("fuzz_observation_set"),
+        FUZZ_HOTSPOT_SET_SCHEMA => Some("fuzz_hotspot_set"),
+        _ => None,
+    };
+    let Some(canonical_kind) = canonical_kind else {
+        return (kind.to_string(), metadata);
+    };
+
+    metadata["schema"] = serde_json::json!(schema);
+    metadata["typed_artifact_kind"] = serde_json::json!(canonical_kind);
+    metadata["promoted_kind"] = serde_json::json!(kind);
+    (canonical_kind.to_string(), metadata)
+}
+
+fn persist_derived_fuzz_artifacts(
+    store: &ObservationStore,
+    run_id: &str,
+    source_record: &ArtifactRecord,
+) -> homeboy::core::Result<Vec<ArtifactRecord>> {
+    if source_record.artifact_type != "file" || source_record.kind != "fuzz_result_envelope" {
+        return Ok(Vec::new());
+    }
+
+    let Some(json) = read_json_file(Path::new(&source_record.path)) else {
+        return Ok(Vec::new());
+    };
+    let Some(observation_set) = parse_fuzz_observation_set_value(&json) else {
+        return Ok(Vec::new());
+    };
+
+    let mut records = Vec::new();
+    let observation_record = persist_json_artifact(
+        store,
+        run_id,
+        "fuzz_observation_set",
+        &observation_set,
+        serde_json::json!({
+            "schema": FUZZ_OBSERVATION_SET_SCHEMA,
+            "typed_artifact_kind": "fuzz_observation_set",
+            "derived_from_artifact_id": source_record.id,
+            "derived_from_artifact_kind": source_record.kind,
+        }),
+    )?;
+    records.push(observation_record);
+
+    let hotspot_set = rank_fuzz_observation_set_hotspots(&observation_set);
+    let hotspot_record = persist_json_artifact(
+        store,
+        run_id,
+        "fuzz_hotspot_set",
+        &hotspot_set,
+        serde_json::json!({
+            "schema": FUZZ_HOTSPOT_SET_SCHEMA,
+            "typed_artifact_kind": "fuzz_hotspot_set",
+            "derived_from_artifact_id": source_record.id,
+            "derived_from_artifact_kind": source_record.kind,
+            "derived_from_observation_set_id": observation_set.id,
+        }),
+    )?;
+    records.push(hotspot_record);
+    Ok(records)
+}
+
+fn persist_json_artifact(
+    store: &ObservationStore,
+    run_id: &str,
+    kind: &str,
+    value: &impl serde::Serialize,
+    metadata: serde_json::Value,
+) -> homeboy::core::Result<ArtifactRecord> {
+    let file = tempfile::NamedTempFile::new().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("create derived {kind} artifact")),
+        )
+    })?;
+    serde_json::to_writer_pretty(&file, value).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("write derived {kind} artifact")),
+        )
+    })?;
+    store.record_artifact_with_metadata(run_id, kind, file.path(), metadata)
+}
+
+fn read_json_file(path: &Path) -> Option<serde_json::Value> {
+    if !path.is_file() {
+        return None;
+    }
+    let file = fs::File::open(path).ok()?;
+    serde_json::from_reader(file).ok()
 }
 
 fn promoted_output(

--- a/src/commands/runner/tests/exec.rs
+++ b/src/commands/runner/tests/exec.rs
@@ -515,6 +515,169 @@ fn runner_exec_promotes_artifact_dir_children_to_run_store() {
 }
 
 #[test]
+fn runner_exec_promotes_fuzz_envelope_observations_and_hotspots_as_typed_artifacts() {
+    homeboy::test_support::with_isolated_home(|home| {
+        let artifact_root = home.path().join("artifacts");
+        homeboy::core::set_artifact_root_override(Some(artifact_root));
+        let workspace = tempfile::tempdir().expect("workspace");
+        let envelope_path = workspace.path().join("fuzz-result-envelope.json");
+        std::fs::write(
+            &envelope_path,
+            r#"{
+                "schema": "homeboy/fuzz-result-envelope/v1",
+                "observation_set": {
+                    "schema": "homeboy/fuzz-observation-set/v1",
+                    "version": 1,
+                    "id": "observations-1",
+                    "observations": [
+                        {
+                            "id": "obs-1",
+                            "family": "timing",
+                            "subject": "search route",
+                            "metric": "duration",
+                            "value": 120.0,
+                            "unit": "ms",
+                            "fingerprint": "route:search",
+                            "sample_count": 3
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .expect("write fuzz envelope");
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                NewRunRecord::builder("runner-exec")
+                    .command("homeboy runner exec lab-local".to_string())
+                    .cwd_path(workspace.path())
+                    .metadata(serde_json::json!({}))
+                    .build(),
+            )
+            .expect("run");
+        let output = runner_exec_output(
+            "lab-local",
+            RunnerExecMode::Local,
+            &workspace.path().display().to_string(),
+        );
+
+        let promoted = promote_runner_exec_artifacts(
+            &run.id,
+            &output,
+            &["fuzz-result-envelope.json".to_string()],
+        )
+        .expect("promote fuzz envelope");
+
+        assert_eq!(promoted.len(), 3);
+        let artifacts = store.list_artifacts(&run.id).expect("artifacts");
+        let kinds = artifacts
+            .iter()
+            .map(|artifact| artifact.kind.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            kinds,
+            vec![
+                "fuzz_result_envelope",
+                "fuzz_observation_set",
+                "fuzz_hotspot_set"
+            ]
+        );
+        assert_eq!(
+            artifacts[0].metadata_json["schema"],
+            "homeboy/fuzz-result-envelope/v1"
+        );
+        assert_eq!(
+            artifacts[1].metadata_json["derived_from_artifact_id"],
+            artifacts[0].id
+        );
+        assert_eq!(
+            artifacts[2].metadata_json["derived_from_observation_set_id"],
+            "observations-1"
+        );
+        let hotspot_json: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(&artifacts[2].path).expect("read hotspot artifact"),
+        )
+        .expect("parse hotspot artifact");
+        assert_eq!(hotspot_json["schema"], "homeboy/fuzz-hotspot-set/v1");
+        assert_eq!(hotspot_json["items"][0]["id"], "route:search");
+    });
+}
+
+#[test]
+fn runner_exec_promotes_artifact_dir_typed_fuzz_children() {
+    homeboy::test_support::with_isolated_home(|home| {
+        let artifact_root = home.path().join("artifacts");
+        homeboy::core::set_artifact_root_override(Some(artifact_root));
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outputs = workspace.path().join("outputs");
+        std::fs::create_dir_all(&outputs).expect("create outputs");
+        std::fs::write(
+            outputs.join("fuzz-observations.json"),
+            r#"{
+                "schema": "homeboy/fuzz-observation-set/v1",
+                "version": 1,
+                "id": "observations-1",
+                "observations": [
+                    {
+                        "id": "obs-1",
+                        "family": "timing",
+                        "subject": "route-a",
+                        "metric": "duration",
+                        "value": 40.0,
+                        "unit": "ms"
+                    }
+                ]
+            }"#,
+        )
+        .expect("write observations");
+        std::fs::write(
+            outputs.join("runner-specific-report.json"),
+            r#"{"schema":"runner/mutation-isolation/v1","passed":true}"#,
+        )
+        .expect("write runner report");
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                NewRunRecord::builder("runner-exec")
+                    .command("homeboy runner exec lab-local".to_string())
+                    .cwd_path(workspace.path())
+                    .metadata(serde_json::json!({}))
+                    .build(),
+            )
+            .expect("run");
+        let output = runner_exec_output(
+            "lab-local",
+            RunnerExecMode::Local,
+            &workspace.path().display().to_string(),
+        );
+
+        let promoted =
+            promote_runner_exec_artifact_dirs(&run.id, &output, &["outputs".to_string()])
+                .expect("promote artifact dir children");
+
+        assert_eq!(promoted.len(), 2);
+        let artifacts = store.list_artifacts(&run.id).expect("artifacts");
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(artifacts[0].kind, "fuzz_observation_set");
+        assert_eq!(
+            artifacts[0].metadata_json["schema"],
+            "homeboy/fuzz-observation-set/v1"
+        );
+        assert_eq!(artifacts[0].metadata_json["artifact_dir"], "outputs");
+        assert_eq!(
+            artifacts[0].metadata_json["promoted_kind"],
+            "fuzz-observations_json"
+        );
+        assert_eq!(artifacts[1].kind, "runner-specific-report_json");
+        assert_eq!(artifacts[1].metadata_json["artifact_dir"], "outputs");
+        assert!(artifacts[1]
+            .metadata_json
+            .get("typed_artifact_kind")
+            .is_none());
+    });
+}
+
+#[test]
 fn runner_exec_rejects_artifacts_without_run_id() {
     let err = exec(
         "lab-local",

--- a/src/commands/runs/hotspots.rs
+++ b/src/commands/runs/hotspots.rs
@@ -8,7 +8,10 @@ use clap::Args;
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::core::fuzz::parse_fuzz_hotspot_set_value;
+use homeboy::core::fuzz::{
+    compare_fuzz_hotspot_cohorts, parse_fuzz_hotspot_set_value, parse_fuzz_observation_set_value,
+    rank_fuzz_observation_set_hotspots, FuzzHotspotCohortComparison, FuzzHotspotCohortItem,
+};
 use homeboy::core::observation::runs_service;
 use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use homeboy::core::Error;
@@ -19,8 +22,16 @@ use super::{CmdResult, RunsOutput};
 #[derive(Args, Clone, Debug)]
 pub struct RunsHotspotsArgs {
     /// One or more persisted Homeboy run ids to inspect.
-    #[arg(value_name = "RUN_ID", required = true)]
+    #[arg(value_name = "RUN_ID")]
     pub run_ids: Vec<String>,
+
+    /// Baseline run id for threshold-free cohort comparison.
+    #[arg(long = "baseline-run", value_name = "RUN_ID")]
+    pub baseline_runs: Vec<String>,
+
+    /// Candidate run id for threshold-free cohort comparison.
+    #[arg(long = "candidate-run", value_name = "RUN_ID")]
+    pub candidate_runs: Vec<String>,
 
     /// Maximum ranked hotspots to return.
     #[arg(long, default_value_t = 20)]
@@ -37,6 +48,8 @@ pub struct RunsHotspotsOutput {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub skipped_artifacts: Vec<SkippedArtifactRow>,
     pub hotspots: Vec<HotspotRanking>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cohort_comparison: Option<FuzzHotspotCohortComparison>,
 }
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
@@ -78,22 +91,109 @@ struct HotspotAccumulator {
 
 pub fn runs_hotspots(args: RunsHotspotsArgs) -> CmdResult<RunsOutput> {
     let limit = args.limit.clamp(1, 500);
+    validate_hotspot_args(&args)?;
     let store = ObservationStore::open_initialized()?;
-    let loaded = load_fuzz_artifacts_for_runs(&store, &args.run_ids)?;
+    let ranking_run_ids = if args.run_ids.is_empty() {
+        combined_run_ids(&args.baseline_runs, &args.candidate_runs)
+    } else {
+        args.run_ids.clone()
+    };
+    let loaded = load_fuzz_artifacts_for_runs(&store, &ranking_run_ids)?;
     let hotspots = rank_hotspots(&loaded.artifacts, limit);
+    let cohort_comparison = cohort_comparison(&store, &args.baseline_runs, &args.candidate_runs)?;
 
     Ok((
         RunsOutput::Hotspots(RunsHotspotsOutput {
             command: "runs.hotspots",
-            run_ids: args.run_ids,
+            run_ids: ranking_run_ids,
             inspected_artifact_count: loaded.inspected_artifact_count,
             matched_artifact_count: loaded.artifacts.len(),
             skipped_artifact_count: loaded.skipped.len(),
             skipped_artifacts: loaded.skipped,
             hotspots,
+            cohort_comparison,
         }),
         0,
     ))
+}
+
+fn validate_hotspot_args(args: &RunsHotspotsArgs) -> homeboy::core::Result<()> {
+    if args.run_ids.is_empty() && args.baseline_runs.is_empty() && args.candidate_runs.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "provide at least one run id or a baseline/candidate cohort".to_string(),
+            None,
+            Some(vec![
+                "Use `homeboy runs hotspots <run-id> ...` for aggregate ranking.".to_string(),
+                "Use `homeboy runs hotspots --baseline-run <run-id> --candidate-run <run-id>` for threshold-free cohort comparison.".to_string(),
+            ]),
+        ));
+    }
+    if args.baseline_runs.is_empty() != args.candidate_runs.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "baseline-run",
+            "baseline and candidate cohorts must both be provided".to_string(),
+            None,
+            Some(vec![
+                "Add one or more `--baseline-run` values and one or more `--candidate-run` values."
+                    .to_string(),
+            ]),
+        ));
+    }
+    Ok(())
+}
+
+fn combined_run_ids(baseline_runs: &[String], candidate_runs: &[String]) -> Vec<String> {
+    baseline_runs
+        .iter()
+        .chain(candidate_runs.iter())
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn cohort_comparison(
+    store: &ObservationStore,
+    baseline_runs: &[String],
+    candidate_runs: &[String],
+) -> homeboy::core::Result<Option<FuzzHotspotCohortComparison>> {
+    if baseline_runs.is_empty() && candidate_runs.is_empty() {
+        return Ok(None);
+    }
+
+    let baseline = load_fuzz_artifacts_for_runs(store, baseline_runs)?;
+    let candidate = load_fuzz_artifacts_for_runs(store, candidate_runs)?;
+    let baseline_hotspots = rank_hotspots(&baseline.artifacts, usize::MAX);
+    let candidate_hotspots = rank_hotspots(&candidate.artifacts, usize::MAX);
+
+    Ok(Some(compare_fuzz_hotspot_cohorts(
+        cohort_id("baseline", baseline_runs),
+        cohort_id("candidate", candidate_runs),
+        &cohort_items(&baseline_hotspots),
+        &cohort_items(&candidate_hotspots),
+    )))
+}
+
+fn cohort_id(prefix: &str, run_ids: &[String]) -> String {
+    if run_ids.len() == 1 {
+        return run_ids[0].clone();
+    }
+    format!("{prefix}:{}", run_ids.join(","))
+}
+
+fn cohort_items(hotspots: &[HotspotRanking]) -> Vec<FuzzHotspotCohortItem> {
+    hotspots
+        .iter()
+        .map(|hotspot| FuzzHotspotCohortItem {
+            key: hotspot.key.clone(),
+            label: hotspot.label.clone(),
+            score: hotspot.score,
+            occurrences: hotspot.occurrences,
+            run_count: hotspot.run_count,
+            rank: hotspot.rank,
+        })
+        .collect()
 }
 
 pub(crate) fn fuzz_hotspot_lines(run: &Value) -> Vec<String> {
@@ -339,6 +439,17 @@ fn collect_typed_hotspots(json: &Value, points: &mut Vec<HotspotPoint>) {
             label: item.label,
             score: item.relative_score.unwrap_or(item.value),
             source: format!("typed:{}", set.id),
+        }));
+        return;
+    }
+
+    if let Some(observation_set) = parse_fuzz_observation_set_value(json) {
+        let hotspot_set = rank_fuzz_observation_set_hotspots(&observation_set);
+        points.extend(hotspot_set.items.into_iter().map(|item| HotspotPoint {
+            key: item.id,
+            label: item.label,
+            score: item.relative_score.unwrap_or(item.value),
+            source: format!("typed:{}", hotspot_set.id),
         }));
         return;
     }
@@ -675,11 +786,100 @@ mod tests {
     }
 
     #[test]
+    fn typed_observation_sets_are_ranked_as_hotspot_points() {
+        let points = extract_hotspot_points(&json!({
+            "schema": "homeboy/fuzz-observation-set/v1",
+            "version": 1,
+            "id": "observations-1",
+            "observations": [
+                {
+                    "id": "obs-1",
+                    "family": "timing",
+                    "subject": "search route",
+                    "metric": "duration",
+                    "value": 120.0,
+                    "unit": "ms",
+                    "fingerprint": "route:search"
+                }
+            ]
+        }));
+
+        assert_eq!(points.len(), 1);
+        assert_eq!(points[0].key, "route:search");
+        assert_eq!(points[0].label.as_deref(), Some("search route"));
+        assert_eq!(points[0].score, 1.0);
+        assert_eq!(points[0].source, "typed:observations-1-hotspots");
+    }
+
+    #[test]
+    fn cohort_comparison_accepts_typed_observation_artifact_inputs() {
+        let baseline = rank_hotspots(
+            &[artifact(
+                "baseline-run",
+                json!({
+                    "schema": "homeboy/fuzz-observation-set/v1",
+                    "version": 1,
+                    "id": "baseline-observations",
+                    "observations": [
+                        {
+                            "id": "baseline-slow-query",
+                            "family": "query",
+                            "subject": "query-a",
+                            "metric": "duration",
+                            "value": 20.0,
+                            "unit": "ms",
+                            "fingerprint": "query-a:duration"
+                        }
+                    ]
+                }),
+            )],
+            usize::MAX,
+        );
+        let candidate = rank_hotspots(
+            &[artifact(
+                "candidate-run",
+                json!({
+                    "schema": "homeboy/fuzz-observation-set/v1",
+                    "version": 1,
+                    "id": "candidate-observations",
+                    "observations": [
+                        {
+                            "id": "candidate-slow-query",
+                            "family": "query",
+                            "subject": "query-a",
+                            "metric": "duration",
+                            "value": 40.0,
+                            "unit": "ms",
+                            "fingerprint": "query-a:duration"
+                        }
+                    ]
+                }),
+            )],
+            usize::MAX,
+        );
+
+        let comparison = compare_fuzz_hotspot_cohorts(
+            "baseline-run",
+            "candidate-run",
+            &cohort_items(&baseline),
+            &cohort_items(&candidate),
+        );
+
+        assert_eq!(comparison.item_count, 1);
+        assert_eq!(comparison.items[0].key, "query-a:duration");
+        assert_eq!(comparison.items[0].change_kind, "unchanged");
+        assert!(serde_json::to_value(&comparison)
+            .expect("serialize comparison")
+            .get("status")
+            .is_none());
+    }
+
+    #[test]
     fn standardized_hotspots_extract_nested_observation_payloads() {
         let points = extract_hotspot_points(&json!({
             "schema": "homeboy/fuzz-campaign/v1",
             "metadata": {
-                "wordpress_fuzz_result": {
+                "runner_fuzz_result": {
                     "cases": [
                         {
                             "metadata": {

--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -43,7 +43,7 @@ use super::{CmdResult, GlobalArgs};
 // Public command-layer API consumed by routing, raw/json output, rig, and bench.
 pub use dispatch::{global_runner_error, run, run_markdown};
 pub use handlers::list_runs;
-pub use types::{RunsArgs, RunsOutput, WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER};
+pub use types::{RunsArgs, RunsOutput, HOSTED_BLUEPRINT_VIEWER};
 
 // Intra-module re-exports so sibling submodules (and the test modules) can
 // reference shared items via `super::` without depending on each other's

--- a/src/commands/runs/tests/mod.rs
+++ b/src/commands/runs/tests/mod.rs
@@ -5,7 +5,7 @@ mod export_import;
 use super::handlers::{artifact_get, artifacts, env, show_run};
 use super::{
     bench_compare, dead_owned_run, findings, latest, list_runs, runs_dossier, RunsArtifactGetArgs,
-    RunsListArgs, RunsOutput, WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER,
+    RunsListArgs, RunsOutput, HOSTED_BLUEPRINT_VIEWER,
 };
 
 use homeboy::core::observation::runs_service;
@@ -911,7 +911,7 @@ fn artifacts_command_derives_viewer_links_from_public_artifact_url_metadata() {
                         "algorithm": "sha256",
                         "value": "abc123"
                     },
-                    "viewer": WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(Some(serde_json::json!({
+                    "viewer": HOSTED_BLUEPRINT_VIEWER.to_metadata(Some(serde_json::json!({
                             "status": "partial",
                             "limitations": ["fixture limitation"]
                     })))
@@ -943,10 +943,7 @@ fn artifacts_command_derives_viewer_links_from_public_artifact_url_metadata() {
         assert!(!artifact_url.ends_with("/content"));
         assert_eq!(replay.mime.as_deref(), Some("application/json"));
         assert_eq!(replay.sha256.as_deref(), Some("abc123"));
-        assert_eq!(
-            replay.viewer_links[0].kind,
-            "wordpress-playground-blueprint"
-        );
+        assert_eq!(replay.viewer_links[0].kind, "hosted-blueprint");
         assert_eq!(
             replay.viewer_url.as_deref(),
             Some(replay.viewer_links[0].url.as_str())
@@ -997,7 +994,7 @@ fn artifacts_command_suppresses_viewer_links_when_public_url_is_unreachable() {
                 "bench_artifact",
                 &artifact_path,
                 serde_json::json!({
-                    "viewer": WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER.to_metadata(None)
+                    "viewer": HOSTED_BLUEPRINT_VIEWER.to_metadata(None)
                 }),
             )
             .expect("record artifact");

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -39,17 +39,16 @@ use crate::commands::fuzz::FuzzCompareOutput;
 
 pub(super) const DEFAULT_LIMIT: i64 = 20;
 
-/// Command-layer artifact viewer for WordPress Playground blueprint artifacts.
+/// Command-layer artifact viewer for hosted blueprint artifacts.
 ///
 /// The viewer is an ecosystem-specific presentation concern, so it lives in the
 /// command layer (which composes ecosystem integrations) rather than in core,
 /// which stays agnostic and only owns the generic [`ArtifactViewerDescriptor`].
-pub const WORDPRESS_PLAYGROUND_BLUEPRINT_VIEWER: ArtifactViewerDescriptor =
-    ArtifactViewerDescriptor::new(
-        "wordpress-playground-blueprint",
-        "https://playground.wordpress.net/",
-        "blueprint-url",
-    );
+pub const HOSTED_BLUEPRINT_VIEWER: ArtifactViewerDescriptor = ArtifactViewerDescriptor::new(
+    "hosted-blueprint",
+    "https://playground.wordpress.net/",
+    "blueprint-url",
+);
 
 #[derive(Args, Clone)]
 pub struct RunsArgs {

--- a/src/core/fuzz/cohorts.rs
+++ b/src/core/fuzz/cohorts.rs
@@ -1,0 +1,202 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FuzzHotspotCohortItem {
+    pub key: String,
+    pub label: Option<String>,
+    pub score: f64,
+    pub occurrences: u64,
+    pub run_count: usize,
+    pub rank: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct FuzzHotspotCohortComparison {
+    pub baseline_id: String,
+    pub candidate_id: String,
+    pub item_count: usize,
+    pub new_items: usize,
+    pub resolved_items: usize,
+    pub increased_items: usize,
+    pub decreased_items: usize,
+    pub unchanged_items: usize,
+    pub items: Vec<FuzzHotspotCohortDelta>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct FuzzHotspotCohortDelta {
+    pub key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub change_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate_score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score_delta: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relative_lift: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub normalized_score_delta: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_rank: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate_rank: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rank_movement: Option<i64>,
+    pub baseline_occurrences: u64,
+    pub candidate_occurrences: u64,
+    pub occurrence_delta: i64,
+    pub baseline_run_count: usize,
+    pub candidate_run_count: usize,
+    pub run_count_delta: i64,
+}
+
+pub fn compare_fuzz_hotspot_cohorts(
+    baseline_id: impl Into<String>,
+    candidate_id: impl Into<String>,
+    baseline: &[FuzzHotspotCohortItem],
+    candidate: &[FuzzHotspotCohortItem],
+) -> FuzzHotspotCohortComparison {
+    let baseline_by_key = baseline
+        .iter()
+        .map(|item| (item.key.clone(), item))
+        .collect::<BTreeMap<_, _>>();
+    let candidate_by_key = candidate
+        .iter()
+        .map(|item| (item.key.clone(), item))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut items = baseline_by_key
+        .keys()
+        .chain(candidate_by_key.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|key| {
+            let before = baseline_by_key.get(&key).copied();
+            let after = candidate_by_key.get(&key).copied();
+            cohort_delta(key, before, after)
+        })
+        .collect::<Vec<_>>();
+
+    items.sort_by(|a, b| {
+        b.normalized_score_delta
+            .unwrap_or(0.0)
+            .abs()
+            .total_cmp(&a.normalized_score_delta.unwrap_or(0.0).abs())
+            .then_with(|| {
+                b.score_delta
+                    .unwrap_or(0.0)
+                    .abs()
+                    .total_cmp(&a.score_delta.unwrap_or(0.0).abs())
+            })
+            .then_with(|| {
+                a.candidate_rank
+                    .unwrap_or(usize::MAX)
+                    .cmp(&b.candidate_rank.unwrap_or(usize::MAX))
+            })
+            .then_with(|| {
+                a.baseline_rank
+                    .unwrap_or(usize::MAX)
+                    .cmp(&b.baseline_rank.unwrap_or(usize::MAX))
+            })
+            .then_with(|| a.key.cmp(&b.key))
+    });
+
+    FuzzHotspotCohortComparison {
+        baseline_id: baseline_id.into(),
+        candidate_id: candidate_id.into(),
+        item_count: items.len(),
+        new_items: items
+            .iter()
+            .filter(|item| item.change_kind == "new")
+            .count(),
+        resolved_items: items
+            .iter()
+            .filter(|item| item.change_kind == "resolved")
+            .count(),
+        increased_items: items
+            .iter()
+            .filter(|item| item.change_kind == "increased")
+            .count(),
+        decreased_items: items
+            .iter()
+            .filter(|item| item.change_kind == "decreased")
+            .count(),
+        unchanged_items: items
+            .iter()
+            .filter(|item| item.change_kind == "unchanged")
+            .count(),
+        items,
+    }
+}
+
+fn cohort_delta(
+    key: String,
+    before: Option<&FuzzHotspotCohortItem>,
+    after: Option<&FuzzHotspotCohortItem>,
+) -> FuzzHotspotCohortDelta {
+    let baseline_score = before.map(|item| item.score);
+    let candidate_score = after.map(|item| item.score);
+    let score_delta = baseline_score
+        .zip(candidate_score)
+        .map(|(baseline, candidate)| candidate - baseline);
+    let relative_lift = baseline_score
+        .zip(candidate_score)
+        .and_then(|(baseline, candidate)| {
+            (baseline != 0.0).then_some((candidate - baseline) / baseline.abs())
+        });
+    let normalized_score_delta = match (baseline_score, candidate_score) {
+        (Some(baseline), Some(candidate)) => {
+            let denominator = baseline.abs().max(candidate.abs());
+            (denominator != 0.0).then_some((candidate - baseline) / denominator)
+        }
+        (None, Some(candidate)) => (candidate != 0.0).then_some(candidate.signum()),
+        (Some(baseline), None) => (baseline != 0.0).then_some(-baseline.signum()),
+        (None, None) => None,
+    };
+    let rank_movement = before
+        .map(|item| item.rank)
+        .zip(after.map(|item| item.rank))
+        .map(|(baseline, candidate)| baseline as i64 - candidate as i64);
+    let baseline_occurrences = before.map(|item| item.occurrences).unwrap_or_default();
+    let candidate_occurrences = after.map(|item| item.occurrences).unwrap_or_default();
+    let baseline_run_count = before.map(|item| item.run_count).unwrap_or_default();
+    let candidate_run_count = after.map(|item| item.run_count).unwrap_or_default();
+
+    FuzzHotspotCohortDelta {
+        key,
+        label: after
+            .and_then(|item| item.label.clone())
+            .or_else(|| before.and_then(|item| item.label.clone())),
+        change_kind: change_kind(score_delta, before.is_some(), after.is_some()).to_string(),
+        baseline_score,
+        candidate_score,
+        score_delta,
+        relative_lift,
+        normalized_score_delta,
+        baseline_rank: before.map(|item| item.rank),
+        candidate_rank: after.map(|item| item.rank),
+        rank_movement,
+        baseline_occurrences,
+        candidate_occurrences,
+        occurrence_delta: candidate_occurrences as i64 - baseline_occurrences as i64,
+        baseline_run_count,
+        candidate_run_count,
+        run_count_delta: candidate_run_count as i64 - baseline_run_count as i64,
+    }
+}
+
+fn change_kind(score_delta: Option<f64>, has_baseline: bool, has_candidate: bool) -> &'static str {
+    match (has_baseline, has_candidate, score_delta) {
+        (false, true, _) => "new",
+        (true, false, _) => "resolved",
+        (true, true, Some(delta)) if delta > 0.0 => "increased",
+        (true, true, Some(delta)) if delta < 0.0 => "decreased",
+        _ => "unchanged",
+    }
+}

--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -4,6 +4,7 @@
 //! runners can attach their own details through `metadata` or flattened extras.
 
 mod artifact_envelope;
+mod cohorts;
 mod contract;
 mod coverage;
 mod defaults;
@@ -22,6 +23,10 @@ mod tests;
 pub use artifact_envelope::{
     inspect_fuzz_result_envelope_artifact, FuzzResultEnvelopeArtifactInspection,
     FuzzResultEnvelopeArtifactSummary,
+};
+pub use cohorts::{
+    compare_fuzz_hotspot_cohorts, FuzzHotspotCohortComparison, FuzzHotspotCohortDelta,
+    FuzzHotspotCohortItem,
 };
 pub use contract::{
     canonical_operation_family, fuzz_core_contract, FuzzContractSchemas, FuzzCoreContract,

--- a/src/core/fuzz/observations.rs
+++ b/src/core/fuzz/observations.rs
@@ -116,11 +116,17 @@ fn normalize_optional_string(value: Option<String>) -> Option<String> {
 }
 
 pub fn parse_fuzz_observation_set_value(value: &Value) -> Option<FuzzObservationSet> {
-    let candidate = value
-        .get("observation_set")
-        .or_else(|| value.get("observations"))
-        .filter(|candidate| {
-            candidate.get("schema").and_then(Value::as_str) == Some(FUZZ_OBSERVATION_SET_SCHEMA)
-        })?;
+    let candidate = if value.get("schema").and_then(Value::as_str)
+        == Some(FUZZ_OBSERVATION_SET_SCHEMA)
+    {
+        Some(value)
+    } else {
+        value
+            .get("observation_set")
+            .or_else(|| value.get("observations"))
+            .filter(|candidate| {
+                candidate.get("schema").and_then(Value::as_str) == Some(FUZZ_OBSERVATION_SET_SCHEMA)
+            })
+    }?;
     FuzzObservationSet::from_value(candidate.clone()).ok()
 }

--- a/src/core/fuzz/tests/cohort_tests.rs
+++ b/src/core/fuzz/tests/cohort_tests.rs
@@ -1,0 +1,99 @@
+use serde_json::Value;
+
+use crate::core::fuzz::{compare_fuzz_hotspot_cohorts, FuzzHotspotCohortItem};
+
+fn item(key: &str, score: f64, rank: usize) -> FuzzHotspotCohortItem {
+    FuzzHotspotCohortItem {
+        key: key.to_string(),
+        label: None,
+        score,
+        occurrences: 1,
+        run_count: 1,
+        rank,
+    }
+}
+
+#[test]
+fn compares_cohorts_without_threshold_or_gate_semantics() {
+    let comparison = compare_fuzz_hotspot_cohorts(
+        "baseline",
+        "candidate",
+        &[item("stable", 10.0, 1), item("resolved", 5.0, 2)],
+        &[item("stable", 15.0, 2), item("new", 3.0, 1)],
+    );
+
+    assert_eq!(comparison.item_count, 3);
+    assert_eq!(comparison.new_items, 1);
+    assert_eq!(comparison.resolved_items, 1);
+    assert_eq!(comparison.increased_items, 1);
+    assert_eq!(comparison.decreased_items, 0);
+
+    let stable = comparison
+        .items
+        .iter()
+        .find(|item| item.key == "stable")
+        .expect("stable delta");
+    assert_eq!(stable.change_kind, "increased");
+    assert_eq!(stable.score_delta, Some(5.0));
+    assert_eq!(stable.relative_lift, Some(0.5));
+    assert_eq!(stable.normalized_score_delta, Some(5.0 / 15.0));
+    assert_eq!(stable.rank_movement, Some(-1));
+
+    let serialized = serde_json::to_value(&comparison).expect("serialize comparison");
+    assert!(serialized.get("status").is_none());
+    assert!(serialized.get("threshold").is_none());
+    assert!(serialized.get("passed").is_none());
+    assert!(serialized.get("failed").is_none());
+}
+
+#[test]
+fn reports_new_and_resolved_effects_without_inventing_relative_lift() {
+    let comparison = compare_fuzz_hotspot_cohorts(
+        "baseline",
+        "candidate",
+        &[item("resolved", 4.0, 1)],
+        &[item("new", 7.0, 1)],
+    );
+
+    let new_item = comparison
+        .items
+        .iter()
+        .find(|item| item.key == "new")
+        .expect("new delta");
+    assert_eq!(new_item.change_kind, "new");
+    assert_eq!(new_item.relative_lift, None);
+    assert_eq!(new_item.normalized_score_delta, Some(1.0));
+
+    let resolved = comparison
+        .items
+        .iter()
+        .find(|item| item.key == "resolved")
+        .expect("resolved delta");
+    assert_eq!(resolved.change_kind, "resolved");
+    assert_eq!(resolved.relative_lift, None);
+    assert_eq!(resolved.normalized_score_delta, Some(-1.0));
+
+    let serialized = serde_json::to_value(&comparison).expect("serialize comparison");
+    assert_no_nested_gate_fields(&serialized);
+}
+
+fn assert_no_nested_gate_fields(value: &Value) {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                assert_ne!(key, "status");
+                assert_ne!(key, "classification");
+                assert_ne!(key, "threshold");
+                assert_ne!(key, "pass");
+                assert_ne!(key, "fail");
+                assert_no_nested_gate_fields(value);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                assert_no_nested_gate_fields(item);
+            }
+        }
+        _ => {}
+    }
+}

--- a/src/core/fuzz/tests/mod.rs
+++ b/src/core/fuzz/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Tests for the product-neutral fuzz contracts.
 
 mod campaign_tests;
+mod cohort_tests;
 mod contract_tests;
 mod hotspot_tests;
 mod observation_tests;


### PR DESCRIPTION
## Summary
- classify and promote typed fuzz result, observation, and hotspot artifacts from runner outputs
- add threshold-free fuzz hotspot cohort comparison for baseline/candidate runs
- document typed fuzz artifact ingestion and cohort hotspot examples

## Tests
- cargo fmt
- cargo test core::fuzz::tests::cohort_tests --lib
- cargo test commands::runs::hotspots::tests --lib
- cargo test runner_exec_promotes_artifact_dir_typed_fuzz_children
- cargo test cohort_comparison_accepts_typed_observation_artifact_inputs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing fuzzing infrastructure, implementing typed artifact promotion, cohort hotspot comparison, docs, and focused tests.