### PR TITLE
fix(runner): harden workspace prune scan quoting

### DIFF
--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -872,13 +872,7 @@ fn prune_candidates_ssh(
     let (_server, mut client) = ssh_client_for_runner(runner)?;
     client.env.extend(runner.env.clone());
     let min_age = options.min_age_hours.saturating_mul(3600);
-    let command = format!(
-        "root={root}; meta_rel={meta}; now=$(date +%s); if [ -d \"$root\" ]; then find \"$root\" -mindepth 1 -maxdepth 1 -type d -exec sh -c 'meta_rel=$1; now=$2; min_age=$3; shift 3; for dir do meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; mtime=$(stat -c %Y \"$dir\" 2>/dev/null || stat -f %m \"$dir\" 2>/dev/null || echo 0); age=$((now-mtime)); [ \"$age\" -ge \"$min_age\" ] || continue; if find \"$dir/.homeboy\" -type f \\( -name \"*.patch\" -o -name \"*.diff\" -o -name \"*patch*\" \\) 2>/dev/null | grep -q .; then continue; fi; bytes=$(du -sk \"$dir\" 2>/dev/null | awk '\''{{print $1 * 1024}}'\''); printf \"%s\\t%s\\t%s\\t\" \"$age\" \"${{bytes:-0}}\" \"$dir\"; base64 < \"$meta\" | tr -d \"\\n\"; printf \"\\n\"; done' sh {meta_arg} \"$now\" {min_age_arg} {{}} +; fi",
-        root = shell::quote_arg(root),
-        meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
-        meta_arg = shell::quote_arg(WORKSPACE_METADATA_FILE),
-        min_age_arg = shell::quote_arg(&min_age.to_string()),
-    );
+    let command = prune_scan_command(root, min_age);
     let output = client.execute(&command);
     if !output.success {
         return Err(Error::internal_unexpected(format!(
@@ -936,6 +930,16 @@ fn prune_candidates_ssh(
             .then_with(|| b.age_seconds.cmp(&a.age_seconds))
     });
     Ok(candidates)
+}
+
+pub(crate) fn prune_scan_command(root: &str, min_age: u64) -> String {
+    format!(
+        "root={root}; meta_rel={meta}; now=$(date +%s); if [ -d \"$root\" ]; then find \"$root\" -mindepth 1 -maxdepth 1 -type d -exec sh -c 'meta_rel=$1; now=$2; min_age=$3; shift 3; for dir do meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; mtime=$(stat -c %Y \"$dir\" 2>/dev/null || stat -f %m \"$dir\" 2>/dev/null || echo 0); age=$((now-mtime)); [ \"$age\" -ge \"$min_age\" ] || continue; if find \"$dir/.homeboy\" -type f \\( -name \"*.patch\" -o -name \"*.diff\" -o -name \"*patch*\" \\) 2>/dev/null | grep -q .; then continue; fi; blocks=$(du -sk \"$dir\" 2>/dev/null); blocks=${{blocks%%[!0-9]*}}; bytes=$((blocks * 1024)); printf \"%s\\t%s\\t%s\\t\" \"$age\" \"${{bytes:-0}}\" \"$dir\"; base64 < \"$meta\" | tr -d \"\\n\"; printf \"\\n\"; done' sh {meta_arg} \"$now\" {min_age_arg} {{}} +; fi",
+        root = shell::quote_arg(root),
+        meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
+        meta_arg = shell::quote_arg(WORKSPACE_METADATA_FILE),
+        min_age_arg = shell::quote_arg(&min_age.to_string()),
+    )
 }
 
 fn remove_workspace(runner: &super::super::Runner, root: &str, remote_path: &str) -> Result<()> {

--- a/src/core/runner/workspace/tests/prune.rs
+++ b/src/core/runner/workspace/tests/prune.rs
@@ -1,7 +1,8 @@
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
-use crate::core::runner::workspace::sync::{prune_workspaces, sync_workspace};
+use crate::core::runner::workspace::sync::{prune_scan_command, prune_workspaces, sync_workspace};
 use crate::core::runner::workspace::types::{
     RunnerWorkspacePruneOptions, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
@@ -103,6 +104,107 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
         assert!(Path::new(&live.remote_path).exists());
         assert!(unmanaged.exists());
     });
+}
+
+#[test]
+fn prune_workspaces_preview_reports_synthetic_odd_path_without_deleting() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let workspace = runner_root
+            .path()
+            .join("_lab_workspaces")
+            .join("repo's odd (name) with spaces");
+        fs::create_dir_all(workspace.join(".homeboy")).expect("workspace metadata dir");
+        fs::write(workspace.join("file.txt"), "orphan\n").expect("workspace file");
+        fs::write(
+            workspace.join(".homeboy/runner-workspace.json"),
+            serde_json::json!({
+                "schema": "homeboy/runner-workspace/v1",
+                "runner_id": "lab-local-prune-odd-preview",
+                "local_path": runner_root.path().join("missing source's (odd) path").display().to_string(),
+                "remote_path": workspace.display().to_string(),
+                "sync_mode": "snapshot",
+                "snapshot_identity": "synthetic",
+                "synced_at": "2026-06-28T00:00:00Z"
+            })
+            .to_string(),
+        )
+        .expect("write metadata");
+        crate::core::runner::create(
+            &format!(
+                r#"{{"id":"lab-local-prune-odd-preview","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let (output, exit_code) = prune_workspaces(
+            "lab-local-prune-odd-preview",
+            RunnerWorkspacePruneOptions {
+                apply: false,
+                min_age_hours: 0,
+                limit: 10,
+            },
+        )
+        .expect("prune preview");
+
+        assert_eq!(exit_code, 0);
+        assert!(output.dry_run);
+        assert_eq!(output.candidates.len(), 1);
+        assert_eq!(
+            output.candidates[0].remote_path,
+            workspace.display().to_string()
+        );
+        assert!(output.candidates[0]
+            .source_path
+            .contains("missing source's (odd) path"));
+        assert_eq!(output.candidates[0].reason, "source_path_missing");
+        assert!(workspace.exists());
+        assert!(output.removed.is_empty());
+    });
+}
+
+#[test]
+fn ssh_prune_scan_command_handles_paths_that_need_shell_quoting() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("root's (quoted) workspaces");
+    let workspace = root.join("repo's odd (name) with spaces");
+    fs::create_dir_all(workspace.join(".homeboy")).expect("workspace metadata dir");
+    fs::write(workspace.join("file.txt"), "orphan\n").expect("workspace file");
+    fs::write(
+        workspace.join(".homeboy/runner-workspace.json"),
+        serde_json::json!({
+            "schema": "homeboy/runner-workspace/v1",
+            "runner_id": "lab-ssh-prune-odd-scan",
+            "local_path": "/missing/source's (odd) path",
+            "remote_path": workspace.display().to_string(),
+            "sync_mode": "snapshot",
+            "snapshot_identity": "synthetic",
+            "synced_at": "2026-06-28T00:00:00Z"
+        })
+        .to_string(),
+    )
+    .expect("write metadata");
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(prune_scan_command(&root.display().to_string(), 0))
+        .output()
+        .expect("run generated prune scan command");
+
+    assert!(
+        output.status.success(),
+        "scan command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&workspace.display().to_string()),
+        "{stdout}"
+    );
+    assert!(stdout.contains('\t'), "{stdout}");
+    assert!(stdout.lines().count() == 1, "{stdout}");
 }
 
 fn sync_options(path: String) -> RunnerWorkspaceSyncOptions {


### PR DESCRIPTION
## Summary
- Fixes the SSH runner workspace prune scan script so it no longer embeds an AWK program inside the single-quoted remote sh payload.
- Uses shell arithmetic on `du -sk` output for byte conversion, preserving the existing non-destructive preview/apply split.
- Adds regression coverage for shell-sensitive workspace/root names and synthetic dry-run preview entries.

Fixes #6902.

## Verification
- `cargo test core::runner::workspace::tests::prune`
- `rustfmt --check src/core/runner/workspace/sync.rs src/core/runner/workspace/tests/prune.rs`
- `cargo fmt --check` was attempted and reports existing formatting drift in unrelated files outside this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, implementation, regression tests, and PR preparation.