### PR TITLE
fuzz: make the core result contract authoritative + generic (de-domain gate evaluator)

### DIFF
--- a/assets/defaults/extension-provided-defaults.json
+++ b/assets/defaults/extension-provided-defaults.json
@@ -66,5 +66,14 @@
     "tracker_reference_regexes": [
       "core\\.trac\\.wordpress\\.org/ticket/\\d+"
     ]
+  },
+  "fuzz": {
+    "case_evidence_kinds": [
+      "fuzz_report",
+      "fuzz_case",
+      "case_artifact",
+      "failing_case",
+      "repro_case"
+    ]
   }
 }

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -10,7 +10,9 @@ use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner, FuzzConfig};
 use homeboy::core::fuzz::{
-    parse_fuzz_results_file, FuzzArtifact, FuzzCampaign, FuzzFindingStatus, FuzzGateProfile,
+    fuzz_artifact_kind_matches, parse_fuzz_results_file, FuzzArtifact, FuzzCampaign,
+    FuzzFindingStatus, FuzzGateProfile, FUZZ_ARTIFACT_KIND_CASE_LOG,
+    FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY, FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE,
 };
 use homeboy::core::lifecycle::LifecyclePhaseStatus;
 use homeboy::core::observation::{ObservationStore, RunRecord, RunStatus};
@@ -224,25 +226,17 @@ pub(super) fn fuzz_run_artifact_validation_error(
     };
 
     let mut missing = Vec::new();
-    if args.require_case_log && !campaign_has_artifact(campaign, &["case-log", "case_log"]) {
+    if args.require_case_log && !campaign_has_artifact(campaign, FUZZ_ARTIFACT_KIND_CASE_LOG) {
         missing.push("case log (--require-case-log)");
     }
     if args.require_coverage_summary
         && campaign.coverage_summary.is_none()
-        && !campaign_has_artifact(campaign, &["coverage-summary", "coverage_summary"])
+        && !campaign_has_artifact(campaign, FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY)
     {
         missing.push("coverage summary (--require-coverage-summary)");
     }
     if args.require_result_envelope
-        && !campaign_has_artifact(
-            campaign,
-            &[
-                "result-envelope",
-                "result_envelope",
-                "fuzz-result-envelope",
-                "fuzz_result_envelope",
-            ],
-        )
+        && !campaign_has_artifact(campaign, FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE)
     {
         missing.push("result envelope (--require-result-envelope)");
     }
@@ -293,17 +287,16 @@ fn fuzz_requested_settings(args: &FuzzRunArgs) -> serde_json::Value {
     })
 }
 
