### PR TITLE
feat(runtime): add core emit-lint-finding and emit-test-failure shims

### DIFF
--- a/src/core/extension/runtime/emit-lint-finding.sh
+++ b/src/core/extension/runtime/emit-lint-finding.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+# Core-materialized normalized LINT-FINDING record emitter for extension runners.
+#
+# Every per-language lint runner (rust/go/swift/nodejs/wordpress) hand-builds the
+# same normalized finding record: a stable identity, a sha1 fingerprint of that
+# identity, and a 240-character excerpt of the offending source line. This shim
+# owns that record shape in one place so the per-language runners can route
+# through it and delete their copies with byte-identical output.
+#
+# Usage:
+#   source "${HOMEBOY_RUNTIME_EMIT_LINT_FINDING:-/path/to/fallback}"
+#   homeboy_emit_lint_finding \
+#       --root "$PROJECT_PATH" \
+#       --id "rust:clippy:src/lib.rs:10:5:unused:unused variable" \
+#       --file src/lib.rs --line 10 --column 5 \
+#       --severity warning --source clippy --code unused \
+#       --category correctness --message "unused variable" --fixable false
+#
+# Prints one normalized LINT-FINDING JSON object (compact, single line) on stdout
+# with this exact key order — the shape per-language runners append/merge into the
+# lint findings sidecar:
+#   {"id":..,"file":..,"line":..,"column":..,"severity":..,"source":..,
+#    "code":..,"category":..,"message":..,"fixable":<bool>,
+#    "fingerprint":<sha1(id)>,"excerpt":<line text truncated to 240 chars|null>}
+#
+# Arguments:
+#   --root      project root used to resolve --file when reading the excerpt
+#   --id        stable identity string (REQUIRED); the fingerprint is sha1(id)
+#   --file      finding file path, relative to --root (used for the excerpt)
+#   --line      1-based line number (default 0; excerpt is null when out of range)
+#   --column    1-based column number (default 1)
+#   --severity  severity label (default "warning")
+#   --source    tool/source label (e.g. clippy, gofmt, eslint)
+#   --code      rule/code identifier
+#   --category  normalized category (e.g. format, correctness, style)
+#   --message   human-readable finding message
+#   --fixable   "true"/"false" (default "false")
+#
+# The fingerprint is sha1 of --id and the excerpt is the first 240 characters of
+# the source line, matching the per-language builders byte-for-byte.
+
+homeboy_emit_lint_finding_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+    if command -v python >/dev/null 2>&1; then
+        command -v python
+        return 0
+    fi
+    echo "[emit-lint-finding] python3 or python is required" >&2
+    return 1
+}
+
+homeboy_emit_lint_finding() {
+    local lf_root="" lf_id="" lf_file="" lf_line="0" lf_column="1" \
+        lf_severity="warning" lf_source="" lf_code="" lf_category="" \
+        lf_message="" lf_fixable="false"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --root) lf_root="${2:-}"; shift 2 ;;
+            --id) lf_id="${2:-}"; shift 2 ;;
+            --file) lf_file="${2:-}"; shift 2 ;;
+            --line) lf_line="${2:-0}"; shift 2 ;;
+            --column) lf_column="${2:-1}"; shift 2 ;;
+            --severity) lf_severity="${2:-}"; shift 2 ;;
+            --source) lf_source="${2:-}"; shift 2 ;;
+            --code) lf_code="${2:-}"; shift 2 ;;
+            --category) lf_category="${2:-}"; shift 2 ;;
+            --message) lf_message="${2:-}"; shift 2 ;;
+            --fixable) lf_fixable="${2:-false}"; shift 2 ;;
+            *)
+                echo "[emit-lint-finding] unknown argument: $1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [ -z "$lf_id" ]; then
+        echo "[emit-lint-finding] --id is required" >&2
+        return 2
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_emit_lint_finding_python)" || return 1
+
+    HOMEBOY_LF_ROOT="$lf_root" \
+    HOMEBOY_LF_ID="$lf_id" \
+    HOMEBOY_LF_FILE="$lf_file" \
+    HOMEBOY_LF_LINE="$lf_line" \
+    HOMEBOY_LF_COLUMN="$lf_column" \
+    HOMEBOY_LF_SEVERITY="$lf_severity" \
+    HOMEBOY_LF_SOURCE="$lf_source" \
+    HOMEBOY_LF_CODE="$lf_code" \
+    HOMEBOY_LF_CATEGORY="$lf_category" \
+    HOMEBOY_LF_MESSAGE="$lf_message" \
+    HOMEBOY_LF_FIXABLE="$lf_fixable" \
+    "$python_bin" <<'PYEOF'
+import hashlib
+import json
+import os
+import sys
+
+
+def env_int(name, default=0):
+    raw = os.environ.get(name, "")
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+root = os.environ.get("HOMEBOY_LF_ROOT", "")
+identity = os.environ.get("HOMEBOY_LF_ID", "")
+file = os.environ.get("HOMEBOY_LF_FILE", "")
+line = env_int("HOMEBOY_LF_LINE", 0)
+column = env_int("HOMEBOY_LF_COLUMN", 1)
+fixable = os.environ.get("HOMEBOY_LF_FIXABLE", "false").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+
+def excerpt(root, file, line):
+    if not file or line <= 0:
+        return None
+    try:
+        with open(os.path.join(root, file), encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+    except OSError:
+        return None
+    if 1 <= line <= len(lines):
+        return lines[line - 1][:240]
+    return None
+
+
+record = {
+    "id": identity,
+    "file": file,
+    "line": line,
+    "column": column,
+    "severity": os.environ.get("HOMEBOY_LF_SEVERITY", ""),
+    "source": os.environ.get("HOMEBOY_LF_SOURCE", ""),
+    "code": os.environ.get("HOMEBOY_LF_CODE", ""),
+    "category": os.environ.get("HOMEBOY_LF_CATEGORY", ""),
+    "message": os.environ.get("HOMEBOY_LF_MESSAGE", ""),
+    "fixable": fixable,
+    "fingerprint": hashlib.sha1(identity.encode("utf-8")).hexdigest(),
+    "excerpt": excerpt(root, file, line),
+}
+
+json.dump(record, sys.stdout, separators=(",", ":"), ensure_ascii=False)
+sys.stdout.write("\n")
+PYEOF
+}

