### PR TITLE
Table-drive code_audit Manual detectors onto descriptor dispatch

### DIFF
--- a/src/core/code_audit/descriptor_runtime.rs
+++ b/src/core/code_audit/descriptor_runtime.rs
@@ -1,18 +1,43 @@
+use super::detectors::layer_ownership::run as run_layer_ownership;
 use super::detectors::{
-    aggregate_construction, facade_passthrough, repeated_literal_shape, shared_scaffolding,
-    test_topology, test_wiring,
+    aggregate_construction, command_status_contracts, config_key_usage, dead_guard,
+    deprecation_age, enum_dispatch_contracts, facade_passthrough, field_patterns, global_env_guard,
+    mutating_resource_access, parallel_runner_setup, public_registry_exposure, redirect_validation,
+    remote_execution_preflight, repeated_literal_shape, requested_detectors, shared_scaffolding,
+    source_policy, test_coverage, test_topology, test_wiring, thin_command_adapter,
+    unbounded_output_capture, wrapper_inference,
 };
+use super::doc_drift::detect_doc_drift;
+use super::reference::{fingerprint_component_reference_files, fingerprint_reference_paths};
 use super::{
-    fingerprint, shadow_modules, time_audit_detector, AuditExecutionPlan, AuditTiming,
-    DetectorDescriptor, DetectorRuntime, Finding, FingerprintDetectorRunner, RootDetectorRunner,
+    comment_hygiene, compiler_warnings, dead_code, fingerprint, shadow_modules, structural,
+    time_audit_detector, AuditExecutionPlan, AuditTiming, DetectorDescriptor, DetectorRuntime,
+    Finding, FingerprintDetectorRunner, GenericDetectorRunner, RootDetectorRunner,
 };
-use crate::core::component::AuditConfig;
+use crate::core::component::{self, AuditConfig};
+use crate::core::engine::codebase_scan::CodebaseSnapshot;
 use std::path::Path;
 
+/// Inputs shared by every data-driven detector. The descriptor table dispatches
+/// through [`run_descriptor_detectors`]; each runner reads only the fields it
+/// needs from this context, so adding a detector means one descriptor row plus
+/// one match arm — never a new hand-wired block in `engine.rs`.
 pub(super) struct DetectorRunContext<'a> {
     pub(super) root: &'a Path,
+    pub(super) component_id: &'a str,
     pub(super) audit_config: &'a AuditConfig,
+    /// Full fingerprint corpus. Cross-file detectors (dead code, duplication
+    /// inputs) need the whole tree even when the audit is scoped.
     pub(super) all_fingerprints: &'a [&'a fingerprint::FileFingerprint],
+    /// Per-file detector input: the scoped subset under `--changed-since`, else
+    /// the full corpus. Detectors keyed strictly to the file they inspect read
+    /// this so scoped runs avoid O(repo) work.
+    pub(super) per_file_fingerprints: &'a [&'a fingerprint::FileFingerprint],
+    /// Shared source snapshot for whole-tree detectors. `None` only on the
+    /// root-only fast path when no snapshot-backed detector is enabled.
+    pub(super) source_snapshot: Option<&'a CodebaseSnapshot>,
+    /// External reference codebases included in dead-code cross-referencing.
+    pub(super) reference_paths: &'a [String],
 }
 
 fn run_fingerprint_descriptor(
@@ -50,6 +75,124 @@ fn run_root_descriptor(
     }
 }
 
