### PR TITLE
Symlink shared monorepo assets for linked extension installs (live local iteration)

### DIFF
--- a/src/core/extension/lifecycle/install_sources.rs
+++ b/src/core/extension/lifecycle/install_sources.rs
@@ -161,7 +161,9 @@ pub(crate) fn resolve_cloned_extension(
         let content = local_files::local().read(&manifest_in_subdir)?;
         let _manifest: ExtensionManifest = from_str(&content)?;
 
-        install_shared_assets_from_root(temp_dir, extension_dir)?;
+        // Cloned installs copy: the clone temp dir is discarded after install,
+        // so the shared trees must be materialized as standalone copies.
+        install_shared_assets_from_root(temp_dir, extension_dir, SharedAssetMode::Copy)?;
 
         // Move just the subdirectory to the final extension location.
         rename_dir(&subdir, extension_dir)?;
@@ -199,6 +201,21 @@ pub(crate) fn resolve_cloned_extension(
     )))
 }
 
+/// How a shared monorepo asset tree is materialized into `~/.config/homeboy/`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SharedAssetMode {
+    /// Copy the tree into place. Used for cloned installs, where the clone temp
+    /// directory is discarded after install and there is no live source to point
+    /// back to.
+    Copy,
+    /// Symlink the install target to its live source tree. Used for linked/dev
+    /// installs (local-path source): edits to the shared monorepo assets
+    /// (`agent-runtimes`, `runtime-agent-ci`, `scripts/lib`,
+    /// `agent-task-contracts`) in the source worktree are visible to the live
+    /// install immediately, with no reinstall or release. See #6396 / #1954.
+    Symlink,
+}
+
 /// Shared assets installed from a monorepo extension source root.
 ///
 /// Each entry maps a source-relative directory to its install target. The
@@ -208,7 +225,15 @@ pub(crate) fn resolve_cloned_extension(
 /// invocation. The rest of the monorepo `scripts/` tree is repo dev/CI tooling
 /// that never participates in the installed layout, so lifecycle no longer
 /// installs it under `~/.config/homeboy/extensions/scripts`.
-fn install_shared_assets_from_root(source_root: &Path, extension_dir: &Path) -> Result<()> {
+///
+/// `mode` selects copy vs symlink materialization. Cloned installs copy;
+/// linked/dev installs symlink so local edits to the shared trees go live
+/// without a reinstall.
+fn install_shared_assets_from_root(
+    source_root: &Path,
+    extension_dir: &Path,
+    mode: SharedAssetMode,
+) -> Result<()> {
     let Some(extensions_dir) = extension_dir.parent() else {
         return Ok(());
     };
@@ -239,31 +264,81 @@ fn install_shared_assets_from_root(source_root: &Path, extension_dir: &Path) -> 
                 )
             })?;
         }
-        if target.exists() {
-            std::fs::remove_dir_all(&target).map_err(|e| {
-                Error::internal_io(
-                    e.to_string(),
-                    Some(format!("replace shared extension {shared_dir}")),
-                )
-            })?;
+        remove_existing_target(&target, shared_dir)?;
+
+        match mode {
+            SharedAssetMode::Copy => copy_dir_recursive(&source, &target)?,
+            SharedAssetMode::Symlink => symlink_shared_asset(&source, &target, shared_dir)?,
         }
-        copy_dir_recursive(&source, &target)?;
     }
 
     Ok(())
 }
 
