### PR TITLE
refactor(git,release): unify CI-check classification and advanced-remote rebase recovery

### DIFF
--- a/src/core/git/github/checks.rs
+++ b/src/core/git/github/checks.rs
@@ -1,0 +1,169 @@
+//! Shared GitHub status-check classification.
+//!
+//! `gh pr view --json statusCheckRollup` returns one entry per check run. Three
+//! readiness surfaces interpret those entries: the readiness summary
+//! ([`super::readiness::classify_pr_ci`]), the fleet rollup
+//! ([`super::fleet`]), and the PR-land merge gate
+//! ([`crate::core::git::pr_land`]). They previously each re-matched
+//! `(status, conclusion)` with subtly different groupings — most visibly, the
+//! fleet rollup folded `SKIPPED` into its passed count while the readiness
+//! summary tracked it separately. This module is the single place that maps one
+//! check entry to a [`CheckClass`], so every surface agrees on what each
+//! outcome means.
+
+use serde_json::Value;
+
+/// Terminal/transient classification of a single GitHub status check.
+///
+/// `SKIPPED` is modeled as its own terminal, **non-blocking** outcome
+/// ([`CheckClass::Skipped`]): it never counts as a failure and never counts as a
+/// pending check, but it is tracked separately from [`CheckClass::Passed`] so
+/// reports can distinguish "ran and passed" from "skipped". The non-terminal
+/// state is split into [`CheckClass::Queued`], [`CheckClass::Running`], and
+/// [`CheckClass::Pending`] so the readiness summary can describe *why* a check
+/// has not settled; callers that only need a binary terminal/pending signal
+/// collapse the three via [`CheckClass::is_waiting`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::core::git) enum CheckClass {
+    /// Completed successfully (`SUCCESS`/`NEUTRAL`).
+    Passed,
+    /// Completed as `SKIPPED` — terminal and non-blocking.
+    Skipped,
+    /// Completed with a hard failure (`FAILURE`/`ACTION_REQUIRED`).
+    Failed,
+    /// Completed with a transient failure worth re-running
+    /// (`CANCELLED`/`TIMED_OUT`/`STARTUP_FAILURE`).
+    Rerunnable,
+    /// Completed with an unrecognized conclusion, or `COMPLETED` with no
+    /// conclusion at all — blocks merge until a human inspects it.
+    Unknown,
+    /// Not started yet (`QUEUED`/`REQUESTED`/`WAITING`).
+    Queued,
+    /// Currently executing (`IN_PROGRESS`).
+    Running,
+    /// Reported but not yet terminal in any recognized state.
+    Pending,
+}
+
+impl CheckClass {
+    /// True for terminal failure-shaped outcomes (hard or rerunnable) plus
+    /// `Unknown`, which blocks merge until a human inspects it.
+    pub(in crate::core::git) fn is_blocking(self) -> bool {
+        matches!(
+            self,
+            CheckClass::Failed | CheckClass::Rerunnable | CheckClass::Unknown
+        )
+    }
+
+    /// True while the check has not reached a terminal state.
+    pub(in crate::core::git) fn is_waiting(self) -> bool {
+        matches!(
+            self,
+            CheckClass::Queued | CheckClass::Running | CheckClass::Pending
+        )
+    }
+}
+
+/// Classify one `statusCheckRollup` entry by its `status` + `conclusion`.
+///
+/// Both fields are upper-cased before matching: GitHub's GraphQL enums are
+/// upper-case in practice, and normalizing keeps the classifier robust to any
+/// lower-cased payloads the previous hand-rolled classifiers tolerated.
+pub(in crate::core::git) fn classify_check(check: &Value) -> CheckClass {
+    let status = upper_field(check, "status");
+    let conclusion = upper_field(check, "conclusion");
+    match (status.as_deref(), conclusion.as_deref()) {
+        (_, Some("FAILURE" | "ACTION_REQUIRED")) => CheckClass::Failed,
+        (_, Some("CANCELLED" | "TIMED_OUT" | "STARTUP_FAILURE")) => CheckClass::Rerunnable,
+        (Some("COMPLETED"), Some("SUCCESS" | "NEUTRAL")) => CheckClass::Passed,
+        (Some("COMPLETED"), Some("SKIPPED")) => CheckClass::Skipped,
+        (Some("COMPLETED"), Some(_) | None) => CheckClass::Unknown,
+        (Some("QUEUED" | "REQUESTED" | "WAITING"), _) => CheckClass::Queued,
+        (Some("IN_PROGRESS"), _) => CheckClass::Running,
+        _ => CheckClass::Pending,
+    }
+}
+
+fn upper_field(check: &Value, key: &str) -> Option<String> {
+    check
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_uppercase)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check(status: &str, conclusion: &str) -> Value {
+        serde_json::json!({ "status": status, "conclusion": conclusion })
+    }
+
+    #[test]
+    fn classifies_terminal_outcomes() {
+        assert_eq!(classify_check(&check("COMPLETED", "SUCCESS")), CheckClass::Passed);
+        assert_eq!(classify_check(&check("COMPLETED", "NEUTRAL")), CheckClass::Passed);
+        assert_eq!(classify_check(&check("COMPLETED", "SKIPPED")), CheckClass::Skipped);
+        assert_eq!(classify_check(&check("COMPLETED", "FAILURE")), CheckClass::Failed);
+        assert_eq!(
+            classify_check(&check("COMPLETED", "ACTION_REQUIRED")),
+            CheckClass::Failed
+        );
+        assert_eq!(
+            classify_check(&check("COMPLETED", "CANCELLED")),
+            CheckClass::Rerunnable
+        );
+        assert_eq!(
+            classify_check(&check("COMPLETED", "TIMED_OUT")),
+            CheckClass::Rerunnable
+        );
+        assert_eq!(classify_check(&check("COMPLETED", "BOGUS")), CheckClass::Unknown);
+    }
+
+    #[test]
+    fn classifies_waiting_outcomes() {
+        assert_eq!(classify_check(&check("QUEUED", "")), CheckClass::Queued);
+        assert_eq!(classify_check(&check("REQUESTED", "")), CheckClass::Queued);
+        assert_eq!(classify_check(&check("IN_PROGRESS", "")), CheckClass::Running);
+        assert_eq!(classify_check(&check("PENDING", "")), CheckClass::Pending);
+        assert_eq!(
+            classify_check(&serde_json::json!({})),
+            CheckClass::Pending
+        );
+    }
+
+    #[test]
+    fn completed_without_conclusion_is_unknown() {
+        assert_eq!(
+            classify_check(&serde_json::json!({ "status": "COMPLETED" })),
+            CheckClass::Unknown
+        );
+    }
+
+    #[test]
+    fn skipped_is_terminal_and_non_blocking() {
+        let skipped = classify_check(&check("COMPLETED", "SKIPPED"));
+        assert!(!skipped.is_blocking());
+        assert!(!skipped.is_waiting());
+    }
+
+    #[test]
+    fn matches_are_case_insensitive() {
+        assert_eq!(classify_check(&check("completed", "failure")), CheckClass::Failed);
+        assert_eq!(classify_check(&check("in_progress", "")), CheckClass::Running);
+    }
+
+    #[test]
+    fn blocking_and_waiting_partition_failure_and_pending() {
+        assert!(CheckClass::Failed.is_blocking());
+        assert!(CheckClass::Rerunnable.is_blocking());
+        assert!(CheckClass::Unknown.is_blocking());
+        assert!(!CheckClass::Passed.is_blocking());
+        assert!(CheckClass::Queued.is_waiting());
+        assert!(CheckClass::Running.is_waiting());
+        assert!(CheckClass::Pending.is_waiting());
+        assert!(!CheckClass::Passed.is_waiting());
+    }
+}

