### PR TITLE
feat(deploy): report explicit build provenance on every deploy

### DIFF
--- a/src/core/deploy/execution/prepare.rs
+++ b/src/core/deploy/execution/prepare.rs
@@ -8,7 +8,10 @@ use crate::core::project::Project;
 use super::super::generated_artifacts::GeneratedBuildArtifactCleanupGuard;
 use super::super::path_roots::{component_remote_path, resolve_effective_remote_path};
 use super::super::policy::{owner_hint_for_path, protected_path_suffixes, validate_deploy_target};
-use super::super::types::{ComponentDeployResult, DeployArtifactSource, DeployConfig};
+use super::super::provenance::capture_build_provenance;
+use super::super::types::{
+    BuildProvenance, BuildSource, ComponentDeployResult, DeployArtifactSource, DeployConfig,
+};
 use super::super::version_overrides::is_self_deploy;
 use super::preflight::{resolve_preflight_artifact_path, validate_preflight_file_artifact};
 use super::release_plan::{
@@ -25,6 +28,7 @@ pub(crate) struct PreparedComponentDeploy {
     pub build_exit_code: Option<i32>,
     pub artifact_path: Option<PathBuf>,
     pub artifact_source: Option<DeployArtifactSource>,
+    pub build_provenance: BuildProvenance,
     pub cleanup_local_artifact: bool,
 }
 
@@ -192,6 +196,24 @@ pub(crate) fn prepare_component_deploy(
         release_artifact.is_none() && !config.skip_build && !is_self_deploy(component)
     });
 
+    // Capture provenance now, while the source tree is at the built state and the
+    // artifact still exists on disk (it may be cleaned up after a successful deploy).
+    let build_ran =
+        !(is_git_deploy || is_file_deploy || config.skip_build || release_artifact.is_some());
+    let build_source = if is_git_deploy {
+        BuildSource::GitPush
+    } else if is_file_deploy {
+        BuildSource::FileCopy
+    } else if release_artifact.is_some() {
+        BuildSource::DownloadedRelease
+    } else if config.skip_build {
+        BuildSource::ReusedArtifact
+    } else {
+        BuildSource::FreshBuild
+    };
+    let build_provenance =
+        capture_build_provenance(component, build_source, build_ran, artifact_path.as_deref());
+
     Ok(PreparedComponentDeploy {
         component: component.clone(),
         config: config.clone(),
@@ -201,6 +223,7 @@ pub(crate) fn prepare_component_deploy(
         build_exit_code,
         artifact_path,
         artifact_source,
+        build_provenance,
         cleanup_local_artifact,
     })
 }

