### PR TITLE
test(audit): close harness fidelity gap (test-path + agnostic coverage)

### DIFF
--- a/tests/core/code_audit/audit_runtime_regression_test.rs
+++ b/tests/core/code_audit/audit_runtime_regression_test.rs
@@ -15,6 +15,21 @@
 //! the live audit. This test closes it: any change that alters what the audit
 //! emits on a fixed input fails here, locally, at `cargo test`.
 //!
+//! FIXTURE COVERAGE: the fixture tree deliberately exercises the two detector
+//! behaviors a real-codebase regression (#6906) slipped past the original
+//! harness:
+//!   1. TEST-PATH SKIPPING — `src/commands/tests/skipped_helper.rs` carries the
+//!      configured orchestration marker but lives under a `/tests/` path, so the
+//!      `thin_command_adapter` policy (with `skip_test_paths: true`) must skip
+//!      it. Its absence from the snapshot, plus the dedicated
+//!      `audit_runtime_regression_skips_test_paths` test, catch a regression
+//!      that wrongly scans test files.
+//!   2. CORE-AGNOSTIC / CORE-BOUNDARY-LEAK — `src/boundary_leak.rs` contains a
+//!      synthetic ecosystem term (`florpstack`) on a behavioral line, firing the
+//!      `core_boundary_leaks` detector, while an allowlisted comment occurrence
+//!      proves the allow path is honored. This exercises the detector whose
+//!      findings exploded in #6906.
+//!
 //! IF THIS TEST FAILS after a detector/config/grammar change: inspect the diff
 //! between `actual` and `EXPECTED_FINDINGS`. The change altered audit output.
 //! Only update the snapshot below if the change is *intentional* — never to
@@ -64,9 +79,11 @@ fn finding_fingerprints(result: &crate::core::code_audit::CodeAuditResult) -> Ve
 ///
 /// This list IS the regression guard. See module docs before editing.
 const EXPECTED_FINDINGS: &[&str] = &[
+    "core_boundary_leak::src/boundary_leak.rs",
     "high_item_count::src/god_file.rs",
     "source_policy_violation::src/policy_violation.rs",
     "thin_command_adapter_violation::src/commands/thick_adapter.rs",
+    "unreferenced_export::src/boundary_leak.rs",
     "unreferenced_export::src/god_file.rs",
     "unreferenced_export::src/policy_violation.rs",
 ];
@@ -106,5 +123,34 @@ fn audit_runtime_regression_is_deterministic() {
     assert_eq!(
         first, second,
         "audit output must be deterministic across runs"
+    );
+}
+
+/// Invariant: the audit must never emit a finding for a file living under a
+/// test path (a path segment of `tests/`), because the walker skips test paths.
+///
+/// This directly encodes the contract that the #6906 regression violated, where
+/// test files were wrongly scanned. The fixture ships
+/// `src/commands/tests/skipped_helper.rs` — a command-path file carrying the
+/// configured `ORCHESTRATION_MARKER`. The `thin_command_adapter` policy has
+/// `skip_test_paths: true`, so a healthy walker skips it. If test-path skipping
+/// regresses, that file produces a `thin_command_adapter_violation` whose `file`
+/// contains `/tests/`, tripping this assertion (and the snapshot test above).
+#[test]
+fn audit_runtime_regression_skips_test_paths() {
+    let root = fixture_root();
+    let result = audit_path_with_id(FIXTURE_COMPONENT_ID, &root.to_string_lossy())
+        .expect("audit pipeline runs on the fixture tree");
+
+    let test_path_findings: Vec<String> = result
+        .findings
+        .iter()
+        .map(|finding| finding.file.replace('\\', "/"))
+        .filter(|file| file.starts_with("tests/") || file.contains("/tests/"))
+        .collect();
+
+    assert!(
+        test_path_findings.is_empty(),
+        "audit emitted findings for test-path files (walker test-path skipping regressed): {test_path_findings:#?}"
     );
 }

