### PR TITLE
git/release/deploy: make remote name and GitHub host generic

### DIFF
--- a/src/core/deploy/orchestration/preflight.rs
+++ b/src/core/deploy/orchestration/preflight.rs
@@ -9,8 +9,8 @@ use super::super::types::DeployConfig;
 /// Warn when `--head` would deploy from a non-default branch.
 ///
 /// Detects the current branch for each component and compares it against the
-/// default branch (via `git symbolic-ref refs/remotes/origin/HEAD`, falling
-/// back to "main"). If a component is on a feature branch, this is likely
+/// default branch (via [`git::default_branch_name`], falling back to "main").
+/// If a component is on a feature branch, this is likely
 /// unintentional — the user probably meant to deploy the default branch.
 ///
 /// With `--force`, this emits a log warning but proceeds. Without `--force`,
@@ -36,17 +36,9 @@ pub(super) fn warn_non_default_branch(
             _ => continue,                              // detached or error — skip
         };
 
-        // Detect default branch from remote HEAD symref, fallback to "main"
-        let default_branch = crate::core::engine::command::run_in_optional(
-            path,
-            "git",
-            &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-        )
-        .map(|s| {
-            // Output is like "origin/main" — strip the remote prefix
-            s.strip_prefix("origin/").unwrap_or(&s).to_string()
-        })
-        .unwrap_or_else(|| "main".to_string());
+        // Detect default branch from the resolved remote HEAD symref, fallback to "main"
+        let default_branch = git::default_branch_name(std::path::Path::new(path))
+            .unwrap_or_else(|| "main".to_string());
 
         if current_branch != default_branch {
             let message = format!(

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -526,7 +526,7 @@ impl GitProbeCache {
         }
 
         self.fetch_origin(git_root);
-        let default_branch = default_remote_branch(Path::new(git_root));
+        let default_branch = git::default_remote_branch(Path::new(git_root));
         self.default_remote_branch
             .insert(git_root.to_string(), default_branch.clone());
 
@@ -535,7 +535,7 @@ impl GitProbeCache {
 
     fn fetch_origin(&mut self, git_root: &str) {
         if self.fetched_origin.insert(git_root.to_string()) {
-            fetch_origin(Path::new(git_root));
+            fetch_default_remote(Path::new(git_root));
         }
     }
 }
@@ -580,9 +580,10 @@ pub(super) fn calculate_component_status_with_git_cache(
     version_status
 }
 
-fn fetch_origin(path: &Path) {
+fn fetch_default_remote(path: &Path) {
+    let remote = git::resolve_default_remote(path);
     let _ = Command::new("git")
-        .args(["fetch", "--quiet", "origin"])
+        .args(["fetch", "--quiet", &remote])
         .current_dir(path)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
@@ -603,24 +604,6 @@ fn git_output(path: &Path, args: &[&str]) -> Option<String> {
             let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
             (!value.is_empty()).then_some(value)
         })
-}
-
-fn default_remote_branch(path: &Path) -> Option<String> {
-    git_output(
-        path,
-        &[
-            "symbolic-ref",
-            "--quiet",
-            "--short",
-            "refs/remotes/origin/HEAD",
-        ],
-    )
-    .or_else(|| {
-        ["origin/main", "origin/trunk", "origin/master"]
-            .iter()
-            .find(|branch| git_output(path, &["rev-parse", "--verify", branch]).is_some())
-            .map(|branch| (*branch).to_string())
-    })
 }
 
 /// Calculate release state for a component.

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -472,10 +472,12 @@ fn is_mutable_dependency_spec(spec: &str) -> bool {
 
 /// Auto-detect the git remote URL from a local repository.
 ///
-/// Runs `git remote get-url origin` in the given directory.
+/// Resolves the repository's remote (preferring `origin`, falling back to a sole
+/// configured remote) and runs `git remote get-url <remote>` in the directory.
 pub fn detect_remote_url(repo_path: &Path) -> Option<String> {
+    let remote = crate::core::git::resolve_default_remote(repo_path);
     let output = std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
+        .args(["remote", "get-url", &remote])
         .current_dir(repo_path)
         .output()
         .ok()?;

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -373,7 +373,7 @@ impl ComponentDeployResult {
         self.git_branch = git_output(path, &["branch", "--show-current"]);
         self.git_head = git_output(path, &["rev-parse", "HEAD"]);
         self.upstream_branch = git_output(path, &["rev-parse", "--abbrev-ref", "@{upstream}"])
-            .or_else(|| default_remote_branch(path));
+            .or_else(|| crate::core::git::default_remote_branch(path));
         self.upstream_head = self
             .upstream_branch
             .as_deref()
@@ -443,24 +443,6 @@ fn detect_linked_worktree(path: &Path) -> Option<bool> {
         &["rev-parse", "--path-format=absolute", "--git-common-dir"],
     )?;
     Some(git_dir != common_dir)
-}
-
-fn default_remote_branch(path: &Path) -> Option<String> {
-    git_output(
-        path,
-        &[
-            "symbolic-ref",
-            "--quiet",
-            "--short",
-            "refs/remotes/origin/HEAD",
-        ],
-    )
-    .or_else(|| {
-        ["origin/main", "origin/trunk", "origin/master"]
-            .iter()
-            .find(|branch| git_output(path, &["rev-parse", "--verify", branch]).is_some())
-            .map(|branch| (*branch).to_string())
-    })
 }
 
 #[cfg(test)]

--- a/src/core/git/changes.rs
+++ b/src/core/git/changes.rs
@@ -265,7 +265,8 @@ fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
     eprintln!("Shallow clone detected — deepening to resolve merge base for {git_ref}");
 
     // Fetch the ref itself if it's not already present.
-    let _ = execute_git(path, &["fetch", "origin", git_ref, "--depth=50"]);
+    let remote = super::resolve_default_remote(Path::new(path));
+    let _ = execute_git(path, &["fetch", &remote, git_ref, "--depth=50"]);
 
     // Progressive deepening: try increasingly generous depths.
     for depth in &["50", "200"] {

--- a/src/core/git/gh_client.rs
+++ b/src/core/git/gh_client.rs
@@ -289,6 +289,26 @@ mod tests {
     }
 
     #[test]
+    fn for_repo_targets_parsed_enterprise_host_not_github_com() {
+        // Regression guard: GitHub primitives must target the host parsed from
+        // the component's remote_url, not silently default to github.com.
+        let repo = crate::core::deploy::release_download::GitHubRepo {
+            host: "github.a8c.com".to_string(),
+            owner: "acme".to_string(),
+            repo: "widgets".to_string(),
+        };
+
+        let client = GhClient::for_repo(&repo);
+
+        assert_eq!(client.host(), "github.a8c.com");
+        assert_eq!(client.repo(), Some("acme/widgets"));
+        // The enterprise host must be exported as GH_HOST for the `gh` process.
+        assert!(client
+            .env
+            .contains(&("GH_HOST".to_string(), "github.a8c.com".to_string())));
+    }
+
+    #[test]
     fn github_cli_env_sets_enterprise_host_and_configured_proxy() {
         let mut hosts = HashMap::new();
         hosts.insert(

--- a/src/core/git/github/client.rs
+++ b/src/core/git/github/client.rs
@@ -12,16 +12,22 @@ use crate::core::error::{Error, Result};
 use super::super::gh_client::GhClient;
 use super::super::resolve_target;
 
-/// Resolve a component ID to its GitHub owner/repo via `remote_url` (or git fallback).
+/// Resolve a component ID to its GitHub owner/repo via `remote_url` (or git fallback),
+/// returning a [`GhClient`] pre-configured for the repository's host.
 ///
 /// `path_override` lets callers point at an unregistered checkout (e.g. a CI
 /// runner workspace with a portable `homeboy.json` but no global component
 /// registry entry). When set, the component is discovered from the portable
 /// config at that path instead of the global registry.
+///
+/// The returned client carries the host parsed from `remote_url` plus the
+/// component's per-host GitHub config (proxy/env), so `gh` operations target the
+/// component's actual host — including GitHub Enterprise — instead of silently
+/// defaulting to `github.com`.
 pub(in crate::core::git) fn resolve_component_github(
     component_id: Option<&str>,
     path_override: Option<&str>,
-) -> Result<(String, GitHubRepo)> {
+) -> Result<(String, GitHubRepo, GhClient)> {
     let (id, path) = resolve_target(component_id, path_override)?;
     let comp = component::resolve_effective(Some(&id), path_override, None)?;
 
@@ -33,7 +39,7 @@ pub(in crate::core::git) fn resolve_component_github(
             Error::validation_invalid_argument(
                 "remote_url",
                 format!(
-                    "Component '{}' has no GitHub remote (remote_url not set and `git remote get-url origin` failed)",
+                    "Component '{}' has no GitHub remote (remote_url not set and `git remote get-url` failed)",
                     id
                 ),
                 None,
@@ -49,17 +55,19 @@ pub(in crate::core::git) fn resolve_component_github(
         Error::validation_invalid_argument(
             "remote_url",
             format!(
-                "Remote URL '{}' is not a GitHub URL (only github.com is supported)",
+                "Remote URL '{}' is not a GitHub URL (github.com and GitHub Enterprise hosts are supported)",
                 remote_url
             ),
             None,
             Some(vec![
                 "Use an HTTPS (https://github.com/owner/repo) or SSH (git@github.com:owner/repo) URL".to_string(),
+                "GitHub Enterprise equivalents such as git@github.example.com:owner/repo are also supported".to_string(),
             ]),
         )
     })?;
 
-    Ok((id, repo))
+    let client = GhClient::for_repo_with_config(&repo, &comp.github);
+    Ok((id, repo, client))
 }
 
 /// Run `gh <args>` swallowing stdout/stderr, return whether it exited successfully.
@@ -112,27 +120,15 @@ fn gh_auth_token() -> Option<String> {
     non_empty_token(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-/// Error out if `gh` is missing or unauthenticated. Unlike `run_github_release`
-/// (which soft-fails because the tag is already pushed), primitive operations
-/// have no already-committed side effect to preserve — fail loudly.
-pub(in crate::core::git) fn ensure_gh_ready() -> Result<()> {
-    let host = std::env::var("GH_HOST")
+/// Resolve the GitHub host for a repo-less `gh` probe, honoring `GH_HOST` and
+/// defaulting to `github.com`. Used by the few flows that run `gh` without a
+/// resolved component (e.g. commit-indexed PR search).
+pub(in crate::core::git) fn default_gh_host() -> String {
+    std::env::var("GH_HOST")
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "github.com".to_string());
-    GhClient::for_host(host).ensure_ready()
-}
-
-/// Run `gh <args>` and return stdout on success, or a structured error on
-/// failure (with stderr captured in the error message).
-pub(in crate::core::git) fn run_gh(args: &[String]) -> Result<String> {
-    let host = std::env::var("GH_HOST")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "github.com".to_string());
-    GhClient::for_host(host).run(args)
+        .unwrap_or_else(|| "github.com".to_string())
 }
 
 pub(super) fn parse_issue_number_from_url(url: &str) -> Option<u64> {

--- a/src/core/git/github/fleet.rs
+++ b/src/core/git/github/fleet.rs
@@ -3,12 +3,12 @@
 
 use crate::core::error::Result;
 
-use super::super::gh_client::pr_merge_api_args;
+use super::super::gh_client::{pr_merge_api_args, GhClient};
 use super::super::github_types::{
     GithubPrCheckRollup, GithubPrFleetItem, GithubPrFleetOutput, GithubPrFleetSummary,
     GithubPrView, PrFleetOptions,
 };
-use super::client::{ensure_gh_ready, resolve_component_github, run_gh};
+use super::client::resolve_component_github;
 use super::pulls::{pr_view, validate_pr_merge_method};
 
 /// Report and optionally land a fleet of PRs.
@@ -16,8 +16,8 @@ pub fn pr_fleet(
     component_id: Option<&str>,
     options: PrFleetOptions,
 ) -> Result<GithubPrFleetOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let merge_method = validate_pr_merge_method(&options.merge_method)?;
 
@@ -48,7 +48,7 @@ pub fn pr_fleet(
                 "-R".into(),
                 repo_flag.clone(),
             ];
-            match run_gh(&args) {
+            match gh.run(&args) {
                 Ok(_) => {
                     updated = true;
                     view = pr_view(Some(&id), parsed, options.path.clone())?;
@@ -63,13 +63,13 @@ pub fn pr_fleet(
             }
         }
 
-        let rollup = pr_fleet_check_rollup(&repo_flag, parsed)?;
+        let rollup = pr_fleet_check_rollup(&gh, &repo_flag, parsed)?;
         let mut item = pr_fleet_item(input, &view, rollup);
         item.updated = updated;
 
         if options.apply && item.mergeable {
             let args = pr_merge_api_args(&repo_flag, parsed, &merge_method);
-            match run_gh(&args) {
+            match gh.run(&args) {
                 Ok(_) => {
                     item.merged = true;
                     item.required_action = "merged".to_string();
@@ -133,7 +133,11 @@ fn pr_fleet_should_update_branch(view: &GithubPrView) -> bool {
     view.state == "OPEN" && view.merge_state.as_deref() == Some("BEHIND")
 }
 
-fn pr_fleet_check_rollup(repo_flag: &str, number: u64) -> Result<GithubPrCheckRollup> {
+fn pr_fleet_check_rollup(
+    gh: &GhClient,
+    repo_flag: &str,
+    number: u64,
+) -> Result<GithubPrCheckRollup> {
     let args: Vec<String> = vec![
         "pr".into(),
         "view".into(),
@@ -143,7 +147,7 @@ fn pr_fleet_check_rollup(repo_flag: &str, number: u64) -> Result<GithubPrCheckRo
         "--json".into(),
         "statusCheckRollup".into(),
     ];
-    let raw = run_gh(&args)?;
+    let raw = gh.run(&args)?;
     let parsed: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
         crate::core::error::Error::internal_json(
             format!("Failed to parse gh pr view statusCheckRollup JSON: {e}"),

--- a/src/core/git/github/issues.rs
+++ b/src/core/git/github/issues.rs
@@ -6,9 +6,7 @@ use super::super::github_types::{
     GithubFindItem, GithubFindOutput, GithubIssueOutput, IssueCloseOptions, IssueCommentOptions,
     IssueCreateOptions, IssueEditOptions, IssueFindOptions,
 };
-use super::client::{
-    ensure_gh_ready, parse_issue_number_from_url, resolve_component_github, run_gh,
-};
+use super::client::{parse_issue_number_from_url, resolve_component_github};
 use super::push_markdown_body_file_arg;
 
 /// Create a new issue on the component's GitHub repository.
@@ -16,8 +14,8 @@ pub fn issue_create(
     component_id: Option<&str>,
     options: IssueCreateOptions,
 ) -> Result<GithubIssueOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
 
     if options.title.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -44,7 +42,7 @@ pub fn issue_create(
         args.push(label.clone());
     }
 
-    let output = run_gh(&args)?;
+    let output = gh.run(&args)?;
     let url = output.trim().to_string();
     let number = parse_issue_number_from_url(&url);
 
@@ -66,8 +64,8 @@ pub fn issue_comment(
     component_id: Option<&str>,
     options: IssueCommentOptions,
 ) -> Result<GithubIssueOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let mut args: Vec<String> = vec![
@@ -80,7 +78,7 @@ pub fn issue_comment(
     let mut body_files = Vec::new();
     push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &options.body)?;
 
-    let output = run_gh(&args)?;
+    let output = gh.run(&args)?;
     Ok(GithubIssueOutput {
         component_id: id,
         owner: repo.owner,
@@ -105,8 +103,8 @@ pub fn issue_close(
     component_id: Option<&str>,
     options: IssueCloseOptions,
 ) -> Result<GithubIssueOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let mut args: Vec<String> = vec![
@@ -123,7 +121,7 @@ pub fn issue_close(
         args.push(comment.clone());
     }
 
-    let _ = run_gh(&args)?;
+    let _ = gh.run(&args)?;
     Ok(GithubIssueOutput {
         component_id: id,
         owner: repo.owner,
@@ -148,8 +146,8 @@ pub fn issue_edit(
     component_id: Option<&str>,
     options: IssueEditOptions,
 ) -> Result<GithubIssueOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
 
     if options.title.is_none()
         && options.body.is_none()
@@ -189,7 +187,7 @@ pub fn issue_edit(
         args.push(label.clone());
     }
 
-    let output = run_gh(&args)?;
+    let output = gh.run(&args)?;
     Ok(GithubIssueOutput {
         component_id: id,
         owner: repo.owner,
@@ -212,8 +210,8 @@ pub fn issue_find(
     component_id: Option<&str>,
     options: IssueFindOptions,
 ) -> Result<GithubFindOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let limit = if options.limit == 0 {
@@ -241,7 +239,7 @@ pub fn issue_find(
         args.push(label.clone());
     }
 
-    let raw = run_gh(&args)?;
+    let raw = gh.run(&args)?;
     let items = parse_issue_list_json(&raw, &options)?;
 
     Ok(GithubFindOutput {

--- a/src/core/git/github/mod.rs
+++ b/src/core/git/github/mod.rs
@@ -53,7 +53,7 @@ pub use super::github_types::{
 // re-exported at this module path so existing `super::github::X` paths keep
 // resolving after the split.
 pub(in crate::core) use body_file::push_markdown_body_file_arg;
-pub(in crate::core::git) use client::{ensure_gh_ready, resolve_component_github, run_gh};
+pub(in crate::core::git) use client::resolve_component_github;
 
 // Public probe/token helpers.
 pub use client::{gh_probe_succeeds, github_token_from_env_or_gh};

--- a/src/core/git/github/pulls.rs
+++ b/src/core/git/github/pulls.rs
@@ -6,21 +6,21 @@ use std::process::Command;
 
 use crate::core::error::{Error, Result};
 
-use super::super::gh_client::{delete_branch_ref_api_args, pr_merge_api_args};
+use super::super::gh_client::{delete_branch_ref_api_args, pr_merge_api_args, GhClient};
 use super::super::github_types::{
     GithubFindItem, GithubFindOutput, GithubPrOutput, GithubPrView, PrCreateOptions, PrEditOptions,
     PrFindOptions, PrMergeOptions,
 };
 use super::client::{
-    ensure_gh_ready, parse_issue_number_from_url, resolve_component_github, run_gh, string_value,
+    default_gh_host, parse_issue_number_from_url, resolve_component_github, string_value,
 };
 use super::push_markdown_body_file_arg;
 use super::readiness::classify_pr_ci;
 
 /// Open a new pull request.
 pub fn pr_create(component_id: Option<&str>, options: PrCreateOptions) -> Result<GithubPrOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
 
     if options.title.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -58,7 +58,7 @@ pub fn pr_create(component_id: Option<&str>, options: PrCreateOptions) -> Result
         args.push("--draft".into());
     }
 
-    let output = run_gh(&args)?;
+    let output = gh.run(&args)?;
     let url = output.trim().to_string();
     let number = parse_issue_number_from_url(&url);
 
@@ -80,8 +80,8 @@ pub fn pr_create(component_id: Option<&str>, options: PrCreateOptions) -> Result
 
 /// Edit an existing pull request's title and/or body.
 pub fn pr_edit(component_id: Option<&str>, options: PrEditOptions) -> Result<GithubPrOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
 
     if options.title.is_none() && options.body.is_none() {
         return Err(Error::validation_invalid_argument(
@@ -109,7 +109,7 @@ pub fn pr_edit(component_id: Option<&str>, options: PrEditOptions) -> Result<Git
         push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", body)?;
     }
 
-    let output = run_gh(&args)?;
+    let output = gh.run(&args)?;
     Ok(GithubPrOutput {
         component_id: id,
         owner: repo.owner,
@@ -125,8 +125,8 @@ pub fn pr_edit(component_id: Option<&str>, options: PrEditOptions) -> Result<Git
 
 /// Find PRs matching the given filter.
 pub fn pr_find(component_id: Option<&str>, options: PrFindOptions) -> Result<GithubFindOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let limit = if options.limit == 0 {
@@ -155,7 +155,7 @@ pub fn pr_find(component_id: Option<&str>, options: PrFindOptions) -> Result<Git
         args.push(head.clone());
     }
 
-    let raw = run_gh(&args)?;
+    let raw = gh.run(&args)?;
     let items = parse_pr_list_json(&raw)?;
 
     Ok(GithubFindOutput {
@@ -178,7 +178,13 @@ pub fn pr_find_by_commit(
     repo: Option<&str>,
     limit: usize,
 ) -> Result<Vec<GithubFindItem>> {
-    ensure_gh_ready()?;
+    // Resolve a host-aware client so readiness (and the GH_HOST passed to the
+    // raw `gh` below) target the repo's actual host, not always github.com.
+    let client = match repo {
+        Some(repo) => GhClient::from_repo_arg(repo)?,
+        None => GhClient::for_host(default_gh_host()),
+    };
+    client.ensure_ready()?;
 
     let mut args: Vec<String> = vec![
         "pr".into(),
@@ -197,9 +203,12 @@ pub fn pr_find_by_commit(
         args.push(repo.to_string());
     }
 
-    let output = Command::new("gh")
-        .args(&args)
-        .current_dir(repo_path)
+    let mut command = Command::new("gh");
+    command.args(&args).current_dir(repo_path);
+    if client.host() != "github.com" {
+        command.env("GH_HOST", client.host());
+    }
+    let output = command
         .stdin(std::process::Stdio::null())
         .output()
         .map_err(|e| {
@@ -228,8 +237,8 @@ pub fn pr_view(
     number: u64,
     path: Option<String>,
 ) -> Result<GithubPrView> {
-    let (id, repo) = resolve_component_github(component_id, path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, path.as_deref())?;
+    gh.ensure_ready()?;
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let args: Vec<String> = vec![
@@ -241,7 +250,7 @@ pub fn pr_view(
         "--json".into(),
         "author,baseRefName,headRefName,headRepository,title,url,state,isDraft,mergedAt,headRefOid,reviewDecision,mergeStateStatus,statusCheckRollup".into(),
     ];
-    let raw = run_gh(&args)?;
+    let raw = gh.run(&args)?;
     let parsed: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
         Error::internal_json(
             format!("Failed to parse gh pr view JSON: {}", e),
@@ -319,8 +328,8 @@ pub fn pr_files(
     number: u64,
     path: Option<String>,
 ) -> Result<Vec<String>> {
-    let (_id, repo) = resolve_component_github(component_id, path.as_deref())?;
-    ensure_gh_ready()?;
+    let (_id, repo, gh) = resolve_component_github(component_id, path.as_deref())?;
+    gh.ensure_ready()?;
     let args: Vec<String> = vec![
         "api".into(),
         "--paginate".into(),
@@ -328,7 +337,7 @@ pub fn pr_files(
         "--jq".into(),
         ".[].filename".into(),
     ];
-    let raw = run_gh(&args)?;
+    let raw = gh.run(&args)?;
     Ok(raw
         .lines()
         .map(str::trim)
@@ -340,8 +349,8 @@ pub fn pr_files(
 /// Merge a PR with an explicit method.
 pub fn pr_merge(component_id: Option<&str>, options: PrMergeOptions) -> Result<GithubPrOutput> {
     let method = validate_pr_merge_method(&options.method)?;
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let branch_to_delete = if options.delete_branch {
         let view = pr_view(Some(&id), options.number, options.path.clone())?;
@@ -351,11 +360,11 @@ pub fn pr_merge(component_id: Option<&str>, options: PrMergeOptions) -> Result<G
         None
     };
 
-    run_gh(&pr_merge_api_args(&repo_flag, options.number, &method))?;
+    gh.run(&pr_merge_api_args(&repo_flag, options.number, &method))?;
 
     let mut warnings = Vec::new();
     if let Some(branch) = branch_to_delete {
-        if let Err(error) = run_gh(&delete_branch_ref_api_args(&repo_flag, &branch)) {
+        if let Err(error) = gh.run(&delete_branch_ref_api_args(&repo_flag, &branch)) {
             warnings.push(format!("failed to delete branch {branch}: {error}"));
         }
     }

--- a/src/core/git/github_pr_comments.rs
+++ b/src/core/git/github_pr_comments.rs
@@ -3,9 +3,8 @@
 use crate::core::deploy::release_download::GitHubRepo;
 use crate::core::error::{Error, Result};
 
-use super::github::{
-    ensure_gh_ready, push_markdown_body_file_arg, resolve_component_github, run_gh, GithubPrOutput,
-};
+use super::gh_client::GhClient;
+use super::github::{push_markdown_body_file_arg, resolve_component_github, GithubPrOutput};
 use super::github_comment_sections::{
     comment_matches_key, extract_footer, extract_header, merge_section, parse_comment_sections,
     render_comment,
@@ -86,13 +85,13 @@ pub enum PrCommentMode {
 ///   invocation's section under `section_key` into the shared comment tagged
 ///   `<!-- homeboy:comment-key=<comment_key> -->`.
 pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Result<GithubPrOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
+    let (id, repo, gh) = resolve_component_github(component_id, options.path.as_deref())?;
+    gh.ensure_ready()?;
 
     match options.mode.clone() {
-        PrCommentMode::Fresh => pr_comment_fresh(id, repo, options),
+        PrCommentMode::Fresh => pr_comment_fresh(id, repo, &gh, options),
         PrCommentMode::StickyWholeBody { key } => {
-            pr_comment_sticky_whole(id, repo, options.number, options.body, key)
+            pr_comment_sticky_whole(id, repo, &gh, options.number, options.body, key)
         }
         PrCommentMode::Sectioned {
             comment_key,
@@ -103,6 +102,7 @@ pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Resu
         } => pr_comment_sectioned(
             id,
             repo,
+            &gh,
             options.number,
             options.body,
             comment_key,
@@ -119,6 +119,7 @@ pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Resu
 fn pr_comment_fresh(
     id: String,
     repo: GitHubRepo,
+    gh: &GhClient,
     options: PrCommentOptions,
 ) -> Result<GithubPrOutput> {
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
@@ -131,7 +132,7 @@ fn pr_comment_fresh(
     ];
     let mut body_files = Vec::new();
     push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &options.body)?;
-    let output = run_gh(&args)?;
+    let output = gh.run(&args)?;
     Ok(GithubPrOutput {
         component_id: id,
         owner: repo.owner,
@@ -148,13 +149,14 @@ fn pr_comment_fresh(
 fn pr_comment_sticky_whole(
     id: String,
     repo: GitHubRepo,
+    gh: &GhClient,
     pr_number: u64,
     body: String,
     key: String,
 ) -> Result<GithubPrOutput> {
     let full_body = format!("{}\n{}", marker_for_key(&key), body);
 
-    if let Some(existing_id) = find_sticky_comment_id(&repo, pr_number, &key)? {
+    if let Some(existing_id) = find_sticky_comment_id(gh, &repo, pr_number, &key)? {
         let args: Vec<String> = vec![
             "api".into(),
             format!(
@@ -166,7 +168,7 @@ fn pr_comment_sticky_whole(
             "-f".into(),
             format!("body={}", full_body),
         ];
-        run_gh(&args)?;
+        gh.run(&args)?;
         return Ok(GithubPrOutput {
             component_id: id,
             owner: repo.owner,
@@ -189,7 +191,7 @@ fn pr_comment_sticky_whole(
     ];
     let mut body_files = Vec::new();
     push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &full_body)?;
-    let output = run_gh(&args)?;
+    let output = gh.run(&args)?;
     Ok(GithubPrOutput {
         component_id: id,
         owner: repo.owner,
@@ -219,6 +221,7 @@ fn pr_comment_sticky_whole(
 fn pr_comment_sectioned(
     id: String,
     repo: GitHubRepo,
+    gh: &GhClient,
     pr_number: u64,
     section_body: String,
     comment_key: String,
@@ -227,7 +230,7 @@ fn pr_comment_sectioned(
     footer: Option<String>,
     section_order: Option<Vec<String>>,
 ) -> Result<GithubPrOutput> {
-    let matches = list_matching_comments(&repo, pr_number, &comment_key)?;
+    let matches = list_matching_comments(gh, &repo, pr_number, &comment_key)?;
 
     if matches.is_empty() {
         let sections: Vec<(String, String)> = vec![(section_key.clone(), section_body.clone())];
@@ -248,7 +251,7 @@ fn pr_comment_sectioned(
         ];
         let mut body_files = Vec::new();
         push_markdown_body_file_arg(&mut args, &mut body_files, "--body-file", &rendered)?;
-        let output = run_gh(&args)?;
+        let output = gh.run(&args)?;
         return Ok(GithubPrOutput {
             component_id: id,
             owner: repo.owner,
@@ -306,7 +309,7 @@ fn pr_comment_sectioned(
             "-f".into(),
             format!("body={}", rendered),
         ];
-        run_gh(&args)?;
+        gh.run(&args)?;
     }
 
     for comment in matches.iter().skip(1) {
@@ -319,7 +322,7 @@ fn pr_comment_sectioned(
             "--method".into(),
             "DELETE".into(),
         ];
-        if run_gh(&args).is_err() {
+        if gh.run(&args).is_err() {
             warnings.push(format!(
                 "failed to delete duplicate comment id={} — next invocation will retry",
                 comment.id
@@ -351,7 +354,12 @@ fn marker_for_key(key: &str) -> String {
 }
 
 /// Search a PR's issue-comments for one carrying our sticky marker.
-fn find_sticky_comment_id(repo: &GitHubRepo, pr_number: u64, key: &str) -> Result<Option<u64>> {
+fn find_sticky_comment_id(
+    gh: &GhClient,
+    repo: &GitHubRepo,
+    pr_number: u64,
+    key: &str,
+) -> Result<Option<u64>> {
     let marker = marker_for_key(key);
     let args: Vec<String> = vec![
         "api".into(),
@@ -363,7 +371,7 @@ fn find_sticky_comment_id(repo: &GitHubRepo, pr_number: u64, key: &str) -> Resul
         "--jq".into(),
         format!(".[] | select(.body | contains(\"{}\")) | .id", marker),
     ];
-    let raw = run_gh(&args)?;
+    let raw = gh.run(&args)?;
     Ok(raw.lines().next().and_then(|l| l.trim().parse().ok()))
 }
 
@@ -376,6 +384,7 @@ struct FetchedComment {
 /// List all PR issue-comments that carry the given comment-key marker. Returns
 /// `(id, body)` pairs so the merge step can parse each body.
 fn list_matching_comments(
+    gh: &GhClient,
     repo: &GitHubRepo,
     pr_number: u64,
     comment_key: &str,
@@ -388,7 +397,7 @@ fn list_matching_comments(
         ),
         "--paginate".into(),
     ];
-    let raw = run_gh(&args)?;
+    let raw = gh.run(&args)?;
     parse_comments_list_json(&raw, comment_key)
 }
 

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -77,9 +77,10 @@ pub use pr_refresh::{
     pr_refresh, PrRefreshCheck, PrRefreshOptions, PrRefreshOutput, PrRefreshStrategy,
 };
 pub use primitives::{
-    clone_repo, clone_repo_at_ref, commit_staged_with_author, get_component_path_prefix,
-    get_git_root, git_probe_path, has_staged_changes, is_workdir_clean_or_not_git, pull_repo,
-    run_git, run_git_output, stage_all, update_to_remote_default_branch,
+    clone_repo, clone_repo_at_ref, commit_staged_with_author, default_branch_name,
+    default_remote_branch, get_component_path_prefix, get_git_root, git_probe_path,
+    has_staged_changes, is_workdir_clean_or_not_git, pull_repo, resolve_default_remote, run_git,
+    run_git_output, stage_all, update_to_remote_default_branch,
 };
 pub(crate) use primitives::{is_git_repo, is_tracked_path, list_tracked_markdown_files};
 pub use primitives_query::{

--- a/src/core/git/operations_push.rs
+++ b/src/core/git/operations_push.rs
@@ -58,8 +58,16 @@ pub fn push_at(
         resolve_push_remote_url(options.remote_url.as_deref(), options.token.as_deref())?;
     let mut args: Vec<String> = Vec::new();
     if options.strip_extraheader {
+        // Clear the auth header injected by actions/checkout so URL auth wins.
+        // The header key is host-specific; derive it from the remote URL so
+        // GitHub Enterprise remotes are stripped correctly, not just github.com.
+        let host = options
+            .remote_url
+            .as_deref()
+            .and_then(github_https_host)
+            .unwrap_or_else(|| "github.com".to_string());
         args.push("-c".to_string());
-        args.push("http.https://github.com/.extraheader=".to_string());
+        args.push(format!("http.https://{host}/.extraheader="));
     }
     args.push("push".to_string());
     if options.tags {
@@ -71,7 +79,7 @@ pub fn push_at(
     if let Some(remote) = remote_url {
         args.push(remote);
     } else if options.refspec.is_some() {
-        args.push("origin".to_string());
+        args.push(super::resolve_default_remote(std::path::Path::new(&path)));
     }
     if let Some(refspec) = options.refspec {
         args.push(refspec);
@@ -82,16 +90,25 @@ pub fn push_at(
     Ok(GitOutput::from_output(id, path, "push", output))
 }
 
+/// Host of an `https://` GitHub remote URL (github.com or Enterprise), if the
+/// URL is an HTTPS GitHub URL. Returns `None` for SSH or non-GitHub URLs.
+fn github_https_host(url: &str) -> Option<String> {
+    if !url.starts_with("https://") {
+        return None;
+    }
+    crate::core::deploy::release_download::parse_github_url(url).map(|repo| repo.host)
+}
+
 fn resolve_push_remote_url(
     remote_url: Option<&str>,
     token: Option<&str>,
 ) -> Result<Option<String>> {
     match (remote_url, token) {
         (Some(url), Some(token)) => {
-            if !url.starts_with("https://github.com/") {
+            if github_https_host(url).is_none() {
                 return Err(Error::validation_invalid_argument(
                     "token",
-                    "--token requires --remote-url to start with https://github.com/",
+                    "--token requires --remote-url to be an https GitHub URL (e.g. https://github.com/owner/repo or https://github.a8c.com/owner/repo)",
                     None,
                     None,
                 ));
@@ -142,4 +159,42 @@ pub fn push_bulk(json_spec: &str) -> Result<BulkResult<GitOutput>> {
             },
         )
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_https_host_parses_github_com_and_enterprise() {
+        assert_eq!(
+            github_https_host("https://github.com/owner/repo.git").as_deref(),
+            Some("github.com")
+        );
+        assert_eq!(
+            github_https_host("https://github.a8c.com/owner/repo").as_deref(),
+            Some("github.a8c.com")
+        );
+    }
+
+    #[test]
+    fn github_https_host_rejects_ssh_and_non_github() {
+        assert_eq!(github_https_host("git@github.com:owner/repo.git"), None);
+        assert_eq!(github_https_host("https://example.com/owner/repo"), None);
+    }
+
+    #[test]
+    fn token_push_injects_token_for_enterprise_https_remote() {
+        let url = resolve_push_remote_url(Some("https://github.a8c.com/owner/repo.git"), Some("tok"))
+            .expect("enterprise https remote should be accepted");
+        assert_eq!(
+            url.as_deref(),
+            Some("https://x-access-token:tok@github.a8c.com/owner/repo.git")
+        );
+    }
+
+    #[test]
+    fn token_push_rejects_ssh_remote() {
+        assert!(resolve_push_remote_url(Some("git@github.com:owner/repo.git"), Some("tok")).is_err());
+    }
 }

--- a/src/core/git/operations_tags.rs
+++ b/src/core/git/operations_tags.rs
@@ -54,10 +54,11 @@ pub fn remote_tag_commit(path: &str, tag_name: &str) -> Result<Option<String>> {
 }
 
 fn remote_ref_commit(path: &str, ref_name: &str) -> Option<String> {
+    let remote = super::resolve_default_remote(Path::new(path));
     crate::core::engine::command::run_in_optional(
         path,
         "git",
-        &["ls-remote", "--tags", "origin", ref_name],
+        &["ls-remote", "--tags", &remote, ref_name],
     )
     .and_then(|output| {
         output
@@ -97,11 +98,12 @@ pub fn get_head_commit(path: &str) -> Result<String> {
 /// were created — the partial-release state in issue #3611, where the tag push
 /// succeeded but the branch push was rejected as non-fast-forward.
 pub fn remote_branch_commit(path: &str, branch: &str) -> Result<Option<String>> {
+    let remote = super::resolve_default_remote(Path::new(path));
     let ref_name = format!("refs/heads/{}", branch);
     Ok(crate::core::engine::command::run_in_optional(
         path,
         "git",
-        &["ls-remote", "--heads", "origin", &ref_name],
+        &["ls-remote", "--heads", &remote, &ref_name],
     )
     .and_then(|output| {
         output
@@ -110,12 +112,20 @@ pub fn remote_branch_commit(path: &str, branch: &str) -> Result<Option<String>> 
     }))
 }
 
-/// Fetch `origin` so remote-tracking refs reflect the current remote state.
+/// Fetch the resolved default remote so remote-tracking refs reflect the
+/// current remote state.
 ///
 /// A thin wrapper used by release recovery before it inspects how far the local
-/// branch has diverged from the advanced remote (issue #3611).
+/// branch has diverged from the advanced remote (issue #3611). The remote is
+/// resolved from the repository (preferring `origin`) rather than assumed.
 pub fn fetch_origin(path: &str) -> Result<()> {
-    crate::core::engine::command::run_in(path, "git", &["fetch", "origin"], "git fetch origin")?;
+    let remote = super::resolve_default_remote(Path::new(path));
+    crate::core::engine::command::run_in(
+        path,
+        "git",
+        &["fetch", &remote],
+        &format!("git fetch {remote}"),
+    )?;
     Ok(())
 }
 
@@ -155,11 +165,12 @@ pub fn delete_local_tag(path: &str, tag_name: &str) -> Result<GitOutput> {
     Ok(GitOutput::from_output(id, resolved, "tag.delete", output))
 }
 
-/// Delete a tag on the `origin` remote.
+/// Delete a tag on the resolved default remote.
 pub fn delete_remote_tag(path: &str, tag_name: &str) -> Result<GitOutput> {
     let (id, resolved) = resolve_target(None, Some(path))?;
+    let remote = super::resolve_default_remote(Path::new(&resolved));
     let refspec = format!(":refs/tags/{}", tag_name);
-    let output = execute_git(&resolved, &["push", "origin", &refspec])
+    let output = execute_git(&resolved, &["push", &remote, &refspec])
         .map_err(|e| Error::git_command_failed(e.to_string()))?;
     Ok(GitOutput::from_output(
         id,

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -160,31 +160,89 @@ pub fn commit_staged_with_author(git_root: &Path, message: &str, author: &str) -
     Ok(())
 }
 
-fn default_remote_branch(git_root: &Path) -> Option<String> {
-    run_git(
-        git_root,
-        &[
-            "symbolic-ref",
-            "--quiet",
-            "--short",
-            "refs/remotes/origin/HEAD",
-        ],
+/// Resolve the git remote name to use for release/deploy operations on a repo.
+///
+/// Homeboy core is framework-agnostic and must operate on repositories whose
+/// remote is not named `origin` (forks, renamed remotes, Enterprise mirrors).
+/// Resolution prefers `origin` when it exists (the overwhelmingly common case),
+/// then falls back to the repository's sole configured remote, and finally to
+/// the literal `"origin"` when nothing can be determined.
+pub fn resolve_default_remote(path: &Path) -> String {
+    let remotes: Vec<String> = run_git(path, &["remote"], "git remote")
+        .ok()
+        .map(|out| {
+            out.lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if remotes.iter().any(|remote| remote == "origin") {
+        return "origin".to_string();
+    }
+    if let [only] = remotes.as_slice() {
+        return only.clone();
+    }
+    "origin".to_string()
+}
+
+/// Resolve the remote-qualified default branch ref of a repository, e.g.
+/// `"origin/main"` or `"upstream/trunk"`.
+///
+/// Reads the resolved remote's `HEAD` symref first; when that is unset (common
+/// on fresh clones that never ran `git remote set-head`), probes the well-known
+/// default branch names against the resolved remote.
+pub fn default_remote_branch(path: &Path) -> Option<String> {
+    let remote = resolve_default_remote(path);
+    let head_ref = format!("refs/remotes/{remote}/HEAD");
+
+    if let Some(value) = run_git(
+        path,
+        &["symbolic-ref", "--quiet", "--short", &head_ref],
         "git default remote branch",
     )
     .ok()
     .map(|value| value.trim().to_string())
     .filter(|value| !value.is_empty())
+    {
+        return Some(value);
+    }
+
+    ["main", "trunk", "master"].iter().find_map(|branch| {
+        let candidate = format!("{remote}/{branch}");
+        run_git(
+            path,
+            &["rev-parse", "--verify", "--quiet", &candidate],
+            "git rev-parse",
+        )
+        .is_ok()
+        .then_some(candidate)
+    })
+}
+
+/// Resolve the bare default branch name of a repository, e.g. `"main"`,
+/// stripping the remote prefix from [`default_remote_branch`].
+pub fn default_branch_name(path: &Path) -> Option<String> {
+    default_remote_branch(path).map(|reference| {
+        reference
+            .split_once('/')
+            .map(|(_, branch)| branch.to_string())
+            .unwrap_or(reference)
+    })
 }
 
 /// Update a clean linked repo to the latest remote default-branch revision.
 pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
+    let remote = resolve_default_remote(git_root);
     let old_branch = current_branch(git_root);
-    run_git(git_root, &["fetch", "origin"], "git fetch origin")?;
+    run_git(git_root, &["fetch", &remote], &format!("git fetch {remote}"))?;
     let mut detached_default_branch: Option<String> = None;
 
     if let Some(remote_branch) = default_remote_branch(git_root) {
         let local_branch = remote_branch
-            .strip_prefix("origin/")
+            .strip_prefix(&format!("{remote}/"))
             .unwrap_or(&remote_branch)
             .to_string();
 
@@ -208,7 +266,7 @@ pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
     if let Some(branch) = detached_default_branch {
         run_git(
             git_root,
-            &["pull", "--ff-only", "origin", &branch],
+            &["pull", "--ff-only", &remote, &branch],
             "git pull detached default branch --ff-only",
         )?;
     } else {
@@ -357,5 +415,68 @@ mod tests {
         assert!(err.details["io_error"].as_str().is_some());
         assert_eq!(err.details["stdout"], "");
         assert_eq!(err.details["stderr"], "");
+    }
+
+    #[test]
+    fn resolve_default_remote_prefers_origin_then_sole_remote() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path();
+        git(path, &["init", "-q"]);
+
+        // No remotes configured — fall back to the conventional "origin".
+        assert_eq!(resolve_default_remote(path), "origin");
+
+        // A single non-origin remote resolves to that remote.
+        git(
+            path,
+            &["remote", "add", "upstream", "https://example.test/x.git"],
+        );
+        assert_eq!(resolve_default_remote(path), "upstream");
+
+        // Once origin exists it is preferred even alongside other remotes.
+        git(
+            path,
+            &["remote", "add", "origin", "https://example.test/y.git"],
+        );
+        assert_eq!(resolve_default_remote(path), "origin");
+    }
+
+    #[test]
+    fn default_branch_resolves_through_a_non_origin_remote() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = tmp.path().join("remote.git");
+        let seed = tmp.path().join("seed");
+        let clone = tmp.path().join("clone");
+
+        git(
+            tmp.path(),
+            &["init", "--bare", "-b", "main", remote.to_str().unwrap()],
+        );
+        git(
+            tmp.path(),
+            &["clone", "-q", remote.to_str().unwrap(), seed.to_str().unwrap()],
+        );
+        git(&seed, &["config", "user.email", "t@x.test"]);
+        git(&seed, &["config", "user.name", "T"]);
+        git(&seed, &["config", "commit.gpgsign", "false"]);
+        std::fs::write(seed.join("f.txt"), "x").unwrap();
+        git(&seed, &["add", "."]);
+        git(&seed, &["commit", "-q", "-m", "init"]);
+        git(&seed, &["push", "-q", "origin", "main"]);
+
+        // Fresh clone records refs/remotes/origin/HEAD; rename it so the remote
+        // is deliberately NOT named origin.
+        git(
+            tmp.path(),
+            &["clone", "-q", remote.to_str().unwrap(), clone.to_str().unwrap()],
+        );
+        git(&clone, &["remote", "rename", "origin", "upstream"]);
+
+        assert_eq!(resolve_default_remote(&clone), "upstream");
+        assert_eq!(
+            default_remote_branch(&clone).as_deref(),
+            Some("upstream/main")
+        );
+        assert_eq!(default_branch_name(&clone).as_deref(), Some("main"));
     }
 }

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -252,11 +252,12 @@ fn latest_release_tag(local_path: &str, tag_prefix: Option<&str>) -> Result<Opti
 }
 
 fn latest_remote_release_tag(local_path: &str, tag_prefix: Option<&str>) -> Result<Option<String>> {
-    let output = git::execute_git_for_release(local_path, &["ls-remote", "--tags", "origin"])
+    let remote = git::resolve_default_remote(std::path::Path::new(local_path));
+    let output = git::execute_git_for_release(local_path, &["ls-remote", "--tags", &remote])
         .map_err(|e| {
             Error::internal_io(
                 format!("Failed to inspect remote release tags: {}", e),
-                Some("git ls-remote --tags origin".to_string()),
+                Some(format!("git ls-remote --tags {remote}")),
             )
         })?;
 

--- a/src/core/release/planning_git.rs
+++ b/src/core/release/planning_git.rs
@@ -53,8 +53,9 @@ pub(super) fn validate_default_branch(component: &Component) -> Result<()> {
 
 pub(super) fn validate_default_branch_ancestry(component: &Component) -> Result<()> {
     let current_branch = current_branch(component)?;
+    let remote = source_remote(component);
     let default_branch = default_branch(component);
-    let remote_default_ref = format!("origin/{default_branch}");
+    let remote_default_ref = format!("{remote}/{default_branch}");
 
     let remote_default_revision = git::run_git(
         std::path::Path::new(&component.local_path),
@@ -74,8 +75,8 @@ pub(super) fn validate_default_branch_ancestry(component: &Component) -> Result<
             None,
             Some(vec![
                 format!(
-                    "Fetch the default branch before running `homeboy release --apply`: git fetch origin {}",
-                    default_branch
+                    "Fetch the default branch before running `homeboy release --apply`: git fetch {} {}",
+                    remote, default_branch
                 ),
                 format!(
                     "Release from '{}' so the tag target is published through the default branch",
@@ -116,8 +117,9 @@ pub(super) fn validate_head_reachable_from_default_branch(component: &Component)
         &["symbolic-ref", "--short", "HEAD"],
     )
     .unwrap_or_else(|| "detached HEAD".to_string());
+    let remote = source_remote(component);
     let default_branch = default_branch(component);
-    let remote_default_ref = format!("origin/{default_branch}");
+    let remote_default_ref = format!("{remote}/{default_branch}");
     let remote_default_revision = git::run_git(
         std::path::Path::new(&component.local_path),
         &["rev-parse", &remote_default_ref],
@@ -135,8 +137,8 @@ pub(super) fn validate_head_reachable_from_default_branch(component: &Component)
             ),
             None,
             Some(vec![format!(
-                "Fetch the default branch before running `homeboy release --apply`: git fetch origin {}",
-                default_branch
+                "Fetch the default branch before running `homeboy release --apply`: git fetch {} {}",
+                remote, default_branch
             )]),
         )
     })?;
@@ -184,14 +186,13 @@ fn current_branch(component: &Component) -> Result<String> {
 }
 
 fn default_branch(component: &Component) -> String {
-    command::run_in_optional(
-        &component.local_path,
-        "git",
-        &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-    )
-    .map(|value| value.trim().trim_start_matches("origin/").to_string())
-    .filter(|value| !value.is_empty())
-    .unwrap_or_else(|| "main".to_string())
+    git::default_branch_name(std::path::Path::new(&component.local_path))
+        .unwrap_or_else(|| "main".to_string())
+}
+
+/// Remote name to use for the component's source repo (resolved, not assumed).
+fn source_remote(component: &Component) -> String {
+    git::resolve_default_remote(std::path::Path::new(&component.local_path))
 }
 
 #[cfg(test)]
@@ -238,6 +239,37 @@ mod tests {
         run_git(dir, &["symbolic-ref", "HEAD", "refs/heads/main"]);
 
         validate_default_branch(&git_component(dir)).expect("main should be allowed");
+    }
+
+    #[test]
+    fn test_validate_default_branch_allows_default_branch_with_non_origin_remote() {
+        // A framework-agnostic orchestrator must release repos whose remote is
+        // not named `origin`. Clone, rename the remote to `upstream`, and verify
+        // the default-branch validation still resolves the default through the
+        // renamed remote.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote = temp.path().join("remote.git");
+        let seed = temp.path().join("seed");
+        let checkout = temp.path().join("checkout");
+        let remote_str = remote.to_string_lossy().to_string();
+
+        run_git(
+            temp.path(),
+            &["init", "--bare", "--initial-branch", "main", &remote_str],
+        );
+        run_git(temp.path(), &["clone", &remote_str, "seed"]);
+        configure_git_user(&seed);
+        std::fs::write(seed.join("README.md"), "fixture\n").expect("write fixture");
+        run_git(&seed, &["add", "."]);
+        run_git(&seed, &["commit", "-q", "-m", "Initial commit"]);
+        run_git(&seed, &["push", "-q", "origin", "main"]);
+
+        run_git(temp.path(), &["clone", &remote_str, "checkout"]);
+        configure_git_user(&checkout);
+        run_git(&checkout, &["remote", "rename", "origin", "upstream"]);
+
+        validate_default_branch(&git_component(&checkout))
+            .expect("default branch should be allowed through a non-origin remote");
     }
 
     #[test]


### PR DESCRIPTION
Closes #6749.

## Problem

Homeboy core's release/deploy/git cluster was not framework-agnostic about the git remote or the GitHub host:

1. The remote name `origin` was hardcoded across ~12 sites, so repos whose remote is not named `origin` (forks, renamed remotes, mirrors) could not be released/deployed.
2. `run_gh` / `ensure_gh_ready` ignored the host parsed into `GitHubRepo` and re-derived it from `GH_HOST` (defaulting to `github.com`), so a `github.a8c.com` component silently targeted `github.com`. Token pushes also hardcoded `https://github.com/`.

Per the project rule that Homeboy core must remain product/framework agnostic, remote name and host must be resolved from the repository/component, not assumed.

## Changes

**1. One shared default-branch helper; delete the copies**
- New `git::resolve_default_remote`, `git::default_remote_branch`, `git::default_branch_name` in `git/primitives.rs`.
- Removed the 5+ re-rolled copies in `git/primitives.rs`, `deploy/planning.rs`, `deploy/types.rs`, `deploy/orchestration/preflight.rs`, and the inline copy in `release/planning_git.rs`.

**2. Resolve the remote instead of hardcoding `origin`**
- `git/operations_tags.rs` (ls-remote/fetch/push), `git/operations_push.rs` (refspec push), `git/changes.rs` (shallow deepen fetch), `git/primitives.rs` (`update_to_remote_default_branch`), `deploy/planning.rs` (fetch), `deploy/release_download.rs` (`detect_remote_url`), `release/execution_plan.rs` (ls-remote tags), and `release/planning_git.rs` (`origin/<branch>` refs + hints) now operate on the repo's actual remote (prefer `origin`, else a sole configured remote). Low-level primitives resolve internally from the path they already hold, so no out-of-scope caller signatures change.

**3. Fix the GitHub Enterprise host defect**
- `resolve_component_github` now returns a host-aware `GhClient` built via `GhClient::for_repo_with_config(&repo, &component.github)` (host parsed from `remote_url` + per-host proxy/env) and threads it through every `gh` primitive in `issues.rs`, `pulls.rs`, `fleet.rs`, and `github_pr_comments.rs`. The host-ignoring free `run_gh`/`ensure_gh_ready` wrappers are removed.
- `pr_find_by_commit` (the one repo-less flow) builds a host-aware client from its `repo` arg / `GH_HOST` and passes `GH_HOST` to its raw `gh` invocation.
- Token pushes in `operations_push.rs` derive the host from the supplied remote URL (accepting Enterprise https remotes) instead of hardcoding `https://github.com/`; the actions/checkout extraheader strip is now host-specific too.
- Corrected the misleading "only github.com is supported" validation message.

## Tests

- `resolve_default_remote` prefers `origin`, falls back to a sole non-origin remote.
- `default_remote_branch` / `default_branch_name` resolve through a renamed (`upstream`) remote.
- `validate_default_branch` passes through a non-origin remote end-to-end (planning path).
- `GhClient::for_repo` targets the parsed Enterprise host (`github.a8c.com`) and exports `GH_HOST` — regression guard for the host bug.
- `operations_push` token-push helpers accept Enterprise https remotes, reject SSH.

## Verification

- `cargo check` — clean (no new errors/warnings in scope).
- `cargo test --lib core::git::` — 165 passed, 0 failed.
- `cargo test --lib core::release::` — 281 passed, 0 failed.
- `cargo test --lib core::deploy::` — 176 passed, 0 failed.

## Scope / deferred

Intentionally out of scope (noted in #6749 for separate follow-ups): broader `GhClient` sprawl consolidation, stack right-sizing, and `reconcile_branch` dedup. `deploy/types.rs` remains a DTO that shells out to git for several fields; only the duplicated default-branch helper was removed here — fully de-git-ifying that DTO is a larger refactor.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Investigating the remote/host hardcoding across the release/deploy/git cluster, implementing the shared helper + remote resolution + GitHub Enterprise host fix, and writing the regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