+/// Remove a shared-asset install target if present, handling both real
+/// directories (previous copy installs) and symlinks (previous linked installs)
+/// so re-installs are idempotent regardless of the prior materialization mode.
+fn remove_existing_target(target: &Path, shared_dir: &str) -> Result<()> {
+    let Ok(meta) = std::fs::symlink_metadata(target) else {
+        return Ok(());
+    };
+    let remove = if meta.file_type().is_symlink() || meta.is_file() {
+        std::fs::remove_file(target)
+    } else {
+        std::fs::remove_dir_all(target)
+    };
+    remove.map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("replace shared extension {shared_dir}")),
+        )
+    })
+}
+
+/// Symlink a shared-asset install target to its live source tree.
+///
+/// The source is canonicalized to an absolute path so the link stays valid
+/// regardless of the caller's working directory and resolves to the live source
+/// worktree (making in-place edits visible to the install).
+fn symlink_shared_asset(source: &Path, target: &Path, shared_dir: &str) -> Result<()> {
+    let resolved = std::fs::canonicalize(source).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("resolve shared extension source {shared_dir}")),
+        )
+    })?;
+
+    #[cfg(unix)]
+    let result = std::os::unix::fs::symlink(&resolved, target);
+
+    #[cfg(windows)]
+    let result = std::os::windows::fs::symlink_dir(&resolved, target);
+
+    result.map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("symlink shared extension {shared_dir}")),
+        )
+    })
+}
+
+/// Materialize shared monorepo assets for a linked (local-path) install.
+///
+/// Linked installs symlink the shared trees to their live source so that edits
+/// to `agent-runtimes`, `runtime-agent-ci`, `scripts/lib`, and
+/// `agent-task-contracts` in the source worktree take effect immediately,
+/// enabling rapid local iteration without a reinstall or release.
 pub(crate) fn install_linked_shared_assets(
     source: &Path,
     extension_dir: &Path,
     source_root: Option<&Path>,
 ) -> Result<()> {
     if let Some(source_root) = source_root {
-        return install_shared_assets_from_root(source_root, extension_dir);
+        return install_shared_assets_from_root(source_root, extension_dir, SharedAssetMode::Symlink);
     }
 
     if let Some(parent) = source.parent() {
-        install_shared_assets_from_root(parent, extension_dir)?;
+        install_shared_assets_from_root(parent, extension_dir, SharedAssetMode::Symlink)?;
     }
     Ok(())
 }

--- a/src/core/extension/lifecycle/mod.rs
+++ b/src/core/extension/lifecycle/mod.rs
@@ -804,6 +804,35 @@ exec '{}' "$@"
         });
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn cloned_install_copies_shared_trees_rather_than_symlinking() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            write_extension_fixture(&source, "wordpress");
+            write_shared_runtime_fixture(&source);
+            let remote = match prepare_git_repo(&source) {
+                Some(remote) => remote,
+                None => return,
+            };
+            let remote_url = remote.path().join("extension.git");
+
+            install(&remote_url.to_string_lossy(), Some("wordpress"))
+                .expect("install cloned extension");
+
+            // Cloned installs must keep copying: the clone temp dir is discarded,
+            // so the shared trees have to be standalone copies, not symlinks.
+            let runtimes = home.join(".config/homeboy/agent-runtimes");
+            let meta = fs::symlink_metadata(&runtimes).expect("agent-runtimes exists");
+            assert!(
+                meta.file_type().is_dir() && !meta.file_type().is_symlink(),
+                "cloned install should copy agent-runtimes as a real directory"
+            );
+        });
+    }
+
     #[test]
     fn extracted_monorepo_update_materializes_shared_agent_runtimes() {
         with_isolated_home(|home| {
@@ -895,6 +924,96 @@ exec '{}' "$@"
             assert!(home
                 .join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js")
                 .exists());
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn linked_install_symlinks_shared_trees_instead_of_copying() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            write_extension_fixture(&source, "wordpress");
+            write_shared_runtime_fixture(&source);
+            let shared_helper = source.join("scripts/lib/test-result-adapters.sh");
+            fs::create_dir_all(shared_helper.parent().expect("helper parent"))
+                .expect("shared scripts dir");
+            fs::write(&shared_helper, "noop() { :; }\n").expect("shared helper");
+
+            install(
+                &source.join("wordpress").to_string_lossy(),
+                Some("wordpress"),
+            )
+            .expect("install linked extension");
+
+            // Each shared tree must be a symlink pointing back at the live source,
+            // not a standalone copy, so local edits go live without a reinstall.
+            for (target, link_source) in [
+                (
+                    home.join(".config/homeboy/agent-runtimes"),
+                    source.join("agent-runtimes"),
+                ),
+                (
+                    home.join(".config/homeboy/runtime-agent-ci"),
+                    source.join("runtime-agent-ci"),
+                ),
+                (
+                    home.join(".config/homeboy/agent-task-contracts"),
+                    source.join("agent-task-contracts"),
+                ),
+                (
+                    home.join(".config/homeboy/extensions/scripts/lib"),
+                    source.join("scripts/lib"),
+                ),
+            ] {
+                let meta = fs::symlink_metadata(&target)
+                    .unwrap_or_else(|_| panic!("shared target exists: {}", target.display()));
+                assert!(
+                    meta.file_type().is_symlink(),
+                    "{} should be a symlink for a linked install",
+                    target.display()
+                );
+                assert_eq!(
+                    fs::canonicalize(&target).expect("resolve symlink target"),
+                    fs::canonicalize(&link_source).expect("resolve link source"),
+                    "{} should resolve to the live source tree",
+                    target.display()
+                );
+            }
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn editing_symlinked_shared_file_is_visible_to_linked_install() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            write_extension_fixture(&source, "wordpress");
+            write_shared_runtime_fixture(&source);
+
+            install(
+                &source.join("wordpress").to_string_lossy(),
+                Some("wordpress"),
+            )
+            .expect("install linked extension");
+
+            // Edit the shared asset in the source worktree after install. Because
+            // the install symlinks the tree, the edit must be visible at the live
+            // install path with no reinstall — the iteration-blocker fix.
+            let source_contract = source.join("agent-task-contracts/agent-task-provider-contract.js");
+            fs::write(&source_contract, "module.exports = { contract: 'edited-live' };\n")
+                .expect("edit shared source file");
+
+            let installed_contract =
+                home.join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js");
+            let observed = fs::read_to_string(&installed_contract).expect("read installed contract");
+            assert!(
+                observed.contains("edited-live"),
+                "edit to the symlinked shared tree should be visible to the install, got: {observed}"
+            );
         });
     }
 