--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -217,22 +217,33 @@ pub(super) fn deploy_components(
 
         let mut result = execute_preflighted_component_deploy(prepared, ctx, base_path, &project);
 
-        // Record which git ref was deployed
-        if let Some(checkout) = tag_checkouts
+        // Record which git ref was deployed. The same label feeds build provenance
+        // so `deployed_ref` and `build_provenance.built_from_ref` never disagree.
+        let deployed_ref = if let Some(checkout) = tag_checkouts
             .iter()
             .find(|c| c.component_id == component.id)
         {
-            result = result.with_deployed_ref(checkout.provenance_ref());
+            Some(checkout.provenance_ref())
         } else if config.head {
             // Deploying from HEAD — record the current branch
-            if let Some(branch) = crate::core::engine::command::run_in_optional(
+            crate::core::engine::command::run_in_optional(
                 &component.local_path,
                 "git",
                 &["rev-parse", "--abbrev-ref", "HEAD"],
-            ) {
-                result = result.with_deployed_ref(format!("{} (HEAD)", branch));
-            }
+            )
+            .map(|branch| format!("{} (HEAD)", branch))
+        } else {
+            None
+        };
+
+        if let Some(ref git_ref) = deployed_ref {
+            result = result.with_deployed_ref(git_ref.clone());
         }
+
+        // Attach explicit build provenance to every result, regardless of strategy.
+        let mut build_provenance = prepared.build_provenance.clone();
+        build_provenance.built_from_ref = deployed_ref;
+        result = result.with_build_provenance(build_provenance);
 
         if result.status == "deployed" {
             succeeded += 1;

--- a/src/core/deploy/provenance.rs
+++ b/src/core/deploy/provenance.rs
@@ -1,11 +1,102 @@
 //! Build provenance tracking.
 //!
 //! Provides tag-gap detection so `build` and `deploy` can warn about
-//! unreleased commits ahead of the latest tag.
+//! unreleased commits ahead of the latest tag, plus per-deploy build provenance
+//! capture (which source/ref produced the payload, whether a fresh build ran, and
+//! the identity of the artifact that shipped).
+
+use std::path::Path;
+use std::time::UNIX_EPOCH;
+
+use sha2::{Digest, Sha256};
 
 use crate::core::component::Component;
 use crate::core::engine::command;
 use crate::core::git;
+
+use super::generated_artifacts::uncommitted_file_report_excluding_known_generated;
+use super::types::{ArtifactIdentity, BuildProvenance, BuildSource};
+
+/// Capture explicit build provenance for a prepared deploy.
+///
+/// Called once per component during preflight (while the source tree is at the
+/// built state and the artifact still exists), so the deploy result can report,
+/// consistently across every strategy, exactly what was built and shipped.
+/// `built_from_ref` is left unset here and filled in by the orchestrator, which
+/// owns the deployed tag/branch label.
+pub(super) fn capture_build_provenance(
+    component: &Component,
+    source: BuildSource,
+    build_ran: bool,
+    artifact_path: Option<&Path>,
+) -> BuildProvenance {
+    let local_path = &component.local_path;
+    let built_from_commit = command::run_in_optional(local_path, "git", &["rev-parse", "HEAD"])
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    // A downloaded release is not built from the local tree, so local dirtiness is
+    // not meaningful provenance for it.
+    let working_tree_dirty = match source {
+        BuildSource::DownloadedRelease => None,
+        _ => uncommitted_file_report_excluding_known_generated(component)
+            .ok()
+            .map(|report| !report.unexpected.is_empty()),
+    };
+
+    let artifact_identity = artifact_path.and_then(resolve_artifact_identity);
+
+    BuildProvenance {
+        source,
+        build_ran,
+        built_from_ref: None,
+        built_from_commit,
+        working_tree_dirty,
+        artifact_identity,
+    }
+}
+
+fn resolve_artifact_identity(path: &Path) -> Option<ArtifactIdentity> {
+    let metadata = std::fs::metadata(path).ok()?;
+    let modified_unix = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|elapsed| elapsed.as_secs() as i64);
+
+    if metadata.is_file() {
+        Some(ArtifactIdentity {
+            path: path.to_string_lossy().to_string(),
+            size_bytes: Some(metadata.len()),
+            sha256: sha256_file(path),
+            modified_unix,
+        })
+    } else {
+        // Directory artifacts (e.g. rsync of a tree) have no single-file hash.
+        Some(ArtifactIdentity {
+            path: path.to_string_lossy().to_string(),
+            size_bytes: None,
+            sha256: None,
+            modified_unix,
+        })
+    }
+}
+
+fn sha256_file(path: &Path) -> Option<String> {
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer).ok()?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Some(format!("{:x}", hasher.finalize()))
+}
 
 /// Information about the HEAD-vs-tag gap for a component.
 #[derive(Debug, Clone)]
