### PR TITLE
fix(code-audit): grammar-drive the four starved fingerprint fields (#6826)

### DIFF
--- a/src/core/code_audit/core_fingerprint/mod.rs
+++ b/src/core/code_audit/core_fingerprint/mod.rs
@@ -34,11 +34,14 @@
 //! - Comment and string syntax
 //! - Block delimiters
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
 
-use crate::core::extension::grammar::{self, Grammar, Symbol};
-use crate::core::extension::{self, DeadCodeMarker, HookRef, UnusedParam};
+use crate::core::extension::grammar::{self, AggregateSeamConfig, Grammar, Symbol};
+use crate::core::extension::{
+    self, AggregateConstructionSeam, AggregateLiteral, CallSite, DeadCodeMarker, HookRef,
+    UnusedParam,
+};
 
 use super::conventions::Language;
 use super::fingerprint::FileFingerprint;
@@ -230,6 +233,14 @@ pub fn fingerprint_from_grammar(
     // --- Runtime-dispatched types (extension-owned grammar metadata) ---
     let runtime_dispatched_types = extract_runtime_dispatched_types(&symbols);
 
+    // --- Aggregate construction facts (grammar-driven) ---
+    let aggregate_construction_seams = extract_aggregate_construction_seams(&functions, grammar);
+    let aggregate_literals = extract_aggregate_literals(content, grammar);
+
+    // --- Hook/callback targets and call sites (grammar-driven) ---
+    let hook_callbacks = extract_hook_callbacks(content, grammar);
+    let call_sites = extract_call_sites(content, grammar);
+
     Some(FileFingerprint {
         relative_path: relative_path.to_string(),
         language,
@@ -251,14 +262,14 @@ pub fn fingerprint_from_grammar(
         unused_parameters,
         dead_code_markers,
         internal_calls,
-        call_sites: Vec::new(), // Core grammar engine doesn't extract call sites yet
+        call_sites,
         public_api,
-        hook_callbacks: Vec::new(), // Core grammar engine doesn't extract hook callbacks yet
+        hook_callbacks,
         runtime_dispatched_types,
         convention_tags: Vec::new(),
         trait_impl_methods,
-        aggregate_literals: Vec::new(),
-        aggregate_construction_seams: Vec::new(),
+        aggregate_literals,
+        aggregate_construction_seams,
     })
 }
 
@@ -299,8 +310,12 @@ struct FunctionInfo {
     /// that happen to start with `test_` are NOT actual tests.
     has_test_attr: bool,
     is_trait_impl: bool,
+    /// Owning aggregate type name when this function is an impl method.
+    /// `None` for free functions. Drives construction-seam recognition.
+    impl_type: Option<String>,
     params: String,
-    _start_line: usize,
+    /// 1-indexed declaration line. Used as the construction-seam source line.
+    start_line: usize,
 }
 
 /// Build a map of line ranges → impl context.
@@ -317,7 +332,7 @@ fn build_impl_contexts(symbols: &[Symbol]) -> Vec<ImplContext> {
             ImplContext {
                 line: s.line,
                 depth: s.depth,
-                _type_name: type_name,
+                type_name,
                 trait_name,
             }
         })
@@ -327,7 +342,7 @@ fn build_impl_contexts(symbols: &[Symbol]) -> Vec<ImplContext> {
 struct ImplContext {
     line: usize,
     depth: i32,
-    _type_name: String,
+    type_name: String,
     trait_name: Option<String>,
 }
 
@@ -433,18 +448,23 @@ fn extract_functions(
         let in_test_mod = is_in_test_range(symbol.line, test_range);
         let is_test = has_test_attr || in_test_mod;
 
-        // Determine if inside a trait impl by finding the nearest enclosing
-        // impl context (the last one that starts before this function at a
-        // shallower depth). Using `any()` was wrong — it matched unrelated
-        // impl blocks earlier in the file.
-        let is_trait_impl = if symbol.depth > 0 {
+        // Find the nearest enclosing impl context (the last one that starts
+        // before this function at a shallower depth). Using `any()` was wrong —
+        // it matched unrelated impl blocks earlier in the file. This drives both
+        // trait-impl detection and the owning type used for construction-seam
+        // recognition.
+        let enclosing_impl = if symbol.depth > 0 {
             impl_contexts
                 .iter()
                 .rfind(|ctx| ctx.depth < symbol.depth && ctx.line < symbol.line)
-                .is_some_and(|ctx| ctx.trait_name.as_ref().is_some_and(|t| !t.is_empty()))
         } else {
-            false
+            None
         };
+        let is_trait_impl = enclosing_impl
+            .is_some_and(|ctx| ctx.trait_name.as_ref().is_some_and(|t| !t.is_empty()));
+        let impl_type = enclosing_impl
+            .map(|ctx| ctx.type_name.clone())
+            .filter(|t| !t.is_empty());
 
         // Extract visibility
         let visibility = extract_fn_visibility(symbol);
@@ -462,8 +482,9 @@ fn extract_functions(
             is_test,
             has_test_attr,
             is_trait_impl,
+            impl_type,
             params,
-            _start_line: symbol.line,
+            start_line: symbol.line,
         });
     }
 
@@ -1039,6 +1060,357 @@ fn extract_hooks(symbols: &[Symbol], grammar: &Grammar) -> Vec<HookRef> {
     }
 
     hooks
+}
+
+// ============================================================================
+// Aggregate construction facts (grammar-driven)
+// ============================================================================
+
+/// Extract canonical aggregate construction seams from impl methods.
+///
+/// A seam is a method whose owning type and name match the grammar's
+/// construction-seam naming policy (e.g. `Config::new`, `Plan::from_parts`).
+/// Drives the `aggregate_construction_seams` fingerprint field consumed by the
+/// direct-aggregate-construction detector. Test functions and free functions
+/// with no owning type are excluded. Returns empty when the grammar declares no
+/// seam policy.
+fn extract_aggregate_construction_seams(
+    functions: &[FunctionInfo],
+    grammar: &Grammar,
+) -> Vec<AggregateConstructionSeam> {
+    let Some(cfg) = grammar.fingerprint.aggregate_seams.as_ref() else {
+        return Vec::new();
+    };
+
+    let mut seams = Vec::new();
+    let mut seen = HashSet::new();
+    for f in functions {
+        if f.is_test {
+            continue;
+        }
+        let Some(type_name) = f.impl_type.as_ref() else {
+            continue;
+        };
+        if !is_canonical_seam(&f.name, type_name, cfg) {
+            continue;
+        }
+        if seen.insert((type_name.clone(), f.name.clone())) {
+            seams.push(AggregateConstructionSeam {
+                type_name: type_name.clone(),
+                method: f.name.clone(),
+                line: f.start_line,
+            });
+        }
+    }
+
+    seams
+}
+
+/// Whether `method` is a canonical construction seam for `type_name` under the
+/// grammar's naming policy.
+fn is_canonical_seam(method: &str, type_name: &str, cfg: &AggregateSeamConfig) -> bool {
+    if cfg.method_names.iter().any(|name| name == method) {
+        return true;
+    }
+    if cfg
+        .method_prefixes
+        .iter()
+        .any(|prefix| method.starts_with(prefix.as_str()))
+    {
+        return true;
+    }
+    if !cfg.type_method_templates.is_empty() {
+        let snake = to_snake_case(type_name);
+        if cfg
+            .type_method_templates
+            .iter()
+            .any(|template| method == template.replace("{type}", &snake))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Convert a type name to snake_case (e.g. `DispatchPlan` → `dispatch_plan`).
+fn to_snake_case(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 4);
+    for (i, ch) in name.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if i > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Extract direct aggregate literal construction sites from raw content.
+///
+/// Drives the `aggregate_literals` fingerprint field. The grammar supplies the
+/// literal-site regex (capture 1 = type, capture 2 = body), the field regex
+/// (capture 1 = field name), the minimum field count, and an optional
+/// "skip if preceded by a definition keyword" guard. Returns empty when the
+/// grammar declares no literal policy.
+fn extract_aggregate_literals(content: &str, grammar: &Grammar) -> Vec<AggregateLiteral> {
+    let Some(cfg) = grammar.fingerprint.aggregate_literals.as_ref() else {
+        return Vec::new();
+    };
+    let Some(literal_re) = grammar::cached_regex(&cfg.pattern) else {
+        return Vec::new();
+    };
+    let Some(field_re) = grammar::cached_regex(&cfg.field_pattern) else {
+        return Vec::new();
+    };
+    let skip_before_re = cfg
+        .skip_before_pattern
+        .as_ref()
+        .and_then(|pattern| grammar::cached_regex(pattern));
+
+    let mut literals = Vec::new();
+    let mut seen: HashSet<(String, Vec<String>, usize)> = HashSet::new();
+
+    for caps in literal_re.captures_iter(content) {
+        let full = match caps.get(0) {
+            Some(m) => m,
+            None => continue,
+        };
+        let Some(type_match) = caps.get(1) else {
+            continue;
+        };
+        let type_name = type_match.as_str().to_string();
+        let before = &content[..full.start()];
+
+        // Skip type definitions (e.g. `struct Foo { ... }`); only construction
+        // sites count as literals.
+        if let Some(re) = &skip_before_re {
+            if re.is_match(window_suffix(before, cfg.skip_before_window)) {
+                continue;
+            }
+        }
+
+        let body = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+        let mut fields: Vec<String> = Vec::new();
+        for field_caps in field_re.captures_iter(body) {
+            if let Some(field) = field_caps.get(1) {
+                let field = field.as_str().to_string();
+                if !fields.contains(&field) {
+                    fields.push(field);
+                }
+            }
+        }
+        if fields.len() < cfg.min_fields {
+            continue;
+        }
+
+        let line = before.bytes().filter(|byte| *byte == b'\n').count() + 1;
+        let key = (type_name.clone(), fields.clone(), line);
+        if seen.insert(key) {
+            literals.push(AggregateLiteral {
+                type_name,
+                fields,
+                line,
+            });
+        }
+    }
+
+    literals
+}
+
+/// Return the last `window` characters of `s`. A `window` of 0 returns all of
+/// `s` (no limit), which is safe for end-anchored guard patterns.
+fn window_suffix(s: &str, window: usize) -> &str {
+    if window == 0 {
+        return s;
+    }
+    match s.char_indices().rev().nth(window - 1) {
+        Some((idx, _)) => &s[idx..],
+        None => s,
+    }
+}
+
+// ============================================================================
+// Hook callbacks and call sites (grammar-driven)
+// ============================================================================
+
+/// Extract framework runtime hook/callback registration targets from raw
+/// content.
+///
+/// Drives the `hook_callbacks` fingerprint field, which the dead-code detector
+/// uses to recognize that a function defined and hook-registered in the same
+/// file is live code invoked by the framework runtime. Each grammar pattern's
+/// first capture group is the callback name. Returns a sorted, de-duplicated
+/// list; empty when the grammar declares no hook-callback patterns.
+fn extract_hook_callbacks(content: &str, grammar: &Grammar) -> Vec<String> {
+    let patterns = &grammar.fingerprint.hook_callback_patterns;
+    if patterns.is_empty() {
+        return Vec::new();
+    }
+
+    let mut callbacks: BTreeSet<String> = BTreeSet::new();
+    for pattern in patterns {
+        let Some(re) = grammar::cached_regex(pattern) else {
+            continue;
+        };
+        for caps in re.captures_iter(content) {
+            if let Some(name) = caps.get(1) {
+                callbacks.insert(name.as_str().to_string());
+            }
+        }
+    }
+
+    callbacks.into_iter().collect()
+}
+
+/// Extract call sites with argument counts from raw content.
+///
+/// Drives the `call_sites` fingerprint field consumed by cross-file parameter
+/// analysis (dead-code) and deprecation-age reference counting. The grammar
+/// supplies call-match patterns (capture 1 = target, match ends at the opening
+/// delimiter), an optional declaration-line skip pattern, and target name
+/// prefixes to ignore. Patterns are applied in order per line; the first to
+/// record a `(target, line)` pair wins. Returns empty when the grammar declares
+/// no call-site policy.
+fn extract_call_sites(content: &str, grammar: &Grammar) -> Vec<CallSite> {
+    let Some(cfg) = grammar.fingerprint.call_sites.as_ref() else {
+        return Vec::new();
+    };
+    if cfg.patterns.is_empty() {
+        return Vec::new();
+    }
+
+    let skip_line_re = cfg
+        .skip_line_pattern
+        .as_ref()
+        .and_then(|pattern| grammar::cached_regex(pattern));
+    let skip_calls: HashSet<&str> = grammar
+        .fingerprint
+        .skip_calls
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let compiled: Vec<(Option<regex::Regex>, bool)> = cfg
+        .patterns
+        .iter()
+        .map(|pattern| (grammar::cached_regex(&pattern.regex), pattern.apply_skip_calls))
+        .collect();
+
+    let mut sites = Vec::new();
+    let mut seen: HashSet<(String, usize)> = HashSet::new();
+
+    for (idx, line) in content.split('\n').enumerate() {
+        let line_no = idx + 1;
+
+        // Declaration lines are signatures, not call sites.
+        if let Some(re) = &skip_line_re {
+            let trimmed = line.trim_start();
+            if re.find(trimmed).is_some_and(|m| m.start() == 0) {
+                continue;
+            }
+        }
+
+        for (re, apply_skip_calls) in &compiled {
+            let Some(re) = re else {
+                continue;
+            };
+            for caps in re.captures_iter(line) {
+                let Some(name_match) = caps.get(1) else {
+                    continue;
+                };
+                let name = name_match.as_str();
+                if cfg
+                    .skip_name_prefixes
+                    .iter()
+                    .any(|prefix| name.starts_with(prefix.as_str()))
+                {
+                    continue;
+                }
+                if *apply_skip_calls && skip_calls.contains(name) {
+                    continue;
+                }
+                let key = (name.to_string(), line_no);
+                if seen.contains(&key) {
+                    continue;
+                }
+                // The match ends at the opening delimiter; count args from there.
+                let full = match caps.get(0) {
+                    Some(m) => m,
+                    None => continue,
+                };
+                let remaining = &line[full.end().saturating_sub(1)..];
+                let Some(arg_count) = count_call_args(remaining) else {
+                    continue;
+                };
+                seen.insert(key);
+                sites.push(CallSite {
+                    target: name.to_string(),
+                    line: line_no,
+                    arg_count,
+                });
+            }
+        }
+    }
+
+    sites
+}
+
+/// Count the arguments in a call whose text begins at the opening `(`.
+///
+/// Tracks paren depth and counts top-level commas, honoring single/double
+/// quoted strings so commas and parens inside string literals do not skew the
+/// count. Returns `None` when the parentheses do not balance within `text`
+/// (e.g. a multi-line call), matching the reference behavior of skipping such
+/// call sites.
+fn count_call_args(text: &str) -> Option<usize> {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.first() != Some(&'(') {
+        return None;
+    }
+    let mut depth: i32 = 0;
+    let mut commas: usize = 0;
+    let mut has_content = false;
+    let mut in_single = false;
+    let mut in_double = false;
+    for i in 0..chars.len() {
+        let ch = chars[i];
+        if in_single {
+            if ch == '\'' && (i == 0 || chars[i - 1] != '\\') {
+                in_single = false;
+            }
+            continue;
+        }
+        if in_double {
+            if ch == '"' && (i == 0 || chars[i - 1] != '\\') {
+                in_double = false;
+            }
+            continue;
+        }
+        match ch {
+            '\'' => {
+                in_single = true;
+                has_content = true;
+            }
+            '"' => {
+                in_double = true;
+                has_content = true;
+            }
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(if has_content { commas + 1 } else { 0 });
+                }
+            }
+            ',' if depth == 1 => commas += 1,
+            c if depth == 1 && !c.is_whitespace() => has_content = true,
+            _ => {}
+        }
+    }
+
+    None
 }
 
 // ============================================================================

--- a/src/core/code_audit/core_fingerprint/tests.rs
+++ b/src/core/code_audit/core_fingerprint/tests.rs
@@ -868,3 +868,262 @@ mod tests {
         fp.methods
     );
 }
