### PR TITLE
test: make six recurring local test reds deterministic

### DIFF
--- a/src/core/agent_task_provider/tests/selection_tests.rs
+++ b/src/core/agent_task_provider/tests/selection_tests.rs
@@ -94,9 +94,14 @@ fn lab_runtime_component_ids_follow_selected_agent_task_providers() {
         vec![request_a, request_b],
     ));
 
+    // `lab_runtime_component_ids_for_plan` dedups across the selected providers
+    // into a `BTreeSet`, so the result is deterministically sorted. provider_a
+    // and provider_b both contribute `sample-component`, which collapses to one
+    // entry. (#6705's rename of `data-machine` -> `sample-component` left the
+    // expected literal in the old, no-longer-sorted order.)
     assert_eq!(
         component_ids,
-        vec!["agents-api", "sample-component", "php-ai-client"]
+        vec!["agents-api", "php-ai-client", "sample-component"]
     );
 }
 

--- a/src/core/extension/setup_env.rs
+++ b/src/core/extension/setup_env.rs
@@ -125,97 +125,64 @@ pub(crate) fn load(extension_id: &str) -> Vec<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-    struct HomeGuard {
-        prior_home: Option<String>,
-        prior_xdg: Option<String>,
-        _dir: tempfile::TempDir,
-    }
-
-    impl HomeGuard {
-        fn set() -> Self {
-            let dir = tempfile::tempdir().expect("tempdir");
-            let prior_home = std::env::var("HOME").ok();
-            let prior_xdg = std::env::var("XDG_DATA_HOME").ok();
-            std::env::set_var("HOME", dir.path());
-            std::env::remove_var("XDG_DATA_HOME");
-            Self {
-                prior_home,
-                prior_xdg,
-                _dir: dir,
-            }
-        }
-    }
-
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            match &self.prior_home {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-            match &self.prior_xdg {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
+    use crate::test_support::with_isolated_home;
 
     #[test]
     fn persist_then_load_round_trips_sorted_env() {
-        let _lock = ENV_TEST_LOCK.lock().expect("lock");
-        let _home = HomeGuard::set();
+        // Route HOME/XDG isolation through the shared `home_lock()` so this
+        // test is globally serialized against every other env-mutating test,
+        // rather than racing under a private lock (#6804).
+        with_isolated_home(|_| {
+            persist(
+                "wordpress",
+                &[
+                    (
+                        "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
+                        "/runner/sample-runtime/core.mjs".to_string(),
+                    ),
+                    ("ANOTHER".to_string(), "value".to_string()),
+                ],
+            )
+            .expect("persist");
 
-        persist(
-            "wordpress",
-            &[
-                (
-                    "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
-                    "/runner/sample-runtime/core.mjs".to_string(),
-                ),
-                ("ANOTHER".to_string(), "value".to_string()),
-            ],
-        )
-        .expect("persist");
-
-        let loaded = load("wordpress");
-        assert_eq!(
-            loaded,
-            vec![
-                ("ANOTHER".to_string(), "value".to_string()),
-                (
-                    "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
-                    "/runner/sample-runtime/core.mjs".to_string()
-                ),
-            ]
-        );
+            let loaded = load("wordpress");
+            assert_eq!(
+                loaded,
+                vec![
+                    ("ANOTHER".to_string(), "value".to_string()),
+                    (
+                        "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
+                        "/runner/sample-runtime/core.mjs".to_string()
+                    ),
+                ]
+            );
+        });
     }
 
     #[test]
     fn load_returns_empty_when_nothing_persisted() {
-        let _lock = ENV_TEST_LOCK.lock().expect("lock");
-        let _home = HomeGuard::set();
-
-        assert!(load("never-persisted").is_empty());
+        with_isolated_home(|_| {
+            assert!(load("never-persisted").is_empty());
+        });
     }
 
     #[test]
     fn persist_empty_clears_previous_document() {
-        let _lock = ENV_TEST_LOCK.lock().expect("lock");
-        let _home = HomeGuard::set();
+        with_isolated_home(|_| {
+            persist("wordpress", &[("KEY".to_string(), "value".to_string())]).expect("persist");
+            assert!(!load("wordpress").is_empty());
 
-        persist("wordpress", &[("KEY".to_string(), "value".to_string())]).expect("persist");
-        assert!(!load("wordpress").is_empty());
-
-        persist("wordpress", &[]).expect("clear");
-        assert!(load("wordpress").is_empty());
+            persist("wordpress", &[]).expect("clear");
+            assert!(load("wordpress").is_empty());
+        });
     }
 
     #[test]
     fn sanitizes_extension_id_for_filesystem_safety() {
-        assert_eq!(sanitize_extension_id("wp/sandbox"), "selected_runtime");
+        // The sanitizer maps every filesystem-unsafe character (here `/`) to
+        // `_`; `wp/sandbox` therefore becomes `wp_sandbox`. (#6705's mechanical
+        // term rename left a stale expected literal here.)
+        assert_eq!(sanitize_extension_id("wp/sandbox"), "wp_sandbox");
         assert_eq!(sanitize_extension_id("wordpress"), "wordpress");
     }
 }

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -1097,70 +1097,76 @@ printf '{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\n' "$total" "$passed" 
 
     #[test]
     fn declared_result_parser_errors_with_context_on_non_zero_exit() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let extension_dir = temp_dir.path().join("extension");
-        std::fs::create_dir_all(&extension_dir).expect("extension dir");
-        let parser_script = extension_dir.join("parse-results.sh");
-        std::fs::write(
-            &parser_script,
-            r#"#!/usr/bin/env bash
+        // This test executes a capability script, which builds an env derived
+        // from HOME / homeboy paths. Run it under the shared `home_lock()` so it
+        // is globally serialized against env-mutating tests instead of racing
+        // them under default parallelism (#6760, #6804).
+        with_isolated_home(|_| {
+            let temp_dir = tempfile::tempdir().expect("temp dir");
+            let extension_dir = temp_dir.path().join("extension");
+            std::fs::create_dir_all(&extension_dir).expect("extension dir");
+            let parser_script = extension_dir.join("parse-results.sh");
+            std::fs::write(
+                &parser_script,
+                r#"#!/usr/bin/env bash
 printf 'parser stdout detail\n'
 printf 'parser stderr detail\n' >&2
 exit 23
 "#,
-        )
-        .expect("parser script");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&parser_script, std::fs::Permissions::from_mode(0o755))
-                .expect("parser script permissions");
-        }
+            )
+            .expect("parser script");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&parser_script, std::fs::Permissions::from_mode(0o755))
+                    .expect("parser script permissions");
+            }
 
