### PR TITLE
Make stuck rig locks reclaimable + surface holder details (refs #6891)

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -11,9 +11,9 @@ use homeboy::core::rig;
 
 use self::output::{
     RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledStackSummary,
-    RigInstalledSummary, RigListOutput, RigRepairOutput, RigShowOutput, RigSourceSummary,
-    RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput, RigUpPlanOutput, RigUpPlanStep,
-    RigUpdateOutput,
+    RigInstalledSummary, RigListOutput, RigReleaseLockOutput, RigRepairOutput, RigShowOutput,
+    RigSourceSummary, RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput, RigUpPlanOutput,
+    RigUpPlanStep, RigUpdateOutput,
 };
 use super::CmdResult;
 use crate::command_contract::{
@@ -165,6 +165,19 @@ enum RigCommand {
         #[arg(long, default_value_t = 20)]
         limit: i64,
     },
+    /// Release a stuck active-run lock (rig lease) so a new run can proceed.
+    ///
+    /// By default the lock is only released when its holder is provably gone or
+    /// past its TTL. Pass `--force` to reclaim a lock whose holder is still
+    /// alive but wedged. Releasing the lock frees the local guardrail; it does
+    /// not terminate the holder process.
+    ReleaseLock {
+        /// Rig ID
+        rig_id: String,
+        /// Reclaim the lock even if its holder process is still alive.
+        #[arg(long)]
+        force: bool,
+    },
     /// Install rigs from a local package path or git URL
     Install {
         /// Git URL or local path containing rig.json or rigs/<id>/rig.json
@@ -239,6 +252,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
         RigCommand::Status { rig_id } => status(&rig_id),
         RigCommand::Runs { rig_id, limit } => runs(&rig_id, limit),
+        RigCommand::ReleaseLock { rig_id, force } => release_lock(&rig_id, force),
         RigCommand::Install {
             source,
             id,
@@ -249,6 +263,17 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Sources { command } => sources::run(command),
         RigCommand::App { command } => app(command),
     }
+}
+
+fn release_lock(rig_id: &str, force: bool) -> CmdResult<RigCommandOutput> {
+    let outcome = rig::release_active_run_lease(rig_id, force)?;
+    Ok((
+        RigCommandOutput::ReleaseLock(RigReleaseLockOutput {
+            command: "rig.release_lock",
+            outcome,
+        }),
+        0,
+    ))
 }
 
 fn runs(rig_id: &str, limit: i64) -> CmdResult<RigCommandOutput> {

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -26,6 +26,14 @@ pub enum RigCommandOutput {
     Sources(RigSourcesOutput),
     App(RigAppOutput),
     Runs(RunsOutput),
+    ReleaseLock(RigReleaseLockOutput),
+}
+
+#[derive(Serialize)]
+pub struct RigReleaseLockOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub outcome: rig::ReleaseLeaseOutcome,
 }
 
 #[derive(Serialize)]

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -219,6 +219,27 @@ pub struct RigResourceConflictInfo {
     pub held_since: String,
     pub held_by_run_id: Option<String>,
     pub held_by_runner_id: Option<String>,
+    /// Wall-clock age of the holding lease in seconds, when it can be derived
+    /// from `held_since`. Surfaced so operators can judge whether the holder is
+    /// a fresh, legitimate run or a stale/wedged one worth reclaiming.
+    pub held_age_seconds: Option<i64>,
+}
+
+/// Render a duration in seconds as a compact human string (e.g. `28m`, `2h 5m`).
+fn humanize_age_seconds(seconds: i64) -> String {
+    if seconds < 0 {
+        return "unknown".to_string();
+    }
+    let hours = seconds / 3600;
+    let minutes = (seconds % 3600) / 60;
+    let secs = seconds % 60;
+    if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m {secs}s")
+    } else {
+        format!("{secs}s")
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -608,10 +629,15 @@ impl Error {
     pub fn rig_resource_conflict(info: RigResourceConflictInfo) -> Self {
         let held_by_run_id = info.held_by_run_id.clone();
         let held_by_runner_id = info.held_by_runner_id.clone();
+        let held_rig_id = info.held_by_rig.clone();
+        let age_label = info
+            .held_age_seconds
+            .map(humanize_age_seconds)
+            .unwrap_or_else(|| "unknown".to_string());
         let mut error = Self::new(
             ErrorCode::RigResourceConflict,
             format!(
-                "Rig '{}' cannot run '{}': {} resource '{}' is already held by rig '{}' running '{}' (pid {}, since {})",
+                "Rig '{}' cannot run '{}': {} resource '{}' is already held by rig '{}' running '{}' (pid {}, since {}, held for {})",
                 info.rig_id,
                 info.command,
                 info.resource_kind,
@@ -619,7 +645,8 @@ impl Error {
                 info.held_by_rig,
                 info.held_by_command,
                 info.held_by_pid,
-                info.held_since
+                info.held_since,
+                age_label
             ),
             serde_json::json!({
                 "rig_id": info.rig_id,
@@ -631,6 +658,7 @@ impl Error {
                     "command": info.held_by_command,
                     "pid": info.held_by_pid,
                     "since": info.held_since,
+                    "age_seconds": info.held_age_seconds,
                     "run_id": info.held_by_run_id,
                     "runner_id": info.held_by_runner_id,
                 }
@@ -639,7 +667,11 @@ impl Error {
         .with_hint(
             "If this parallel run is intentional, give each run a distinct namespace or port range so their rig resources no longer overlap."
                 .to_string(),
-        );
+        )
+        .with_hint(format!(
+            "If the holder (pid {}) is dead or wedged and will never finish, reclaim the lock with `homeboy rig release-lock {} --force`; without `--force` the lock is only released when its holder is provably gone or past its TTL.",
+            info.held_by_pid, held_rig_id
+        ));
         if let Some(run_id) = held_by_run_id {
             error = error
                 .with_hint(format!(

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -8,8 +8,17 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 mod lock;
+
+/// Environment variable that, when set to a positive integer number of seconds,
+/// enables time-to-live based reclaim of rig run leases. A lease whose holder is
+/// still alive but has been held longer than this TTL is treated as stale and
+/// becomes reclaimable on the next acquire. Unset (the default) means leases are
+/// only reclaimed when their holder process is provably gone — a live, recent
+/// holder is never reclaimed automatically.
+pub const RIG_LEASE_TTL_ENV: &str = "HOMEBOY_RIG_LEASE_TTL_SECS";
 
 use super::expand::expand_resources;
 use super::spec::{RigResourcesSpec, RigSpec};
@@ -74,6 +83,7 @@ pub fn acquire_active_run_lease(rig: &RigSpec, command: &str) -> Result<Option<A
         return Ok(None);
     }
     if let Some(conflict) = find_conflict(rig, command, &resources)? {
+        let held_age_seconds = lease_age_seconds(&conflict.lease.started_at);
         return Err(Error::rig_resource_conflict(RigResourceConflictInfo {
             rig_id: rig.id.clone(),
             command: command.to_string(),
@@ -85,6 +95,7 @@ pub fn acquire_active_run_lease(rig: &RigSpec, command: &str) -> Result<Option<A
             held_since: conflict.lease.started_at,
             held_by_run_id: conflict.lease.run_id,
             held_by_runner_id: conflict.lease.runner_id,
+            held_age_seconds,
         }));
     }
 
@@ -233,12 +244,46 @@ fn paths_overlap(a: &str, b: &str) -> bool {
     a == b || a.starts_with(b) || b.starts_with(a)
 }
 
+/// Read the configured lease TTL, if any. Returns `None` when the env var is
+/// unset, empty, non-numeric, or zero — in which case TTL-based reclaim is
+/// disabled and only dead holders are reclaimed.
+fn lease_ttl() -> Option<Duration> {
+    std::env::var(RIG_LEASE_TTL_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map(Duration::from_secs)
+}
+
+/// Wall-clock age of a lease in seconds derived from its `started_at` timestamp.
+/// Returns `None` if the timestamp cannot be parsed.
+fn lease_age_seconds(started_at: &str) -> Option<i64> {
+    let started = chrono::DateTime::parse_from_rfc3339(started_at).ok()?;
+    let age = chrono::Utc::now().signed_duration_since(started.with_timezone(&chrono::Utc));
+    Some(age.num_seconds())
+}
+
+/// A lease is reclaimable when its holder process is provably gone, or — when a
+/// TTL is configured — when it has been held longer than that TTL. A live holder
+/// within its TTL window is never reclaimable: we never steal an active lock.
+fn lease_is_reclaimable(lease: &RigRunLease) -> bool {
+    if !crate::core::process::pid_is_running(lease.pid) {
+        return true;
+    }
+    if let Some(ttl) = lease_ttl() {
+        if let Some(age) = lease_age_seconds(&lease.started_at) {
+            return age >= 0 && (age as u64) > ttl.as_secs();
+        }
+    }
+    false
+}
+
 fn prune_stale_leases() -> Result<()> {
     for path in lease_files()? {
         let Some(lease) = read_lease(&path)? else {
             continue;
         };
-        if !crate::core::process::pid_is_running(lease.pid) {
+        if lease_is_reclaimable(&lease) {
             fs::remove_file(&path).map_err(|e| {
                 Error::internal_unexpected(format!(
                     "Failed to remove stale rig lease {}: {}",
@@ -255,12 +300,83 @@ fn live_leases() -> Result<Vec<RigRunLease>> {
     let mut leases = Vec::new();
     for path in lease_files()? {
         if let Some(lease) = read_lease(&path)? {
-            if crate::core::process::pid_is_running(lease.pid) {
+            if !lease_is_reclaimable(&lease) {
                 leases.push(lease);
             }
         }
     }
     Ok(leases)
+}
+
+/// Outcome of an operator-initiated rig lock release.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleaseLeaseOutcome {
+    /// No lease was held for this rig.
+    NoLease { rig_id: String },
+    /// A lease was released.
+    Released {
+        rig_id: String,
+        /// The released lease.
+        lease: RigRunLease,
+        /// Wall-clock age of the released lease in seconds, when derivable.
+        age_seconds: Option<i64>,
+        /// Whether the holder was already dead/stale (safe release) vs. a live
+        /// holder forcibly reclaimed via `--force`.
+        was_reclaimable: bool,
+        /// Whether `--force` was used to override a live holder.
+        forced: bool,
+    },
+}
+
+/// Release the active run lease held for `rig_id`.
+///
+/// Without `force`, a lease is only released when its holder is provably gone or
+/// past its configured TTL — releasing a live, recent holder requires `force`.
+/// Releasing the lock does not terminate the holder process; it only frees the
+/// local guardrail so a new run can proceed. With `force`, the caller is
+/// asserting the holder is dead or wedged.
+pub fn release_active_run_lease(rig_id: &str, force: bool) -> Result<ReleaseLeaseOutcome> {
+    let _lock = LeaseIndexLock::acquire()?;
+    let path = lease_path(rig_id)?;
+    let Some(lease) = read_lease(&path)? else {
+        return Ok(ReleaseLeaseOutcome::NoLease {
+            rig_id: rig_id.to_string(),
+        });
+    };
+
+    let was_reclaimable = lease_is_reclaimable(&lease);
+    let age_seconds = lease_age_seconds(&lease.started_at);
+    if !was_reclaimable && !force {
+        return Err(Error::rig_resource_conflict(RigResourceConflictInfo {
+            rig_id: rig_id.to_string(),
+            command: "release-lock".to_string(),
+            resource_kind: "rig".to_string(),
+            resource_value: rig_id.to_string(),
+            held_by_rig: lease.rig_id.clone(),
+            held_by_command: lease.command.clone(),
+            held_by_pid: lease.pid,
+            held_since: lease.started_at.clone(),
+            held_by_run_id: lease.run_id.clone(),
+            held_by_runner_id: lease.runner_id.clone(),
+            held_age_seconds: age_seconds,
+        }));
+    }
+
+    fs::remove_file(&path).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to release rig lease for '{}': {}",
+            rig_id, e
+        ))
+    })?;
+
+    Ok(ReleaseLeaseOutcome::Released {
+        rig_id: rig_id.to_string(),
+        lease,
+        age_seconds,
+        was_reclaimable,
+        forced: force && !was_reclaimable,
+    })
 }
 
 /// List active rig run leases without acquiring or mutating leases.

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -51,7 +51,10 @@ pub use install::{
     DiscoveredRig, DiscoveredStack, InstalledStack, RigInstallResult, RigSourceMetadata,
     StackSourceMetadata,
 };
-pub use lease::{acquire_active_run_lease, active_run_leases, ActiveRigRunLease, RigRunLease};
+pub use lease::{
+    acquire_active_run_lease, active_run_leases, release_active_run_lease, ActiveRigRunLease,
+    ReleaseLeaseOutcome, RigRunLease, RIG_LEASE_TTL_ENV,
+};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
     head_sha_and_branch, run_bench_prepare, run_check, run_check_groups, run_down,

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -1,7 +1,10 @@
 //! Tests for active rig run leases.
 
 use crate::core::error::ErrorCode;
-use crate::core::rig::lease::{acquire_active_run_lease, active_run_leases};
+use crate::core::rig::lease::{
+    acquire_active_run_lease, active_run_leases, release_active_run_lease, ReleaseLeaseOutcome,
+    RIG_LEASE_TTL_ENV,
+};
 use crate::core::rig::spec::{RigResourcesSpec, RigSpec};
 use crate::core::rig::{run_up, RigRunLease};
 use crate::test_support::with_isolated_home;
@@ -247,6 +250,165 @@ fn test_acquire_active_run_lease_prunes_stale_pid() {
         assert!(acquire_active_run_lease(&studio_bfb, "up")
             .expect("stale pid ignored")
             .is_some());
+    });
+}
+
+fn write_lease(lease: &RigRunLease) {
+    let lease_dir = crate::core::paths::rig_leases_dir().expect("lease dir");
+    std::fs::create_dir_all(&lease_dir).expect("create lease dir");
+    std::fs::write(
+        lease_dir.join(format!("{}.json", lease.rig_id)),
+        serde_json::to_string_pretty(lease).expect("serialize lease"),
+    )
+    .expect("write lease");
+}
+
+fn live_lease(rig_id: &str, started_at: &str) -> RigRunLease {
+    RigRunLease {
+        rig_id: rig_id.to_string(),
+        command: "bench".to_string(),
+        // This test process is alive, so the lease holder is a live pid.
+        pid: std::process::id(),
+        started_at: started_at.to_string(),
+        run_id: Some("run-abc".to_string()),
+        runner_id: Some("lab-runner-1".to_string()),
+        resources: resources(),
+    }
+}
+
+#[test]
+fn test_ttl_reclaims_live_but_stale_lease() {
+    with_isolated_home(|_| {
+        let _ttl = EnvVarGuard::set(RIG_LEASE_TTL_ENV, "1");
+        // Live holder pid, but started far in the past => past the 1s TTL.
+        write_lease(&live_lease("studio", "2020-01-01T00:00:00Z"));
+
+        let studio_bfb = rig("studio-bfb", resources());
+        assert!(
+            acquire_active_run_lease(&studio_bfb, "bench")
+                .expect("ttl-stale lease is reclaimable")
+                .is_some(),
+            "a live-but-stale holder past its TTL must be reclaimable"
+        );
+    });
+}
+
+#[test]
+fn test_live_holder_within_ttl_still_conflicts() {
+    with_isolated_home(|_| {
+        let _ttl = EnvVarGuard::set(RIG_LEASE_TTL_ENV, "100000");
+        let studio = rig("studio", resources());
+        let lease = acquire_active_run_lease(&studio, "bench")
+            .expect("first lease")
+            .expect("resourceful rig leases");
+
+        let studio_bfb = rig("studio-bfb", resources());
+        let conflict = acquire_active_run_lease(&studio_bfb, "bench")
+            .expect_err("a live, recent holder within its TTL must still conflict");
+        assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
+
+        drop(lease);
+    });
+}
+
+#[test]
+fn test_no_ttl_keeps_live_holder_locked() {
+    with_isolated_home(|_| {
+        // No TTL configured: even a very old live holder is never auto-reclaimed.
+        std::env::remove_var(RIG_LEASE_TTL_ENV);
+        write_lease(&live_lease("studio", "2020-01-01T00:00:00Z"));
+
+        let studio_bfb = rig("studio-bfb", resources());
+        let conflict = acquire_active_run_lease(&studio_bfb, "bench")
+            .expect_err("without a TTL a live holder is never stolen");
+        assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
+    });
+}
+
+#[test]
+fn test_resource_conflict_includes_age_and_reclaim_command() {
+    with_isolated_home(|_| {
+        write_lease(&live_lease("studio", "2020-01-01T00:00:00Z"));
+
+        let studio_bfb = rig("studio-bfb", resources());
+        let conflict = acquire_active_run_lease(&studio_bfb, "bench")
+            .expect_err("live holder conflicts without a TTL");
+
+        let age = conflict.details["held_by"]["age_seconds"]
+            .as_i64()
+            .expect("age_seconds present");
+        assert!(age > 0, "holder age should be a positive number of seconds");
+        assert!(conflict.message.contains("held for"));
+        assert!(
+            conflict.hints.iter().any(|hint| hint
+                .message
+                .contains("homeboy rig release-lock studio --force")),
+            "conflict must surface the exact reclaim command"
+        );
+    });
+}
+
+#[test]
+fn test_release_lock_reports_no_lease_when_absent() {
+    with_isolated_home(|_| {
+        let outcome = release_active_run_lease("studio", false).expect("release with no lease");
+        assert!(matches!(outcome, ReleaseLeaseOutcome::NoLease { .. }));
+    });
+}
+
+#[test]
+fn test_release_lock_frees_dead_holder_without_force() {
+    with_isolated_home(|_| {
+        let dead = RigRunLease {
+            rig_id: "studio".to_string(),
+            command: "bench".to_string(),
+            pid: u32::MAX,
+            started_at: "2020-01-01T00:00:00Z".to_string(),
+            run_id: None,
+            runner_id: None,
+            resources: resources(),
+        };
+        write_lease(&dead);
+
+        let outcome = release_active_run_lease("studio", false).expect("release dead holder");
+        match outcome {
+            ReleaseLeaseOutcome::Released {
+                was_reclaimable,
+                forced,
+                ..
+            } => {
+                assert!(was_reclaimable, "dead holder is reclaimable");
+                assert!(!forced, "no force was needed for a dead holder");
+            }
+            other => panic!("expected Released, got {other:?}"),
+        }
+        assert!(active_run_leases().expect("list").is_empty());
+    });
+}
+
+#[test]
+fn test_release_lock_requires_force_for_live_holder() {
+    with_isolated_home(|_| {
+        std::env::remove_var(RIG_LEASE_TTL_ENV);
+        write_lease(&live_lease("studio", "2020-01-01T00:00:00Z"));
+
+        let err = release_active_run_lease("studio", false)
+            .expect_err("a live holder must not be released without force");
+        assert_eq!(err.code, ErrorCode::RigResourceConflict);
+
+        let outcome =
+            release_active_run_lease("studio", true).expect("force releases the live holder");
+        match outcome {
+            ReleaseLeaseOutcome::Released {
+                was_reclaimable,
+                forced,
+                ..
+            } => {
+                assert!(!was_reclaimable, "live holder was not otherwise reclaimable");
+                assert!(forced, "force was required");
+            }
+            other => panic!("expected Released, got {other:?}"),
+        }
     });
 }
 


### PR DESCRIPTION
## Problem
When a long Lab bench exceeds the controller's runner-exec wait budget, the controller returns exit 2 (wait timeout) but the remote job keeps running and keeps holding its rig lease. The only liveness signal today is "is the holder pid alive?", so a wedged-but-alive holder pins the lock and every later run of that rig fails with `rig.resource_conflict` (exit 20) until someone manually finds the pid and `kill -9`s it.

Refs #6891.

## What this PR does
Addresses the lock-recoverability and error-surfacing asks from the issue:

1. **Opt-in lease TTL** (`HOMEBOY_RIG_LEASE_TTL_SECS`). When set, a lease whose holder is still alive but has been held longer than the TTL is treated as stale and reclaimed on the next acquire (and prunes via the existing stale-lease sweep). Unset (the default) preserves today's behavior exactly.
2. **`homeboy rig release-lock <rig> [--force]`**. Without `--force`, the lock is only released when its holder is provably gone or past its TTL (safe). With `--force`, an operator can reclaim a wedged-but-alive holder. Releasing the lock frees the local guardrail; it does **not** terminate the holder process.
3. **Improved `rig.resource_conflict` error.** Now includes the holder's wall-clock age (`held_age_seconds` + a humanized `held for ...` in the message) and a hint with the exact reclaim command, alongside the existing pid / run-id / runner-id.

## Reclaim safety (no stealing live locks)
A lease is reclaimable only when:
- its holder **pid is gone** (existing behavior, unchanged), or
- a TTL is configured **and** the lease has outlived that operator-declared TTL window.

A live holder **inside** its TTL window always still conflicts. With no TTL set, a live holder is never auto-reclaimed. Forced release is an explicit, opt-in operator action. We never silently steal an active, recent lock.

## Deferred (separate scope)
Best-effort remote cancel on controller wait-timeout. The `runner_job_cancel` primitive already exists, but auto-cancelling on timeout contradicts the deliberate `timeout_mirrors_remote_job_without_cancelling` handoff contract, so it should land as its own opt-in change rather than flipping that default here.

## Tests
Added deterministic unit tests in `tests/core/rig/lease_test.rs`:
- TTL-stale live holder is reclaimable; live holder within TTL still conflicts; no-TTL live holder is never stolen.
- conflict error includes `age_seconds` + the `homeboy rig release-lock <rig> --force` hint.
- `release_active_run_lease`: no-lease, dead-holder release without force, live-holder requires force.

`cargo build` and `cargo test --lib lease` green (388 passed, 0 failed).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (claude-opus-4-8) via Claude Code
- **Used for:** Investigating the rig-lease/runner-exec code paths, implementing the TTL/reclaim logic, the `rig release-lock` command, the improved error, and the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)