### PR TITLE
feat(audit): exempt module-qualified delegation from thin_command_adapter name markers

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -486,12 +486,18 @@
         },
         {
           "label": "run artifact persistence",
+          "exempt_when_line_matches": [
+            "[A-Za-z_][A-Za-z0-9_]*::(dispatch|execute|persist)[A-Za-z0-9_]*\\s*\\("
+          ],
           "patterns": [
             "\\b(RunDir::create|write_to_run_dir|ObservationBuilder|finish_run|persist_[A-Za-z0-9_]+)\\b"
           ]
         },
         {
           "label": "runner execution orchestration",
+          "exempt_when_line_matches": [
+            "[A-Za-z_][A-Za-z0-9_]*::(dispatch|execute|persist)[A-Za-z0-9_]*\\s*\\("
+          ],
           "patterns": [
             "\\b(runner::exec|execute_[A-Za-z0-9_]+|dispatch_[A-Za-z0-9_]+)\\s*\\("
           ]

--- a/src/core/code_audit/detectors/thin_command_adapter.rs
+++ b/src/core/code_audit/detectors/thin_command_adapter.rs
@@ -37,6 +37,9 @@ struct CompiledMarkerGroup {
     label: String,
     weight: u32,
     patterns: Vec<Regex>,
+    /// When non-empty, a line matching `patterns` is still suppressed for this
+    /// group if it also matches one of these (module-qualified delegation).
+    exempt: Vec<Regex>,
 }
 
 /// A single orchestration hit contributing to a module's weight.
@@ -107,10 +110,16 @@ fn compile_marker_groups(config: &ThinCommandAdapterConfig) -> Vec<CompiledMarke
             if patterns.is_empty() {
                 return None;
             }
+            let exempt: Vec<Regex> = group
+                .exempt_when_line_matches
+                .iter()
+                .filter_map(|pattern| Regex::new(pattern).ok())
+                .collect();
             Some(CompiledMarkerGroup {
                 label: group.label.clone(),
                 weight: group.weight.max(1),
                 patterns,
+                exempt,
             })
         })
         .collect()
@@ -209,6 +218,12 @@ fn scan_orchestration(
                 .iter()
                 .any(|pattern| pattern.is_match(raw_line))
             {
+                // Suppress this group's hit when it declares exemptions and the
+                // line matches one (module-qualified delegation is correct
+                // thin-adapter behavior, not a leak).
+                if !group.exempt.is_empty() && group.exempt.iter().any(|re| re.is_match(raw_line)) {
+                    continue;
+                }
                 hits.push(OrchestrationHit {
                     label: group.label.clone(),
                     weight: group.weight,

--- a/src/core/component/audit/mod.rs
+++ b/src/core/component/audit/mod.rs
@@ -279,6 +279,7 @@ mod tests {
                     label: "process execution".to_string(),
                     patterns: vec!["Command::new".to_string()],
                     weight: 1,
+                    exempt_when_line_matches: Vec::new(),
                 }],
                 ..Default::default()
             },

--- a/src/core/component/audit/thin_command_adapter.rs
+++ b/src/core/component/audit/thin_command_adapter.rs
@@ -18,6 +18,12 @@ pub struct ThinCommandAdapterMarkerGroup {
         skip_serializing_if = "is_default_thin_command_adapter_group_weight"
     )]
     pub weight: u32,
+    /// Regex patterns; if a line matches this group's `patterns` AND also matches
+    /// one of these, the hit is NOT counted. Use to exempt module-qualified
+    /// delegation calls from name-shaped markers (calling into another
+    /// module/core is correct, not a leak).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exempt_when_line_matches: Vec<String>,
 }
 
 fn default_thin_command_adapter_group_weight() -> u32 {

--- a/tests/core/code_audit/detectors/thin_command_adapter_test.rs
+++ b/tests/core/code_audit/detectors/thin_command_adapter_test.rs
@@ -22,11 +22,13 @@ fn config() -> ThinCommandAdapterConfig {
                 label: "process execution".to_string(),
                 patterns: vec![r"Command::new\s*\(".to_string()],
                 weight: 1,
+                exempt_when_line_matches: Vec::new(),
             },
             ThinCommandAdapterMarkerGroup {
                 label: "filesystem mutation".to_string(),
                 patterns: vec![r"std::fs::(write|remove_file)\s*\(".to_string()],
                 weight: 1,
+                exempt_when_line_matches: Vec::new(),
             },
         ],
         max_orchestration_weight: 2,