--- a/src/core/extension/validation.rs
+++ b/src/core/extension/validation.rs
@@ -1,6 +1,6 @@
 use crate::core::error::Result;
 
-use super::registry::load_extension;
+use super::registry::{is_extension_linked, load_extension};
 use super::version;
 
 /// Validate that all extensions declared in a component's `extensions` field are installed.
@@ -102,7 +102,15 @@ pub fn validate_extension_requirements(
         match load_extension(extension_id) {
             Ok(extension) => match extension.semver() {
                 Ok(installed_version) => {
-                    if !constraint.matches(&installed_version) {
+                    // Linked (symlinked) dev installs intentionally track a local
+                    // worktree whose version may lag the published constraint.
+                    // Soften enforcement for those so a symlinked extension under
+                    // active iteration isn't rejected and steered to a re-clone via
+                    // `homeboy extension update`. Cloned/copied installs still
+                    // enforce, so genuinely incompatible non-dev versions are caught.
+                    if !constraint.matches(&installed_version)
+                        && !is_extension_linked(extension_id)
+                    {
                         errors.push(format!(
                             "'{}' requires {}, but {} is installed",
                             extension_id, constraint, installed_version
@@ -236,5 +244,69 @@ mod tests {
         };
 
         assert!(!extension_provides_build(&component));
+    }
+
+    fn component_requiring(extension_id: &str, version: &str) -> Component {
+        let mut extensions = std::collections::HashMap::new();
+        extensions.insert(
+            extension_id.to_string(),
+            crate::core::component::ScopedExtensionConfig {
+                version: Some(version.to_string()),
+                ..Default::default()
+            },
+        );
+        Component {
+            id: "consumer".to_string(),
+            extensions: Some(extensions),
+            ..Default::default()
+        }
+    }
+
+    fn write_extension_manifest(dir: &std::path::Path, id: &str, version: &str) {
+        std::fs::create_dir_all(dir).expect("extension dir");
+        std::fs::write(
+            dir.join(format!("{}.json", id)),
+            format!(r#"{{"name":"{} ext","version":"{}"}}"#, id, version),
+        )
+        .expect("extension manifest");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn version_constraint_softened_only_for_linked_install() {
+        crate::test_support::with_isolated_home(|home| {
+            let home = home.path();
+
+            // Linked (symlinked) install at v1.0.0 — should satisfy a ^2.0.0
+            // requirement because dev iteration may lag the published constraint.
+            let source = home.join("source/wordpress");
+            write_extension_manifest(&source, "wordpress", "1.0.0");
+            crate::core::extension::install(&source.to_string_lossy(), Some("wordpress"))
+                .expect("install linked extension");
+            assert!(super::is_extension_linked("wordpress"));
+
+            let component = component_requiring("wordpress", "^2.0.0");
+            assert!(
+                validate_extension_requirements(&component).is_ok(),
+                "linked dev install should soften the version constraint"
+            );
+        });
+    }
+
+    #[test]
+    fn version_constraint_enforced_for_copied_install() {
+        crate::test_support::with_isolated_home(|home| {
+            // Copied (real directory) install at v1.0.0 — must still be rejected
+            // against a ^2.0.0 requirement so genuinely incompatible non-dev
+            // versions are caught.
+            let extensions_dir = home.path().join(".config/homeboy/extensions/postgres");
+            write_extension_manifest(&extensions_dir, "postgres", "1.0.0");
+            assert!(!super::is_extension_linked("postgres"));
+
+            let component = component_requiring("postgres", "^2.0.0");
+            let err = validate_extension_requirements(&component)
+                .expect_err("copied install must enforce the version constraint");
+            assert!(err.message.contains("requires"));
+        });
     }
 }


### PR DESCRIPTION
## What

Enables rapid local iteration on extensions without a release. Linked/dev extension installs (local-path source) now **symlink** the four shared monorepo trees instead of copying them, so local edits go live immediately.

### The iteration blocker
`install_from_path` (the local-path "dev" install) symlinked only the extension subdir; the four shared trees — `agent-runtimes`, `runtime-agent-ci`, `scripts/lib`, `agent-task-contracts` — were hard-copied into `~/.config/homeboy/` via `install_shared_assets_from_root` → `copy_dir_recursive`. Editing those shared trees in a worktree had **zero effect** on the live install until a reinstall/re-clone — i.e. "wait for a release to iterate."

### Fix
- New `SharedAssetMode { Copy, Symlink }` threaded through `install_shared_assets_from_root`.
- `install_linked_shared_assets` (the linked/local-path flow) now uses `Symlink`: each shared tree is linked to its **canonicalized live source**, so edits are visible to the install with no reinstall.
- Cloned installs keep `Copy` (the clone temp dir is discarded after install, so there is no live source to point at). Gating is the call site — `resolve_cloned_extension` still copies; only the linked install/update/replace flows symlink.
- Target removal handles both prior copies (real dirs) and prior symlinks, so re-installs stay idempotent regardless of prior mode.

### Version-constraint escape hatch (linked only)
`validate_extension_requirements` previously rejected a symlinked dev extension whose local version lagged a published constraint (e.g. `^2.0.0` vs an older linked copy) and steered the user to a re-clone via `homeboy extension update`. It now softens the **constraint-mismatch** case **only for linked installs** (`is_extension_linked`). Copied/cloned installs still enforce, and the missing-install / invalid-version cases are untouched, so genuinely incompatible non-dev versions are still caught.

## Why it matters
This makes local shared-asset edits live, which directly **unblocks homeboy-extensions#1972** (shell-lib single-source): editing shared shell libs in the monorepo worktree now affects the running install without a release.

## Tests
- `linked_install_symlinks_shared_trees_instead_of_copying` — linked install produces symlinks resolving to the live source, not copies.
- `editing_symlinked_shared_file_is_visible_to_linked_install` — editing a shared file post-install is visible at the install path.
- `cloned_install_copies_shared_trees_rather_than_symlinking` — cloned install still copies (gating locked).
- `version_constraint_softened_only_for_linked_install` / `version_constraint_enforced_for_copied_install` — constraint softening is scoped to linked installs.

### Verification
- `cargo check`: passes (only pre-existing unrelated warnings).
- `cargo test --lib core::extension::lifecycle` / `core::extension::validation`: all pass including the 5 new tests.
- One unrelated pre-existing failure (`core::extension::setup_env::tests::sanitizes_extension_id_for_filesystem_safety`) also fails on clean `origin/main` (a test-isolation flake in a file this PR does not touch).

Refs Extra-Chill/homeboy#6396 (local ext reinstall loses sourceUrl metadata), Extra-Chill/homeboy#1954 (materialize local ext source for runner/offload).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Diagnosing the copy-vs-symlink iteration blocker, implementing the symlink materialization path and the linked-only version-constraint escape hatch, and writing the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)