--- a/tests/fixtures/audit_runtime/homeboy.json
+++ b/tests/fixtures/audit_runtime/homeboy.json
@@ -2,6 +2,11 @@
   "id": "audit-runtime-fixture",
   "remote_path": "",
   "audit": {
+    "core_boundary_leaks": {
+      "terms": ["florpstack"],
+      "scan_path_contains": ["src/"],
+      "allow_line_contains": ["audit-allow-florpstack"]
+    },
     "source_policies": [
       {
         "id": "fixture-forbidden-term",

--- a/tests/fixtures/audit_runtime/src/boundary_leak.rs
+++ b/tests/fixtures/audit_runtime/src/boundary_leak.rs
@@ -1,0 +1,25 @@
+// Fixture core source file that trips the `core_boundary_leaks` agnostic check.
+//
+// PURPOSE: exercise the CoreBoundaryLeak / core-agnostic-source detector — the
+// same detector whose findings exploded in the #6906 regression. The fixture's
+// `core_boundary_leaks` config scans `src/` for the synthetic ecosystem term
+// `florpstack` (a made-up token, intentionally NOT a real language/framework
+// name, so the snapshot stays stable and the check is deterministic).
+//
+// The BEHAVIORAL line below contains `florpstack` outside any comment, so the
+// detector fires and the finding is captured in EXPECTED_FINDINGS.
+//
+// The comment-only line further down also names the term, but carries the
+// configured `allow_line_contains` marker (`audit-allow-florpstack`), so the
+// detector treats it as an explicitly allowed example and does NOT fire. This
+// proves the allowlist path is exercised and that a comment-context occurrence
+// alone does not generate a finding.
+pub fn florpstack_adapter() -> &'static str {
+    let florpstack = "ecosystem-leak";
+    florpstack
+}
+
+// Naming florpstack here is intentional and allowlisted. audit-allow-florpstack
+pub fn allowed_reference() -> u32 {
+    0
+}

--- a/tests/fixtures/audit_runtime/src/commands/tests/skipped_helper.rs
+++ b/tests/fixtures/audit_runtime/src/commands/tests/skipped_helper.rs
@@ -1,0 +1,25 @@
+// Fixture command-layer file under a `tests/` subdirectory.
+//
+// PURPOSE: exercise the walker's test-path skipping. This file lives under
+// `src/commands/tests/`, so its relative path contains `/tests/` and
+// `walker::is_test_path` returns true. The fixture's `thin_command_adapter`
+// policy has `skip_test_paths: true`, so this file MUST be skipped even though
+// it sits inside the configured `src/commands/` include path and carries the
+// configured ORCHESTRATION_MARKER below.
+//
+// REGRESSION GUARD: if the walker's test-path skipping breaks (the #6906 class
+// of bug where test files are wrongly scanned), this file's orchestration
+// weight starts producing a `thin_command_adapter_violation` finding. That new
+// finding is NOT in EXPECTED_FINDINGS, so the snapshot harness fails — exactly
+// the catch that was missing. The dedicated
+// `audit_runtime_regression_skips_test_paths` test asserts the same invariant
+// directly.
+pub fn run_skipped_command() {
+    // ORCHESTRATION_MARKER: orchestration weight that MUST be ignored because
+    // this file lives under a test path.
+    let _ = skipped_orchestrate();
+}
+
+fn skipped_orchestrate() -> u32 {
+    7
+}


### PR DESCRIPTION
The runtime audit harness (#6903) passed while #6906s real-codebase regression (test files wrongly scanned + CoreBoundaryLeak explosion) slipped through, because the fixture had no tests/ subdir (walker test-path skip never exercised) and no forbidden-ecosystem-term content (agnostic detector never triggered). Adds: a tests/-subdir fixture file containing a forbidden term that MUST be skipped (snapshot asserts its absence; a #6906-style regression makes it appear and fails the harness), a behavioral forbidden-term file that fires, and an explicit test-path-invariant test. Fixtures + test only; no detector/config change. This is the prerequisite for safely landing #6855 Phase 1.