### PR TITLE
runner: reap run-scoped offload workspaces with a MaterializedWorkspace RAII handle (#6678)

### DIFF
--- a/src/core/runner/lab/offload/errors.rs
+++ b/src/core/runner/lab/offload/errors.rs
@@ -101,27 +101,28 @@ pub(crate) fn write_local_output_file_atomically(
 ) -> std::io::Result<()> {
     use std::io::Write;
     let target = std::path::Path::new(path);
-    let file_name = target
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("output");
-    let temp_name = format!(".{file_name}.{}.tmp", std::process::id());
-    let temp = target.with_file_name(temp_name);
-    {
-        let mut file = std::fs::File::create(&temp)?;
-        file.write_all(contents.as_bytes())?;
-        if !contents.ends_with('\n') {
-            file.write_all(b"\n")?;
-        }
-        file.sync_all()?;
+    // Stage the write in a unique, Drop-cleaned temp file in the SAME directory
+    // as the target so the final `persist` is an atomic same-filesystem rename.
+    // `NamedTempFile` removes the staging file on every early-return path — the
+    // `write_all` / `sync_all` `?` errors below and a failed `persist` — closing
+    // the leak where the previous deterministic `.{name}.{pid}.tmp` staging file
+    // was left behind whenever an intermediate write errored (#6678).
+    let dir = target
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let mut temp = tempfile::Builder::new()
+        .prefix(".homeboy-output-")
+        .suffix(".tmp")
+        .tempfile_in(&dir)?;
+    temp.write_all(contents.as_bytes())?;
+    if !contents.ends_with('\n') {
+        temp.write_all(b"\n")?;
     }
-    match std::fs::rename(&temp, target) {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            let _ = std::fs::remove_file(&temp);
-            Err(err)
-        }
-    }
+    temp.as_file().sync_all()?;
+    temp.persist(target).map_err(|err| err.error)?;
+    Ok(())
 }
 
 pub(crate) fn in_flight_daemon_disconnect_error(

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -465,6 +465,36 @@ pub(crate) fn run_lab_offload_inner(
     } = workspace_stage;
     plan = next_plan;
 
+    // Run-scoped RAII ownership of the materialized remote workspace (#6678).
+    // Historically every offloaded run left its `_lab_workspaces/<snapshot>`
+    // checkout and sibling artifact directory on the lab; the only teardown was
+    // the operator-driven `runner workspace prune`. This handle reaps the run's
+    // workspace on the success path while the default `PreserveOnFailure` policy
+    // keeps it on failure so post-mortem evidence survives. Paths that hand the
+    // workspace off to a still-running remote job (detach, in-flight daemon
+    // disconnect) call `preserve()` so the live job keeps its checkout. The
+    // artifact sibling is only created when the run requested `--output`, so it
+    // is only tracked for reaping in that case.
+    //
+    // Durable agent-task runs are inspected post-hoc (`agent-task
+    // status/logs/artifacts`) and an operator may need to exec back into the
+    // run's checkout, so those preserve the workspace regardless of outcome and
+    // rely on the operator-driven prune; ephemeral cooks/bench/lint runs reap on
+    // success and preserve on failure.
+    let cleanup_policy = if agent_task_run_id.is_some() {
+        WorkspaceCleanupPolicy::PreserveAlways
+    } else {
+        WorkspaceCleanupPolicy::PreserveOnFailure
+    };
+    let mut materialized_workspace = MaterializedWorkspace::new(
+        runner_id.to_string(),
+        remote_cwd.clone(),
+        remote_output_file
+            .as_deref()
+            .map(|_| remote_lab_artifact_dir(&remote_cwd)),
+        cleanup_policy,
+    );
+
     // The structured-output file lives in a Homeboy-owned artifact directory
     // that is a sibling of the synced checkout (#6219), so it is never created
     // by workspace sync. Create it explicitly before dispatch so the remote
@@ -713,6 +743,10 @@ pub(crate) fn run_lab_offload_inner(
     let (exec_output, exit_code) = match exec_result {
         Ok(output) => output,
         Err(err) => {
+            // The remote exec failed: preserve the materialized workspace for
+            // post-mortem evidence, and — when the daemon disconnected with a
+            // job still in flight — so the live remote job keeps its checkout.
+            materialized_workspace.preserve();
             if let Some(health) = runner_daemon_health_failure(&err) {
                 let reason = health.reason.clone();
                 plan = with_step(
@@ -794,6 +828,10 @@ pub(crate) fn run_lab_offload_inner(
         plan = add_success_step(plan, "lab.mirror_evidence");
     }
     if request.detach_after_handoff {
+        // The remote run continues detached and still owns its workspace; hand
+        // ownership off so the RAII handle never reaps it out from under the
+        // live job.
+        materialized_workspace.preserve();
         let mut stderr = String::new();
         for message in messages {
             stderr.push_str(&message);
@@ -932,6 +970,10 @@ pub(crate) fn run_lab_offload_inner(
         }
     }
 
+    // Synchronous offload complete: reap the run-scoped workspace on success
+    // (exit 0); a non-zero remote exit preserves it for post-mortem evidence
+    // under the default `PreserveOnFailure` cleanup policy.
+    materialized_workspace.set_success(exit_code == 0);
     Ok(LabOffloadOutcome::Offloaded {
         plan,
         stdout: exec_output.stdout,
@@ -1019,19 +1061,112 @@ pub(crate) fn lab_offload_structured_result_available(
 }
 
 pub(crate) fn download_lab_output_file(runner_id: &str, remote_path: &str) -> Result<String> {
-    let temp = local_lab_output_temp_path(runner_id, remote_path);
-    let temp_text = temp.display().to_string();
-    lab_runner_file_transfer(runner_id)?
-        .download_file(remote_path, &temp_text)
-        .map_err(|err| lab_output_download_error(runner_id, remote_path, err))?;
-    let content = std::fs::read_to_string(&temp).map_err(|err| {
+    let transfer = lab_runner_file_transfer(runner_id)?;
+    read_downloaded_output_via_temp_file(|local_path| {
+        transfer
+            .download_file(remote_path, local_path)
+            .map_err(|err| lab_output_download_error(runner_id, remote_path, err))
+    })
+}
+
+/// Download a remote file into a unique, Drop-cleaned local temp file via
+/// `download`, then read and return its contents as a string.
+///
+/// The temp file is a [`tempfile::NamedTempFile`]: it has a unique name (no
+/// cross-run collision) and is removed when this function returns through ANY
+/// path — including the `?`-error path on `download` and the `?`-error path on
+/// `read_to_string`. The previous implementation built a DETERMINISTIC temp
+/// path under `std::env::temp_dir()` and relied on a best-effort `remove_file`
+/// placed AFTER the fallible read, so a read error (`?`) leaked the file and a
+/// concurrent run at the same name could collide (#6678).
+fn read_downloaded_output_via_temp_file<F>(download: F) -> Result<String>
+where
+    F: FnOnce(&str) -> Result<()>,
+{
+    let temp = tempfile::Builder::new()
+        .prefix("homeboy-lab-output-")
+        .suffix(".json")
+        .tempfile()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("create Lab output temp file".to_string()),
+            )
+        })?;
+    let temp_text = temp.path().display().to_string();
+    download(&temp_text)?;
+    std::fs::read_to_string(temp.path()).map_err(|err| {
         Error::internal_io(
             err.to_string(),
-            Some(format!("read downloaded Lab output {}", temp.display())),
+            Some(format!(
+                "read downloaded Lab output {}",
+                temp.path().display()
+            )),
         )
-    })?;
-    let _ = std::fs::remove_file(&temp);
-    Ok(content)
+    })
+    // `temp` (NamedTempFile) is dropped here, removing the unique file on every
+    // return path above, including the `download(...)?` and `read_to_string`
+    // error paths.
+}
+
+#[cfg(test)]
+mod read_downloaded_output_tests {
+    use super::*;
+
+    #[test]
+    fn returns_downloaded_contents_and_removes_temp_on_success() {
+        let mut temp_path = String::new();
+        let content = read_downloaded_output_via_temp_file(|local_path| {
+            temp_path = local_path.to_string();
+            std::fs::write(local_path, "structured-output\n")
+                .map_err(|err| Error::internal_io(err.to_string(), None))
+        })
+        .expect("download + read succeeds");
+
+        assert_eq!(content, "structured-output\n");
+        assert!(!temp_path.is_empty());
+        assert!(
+            !Path::new(&temp_path).exists(),
+            "temp file leaked after success: {temp_path}"
+        );
+    }
+
+    #[test]
+    fn removes_temp_when_download_errors() {
+        let mut temp_path = String::new();
+        let result = read_downloaded_output_via_temp_file(|local_path| {
+            temp_path = local_path.to_string();
+            Err(Error::internal_unexpected("download failed"))
+        });
+
+        assert!(result.is_err(), "download error should propagate");
+        assert!(!temp_path.is_empty());
+        assert!(
+            !Path::new(&temp_path).exists(),
+            "temp file leaked after download error: {temp_path}"
+        );
+    }
+
+    #[test]
+    fn removes_temp_when_read_errors() {
+        // Reproduce the leak the fix targets: the download succeeds, but the
+        // subsequent read fails (invalid UTF-8), so `read_to_string` `?`-returns
+        // before any manual cleanup could run. The unique NamedTempFile must
+        // still be removed on this error path.
+        let mut temp_path = String::new();
+        let result = read_downloaded_output_via_temp_file(|local_path| {
+            temp_path = local_path.to_string();
+            std::fs::write(local_path, [0xff, 0xfe, 0x00])
+                .map_err(|err| Error::internal_io(err.to_string(), None))
+        });
+
+        assert!(result.is_err(), "invalid UTF-8 must fail the read");
+        assert!(!temp_path.is_empty());
+        assert!(
+            !Path::new(&temp_path).exists(),
+            "temp file leaked after read error: {temp_path}"
+        );
+    }
 }
 
 pub(crate) fn lab_output_download_error(runner_id: &str, remote_path: &str, err: Error) -> Error {
@@ -1046,20 +1181,4 @@ pub(crate) fn lab_output_download_error(runner_id: &str, remote_path: &str, err:
     error.retryable = err.retryable;
     error.hints = err.hints;
     error.with_hint("The remote command was invoked with --output, but the runner-side file was not readable after execution.".to_string())
-}
-
-pub(crate) fn local_lab_output_temp_path(runner_id: &str, remote_path: &str) -> PathBuf {
-    let sanitized_runner = runner_id
-        .chars()
-        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
-        .collect::<String>();
-    let sanitized_remote = remote_path
-        .chars()
-        .rev()
-        .take(48)
-        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
-        .collect::<String>();
-    std::env::temp_dir().join(format!(
-        "homeboy-lab-output-{sanitized_runner}-{sanitized_remote}"
-    ))
 }

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -100,9 +100,10 @@ use super::super::{
     lab_offload_metadata, lab_offload_metadata_with_workspace_mapping, load,
     plan_managed_runner_source_syncs, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since, prepare_lab_runner_capability, rig_materialization,
-    status, sync_workspace, LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions,
-    RunnerFileTransfer, RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    status, sync_workspace, LabRunnerGateDecision, MaterializedWorkspace, RunnerCapabilityPreflight,
+    RunnerExecOptions, RunnerFileTransfer, RunnerStatusReport, RunnerWorkspaceApplyOutput,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    WorkspaceCleanupPolicy,
 };
 
 use super::super::workload::{build_runner_workload, RunnerWorkloadBuildInput};

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -58,6 +58,7 @@ mod worker;
 pub(crate) mod workload;
 mod workspace;
 pub(crate) use workspace::copy_snapshot_to_directory;
+pub(crate) use workspace::{MaterializedWorkspace, WorkspaceCleanupPolicy};
 
 pub use apply::{
     apply_change_artifact, apply_workspace_patch, RunnerWorkspaceApplyOptions,

--- a/src/core/runner/workspace/materialized.rs
+++ b/src/core/runner/workspace/materialized.rs
@@ -1,0 +1,123 @@
+//! Run-scoped RAII ownership of a materialized remote runner workspace (#6678).
+//!
+//! Offloaded Lab runs stage a per-run checkout under
+//! `<workspace_root>/_lab_workspaces/<snapshot>` plus a sibling
+//! `<checkout>-homeboy-artifacts` directory. Historically nothing reaped those
+//! on the success path — the only teardown was the operator-driven CLI prune
+//! (`runner workspace prune`), so every offloaded run left scraps on the lab.
+//!
+//! [`MaterializedWorkspace`] is the run-owned handle that closes that gap: it
+//! carries a [`WorkspaceCleanupPolicy`] and reaps the remote workspace (and its
+//! artifact sibling) on drop. The default policy
+//! [`WorkspaceCleanupPolicy::PreserveOnFailure`] reaps only when the run is
+//! marked successful, preserving the remote tree on failure so post-mortem
+//! evidence survives. Reap is best-effort: a teardown error is logged, never
+//! propagated, and the controller-side `runner workspace prune` remains the
+//! backstop.
+
+use super::sync::reap_run_workspace;
+
+/// Teardown policy for a run-owned materialized workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkspaceCleanupPolicy {
+    /// Reap the workspace when the run succeeds; preserve it on failure so
+    /// post-mortem evidence survives on the lab. Default — chosen to avoid
+    /// behavior shock (failed runs keep their evidence as before) while still
+    /// reclaiming the common success path that previously leaked.
+    PreserveOnFailure,
+    /// Never auto-reap; rely entirely on the operator-driven
+    /// `runner workspace prune` CLI (the legacy behavior).
+    PreserveAlways,
+}
+
+impl Default for WorkspaceCleanupPolicy {
+    fn default() -> Self {
+        Self::PreserveOnFailure
+    }
+}
+
+/// Run-owned handle to a materialized remote runner workspace. Reaps the remote
+/// `_lab_workspaces/<snapshot>` checkout (and its sibling Homeboy artifact
+/// directory) on drop, according to its [`WorkspaceCleanupPolicy`].
+///
+/// Create one right after the run materializes its workspace and let it own the
+/// remainder of the offload scope. Mark the run outcome with [`set_success`] on
+/// the success path; call [`preserve`] on any path that hands the checkout off
+/// to a still-running remote job (detach, in-flight daemon disconnect) so the
+/// live job keeps its workspace.
+///
+/// [`set_success`]: MaterializedWorkspace::set_success
+/// [`preserve`]: MaterializedWorkspace::preserve
+pub(crate) struct MaterializedWorkspace {
+    runner_id: String,
+    remote_path: String,
+    artifact_dir: Option<String>,
+    policy: WorkspaceCleanupPolicy,
+    succeeded: bool,
+    relinquished: bool,
+}
+
+impl MaterializedWorkspace {
+    pub(crate) fn new(
+        runner_id: String,
+        remote_path: String,
+        artifact_dir: Option<String>,
+        policy: WorkspaceCleanupPolicy,
+    ) -> Self {
+        Self {
+            runner_id,
+            remote_path,
+            artifact_dir,
+            policy,
+            succeeded: false,
+            relinquished: false,
+        }
+    }
+
+    /// Record the run outcome. Under the default `PreserveOnFailure` policy the
+    /// workspace is reaped on drop only when `succeeded` is `true`.
+    pub(crate) fn set_success(&mut self, succeeded: bool) {
+        self.succeeded = succeeded;
+    }
+
+    /// Relinquish run-scoped ownership without reaping — e.g. the remote run
+    /// continues detached, or its daemon job is still in flight, and still owns
+    /// the checkout. After this the handle never reaps on drop.
+    pub(crate) fn preserve(&mut self) {
+        self.relinquished = true;
+    }
+
+    fn should_reap(&self) -> bool {
+        // Preserve evidence if we are unwinding from a panic, and honor an
+        // explicit relinquish handing the workspace to a live remote job.
+        if self.relinquished || std::thread::panicking() {
+            return false;
+        }
+        match self.policy {
+            WorkspaceCleanupPolicy::PreserveAlways => false,
+            WorkspaceCleanupPolicy::PreserveOnFailure => self.succeeded,
+        }
+    }
+}
+
+impl Drop for MaterializedWorkspace {
+    fn drop(&mut self) {
+        if !self.should_reap() {
+            return;
+        }
+        match reap_run_workspace(
+            &self.runner_id,
+            &self.remote_path,
+            self.artifact_dir.as_deref(),
+        ) {
+            Ok(()) => eprintln!(
+                "Lab offload: reaped run-scoped workspace `{}` on runner `{}` (delete-on-success cleanup policy).",
+                self.remote_path, self.runner_id
+            ),
+            Err(err) => eprintln!(
+                "Lab offload: warning: could not reap run-scoped workspace `{}` on runner `{}`: {}. Reclaim leftover lab workspaces with `homeboy runner workspace prune {}`.",
+                self.remote_path, self.runner_id, err.message, self.runner_id
+            ),
+        }
+    }
+}

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -7,6 +7,7 @@
 //! runner subsystem so the historical `workspace::*` paths keep resolving.
 
 mod git;
+mod materialized;
 mod pull;
 mod snapshot;
 mod sync;
@@ -25,6 +26,7 @@ pub use types::{
     RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
+pub(crate) use materialized::{MaterializedWorkspace, WorkspaceCleanupPolicy};
 pub(crate) use snapshot::{
     copy_snapshot_to_directory, effective_snapshot_excludes, local_snapshot_stats,
     materialize_snapshot, materialize_snapshot_git, snapshot_identity,

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -298,6 +298,50 @@ pub fn prune_workspaces(
     ))
 }
 
+/// Reap a single run-scoped materialized workspace (and its sibling Homeboy
+/// artifact directory) created during an offloaded run.
+///
+/// This is the success-path teardown invoked by the run-owned
+/// [`MaterializedWorkspace`](super::materialized::MaterializedWorkspace) RAII
+/// handle. Historically the only teardown for `_lab_workspaces/<snapshot>`
+/// checkouts was the operator-driven [`prune_workspaces`] CLI, so every
+/// offloaded run left scraps on the lab (#6678).
+///
+/// Safety mirrors [`prune_workspaces`]: the target must live under
+/// `<workspace_root>/_lab_workspaces`, and removal is delegated to
+/// [`remove_workspace`], which refuses to delete the root itself or anything
+/// outside it. The controller owns the run lifecycle
+/// (`RunnerLifecycleOwner::Controller`, surfaced via the workspace lease built
+/// by [`workspace_lease`]), so reaping the exact path this run materialized is
+/// safe without the source-path-missing heuristic the bulk orphan prune applies.
+pub(crate) fn reap_run_workspace(
+    runner_id: &str,
+    remote_path: &str,
+    artifact_dir: Option<&str>,
+) -> Result<()> {
+    let runner = load(runner_id)?;
+    let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace_root",
+            "runner workspace reap requires workspace_root",
+            Some(runner.id.clone()),
+            None,
+        )
+    })?;
+    validate_absolute_path("workspace_root", workspace_root)?;
+    let lab_workspaces_root = format!("{}/_lab_workspaces", workspace_root.trim_end_matches('/'));
+    remove_workspace(&runner, &lab_workspaces_root, remote_path)?;
+    // The sibling Homeboy artifact directory (`<checkout>-homeboy-artifacts`)
+    // also lives under `_lab_workspaces`, so it passes the same containment
+    // guard. It only exists when the run requested `--output`, so a
+    // missing-directory removal error here is expected and non-fatal: the
+    // run-scoped checkout is already reaped above.
+    if let Some(artifact_dir) = artifact_dir {
+        let _ = remove_workspace(&runner, &lab_workspaces_root, artifact_dir);
+    }
+    Ok(())
+}
+
 pub fn list_workspaces(runner_id: &str, limit: usize) -> Result<(RunnerWorkspaceListOutput, i32)> {
     let runner = load(runner_id)?;
     let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {

--- a/src/core/runner/workspace/tests/mod.rs
+++ b/src/core/runner/workspace/tests/mod.rs
@@ -1,6 +1,7 @@
 mod deterministic;
 mod git;
 mod prune;
+mod reap;
 mod snapshot;
 mod snapshots;
 

--- a/src/core/runner/workspace/tests/reap.rs
+++ b/src/core/runner/workspace/tests/reap.rs
@@ -1,0 +1,193 @@
+use std::fs;
+use std::path::Path;
+
+use crate::core::runner::workspace::sync::{reap_run_workspace, sync_workspace};
+use crate::core::runner::workspace::types::{
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+};
+use crate::core::runner::{MaterializedWorkspace, WorkspaceCleanupPolicy};
+
+fn sync_options(path: String) -> RunnerWorkspaceSyncOptions {
+    RunnerWorkspaceSyncOptions {
+        path,
+        mode: RunnerWorkspaceSyncMode::Snapshot,
+        controller_routed_git: false,
+        changed_since_base: None,
+        git_fetch_refs: Vec::new(),
+        snapshot_includes: Vec::new(),
+        allow_dirty_lab_workspace: false,
+        run_isolation_token: None,
+    }
+}
+
+fn create_local_runner(id: &str, root: &Path) {
+    crate::core::runner::create(
+        &format!(
+            r#"{{"id":"{id}","kind":"local","workspace_root":"{}"}}"#,
+            root.display()
+        ),
+        false,
+    )
+    .expect("create runner");
+}
+
+/// Sync a fresh local runner workspace and return its remote checkout path.
+fn sync_local_workspace(runner_id: &str, runner_root: &Path) -> String {
+    let source_parent = tempfile::tempdir().expect("source parent");
+    let source = source_parent.path().join("reap-source");
+    fs::create_dir_all(&source).expect("source dir");
+    fs::write(source.join("file.txt"), "hello\n").expect("source file");
+    create_local_runner(runner_id, runner_root);
+    let (synced, _) = sync_workspace(runner_id, sync_options(source.display().to_string()))
+        .expect("sync workspace");
+    synced.remote_path
+}
+
+#[test]
+fn reap_run_workspace_removes_checkout_and_artifact_sibling() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let remote_path = sync_local_workspace("lab-local-reap", runner_root.path());
+
+        // The Homeboy-owned structured-output artifact dir is a sibling of the
+        // checkout (`<checkout>-homeboy-artifacts`), created only when the run
+        // requested `--output`. Reap must remove it alongside the checkout.
+        let artifact_dir = format!("{remote_path}-homeboy-artifacts");
+        fs::create_dir_all(&artifact_dir).expect("artifact dir");
+        fs::write(Path::new(&artifact_dir).join("out.json"), "{}").expect("artifact file");
+        assert!(Path::new(&remote_path).exists());
+        assert!(Path::new(&artifact_dir).exists());
+
+        reap_run_workspace("lab-local-reap", &remote_path, Some(&artifact_dir)).expect("reap");
+
+        assert!(!Path::new(&remote_path).exists(), "checkout was not reaped");
+        assert!(
+            !Path::new(&artifact_dir).exists(),
+            "artifact sibling was not reaped"
+        );
+    });
+}
+
+#[test]
+fn reap_run_workspace_refuses_paths_outside_lab_workspaces() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        create_local_runner("lab-local-reap-guard", runner_root.path());
+
+        // A path under workspace_root but NOT under `_lab_workspaces` must be
+        // refused by the containment guard, mirroring `prune_workspaces`.
+        let outside = runner_root.path().join("not-a-lab-workspace");
+        fs::create_dir_all(&outside).expect("outside dir");
+
+        let result = reap_run_workspace(
+            "lab-local-reap-guard",
+            &outside.display().to_string(),
+            None,
+        );
+
+        assert!(
+            result.is_err(),
+            "reap must refuse a path outside _lab_workspaces"
+        );
+        assert!(
+            outside.exists(),
+            "the containment guard must not delete an out-of-root path"
+        );
+    });
+}
+
+#[test]
+fn materialized_workspace_reaps_on_success_under_default_policy() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let remote_path = sync_local_workspace("lab-local-mat-success", runner_root.path());
+        assert!(Path::new(&remote_path).exists());
+
+        {
+            let mut handle = MaterializedWorkspace::new(
+                "lab-local-mat-success".to_string(),
+                remote_path.clone(),
+                None,
+                WorkspaceCleanupPolicy::default(),
+            );
+            handle.set_success(true);
+        } // drop reaps under the default delete-on-success policy
+
+        assert!(
+            !Path::new(&remote_path).exists(),
+            "success path must reap the run-scoped workspace"
+        );
+    });
+}
+
+#[test]
+fn materialized_workspace_preserves_on_failure_under_default_policy() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let remote_path = sync_local_workspace("lab-local-mat-failure", runner_root.path());
+
+        {
+            let mut handle = MaterializedWorkspace::new(
+                "lab-local-mat-failure".to_string(),
+                remote_path.clone(),
+                None,
+                WorkspaceCleanupPolicy::default(),
+            );
+            // A failed run is the default outcome (success never recorded).
+            handle.set_success(false);
+        } // drop preserves the workspace for post-mortem evidence
+
+        assert!(
+            Path::new(&remote_path).exists(),
+            "failure path must preserve the run-scoped workspace as evidence"
+        );
+    });
+}
+
+#[test]
+fn materialized_workspace_preserve_disarms_reap_even_on_success() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let remote_path = sync_local_workspace("lab-local-mat-detach", runner_root.path());
+
+        {
+            let mut handle = MaterializedWorkspace::new(
+                "lab-local-mat-detach".to_string(),
+                remote_path.clone(),
+                None,
+                WorkspaceCleanupPolicy::default(),
+            );
+            handle.set_success(true);
+            // A detached/in-flight remote job still owns the workspace.
+            handle.preserve();
+        }
+
+        assert!(
+            Path::new(&remote_path).exists(),
+            "preserve() must hand off ownership without reaping, even on success"
+        );
+    });
+}
+
+#[test]
+fn materialized_workspace_preserve_always_policy_never_reaps() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let remote_path = sync_local_workspace("lab-local-mat-preserve", runner_root.path());
+
+        {
+            let mut handle = MaterializedWorkspace::new(
+                "lab-local-mat-preserve".to_string(),
+                remote_path.clone(),
+                None,
+                WorkspaceCleanupPolicy::PreserveAlways,
+            );
+            handle.set_success(true);
+        }
+
+        assert!(
+            Path::new(&remote_path).exists(),
+            "PreserveAlways must never auto-reap, even on success"
+        );
+    });
+}


