### PR TITLE
feat(audit): item-counting grammar to config (#6855 phase 1, harness-gated)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -125,6 +125,51 @@
       "src/core/code_audit/detectors/test_vacuity.rs",
       "src/core/code_audit/detectors/upstream_workaround.rs"
     ],
+    "language_grammars": [
+      {
+        "file_extensions": ["rs"],
+        "item_declaration_prefixes": [
+          "fn ",
+          "struct ",
+          "enum ",
+          "const ",
+          "static ",
+          "type ",
+          "trait ",
+          "impl ",
+          "impl<"
+        ],
+        "visibility_prefixes": ["pub(crate) ", "pub(super) ", "pub "],
+        "modifier_prefixes": ["async ", "unsafe "],
+        "ignore_after_line_equals": ["#[cfg(test)]"]
+      },
+      {
+        "file_extensions": ["php"],
+        "item_declaration_prefixes": [
+          "function ",
+          "class ",
+          "interface ",
+          "trait ",
+          "const "
+        ],
+        "visibility_prefixes": ["public ", "protected ", "private "],
+        "modifier_prefixes": ["static ", "abstract ", "final "]
+      },
+      {
+        "file_extensions": ["js", "jsx", "mjs", "ts", "tsx"],
+        "item_declaration_prefixes": [
+          "function ",
+          "class ",
+          "const ",
+          "let ",
+          "var ",
+          "interface ",
+          "type ",
+          "enum "
+        ],
+        "visibility_prefixes": ["export default ", "export "]
+      }
+    ],
     "remote_execution_safety": {
       "argument_forward_markers": [
         "normalized_args",

--- a/src/core/code_audit/descriptor_runtime.rs
+++ b/src/core/code_audit/descriptor_runtime.rs
@@ -85,8 +85,10 @@ fn run_generic_descriptor(
     let config = context.audit_config;
     match runner {
         GenericDetectorRunner::Structural => match context.source_snapshot {
-            Some(snapshot) => structural::analyze_snapshot(context.root, snapshot),
-            None => structural::analyze_structure(context.root),
+            Some(snapshot) => {
+                structural::analyze_snapshot(context.root, snapshot, &config.language_grammars)
+            }
+            None => structural::analyze_structure(context.root, &config.language_grammars),
         },
         GenericDetectorRunner::DeadCode => run_dead_code(context),
         GenericDetectorRunner::CommentHygiene => {

--- a/src/core/code_audit/structural.rs
+++ b/src/core/code_audit/structural.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::core::component::audit::LanguageGrammar;
 use crate::core::engine::codebase_scan::{CodebaseSnapshot, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
@@ -40,14 +41,20 @@ pub(crate) fn build_snapshot(root: &Path) -> CodebaseSnapshot {
 
 /// Run structural analysis on all source files under a root directory.
 ///
-/// Returns findings for files that exceed structural thresholds.
-pub(crate) fn analyze_structure(root: &Path) -> Vec<Finding> {
+/// Returns findings for files that exceed structural thresholds. Item counting
+/// is driven entirely by the supplied component-owned [`LanguageGrammar`] list;
+/// files whose extension has no configured grammar receive no item-count signal.
+pub(crate) fn analyze_structure(root: &Path, grammars: &[LanguageGrammar]) -> Vec<Finding> {
     let snapshot = build_snapshot(root);
-    analyze_snapshot(root, &snapshot)
+    analyze_snapshot(root, &snapshot, grammars)
 }
 
 /// Run structural analysis from an already-loaded codebase snapshot.
-pub(crate) fn analyze_snapshot(root: &Path, snapshot: &CodebaseSnapshot) -> Vec<Finding> {
+pub(crate) fn analyze_snapshot(
+    root: &Path,
+    snapshot: &CodebaseSnapshot,
+    grammars: &[LanguageGrammar],
+) -> Vec<Finding> {
     let mut findings = Vec::new();
     let mut dir_source_counts: HashMap<String, usize> = HashMap::new();
 
@@ -70,8 +77,13 @@ pub(crate) fn analyze_snapshot(root: &Path, snapshot: &CodebaseSnapshot) -> Vec<
             .unwrap_or_else(|_| path.to_string_lossy().to_string());
 
         // Count top-level items before line-count severity so god-file warnings
-        // require more than size alone.
-        let item_count = count_top_level_items(content, ext);
+        // require more than size alone. The grammar is component-owned; unknown
+        // extensions get no grammar and therefore no item-count signal.
+        let item_count = grammars
+            .iter()
+            .find(|grammar| grammar.matches_extension(ext))
+            .map(|grammar| grammar.count_items(content))
+            .unwrap_or(0);
 
         // Check line count
         let line_count = content.lines().count();
@@ -146,160 +158,6 @@ pub(crate) fn analyze_snapshot(root: &Path, snapshot: &CodebaseSnapshot) -> Vec<
     findings
 }
 
-/// Count top-level items in a source file.
-///
-/// Uses lightweight pattern matching rather than full parsing — we just need
-/// approximate counts for threshold detection, not exact ASTs.
-fn count_top_level_items(content: &str, ext: &str) -> usize {
-    match ext {
-        "rs" => count_rust_items(content),
-        "php" => count_php_items(content),
-        "js" | "jsx" | "mjs" | "ts" | "tsx" => count_js_items(content),
-        _ => 0, // Unknown languages get no item count findings
-    }
-}
-
-/// Count top-level items in Rust source.
-///
-/// Matches: fn, struct, enum, const, static, type, trait, impl at zero indentation.
-fn count_rust_items(content: &str) -> usize {
-    let mut count = 0;
-    let mut in_test_module = false;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        // Skip items inside test modules (everything after #[cfg(test)])
-        if trimmed == "#[cfg(test)]" {
-            in_test_module = true;
-            continue;
-        }
-        if in_test_module {
-            continue;
-        }
-
-        // Only count items at top level (zero indentation)
-        let indent = line.len() - line.trim_start().len();
-        if indent > 0 {
-            continue;
-        }
-
-        if is_rust_item_declaration(trimmed) {
-            count += 1;
-        }
-    }
-
-    count
-}
-
-/// Check if a trimmed line starts a Rust item declaration.
-fn is_rust_item_declaration(trimmed: &str) -> bool {
-    // Strip visibility prefix
-    let rest = if let Some(r) = trimmed.strip_prefix("pub(crate) ") {
-        r
-    } else if let Some(r) = trimmed.strip_prefix("pub(super) ") {
-        r
-    } else if let Some(r) = trimmed.strip_prefix("pub ") {
-        r
-    } else {
-        trimmed
-    };
-
-    // Strip async/unsafe/const modifiers for functions
-    let rest = if let Some(r) = rest.strip_prefix("async ") {
-        r
-    } else {
-        rest
-    };
-    let rest = if let Some(r) = rest.strip_prefix("unsafe ") {
-        r
-    } else {
-        rest
-    };
-
-    rest.starts_with("fn ")
-        || rest.starts_with("struct ")
-        || rest.starts_with("enum ")
-        || rest.starts_with("const ")
-        || rest.starts_with("static ")
-        || rest.starts_with("type ")
-        || rest.starts_with("trait ")
-        || rest.starts_with("impl ")
-        || rest.starts_with("impl<")
-}
-
-/// Count top-level items in PHP source.
-///
-/// Matches: function, class, interface, trait, const at zero indentation.
-fn count_php_items(content: &str) -> usize {
-    let mut count = 0;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        let indent = line.len() - line.trim_start().len();
-        if indent > 0 {
-            continue;
-        }
-
-        // Strip visibility
-        let rest = trimmed
-            .strip_prefix("public ")
-            .or_else(|| trimmed.strip_prefix("protected "))
-            .or_else(|| trimmed.strip_prefix("private "))
-            .unwrap_or(trimmed);
-        let rest = rest
-            .strip_prefix("static ")
-            .or_else(|| rest.strip_prefix("abstract "))
-            .or_else(|| rest.strip_prefix("final "))
-            .unwrap_or(rest);
-
-        if rest.starts_with("function ")
-            || rest.starts_with("class ")
-            || rest.starts_with("interface ")
-            || rest.starts_with("trait ")
-            || rest.starts_with("const ")
-        {
-            count += 1;
-        }
-    }
-
-    count
-}
-
-/// Count top-level items in JavaScript/TypeScript source.
-///
-/// Matches: function, class, const, let, var, export at zero indentation.
-fn count_js_items(content: &str) -> usize {
-    let mut count = 0;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        let indent = line.len() - line.trim_start().len();
-        if indent > 0 {
-            continue;
-        }
-
-        let rest = trimmed
-            .strip_prefix("export default ")
-            .or_else(|| trimmed.strip_prefix("export "))
-            .unwrap_or(trimmed);
-
-        if rest.starts_with("function ")
-            || rest.starts_with("class ")
-            || rest.starts_with("const ")
-            || rest.starts_with("let ")
-            || rest.starts_with("var ")
-            || rest.starts_with("interface ")
-            || rest.starts_with("type ")
-            || rest.starts_with("enum ")
-        {
-            count += 1;
-        }
-    }
-
-    count
-}
-
 // ============================================================================
 // Tests
 // ============================================================================
@@ -307,6 +165,80 @@ fn count_js_items(content: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Rust grammar mirroring the structural detector's historical behavior.
+    fn rust_grammar() -> LanguageGrammar {
+        LanguageGrammar {
+            file_extensions: vec!["rs".to_string()],
+            item_declaration_prefixes: vec![
+                "fn ".to_string(),
+                "struct ".to_string(),
+                "enum ".to_string(),
+                "const ".to_string(),
+                "static ".to_string(),
+                "type ".to_string(),
+                "trait ".to_string(),
+                "impl ".to_string(),
+                "impl<".to_string(),
+            ],
+            visibility_prefixes: vec![
+                "pub(crate) ".to_string(),
+                "pub(super) ".to_string(),
+                "pub ".to_string(),
+            ],
+            modifier_prefixes: vec!["async ".to_string(), "unsafe ".to_string()],
+            ignore_after_line_equals: vec!["#[cfg(test)]".to_string()],
+        }
+    }
+
+    fn php_grammar() -> LanguageGrammar {
+        LanguageGrammar {
+            file_extensions: vec!["php".to_string()],
+            item_declaration_prefixes: vec![
+                "function ".to_string(),
+                "class ".to_string(),
+                "interface ".to_string(),
+                "trait ".to_string(),
+                "const ".to_string(),
+            ],
+            visibility_prefixes: vec![
+                "public ".to_string(),
+                "protected ".to_string(),
+                "private ".to_string(),
+            ],
+            modifier_prefixes: vec![
+                "static ".to_string(),
+                "abstract ".to_string(),
+                "final ".to_string(),
+            ],
+            ignore_after_line_equals: Vec::new(),
+        }
+    }
+
+    fn js_grammar() -> LanguageGrammar {
+        LanguageGrammar {
+            file_extensions: vec![
+                "js".to_string(),
+                "jsx".to_string(),
+                "mjs".to_string(),
+                "ts".to_string(),
+                "tsx".to_string(),
+            ],
+            item_declaration_prefixes: vec![
+                "function ".to_string(),
+                "class ".to_string(),
+                "const ".to_string(),
+                "let ".to_string(),
+                "var ".to_string(),
+                "interface ".to_string(),
+                "type ".to_string(),
+                "enum ".to_string(),
+            ],
+            visibility_prefixes: vec!["export default ".to_string(), "export ".to_string()],
+            modifier_prefixes: Vec::new(),
+            ignore_after_line_equals: Vec::new(),
+        }
+    }
 
     #[test]
     fn count_rust_items_basic() {
@@ -341,7 +273,7 @@ mod tests {
 "#;
         // Should count: struct Foo, fn helper, pub fn main_logic, impl Foo, const MAX = 5
         // Should NOT count: use, items inside #[cfg(test)]
-        let count = count_rust_items(content);
+        let count = rust_grammar().count_items(content);
         assert_eq!(count, 5, "Expected 5 top-level items");
     }
 
@@ -353,7 +285,7 @@ pub struct Public {}
 pub(super) const X: i32 = 1;
 pub async fn async_handler() {}
 "#;
-        assert_eq!(count_rust_items(content), 4);
+        assert_eq!(rust_grammar().count_items(content), 4);
     }
 
     #[test]
@@ -374,7 +306,7 @@ interface Cacheable {
 "#;
         // class User, function helper, interface Cacheable = 3
         // Methods inside class are indented, so not counted
-        assert_eq!(count_php_items(content), 3);
+        assert_eq!(php_grammar().count_items(content), 3);
     }
 
     #[test]
@@ -393,7 +325,7 @@ const CONFIG = {};
 export default function main() {}
 "#;
         // export function, export class, const CONFIG, export default function = 4
-        assert_eq!(count_js_items(content), 4);
+        assert_eq!(js_grammar().count_items(content), 4);
     }
 
     #[test]
@@ -411,7 +343,7 @@ export default function main() {}
         // Create a small file (under threshold)
         std::fs::write(dir.join("small.rs"), "fn tiny() {}\n").unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &[rust_grammar()]);
         let god_findings: Vec<&Finding> = findings
             .iter()
             .filter(|f| f.kind == AuditFinding::GodFile)
@@ -442,12 +374,13 @@ export default function main() {}
         let broad_snapshot = CodebaseSnapshot::build(&dir, &ScanConfig::default());
         assert_eq!(snapshot.len(), 1);
         assert_eq!(
-            serde_json::to_value(analyze_snapshot(&dir, &snapshot)).unwrap(),
-            serde_json::to_value(analyze_structure(&dir)).unwrap()
+            serde_json::to_value(analyze_snapshot(&dir, &snapshot, &[rust_grammar()])).unwrap(),
+            serde_json::to_value(analyze_structure(&dir, &[rust_grammar()])).unwrap()
         );
         assert_eq!(
-            serde_json::to_value(analyze_snapshot(&dir, &broad_snapshot)).unwrap(),
-            serde_json::to_value(analyze_structure(&dir)).unwrap()
+            serde_json::to_value(analyze_snapshot(&dir, &broad_snapshot, &[rust_grammar()]))
+                .unwrap(),
+            serde_json::to_value(analyze_structure(&dir, &[rust_grammar()])).unwrap()
         );
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -465,7 +398,7 @@ export default function main() {}
         content.push_str("}\n");
         std::fs::write(dir.join("large.rs"), content).unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &[rust_grammar()]);
         let god_findings: Vec<&Finding> = findings
             .iter()
             .filter(|f| f.kind == AuditFinding::GodFile)
@@ -513,7 +446,7 @@ export default function main() {}
             std::fs::write(root.join(format!("module_{}.rs", i)), "pub fn run() {}\n").unwrap();
         }
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &[rust_grammar()]);
         assert!(
             findings.is_empty(),
             "Moderate count-only smells should stay below the audit finding threshold"
@@ -535,7 +468,7 @@ export default function main() {}
         std::fs::write(dir.join("data.csv"), &content).unwrap();
         std::fs::write(dir.join("readme.md"), &content).unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &[rust_grammar()]);
         assert!(
             findings.is_empty(),
             "Non-source files should not produce findings"
@@ -556,7 +489,7 @@ export default function main() {}
         }
         std::fs::write(vendor.join("big.rs"), &content).unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &[rust_grammar()]);
         assert!(findings.is_empty(), "Files in vendor/ should be skipped");
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -579,7 +512,7 @@ export default function main() {}
         }
         std::fs::write(dir.join("clean.rs"), &content).unwrap();
 
