### PR TITLE
chore: annotate agent_task/tool thin-adapter false-positive

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -672,7 +672,6 @@
         "test_quality::src/core/runner/execution/tests/redaction.rs::VacuousTest",
         "test_quality::src/core/runner/execution/tests/secret_source.rs::VacuousTest",
         "test_quality::tests/command_surface_test.rs::VacuousTest",
-        "thin_command_adapter::src/commands/agent_task/tool.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/bench/settings_matrix.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/observe.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/review/mod.rs::ThinCommandAdapterViolation",

--- a/src/commands/agent_task/tool.rs
+++ b/src/commands/agent_task/tool.rs
@@ -23,7 +23,9 @@ pub enum AgentTaskToolCommand {
 pub struct AgentTaskToolDispatchArgs {}
 
 pub fn dispatch_raw(_args: AgentTaskToolDispatchArgs) -> i32 {
+    // homeboy-audit: allow-thin-command-adapter
     match dispatch_raw_result() {
+        // homeboy-audit: allow-thin-command-adapter
         Ok(result) => {
             println!("{}", result);
             0
@@ -36,6 +38,7 @@ pub fn dispatch_raw(_args: AgentTaskToolDispatchArgs) -> i32 {
 }
 
 fn dispatch_raw_result() -> Result<String, String> {
+    // homeboy-audit: allow-thin-command-adapter
     let mut stdin = String::new();
     std::io::stdin()
         .read_to_string(&mut stdin)
@@ -45,7 +48,7 @@ fn dispatch_raw_result() -> Result<String, String> {
         .map_err(|error| format!("invalid agent tool request JSON: {error}"))?;
     let policy = policy_from_env()?;
     let outcome =
-        dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher);
+        dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher); // homeboy-audit: allow-thin-command-adapter
 
     serde_json::to_string(&outcome.result)
         .map_err(|error| format!("failed to serialize agent tool result JSON: {error}"))


### PR DESCRIPTION
agent_task/tool.rs is already a thin adapter delegating to the core dispatch_agent_tool_request service (no process/fs/persistence orchestration). The ThinCommandAdapter finding is a false positive from the dispatch_* function-name regex. Adds the sanctioned // homeboy-audit: allow-thin-command-adapter annotation on the triggering lines and clears the baseline row. Comment-only, no behavior change.