--- a/src/core/extension/runtime/emit-test-failure.sh
+++ b/src/core/extension/runtime/emit-test-failure.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+
+# Core-materialized normalized TEST-FAILURE record emitter for extension runners.
+#
+# Every per-language test runner (rust/go/swift/nodejs) and the WordPress
+# parse-test-failures.php hand-build the same normalized failure record: a stable
+# identity, a sha256 fingerprint of that identity, a bounded output excerpt, and
+# an "infrastructure" fallback failure_type when no individual failures could be
+# parsed. This shim owns that record shape in one place so the per-language
+# runners can route through it and delete their copies with byte-identical output.
+#
+# Usage:
+#   source "${HOMEBOY_RUNTIME_EMIT_TEST_FAILURE:-/path/to/fallback}"
+#   homeboy_emit_test_failure \
+#       --test-id "suite::case" \
+#       --suite phpunit --file src/Foo.php --line 42 \
+#       --failure-type AssertionError \
+#       --message "Failed asserting that false is true" \
+#       --identity "rust:test:suite::case" \
+#       --stdout-excerpt "$(homeboy_test_failure_bound_excerpt "$RAW_OUTPUT")"
+#
+# Prints one normalized TEST-FAILURE JSON object (compact, single line) on stdout
+# with this exact key order — the shape per-language runners append/merge into the
+# test failures sidecar:
+#   {"test_id":..,"suite":..|null,"file":..|null,"line":..|null,"message":..,
+#    "failure_type":..,"fingerprint":<sha256(identity)>,
+#    "stdout_excerpt":..,"stderr_excerpt":..}
+#
+# Arguments:
+#   --test-id       fully-qualified test identifier (REQUIRED)
+#   --suite         suite/framework label (empty -> null)
+#   --file          normalized failure file path (empty -> null)
+#   --line          1-based line number (omitted/empty -> null, "0" -> 0)
+#   --message       human-readable failure message
+#   --failure-type  failure classification (default "test_failure"); pass
+#                   "infrastructure" for the infra-fallback record emitted when no
+#                   individual failures could be parsed
+#   --identity      identity string the fingerprint is sha256'd from. When omitted
+#                   the canonical identity is derived as the NUL-joined tuple of
+#                   test_id, file, line, failure_type, and the first message line
+#                   (matching the WordPress make_failure_fingerprint contract).
+#   --stdout-excerpt  bounded stdout excerpt (used verbatim; default "")
+#   --stderr-excerpt  bounded stderr excerpt (used verbatim; default "")
+#
+# Bounded excerpts: callers may pre-bound their captured output, or pipe it
+# through homeboy_test_failure_bound_excerpt, which reproduces the canonical
+# WordPress make_output_excerpt bound (first 40 lines, trimmed, capped at 4000
+# characters with a trailing ellipsis).
+
+homeboy_emit_test_failure_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+    if command -v python >/dev/null 2>&1; then
+        command -v python
+        return 0
+    fi
+    echo "[emit-test-failure] python3 or python is required" >&2
+    return 1
+}
+
+# Bound a raw output blob to the canonical sidecar excerpt shape: keep the first
+# 40 lines, trim surrounding whitespace, and cap the result at 4000 characters
+# (replacing the tail with "..."). Mirrors WordPress make_output_excerpt.
+homeboy_test_failure_bound_excerpt() {
+    local raw="${1:-}"
+
+    local python_bin
+    python_bin="$(homeboy_emit_test_failure_python)" || return 1
+
+    HOMEBOY_TF_RAW="$raw" "$python_bin" <<'PYEOF'
+import os
+import sys
+
+raw = os.environ.get("HOMEBOY_TF_RAW", "")
+excerpt = "\n".join(raw.split("\n")[:40]).strip()
+if len(excerpt) > 4000:
+    excerpt = excerpt[:3997] + "..."
+sys.stdout.write(excerpt)
+PYEOF
+}
+
+homeboy_emit_test_failure() {
+    local tf_test_id="" tf_suite="" tf_file="" tf_line="" tf_message="" \
+        tf_failure_type="test_failure" tf_identity="" tf_identity_set="0" \
+        tf_stdout_excerpt="" tf_stderr_excerpt=""
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --test-id) tf_test_id="${2:-}"; shift 2 ;;
+            --suite) tf_suite="${2:-}"; shift 2 ;;
+            --file) tf_file="${2:-}"; shift 2 ;;
+            --line) tf_line="${2:-}"; shift 2 ;;
+            --message) tf_message="${2:-}"; shift 2 ;;
+            --failure-type) tf_failure_type="${2:-test_failure}"; shift 2 ;;
+            --identity) tf_identity="${2:-}"; tf_identity_set="1"; shift 2 ;;
+            --stdout-excerpt) tf_stdout_excerpt="${2:-}"; shift 2 ;;
+            --stderr-excerpt) tf_stderr_excerpt="${2:-}"; shift 2 ;;
+            *)
+                echo "[emit-test-failure] unknown argument: $1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [ -z "$tf_test_id" ]; then
+        echo "[emit-test-failure] --test-id is required" >&2
+        return 2
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_emit_test_failure_python)" || return 1
+
+    HOMEBOY_TF_TEST_ID="$tf_test_id" \
+    HOMEBOY_TF_SUITE="$tf_suite" \
+    HOMEBOY_TF_FILE="$tf_file" \
+    HOMEBOY_TF_LINE="$tf_line" \
+    HOMEBOY_TF_MESSAGE="$tf_message" \
+    HOMEBOY_TF_FAILURE_TYPE="$tf_failure_type" \
+    HOMEBOY_TF_IDENTITY="$tf_identity" \
+    HOMEBOY_TF_IDENTITY_SET="$tf_identity_set" \
+    HOMEBOY_TF_STDOUT_EXCERPT="$tf_stdout_excerpt" \
+    HOMEBOY_TF_STDERR_EXCERPT="$tf_stderr_excerpt" \
+    "$python_bin" <<'PYEOF'
+import hashlib
+import json
+import os
+import sys
+
+test_id = os.environ.get("HOMEBOY_TF_TEST_ID", "")
+suite = os.environ.get("HOMEBOY_TF_SUITE", "")
+file = os.environ.get("HOMEBOY_TF_FILE", "")
+line_raw = os.environ.get("HOMEBOY_TF_LINE", "")
+message = os.environ.get("HOMEBOY_TF_MESSAGE", "")
+failure_type = os.environ.get("HOMEBOY_TF_FAILURE_TYPE", "") or "test_failure"
+
+line = None
+if line_raw != "":
+    try:
+        line = int(line_raw)
+    except ValueError:
+        line = None
+
+if os.environ.get("HOMEBOY_TF_IDENTITY_SET", "0") == "1":
+    identity = os.environ.get("HOMEBOY_TF_IDENTITY", "")
+else:
+    first_message_line = message.split("\n", 1)[0]
+    line_part = str(line) if line is not None else ""
+    identity = "\0".join([test_id, file, line_part, failure_type, first_message_line])
+
+record = {
+    "test_id": test_id,
+    "suite": suite or None,
+    "file": file or None,
+    "line": line,
+    "message": message,
+    "failure_type": failure_type,
+    "fingerprint": hashlib.sha256(identity.encode("utf-8")).hexdigest(),
+    "stdout_excerpt": os.environ.get("HOMEBOY_TF_STDOUT_EXCERPT", ""),
+    "stderr_excerpt": os.environ.get("HOMEBOY_TF_STDERR_EXCERPT", ""),
+}
+
+json.dump(record, sys.stdout, separators=(",", ":"), ensure_ascii=False)
+sys.stdout.write("\n")
+PYEOF
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -13,6 +13,8 @@ pub const COMMAND_CAPTURE_ENV: &str = "HOMEBOY_RUNTIME_COMMAND_CAPTURE";
 pub const BASH_PREFLIGHT_ENV: &str = "HOMEBOY_RUNTIME_BASH_PREFLIGHT";
 pub const FAILURE_TRAP_ENV: &str = "HOMEBOY_RUNTIME_FAILURE_TRAP";
 pub const WRITE_TEST_RESULTS_ENV: &str = "HOMEBOY_RUNTIME_WRITE_TEST_RESULTS";