--- a/src/core/git/github/fleet.rs
+++ b/src/core/git/github/fleet.rs
@@ -10,6 +10,7 @@ use super::super::github_types::{
 };
 use super::client::resolve_component_github;
 use super::pulls::{pr_view, validate_pr_merge_method};
+use super::{classify_check, CheckClass};
 
 /// Report and optionally land a fleet of PRs.
 pub fn pr_fleet(
@@ -168,20 +169,14 @@ fn summarize_check_rollup(checks: &[serde_json::Value]) -> GithubPrCheckRollup {
         ..Default::default()
     };
     for check in checks {
-        let status = check.get("status").and_then(serde_json::Value::as_str);
-        let conclusion = check
-            .get("conclusion")
-            .and_then(serde_json::Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty());
-        match (status, conclusion) {
-            (
-                _,
-                Some("FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE"),
-            ) => rollup.failed += 1,
-            (Some("COMPLETED"), Some("SUCCESS" | "SKIPPED" | "NEUTRAL")) => rollup.passed += 1,
-            (Some("COMPLETED"), Some(_)) | (Some("COMPLETED"), None) => rollup.unknown += 1,
-            _ => rollup.pending += 1,
+        match classify_check(check) {
+            CheckClass::Passed => rollup.passed += 1,
+            // SKIPPED is its own non-blocking terminal bucket here, matching the
+            // readiness summary — it is no longer folded into `passed`.
+            CheckClass::Skipped => rollup.skipped += 1,
+            CheckClass::Failed | CheckClass::Rerunnable => rollup.failed += 1,
+            CheckClass::Unknown => rollup.unknown += 1,
+            CheckClass::Queued | CheckClass::Running | CheckClass::Pending => rollup.pending += 1,
         }
     }
     rollup
@@ -317,6 +312,26 @@ mod tests {
         assert_eq!(rollup.failed, 1);
         assert_eq!(rollup.pending, 1);
         assert_eq!(rollup.unknown, 1);
+        assert_eq!(rollup.skipped, 0);
+    }
+
+    #[test]
+    fn summarize_check_rollup_counts_skipped_separately_from_passed() {
+        // Regression guard for the standardized SKIPPED handling: a skipped
+        // check must land in its own bucket, not inflate the passed count the
+        // way the previous fleet-only classifier did.
+        let checks = serde_json::json!([
+            {"status":"COMPLETED","conclusion":"SUCCESS"},
+            {"status":"COMPLETED","conclusion":"SKIPPED"}
+        ]);
+        let rollup = summarize_check_rollup(checks.as_array().unwrap());
+
+        assert_eq!(rollup.total, 2);
+        assert_eq!(rollup.passed, 1);
+        assert_eq!(rollup.skipped, 1);
+        assert_eq!(rollup.failed, 0);
+        assert_eq!(rollup.pending, 0);
+        assert_eq!(rollup.unknown, 0);
     }
 
     #[test]

--- a/src/core/git/github/mod.rs
+++ b/src/core/git/github/mod.rs
@@ -31,6 +31,7 @@
 //! - [`readiness`] — CI-check classification and merge-readiness reasoning.
 
 mod body_file;
+mod checks;
 mod client;
 mod fleet;
 mod issues;
@@ -53,6 +54,9 @@ pub use super::github_types::{
 // re-exported at this module path so existing `super::github::X` paths keep
 // resolving after the split.
 pub(in crate::core) use body_file::push_markdown_body_file_arg;
+// Shared status-check classifier consumed by the readiness summary, the fleet
+// rollup, and the sibling PR-land merge gate (`crate::core::git::pr_land`).
+pub(in crate::core::git) use checks::{classify_check, CheckClass};
 pub(in crate::core::git) use client::resolve_component_github;
 
 // Public probe/token helpers.

--- a/src/core/git/github/readiness.rs
+++ b/src/core/git/github/readiness.rs
@@ -12,6 +12,7 @@ use super::super::github_types::{
 };
 use super::super::{resolve_target, run_git, run_git_output};
 use super::pulls::pr_view;
+use super::{classify_check, CheckClass};
 
 /// Explain whether a PR is ready to merge without attempting a merge.
 pub fn pr_readiness(
@@ -175,16 +176,6 @@ pub(super) fn classify_pr_ci(
     for check in checks {
         let name = check_name(check);
         let workflow = string_field(check, &["workflowName", "workflow_name"]);
-        let status = check
-            .get("status")
-            .and_then(serde_json::Value::as_str)
-            .map(str::trim)
-            .filter(|v| !v.is_empty());
-        let conclusion = check
-            .get("conclusion")
-            .and_then(serde_json::Value::as_str)
-            .map(str::trim)
-            .filter(|v| !v.is_empty());
         if let Some(is_required) = bool_field(check, &["isRequired", "required"]) {
             if is_required {
                 required += 1;
@@ -193,39 +184,35 @@ pub(super) fn classify_pr_ci(
             }
         }
 
-        match (status, conclusion) {
-            (_, Some("FAILURE" | "ACTION_REQUIRED")) => {
+        match classify_check(check) {
+            CheckClass::Failed => {
                 failed += 1;
                 failed_details.push(check_detail(check, &name));
             }
-            (_, Some("CANCELLED" | "TIMED_OUT" | "STARTUP_FAILURE")) => {
+            CheckClass::Rerunnable => {
                 failed += 1;
                 rerunnable += 1;
                 failed_details.push(check_detail(check, &name));
             }
-            (Some("COMPLETED"), Some("SUCCESS" | "NEUTRAL")) => {
+            CheckClass::Passed => {
                 passed += 1;
             }
-            (Some("COMPLETED"), Some("SKIPPED")) => {
+            CheckClass::Skipped => {
                 skipped += 1;
             }
-            (Some("COMPLETED"), Some(_)) => {
+            CheckClass::Unknown => {
                 unknown += 1;
                 failed_details.push(check_detail(check, &name));
             }
-            (Some("COMPLETED"), None) => {
-                unknown += 1;
-                failed_details.push(check_detail(check, &name));
-            }
-            (Some("QUEUED" | "REQUESTED" | "WAITING"), _) => {
+            CheckClass::Queued => {
                 queued += 1;
                 pending_details.push(check_pending_detail(check, &name, workflow.as_deref()));
             }
-            (Some("IN_PROGRESS"), _) => {
+            CheckClass::Running => {
                 running += 1;
                 pending_details.push(check_pending_detail(check, &name, workflow.as_deref()));
             }
-            _ => {
+            CheckClass::Pending => {
                 pending += 1;
                 pending_details.push(check_pending_detail(check, &name, workflow.as_deref()));
             }

--- a/src/core/git/github_types.rs
+++ b/src/core/git/github_types.rs
@@ -226,6 +226,11 @@ mod outputs {
     pub struct GithubPrCheckRollup {
         pub total: usize,
         pub passed: usize,
+        /// Checks that completed as SKIPPED. Tracked separately from `passed`
+        /// (rather than folded into it) so the fleet rollup agrees with the
+        /// readiness summary that SKIPPED is a distinct, non-blocking terminal
+        /// outcome — see [`crate::core::git::github::checks`].
+        pub skipped: usize,
         pub failed: usize,
         pub pending: usize,
         pub unknown: usize,

--- a/src/core/git/pr_land.rs
+++ b/src/core/git/pr_land.rs
@@ -6,6 +6,7 @@ use crate::core::error::{Error, Result};
 
 use super::gh_client::GhClient;
 use super::gh_client::{delete_branch_ref_api_args, pr_merge_api_args};
+use super::github::classify_check;
 
 #[derive(Debug, Clone, Default)]
 pub struct PrLandOptions {
@@ -576,21 +577,26 @@ fn non_empty(value: Option<String>) -> Option<String> {
     })
 }
 
+/// Collapse a PR's status-check rollup into the merge-gate signal this module
+/// reasons over: `FAILURE` (any blocking outcome), `PENDING` (anything still
+/// waiting), or `SUCCESS` (every check reached a non-blocking terminal state).
+///
+/// Routes through the shared [`classify_check`] classifier so the land gate
+/// agrees with the readiness summary and fleet rollup. This treats SKIPPED as a
+/// non-blocking terminal outcome (as before) and also blocks on
+/// `ACTION_REQUIRED`/`STARTUP_FAILURE`, which the previous land-only classifier
+/// silently let through.
 fn summarize_checks(items: &[Value]) -> Option<String> {
     if items.is_empty() {
         return None;
     }
     let mut pending = false;
     for item in items {
-        let conclusion = item.get("conclusion").and_then(Value::as_str).unwrap_or("");
-        let status = item.get("status").and_then(Value::as_str).unwrap_or("");
-        if matches!(
-            conclusion,
-            "FAILURE" | "failure" | "CANCELLED" | "cancelled" | "TIMED_OUT" | "timed_out"
-        ) {
+        let class = classify_check(item);
+        if class.is_blocking() {
             return Some("FAILURE".to_string());
         }
-        if conclusion.is_empty() && !matches!(status, "COMPLETED" | "completed") {
+        if class.is_waiting() {
             pending = true;
         }
     }
@@ -683,6 +689,50 @@ mod tests {
             max_base_retries: 1,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn summarize_checks_routes_through_shared_classifier() {
+        // No checks reported at all.
+        assert_eq!(summarize_checks(&[]), None);
+
+        // SKIPPED is a non-blocking terminal outcome — clean rollups read SUCCESS.
+        let success = serde_json::json!([
+            {"status":"COMPLETED","conclusion":"SUCCESS"},
+            {"status":"COMPLETED","conclusion":"SKIPPED"}
+        ]);
+        assert_eq!(
+            summarize_checks(success.as_array().unwrap()).as_deref(),
+            Some("SUCCESS")
+        );
+
+        // Any waiting check downgrades the gate to PENDING.
+        let pending = serde_json::json!([
+            {"status":"COMPLETED","conclusion":"SUCCESS"},
+            {"status":"IN_PROGRESS","conclusion":""}
+        ]);
+        assert_eq!(
+            summarize_checks(pending.as_array().unwrap()).as_deref(),
+            Some("PENDING")
+        );
+
+        // Hard and transient failures both block.
+        for conclusion in ["FAILURE", "ACTION_REQUIRED", "CANCELLED", "STARTUP_FAILURE"] {
+            let failing = serde_json::json!([{ "status": "COMPLETED", "conclusion": conclusion }]);
+            assert_eq!(
+                summarize_checks(failing.as_array().unwrap()).as_deref(),
+                Some("FAILURE"),
+                "conclusion {conclusion} must block the land gate"
+            );
+        }
+
+        // A COMPLETED check with an unrecognized conclusion blocks rather than
+        // silently merging — the land gate now agrees with readiness/fleet.
+        let unknown = serde_json::json!([{ "status": "COMPLETED", "conclusion": "MYSTERY" }]);
+        assert_eq!(
+            summarize_checks(unknown.as_array().unwrap()).as_deref(),
+            Some("FAILURE")
+        );
     }
 
     #[test]

--- a/src/core/release/advanced_remote.rs
+++ b/src/core/release/advanced_remote.rs
@@ -1,0 +1,302 @@
+//! Shared advanced-remote reconciliation for the release push step and
+//! `release --recover` (issues #3611, #5502, #6141).
+//!
+//! When the remote release branch advances after the release commit/tag were
+//! created, git rejects the branch push as non-fast-forward. Two callers must
+//! reconcile that state the same way:
+//!
+//! - the reactive push step ([`super::executor`]'s `git_push`), which hits the
+//!   rejection live, and
+//! - the proactive `--recover` flow ([`super::workflow_recover`]), which finds
+//!   the same partial state after the fact.
+//!
+//! Both replay the local release commit onto the advanced remote head and
+//! re-push the branch ref — never a force-push over divergent history. This
+//! module owns that shared "rebase onto the advanced remote → optionally move
+//! the tag → push the branch" mechanic so the two callers cannot drift. Each
+//! caller keeps its own pre-checks (how it discovers the divergence) and its own
+//! result contract (the push step reports a recovery payload; recover returns a
+//! human action string), and maps a rebase conflict ([`Ok(None)`]) onto its own
+//! failure path.
+
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::git;
+
+/// Outcome of recovering a release push from an advanced remote branch.
+///
+/// Carries the final push output plus the newly-included commit range that
+/// landed on the remote during the release window. The range is surfaced both as
+/// a prominent operator warning and in structured step output so downstream
+/// summaries can state exactly what changed since the dry-run plan (issue #6141).
+pub(crate) struct AdvancedRemoteRecovery {
+    pub(crate) push: git::GitOutput,
+    pub(crate) advance: ConcurrentAdvance,
+}
+
+impl AdvancedRemoteRecovery {
+    /// Recovery that did not actually rebase over an advance (already reconciled
+    /// or a spurious rejection): there is no newly-included range to report.
+    pub(crate) fn without_advance(push: git::GitOutput) -> Self {
+        Self {
+            push,
+            advance: ConcurrentAdvance::default(),
+        }
+    }
+}
+
+/// Describes the commits that landed on the remote branch between the reviewed
+/// dry-run/preflight plan and the final tag/notes creation (issue #6141).
+#[derive(Default)]
+pub(crate) struct ConcurrentAdvance {
+    /// The pre-rebase release HEAD — the tip the dry-run plan was built against.
+    base: String,
+    /// The advanced remote head the release commit was rebased onto.
+    remote_head: String,
+    /// Commits newly included by the advance (`base..remote_head`), newest first.
+    commits: Vec<git::CommitInfo>,
+}
+
+impl ConcurrentAdvance {
+    fn short(rev: &str) -> &str {
+        &rev[..rev.len().min(8)]
+    }
+
+    /// True when no actual advance was recorded (e.g. an already-reconciled retry
+    /// or a spurious non-fast-forward rejection) — nothing new was auto-included.
+    pub(crate) fn is_noop(&self) -> bool {
+        self.base.is_empty() && self.remote_head.is_empty()
+    }
+
+    /// Structured representation for the step `data` payload so downstream
+    /// summaries can report exactly which commits/PRs were auto-included.
+    pub(crate) fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "base": self.base,
+            "remote_head": self.remote_head,
+            "range": format!("{}..{}", Self::short(&self.base), Self::short(&self.remote_head)),
+            "count": self.commits.len(),
+            "commits": self.commits
+                .iter()
+                .map(|c| serde_json::json!({ "hash": c.hash, "subject": c.subject }))
+                .collect::<Vec<_>>(),
+        })
+    }
+
+    /// Emit a prominent warning listing the newly-included commits so an operator
+    /// reviewing the release sees that the published contents differ from the
+    /// reviewed dry-run plan (issue #6141).
+    pub(crate) fn warn(&self, branch: &str) {
+        log_status!(
+            "release",
+            "⚠ CONCURRENT MAIN ADVANCE: remote '{}' advanced during the release. \
+             The final published release content CHANGED since the dry-run/preflight plan.",
+            branch
+        );
+        log_status!(
+            "release",
+            "⚠ Auto-included {} commit(s) ({}..{}) not present in the reviewed dry-run plan:",
+            self.commits.len(),
+            Self::short(&self.base),
+            Self::short(&self.remote_head)
+        );
+        if self.commits.is_empty() {
+            log_status!(
+                "release",
+                "⚠   (remote advanced but no new commits were resolved in the recovered range)"
+            );
+        } else {
+            for commit in &self.commits {
+                log_status!("release", "⚠   {} {}", commit.hash, commit.subject);
+            }
+        }
+    }
+}
+
+/// Push the release branch (HEAD) and tags to `origin`.
+///
+/// Shared by both reconciliation paths and the initial release push so the
+/// branch refspec (`HEAD:refs/heads/<branch>`) and tag-follow behavior cannot
+/// drift between them. The branch is never force-pushed.
+pub(crate) fn push_release_branch(
+    component: &Component,
+    component_id: &str,
+    branch: &str,
+) -> Result<git::GitOutput> {
+    git::push_at(
+        Some(component_id),
+        git::PushOptions {
+            tags: true,
+            force_with_lease: false,
+            refspec: Some(format!("HEAD:refs/heads/{branch}")),
+            ..Default::default()
+        },
+        Some(&component.local_path),
+    )
+}
+
+/// Rebase the local release commit onto an already-known advanced remote head,
+/// optionally move the release tag onto the rebased commit, and push the branch.
+///
+/// Callers invoke this only after they have established that the histories
+/// diverged (the remote advanced past a shared ancestor); the caller-side
+/// ancestor checks are intentionally not duplicated here. The commits the remote
+/// gained during the release window are captured for issue #6141 reporting,
+/// HEAD is rebased onto `remote_commit`, and — when `retag` names the release
+/// tag — the tag is moved onto the rebased commit before the branch is pushed so
+/// a successful branch push is never left with a stranded, off-branch tag
+/// (issue #5502).
+///
+/// Returns `Ok(None)` when the rebase conflicts (it is aborted to leave a clean
+/// tree) so each caller can map the un-automatable state onto its own failure
+/// contract. The returned [`AdvancedRemoteRecovery`] carries the push output;
+/// callers that must surface a failed post-rebase push inspect `push.success`.
+pub(crate) fn rebase_onto_advanced_remote_and_push(
+    component: &Component,
+    component_id: &str,
+    branch: &str,
+    head_commit: &str,
+    remote_commit: &str,
+    retag: Option<&str>,
+) -> Result<Option<AdvancedRemoteRecovery>> {
+    let path = &component.local_path;
+
+    // Capture the commits that landed on the remote between the pre-rebase
+    // release HEAD (what the dry-run plan was reviewed against) and the advanced
+    // remote head. These are auto-included in the final release after the rebase
+    // (issue #6141).
+    let advance = resolve_concurrent_advance(path, head_commit, remote_commit);
+
+    let rebase = git::rebase_at(
+        Some(component_id),
+        git::RebaseOptions {
+            onto: Some(remote_commit.to_string()),
+            ..Default::default()
+        },
+        Some(path),
+    )?;
+    if !rebase.success {
+        // Conflicting rebase — abort to leave the tree clean and defer to the
+        // operator. Recovery is not safe to automate here.
+        let _ = git::rebase_at(
+            Some(component_id),
+            git::RebaseOptions {
+                abort: true,
+                ..Default::default()
+            },
+            Some(path),
+        );
+        return Ok(None);
+    }
+
+    // The rebase moved the release commit to a new SHA on the branch line. Move
+    // the release tag onto the rebased release commit so it stays an ancestor of
+    // the pushed branch (issue #5502). Do this BEFORE pushing the branch so a
+    // successful branch push is never left with a stranded, off-branch tag.
+    if let Some(tag_name) = retag {
+        retag_rebased_release(component, component_id, branch, tag_name)?;
+    }
+
+    push_release_branch(component, component_id, branch)
+        .map(|push| Some(AdvancedRemoteRecovery { push, advance }))
+}
+
+/// Resolve the commits that landed on the remote between the pre-rebase release
+/// HEAD and the advanced remote head (`base..remote_head`).
+///
+/// Best-effort: a git failure listing the range must never block the recovery —
+/// the advance still gets reported (with an empty commit list) so the operator
+/// at least sees the base/head SHAs that changed (issue #6141).
+fn resolve_concurrent_advance(path: &str, base: &str, remote_head: &str) -> ConcurrentAdvance {
+    let commits = git::get_commits_in_range(path, base, remote_head).unwrap_or_default();
+    ConcurrentAdvance {
+        base: base.to_string(),
+        remote_head: remote_head.to_string(),
+        commits,
+    }
+}
+
+/// Re-point the release tag at the post-rebase HEAD (the release commit that is
+/// now on the branch line) and force-push the tag.
+///
+/// After [`rebase_onto_advanced_remote_and_push`] rebases the release commit
+/// onto the advanced remote head, the original tagged commit is orphaned
+/// off-branch. This deletes the stale local tag, recreates the annotated tag at
+/// HEAD, and force-pushes only the tag ref — guaranteeing the tag is an ancestor
+/// of the pushed branch and that no second release commit with the same version
+/// is left stranded (issue #5502). The branch itself is never force-pushed.
+fn retag_rebased_release(
+    component: &Component,
+    component_id: &str,
+    branch: &str,
+    tag_name: &str,
+) -> Result<()> {
+    let path = &component.local_path;
+    let head_commit = git::get_head_commit(path)?;
+
+    // If the tag already points at the rebased HEAD there is nothing to move.
+    if git::tag_exists_locally(path, tag_name).unwrap_or(false) {
+        let current = git::get_tag_commit(path, tag_name)?;
+        if current == head_commit {
+            return Ok(());
+        }
+        git::delete_local_tag(path, tag_name)?;
+    }
+
+    log_status!(
+        "release",
+        "Moving release tag {} onto the rebased release commit on {} ({})...",
+        tag_name,
+        branch,
+        &head_commit[..head_commit.len().min(8)]
+    );
+
+    let message = format!("Release {}", tag_name);
+    let tag_output = git::tag_at(
+        Some(component_id),
+        Some(tag_name),
+        Some(&message),
+        Some(path),
+    )?;
+    if !tag_output.success {
+        return Err(Error::git_command_failed(format!(
+            "Failed to recreate release tag {} at the rebased HEAD: {}",
+            tag_name,
+            tag_output.stderr.trim()
+        )));
+    }
+
+    // Re-publish the tag ref only (never the branch). If the orphaned tag was
+    // already pushed (the initial `--follow-tags` push lands the tag even when
+    // the branch is rejected), delete it on the remote first so the fresh tag
+    // publishes as a clean, non-forced update. Tags are deliberately moved here:
+    // the rebased commit supersedes the orphaned one within the same release.
+    if git::tag_exists_on_remote(path, tag_name).unwrap_or(false) {
+        let delete = git::delete_remote_tag(path, tag_name)?;
+        if !delete.success {
+            return Err(Error::git_command_failed(format!(
+                "Failed to delete the orphaned remote release tag {} before retagging: {}",
+                tag_name,
+                delete.stderr.trim()
+            )));
+        }
+    }
+
+    let push = git::push_at(
+        Some(component_id),
+        git::PushOptions {
+            refspec: Some(format!("refs/tags/{tag_name}:refs/tags/{tag_name}")),
+            ..Default::default()
+        },
+        Some(path),
+    )?;
+    if !push.success {
+        return Err(Error::git_command_failed(format!(
+            "Failed to push the moved release tag {}: {}",
+            tag_name,
+            push.stderr.trim()
+        )));
+    }
+
+    Ok(())
+}

--- a/src/core/release/executor/git_push.rs
+++ b/src/core/release/executor/git_push.rs
@@ -7,98 +7,11 @@
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
 
+use super::super::advanced_remote::{
+    push_release_branch, rebase_onto_advanced_remote_and_push, AdvancedRemoteRecovery,
+};
 use super::super::types::ReleaseStepResult;
 use super::{step_failed, step_success};
-
-/// Outcome of recovering a release push from an advanced remote branch.
-///
-/// Carries the final push output plus the newly-included commit range that
-/// landed on the remote during the release window. The range is surfaced both as
-/// a prominent operator warning and in structured step output so downstream
-/// summaries can state exactly what changed since the dry-run plan (issue #6141).
-struct AdvancedRemoteRecovery {
-    push: crate::core::git::GitOutput,
-    advance: ConcurrentAdvance,
-}
-
-impl AdvancedRemoteRecovery {
-    /// Recovery that did not actually rebase over an advance (already reconciled
-    /// or a spurious rejection): there is no newly-included range to report.
-    fn without_advance(push: crate::core::git::GitOutput) -> Self {
-        Self {
-            push,
-            advance: ConcurrentAdvance::default(),
-        }
-    }
-}
-
-/// Describes the commits that landed on the remote branch between the reviewed
-/// dry-run/preflight plan and the final tag/notes creation (issue #6141).
-#[derive(Default)]
-struct ConcurrentAdvance {
-    /// The pre-rebase release HEAD — the tip the dry-run plan was built against.
-    base: String,
-    /// The advanced remote head the release commit was rebased onto.
-    remote_head: String,
-    /// Commits newly included by the advance (`base..remote_head`), newest first.
-    commits: Vec<crate::core::git::CommitInfo>,
-}
-
-impl ConcurrentAdvance {
-    fn short(rev: &str) -> &str {
-        &rev[..rev.len().min(8)]
-    }
-
-    /// True when no actual advance was recorded (e.g. an already-reconciled retry
-    /// or a spurious non-fast-forward rejection) — nothing new was auto-included.
-    fn is_noop(&self) -> bool {
-        self.base.is_empty() && self.remote_head.is_empty()
-    }
-
-    /// Structured representation for the step `data` payload so downstream
-    /// summaries can report exactly which commits/PRs were auto-included.
-    fn to_json(&self) -> serde_json::Value {
-        serde_json::json!({
-            "base": self.base,
-            "remote_head": self.remote_head,
-            "range": format!("{}..{}", Self::short(&self.base), Self::short(&self.remote_head)),
-            "count": self.commits.len(),
-            "commits": self.commits
-                .iter()
-                .map(|c| serde_json::json!({ "hash": c.hash, "subject": c.subject }))
-                .collect::<Vec<_>>(),
-        })
-    }
-
-    /// Emit a prominent warning listing the newly-included commits so an operator
-    /// reviewing the release sees that the published contents differ from the
-    /// reviewed dry-run plan (issue #6141).
-    fn warn(&self, branch: &str) {
-        log_status!(
-            "release",
-            "⚠ CONCURRENT MAIN ADVANCE: remote '{}' advanced during the release. \
-             The final published release content CHANGED since the dry-run/preflight plan.",
-            branch
-        );
-        log_status!(
-            "release",
-            "⚠ Auto-included {} commit(s) ({}..{}) not present in the reviewed dry-run plan:",
-            self.commits.len(),
-            Self::short(&self.base),
-            Self::short(&self.remote_head)
-        );
-        if self.commits.is_empty() {
-            log_status!(
-                "release",
-                "⚠   (remote advanced but no new commits were resolved in the recovered range)"
-            );
-        } else {
-            for commit in &self.commits {
-                log_status!("release", "⚠   {} {}", commit.hash, commit.subject);
-            }
-        }
-    }
-}
 
 pub(crate) fn run_git_push(
     component: &Component,
@@ -116,7 +29,7 @@ pub(crate) fn run_git_push(
                 ]),
             )
         })?;
-    let output = git_push_release_branch(component, component_id, &branch)?;
+    let output = push_release_branch(component, component_id, &branch)?;
     let data = serde_json::to_value(&output)
         .map_err(|e| Error::internal_json(e.to_string(), Some("git push output".to_string())))?;
 
@@ -191,46 +104,20 @@ pub(crate) fn run_git_push(
     ))
 }
 
-/// Push the release branch (and tags) to `origin`.
-fn git_push_release_branch(
-    component: &Component,
-    component_id: &str,
-    branch: &str,
-) -> Result<crate::core::git::GitOutput> {
-    crate::core::git::push_at(
-        Some(component_id),
-        crate::core::git::PushOptions {
-            tags: true,
-            force_with_lease: false,
-            refspec: Some(format!("HEAD:refs/heads/{branch}")),
-            ..Default::default()
-        },
-        Some(&component.local_path),
-    )
-}
-
 /// Recover from a non-fast-forward branch rejection caused by the remote
-/// advancing after the release commit/tag were created (issue #3611, #5502).
+/// advancing after the release commit/tag were created (issues #3611, #5502).
 ///
-/// Fetches `origin`, confirms the local branch is strictly ahead of a common
-/// ancestor (so a rebase is the right reconciliation, not a force-push over
-/// divergent history), rebases HEAD onto the advanced remote head, and re-pushes
-/// the branch.
-///
-/// Rebasing replays the release commit onto the new remote head, producing a
-/// *new* release commit object. The annotated release tag was created in the
-/// earlier `git.tag` step pointing at the original (pre-rebase) release commit,
-/// which is now orphaned off the branch line. If left untouched, the tag points
-/// at a commit that is NOT an ancestor of the pushed branch, and the next
-/// release sees a stranded duplicate-version commit (issue #5502). So after a
-/// successful rebase this re-creates the tag at the new HEAD and force-pushes
-/// it, keeping exactly one release commit on the branch and the tag always an
-/// ancestor of the pushed branch.
+/// Fetches `origin`, then classifies the local/remote relationship: an
+/// already-reconciled or spurious rejection (remote head equal to or contained
+/// in HEAD) is re-pushed directly; a genuine divergence is reconciled by
+/// [`rebase_onto_advanced_remote_and_push`], which rebases HEAD onto the advanced
+/// remote head, moves the release tag onto the rebased commit (issue #5502), and
+/// re-pushes the branch.
 ///
 /// Returns:
-/// - `Ok(Some(push_output))` when the rebase + re-push succeeded,
-/// - `Ok(None)` when automatic recovery is unsafe (e.g. rebase conflict, or the
-///   remote branch is unexpectedly gone) — the caller emits manual guidance,
+/// - `Ok(Some(recovery))` when the re-push (with or without a rebase) was issued,
+/// - `Ok(None)` when automatic recovery is unsafe (rebase conflict, or the remote
+///   branch is unexpectedly gone) — the caller emits manual guidance,
 /// - `Err(_)` on an unexpected git failure.
 fn recover_advanced_remote_push(
     component: &Component,
@@ -248,167 +135,33 @@ fn recover_advanced_remote_push(
     };
     let head_commit = crate::core::git::get_head_commit(path)?;
 
-    // Already reconciled (e.g. a retry after a manual fix): nothing to do.
-    if remote_commit == head_commit {
-        return git_push_release_branch(component, component_id, branch)
+    // Already reconciled (a retry after a manual fix), or the remote head is
+    // already contained in HEAD (spurious rejection): re-push directly without a
+    // rebase. Confirming an ancestor relationship also guards against replaying
+    // onto unrelated history in the divergent branch below.
+    if remote_commit == head_commit
+        || crate::core::git::is_ancestor(path, &remote_commit, &head_commit)?
+    {
+        return push_release_branch(component, component_id, branch)
             .map(|push| Some(AdvancedRemoteRecovery::without_advance(push)));
     }
 
-    // Only rebase when the remote head is NOT already contained in HEAD — if it
-    // were, the push would have fast-forwarded. Confirm the histories share an
-    // ancestor before rebasing so we never replay onto unrelated history.
-    if crate::core::git::is_ancestor(path, &remote_commit, &head_commit)? {
-        // Remote head is an ancestor of HEAD; the rejection was spurious or
-        // already resolved. Re-push directly.
-        return git_push_release_branch(component, component_id, branch)
-            .map(|push| Some(AdvancedRemoteRecovery::without_advance(push)));
-    }
-
-    // Capture the commits that landed on the remote between the pre-rebase
-    // release HEAD (what the dry-run plan was reviewed against) and the advanced
-    // remote head. These are auto-included in the final release after the rebase,
-    // so surface them prominently and in structured output (issue #6141).
-    let advance = resolve_concurrent_advance(path, &head_commit, &remote_commit);
-
+    // Histories diverged: the remote advanced after the release commit. Rebase
+    // the release commit onto the advanced remote head and re-push (never force).
     log_status!(
         "release",
         "Rebasing release commit onto advanced remote {} ({})...",
         branch,
         &remote_commit[..remote_commit.len().min(8)]
     );
-    let rebase = crate::core::git::rebase_at(
-        Some(component_id),
-        crate::core::git::RebaseOptions {
-            onto: Some(remote_commit.clone()),
-            ..Default::default()
-        },
-        Some(path),
-    )?;
-    if !rebase.success {
-        // Conflicting rebase — abort to leave the tree clean and defer to the
-        // operator. Recovery is not safe to automate here.
-        let _ = crate::core::git::rebase_at(
-            Some(component_id),
-            crate::core::git::RebaseOptions {
-                abort: true,
-                ..Default::default()
-            },
-            Some(path),
-        );
-        return Ok(None);
-    }
-
-    // The rebase moved the release commit to a new SHA on the branch line. Move
-    // the release tag onto the rebased release commit so it stays an ancestor of
-    // the pushed branch (issue #5502). Do this BEFORE pushing the branch so a
-    // successful branch push is never left with a stranded, off-branch tag.
-    if let Some(tag_name) = release_tag {
-        retag_rebased_release(component, component_id, branch, tag_name)?;
-    }
-
-    git_push_release_branch(component, component_id, branch)
-        .map(|push| Some(AdvancedRemoteRecovery { push, advance }))
-}
-
-/// Resolve the commits that landed on the remote between the pre-rebase release
-/// HEAD and the advanced remote head (`base..remote_head`).
-///
-/// Best-effort: a git failure listing the range must never block the recovery —
-/// the advance still gets reported (with an empty commit list) so the operator
-/// at least sees the base/head SHAs that changed (issue #6141).
-fn resolve_concurrent_advance(path: &str, base: &str, remote_head: &str) -> ConcurrentAdvance {
-    let commits =
-        crate::core::git::get_commits_in_range(path, base, remote_head).unwrap_or_default();
-    ConcurrentAdvance {
-        base: base.to_string(),
-        remote_head: remote_head.to_string(),
-        commits,
-    }
-}
-
-/// Re-point the release tag at the post-rebase HEAD (the release commit that is
-/// now on the branch line) and force-push the tag.
-///
-/// After [`recover_advanced_remote_push`] rebases the release commit onto the
-/// advanced remote head, the original tagged commit is orphaned off-branch. This
-/// deletes the stale local tag, recreates the annotated tag at HEAD, and
-/// force-pushes only the tag ref — guaranteeing the tag is an ancestor of the
-/// pushed branch and that no second release commit with the same version is left
-/// stranded (issue #5502). The branch itself is never force-pushed.
-fn retag_rebased_release(
-    component: &Component,
-    component_id: &str,
-    branch: &str,
-    tag_name: &str,
-) -> Result<()> {
-    let path = &component.local_path;
-    let head_commit = crate::core::git::get_head_commit(path)?;
-
-    // If the tag already points at the rebased HEAD there is nothing to move.
-    if crate::core::git::tag_exists_locally(path, tag_name).unwrap_or(false) {
-        let current = crate::core::git::get_tag_commit(path, tag_name)?;
-        if current == head_commit {
-            return Ok(());
-        }
-        crate::core::git::delete_local_tag(path, tag_name)?;
-    }
-
-    log_status!(
-        "release",
-        "Moving release tag {} onto the rebased release commit on {} ({})...",
-        tag_name,
+    rebase_onto_advanced_remote_and_push(
+        component,
+        component_id,
         branch,
-        &head_commit[..head_commit.len().min(8)]
-    );
-
-    let message = format!("Release {}", tag_name);
-    let tag_output = crate::core::git::tag_at(
-        Some(component_id),
-        Some(tag_name),
-        Some(&message),
-        Some(path),
-    )?;
-    if !tag_output.success {
-        return Err(Error::git_command_failed(format!(
-            "Failed to recreate release tag {} at the rebased HEAD: {}",
-            tag_name,
-            tag_output.stderr.trim()
-        )));
-    }
-
-    // Re-publish the tag ref only (never the branch). If the orphaned tag was
-    // already pushed (the initial `--follow-tags` push lands the tag even when
-    // the branch is rejected), delete it on the remote first so the fresh tag
-    // publishes as a clean, non-forced update. Tags are deliberately moved here:
-    // the rebased commit supersedes the orphaned one within the same release.
-    if crate::core::git::tag_exists_on_remote(path, tag_name).unwrap_or(false) {
-        let delete = crate::core::git::delete_remote_tag(path, tag_name)?;
-        if !delete.success {
-            return Err(Error::git_command_failed(format!(
-                "Failed to delete the orphaned remote release tag {} before retagging: {}",
-                tag_name,
-                delete.stderr.trim()
-            )));
-        }
-    }
-
-    let push = crate::core::git::push_at(
-        Some(component_id),
-        crate::core::git::PushOptions {
-            refspec: Some(format!("refs/tags/{tag_name}:refs/tags/{tag_name}")),
-            ..Default::default()
-        },
-        Some(path),
-    )?;
-    if !push.success {
-        return Err(Error::git_command_failed(format!(
-            "Failed to push the moved release tag {}: {}",
-            tag_name,
-            push.stderr.trim()
-        )));
-    }
-
-    Ok(())
+        &head_commit,
+        &remote_commit,
+        release_tag,
+    )
 }
 
 /// True when git's stderr indicates a non-fast-forward / stale-remote branch

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -1,3 +1,4 @@
+mod advanced_remote;
 pub mod changelog;
 mod checkout_guard;
 mod context;

--- a/src/core/release/workflow_recover.rs
+++ b/src/core/release/workflow_recover.rs
@@ -8,6 +8,7 @@ use crate::core::error::{Error, Result};
 use crate::core::git;
 use crate::core::plan::PlanStep;
 
+use super::advanced_remote;
 use super::context::load_component;
 use super::types::{ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePlan};
 use super::workflow::{format_tag, release_execution_plan, short_sha};
@@ -412,28 +413,6 @@ pub(super) fn reconcile_release_branch(
     };
     let head_commit = git::get_head_commit(path)?;
 
-    // Push HEAD to the branch (tags included), surfacing `err_label` on failure.
-    // Shared by the fast-forward and post-rebase paths below, which push the
-    // identical refspec and differ only in the error wording.
-    let push_branch = |err_label: &str| -> Result<()> {
-        let push = git::push_at(
-            Some(component_id),
-            git::PushOptions {
-                tags: true,
-                refspec: Some(format!("HEAD:refs/heads/{branch}")),
-                ..Default::default()
-            },
-            Some(path),
-        )?;
-        if !push.success {
-            return Err(Error::git_command_failed(format!(
-                "Failed to push {} branch {}: {}",
-                err_label, branch, push.stderr
-            )));
-        }
-        Ok(())
-    };
-
     // The release commit is already on the remote branch — nothing to do.
     if git::is_ancestor(path, &head_commit, &remote_commit)? {
         return Ok(None);
@@ -446,35 +425,47 @@ pub(super) fn reconcile_release_branch(
             "Pushing release commit to remote {} (remote did not advance)...",
             branch
         );
-        push_branch("release")?;
+        let push = advanced_remote::push_release_branch(component, component_id, &branch)?;
+        if !push.success {
+            return Err(Error::git_command_failed(format!(
+                "Failed to push release branch {}: {}",
+                branch, push.stderr
+            )));
+        }
         return Ok(Some(format!("pushed release commit to {}", branch)));
     }
 
     // Histories diverged: the remote advanced after the release commit. Rebase
-    // the release commit onto the advanced remote head, then push. Never force.
+    // the release commit onto the advanced remote head, then push. Never force,
+    // and never retag — `--recover` reconciles the branch only (the tag-push
+    // block above already handled the tag). Shared with the release push step's
+    // recovery so the two cannot drift (issue #3611).
     log_status!(
         "recover",
         "Remote {} advanced — rebasing release commit onto the new head and re-pushing...",
         branch
     );
-    let rebase = git::rebase_at(
-        Some(component_id),
-        git::RebaseOptions {
-            onto: Some(remote_commit.clone()),
-            ..Default::default()
-        },
-        Some(path),
-    )?;
-    if !rebase.success {
-        let _ = git::rebase_at(
-            Some(component_id),
-            git::RebaseOptions {
-                abort: true,
-                ..Default::default()
-            },
-            Some(path),
-        );
-        return Err(Error::validation_invalid_argument(
+    match advanced_remote::rebase_onto_advanced_remote_and_push(
+        component,
+        component_id,
+        &branch,
+        &head_commit,
+        &remote_commit,
+        None,
+    )? {
+        Some(recovery) => {
+            if !recovery.push.success {
+                return Err(Error::git_command_failed(format!(
+                    "Failed to push rebased release branch {}: {}",
+                    branch, recovery.push.stderr
+                )));
+            }
+            Ok(Some(format!(
+                "rebased release commit onto advanced remote and pushed {}",
+                branch
+            )))
+        }
+        None => Err(Error::validation_invalid_argument(
             "recover",
             format!(
                 "Rebasing the release commit onto the advanced remote {} hit a conflict",
@@ -487,15 +478,8 @@ pub(super) fn reconcile_release_branch(
                     component_id
                 ),
             ]),
-        ));
+        )),
     }
-
-    push_branch("rebased release")?;
-
-    Ok(Some(format!(
-        "rebased release commit onto advanced remote and pushed {}",
-        branch
-    )))
 }
 
 pub(super) fn recovery_release_plan(


### PR DESCRIPTION
## What

Collapses two pieces of duplicated readiness/release logic onto single shared helpers. Builds on wave-1 #6754 (GH-Enterprise host fix); does **not** re-touch the host plumbing. Follow-ups deferred from #6749.

### 1. One CI-check classifier (was 3 divergent copies)
`gh pr view --json statusCheckRollup` is interpreted by the readiness summary (`github/readiness.rs`), the fleet rollup (`github/fleet.rs`), and the PR-land merge gate (`pr_land.rs`). Each re-matched `(status, conclusion)` differently. The flagged real inconsistency: the **fleet rollup folded `SKIPPED` into its passed count** while readiness tracked it separately.

- New `github/checks.rs`: one `classify_check` → `CheckClass` classifier with explicit, documented `SKIPPED` handling (terminal + non-blocking, its own bucket).
- All three consumers route through it.
- `GithubPrCheckRollup` gains a `skipped` field so the fleet rollup reports SKIPPED separately (no longer inflating `passed`), matching the readiness summary.
- **Intentional semantic alignment in the land gate:** it now also blocks on `ACTION_REQUIRED` / `STARTUP_FAILURE` and on `COMPLETED` checks with unrecognized/empty conclusions, which the land-only classifier previously let merge. This is the conservative (safer) direction and matches readiness/fleet. Case-insensitive matching is preserved.

### 2. One advanced-remote rebase recovery (issue #3611, was 2 copies)
The release push step (`executor/git_push.rs::recover_advanced_remote_push`) and `release --recover` (`workflow_recover.rs::reconcile_release_branch`) both implemented the same fetch → ancestor-check → rebase-onto-advanced-remote → abort-on-conflict → push-`HEAD:refs/heads` mechanic.

- New `release/advanced_remote.rs` owns the shared mechanic: `rebase_onto_advanced_remote_and_push` (rebase + optional tag relocation #5502 + concurrent-advance capture #6141 + push) and `push_release_branch`.
- Both callers delegate the diverged-history case. Each keeps its own pre-checks (how it discovers the divergence) and result contract: the push step reports its recovery payload unchanged; `--recover` maps a rebase conflict onto its own `Err`. A failed post-rebase push is still surfaced exactly as before in each path.

## Why not the full "collapse"
The two reconcile functions are **not** as identical as the duplicated core suggests — they differ in conflict handling (`Ok(None)` vs `Err`), `#6141` advance capture, retag policy, and return shape — so the safe behavior-preserving move shares the core mechanic while preserving each caller's distinct decisions, rather than forcing one signature. Raw LOC rises (extracted code carries its docs to a shared home + ~150 lines of mandated tests) but the duplication and drift risk are removed.

## Verification
- `cargo check`: clean (no new warnings in changed files).
- `cargo test --lib core::git::` → 173 passed; `core::release::` → 281 passed. Includes the `#3611/#5502/#6141` recovery tests (`run_git_push_recovers_when_remote_advanced`, `reconcile_release_branch_rebases_onto_advanced_remote`, `reconcile_release_branch_noop_when_already_pushed`) and the new classifier tests.

## Deferred (follow-up issues filed)
- GhClient convergence of remaining free-function `gh` callers (item 1).
- Unified PR-view fetcher across `pulls`/`pr_land`/`pr_refresh` + routing `pr_refresh` through shared git primitives (item 2).
- `core/stack` right-sizing (5 CLI-only verbs re-implementing `core::git`).
- `core/triage` carries further `summarize_checks` copies that could adopt `classify_check` (out of this PR's scope).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Analysis of the duplicated code paths, the refactor, and tests.