### PR TITLE
feat(audit): item-counting grammar to config, harness-gated (#6855 phase 1)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -125,6 +125,81 @@
       "src/core/code_audit/detectors/test_vacuity.rs",
       "src/core/code_audit/detectors/upstream_workaround.rs"
     ],
+    "language_grammars": [
+      {
+        "file_extensions": [
+          "rs"
+        ],
+        "ignore_after_line_equals": [
+          "#[cfg(test)]"
+        ],
+        "item_declaration_prefixes": [
+          "fn ",
+          "struct ",
+          "enum ",
+          "const ",
+          "static ",
+          "type ",
+          "trait ",
+          "impl ",
+          "impl<"
+        ],
+        "modifier_prefixes": [
+          "async ",
+          "unsafe "
+        ],
+        "visibility_prefixes": [
+          "pub(crate) ",
+          "pub(super) ",
+          "pub "
+        ]
+      },
+      {
+        "file_extensions": [
+          "php"
+        ],
+        "item_declaration_prefixes": [
+          "function ",
+          "class ",
+          "interface ",
+          "trait ",
+          "const "
+        ],
+        "modifier_prefixes": [
+          "static ",
+          "abstract ",
+          "final "
+        ],
+        "visibility_prefixes": [
+          "public ",
+          "protected ",
+          "private "
+        ]
+      },
+      {
+        "file_extensions": [
+          "js",
+          "jsx",
+          "mjs",
+          "ts",
+          "tsx"
+        ],
+        "item_declaration_prefixes": [
+          "function ",
+          "class ",
+          "const ",
+          "let ",
+          "var ",
+          "interface ",
+          "type ",
+          "enum "
+        ],
+        "visibility_prefixes": [
+          "export default ",
+          "export "
+        ]
+      }
+    ],
     "remote_execution_safety": {
       "argument_forward_markers": [
         "normalized_args",

--- a/src/core/code_audit/descriptor_runtime.rs
+++ b/src/core/code_audit/descriptor_runtime.rs
@@ -85,8 +85,10 @@ fn run_generic_descriptor(
     let config = context.audit_config;
     match runner {
         GenericDetectorRunner::Structural => match context.source_snapshot {
-            Some(snapshot) => structural::analyze_snapshot(context.root, snapshot),
-            None => structural::analyze_structure(context.root),
+            Some(snapshot) => {
+                structural::analyze_snapshot(context.root, snapshot, &config.language_grammars)
+            }
+            None => structural::analyze_structure(context.root, &config.language_grammars),
         },
         GenericDetectorRunner::DeadCode => run_dead_code(context),
         GenericDetectorRunner::CommentHygiene => {
@@ -103,9 +105,11 @@ fn run_generic_descriptor(
             Some(snapshot) => field_patterns::run(snapshot, &config.detector_profile),
             None => Vec::new(),
         },
-        GenericDetectorRunner::DeprecationAge => {
-            deprecation_age::run(context.all_fingerprints, context.root, &config.detector_profile)
-        }
+        GenericDetectorRunner::DeprecationAge => deprecation_age::run(
+            context.all_fingerprints,
+            context.root,
+            &config.detector_profile,
+        ),
         GenericDetectorRunner::DeadGuard => {
             dead_guard::run(context.per_file_fingerprints, context.root, config)
         }
@@ -136,16 +140,18 @@ fn run_generic_descriptor(
         GenericDetectorRunner::ParallelRunnerSetup => {
             parallel_runner_setup::run(context.all_fingerprints)
         }
-        GenericDetectorRunner::RemoteExecutionPreflight => {
-            remote_execution_preflight::run(context.all_fingerprints, &config.remote_execution_safety)
-        }
+        GenericDetectorRunner::RemoteExecutionPreflight => remote_execution_preflight::run(
+            context.all_fingerprints,
+            &config.remote_execution_safety,
+        ),
         GenericDetectorRunner::EnumDispatchContracts => match context.source_snapshot {
             Some(snapshot) => enum_dispatch_contracts::run(snapshot),
             None => Vec::new(),
         },
-        GenericDetectorRunner::PublicRegistryExposure => {
-            public_registry_exposure::run(context.all_fingerprints, &config.public_registry_exposure)
-        }
+        GenericDetectorRunner::PublicRegistryExposure => public_registry_exposure::run(
+            context.all_fingerprints,
+            &config.public_registry_exposure,
+        ),
         GenericDetectorRunner::CommandStatusContracts => {
             command_status_contracts::run(context.root, &config.command_status_contracts)
         }

--- a/src/core/code_audit/structural.rs
+++ b/src/core/code_audit/structural.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::core::component::{grammar_for_extension, LanguageGrammar};
 use crate::core::engine::codebase_scan::{CodebaseSnapshot, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
@@ -41,13 +42,17 @@ pub(crate) fn build_snapshot(root: &Path) -> CodebaseSnapshot {
 /// Run structural analysis on all source files under a root directory.
 ///
 /// Returns findings for files that exceed structural thresholds.
-pub(crate) fn analyze_structure(root: &Path) -> Vec<Finding> {
+pub(crate) fn analyze_structure(root: &Path, grammars: &[LanguageGrammar]) -> Vec<Finding> {
     let snapshot = build_snapshot(root);
-    analyze_snapshot(root, &snapshot)
+    analyze_snapshot(root, &snapshot, grammars)
 }
 
 /// Run structural analysis from an already-loaded codebase snapshot.
-pub(crate) fn analyze_snapshot(root: &Path, snapshot: &CodebaseSnapshot) -> Vec<Finding> {
+pub(crate) fn analyze_snapshot(
+    root: &Path,
+    snapshot: &CodebaseSnapshot,
+    grammars: &[LanguageGrammar],
+) -> Vec<Finding> {
     let mut findings = Vec::new();
     let mut dir_source_counts: HashMap<String, usize> = HashMap::new();
 
@@ -71,7 +76,7 @@ pub(crate) fn analyze_snapshot(root: &Path, snapshot: &CodebaseSnapshot) -> Vec<
 
         // Count top-level items before line-count severity so god-file warnings
         // require more than size alone.
-        let item_count = count_top_level_items(content, ext);
+        let item_count = count_top_level_items(content, ext, grammars);
 
         // Check line count
         let line_count = content.lines().count();
@@ -146,158 +151,16 @@ pub(crate) fn analyze_snapshot(root: &Path, snapshot: &CodebaseSnapshot) -> Vec<
     findings
 }
 
-/// Count top-level items in a source file.
+/// Count top-level items in a source file using component-supplied grammars.
 ///
-/// Uses lightweight pattern matching rather than full parsing — we just need
-/// approximate counts for threshold detection, not exact ASTs.
-fn count_top_level_items(content: &str, ext: &str) -> usize {
-    match ext {
-        "rs" => count_rust_items(content),
-        "php" => count_php_items(content),
-        "js" | "jsx" | "mjs" | "ts" | "tsx" => count_js_items(content),
-        _ => 0, // Unknown languages get no item count findings
+/// Core is language-agnostic: it looks up the grammar whose `file_extensions`
+/// contains `ext` and applies it generically. Files with no matching grammar
+/// get no item count (returns 0).
+fn count_top_level_items(content: &str, ext: &str, grammars: &[LanguageGrammar]) -> usize {
+    match grammar_for_extension(grammars, ext) {
+        Some(grammar) => grammar.count_items(content),
+        None => 0,
     }
-}
-
-/// Count top-level items in Rust source.
-///
-/// Matches: fn, struct, enum, const, static, type, trait, impl at zero indentation.
-fn count_rust_items(content: &str) -> usize {
-    let mut count = 0;
-    let mut in_test_module = false;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        // Skip items inside test modules (everything after #[cfg(test)])
-        if trimmed == "#[cfg(test)]" {
-            in_test_module = true;
-            continue;
-        }
-        if in_test_module {
-            continue;
-        }
-
-        // Only count items at top level (zero indentation)
-        let indent = line.len() - line.trim_start().len();
-        if indent > 0 {
-            continue;
-        }
-
-        if is_rust_item_declaration(trimmed) {
-            count += 1;
-        }
-    }
-
-    count
-}
-
-/// Check if a trimmed line starts a Rust item declaration.
-fn is_rust_item_declaration(trimmed: &str) -> bool {
-    // Strip visibility prefix
-    let rest = if let Some(r) = trimmed.strip_prefix("pub(crate) ") {
-        r
-    } else if let Some(r) = trimmed.strip_prefix("pub(super) ") {
-        r
-    } else if let Some(r) = trimmed.strip_prefix("pub ") {
-        r
-    } else {
-        trimmed
-    };
-
-    // Strip async/unsafe/const modifiers for functions
-    let rest = if let Some(r) = rest.strip_prefix("async ") {
-        r
-    } else {
-        rest
-    };
-    let rest = if let Some(r) = rest.strip_prefix("unsafe ") {
-        r
-    } else {
-        rest
-    };
-
-    rest.starts_with("fn ")
-        || rest.starts_with("struct ")
-        || rest.starts_with("enum ")
-        || rest.starts_with("const ")
-        || rest.starts_with("static ")
-        || rest.starts_with("type ")
-        || rest.starts_with("trait ")
-        || rest.starts_with("impl ")
-        || rest.starts_with("impl<")
-}
-
-/// Count top-level items in PHP source.
-///
-/// Matches: function, class, interface, trait, const at zero indentation.
-fn count_php_items(content: &str) -> usize {
-    let mut count = 0;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        let indent = line.len() - line.trim_start().len();
-        if indent > 0 {
-            continue;
-        }
-
-        // Strip visibility
-        let rest = trimmed
-            .strip_prefix("public ")
-            .or_else(|| trimmed.strip_prefix("protected "))
-            .or_else(|| trimmed.strip_prefix("private "))
-            .unwrap_or(trimmed);
-        let rest = rest
-            .strip_prefix("static ")
-            .or_else(|| rest.strip_prefix("abstract "))
-            .or_else(|| rest.strip_prefix("final "))
-            .unwrap_or(rest);
-
-        if rest.starts_with("function ")
-            || rest.starts_with("class ")
-            || rest.starts_with("interface ")
-            || rest.starts_with("trait ")
-            || rest.starts_with("const ")
-        {
-            count += 1;
-        }
-    }
-
-    count
-}
-
-/// Count top-level items in JavaScript/TypeScript source.
-///
-/// Matches: function, class, const, let, var, export at zero indentation.
-fn count_js_items(content: &str) -> usize {
-    let mut count = 0;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        let indent = line.len() - line.trim_start().len();
-        if indent > 0 {
-            continue;
-        }
-
-        let rest = trimmed
-            .strip_prefix("export default ")
-            .or_else(|| trimmed.strip_prefix("export "))
-            .unwrap_or(trimmed);
-
-        if rest.starts_with("function ")
-            || rest.starts_with("class ")
-            || rest.starts_with("const ")
-            || rest.starts_with("let ")
-            || rest.starts_with("var ")
-            || rest.starts_with("interface ")
-            || rest.starts_with("type ")
-            || rest.starts_with("enum ")
-        {
-            count += 1;
-        }
-    }
-
-    count
 }
 
 // ============================================================================
@@ -307,6 +170,75 @@ fn count_js_items(content: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Test-only grammars mirroring the rust/php/js item-counting behavior that
+    /// production reads from `homeboy.json`. Kept here (not in core production)
+    /// so structural.rs core logic stays language-agnostic.
+    fn test_grammars() -> Vec<LanguageGrammar> {
+        let s = |v: &[&str]| v.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+        vec![
+            LanguageGrammar {
+                file_extensions: s(&["rs"]),
+                item_declaration_prefixes: s(&[
+                    "fn ", "struct ", "enum ", "const ", "static ", "type ", "trait ", "impl ",
+                    "impl<",
+                ]),
+                visibility_prefixes: s(&["pub(crate) ", "pub(super) ", "pub "]),
+                modifier_prefixes: s(&["async ", "unsafe "]),
+                ignore_after_line_equals: s(&["#[cfg(test)]"]),
+            },
+            LanguageGrammar {
+                file_extensions: s(&["php"]),
+                item_declaration_prefixes: s(&[
+                    "function ",
+                    "class ",
+                    "interface ",
+                    "trait ",
+                    "const ",
+                ]),
+                visibility_prefixes: s(&["public ", "protected ", "private "]),
+                modifier_prefixes: s(&["static ", "abstract ", "final "]),
+                ignore_after_line_equals: Vec::new(),
+            },
+            LanguageGrammar {
+                file_extensions: s(&["js", "jsx", "mjs", "ts", "tsx"]),
+                item_declaration_prefixes: s(&[
+                    "function ",
+                    "class ",
+                    "const ",
+                    "let ",
+                    "var ",
+                    "interface ",
+                    "type ",
+                    "enum ",
+                ]),
+                visibility_prefixes: s(&["export default ", "export "]),
+                modifier_prefixes: Vec::new(),
+                ignore_after_line_equals: Vec::new(),
+            },
+        ]
+    }
+
+    fn rust_grammar() -> LanguageGrammar {
+        test_grammars()
+            .into_iter()
+            .find(|g| g.matches_extension("rs"))
+            .unwrap()
+    }
+
+    fn php_grammar() -> LanguageGrammar {
+        test_grammars()
+            .into_iter()
+            .find(|g| g.matches_extension("php"))
+            .unwrap()
+    }
+
+    fn js_grammar() -> LanguageGrammar {
+        test_grammars()
+            .into_iter()
+            .find(|g| g.matches_extension("js"))
+            .unwrap()
+    }
 
     #[test]
     fn count_rust_items_basic() {
@@ -341,7 +273,7 @@ mod tests {
 "#;
         // Should count: struct Foo, fn helper, pub fn main_logic, impl Foo, const MAX = 5
         // Should NOT count: use, items inside #[cfg(test)]
-        let count = count_rust_items(content);
+        let count = rust_grammar().count_items(content);
         assert_eq!(count, 5, "Expected 5 top-level items");
     }
 
@@ -353,7 +285,7 @@ pub struct Public {}
 pub(super) const X: i32 = 1;
 pub async fn async_handler() {}
 "#;
-        assert_eq!(count_rust_items(content), 4);
+        assert_eq!(rust_grammar().count_items(content), 4);
     }
 
     #[test]
@@ -374,7 +306,7 @@ interface Cacheable {
 "#;
         // class User, function helper, interface Cacheable = 3
         // Methods inside class are indented, so not counted
-        assert_eq!(count_php_items(content), 3);
+        assert_eq!(php_grammar().count_items(content), 3);
     }
 
     #[test]
@@ -393,7 +325,7 @@ const CONFIG = {};
 export default function main() {}
 "#;
         // export function, export class, const CONFIG, export default function = 4
-        assert_eq!(count_js_items(content), 4);
+        assert_eq!(js_grammar().count_items(content), 4);
     }
 
     #[test]
@@ -411,7 +343,7 @@ export default function main() {}
         // Create a small file (under threshold)
         std::fs::write(dir.join("small.rs"), "fn tiny() {}\n").unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &test_grammars());
         let god_findings: Vec<&Finding> = findings
             .iter()
             .filter(|f| f.kind == AuditFinding::GodFile)
@@ -442,12 +374,13 @@ export default function main() {}
         let broad_snapshot = CodebaseSnapshot::build(&dir, &ScanConfig::default());
         assert_eq!(snapshot.len(), 1);
         assert_eq!(
-            serde_json::to_value(analyze_snapshot(&dir, &snapshot)).unwrap(),
-            serde_json::to_value(analyze_structure(&dir)).unwrap()
+            serde_json::to_value(analyze_snapshot(&dir, &snapshot, &test_grammars())).unwrap(),
+            serde_json::to_value(analyze_structure(&dir, &test_grammars())).unwrap()
         );
         assert_eq!(
-            serde_json::to_value(analyze_snapshot(&dir, &broad_snapshot)).unwrap(),
-            serde_json::to_value(analyze_structure(&dir)).unwrap()
+            serde_json::to_value(analyze_snapshot(&dir, &broad_snapshot, &test_grammars()))
+                .unwrap(),
+            serde_json::to_value(analyze_structure(&dir, &test_grammars())).unwrap()
         );
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -465,7 +398,7 @@ export default function main() {}
         content.push_str("}\n");
         std::fs::write(dir.join("large.rs"), content).unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &test_grammars());
         let god_findings: Vec<&Finding> = findings
             .iter()
             .filter(|f| f.kind == AuditFinding::GodFile)
@@ -513,7 +446,7 @@ export default function main() {}
             std::fs::write(root.join(format!("module_{}.rs", i)), "pub fn run() {}\n").unwrap();
         }
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &test_grammars());
         assert!(
             findings.is_empty(),
             "Moderate count-only smells should stay below the audit finding threshold"
@@ -535,7 +468,7 @@ export default function main() {}
         std::fs::write(dir.join("data.csv"), &content).unwrap();
         std::fs::write(dir.join("readme.md"), &content).unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &test_grammars());
         assert!(
             findings.is_empty(),
             "Non-source files should not produce findings"
@@ -556,7 +489,7 @@ export default function main() {}
         }
         std::fs::write(vendor.join("big.rs"), &content).unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &test_grammars());
         assert!(findings.is_empty(), "Files in vendor/ should be skipped");
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -579,7 +512,7 @@ export default function main() {}
         }
         std::fs::write(dir.join("clean.rs"), &content).unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &test_grammars());
         assert!(
             findings.is_empty(),
             "Clean files should produce no findings"

--- a/src/core/component/audit/language_grammar.rs
+++ b/src/core/component/audit/language_grammar.rs
@@ -1,0 +1,134 @@
+use serde::{Deserialize, Serialize};
+
+use super::extend_unique;
+
+/// A component-supplied grammar describing how to count top-level item
+/// declarations in a family of source files.
+///
+/// Core stays ecosystem-agnostic: it never hardcodes language, framework, or
+/// project item keywords. All extensions, prefixes, and markers come from
+/// config. The structural detector applies this grammar generically:
+///
+/// 1. Walk each line of the file in order.
+/// 2. If a line (trimmed) equals one of `ignore_after_line_equals`, stop
+///    counting the remainder of the file (e.g. an inline test-module marker).
+/// 3. Skip lines that are not at zero indentation.
+/// 4. Strip at most one matching prefix from `visibility_prefixes` (first match
+///    wins), then repeatedly strip matching prefixes from `modifier_prefixes`
+///    until none match (so chained modifiers like `async` then `unsafe` are
+///    both removed).
+/// 5. If the remainder starts with any of `item_declaration_prefixes`, count it
+///    as one top-level item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct LanguageGrammar {
+    /// File extensions (without dot) this grammar applies to, e.g.
+    /// `["js", "jsx", "mjs", "ts", "tsx"]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_extensions: Vec<String>,
+    /// Prefixes that mark a top-level item declaration once visibility and
+    /// modifier prefixes are stripped, e.g. `"fn "`, `"struct "`, `"class "`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub item_declaration_prefixes: Vec<String>,
+    /// Visibility prefixes stripped FIRST (at most one, first match wins),
+    /// e.g. `"pub(crate) "`, `"pub "`, `"public "`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub visibility_prefixes: Vec<String>,
+    /// Modifier prefixes stripped SECOND, repeatedly until none match, e.g.
+    /// `"async "`, `"unsafe "`, `"static "`, `"final "`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modifier_prefixes: Vec<String>,
+    /// When a line (trimmed) equals one of these, stop counting the remainder of
+    /// the file, e.g. `"#[cfg(test)]"` to exclude inline test modules.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore_after_line_equals: Vec<String>,
+}
+
+impl LanguageGrammar {
+    /// Whether this grammar applies to the given file extension (without dot).
+    pub fn matches_extension(&self, ext: &str) -> bool {
+        self.file_extensions.iter().any(|e| e == ext)
+    }
+
+    /// Count top-level item declarations in `content` using this grammar.
+    ///
+    /// Lightweight pattern matching, not full parsing — we just need
+    /// approximate counts for threshold detection, not exact ASTs.
+    pub fn count_items(&self, content: &str) -> usize {
+        let mut count = 0;
+        let mut stop = false;
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+
+            if !stop
+                && self
+                    .ignore_after_line_equals
+                    .iter()
+                    .any(|marker| marker == trimmed)
+            {
+                stop = true;
+                continue;
+            }
+            if stop {
+                continue;
+            }
+
+            // Only count items at top level (zero indentation).
+            let indent = line.len() - line.trim_start().len();
+            if indent > 0 {
+                continue;
+            }
+
+            // Strip at most one visibility prefix (first match wins).
+            let mut rest = trimmed;
+            for prefix in &self.visibility_prefixes {
+                if let Some(stripped) = rest.strip_prefix(prefix.as_str()) {
+                    rest = stripped;
+                    break;
+                }
+            }
+
+            // Strip modifier prefixes repeatedly until none match.
+            loop {
+                let mut stripped_any = false;
+                for prefix in &self.modifier_prefixes {
+                    if let Some(stripped) = rest.strip_prefix(prefix.as_str()) {
+                        rest = stripped;
+                        stripped_any = true;
+                        break;
+                    }
+                }
+                if !stripped_any {
+                    break;
+                }
+            }
+
+            if self
+                .item_declaration_prefixes
+                .iter()
+                .any(|prefix| rest.starts_with(prefix.as_str()))
+            {
+                count += 1;
+            }
+        }
+
+        count
+    }
+}
+
+/// Look up the grammar whose `file_extensions` contains `ext`.
+pub fn grammar_for_extension<'a>(
+    grammars: &'a [LanguageGrammar],
+    ext: &str,
+) -> Option<&'a LanguageGrammar> {
+    grammars
+        .iter()
+        .find(|grammar| grammar.matches_extension(ext))
+}
+
+pub(super) fn merge_language_grammars(
+    target: &mut Vec<LanguageGrammar>,
+    source: &[LanguageGrammar],
+) {
+    extend_unique(target, source);
+}