+pub const EMIT_LINT_FINDING_ENV: &str = "HOMEBOY_RUNTIME_EMIT_LINT_FINDING";
+pub const EMIT_TEST_FAILURE_ENV: &str = "HOMEBOY_RUNTIME_EMIT_TEST_FAILURE";
 pub const SIDECAR_WRITER_ENV: &str = "HOMEBOY_RUNTIME_SIDECAR_WRITER";
 pub const RESOLVE_CONTEXT_ENV: &str = "HOMEBOY_RUNTIME_RESOLVE_CONTEXT";
 pub const BENCH_HELPER_SH_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_SH";
@@ -61,6 +63,18 @@ const HELPERS: &[RuntimeHelper] = &[
         filename: "write-test-results.sh",
         content: assets::WRITE_TEST_RESULTS_SH,
         env_var: WRITE_TEST_RESULTS_ENV,
+        legacy_fallback: false,
+    },
+    RuntimeHelper {
+        filename: "emit-lint-finding.sh",
+        content: assets::EMIT_LINT_FINDING_SH,
+        env_var: EMIT_LINT_FINDING_ENV,
+        legacy_fallback: false,
+    },
+    RuntimeHelper {
+        filename: "emit-test-failure.sh",
+        content: assets::EMIT_TEST_FAILURE_SH,
+        env_var: EMIT_TEST_FAILURE_ENV,
         legacy_fallback: false,
     },
     RuntimeHelper {

--- a/src/core/extension/runtime_helper/assets.rs
+++ b/src/core/extension/runtime_helper/assets.rs
@@ -4,6 +4,8 @@ pub(super) const COMMAND_CAPTURE_SH: &str = include_str!("../runtime/command-cap
 pub(super) const BASH_PREFLIGHT_SH: &str = include_str!("../runtime/bash-preflight.sh");
 pub(super) const FAILURE_TRAP_SH: &str = include_str!("../runtime/failure-trap.sh");
 pub(super) const WRITE_TEST_RESULTS_SH: &str = include_str!("../runtime/write-test-results.sh");
+pub(super) const EMIT_LINT_FINDING_SH: &str = include_str!("../runtime/emit-lint-finding.sh");
+pub(super) const EMIT_TEST_FAILURE_SH: &str = include_str!("../runtime/emit-test-failure.sh");
 pub(super) const SIDECAR_WRITER_SH: &str = include_str!("../runtime/sidecar-writer.sh");
 pub(super) const RESOLVE_CONTEXT_SH: &str = include_str!("../runtime/resolve-context.sh");
 pub(super) const BENCH_HELPER_SH: &str = include_str!("../runtime/bench-helper.sh");
@@ -28,6 +30,8 @@ mod tests {
             BASH_PREFLIGHT_SH,
             FAILURE_TRAP_SH,
             WRITE_TEST_RESULTS_SH,
+            EMIT_LINT_FINDING_SH,
+            EMIT_TEST_FAILURE_SH,
             SIDECAR_WRITER_SH,
             RESOLVE_CONTEXT_SH,
             BENCH_HELPER_SH,

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -34,6 +34,14 @@ fn ensure_all_helpers_writes_all_files() {
             "write test results helper should be in pairs"
         );
         assert!(
+            pairs.iter().any(|(k, _)| k == EMIT_LINT_FINDING_ENV),
+            "emit lint finding helper should be in pairs"
+        );
+        assert!(
+            pairs.iter().any(|(k, _)| k == EMIT_TEST_FAILURE_ENV),
+            "emit test failure helper should be in pairs"
+        );
+        assert!(
             pairs.iter().any(|(k, _)| k == SIDECAR_WRITER_ENV),
             "sidecar writer helper should be in pairs"
         );
@@ -170,6 +178,247 @@ fn sidecar_writer_appends_and_merges_json_arrays() {
         r#"[{"tool":"lint","message":"one","fingerprint":"first"},{"tool":"lint","message":"two","fingerprint":"second"},{"tool":"lint","message":"three","fingerprint":"third"}]
 "#
     );
+}
+
+fn shasum_hex(algo: &str, identity: &str) -> String {
+    use std::io::Write;
+    let mut child = std::process::Command::new("shasum")
+        .arg("-a")
+        .arg(algo)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn shasum");
+    child
+        .stdin
+        .take()
+        .expect("shasum stdin")
+        .write_all(identity.as_bytes())
+        .expect("write identity");
+    let output = child.wait_with_output().expect("shasum output");
+    assert!(output.status.success(), "shasum should succeed");
+    String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .next()
+        .expect("hash field")
+        .to_string()
+}
+
+#[test]
+fn emit_lint_finding_shim_emits_normalized_record() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("emit-lint-finding.sh");
+    std::fs::write(&helper_path, assets::EMIT_LINT_FINDING_SH).expect("write helper");
+
+    // Line 1 is long enough to prove the 240-char excerpt truncation; line 2 is a
+    // normal short line.
+    let src_dir = dir.path().join("src");
+    std::fs::create_dir_all(&src_dir).expect("src dir");
+    let long_line = "a".repeat(300);
+    std::fs::write(src_dir.join("lib.rs"), format!("{long_line}\nlet x = 1;\n"))
+        .expect("write source");
+
+    let identity = "rust:clippy:src/lib.rs:1:5:unused:unused variable";
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; homeboy_emit_lint_finding --root {} --id '{}' --file src/lib.rs --line 1 --column 5 --severity warning --source clippy --code unused --category correctness --message 'unused variable' --fixable false",
+            helper_path.display(),
+            dir.path().display(),
+            identity
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let record: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("record is valid json");
+    assert_eq!(record["id"], identity);
+    assert_eq!(record["file"], "src/lib.rs");
+    assert_eq!(record["line"], 1);
+    assert_eq!(record["column"], 5);
+    assert_eq!(record["severity"], "warning");
+    assert_eq!(record["source"], "clippy");
+    assert_eq!(record["code"], "unused");
+    assert_eq!(record["category"], "correctness");
+    assert_eq!(record["message"], "unused variable");
+    assert_eq!(record["fixable"], false);
+
+    // Fingerprint matches the per-language builders byte-for-byte: sha1 of identity.
+    assert_eq!(
+        record["fingerprint"].as_str().expect("fingerprint string"),
+        shasum_hex("1", identity)
+    );
+
+    // Excerpt is the first 240 characters of the source line, like the reference builders.
+    let excerpt = record["excerpt"].as_str().expect("excerpt string");
+    assert_eq!(excerpt.chars().count(), 240);
+    assert_eq!(excerpt, "a".repeat(240));
+}
+
+#[test]
+fn emit_lint_finding_shim_null_excerpt_when_line_out_of_range() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("emit-lint-finding.sh");
+    std::fs::write(&helper_path, assets::EMIT_LINT_FINDING_SH).expect("write helper");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; homeboy_emit_lint_finding --root {} --id 'go:gofmt:missing.go:1' --file missing.go --line 1 --source gofmt --code formatting --category format --message 'File is not gofmt-formatted' --fixable true",
+            helper_path.display(),
+            dir.path().display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let record: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("record is valid json");
+    assert!(record["excerpt"].is_null(), "excerpt should be null");
+    assert_eq!(record["fixable"], true);
+}
+
+#[test]
+fn emit_test_failure_shim_uses_identity_override_for_fingerprint() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("emit-test-failure.sh");
+    std::fs::write(&helper_path, assets::EMIT_TEST_FAILURE_SH).expect("write helper");
+
+    // Identity override reproduces the per-language fingerprint (e.g. rust's
+    // sha256("rust:test:<name>")) byte-for-byte.
+    let identity = "rust:test:mymod::tests::it_works";
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; homeboy_emit_test_failure --test-id 'mymod::tests::it_works' --message 'Rust test failed: mymod::tests::it_works' --identity '{}' --stdout-excerpt 'tail'",
+            helper_path.display(),
+            identity
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let record: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("record is valid json");
+    assert_eq!(record["test_id"], "mymod::tests::it_works");
+    assert!(record["suite"].is_null(), "suite should be null when empty");
+    assert!(record["file"].is_null(), "file should be null when empty");
+    assert!(record["line"].is_null(), "line should be null when absent");
+    assert_eq!(record["failure_type"], "test_failure");
+    assert_eq!(record["stdout_excerpt"], "tail");
+    assert_eq!(record["stderr_excerpt"], "");
+    assert_eq!(
+        record["fingerprint"].as_str().expect("fingerprint string"),
+        shasum_hex("256", identity)
+    );
+}
+
+#[test]
+fn emit_test_failure_shim_derives_canonical_fingerprint_and_supports_infra_fallback() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("emit-test-failure.sh");
+    std::fs::write(&helper_path, assets::EMIT_TEST_FAILURE_SH).expect("write helper");
+
+    // No --identity: the shim derives the canonical NUL-joined identity
+    // [test_id, file, line, failure_type, first_message_line], matching the
+    // WordPress make_failure_fingerprint contract.
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; homeboy_emit_test_failure --test-id 'Foo::testBar' --suite phpunit --file src/Foo.php --line 42 --failure-type AssertionError --message 'Failed asserting that false is true.' --stdout-excerpt 'out'",
+            helper_path.display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let record: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("record is valid json");
+    assert_eq!(record["test_id"], "Foo::testBar");
+    assert_eq!(record["suite"], "phpunit");
+    assert_eq!(record["file"], "src/Foo.php");
+    assert_eq!(record["line"], 42);
+    assert_eq!(record["failure_type"], "AssertionError");
+
+    let identity = ["Foo::testBar", "src/Foo.php", "42", "AssertionError", "Failed asserting that false is true."]
+        .join("\0");
+    assert_eq!(
+        record["fingerprint"].as_str().expect("fingerprint string"),
+        shasum_hex("256", &identity)
+    );
+
+    // Infra-fallback record: failure_type is "infrastructure".
+    let infra = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; homeboy_emit_test_failure --test-id 'cargo test' --failure-type infrastructure --message 'cargo test failed before individual test failures could be parsed' --identity 'rust:cargo-test:failed'",
+            helper_path.display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        infra.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&infra.stderr)
+    );
+    let infra_record: serde_json::Value =
+        serde_json::from_slice(&infra.stdout).expect("infra record is valid json");
+    assert_eq!(infra_record["failure_type"], "infrastructure");
+    assert_eq!(
+        infra_record["fingerprint"].as_str().expect("fingerprint string"),
+        shasum_hex("256", "rust:cargo-test:failed")
+    );
+}
+
+#[test]
+fn emit_test_failure_bound_excerpt_matches_canonical_bound() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("emit-test-failure.sh");
+    std::fs::write(&helper_path, assets::EMIT_TEST_FAILURE_SH).expect("write helper");
+
+    // 50 lines of 200 chars each: first 40 lines kept, then capped at 4000 chars.
+    let raw: String = (0..50)
+        .map(|i| format!("{}-{}", i, "x".repeat(196)))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; homeboy_test_failure_bound_excerpt \"$RAW\"",
+            helper_path.display()
+        ))
+        .env("RAW", &raw)
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let excerpt = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(excerpt.chars().count(), 4000, "excerpt should cap at 4000 chars");
+    assert!(excerpt.ends_with("..."), "capped excerpt should end with ellipsis");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds two core-materialized runtime helper shims so downstream per-language runners stop hand-building normalized sidecar records. Both follow the existing `write-test-results.sh` shim pattern exactly (registered in `runtime_helper.rs` / `assets.rs`, injected via a `HOMEBOY_RUNTIME_*` env var).

