### PR TITLE
refactor(agent_task): shared From bridges for status enums + single run-state setter

### DIFF
--- a/src/core/agent_task_gate.rs
+++ b/src/core/agent_task_gate.rs
@@ -91,6 +91,19 @@ pub enum AgentTaskGateStatus {
     Failed,
 }
 
+/// Canonical bridge from the binary agent-task gate status to the shared
+/// `HomeboyGateStatus`. Both the report constructor and the
+/// `HomeboyGateResult` conversion route through this single mapping so the
+/// pass/fail projection cannot drift between call sites.
+impl From<AgentTaskGateStatus> for HomeboyGateStatus {
+    fn from(status: AgentTaskGateStatus) -> Self {
+        match status {
+            AgentTaskGateStatus::Succeeded => HomeboyGateStatus::Passed,
+            AgentTaskGateStatus::Failed => HomeboyGateStatus::Failed,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskGateFailureEvidence {
     pub summary: String,
@@ -125,10 +138,7 @@ impl AgentTaskGateReport {
             id.clone(),
             id.clone(),
             HomeboyGateKind::Command,
-            match status {
-                AgentTaskGateStatus::Succeeded => HomeboyGateStatus::Passed,
-                AgentTaskGateStatus::Failed => HomeboyGateStatus::Failed,
-            },
+            HomeboyGateStatus::from(status),
         )
         .visibility(visibility)
         .reveal_policy(reveal_policy)
@@ -278,10 +288,7 @@ pub(crate) fn text_tail(text: &str, max_lines: usize) -> String {
 
 impl From<AgentTaskGateReport> for HomeboyGateResult {
     fn from(report: AgentTaskGateReport) -> Self {
-        let status = match report.status {
-            AgentTaskGateStatus::Succeeded => HomeboyGateStatus::Passed,
-            AgentTaskGateStatus::Failed => HomeboyGateStatus::Failed,
-        };
+        let status = HomeboyGateStatus::from(report.status);
         let command = report.command.join(" ");
         let summary = gate_result_summary(&report, &command);
         let agent_feedback = gate_result_agent_feedback(&report);
@@ -401,6 +408,18 @@ mod tests {
     use std::sync::Mutex;
 
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn agent_task_gate_status_bridges_to_homeboy_gate_status() {
+        assert_eq!(
+            HomeboyGateStatus::from(AgentTaskGateStatus::Succeeded),
+            HomeboyGateStatus::Passed
+        );
+        assert_eq!(
+            HomeboyGateStatus::from(AgentTaskGateStatus::Failed),
+            HomeboyGateStatus::Failed
+        );
+    }
 
     #[test]
     fn gate_command_reports_success_without_failure_evidence() {

--- a/src/core/agent_task_lifecycle/cancellation.rs
+++ b/src/core/agent_task_lifecycle/cancellation.rs
@@ -35,9 +35,8 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
 
     let cancelled_at = now_timestamp();
     let was_stale_running = record.state == AgentTaskRunState::Running;
-    record.state = AgentTaskRunState::Cancelled;
     record.updated_at = Some(cancelled_at.clone());
-    update_lifecycle_execution(&mut record, AgentTaskRunState::Cancelled);
+    set_run_state(&mut record, AgentTaskRunState::Cancelled);
     for task in &mut record.tasks {
         if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
             task.state = AgentTaskState::Cancelled;
@@ -200,9 +199,8 @@ pub fn cancel(run_id: &str) -> Result<AgentTaskRunRecord> {
         ));
     }
 
-    record.state = AgentTaskRunState::Cancelled;
     record.updated_at = Some(now_timestamp());
-    update_lifecycle_execution(&mut record, AgentTaskRunState::Cancelled);
+    set_run_state(&mut record, AgentTaskRunState::Cancelled);
     for task in &mut record.tasks {
         if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
             task.state = AgentTaskState::Cancelled;

--- a/src/core/agent_task_lifecycle/failure_recording.rs
+++ b/src/core/agent_task_lifecycle/failure_recording.rs
@@ -535,8 +535,8 @@ pub(crate) fn apply_aggregate_to_record(
     aggregate: &AgentTaskAggregate,
     aggregate_path: String,
 ) {
-    record.state = run_state_for_aggregate(aggregate);
     record.updated_at = Some(now_timestamp());
+    set_run_state(record, run_state_for_aggregate(aggregate));
     record.aggregate_path = Some(aggregate_path);
     record.totals = Some(aggregate.totals.clone());
     record.tasks = tasks_for_aggregate(plan, aggregate);

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -90,9 +90,8 @@ pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
     }
 
     let reclaimed_stale = record.state == AgentTaskRunState::Running;
-    record.state = AgentTaskRunState::Running;
     record.updated_at = Some(now_timestamp());
-    update_lifecycle_execution(&mut record, AgentTaskRunState::Running);
+    set_run_state(&mut record, AgentTaskRunState::Running);
     update_lifecycle_heartbeat(&mut record);
     for task in &mut record.tasks {
         if task.state == AgentTaskState::Queued {

--- a/src/core/agent_task_lifecycle/lifecycle_record_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_record_ops.rs
@@ -14,12 +14,15 @@ pub(crate) fn lifecycle_for_submitted_plan(plan: &AgentTaskPlan) -> RunLifecycle
     lifecycle
 }
 
-pub(crate) fn update_lifecycle_execution(
-    record: &mut AgentTaskRunRecord,
-    state: AgentTaskRunState,
-) {
+/// Single authoritative setter for a run's state. It writes both the
+/// top-level `record.state` and the derived `lifecycle.execution.state`
+/// projection together, so the two cannot silently diverge: every state
+/// transition routes through here instead of assigning `record.state`
+/// separately from refreshing the lifecycle projection.
+pub(crate) fn set_run_state(record: &mut AgentTaskRunRecord, state: AgentTaskRunState) {
+    record.state = state;
     let timestamp = record.updated_at.clone().unwrap_or_else(now_timestamp);
-    record.lifecycle.execution.state = execution_state_for_run_state(state);
+    record.lifecycle.execution.state = RunExecutionState::from(state);
     record.lifecycle.execution.updated_at = Some(timestamp.clone());
     if state == AgentTaskRunState::Running && record.lifecycle.execution.started_at.is_none() {
         record.lifecycle.execution.started_at = Some(timestamp.clone());
@@ -46,7 +49,7 @@ pub(crate) fn update_lifecycle_heartbeat(record: &mut AgentTaskRunRecord) {
 }
 
 pub(crate) fn update_lifecycle_from_record(record: &mut AgentTaskRunRecord, plan: &AgentTaskPlan) {
-    update_lifecycle_execution(record, record.state);
+    set_run_state(record, record.state);
     record.lifecycle.cleanup = cleanup_lifecycle_for_plan(plan, record.updated_at.clone());
     record.lifecycle.provider_runtime = record
         .provider_handles
@@ -108,17 +111,6 @@ pub(crate) fn provider_runtime_for_handle(
             url: handle.stream_uri.clone(),
         }],
         metadata: handle.metadata.clone(),
-    }
-}
-
-pub(crate) fn execution_state_for_run_state(state: AgentTaskRunState) -> RunExecutionState {
-    match state {
-        AgentTaskRunState::Queued => RunExecutionState::Queued,
-        AgentTaskRunState::Running => RunExecutionState::Running,
-        AgentTaskRunState::Succeeded => RunExecutionState::Succeeded,
-        AgentTaskRunState::PartialFailure => RunExecutionState::PartialFailure,
-        AgentTaskRunState::Failed => RunExecutionState::Failed,
-        AgentTaskRunState::Cancelled => RunExecutionState::Cancelled,
     }
 }
 

--- a/src/core/agent_task_lifecycle/records.rs
+++ b/src/core/agent_task_lifecycle/records.rs
@@ -155,6 +155,24 @@ pub enum AgentTaskRunState {
     Cancelled,
 }
 
+/// Canonical projection of a run's aggregate state onto the generic
+/// `RunExecutionState` carried by `RunLifecycleRecord`. The two enums share
+/// every agent-task variant 1:1 (`RunExecutionState` additionally models the
+/// generic `Unknown` default), so this single `From` keeps `record.state` and
+/// `record.lifecycle.execution.state` in lockstep instead of a hand-synced map.
+impl From<AgentTaskRunState> for RunExecutionState {
+    fn from(state: AgentTaskRunState) -> Self {
+        match state {
+            AgentTaskRunState::Queued => RunExecutionState::Queued,
+            AgentTaskRunState::Running => RunExecutionState::Running,
+            AgentTaskRunState::Succeeded => RunExecutionState::Succeeded,
+            AgentTaskRunState::PartialFailure => RunExecutionState::PartialFailure,
+            AgentTaskRunState::Failed => RunExecutionState::Failed,
+            AgentTaskRunState::Cancelled => RunExecutionState::Cancelled,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskRunTask {
     pub task_id: String,

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -715,6 +715,45 @@ fn submitted_run_can_be_loaded_marked_running_and_completed() {
 }
 
 #[test]
+fn run_state_bridges_one_to_one_onto_execution_state() {
+    let cases = [
+        (AgentTaskRunState::Queued, RunExecutionState::Queued),
+        (AgentTaskRunState::Running, RunExecutionState::Running),
+        (AgentTaskRunState::Succeeded, RunExecutionState::Succeeded),
+        (
+            AgentTaskRunState::PartialFailure,
+            RunExecutionState::PartialFailure,
+        ),
+        (AgentTaskRunState::Failed, RunExecutionState::Failed),
+        (AgentTaskRunState::Cancelled, RunExecutionState::Cancelled),
+    ];
+    for (run_state, expected) in cases {
+        assert_eq!(RunExecutionState::from(run_state), expected);
+    }
+}
+
+#[test]
+fn cancel_keeps_run_state_and_execution_state_paired() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("run-cancel-pairing")).expect("submitted");
+        mark_running("run-cancel-pairing").expect("marked running");
+
+        let cancelled = cancel("run-cancel-pairing").expect("cancelled");
+
+        assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+        assert_eq!(
+            cancelled.lifecycle.execution.state,
+            RunExecutionState::from(cancelled.state),
+        );
+        assert_eq!(
+            cancelled.lifecycle.execution.state,
+            RunExecutionState::Cancelled,
+        );
+    });
+}
+
+#[test]
 fn lifecycle_store_round_trips_record_log_artifacts_and_lifecycle_contract() {
     with_isolated_home(|_| {
         let mut plan = test_plan();

--- a/src/core/agent_task_loop_controller/diagnostics.rs
+++ b/src/core/agent_task_loop_controller/diagnostics.rs
@@ -97,6 +97,23 @@ pub enum AgentTaskLoopAcceptanceGateStatus {
     Pending,
 }
 
+/// Canonical projection from a (possibly absent) recorded gate-bundle result
+/// status to the acceptance-gate status surfaced in diagnostics. An absent
+/// result maps to `Missing`; the present statuses map 1:1 onto their
+/// acceptance-gate equivalents. Routing every call site through this `From`
+/// keeps the projection in one place instead of hand-synced match arms.
+impl From<Option<AgentTaskGateBundleStatus>> for AgentTaskLoopAcceptanceGateStatus {
+    fn from(status: Option<AgentTaskGateBundleStatus>) -> Self {
+        match status {
+            Some(AgentTaskGateBundleStatus::Passed) => AgentTaskLoopAcceptanceGateStatus::Satisfied,
+            Some(AgentTaskGateBundleStatus::Failed) => AgentTaskLoopAcceptanceGateStatus::Failed,
+            Some(AgentTaskGateBundleStatus::Warn) => AgentTaskLoopAcceptanceGateStatus::Warning,
+            Some(AgentTaskGateBundleStatus::Pending) => AgentTaskLoopAcceptanceGateStatus::Pending,
+            None => AgentTaskLoopAcceptanceGateStatus::Missing,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskLoopAcceptanceGateDiagnostic {
     pub bundle_id: String,
@@ -132,4 +149,33 @@ pub struct AgentTaskLoopPendingActionDiagnostic {
     pub problems: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub recovery_commands: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acceptance_gate_status_bridges_from_bundle_status() {
+        assert_eq!(
+            AgentTaskLoopAcceptanceGateStatus::from(Some(AgentTaskGateBundleStatus::Passed)),
+            AgentTaskLoopAcceptanceGateStatus::Satisfied
+        );
+        assert_eq!(
+            AgentTaskLoopAcceptanceGateStatus::from(Some(AgentTaskGateBundleStatus::Failed)),
+            AgentTaskLoopAcceptanceGateStatus::Failed
+        );
+        assert_eq!(
+            AgentTaskLoopAcceptanceGateStatus::from(Some(AgentTaskGateBundleStatus::Warn)),
+            AgentTaskLoopAcceptanceGateStatus::Warning
+        );
+        assert_eq!(
+            AgentTaskLoopAcceptanceGateStatus::from(Some(AgentTaskGateBundleStatus::Pending)),
+            AgentTaskLoopAcceptanceGateStatus::Pending
+        );
+        assert_eq!(
+            AgentTaskLoopAcceptanceGateStatus::from(None),
+            AgentTaskLoopAcceptanceGateStatus::Missing
+        );
+    }
 }

--- a/src/core/agent_task_loop_controller/service.rs
+++ b/src/core/agent_task_loop_controller/service.rs
@@ -452,19 +452,8 @@ fn acceptance_gate_diagnostics(
                 .iter()
                 .rev()
                 .find(|result| result.bundle_id == bundle_id && result.entity_id == entity_id);
-            let status = match result.map(|result| result.status) {
-                Some(AgentTaskGateBundleStatus::Passed) => {
-                    AgentTaskLoopAcceptanceGateStatus::Satisfied
-                }
-                Some(AgentTaskGateBundleStatus::Failed) => {
-                    AgentTaskLoopAcceptanceGateStatus::Failed
-                }
-                Some(AgentTaskGateBundleStatus::Warn) => AgentTaskLoopAcceptanceGateStatus::Warning,
-                Some(AgentTaskGateBundleStatus::Pending) => {
-                    AgentTaskLoopAcceptanceGateStatus::Pending
-                }
-                None => AgentTaskLoopAcceptanceGateStatus::Missing,
-            };
+            let status =
+                AgentTaskLoopAcceptanceGateStatus::from(result.map(|result| result.status));
             let problems = match status {
                 AgentTaskLoopAcceptanceGateStatus::Missing => {
                     vec!["acceptance gate has no recorded result".to_string()]


### PR DESCRIPTION
## Summary

Consolidates the highest-confidence subset of the overlapping agent-task status/gate enum machinery behind canonical `From` bridges, and removes the silent-desync risk between a run's two state projections. Behavior-preserving: no enum variants or serde representations change. Deferred consolidation behind the now-merged loop-bug fixes (#6762).

Refs #6761 (Consolidate agent_task status/gate enums + scheduler wrapper services) and #6677.

## What changed

**Gate-status bridges (item 1, scoped subset)**
- `From<AgentTaskGateStatus> for HomeboyGateStatus` — the gate report constructor and the `HomeboyGateResult` conversion now route through one mapping instead of two inline matches.
- `From<Option<AgentTaskGateBundleStatus>> for AgentTaskLoopAcceptanceGateStatus` — replaces the hand-synced remap in the loop-controller diagnostics service (`service.rs`). The acceptance-gate enum keeps its distinct `Missing`/`Satisfied`/`Warning` serialization; an absent result still maps to `Missing`. The merged blocking `Pending` status is folded into the single bridge.

**Single-source run state (item 3)**
- Replaced the `execution_state_for_run_state` free function with `From<AgentTaskRunState> for RunExecutionState`.
- Funnel every run-state transition through one `set_run_state` setter (renamed from `update_lifecycle_execution`) that writes `record.state` and the derived `record.lifecycle.execution.state` together, so the paired projection can no longer silently desync. Dropped the redundant standalone `record.state = …` assignments in `mark_running`, `cancel`, `cancel_run`, and `apply_aggregate_to_record`.
- The lossy ObservationStore `RunStatus` projection (`PartialFailure`/`Failed` → `Fail`, `Cancelled` → `Skipped`) in `lifecycle_store.rs` is intentionally **preserved** and untouched.

**Tests**
- Exhaustive `From` bridge tests for all three conversions, plus a setter-pairing test asserting `record.state` and `lifecycle.execution.state` stay coupled across a cancel transition.

## What was intentionally deferred (follow-ups to file under #6761)

These are **not** pure-remap enums — each has distinct serde output persisted in durable records, so collapsing them into one canonical type would change on-disk JSON and is **not** behavior-preserving. They are tracked rather than forced:

- **Item 1 (full collapse):** `AgentTaskGateBundleStatus`, `AgentTaskLoopAcceptanceGateStatus`, and the generic `HomeboyGateStatus` serialize to different strings and cannot be unified without a record-format migration.
- **Item 2 (terminal/aggregate enums):** `DeterministicLoopStatus` lives in the generic `deterministic_loop` engine; coupling it to agent-task `AgentTaskLoopControllerState`/`AgentTaskLoopTerminalStatus` would push domain semantics into the generic engine, against the architecture direction. `ControllerState`/`TerminalStatus` have distinct domain variants, not a 1:1 remap.
- **Item 4 (scheduler-wrapper dedup):** `agent_task_dispatch_service` vs `agent_task_service/execution` consolidation is a larger structural change; out of scope for a reviewable behavior-preserving PR.

## Verification

- `cargo check` — clean (only pre-existing warnings in untouched files).
- `cargo test --lib agent_task_lifecycle` — 35 passed.
- `cargo test --lib agent_task_gate` — 12 passed.
- `cargo test --lib agent_task_loop_controller` — 26 passed.
- Full `cargo test --lib agent_task` — 2 pre-existing env/ordering flakes (`lab_runtime_component_ids_follow_selected_agent_task_providers`, `generic_contract_fixtures_surface_runtime_import_before_missing_artifact`). Both confirmed unrelated: the first fails identically on clean `origin/main` via `git stash`; the second passes in isolation (parallel-execution contention on shared HOME).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Auditing the overlapping status/gate enums, implementing the `From` bridges and single run-state setter, and adding the bridge/pairing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)