### PR TITLE
Fix fuzz run status reconciliation

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -298,12 +298,35 @@ fn campaign_has_artifact(campaign: &FuzzCampaign, aliases: &[&str]) -> bool {
         .artifacts
         .iter()
         .any(|artifact| fuzz_artifact_matches(artifact, aliases))
+        || campaign_metadata_has_artifact_ref(&campaign.metadata, aliases)
 }
 
 fn fuzz_artifact_matches(artifact: &FuzzArtifact, aliases: &[&str]) -> bool {
     aliases
         .iter()
         .any(|alias| artifact.id == *alias || artifact.kind == *alias)
+}
+
+fn campaign_metadata_has_artifact_ref(metadata: &serde_json::Value, aliases: &[&str]) -> bool {
+    metadata
+        .get("artifact_refs")
+        .and_then(|refs| refs.as_array())
+        .is_some_and(|refs| {
+            refs.iter()
+                .any(|artifact_ref| artifact_ref_matches_alias(artifact_ref, aliases))
+        })
+}
+
+fn artifact_ref_matches_alias(artifact_ref: &serde_json::Value, aliases: &[&str]) -> bool {
+    let fields = ["id", "kind", "name", "role", "semantic_key"];
+    aliases.iter().any(|alias| {
+        fields.iter().any(|field| {
+            artifact_ref
+                .get(field)
+                .and_then(|value| value.as_str())
+                .is_some_and(|value| value == *alias)
+        })
+    })
 }
 
 fn fuzz_prepare_settings(args: &FuzzRunArgs) -> Vec<(String, String)> {
@@ -492,17 +515,36 @@ pub(super) fn fuzz_run_outcome(
 
     let campaign_failed = gate_profile != FuzzGateProfile::Measurement
         && results.is_some_and(fuzz_campaign_reports_failure);
-    let success = runner_success && !campaign_failed && results_error.is_none();
+    let campaign_passed = results.is_some_and(fuzz_campaign_reports_success);
+    let success =
+        (runner_success || campaign_passed) && !campaign_failed && results_error.is_none();
     FuzzRunOutcome {
         status: if success { "passed" } else { "failed" },
         success,
         exit_code: if success {
-            runner_exit_code
+            0
         } else if runner_exit_code == 0 {
             1
         } else {
             runner_exit_code
         },
+    }
+}
+
+fn fuzz_campaign_reports_success(campaign: &FuzzCampaign) -> bool {
+    fuzz_metadata_reports_success(&campaign.metadata)
+}
+
+fn fuzz_metadata_reports_success(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(object) => {
+            object.get("success").and_then(|success| success.as_bool()) == Some(true)
+                || object
+                    .get("status")
+                    .and_then(|status| status.as_str())
+                    .is_some_and(|status| matches!(status, "pass" | "passed" | "success"))
+        }
+        _ => false,
     }
 }
 

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -319,6 +319,46 @@ fn fuzz_run_outcome_measurement_profile_records_open_findings_without_failing() 
 }
 
 #[test]
+fn fuzz_run_outcome_prefers_passed_campaign_over_transport_exit_code() {
+    let mut campaign = empty_fuzz_campaign();
+    campaign.metadata = serde_json::json!({
+        "status": "passed",
+        "success": true,
+    });
+
+    let outcome = fuzz_run_outcome(
+        1,
+        false,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Evidence,
+    );
+
+    assert_eq!(outcome.status, "passed");
+    assert!(outcome.success);
+    assert_eq!(outcome.exit_code, 0);
+}
+
+#[test]
+fn fuzz_run_outcome_keeps_transport_failure_without_passed_campaign() {
+    let campaign = empty_fuzz_campaign();
+
+    let outcome = fuzz_run_outcome(
+        1,
+        false,
+        false,
+        Some(&campaign),
+        None,
+        homeboy::core::fuzz::FuzzGateProfile::Evidence,
+    );
+
+    assert_eq!(outcome.status, "failed");
+    assert!(!outcome.success);
+    assert_eq!(outcome.exit_code, 1);
+}
+
+#[test]
 fn fuzz_run_expected_metric_gate_fails_when_observed_metric_differs() {
     let mut campaign = empty_fuzz_campaign();
     campaign.metadata = serde_json::json!({
@@ -608,6 +648,24 @@ fn strict_fuzz_run_artifact_validation_passes_with_required_artifacts() {
         artifact: None,
         metadata: serde_json::Value::Null,
         extra: std::collections::BTreeMap::new(),
+    });
+
+    assert!(fuzz_run_artifact_validation_error(&args, Some(&campaign)).is_none());
+}
+
+#[test]
+fn strict_fuzz_run_artifact_validation_accepts_metadata_artifact_refs() {
+    let mut args = fuzz_run_args_with_run_id("strict-proof");
+    args.require_case_log = true;
+    args.require_coverage_summary = true;
+    args.require_result_envelope = true;
+    let mut campaign = empty_fuzz_campaign();
+    campaign.metadata = serde_json::json!({
+        "artifact_refs": [
+            { "name": "case-log", "role": "case_log", "path": "files/case-log.jsonl" },
+            { "name": "coverage-summary", "role": "coverage_summary", "path": "files/coverage-summary.json" },
+            { "name": "result-envelope", "role": "result_envelope", "path": "files/result-envelope.json" }
+        ]
     });
 
     assert!(fuzz_run_artifact_validation_error(&args, Some(&campaign)).is_none());


### PR DESCRIPTION
## Summary
- Reconcile successful fuzz campaigns as passed even when the runner transport exits nonzero after emitting a canonical passed campaign.
- Treat required artifact refs declared in campaign metadata as satisfying strict fuzz artifact validation.
- Add regression coverage for passed campaign reconciliation and metadata artifact refs.

## Verification
- `cargo test --lib fuzz_run_artifact_validation`
- `cargo test --lib fuzz_run_outcome_`
- `cargo build --release`
- Lab proof run: `homeboy runs show woo-db-api-fuzz-20260627-rest-db-query-profile-r10` reports `Status: pass`
- Evidence refs:
  - `runner-artifact://homeboy-lab/woo-db-api-fuzz-20260627-rest-db-query-profile-r10/d6249941-1aed-4ae9-bd5a-5cb03eb40c8f`
  - `runner-artifact://homeboy-lab/woo-db-api-fuzz-20260627-rest-db-query-profile-r10/0a0d6a03-a66d-4bfb-842a-2df3560b1e96`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the fuzz run status mismatch, drafting the code changes, running focused verification, and preparing this PR.