### PR TITLE
feat(rig): lint-only entry point + array-merge mode for extends

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -121,6 +121,19 @@ enum RigCommand {
         #[arg(long, value_name = "CHECKOUT")]
         path: Option<String>,
     },
+    /// Lint a rig package without touching the environment.
+    ///
+    /// Runs ONLY the env-independent package lint (conflict markers, JSON
+    /// validity, and `extends` template materialization) — no requirements and
+    /// no live `check` probes. This is the entry point CI uses to validate a
+    /// rig package where no component checkouts exist.
+    Lint {
+        /// Rig ID, local package path, or direct rig.json path
+        target: String,
+        /// Select a rig from a local package path containing multiple rigs
+        #[arg(long)]
+        id: Option<String>,
+    },
     /// Tear down a rig: stop services and run its `down` pipeline
     Down {
         /// Rig ID
@@ -220,6 +233,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Show { rig_id } => show(&rig_id),
         RigCommand::Up { rig_id, dry_run } => up(&rig_id, dry_run),
         RigCommand::Check { target, id, path } => check(&target, id.as_deref(), path.as_deref()),
+        RigCommand::Lint { target, id } => lint(&target, id.as_deref()),
         RigCommand::Down { rig_id } => down(&rig_id),
         RigCommand::Repair { rig_id } => repair(&rig_id),
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
@@ -533,6 +547,31 @@ fn check(
     ))
 }
 
+fn lint(target: &str, id: Option<&str>) -> CmdResult<RigCommandOutput> {
+    let rig = if std::path::Path::new(target).exists() {
+        rig::load_local_source(target, id)?
+    } else {
+        if id.is_some() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "id",
+                "--id is only valid when linting a local package path",
+                id.map(str::to_string),
+                None,
+            ));
+        }
+        rig::load(target)?
+    };
+    let report = rig::run_lint(&rig)?;
+    let exit_code = if report.success { 0 } else { 1 };
+    Ok((
+        RigCommandOutput::Check(RigCheckOutput {
+            command: "rig.lint",
+            report,
+        }),
+        exit_code,
+    ))
+}
+
 fn apply_check_path_override(rig: &mut rig::RigSpec, path: &str) -> homeboy::core::Result<()> {
     if path.trim().is_empty() {
         return Err(homeboy::core::Error::validation_invalid_argument(
@@ -788,6 +827,65 @@ mod tests {
 
             assert_eq!(err.code.as_str(), "validation.invalid_argument");
             assert!(err.message.contains("bench.default_component"));
+        });
+    }
+
+    #[test]
+    fn lint_command_parses_target_and_id() {
+        let cli = TestCli::try_parse_from(["homeboy", "lint", "./pkg", "--id", "alpha"])
+            .expect("rig lint should parse");
+
+        let RigCommand::Lint { target, id } = cli.rig.command else {
+            panic!("expected rig lint command");
+        };
+        assert_eq!(target, "./pkg");
+        assert_eq!(id.as_deref(), Some("alpha"));
+    }
+
+    #[test]
+    fn lint_runs_package_lint_only_ignoring_requirements() {
+        crate::test_support::with_isolated_home(|home| {
+            write_rig(
+                home.path(),
+                "lint-cmd",
+                serde_json::json!({
+                    "id": "lint-cmd",
+                    "requirements": {
+                        "filesystem_assertions": [
+                            { "kind": "file", "path": "/definitely/missing/lint-cmd/marker.txt" }
+                        ]
+                    }
+                }),
+            );
+
+            // Full check fails on the missing requirement file.
+            let (_check, check_exit) = check("lint-cmd", None, None).expect("rig check runs");
+            assert_eq!(check_exit, 1, "missing requirement should fail rig check");
+
+            // The lint command skips requirements entirely and succeeds.
+            let (output, exit_code) = lint("lint-cmd", None).expect("rig lint runs");
+            assert_eq!(exit_code, 0);
+            let json = serde_json::to_value(output).expect("serialize lint output");
+            assert_eq!(json["payload"]["command"], "rig.lint");
+            assert_eq!(json["payload"]["success"], true);
+        });
+    }
+
+    #[test]
+    fn lint_rejects_id_for_installed_rig_id() {
+        crate::test_support::with_isolated_home(|home| {
+            write_rig(
+                home.path(),
+                "lint-id-guard",
+                serde_json::json!({ "id": "lint-id-guard" }),
+            );
+
+            let err = match lint("lint-id-guard", Some("alpha")) {
+                Ok(_) => panic!("--id against an installed rig id should fail"),
+                Err(err) => err,
+            };
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("local package path"));
         });
     }
 

--- a/src/core/rig/discovery.rs
+++ b/src/core/rig/discovery.rs
@@ -51,7 +51,11 @@ fn discover_rigs_matching(
 
     let single = package_path.join("rig.json");
     if single.is_file() {
-        rigs.push(discovered_from_path(&single, package_path.file_name())?);
+        rigs.push(discovered_from_path(
+            &single,
+            package_path.file_name(),
+            package_path,
+        )?);
     }
 
     let rigs_dir = package_path.join("rigs");
@@ -78,7 +82,7 @@ fn discover_rigs_matching(
                         continue;
                     }
                 }
-                rigs.push(discovered_from_path(&rig_path, path.file_name())?);
+                rigs.push(discovered_from_path(&rig_path, path.file_name(), package_path)?);
             }
         }
     }
