### PR TITLE
Inspect provider boundary inputs

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -32,12 +32,20 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `latest [--limit <n>]` | Show the latest durable run. |
 | `logs <run-id>` | Read durable run scheduler events. |
 | `artifacts <run-id>` | List artifacts and evidence refs recorded for a completed run. |
+| `replay-provider-boundary <run-id> [--task <task-id>]` | Hydrate the latest raw executor input and print provider-boundary fields without relaunching a provider. |
 | `cancel <run-id>` | Mark a queued or stale-running durable run as cancelled. |
 | `resume <run-id>` | Resume a queued or stale-running durable run. |
 | `retry <run-id>` | Submit a fresh durable run from an existing run's plan. |
 | `prompts save\|list\|show\|remove` | Manage markdown prompts in Homeboy-owned storage. |
 
 `agent-task list`, `agent-task active`, and `agent-task latest` accept `--limit <n>` to cap discovery output. `agent-task active --reconcile` cancels stale, suspect, or unreconciled active records through the durable lifecycle path; add `--dry-run` to report candidates without mutating records.
+
+`agent-task replay-provider-boundary <run-id>` is a focused inspect/replay path for
+provider-boundary debugging. It loads saved `executor-input` evidence, projects the
+normalized `runtime_task`, provider config, `runtime_component_paths`,
+`runtime_env`, artifact declarations, and package descriptor, then persists the
+inspection as `provider-boundary-replay` evidence. Use `--task <task-id>` for
+multi-task runs.
 
 ### Durable Fanout Batches
 

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -35,8 +35,8 @@ pub use args::{
     AgentTaskFanoutSubmitBatchArgs, AgentTaskLoopArgs, AgentTaskLoopCommand,
     AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs, AgentTaskLoopStatusArgs, CancelArgs,
     CompileLoopArgs, ContractArgs, ContractFormat, DiagnoseArgs, EvidenceArgs, FinalizePrArgs,
-    GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs, ProvidersArgs, RetryArgs, ReviewArgs,
-    RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs, ProvidersArgs, ReplayProviderBoundaryArgs,
+    RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
@@ -69,6 +69,9 @@ pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::Artifacts(status_args) => status::artifacts(status_args),
         AgentTaskCommand::Evidence(evidence_args) => status::evidence(evidence_args),
         AgentTaskCommand::Diagnose(diagnose_args) => status::diagnose(diagnose_args),
+        AgentTaskCommand::ReplayProviderBoundary(replay_args) => {
+            status::replay_provider_boundary(replay_args)
+        }
         AgentTaskCommand::Cancel(cancel_args) => status::cancel(cancel_args),
         AgentTaskCommand::Resume(status_args) => run::resume(status_args),
         AgentTaskCommand::Retry(retry_args) => run::retry(retry_args),

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -239,6 +239,8 @@ pub enum AgentTaskCommand {
     Evidence(EvidenceArgs),
     /// Lifecycle: hydrate run evidence into a structured diagnostic report.
     Diagnose(DiagnoseArgs),
+    /// Provider: inspect the latest raw executor input at the provider boundary.
+    ReplayProviderBoundary(ReplayProviderBoundaryArgs),
     /// Lifecycle: mark a queued or stale-running durable agent-task run as cancelled.
     Cancel(CancelArgs),
     /// Lifecycle: resume a queued or stale-running durable run.
@@ -689,6 +691,16 @@ pub struct EvidenceArgs {
 pub struct DiagnoseArgs {
     /// Durable run id returned by `agent-task submit` or `agent-task run-plan --record-run-id`.
     pub run_id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ReplayProviderBoundaryArgs {
+    /// Durable run id whose latest executor input should be inspected.
+    pub run_id: String,
+
+    /// Task id to inspect when the run has multiple executor-input evidence refs.
+    #[arg(long = "task", value_name = "TASK_ID")]
+    pub task: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -19,7 +19,7 @@ use homeboy::core::agent_tasks::{AgentTaskEvidenceRef, AgentTaskOutcomeStatus};
 use homeboy::core::redaction::{self, RedactionPolicy};
 
 use super::super::CmdResult;
-use super::args::{CancelArgs, DiagnoseArgs, EvidenceArgs, StatusArgs};
+use super::args::{CancelArgs, DiagnoseArgs, EvidenceArgs, ReplayProviderBoundaryArgs, StatusArgs};
 
 /// Cap the number of detail refs rendered in the compact summary so a noisy
 /// aggregate cannot flood recovery output. Overflow is reported as an
@@ -252,11 +252,177 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
     ))
 }
 
+pub(super) fn replay_provider_boundary(args: ReplayProviderBoundaryArgs) -> CmdResult<Value> {
+    let artifacts = agent_task_service::artifacts(&args.run_id)?;
+    let aggregate = completed_run_aggregate(&args.run_id).transpose()?;
+    let plan = agent_task_lifecycle::load_plan(&args.run_id).ok();
+    let evidence_entries = evidence_refs_with_tasks(&artifacts.evidence_refs, aggregate.as_ref());
+    let candidates = evidence_entries
+        .into_iter()
+        .filter(|(evidence_ref, task_id)| {
+            evidence_ref.kind == "executor-input"
+                && args
+                    .task
+                    .as_deref()
+                    .is_none_or(|requested| task_id.as_deref() == Some(requested))
+        })
+        .collect::<Vec<_>>();
+
+    let candidate_count = candidates.len();
+    let selected_index = candidates
+        .iter()
+        .position(|(evidence_ref, _)| !evidence_ref.uri.contains("/plan#"))
+        .unwrap_or(0);
+    let Some((evidence_ref, task_id)) = candidates.into_iter().nth(selected_index) else {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "agent-task replay-provider-boundary",
+            "no executor-input evidence was found for this run",
+            Some(args.run_id),
+            Some(vec![
+                "Run the task through an executor that records latest raw executor input evidence.".to_string(),
+                "Pass --task when inspecting a multi-task run and only one task should be selected.".to_string(),
+            ]),
+        ));
+    };
+
+    let hydrated = hydrate_evidence_ref(
+        &args.run_id,
+        &evidence_ref,
+        task_id.as_deref(),
+        plan.as_ref(),
+        aggregate.as_ref(),
+    );
+    let input = hydrated_executor_input_value(&hydrated)?;
+    let boundary = provider_boundary_projection(&input);
+    let report = json!({
+        "schema": "homeboy/agent-task-provider-boundary-replay/v1",
+        "run_id": args.run_id,
+        "task_id": task_id,
+        "selected_evidence": {
+            "kind": evidence_ref.kind,
+            "label": evidence_ref.label,
+            "uri": evidence_ref.uri,
+        },
+        "selection": {
+            "matching_executor_input_count": candidate_count,
+            "rule": "prefer concrete executor-input evidence over plan-level input refs; otherwise first matching ref wins",
+        },
+        "normalized_provider_boundary": boundary,
+    });
+    let evidence_uri = persist_provider_boundary_replay_evidence(&report);
+    let report = match evidence_uri {
+        Some(uri) => {
+            let mut report = report;
+            report["typed_evidence"] = json!({
+                "kind": "provider-boundary-replay",
+                "uri": uri,
+                "label": "provider boundary replay inspection",
+            });
+            report
+        }
+        None => report,
+    };
+
+    Ok((report, 0))
+}
+
 pub(super) fn cancel(args: CancelArgs) -> CmdResult<Value> {
     let record = agent_task_service::cancel(&args.run_id, args.reason.as_deref())?;
     let mut value = serde_json::to_value(record).unwrap_or(Value::Null);
     surface_cancellation_recovery(&mut value);
     Ok((value, 0))
+}
+
+fn hydrated_executor_input_value(result: &HydratedEvidence) -> homeboy::core::Result<Value> {
+    if result.status != "ok" {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "executor-input evidence",
+            "selected executor-input evidence could not be hydrated",
+            result.error.clone(),
+            None,
+        ));
+    }
+    if result.truncated {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "executor-input evidence",
+            "selected executor-input evidence is truncated and cannot be replayed deterministically",
+            Some(result.uri.clone()),
+            None,
+        ));
+    }
+    match result.content.get("format").and_then(Value::as_str) {
+        Some("json") => Ok(result.content.get("value").cloned().unwrap_or(Value::Null)),
+        _ => Err(homeboy::core::Error::validation_invalid_argument(
+            "executor-input evidence",
+            "selected executor-input evidence is not JSON",
+            Some(result.uri.clone()),
+            None,
+        )),
+    }
+}
+
+fn provider_boundary_projection(input: &Value) -> Value {
+    let executor_config = input
+        .get("executor")
+        .and_then(|executor| executor.get("config"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let runtime_task = input
+        .get("inputs")
+        .and_then(|inputs| inputs.get("runtime_task"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let package_descriptor = runtime_task
+        .pointer("/input/package")
+        .or_else(|| input.pointer("/inputs/package_descriptor"))
+        .or_else(|| input.pointer("/metadata/package_descriptor"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    json!({
+        "runtime_task": runtime_task,
+        "provider_config": executor_config,
+        "runtime_component_paths": input.pointer("/executor/config/runtime_component_paths").cloned().unwrap_or(Value::Null),
+        "runtime_env": input.pointer("/executor/config/runtime_env").cloned().unwrap_or(Value::Null),
+        "artifact_declarations": input.get("artifact_declarations").cloned().unwrap_or(Value::Null),
+        "package_descriptor": package_descriptor,
+    })
+}
+
+fn persist_provider_boundary_replay_evidence(report: &Value) -> Option<String> {
+    let run_id = report.get("run_id")?.as_str().unwrap_or("unknown-run");
+    let task_id = report
+        .get("task_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown-task");
+    let dir = std::env::temp_dir()
+        .join("homeboy-agent-task-evidence")
+        .join(sanitize_evidence_path_part(run_id));
+    fs::create_dir_all(&dir).ok()?;
+    let path = dir.join(format!(
+        "provider-boundary-replay-{}.json",
+        sanitize_evidence_path_part(task_id)
+    ));
+    fs::write(&path, serde_json::to_vec_pretty(report).ok()?).ok()?;
+    Some(format!("file://{}", path.display()))
+}
+
+fn sanitize_evidence_path_part(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "unknown".to_string()
+    } else {
+        sanitized
+    }
 }
 
 #[derive(Serialize)]

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -256,6 +256,88 @@ fn diagnose_hydrates_executor_result_evidence_root_cause() {
 }
 
 #[test]
+fn replay_provider_boundary_projects_latest_executor_input() {
+    with_temp_home(|| {
+        let evidence_dir = tempfile::tempdir().expect("evidence dir");
+        let evidence_path = evidence_dir.path().join("executor-input.json");
+        std::fs::write(
+            &evidence_path,
+            serde_json::to_string(&json!({
+                "task_id": "task-a",
+                "executor": {
+                    "backend": "codebox",
+                    "config": {
+                        "runtime_component_paths": {
+                            "agent_runtime": "/runner/data-machine-patched"
+                        },
+                        "runtime_env": {
+                            "WP_CODEBOX_DATA_MACHINE_PATH": "/runner/data-machine-patched"
+                        }
+                    }
+                },
+                "inputs": {
+                    "runtime_task": {
+                        "ability": "runtime-package/run",
+                        "input": {
+                            "package": {
+                                "source": "data-machine"
+                            }
+                        }
+                    }
+                },
+                "artifact_declarations": [
+                    { "name": "runtime-package", "required": true }
+                ]
+            }))
+            .expect("evidence json"),
+        )
+        .expect("write evidence");
+
+        run_loaded_plan(
+            test_plan(),
+            Some("run-cli-provider-boundary-replay"),
+            ExecutorInputEvidenceExecutor {
+                evidence_uri: format!("file://{}", evidence_path.display()),
+            },
+        )
+        .expect("run completed");
+
+        let (value, exit_code) = replay_provider_boundary(ReplayProviderBoundaryArgs {
+            run_id: "run-cli-provider-boundary-replay".to_string(),
+            task: Some("task-a".to_string()),
+        })
+        .expect("replay report");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            value["schema"],
+            "homeboy/agent-task-provider-boundary-replay/v1"
+        );
+        assert_eq!(
+            value["normalized_provider_boundary"]["runtime_task"]["ability"],
+            "runtime-package/run"
+        );
+        assert_eq!(
+            value["normalized_provider_boundary"]["runtime_component_paths"]["agent_runtime"],
+            "/runner/data-machine-patched"
+        );
+        assert_eq!(
+            value["normalized_provider_boundary"]["runtime_env"]["WP_CODEBOX_DATA_MACHINE_PATH"],
+            "/runner/data-machine-patched"
+        );
+        assert_eq!(
+            value["normalized_provider_boundary"]["package_descriptor"]["source"],
+            "data-machine"
+        );
+        assert_eq!(
+            value["normalized_provider_boundary"]["artifact_declarations"][0]["name"],
+            "runtime-package"
+        );
+        assert_eq!(value["typed_evidence"]["kind"], "provider-boundary-replay");
+    });
+}
+
+#[test]
 fn generic_contract_fixtures_surface_runtime_import_before_missing_artifact() {
     with_temp_home(|| {
         let run_id = "run-contract-import-diagnostics";

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -14,8 +14,8 @@ pub(in crate::commands::agent_task) use super::super::args::{
     AgentTaskControllerProofArgs, AgentTaskControllerRunFromSpecArgs,
 };
 pub(in crate::commands::agent_task) use super::super::args::{
-    AgentTaskCookArgs, CompileLoopArgs, DiagnoseArgs, EvidenceArgs, ReviewArgs, StatusArgs,
-    SubmitArgs, VerifyGateArgs,
+    AgentTaskCookArgs, CompileLoopArgs, DiagnoseArgs, EvidenceArgs, ReplayProviderBoundaryArgs,
+    ReviewArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(in crate::commands::agent_task) use super::super::controller::{
     apply_controller_event, controller_from_spec, controller_materialize,
@@ -27,7 +27,7 @@ pub(in crate::commands::agent_task) use super::super::run::{
     run_resume_with_executor, run_submitted, submit,
 };
 pub(in crate::commands::agent_task) use super::super::status::{
-    cancel, diagnose, evidence, logs, status,
+    cancel, diagnose, evidence, logs, replay_provider_boundary, status,
 };
 pub(in crate::commands::agent_task) use super::super::{
     review, CancelArgs, ProvidersArgs, RetryArgs,
@@ -246,6 +246,38 @@ impl AgentTaskExecutorAdapter for ExecutorResultEvidenceFailureExecutor {
             workflow: None,
             follow_up: None,
             metadata: json!({ "expected_artifacts": ["concept_packet", "design_packet"] }),
+        }
+    }
+}
+
+pub(crate) struct ExecutorInputEvidenceExecutor {
+    pub(crate) evidence_uri: String,
+}
+
+impl AgentTaskExecutorAdapter for ExecutorInputEvidenceExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: request.task_id,
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: Some("captured executor input".to_string()),
+            failure_classification: None,
+            artifacts: Vec::new(),
+            typed_artifacts: Vec::new(),
+            evidence_refs: vec![AgentTaskEvidenceRef {
+                kind: "executor-input".to_string(),
+                uri: self.evidence_uri.clone(),
+                label: Some("latest raw executor input".to_string()),
+            }],
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
         }
     }
 }

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -382,7 +382,11 @@ fn remap_provider_config_spec(spec: &str, mappings: &[&LabPathRemap]) -> Result<
     // spec always needs inlining). Without that pruning a stale path is forwarded
     // verbatim and breaks remote recipe validation, so we cannot early-return
     // here just because there is nothing to remap.
-    if !needs_inlining && mappings.is_empty() && !spec_has_provider_plugin_paths(spec) {
+    if !needs_inlining
+        && mappings.is_empty()
+        && !spec_has_provider_plugin_paths(spec)
+        && !spec_has_runtime_env_path_aliases(spec)
+    {
         return Ok(spec.to_string());
     }
 
@@ -417,6 +421,7 @@ fn remap_provider_config_spec(spec: &str, mappings: &[&LabPathRemap]) -> Result<
     };
     remap_paths_in_value(&mut value, mappings);
     prune_unresolved_provider_plugin_paths(&mut value, mappings);
+    normalize_runtime_env_path_aliases(&mut value);
     Ok(serde_json::to_string(&value).unwrap_or_else(|_| spec.to_string()))
 }
 
@@ -425,6 +430,119 @@ fn remap_provider_config_spec(spec: &str, mappings: &[&LabPathRemap]) -> Result<
 /// need pruning. Avoids round-tripping every untouched provider-config.
 fn spec_has_provider_plugin_paths(spec: &str) -> bool {
     spec.contains("provider_plugin_paths")
+}
+
+fn spec_has_runtime_env_path_aliases(spec: &str) -> bool {
+    spec.contains("runtime_env_path_aliases") || spec.contains("runtime_env_aliases")
+}
+
+/// Normalize declared legacy/runtime env aliases to the structured component path.
+///
+/// Homeboy core stays provider-agnostic by requiring the provider config to
+/// declare aliases explicitly, either as:
+///
+/// - `runtime_env_path_aliases`: `{ "component_key": "ENV_NAME" }`
+/// - `runtime_env_aliases`: `{ "ENV_NAME": "component_key" }`
+///
+/// When both the structured component path and env alias are present but differ,
+/// `runtime_component_paths` wins. The original env value and precedence rule are
+/// retained in `runtime_env_path_alias_diagnostics` for operator diagnostics.
+fn normalize_runtime_env_path_aliases(value: &mut Value) {
+    let aliases = runtime_env_path_aliases(value);
+    if aliases.is_empty() {
+        return;
+    }
+
+    let Some(root) = value.as_object_mut() else {
+        return;
+    };
+    let component_paths = root
+        .get("runtime_component_paths")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if component_paths.is_empty() {
+        return;
+    }
+
+    if !root.get("runtime_env").is_some_and(Value::is_object) {
+        root.insert(
+            "runtime_env".to_string(),
+            Value::Object(serde_json::Map::new()),
+        );
+    }
+
+    let mut diagnostics = Vec::new();
+    let Some(runtime_env) = root.get_mut("runtime_env").and_then(Value::as_object_mut) else {
+        return;
+    };
+
+    for (component_key, env_name) in aliases {
+        let Some(selected_path) = component_paths
+            .get(&component_key)
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        let previous = runtime_env.get(&env_name).cloned().unwrap_or(Value::Null);
+        if previous.as_str() == Some(selected_path.as_str()) {
+            continue;
+        }
+        runtime_env.insert(env_name.clone(), Value::String(selected_path.clone()));
+        diagnostics.push(serde_json::json!({
+            "component_path_field": format!("runtime_component_paths.{component_key}"),
+            "env_field": format!("runtime_env.{env_name}"),
+            "selected_path": selected_path,
+            "overridden_path": previous,
+            "precedence": "runtime_component_paths wins over declared runtime_env alias before provider launch",
+        }));
+    }
+
+    if !diagnostics.is_empty() {
+        root.insert(
+            "runtime_env_path_alias_diagnostics".to_string(),
+            Value::Array(diagnostics),
+        );
+    }
+}
+
+fn runtime_env_path_aliases(value: &Value) -> Vec<(String, String)> {
+    let mut aliases = Vec::new();
+    if let Some(map) = value
+        .get("runtime_env_path_aliases")
+        .and_then(Value::as_object)
+    {
+        for (component_key, env_names) in map {
+            collect_alias_env_names(component_key, env_names, &mut aliases);
+        }
+    }
+    if let Some(map) = value.get("runtime_env_aliases").and_then(Value::as_object) {
+        for (env_name, component_key) in map {
+            if let Some(component_key) = component_key.as_str() {
+                aliases.push((component_key.to_string(), env_name.to_string()));
+            }
+        }
+    }
+    aliases
+}
+
+fn collect_alias_env_names(
+    component_key: &str,
+    value: &Value,
+    aliases: &mut Vec<(String, String)>,
+) {
+    match value {
+        Value::String(env_name) => aliases.push((component_key.to_string(), env_name.to_string())),
+        Value::Array(items) => {
+            for item in items {
+                if let Some(env_name) = item.as_str() {
+                    aliases.push((component_key.to_string(), env_name.to_string()));
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Drop `provider_plugin_paths` entries that point at a controller-local

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -474,6 +474,60 @@ mod provider_config_remap_tests {
     }
 
     #[test]
+    fn remap_normalizes_runtime_env_alias_to_structured_component_path() {
+        let config = serde_json::json!({
+            "runtime_component_paths": {
+                "agent_runtime": "/runner/data-machine-patched"
+            },
+            "runtime_env": {
+                "WP_CODEBOX_DATA_MACHINE_PATH": "/runner/data-machine-stale"
+            },
+            "runtime_env_path_aliases": {
+                "agent_runtime": "WP_CODEBOX_DATA_MACHINE_PATH"
+            }
+        })
+        .to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--provider-config".to_string(),
+            config,
+        ];
+
+        let out = remap_provider_config_in_args(&args, &[]).expect("remap provider config");
+        let cfg_idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
+        let remapped: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("inline json");
+
+        assert_eq!(
+            remapped["runtime_env"]["WP_CODEBOX_DATA_MACHINE_PATH"],
+            "/runner/data-machine-patched"
+        );
+        assert_eq!(
+            remapped["runtime_env_path_alias_diagnostics"][0]["component_path_field"],
+            "runtime_component_paths.agent_runtime"
+        );
+        assert_eq!(
+            remapped["runtime_env_path_alias_diagnostics"][0]["env_field"],
+            "runtime_env.WP_CODEBOX_DATA_MACHINE_PATH"
+        );
+        assert_eq!(
+            remapped["runtime_env_path_alias_diagnostics"][0]["selected_path"],
+            "/runner/data-machine-patched"
+        );
+        assert_eq!(
+            remapped["runtime_env_path_alias_diagnostics"][0]["overridden_path"],
+            "/runner/data-machine-stale"
+        );
+        assert!(
+            remapped["runtime_env_path_alias_diagnostics"][0]["precedence"]
+                .as_str()
+                .expect("precedence")
+                .contains("runtime_component_paths wins")
+        );
+    }
+
+    #[test]
     fn remap_preserves_relative_and_materialized_provider_plugin_paths() {
         // Relative paths resolve against the runner workspace, and non-string
         // entries (materialized ref objects) are left untouched. Neither should be


### PR DESCRIPTION
## Summary
- Add `agent-task replay-provider-boundary <run-id> [--task <task-id>]` to hydrate saved executor input and report provider-boundary fields without relaunching a provider.
- Persist the replay report as `provider-boundary-replay` evidence when possible.
- Normalize provider-declared runtime env path aliases so structured `runtime_component_paths` wins over contradictory `runtime_env` values before provider launch.
- Document the new replay command.

Closes #6884.
Closes #6885.

## Tests
- `rustfmt --check src/commands/agent_task.rs src/commands/agent_task/args/mod.rs src/commands/agent_task/status.rs src/commands/agent_task/tests/support.rs src/commands/agent_task/tests/lifecycle.rs src/core/runner/lab_args/provider_config.rs src/core/runner/lab_args/tests.rs`
- `cargo test replay_provider_boundary_projects_latest_executor_input`
- `cargo test remap_normalizes_runtime_env_alias_to_structured_component_path`
- `cargo test commands::agent_task::tests::lifecycle`
- `cargo test core::runner::lab_args::tests::provider_config_remap_tests`
- `cargo test --test command_surface_test`
- `git diff --check`

Note: full `cargo fmt --check` reports pre-existing formatting diffs outside this PR, so I used touched-file `rustfmt --check` for this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the provider-boundary replay command, generic runtime env alias normalization, tests, docs, and verification.