+/// Dispatch a single-closure detector. Each arm is the one invocation that used
+/// to live in a hand-wired `time_audit_detector` block in `engine.rs`; the
+/// descriptor table now supplies enable state, timing id, and logging.
+fn run_generic_descriptor(
+    runner: GenericDetectorRunner,
+    context: &DetectorRunContext<'_>,
+) -> Vec<Finding> {
+    let config = context.audit_config;
+    match runner {
+        GenericDetectorRunner::Structural => match context.source_snapshot {
+            Some(snapshot) => structural::analyze_snapshot(context.root, snapshot),
+            None => structural::analyze_structure(context.root),
+        },
+        GenericDetectorRunner::DeadCode => run_dead_code(context),
+        GenericDetectorRunner::CommentHygiene => {
+            comment_hygiene::run(context.per_file_fingerprints, &config.detector_profile)
+        }
+        GenericDetectorRunner::TestCoverage => run_test_coverage(context),
+        GenericDetectorRunner::LayerOwnership => run_layer_ownership(context.root),
+        GenericDetectorRunner::Docs => detect_doc_drift(context.root, context.component_id),
+        GenericDetectorRunner::CompilerWarnings => compiler_warnings::run(context.root),
+        GenericDetectorRunner::WrapperInference => {
+            wrapper_inference::run(context.all_fingerprints, context.root)
+        }
+        GenericDetectorRunner::FieldPatterns => match context.source_snapshot {
+            Some(snapshot) => field_patterns::run(snapshot, &config.detector_profile),
+            None => Vec::new(),
+        },
+        GenericDetectorRunner::DeprecationAge => {
+            deprecation_age::run(context.all_fingerprints, context.root, &config.detector_profile)
+        }
+        GenericDetectorRunner::DeadGuard => {
+            dead_guard::run(context.per_file_fingerprints, context.root, config)
+        }
+        GenericDetectorRunner::RequestedDetectors => {
+            requested_detectors::run(context.all_fingerprints, config)
+        }
+        GenericDetectorRunner::ConfigKeyUsage => {
+            config_key_usage::run(context.all_fingerprints, &config.config_key_usage.rules)
+        }
+        GenericDetectorRunner::OutputCapture => {
+            unbounded_output_capture::run(context.per_file_fingerprints)
+        }
+        GenericDetectorRunner::CoreBoundaryLeaks => source_policy::run(
+            context.per_file_fingerprints,
+            &config.core_boundary_leaks.to_source_policy_rules(),
+        ),
+        GenericDetectorRunner::SourcePolicy => {
+            source_policy::run(context.per_file_fingerprints, &config.source_policies)
+        }
+        GenericDetectorRunner::MutatingResourceAccess => mutating_resource_access::run(
+            context.per_file_fingerprints,
+            &config.mutating_resource_access,
+        ),
+        GenericDetectorRunner::RedirectValidation => {
+            redirect_validation::run(context.per_file_fingerprints, &config.redirect_validation)
+        }
+        GenericDetectorRunner::GlobalEnvGuard => global_env_guard::run(context.all_fingerprints),
+        GenericDetectorRunner::ParallelRunnerSetup => {
+            parallel_runner_setup::run(context.all_fingerprints)
+        }
+        GenericDetectorRunner::RemoteExecutionPreflight => {
+            remote_execution_preflight::run(context.all_fingerprints, &config.remote_execution_safety)
+        }
+        GenericDetectorRunner::EnumDispatchContracts => match context.source_snapshot {
+            Some(snapshot) => enum_dispatch_contracts::run(snapshot),
+            None => Vec::new(),
+        },
+        GenericDetectorRunner::PublicRegistryExposure => {
+            public_registry_exposure::run(context.all_fingerprints, &config.public_registry_exposure)
+        }
+        GenericDetectorRunner::CommandStatusContracts => {
+            command_status_contracts::run(context.root, &config.command_status_contracts)
+        }
+        GenericDetectorRunner::ThinCommandAdapter => {
+            thin_command_adapter::run(context.root, &config.thin_command_adapter)
+        }
+    }
+}
+
+/// Dead-code analysis fingerprints external/component reference files lazily so
+/// the (potentially expensive) reference walk only happens when the detector is
+/// enabled. The dispatch only invokes this runner for an enabled descriptor, so
+/// the walk stays gated exactly as it was when hand-wired in `engine.rs`.
+fn run_dead_code(context: &DetectorRunContext<'_>) -> Vec<Finding> {
+    let ref_fingerprints = fingerprint_reference_paths(context.reference_paths);
+    let component_ref_fingerprints = fingerprint_component_reference_files(context.root);
+    let ref_fp_refs: Vec<&fingerprint::FileFingerprint> = ref_fingerprints
+        .iter()
+        .chain(component_ref_fingerprints.iter())
+        .collect();
+    dead_code::analyze_dead_code_with_config(
+        context.all_fingerprints,
+        &ref_fp_refs,
+        context.audit_config,
+    )
+}
+
+/// Structural test-coverage gap detection. Uses the first installed extension
+/// that declares a `test_mapping` for the component, matching the prior
+/// hand-wired loop's "first extension wins, then stop" behavior.
+fn run_test_coverage(context: &DetectorRunContext<'_>) -> Vec<Finding> {
+    let Ok(comp) = component::load(context.component_id) else {
+        return Vec::new();
+    };
+    let Some(extensions) = comp.extensions else {
+        return Vec::new();
+    };
+    for ext_id in extensions.keys() {
+        if let Ok(ext_manifest) = crate::core::extension::load_extension(ext_id) {
+            if let Some(test_mapping) = ext_manifest.test_mapping() {
+                return test_coverage::run(context.root, context.all_fingerprints, test_mapping);
+            }
+        }
+    }
+    Vec::new()
+}
+
 fn extend_descriptor_findings(
     all_findings: &mut Vec<Finding>,
     descriptor: &DetectorDescriptor,
@@ -69,19 +212,33 @@ fn extend_descriptor_findings(
     all_findings.extend(findings);
 }
 
+/// Drive the descriptor table. `ids = None` runs every data-driven detector
+/// (the full-discovery path); `ids = Some(subset)` runs only the listed
+/// detectors (the root-only fast path). `Manual` descriptors — the convention
+/// pipeline, the multi-pass duplication family, and artifact portability — are
+/// sequenced by hand in `engine.rs` and skipped here.
 pub(super) fn run_descriptor_detectors(
     plan: &AuditExecutionPlan,
     timing: &mut AuditTiming,
     all_findings: &mut Vec<Finding>,
     context: &DetectorRunContext<'_>,
-    detector_ids: &[&str],
+    ids: Option<&[&str]>,
 ) {
     for descriptor in AuditExecutionPlan::descriptors() {
-        if !detector_ids.contains(&descriptor.id) {
-            continue;
+        if let Some(ids) = ids {
+            if !ids.contains(&descriptor.id) {
+                continue;
+            }
         }
 
         let findings = match descriptor.runtime {
+            DetectorRuntime::Generic(runner) => time_audit_detector(
+                timing,
+                descriptor.timing_id,
+                plan.detector_enabled(descriptor.id),
+                || run_generic_descriptor(runner, context),
+                Vec::new,
+            ),
             DetectorRuntime::Fingerprint(runner) => time_audit_detector(
                 timing,
                 descriptor.timing_id,
@@ -99,5 +256,96 @@ pub(super) fn run_descriptor_detectors(
             DetectorRuntime::Manual => continue,
         };
         extend_descriptor_findings(all_findings, descriptor, findings);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::code_audit::AuditProfile;
+
+    /// Only the three hand-sequenced families remain `Manual`; every other
+    /// detector is dispatched through the data-driven runtime. This guards
+    /// against a new detector being added as a hand-wired `engine.rs` block.
+    #[test]
+    fn only_special_families_remain_manual() {
+        let manual: Vec<&str> = AuditExecutionPlan::descriptors()
+            .iter()
+            .filter(|descriptor| matches!(descriptor.runtime, DetectorRuntime::Manual))
+            .map(|descriptor| descriptor.id)
+            .collect();
+
+        assert_eq!(
+            manual,
+            vec!["conventions", "duplication", "artifact_portability"]
+        );
+    }
+
+    /// A detector that used to be hand-wired in `engine.rs` (`structural`) now
+    /// flows through `run_descriptor_detectors` end to end: the descriptor's
+    /// `Generic` runtime is dispatched, the finding is collected, and timing is
+    /// recorded — none of which touches a per-detector block.
+    #[test]
+    fn migrated_detector_runs_via_data_driven_dispatch() {
+        let dir = std::env::temp_dir().join(format!(
+            "homeboy_descriptor_dispatch_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // A god file well past the structural line threshold.
+        let mut content = String::new();
+        for i in 0..1600 {
+            content.push_str(&format!("// line {i}\n"));
+        }
+        std::fs::write(dir.join("big.rs"), content).unwrap();
+
+        // Confirm the descriptor is genuinely data-driven, not Manual.
+        let structural = AuditExecutionPlan::descriptors()
+            .iter()
+            .find(|descriptor| descriptor.id == "structural")
+            .expect("structural descriptor");
+        assert_eq!(
+            structural.runtime,
+            DetectorRuntime::Generic(GenericDetectorRunner::Structural)
+        );
+
+        let audit_config = AuditConfig::default();
+        let context = DetectorRunContext {
+            root: &dir,
+            component_id: "fixture-component",
+            audit_config: &audit_config,
+            all_fingerprints: &[],
+            per_file_fingerprints: &[],
+            source_snapshot: None,
+            reference_paths: &[],
+        };
+
+        let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Full, &[], &[]);
+        let mut timing = AuditTiming::default();
+        let mut findings = Vec::new();
+        run_descriptor_detectors(
+            &plan,
+            &mut timing,
+            &mut findings,
+            &context,
+            Some(&["structural"]),
+        );
+
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.file.contains("big.rs")),
+            "structural detector should emit a god-file finding via the data-driven dispatch"
+        );
+        assert!(
+            timing
+                .spans
+                .iter()
+                .any(|span| span.id == "detector.structural" && span.status == "ok"),
+            "dispatch should record the structural timing span"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/core/code_audit/engine.rs
+++ b/src/core/code_audit/engine.rs
@@ -3,36 +3,45 @@
 //!
 //! Mechanically split out of `mod.rs`; behavior and the surrounding public API
 //! are preserved by the re-exports in the module root.
+//!
+//! Detector dispatch is table-driven: the descriptor table in `execution_plan`
+//! declares every detector and `descriptor_runtime::run_descriptor_detectors`
+//! executes it. Only three families are still sequenced by hand below because
+//! they have a non-uniform shape — the convention pipeline, the multi-pass
+//! `duplication` family (five timing spans plus the `duplicate_groups` side
+//! output), and `artifact_portability` (logs scan statistics even when empty).
 
 use std::collections::HashSet;
 use std::path::Path;
 
 use super::descriptor_runtime::{run_descriptor_detectors, DetectorRunContext};
-use super::detectors::layer_ownership::run as run_layer_ownership;
-use super::detectors::{
-    artifact_portability, command_status_contracts, config_key_usage, dead_guard, deprecation_age,
-    enum_dispatch_contracts, field_patterns, global_env_guard, mutating_resource_access,
-    parallel_runner_setup, public_registry_exposure, redirect_validation,
-    remote_execution_preflight, requested_detectors, source_policy, test_coverage,
-    thin_command_adapter, unbounded_output_capture, wrapper_inference,
-};
-use super::doc_drift::detect_doc_drift;
+use super::detectors::{artifact_portability, field_patterns};
 use super::entry::audit_config_for;
 use super::execution_plan::AuditExecutionPlan;
 use super::findings;
-use super::reference::{
-    build_convention_method_set, fingerprint_component_reference_files, fingerprint_reference_paths,
-};
+use super::reference::build_convention_method_set;
 use super::types::{
     time_audit_detector, AuditAnalysisContext, AuditSummary, AuditTiming, AuditWithAnalysis,
     CodeAuditResult, ConventionReport, ScopedAuditExecution,
 };
-use super::{
-    checks, comment_hygiene, compiler_warnings, conventions, dead_code, discovery, duplication,
-    fingerprint, impact, structural, walker,
-};
-use crate::core::component::{self, AuditConfig};
+use super::{checks, conventions, discovery, duplication, fingerprint, impact, structural, walker};
+use crate::core::component::AuditConfig;
 use crate::core::Result;
+
+/// Detectors run on the root-only fast path (no discovery/fingerprinting). The
+/// full path drives every data-driven detector via `ids = None`; this subset
+/// keeps the fast path's timing spans and findings identical to before.
+const ROOT_ONLY_DETECTOR_IDS: &[&str] = &[
+    "structural",
+    "layer_ownership",
+    "test_topology",
+    "test_wiring",
+    "docs",
+    "compiler_warnings",
+    "field_patterns",
+    "command_status_contracts",
+    "thin_command_adapter",
+];
 
 /// Internal audit implementation supporting optional file scoping and impact tracing.
 ///
@@ -180,23 +189,6 @@ pub(super) fn audit_internal(
     let mut all_findings = findings::build_findings(&check_results);
     let detectors_started = std::time::Instant::now();
 
-    // Phase 4b: Structural complexity analysis (god files, high item counts)
-    let structural_findings = time_audit_detector(
-        &mut timing,
-        "detector.structural",
-        plan.run_structural(),
-        || structural::analyze_snapshot(root, &source_snapshot),
-        Vec::new,
-    );
-    if !structural_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Structural: {} finding(s) (god files, high item counts)",
-            structural_findings.len()
-        );
-        all_findings.extend(structural_findings);
-    }
-
     // Phase 4c: Duplication detection (identical function bodies across files)
     let all_fingerprints: Vec<&fingerprint::FileFingerprint> = discovery
         .groups
@@ -281,21 +273,27 @@ pub(super) fn audit_internal(
 
     let detector_context = DetectorRunContext {
         root,
+        component_id,
         audit_config: &audit_config,
         all_fingerprints: &all_fingerprints,
+        per_file_fingerprints,
+        source_snapshot: Some(&source_snapshot),
+        reference_paths,
     };
 
+    // The duplication family stays hand-sequenced: it runs five timing spans and
+    // also produces `duplicate_groups`, a side output threaded into the report.
     let duplication_findings = time_audit_detector(
         &mut timing,
         "detector.duplication.exact",
-        plan.run_duplication(),
+        plan.detector_enabled("duplication"),
         || duplication::detect_duplicates(&all_fingerprints, &convention_methods),
         Vec::new,
     );
     let duplicate_groups = time_audit_detector(
         &mut timing,
         "detector.duplication.groups",
-        plan.run_duplication(),
+        plan.detector_enabled("duplication"),
         || duplication::detect_duplicate_groups(&all_fingerprints),
         Vec::new,
     );
@@ -313,7 +311,7 @@ pub(super) fn audit_internal(
     let intra_dup_findings = time_audit_detector(
         &mut timing,
         "detector.duplication.intra_method",
-        plan.run_duplication(),
+        plan.detector_enabled("duplication"),
         || duplication::detect_intra_method_duplicates(&all_fingerprints),
         Vec::new,
     );
@@ -330,7 +328,7 @@ pub(super) fn audit_internal(
     let near_dup_findings = time_audit_detector(
         &mut timing,
         "detector.duplication.near_duplicate",
-        plan.run_duplication(),
+        plan.detector_enabled("duplication"),
         || duplication::detect_near_duplicates(&all_fingerprints),
         Vec::new,
     );
@@ -347,7 +345,7 @@ pub(super) fn audit_internal(
     let parallel_findings = time_audit_detector(
         &mut timing,
         "detector.duplication.parallel_implementation",
-        plan.run_duplication(),
+        plan.detector_enabled("duplication"),
         || {
             duplication::detect_parallel_implementations(
                 &all_fingerprints,
@@ -366,478 +364,18 @@ pub(super) fn audit_internal(
         all_findings.extend(parallel_findings);
     }
 
-    // Phase 4e: Dead code detection (unused params, unreferenced exports, orphaned internals)
-    //
-    // Reference dependencies (e.g. WordPress core, plugin dependencies) are fingerprinted
-    // and included in the cross-reference set so that functions called via framework hooks,
-    // callbacks, or inherited methods are recognized as referenced.
-    let ref_fingerprints = if plan.run_dead_code() {
-        fingerprint_reference_paths(reference_paths)
-    } else {
-        Vec::new()
-    };
-    let component_ref_fingerprints = if plan.run_dead_code() {
-        fingerprint_component_reference_files(root)
-    } else {
-        Vec::new()
-    };
-    let ref_fp_refs: Vec<&fingerprint::FileFingerprint> = ref_fingerprints
-        .iter()
-        .chain(component_ref_fingerprints.iter())
-        .collect();
-    let dead_code_findings = time_audit_detector(
-        &mut timing,
-        "detector.dead_code",
-        plan.run_dead_code(),
-        || dead_code::analyze_dead_code_with_config(&all_fingerprints, &ref_fp_refs, &audit_config),
-        Vec::new,
-    );
-    if !dead_code_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Dead code: {} finding(s) (unused params, unreferenced exports, orphaned internals)",
-            dead_code_findings.len()
-        );
-        all_findings.extend(dead_code_findings);
-    }
+    // Every other detector — structural, dead code, comment hygiene, the policy
+    // packs, the fingerprint/root families, etc. — is dispatched by the
+    // descriptor table in one pass. Adding a detector is a descriptor row plus a
+    // `run_generic_descriptor` arm, never a new block here.
+    run_descriptor_detectors(plan, &mut timing, &mut all_findings, &detector_context, None);
 
-    // Phase 4f: Comment hygiene detection (TODO/FIXME/HACK + stale phrasing)
-    let comment_findings = time_audit_detector(
-        &mut timing,
-        "detector.comment_hygiene",
-        plan.run_comment_hygiene(),
-        || comment_hygiene::run(per_file_fingerprints, &audit_config.detector_profile),
-        Vec::new,
-    );
-    if !comment_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Comment hygiene: {} finding(s) (TODO/FIXME/HACK markers, stale phrasing)",
-            comment_findings.len()
-        );
-        all_findings.extend(comment_findings);
-    }
-
-    // Phase 4g: Structural test coverage gap detection
-    // Look up the extension's test mapping config for the component.
-    if plan.run_test_coverage() {
-        let detector_started = std::time::Instant::now();
-        if let Ok(comp) = component::load(component_id) {
-            if let Some(extensions) = &comp.extensions {
-                for ext_id in extensions.keys() {
-                    if let Ok(ext_manifest) = crate::core::extension::load_extension(ext_id) {
-                        if let Some(test_mapping) = ext_manifest.test_mapping() {
-                            let coverage_findings =
-                                test_coverage::run(root, &all_fingerprints, test_mapping);
-                            if !coverage_findings.is_empty() {
-                                log_status!(
-                                    "audit",
-                                    "Test coverage: {} finding(s) (missing test files, uncovered methods, orphaned tests)",
-                                    coverage_findings.len()
-                                );
-                                all_findings.extend(coverage_findings);
-                            }
-                            break; // Only use the first extension that has test_mapping
-                        }
-                    }
-                }
-            }
-        }
-        timing.push_ok("detector.test_coverage", detector_started.elapsed());
-    } else {
-        timing.push_skipped("detector.test_coverage");
-    }
-
-    // Phase 4h: Architecture/layer ownership rule checks (optional config)
-    let layer_findings = time_audit_detector(
-        &mut timing,
-        "detector.layer_ownership",
-        plan.run_layer_ownership(),
-        || run_layer_ownership(root),
-        Vec::new,
-    );
-    if !layer_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Layer ownership: {} finding(s) (architecture ownership violations)",
-            layer_findings.len()
-        );
-        all_findings.extend(layer_findings);
-    }
-
-    run_descriptor_detectors(
-        plan,
-        &mut timing,
-        &mut all_findings,
-        &detector_context,
-        &["test_topology", "test_wiring"],
-    );
-
-    // Phase 4j: Documentation drift detection (broken/stale references in markdown)
-    let doc_findings = time_audit_detector(
-        &mut timing,
-        "detector.docs",
-        plan.run_docs(),
-        || detect_doc_drift(root, component_id),
-        Vec::new,
-    );
-    if !doc_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Docs: {} finding(s) (broken references, stale paths)",
-            doc_findings.len()
-        );
-        all_findings.extend(doc_findings);
-    }
-
-    // Phase 4l: Compiler warnings (dead code, unused imports, unused variables)
-    // Runs extension-owned warning scripts and maps their output to findings.
-    let compiler_findings = time_audit_detector(
-        &mut timing,
-        "detector.compiler_warnings",
-        plan.run_compiler_warnings(),
-        || compiler_warnings::run(root),
-        Vec::new,
-    );
-    if !compiler_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Compiler warnings: {} finding(s) (dead code, unused imports, unused variables)",
-            compiler_findings.len()
-        );
-        all_findings.extend(compiler_findings);
-    }
-
-    // Phase 4m: Wrapper-to-implementation inference
-    // Detects wrapper files missing explicit declarations of what they wrap.
-    // Uses configurable call pattern tracing to infer the implementation target.
-    let wrapper_findings = time_audit_detector(
-        &mut timing,
-        "detector.wrapper_inference",
-        plan.run_wrapper_inference(),
-        || wrapper_inference::run(&all_fingerprints, root),
-        Vec::new,
-    );
-    if !wrapper_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Wrapper inference: {} finding(s) (missing wrapper declarations)",
-            wrapper_findings.len()
-        );
-        all_findings.extend(wrapper_findings);
-    }
-
-    run_descriptor_detectors(
-        plan,
-        &mut timing,
-        &mut all_findings,
-        &detector_context,
-        &["shadow_modules"],
-    );
-
-    // Phase 4o: Repeated struct field pattern detection.
-    let field_pattern_findings = time_audit_detector(
-        &mut timing,
-        "detector.field_patterns",
-        plan.run_field_patterns(),
-        || field_patterns::run(&source_snapshot, &audit_config.detector_profile),
-        Vec::new,
-    );
-    if !field_pattern_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Field patterns: {} finding(s) (repeated struct fields)",
-            field_pattern_findings.len()
-        );
-        all_findings.extend(field_pattern_findings);
-    }
-
-    run_descriptor_detectors(
-        plan,
-        &mut timing,
-        &mut all_findings,
-        &detector_context,
-        &["facade_passthrough", "literal_shapes"],
-    );
-
-    // Phase 4r: Deprecation age detection
-    let deprecation_findings = time_audit_detector(
-        &mut timing,
-        "detector.deprecation_age",
-        plan.run_deprecation_age(),
-        || deprecation_age::run(&all_fingerprints, root, &audit_config.detector_profile),
-        Vec::new,
-    );
-    if !deprecation_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Deprecation age: {} finding(s) (stale @deprecated tags)",
-            deprecation_findings.len()
-        );
-        all_findings.extend(deprecation_findings);
-    }
-
-    // Phase 4q: Dead guard detection — flag function_exists/class_exists/defined
-    // guards on symbols guaranteed to exist given plugin requirements, composer
-    // dependencies, and bootstrap requires.
-    let dead_guard_findings = time_audit_detector(
-        &mut timing,
-        "detector.dead_guard",
-        plan.run_dead_guard(),
-        || dead_guard::run(per_file_fingerprints, root, &audit_config),
-        Vec::new,
-    );
-    if !dead_guard_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Dead guards: {} finding(s) (guards on guaranteed-available symbols)",
-            dead_guard_findings.len()
-        );
-        all_findings.extend(dead_guard_findings);
-    }
-
-    // Phase 4t: Extension-owned requested detector rule packs.
-    let requested_findings = time_audit_detector(
-        &mut timing,
-        "detector.requested_detectors",
-        plan.run_requested_detectors(),
-        || requested_detectors::run(&all_fingerprints, &audit_config),
-        Vec::new,
-    );
-    if !requested_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Requested detectors: {} finding(s) (extension rule packs)",
-            requested_findings.len()
-        );
-        all_findings.extend(requested_findings);
-    }
-
-    // Phase 4t1: Component-owned config-key write/accessor/read correlation.
-    let config_key_findings = time_audit_detector(
-        &mut timing,
-        "detector.config_key_usage",
-        plan.run_config_key_usage(),
-        || config_key_usage::run(&all_fingerprints, &audit_config.config_key_usage.rules),
-        Vec::new,
-    );
-    if !config_key_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Config key usage: {} finding(s) (write/accessor evidence without production reads)",
-            config_key_findings.len()
-        );
-        all_findings.extend(config_key_findings);
-    }
-
-    // Phase 4t1b: Generic command-output capture hygiene.
-    let output_capture_findings = time_audit_detector(
-        &mut timing,
-        "detector.output_capture",
-        plan.run_output_capture(),
-        || unbounded_output_capture::run(per_file_fingerprints),
-        Vec::new,
-    );
-    if !output_capture_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Output capture: {} finding(s) (unbounded stdout/stderr capture)",
-            output_capture_findings.len()
-        );
-        all_findings.extend(output_capture_findings);
-    }
-
-    // Phase 4t2: Configured core-boundary ecosystem leak detection.
-    let core_boundary_findings = time_audit_detector(
-        &mut timing,
-        "detector.core_boundary_leaks",
-        plan.run_core_boundary_leaks(),
-        || {
-            source_policy::run(
-                per_file_fingerprints,
-                &audit_config.core_boundary_leaks.to_source_policy_rules(),
-            )
-        },
-        Vec::new,
-    );
-    if !core_boundary_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Core boundary leaks: {} finding(s) (configured ecosystem terms in core source)",
-            core_boundary_findings.len()
-        );
-        all_findings.extend(core_boundary_findings);
-    }
-
-    // Phase 4t2b: Generic component-owned source policy checks.
-    let source_policy_findings = time_audit_detector(
-        &mut timing,
-        "detector.source_policy",
-        plan.run_source_policy(),
-        || source_policy::run(per_file_fingerprints, &audit_config.source_policies),
-        Vec::new,
-    );
-    if !source_policy_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Source policy: {} finding(s) (configured source boundary rules)",
-            source_policy_findings.len()
-        );
-        all_findings.extend(source_policy_findings);
-    }
-
-    // Phase 4t3: Configured mutating handler/resource access detection.
-    let mutating_access_findings = time_audit_detector(
-        &mut timing,
-        "detector.mutating_resource_access",
-        plan.run_mutating_resource_access(),
-        || {
-            mutating_resource_access::run(
-                per_file_fingerprints,
-                &audit_config.mutating_resource_access,
-            )
-        },
-        Vec::new,
-    );
-    if !mutating_access_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Mutating resource access: {} finding(s) (resource mutations without configured access checks)",
-            mutating_access_findings.len()
-        );
-        all_findings.extend(mutating_access_findings);
-    }
-
-    // Phase 4t4: Configured redirect-destination dominance checks.
-    let redirect_validation_findings = time_audit_detector(
-        &mut timing,
-        "detector.redirect_validation",
-        plan.run_redirect_validation(),
-        || redirect_validation::run(per_file_fingerprints, &audit_config.redirect_validation),
-        Vec::new,
-    );
-    if !redirect_validation_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Redirect validation: {} finding(s) (request-derived redirects without dominating validation)",
-            redirect_validation_findings.len()
-        );
-        all_findings.extend(redirect_validation_findings);
-    }
-
-    // Phase 4v: Process-global environment mutation guard consistency in tests.
-    let env_guard_findings = time_audit_detector(
-        &mut timing,
-        "detector.global_env_guard",
-        plan.run_global_env_guard(),
-        || global_env_guard::run(&all_fingerprints),
-        Vec::new,
-    );
-    if !env_guard_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Global env guards: {} finding(s) (test env mutation without shared guard)",
-            env_guard_findings.len()
-        );
-        all_findings.extend(env_guard_findings);
-    }
-
-    run_descriptor_detectors(
-        plan,
-        &mut timing,
-        &mut all_findings,
-        &detector_context,
-        &["shared_scaffolding"],
-    );
-
-    // Phase 4w: Parallel runner setup detection — command-family files that
-    // assemble the same generic execution contract independently.
-    let parallel_runner_findings = time_audit_detector(
-        &mut timing,
-        "detector.parallel_runner_setup",
-        plan.run_parallel_runner_setup(),
-        || parallel_runner_setup::run(&all_fingerprints),
-        Vec::new,
-    );
-    if !parallel_runner_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Parallel runner setup: {} finding(s) (duplicated execution contract setup)",
-            parallel_runner_findings.len()
-        );
-        all_findings.extend(parallel_runner_findings);
-    }
-
-    // Phase 4w1: Remote execution preflight detection — remote dispatch sites
-    // that do not prove path/artifact parity before remote execution.
-    let remote_execution_findings = time_audit_detector(
-        &mut timing,
-        "detector.remote_execution_preflight",
-        plan.run_remote_execution_preflight(),
-        || {
-            remote_execution_preflight::run(
-                &all_fingerprints,
-                &audit_config.remote_execution_safety,
-            )
-        },
-        Vec::new,
-    );
-    if !remote_execution_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Remote execution preflight: {} finding(s) (remote path/artifact parity gaps)",
-            remote_execution_findings.len()
-        );
-        all_findings.extend(remote_execution_findings);
-    }
-
-    // Phase 4w: Repeated enum-dispatch contract detection.
-    let enum_dispatch_findings = time_audit_detector(
-        &mut timing,
-        "detector.enum_dispatch_contracts",
-        plan.run_enum_dispatch_contracts(),
-        || enum_dispatch_contracts::run(&source_snapshot),
-        Vec::new,
-    );
-    if !enum_dispatch_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Enum dispatch contracts: {} finding(s) (repeated exhaustive enum matches)",
-            enum_dispatch_findings.len()
-        );
-        all_findings.extend(enum_dispatch_findings);
-    }
-
-    run_descriptor_detectors(
-        plan,
-        &mut timing,
-        &mut all_findings,
-        &detector_context,
-        &["aggregate_construction"],
-    );
-
-    // Phase 4y: Public metadata routes returning raw registry/config getters
-    // while a permission-aware resolver/helper exists in the same area.
-    let public_registry_findings = time_audit_detector(
-        &mut timing,
-        "detector.public_registry_exposure",
-        plan.run_public_registry_exposure(),
-        || public_registry_exposure::run(&all_fingerprints, &audit_config.public_registry_exposure),
-        Vec::new,
-    );
-    if !public_registry_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Public registry exposure: {} finding(s) (public metadata routes bypassing resolvers)",
-            public_registry_findings.len()
-        );
-        all_findings.extend(public_registry_findings);
-    }
-
+    // `artifact_portability` stays hand-sequenced: it logs scan statistics (runs,
+    // artifacts, metadata fields) even when it produces no findings.
     let artifact_portability_report = time_audit_detector(
         &mut timing,
         "detector.artifact_portability",
-        plan.run_artifact_portability(),
+        plan.detector_enabled("artifact_portability"),
         || {
             if audit_config.artifact_portability.is_empty() {
                 artifact_portability::run_report(component_id)
@@ -850,7 +388,7 @@ pub(super) fn audit_internal(
         },
         Default::default,
     );
-    if plan.run_artifact_portability() {
+    if plan.detector_enabled("artifact_portability") {
         log_status!(
             "audit",
             "Artifact portability: scanned {} recent run(s), {} artifact row(s), {} metadata string field(s) (window: {})",
@@ -868,42 +406,6 @@ pub(super) fn audit_internal(
             artifact_portability_findings.len()
         );
         all_findings.extend(artifact_portability_findings);
-    }
-
-    // Phase 4z: Declared command status scenario fixtures.
-    let command_status_findings = time_audit_detector(
-        &mut timing,
-        "detector.command_status_contracts",
-        plan.run_command_status_contracts(),
-        || command_status_contracts::run(root, &audit_config.command_status_contracts),
-        Vec::new,
-    );
-    if !command_status_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Command status contracts: {} finding(s) (inconsistent no-op/dry-run status fields)",
-            command_status_findings.len()
-        );
-        all_findings.extend(command_status_findings);
-    }
-
-    // Phase 4za: Thin-command-adapter boundary checks. Flags command-layer
-    // modules that accumulate orchestration/business logic instead of staying
-    // thin adapters over core services.
-    let thin_command_adapter_findings = time_audit_detector(
-        &mut timing,
-        "detector.thin_command_adapter",
-        plan.run_thin_command_adapter(),
-        || thin_command_adapter::run(root, &audit_config.thin_command_adapter),
-        Vec::new,
-    );
-    if !thin_command_adapter_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Thin command adapters: {} finding(s) (command modules accumulating orchestration logic)",
-            thin_command_adapter_findings.len()
-        );
-        all_findings.extend(thin_command_adapter_findings);
     }
     timing.push_ok("detectors", detectors_started.elapsed());
 