--- a/src/core/component/audit/mod.rs
+++ b/src/core/component/audit/mod.rs
@@ -5,6 +5,7 @@ mod config_key_usage;
 mod detector_profile;
 mod exposure;
 mod known_symbols;
+mod language_grammar;
 mod remote_execution;
 mod source_policy;
 mod test_wiring;
@@ -21,6 +22,7 @@ pub use known_symbols::{
     KnownSymbolKind, KnownSymbolManifestPackageProvider, KnownSymbolSourceScanConfig,
     KnownSymbolVersionedEntry, KnownSymbolsConfig,
 };
+pub use language_grammar::{grammar_for_extension, LanguageGrammar};
 pub use remote_execution::{ArtifactPortabilityConfig, RemoteExecutionSafetyConfig};
 pub use source_policy::{
     ConventionTagGlob, CoreBoundaryLeakConfig, MutatingResourceAccessConfig, RequestedDetectorRule,
@@ -122,6 +124,17 @@ pub struct AuditConfig {
     /// adapters over core services.
     #[serde(default, skip_serializing_if = "ThinCommandAdapterConfig::is_empty")]
     pub thin_command_adapter: ThinCommandAdapterConfig,
+    /// Component-owned per-language grammars describing how to count top-level
+    /// item declarations. Core applies them generically; the component owns all
+    /// language item keywords (e.g. `fn `, `struct `, `function `, `class `).
+    ///
+    /// NOTE: intentionally NOT part of [`AuditConfig::is_empty`]. Adding it
+    /// there flipped the empty-state semantics in PR #6896 and is a suspected
+    /// contributor to that PR's live-audit regression; item-counting grammars
+    /// are presentation/threshold tuning, not a signal that the audit config is
+    /// non-empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub language_grammars: Vec<LanguageGrammar>,
 }
 
 impl AuditConfig {
@@ -186,6 +199,10 @@ impl AuditConfig {
         self.artifact_portability.merge(&other.artifact_portability);
         self.detector_profile.merge(&other.detector_profile);
         self.thin_command_adapter.merge(&other.thin_command_adapter);
+        language_grammar::merge_language_grammars(
+            &mut self.language_grammars,
+            &other.language_grammars,
+        );
         for rule in &other.source_policies {
             if !self
                 .source_policies

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -13,14 +13,15 @@ pub mod versioning;
 
 pub use artifacts::{cleanup_artifact_report, CleanupArtifactCandidate, CleanupArtifactReport};
 pub use audit::{
-    ArtifactPortabilityConfig, AuditConfig, CommandStatusContractConfig,
+    grammar_for_extension, ArtifactPortabilityConfig, AuditConfig, CommandStatusContractConfig,
     CommandStatusContractScenario, ConfigKeyUsageConfig, ConfigKeyUsagePattern, ConfigKeyUsageRule,
     ConventionTagGlob, CoreBoundaryLeakConfig, DetectorProfileConfig, DuplicationDetectorConfig,
     KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind, KnownSymbolVersionedEntry,
-    MutatingResourceAccessConfig, PublicRegistryExposureConfig, RedirectValidationConfig,
-    RequestedDetectorRule, RequestedDetectorRuleBody, RequiredRegexScope, SourcePolicyMatchMode,
-    SourcePolicyRule, SourcePolicyRuleBody, SourcePolicyTerm, TestWiringConfig, TestWiringPolicy,
-    ThinCommandAdapterConfig, ThinCommandAdapterMarkerGroup, VersionSource,
+    LanguageGrammar, MutatingResourceAccessConfig, PublicRegistryExposureConfig,
+    RedirectValidationConfig, RequestedDetectorRule, RequestedDetectorRuleBody, RequiredRegexScope,
+    SourcePolicyMatchMode, SourcePolicyRule, SourcePolicyRuleBody, SourcePolicyTerm,
+    TestWiringConfig, TestWiringPolicy, ThinCommandAdapterConfig, ThinCommandAdapterMarkerGroup,
+    VersionSource,
 };
 pub use config::{
     ArtifactInput, CleanupArtifactDeclaration, CommandScopeConfig, ComponentDeployConfig,

--- a/tests/core/code_audit/audit_runtime_regression_test.rs
+++ b/tests/core/code_audit/audit_runtime_regression_test.rs
@@ -67,6 +67,15 @@ const EXPECTED_FINDINGS: &[&str] = &[
     "high_item_count::src/god_file.rs",
     "source_policy_violation::src/policy_violation.rs",
     "thin_command_adapter_violation::src/commands/thick_adapter.rs",
+    // Cross-file symbol-graph resolution: `consumer.rs::wire_up` and
+    // `exports.rs::orphaned_helper` are exported and referenced by nobody, so
+    // they surface; `exports.rs::referenced_helper` is SUPPRESSED because
+    // `consumer.rs` calls it across files. These rows guard the symbol-graph /
+    // reference-resolution detectors that PR #6896 silently broke — a grammar
+    // or audit-config regression that drops the component config (and thus the
+    // suppressions) changes this set and fails the harness.
+    "unreferenced_export::src/consumer.rs",
+    "unreferenced_export::src/exports.rs",
     "unreferenced_export::src/god_file.rs",
     "unreferenced_export::src/policy_violation.rs",
 ];

--- a/tests/fixtures/audit_runtime/homeboy.json
+++ b/tests/fixtures/audit_runtime/homeboy.json
@@ -2,6 +2,25 @@
   "id": "audit-runtime-fixture",
   "remote_path": "",
   "audit": {
+    "language_grammars": [
+      {
+        "file_extensions": ["rs"],
+        "ignore_after_line_equals": ["#[cfg(test)]"],
+        "item_declaration_prefixes": [
+          "fn ",
+          "struct ",
+          "enum ",
+          "const ",
+          "static ",
+          "type ",
+          "trait ",
+          "impl ",
+          "impl<"
+        ],
+        "modifier_prefixes": ["async ", "unsafe "],
+        "visibility_prefixes": ["pub(crate) ", "pub(super) ", "pub "]
+      }
+    ],
     "source_policies": [
       {
         "id": "fixture-forbidden-term",

--- a/tests/fixtures/audit_runtime/src/consumer.rs
+++ b/tests/fixtures/audit_runtime/src/consumer.rs
@@ -1,0 +1,10 @@
+// Fixture file: cross-references `exports::referenced_helper` so the symbol
+// graph resolves a real cross-file edge (suppressing an unreferenced-export
+// finding for `referenced_helper`). `wire_up` is itself exported and called by
+// nobody, so it surfaces as its own unreferenced_export finding — a second
+// stable symbol-graph assertion. Both are captured in EXPECTED_FINDINGS.
+use crate::exports::referenced_helper;
+
+pub fn wire_up() -> u32 {
+    referenced_helper() + 1
+}

--- a/tests/fixtures/audit_runtime/src/exports.rs
+++ b/tests/fixtures/audit_runtime/src/exports.rs
@@ -1,0 +1,14 @@
+// Fixture file: exercises the cross-file symbol graph / reference resolution.
+//
+// `referenced_helper` is exported AND called from `consumer.rs`, so the symbol
+// graph must resolve that cross-file edge and SUPPRESS an unreferenced-export
+// finding for it. `orphaned_helper` is exported but referenced by nobody, so it
+// MUST surface as an unreferenced_export finding. This pins symbol-resolution
+// behavior so a config/grammar regression that breaks the graph is caught.
+pub fn referenced_helper() -> u32 {
+    7
+}
+
+pub fn orphaned_helper() -> u32 {
+    11
+}


### PR DESCRIPTION
Retry of #6896 gated by the new runtime audit regression harness (#6903).

Extracts structural.rs item counting into config-driven `LanguageGrammar`. Extends the fixture to cover symbol-graph / cross-reference detectors (the ones #6896 broke) and asserts the live audit finding set is IDENTICAL before/after.

## Scope (tight — learned from #6896)
- ONLY changes how `structural.rs::count_top_level_items` counts items.
- `enum Language`, `symbol_graph`, `import_matching`, `field_patterns`, `edit_op_apply` untouched.
- `AuditConfig::is_empty()` semantics UNCHANGED — `language_grammars` is deliberately NOT added to `is_empty()` (suspected contributor to #6896's regression; documented inline).

## What moved
- New `LanguageGrammar` config (`file_extensions`, `item_declaration_prefixes`, `visibility_prefixes`, `modifier_prefixes`, `ignore_after_line_equals`) + generic `count_items`.
- `AuditConfig.language_grammars` field (`#[serde(default, skip_serializing_if = "Vec::is_empty")]`) + merge.
- `structural.rs` now applies grammar generically — ZERO language keyword literals in detector code; deleted `count_rust_items`/`count_php_items`/`count_js_items`/`is_rust_item_declaration`.
- Wired grammars through `descriptor_runtime.rs` only.
- rs/php/js grammars applied in fixture `homeboy.json` and the real `homeboy.json` so counts are preserved.

## Harness gate
- Extended `tests/fixtures/audit_runtime` with `exports.rs`/`consumer.rs` to exercise cross-file symbol resolution (a referenced export is suppressed; orphaned exports surface). `EXPECTED_FINDINGS` now covers structural AND symbol-graph.
- `cargo test --lib audit_runtime_regression` passes with the finding set IDENTICAL before/after the migration — the #6896 break does not reproduce.
- `cargo test --lib structural` (24 tests incl. parity) green; `cargo build --lib --tests` clean.