### PR TITLE
refactor: thin trace observation_lifecycle command adapter

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -678,7 +678,6 @@
         "thin_command_adapter::src/commands/runs/gh_actions.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/runs/loop_sync.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/trace/compare_targets.rs::ThinCommandAdapterViolation",
-        "thin_command_adapter::src/commands/trace/observation_lifecycle.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/trace/test_fixture.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/utils/observed_workflow.rs::ThinCommandAdapterViolation"
       ],

--- a/src/commands/trace/observation_lifecycle.rs
+++ b/src/commands/trace/observation_lifecycle.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::trace as extension_trace;
 use homeboy::core::observation::{
-    ActiveObservation, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, ObservationStore,
-    RunStatus,
+    finish_run_best_effort, ActiveObservation, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord,
+    ObservationStore, RunStatus,
 };
 use homeboy::core::rig;
 
@@ -146,9 +146,12 @@ pub(crate) fn finish_lab_dispatch_observation(
         .metadata(metadata.clone())
         .build(),
     );
-    let _ = observation
-        .store
-        .finish_run(&observation.run_id, status, Some(metadata));
+    finish_run_best_effort(
+        &observation.store,
+        &observation.run_id,
+        status,
+        Some(metadata),
+    );
     Some(retrieval)
 }
 
@@ -224,7 +227,8 @@ pub(super) fn persist_trace_workflow_result(
         } else {
             run_status
         };
-    let _ = observation.active.store().finish_run(
+    finish_run_best_effort(
+        observation.active.store(),
         observation.active.run_id(),
         finish_status,
         Some(trace_run_finish_metadata(
@@ -263,7 +267,8 @@ pub(super) fn persist_trace_workflow_error(
         run_dir,
         None,
     );
-    let _ = observation.active.store().finish_run(
+    finish_run_best_effort(
+        observation.active.store(),
         observation.active.run_id(),
         RunStatus::Error,
         Some(merge_trace_artifact_metadata(

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -90,6 +90,23 @@ impl ActiveObservation {
     }
 }
 
+/// Best-effort persistence of a run's terminal state.
+///
+/// Encapsulates the `ObservationStore::finish_run` call plus the deliberate
+/// drop of its result so command/orchestration layers can hand off a computed
+/// status and finalized metadata without re-implementing the
+/// observation-persistence primitive. Failures to persist are intentionally
+/// swallowed: finishing a run is an observability side effect that must never
+/// abort the workflow it is recording.
+pub fn finish_run_best_effort(
+    store: &ObservationStore,
+    run_id: &str,
+    status: RunStatus,
+    metadata: Option<serde_json::Value>,
+) {
+    let _ = store.finish_run(run_id, status, metadata);
+}
+
 pub fn merge_metadata(
     mut initial: serde_json::Value,
     finish: serde_json::Value,

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -17,7 +17,8 @@ mod test_findings;
 pub mod timeline;
 
 pub use lifecycle::{
-    merge_metadata, run_owner_pid, running_status_note, ActiveObservation, ACTIVE_RUN_ID_ENV,
+    finish_run_best_effort, merge_metadata, run_owner_pid, running_status_note, ActiveObservation,
+    ACTIVE_RUN_ID_ENV,
 };
 
 pub use budget_findings::finding_records_from_budget;


### PR DESCRIPTION
Moves trace observation-finish persistence from src/commands/trace/observation_lifecycle.rs into core/observation/lifecycle (or annotates false-positive delegation), keeping the command a thin adapter. Clears the ThinCommandAdapter finding. Identical behavior. Verified cargo build --lib --tests exit 0.