### PR TITLE
refactor: extract trace-matrix fs writes to core/trace_compare (thin command adapter)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -679,7 +679,6 @@
         "thin_command_adapter::src/commands/runs/loop_sync.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/trace/bundle.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/trace/compare_targets.rs::ThinCommandAdapterViolation",
-        "thin_command_adapter::src/commands/trace/matrix.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/trace/observation_lifecycle.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/trace/test_fixture.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/utils/observed_workflow.rs::ThinCommandAdapterViolation"

--- a/src/commands/trace/compare_bundle.rs
+++ b/src/commands/trace/compare_bundle.rs
@@ -5,9 +5,9 @@ use homeboy::core::extension::trace::{self as extension_trace, TraceCommandOutpu
 use serde::Serialize;
 
 use super::compare_targets::run_compare_targets;
-use super::matrix::write_json_artifact;
 use super::TraceArgs;
 use crate::commands::CmdResult;
+use homeboy::core::trace_compare::write_json_artifact;
 
 pub(super) fn run_compare_bundle(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     if args.baseline_target.is_none() || args.candidate.is_none() {

--- a/src/commands/trace/matrix.rs
+++ b/src/commands/trace/matrix.rs
@@ -3,6 +3,10 @@ use std::path::{Path, PathBuf};
 
 use homeboy::core::extension::trace as extension_trace;
 use homeboy::core::extension::trace::TraceCommandOutput;
+use homeboy::core::trace_compare::{
+    prepare_matrix_cell_dir, prepare_matrix_output_dir, prepare_variant_matrix_output_dir,
+    write_json_artifact, write_matrix_summary, write_variant_matrix_summary,
+};
 
 use super::output::{
     compare_trace_aggregates_with_focus, render_matrix_markdown, TraceAggregateIdentity,
@@ -193,16 +197,7 @@ pub(super) fn run_scenario_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutp
             chrono::Utc::now().format("%Y%m%d%H%M%S")
         ))
     });
-    std::fs::create_dir_all(&output_dir).map_err(|err| {
-        homeboy::core::Error::internal_io(
-            format!(
-                "Failed to create trace matrix output dir {}: {}",
-                output_dir.display(),
-                err
-            ),
-            Some("trace.matrix.output_dir".to_string()),
-        )
-    })?;
+    prepare_matrix_output_dir(&output_dir)?;
 
     let mut outputs = Vec::new();
     let mut failure_count = 0;
@@ -210,16 +205,7 @@ pub(super) fn run_scenario_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutp
         let mut cell_args = args.clone();
         apply_trace_matrix_cell_to_args(&mut cell_args, &cell);
         let cell_dir = output_dir.join(format!("cell-{:03}-{}", cell.index + 1, cell.label));
-        std::fs::create_dir_all(&cell_dir).map_err(|err| {
-            homeboy::core::Error::internal_io(
-                format!(
-                    "Failed to create trace matrix cell dir {}: {}",
-                    cell_dir.display(),
-                    err
-                ),
-                Some("trace.matrix.cell_dir".to_string()),
-            )
-        })?;
+        prepare_matrix_cell_dir(&cell_dir)?;
         let output_path = cell_dir.join("trace.json");
         let (passed, status, exit_code, artifact_path, artifact_dir, failure) =
             match execute_trace_run(cell_args) {
@@ -319,20 +305,10 @@ pub(super) fn run_scenario_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutp
         cells: outputs,
     };
     write_json_artifact(&matrix_path, &output)?;
-    std::fs::write(
+    write_matrix_summary(
         &summary_path,
-        super::output::render_scenario_matrix_markdown(&output),
-    )
-    .map_err(|err| {
-        homeboy::core::Error::internal_io(
-            format!(
-                "Failed to write trace matrix summary {}: {}",
-                summary_path.display(),
-                err
-            ),
-            Some("trace.matrix.summary".to_string()),
-        )
-    })?;
+        &super::output::render_scenario_matrix_markdown(&output),
+    )?;
 
     Ok((TraceCommandOutput::ScenarioMatrix(output), exit_code))
 }
@@ -357,16 +333,7 @@ pub(super) fn run_variant_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutpu
             chrono::Utc::now().format("%Y%m%d%H%M%S")
         ))
     });
-    std::fs::create_dir_all(&output_dir).map_err(|err| {
-        homeboy::core::Error::internal_io(
-            format!(
-                "Failed to create trace variant output dir {}: {}",
-                output_dir.display(),
-                err
-            ),
-            Some("trace.variant.output_dir".to_string()),
-        )
-    })?;
+    prepare_variant_matrix_output_dir(&output_dir)?;
 
     let baseline = run_variant_aggregate(&args, Vec::new())?;
     let baseline_path = output_dir.join("baseline.aggregate.json");
@@ -437,16 +404,7 @@ pub(super) fn run_variant_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutpu
         exit_code,
         runs,
     };
