### PR TITLE
test(audit): runtime audit regression harness (#6855 enabler)

### DIFF
--- a/src/core/code_audit/entry.rs
+++ b/src/core/code_audit/entry.rs
@@ -205,3 +205,7 @@ pub(super) fn audit_config_for(
 
     audit_config
 }
+
+#[cfg(test)]
+#[path = "../../../tests/core/code_audit/audit_runtime_regression_test.rs"]
+mod audit_runtime_regression_test;

--- a/tests/core/code_audit/audit_runtime_regression_test.rs
+++ b/tests/core/code_audit/audit_runtime_regression_test.rs
@@ -1,0 +1,110 @@
+//! Runtime audit regression harness.
+//!
+//! This test runs the **full audit pipeline** ([`audit_path_with_id`]) against a
+//! self-contained fixture component tree (`tests/fixtures/audit_runtime/`) and
+//! asserts that the produced finding set is byte-for-byte identical to a
+//! committed snapshot.
+//!
+//! The fixture directory ships its own `homeboy.json` portable config (with an
+//! `id` and an `audit` block), so it is audited with that config — independent
+//! of the host's real `homeboy.json` or any `HOMEBOY_*` reference-path env vars.
+//!
+//! WHY THIS EXISTS: detector, config-schema, or grammar changes can silently
+//! alter audit OUTPUT while still passing `cargo build` and unrelated unit
+//! tests. That gap is exactly what let PR #6896 pass Lint+Test while breaking
+//! the live audit. This test closes it: any change that alters what the audit
+//! emits on a fixed input fails here, locally, at `cargo test`.
+//!
+//! IF THIS TEST FAILS after a detector/config/grammar change: inspect the diff
+//! between `actual` and `EXPECTED_FINDINGS`. The change altered audit output.
+//! Only update the snapshot below if the change is *intentional* — never to
+//! make a red test green without understanding what moved.
+//!
+//! Wired into `src/core/code_audit/entry.rs` via
+//! `#[cfg(test)] #[path = ...] mod audit_runtime_regression_test`.
+
+use std::path::PathBuf;
+
+use crate::core::code_audit::audit_path_with_id;
+
+/// Component id declared in the fixture's `homeboy.json`.
+const FIXTURE_COMPONENT_ID: &str = "audit-runtime-fixture";
+
+/// Absolute path to the fixture component tree, derived from the crate root so
+/// the test is independent of the current working directory.
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("audit_runtime")
+}
+
+/// Render the audit result into a deterministic, sorted list of compact,
+/// volatile-data-free fingerprints (`<kind>::<file>`).
+///
+/// Line numbers, absolute paths, and counts are intentionally excluded so the
+/// snapshot is stable across machines and across non-behavioral refactors. The
+/// `file` field is already a path relative to the audited root.
+fn finding_fingerprints(result: &crate::core::code_audit::CodeAuditResult) -> Vec<String> {
+    let mut rendered: Vec<String> = result
+        .findings
+        .iter()
+        .map(|finding| {
+            let kind = super::super::findings::finding_kind_key(&finding.kind);
+            let file = finding.file.replace('\\', "/");
+            format!("{kind}::{file}")
+        })
+        .collect();
+    rendered.sort();
+    rendered.dedup();
+    rendered
+}
+
+/// Committed snapshot of the finding fingerprints the fixture must produce.
+///
+/// This list IS the regression guard. See module docs before editing.
+const EXPECTED_FINDINGS: &[&str] = &[
+    "high_item_count::src/god_file.rs",
+    "source_policy_violation::src/policy_violation.rs",
+    "thin_command_adapter_violation::src/commands/thick_adapter.rs",
+    "unreferenced_export::src/god_file.rs",
+    "unreferenced_export::src/policy_violation.rs",
+];
+
+#[test]
+fn audit_runtime_regression_matches_snapshot() {
+    let root = fixture_root();
+    assert!(root.is_dir(), "fixture root must exist: {}", root.display());
+
+    let result = audit_path_with_id(FIXTURE_COMPONENT_ID, &root.to_string_lossy())
+        .expect("audit pipeline runs on the fixture tree");
+
+    let actual = finding_fingerprints(&result);
+    let expected: Vec<String> = EXPECTED_FINDINGS.iter().map(|s| s.to_string()).collect();
+
+    assert_eq!(
+        actual, expected,
+        "\nAudit output on the fixture tree changed.\n\
+         A detector/config/grammar change altered what the audit emits.\n\
+         Inspect the diff; update EXPECTED_FINDINGS only if the change is intentional.\n\
+         actual = {actual:#?}\n"
+    );
+}
+
+#[test]
+fn audit_runtime_regression_is_deterministic() {
+    let root = fixture_root();
+    let path = root.to_string_lossy().to_string();
+
+    let first = finding_fingerprints(
+        &audit_path_with_id(FIXTURE_COMPONENT_ID, &path).expect("first audit run"),
+    );
+    let second = finding_fingerprints(
+        &audit_path_with_id(FIXTURE_COMPONENT_ID, &path).expect("second audit run"),
+    );
+
+    assert_eq!(
+        first, second,
+        "audit output must be deterministic across runs"
+    );
+}

