### PR TITLE
Surface child failure diagnostics in controller status

### DIFF
--- a/src/core/agent_task_loop_controller/diagnostics.rs
+++ b/src/core/agent_task_loop_controller/diagnostics.rs
@@ -66,14 +66,39 @@ pub struct AgentTaskLoopFailedChildActionDiagnostic {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_run_status: Option<String>,
     pub top_diagnostic: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_diagnostic_class: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hydrated_root_cause: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_dir: Option<String>,
     pub owner_surface: String,
+    pub failure_signature: AgentTaskLoopFailureSignature,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repeated_failure: Option<AgentTaskLoopRepeatedFailureDiagnostic>,
     pub next_command: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evidence_refs: Vec<AgentTaskLoopFailedChildEvidenceRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskLoopFailureSignature {
+    pub digest: String,
+    pub task_id: Option<String>,
+    pub diagnostic_class: Option<String>,
+    pub root_message: String,
+    pub owner_surface: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskLoopRepeatedFailureDiagnostic {
+    pub matching_failed_child_action_count: usize,
+    pub guidance: String,
+    pub next_command: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/agent_task_loop_controller/service.rs
+++ b/src/core/agent_task_loop_controller/service.rs
@@ -3,10 +3,11 @@ use crate::core::{agent_task_lifecycle, paths, Error, Result};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use std::fs;
 use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn controller_status_report(loop_id: &str) -> Result<AgentTaskLoopControllerStatusReport> {
     let controller = controller_status(loop_id)?;
@@ -155,28 +156,43 @@ fn failed_child_action_diagnostic(
         .as_ref()
         .map(|run| format!("{:?}", run.state).to_ascii_lowercase());
     let aggregate = child_run_id.as_deref().and_then(load_child_aggregate_value);
-    let top_diagnostic = action
-        .diagnostics
-        .first()
-        .map(|diagnostic| diagnostic.message.clone())
-        .or_else(|| aggregate.as_ref().and_then(first_diagnostic_message))
-        .unwrap_or_else(|| "controller child action failed".to_string());
+    let child_task_id = aggregate.as_ref().and_then(first_failed_task_id);
+    let top_diagnostic = action_top_diagnostic(action)
+        .or_else(|| aggregate.as_ref().and_then(first_diagnostic))
+        .unwrap_or_else(|| CollectedDiagnostic {
+            class: "controller_child_action_failed".to_string(),
+            message: "controller child action failed".to_string(),
+        });
     let hydrated_root_cause = child_run
         .as_ref()
         .and_then(root_cause_from_run_evidence)
         .or_else(|| aggregate.as_ref().and_then(root_cause_from_aggregate))
-        .filter(|message| message != &top_diagnostic)
+        .filter(|message| message != &top_diagnostic.message)
         .filter(|message| {
-            diagnostic_priority("", message) <= diagnostic_priority("", &top_diagnostic)
+            diagnostic_priority("", message) <= diagnostic_priority("", &top_diagnostic.message)
         });
     let evidence_refs = child_run
         .as_ref()
         .map(evidence_refs_from_run)
         .unwrap_or_default();
+    let artifact_dir = child_run.as_ref().and_then(run_artifact_dir);
     let owner_surface = classify_failed_child_owner(
-        hydrated_root_cause.as_deref().unwrap_or(&top_diagnostic),
+        hydrated_root_cause
+            .as_deref()
+            .unwrap_or(&top_diagnostic.message),
         &evidence_refs,
     );
+    let signature_root = hydrated_root_cause
+        .clone()
+        .unwrap_or_else(|| top_diagnostic.message.clone());
+    let failure_signature = failed_child_failure_signature(
+        child_run_id.as_deref(),
+        child_task_id.as_deref(),
+        Some(top_diagnostic.class.as_str()),
+        &signature_root,
+        &owner_surface,
+    );
+    let repeated_failure = repeated_failure_diagnostic(record, &failure_signature);
     let next_command = child_run_id
         .as_ref()
         .map(|run_id| format!("homeboy agent-task status {run_id} --full"))
@@ -191,13 +207,112 @@ fn failed_child_action_diagnostic(
         action_id: action.action_id.clone(),
         dedupe_key: action.dedupe_key.clone(),
         child_run_id,
+        child_task_id,
         child_run_status,
-        top_diagnostic,
+        top_diagnostic: top_diagnostic.message,
+        top_diagnostic_class: Some(top_diagnostic.class),
         hydrated_root_cause,
+        artifact_dir,
         owner_surface,
+        failure_signature,
+        repeated_failure,
         next_command,
         evidence_refs,
     }
+}
+
+fn action_top_diagnostic(action: &AgentTaskLoopPolicyActionRecord) -> Option<CollectedDiagnostic> {
+    action
+        .diagnostics
+        .first()
+        .map(|diagnostic| CollectedDiagnostic {
+            class: diagnostic.code.clone(),
+            message: diagnostic.message.clone(),
+        })
+}
+
+fn first_failed_task_id(value: &Value) -> Option<String> {
+    value
+        .get("outcomes")
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|outcome| {
+            outcome
+                .get("status")
+                .and_then(Value::as_str)
+                .is_some_and(|status| status != "succeeded" && status != "no_op")
+        })
+        .and_then(|outcome| outcome.get("task_id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn run_artifact_dir(run: &agent_task_lifecycle::AgentTaskRunRecord) -> Option<String> {
+    run.aggregate_path
+        .as_deref()
+        .and_then(|path| Path::new(path).parent())
+        .map(|path| path.display().to_string())
+}
+
+fn failed_child_failure_signature(
+    child_run_id: Option<&str>,
+    task_id: Option<&str>,
+    diagnostic_class: Option<&str>,
+    root_message: &str,
+    owner_surface: &str,
+) -> AgentTaskLoopFailureSignature {
+    let normalized_message = normalize_signature_text(root_message);
+    let signature_material = format!(
+        "{}\n{}\n{}",
+        owner_surface,
+        diagnostic_class.unwrap_or(""),
+        normalized_message
+    );
+    let digest = format!("sha256:{:x}", Sha256::digest(signature_material.as_bytes()));
+    AgentTaskLoopFailureSignature {
+        digest,
+        task_id: task_id.or(child_run_id).map(str::to_string),
+        diagnostic_class: diagnostic_class.map(str::to_string),
+        root_message: root_message.to_string(),
+        owner_surface: owner_surface.to_string(),
+    }
+}
+
+fn repeated_failure_diagnostic(
+    record: &AgentTaskLoopControllerRecord,
+    signature: &AgentTaskLoopFailureSignature,
+) -> Option<AgentTaskLoopRepeatedFailureDiagnostic> {
+    let matching_failed_child_action_count = record
+        .next_actions
+        .iter()
+        .filter(|action| {
+            matches!(action.status, AgentTaskLoopActionStatus::Failed)
+                && action_top_diagnostic(action).is_some_and(|diagnostic| {
+                    failed_child_failure_signature(
+                        action_referenced_run_id(action, record).as_deref(),
+                        None,
+                        Some(diagnostic.class.as_str()),
+                        &diagnostic.message,
+                        &signature.owner_surface,
+                    )
+                    .digest
+                        == signature.digest
+                })
+        })
+        .count();
+    (matching_failed_child_action_count > 1).then(|| AgentTaskLoopRepeatedFailureDiagnostic {
+        matching_failed_child_action_count,
+        guidance: "This failure signature has repeated in this controller; inspect the child input or provider boundary before another full rerun.".to_string(),
+        next_command: "homeboy agent-task evidence <child-run-id> --failure-only".to_string(),
+    })
+}
+
+fn normalize_signature_text(message: &str) -> String {
+    message
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
 }
 
 fn load_child_aggregate_value(run_id: &str) -> Option<Value> {
@@ -272,11 +387,8 @@ fn push_failed_child_evidence_ref(
     }
 }
 
-fn first_diagnostic_message(value: &Value) -> Option<String> {
-    collect_diagnostics(value)
-        .into_iter()
-        .next()
-        .map(|diagnostic| diagnostic.message)
+fn first_diagnostic(value: &Value) -> Option<CollectedDiagnostic> {
+    collect_diagnostics(value).into_iter().next()
 }
 
 fn root_cause_from_aggregate(value: &Value) -> Option<String> {

--- a/src/core/agent_task_loop_controller/tests.rs
+++ b/src/core/agent_task_loop_controller/tests.rs
@@ -292,21 +292,92 @@ fn status_diagnostics_surface_failed_child_run_root_cause() {
         assert_eq!(failed.action_id, "action-1");
         assert_eq!(failed.dedupe_key.as_deref(), Some("finding:abc:repair"));
         assert_eq!(failed.child_run_id.as_deref(), Some("agent-task-child-1"));
+        assert_eq!(failed.child_task_id.as_deref(), Some("child-task"));
         assert_eq!(failed.child_run_status.as_deref(), Some("failed"));
         assert_eq!(
             failed.top_diagnostic,
             "Agent runtime did not produce required typed artifacts: concept_packet, design_packet."
         );
         assert_eq!(
+            failed.top_diagnostic_class.as_deref(),
+            Some("child_run_failed")
+        );
+        assert_eq!(
             failed.hydrated_root_cause.as_deref(),
             Some("Provider runtime import failed: module not found")
         );
+        assert!(failed
+            .artifact_dir
+            .as_deref()
+            .is_some_and(|path| path.contains("agent-task-child-1")));
         assert_eq!(failed.owner_surface, "agent_runtime");
+        assert!(failed.failure_signature.digest.starts_with("sha256:"));
+        assert_eq!(
+            failed.failure_signature.task_id.as_deref(),
+            Some("child-task")
+        );
+        assert_eq!(
+            failed.failure_signature.root_message,
+            "Provider runtime import failed: module not found"
+        );
         assert_eq!(
             failed.next_command,
             "homeboy agent-task status agent-task-child-1 --full"
         );
     });
+}
+
+#[test]
+fn status_diagnostics_fingerprints_repeated_failed_child_actions() {
+    let mut record = AgentTaskLoopControllerRecord::new("loop", "repair", "v1");
+    for entity in ["finding:abc", "finding:def"] {
+        record.record_action(
+            AgentTaskLoopPolicyAction::SpawnTask {
+                dedupe_key: format!("{entity}:repair"),
+                entity_id: Some(entity.to_string()),
+                request: json!({}),
+            },
+            "finding emitted",
+        );
+    }
+    for action in &mut record.next_actions {
+        action.status = AgentTaskLoopActionStatus::Failed;
+        action.diagnostics.push(AgentTaskLoopActionDiagnostic {
+            code: "typed_artifacts_missing".to_string(),
+            message: "Agent runtime did not produce required typed artifacts: summary_packet."
+                .to_string(),
+            runner: None,
+            details: Value::Null,
+        });
+    }
+
+    let diagnostics = controller_status_diagnostics_with(
+        &record,
+        DateTime::parse_from_rfc3339("2026-06-11T00:05:00Z")
+            .expect("now")
+            .with_timezone(&Utc),
+        |_| Ok(true),
+    )
+    .expect("diagnostics");
+
+    assert_eq!(diagnostics.summary.failed_child_action_count, 2);
+    let first = &diagnostics.failed_child_actions[0];
+    let second = &diagnostics.failed_child_actions[1];
+    assert_eq!(
+        first.failure_signature.digest,
+        second.failure_signature.digest
+    );
+    assert_eq!(
+        first
+            .repeated_failure
+            .as_ref()
+            .map(|repeat| repeat.matching_failed_child_action_count),
+        Some(2)
+    );
+    assert!(first
+        .repeated_failure
+        .as_ref()
+        .is_some_and(|repeat| repeat.guidance.contains("provider boundary")));
 }
 
 #[test]
@@ -989,4 +1060,3 @@ fn verify_commands_are_reusable_gate_bundle_checks() {
     assert_eq!(bundle.checks[0].input["command"], json!("cargo test --lib"));
     assert!(bundle.checks[0].retryable);
 }
-


### PR DESCRIPTION
## Summary
- Inline child failure task/run details in controller diagnostics: child task id, top diagnostic class, hydrated root cause, artifact directory, and evidence refs.
- Add stable child failure signatures with digest, human-readable fields, and repeated-failure guidance when identical failures appear in the controller.
- Preserve typed-artifact-missing as the top controller diagnostic while surfacing upstream runtime/provider failures as the hydrated root cause.

Fixes #6883.
Fixes #6886.

## Tests
- rustfmt --check src/core/agent_task_loop_controller/diagnostics.rs src/core/agent_task_loop_controller/service.rs src/core/agent_task_loop_controller/tests.rs
- cargo test --lib core::agent_task_loop_controller::tests::status_diagnostics (8 passed)

Note: cargo fmt --check reports pre-existing formatting diffs outside this patch, so scoped rustfmt check was used for touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing child-failure diagnostic fields, failure signature guidance, tests, and PR preparation.