### PR TITLE
refactor: extract settings-matrix run persistence to core (thin command adapter)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -680,7 +680,6 @@
         "test_quality::src/core/runner/execution/tests/redaction.rs::VacuousTest",
         "test_quality::src/core/runner/execution/tests/secret_source.rs::VacuousTest",
         "test_quality::tests/command_surface_test.rs::VacuousTest",
-        "thin_command_adapter::src/commands/bench/settings_matrix.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/observe.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/review/mod.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/runs/gh_actions.rs::ThinCommandAdapterViolation",

--- a/src/commands/bench/settings_matrix.rs
+++ b/src/commands/bench/settings_matrix.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use homeboy::core::agent_tasks::AgentTaskMatrixExecutionState;
 use homeboy::core::extension::bench::{BenchCommandOutput, BenchScenario};
-use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+use homeboy::core::matrix_artifact_summary;
 
 use super::{filter_homeboy_flags, matrix as bench_runner, BenchRunArgs};
 
@@ -239,45 +239,14 @@ fn persist_settings_matrix_parent_run(
     child_run_ids: &[String],
     passed: bool,
 ) -> Option<String> {
-    try_persist_settings_matrix_parent_run(run_args, component, axes, cells, child_run_ids, passed)
-        .ok()
-}
-
-fn try_persist_settings_matrix_parent_run(
-    run_args: &BenchRunArgs,
-    component: &str,
-    axes: &[BenchSettingsMatrixAxisOutput],
-    cells: &[BenchSettingsMatrixCellOutput],
-    child_run_ids: &[String],
-    passed: bool,
-) -> homeboy::core::Result<String> {
-    let store = ObservationStore::open_initialized()?;
-    let cwd = std::env::current_dir().ok();
-    let run = store.start_run(
-        NewRunRecord::builder("bench.matrix")
-            .component_id(component)
-            .command(settings_matrix_parent_command(component, run_args))
-            .optional_cwd_path(cwd.as_deref())
-            .current_homeboy_version()
-            .optional_rig_id(run_args.rig.first().map(String::as_str))
-            .metadata(settings_matrix_parent_metadata(
-                axes,
-                cells,
-                child_run_ids,
-                passed,
-            ))
-            .build(),
-    )?;
-    store.finish_run(
-        &run.id,
-        if passed {
-            RunStatus::Pass
-        } else {
-            RunStatus::Fail
-        },
-        None,
-    )?;
-    Ok(run.id)
+    matrix_artifact_summary::persist_settings_matrix_parent_run(
+        component,
+        settings_matrix_parent_command(component, run_args),
+        run_args.rig.first().map(String::as_str),
+        settings_matrix_parent_metadata(axes, cells, child_run_ids, passed),
+        passed,
+    )
+    .ok()
 }
 
 fn settings_matrix_parent_command(component: &str, run_args: &BenchRunArgs) -> String {
@@ -689,7 +658,7 @@ mod tests {
             ];
             let child_run_ids = vec!["run-a".to_string(), "run-b".to_string()];
 
-            let parent_run_id = try_persist_settings_matrix_parent_run(
+            let parent_run_id = persist_settings_matrix_parent_run(
                 &args,
                 "studio-web",
                 &axes,
@@ -699,7 +668,8 @@ mod tests {
             )
             .expect("parent run should persist");
 
-            let store = ObservationStore::open_initialized().expect("store");
+            let store =
+                homeboy::core::observation::ObservationStore::open_initialized().expect("store");
             let run = store
                 .get_run(&parent_run_id)
                 .expect("read parent")

--- a/src/core/matrix_artifact_summary.rs
+++ b/src/core/matrix_artifact_summary.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::artifact_ref::{ArtifactRef, EvidenceRef, ARTIFACT_REF_SCHEMA};
-use crate::core::observation::{ArtifactRecord, FindingRecord};
+use crate::core::observation::{
+    ArtifactRecord, FindingRecord, NewRunRecord, ObservationStore, RunStatus,
+};
 
 pub const MATRIX_ARTIFACT_SUMMARY_SCHEMA: &str = "homeboy/matrix-artifact-summary/v1";
 pub const GENERIC_MATRIX_SUMMARY_SCHEMA: &str = "homeboy/matrix-summary/v1";
@@ -811,6 +813,43 @@ fn top_counts(counts: BTreeMap<String, usize>, limit: usize) -> Vec<MatrixSummar
     rows.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.key.cmp(&b.key)));
     rows.truncate(limit);
     rows
+}
+
+/// Persist a settings-matrix parent run to the observation store.
+///
+/// Opens (and initializes) the observation store, records a parent run with the
+/// supplied command/metadata, finishes it with a pass/fail status, and returns
+/// the new run id. The caller computes the agnostic inputs (command string,
+/// rig id, metadata payload); this owns the run-persistence orchestration.
+pub fn persist_settings_matrix_parent_run(
+    component: &str,
+    command: String,
+    rig_id: Option<&str>,
+    metadata: Value,
+    passed: bool,
+) -> crate::core::Result<String> {
+    let store = ObservationStore::open_initialized()?;
+    let cwd = std::env::current_dir().ok();
+    let run = store.start_run(
+        NewRunRecord::builder("bench.matrix")
+            .component_id(component)
+            .command(command)
+            .optional_cwd_path(cwd.as_deref())
+            .current_homeboy_version()
+            .optional_rig_id(rig_id)
+            .metadata(metadata)
+            .build(),
+    )?;
+    store.finish_run(
+        &run.id,
+        if passed {
+            RunStatus::Pass
+        } else {
+            RunStatus::Fail
+        },
+        None,
+    )?;
+    Ok(run.id)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Moves settings-matrix parent-run persistence (ObservationStore + finish_run + metadata) from src/commands/bench/settings_matrix.rs into core (matrix_artifact_summary), keeping the command a thin adapter. Clears the ThinCommandAdapter finding. Identical behavior. Verified cargo build --lib --tests exit 0.