@@ -86,4 +177,126 @@ fn format_tag_gap(component_id: &str, gap: &TagGap, context: &str) -> String {
 /// Print a tag gap warning to stderr. Always prints regardless of TTY.
 pub fn warn_tag_gap(component_id: &str, gap: &TagGap, context: &str) {
     eprintln!("{}", format_tag_gap(component_id, gap, context));
+}
+
+#[cfg(test)]
+mod provenance_tests {
+    use super::*;
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn committed_repo() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_git(dir, &["init", "-q", "-b", "main"]);
+        run_git(dir, &["config", "user.email", "homeboy@example.com"]);
+        run_git(dir, &["config", "user.name", "Fixture Test"]);
+        std::fs::write(dir.join("README.md"), "fixture\n").expect("readme");
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
+        temp
+    }
+
+    fn component_at(path: &Path) -> Component {
+        Component {
+            local_path: path.to_string_lossy().to_string(),
+            ..Component::default()
+        }
+    }
+
+    #[test]
+    fn fresh_build_records_commit_clean_tree_and_artifact_identity() {
+        let temp = committed_repo();
+        let dir = temp.path();
+        let artifact = dir.join("plugin.zip");
+        std::fs::write(&artifact, b"artifact-bytes").expect("artifact");
+
+        let provenance = capture_build_provenance(
+            &component_at(dir),
+            BuildSource::FreshBuild,
+            true,
+            Some(artifact.as_path()),
+        );
+
+        assert_eq!(provenance.source, BuildSource::FreshBuild);
+        assert!(provenance.build_ran);
+        assert!(provenance.built_from_ref.is_none());
+        assert_eq!(
+            provenance.built_from_commit.as_deref().map(str::len),
+            Some(40)
+        );
+        assert_eq!(provenance.working_tree_dirty, Some(false));
+
+        let identity = provenance.artifact_identity.expect("artifact identity");
+        assert_eq!(identity.size_bytes, Some(b"artifact-bytes".len() as u64));
+        // SHA-256 of the artifact bytes is reported so stale artifacts are detectable.
+        assert_eq!(
+            identity.sha256.as_deref(),
+            Some("6521df166eb07efaf36eba5b6bedefd9d6a252e9c80bab1c99653700ec71473c"),
+            "sha256 should be the lowercase hex digest of the artifact contents"
+        );
+    }
+
+    #[test]
+    fn fresh_build_flags_dirty_working_tree() {
+        let temp = committed_repo();
+        let dir = temp.path();
+        std::fs::write(dir.join("README.md"), "modified\n").expect("modify tracked file");
+
+        let provenance =
+            capture_build_provenance(&component_at(dir), BuildSource::FreshBuild, true, None);
+
+        assert_eq!(provenance.working_tree_dirty, Some(true));
+        assert!(provenance.artifact_identity.is_none());
+    }
+
+    #[test]
+    fn downloaded_release_skips_local_dirtiness_and_reports_not_built() {
+        let temp = committed_repo();
+        let dir = temp.path();
+        std::fs::write(dir.join("README.md"), "modified\n").expect("modify tracked file");
+
+        let provenance = capture_build_provenance(
+            &component_at(dir),
+            BuildSource::DownloadedRelease,
+            false,
+            None,
+        );
+
+        assert_eq!(provenance.source, BuildSource::DownloadedRelease);
+        assert!(!provenance.build_ran);
+        // Local tree dirtiness is not meaningful provenance for a downloaded asset.
+        assert_eq!(provenance.working_tree_dirty, None);
+    }
+
+    #[test]
+    fn reused_artifact_reports_no_build_ran() {
+        let temp = committed_repo();
+        let dir = temp.path();
+        let artifact = dir.join("plugin.zip");
+        std::fs::write(&artifact, b"reused").expect("artifact");
+
+        let provenance = capture_build_provenance(
+            &component_at(dir),
+            BuildSource::ReusedArtifact,
+            false,
+            Some(artifact.as_path()),
+        );
+
+        assert_eq!(provenance.source, BuildSource::ReusedArtifact);
+        assert!(!provenance.build_ran);
+        assert!(provenance.artifact_identity.is_some());
+    }
 }

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -108,6 +108,71 @@ pub enum DeployArtifactSource {
     LocalBuild,
 }
 
+/// Where the payload that was deployed actually came from.
+///
+/// Unlike [`DeployArtifactSource`] (which only distinguishes a downloaded release
+/// asset from a local build for artifact strategies), this covers every deploy
+/// strategy so the deploy result is explicit and consistent about build provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildSource {
+    /// A fresh build ran locally against the checked-out source tree.
+    FreshBuild,
+    /// An existing local build artifact was reused without rebuilding (`--skip-build`).
+    ReusedArtifact,
+    /// A prebuilt release asset was downloaded instead of building locally.
+    DownloadedRelease,
+    /// Committed source was pushed directly via the `git` deploy strategy.
+    GitPush,
+    /// Source files were copied directly via the `file` deploy strategy.
+    FileCopy,
+}
+
+/// Content identity of a deployed artifact file, so stale artifacts are detectable.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactIdentity {
+    /// Path to the artifact that was deployed.
+    pub path: String,
+    /// Size of the artifact in bytes (absent for directory artifacts).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    /// SHA-256 of the artifact contents (best-effort; absent for directories).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    /// Last-modified time of the artifact, in seconds since the Unix epoch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modified_unix: Option<i64>,
+}
+
+/// Explicit, strategy-complete build provenance for a single component deploy.
+///
+/// Answers, for every deploy and regardless of strategy: which source/ref produced
+/// the payload, whether a fresh build actually ran, whether the built source tree
+/// was dirty, and the identity of the artifact that shipped. This makes the
+/// otherwise-implicit "working tree vs. committed ref vs. reused artifact" choice
+/// explicit so stale artifacts cannot ship unnoticed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BuildProvenance {
+    /// Where the deployed payload came from.
+    pub source: BuildSource,
+    /// Whether a fresh build ran for this deploy (vs. a reused or downloaded
+    /// artifact, or a strategy that ships source directly).
+    pub build_ran: bool,
+    /// The git ref the payload was built/deployed from (tag, or `"<branch> (HEAD)"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub built_from_ref: Option<String>,
+    /// The commit (HEAD) of the source tree the payload was built/deployed from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub built_from_commit: Option<String>,
+    /// Whether the built source tree had uncommitted changes (excluding generated
+    /// build artifacts). `None` when not applicable (e.g. a downloaded release).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_tree_dirty: Option<bool>,
+    /// Identity of the deployed artifact, when the strategy produces an artifact file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_identity: Option<ArtifactIdentity>,
+}
+
 /// Reason why a component was selected for deployment.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -251,6 +316,10 @@ pub struct ComponentDeployResult {
     /// The git ref (tag or branch) that was built and deployed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deployed_ref: Option<String>,
