### PR TITLE
runner: record path materialization plan

### DIFF
--- a/src/core/runner/execution/broker.rs
+++ b/src/core/runner/execution/broker.rs
@@ -192,6 +192,8 @@ pub(super) fn exec_via_reverse_broker(
         exit_code,
         Some(job.id.to_string()),
         mirror_run_id.clone(),
+        Some(&source_snapshot),
+        &require_paths,
         &artifacts,
         Some(&runner_result),
     );

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -197,6 +197,8 @@ pub(super) fn exec_via_daemon(
         exit_code,
         Some(job.id.to_string()),
         mirror_run_id.clone(),
+        Some(&source_snapshot),
+        &require_paths,
         &artifacts,
         Some(&runner_result),
     );
@@ -425,6 +427,8 @@ pub(super) fn detached_handoff_output(
                 0,
                 Some(job.id.to_string()),
                 mirror_run_id.clone(),
+                Some(&source_snapshot),
+                &require_paths,
                 &[],
                 Some(&runner_result),
             )),

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -15,7 +15,8 @@ use crate::core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobStatus};
 use crate::core::engine::command::CommandCaptureMetadata;
 use crate::core::error::{Error, Result};
 use crate::core::runner_execution_envelope::{
-    RunnerExecutionArtifactRef, RunnerExecutionNextAction, RunnerExecutionRecord,
+    PathMaterializationEntry, PathMaterializationPlan, RunnerExecutionArtifactRef,
+    RunnerExecutionNextAction, RunnerExecutionRecord,
 };
 use crate::core::source_snapshot::SourceSnapshot;
 