+
+// ============================================================================
+// Grammar-driven aggregate / hook-callback / call-site extraction (#6826)
+//
+// These prove the grammar engine now populates the four FileFingerprint fields
+// that were hardcoded to `Vec::new()` — starving the aggregate-construction,
+// dead-code, and deprecation-age detectors for every grammar-fingerprinted
+// Rust/PHP file. The grammar config below mirrors the per-language reference
+// fingerprint scripts (homeboy-extensions rust/wordpress fingerprint.sh), which
+// are the only prior producers of these fields and define the correct output.
+// ============================================================================
+
+/// Rust grammar extended with the construction-seam + aggregate-literal policy
+/// the reference Rust fingerprint script encodes.
+fn rust_aggregate_grammar() -> Grammar {
+    let mut grammar = rust_grammar();
+    grammar.fingerprint.aggregate_seams = Some(AggregateSeamConfig {
+        method_names: vec!["new".to_string(), "builder".to_string(), "default".to_string()],
+        method_prefixes: vec!["from_".to_string(), "for_".to_string(), "with_".to_string()],
+        type_method_templates: vec!["build_{type}".to_string(), "create_{type}".to_string()],
+    });
+    grammar.fingerprint.aggregate_literals = Some(grammar::AggregateLiteralConfig {
+        pattern: r"\b([A-Z][A-Za-z0-9_]*)\s*\{([^{};]*)\}".to_string(),
+        field_pattern: r"\b([a-z_][A-Za-z0-9_]*)\s*:".to_string(),
+        min_fields: 2,
+        skip_before_pattern: Some(r"(?:struct|enum|impl|trait|type|use)\s+$".to_string()),
+        skip_before_window: 80,
+    });
+    grammar
+}
+
+/// PHP metadata grammar extended with the hook-callback + call-site policy the
+/// reference WordPress fingerprint script encodes.
+fn php_callback_grammar() -> Grammar {
+    let mut grammar = php_metadata_grammar();
+    // Match the WordPress grammar's PHP call skip set so free-function call
+    // sites mirror the reference script.
+    grammar.fingerprint.skip_calls = [
+        "if", "while", "for", "foreach", "switch", "match", "catch", "return", "echo", "print",
+        "isset", "unset", "empty", "list", "array", "function", "class", "interface", "trait",
+        "new", "require", "require_once", "include", "include_once", "define", "defined", "die",
+        "exit", "eval", "compact", "extract", "var_dump", "print_r", "var_export",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    grammar.fingerprint.hook_callback_patterns = vec![
+        // add_action/add_filter/add_shortcode with string callback
+        r#"(?:add_action|add_filter|add_shortcode)\s*\([^,]+,\s*['"](\w+)['"]\s*[,)]"#.to_string(),
+        // ... with array( $this, 'method' )
+        r#"(?:add_action|add_filter|add_shortcode)\s*\([^,]+,\s*array\s*\(\s*\$this\s*,\s*['"](\w+)['"]\s*\)"#.to_string(),
+        // ... with [ $this, 'method' ]
+        r#"(?:add_action|add_filter|add_shortcode)\s*\([^,]+,\s*\[\s*\$this\s*,\s*['"](\w+)['"]\s*\]"#.to_string(),
+        // ... with __CLASS__ / self::class / static::class
+        r#"(?:add_action|add_filter|add_shortcode)\s*\([^,]+,\s*(?:array\s*\(|\[)\s*(?:__CLASS__|self::class|static::class)\s*,\s*['"](\w+)['"]"#.to_string(),
+        // register_(de)activation/uninstall hooks
+        r#"register_(?:activation|deactivation|uninstall)_hook\s*\([^,]+,\s*['"](\w+)['"]"#.to_string(),
+        // 'callback' => 'function_name'
+        r#"['"](?:callback|[a-z_]+_callback)['"]\s*=>\s*['"](\w+)['"]"#.to_string(),
+        // 'callback' => array( $this, 'method' )
+        r#"['"](?:callback|[a-z_]+_callback)['"]\s*=>\s*(?:array\s*\(|\[)\s*\$this\s*,\s*['"](\w+)['"]"#.to_string(),
+        // 'callback' => array( self::class, 'method' )
+        r#"['"](?:callback|[a-z_]+_callback)['"]\s*=>\s*(?:array\s*\(|\[)\s*(?:__CLASS__|self::class|static::class)\s*,\s*['"](\w+)['"]"#.to_string(),
+    ];
+    grammar.fingerprint.call_sites = Some(grammar::CallSiteConfig {
+        patterns: vec![
+            grammar::CallSitePattern {
+                regex: r"(?:\$this->|self::|static::|[A-Z]\w*::)(\w+)\s*\(".to_string(),
+                apply_skip_calls: false,
+            },
+            grammar::CallSitePattern {
+                regex: r"\b([a-z_]\w*)\s*\(".to_string(),
+                apply_skip_calls: true,
+            },
+        ],
+        skip_line_pattern: Some(
+            r"(?:public|protected|private|static|abstract|final|\s)*function\s".to_string(),
+        ),
+        skip_name_prefixes: vec!["test".to_string()],
+    });
+    grammar
+}
+
+#[test]
+fn grammar_engine_extracts_rust_aggregate_seams_and_literals() {
+    // Reference Rust fingerprint script output for this source:
+    //   aggregate_construction_seams: [{Config,new},{Config,from_parts}]
+    //   aggregate_literals:           [{Other,[x,y]}]
+    let grammar = rust_aggregate_grammar();
+    let content = r#"pub struct Config { a: String, b: usize }
+
+impl Config {
+    pub fn new(a: String) -> Self {
+        Self { a, b: 0 }
+    }
+    pub fn from_parts(a: String, b: usize) -> Config {
+        Config { a, b }
+    }
+    pub fn describe(&self) -> String {
+        self.a.clone()
+    }
+}
+
+pub fn build_something() -> Other {
+    Other { x: 1, y: 2 }
+}
+"#;
+
+    let fp = fingerprint_from_grammar(content, &grammar, "src/config.rs")
+        .expect("fingerprint should succeed");
+
+    // Seams: canonical constructors on Config — `new` (exact) and `from_parts`
+    // (from_ prefix). `describe` is not a seam; `build_something` is a free
+    // function with no owning type.
+    let mut seams: Vec<(String, String)> = fp
+        .aggregate_construction_seams
+        .iter()
+        .map(|s| (s.type_name.clone(), s.method.clone()))
+        .collect();
+    seams.sort();
+    assert_eq!(
+        seams,
+        vec![
+            ("Config".to_string(), "from_parts".to_string()),
+            ("Config".to_string(), "new".to_string()),
+        ],
+        "expected Config::new + Config::from_parts seams, got {:?}",
+        fp.aggregate_construction_seams
+    );
+
+    // Literals: only the explicit `Other { x: 1, y: 2 }` qualifies. The struct
+    // definition is skipped (preceded by `struct `), and `Self { a, b: 0 }` /
+    // `Config { a, b }` have fewer than two `field:` initializers.
+    let literals: Vec<(String, Vec<String>)> = fp
+        .aggregate_literals
+        .iter()
+        .map(|l| (l.type_name.clone(), l.fields.clone()))
+        .collect();
+    assert_eq!(
+        literals,
+        vec![("Other".to_string(), vec!["x".to_string(), "y".to_string()])],
+        "expected a single Other literal with fields [x, y], got {:?}",
+        fp.aggregate_literals
+    );
+}
+
+#[test]
+fn restored_aggregate_fields_make_construction_detector_fire() {
+    use crate::core::code_audit::detectors::aggregate_construction;
+
+    let grammar = rust_aggregate_grammar();
+    let def = r#"pub struct Widget { name: String, size: usize, active: bool }
+impl Widget {
+    pub fn new(name: String) -> Self {
+        Self { name, size: 0, active: false }
+    }
+}
+"#;
+    let usage = |var: &str| {
+        format!(
+            "pub fn make_{var}() -> Widget {{\n    Widget {{ name: n, size: s, active: t }}\n}}\n"
+        )
+    };
+
+    let fingerprints = vec![
+        fingerprint_from_grammar(def, &grammar, "src/widget.rs").unwrap(),
+        fingerprint_from_grammar(&usage("a"), &grammar, "src/a.rs").unwrap(),
+        fingerprint_from_grammar(&usage("b"), &grammar, "src/b.rs").unwrap(),
+        fingerprint_from_grammar(&usage("c"), &grammar, "src/c.rs").unwrap(),
+    ];
+
+    // With the fields populated, the seam (Widget::new) + three repeated inline
+    // literals across files trip the direct-aggregate-construction detector.
+    let refs: Vec<&FileFingerprint> = fingerprints.iter().collect();
+    let findings = aggregate_construction::run(&refs);
+    assert_eq!(
+        findings.len(),
+        1,
+        "expected the construction detector to fire, got {findings:?}"
+    );
+    assert!(
+        findings[0].description.contains("Widget"),
+        "finding should name the Widget aggregate: {}",
+        findings[0].description
+    );
+
+    // Proof of the regression: with the four fields empty (the pre-fix state),
+    // the very same files produce no finding — the detector was starved.
+    let starved: Vec<FileFingerprint> = fingerprints
+        .iter()
+        .cloned()
+        .map(|mut fp| {
+            fp.aggregate_literals.clear();
+            fp.aggregate_construction_seams.clear();
+            fp
+        })
+        .collect();
+    let starved_refs: Vec<&FileFingerprint> = starved.iter().collect();
+    assert!(
+        aggregate_construction::run(&starved_refs).is_empty(),
+        "with the fields empty the detector must not fire — proving the starvation"
+    );
+}
+
+#[test]
+fn grammar_engine_extracts_php_hook_callbacks_and_call_sites() {
+    // Reference WordPress fingerprint script output for this source:
+    //   hook_callbacks: ["handle"]
+    //   call_sites includes: {add_action, .., 2} and {compute, .., 2}
+    let grammar = php_callback_grammar();
+    let content = "<?php\nnamespace Sample;\n\nclass Plugin {\n    public function register() {\n        add_action( 'init', array( $this, 'handle' ) );\n        register_rest_route( 'ns/v1', '/x', array( 'callback' => array( $this, 'handle' ) ) );\n    }\n    public function handle( $request ) {\n        return $this->compute( 1, 2 );\n    }\n    public function compute( $a, $b ) {\n        return $a + $b;\n    }\n}\n";
+
+    let fp = fingerprint_from_grammar(content, &grammar, "inc/Plugin.php")
+        .expect("fingerprint should succeed");
+
+    assert_eq!(
+        fp.hook_callbacks,
+        vec!["handle".to_string()],
+        "expected the hook callback `handle` to be extracted, got {:?}",
+        fp.hook_callbacks
+    );
+
+    // add_action(...) is a free-function call with two top-level args.
+    assert!(
+        fp.call_sites
+            .iter()
+            .any(|cs| cs.target == "add_action" && cs.arg_count == 2),
+        "expected an add_action call site with arg_count 2, got {:?}",
+        fp.call_sites
+    );
+    // $this->compute( 1, 2 ) is a receiver-qualified call with two args.
+    assert!(
+        fp.call_sites
+            .iter()
+            .any(|cs| cs.target == "compute" && cs.arg_count == 2),
+        "expected a compute call site with arg_count 2, got {:?}",
+        fp.call_sites
+    );
+    // Declaration lines (`public function handle(...)`) are signatures, not
+    // call sites, and must not be recorded as calls.
+    assert!(
+        !fp.call_sites.iter().any(|cs| cs.target == "handle"),
+        "function declarations must not appear as call sites, got {:?}",
+        fp.call_sites
+    );
+}
+
+#[test]
+fn grammar_aggregate_fields_stay_empty_without_grammar_policy() {
+    // Without seam/literal/callback/call-site policy in the grammar, the engine
+    // emits nothing — language idioms stay grammar-owned, not baked into core.
+    let grammar = rust_grammar();
+    let content = "pub struct Config { a: usize }\nimpl Config {\n    pub fn new() -> Self { Self { a: 0 } }\n}\n";
+    let fp = fingerprint_from_grammar(content, &grammar, "src/config.rs").unwrap();
+    assert!(fp.aggregate_construction_seams.is_empty());
+    assert!(fp.aggregate_literals.is_empty());
+    assert!(fp.hook_callbacks.is_empty());
+    assert!(fp.call_sites.is_empty());
+}

--- a/src/core/extension/grammar/extract.rs
+++ b/src/core/extension/grammar/extract.rs
@@ -129,7 +129,7 @@ pub fn extract(content: &str, grammar: &Grammar) -> Vec<Symbol> {
 
 static REGEX_CACHE: OnceLock<Mutex<HashMap<String, Option<Regex>>>> = OnceLock::new();
 
-fn cached_regex(pattern: &str) -> Option<Regex> {
+pub(crate) fn cached_regex(pattern: &str) -> Option<Regex> {
     let cache = REGEX_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
 
     if let Some(cached) = cache

--- a/src/core/extension/grammar/mod.rs
+++ b/src/core/extension/grammar/mod.rs
@@ -31,11 +31,13 @@ pub use super::grammar_strings::find_unclosed_raw_string_on_line;
 use super::grammar_strings::{line_closes_regular_string, line_has_unclosed_regular_string};
 
 pub use extract::{extract, namespace, Symbol};
+pub(crate) use extract::cached_regex;
 pub use loading::{load_for_extension_path, load_grammar, load_grammar_json};
 pub use parser::{ContextualLine, Region, StructuralContext};
 pub use types::{
-    BlockSyntax, CommentSyntax, ConceptPattern, ContractGrammar, FingerprintGrammar, Grammar,
-    LanguageMeta, NamespaceDerivationConfig, StringSyntax, TypeConstructor, TypeDefault,
+    AggregateLiteralConfig, AggregateSeamConfig, BlockSyntax, CallSiteConfig, CallSitePattern,
+    CommentSyntax, ConceptPattern, ContractGrammar, FingerprintGrammar, Grammar, LanguageMeta,
+    NamespaceDerivationConfig, StringSyntax, TypeConstructor, TypeDefault,
 };
 
 #[cfg(test)]

--- a/src/core/extension/grammar/types.rs
+++ b/src/core/extension/grammar/types.rs
@@ -98,6 +98,109 @@ pub struct FingerprintGrammar {
     /// than a parsed source symbol.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace_derivation: Option<NamespaceDerivationConfig>,
+
+    /// Recognition rules for canonical aggregate construction seams (the
+    /// blessed constructors/builders for an aggregate type). Drives the
+    /// `aggregate_construction_seams` fingerprint field. Grammar owners declare
+    /// the naming policy; core stays language-agnostic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregate_seams: Option<AggregateSeamConfig>,
+
+    /// Recognition rules for direct aggregate literal construction sites. Drives
+    /// the `aggregate_literals` fingerprint field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregate_literals: Option<AggregateLiteralConfig>,
+
+    /// Patterns matching framework runtime hook/callback registrations. Each
+    /// regex's first capture group is the registered callback name. Drives the
+    /// `hook_callbacks` fingerprint field, which the dead-code detector uses to
+    /// recognize functions invoked by a framework runtime rather than by direct
+    /// calls.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hook_callback_patterns: Vec<String>,
+
+    /// Call-site extraction configuration. Drives the `call_sites` fingerprint
+    /// field consumed by cross-file parameter analysis and deprecation-age
+    /// reference counting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub call_sites: Option<CallSiteConfig>,
+}
+
+/// Recognition rules for canonical aggregate construction seams.
+///
+/// A construction seam is the canonical way to build an aggregate type — e.g.
+/// `Config::new`, `Plan::builder`, `Report::from_parts`. The grammar owner
+/// declares the naming policy so core never hardcodes language idioms.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AggregateSeamConfig {
+    /// Exact method names that are canonical seams (e.g. `new`, `builder`,
+    /// `default`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub method_names: Vec<String>,
+    /// Method-name prefixes that denote a canonical seam (e.g. `from_`, `for_`,
+    /// `with_`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub method_prefixes: Vec<String>,
+    /// Method-name templates derived from the snake_case type name. The literal
+    /// `{type}` is replaced with the aggregate type's snake_case form, e.g.
+    /// `build_{type}` matches `build_dispatch_plan` for type `DispatchPlan`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub type_method_templates: Vec<String>,
+}
+
+/// Recognition rules for direct aggregate literal construction sites.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AggregateLiteralConfig {
+    /// Regex matching a literal construction site. Capture group 1 is the
+    /// aggregate type name; capture group 2 is the literal body scanned for
+    /// field names.
+    pub pattern: String,
+    /// Regex matching a single initialized field inside the literal body.
+    /// Capture group 1 is the field name.
+    pub field_pattern: String,
+    /// Minimum number of distinct fields a literal must initialize to be
+    /// recorded.
+    #[serde(default)]
+    pub min_fields: usize,
+    /// Regex tested against the text immediately preceding a candidate match.
+    /// When it matches, the candidate is a type definition (not a literal) and
+    /// is skipped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_before_pattern: Option<String>,
+    /// Number of preceding characters fed to `skip_before_pattern`.
+    #[serde(default)]
+    pub skip_before_window: usize,
+}
+
+/// Recognition rules for call-site extraction with argument counting.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CallSiteConfig {
+    /// Call-match patterns. Each pattern's first capture group is the call
+    /// target, and the match must end at the call's opening delimiter so
+    /// argument counting can begin there. Patterns are applied in order on each
+    /// line; the first pattern to record a `(target, line)` pair wins.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub patterns: Vec<CallSitePattern>,
+    /// Regex identifying declaration lines (which are not call sites). A line
+    /// whose trimmed start matches is skipped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_line_pattern: Option<String>,
+    /// Call-target name prefixes whose calls are ignored (e.g. `test`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skip_name_prefixes: Vec<String>,
+}
+
+/// A single call-site match pattern.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CallSitePattern {
+    /// Regex whose first capture group is the call target and which ends at the
+    /// opening call delimiter.
+    pub regex: String,
+    /// When true, targets present in `skip_calls` are ignored. Use this for
+    /// bare free-function calls; leave false for receiver-qualified calls
+    /// (`$this->m(`, `Type::m(`) whose name space cannot collide with keywords.
+    #[serde(default)]
+    pub apply_skip_calls: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -131,6 +234,10 @@ impl FingerprintGrammar {
             && self.registration_skip_names.is_empty()
             && self.registration_skip_prefixes.is_empty()
             && self.namespace_derivation.is_none()
+            && self.aggregate_seams.is_none()
+            && self.aggregate_literals.is_none()
+            && self.hook_callback_patterns.is_empty()
+            && self.call_sites.is_none()
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #6826. The grammar fingerprint engine hardcoded four `FileFingerprint` fields to `Vec::new()` at `core_fingerprint/mod.rs`:

- `aggregate_literals`
- `aggregate_construction_seams`
- `hook_callbacks`
- `call_sites`

Because the grammar path **wins** fingerprint selection whenever a `grammar.toml` is present (`fingerprint.rs` tries the grammar engine first and only falls back to the extension script when it returns `None`), these fields were **already empty in production** for every grammar-fingerprinted `.rs`/`.php` file — silently starving the live detectors that consume them:

- `detectors/aggregate_construction.rs` — reads `aggregate_literals` + `aggregate_construction_seams`
- `dead_code.rs` — reads `hook_callbacks` + `call_sites`
- `detectors/deprecation_age.rs` — reads `call_sites`

## What changed

The engine now extracts all four fields from **grammar-owned policy**, mirroring the per-language reference fingerprint scripts (`homeboy-extensions` `rust/`+`wordpress/` `fingerprint.sh`) that were the only prior producers and define the correct output shape. New `FingerprintGrammar` config:

- **`aggregate_seams`** — exact method names, name prefixes, and snake_case type templates that recognize canonical construction seams on impl methods (e.g. `Config::new`, `Config::from_parts`, `build_{type}`).
- **`aggregate_literals`** — literal-site regex (capture 1 = type, 2 = body), field regex, minimum field count, and a "skip if preceded by a definition keyword" guard.
- **`hook_callback_patterns`** — regexes whose first capture group is a framework runtime callback target.
- **`call_sites`** — call-match patterns (capture 1 = target, match ends at the opening delimiter), a declaration-line skip pattern, skip-name prefixes, and per-pattern opt-in to the grammar `skip_calls` set; arguments are counted with a string-aware paren tracker ported from the reference script.

The owning impl type and declaration line are now threaded through `FunctionInfo` (computed once from the nearest enclosing impl context, alongside the existing trait-impl detection).

## Architecture / behavior restoration

- **Language idioms stay grammar-owned.** With no policy declared, all four fields stay empty — core never bakes in Rust/PHP syntax. Verified by `grammar_aggregate_fields_stay_empty_without_grammar_policy`.
- This restores a **starved** capability: once the companion `grammar.toml` policy lands in `homeboy-extensions` (the sibling fingerprint-to-core effort), the aggregate-construction / dead-code-suppression / deprecation-age detectors begin firing again for Rust/PHP. This change is the core half; it provides the generic grammar-driven extraction and unblocks deleting the ~1,280-line `fingerprint.sh` producers downstream.
- **Audit baseline unchanged.** `homeboy audit` reports identical state (`passed: false`, 9 outliers, alignment `0.9011`) with and without this change — no new findings, no `homeboy.json` update needed. (Production audit of homeboy's own Rust does not populate these fields until the extension `grammar.toml` carries the new policy.)

## Parity evidence (mandatory)

New tests in `core_fingerprint/tests.rs`, modeled on the existing parity test, build inline grammars carrying the policy the companion `grammar.toml` will ship and assert the engine emits the same four fields as the reference scripts:

- `grammar_engine_extracts_rust_aggregate_seams_and_literals` — seams `[{Config,new},{Config,from_parts}]`, literals `[{Other,[x,y]}]`.
- `grammar_engine_extracts_php_hook_callbacks_and_call_sites` — `hook_callbacks: ["handle"]`, call sites `{add_action,..,2}` + `{compute,..,2}`, with declaration lines excluded.
- `restored_aggregate_fields_make_construction_detector_fire` — the aggregate-construction detector fires on Rust input it previously missed, with a **negative control** clearing the fields to reproduce the starved (pre-fix) state where it does not fire.
- `grammar_aggregate_fields_stay_empty_without_grammar_policy` — core stays generic.

## Restored fields / languages

- Rust: `aggregate_construction_seams` + `aggregate_literals`
- PHP/WordPress: `hook_callbacks` + `call_sites`

## Follow-ups

- Companion `grammar.toml` policy for `rust/` + `wordpress/` in `homeboy-extensions` (carries the regexes/lists embedded in the parity tests here) to flip extraction on in production, then delete the `fingerprint.sh` producers.
- The reference WP script also folds `hook_callbacks` into `internal_calls`; left out here to keep the PR focused on the four fields (the dead-code detector reads `hook_callbacks` directly). Worth revisiting when the scripts are deleted.

## Verification

- `cargo check` — clean
- `cargo test --lib code_audit` — 773 passed, 0 failed
- `cargo test --lib core_fingerprint` — 38 passed (incl. 4 new), 0 failed
- `cargo test --lib aggregate_construction|deprecation_age|dead_code` — all pass

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Diagnosing the starved-field root cause, implementing the grammar-driven extraction for all four fields, and writing the parity + detector-restoration tests.