--- a/tests/fixtures/audit_runtime/homeboy.json
+++ b/tests/fixtures/audit_runtime/homeboy.json
@@ -1,0 +1,35 @@
+{
+  "id": "audit-runtime-fixture",
+  "remote_path": "",
+  "audit": {
+    "source_policies": [
+      {
+        "id": "fixture-forbidden-term",
+        "kind": "source_policy",
+        "severity": "warning",
+        "convention": "fixture_source_policy",
+        "include_path_contains": ["src/"],
+        "description": "Forbidden term `{term}` appears at line {line} in {classification} context `{context}`",
+        "suggestion": "Remove the forbidden term `{term}` from source.",
+        "type": "forbidden_terms",
+        "terms": [
+          { "value": "forbiddenmarker", "match_mode": "token" }
+        ],
+        "case_insensitive": false
+      }
+    ],
+    "thin_command_adapter": {
+      "convention": "fixture_thin_command_adapter",
+      "include_path_contains": ["src/commands/"],
+      "skip_test_paths": true,
+      "max_orchestration_weight": 1,
+      "orchestration_markers": [
+        {
+          "label": "fixture orchestration",
+          "patterns": ["ORCHESTRATION_MARKER"],
+          "weight": 1
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/audit_runtime/src/clean.rs
+++ b/tests/fixtures/audit_runtime/src/clean.rs
@@ -1,0 +1,4 @@
+// Fixture file: a small, clean source file that should produce no findings.
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}

--- a/tests/fixtures/audit_runtime/src/commands/thick_adapter.rs
+++ b/tests/fixtures/audit_runtime/src/commands/thick_adapter.rs
@@ -1,0 +1,10 @@
+// Fixture command-layer file: trips the thin_command_adapter policy because it
+// contains the configured ORCHESTRATION_MARKER inside a command path.
+pub fn run_command() {
+    // ORCHESTRATION_MARKER: this command module carries orchestration weight.
+    let _ = orchestrate();
+}
+
+fn orchestrate() -> u32 {
+    42
+}

--- a/tests/fixtures/audit_runtime/src/god_file.rs
+++ b/tests/fixtures/audit_runtime/src/god_file.rs
@@ -1,0 +1,37 @@
+// Fixture file: deliberately exceeds the high-item-count threshold (>30).
+// Generated content for the audit runtime regression harness.
+pub fn item_1() -> u32 { 1 }
+pub fn item_2() -> u32 { 2 }
+pub fn item_3() -> u32 { 3 }
+pub fn item_4() -> u32 { 4 }
+pub fn item_5() -> u32 { 5 }
+pub fn item_6() -> u32 { 6 }
+pub fn item_7() -> u32 { 7 }
+pub fn item_8() -> u32 { 8 }
+pub fn item_9() -> u32 { 9 }
+pub fn item_10() -> u32 { 10 }
+pub fn item_11() -> u32 { 11 }
+pub fn item_12() -> u32 { 12 }
+pub fn item_13() -> u32 { 13 }
+pub fn item_14() -> u32 { 14 }
+pub fn item_15() -> u32 { 15 }
+pub fn item_16() -> u32 { 16 }
+pub fn item_17() -> u32 { 17 }
+pub fn item_18() -> u32 { 18 }
+pub fn item_19() -> u32 { 19 }
+pub fn item_20() -> u32 { 20 }
+pub fn item_21() -> u32 { 21 }
+pub fn item_22() -> u32 { 22 }
+pub fn item_23() -> u32 { 23 }
+pub fn item_24() -> u32 { 24 }
+pub fn item_25() -> u32 { 25 }
+pub fn item_26() -> u32 { 26 }
+pub fn item_27() -> u32 { 27 }
+pub fn item_28() -> u32 { 28 }
+pub fn item_29() -> u32 { 29 }
+pub fn item_30() -> u32 { 30 }
+pub fn item_31() -> u32 { 31 }
+pub fn item_32() -> u32 { 32 }
+pub fn item_33() -> u32 { 33 }
+pub fn item_34() -> u32 { 34 }
+pub fn item_35() -> u32 { 35 }

--- a/tests/fixtures/audit_runtime/src/policy_violation.rs
+++ b/tests/fixtures/audit_runtime/src/policy_violation.rs
@@ -1,0 +1,6 @@
+// Fixture file: trips the component-configured source_policy forbidden-term rule.
+// The token `forbiddenmarker` below is the configured forbidden term.
+pub fn uses_forbidden_marker() -> &'static str {
+    let forbiddenmarker = "value";
+    forbiddenmarker
+}


### PR DESCRIPTION
Adds a fast cargo test that runs the FULL audit pipeline (audit_path_with_id) against a self-contained fixture component tree and asserts the finding set matches a committed snapshot. This catches detector/config/grammar changes that alter audit OUTPUT at the unit level — the gap that let PR #6896 pass Lint+Test while breaking the live audit. Adds fixtures + test only; no detector or real-config change. Unblocks #6855 phased migration (each phase can now assert identical findings before merge).