### PR TITLE
fix(report): hydrate remote matrix packets and accept run labels in report matrix-artifacts

### DIFF
--- a/src/commands/report/matrix_artifacts.rs
+++ b/src/commands/report/matrix_artifacts.rs
@@ -9,7 +9,7 @@ use homeboy::core::Error;
 
 #[derive(Args, Debug, Clone)]
 pub struct MatrixArtifactsArgs {
-    /// Observation run ID to summarize.
+    /// Observation run ID or the human `--run-id` launch label to summarize.
     pub run_id: String,
     /// Output format: json or markdown.
     #[arg(long, default_value = "markdown")]
@@ -26,29 +26,37 @@ pub fn matrix_artifacts_from_args(
     args: &MatrixArtifactsArgs,
 ) -> homeboy::core::Result<MatrixArtifactsReport> {
     let store = ObservationStore::open_initialized()?;
-    runs_service::require_run(&store, &args.run_id)?;
-    let artifacts = runs_service::list_artifacts_for_run(&store, &args.run_id)?;
+    // Accept either the observation UUID or the human `--run-id` launch label.
+    let run_id = runs_service::resolve_run_id_or_label(&store, &args.run_id)?;
+    let artifacts = runs_service::list_artifacts_for_run(&store, &run_id)?;
+    // Pull remote finding-packet / result packets to the operator-local
+    // artifact root so their real contents are summarized instead of 0.
+    let (artifacts, hydration_diagnostics) = runs_service::hydrate_remote_artifacts_via_runner(
+        artifacts,
+        homeboy::core::artifacts::is_matrix_summary_artifact,
+    );
     let findings = store.list_findings(FindingListFilter {
-        run_id: Some(args.run_id.clone()),
+        run_id: Some(run_id.clone()),
         tool: None,
         file: None,
         fingerprint: None,
         limit: Some(10_000),
     })?;
-    let summary = summarize_matrix_artifacts(&args.run_id, &artifacts, &findings).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "run_id",
-            format!(
-                "run {} does not expose matrix-style artifact metadata or JSON packets",
-                args.run_id
-            ),
-            Some(args.run_id.clone()),
-            Some(vec![
-                "Run `homeboy runs artifacts <run-id>` to inspect the raw artifact list.".to_string(),
-                "Matrix summaries are derived from artifact roles, filenames, schemas, fixtures, findings, and group counts.".to_string(),
-            ]),
-        )
-    })?;
+    let mut summary =
+        summarize_matrix_artifacts(&run_id, &artifacts, &findings).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_id",
+                format!(
+                    "run {run_id} does not expose matrix-style artifact metadata or JSON packets",
+                ),
+                Some(run_id.clone()),
+                Some(vec![
+                    "Run `homeboy runs artifacts <run-id>` to inspect the raw artifact list.".to_string(),
+                    "Matrix summaries are derived from artifact roles, filenames, schemas, fixtures, findings, and group counts.".to_string(),
+                ]),
+            )
+        })?;
+    summary.parse_diagnostics.extend(hydration_diagnostics);
     let markdown = render_matrix_artifact_summary_markdown(&summary);
     Ok(MatrixArtifactsReport { summary, markdown })
 }

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -53,9 +53,10 @@ pub use super::change_artifact::{
     CHANGE_APPLY_RESULT_SCHEMA, CHANGE_ARTIFACT_SCHEMA,
 };
 pub use super::matrix_artifact_summary::{
-    generic_matrix_summary_from_artifacts, render_matrix_artifact_summary_markdown,
-    summarize_matrix_artifacts, GenericMatrixSummary, MatrixArtifactSummary, MatrixSummaryCount,
-    GENERIC_MATRIX_SUMMARY_SCHEMA, MATRIX_ARTIFACT_SUMMARY_SCHEMA,
+    generic_matrix_summary_from_artifacts, is_matrix_summary_artifact,
+    render_matrix_artifact_summary_markdown, summarize_matrix_artifacts, GenericMatrixSummary,
+    MatrixArtifactSummary, MatrixSummaryCount, GENERIC_MATRIX_SUMMARY_SCHEMA,
+    MATRIX_ARTIFACT_SUMMARY_SCHEMA,
 };
 pub use super::publication_artifacts::index_remote_published_artifact_refs_for_run;
 pub use super::structured_sidecar::{

--- a/src/core/matrix_artifact_summary.rs
+++ b/src/core/matrix_artifact_summary.rs
@@ -340,6 +340,15 @@ struct ArtifactClass {
     is_finding_packet: bool,
 }
 
+/// Returns true when an artifact looks like a matrix result or finding-packet
+/// JSON artifact whose remote bytes are worth hydrating before summarizing.
+/// Used to scope remote-artifact hydration to the packets the matrix summary
+/// actually reads, instead of pulling unrelated runner binaries.
+pub fn is_matrix_summary_artifact(artifact: &ArtifactRecord) -> bool {
+    let class = classify_artifact(artifact);
+    class.is_matrix || class.is_result || class.is_finding_packet
+}
+
 fn classify_artifact(artifact: &ArtifactRecord) -> ArtifactClass {
     let mut tokens = vec![
         artifact.kind.as_str(),

--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -461,6 +461,171 @@ mod artifact_resolve {
         }
         ArtifactStorage::Other
     }
+
+    /// Hydrate remote runner artifacts into local-file artifact records by
+    /// downloading their bytes, so JSON summarizers (e.g. matrix-artifacts)
+    /// can parse remote finding-packets / result packets instead of seeing
+    /// an opaque `remote_file` they cannot read.
+    ///
+    /// `should_hydrate` selects which remote artifacts are worth a round-trip
+    /// (so we never pull unrelated binaries). `download` performs the actual
+    /// per-artifact runner round-trip — that is the live hop and is supplied
+    /// by [`hydrate_remote_artifacts_via_runner`] in production. Everything
+    /// around it (selection, record rewriting, diagnostics) is pure and unit
+    /// tested with a fake downloader.
+    ///
+    /// Failures never abort the pass: the original (un-hydrated) record is kept
+    /// and a diagnostic is recorded so the operator sees exactly which packet
+    /// was unreachable and why.
+    pub fn hydrate_remote_artifacts<P, F>(
+        artifacts: Vec<ArtifactRecord>,
+        mut should_hydrate: P,
+        mut download: F,
+    ) -> (Vec<ArtifactRecord>, Vec<String>)
+    where
+        P: FnMut(&ArtifactRecord) -> bool,
+        F: FnMut(&ArtifactRecord) -> Result<ArtifactFetchOutcome>,
+    {
+        let mut hydrated = Vec::with_capacity(artifacts.len());
+        let mut diagnostics = Vec::new();
+        for artifact in artifacts {
+            let is_remote = classify_artifact_storage(&artifact) == ArtifactStorage::Remote;
+            if !is_remote || !should_hydrate(&artifact) {
+                hydrated.push(artifact);
+                continue;
+            }
+            match download(&artifact) {
+                Ok(outcome) => {
+                    let mut record = artifact;
+                    record.artifact_type = "file".to_string();
+                    record.path = outcome.output_path.display().to_string();
+                    if record.mime.is_none() {
+                        record.mime = outcome.content_type;
+                    }
+                    if record.size_bytes.is_none() {
+                        record.size_bytes = outcome.size_bytes;
+                    }
+                    if record.sha256.is_none() {
+                        record.sha256 = outcome.sha256;
+                    }
+                    hydrated.push(record);
+                }
+                Err(err) => {
+                    diagnostics.push(format!(
+                        "remote artifact {} could not be hydrated for summary: {}",
+                        artifact.id, err.message
+                    ));
+                    hydrated.push(artifact);
+                }
+            }
+        }
+        (hydrated, diagnostics)
+    }
+
+    /// Hydrate remote artifacts using the live runner download path
+    /// (`download_remote_artifact`, the same mechanism `runs artifacts --pull`
+    /// uses). Convenience wrapper over [`hydrate_remote_artifacts`].
+    pub fn hydrate_remote_artifacts_via_runner<P>(
+        artifacts: Vec<ArtifactRecord>,
+        should_hydrate: P,
+    ) -> (Vec<ArtifactRecord>, Vec<String>)
+    where
+        P: FnMut(&ArtifactRecord) -> bool,
+    {
+        hydrate_remote_artifacts(artifacts, should_hydrate, |artifact| {
+            download_remote_artifact(artifact.clone(), None)
+        })
+    }
+
+    /// Resolve a run id *or* a human run label to an observation run id.
+    ///
+    /// First tries the value as a run id (local store or a mirrorable
+    /// connected-runner run). If that fails, scans connected runners' run
+    /// lists for a run whose human label matches and returns its observation
+    /// run id, so `report matrix-artifacts <my-run-id>` works as a one-liner
+    /// from the `--run-id` label the operator set at launch. When nothing
+    /// matches, the canonical missing-run error for the input is returned.
+    pub fn resolve_run_id_or_label(
+        store: &ObservationStore,
+        run_id_or_label: &str,
+    ) -> Result<String> {
+        if require_run(store, run_id_or_label).is_ok() {
+            return Ok(run_id_or_label.to_string());
+        }
+        if let Some(run) = find_run_by_label_on_connected_runners(run_id_or_label)? {
+            return Ok(run.id);
+        }
+        // No label match — surface the canonical missing-run error.
+        require_run(store, run_id_or_label).map(|run| run.id)
+    }
+
+    /// Scan connected runners' run lists for a run whose human label matches.
+    /// This is the live hop; the matching predicate [`match_run_label`] is pure.
+    fn find_run_by_label_on_connected_runners(label: &str) -> Result<Option<RunRecord>> {
+        for report in crate::core::runners::statuses()?
+            .into_iter()
+            .filter(|report| report.connected)
+        {
+            let Ok(data) =
+                crate::core::runners::daemon_api_get(&report.runner_id, "/runs?limit=200")
+            else {
+                continue;
+            };
+            let runs: Vec<RunRecord> =
+                serde_json::from_value(data["body"]["runs"].clone()).unwrap_or_default();
+            if let Some(run) = match_run_label(&runs, label) {
+                return Ok(Some(run));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Find the first run whose human label matches `label`. A run matches when
+    /// its id equals the label, its command carries `--run-id <label>`, or a
+    /// known metadata pointer (lab label / proof provenance) equals the label.
+    pub fn match_run_label(runs: &[RunRecord], label: &str) -> Option<RunRecord> {
+        runs.iter()
+            .find(|run| run_matches_label(run, label))
+            .cloned()
+    }
+
+    fn run_matches_label(run: &RunRecord, label: &str) -> bool {
+        if run.id == label {
+            return true;
+        }
+        if let Some(command) = run.command.as_deref() {
+            if command_run_id_label(command) == Some(label) {
+                return true;
+            }
+        }
+        for pointer in [
+            "/lab/run_label",
+            "/lab/explicit_run_id",
+            "/proof/provenance/run_id",
+            "/run_id",
+        ] {
+            if run.metadata_json.pointer(pointer).and_then(Value::as_str) == Some(label) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Parse the `--run-id <value>` proof label out of a command string.
+    fn command_run_id_label(command: &str) -> Option<&str> {
+        let mut expect_value = false;
+        for token in command.split_whitespace() {
+            if expect_value {
+                return (!token.is_empty()).then_some(token);
+            }
+            if token == "--run-id" {
+                expect_value = true;
+            } else if let Some(value) = token.strip_prefix("--run-id=") {
+                return (!value.is_empty()).then_some(value);
+            }
+        }
+        None
+    }
 }
 pub use artifact_resolve::*;
 
@@ -1029,5 +1194,202 @@ mod tests {
         );
         artifact.artifact_type = "url".into();
         assert_eq!(classify_artifact_storage(&artifact), ArtifactStorage::Other);
+    }
+
+    fn remote_artifact(id: &str, kind: &str) -> ArtifactRecord {
+        ArtifactRecord {
+            id: id.into(),
+            run_id: "run-1".into(),
+            kind: kind.into(),
+            artifact_type: "remote_file".into(),
+            path: format!("runner-artifact://homeboy-lab/run-1/{id}"),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: None,
+            metadata_json: serde_json::json!({ "role": "matrix-finding-packets" }),
+            created_at: "2026-06-26T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn hydrate_remote_artifacts_rewrites_remote_packets_into_readable_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let packet_path = temp.path().join("finding-packets.json");
+        std::fs::write(
+            &packet_path,
+            br#"{"finding_packets":[{"diagnostic_kind":"missing_title","fixture_id":"home"}]}"#,
+        )
+        .expect("write packet");
+
+        let local = ArtifactRecord {
+            id: "local".into(),
+            run_id: "run-1".into(),
+            kind: "summary".into(),
+            artifact_type: "file".into(),
+            path: temp.path().join("summary.json").display().to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: None,
+            metadata_json: Value::Null,
+            created_at: "2026-06-26T00:00:00Z".into(),
+        };
+        let remote = remote_artifact("finding-packets", "bench_artifact");
+
+        let mut downloads = 0;
+        let (hydrated, diagnostics) = hydrate_remote_artifacts(
+            vec![local.clone(), remote.clone()],
+            |_| true,
+            |artifact| {
+                downloads += 1;
+                assert_eq!(artifact.id, "finding-packets");
+                Ok(ArtifactFetchOutcome {
+                    run_id: artifact.run_id.clone(),
+                    artifact_id: artifact.id.clone(),
+                    output_path: packet_path.clone(),
+                    content_type: Some("application/json".into()),
+                    size_bytes: Some(42),
+                    sha256: None,
+                    artifact_ref: None,
+                })
+            },
+        );
+
+        // Only the remote artifact triggers a download; the local file is left
+        // untouched.
+        assert_eq!(downloads, 1);
+        assert!(diagnostics.is_empty());
+        assert_eq!(hydrated[0].artifact_type, "file");
+        assert_eq!(hydrated[0].path, local.path);
+        let hydrated_remote = &hydrated[1];
+        assert_eq!(hydrated_remote.artifact_type, "file");
+        assert_eq!(hydrated_remote.path, packet_path.display().to_string());
+        assert_eq!(hydrated_remote.mime.as_deref(), Some("application/json"));
+
+        // The hydrated record now parses into a non-zero matrix summary, where
+        // the un-hydrated `remote_file` record would have summarized 0.
+        let summary =
+            crate::core::artifacts::summarize_matrix_artifacts("run-1", &hydrated, &[])
+                .expect("summary");
+        assert_eq!(summary.finding_count, 1);
+        assert_eq!(summary.top_diagnostic_kinds[0].key, "missing_title");
+        assert_eq!(summary.top_fixtures[0].key, "home");
+
+        let zero =
+            crate::core::artifacts::summarize_matrix_artifacts("run-1", &[remote], &[])
+                .expect("summary");
+        assert_eq!(zero.finding_count, 0);
+    }
+
+    #[test]
+    fn hydrate_remote_artifacts_records_diagnostic_without_aborting() {
+        let remote = remote_artifact("finding-packets", "bench_artifact");
+        let (hydrated, diagnostics) = hydrate_remote_artifacts(
+            vec![remote.clone()],
+            |_| true,
+            |_| Err(Error::internal_unexpected("runner offline")),
+        );
+        assert_eq!(hydrated.len(), 1);
+        // The original record is preserved on failure.
+        assert_eq!(hydrated[0].artifact_type, "remote_file");
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].contains("could not be hydrated"));
+        assert!(diagnostics[0].contains("runner offline"));
+    }
+
+    #[test]
+    fn hydrate_remote_artifacts_skips_non_selected_remote_artifacts() {
+        let remote = remote_artifact("trace.zip", "trace");
+        let mut downloads = 0;
+        let (hydrated, diagnostics) = hydrate_remote_artifacts(
+            vec![remote],
+            |artifact| artifact.kind == "bench_artifact",
+            |_| {
+                downloads += 1;
+                Err(Error::internal_unexpected("should not download"))
+            },
+        );
+        assert_eq!(downloads, 0);
+        assert!(diagnostics.is_empty());
+        assert_eq!(hydrated[0].artifact_type, "remote_file");
+    }
+
+    fn labeled_run(id: &str, command: &str, metadata: Value) -> RunRecord {
+        RunRecord {
+            id: id.into(),
+            kind: "bench.matrix".into(),
+            component_id: Some("homeboy".into()),
+            started_at: "2026-06-26T00:00:00Z".into(),
+            finished_at: None,
+            status: "fail".into(),
+            command: Some(command.into()),
+            cwd: None,
+            homeboy_version: None,
+            git_sha: None,
+            rig_id: None,
+            metadata_json: metadata,
+        }
+    }
+
+    #[test]
+    fn match_run_label_resolves_label_from_command_id_and_metadata() {
+        let by_command = labeled_run(
+            "8752006e-uuid",
+            "homeboy bench run homeboy --run-id my-matrix-run",
+            Value::Null,
+        );
+        let by_command_eq = labeled_run(
+            "uuid-2",
+            "homeboy bench run homeboy --run-id=eq-label",
+            Value::Null,
+        );
+        let by_metadata = labeled_run(
+            "uuid-3",
+            "homeboy bench run homeboy",
+            serde_json::json!({ "lab": { "run_label": "meta-label" } }),
+        );
+        let runs = vec![by_command.clone(), by_command_eq.clone(), by_metadata.clone()];
+
+        // Human label carried in the command resolves to its observation UUID.
+        assert_eq!(
+            match_run_label(&runs, "my-matrix-run").map(|run| run.id),
+            Some("8752006e-uuid".to_string())
+        );
+        assert_eq!(
+            match_run_label(&runs, "eq-label").map(|run| run.id),
+            Some("uuid-2".to_string())
+        );
+        assert_eq!(
+            match_run_label(&runs, "meta-label").map(|run| run.id),
+            Some("uuid-3".to_string())
+        );
+
+        // The observation UUID itself still resolves (back-compat).
+        assert_eq!(
+            match_run_label(&runs, "8752006e-uuid").map(|run| run.id),
+            Some("8752006e-uuid".to_string())
+        );
+
+        // An unknown label matches nothing.
+        assert!(match_run_label(&runs, "nope").is_none());
+    }
+
+    #[test]
+    fn resolve_run_id_or_label_returns_local_run_id_unchanged() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(sample_run("bench.matrix")).expect("run");
+            let resolved =
+                resolve_run_id_or_label(&store, &run.id).expect("resolve existing run id");
+            assert_eq!(resolved, run.id);
+        });
     }
 }