@@ -1082,17 +584,14 @@ fn audit_root_only(
 ) -> CodeAuditResult {
     let audit_config = audit_config_for(component_id, root, extension_overrides);
     let mut findings = Vec::new();
-    let detector_context = DetectorRunContext {
-        root,
-        audit_config: &audit_config,
-        all_fingerprints: &[],
-    };
 
     // Build the shared source snapshot once for the root-only path so the
     // whole-tree detectors below (structural, field patterns) consume a single
     // walk/read instead of each re-walking and re-reading the tree. Built only
     // when at least one snapshot-backed detector is enabled.
-    let source_snapshot = if plan.run_structural() || plan.run_field_patterns() {
+    let source_snapshot = if plan.detector_enabled("structural")
+        || plan.detector_enabled("field_patterns")
+    {
         let snapshot_started = std::time::Instant::now();
         let snapshot = build_shared_source_snapshot(root, &audit_config);
         timing.push_ok("source_snapshot", snapshot_started.elapsed());
@@ -1101,104 +600,30 @@ fn audit_root_only(
         None
     };
 
-    let structural_findings = time_audit_detector(
-        timing,
-        "detector.structural",
-        plan.run_structural(),
-        || match source_snapshot.as_ref() {
-            Some(snapshot) => structural::analyze_snapshot(root, snapshot),
-            None => structural::analyze_structure(root),
-        },
-        Vec::new,
-    );
-    if !structural_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Structural: {} finding(s) (god files, high item counts)",
-            structural_findings.len()
-        );
-        findings.extend(structural_findings);
-    }
-
-    let layer_findings = time_audit_detector(
-        timing,
-        "detector.layer_ownership",
-        plan.run_layer_ownership(),
-        || run_layer_ownership(root),
-        Vec::new,
-    );
-    if !layer_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Layer ownership: {} finding(s) (architecture ownership violations)",
-            layer_findings.len()
-        );
-        findings.extend(layer_findings);
-    }
+    let detector_context = DetectorRunContext {
+        root,
+        component_id,
+        audit_config: &audit_config,
+        all_fingerprints: &[],
+        per_file_fingerprints: &[],
+        source_snapshot: source_snapshot.as_ref(),
+        reference_paths: &[],
+    };
 
     run_descriptor_detectors(
         plan,
         timing,
         &mut findings,
         &detector_context,
-        &["test_topology", "test_wiring"],
+        Some(ROOT_ONLY_DETECTOR_IDS),
     );
 
