### PR TITLE
fix(runner): keep secret env off SSH argv, drop hardcoded provider tokens, close offload orphan

### DIFF
--- a/src/core/redaction.rs
+++ b/src/core/redaction.rs
@@ -132,6 +132,21 @@ impl RedactionPolicy {
         redact_argv_with_policy(argv, self)
     }
 
+    /// Redact a single environment-variable (or inline argument) value.
+    ///
+    /// URL-shaped values get query-aware redaction so non-sensitive path and
+    /// query parts survive; everything else goes through inline-assignment
+    /// redaction. This is the canonical env-value heuristic shared by the
+    /// secret-env plan and argv redaction so the URL-vs-string dispatch lives in
+    /// exactly one place.
+    pub fn redact_env_value(&self, value: &str) -> String {
+        if looks_like_url(value) {
+            self.redact_url(value)
+        } else {
+            self.redact_string(value)
+        }
+    }
+
     fn redact_json_with_key(&self, key: Option<&str>, value: &Value) -> Value {
         if key.is_some_and(|key| self.is_sensitive_key(key) || self.is_sensitive_header(key)) {
             return Value::String(self.replacement.clone());
@@ -277,11 +292,7 @@ fn redact_key_value_arg(value: &str, policy: &RedactionPolicy) -> String {
 }
 
 fn redact_sensitive_inline_arg(value: &str, policy: &RedactionPolicy) -> String {
-    if looks_like_url(value) {
-        policy.redact_url(value)
-    } else {
-        policy.redact_string(value)
-    }
+    policy.redact_env_value(value)
 }
 
 fn normalize_key(key: &str) -> String {

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -509,6 +509,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
             cwd,
             options.command,
             request_env,
+            &secret_env_names,
             options.require_paths,
         );
     }
@@ -575,6 +576,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
             cwd,
             options.command,
             request_env,
+            &secret_env_names,
             options.require_paths,
         ),
         RunnerTransport::Unavailable => Err(Error::validation_invalid_argument(

--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
-use crate::core::redaction::redact_argv;
+use crate::core::redaction::{redact_argv, RedactionPolicy};
 use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
 
@@ -38,6 +38,7 @@ pub(super) fn exec_diagnostic_ssh(
     cwd: String,
     command: Vec<String>,
     env: HashMap<String, String>,
+    secret_env_names: &[String],
     require_paths: Vec<String>,
 ) -> Result<(RunnerExecOutput, i32)> {
     let server_id = runner.server_id.as_deref().ok_or_else(|| {
@@ -49,10 +50,15 @@ pub(super) fn exec_diagnostic_ssh(
         )
     })?;
     let server = server::load(server_id)?;
+    let mut merged_env = runner.env.clone();
+    merged_env.extend(env);
+    // Keep the full merged env for stream redaction, but route secret-bearing
+    // entries over stdin rather than the SSH command argv so tokens never land
+    // in the controller `ps` table or the remote login-shell argv (#6676).
+    let redaction_env = merged_env.clone();
+    let (public_env, secret_env) = partition_runner_secret_env(merged_env, secret_env_names);
     let mut client = SshClient::from_server(&server, server_id)?;
-    client.env.extend(runner.env.clone());
-    client.env.extend(env);
-    let redaction_env = client.env.clone();
+    client.env.extend(public_env);
     validate_remote_required_paths(&mut client, &require_paths)?;
     let command_line = format!(
         "cd {} && {}",
@@ -63,7 +69,7 @@ pub(super) fn exec_diagnostic_ssh(
             .collect::<Vec<_>>()
             .join(" ")
     );
-    let output = client.execute(&command_line);
+    let output = client.execute_with_secret_env(&command_line, &secret_env);
     let source_snapshot =
         SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref());
     Ok(exec_output(
@@ -83,6 +89,34 @@ pub(super) fn exec_diagnostic_ssh(
         &redaction_env,
         &[],
     ))
+}
+
+/// Split a runner's merged environment into the public exports that stay inline
+/// on the SSH command line and the secret values that must be streamed over
+/// stdin instead.
+///
+/// A key is treated as secret when the caller explicitly declared it in
+/// `secret_env_names` or when the shared redaction policy recognizes it as a
+/// sensitive key (token/secret/api_key/...). This is defense in depth: any
+/// credential-shaped value is kept off the argv even if a caller forgets to
+/// declare its name.
+fn partition_runner_secret_env(
+    env: HashMap<String, String>,
+    secret_env_names: &[String],
+) -> (HashMap<String, String>, BTreeMap<String, String>) {
+    let policy = RedactionPolicy::default();
+    let mut public_env = HashMap::new();
+    let mut secret_env = BTreeMap::new();
+    for (key, value) in env {
+        let is_secret =
+            secret_env_names.iter().any(|name| name == &key) || policy.is_sensitive_key(&key);
+        if is_secret {
+            secret_env.insert(key, value);
+        } else {
+            public_env.insert(key, value);
+        }
+    }
+    (public_env, secret_env)
 }
 
 pub(crate) fn prepare_runner_process(

--- a/src/core/runner/execution/secrets.rs
+++ b/src/core/runner/execution/secrets.rs
@@ -350,43 +350,21 @@ pub(crate) fn runner_exec_secret_env_plan(
     SecretEnvPlan::from_secret_env_names(names)
 }
 
+/// Runtime/extension-declared secret env names for a hosted agent run.
+///
+/// The provider runtime (or extension) is the only authority on which secret
+/// env names its agent process needs, so it declares them explicitly via the
+/// generic `HOMEBOY_AGENT_RUNTIME_SECRET_ENV` allowlist (a comma-separated list
+/// of variable names). Homeboy core stays provider-agnostic and carries no
+/// literal provider token names: a `codex`/`claude-code`/`openai` runtime keeps
+/// working by exporting the same allowlist it already owns, and any new provider
+/// is supported without a core change (generic-core rule, #6676).
 fn declared_runtime_provider_secret_env(env: &HashMap<String, String>) -> Vec<String> {
-    let explicit = env
-        .get("HOMEBOY_AGENT_RUNTIME_SECRET_ENV")
+    env.get("HOMEBOY_AGENT_RUNTIME_SECRET_ENV")
         .into_iter()
         .flat_map(|value| value.split(','))
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
-        .collect::<Vec<_>>();
-    if !explicit.is_empty() {
-        return explicit;
-    }
-
-    match env
-        .get("HOMEBOY_AGENT_RUNTIME_PROVIDER")
-        .map(String::as_str)
-        .map(str::trim)
-    {
-        Some("codex") => [
-            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
-            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
-            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
-            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
-            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP",
-        ]
-        .into_iter()
-        .map(str::to_string)
-        .collect(),
-        Some("openai") => vec!["OPENAI_API_KEY".to_string()],
-        Some("claude-code") => [
-            "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN",
-            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN",
-            "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT",
-        ]
-        .into_iter()
-        .map(str::to_string)
-        .collect(),
-        _ => Vec::new(),
-    }
+        .collect()
 }

--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -234,7 +234,11 @@ fn runner_exec_secret_env_names_include_tunnel_preview_client_token() {
 }
 
 #[test]
-fn runner_exec_secret_env_names_include_runtime_provider_defaults() {
+fn runner_exec_secret_env_names_carry_no_hardcoded_provider_literals() {
+    // Generic core must not embed provider-specific token names. A bare
+    // provider hint without an explicit allowlist contributes no secret env
+    // names; the runtime/extension is the authority and declares them itself
+    // (generic-core rule, #6676).
     let names = runner_exec_secret_env_names(
         &["node".to_string(), "run-headless-loop.cjs".to_string()],
         None,
@@ -245,13 +249,37 @@ fn runner_exec_secret_env_names_include_runtime_provider_defaults() {
         )]),
     );
 
+    assert!(
+        names.is_empty(),
+        "provider hint alone must not imply provider token names: {names:?}"
+    );
+}
+
+#[test]
+fn runner_exec_secret_env_names_use_runtime_declared_allowlist() {
+    // A codex-style runtime keeps working by declaring the exact names it owns
+    // through the generic allowlist — no core change per provider.
+    let names = runner_exec_secret_env_names(
+        &["node".to_string(), "run-headless-loop.cjs".to_string()],
+        None,
+        &[],
+        &HashMap::from([
+            (
+                "HOMEBOY_AGENT_RUNTIME_PROVIDER".to_string(),
+                "codex".to_string(),
+            ),
+            (
+                "HOMEBOY_AGENT_RUNTIME_SECRET_ENV".to_string(),
+                "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN,AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN"
+                    .to_string(),
+            ),
+        ]),
+    );
+
     assert_eq!(
         names,
         vec![
             "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
-            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID".to_string(),
-            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT".to_string(),
-            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP".to_string(),
             "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN".to_string(),
         ]
     );

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -845,6 +845,70 @@ mod tests {
     }
 
     #[test]
+    fn sync_workspace_rolls_back_checkout_when_validation_dependency_fails() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace_parent = tempfile::tempdir().expect("workspace parent");
+            let source = workspace_parent.path().join("host-app");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            fs::create_dir_all(&source).expect("source dir");
+            fs::write(
+                source.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "host-app",
+                    "extensions": {
+                        "wordpress": {
+                            "settings": { "validation_dependencies": ["shared-runtime"] }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .expect("source manifest");
+            fs::write(source.join("main.php"), "<?php\n").expect("source file");
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local-rollback","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            // The missing `shared-runtime` sibling makes validation-dependency
+            // sync fail *after* the main checkout and its metadata are already
+            // materialized — the exact partial-failure window from #6752.
+            let err = sync_workspace(
+                "lab-local-rollback",
+                RunnerWorkspaceSyncOptions {
+                    path: source.display().to_string(),
+                    mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
+                    changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
+                    snapshot_includes: Vec::new(),
+                    allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
+                },
+            )
+            .expect_err("missing validation dependency should fail sync");
+            assert!(err.message.contains("shared-runtime"));
+
+            // The materialized checkout must be rolled back so no orphaned remote
+            // directory survives under _lab_workspaces.
+            let lab_workspaces = runner_root.path().join("_lab_workspaces");
+            let leftovers = fs::read_dir(&lab_workspaces)
+                .map(|entries| entries.filter_map(|entry| entry.ok()).count())
+                .unwrap_or(0);
+            assert_eq!(
+                leftovers, 0,
+                "partial sync must not leave an orphaned remote checkout under {}",
+                lab_workspaces.display()
+            );
+        });
+    }
+
+    #[test]
     fn validation_dependency_workspace_errors_when_sibling_missing() {
         crate::test_support::with_isolated_home(|_| {
             let workspace_parent = tempfile::tempdir().expect("workspace parent");

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -7,7 +7,9 @@ use base64::Engine;
 use crate::core::engine::temp;
 use crate::core::error::{Error, Result};
 
-use super::super::validation_dependencies::sync_validation_dependency_workspaces;
+use super::super::validation_dependencies::{
+    sync_validation_dependency_workspaces, RunnerValidationDependencySyncOutput,
+};
 use super::super::{
     load, source_materialization, RunnerKind, RunnerLifecycleOwner, RunnerWorkspaceLease,
 };
@@ -90,7 +92,7 @@ pub fn sync_workspace(
                 materialize_snapshot(&runner, &local_path, &remote_path, &excludes)?;
                 None
             };
-            write_workspace_metadata(
+            let validation_dependencies = match write_metadata_and_sync_validation_dependencies(
                 &runner,
                 workspace_metadata(
                     &runner.id,
@@ -100,13 +102,16 @@ pub fn sync_workspace(
                     &snapshot,
                     options.run_isolation_token.as_deref(),
                 ),
-            )?;
-            let validation_dependencies = sync_validation_dependency_workspaces(
-                &runner,
                 &local_path,
                 &remote_path,
                 &excludes,
-            )?;
+            ) {
+                Ok(dependencies) => dependencies,
+                Err(err) => {
+                    rollback_materialized_workspace(&runner, workspace_root, &remote_path);
+                    return Err(err);
+                }
+            };
             let current_workspace = current_workspace_summary(
                 &local_path,
                 &remote_path,
@@ -185,7 +190,7 @@ pub fn sync_workspace(
                     options.allow_dirty_lab_workspace,
                 )?;
             }
-            write_workspace_metadata(
+            let validation_dependencies = match write_metadata_and_sync_validation_dependencies(
                 &runner,
                 workspace_metadata(
                     &runner.id,
@@ -195,13 +200,16 @@ pub fn sync_workspace(
                     &git.head,
                     options.run_isolation_token.as_deref(),
                 ),
-            )?;
-            let validation_dependencies = sync_validation_dependency_workspaces(
-                &runner,
                 &local_path,
                 &remote_path,
                 &excludes,
-            )?;
+            ) {
+                Ok(dependencies) => dependencies,
+                Err(err) => {
+                    rollback_materialized_workspace(&runner, workspace_root, &remote_path);
+                    return Err(err);
+                }
+            };
             let current_workspace = current_workspace_summary(
                 &local_path,
                 &remote_path,
@@ -665,6 +673,48 @@ fn workspace_repo_from_path(path: &str) -> String {
         .next()
         .unwrap_or(path)
         .to_string()
+}
+
+/// Write the run checkout's tracking metadata, then materialize its
+/// validation-dependency siblings.
+///
+/// These are the two sync steps that run *after* the remote checkout directory
+/// already exists on the runner. Grouping them lets [`sync_workspace`] roll the
+/// materialized checkout back as a unit if either fails, so a partially-synced
+/// run never leaves an orphaned remote directory behind (#6752).
+fn write_metadata_and_sync_validation_dependencies(
+    runner: &super::super::Runner,
+    metadata: RunnerWorkspaceMetadata,
+    local_path: &Path,
+    remote_path: &str,
+    excludes: &[String],
+) -> Result<Vec<RunnerValidationDependencySyncOutput>> {
+    write_workspace_metadata(runner, metadata)?;
+    sync_validation_dependency_workspaces(runner, local_path, remote_path, excludes)
+}
+
+/// Remove a just-materialized run checkout after a later sync step fails.
+///
+/// Materialization creates the remote `_lab_workspaces/<checkout>` directory
+/// before metadata is written and before validation-dependency siblings sync.
+/// If one of those later steps fails, [`sync_workspace`] returns an error and
+/// never hands the caller a `remote_path` to wrap in the run-owned
+/// [`MaterializedWorkspace`](super::materialized::MaterializedWorkspace) RAII
+/// handle — so without this rollback the checkout is orphaned: invisible to the
+/// reap handle and untracked by inventory until a bulk orphan prune eventually
+/// notices the missing source path (#6752).
+///
+/// This is best-effort cleanup: the original sync error is the actionable
+/// failure, so a removal error here is swallowed rather than masking it. The
+/// containment guard in [`remove_workspace`] still refuses to remove anything
+/// outside `_lab_workspaces`.
+fn rollback_materialized_workspace(
+    runner: &super::super::Runner,
+    workspace_root: &str,
+    remote_path: &str,
+) {
+    let lab_workspaces_root = format!("{}/_lab_workspaces", workspace_root.trim_end_matches('/'));
+    let _ = remove_workspace(runner, &lab_workspaces_root, remote_path);
 }
 
 fn write_workspace_metadata(

--- a/src/core/secret_env_plan.rs
+++ b/src/core/secret_env_plan.rs
@@ -348,7 +348,7 @@ impl SecretEnvPlan {
         let mut env = self
             .public_env
             .iter()
-            .map(|(name, value)| (name.clone(), redact_env_value(&policy, value)))
+            .map(|(name, value)| (name.clone(), policy.redact_env_value(value)))
             .collect::<BTreeMap<_, _>>();
         for name in self.secret_env_names() {
             env.insert(name, self.redaction.replacement.clone());
@@ -362,7 +362,7 @@ impl SecretEnvPlan {
         redacted.public_env = self
             .public_env
             .iter()
-            .map(|(name, value)| (name.clone(), redact_env_value(&policy, value)))
+            .map(|(name, value)| (name.clone(), policy.redact_env_value(value)))
             .collect();
         redacted
     }
@@ -451,14 +451,6 @@ fn secret_env_status(name: String, configured: bool, source: impl Into<String>) 
         name,
         configured,
         source: source.into(),
-    }
-}
-
-fn redact_env_value(policy: &RedactionPolicy, value: &str) -> String {
-    if value.contains("://") || value.starts_with('/') && value.contains('?') {
-        policy.redact_url(value)
-    } else {
-        policy.redact_string(value)
     }
 }
 

--- a/src/core/server/client/local_exec.rs
+++ b/src/core/server/client/local_exec.rs
@@ -17,6 +17,16 @@ pub fn execute_local_command(command: &str) -> CommandOutput {
     execute_local_command_in_dir(command, None, None)
 }
 
+/// Run a local command, streaming `stdin` bytes to the child's standard input.
+///
+/// Used by the SSH transport's localhost fast path to feed a secret-env block
+/// to the command over stdin instead of interpolating secret values into the
+/// `sh -c` argv (where they would be visible in `ps`). The bytes are written on
+/// a dedicated thread and stdin is closed (EOF) once they are flushed.
+pub(crate) fn execute_local_command_with_stdin(command: &str, stdin: &[u8]) -> CommandOutput {
+    execute_local_command_in_dir_impl(command, None, None, None, Some(stdin.to_vec()))
+}
+
 /// Run a local command, capturing stdout/stderr.
 ///
 /// All locally-spawned commands run in their own process group with guaranteed
@@ -27,7 +37,7 @@ pub fn execute_local_command_in_dir(
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
 ) -> CommandOutput {
-    execute_local_command_in_dir_impl(command, current_dir, env, None)
+    execute_local_command_in_dir_impl(command, current_dir, env, None, None)
 }
 
 pub(crate) fn execute_local_command_in_dir_with_timeout(
@@ -36,7 +46,7 @@ pub(crate) fn execute_local_command_in_dir_with_timeout(
     env: Option<&[(&str, &str)]>,
     timeout: Duration,
 ) -> CommandOutput {
-    execute_local_command_in_dir_impl(command, current_dir, env, Some(timeout))
+    execute_local_command_in_dir_impl(command, current_dir, env, Some(timeout), None)
 }
 
 fn execute_local_command_in_dir_impl(
@@ -44,8 +54,9 @@ fn execute_local_command_in_dir_impl(
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
     timeout: Option<Duration>,
+    stdin: Option<Vec<u8>>,
 ) -> CommandOutput {
-    use std::io::Read;
+    use std::io::{Read, Write};
     use std::thread;
 
     #[cfg(windows)]
@@ -72,6 +83,9 @@ fn execute_local_command_in_dir_impl(
 
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
+    if stdin.is_some() {
+        cmd.stdin(Stdio::piped());
+    }
     configure_process_group_cleanup(&mut cmd);
 
     let mut child = match cmd.spawn() {
@@ -109,6 +123,17 @@ fn execute_local_command_in_dir_impl(
         String::from_utf8_lossy(&captured).to_string()
     }
 
+    // Stream the provided stdin bytes on a dedicated thread, then close the pipe
+    // (EOF). The command's own stdin is empty for this path, so the buffer is
+    // small and never deadlocks against the captured stdout/stderr pipes.
+    let stdin_handle = stdin.and_then(|bytes| {
+        child.stdin.take().map(|mut pipe| {
+            thread::spawn(move || {
+                let _ = pipe.write_all(&bytes);
+            })
+        })
+    });
+
     let stdout_handle = child
         .stdout
         .take()
@@ -122,6 +147,9 @@ fn execute_local_command_in_dir_impl(
         wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard, timeout);
     let interrupted_signal = active_cleanup_signal();
 
+    if let Some(handle) = stdin_handle {
+        let _ = handle.join();
+    }
     let stdout = stdout_handle
         .and_then(|h| h.join().ok())
         .unwrap_or_default();

--- a/src/core/server/client/ssh_client.rs
+++ b/src/core/server/client/ssh_client.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+use std::io::Write;
 use std::process::{Command, Stdio};
 
 use crate::core::engine::shell;
@@ -9,8 +11,90 @@ use super::super::{
     ManagedSshSession, ManagedSshSessionOutput, Server, ServerAuthMode, ServerSessionConfig,
 };
 use super::host::{is_local_host, is_transient_ssh_error};
-use super::local_exec::{execute_local_command, execute_local_command_interactive};
+use super::local_exec::{
+    execute_local_command, execute_local_command_interactive, execute_local_command_with_stdin,
+};
 use super::{CommandOutput, SshClient};
+
+/// Sentinel terminating the secret-env block streamed over the SSH channel's
+/// stdin. Chosen to never collide with an env var name or a `NAME=VALUE` line.
+pub(crate) const SECRET_ENV_STDIN_SENTINEL: &str = "__HOMEBOY_SECRET_ENV_END__";
+
+/// Where a command's stdin bytes come from when it is dispatched over SSH (or
+/// the localhost fast path).
+#[derive(Clone, Copy)]
+enum SshStdin<'a> {
+    /// No stdin payload — the remote command inherits an empty stdin.
+    None,
+    /// Stream a local file as the command's stdin (used by `upload_file`).
+    File(&'a str),
+    /// Stream in-memory bytes as the command's stdin (used to deliver the
+    /// secret-env block without placing secrets in the command argv).
+    Inline(&'a [u8]),
+}
+
+/// POSIX-sh prologue that imports a secret-env block streamed over stdin.
+///
+/// Each line before the sentinel is a literal `NAME=VALUE` pair. Names and
+/// values arrive on the SSH channel's stdin, so neither the controller-local
+/// `ssh` argv nor the remote login-shell argv (both visible in `ps`) ever carry
+/// the secret. Values are applied with the `export` builtin — not `eval` — so
+/// shell metacharacters in a value are inert (no command injection). A value
+/// containing a literal newline is the one unsupported shape; OAuth/API tokens
+/// never contain one.
+fn secret_env_stdin_read_loop() -> String {
+    format!(
+        "while IFS= read -r __homeboy_env_line; do \
+[ \"$__homeboy_env_line\" = \"{sentinel}\" ] && break; \
+__homeboy_env_key=${{__homeboy_env_line%%=*}}; \
+export \"$__homeboy_env_key=${{__homeboy_env_line#*=}}\"; \
+done",
+        sentinel = SECRET_ENV_STDIN_SENTINEL,
+    )
+}
+
+/// Prepend the secret-env read loop to an already-composed command line so the
+/// secrets are imported before the command runs.
+pub(crate) fn wrap_command_with_secret_env_read_loop(command_line: &str) -> String {
+    format!("{} && {}", secret_env_stdin_read_loop(), command_line)
+}
+
+/// Serialize the secret env map into the stdin block consumed by
+/// [`secret_env_stdin_read_loop`]. Sorted for deterministic output.
+pub(crate) fn build_secret_env_stdin_block(secret_env: &BTreeMap<String, String>) -> Vec<u8> {
+    let mut block = String::new();
+    for (key, value) in secret_env {
+        block.push_str(key);
+        block.push('=');
+        block.push_str(value);
+        block.push('\n');
+    }
+    block.push_str(SECRET_ENV_STDIN_SENTINEL);
+    block.push('\n');
+    block.into_bytes()
+}
+
+/// Map a finished `ssh` invocation's captured output into a [`CommandOutput`].
+fn map_ssh_output(output: std::io::Result<std::process::Output>) -> CommandOutput {
+    match output {
+        Ok(out) => CommandOutput {
+            stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+            success: out.status.success(),
+            exit_code: out.status.code().unwrap_or(-1),
+            timed_out: false,
+            child_resource: None,
+        },
+        Err(err) => CommandOutput {
+            stdout: String::new(),
+            stderr: format!("SSH error: {}", err),
+            success: false,
+            exit_code: -1,
+            timed_out: false,
+            child_resource: None,
+        },
+    }
+}
 
 impl SshClient {
     pub fn from_server(server: &Server, server_id: &str) -> Result<Self> {
@@ -274,7 +358,31 @@ impl SshClient {
 
     pub fn execute(&self, command: &str) -> CommandOutput {
         let effective = self.prepend_env(command);
-        self.execute_with_stdin(&effective, None)
+        self.execute_with_stdin(&effective, SshStdin::None)
+    }
+
+    /// Execute `command` with secret env vars delivered over stdin instead of
+    /// interpolated into the SSH command argv.
+    ///
+    /// Non-secret env (PATH and other public config) is still exported inline by
+    /// [`prepend_env`], preserving `$PATH`-style shell expansion. The secret
+    /// values are streamed as a `NAME=VALUE` block (terminated by a sentinel)
+    /// over the SSH channel's stdin and imported by a read loop, so OAuth/API
+    /// tokens never appear in the controller-local `ssh` argv or the remote
+    /// login-shell argv (both visible in `ps`). When `secret_env` is empty this
+    /// is identical to [`execute`].
+    pub fn execute_with_secret_env(
+        &self,
+        command: &str,
+        secret_env: &BTreeMap<String, String>,
+    ) -> CommandOutput {
+        let effective = self.prepend_env(command);
+        if secret_env.is_empty() {
+            return self.execute_with_stdin(&effective, SshStdin::None);
+        }
+        let wrapped = wrap_command_with_secret_env_read_loop(&effective);
+        let block = build_secret_env_stdin_block(secret_env);
+        self.execute_with_stdin(&wrapped, SshStdin::Inline(&block))
     }
 
     /// Build an env preamble that normalizes runner command lookup and sets
@@ -292,7 +400,7 @@ impl SshClient {
 
     pub fn upload_file(&self, local_path: &str, remote_path: &str) -> CommandOutput {
         let remote_command = format!("cat > {}", shell::quote_path(remote_path));
-        self.execute_with_stdin(&remote_command, Some(local_path))
+        self.execute_with_stdin(&remote_command, SshStdin::File(local_path))
     }
 
     pub fn download_file(&self, remote_path: &str, local_path: &str) -> CommandOutput {
@@ -360,20 +468,20 @@ impl SshClient {
         }
     }
 
-    fn execute_with_stdin(&self, command: &str, stdin_file: Option<&str>) -> CommandOutput {
-        self.execute_with_retry(command, stdin_file, 3)
+    fn execute_with_stdin(&self, command: &str, stdin: SshStdin<'_>) -> CommandOutput {
+        self.execute_with_retry(command, stdin, 3)
     }
 
     fn execute_with_retry(
         &self,
         command: &str,
-        stdin_file: Option<&str>,
+        stdin: SshStdin<'_>,
         max_attempts: u32,
     ) -> CommandOutput {
         let backoff_secs = [0, 2, 5]; // delays before retry 1, 2, 3
 
         for attempt in 0..max_attempts {
-            let result = self.execute_once(command, stdin_file);
+            let result = self.execute_once(command, stdin);
 
             // Only retry on transient connection errors, not command failures
             if result.success || attempt + 1 >= max_attempts || !is_transient_ssh_error(&result) {
@@ -402,15 +510,19 @@ impl SshClient {
         }
     }
 
-    fn execute_once(&self, command: &str, stdin_file: Option<&str>) -> CommandOutput {
+    fn execute_once(&self, command: &str, stdin: SshStdin<'_>) -> CommandOutput {
         // Local execution: run command directly instead of over SSH
         if self.is_local {
-            if let Some(stdin_file_path) = stdin_file {
-                // For stdin piping (used by upload_file), use shell redirection
-                let local_cmd = format!("cat {} | {}", shell::quote_path(stdin_file_path), command);
-                return execute_local_command(&local_cmd);
-            }
-            return execute_local_command(command);
+            return match stdin {
+                SshStdin::File(stdin_file_path) => {
+                    // For stdin piping (used by upload_file), use shell redirection
+                    let local_cmd =
+                        format!("cat {} | {}", shell::quote_path(stdin_file_path), command);
+                    execute_local_command(&local_cmd)
+                }
+                SshStdin::Inline(bytes) => execute_local_command_with_stdin(command, bytes),
+                SshStdin::None => execute_local_command(command),
+            };
         }
 
         let args = self.build_ssh_args(Some(command), false);
@@ -418,44 +530,54 @@ impl SshClient {
         let mut cmd = Command::new("ssh");
         cmd.args(&args);
 
-        if let Some(stdin_file_path) = stdin_file {
-            match std::fs::File::open(stdin_file_path) {
+        match stdin {
+            SshStdin::File(stdin_file_path) => match std::fs::File::open(stdin_file_path) {
                 Ok(file) => {
                     cmd.stdin(file);
+                    map_ssh_output(cmd.output())
                 }
-                Err(err) => {
-                    return CommandOutput {
-                        stdout: String::new(),
-                        stderr: format!("Failed to open stdin file: {}", err),
-                        success: false,
-                        exit_code: -1,
-                        timed_out: false,
-                        child_resource: None,
-                    };
-                }
+                Err(err) => CommandOutput {
+                    stdout: String::new(),
+                    stderr: format!("Failed to open stdin file: {}", err),
+                    success: false,
+                    exit_code: -1,
+                    timed_out: false,
+                    child_resource: None,
+                },
+            },
+            SshStdin::Inline(bytes) => self.run_ssh_with_inline_stdin(cmd, bytes),
+            SshStdin::None => map_ssh_output(cmd.output()),
+        }
+    }
+
+    /// Spawn `ssh`, stream `stdin` bytes to the channel, and collect output.
+    ///
+    /// Used for the secret-env block: the bytes carry `NAME=VALUE` secret pairs
+    /// the remote read loop imports, so they stay off the `ssh` argv. The block
+    /// is small (a handful of tokens) and fits the OS pipe buffer, so writing it
+    /// before `wait_with_output` never deadlocks against captured stdout/stderr.
+    fn run_ssh_with_inline_stdin(&self, mut cmd: Command, stdin: &[u8]) -> CommandOutput {
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                return CommandOutput {
+                    stdout: String::new(),
+                    stderr: format!("SSH error: {}", err),
+                    success: false,
+                    exit_code: -1,
+                    timed_out: false,
+                    child_resource: None,
+                };
             }
+        };
+        if let Some(mut pipe) = child.stdin.take() {
+            let _ = pipe.write_all(stdin);
+            // Drop closes stdin (EOF) so the remote read loop terminates.
         }
-
-        let output = cmd.output();
-
-        match output {
-            Ok(out) => CommandOutput {
-                stdout: String::from_utf8_lossy(&out.stdout).to_string(),
-                stderr: String::from_utf8_lossy(&out.stderr).to_string(),
-                success: out.status.success(),
-                exit_code: out.status.code().unwrap_or(-1),
-                timed_out: false,
-                child_resource: None,
-            },
-            Err(e) => CommandOutput {
-                stdout: String::new(),
-                stderr: format!("SSH error: {}", e),
-                success: false,
-                exit_code: -1,
-                timed_out: false,
-                child_resource: None,
-            },
-        }
+        map_ssh_output(child.wait_with_output())
     }
 
     pub fn execute_interactive(&self, command: Option<&str>) -> i32 {

--- a/src/core/server/client/tests.rs
+++ b/src/core/server/client/tests.rs
@@ -10,7 +10,64 @@ use super::local_exec::{
     execute_local_command_in_dir, execute_local_command_interactive,
     execute_local_command_passthrough, execute_local_command_stderr_passthrough,
 };
+use super::ssh_client::{
+    build_secret_env_stdin_block, wrap_command_with_secret_env_read_loop,
+    SECRET_ENV_STDIN_SENTINEL,
+};
 use super::{CommandOutput, SshClient};
+
+#[test]
+fn secret_env_values_stream_over_stdin_not_command_argv() {
+    // OAuth/API tokens that earlier went inline as `export KEY=value` in the
+    // SSH command argv (visible in the controller `ps` table and the remote
+    // login-shell argv) must now travel over stdin instead.
+    let secret_env = std::collections::BTreeMap::from([
+        (
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
+            "super-secret-access-token".to_string(),
+        ),
+        (
+            "OPENAI_API_KEY".to_string(),
+            "sk-do-not-leak-this".to_string(),
+        ),
+    ]);
+    let command_line = "cd /srv/app && node run-headless-loop.cjs";
+
+    let wrapped = wrap_command_with_secret_env_read_loop(command_line);
+    let block = String::from_utf8(build_secret_env_stdin_block(&secret_env)).expect("utf8 block");
+
+    // The command argv (what lands in `ps`) must carry neither the secret
+    // values nor even the secret env names.
+    assert!(
+        !wrapped.contains("super-secret-access-token"),
+        "argv must not contain the access token: {wrapped}"
+    );
+    assert!(
+        !wrapped.contains("sk-do-not-leak-this"),
+        "argv must not contain the api key: {wrapped}"
+    );
+    assert!(
+        !wrapped.contains("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN"),
+        "argv must not contain the secret env name: {wrapped}"
+    );
+    assert!(
+        wrapped.contains(command_line),
+        "argv must still run the original command: {wrapped}"
+    );
+
+    // The stdin block carries the assignments and the terminating sentinel.
+    assert!(block.contains("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN=super-secret-access-token"));
+    assert!(block.contains("OPENAI_API_KEY=sk-do-not-leak-this"));
+    assert!(block.trim_end().ends_with(SECRET_ENV_STDIN_SENTINEL));
+}
+
+#[test]
+fn empty_secret_env_block_carries_only_the_sentinel() {
+    let block =
+        String::from_utf8(build_secret_env_stdin_block(&std::collections::BTreeMap::new()))
+            .expect("utf8 block");
+    assert_eq!(block, format!("{SECRET_ENV_STDIN_SENTINEL}\n"));
+}
 
 #[test]
 fn test_non_local_hosts() {


### PR DESCRIPTION
## What

Hardens the Lab runner secret/env contract and closes the partial-sync orphan window. Four coherent changes in `src/core/runner/` and `src/core/server/client/`.

### 1. Secrets no longer inlined into the SSH command argv (#6676)
`exec_diagnostic_ssh` merged controller-resolved provider tokens into the `SshClient` env, which `prepend_env` then inlined as `export KEY=value` into the single command string handed to local `ssh`. That put OAuth/API tokens in the controller `ps` table **and** the remote login-shell argv.

Now secret-bearing entries (names declared in `secret_env_names`, plus any redaction-sensitive key as defense in depth) are partitioned out of the inline exports and streamed as a `NAME=VALUE` block over the SSH channel's **stdin**, imported by a POSIX-sh read loop terminated by a sentinel. Values are applied via the `export` builtin (not `eval`), so shell metacharacters in a value are inert. Non-secret exports (PATH and other public config) stay inline, preserving `$PATH` expansion. The localhost fast path streams the same block to the child's stdin.

### 2. Generic core carries no provider-token literals (#6676)
`declared_runtime_provider_secret_env` dropped the hardcoded `AI_PROVIDER_OPENAI_CODEX_*` / `OPENAI_API_KEY` / `AI_PROVIDER_CLAUDE_CODE_*` match arms keyed off `HOMEBOY_AGENT_RUNTIME_PROVIDER`. The generic `HOMEBOY_AGENT_RUNTIME_SECRET_ENV` allowlist was already checked first, making the map redundant baggage that violated the generic-core rule. The runtime/extension now declares names it owns; codex/claude-code keep working by exporting that allowlist, and new providers need no core change.

### 3. Partial-sync orphan rollback (#6752)
`sync_workspace` materialized the remote `_lab_workspaces/<checkout>` dir **before** writing metadata and syncing validation-dependency siblings. A failure in those later steps returned an error without ever handing the caller a `remote_path` to wrap in the `MaterializedWorkspace` RAII handle (#6753), orphaning an untracked remote directory invisible to inventory and the reap path. The post-materialize steps are now grouped and the materialized checkout is rolled back on failure, so every materialized path stays tracked/reapable.

### 4. Redaction heuristic dedup
The URL-vs-string env-value heuristic was copy-pasted in `secret_env_plan.rs` and `redaction.rs`; both now route through one `RedactionPolicy::redact_env_value`.

## Tests
- `secret_env_values_stream_over_stdin_not_command_argv` — secret values and names are absent from the command argv and present only in the stdin block.
- `runner_exec_secret_env_names_carry_no_hardcoded_provider_literals` / `..._use_runtime_declared_allowlist` — a bare provider hint implies no token names; a declared allowlist still resolves.
- `sync_workspace_rolls_back_checkout_when_validation_dependency_fails` — a post-materialize failure leaves no orphaned checkout under `_lab_workspaces`.

## Verification
- `cargo check` clean.
- Targeted suites pass: `core::server::client` (21), `core::redaction` (6), `secret_env` (68), `core::runner::execution` (73), `core::deploy` (176), `core::runner::validation_dependencies` (7).
- One pre-existing failure (`workspace::tests::git::git_materialization_ignores_generated_homeboy_output_but_refuses_source_dirty_state`) reproduces on clean `origin/main` via `git stash` and is unrelated to this change.

## Follow-ups
- Unifying the diagnostic `value_preview` placeholders (`<redacted>` / `REDACTED_ENV_VALUE`) is a separate concern from the env-value redaction heuristic and left out of scope.
- Extension-side: any caller that relied on the implicit provider→token map must now declare names via `HOMEBOY_AGENT_RUNTIME_SECRET_ENV`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Investigating the runner secret/env + offload-sync code paths, implementing the stdin secret-env transport, the provider-map removal, the partial-sync rollback, the redaction dedup, and the accompanying tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)