### PR TITLE
Fix Lab runner disk pressure lifecycle gap

### DIFF
--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -656,6 +656,11 @@ pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
             command: format!("homeboy runner exec {runner_arg} -- <command>"),
             purpose: "Run a managed follow-up command through Homeboy instead of opening an ad-hoc shell.".to_string(),
         },
+        LabFollowup {
+            label: "workspace_prune".to_string(),
+            command: format!("homeboy runner workspace prune {runner_arg} --apply"),
+            purpose: "Reclaim safe orphaned Lab workspaces when the runner workspace filesystem is under disk pressure.".to_string(),
+        },
     ]);
     followups.extend(declared_followups_for_legacy(
         "managed_followups",

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -13,7 +13,7 @@ use super::super::jobs::format_job_event;
 use super::super::status::{
     declared_executable_requirement_diagnostics, declared_run_followups_for_legacy,
     declared_runtime_diagnostics, declared_runtime_source_diagnostics, declared_tool_diagnostics,
-    lab_runner_homeboy_output, runner_artifact_feature_diagnostics,
+    lab_runner_homeboy_output, runner_artifact_feature_diagnostics, runner_followups,
     runner_status_operator_commands,
 };
 
@@ -133,6 +133,15 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
     assert!(serialized.contains("homeboy runner job reconcile homeboy-lab"));
     assert!(serialized.contains("homeboy runner job artifacts homeboy-lab job-123 <artifact-id>"));
     assert!(!serialized.contains("curl -fsS"));
+}
+
+#[test]
+fn runner_followups_include_workspace_prune_for_disk_pressure_recovery() {
+    let followups = runner_followups(Some("homeboy-lab"));
+    let serialized = serde_json::to_string(&followups).expect("serialize followups");
+
+    assert!(serialized.contains("homeboy runner workspace prune homeboy-lab --apply"));
+    assert!(serialized.contains("disk pressure"));
 }
 
 #[test]

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -35,6 +35,8 @@ use crate::core::engine::shell;
 use crate::core::server::{self, SshClient};
 
 const WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";
+const MIN_RUNNER_WORKSPACE_FREE_BYTES: u64 = 1024 * 1024 * 1024;
+const MIN_RUNNER_WORKSPACE_FREE_RATIO: f64 = 0.01;
 
 pub fn sync_workspace(
     runner_id: &str,
@@ -53,6 +55,7 @@ pub fn sync_workspace(
         )
     })?;
     validate_absolute_path("workspace_root", workspace_root)?;
+    require_runner_workspace_disk_headroom(&runner, workspace_root)?;
 
     let mut excludes = DEFAULT_EXCLUDES
         .iter()
