### PR TITLE
refactor: extract loop-inventory run persistence to core (thin command adapter)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -682,8 +682,7 @@
         "test_quality::tests/command_surface_test.rs::VacuousTest",
         "thin_command_adapter::src/commands/observe.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::src/commands/review/mod.rs::ThinCommandAdapterViolation",
-        "thin_command_adapter::src/commands/runs/gh_actions.rs::ThinCommandAdapterViolation",
-        "thin_command_adapter::src/commands/runs/loop_sync.rs::ThinCommandAdapterViolation"
+        "thin_command_adapter::src/commands/runs/gh_actions.rs::ThinCommandAdapterViolation"
       ],
       "metadata": {
         "alignment_score": 0.9021739363670349,

--- a/src/commands/runs/loop_sync.rs
+++ b/src/commands/runs/loop_sync.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use homeboy::core::observation::{ArtifactRecord, NewRunRecord, ObservationStore, RunStatus};
+use homeboy::core::observation::{persist_loop_inventory_run, ArtifactRecord, NewRunRecord};
 use homeboy::core::{Error, Result};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -156,26 +156,20 @@ fn persist_loop_inventory(
     triage: &LoopTriageSummary,
     args: &RunsLoopSyncArgs,
 ) -> Result<(Option<String>, Vec<ArtifactRecord>)> {
-    let store = ObservationStore::open_initialized()?;
-    let run = store.start_run(loop_run_record(inventory, triage, args))?;
-    let mut artifacts = Vec::new();
+    let indexed_artifacts = files_for_artifact_index(inventory)
+        .into_iter()
+        .map(|file| {
+            let kind = classify_file(&file).to_string();
+            (file, kind)
+        })
+        .collect::<Vec<_>>();
 
-    for archive in &inventory.archives {
-        if archive.is_dir() {
-            artifacts.push(store.record_directory_artifact(&run.id, "loop_archive", archive)?);
-        } else if archive.is_file() {
-            artifacts.push(store.record_artifact(&run.id, "loop_archive", archive)?);
-        }
-    }
-
-    for file in files_for_artifact_index(inventory) {
-        if file.is_file() {
-            artifacts.push(store.record_artifact(&run.id, classify_file(&file), file)?);
-        }
-    }
-
-    let finished = store.finish_run(&run.id, RunStatus::Pass, None)?;
-    Ok((Some(finished.id), artifacts))
+    let (run_id, artifacts) = persist_loop_inventory_run(
+        loop_run_record(inventory, triage, args),
+        &inventory.archives,
+        &indexed_artifacts,
+    )?;
+    Ok((Some(run_id), artifacts))
 }
 
 fn loop_run_record(

--- a/src/core/observation/loop_inventory_run.rs
+++ b/src/core/observation/loop_inventory_run.rs
@@ -1,0 +1,48 @@
+//! Loop-archive inventory run persistence.
+//!
+//! Boundary: the caller computes the agnostic inputs (the run record, the set of
+//! archive paths, and the indexed artifact paths with their kind labels). This
+//! module owns the run-persistence orchestration: opening the observation store,
+//! starting the run, recording each artifact, and finishing the run as a pass.
+
+use std::path::PathBuf;
+
+use crate::core::observation::{ArtifactRecord, NewRunRecord, ObservationStore, RunStatus};
+use crate::core::Result;
+
+/// Persist a loop-archive inventory run to the observation store.
+///
+/// Opens (and initializes) the observation store, starts a run from the supplied
+/// record, records each top-level archive (as a directory or file artifact) and
+/// each indexed artifact (with its supplied kind), then finishes the run as a
+/// pass. Returns the finished run id and the recorded artifacts.
+///
+/// `archive_paths` are recorded under the `loop_archive` kind; directories use a
+/// directory artifact and files use a file artifact. `indexed_artifacts` are
+/// `(path, kind)` pairs recorded as file artifacts when the path is a file.
+pub fn persist_loop_inventory_run(
+    run_record: NewRunRecord,
+    archive_paths: &[PathBuf],
+    indexed_artifacts: &[(PathBuf, String)],
+) -> Result<(String, Vec<ArtifactRecord>)> {
+    let store = ObservationStore::open_initialized()?;
+    let run = store.start_run(run_record)?;
+    let mut artifacts = Vec::new();
+
+    for archive in archive_paths {
+        if archive.is_dir() {
+            artifacts.push(store.record_directory_artifact(&run.id, "loop_archive", archive)?);
+        } else if archive.is_file() {
+            artifacts.push(store.record_artifact(&run.id, "loop_archive", archive)?);
+        }
+    }
+
+    for (file, kind) in indexed_artifacts {
+        if file.is_file() {
+            artifacts.push(store.record_artifact(&run.id, kind, file)?);
+        }
+    }
+
+    let finished = store.finish_run(&run.id, RunStatus::Pass, None)?;
+    Ok((finished.id, artifacts))
+}

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -9,6 +9,7 @@ pub mod context;
 pub mod disk_budget;
 pub mod evidence_report;
 mod lifecycle;
+pub mod loop_inventory_run;
 pub mod observed_workflow;
 pub mod records;
 mod run_failure_causes;
@@ -21,6 +22,8 @@ pub use lifecycle::{
     finish_run_best_effort, merge_metadata, run_owner_pid, running_status_note, ActiveObservation,
     ACTIVE_RUN_ID_ENV,
 };
+
+pub use loop_inventory_run::persist_loop_inventory_run;
 
 pub use budget_findings::finding_records_from_budget;
 pub use context::{RunContext, RunProvenance};


### PR DESCRIPTION
Moves loop-inventory run persistence (ObservationStore start_run/record_artifact/finish_run) from src/commands/runs/loop_sync.rs into core/observation, keeping the command a thin adapter. Clears the ThinCommandAdapter finding. Identical behavior. Verified cargo build --lib --tests exit 0.