### `emit-lint-finding.sh` (#6830)
Owns the normalized **LINT-FINDING** record: stable identity, its **sha1 fingerprint**, and the **240-character** source-line excerpt that `rust/go/swift/nodejs/wordpress` `lint-runner.sh` currently each reproduce by hand. Injected via `HOMEBOY_RUNTIME_EMIT_LINT_FINDING`. Emits one compact JSON record on stdout in the exact reference field order:
`{id, file, line, column, severity, source, code, category, message, fixable, fingerprint=sha1(id), excerpt=line[:240]|null}`.

### `emit-test-failure.sh` (#6831)
Owns the normalized **TEST-FAILURE** record: the **sha256 fingerprint** (caller-supplied `--identity`, reproducing each runner's existing identity byte-for-byte; or the canonical NUL-joined `[test_id, file, line, failure_type, first_message_line]` tuple matching the WordPress `make_failure_fingerprint` contract), a **bounded output excerpt** (`homeboy_test_failure_bound_excerpt` reproduces the canonical `make_output_excerpt` bound: first 40 lines, trimmed, capped at 4000 chars with ellipsis), and the **infrastructure fallback** `failure_type`. Injected via `HOMEBOY_RUNTIME_EMIT_TEST_FAILURE`. Emits:
`{test_id, suite|null, file|null, line|null, message, failure_type, fingerprint=sha256(identity), stdout_excerpt, stderr_excerpt}`.

The shared, byte-identical-preserving primitive across every runner is `fingerprint = hash(identity)` (sha1 for lint, sha256 for test-failure) where the caller passes its own identity string — so each per-language runner can route through the shim and keep its current fingerprints. The canonical derive path additionally gives a single source of truth matching the documented WordPress normalized contract.

**Additive only** — existing runtime helper behavior is unchanged.

## Reference shapes matched
- lint: `homeboy-extensions/{rust,go,swift,nodejs}/scripts/.../lint-runner.sh` (`fingerprint=sha1(identity)`, `excerpt=lines[line-1][:240]`)
- test-failure: `homeboy-extensions/{rust,go,swift,nodejs}/scripts/.../test-runner.sh` + `wordpress/scripts/test/parse-test-failures.php` (`fingerprint=sha256(identity)`, bounded excerpt, infra-fallback)

## Verification
- `cargo check` — passes (only pre-existing dead_code warnings).
- `cargo test --lib core::extension` — 654 passed, 0 failed.
- `cargo test --lib core::extension::runtime_helper` — 29 passed, including 5 new shim tests + the augmented all-helpers/embedded-asset tests.
- `bash -n` on both new shims — clean.
- New tests prove each shim's fingerprint equals an independent `shasum` of the identity, the 240-char lint excerpt truncation (and null on out-of-range line), the test-failure identity-override and canonical-derive sha256, the infra-fallback `failure_type`, and the canonical 4000-char excerpt bound.

## Follow-ups
- Route the per-language `lint-runner.sh` builders through `emit-lint-finding.sh` and delete the hand-rolled python record builders.
- Route the per-language `test-runner.sh` builders (and `wordpress/scripts/test/parse-test-failures.php`) through `emit-test-failure.sh` and delete their copies.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Reading the reference record builders, authoring both runtime shims and their registration/injection, and writing the verification tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)