### PR TITLE
fix(release): fetch tags before reachability guard; fix batch rollup (#6916)

### DIFF
--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -64,7 +64,7 @@ pub use operations_changes::{
 pub use operations_commit::{commit, commit_at, commit_from_json, CommitJsonOutput, CommitOptions};
 pub use operations_push::{push, push_at, push_bulk, PushOptions};
 pub use operations_tags::{
-    delete_local_tag, delete_remote_tag, fetch_origin, get_head_commit, get_tag_commit,
+    delete_local_tag, delete_remote_tag, fetch_origin, fetch_tags, get_head_commit, get_tag_commit,
     is_ancestor, remote_branch_commit, remote_tag_commit, short_head_revision_at, tag, tag_at,
     tag_exists_locally, tag_exists_on_remote,
 };

--- a/src/core/git/operations_tags.rs
+++ b/src/core/git/operations_tags.rs
@@ -129,6 +129,65 @@ pub fn fetch_origin(path: &str) -> Result<()> {
     Ok(())
 }
 
+/// Ensure the operating checkout has the relevant release tags (and enough
+/// connecting history) before a reachability/changelog-range guard inspects
+/// them.
+///
+/// A release checkout can be materialized without tags, or shallow, so the
+/// latest release tag is either absent or its connecting commits are missing.
+/// Either way the reachability guard sees "tag not reachable from HEAD" and
+/// refuses, even though the tag genuinely is an ancestor of HEAD in the real
+/// history on `origin` (issue #6916).
+///
+/// This fetches tags from the resolved default remote and, when the checkout is
+/// shallow, unshallows it so `git merge-base --is-ancestor` can be computed
+/// accurately. It is intentionally best-effort: a missing network or remote is
+/// not fatal here, because the downstream guard still runs against whatever
+/// local history exists and remains correct — it just no longer refuses a tag
+/// that was only missing because tags were never fetched.
+pub fn fetch_tags(path: &str) -> Result<()> {
+    if !super::is_git_repo(path) {
+        return Ok(());
+    }
+
+    let remote = super::resolve_default_remote(Path::new(path));
+
+    // Unshallow first when shallow so the fetched tags have their connecting
+    // commits and ancestry can be evaluated. `--unshallow` errors on a complete
+    // repo, so it is gated on the shallow marker and run best-effort.
+    if is_shallow(path) {
+        let _ = crate::core::engine::command::run_in_optional(
+            path,
+            "git",
+            &["fetch", "--unshallow", "--tags", &remote],
+        );
+    }
+
+    // Fetch tags from the remote so the latest release tag and its commits are
+    // present locally. Best-effort: offline/no-remote checkouts fall through to
+    // the guard with whatever local history exists.
+    let _ = crate::core::engine::command::run_in_optional(
+        path,
+        "git",
+        &["fetch", "--tags", &remote],
+    );
+
+    Ok(())
+}
+
+/// Return true when the checkout is a shallow clone (has a `shallow` file in the
+/// git dir). Used to decide whether an `--unshallow` fetch is applicable before
+/// computing tag reachability.
+fn is_shallow(path: &str) -> bool {
+    crate::core::engine::command::run_in_optional(
+        path,
+        "git",
+        &["rev-parse", "--is-shallow-repository"],
+    )
+    .map(|out| out.trim() == "true")
+    .unwrap_or(false)
+}
+
 /// Return true when `ancestor` is an ancestor of (i.e. reachable from)
 /// `descendant`. Used to confirm a stale tag's commit is strictly behind HEAD
 /// before moving it, so a tag is never relocated onto an unrelated/divergent

--- a/src/core/release/planning_semver.rs
+++ b/src/core/release/planning_semver.rs
@@ -293,6 +293,17 @@ pub(super) fn resolve_tag_and_commits(
     local_path: &str,
     monorepo: Option<&git::MonorepoContext>,
 ) -> Result<(Option<String>, Vec<git::CommitInfo>)> {
+    // Make release tags (and connecting history) available before the
+    // reachability/changelog-range guard inspects them. A tagless or shallow
+    // release checkout would otherwise report a genuinely-reachable tag as "not
+    // reachable from HEAD" and refuse (issue #6916). Best-effort: offline
+    // checkouts still fall through to the guard against local history, so a tag
+    // that is truly not an ancestor of HEAD is still refused.
+    let guard_root = monorepo
+        .map(|ctx| ctx.git_root.as_str())
+        .unwrap_or(local_path);
+    git::fetch_tags(guard_root)?;
+
     match monorepo {
         Some(ctx) => {
             let latest_tag = git::get_latest_tag_with_prefix(&ctx.git_root, Some(&ctx.tag_prefix))?;
@@ -721,5 +732,107 @@ mod tests {
             .expect("validation should run");
 
         assert!(message.is_none());
+    }
+
+    /// Issue #6916: a release checkout that is missing the latest release tag
+    /// locally, but where the tag is genuinely reachable on `origin`, must
+    /// fetch the tag and proceed past the reachability/changelog-range guard
+    /// rather than refusing.
+    #[test]
+    fn resolve_tag_and_commits_fetches_missing_tag_reachable_on_origin() {
+        // Build a real upstream repo: initial commit, a release tag, then a
+        // post-release fix commit on the same linear history.
+        let origin = git_repo();
+        let origin_dir = origin.path();
+        commit_file(origin_dir, "README.md", "initial", "chore: initial");
+        run_git(origin_dir, &["branch", "-M", "main"]);
+        run_git(origin_dir, &["tag", "v0.1.18"]);
+        commit_file(origin_dir, "fix.txt", "fix", "fix: patch bug");
+
+        // Materialize a tagless working checkout from origin: the connecting
+        // history is present (the tag's commit IS an ancestor of HEAD) but the
+        // tag ref itself was never fetched, mirroring the materialization that
+        // triggered the false "not reachable from HEAD" refusal.
+        let work = tempfile::tempdir().expect("tempdir");
+        let work_dir = work.path();
+        run_git(
+            work_dir,
+            &[
+                "clone",
+                "--no-tags",
+                "-q",
+                &origin_dir.to_string_lossy(),
+                ".",
+            ],
+        );
+        run_git(work_dir, &["config", "user.email", "homeboy@example.com"]);
+        run_git(work_dir, &["config", "user.name", "Homeboy Test"]);
+
+        // Precondition: the release tag is genuinely absent locally.
+        let listed = std::process::Command::new("git")
+            .args(["tag", "-l", "v0.1.18"])
+            .current_dir(work_dir)
+            .output()
+            .expect("git tag -l");
+        assert!(
+            String::from_utf8_lossy(&listed.stdout).trim().is_empty(),
+            "tag should be missing locally before the fetch-before-guard step"
+        );
+
+        // resolve_tag_and_commits fetches tags from origin before the guard, so
+        // the now-reachable tag is found and the call proceeds.
+        let (latest_tag, commits) = resolve_tag_and_commits(&work_dir.to_string_lossy(), None)
+            .expect("tag reachable on origin should let the release proceed past the guard");
+
+        assert_eq!(latest_tag.as_deref(), Some("v0.1.18"));
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].subject, "fix: patch bug");
+    }
+
+    /// Guard correctness preserved: a tag that is genuinely NOT an ancestor of
+    /// HEAD must still refuse, even after the fetch-before-guard step pulls all
+    /// tags from origin.
+    #[test]
+    fn resolve_tag_and_commits_still_refuses_genuinely_unreachable_tag_after_fetch() {
+        // Upstream has a tag on an off-branch commit that never merges into the
+        // main line that the working checkout tracks.
+        let origin = git_repo();
+        let origin_dir = origin.path();
+        commit_file(origin_dir, "README.md", "initial", "chore: initial");
+        run_git(origin_dir, &["branch", "-M", "main"]);
+        run_git(origin_dir, &["tag", "v0.1.0"]);
+        commit_file(origin_dir, "feature.txt", "work", "feat: first work");
+        run_git(origin_dir, &["branch", "release-v0.2.0"]);
+        run_git(origin_dir, &["checkout", "-q", "release-v0.2.0"]);
+        commit_file(origin_dir, "VERSION", "0.2.0", "release: v0.2.0");
+        run_git(origin_dir, &["tag", "v0.2.0"]);
+        run_git(origin_dir, &["checkout", "-q", "main"]);
+        commit_file(origin_dir, "fix.txt", "more", "fix: second work");
+
+        // Working checkout tracks main and, like the real failure, is missing
+        // tags locally. The fetch step will pull v0.2.0, but it remains
+        // off-branch — so the guard must still fail closed.
+        let work = tempfile::tempdir().expect("tempdir");
+        let work_dir = work.path();
+        run_git(
+            work_dir,
+            &[
+                "clone",
+                "--no-tags",
+                "-q",
+                "--branch",
+                "main",
+                &origin_dir.to_string_lossy(),
+                ".",
+            ],
+        );
+        run_git(work_dir, &["config", "user.email", "homeboy@example.com"]);
+        run_git(work_dir, &["config", "user.name", "Homeboy Test"]);
+
+        let err = resolve_tag_and_commits(&work_dir.to_string_lossy(), None)
+            .expect_err("off-branch tag must still fail closed after fetching tags");
+
+        assert!(err.message.contains("Latest release tag v0.2.0"));
+        assert!(err.message.contains("not reachable from HEAD"));
     }
 }

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -658,6 +658,26 @@ fn release_command_exit_code(
     }
 }
 
+/// Which batch summary counter a per-component release status rolls up into.
+#[derive(Debug, PartialEq, Eq)]
+enum BatchStatusBucket {
+    Released,
+    Skipped,
+    Failed,
+}
+
+/// Map an authoritative per-component release status string to its batch
+/// summary bucket. Only a clean `released` counts as released; `skipped` is its
+/// own bucket; every other outcome (failed, missing, partial, or unknown) rolls
+/// up as failed so the summary never overstates success (issue #6916).
+fn batch_status_bucket(status: &str) -> BatchStatusBucket {
+    match status {
+        "released" => BatchStatusBucket::Released,
+        "skipped" => BatchStatusBucket::Skipped,
+        _ => BatchStatusBucket::Failed,
+    }
+}
+
 /// Run releases for multiple components sequentially.
 ///
 /// Continue-on-error: if one component fails, the rest still run.
@@ -699,18 +719,22 @@ pub fn run_batch(
 
         match run_command(input) {
             Ok((result, _exit_code)) => {
-                let was_skipped = result.skipped_reason.is_some();
-                let status = if was_skipped {
-                    skipped += 1;
-                    "skipped"
-                } else {
-                    released += 1;
-                    "released"
-                };
+                // Roll up the authoritative per-component status rather than
+                // assuming a non-skipped `Ok` means "released". A component can
+                // return `Ok` with a nested status of failed/missing/partial
+                // (e.g. a dependency release failed), and counting that as
+                // `released` produced a misleading `{released, failed}` summary
+                // (issue #6916).
+                let status = result.status.clone();
+                match batch_status_bucket(&status) {
+                    BatchStatusBucket::Skipped => skipped += 1,
+                    BatchStatusBucket::Released => released += 1,
+                    BatchStatusBucket::Failed => failed += 1,
+                }
 
                 results.push(BatchReleaseComponentResult {
                     component_id: component_id.clone(),
-                    status: status.to_string(),
+                    status,
                     error: None,
                     result: Some(result),
                 });
@@ -760,6 +784,17 @@ mod tests {
     use crate::core::plan::{PlanStep, PlanStepStatus, PlanValues};
     use crate::core::release::types::ReleasePhase;
     use crate::core::release::{ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus};
+
+    #[test]
+    fn batch_status_bucket_rolls_up_non_released_outcomes_as_failed() {
+        // Issue #6916: a failed component must not be counted as released.
+        assert_eq!(batch_status_bucket("released"), BatchStatusBucket::Released);
+        assert_eq!(batch_status_bucket("skipped"), BatchStatusBucket::Skipped);
+        assert_eq!(batch_status_bucket("failed"), BatchStatusBucket::Failed);
+        assert_eq!(batch_status_bucket("missing"), BatchStatusBucket::Failed);
+        assert_eq!(batch_status_bucket("partial"), BatchStatusBucket::Failed);
+        assert_eq!(batch_status_bucket("unknown"), BatchStatusBucket::Failed);
+    }
 
     #[test]
     fn extracts_new_version_from_plan() {


### PR DESCRIPTION
Closes #6916

## Problem
`homeboy release <component>` refuses with:

```
Invalid argument 'release-range': Latest release tag <tag> is not reachable from HEAD. Refusing to plan changelog entries
```

even when the tag genuinely IS reachable from HEAD in the real repo. The release flow computes a release-range (`latest tag..HEAD`) and requires the latest release tag be an ancestor of HEAD. When the operating checkout was materialized without tags (or shallow), the tag is either absent or its connecting commits are missing, so `git merge-base --is-ancestor <tag> HEAD` reports false and the guard refuses — fully blocking releases.

## Fix 1 — make tags available before the guard (guard correctness preserved)
The reachability/changelog-range guard lives in `validate_latest_release_tag_reachable`, called from the single chokepoint `resolve_tag_and_commits` (which also computes the latest tag and the commit range). I added `git::fetch_tags()` and call it at the entry of `resolve_tag_and_commits`, before the guard:

- Fetches tags from the resolved default remote (`git fetch --tags <remote>`).
- Unshallows a shallow checkout (`git fetch --unshallow --tags`) so ancestry can be computed accurately.
- Best-effort: an offline/no-remote checkout falls through to the guard against whatever local history exists.

The fix makes tags **available** so the check is accurate — it does not skip or weaken the check. A tag that is genuinely **not** an ancestor of HEAD is still refused.

## Fix 2 — batch summary rollup
`run_batch` labeled any non-skipped `Ok` component as `released`, even when its authoritative per-component status was `failed`/`missing`/`partial`. That produced the misleading `{"released": 1, "failed": 1}` summary in the issue. The rollup now reads the real `result.status` via a new `batch_status_bucket`: only a clean `released` counts as released; `skipped` is its own bucket; every other non-skipped outcome (failed/missing/partial/unknown) counts as failed so the summary never overstates success.

## Tests
- `resolve_tag_and_commits_fetches_missing_tag_reachable_on_origin` — a tagless checkout (cloned `--no-tags` from a local bare-ish origin) where the tag is reachable on origin now proceeds past the guard (no network: uses a local fixture origin).
- `resolve_tag_and_commits_still_refuses_genuinely_unreachable_tag_after_fetch` — an off-branch tag fetched from origin still fails closed (guard correctness preserved).
- `batch_status_bucket_rolls_up_non_released_outcomes_as_failed` — failed/missing/partial/unknown roll up as failed, not released.
- Pre-existing `resolve_tag_and_commits_fails_closed_when_latest_release_tag_is_off_branch` still passes (`fetch_tags` is a no-op without a remote).

`cargo build` clean; `cargo test --lib release::` 304 passed single-threaded. (One env-dependent enterprise-proxy test in `github_release` is flaky under parallelism on both base and branch — unrelated to this change.)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Investigating the release guard/materialization flow, implementing the tag-fetch helper and batch rollup fix, and writing regression tests.