+    /// Explicit build provenance: source/ref, whether a fresh build ran, and the
+    /// identity of the artifact that shipped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_provenance: Option<BuildProvenance>,
 }
 
 impl ComponentDeployResult {
@@ -279,6 +348,7 @@ impl ComponentDeployResult {
             deploy_exit_code: None,
             release_state: None,
             deployed_ref: None,
+            build_provenance: None,
         }
     }
 
@@ -364,6 +434,11 @@ impl ComponentDeployResult {
 
     pub(super) fn with_deployed_ref(mut self, git_ref: String) -> Self {
         self.deployed_ref = Some(git_ref);
+        self
+    }
+
+    pub(super) fn with_build_provenance(mut self, provenance: BuildProvenance) -> Self {
+        self.build_provenance = Some(provenance);
         self
     }
 


### PR DESCRIPTION
## Summary

`homeboy deploy` build provenance was inconsistent and opaque. Across components a deploy could build from the working tree, a committed tag, a reused artifact, or a downloaded release — with nothing in the result clearly saying which source/ref was built or whether a fresh build actually ran. Worse, the only source-identity fields (`git_head`, `git_branch`, dirty state) were populated in `--check`/`--dry-run` modes only, `deployed_ref` was unset for the skip-build and release-download paths, and `build_exit_code` reported `Some(0)` even when no build ran. The net effect: stale artifacts could ship unnoticed.

This adds a strategy-complete `build_provenance` object attached to **every** `ComponentDeployResult`, regardless of deploy strategy:

- **`source`** — `fresh_build` | `reused_artifact` | `downloaded_release` | `git_push` | `file_copy`
- **`build_ran`** — whether a fresh build actually ran vs. a reused/downloaded artifact or a source-shipping strategy
- **`built_from_ref` / `built_from_commit`** — the ref and HEAD commit the payload was built/deployed from (the ref is sourced from the same logic as `deployed_ref`, so they never disagree)
- **`working_tree_dirty`** — whether the built source tree had uncommitted changes (excluding generated build artifacts), making working-tree builds explicit
- **`artifact_identity`** — path + size + SHA-256 + mtime of the deployed artifact, so stale artifacts are detectable by content

Provenance is captured during preflight (while the source tree is at the built state and the artifact still exists on disk), then the orchestrator fills in the deployed ref so a single per-component loop attaches provenance uniformly across the git / file / artifact strategies.

Kept fully generic — no product, framework, or package-specific names or assumptions.

### Scope / follow-up
The underlying working-tree-vs-tag build-source *selection* is intentionally unchanged. This PR makes that choice explicit and observable in the result rather than altering the selection itself, which keeps the change small and low-risk. A future change could add a warning (or hard gate) when, e.g., a `reused_artifact` deploy ships an artifact older than the current HEAD.

Closes #6864

## Testing
- `cargo build` — clean (no new warnings)
- `cargo test --lib deploy::` — 183 passed (179 existing + 4 new provenance tests)
- `rustfmt` clean on changed files; `cargo clippy` introduces no new findings
- 4 new unit tests cover fresh-build (commit + clean tree + artifact SHA-256/size), dirty-working-tree detection, downloaded-release (no local dirtiness, `build_ran=false`), and reused-artifact (`build_ran=false`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Reconnaissance of the deploy module, implementing the `BuildProvenance` type and capture logic, wiring it through preflight/orchestration, and writing tests. Reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)