-        let component = Component::new(
-            "fixture".to_string(),
-            temp_dir.path().to_string_lossy().to_string(),
-            "fixture-extension".to_string(),
-            None,
-        );
-        let context = crate::core::extension::ExtensionExecutionContext {
-            component: component.clone(),
-            capability: ExtensionCapability::Test,
-            extension_id: "fixture-extension".to_string(),
-            extension_path: extension_dir,
-            script_path: "test.sh".to_string(),
-            settings: Vec::new(),
-            accepted_setting_keys: Vec::new(),
-        };
-        let spec = ParseSpec {
-            extension_script: Some("parse-results.sh".to_string()),
-            adapters: vec!["fixture-json".to_string()],
-            rules: Vec::new(),
-            defaults: std::collections::HashMap::new(),
-            derive: Vec::new(),
-        };
-        let run_dir = RunDir::create().expect("run dir");
+            let component = Component::new(
+                "fixture".to_string(),
+                temp_dir.path().to_string_lossy().to_string(),
+                "fixture-extension".to_string(),
+                None,
+            );
+            let context = crate::core::extension::ExtensionExecutionContext {
+                component: component.clone(),
+                capability: ExtensionCapability::Test,
+                extension_id: "fixture-extension".to_string(),
+                extension_path: extension_dir,
+                script_path: "test.sh".to_string(),
+                settings: Vec::new(),
+                accepted_setting_keys: Vec::new(),
+            };
+            let spec = ParseSpec {
+                extension_script: Some("parse-results.sh".to_string()),
+                adapters: vec!["fixture-json".to_string()],
+                rules: Vec::new(),
+                defaults: std::collections::HashMap::new(),
+                derive: Vec::new(),
+            };
+            let run_dir = RunDir::create().expect("run dir");
 
