### PR TITLE
feat(audit): ignore_line_matches for thin_command_adapter (reduce false positives)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -452,6 +452,9 @@
       "ignore_after_line_equals": [
         "#[cfg(test)]"
       ],
+      "ignore_line_matches": [
+        "^\\s*(pub(\\([^)]*\\))?\\s+)?(async\\s+)?fn\\s"
+      ],
       "ignore_line_prefixes": [
         "//",
         "///",

--- a/src/core/code_audit/detectors/thin_command_adapter.rs
+++ b/src/core/code_audit/detectors/thin_command_adapter.rs
@@ -58,6 +58,8 @@ pub(in crate::core::code_audit) fn run(
         return Vec::new();
     }
 
+    let ignore_line_matches = compile_ignore_line_matches(config);
+
     let files = match walk_candidate_files(root, config) {
         Ok(files) => files,
         Err(_) => return Vec::new(),
@@ -79,7 +81,7 @@ pub(in crate::core::code_audit) fn run(
             continue;
         };
 
-        let hits = scan_orchestration(&content, &groups, config);
+        let hits = scan_orchestration(&content, &groups, &ignore_line_matches, config);
         let total_weight: u32 = hits.iter().map(|hit| hit.weight).sum();
         if total_weight < config.max_orchestration_weight {
             continue;
@@ -111,6 +113,14 @@ fn compile_marker_groups(config: &ThinCommandAdapterConfig) -> Vec<CompiledMarke
                 patterns,
             })
         })
+        .collect()
+}
+
+fn compile_ignore_line_matches(config: &ThinCommandAdapterConfig) -> Vec<Regex> {
+    config
+        .ignore_line_matches
+        .iter()
+        .filter_map(|pattern| Regex::new(pattern).ok())
         .collect()
 }
 
@@ -150,6 +160,7 @@ fn is_in_scope(normalized: &str, config: &ThinCommandAdapterConfig) -> bool {
 fn scan_orchestration(
     content: &str,
     groups: &[CompiledMarkerGroup],
+    ignore_line_matches: &[Regex],
     config: &ThinCommandAdapterConfig,
 ) -> Vec<OrchestrationHit> {
     let mut hits = Vec::new();
@@ -173,6 +184,13 @@ fn scan_orchestration(
             .ignore_line_prefixes
             .iter()
             .any(|prefix| trimmed.starts_with(prefix.as_str()))
+        {
+            continue;
+        }
+
+        if ignore_line_matches
+            .iter()
+            .any(|pattern| pattern.is_match(raw_line))
         {
             continue;
         }

--- a/src/core/component/audit/thin_command_adapter.rs
+++ b/src/core/component/audit/thin_command_adapter.rs
@@ -68,6 +68,11 @@ pub struct ThinCommandAdapterConfig {
     /// Line prefixes ignored entirely (e.g. comment markers).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ignore_line_prefixes: Vec<String>,
+    /// Regex patterns; any line matching one is skipped entirely (does not
+    /// contribute orchestration weight). Use for line shapes that are never
+    /// orchestration, e.g. function declarations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore_line_matches: Vec<String>,
     /// When a line equals one of these (trimmed), the remainder of the file is
     /// ignored (e.g. an inline test module marker).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -118,6 +123,7 @@ impl Default for ThinCommandAdapterConfig {
             file_extensions: Vec::new(),
             allow_line_contains: Vec::new(),
             ignore_line_prefixes: Vec::new(),
+            ignore_line_matches: Vec::new(),
             ignore_after_line_equals: Vec::new(),
             orchestration_markers: Vec::new(),
             max_orchestration_weight: default_thin_command_adapter_threshold(),
@@ -148,6 +154,7 @@ impl ThinCommandAdapterConfig {
         extend_unique(&mut self.file_extensions, &other.file_extensions);
         extend_unique(&mut self.allow_line_contains, &other.allow_line_contains);
         extend_unique(&mut self.ignore_line_prefixes, &other.ignore_line_prefixes);
+        extend_unique(&mut self.ignore_line_matches, &other.ignore_line_matches);
         extend_unique(
             &mut self.ignore_after_line_equals,
             &other.ignore_after_line_equals,

--- a/tests/core/code_audit/detectors/thin_command_adapter_test.rs
+++ b/tests/core/code_audit/detectors/thin_command_adapter_test.rs
@@ -126,6 +126,70 @@ fn test_module_tail_is_ignored() {
     assert!(findings.is_empty());
 }
 
+fn name_shaped_config() -> ThinCommandAdapterConfig {
+    ThinCommandAdapterConfig {
+        include_path_contains: vec!["src/commands/".to_string()],
+        file_extensions: vec!["rs".to_string()],
+        orchestration_markers: vec![ThinCommandAdapterMarkerGroup {
+            label: "dispatch".to_string(),
+            patterns: vec![r"dispatch_[A-Za-z0-9_]+\s*\(".to_string()],
+            weight: 1,
+        }],
+        max_orchestration_weight: 1,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn ignore_line_matches_excludes_fn_definitions() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "src/commands/def_only.rs",
+        "pub fn dispatch_foo() {\n    let x = 1;\n}\n",
+    );
+    let mut config = name_shaped_config();
+    config.ignore_line_matches = vec![r"^\s*(pub(\([^)]*\))?\s+)?(async\s+)?fn\s".to_string()];
+    let findings = super::run(dir.path(), &config);
+    assert!(
+        findings.is_empty(),
+        "fn-definition line should not count as orchestration"
+    );
+}
+
+#[test]
+fn ignore_line_matches_still_flags_real_calls() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "src/commands/real_call.rs",
+        "pub fn run() {\n    dispatch_foo();\n}\n",
+    );
+    let mut config = name_shaped_config();
+    config.ignore_line_matches = vec![r"^\s*(pub(\([^)]*\))?\s+)?(async\s+)?fn\s".to_string()];
+    let findings = super::run(dir.path(), &config);
+    assert_eq!(
+        findings.len(),
+        1,
+        "an actual dispatch_foo() call must still be flagged"
+    );
+    assert!(findings[0].description.contains("dispatch"));
+}
+
+#[test]
+fn empty_ignore_line_matches_preserves_existing_behavior() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "src/commands/def_only.rs",
+        "pub fn dispatch_foo() {\n    let x = 1;\n}\n",
+    );
+    // With no ignore_line_matches, the fn-def line trips the marker (legacy
+    // behavior) and produces a finding.
+    let findings = super::run(dir.path(), &name_shaped_config());
+    assert_eq!(findings.len(), 1);
+}
+
 #[test]
 fn weighted_group_reaches_threshold_alone() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Implements #6856 first slice. Adds a config-driven ignore_line_matches (regex) to the thin_command_adapter detector so function-DECLARATION lines (fn dispatch_*/execute_*/persist_*) no longer count as orchestration — a definition is not a leak. Generic + agnostic (regex declared in component config). Applies a fn-decl pattern in homeboy.json. Unit tests cover: fn-def excluded, real call still flagged, backward-compat with empty config. Verified cargo build --lib --tests + cargo test --lib thin_command_adapter.