-    let doc_findings = time_audit_detector(
-        timing,
-        "detector.docs",
-        plan.run_docs(),
-        || detect_doc_drift(root, component_id),
-        Vec::new,
-    );
-    if !doc_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Docs: {} finding(s) (broken references, stale paths)",
-            doc_findings.len()
-        );
-        findings.extend(doc_findings);
-    }
-
-    let compiler_findings = time_audit_detector(
-        timing,
-        "detector.compiler_warnings",
-        plan.run_compiler_warnings(),
-        || compiler_warnings::run(root),
-        Vec::new,
-    );
-    if !compiler_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Compiler warnings: {} finding(s) (dead code, unused imports, unused variables)",
-            compiler_findings.len()
-        );
-        findings.extend(compiler_findings);
-    }
-
-    let field_pattern_findings = time_audit_detector(
-        timing,
-        "detector.field_patterns",
-        plan.run_field_patterns(),
-        || match source_snapshot.as_ref() {
-            Some(snapshot) => field_patterns::run(snapshot, &audit_config.detector_profile),
-            None => Vec::new(),
-        },
-        Vec::new,
-    );
-    if !field_pattern_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Field patterns: {} finding(s) (repeated struct fields)",
-            field_pattern_findings.len()
-        );
-        findings.extend(field_pattern_findings);
-    }
-
+    // `artifact_portability` stays hand-sequenced (logs scan statistics even
+    // when empty), mirroring the full path.
     let artifact_portability_report = time_audit_detector(
         timing,
         "detector.artifact_portability",
-        plan.run_artifact_portability(),
+        plan.detector_enabled("artifact_portability"),
         || {
             if audit_config.artifact_portability.is_empty() {
                 artifact_portability::run_report(component_id)
@@ -1211,7 +636,7 @@ fn audit_root_only(
         },
         Default::default,
     );
-    if plan.run_artifact_portability() {
+    if plan.detector_enabled("artifact_portability") {
         log_status!(
             "audit",
             "Artifact portability: scanned {} recent run(s), {} artifact row(s), {} metadata string field(s) (window: {})",
@@ -1229,38 +654,6 @@ fn audit_root_only(
             artifact_portability_findings.len()
         );
         findings.extend(artifact_portability_findings);
-    }
-
-    let command_status_findings = time_audit_detector(
-        timing,
-        "detector.command_status_contracts",
-        plan.run_command_status_contracts(),
-        || command_status_contracts::run(root, &audit_config.command_status_contracts),
-        Vec::new,
-    );
-    if !command_status_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Command status contracts: {} finding(s) (inconsistent no-op/dry-run status fields)",
-            command_status_findings.len()
-        );
-        findings.extend(command_status_findings);
-    }
-
-    let thin_command_adapter_findings = time_audit_detector(
-        timing,
-        "detector.thin_command_adapter",
-        plan.run_thin_command_adapter(),
-        || thin_command_adapter::run(root, &audit_config.thin_command_adapter),
-        Vec::new,
-    );
-    if !thin_command_adapter_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Thin command adapters: {} finding(s) (command modules accumulating orchestration logic)",
-            thin_command_adapter_findings.len()
-        );
-        findings.extend(thin_command_adapter_findings);
     }
 
     if let Some(filter) = file_filter {

--- a/src/core/code_audit/execution_plan.rs
+++ b/src/core/code_audit/execution_plan.rs
@@ -78,7 +78,15 @@ impl DetectorAccess {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DetectorRuntime {
+    /// Detectors the engine still sequences by hand because they have a
+    /// non-uniform shape: the convention pipeline (`conventions`), the
+    /// multi-pass `duplication` family (five timing spans plus the
+    /// `duplicate_groups` side output), and `artifact_portability` (logs scan
+    /// statistics even when it finds nothing). Everything else is data-driven.
     Manual,
+    /// Single-closure detectors driven entirely by the descriptor table via
+    /// [`super::descriptor_runtime::run_descriptor_detectors`].
+    Generic(GenericDetectorRunner),
     Fingerprint(FingerprintDetectorRunner),
     Root(RootDetectorRunner),
 }
@@ -96,6 +104,38 @@ pub(crate) enum FingerprintDetectorRunner {
 pub(crate) enum RootDetectorRunner {
     TestTopology,
     TestWiring,
+}
+
+/// Identifies which single-closure detector a [`DetectorRuntime::Generic`]
+/// descriptor dispatches to. The descriptor table is the single registration
+/// site; [`super::descriptor_runtime`] owns the one-line invocation per variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GenericDetectorRunner {
+    Structural,
+    DeadCode,
+    CommentHygiene,
+    TestCoverage,
+    LayerOwnership,
+    Docs,
+    CompilerWarnings,
+    WrapperInference,
+    FieldPatterns,
+    DeprecationAge,
+    DeadGuard,
+    RequestedDetectors,
+    ConfigKeyUsage,
+    OutputCapture,
+    CoreBoundaryLeaks,
+    SourcePolicy,
+    MutatingResourceAccess,
+    RedirectValidation,
+    GlobalEnvGuard,
+    ParallelRunnerSetup,
+    RemoteExecutionPreflight,
+    EnumDispatchContracts,
+    PublicRegistryExposure,
+    CommandStatusContracts,
+    ThinCommandAdapter,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -137,7 +177,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::DirectorySprawl,
         ],
         access: DetectorAccess::RootOnly,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::Structural),
         timing_id: "detector.structural",
         log_label: "Structural",
         log_summary: "god files, high item counts",
@@ -166,7 +206,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::OrphanedInternal,
         ],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::DeadCode),
         timing_id: "detector.dead_code",
         log_label: "Dead code",
         log_summary: "unused params, unreferenced exports, orphaned internals",
