### PR TITLE
test: make four recurring local test reds deterministic

### DIFF
--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -390,14 +390,31 @@ mod process_tree_tests {
         assert!(commands.iter().any(|cmd| cmd.contains("kill -KILL 4242")));
     }
 
+    /// Reap a test-owned child as soon as it exits, off-thread, so the kernel
+    /// clears the zombie promptly while `terminate_process_tree` is still
+    /// polling. The test process is the direct parent of these children, so it
+    /// alone is responsible for reaping them. On platforms without a /proc-based
+    /// zombie check (e.g. macOS), `pid_is_running` answers `kill(pid, 0) == 0`,
+    /// which stays `true` for an un-reaped zombie — so a child reaped only after
+    /// the assertions would be misreported as a survivor. Reaping concurrently
+    /// keeps the test honest about whether SIGTERM/SIGKILL actually took.
+    fn reap_in_background(mut child: std::process::Child) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        })
+    }
+
     #[test]
     fn terminate_process_tree_escalates_to_sigkill_on_sigterm_resistant_child() {
         // A child that ignores SIGTERM forces the SIGKILL escalation path.
-        let mut child = Command::new("sh")
+        let child = Command::new("sh")
             .args(["-c", "trap '' TERM; sleep 30"])
             .spawn()
             .expect("spawn sigterm-resistant child");
         let pid = child.id();
+        // Reap concurrently so the post-SIGKILL zombie is cleared during the
+        // reap grace window instead of lingering as a false survivor.
+        let reaper = reap_in_background(child);
 
         let termination = terminate_process_tree(pid).expect("terminate sigterm-resistant tree");
 
@@ -410,19 +427,21 @@ mod process_tree_tests {
             .iter()
             .any(|cmd| cmd.contains(&pid.to_string())));
 
-        // Reap so we do not leak a zombie into the test runner.
-        let _ = child.wait();
+        let _ = reaper.join();
         assert!(!pid_is_running(pid));
     }
 
     #[test]
     fn terminate_process_tree_uses_sigterm_for_cooperative_child() {
         // A plain sleep exits on SIGTERM, so no escalation is needed.
-        let mut child = Command::new("sleep")
+        let child = Command::new("sleep")
             .arg("30")
             .spawn()
             .expect("spawn cooperative child");
         let pid = child.id();
+        // Reap concurrently so the SIGTERM-exited zombie is cleared during the
+        // grace window and is not mistaken for a process that ignored SIGTERM.
+        let reaper = reap_in_background(child);
 
         let termination = terminate_process_tree(pid).expect("terminate cooperative tree");
 
@@ -430,7 +449,7 @@ mod process_tree_tests {
         assert!(termination.killed_pids.is_empty());
         assert!(termination.surviving_pids.is_empty());
 
-        let _ = child.wait();
+        let _ = reaper.join();
         assert!(!pid_is_running(pid));
     }
 }

--- a/src/core/refactor/plan/generate/module_surface.rs
+++ b/src/core/refactor/plan/generate/module_surface.rs
@@ -256,6 +256,16 @@ mod tests {
 
     #[test]
     fn build_uses_snapshot_content_for_module_surfaces() {
+        // `ModuleSurfaceIndex::build` only walks files whose extensions the
+        // installed extension registry provides, and that registry is read from
+        // `$HOME`. Other tests swap `HOME` (via the shared `home_lock`) while
+        // this one runs; if `.rs` is not a provided extension at the instant of
+        // the walk, `producer.rs` is skipped and `index.get(...)` returns
+        // `None`. Hold the shared home lock so no `HOME`-mutating test can run
+        // concurrently — the ambient registry (with its real `.rs` grammar)
+        // stays put for the duration of the walk.
+        let _home_guard = crate::test_support::home_env_guard();
+
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("src/core/example");
         std::fs::create_dir_all(&src).unwrap();

--- a/src/core/rig/pipeline/command_step.rs
+++ b/src/core/rig/pipeline/command_step.rs
@@ -160,7 +160,7 @@ mod tests {
         )]);
 
         assert!(env.iter().any(|(key, value)| {
-            key == "HOMEBOY_SETTINGS_COMPONENTS_WOOCOMMERCE_EXTENSIONS_WORDPRESS_SAMPLE_RUNTIME_SOURCE_ROOT"
+            key == "HOMEBOY_SETTINGS_COMPONENTS_WOOCOMMERCE_EXTENSIONS_WORDPRESS_SELECTED_RUNTIME_SOURCE_ROOT"
                 && value == "/workspace/source"
         }));
     }


### PR DESCRIPTION
Four `cargo test --lib` reds whose failing set shifts run-to-run under the parallel test harness. Each traced to a test-only root cause — no product source is touched and every assertion stays exact. Refs #6804 (test determinism umbrella).

## Root causes & fixes

### `core::process` process_tree_tests (`..._escalates_to_sigkill...`, `..._uses_sigterm...`)
The tests spawn children directly, so the **test process** is their parent and is solely responsible for reaping them — but they only call `child.wait()` *after* the assertions. On hosts without a `/proc`-based zombie check (macOS), `pid_is_running` falls back to `libc::kill(pid, 0) == 0`, which stays `true` for an **un-reaped zombie**. So `terminate_process_tree`'s grace-window polling sees the already-exited child as still alive and misreports it as a SIGKILL escalation (`killed_pids` non-empty) / a survivor (`surviving_pids` non-empty).

Fix: reap each test-owned child off-thread so the kernel clears the zombie during the grace window. The real SIGTERM-vs-SIGKILL behavior is asserted unchanged.

### `core::refactor::plan::generate::module_surface::build_uses_snapshot_content_for_module_surfaces`
`ModuleSurfaceIndex::build` only walks files whose extensions the installed extension registry provides, and that registry is read from `$HOME`. Concurrent tests swap `HOME` via the shared `home_lock`; if `.rs` is not a provided extension at the instant of the walk, `producer.rs` is skipped and `index.get(...)` returns `None`.

Fix: hold the shared `home_env_guard()` lock so no `HOME`-mutating test runs concurrently and the ambient registry (with its real `.rs` grammar) stays put for the duration of the walk. Uses the existing blessed serialization helper — no new local guard.

### `core::rig::pipeline::command_step::settings_env_adds_shell_safe_dotted_keys`
A **deterministic** red, not a flake. PR #6705's term-cleaning rename mapped the input key to `selected_runtime_source_root` but the expected literal to `SAMPLE_RUNTIME_SOURCE_ROOT`. `settings_env` correctly produces `...SELECTED_RUNTIME_SOURCE_ROOT`. Corrected the expectation to assert the genuinely-correct current output (the test's purpose — dotted keys become shell-safe underscores — is preserved).

## Verification
`cargo check` clean. Ran full `cargo test --lib` (debug, never release) 3 times plus targeted repeated runs (process_tree 6x, command_step, module_surface). Across every run, all four targets passed; they never appeared in any FAILED list. The remaining reds (`commands::infra::route`, `agent_task_lifecycle::cancel_run`, `release::executor::github_release::repair`, `extension::runner`) are pre-existing out-of-scope flakes that shift run-to-run (left for #6804 / other cooks).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Root-cause investigation and test-isolation fixes for the four shifting test reds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)