@@ -164,6 +165,8 @@ fn runner_execution_record_for_output(
     exit_code: i32,
     job_id: Option<String>,
     mirror_run_id: Option<String>,
+    source_snapshot: Option<&SourceSnapshot>,
+    require_paths: &[String],
     artifacts: &[JobArtifactMetadata],
     runner_result: Option<&RunnerResult>,
 ) -> RunnerExecutionRecord {
@@ -192,6 +195,7 @@ fn runner_execution_record_for_output(
         exit_code,
     )
     .with_mirror_run_id(mirror_run_id)
+    .with_path_materialization_plan(path_materialization_plan(source_snapshot, require_paths))
     .with_artifact_refs(artifact_refs);
     if let Some(job_id) = job_id {
         record = record
@@ -199,6 +203,54 @@ fn runner_execution_record_for_output(
             .with_next_actions(runner_execution_next_actions(&runner.id, &job_id));
     }
     record
+}
+
+fn path_materialization_plan(
+    source_snapshot: Option<&SourceSnapshot>,
+    require_paths: &[String],
+) -> Option<PathMaterializationPlan> {
+    let mut entries = Vec::new();
+    if let Some(snapshot) = source_snapshot.and_then(path_materialization_entry_from_snapshot) {
+        entries.push(snapshot);
+    }
+    entries.extend(require_paths.iter().filter_map(|path| {
+        let trimmed = path.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        Some(PathMaterializationEntry {
+            role: "required_path".to_string(),
+            owner: "runner_exec.require_paths".to_string(),
+            local_path: None,
+            remote_path: trimmed.to_string(),
+            materialization_mode: "existing_remote".to_string(),
+            validation_status: "validated".to_string(),
+        })
+    }));
+    if entries.is_empty() {
+        return None;
+    }
+    Some(PathMaterializationPlan {
+        schema: "homeboy/path-materialization-plan/v1".to_string(),
+        entries,
+    })
+}
+
+fn path_materialization_entry_from_snapshot(
+    snapshot: &SourceSnapshot,
+) -> Option<PathMaterializationEntry> {
+    let remote_path = snapshot.remote_path.as_deref()?.trim();
+    if remote_path.is_empty() {
+        return None;
+    }
+    Some(PathMaterializationEntry {
+        role: "primary_workspace".to_string(),
+        owner: "runner_exec.source_snapshot".to_string(),
+        local_path: snapshot.local_path.clone(),
+        remote_path: remote_path.to_string(),
+        materialization_mode: snapshot.sync_mode.clone(),
+        validation_status: "materialized".to_string(),
+    })
 }
 
 fn job_artifact_refs(artifacts: &[JobArtifactMetadata]) -> Vec<RunnerExecutionArtifactRef> {

--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -361,6 +361,8 @@ pub(super) fn exec_output(
         exit_code,
         None,
         None,
+        source_snapshot.as_ref(),
+        &require_paths,
         &[],
         Some(&runner_result),
     );

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -55,10 +55,31 @@ pub struct RunnerExecutionRecord {
     pub agent_task_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mirror_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_materialization_plan: Option<PathMaterializationPlan>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_refs: Vec<RunnerExecutionArtifactRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<RunnerExecutionNextAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathMaterializationPlan {
+    #[serde(default = "path_materialization_plan_schema")]
+    pub schema: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entries: Vec<PathMaterializationEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathMaterializationEntry {
+    pub role: String,
+    pub owner: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_path: Option<String>,
+    pub remote_path: String,
+    pub materialization_mode: String,
+    pub validation_status: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -101,6 +122,7 @@ impl RunnerExecutionRecord {
             remote_run_id: None,
             agent_task_run_id: None,
             mirror_run_id: None,
+            path_materialization_plan: None,
             artifact_refs: Vec::new(),
             next_actions: Vec::new(),
         }
@@ -122,6 +144,14 @@ impl RunnerExecutionRecord {
         artifact_refs: impl IntoIterator<Item = RunnerExecutionArtifactRef>,
     ) -> Self {
         self.artifact_refs = artifact_refs.into_iter().collect();
+        self
+    }
+
+    pub fn with_path_materialization_plan(
+        mut self,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+    ) -> Self {
+        self.path_materialization_plan = path_materialization_plan;
         self
     }
 
@@ -370,6 +400,10 @@ fn runner_execution_record_schema() -> String {
     RUNNER_EXECUTION_RECORD_SCHEMA.to_string()
 }
 
+fn path_materialization_plan_schema() -> String {
+    "homeboy/path-materialization-plan/v1".to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -459,6 +493,17 @@ mod tests {
                 path: Some("artifacts/report.json".to_string()),
                 url: None,
             }])
+            .with_path_materialization_plan(Some(PathMaterializationPlan {
+                schema: path_materialization_plan_schema(),
+                entries: vec![PathMaterializationEntry {
+                    role: "primary_workspace".to_string(),
+                    owner: "runner_exec.source_snapshot".to_string(),
+                    local_path: Some("/local/project".to_string()),
+                    remote_path: "/runner/project".to_string(),
+                    materialization_mode: "snapshot".to_string(),
+                    validation_status: "materialized".to_string(),
+                }],
+            }))
             .with_next_actions(vec![RunnerExecutionNextAction {
                 label: "runner_job_logs".to_string(),
                 command: vec![
@@ -479,6 +524,14 @@ mod tests {
         assert_eq!(value["status"], "succeeded");
         assert_eq!(value["job_id"], "job-1");
         assert_eq!(value["remote_run_id"], "run-1");
+        assert_eq!(
+            value["path_materialization_plan"]["schema"],
+            "homeboy/path-materialization-plan/v1"
+        );
+        assert_eq!(
+            value["path_materialization_plan"]["entries"][0]["remote_path"],
+            "/runner/project"
+        );
         assert_eq!(value["artifact_refs"][0]["id"], "artifact-1");
         assert_eq!(value["next_actions"][0]["label"], "runner_job_logs");
     }


### PR DESCRIPTION
## Summary
- Add a typed `homeboy/path-materialization-plan/v1` payload to runner execution records.
- Derive primary workspace materialization from `SourceSnapshot`.
- Record validated `runner exec --require-path` paths as existing remote materialization entries.

## Tests
- `cargo test runner_execution_record`
- `cargo test runner_exec`

## Notes
This is additive and does not change runner dispatch behavior yet. It gives Lab/offload consumers one structured place to inspect path handoff state before the next slice wires failure/timeout messaging to the record.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, test execution, and PR preparation.