-    std::fs::write(&summary_path, render_matrix_markdown(&output)).map_err(|err| {
-        homeboy::core::Error::internal_io(
-            format!(
-                "Failed to write trace variant summary {}: {}",
-                summary_path.display(),
-                err
-            ),
-            Some("trace.variant.summary".to_string()),
-        )
-    })?;
+    write_variant_matrix_summary(&summary_path, &render_matrix_markdown(&output))?;
 
     Ok((TraceCommandOutput::Matrix(output), exit_code))
 }
@@ -607,19 +565,4 @@ pub(super) fn aggregate_to_compare_input(
         guardrails: aggregate.guardrails.clone(),
         guardrail_failure_count: aggregate.guardrail_failure_count,
     }
-}
-
-pub(super) fn write_json_artifact<T: serde::Serialize>(
-    path: &Path,
-    value: &T,
-) -> homeboy::core::Result<()> {
-    let content = serde_json::to_string_pretty(value).map_err(|err| {
-        homeboy::core::Error::internal_json(err.to_string(), Some("trace.variant.json".to_string()))
-    })?;
-    std::fs::write(path, content).map_err(|err| {
-        homeboy::core::Error::internal_io(
-            format!("Failed to write trace artifact {}: {}", path.display(), err),
-            Some("trace.variant.write".to_string()),
-        )
-    })
 }

--- a/src/core/trace_compare.rs
+++ b/src/core/trace_compare.rs
@@ -369,3 +369,83 @@ pub fn write_compare_variant_summary(path: &Path, summary: &str) -> crate::core:
         )
     })
 }
+
+/// Create the top-level output directory for a scenario-matrix run, mirroring
+/// `mkdir -p`. Owns the filesystem orchestration so the command layer only
+/// computes the directory it needs.
+pub fn prepare_matrix_output_dir(output_dir: &Path) -> crate::core::Result<()> {
+    std::fs::create_dir_all(output_dir).map_err(|err| {
+        crate::core::Error::internal_io(
+            format!(
+                "Failed to create trace matrix output dir {}: {}",
+                output_dir.display(),
+                err
+            ),
+            Some("trace.matrix.output_dir".to_string()),
+        )
+    })
+}
+
+/// Create the per-cell output directory for a scenario-matrix run, mirroring
+/// `mkdir -p`. Each matrix cell writes its own artifacts, so the directory
+/// orchestration lives here, keeping the command a thin adapter.
+pub fn prepare_matrix_cell_dir(cell_dir: &Path) -> crate::core::Result<()> {
+    std::fs::create_dir_all(cell_dir).map_err(|err| {
+        crate::core::Error::internal_io(
+            format!(
+                "Failed to create trace matrix cell dir {}: {}",
+                cell_dir.display(),
+                err
+            ),
+            Some("trace.matrix.cell_dir".to_string()),
+        )
+    })
+}
+
+/// Write the pre-rendered scenario-matrix summary markdown to `path`. The
+/// command layer renders the markdown; this owns the filesystem write so
+/// persistence orchestration never accumulates in the command.
+pub fn write_matrix_summary(path: &Path, summary: &str) -> crate::core::Result<()> {
+    std::fs::write(path, summary).map_err(|err| {
+        crate::core::Error::internal_io(
+            format!(
+                "Failed to write trace matrix summary {}: {}",
+                path.display(),
+                err
+            ),
+            Some("trace.matrix.summary".to_string()),
+        )
+    })
+}
+
+/// Create the top-level output directory for a variant-matrix run, mirroring
+/// `mkdir -p`. Owns the filesystem orchestration so the command layer only
+/// computes the directory it needs.
+pub fn prepare_variant_matrix_output_dir(output_dir: &Path) -> crate::core::Result<()> {
+    std::fs::create_dir_all(output_dir).map_err(|err| {
+        crate::core::Error::internal_io(
+            format!(
+                "Failed to create trace variant output dir {}: {}",
+                output_dir.display(),
+                err
+            ),
+            Some("trace.variant.output_dir".to_string()),
+        )
+    })
+}
+
+/// Write the pre-rendered variant-matrix summary markdown to `path`. The
+/// command layer renders the markdown; this owns the filesystem write so
+/// persistence orchestration never accumulates in the command.
+pub fn write_variant_matrix_summary(path: &Path, summary: &str) -> crate::core::Result<()> {
+    std::fs::write(path, summary).map_err(|err| {
+        crate::core::Error::internal_io(
+            format!(
+                "Failed to write trace variant summary {}: {}",
+                path.display(),
+                err
+            ),
+            Some("trace.variant.summary".to_string()),
+        )
+    })
+}


### PR DESCRIPTION
Moves trace-matrix artifact writing (create_dir_all + write) from src/commands/trace/matrix.rs into core/trace_compare, mirroring #6797/#6803. Command stays a thin adapter. Clears the ThinCommandAdapter finding. Identical output. Verified cargo build --lib --tests exit 0.