### PR TITLE
refactor: extract gh-actions fs writes to core (thin command adapter)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -681,8 +681,7 @@
         "test_quality::src/core/runner/execution/tests/secret_source.rs::VacuousTest",
         "test_quality::tests/command_surface_test.rs::VacuousTest",
         "thin_command_adapter::src/commands/observe.rs::ThinCommandAdapterViolation",
-        "thin_command_adapter::src/commands/review/mod.rs::ThinCommandAdapterViolation",
-        "thin_command_adapter::src/commands/runs/gh_actions.rs::ThinCommandAdapterViolation"
+        "thin_command_adapter::src/commands/review/mod.rs::ThinCommandAdapterViolation"
       ],
       "metadata": {
         "alignment_score": 0.9021739363670349,

--- a/src/commands/runs/gh_actions.rs
+++ b/src/commands/runs/gh_actions.rs
@@ -199,8 +199,12 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
                     continue;
                 }
 
-                let stored_path =
-                    persist_artifact_file(&homeboy_run_id, &artifact_id, &file_name, &json_bytes)?;
+                let stored_path = homeboy::core::gh_actions_cache::persist_artifact_file(
+                    &homeboy_run_id,
+                    &artifact_id,
+                    &file_name,
+                    &json_bytes,
+                )?;
                 let sha = format!("{:x}", Sha256::digest(&json_bytes));
                 let size = i64::try_from(json_bytes.len()).ok();
                 let artifact_record = homeboy::core::observation::ArtifactRecord {
@@ -460,13 +464,12 @@ fn list_workflow_runs(
     let (etag, body) = split_headers_and_body(&raw);
 
     // Persist body and ETag for the next invocation.
-    if let Some(parent) = body_path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
-    let _ = fs::write(&body_path, body.as_bytes());
-    if let Some(value) = etag {
-        let _ = fs::write(&etag_path, value);
-    }
+    homeboy::core::gh_actions_cache::write_runs_cache(
+        &body_path,
+        &etag_path,
+        body.as_bytes(),
+        etag.as_deref(),
+    );
 
     let runs = parse_runs_payload(body.as_bytes())?;
     let runs = filter_runs_by_since(runs, since)?;
@@ -697,40 +700,8 @@ fn unpack_json_files_from_zip(zip_bytes: &[u8]) -> homeboy::core::Result<Vec<(St
     Ok(out)
 }
 
-// ── Local persistence ───────────────────────────────────────────────────────
-
-fn persist_artifact_file(
-    homeboy_run_id: &str,
-    artifact_id: &str,
-    file_name: &str,
-    bytes: &[u8],
-) -> homeboy::core::Result<PathBuf> {
-    let safe_name = sanitize_file_name(file_name);
-    let target_dir = crate::core::paths::homeboy_data()?
-        .join("artifacts")
-        .join(homeboy_run_id);
-    fs::create_dir_all(&target_dir).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("create artifact dir {}", target_dir.display())),
-        )
-    })?;
-    let target = target_dir.join(format!("{artifact_id}-{safe_name}"));
-    fs::write(&target, bytes).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("write artifact file {}", target.display())),
-        )
-    })?;
-    Ok(target)
-}
-
 mod helpers {
     use super::*;
-
-    pub fn sanitize_file_name(raw: &str) -> String {
-        raw.replace(['/', '\\', '\0'], "_")
-    }
 
     pub fn list_runs_cache_key(repo: &str, workflow: &str) -> String {
         let composite = format!("{repo}::{workflow}");
@@ -739,16 +710,7 @@ mod helpers {
     }
 
     pub fn list_runs_cache_path(key: &str, ext: &str) -> homeboy::core::Result<PathBuf> {
-        let base = crate::core::paths::homeboy()?
-            .join("cache")
-            .join("gh-actions-runs");
-        fs::create_dir_all(&base).map_err(|e| {
-            Error::internal_io(
-                e.to_string(),
-                Some(format!("create cache dir {}", base.display())),
-            )
-        })?;
-        Ok(base.join(format!("{key}.{ext}")))
+        homeboy::core::gh_actions_cache::list_runs_cache_path(key, ext)
     }
 
     // ── Glob compilation ────────────────────────────────────────────────────

--- a/src/core/gh_actions_cache.rs
+++ b/src/core/gh_actions_cache.rs
@@ -1,0 +1,74 @@
+//! Filesystem persistence for GitHub Actions run ingestion.
+//!
+//! The `runs gh-actions` command is a thin adapter: it computes data and paths,
+//! then delegates artifact and HTTP-cache file writes to these helpers so the
+//! orchestration of directory creation and byte writes lives in core.
+
+use crate::core::error::{Error, Result};
+use crate::core::paths;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Sanitize an artifact file name so it cannot escape its target directory.
+pub fn sanitize_artifact_file_name(raw: &str) -> String {
+    raw.replace(['/', '\\', '\0'], "_")
+}
+
+/// Materialize a downloaded artifact file under the homeboy data dir.
+///
+/// Creates `<data>/artifacts/<homeboy_run_id>/` and writes
+/// `<artifact_id>-<safe_name>`, returning the written path. Errors propagate.
+pub fn persist_artifact_file(
+    homeboy_run_id: &str,
+    artifact_id: &str,
+    file_name: &str,
+    bytes: &[u8],
+) -> Result<PathBuf> {
+    let safe_name = sanitize_artifact_file_name(file_name);
+    let target_dir = paths::homeboy_data()?
+        .join("artifacts")
+        .join(homeboy_run_id);
+    fs::create_dir_all(&target_dir).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("create artifact dir {}", target_dir.display())),
+        )
+    })?;
+    let target = target_dir.join(format!("{artifact_id}-{safe_name}"));
+    fs::write(&target, bytes).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("write artifact file {}", target.display())),
+        )
+    })?;
+    Ok(target)
+}
+
+/// Compute (and ensure) the cache path for a list-runs cache entry.
+///
+/// Creates `<homeboy>/cache/gh-actions-runs/` and returns the path for
+/// `<key>.<ext>`. Errors propagate.
+pub fn list_runs_cache_path(key: &str, ext: &str) -> Result<PathBuf> {
+    let base = paths::homeboy()?.join("cache").join("gh-actions-runs");
+    fs::create_dir_all(&base).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("create cache dir {}", base.display())),
+        )
+    })?;
+    Ok(base.join(format!("{key}.{ext}")))
+}
+
+/// Persist the list-runs HTTP cache body and optional ETag for the next call.
+///
+/// Best-effort: directory creation and writes are ignored on failure to match
+/// the prior inline behavior (a failed cache write must not fail the command).
+pub fn write_runs_cache(body_path: &Path, etag_path: &Path, body: &[u8], etag: Option<&str>) {
+    if let Some(parent) = body_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(body_path, body);
+    if let Some(value) = etag {
+        let _ = fs::write(etag_path, value);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -86,6 +86,7 @@ pub mod finding;
 pub mod fleet;
 pub mod fuzz;
 pub mod gate;
+pub mod gh_actions_cache;
 pub mod git;
 pub mod http_api;
 pub(crate) mod http_probe;


### PR DESCRIPTION
Moves gh-actions artifact persistence (persist_artifact_file) and HTTP-cache file writes from src/commands/runs/gh_actions.rs into core, keeping the command a thin adapter. Clears the ThinCommandAdapter finding. Identical behavior (best-effort/propagating error semantics preserved). Verified cargo build --lib --tests exit 0.