@@ -134,6 +136,7 @@ fn name_shaped_config() -> ThinCommandAdapterConfig {
             label: "dispatch".to_string(),
             patterns: vec![r"dispatch_[A-Za-z0-9_]+\s*\(".to_string()],
             weight: 1,
+            exempt_when_line_matches: Vec::new(),
         }],
         max_orchestration_weight: 1,
         ..Default::default()
@@ -203,4 +206,97 @@ fn weighted_group_reaches_threshold_alone() {
     let findings = super::run(dir.path(), &config);
     assert_eq!(findings.len(), 1);
     assert!(findings[0].description.contains("process execution"));
+}
+
+fn delegation_exempt_config() -> ThinCommandAdapterConfig {
+    ThinCommandAdapterConfig {
+        include_path_contains: vec!["src/commands/".to_string()],
+        file_extensions: vec!["rs".to_string()],
+        orchestration_markers: vec![ThinCommandAdapterMarkerGroup {
+            label: "dispatch".to_string(),
+            patterns: vec![r"dispatch_[A-Za-z0-9_]+\s*\(".to_string()],
+            weight: 1,
+            exempt_when_line_matches: vec![
+                r"[A-Za-z_][A-Za-z0-9_]*::(dispatch|execute|persist)_".to_string()
+            ],
+        }],
+        max_orchestration_weight: 1,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn exempt_when_line_matches_skips_module_qualified_delegation() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "src/commands/delegation.rs",
+        "pub fn run() {\n    foo::dispatch_thing();\n}\n",
+    );
+    let findings = super::run(dir.path(), &delegation_exempt_config());
+    assert!(
+        findings.is_empty(),
+        "module-qualified delegation foo::dispatch_thing() must be exempt, not flagged"
+    );
+}
+
+#[test]
+fn exempt_when_line_matches_still_flags_local_call() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "src/commands/local_call.rs",
+        "pub fn run() {\n    dispatch_thing();\n}\n",
+    );
+    let findings = super::run(dir.path(), &delegation_exempt_config());
+    assert_eq!(
+        findings.len(),
+        1,
+        "a bare local dispatch_thing() call must still be flagged"
+    );
+    assert!(findings[0].description.contains("dispatch"));
+}
+
+#[test]
+fn concrete_group_with_empty_exempt_always_counts() {
+    let dir = tempfile::tempdir().unwrap();
+    // A concrete marker line that also contains '::' must still count even
+    // though the line is module-qualified — empty exempt means no suppression.
+    write(
+        dir.path(),
+        "src/commands/concrete.rs",
+        "pub fn run() {\n    std::fs::write(\"a\", \"b\").unwrap();\n}\n",
+    );
+    let config = ThinCommandAdapterConfig {
+        include_path_contains: vec!["src/commands/".to_string()],
+        file_extensions: vec!["rs".to_string()],
+        orchestration_markers: vec![ThinCommandAdapterMarkerGroup {
+            label: "filesystem mutation".to_string(),
+            patterns: vec![r"std::fs::(write|remove_file)\s*\(".to_string()],
+            weight: 1,
+            exempt_when_line_matches: Vec::new(),
+        }],
+        max_orchestration_weight: 1,
+        ..Default::default()
+    };
+    let findings = super::run(dir.path(), &config);
+    assert_eq!(
+        findings.len(),
+        1,
+        "concrete marker std::fs::write must count despite containing '::'"
+    );
+    assert!(findings[0].description.contains("filesystem mutation"));
+}
+
+#[test]
+fn empty_exempt_when_line_matches_preserves_existing_behavior() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "src/commands/legacy.rs",
+        "pub fn run() {\n    foo::dispatch_thing();\n}\n",
+    );
+    // With no exempt configured, the legacy behavior flags the delegation line.
+    let findings = super::run(dir.path(), &name_shaped_config());
+    assert_eq!(findings.len(), 1);
 }


### PR DESCRIPTION
Implements #6856 delegation slice. Adds per-marker-group exempt_when_line_matches so the name-shaped orchestration markers (dispatch_/execute_/persist_) stop counting module-qualified DELEGATION calls (foo::execute_bar()) as leaks — calling into another module/core is correct thin-adapter behavior. Concrete markers (Command::new, std::fs, RunDir, finish_run) are unaffected (empty exempt). Tests cover delegation-exempt, local-call-still-flagged, concrete-always-counts, backward-compat. Verified cargo build --lib --tests + cargo test --lib thin_command_adapter.