@@ -183,7 +223,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::UpstreamWorkaround,
         ],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::CommentHygiene),
         timing_id: "detector.comment_hygiene",
         log_label: "Comment hygiene",
         log_summary: "TODO/FIXME/HACK markers, stale phrasing",
@@ -197,7 +237,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::VacuousTest,
         ],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::TestCoverage),
         timing_id: "detector.test_coverage",
         log_label: "Test coverage",
         log_summary: "missing test files, uncovered methods, orphaned tests",
@@ -206,7 +246,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "layer_ownership",
         findings: &[AuditFinding::LayerOwnershipViolation],
         access: DetectorAccess::RootOnly,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::LayerOwnership),
         timing_id: "detector.layer_ownership",
         log_label: "Layer ownership",
         log_summary: "architecture ownership violations",
@@ -241,7 +281,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::StaleDocReference,
         ],
         access: DetectorAccess::RootOnly,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::Docs),
         timing_id: "detector.docs",
         log_label: "Docs",
         log_summary: "broken references, stale paths",
@@ -250,7 +290,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "compiler_warnings",
         findings: &[AuditFinding::CompilerWarning],
         access: DetectorAccess::RootOnly,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::CompilerWarnings),
         timing_id: "detector.compiler_warnings",
         log_label: "Compiler warnings",
         log_summary: "dead code, unused imports, unused variables",