### PR DESCRIPTION
## Problem
`homeboy report matrix-artifacts <RUN_ID>` is the intended reader for matrix runs but was unusable end-to-end:

1. **It never hydrated remote finding-packets.** On a real run it printed `Fixtures: 0 / Findings: 0` while listing the result + finding-packet artifacts as `(bench_artifact, remote_file)`. The packets live on the runner; the reader listed them but `read_json_artifact` only parses local `file`/`url` artifacts, so remote packets summarized 0.
2. **It only accepted the internal observation UUID**, not the human `--run-id` launch label, forcing an extra `runs list --runner homeboy-lab` lookup first.

## Fix
- **Hydration:** new `runs_service::hydrate_remote_artifacts` (+ `_via_runner` wrapper) pulls remote runner artifacts to the operator-local artifact root via the same `download_remote_artifact` path that `runs artifacts --pull` uses (ref #6740), rewriting them into readable local-file records before summarizing. Hydration is scoped to matrix result/finding-packet artifacts via the new `is_matrix_summary_artifact` predicate (so we don't pull unrelated runner binaries), and a failed pull records a parse diagnostic instead of aborting. The summary now reflects real fixtures / pass-fail / finding kinds / fixtures.
- **Label resolution:** new `runs_service::resolve_run_id_or_label` + pure `match_run_label`. A non-UUID input is resolved against connected runners' run lists — matching the run id, the `--run-id` value in the command, or `lab`/`proof` metadata — to its observation run id. So `report matrix-artifacts <my-run-id>` works as a one-liner; the UUID still works.

## Tests
Unit tests cover the parse/summarize-from-hydrated-bytes path with a fake downloader (hydrated remote packet → non-zero finding summary, vs. 0 for the un-hydrated `remote_file` record), failure-diagnostic capture, selection scoping, and label resolution by command/id/metadata (UUID back-compat included). The live runner download + run-list round-trips remain the integration hop and are documented in the helpers.

- `cargo build -p homeboy`: OK
- `cargo test -p homeboy --lib runs_service`: 11 passed
- `cargo test -p homeboy --lib matrix_artifact`: 4 passed

Closes #6865
Refs #6740

🤖 Generated with [Claude Code](https://claude.com/claude-code)