### PR TITLE
chore: fix agent_task/tool thin-adapter allow-annotation (fmt-stable follow-up to #6785)

### DIFF
--- a/src/commands/agent_task/tool.rs
+++ b/src/commands/agent_task/tool.rs
@@ -22,10 +22,15 @@ pub enum AgentTaskToolCommand {
 #[derive(Args, Debug)]
 pub struct AgentTaskToolDispatchArgs {}
 
-pub fn dispatch_raw(_args: AgentTaskToolDispatchArgs) -> i32 {
-    // homeboy-audit: allow-thin-command-adapter
-    match dispatch_raw_result() {
-        // homeboy-audit: allow-thin-command-adapter
+// `dispatch_raw` is a textbook thin command adapter: it parses args and delegates
+// to the core `dispatch_agent_tool_request` service. The orchestration detector's
+// `dispatch_[A-Za-z0-9_]+\(` marker is a false positive here (it matches this
+// command's own entry-point names and the legit core-service call). The
+// `#[rustfmt::skip]` keeps the per-line `homeboy-audit: allow-thin-command-adapter`
+// markers as trailing comments on the exact lines the detector scans.
+#[rustfmt::skip]
+pub fn dispatch_raw(_args: AgentTaskToolDispatchArgs) -> i32 { // homeboy-audit: allow-thin-command-adapter (thin: delegates to core dispatch_agent_tool_request)
+    match dispatch_raw_result() { // homeboy-audit: allow-thin-command-adapter (thin: delegates to core dispatch_agent_tool_request)
         Ok(result) => {
             println!("{}", result);
             0
@@ -37,8 +42,8 @@ pub fn dispatch_raw(_args: AgentTaskToolDispatchArgs) -> i32 {
     }
 }
 
-fn dispatch_raw_result() -> Result<String, String> {
-    // homeboy-audit: allow-thin-command-adapter
+#[rustfmt::skip]
+fn dispatch_raw_result() -> Result<String, String> { // homeboy-audit: allow-thin-command-adapter (thin: delegates to core dispatch_agent_tool_request)
     let mut stdin = String::new();
     std::io::stdin()
         .read_to_string(&mut stdin)
@@ -48,7 +53,7 @@ fn dispatch_raw_result() -> Result<String, String> {
         .map_err(|error| format!("invalid agent tool request JSON: {error}"))?;
     let policy = policy_from_env()?;
     let outcome =
-        dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher); // homeboy-audit: allow-thin-command-adapter
+        dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher); // homeboy-audit: allow-thin-command-adapter (thin: delegates to core dispatch_agent_tool_request)
 
     serde_json::to_string(&outcome.result)
         .map_err(|error| format!("failed to serialize agent tool result JSON: {error}"))


### PR DESCRIPTION
## Summary

Follow-up correction to #6785, which annotated `src/commands/agent_task/tool.rs` as a sanctioned thin-command adapter to clear a **false-positive** `ThinCommandAdapter` finding — but did so in a way that does **not** actually exclude the triggering lines, leaving an unbaselined regression on `main`.

`tool.rs` is a textbook thin adapter: it parses args, reads the request from stdin, builds an `AgentToolRequest`, and delegates to the core service `dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher)`. There is **no** real orchestration — no `Command::new`, no `std::fs`/`File::create` mutation, no `RunDir`/`persist_`. The finding is purely the `dispatch_[A-Za-z0-9_]+\(` marker matching the command's own entry-point names plus the legit core-service call.

## The bug in the prior fix

The `thin_command_adapter` detector excludes a line only when **that exact line** contains the allow marker (`raw_line.contains(marker)`), and it skips comment-only lines via `ignore_line_prefixes` (`//`). #6785 placed the markers on **standalone comment lines** above the triggering lines, so:

- The marker lines themselves are skipped as comments.
- The actual triggering lines (`pub fn dispatch_raw`, `match dispatch_raw_result()`, `fn dispatch_raw_result`) were **not** excluded.
- Those 3 non-test hits = weight 3, which is `>= max_orchestration_weight (3)` -> the finding still fires.
- But #6785 also removed the baseline row -> the finding is now **unbaselined** on `main`.

`rustfmt` is the root cause of the original mistake: it relocates trailing comments off brace-opening lines, so a naive trailing `// marker` on a `fn ... {` line gets moved away.

## The fix

Wrap the two functions in `#[rustfmt::skip]` and place the marker as a **same-line trailing comment** on every non-test line the orchestration regex matches (`dispatch_raw`, `dispatch_raw_result`, and the core `dispatch_agent_tool_request` call). The `#[cfg(test)]` module is already excluded by the detector's `ignore_after_line_equals`, so the in-test `dispatch_*` calls are not scanned. The baseline row was already removed by #6785, so no `homeboy.json` change is needed.

Comments + one formatting attribute only — **no behavior change**.

## Verification
- `cargo build --lib --tests` -> EXIT 0 (pre-existing warnings only)
- `rustfmt --check` on `tool.rs` -> clean
- All 4 non-test triggering lines now carry the same-line allow marker -> orchestration weight 0