@@ -259,7 +299,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "wrapper_inference",
         findings: &[AuditFinding::MissingWrapperDeclaration],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::WrapperInference),
         timing_id: "detector.wrapper_inference",
         log_label: "Wrapper inference",
         log_summary: "missing wrapper declarations",
@@ -277,7 +317,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "field_patterns",
         findings: &[AuditFinding::RepeatedFieldPattern],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::FieldPatterns),
         timing_id: "detector.field_patterns",
         log_label: "Field patterns",
         log_summary: "repeated struct fields",
@@ -304,7 +344,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "deprecation_age",
         findings: &[AuditFinding::DeprecationAge],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::DeprecationAge),
         timing_id: "detector.deprecation_age",
         log_label: "Deprecation age",
         log_summary: "stale @deprecated tags",
@@ -313,7 +353,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "dead_guard",
         findings: &[AuditFinding::DeadGuard],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::DeadGuard),
         timing_id: "detector.dead_guard",
         log_label: "Dead guards",
         log_summary: "guards on guaranteed-available symbols",
@@ -328,7 +368,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::ConfigRoundtripAsymmetry,
         ],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::RequestedDetectors),
         timing_id: "detector.requested_detectors",
         log_label: "Requested detectors",
         log_summary: "extension rule packs",
@@ -337,7 +377,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "core_boundary_leaks",
         findings: &[AuditFinding::CoreBoundaryLeak],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::CoreBoundaryLeaks),
         timing_id: "detector.core_boundary_leaks",
         log_label: "Core boundary leaks",
         log_summary: "configured ecosystem terms in core source",