@@ -769,6 +772,136 @@ fn write_workspace_metadata(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RunnerWorkspaceDiskProbe {
+    available_bytes: u64,
+    total_bytes: u64,
+}
+
+fn require_runner_workspace_disk_headroom(
+    runner: &super::super::Runner,
+    workspace_root: &str,
+) -> Result<()> {
+    let Some(probe) = runner_workspace_disk_probe(runner, workspace_root)? else {
+        return Ok(());
+    };
+    if !runner_workspace_disk_is_critical(probe) {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "workspace_root",
+        format!(
+            "runner workspace filesystem for `{}` is critically low on free space: {} available of {} total; refusing to sync another Lab workspace",
+            runner.id,
+            human_bytes(probe.available_bytes),
+            human_bytes(probe.total_bytes)
+        ),
+        Some(workspace_root.to_string()),
+        Some(vec![
+            format!(
+                "Preview safe cleanup candidates with `homeboy runner workspace prune {}`.",
+                shell_arg(&runner.id)
+            ),
+            format!(
+                "Remove safe cleanup candidates with `homeboy runner workspace prune {} --apply`.",
+                shell_arg(&runner.id)
+            ),
+            "Increase runner.workspace_root capacity before retrying the Lab run.".to_string(),
+        ]),
+    ))
+}
+
+fn runner_workspace_disk_is_critical(probe: RunnerWorkspaceDiskProbe) -> bool {
+    if probe.available_bytes < MIN_RUNNER_WORKSPACE_FREE_BYTES {
+        return true;
+    }
+    probe.total_bytes > 0
+        && (probe.available_bytes as f64 / probe.total_bytes as f64)
+            < MIN_RUNNER_WORKSPACE_FREE_RATIO
+}
+
+fn runner_workspace_disk_probe(
+    runner: &super::super::Runner,
+    workspace_root: &str,
+) -> Result<Option<RunnerWorkspaceDiskProbe>> {
+    match runner.kind {
+        RunnerKind::Local => Ok(local_runner_workspace_disk_probe(Path::new(workspace_root))),
+        RunnerKind::Ssh => ssh_runner_workspace_disk_probe(runner, workspace_root),
+    }
+}
+
+#[cfg(unix)]
+fn local_runner_workspace_disk_probe(path: &Path) -> Option<RunnerWorkspaceDiskProbe> {
+    let probe_path = existing_ancestor(path)?;
+    let c_path = std::ffi::CString::new(probe_path.to_string_lossy().as_bytes()).ok()?;
+    let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    let rc = unsafe { libc::statvfs(c_path.as_ptr(), stat.as_mut_ptr()) };
+    if rc != 0 {
+        return None;
+    }
+    let stat = unsafe { stat.assume_init() };
+    let block_size = u128::from(stat.f_frsize.max(1));
+    Some(RunnerWorkspaceDiskProbe {
+        available_bytes: u64::try_from(u128::from(stat.f_bavail).saturating_mul(block_size))
+            .ok()?,
+        total_bytes: u64::try_from(u128::from(stat.f_blocks).saturating_mul(block_size)).ok()?,
+    })
+}
+
+#[cfg(not(unix))]
+fn local_runner_workspace_disk_probe(_path: &Path) -> Option<RunnerWorkspaceDiskProbe> {
+    None
+}
+
+fn existing_ancestor(path: &Path) -> Option<&Path> {
+    let mut current = path;
+    loop {
+        if current.exists() {
+            return Some(current);
+        }
+        current = current.parent()?;
+    }
+}
+
+fn ssh_runner_workspace_disk_probe(
+    runner: &super::super::Runner,
+    workspace_root: &str,
+) -> Result<Option<RunnerWorkspaceDiskProbe>> {
+    let (_server, mut client) = ssh_client_for_runner(runner)?;
+    client.env.extend(runner.env.clone());
+    let command = format!(
+        "p={path}; while [ ! -e \"$p\" ] && [ \"$p\" != / ]; do p=$(dirname \"$p\"); done; df -Pk \"$p\" 2>/dev/null | awk 'NR==2 {{print $2 \" \" $4}}'",
+        path = shell::quote_arg(workspace_root),
+    );
+    let output = client.execute(&command);
+    if !output.success {
+        return Ok(None);
+    }
+    let mut parts = output.stdout.split_whitespace();
+    let total_kb = match parts.next().and_then(|value| value.parse::<u64>().ok()) {
+        Some(value) => value,
+        None => return Ok(None),
+    };
+    let available_kb = match parts.next().and_then(|value| value.parse::<u64>().ok()) {
+        Some(value) => value,
+        None => return Ok(None),
+    };
+    Ok(Some(RunnerWorkspaceDiskProbe {
+        available_bytes: available_kb.saturating_mul(1024),
+        total_bytes: total_kb.saturating_mul(1024),
+    }))
+}
+
+fn human_bytes(bytes: u64) -> String {
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else {
+        format!("{} MiB", bytes / MIB)
+    }
+}
+
 fn prune_candidates_local(
     root: &Path,
     options: &RunnerWorkspacePruneOptions,
@@ -1083,5 +1216,40 @@ fn local_git_state(local_path: &Path) -> LocalGitState {
         commit,
         ref_name,
         dirty,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{runner_workspace_disk_is_critical, RunnerWorkspaceDiskProbe};
+
+    #[test]
+    fn runner_workspace_disk_pressure_blocks_low_absolute_free_space() {
+        assert!(runner_workspace_disk_is_critical(
+            RunnerWorkspaceDiskProbe {
+                available_bytes: 512 * 1024 * 1024,
+                total_bytes: 500 * 1024 * 1024 * 1024,
+            }
+        ));
+    }
+
+    #[test]
+    fn runner_workspace_disk_pressure_blocks_low_free_ratio() {
+        assert!(runner_workspace_disk_is_critical(
+            RunnerWorkspaceDiskProbe {
+                available_bytes: 2 * 1024 * 1024 * 1024,
+                total_bytes: 500 * 1024 * 1024 * 1024,
+            }
+        ));
+    }
+
+    #[test]
+    fn runner_workspace_disk_pressure_allows_headroom() {
+        assert!(!runner_workspace_disk_is_critical(
+            RunnerWorkspaceDiskProbe {
+                available_bytes: 20 * 1024 * 1024 * 1024,
+                total_bytes: 500 * 1024 * 1024 * 1024,
+            }
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Add a generic runner workspace disk preflight before `runner workspace sync` materializes another Lab workspace.
- Fail early when the runner workspace filesystem has less than 1 GiB free or less than 1% free, with actionable `homeboy runner workspace prune` cleanup commands.
- Surface `runner workspace prune --apply` in runner followups for disk-pressure recovery.

Fixes #6901.

## Testing
- `cargo fmt`
- `cargo test runner_workspace_disk_pressure`
- `cargo test prune_workspaces`
- `cargo test runner_followups_include_workspace_prune_for_disk_pressure_recovery`
- `cargo test --lib` failed on pre-existing/unrelated checks: `cli_surface::tests::docs_cover_high_use_command_surfaces`, `command_contract::safety_manifest::tests::suspicious_command_paths_require_safety_classification`, `commands::infra::route::tests::explicit_runner_for_changed_scope_test_is_lab_portable`, `core::agent_task_lifecycle::tests::cancel_run_signals_live_running_record`, and `core::code_audit::entry::audit_runtime_regression_test::audit_runtime_regression_matches_snapshot`. The new runner workspace tests passed within the run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the runner workspace disk preflight, focused tests, and PR preparation.
