### PR TITLE
fix: resolve compiler warnings in 6 core files

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -509,14 +509,8 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-06-22T13:13:12Z",
-      "item_count": 338,
+      "item_count": 332,
       "known_fingerprints": [
-        "compiler::src/commands/runs/gh_actions.rs::CompilerWarning",
-        "compiler::src/commands/trace.rs::CompilerWarning",
-        "compiler::src/core/agent_runtime_manifest.rs::CompilerWarning",
-        "compiler::src/core/deploy/generated_artifacts.rs::CompilerWarning",
-        "compiler::src/core/lab_routing.rs::CompilerWarning",
-        "compiler::src/core/runner/lab/agent_task_bridge.rs::CompilerWarning",
         "core_boundary_leak:core-agnostic-source::src/core/ci_failure_log_triage.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `classify_failure`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/ci_failure_log_triage.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `looks_like_source_path`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/code_audit/codebase_map.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `default_source_extensions`::CoreBoundaryLeak",

--- a/src/commands/runs/gh_actions.rs
+++ b/src/commands/runs/gh_actions.rs
@@ -560,12 +560,6 @@ fn parse_runs_payload(body: &[u8]) -> homeboy::core::Result<Vec<GhWorkflowRun>> 
     Ok(runs)
 }
 
-fn parse_run_payload(body: &[u8]) -> homeboy::core::Result<GhWorkflowRun> {
-    let raw: GhWorkflowRunRaw = serde_json::from_slice(body)
-        .map_err(|e| Error::internal_json(e.to_string(), Some("parse workflow run".into())))?;
-    Ok(GhWorkflowRun::from(raw))
-}
-
 /// Drop runs whose `created_at` is older than the `--since` window.
 fn filter_runs_by_since(
     runs: Vec<GhWorkflowRun>,
@@ -878,36 +872,6 @@ mod tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].common.id, 100);
         assert_eq!(runs[0].pull_request_numbers, vec![98]);
-    }
-
-    #[test]
-    fn parse_run_payload_handles_single_run_response() {
-        let raw = serde_json::to_vec(&serde_json::json!({
-            "id": 26731420339u64,
-            "run_number": 42,
-            "name": "Static site validation iterator",
-            "workflow_id": 123,
-            "head_branch": "main",
-            "head_sha": "deadbeef",
-            "event": "workflow_dispatch",
-            "status": "completed",
-            "conclusion": "failure",
-            "run_started_at": "2026-05-31T10:00:00Z",
-            "created_at": "2026-05-31T09:59:00Z",
-            "updated_at": "2026-05-31T10:05:00Z",
-            "run_attempt": 1,
-            "pull_requests": []
-        }))
-        .unwrap();
-
-        let run = parse_run_payload(&raw).expect("parse run");
-        assert_eq!(run.common.id, 26731420339);
-        assert_eq!(
-            run.workflow_name.as_deref(),
-            Some("Static site validation iterator")
-        );
-        assert_eq!(run.common.workflow_id, Some(123));
-        assert_eq!(map_gh_conclusion_to_status(&run), "fail");
     }
 
     #[test]

--- a/src/core/deploy/generated_artifacts.rs
+++ b/src/core/deploy/generated_artifacts.rs
@@ -11,12 +11,6 @@ pub(super) fn is_generated_build_path(rel_path: &str) -> bool {
     rel_path == build_dir || rel_path.starts_with(&format!("{build_dir}/"))
 }
 
-pub(super) fn unexpected_uncommitted_files_excluding_generated_build(
-    component: &Component,
-) -> Result<Vec<String>> {
-    Ok(uncommitted_file_report_excluding_known_generated(component)?.unexpected)
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct UncommittedFileReport {
     pub(super) unexpected: Vec<String>,
@@ -191,7 +185,6 @@ mod tests {
     use super::{
         cleanup_generated_build_artifacts, is_deploy_target_debris_path, is_generated_build_path,
         uncommitted_file_report_excluding_known_generated,
-        unexpected_uncommitted_files_excluding_generated_build,
     };
     use crate::core::component::{CleanupArtifactDeclaration, Component};
     use crate::core::defaults::deploy_generated_build_dir;
@@ -247,8 +240,9 @@ mod tests {
             local_path: dir.to_string_lossy().to_string(),
             ..Component::default()
         };
-        let unexpected =
-            unexpected_uncommitted_files_excluding_generated_build(&component).expect("status");
+        let unexpected = uncommitted_file_report_excluding_known_generated(&component)
+            .expect("status")
+            .unexpected;
 
         assert_eq!(unexpected, vec!["src.rs"]);
     }

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -156,20 +156,6 @@ fn agent_task_run_plan_lifecycle_output<'a>(
     output_file_content.unwrap_or(stdout)
 }
 
-pub(super) fn parse_offloaded_dispatch_envelope(stdout: &str) -> Result<Option<serde_json::Value>> {
-    Ok(parse_offloaded_agent_task_handoff(stdout)?.map(|handoff| handoff.envelope))
-}
-
-pub(super) fn parse_offloaded_dispatch_envelope_from_outputs(
-    stdout: &str,
-    stderr: &str,
-) -> Result<Option<serde_json::Value>> {
-    Ok(
-        parse_offloaded_agent_task_handoff_from_outputs(stdout, stderr)?
-            .map(|handoff| handoff.envelope),
-    )
-}
-
 pub(super) fn parse_offloaded_agent_task_handoff_from_outputs(
     stdout: &str,
     stderr: &str,
@@ -627,8 +613,9 @@ mod tests {
             "{\"success\":false,\"data\":{\"schema\":\"homeboy/agent-task-dispatch/v1\",\"run_id\":\"run-1\",\"state\":\"failed\",\"record\":{},\"aggregate\":{\"status\":\"failed\"}}}\n"
         );
 
-        let parsed = parse_offloaded_dispatch_envelope(stdout)
+        let parsed = parse_offloaded_agent_task_handoff(stdout)
             .expect("parse dispatch stdout")
+            .map(|handoff| handoff.envelope)
             .expect("dispatch envelope found");
 
         assert_eq!(parsed["run_id"], "run-1");
@@ -665,8 +652,9 @@ mod tests {
             "}\n"
         );
 
-        let parsed = parse_offloaded_dispatch_envelope_from_outputs(stdout, stderr)
+        let parsed = parse_offloaded_agent_task_handoff_from_outputs(stdout, stderr)
             .expect("parse dispatch outputs")
+            .map(|handoff| handoff.envelope)
             .expect("dispatch envelope found");
 
         assert_eq!(


### PR DESCRIPTION
Removes dead private functions, unused imports, and fixes privacy-mismatch warnings across gh_actions, trace, agent_runtime_manifest, deploy/generated_artifacts, lab_routing, agent_task_bridge. Clears CompilerWarning baseline rows. Verified cargo build --lib --tests exit 0, warning-free.