### PR TITLE
feat(runner): opt-in remote cancel on controller wait-timeout (#6891)

### DIFF
--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -570,14 +570,37 @@ pub(super) fn daemon_job_wait_timeout(
     let timeout_hint = format!(
         "Set controller-side `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}` before invoking homeboy to change this wait budget, e.g. `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}=2400 homeboy ...`; workload settings are applied inside the remote job and cannot extend the controller wait."
     );
+    // Opt-in (#6891): when the operator set `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT`,
+    // best-effort cancel the still-running remote job so it stops holding its rig
+    // lock. Off by default — the historical contract is preserved exactly.
+    let cancel_outcome = attempt_wait_timeout_cancel(&runner.id, &job_id);
+    let message_tail = match &cancel_outcome {
+        WaitTimeoutCancelOutcome::Disabled => {
+            "the remote job is still in flight and was not cancelled".to_string()
+        }
+        WaitTimeoutCancelOutcome::Cancelled => format!(
+            "remote cancellation was requested on the runner job (opt-in `{RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV}`)"
+        ),
+        WaitTimeoutCancelOutcome::Failed(reason) => format!(
+            "remote cancellation was requested (opt-in `{RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV}`) but failed: {reason}; the remote job may still be in flight"
+        ),
+    };
     let mut error = Error::internal_unexpected(format!(
-        "{label} {job_id} on runner {} did not finish before timeout; the remote job is still in flight and was not cancelled",
+        "{label} {job_id} on runner {} did not finish before timeout; {message_tail}",
         runner.id
     ));
     error.details["runner_id"] = Value::String(runner.id.clone());
     error.details["job_id"] = Value::String(job_id.clone());
     error.details["remote_cwd"] = Value::String(cwd.to_string());
     error.details["command"] = json!(redact_argv(command));
+    error.details["cancel_on_wait_timeout"] = Value::String(
+        match &cancel_outcome {
+            WaitTimeoutCancelOutcome::Disabled => "disabled",
+            WaitTimeoutCancelOutcome::Cancelled => "requested",
+            WaitTimeoutCancelOutcome::Failed(_) => "failed",
+        }
+        .to_string(),
+    );
     match mirrored {
         Ok(run) => {
             error.details["active_run_id"] = Value::String(run.id.clone());
@@ -607,6 +630,21 @@ pub(super) fn daemon_job_wait_timeout(
         supports_cancellation,
     ) {
         error = error.with_hint(hint);
+    }
+    match &cancel_outcome {
+        WaitTimeoutCancelOutcome::Disabled => {}
+        WaitTimeoutCancelOutcome::Cancelled => {
+            error = error.with_hint(format!(
+                "Opt-in `{RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV}` is set: requested remote cancellation of job `{job_id}` to release its rig lock. Confirm with `homeboy runner job logs {} {job_id}`.",
+                runner.id
+            ));
+        }
+        WaitTimeoutCancelOutcome::Failed(reason) => {
+            error = error.with_hint(format!(
+                "Opt-in `{RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV}` is set but remote cancellation failed: {reason}. Cancel manually with `homeboy runner job cancel {} {job_id}`.",
+                runner.id
+            ));
+        }
     }
     error.with_hint(timeout_hint)
 }

--- a/src/core/runner/execution/handoff.rs
+++ b/src/core/runner/execution/handoff.rs
@@ -93,6 +93,90 @@ pub(super) fn print_lab_offload_handoff(
     }
 }
 
+/// Outcome of the opt-in best-effort remote cancellation attempted when the
+/// controller's runner-exec wait budget expires. `Disabled` is the default
+/// (opt-in off) and preserves the historical contract: the remote job is left
+/// in flight and uncancelled (#6891).
+#[derive(Debug)]
+pub(super) enum WaitTimeoutCancelOutcome {
+    Disabled,
+    Cancelled,
+    Failed(String),
+}
+
+/// Whether the operator opted in to cancelling the remote job on wait-timeout
+/// via `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT`. Accepts the usual truthy
+/// spellings; anything else (including unset) keeps the default behavior.
+pub(super) fn cancel_on_wait_timeout_enabled() -> bool {
+    std::env::var(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+}
+
+/// Best-effort remote cancellation on wait-timeout. Returns `Disabled` when the
+/// opt-in is off so callers preserve the byte-identical default contract. When
+/// the opt-in is on, the existing `runner_job_cancel` primitive is invoked and
+/// any error is captured rather than propagated (the controller still needs to
+/// surface the timeout).
+pub(super) fn attempt_wait_timeout_cancel(runner_id: &str, job_id: &str) -> WaitTimeoutCancelOutcome {
+    if !cancel_on_wait_timeout_enabled() {
+        return WaitTimeoutCancelOutcome::Disabled;
+    }
+    match invoke_runner_job_cancel(runner_id, job_id) {
+        Ok(()) => WaitTimeoutCancelOutcome::Cancelled,
+        Err(err) => WaitTimeoutCancelOutcome::Failed(err.message),
+    }
+}
+
+/// Invoke the remote-cancel primitive. In production this hits the daemon/broker
+/// `/jobs/{id}/cancel` endpoint via `runner_job_cancel`; tests inject a hook so
+/// the opt-in path can be asserted without a live runner.
+fn invoke_runner_job_cancel(runner_id: &str, job_id: &str) -> Result<()> {
+    #[cfg(test)]
+    {
+        if let Some(result) = test_cancel_hook::take_invoke(runner_id, job_id) {
+            return result;
+        }
+    }
+    runner_job_cancel(runner_id, job_id).map(|_| ())
+}
+
+#[cfg(test)]
+pub(super) mod test_cancel_hook {
+    use crate::core::error::Result;
+    use std::cell::RefCell;
+
+    type CancelHook = Box<dyn FnMut(&str, &str) -> Result<()>>;
+
+    thread_local! {
+        static HOOK: RefCell<Option<CancelHook>> = const { RefCell::new(None) };
+    }
+
+    /// Install a thread-local cancel hook for the duration of `Guard`'s lifetime.
+    pub(in crate::core::runner::execution) struct Guard;
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            HOOK.with(|cell| *cell.borrow_mut() = None);
+        }
+    }
+
+    pub(in crate::core::runner::execution) fn install(hook: CancelHook) -> Guard {
+        HOOK.with(|cell| *cell.borrow_mut() = Some(hook));
+        Guard
+    }
+
+    pub(super) fn take_invoke(runner_id: &str, job_id: &str) -> Option<Result<()>> {
+        HOOK.with(|cell| cell.borrow_mut().as_mut().map(|hook| hook(runner_id, job_id)))
+    }
+}
+
 pub fn runner_job_cancel(runner_id: &str, job_id: &str) -> Result<(Job, Vec<JobEvent>)> {
     let runner = load(runner_id)?;
     let connected = status(runner_id)?;

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -28,6 +28,11 @@ use super::{
 
 const DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS: u64 = 20 * 60;
 pub(crate) const RUNNER_EXEC_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS";
+/// Opt-in: when set to a truthy value, a controller-side wait-timeout best-effort
+/// cancels the still-running remote runner job (freeing its rig lock) instead of
+/// only mirroring it. Off by default — the default contract leaves the remote job
+/// in flight and uncancelled (#6891).
+pub(crate) const RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT";
 pub(crate) const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
 pub(crate) const RUNNER_ID_ENV: &str = "HOMEBOY_RUNNER_ID";
 

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -76,6 +76,144 @@ fn timeout_mirrors_remote_job_without_cancelling() {
     });
 }
 
+fn running_job_with_id(id: uuid::Uuid) -> Job {
+    Job {
+        id,
+        operation: "runner.exec".to_string(),
+        status: JobStatus::Running,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: None,
+        event_count: 0,
+        source_snapshot: None,
+        stale_reason: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+    }
+}
+
+#[test]
+fn opt_in_cancels_remote_job_on_wait_timeout() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    crate::test_support::with_isolated_home(|_| {
+        let _env = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "1");
+        let calls: Rc<RefCell<Vec<(String, String)>>> = Rc::new(RefCell::new(Vec::new()));
+        let recorder = calls.clone();
+        let _hook = test_cancel_hook::install(Box::new(move |runner_id: &str, job_id: &str| {
+            recorder
+                .borrow_mut()
+                .push((runner_id.to_string(), job_id.to_string()));
+            Ok(())
+        }));
+
+        let runner = ssh_runner();
+        let job_id = uuid::Uuid::new_v4();
+        let job = running_job_with_id(job_id);
+        let err = daemon_job_wait_timeout(
+            &runner,
+            "/srv/homeboy/project",
+            &["homeboy".to_string(), "bench".to_string()],
+            &job,
+            &[],
+            "runner daemon job",
+            true,
+        );
+
+        // The opt-in cancel primitive fired exactly once, targeting this job.
+        assert_eq!(calls.borrow().len(), 1);
+        assert_eq!(
+            calls.borrow()[0],
+            ("lab".to_string(), job_id.to_string())
+        );
+        // The timeout still surfaces, but no longer claims the job was left running.
+        assert!(!err.message.contains("was not cancelled"));
+        assert!(err.message.contains("remote cancellation was requested"));
+        assert_eq!(err.details["cancel_on_wait_timeout"], "requested");
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("requested remote cancellation of job")));
+    });
+}
+
+#[test]
+fn opt_in_off_leaves_remote_job_uncancelled() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    crate::test_support::with_isolated_home(|_| {
+        let _env = EnvVarGuard::unset(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV);
+        let calls: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
+        let recorder = calls.clone();
+        let _hook = test_cancel_hook::install(Box::new(move |_runner_id: &str, _job_id: &str| {
+            *recorder.borrow_mut() += 1;
+            Ok(())
+        }));
+
+        let runner = ssh_runner();
+        let job_id = uuid::Uuid::new_v4();
+        let job = running_job_with_id(job_id);
+        let err = daemon_job_wait_timeout(
+            &runner,
+            "/srv/homeboy/project",
+            &["homeboy".to_string(), "bench".to_string()],
+            &job,
+            &[],
+            "runner daemon job",
+            true,
+        );
+
+        // Default contract: the cancel primitive is never invoked.
+        assert_eq!(*calls.borrow(), 0);
+        assert!(err.message.contains("was not cancelled"));
+        assert_eq!(err.details["cancel_on_wait_timeout"], "disabled");
+    });
+}
+
+#[test]
+fn opt_in_surfaces_remote_cancel_failure_on_wait_timeout() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    crate::test_support::with_isolated_home(|_| {
+        let _env = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "true");
+        let calls: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
+        let recorder = calls.clone();
+        let _hook = test_cancel_hook::install(Box::new(move |_runner_id: &str, _job_id: &str| {
+            *recorder.borrow_mut() += 1;
+            Err(crate::core::error::Error::internal_unexpected(
+                "runner is not connected",
+            ))
+        }));
+
+        let runner = ssh_runner();
+        let job_id = uuid::Uuid::new_v4();
+        let job = running_job_with_id(job_id);
+        let err = daemon_job_wait_timeout(
+            &runner,
+            "/srv/homeboy/project",
+            &["homeboy".to_string(), "bench".to_string()],
+            &job,
+            &[],
+            "runner daemon job",
+            true,
+        );
+
+        assert_eq!(*calls.borrow(), 1);
+        assert!(err.message.contains("remote cancellation was requested"));
+        assert!(err.message.contains("but failed"));
+        assert!(err.message.contains("runner is not connected"));
+        assert_eq!(err.details["cancel_on_wait_timeout"], "failed");
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("remote cancellation failed")));
+    });
+}
+
 #[test]
 fn lab_offload_handoff_hints_render_durable_commands() {
     let hints = lab_offload_handoff_hints(

--- a/src/core/runner/execution/tests/mod.rs
+++ b/src/core/runner/execution/tests/mod.rs
@@ -102,6 +102,12 @@ impl EnvVarGuard {
         std::env::set_var(name, value);
         Self { name, prior }
     }
+
+    fn unset(name: &'static str) -> Self {
+        let prior = std::env::var(name).ok();
+        std::env::remove_var(name);
+        Self { name, prior }
+    }
 }
 
 impl Drop for EnvVarGuard {


### PR DESCRIPTION
Closes #6891 (the deferred remote-cancel half; the lock-reclaim half merged as #6895).

## Problem
When the controller's runner-exec wait budget expires, it mirrors the remote job and returns a timeout but **leaves the remote job running** — by deliberate design. The orphaned job keeps holding its rig lock, which wedges all later runs of that rig with `rig.resource_conflict` (the #6891 symptom: a 28-min idle bench still held `static-site-fixture-matrix`).

This is intentional default behavior, covered by the contract test `timeout_mirrors_remote_job_without_cancelling` and the "still in flight, not cancelled" handoff semantics. The goal is to let an operator **opt in** to cancelling the remote job on timeout, without changing the default.

## Change
- New opt-in env var **`HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT`** (truthy spellings: `1`/`true`/`yes`/`on`; unset/anything else = off).
- `daemon_job_wait_timeout` — the single shared timeout builder used by both the direct-daemon and reverse-broker wait loops — now calls the existing `runner_job_cancel` primitive (hits the daemon/broker `/jobs/{id}/cancel`) **only when opted in**, best-effort. The remote job is cancelled and its rig lock freed.
- The cancel outcome (`disabled` / `requested` / `failed`) is surfaced in the error message, the new `cancel_on_wait_timeout` detail, and a dedicated hint. A failed best-effort cancel never masks the underlying timeout.

## Default preserved (byte-identical)
With the opt-in **off**:
- No cancel call is made.
- The error message still reads `the remote job is still in flight and was not cancelled`.
- `detail.cancel_on_wait_timeout = "disabled"`.
- `timeout_mirrors_remote_job_without_cancelling` and all existing handoff-contract tests stay green.

## Tests
A test-only injectable cancel hook lets the opt-in path be asserted without a live runner:
- `opt_in_cancels_remote_job_on_wait_timeout` — flag on: cancel fires exactly once for the job; message reflects cancellation.
- `opt_in_off_leaves_remote_job_uncancelled` — flag off: injected cancel is never called; default message intact.
- `opt_in_surfaces_remote_cancel_failure_on_wait_timeout` — flag on + cancel errors: timeout still surfaces with a `failed` outcome and remediation hint.

`cargo build` clean (pre-existing warnings only); `cargo test --lib runner::execution` → 76 passed, 0 failed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Investigating the wait-timeout path, wiring the opt-in, and writing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)