### PR DESCRIPTION
## Summary

Offloaded Lab runs stage a per-run checkout under `<workspace_root>/_lab_workspaces/<snapshot>` plus a sibling `<checkout>-homeboy-artifacts` directory, but nothing reaped them on the success path — the only teardown was the operator-driven `runner workspace prune` CLI, so **every offloaded run left scraps on the lab**. Local output temps also leaked on error.

**Implements #6678** (run-scoped temp + resource cleanup primitive).

## What changed

### 1. Run-owned `MaterializedWorkspace` RAII handle (`workspace/materialized.rs`)
- Carries a `WorkspaceCleanupPolicy`:
  - `PreserveOnFailure` (**default**): reap on success, preserve on failure so post-mortem evidence survives — chosen to avoid behavior shock.
  - `PreserveAlways`: never auto-reap (legacy prune-only behavior).
- Wired into **every** `run_lab_offload_inner` exit path:
  - **success** (`exit 0`) → reaps the checkout (and its `--output` artifact sibling).
  - **non-zero / pre-dispatch / patch-missing failures** → preserve.
  - **detach** and **in-flight daemon disconnect** → call `preserve()` so the live remote job keeps its checkout.
  - **durable agent-task runs** use `PreserveAlways` so the checkout survives for post-hoc `agent-task status/logs/artifacts` inspection.