@@ -346,7 +386,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "source_policy",
         findings: &[AuditFinding::SourcePolicyViolation],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::SourcePolicy),
         timing_id: "detector.source_policy",
         log_label: "Source policy",
         log_summary: "configured source policy rules",
@@ -355,7 +395,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "mutating_resource_access",
         findings: &[AuditFinding::MutatingResourceAccess],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::MutatingResourceAccess),
         timing_id: "detector.mutating_resource_access",
         log_label: "Mutating resource access",
         log_summary: "resource mutations without configured access checks",
@@ -364,7 +404,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "redirect_validation",
         findings: &[AuditFinding::RedirectValidation],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::RedirectValidation),
         timing_id: "detector.redirect_validation",
         log_label: "Redirect validation",
         log_summary: "request-derived redirects without dominating validation",
@@ -373,7 +413,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "global_env_guard",
         findings: &[AuditFinding::GlobalEnvMutationGuard],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::GlobalEnvGuard),
         timing_id: "detector.global_env_guard",
         log_label: "Global env guards",
         log_summary: "test env mutation without shared guard",
@@ -391,7 +431,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "parallel_runner_setup",
         findings: &[AuditFinding::ParallelRunnerSetup],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::ParallelRunnerSetup),
         timing_id: "detector.parallel_runner_setup",
         log_label: "Parallel runner setup",
         log_summary: "duplicated execution contract setup",
@@ -400,7 +440,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "remote_execution_preflight",
         findings: &[AuditFinding::RemoteExecutionPreflight],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::RemoteExecutionPreflight),
         timing_id: "detector.remote_execution_preflight",
         log_label: "Remote execution preflight",
         log_summary: "remote execution path/artifact parity gaps",
@@ -409,7 +449,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "enum_dispatch_contracts",
         findings: &[AuditFinding::RepeatedEnumDispatchContract],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::EnumDispatchContracts),
         timing_id: "detector.enum_dispatch_contracts",
         log_label: "Enum dispatch contracts",
         log_summary: "repeated exhaustive enum matches",
@@ -427,7 +467,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "public_registry_exposure",
         findings: &[AuditFinding::PublicRegistryExposure],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::PublicRegistryExposure),
         timing_id: "detector.public_registry_exposure",
         log_label: "Public registry exposure",
         log_summary: "public metadata routes bypassing resolvers",
@@ -436,7 +476,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "config_key_usage",
         findings: &[AuditFinding::WriteOnlyConfigKey],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::ConfigKeyUsage),
         timing_id: "detector.config_key_usage",
         log_label: "Config key usage",
         log_summary: "write/accessor evidence without production reads",
@@ -454,7 +494,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "output_capture",
         findings: &[AuditFinding::UnboundedOutputCapture],
         access: DetectorAccess::Discovery,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::OutputCapture),
         timing_id: "detector.output_capture",
         log_label: "Output capture",
         log_summary: "unbounded stdout/stderr capture",
@@ -463,7 +503,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "command_status_contracts",
         findings: &[AuditFinding::CommandStatusContractViolation],
         access: DetectorAccess::RootOnly,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::CommandStatusContracts),
         timing_id: "detector.command_status_contracts",
         log_label: "Command status contracts",
         log_summary: "inconsistent no-op/dry-run status fields",
@@ -472,7 +512,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "thin_command_adapter",
         findings: &[AuditFinding::ThinCommandAdapterViolation],
         access: DetectorAccess::RootOnly,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Generic(GenericDetectorRunner::ThinCommandAdapter),
         timing_id: "detector.thin_command_adapter",
         log_label: "Thin command adapters",
         log_summary: "command modules accumulating orchestration logic",
@@ -527,114 +567,6 @@ impl AuditExecutionPlan {
             .iter()
             .find(|step| step.id == step_id)
             .is_some_and(|step| step.status == PlanStepStatus::Ready)
-    }
-
-    pub(crate) fn run_structural(&self) -> bool {
-        self.detector_enabled("structural")
-    }
-
-    pub(crate) fn run_duplication(&self) -> bool {
-        self.detector_enabled("duplication")
-    }
-
-    pub(crate) fn run_dead_code(&self) -> bool {
-        self.detector_enabled("dead_code")
-    }
-
-    pub(crate) fn run_comment_hygiene(&self) -> bool {
-        self.detector_enabled("comment_hygiene")
-    }
-
-    pub(crate) fn run_test_coverage(&self) -> bool {
-        self.detector_enabled("test_coverage")
-    }
-
-    pub(crate) fn run_layer_ownership(&self) -> bool {
-        self.detector_enabled("layer_ownership")
-    }
-
-    pub(crate) fn run_docs(&self) -> bool {
-        self.detector_enabled("docs")
-    }
-
-    pub(crate) fn run_compiler_warnings(&self) -> bool {
-        self.detector_enabled("compiler_warnings")
-    }
-
-    pub(crate) fn run_wrapper_inference(&self) -> bool {
-        self.detector_enabled("wrapper_inference")
-    }
-
-    pub(crate) fn run_field_patterns(&self) -> bool {
-        self.detector_enabled("field_patterns")
-    }
-
-    pub(crate) fn run_deprecation_age(&self) -> bool {
-        self.detector_enabled("deprecation_age")
-    }
-
-    pub(crate) fn run_dead_guard(&self) -> bool {
-        self.detector_enabled("dead_guard")
-    }
-
-    pub(crate) fn run_requested_detectors(&self) -> bool {
-        self.detector_enabled("requested_detectors")
-    }
-
-    pub(crate) fn run_core_boundary_leaks(&self) -> bool {
-        self.detector_enabled("core_boundary_leaks")
-    }
-
-    pub(crate) fn run_source_policy(&self) -> bool {
-        self.detector_enabled("source_policy")
-    }
-
-    pub(crate) fn run_mutating_resource_access(&self) -> bool {
-        self.detector_enabled("mutating_resource_access")
-    }
-
-    pub(crate) fn run_redirect_validation(&self) -> bool {
-        self.detector_enabled("redirect_validation")
-    }
-
-    pub(crate) fn run_global_env_guard(&self) -> bool {
-        self.detector_enabled("global_env_guard")
-    }
-
-    pub(crate) fn run_parallel_runner_setup(&self) -> bool {
-        self.detector_enabled("parallel_runner_setup")
-    }
-
-    pub(crate) fn run_remote_execution_preflight(&self) -> bool {
-        self.detector_enabled("remote_execution_preflight")
-    }
-
-    pub(crate) fn run_enum_dispatch_contracts(&self) -> bool {
-        self.detector_enabled("enum_dispatch_contracts")
-    }
-
-    pub(crate) fn run_public_registry_exposure(&self) -> bool {
-        self.detector_enabled("public_registry_exposure")
-    }
-
-    pub(crate) fn run_config_key_usage(&self) -> bool {
-        self.detector_enabled("config_key_usage")
-    }
-
-    pub(crate) fn run_artifact_portability(&self) -> bool {
-        self.detector_enabled("artifact_portability")
-    }
-
-    pub(crate) fn run_output_capture(&self) -> bool {
-        self.detector_enabled("output_capture")
-    }
-
-    pub(crate) fn run_command_status_contracts(&self) -> bool {
-        self.detector_enabled("command_status_contracts")
-    }
-
-    pub(crate) fn run_thin_command_adapter(&self) -> bool {
-        self.detector_enabled("thin_command_adapter")
     }
 
     pub(crate) fn requires_discovery(&self) -> bool {
@@ -709,14 +641,14 @@ mod tests {
         let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Pr, &[], &[]);
 
         assert!(!plan.requires_discovery());
-        assert!(plan.run_structural());
+        assert!(plan.detector_enabled("structural"));
         assert!(plan.detector_enabled("test_topology"));
         assert!(plan.detector_enabled("command_status_contracts"));
-        assert!(plan.run_thin_command_adapter());
-        assert!(!plan.run_duplication());
-        assert!(!plan.run_dead_code());
-        assert!(!plan.run_source_policy());
-        assert!(!plan.run_compiler_warnings());
+        assert!(plan.detector_enabled("thin_command_adapter"));
+        assert!(!plan.detector_enabled("duplication"));
+        assert!(!plan.detector_enabled("dead_code"));
+        assert!(!plan.detector_enabled("source_policy"));
+        assert!(!plan.detector_enabled("compiler_warnings"));
     }
 
     #[test]