-        let err = run_declared_result_parser(&component, &context, &spec, "{}", &run_dir)
-            .expect_err("declared parser non-zero exit should fail");
-        run_dir.cleanup();
+            let err = run_declared_result_parser(&component, &context, &spec, "{}", &run_dir)
+                .expect_err("declared parser non-zero exit should fail");
+            run_dir.cleanup();
 
-        assert_eq!(err.code, ErrorCode::ConfigInvalidValue);
-        assert!(err.message.contains("exit code 23"));
-        assert_eq!(err.details["script_path"], "parse-results.sh");
-        assert_eq!(err.details["exit_code"], 23);
-        assert!(err.details["command"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("parse-results.sh"));
-        assert!(err.details["stdout_tail"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("parser stdout detail"));
-        assert!(err.details["stderr_tail"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("parser stderr detail"));
+            assert_eq!(err.code, ErrorCode::ConfigInvalidValue);
+            assert!(err.message.contains("exit code 23"));
+            assert_eq!(err.details["script_path"], "parse-results.sh");
+            assert_eq!(err.details["exit_code"], 23);
+            assert!(err.details["command"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("parse-results.sh"));
+            assert!(err.details["stdout_tail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("parser stdout detail"));
+            assert!(err.details["stderr_tail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("parser stderr detail"));
+        });
     }
 
     #[test]

--- a/src/core/runner/workspace/tests/git.rs
+++ b/src/core/runner/workspace/tests/git.rs
@@ -164,7 +164,14 @@ fn git_materialization_ignores_generated_homeboy_output_but_refuses_source_dirty
         let (output, exit_code) = sync().expect("generated .homeboy output is ignored");
         assert_eq!(exit_code, 0);
         let remote = Path::new(&output.remote_path);
-        assert!(!remote.join(".homeboy").exists());
+        // Re-sync resets generated `.homeboy` *output* (experiments, scratch)
+        // via `git clean -ffdqx`, so the experiment artifact written above is
+        // gone. The sync then legitimately re-writes its own workspace metadata
+        // marker under `.homeboy/runner-workspace.json` (used by orphaned-lab-
+        // workspace pruning, #6678/376bfde56), so `.homeboy` itself persists
+        // with only that metadata.
+        assert!(!remote.join(".homeboy/experiments").exists());
+        assert!(remote.join(".homeboy/runner-workspace.json").is_file());
 
         fs::write(remote.join("dirty-source.txt"), "dirty\n").expect("write dirty source file");
         let err = sync().expect_err("real dirty runner workspace is refused");

--- a/src/extensions/deps_provider.rs
+++ b/src/extensions/deps_provider.rs
@@ -735,13 +735,17 @@ mod tests {
 
         std::env::set_var("PATH", old_path);
         let result = result.expect("install result");
+        // `composer install` runs with `--no-progress` for deterministic,
+        // non-interactive CI installs (see `composer_install_command_args`,
+        // #6544). The test self-provides a fake `composer` on PATH, so this
+        // asserts the exact argv the provider builds, not composer availability.
         assert_eq!(
             result.command,
-            vec!["composer", "install", "--no-interaction"]
+            vec!["composer", "install", "--no-interaction", "--no-progress"]
         );
         assert_eq!(
             std::fs::read_to_string(project.path().join("composer-args.txt")).unwrap(),
-            "install\n--no-interaction\n"
+            "install\n--no-interaction\n--no-progress\n"
         );
     }
 }


### PR DESCRIPTION
## Summary

Six tests fail on a clean local `cargo test --lib` of `main` but pass in CI (where the harness serializes/supplies env). I reproduced each on clean `main`, found the root cause, and fixed it without weakening any real assertion. Tracks #6804; references #6760.

The "flakes" split into two genuinely different root causes:

### 1. Test-isolation / global-env contention (genuine parallel flakes)
The shared helper `crate::test_support::with_isolated_home` acquires a single global `home_lock()` mutex and pins `HOME` / `XDG_DATA_HOME` / `HOMEBOY_RUNTIME_TMPDIR` / the invocation-runtime tempdir per-test.

- **`core::extension::setup_env`** used a *private* `ENV_TEST_LOCK` + ad-hoc `HomeGuard` to mutate `HOME`/`XDG_DATA_HOME`, so it raced every `with_isolated_home` test under default parallelism. Routed all three persist/load tests through `with_isolated_home` and deleted the duplicate lock. This rogue mutator was the contention source behind the intermittent reds in the declared-result-parser and agent-task contract tests (both already isolated, so they only failed when something *else* stomped `HOME`).
- **`declared_result_parser_errors_with_context_on_non_zero_exit`** (#6760) executes a capability script that derives env from HOME/paths but ran with no isolation. Wrapped it in `with_isolated_home`.

### 2. Stale/corrupted expected values from deliberate upstream changes (deterministic reds)
These were not flakes at all — they failed every run because a production or mechanical-rename change updated behavior and left a stale expected literal. Each fix corrects the expectation to the genuinely-correct current behavior; the assertions stay exact (not weakened).

| Test | Cause |
|------|-------|
| `composer_install_runs_full_dependency_install_lifecycle` | #6544 added `--no-progress`; test still expected the old argv. The test self-provides a fake `composer` on PATH, so it never depended on composer being installed (the "self-skip when composer absent" premise did not apply). |
| `lab_runtime_component_ids_follow_selected_agent_task_providers` | #6705 renamed `data-machine` -> `sample-component` in place without re-sorting the expected `BTreeSet` output. |
| `sanitizes_extension_id_for_filesystem_safety` | #6705 left `selected_runtime` as the expected value for an input the sanitizer maps to `wp_sandbox`. |
| `git_materialization_ignores_generated_homeboy_output_but_refuses_source_dirty_state` | #6678/376bfde56 began writing `.homeboy/runner-workspace.json` into the materialized checkout, so the blanket `!.homeboy.exists()` over-asserts. Now asserts the generated `.homeboy/experiments/` output is reset while the legitimate metadata file persists. |

## Verification
`cargo check` clean. Ran the full `cargo test --lib` (default parallelism, not `--release`) 3 times after the fixes:

- Run 2: `6289 passed; 9 failed` — none of my six targets
- Run 3: `6290 passed; 8 failed` — none of my six targets
- Run 4: `6289 passed; 9 failed` — none of my six targets

All six targets stay green across every run. The remaining failures are pre-existing, out-of-scope flakes whose set *shifts* run to run (`commands::infra::route`, `core::agent_task_lifecycle::cancel_run_signals_live_running_record`, `core::extension::runner::with_run_dir_tracks_resource_artifact_path`, `core::refactor::plan::generate::module_surface`, `core::process::process_tree_tests`, `core::rig::pipeline::command_step`, and `core::release::...repair` which is owned by an in-flight cook). They are tracked under the determinism umbrella #6804 and belong to other in-flight work; this PR does not touch them.

## Scope
Test-only changes confined to the six targeted modules: `core/extension/setup_env.rs`, `core/extension/test/run.rs`, `core/agent_task_provider/tests/selection_tests.rs`, `core/runner/workspace/tests/git.rs`, `extensions/deps_provider.rs`. No production source changed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Reproducing the failures, git-archaeology of the root causes, writing the fixes, and verification runs. Chris remains responsible for every line.