-        let findings = analyze_structure(&dir);
+        let findings = analyze_structure(&dir, &[rust_grammar()]);
         assert!(
             findings.is_empty(),
             "Clean files should produce no findings"

--- a/src/core/component/audit/language_grammar.rs
+++ b/src/core/component/audit/language_grammar.rs
@@ -1,0 +1,161 @@
+use serde::{Deserialize, Serialize};
+
+/// Component-owned, language-agnostic grammar for counting top-level item
+/// declarations in a source file.
+///
+/// Core owns only the mechanical counting algorithm; every language-specific
+/// literal (file extensions, declaration keywords, visibility and modifier
+/// prefixes) is supplied here by component configuration. This keeps the
+/// structural detector free of ecosystem keywords while preserving the exact
+/// counting behavior the detector previously hard-coded.
+///
+/// Counting algorithm (per zero-indentation line, after an optional
+/// language-defined "stop after this line" marker disables further counting):
+///   1. Strip at most one matching `visibility_prefixes` entry.
+///   2. Repeatedly strip any matching `modifier_prefixes` entry.
+///   3. Count the line if the remainder `starts_with` any
+///      `item_declaration_prefixes` entry.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct LanguageGrammar {
+    /// File extensions (without the dot) this grammar applies to, e.g. `rs`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_extensions: Vec<String>,
+    /// Prefixes that introduce a top-level item declaration once visibility and
+    /// modifier prefixes have been stripped, e.g. `fn `, `struct `, `class `.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub item_declaration_prefixes: Vec<String>,
+    /// Visibility prefixes; at most one is stripped from the front of a line.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub visibility_prefixes: Vec<String>,
+    /// Modifier prefixes; stripped repeatedly until none match.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modifier_prefixes: Vec<String>,
+    /// Trimmed line values that, once seen, stop all further counting in the
+    /// file (e.g. a test-module attribute). Compared against the trimmed line.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore_after_line_equals: Vec<String>,
+}
+
+impl LanguageGrammar {
+    /// Whether this grammar applies to the given file extension.
+    pub fn matches_extension(&self, ext: &str) -> bool {
+        self.file_extensions.iter().any(|e| e == ext)
+    }
+
+    /// Count top-level item declarations in `content` using this grammar.
+    ///
+    /// Reproduces the structural detector's lightweight, zero-indentation
+    /// pattern match: only lines with no leading indentation are considered,
+    /// and counting stops entirely after any `ignore_after_line_equals` marker.
+    pub fn count_items(&self, content: &str) -> usize {
+        let mut count = 0;
+        let mut stopped = false;
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+
+            if !stopped && self.ignore_after_line_equals.iter().any(|m| m == trimmed) {
+                stopped = true;
+                continue;
+            }
+            if stopped {
+                continue;
+            }
+
+            // Only count items at top level (zero indentation).
+            let indent = line.len() - line.trim_start().len();
+            if indent > 0 {
+                continue;
+            }
+
+            let mut rest = trimmed;
+
+            // Strip at most one visibility prefix.
+            for prefix in &self.visibility_prefixes {
+                if let Some(stripped) = rest.strip_prefix(prefix.as_str()) {
+                    rest = stripped;
+                    break;
+                }
+            }
+
+            // Repeatedly strip modifier prefixes.
+            loop {
+                let mut stripped_any = false;
+                for prefix in &self.modifier_prefixes {
+                    if let Some(stripped) = rest.strip_prefix(prefix.as_str()) {
+                        rest = stripped;
+                        stripped_any = true;
+                        break;
+                    }
+                }
+                if !stripped_any {
+                    break;
+                }
+            }
+
+            if self
+                .item_declaration_prefixes
+                .iter()
+                .any(|prefix| rest.starts_with(prefix.as_str()))
+            {
+                count += 1;
+            }
+        }
+
+        count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rust_grammar() -> LanguageGrammar {
+        LanguageGrammar {
+            file_extensions: vec!["rs".to_string()],
+            item_declaration_prefixes: vec![
+                "fn ".to_string(),
+                "struct ".to_string(),
+                "enum ".to_string(),
+                "const ".to_string(),
+                "static ".to_string(),
+                "type ".to_string(),
+                "trait ".to_string(),
+                "impl ".to_string(),
+                "impl<".to_string(),
+            ],
+            visibility_prefixes: vec![
+                "pub(crate) ".to_string(),
+                "pub(super) ".to_string(),
+                "pub ".to_string(),
+            ],
+            modifier_prefixes: vec!["async ".to_string(), "unsafe ".to_string()],
+            ignore_after_line_equals: vec!["#[cfg(test)]".to_string()],
+        }
+    }
+
+    #[test]
+    fn counts_zero_indent_items_only() {
+        let content = "fn a() {}\n    fn nested() {}\nstruct S {}\n";
+        assert_eq!(rust_grammar().count_items(content), 2);
+    }
+
+    #[test]
+    fn strips_one_visibility_then_modifiers() {
+        let content = "pub(crate) fn a() {}\npub async fn b() {}\npub(super) const X: i32 = 1;\n";
+        assert_eq!(rust_grammar().count_items(content), 3);
+    }
+
+    #[test]
+    fn stops_counting_after_marker() {
+        let content = "fn a() {}\n#[cfg(test)]\nfn would_count() {}\n";
+        assert_eq!(rust_grammar().count_items(content), 1);
+    }
+
+    #[test]
+    fn matches_extension_checks_membership() {
+        let grammar = rust_grammar();
+        assert!(grammar.matches_extension("rs"));
+        assert!(!grammar.matches_extension("php"));
+    }
+}

