### PR TITLE
chore: clear stale trace test_fixture thin-adapter baseline (module already test-gated)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -677,7 +677,6 @@
         "thin_command_adapter::src/commands/review/mod.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/runs/gh_actions.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/runs/loop_sync.rs::ThinCommandAdapterViolation",
-        "thin_command_adapter::src/commands/trace/test_fixture.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/utils/observed_workflow.rs::ThinCommandAdapterViolation"
       ],
       "metadata": {


### PR DESCRIPTION
src/commands/trace/test_fixture.rs is pure test-support (write_trace_extension/write_trace_rig build fixtures in a TempDir, consumed only from #[cfg(test)] code and *_tests.rs files). The module declaration in src/commands/trace.rs is already #[cfg(test)]-gated on main, so its fs/Command orchestration is excluded from production builds and the ThinCommandAdapter detector no longer flags it. This PR removes the now-stale baseline row. Verified cargo build --lib --tests exit 0 (prod lib compiles without the gated module, confirming it is genuinely test-only).