- Reaping goes through a new `reap_run_workspace`, which reuses `remove_workspace`'s `_lab_workspaces` containment guard (refuses the root itself or anything outside it). Reap is best-effort: it logs (never propagates) on error, skips during panic unwind, and the CLI prune remains the backstop.

### 2. Local output-temp leak fix (`offload/inner.rs`, `offload/errors.rs`)
- `download_lab_output_file` and `write_local_output_file_atomically` now stage through `tempfile::NamedTempFile` (unique name, Drop-cleaned on every `?` return) instead of a **deterministic** `std::env::temp_dir()` path cleaned by a best-effort `remove_file` placed *after* the fallible read. The old shape leaked the temp whenever `read_to_string`/`write_all`/`sync_all` `?`-returned and risked cross-run collisions on the deterministic name.

## Verification

`cargo check` — clean (no new warnings; pre-existing warnings only).

Filtered tests (all pass):
- `core::runner::workspace::tests::reap` — 6 passed: reap removes checkout + artifact sibling; refuses out-of-root paths; RAII reaps on success, preserves on failure, honors `preserve()` and `PreserveAlways`.
- `core::runner::lab::offload::inner::read_downloaded_output_tests` — 3 passed: output temp removed on success, download-error, and read-error paths.
- `core::runner::lab::offload::tests::durable_fallbacks` — 7 passed (incl. existing atomic-write test, confirming the `NamedTempFile` refactor preserves behavior with no leftover `.tmp`).
- `core::runner::lab::offload::tests` — 84 passed.

Note: `core::runner::workspace::tests::git::git_materialization_ignores_generated_homeboy_output_but_refuses_source_dirty_state` fails on this machine, but it **also fails on `origin/main` with this branch's changes stashed** — a pre-existing, environment-specific failure unrelated to this PR.

## Scope notes / follow-ups

- **Deferred (item 3): #6752** — `sync_workspace` materializes the remote workspace *before* writing its tracking metadata, so a partial sync failure orphans an untracked directory that neither the bulk prune nor the new reap can see. Reordering conflicts with `snapshot_install_command`'s `rm -rf $dest && mv $tmp $dest`, so the fix needs a rollback-on-failure of the materialized dir; filed separately to keep this PR tight.
- The secret-in-argv `export KEY=value` rework in `ssh_client.rs` is intentionally **not** touched here — it belongs to the SecretEnvPlan work tracked in **#6676**.
- Related durable-workspace / lease + TTL cleanup work: **#6675**, **#6687**.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Investigating the offload cleanup gaps, designing/implementing the `MaterializedWorkspace` RAII handle and `reap_run_workspace`, the `NamedTempFile` temp-leak fixes, and the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)