@@ -162,10 +166,9 @@ fn discovered_stack_from_path(path: &Path) -> Result<DiscoveredStack> {
 fn discovered_from_path(
     path: &Path,
     fallback_name: Option<&std::ffi::OsStr>,
+    source_root: &Path,
 ) -> Result<DiscoveredRig> {
-    let content = fs::read_to_string(path)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("read rig spec".into())))?;
-    let mut spec = parse_discovered_rig_spec(path, &content)?;
+    let mut spec = parse_discovered_rig_spec(path, source_root)?;
     if spec.id.is_empty() {
         spec.id = fallback_name
             .and_then(|name| name.to_str())
@@ -186,14 +189,31 @@ fn discovered_from_path(
     })
 }
 
-fn parse_discovered_rig_spec(path: &Path, content: &str) -> Result<super::RigSpec> {
-    let value: serde_json::Value = serde_json::from_str(content).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some(format!("parse rig spec {}", path.display())),
-            Some(content.chars().take(200).collect()),
-        )
-    })?;
+/// Parse a discovered rig spec for identity/schema validation.
+///
+/// `extends` children are partial specs by design — they may legitimately omit
+/// required fields that a base template supplies, and they may carry
+/// post-materialization-only constructs such as the array-merge directive
+/// (`{ "$merge": "append" }`). Validating the raw child against the full schema
+/// would reject those, so when a spec declares `extends` we materialize it
+/// first (merging templates and stripping directives) and validate the
+/// resolved spec. Specs without `extends` keep the identical raw-parse schema
+/// gate so malformed specs still fail discovery with the same error shape.
+fn parse_discovered_rig_spec(path: &Path, source_root: &Path) -> Result<super::RigSpec> {
+    let value = match super::install::materialize_rig_spec(path, source_root)? {
+        Some(materialized) => materialized,
+        None => {
+            let content = fs::read_to_string(path)
+                .map_err(|e| Error::internal_io(e.to_string(), Some("read rig spec".into())))?;
+            serde_json::from_str(&content).map_err(|e| {
+                Error::validation_invalid_json(
+                    e,
+                    Some(format!("parse rig spec {}", path.display())),
+                    Some(content.chars().take(200).collect()),
+                )
+            })?
+        }
+    };
 
     serde_json::from_value(value).map_err(|e| {
         Error::validation_invalid_argument(

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -501,19 +501,116 @@ fn materialized_runner_source_root(path: &Path) -> Option<PathBuf> {
         .map(|window| window[1].to_path_buf())
 }
 
-fn merge_json(target: &mut serde_json::Value, overlay: serde_json::Value) {
-    match (target, overlay) {
-        (serde_json::Value::Object(target), serde_json::Value::Object(overlay)) => {
-            for (key, value) in overlay {
-                match target.get_mut(&key) {
-                    Some(existing) => merge_json(existing, value),
-                    None => {
-                        target.insert(key, value);
-                    }
-                }
+/// Opt-in array merge mode for `extends` template inheritance.
+///
+/// A child array selects a mode by placing a single directive object —
+/// `{ "$merge": "<mode>" }` — as its first element. Without a directive an
+/// overlay array fully replaces the base array, preserving the historical
+/// `extends` behavior for every existing consumer.
+#[derive(Clone, Copy)]
+enum ArrayMergeMode {
+    /// Base elements first, then the child's elements.
+    Append,
+    /// Child elements first, then the base's elements.
+    Prepend,
+    /// Merge by `label`: child elements deep-merge into the base element with
+    /// the same `label` (or append when no match / no label).
+    ByLabel,
+}
+
+const ARRAY_MERGE_DIRECTIVE_KEY: &str = "$merge";
+
+/// Detect a leading `{ "$merge": "<mode>" }` directive on an overlay array.
+///
+/// The directive object must be the array's first element and carry exactly the
+/// single `$merge` key so a real step that happens to set other fields is never
+/// misread as a directive.
+fn array_merge_mode(overlay: &[serde_json::Value]) -> Option<ArrayMergeMode> {
+    let directive = overlay.first()?.as_object()?;
+    if directive.len() != 1 {
+        return None;
+    }
+    match directive.get(ARRAY_MERGE_DIRECTIVE_KEY)?.as_str()? {
+        "append" => Some(ArrayMergeMode::Append),
+        "prepend" => Some(ArrayMergeMode::Prepend),
+        "by_label" => Some(ArrayMergeMode::ByLabel),
+        _ => None,
+    }
+}
+
+fn merge_array(target: &mut serde_json::Value, overlay: Vec<serde_json::Value>) {
+    let Some(mode) = array_merge_mode(&overlay) else {
+        *target = serde_json::Value::Array(overlay);
+        return;
+    };
+
+    // Strip the leading directive element; the remainder is the child payload.
+    let child: Vec<serde_json::Value> = overlay.into_iter().skip(1).collect();
+    let base = match target.take() {
+        serde_json::Value::Array(base) => base,
+        // No base array (key absent or a different type): the child payload
+        // stands alone, with append/prepend/by_label all collapsing to it.
+        _ => Vec::new(),
+    };
+
+    let merged = match mode {
+        ArrayMergeMode::Append => {
+            let mut merged = base;
+            merged.extend(child);
+            merged
+        }
+        ArrayMergeMode::Prepend => {
+            let mut merged = child;
+            merged.extend(base);
+            merged
+        }
+        ArrayMergeMode::ByLabel => merge_array_by_label(base, child),
+    };
+
+    *target = serde_json::Value::Array(merged);
+}
+
+fn merge_array_by_label(
+    base: Vec<serde_json::Value>,
+    child: Vec<serde_json::Value>,
+) -> Vec<serde_json::Value> {
+    let mut merged = base;
+    for item in child {
+        let label = item
+            .get("label")
+            .and_then(|label| label.as_str())
+            .map(str::to_string);
+        if let Some(label) = label {
+            if let Some(existing) = merged.iter_mut().find(|entry| {
+                entry.get("label").and_then(|label| label.as_str()) == Some(label.as_str())
+            }) {
+                merge_json(existing, item);
+                continue;
             }
         }
-        (target, overlay) => *target = overlay,
+        merged.push(item);
+    }
+    merged
+}
+
+fn merge_json(target: &mut serde_json::Value, overlay: serde_json::Value) {
+    match overlay {
+        serde_json::Value::Object(overlay) => {
+            if let serde_json::Value::Object(target) = target {
+                for (key, value) in overlay {
+                    match target.get_mut(&key) {
+                        Some(existing) => merge_json(existing, value),
+                        None => {
+                            target.insert(key, value);
+                        }
+                    }
+                }
+            } else {
+                *target = serde_json::Value::Object(overlay);
+            }
+        }
+        serde_json::Value::Array(overlay) => merge_array(target, overlay),
+        overlay => *target = overlay,
     }
 }
 

--- a/src/core/rig/lint.rs
+++ b/src/core/rig/lint.rs
@@ -9,10 +9,18 @@ use super::pipeline::{PipelineOutcome, PipelineStepOutcome};
 use super::spec::RigSpec;
 use crate::core::error::{Error, Result};
 
+/// Directories the rig package lint never descends into.
+///
+/// This MUST stay the union of the directories the downstream
+/// `homeboy-rigs` linter ignores (`scripts/lint-rig-packages.mjs`) so a rig
+/// package can never pass one linter and fail the other. `.sampleplugin` holds
+/// generated WP Codebox sample-plugin scaffolds; `.datamachine` is the
+/// top-level Data Machine working directory the homeboy-rigs package carries.
 const IGNORED_DIRECTORIES: &[&str] = &[
     ".git",
     ".claude",
     ".sampleplugin",
+    ".datamachine",
     ".opencode",
     "node_modules",
     "vendor",

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -55,7 +55,7 @@ pub use lease::{acquire_active_run_lease, active_run_leases, ActiveRigRunLease, 
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
     head_sha_and_branch, run_bench_prepare, run_check, run_check_groups, run_down,
-    run_fuzz_prepare, run_repair, run_status, run_up, snapshot_state, BenchPrepareReport,
+    run_fuzz_prepare, run_lint, run_repair, run_status, run_up, snapshot_state, BenchPrepareReport,
     CheckReport, DownReport, FuzzPrepareReport, RepairReport, RepairResourceReport,
     RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
 };

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -229,6 +229,33 @@ pub fn run_check(rig: &RigSpec) -> Result<CheckReport> {
     result
 }
 
+/// Run ONLY the env-independent rig package lint.
+///
+/// Unlike [`run_check`], this skips `evaluate_requirements` and the live
+/// `check` probe pipeline (HTTP/command/file probes) entirely. It runs just the
+/// `run_package_lint` walk/conflict/JSON/template-materialize checks, which
+/// depend only on the package contents on disk — no component checkouts,
+/// services, or network.
+///
+/// This is the CI-friendly entry point: in CI no component checkouts exist, so
+/// `run_check`'s requirement step always fails, making it unusable as a pure
+/// package linter. `run_lint` validates package structure with zero environment
+/// dependencies.
+///
+/// Like [`run_check_groups`], it intentionally does not update `last_check`: a
+/// package lint is not proof that the whole rig passed `homeboy rig check`.
+pub fn run_lint(rig: &RigSpec) -> Result<CheckReport> {
+    let outcome = run_package_lint(rig)?;
+
+    Ok(CheckReport {
+        rig_id: rig.id.clone(),
+        run_id: None,
+        success: outcome.is_success(),
+        pipeline: outcome,
+        artifact_index: None,
+    })
+}
+
 fn merge_check_outcomes(outcomes: Vec<PipelineOutcome>) -> PipelineOutcome {
     let mut steps = Vec::new();
     let mut passed = 0;

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -2,7 +2,7 @@
 
 use crate::core::rig::{
     declared_id, discover_rigs, install, list, list_ids, load, load_local_source,
-    read_source_metadata, read_stack_source_metadata, run_check,
+    read_source_metadata, read_stack_source_metadata, run_check, run_lint,
 };
 use crate::core::ErrorCode;
 use crate::test_support::HomeGuard;
@@ -718,6 +718,286 @@ mod install_flows {
         assert!(workloads[0]
             .trace_span_metadata()
             .contains_key("phase.start_to_done"));
+    }
+
+    #[test]
+    fn run_lint_ignores_requirements_and_probes() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        write_rig(
+            package.path(),
+            "lint-only",
+            r#"{
+            "id": "lint-only",
+            "requirements": {
+                "filesystem_assertions": [
+                    { "kind": "file", "path": "/definitely/missing/lint-only/marker.txt" }
+                ]
+            },
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "missing marker", "file": "/definitely/missing/lint-only/marker.txt" }
+                ]
+            }
+        }"#,
+        );
+
+        install(package.path().to_str().unwrap(), None, false).expect("install");
+        let rig = load("lint-only").expect("load rig");
+
+        // Full check fails: the requirement file and probe file are both absent.
+        let check = run_check(&rig).expect("check report");
+        assert!(!check.success, "missing requirement should fail rig check");
+
+        // Lint-only ignores requirements and probes entirely; a clean package passes.
+        let lint = run_lint(&rig).expect("lint report");
+        assert!(
+            lint.success,
+            "lint should pass for a clean package regardless of requirements/probes"
+        );
+        assert!(
+            lint.pipeline
+                .steps
+                .iter()
+                .all(|step| step.kind == "rig-package-lint"),
+            "lint must run only package-lint steps, not requirement/probe steps"
+        );
+    }
+
+    #[test]
+    fn run_lint_reports_package_conflict_markers() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        write_rig(package.path(), "lint-conflict", &minimal_rig("lint-conflict"));
+        fs::write(package.path().join("conflicted.txt"), "<<<<<<< ours\n")
+            .expect("conflict fixture");
+
+        install(package.path().to_str().unwrap(), None, false).expect("install");
+        let rig = load("lint-conflict").expect("load rig");
+        let lint = run_lint(&rig).expect("lint report");
+
+        assert!(!lint.success, "conflict markers should fail rig lint");
+        assert!(lint.pipeline.steps.iter().any(|step| {
+            step.kind == "rig-package-lint"
+                && step.status == "fail"
+                && step
+                    .error
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("conflicted.txt")
+        }));
+    }
+
+    #[test]
+    fn run_lint_ignores_datamachine_directory() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        write_rig(package.path(), "lint-dm", &minimal_rig("lint-dm"));
+        let datamachine = package.path().join(".datamachine");
+        fs::create_dir_all(&datamachine).expect("datamachine dir");
+        fs::write(datamachine.join("notes.txt"), "<<<<<<< ours\n")
+            .expect("conflict inside ignored dir");
+
+        install(package.path().to_str().unwrap(), None, false).expect("install");
+        let rig = load("lint-dm").expect("load rig");
+        let lint = run_lint(&rig).expect("lint report");
+
+        assert!(
+            lint.success,
+            "conflict markers inside .datamachine must be ignored by the lint walk"
+        );
+    }
+
+    #[test]
+    fn install_appends_pipeline_steps_for_extends_with_merge_directive() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        fs::create_dir_all(package.path().join("templates")).expect("templates dir");
+        fs::write(
+            package.path().join("templates/base.json"),
+            r#"{
+            "description": "base rig",
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "npm available", "command": "npm --version" }
+                ]
+            }
+        }"#,
+        )
+        .expect("base template");
+        write_rig(
+            package.path(),
+            "appender",
+            r#"{
+            "extends": "../../templates/base.json",
+            "id": "appender",
+            "pipeline": {
+                "check": [
+                    { "$merge": "append" },
+                    { "kind": "check", "label": "wp codebox cli exists", "command": "wp-codebox --version" }
+                ]
+            }
+        }"#,
+        );
+
+        install(package.path().to_str().unwrap(), None, false).expect("install");
+
+        let installed_path = crate::core::paths::rig_config("appender").expect("rig config");
+        let installed = fs::read_to_string(&installed_path).expect("installed rig");
+        assert!(
+            !installed.contains("$merge"),
+            "merge directive must be stripped from the materialized spec"
+        );
+        let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
+        let labels: Vec<&str> = value["pipeline"]["check"]
+            .as_array()
+            .expect("check array")
+            .iter()
+            .map(|step| step["label"].as_str().expect("label"))
+            .collect();
+        assert_eq!(labels, vec!["npm available", "wp codebox cli exists"]);
+
+        // The materialized spec still parses as a rig (directive fully removed).
+        load("appender").expect("load appended rig");
+    }
+
+    #[test]
+    fn install_prepends_pipeline_steps_for_extends_with_merge_directive() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        fs::create_dir_all(package.path().join("templates")).expect("templates dir");
+        fs::write(
+            package.path().join("templates/base.json"),
+            r#"{
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "base last", "command": "echo base" }
+                ]
+            }
+        }"#,
+        )
+        .expect("base template");
+        write_rig(
+            package.path(),
+            "prepender",
+            r#"{
+            "extends": "../../templates/base.json",
+            "id": "prepender",
+            "pipeline": {
+                "check": [
+                    { "$merge": "prepend" },
+                    { "kind": "check", "label": "child first", "command": "echo child" }
+                ]
+            }
+        }"#,
+        );
+
+        install(package.path().to_str().unwrap(), None, false).expect("install");
+        let installed_path = crate::core::paths::rig_config("prepender").expect("rig config");
+        let installed = fs::read_to_string(&installed_path).expect("installed rig");
+        let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
+        let labels: Vec<&str> = value["pipeline"]["check"]
+            .as_array()
+            .expect("check array")
+            .iter()
+            .map(|step| step["label"].as_str().expect("label"))
+            .collect();
+        assert_eq!(labels, vec!["child first", "base last"]);
+    }
+
+    #[test]
+    fn install_merges_pipeline_steps_by_label_for_extends() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        fs::create_dir_all(package.path().join("templates")).expect("templates dir");
+        fs::write(
+            package.path().join("templates/base.json"),
+            r#"{
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "npm available", "command": "npm --version" },
+                    { "kind": "check", "label": "build", "command": "make build" }
+                ]
+            }
+        }"#,
+        )
+        .expect("base template");
+        write_rig(
+            package.path(),
+            "keyed",
+            r#"{
+            "extends": "../../templates/base.json",
+            "id": "keyed",
+            "pipeline": {
+                "check": [
+                    { "$merge": "by_label" },
+                    { "kind": "check", "label": "build", "command": "make build --fast" },
+                    { "kind": "check", "label": "lint", "command": "make lint" }
+                ]
+            }
+        }"#,
+        );
+
+        install(package.path().to_str().unwrap(), None, false).expect("install");
+        let installed_path = crate::core::paths::rig_config("keyed").expect("rig config");
+        let installed = fs::read_to_string(&installed_path).expect("installed rig");
+        let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
+        let checks = value["pipeline"]["check"].as_array().expect("check array");
+        let labels: Vec<&str> = checks
+            .iter()
+            .map(|step| step["label"].as_str().expect("label"))
+            .collect();
+        // Base order preserved, the overridden "build" stays in place, "lint" appended.
+        assert_eq!(labels, vec!["npm available", "build", "lint"]);
+        let build = checks
+            .iter()
+            .find(|step| step["label"] == "build")
+            .expect("build step");
+        assert_eq!(build["command"], "make build --fast");
+    }
+
+    #[test]
+    fn install_replaces_pipeline_steps_for_extends_without_merge_directive() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        fs::create_dir_all(package.path().join("templates")).expect("templates dir");
+        fs::write(
+            package.path().join("templates/base.json"),
+            r#"{
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "base only", "command": "echo base" }
+                ]
+            }
+        }"#,
+        )
+        .expect("base template");
+        write_rig(
+            package.path(),
+            "replacer",
+            r#"{
+            "extends": "../../templates/base.json",
+            "id": "replacer",
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "child only", "command": "echo child" }
+                ]
+            }
+        }"#,
+        );
+
+        install(package.path().to_str().unwrap(), None, false).expect("install");
+        let installed_path = crate::core::paths::rig_config("replacer").expect("rig config");
+        let installed = fs::read_to_string(&installed_path).expect("installed rig");
+        let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
+        let labels: Vec<&str> = value["pipeline"]["check"]
+            .as_array()
+            .expect("check array")
+            .iter()
+            .map(|step| step["label"].as_str().expect("label"))
+            .collect();
+        // Default behavior unchanged: no directive means the child array wins wholesale.
+        assert_eq!(labels, vec!["child only"]);
     }
 }
 


