### PR TITLE
chore: annotate review thin-adapter false-positive

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -679,8 +679,7 @@
         "test_quality::src/core/runner/execution/tests/policy.rs::VacuousTest",
         "test_quality::src/core/runner/execution/tests/redaction.rs::VacuousTest",
         "test_quality::src/core/runner/execution/tests/secret_source.rs::VacuousTest",
-        "test_quality::tests/command_surface_test.rs::VacuousTest",
-        "thin_command_adapter::src/commands/review/mod.rs::ThinCommandAdapterViolation"
+        "test_quality::tests/command_surface_test.rs::VacuousTest"
       ],
       "metadata": {
         "alignment_score": 0.9021739363670349,

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -174,7 +174,7 @@ impl<Args, Output: Serialize + ReviewArtifactFindings> ReviewStageDescriptor<Arg
     }
 }
 
-fn dispatch_review_plan_step(
+fn dispatch_review_plan_step( // homeboy-audit: allow-thin-command-adapter
     step: &PlanStep,
     args: &ReviewArgs,
     global: &GlobalArgs,
@@ -304,8 +304,8 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
     let mut lint_stage = None;
     let mut test_stage = None;
 
-    let stage_run = match review::execute_review_plan_steps(&quality_plan.steps, |step| {
-        dispatch_review_plan_step(step, &args, global, &component_label, &review_context)
+    let stage_run = match review::execute_review_plan_steps(&quality_plan.steps, |step| { // homeboy-audit: allow-thin-command-adapter
+        dispatch_review_plan_step(step, &args, global, &component_label, &review_context) // homeboy-audit: allow-thin-command-adapter
     }) {
         Ok(run) => run,
         Err(error) => {


### PR DESCRIPTION
src/commands/review/mod.rs already delegates review execution to the core review::execute_review_plan_steps service with no process/fs/persistence orchestration. The ThinCommandAdapter finding is a false positive from the execute_*/dispatch_* function-name regex. Adds the sanctioned // homeboy-audit: allow-thin-command-adapter annotation to the triggering lines and clears the baseline row. No behavior change. This clears the LAST ThinCommandAdapter finding.