-fn campaign_has_artifact(campaign: &FuzzCampaign, aliases: &[&str]) -> bool {
+fn campaign_has_artifact(campaign: &FuzzCampaign, canonical_kind: &str) -> bool {
     campaign
         .artifacts
         .iter()
-        .any(|artifact| fuzz_artifact_matches(artifact, aliases))
+        .any(|artifact| fuzz_artifact_matches(artifact, canonical_kind))
 }
 
-fn fuzz_artifact_matches(artifact: &FuzzArtifact, aliases: &[&str]) -> bool {
-    aliases
-        .iter()
-        .any(|alias| artifact.id == *alias || artifact.kind == *alias)
+fn fuzz_artifact_matches(artifact: &FuzzArtifact, canonical_kind: &str) -> bool {
+    fuzz_artifact_kind_matches(&artifact.id, canonical_kind)
+        || fuzz_artifact_kind_matches(&artifact.kind, canonical_kind)
 }
 
 fn fuzz_prepare_settings(args: &FuzzRunArgs) -> Vec<(String, String)> {

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -3,10 +3,12 @@ use std::path::Path;
 
 use homeboy::core::artifact_ref::EvidenceRef;
 use homeboy::core::fuzz::{
-    fuzz_gate_profile_contract, parse_fuzz_case_log_file, parse_fuzz_observation_set_value,
-    parse_fuzz_results_file, parse_fuzz_target_inventory_file, rank_fuzz_observation_set_hotspots,
-    FuzzCampaign, FuzzExecutionRequest, FuzzGateProfile, FuzzHotspotSet, FuzzProvenance,
-    FuzzResultEnvelope, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
+    fuzz_case_evidence_artifact_kinds, fuzz_gate_profile_contract, parse_fuzz_case_log_file,
+    parse_fuzz_observation_set_value, parse_fuzz_results_file, parse_fuzz_target_inventory_file,
+    rank_fuzz_observation_set_hotspots, FuzzCampaign, FuzzExecutionRequest, FuzzGateProfile,
+    FuzzHotspotSet, FuzzProvenance, FuzzResultEnvelope, FUZZ_ARTIFACT_KIND_CASE_LOG,
+    FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY, FUZZ_ARTIFACT_KIND_REPLAY_DATA,
+    FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
     FUZZ_RESULT_ENVELOPE_SCHEMA,
 };
 use homeboy::core::observation::{ArtifactRecord, ObservationStore};
@@ -496,15 +498,15 @@ fn observed_gate_metric(metrics: &FuzzGateMetrics, metric: &str) -> f64 {
 
 pub(super) fn required_artifact_count(envelope: &FuzzResultEnvelope, kind: &str) -> usize {
     match kind {
-        "result_envelope" => 1,
-        "case_log" => envelope
+        FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE => 1,
+        FUZZ_ARTIFACT_KIND_CASE_LOG => envelope
             .campaign
             .as_ref()
             .map(|campaign| {
                 case_evidence_artifact_count(campaign, &FuzzGateEvaluationProfile::default())
             })
             .unwrap_or(0),
-        "coverage_summary" => {
+        FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY => {
             usize::from(
                 envelope
                     .campaign
@@ -513,7 +515,9 @@ pub(super) fn required_artifact_count(envelope: &FuzzResultEnvelope, kind: &str)
                     .is_some(),
             ) + artifact_ref_count(envelope, kind)
         }
-        "replay_data" => replay_data_count(envelope) + artifact_ref_count(envelope, kind),
+        FUZZ_ARTIFACT_KIND_REPLAY_DATA => {
+            replay_data_count(envelope) + artifact_ref_count(envelope, kind)
+        }
         _ => artifact_ref_count(envelope, kind),
     }
 }
@@ -585,21 +589,18 @@ fn metadata_artifact_has_kind(artifact: &serde_json::Value, kind: &str) -> bool 
 }
 
 struct FuzzGateEvaluationProfile {
-    case_evidence_kinds: &'static [&'static str],
+    /// Artifact kinds that count as case-level proof for the `has-case-evidence`
+    /// gate. Resolved from the core contract: the canonical `case_log` kind plus
+    /// any ecosystem-specific spellings supplied through the extension-provided
+    /// defaults asset. Core source carries no domain artifact vocabulary (#6766).
+    case_evidence_kinds: Vec<String>,
     metadata_artifact_ref_keys: &'static [&'static str],
 }
 
 impl Default for FuzzGateEvaluationProfile {
     fn default() -> Self {
         Self {
-            case_evidence_kinds: &[
-                "case_log",
-                "fuzz_report",
-                "fuzz_case",
-                "case_artifact",
-                "failing_case",
-                "repro_case",
-            ],
+            case_evidence_kinds: fuzz_case_evidence_artifact_kinds(),
             metadata_artifact_ref_keys: &["artifact_refs", "artifactRefs"],
         }
     }
@@ -657,7 +658,8 @@ fn case_evidence_artifact_count(
         .filter(|artifact| {
             profile
                 .case_evidence_kinds
-                .contains(&artifact.kind.as_str())
+                .iter()
+                .any(|kind| kind == &artifact.kind)
         })
         .count();
     campaign_artifacts + metadata_case_evidence_artifact_count(&campaign.metadata, profile)
@@ -698,7 +700,10 @@ fn metadata_artifact_has_case_evidence_kind(
         .or_else(|| artifact.get("role"))
         .and_then(|value| value.as_str())
         .unwrap_or_default();
-    profile.case_evidence_kinds.contains(&kind)
+    profile
+        .case_evidence_kinds
+        .iter()
+        .any(|evidence_kind| evidence_kind == kind)
 }
 
 pub(super) fn fuzz_coverage_completeness(

--- a/src/commands/fuzz/tests/gate_tests.rs
+++ b/src/commands/fuzz/tests/gate_tests.rs
@@ -1,5 +1,47 @@
 use super::*;
 
+/// The generic gate evaluator must not carry ecosystem-specific artifact-kind
+/// vocabulary as Rust literals. The canonical `case_log` kind stays in core; the
+/// extended alias spellings live in the extension-provided defaults asset (#6766).
+#[test]
+fn gate_evaluator_source_carries_no_domain_artifact_vocabulary() {
+    let source = include_str!("../report.rs");
+    for domain_kind in ["fuzz_report", "fuzz_case", "case_artifact", "failing_case", "repro_case"] {
+        let literal = format!("\"{domain_kind}\"");
+        assert!(
+            !source.contains(&literal),
+            "gate evaluator source must not hardcode domain artifact kind literal {literal}; \
+             it belongs in the extension-provided defaults asset",
+        );
+    }
+}
+
+/// Externalizing the case-evidence vocabulary to the asset must preserve the
+/// exact set the evaluator previously recognized: canonical `case_log` plus the
+/// ecosystem aliases now sourced from the extension-provided defaults.
+#[test]
+fn case_evidence_kinds_preserve_prior_recognized_set() {
+    let kinds = homeboy::core::fuzz::fuzz_case_evidence_artifact_kinds();
+    for expected in [
+        "case_log",
+        "fuzz_report",
+        "fuzz_case",
+        "case_artifact",
+        "failing_case",
+        "repro_case",
+    ] {
+        assert!(
+            kinds.iter().any(|kind| kind == expected),
+            "case-evidence kinds should include {expected}",
+        );
+    }
+    assert_eq!(
+        kinds.first().map(String::as_str),
+        Some("case_log"),
+        "canonical case_log kind must lead the recognized set",
+    );
+}
+
 #[test]
 fn fuzz_gate_evaluation_requires_case_log_evidence() {
     let campaign = FuzzCampaign {

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -20,6 +20,7 @@ pub(crate) use io::reset_config_cache_for_test;
 pub(crate) use builtins::deploy_generated_build_dir;
 pub(crate) use builtins::extension_provided_detector_profile;
 pub(crate) use builtins::extension_provided_direct_test_file_suffixes;
+pub(crate) use builtins::extension_provided_fuzz_case_evidence_kinds;
 pub(crate) use builtins::extension_provided_test_drift_config;
 
 /// Root configuration structure for the product config file.

--- a/src/core/defaults/builtins.rs
+++ b/src/core/defaults/builtins.rs
@@ -20,6 +20,25 @@ struct ExtensionProvidedDefaults {
     /// profile defaults, keeping core source framework-agnostic (#2240).
     #[serde(default)]
     detector_profile: DetectorProfileDefaults,
+    /// Ecosystem-specific fuzz defaults (extra artifact-kind spellings that the
+    /// generic gate evaluator should treat as case-level proof). Core ships no
+    /// domain artifact vocabulary as Rust literals; the framework set lives here
+    /// in the extension-provided defaults asset so the gate evaluator stays
+    /// product-neutral (#6766).
+    #[serde(default)]
+    fuzz: FuzzDefaults,
+}
+
+/// Extension-provided fuzz defaults. Empty by default so a truly generic core
+/// (or an external defaults file that omits the section) carries no
+/// ecosystem-specific artifact-kind vocabulary.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct FuzzDefaults {
+    /// Extra artifact-kind spellings that count as case-level proof for the
+    /// `has-case-evidence` gate, beyond the canonical `case_log` kind that core
+    /// always recognizes.
+    #[serde(default)]
+    pub case_evidence_kinds: Vec<String>,
 }
 
 /// Extension-provided code-audit detector defaults. Empty by default so a
@@ -99,6 +118,10 @@ pub(crate) fn extension_provided_direct_test_file_suffixes() -> Vec<String> {
 
 pub(crate) fn extension_provided_detector_profile() -> DetectorProfileDefaults {
     extension_provided_defaults().detector_profile.clone()
+}
+
+pub(crate) fn extension_provided_fuzz_case_evidence_kinds() -> Vec<String> {
+    extension_provided_defaults().fuzz.case_evidence_kinds.clone()
 }
 
 pub(super) fn default_deploy() -> DeployConfig {
@@ -216,6 +239,21 @@ mod tests {
             .tracker_reference_regexes
             .iter()
             .any(|r| r.contains("wordpress")));
+    }
+
+    #[test]
+    fn fuzz_case_evidence_defaults_live_in_extension_asset() {
+        // The ecosystem-specific case-evidence artifact spellings live in the
+        // extension-provided asset, not core Rust literals, so the generic gate
+        // evaluator stays product-neutral (#6766). Behavior is still wired
+        // one-repo so the previously hardcoded set is preserved.
+        let kinds = extension_provided_fuzz_case_evidence_kinds();
+
+        assert!(kinds.iter().any(|kind| kind == "fuzz_report"));
+        assert!(kinds.iter().any(|kind| kind == "repro_case"));
+        // The canonical `case_log` kind is owned by core and is not duplicated
+        // into the extension-supplied alias list.
+        assert!(!kinds.iter().any(|kind| kind == "case_log"));
     }
 
     #[test]

--- a/src/core/fuzz/artifact_envelope.rs
+++ b/src/core/fuzz/artifact_envelope.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use crate::core::observation::ArtifactRecord;
 
+use super::artifact_kinds::{canonical_fuzz_artifact_kind, FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE};
 use super::envelope::FuzzResultEnvelope;
 use super::schemas::FUZZ_RESULT_ENVELOPE_SCHEMA;
 
@@ -90,7 +91,7 @@ pub fn inspect_fuzz_result_envelope_artifact(
 
 fn recognition_reasons(artifact: &ArtifactRecord) -> Vec<String> {
     let mut reasons = Vec::new();
-    if artifact.kind == "fuzz_result_envelope" {
+    if canonical_fuzz_artifact_kind(&artifact.kind) == Some(FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE) {
         reasons.push("artifact.kind".to_string());
     }
     if artifact

--- a/src/core/fuzz/artifact_kinds.rs
+++ b/src/core/fuzz/artifact_kinds.rs
@@ -1,0 +1,148 @@
+//! Canonical fuzz artifact-kind identifiers and alias resolution.
+//!
+//! Runners, gate evaluation, and result-envelope recognition all refer to the
+//! same small set of contract artifacts. Historically each call site carried
+//! its own list of spelling aliases (`result-envelope`, `fuzz_result_envelope`,
+//! `result_envelope`, ...). This module is the single source of truth: one
+//! canonical identifier per contract artifact plus a resolver that folds every
+//! accepted spelling onto it, so the contract stays authoritative and generic
+//! (#6766).
+
+use crate::core::defaults::extension_provided_fuzz_case_evidence_kinds;
+
+/// Canonical artifact kind for the fuzz result envelope.
+pub const FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE: &str = "result_envelope";
+/// Canonical artifact kind for the case-level execution log.
+pub const FUZZ_ARTIFACT_KIND_CASE_LOG: &str = "case_log";
+/// Canonical artifact kind for the coverage summary.
+pub const FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY: &str = "coverage_summary";
+/// Canonical artifact kind for replay/reproduction data.
+pub const FUZZ_ARTIFACT_KIND_REPLAY_DATA: &str = "replay_data";
+
+/// The canonical contract artifact kinds, in declaration order. Published in the
+/// core fuzz contract so consumers (e.g. the WordPress fuzz runner extension)
+/// can map their artifact roles onto core's identifiers instead of
+/// re-declaring alias arrays by hand.
+pub fn canonical_fuzz_artifact_kinds() -> Vec<String> {
+    [
+        FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE,
+        FUZZ_ARTIFACT_KIND_CASE_LOG,
+        FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY,
+        FUZZ_ARTIFACT_KIND_REPLAY_DATA,
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
+/// Fold an artifact-kind spelling onto its canonical contract identifier.
+///
+/// Normalization lowercases, treats `-` and `_` as equivalent, and strips a
+/// leading `fuzz` segment, so `fuzz-result-envelope`, `fuzz_result_envelope`,
+/// `result-envelope`, and `result_envelope` all resolve to the same canonical
+/// kind. Returns `None` for kinds outside the core contract set.
+pub fn canonical_fuzz_artifact_kind(raw: &str) -> Option<&'static str> {
+    match normalize_artifact_kind(raw).as_str() {
+        "result_envelope" => Some(FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE),
+        "case_log" => Some(FUZZ_ARTIFACT_KIND_CASE_LOG),
+        "coverage_summary" => Some(FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY),
+        "replay_data" => Some(FUZZ_ARTIFACT_KIND_REPLAY_DATA),
+        _ => None,
+    }
+}
+
+/// True when an artifact-kind spelling names the same canonical contract kind
+/// as `canonical`.
+pub fn fuzz_artifact_kind_matches(raw: &str, canonical: &str) -> bool {
+    match canonical_fuzz_artifact_kind(canonical) {
+        Some(target) => canonical_fuzz_artifact_kind(raw) == Some(target),
+        None => false,
+    }
+}
+
+/// Artifact kinds that count as case-level proof for the `has-case-evidence`
+/// gate. The canonical `case_log` kind is always recognized; additional
+/// ecosystem-specific spellings come from the extension-provided defaults asset
+/// so core Rust carries no domain artifact vocabulary (#6766).
+pub fn fuzz_case_evidence_artifact_kinds() -> Vec<String> {
+    let mut kinds = vec![FUZZ_ARTIFACT_KIND_CASE_LOG.to_string()];
+    for kind in extension_provided_fuzz_case_evidence_kinds() {
+        let trimmed = kind.trim();
+        if !trimmed.is_empty() && !kinds.iter().any(|existing| existing == trimmed) {
+            kinds.push(trimmed.to_string());
+        }
+    }
+    kinds
+}
+
+fn normalize_artifact_kind(raw: &str) -> String {
+    let lowered = raw.trim().to_ascii_lowercase().replace('-', "_");
+    lowered
+        .strip_prefix("fuzz_")
+        .map(str::to_string)
+        .unwrap_or(lowered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolver_collapses_result_envelope_aliases() {
+        for alias in [
+            "result_envelope",
+            "result-envelope",
+            "fuzz_result_envelope",
+            "fuzz-result-envelope",
+            "Fuzz-Result-Envelope",
+        ] {
+            assert_eq!(
+                canonical_fuzz_artifact_kind(alias),
+                Some(FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE),
+                "alias {alias} should resolve to the canonical result-envelope kind",
+            );
+        }
+    }
+
+    #[test]
+    fn resolver_collapses_case_log_and_coverage_aliases() {
+        assert_eq!(
+            canonical_fuzz_artifact_kind("case-log"),
+            Some(FUZZ_ARTIFACT_KIND_CASE_LOG),
+        );
+        assert_eq!(
+            canonical_fuzz_artifact_kind("case_log"),
+            Some(FUZZ_ARTIFACT_KIND_CASE_LOG),
+        );
+        assert_eq!(
+            canonical_fuzz_artifact_kind("coverage-summary"),
+            Some(FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY),
+        );
+    }
+
+    #[test]
+    fn resolver_rejects_unknown_kinds() {
+        assert_eq!(canonical_fuzz_artifact_kind("runner-output"), None);
+        assert_eq!(canonical_fuzz_artifact_kind("fuzz_case"), None);
+        assert_eq!(canonical_fuzz_artifact_kind(""), None);
+    }
+
+    #[test]
+    fn kind_matches_across_spellings() {
+        assert!(fuzz_artifact_kind_matches(
+            "fuzz-result-envelope",
+            "result_envelope"
+        ));
+        assert!(fuzz_artifact_kind_matches("case-log", "case_log"));
+        assert!(!fuzz_artifact_kind_matches("case-log", "result_envelope"));
+        assert!(!fuzz_artifact_kind_matches("runner-output", "case_log"));
+    }
+
+    #[test]
+    fn case_evidence_kinds_always_include_canonical_case_log() {
+        let kinds = fuzz_case_evidence_artifact_kinds();
+        assert_eq!(kinds.first().map(String::as_str), Some("case_log"));
+        // No duplicate canonical entry even if the asset repeats it.
+        assert_eq!(kinds.iter().filter(|kind| *kind == "case_log").count(), 1);
+    }
+}

--- a/src/core/fuzz/contract.rs
+++ b/src/core/fuzz/contract.rs
@@ -3,6 +3,7 @@
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
+use super::artifact_kinds::canonical_fuzz_artifact_kinds;
 use super::schema_defaults::{
     fuzz_contract_version, fuzz_core_contract_schema, lifecycle_contract_schema,
     lifecycle_result_schema, lifecycle_snapshot_ref_schema,
@@ -25,6 +26,11 @@ pub struct FuzzCoreContract {
     #[serde(default = "fuzz_contract_version")]
     pub version: u32,
     pub schemas: FuzzContractSchemas,
+    /// Canonical contract artifact-kind identifiers. Published so consumers can
+    /// fold their own artifact-role spellings onto core's identifiers instead of
+    /// re-declaring alias arrays by hand (#6766).
+    #[serde(default = "canonical_fuzz_artifact_kinds")]
+    pub artifact_kinds: Vec<String>,
     pub safety_classes: Vec<FuzzSafetyClass>,
     #[serde(default = "default_fuzz_operation_families")]
     pub operation_families: Vec<FuzzOperationFamily>,
@@ -208,6 +214,7 @@ pub fn fuzz_core_contract() -> FuzzCoreContract {
             lifecycle_snapshot_ref: crate::core::lifecycle::LIFECYCLE_SNAPSHOT_REF_SCHEMA
                 .to_string(),
         },
+        artifact_kinds: canonical_fuzz_artifact_kinds(),
         safety_classes: vec![
             FuzzSafetyClass::ReadOnly,
             FuzzSafetyClass::Idempotent,

--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -4,6 +4,7 @@
 //! runners can attach their own details through `metadata` or flattened extras.
 
 mod artifact_envelope;
+mod artifact_kinds;
 mod cohorts;
 mod contract;
 mod coverage;
@@ -23,6 +24,12 @@ mod tests;
 pub use artifact_envelope::{
     inspect_fuzz_result_envelope_artifact, FuzzResultEnvelopeArtifactInspection,
     FuzzResultEnvelopeArtifactSummary,
+};
+pub use artifact_kinds::{
+    canonical_fuzz_artifact_kind, canonical_fuzz_artifact_kinds, fuzz_artifact_kind_matches,
+    fuzz_case_evidence_artifact_kinds, FUZZ_ARTIFACT_KIND_CASE_LOG,
+    FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY, FUZZ_ARTIFACT_KIND_REPLAY_DATA,
+    FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE,
 };
 pub use cohorts::{
     compare_fuzz_hotspot_cohorts, FuzzHotspotCohortComparison, FuzzHotspotCohortDelta,

--- a/src/core/fuzz/tests/contract_tests.rs
+++ b/src/core/fuzz/tests/contract_tests.rs
@@ -63,6 +63,79 @@ fn core_contract_lists_product_neutral_schema_ids() {
 }
 
 #[test]
+fn core_contract_publishes_canonical_artifact_kinds() {
+    let contract = fuzz_core_contract();
+
+    assert_eq!(contract.artifact_kinds, canonical_fuzz_artifact_kinds());
+    for kind in [
+        FUZZ_ARTIFACT_KIND_RESULT_ENVELOPE,
+        FUZZ_ARTIFACT_KIND_CASE_LOG,
+        FUZZ_ARTIFACT_KIND_COVERAGE_SUMMARY,
+        FUZZ_ARTIFACT_KIND_REPLAY_DATA,
+    ] {
+        assert!(
+            contract.artifact_kinds.iter().any(|k| k == kind),
+            "published contract should list canonical artifact kind {kind}",
+        );
+    }
+}
+
+#[test]
+fn published_result_envelope_schema_matches_struct_serialization() {
+    let contract = fuzz_core_contract();
+
+    // The schema id and version the extension would consume from the published
+    // contract must equal what `FuzzResultEnvelope` actually serializes with, so
+    // the extension can validate against the contract instead of re-declaring
+    // `homeboy/fuzz-result-envelope/v1` and the version by hand (#6766).
+    let envelope: FuzzResultEnvelope = serde_json::from_value(json!({
+        "id": "envelope-1",
+        "status": "passed",
+        "request": {"id": "request-1", "component": "component-a"}
+    }))
+    .expect("minimal result envelope payload backfills schema + version");
+
+    assert_eq!(envelope.schema, contract.schemas.result_envelope);
+    assert_eq!(envelope.schema, FUZZ_RESULT_ENVELOPE_SCHEMA);
+    assert_eq!(envelope.version, contract.version);
+    assert_eq!(envelope.version, FUZZ_CONTRACT_VERSION);
+}
+
+#[test]
+fn core_contract_backfills_artifact_kinds_for_legacy_payloads() {
+    let contract: FuzzCoreContract = serde_json::from_value(json!({
+        "schema": FUZZ_CORE_CONTRACT_SCHEMA,
+        "version": FUZZ_CONTRACT_VERSION,
+        "schemas": {
+            "surface": FUZZ_SURFACE_SCHEMA,
+            "target": FUZZ_TARGET_SCHEMA,
+            "workload": FUZZ_WORKLOAD_SCHEMA,
+            "campaign": FUZZ_CAMPAIGN_SCHEMA,
+            "case": FUZZ_CASE_SCHEMA,
+            "case_log": FUZZ_CASE_LOG_SCHEMA,
+            "seed": FUZZ_SEED_SCHEMA,
+            "coverage": FUZZ_COVERAGE_SCHEMA,
+            "finding": FUZZ_FINDING_SCHEMA,
+            "artifact": FUZZ_ARTIFACT_SCHEMA,
+            "threshold": FUZZ_THRESHOLD_SCHEMA,
+            "provenance": FUZZ_PROVENANCE_SCHEMA,
+            "replay": FUZZ_REPLAY_SCHEMA,
+            "coverage_summary": FUZZ_COVERAGE_SUMMARY_SCHEMA,
+            "target_inventory": FUZZ_TARGET_INVENTORY_SCHEMA,
+            "execution_request": FUZZ_EXECUTION_REQUEST_SCHEMA,
+            "result_envelope": FUZZ_RESULT_ENVELOPE_SCHEMA,
+            "required_artifact": FUZZ_REQUIRED_ARTIFACT_SCHEMA,
+            "gate": FUZZ_GATE_SCHEMA
+        },
+        "safety_classes": ["read_only"],
+        "finding_statuses": ["open"]
+    }))
+    .expect("legacy contract payload without artifact_kinds");
+
+    assert_eq!(contract.artifact_kinds, canonical_fuzz_artifact_kinds());
+}
+
+#[test]
 fn fuzz_gate_profiles_are_measurement_first_and_named() {
     let (measurement_artifacts, measurement_gates) =
         fuzz_gate_profile_contract(FuzzGateProfile::Measurement);


### PR DESCRIPTION
## Summary

Per the fuzz reconcile (#6766), core's generic fuzz layer carried WordPress-flavored artifact vocabulary as Rust literals and re-spelled one concept across several call sites. This makes core's result contract the single authoritative, product-neutral source so the homeboy-extensions WP fuzz runner can consume it instead of hand-redeclaring constants — unblocking #1983/#1984. The extension-side divergent-envelope work stays tracked separately; this PR only hardens CORE's contract.

### 1. Canonical artifact identifiers (collapse the 3–4 aliases for one concept)
- New `src/core/fuzz/artifact_kinds.rs`: one canonical id per contract artifact (`result_envelope`, `case_log`, `coverage_summary`, `replay_data`) plus `canonical_fuzz_artifact_kind()` — a resolver that folds every accepted spelling (hyphen/underscore equivalence, leading `fuzz` segment) onto the canonical id.
- `commands/fuzz/execution.rs` strict-artifact validation now checks canonical kinds instead of the 4-entry `["result-envelope","result_envelope","fuzz-result-envelope","fuzz_result_envelope"]` alias array (and the case-log / coverage-summary pairs).
- `core/fuzz/artifact_envelope.rs` result-envelope recognition resolves the artifact kind through the canonical resolver rather than matching the bare `fuzz_result_envelope` literal.

### 2. De-domain the gate evaluator
- The gate evaluator's case-evidence artifact vocabulary (`fuzz_report`, `fuzz_case`, `case_artifact`, `failing_case`, `repro_case`) moves out of core Rust into the **extension-provided defaults asset** (`assets/defaults/extension-provided-defaults.json`), mirroring the wave-1 `code_audit` de-hardcode (#2240). Core keeps only the canonical `case_log` kind; `fuzz_case_evidence_artifact_kinds()` merges in the asset-supplied spellings. Behavior is wired one-repo so the previously recognized set is preserved.
- `required_artifact_count` now matches against the canonical kind constants instead of magic string literals.

### 3. Publish the contract
- `FuzzCoreContract` publishes the canonical `artifact_kinds` (serde-default backfilled for legacy payloads), so consumers can map their artifact roles onto core's identifiers via `homeboy fuzz contract` instead of redeclaring `homeboy/fuzz-result-envelope/v1` and the version by hand. A regression test pins the published result-envelope schema id and version to `FuzzResultEnvelope`'s serialization.

This is behavior-preserving for existing fuzz reports.

## Tests
- `artifact_kinds`: resolver collapses the former result-envelope / case-log / coverage-summary aliases; rejects unknown kinds; case-evidence set always leads with canonical `case_log`.
- `gate_tests`: gate-evaluator source carries no domain artifact-kind literals; case-evidence recognition preserves the prior six-kind set.
- `contract_tests`: published `artifact_kinds` matches the canonical set and backfills for legacy payloads; published result-envelope schema + version match the struct.
- `builtins`: the case-evidence vocabulary lives in the extension asset, not core Rust.

## Verification
- `cargo check` — clean (only pre-existing warnings in unrelated modules).
- `cargo test --lib fuzz` — 135 passed, 0 failed.
- `cargo test --lib defaults::builtins::tests::fuzz_case_evidence_defaults_live_in_extension_asset` — passed.

## Follow-up
- Typing `FuzzCampaign.metadata` (so skip/failure status isn't inferred by walking free-form metadata strings) is deferred as out-of-theme scope — filed as a separate focused issue.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Reading the existing contract, designing the canonical artifact-kind module and de-domain wiring, and drafting code, tests, and this description. Chris reviews every line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)