### PR DESCRIPTION
Grows two Homeboy core rig primitives so downstream rig packages can consume them. Both changes are additive — existing rig behavior stays green.

## Task 1 — lint-only rig entry point + ignore-set reconcile (#6825)

`homeboy rig check` merges `evaluate_requirements` + `run_package_lint` + the live `check` probe pipeline. In CI no component checkouts exist, so the requirement step always fails — making `rig check` unusable as a package linter.

- New `homeboy rig lint <target>` command and `rig::run_lint`, which run ONLY `run_package_lint` (the env-independent walk/conflict-marker/JSON/template-materialize checks). No requirements, no HTTP/command/file probes, no `last_check` mutation.
- Reconciled core's `IGNORED_DIRECTORIES` to add `.datamachine`, so core and the homeboy-rigs linter (`scripts/lint-rig-packages.mjs`) ignore the same union of directories.

Unblocks the downstream rig-linter strip (#6783): CI calls the lint-only command and the homeboy-rigs `.mjs` drops its generic walk.

## Task 2 — array-append / keyed-step merge for `extends` (#6828)

`merge_json` replaced arrays wholesale, so a base `pipeline.check`/`pipeline.up` array was fully clobbered by the child's — interleaved steps couldn't be shared.

- Opt-in merge directive: a child array selects a non-default mode with a leading `{ "$merge": "append" | "prepend" | "by_label" }` element.
  - `append` — base steps, then child steps.
  - `prepend` — child steps, then base steps.
  - `by_label` — child steps deep-merge into base steps with the same `label`, else append (preserves base order).
- Default stays **replace** — no directive means existing `extends` behavior is unchanged.
- Discovery now validates the **materialized** spec for `extends` children (which are partial by design and may carry post-materialization-only directives) instead of the raw partial child. Specs without `extends` keep the identical raw-parse schema gate, so malformed specs still fail discovery with the same error shape.

Unblocks collapsing the cross-product `"WP Codebox CLI exists"`×6 / `"npm available"`×9 check boilerplate via a shared base.

## Follow-ups this unblocks
- #6783 — downstream rig-linter strip: CI consumes `rig lint`; the homeboy-rigs `.mjs` drops its generic walk.
- #6828 consumers — collapse the cross-product check boilerplate in homeboy-rigs / studio rig packages onto a shared base using `$merge`.

Umbrella: #6783 / #6681.

## Verification
- `cargo check` — clean (pre-existing warnings only).
- `cargo test --lib core::rig` — 320 passed, 0 failed.
- `cargo test --lib commands::rig` — 12 passed (3 new lint command tests).
- `cargo test --lib command_contract` — 44 passed.

New tests cover: lint runs package-lint only (ignoring requirements/probes), reports conflict markers, ignores `.datamachine`; the `rig lint` command skips requirements and rejects `--id` for installed rig ids; and the append/prepend/by_label/default-replace `extends` merge semantics.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Implementation of the lint-only command, `.datamachine` ignore reconcile, array-merge directive, discovery materialization fix, and tests.