@@ -727,8 +659,8 @@ mod tests {
             &[],
         );
 
-        assert!(!plan.run_structural());
-        assert!(!plan.run_duplication());
+        assert!(!plan.detector_enabled("structural"));
+        assert!(!plan.detector_enabled("duplication"));
         assert!(!plan.requires_discovery());
     }
 
@@ -740,8 +672,8 @@ mod tests {
         // which silently disabled the detector under this filter.
         let plan = AuditExecutionPlan::from_filters(&[AuditFinding::UpstreamWorkaround], &[]);
 
-        assert!(plan.run_comment_hygiene());
-        assert!(!plan.run_dead_code());
+        assert!(plan.detector_enabled("comment_hygiene"));
+        assert!(!plan.detector_enabled("dead_code"));
     }
 
     #[test]
@@ -755,6 +687,6 @@ mod tests {
             ],
         );
 
-        assert!(!plan.run_comment_hygiene());
+        assert!(!plan.detector_enabled("comment_hygiene"));
     }
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -71,7 +71,7 @@ pub use duplication::DuplicateGroup;
 pub use execution_plan::AuditProfile;
 pub(crate) use execution_plan::{
     AuditExecutionPlan, DetectorDescriptor, DetectorRuntime, FingerprintDetectorRunner,
-    RootDetectorRunner,
+    GenericDetectorRunner, RootDetectorRunner,
 };
 pub use findings::{homeboy_finding_from_audit, Finding, FindingConfidence, Severity};
 pub use fingerprint::FileFingerprint;
@@ -125,7 +125,7 @@ mod tests {
         let plan = AuditExecutionPlan::from_filters(&[AuditFinding::VacuousTest], &[]);
 
         assert!(
-            plan.run_test_coverage(),
+            plan.detector_enabled("test_coverage"),
             "coverage detector also emits vacuous_test for mapped tests"
         );
         assert!(

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -526,10 +526,10 @@ fn execution_plan_filters_to_requested_detector_family() {
     {
         let plan = AuditExecutionPlan::from_filters(&[finding], &[]);
 
-        assert_eq!(plan.run_structural(), structural_enabled);
-        assert_eq!(plan.run_duplication(), duplication_enabled);
-        assert!(!plan.run_dead_code());
-        assert!(!plan.run_compiler_warnings());
+        assert_eq!(plan.detector_enabled("structural"), structural_enabled);
+        assert_eq!(plan.detector_enabled("duplication"), duplication_enabled);
+        assert!(!plan.detector_enabled("dead_code"));
+        assert!(!plan.detector_enabled("compiler_warnings"));
         assert_eq!(
             detector_step_status(&plan, "conventions"),
             &PlanStepStatus::Disabled
@@ -614,7 +614,7 @@ fn execution_plan_for_excluded_structural_detector_disables_plan_step() {
         ],
     );
 
-    assert!(!plan.run_structural());
+    assert!(!plan.detector_enabled("structural"));
     assert_eq!(
         detector_step_status(&plan, "structural"),
         &PlanStepStatus::Disabled


### PR DESCRIPTION
## Summary

The code_audit descriptor table declared ~36 detectors but only the `Fingerprint`/`Root` runtimes dispatched data-drivenly. The ~25 `Manual` detectors were hand-wired as near-identical `time_audit_detector` blocks in `engine.rs` **plus** a parallel set of ~27 one-line `run_X()` boolean helpers in `execution_plan.rs`. `DetectorRuntime::Manual => continue` in the dispatch loop was the explicit admission that the table did not actually drive these. Adding a detector meant editing 5-6 sites.

This PR makes the descriptor table the single registration + execution site.

## What changed

- New `DetectorRuntime::Generic(GenericDetectorRunner)` variant. The 25 single-closure Manual detectors are migrated onto it; the descriptor row now supplies enable state, timing id, log label/summary, and the detector invocation.
- `DetectorRunContext` is extended to carry every detector input (root, component id, config, full + per-file fingerprints, source snapshot, reference paths), so one `run_generic_descriptor` dispatch fn can invoke any detector.
- `run_descriptor_detectors` takes `ids: Option<&[&str]>`: `None` drives every data-driven detector (full path) in one pass; `Some(subset)` drives the root-only fast path's exact timing/findings set.
- Collapsed ~39 `engine.rs` blocks and deleted the ~27 `run_X()` helpers. Adding a detector is now a descriptor row + one match arm.
- Only three families stay hand-sequenced because their shape is non-uniform, and they are the only remaining `Manual` descriptors (asserted by a test):
  - the **convention** pipeline (built from `check_conventions`, not a detector closure),
  - the **duplication** family (five timing spans plus the `duplicate_groups` side output threaded into the report),
  - **artifact_portability** (logs scan statistics even when it finds nothing).
- `dead_code` fingerprints reference paths lazily inside its runner, preserving the prior enable-gated reference walk.

## Behavior preservation

Report output (`build_audit_summary`/`build_finding_groups`) and baseline fingerprints both sort/dedup, so detector execution order does not affect results or tests. All callers/tests switch from `plan.run_X()` to `plan.detector_enabled("x")`.

New tests:
- `migrated_detector_runs_via_data_driven_dispatch` — a former-Manual detector (`structural`) emits a god-file finding and records its timing span entirely through `run_descriptor_detectors`, touching no per-detector block.
- `only_special_families_remain_manual` — asserts the `Manual` set is exactly `{conventions, duplication, artifact_portability}`, guarding against a new detector being added as a hand-wired block.

## Verification

- `cargo check` — clean (no new warnings in `code_audit`).
- `cargo test --lib code_audit` — **769 passed; 0 failed; 1 ignored** (767 baseline + 2 new tests). Includes the `run::run_test` integration suite and the timing-span tests.

Net **-427 LOC** (`engine.rs` alone -660; offset by the dispatch infrastructure and the new behavioral tests).

Refs #6743 (audit: structural), #2240 (language-agnostic core).

## Follow-ups (filed separately)

- Fold the regex-shaped specialized detectors (`mutating_resource_access`, `redirect_validation`, `config_key_usage`, `public_registry_exposure`, `aggregate_construction`) into `requested_detectors` rule presets — they each re-implement the generic forbidden-term/required-companion shape.
- Merge the `test_*` detector quartet (`test_quality`/`test_topology`/`test_vacuity`/`test_coverage`) with their triple-emitted `VacuousTest`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Migrating the hand-wired Manual code_audit detectors onto the descriptor-table dispatch, deleting the parallel `run_X` helpers, and adding the dispatch/regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)