### PR TITLE
fix(lab): tolerate compatible (same-minor) controller/runner version drift

### DIFF
--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -43,6 +43,7 @@ pub fn run(
                 daemon,
                 concurrency_limit,
                 artifact_policy,
+                ..RunnerSettings::default()
             },
         })),
         RunnerCommand::Enable {
@@ -60,6 +61,7 @@ pub fn run(
                 daemon,
                 concurrency_limit,
                 artifact_policy,
+                ..RunnerSettings::default()
             },
         )),
         RunnerCommand::List => map_registry(list()),

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -277,13 +277,14 @@ pub(crate) fn run_lab_offload_inner(
     }
     let source_checkout = lab_source_checkout_metadata(&source_path);
     let homeboy_path = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
+    let require_exact_runner_version = require_exact_runner_version(&runner.settings);
     let runner_homeboy = lab_runner_homeboy_metadata(runner_id, homeboy_path, &runner_status);
     plan = with_step(
         plan,
         PlanStep::builder(
             "lab.runner_homeboy",
             "lab.runner_homeboy",
-            if lab_runner_homeboy_has_blocking_drift(&runner_status) {
+            if lab_runner_homeboy_has_blocking_drift(&runner_status, require_exact_runner_version) {
                 PlanStepStatus::Failed
             } else {
                 PlanStepStatus::Ready
@@ -314,12 +315,18 @@ pub(crate) fn run_lab_offload_inner(
                 shell::quote_arg(runner_id)
             ))
     );
-    if lab_runner_homeboy_has_blocking_drift(&runner_status) {
+    if lab_runner_homeboy_has_blocking_drift(&runner_status, require_exact_runner_version) {
         return Err(stale_runner_homeboy_error(
             runner_id,
             homeboy_path,
             &runner_status,
         ));
+    }
+    if let Some(warning) =
+        lab_runner_homeboy_compatible_drift_warning(&runner_status, require_exact_runner_version)
+    {
+        eprintln!("{warning}");
+        messages.push(warning);
     }
     let command_prefix = lab_offload_command_prefix(&source_path, homeboy_path);
     eprintln!(

--- a/src/core/runner/lab/offload/metadata.rs
+++ b/src/core/runner/lab/offload/metadata.rs
@@ -225,17 +225,156 @@ pub(crate) fn lab_runner_homeboy_metadata(
     })
 }
 
-pub(crate) fn lab_runner_homeboy_has_blocking_drift(status: &RunnerStatusReport) -> bool {
-    status.stale_daemon.is_some() || lab_runner_homeboy_version_drift(status)
+/// Env var that forces strict exact-match for the controller↔runner version
+/// gate for a single run, regardless of per-runner configuration. Accepts the
+/// usual truthy spellings (`1`, `true`, `yes`, `on`).
+pub(crate) const REQUIRE_EXACT_RUNNER_VERSION_ENV: &str = "HOMEBOY_REQUIRE_EXACT_RUNNER_VERSION";
+
+/// Classification of controller↔runner Homeboy version drift for the Lab
+/// offload dispatch gate.
+///
+/// Patch-level drift within the same `MAJOR.MINOR` is wire-compatible: the
+/// runner daemon and the controller speak the same provider/job contract, so
+/// the run can proceed with a warning. `MAJOR`/`MINOR` drift can genuinely
+/// change that contract and is refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RunnerHomeboyVersionDrift {
+    /// Controller and runner report the same version (no drift).
+    None,
+    /// Same `MAJOR.MINOR`, patch differs — wire-compatible; proceed with a warning.
+    CompatiblePatch,
+    /// `MAJOR`/`MINOR` differs, or a version string could not be parsed while the
+    /// raw strings differ — the provider contract could genuinely differ; refuse.
+    Incompatible,
 }
 
-fn lab_runner_homeboy_version_drift(status: &RunnerStatusReport) -> bool {
+/// Resolve whether the controller↔runner version gate should enforce exact
+/// byte-identical match. Defaults to compatibility-aware (`false`). Operators
+/// opt into strict exact-match either per-runner (the
+/// `require_exact_homeboy_version` runner setting) or for a single run via the
+/// `HOMEBOY_REQUIRE_EXACT_RUNNER_VERSION` env var.
+pub(crate) fn require_exact_runner_version(
+    settings: &crate::core::server::RunnerSettings,
+) -> bool {
+    if std::env::var(REQUIRE_EXACT_RUNNER_VERSION_ENV)
+        .ok()
+        .is_some_and(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+    {
+        return true;
+    }
+    settings.require_exact_homeboy_version.unwrap_or(false)
+}
+
+/// Extract the `(MAJOR, MINOR)` pair from a Homeboy version string, tolerating a
+/// leading label (e.g. `homeboy 0.266.1`) and trailing build/prerelease
+/// metadata (e.g. `0.266.1+abc`). Mirrors the lenient parsing already used by
+/// the runner version probe so the gate accepts the same shapes.
+fn parse_major_minor(version: &str) -> Option<(u64, u64)> {
+    let candidate = version
+        .split_whitespace()
+        .find(|token| token.chars().next().is_some_and(|c| c.is_ascii_digit()))
+        .unwrap_or_else(|| version.trim());
+    let mut parts = candidate.split('.');
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let minor: u64 = parts
+        .next()?
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .parse()
+        .ok()?;
+    Some((major, minor))
+}
+
+/// Classify controller↔runner Homeboy version drift using the same drift
+/// evidence the metadata builder reports (runner session version vs the
+/// compiled controller version).
+pub(crate) fn classify_runner_homeboy_version_drift(
+    status: &RunnerStatusReport,
+) -> RunnerHomeboyVersionDrift {
     let controller_version = env!("CARGO_PKG_VERSION");
-    status
+    let Some(runner_version) = status
         .session
         .as_ref()
         .map(|session| session.homeboy_version.as_str())
-        .is_some_and(|version| version != controller_version)
+    else {
+        // No connected session means no version evidence to compare; leave
+        // connectivity gating to the dedicated preflight checks.
+        return RunnerHomeboyVersionDrift::None;
+    };
+
+    // Preserve the existing exact-match fast path: byte-identical strings are
+    // unambiguously the same build.
+    if runner_version == controller_version {
+        return RunnerHomeboyVersionDrift::None;
+    }
+
+    match (
+        parse_major_minor(controller_version),
+        parse_major_minor(runner_version),
+    ) {
+        (Some(controller), Some(runner)) if controller == runner => {
+            RunnerHomeboyVersionDrift::CompatiblePatch
+        }
+        // Same-MAJOR.MINOR was handled above; any other parseable pair differs
+        // at MAJOR/MINOR. Unparseable strings that already differ are refused
+        // conservatively.
+        _ => RunnerHomeboyVersionDrift::Incompatible,
+    }
+}
+
+pub(crate) fn lab_runner_homeboy_has_blocking_drift(
+    status: &RunnerStatusReport,
+    require_exact: bool,
+) -> bool {
+    // Build-identity drift within the runner (active daemon control plane vs the
+    // configured job command binary) is an internal-inconsistency signal that is
+    // always blocking regardless of the controller↔runner version policy.
+    if status.stale_daemon.is_some() {
+        return true;
+    }
+    match classify_runner_homeboy_version_drift(status) {
+        RunnerHomeboyVersionDrift::None => false,
+        RunnerHomeboyVersionDrift::CompatiblePatch => require_exact,
+        RunnerHomeboyVersionDrift::Incompatible => true,
+    }
+}
+
+/// Warning to surface when the runner is on a wire-compatible patch-drifted
+/// version and the gate is allowing the run to proceed. Returns `None` when
+/// there is nothing to warn about (no drift, refused incompatibility, or strict
+/// mode where the drift is instead surfaced as an error).
+pub(crate) fn lab_runner_homeboy_compatible_drift_warning(
+    status: &RunnerStatusReport,
+    require_exact: bool,
+) -> Option<String> {
+    if require_exact {
+        return None;
+    }
+    if !matches!(
+        classify_runner_homeboy_version_drift(status),
+        RunnerHomeboyVersionDrift::CompatiblePatch
+    ) {
+        return None;
+    }
+    let controller_version = env!("CARGO_PKG_VERSION");
+    let runner_version = status
+        .session
+        .as_ref()
+        .map(|session| session.homeboy_version.as_str())
+        .unwrap_or("<unknown>");
+    Some(format!(
+        "Lab offload: runner reports Homeboy `{runner_version}` while the controller is `{controller_version}`; same MAJOR.MINOR (patch drift only) is wire-compatible, proceeding. Set runner setting `require_exact_homeboy_version` or export `{REQUIRE_EXACT_RUNNER_VERSION_ENV}=1` to enforce exact-match."
+    ))
+}
+
+fn lab_runner_homeboy_version_drift(status: &RunnerStatusReport) -> bool {
+    classify_runner_homeboy_version_drift(status) != RunnerHomeboyVersionDrift::None
 }
 
 pub(crate) fn lab_source_checkout_metadata(source_path: &Path) -> serde_json::Value {

--- a/src/core/runner/lab/offload/tests/capability_metadata.rs
+++ b/src/core/runner/lab/offload/tests/capability_metadata.rs
@@ -277,7 +277,14 @@ fn lab_runner_homeboy_metadata_names_binary_and_refresh_path() {
 fn runner_homeboy_version_drift_blocks_offload_with_upgrade_guidance() {
     let status = reverse_status("homeboy-lab");
 
-    assert!(lab_runner_homeboy_has_blocking_drift(&status));
+    // `reverse_status` reports runner `0.0.0` against the controller's current
+    // version, a MINOR/MAJOR mismatch that is blocking regardless of strict mode.
+    assert!(lab_runner_homeboy_has_blocking_drift(&status, false));
+    assert!(lab_runner_homeboy_has_blocking_drift(&status, true));
+    assert_eq!(
+        classify_runner_homeboy_version_drift(&status),
+        RunnerHomeboyVersionDrift::Incompatible
+    );
 
     let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
 
@@ -297,6 +304,146 @@ fn runner_homeboy_version_drift_blocks_offload_with_upgrade_guidance() {
     assert!(tried.iter().any(|hint| hint
         .as_str()
         .is_some_and(|hint| hint.contains("refresh or select a clean runner binary"))));
+}
+
+/// Build a reverse-connected status whose runner session reports `version`.
+fn status_with_runner_version(runner_id: &str, version: &str) -> RunnerStatusReport {
+    let mut status = reverse_status(runner_id);
+    if let Some(session) = status.session.as_mut() {
+        session.homeboy_version = version.to_string();
+        session.homeboy_build_identity = Some(format!("{version}+test"));
+    }
+    status
+}
+
+/// A version string sharing the controller's MAJOR.MINOR but a different patch.
+fn same_minor_patch_drift_version(prefix: &str) -> String {
+    let controller = env!("CARGO_PKG_VERSION");
+    let mut parts = controller.split('.');
+    let major = parts.next().unwrap_or("0");
+    let minor = parts.next().unwrap_or("0");
+    let patch: u64 = parts
+        .next()
+        .and_then(|p| {
+            p.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+                .parse()
+                .ok()
+        })
+        .unwrap_or(0);
+    format!("{prefix}{major}.{minor}.{}", patch.wrapping_add(1))
+}
+
+#[test]
+fn same_minor_patch_drift_is_compatible_and_proceeds_with_warning() {
+    let status = status_with_runner_version(
+        "homeboy-lab",
+        &same_minor_patch_drift_version("homeboy "),
+    );
+
+    assert_eq!(
+        classify_runner_homeboy_version_drift(&status),
+        RunnerHomeboyVersionDrift::CompatiblePatch
+    );
+    // Compatibility-aware default: patch drift proceeds.
+    assert!(!lab_runner_homeboy_has_blocking_drift(&status, false));
+    let warning = lab_runner_homeboy_compatible_drift_warning(&status, false)
+        .expect("compatible patch drift should warn");
+    assert!(warning.contains("wire-compatible"));
+    assert!(warning.contains("require_exact_homeboy_version"));
+}
+
+#[test]
+fn same_minor_patch_drift_is_refused_under_strict_mode() {
+    let status =
+        status_with_runner_version("homeboy-lab", &same_minor_patch_drift_version(""));
+
+    // Strict override restores exact-match: patch drift now refuses.
+    assert!(lab_runner_homeboy_has_blocking_drift(&status, true));
+    // No "proceeding" warning is emitted under strict mode; the drift surfaces
+    // as the refusal error instead.
+    assert!(lab_runner_homeboy_compatible_drift_warning(&status, true).is_none());
+}
+
+#[test]
+fn minor_version_drift_is_incompatible_and_refused() {
+    let controller = env!("CARGO_PKG_VERSION");
+    let mut parts = controller.split('.');
+    let major = parts.next().unwrap_or("0");
+    let minor: u64 = parts
+        .next()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(0);
+    let drifted = format!("{major}.{}.0", minor.wrapping_add(1));
+    let status = status_with_runner_version("homeboy-lab", &drifted);
+
+    assert_eq!(
+        classify_runner_homeboy_version_drift(&status),
+        RunnerHomeboyVersionDrift::Incompatible
+    );
+    assert!(lab_runner_homeboy_has_blocking_drift(&status, false));
+    assert!(lab_runner_homeboy_has_blocking_drift(&status, true));
+    assert!(lab_runner_homeboy_compatible_drift_warning(&status, false).is_none());
+}
+
+#[test]
+fn exact_version_match_has_no_drift() {
+    let status = status_with_runner_version("homeboy-lab", env!("CARGO_PKG_VERSION"));
+
+    assert_eq!(
+        classify_runner_homeboy_version_drift(&status),
+        RunnerHomeboyVersionDrift::None
+    );
+    assert!(!lab_runner_homeboy_has_blocking_drift(&status, false));
+    assert!(!lab_runner_homeboy_has_blocking_drift(&status, true));
+    assert!(lab_runner_homeboy_compatible_drift_warning(&status, false).is_none());
+}
+
+#[test]
+fn stale_daemon_build_identity_drift_always_blocks_even_on_compatible_version() {
+    // Runner version matches the controller exactly, but the runner's active
+    // daemon was started by a different build than its job command binary: that
+    // internal inconsistency is always blocking, independent of the version policy.
+    let mut status = status_with_runner_version("homeboy-lab", env!("CARGO_PKG_VERSION"));
+    status.stale_daemon = Some(RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "homeboy 0.228.0".to_string(),
+        "homeboy 0.229.11".to_string(),
+        Some("homeboy 0.228.0+old".to_string()),
+        Some("homeboy 0.229.11+new".to_string()),
+    ));
+
+    assert_eq!(
+        classify_runner_homeboy_version_drift(&status),
+        RunnerHomeboyVersionDrift::None
+    );
+    assert!(lab_runner_homeboy_has_blocking_drift(&status, false));
+}
+
+#[test]
+fn require_exact_runner_version_resolves_from_setting_and_env() {
+    use crate::core::server::RunnerSettings;
+
+    let default_settings = RunnerSettings::default();
+    assert!(!require_exact_runner_version(&default_settings));
+
+    let strict_settings = RunnerSettings {
+        require_exact_homeboy_version: Some(true),
+        ..RunnerSettings::default()
+    };
+    assert!(require_exact_runner_version(&strict_settings));
+
+    // Env override forces strict mode even when the setting is unset/false.
+    let prior = std::env::var(REQUIRE_EXACT_RUNNER_VERSION_ENV).ok();
+    std::env::set_var(REQUIRE_EXACT_RUNNER_VERSION_ENV, "1");
+    assert!(require_exact_runner_version(&default_settings));
+    std::env::set_var(REQUIRE_EXACT_RUNNER_VERSION_ENV, "off");
+    assert!(!require_exact_runner_version(&default_settings));
+    match prior {
+        Some(value) => std::env::set_var(REQUIRE_EXACT_RUNNER_VERSION_ENV, value),
+        None => std::env::remove_var(REQUIRE_EXACT_RUNNER_VERSION_ENV),
+    }
 }
 
 #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -953,6 +953,7 @@ mod tests {
                 daemon: true,
                 concurrency_limit: Some(2),
                 artifact_policy: Some("copy".to_string()),
+                ..RunnerSettings::default()
             },
             env: HashMap::from([
                 ("PATH".to_string(), "/runner/bin".to_string()),

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -71,6 +71,14 @@ pub struct RunnerSettings {
     pub concurrency_limit: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_policy: Option<String>,
+    /// When `true`, the Lab offload controller↔runner version gate requires a
+    /// byte-identical Homeboy version on the runner. Default (unset/`false`) is
+    /// compatibility-aware: patch drift within the same MAJOR.MINOR is allowed
+    /// with a warning, and only MAJOR/MINOR drift hard-refuses. The
+    /// `HOMEBOY_REQUIRE_EXACT_RUNNER_VERSION` env var forces strict mode for a
+    /// single run regardless of this setting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_exact_homeboy_version: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Problem
Lab job dispatch hard-refused whenever the controller and runner-daemon Homeboy versions differed at all. During active development the controller version churns constantly, so a one-patch difference (e.g. controller `0.266.2` vs runner `0.266.1`) blocked **every** live matrix/swarm run even though those versions are wire-compatible.

## Change
Make the controller↔runner version gate compatibility-aware instead of exact-match:

- **Same `MAJOR.MINOR` (patch drift only)** → proceed with a warning (wire-compatible).
- **`MAJOR`/`MINOR` mismatch** → hard-refuse (provider contract could genuinely differ).
- **Strict override** to restore exact-match for paranoid runs:
  - per-runner setting `require_exact_homeboy_version: true`, or
  - `HOMEBOY_REQUIRE_EXACT_RUNNER_VERSION=1` env var for a single run.

Build-identity drift *within* a runner (active daemon control plane vs job command binary, `stale_daemon`) stays unconditionally blocking — that's an internal-inconsistency signal, orthogonal to controller↔runner version policy.

Reuses the existing drift evidence (runner session version vs compiled controller version); this is purely the dispatch-gate policy. Error/envelope conventions in `stale_runner_homeboy_error` are unchanged.

## Implementation
- `RunnerSettings.require_exact_homeboy_version: Option<bool>` (`src/core/server/mod.rs`).
- `classify_runner_homeboy_version_drift` + `RunnerHomeboyVersionDrift` enum, `require_exact_runner_version`, and `lab_runner_homeboy_compatible_drift_warning` in `src/core/runner/lab/offload/metadata.rs`; `lab_runner_homeboy_has_blocking_drift` now takes a `require_exact` flag.
- Dispatch gate in `src/core/runner/lab/offload/inner.rs` resolves the strict flag, refuses only on blocking drift, and surfaces the compatibility warning.

## Tests
New unit tests in `offload::tests::capability_metadata`:
- same-minor patch drift → allowed (with warning); strict mode → refused;
- minor/major drift → refused;
- exact match → no drift;
- `stale_daemon` build-identity drift → always blocks;
- `require_exact_runner_version` resolves from setting + env.

`cargo build -p homeboy` clean; `cargo test -p homeboy --lib offload::tests::capability_metadata` → 19 passed.

Closes #6820
Refs #6735

🤖 Generated with [Claude Code](https://claude.com/claude-code)