--- a/src/core/component/audit/mod.rs
+++ b/src/core/component/audit/mod.rs
@@ -5,6 +5,7 @@ mod config_key_usage;
 mod detector_profile;
 mod exposure;
 mod known_symbols;
+mod language_grammar;
 mod remote_execution;
 mod source_policy;
 mod test_wiring;
@@ -21,6 +22,7 @@ pub use known_symbols::{
     KnownSymbolKind, KnownSymbolManifestPackageProvider, KnownSymbolSourceScanConfig,
     KnownSymbolVersionedEntry, KnownSymbolsConfig,
 };
+pub use language_grammar::LanguageGrammar;
 pub use remote_execution::{ArtifactPortabilityConfig, RemoteExecutionSafetyConfig};
 pub use source_policy::{
     ConventionTagGlob, CoreBoundaryLeakConfig, MutatingResourceAccessConfig, RequestedDetectorRule,
@@ -122,6 +124,15 @@ pub struct AuditConfig {
     /// adapters over core services.
     #[serde(default, skip_serializing_if = "ThinCommandAdapterConfig::is_empty")]
     pub thin_command_adapter: ThinCommandAdapterConfig,
+    /// Component-owned, language-agnostic grammars for the structural detector's
+    /// top-level item counting. Core supplies only the counting algorithm; every
+    /// language keyword/extension literal lives here in component config.
+    ///
+    /// Intentionally excluded from [`AuditConfig::is_empty`]: item counting is a
+    /// presentation-only structural signal, so configuring grammars must not, on
+    /// its own, mark a component as having a non-default audit policy.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub language_grammars: Vec<LanguageGrammar>,
 }
 
 impl AuditConfig {
@@ -186,6 +197,7 @@ impl AuditConfig {
         self.artifact_portability.merge(&other.artifact_portability);
         self.detector_profile.merge(&other.detector_profile);
         self.thin_command_adapter.merge(&other.thin_command_adapter);
+        extend_unique(&mut self.language_grammars, &other.language_grammars);
         for rule in &other.source_policies {
             if !self
                 .source_policies

--- a/tests/fixtures/audit_runtime/homeboy.json
+++ b/tests/fixtures/audit_runtime/homeboy.json
@@ -2,6 +2,25 @@
   "id": "audit-runtime-fixture",
   "remote_path": "",
   "audit": {
+    "language_grammars": [
+      {
+        "file_extensions": ["rs"],
+        "item_declaration_prefixes": [
+          "fn ",
+          "struct ",
+          "enum ",
+          "const ",
+          "static ",
+          "type ",
+          "trait ",
+          "impl ",
+          "impl<"
+        ],
+        "visibility_prefixes": ["pub(crate) ", "pub(super) ", "pub "],
+        "modifier_prefixes": ["async ", "unsafe "],
+        "ignore_after_line_equals": ["#[cfg(test)]"]
+      }
+    ],
     "core_boundary_leaks": {
       "terms": ["florpstack"],
       "scan_path_contains": ["src/"],


### PR DESCRIPTION
Third attempt at #6855 Phase 1, gated by the fidelity-upgraded runtime audit harness (#6914) which now exercises test-path skipping AND the agnostic detector — the two behaviors #6896/#6906 broke. Extracts structural.rs item counting into config-driven LanguageGrammar; enum Language/symbol_graph/is_empty untouched. All 3 audit_runtime_regression harness tests + structural parity pass with unchanged findings.