### PR TITLE
fix: bind canonical typed artifacts

### DIFF
--- a/src/core/agent_task_scheduler/scheduling.rs
+++ b/src/core/agent_task_scheduler/scheduling.rs
@@ -235,6 +235,27 @@ impl AgentTaskScheduleSupport {
         };
 
         if let Some(artifact_binding) = &binding.artifact {
+            if let Some(typed_artifact) = outcome.typed_artifacts.iter().find(|artifact| {
+                Self::typed_artifact_matches_artifact_binding(artifact, artifact_binding)
+            }) {
+                let artifact_value = serde_json::to_value(typed_artifact).unwrap_or(Value::Null);
+                if let Some(payload_path) = &artifact_binding.payload_path {
+                    if let Some(value) = typed_artifact
+                        .payload
+                        .pointer(payload_path)
+                        .or_else(|| artifact_value.pointer(payload_path))
+                    {
+                        return Ok(value.clone());
+                    }
+                    return missing_binding_fallback(format!(
+                        "task '{}' skipped because required typed artifact binding '{}' payload was missing at '{}' from task '{}'",
+                        request.task_id, name, payload_path, binding.task_id
+                    ));
+                }
+
+                return Ok(typed_artifact.payload.clone());
+            }
+
             let Some(artifact) = outcome.artifacts.iter().find(|artifact| {
                 artifact.kind == artifact_binding.kind
                     && artifact_binding
@@ -359,10 +380,110 @@ impl AgentTaskScheduleSupport {
                         sha256: artifact.sha256.clone(),
                         payload,
                     });
+                    continue;
+                }
+
+                if let Some(typed_artifact) = outcome.typed_artifacts.iter().find(|artifact| {
+                    Self::typed_artifact_matches_output_declaration(artifact, declaration)
+                }) {
+                    let payload = declaration
+                        .payload_path
+                        .as_ref()
+                        .and_then(|payload_path| typed_artifact.payload.pointer(payload_path))
+                        .cloned()
+                        .unwrap_or_else(|| typed_artifact.payload.clone());
+
+                    lineage.push(AgentTaskArtifactLineage {
+                        task_id: outcome.task_id.clone(),
+                        name: declaration.name.clone(),
+                        kind: typed_artifact
+                            .artifact_type
+                            .clone()
+                            .unwrap_or_else(|| declaration.kind.clone()),
+                        schema: declaration
+                            .schema
+                            .clone()
+                            .or_else(|| typed_artifact.artifact_schema.clone()),
+                        artifact_id: typed_artifact
+                            .artifact
+                            .as_ref()
+                            .map(|artifact| artifact.id.clone()),
+                        path: typed_artifact
+                            .artifact
+                            .as_ref()
+                            .and_then(|artifact| artifact.path.clone()),
+                        url: typed_artifact
+                            .artifact
+                            .as_ref()
+                            .and_then(|artifact| artifact.url.clone()),
+                        sha256: typed_artifact
+                            .artifact
+                            .as_ref()
+                            .and_then(|artifact| artifact.sha256.clone()),
+                        payload,
+                    });
                 }
             }
         }
         lineage
+    }
+
+    fn typed_artifact_matches_artifact_binding(
+        artifact: &AgentTaskTypedArtifact,
+        binding: &AgentTaskArtifactBinding,
+    ) -> bool {
+        let kind_matches = artifact.name == binding.kind
+            || artifact.artifact_type.as_deref() == Some(binding.kind.as_str())
+            || artifact.artifact_schema.as_deref() == Some(binding.kind.as_str());
+        if !kind_matches {
+            return false;
+        }
+
+        if binding.artifact_id.as_ref().map(|artifact_id| {
+            artifact
+                .artifact
+                .as_ref()
+                .map(|artifact| artifact.id.as_str())
+                == Some(artifact_id.as_str())
+                || artifact.name == *artifact_id
+        }) == Some(false)
+        {
+            return false;
+        }
+
+        binding
+            .schema
+            .as_ref()
+            .map(|schema| artifact.artifact_schema.as_deref() == Some(schema.as_str()))
+            .unwrap_or(true)
+    }
+
+    fn typed_artifact_matches_output_declaration(
+        artifact: &AgentTaskTypedArtifact,
+        declaration: &AgentTaskArtifactOutputDeclaration,
+    ) -> bool {
+        let name_matches = artifact.name == declaration.name || artifact.name == declaration.kind;
+        let kind_matches = artifact.artifact_type.as_deref() == Some(declaration.kind.as_str())
+            || artifact.artifact_schema.as_deref() == Some(declaration.kind.as_str());
+        let artifact_id_matches = declaration
+            .artifact_id
+            .as_ref()
+            .map(|artifact_id| {
+                artifact
+                    .artifact
+                    .as_ref()
+                    .map(|artifact| artifact.id.as_str())
+                    == Some(artifact_id.as_str())
+                    || artifact.name == *artifact_id
+            })
+            .unwrap_or(true);
+        let schema_matches = declaration
+            .schema
+            .as_ref()
+            .map(|schema| artifact.artifact_schema.as_deref() == Some(schema.as_str()))
+            .unwrap_or(true);
+
+        (name_matches || kind_matches) && artifact_id_matches && schema_matches
     }
 
     pub(super) fn backpressure_kind(

--- a/src/core/agent_task_scheduler/tests/scheduling_tests.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests.rs
@@ -4,7 +4,8 @@
 use super::super::*;
 use super::fixtures::*;
 use crate::core::agent_task::{
-    expand_agent_task_matrix, AgentTaskArtifact, AgentTaskMatrixAggregate, AgentTaskMatrixAxis,
+    expand_agent_task_matrix, AgentTaskArtifact, AgentTaskArtifactDeclaration,
+    AgentTaskMatrixAggregate, AgentTaskMatrixAxis, AgentTaskTypedArtifact,
     AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
 };
 use serde_json::{json, Value};
@@ -730,6 +731,115 @@ mod artifact_binding_tests {
     }
 
     #[test]
+    fn required_concept_packet_binding_uses_canonical_typed_artifact() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let scheduler = AgentTaskScheduler::new(ConceptPacketExecutor {
+            observed: Arc::clone(&observed),
+            emit_concept_packet: true,
+        });
+        let mut plan = AgentTaskPlan::new(
+            "plan-concept-packet-typed-artifact",
+            vec![request("idea"), request("build")],
+        );
+        plan.options.max_concurrency = 2;
+        plan.tasks[0].artifact_declarations = vec![concept_packet_declaration()];
+        plan.tasks[1].inputs = json!({ "concept_packet": "{{outputs.concept_packet}}" });
+        plan.output_dependencies.insert(
+            "build".to_string(),
+            AgentTaskOutputDependencies {
+                depends_on: Vec::new(),
+                bindings: HashMap::from([(
+                    "concept_packet".to_string(),
+                    AgentTaskOutputBinding {
+                        task_id: "idea".to_string(),
+                        path: String::new(),
+                        artifact: Some(AgentTaskArtifactBinding {
+                            kind: "concept_packet".to_string(),
+                            schema: Some("wp-site-generator/ConceptPacket/v1".to_string()),
+                            artifact_id: None,
+                            payload_path: None,
+                        }),
+                        required: true,
+                        default: Value::Null,
+                    },
+                )]),
+            },
+        );
+
+        let aggregate = scheduler.run(plan);
+        let observed = observed.lock().expect("observed requests");
+        let build = observed
+            .iter()
+            .find(|request| request.task_id == "build")
+            .expect("build request dispatched");
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.totals.succeeded, 2);
+        assert_eq!(build.inputs["concept_packet"]["title"], "Typed concept");
+    }
+
+    #[test]
+    fn required_concept_packet_binding_fails_without_canonical_typed_artifact() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let scheduler = AgentTaskScheduler::new(ConceptPacketExecutor {
+            observed: Arc::clone(&observed),
+            emit_concept_packet: false,
+        });
+        let mut plan = AgentTaskPlan::new(
+            "plan-concept-packet-missing-typed-artifact",
+            vec![request("idea"), request("build")],
+        );
+        plan.options.max_concurrency = 2;
+        plan.tasks[0].artifact_declarations = vec![concept_packet_declaration()];
+        plan.output_dependencies.insert(
+            "build".to_string(),
+            AgentTaskOutputDependencies {
+                depends_on: Vec::new(),
+                bindings: HashMap::from([(
+                    "concept_packet".to_string(),
+                    AgentTaskOutputBinding {
+                        task_id: "idea".to_string(),
+                        path: String::new(),
+                        artifact: Some(AgentTaskArtifactBinding {
+                            kind: "concept_packet".to_string(),
+                            schema: Some("wp-site-generator/ConceptPacket/v1".to_string()),
+                            artifact_id: None,
+                            payload_path: None,
+                        }),
+                        required: true,
+                        default: Value::Null,
+                    },
+                )]),
+            },
+        );
+
+        let aggregate = scheduler.run(plan);
+        let observed = observed.lock().expect("observed requests");
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert!(observed.iter().all(|request| request.task_id != "build"));
+        let idea = aggregate
+            .outcomes
+            .iter()
+            .find(|outcome| outcome.task_id == "idea")
+            .expect("idea outcome");
+        assert!(idea.diagnostics.iter().any(|diagnostic| {
+            diagnostic.class == "agent_task.required_typed_artifacts_missing"
+                && diagnostic.message.contains("concept_packet")
+        }));
+        let build = aggregate
+            .outcomes
+            .iter()
+            .find(|outcome| outcome.task_id == "build")
+            .expect("build skipped outcome");
+        assert!(build.diagnostics.iter().any(|diagnostic| {
+            diagnostic.class == "output_dependency_missing"
+                && diagnostic.message.contains("required artifact binding")
+                && diagnostic.message.contains("concept_packet")
+        }));
+    }
+
+    #[test]
     fn binds_artifacts_to_generic_child_run_ids_for_durable_fanout() {
         let scheduler = AgentTaskScheduler::new(GenericChildRunExecutor);
         let mut plan = AgentTaskPlan::new(
@@ -742,23 +852,27 @@ mod artifact_binding_tests {
 
         assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
         assert_eq!(aggregate.child_runs.len(), 2);
-        assert_eq!(aggregate.child_runs[0].task_id, "case-a");
-        assert_eq!(aggregate.child_runs[0].run_id, "child-case-a");
+        let mut child_runs = aggregate.child_runs.clone();
+        child_runs.sort_by(|left, right| left.task_id.cmp(&right.task_id));
+        assert_eq!(child_runs[0].task_id, "case-a");
+        assert_eq!(child_runs[0].run_id, "child-case-a");
         assert_eq!(
-            aggregate.child_runs[0].provider.as_deref(),
+            child_runs[0].provider.as_deref(),
             Some("generic-fuzz")
         );
-        assert_eq!(aggregate.child_runs[0].state, AgentTaskState::Succeeded);
+        assert_eq!(child_runs[0].state, AgentTaskState::Succeeded);
         assert_eq!(aggregate.artifact_bindings.len(), 2);
-        assert_eq!(aggregate.artifact_bindings[0].task_id, "case-a");
-        assert_eq!(aggregate.artifact_bindings[0].run_id, "child-case-a");
+        let mut artifact_bindings = aggregate.artifact_bindings.clone();
+        artifact_bindings.sort_by(|left, right| left.task_id.cmp(&right.task_id));
+        assert_eq!(artifact_bindings[0].task_id, "case-a");
+        assert_eq!(artifact_bindings[0].run_id, "child-case-a");
         assert_eq!(
-            aggregate.artifact_bindings[0].artifact_id,
+            artifact_bindings[0].artifact_id,
             "artifact-case-a"
         );
-        assert_eq!(aggregate.artifact_bindings[0].kind, "fuzz-report");
+        assert_eq!(artifact_bindings[0].kind, "fuzz-report");
         assert_eq!(
-            aggregate.artifact_bindings[0].path.as_deref(),
+            artifact_bindings[0].path.as_deref(),
             Some("artifacts/case-a/report.json")
         );
     }
@@ -1266,6 +1380,63 @@ mod plan_projection_tests {
         assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
         assert_eq!(aggregate.totals.succeeded, 2);
         assert_eq!(design.instructions, "Build design for issue #3447");
+    }
+}
+
+fn concept_packet_declaration() -> AgentTaskArtifactDeclaration {
+    AgentTaskArtifactDeclaration {
+        name: "concept_packet".to_string(),
+        artifact_type: Some("concept_packet".to_string()),
+        artifact_schema: Some("wp-site-generator/ConceptPacket/v1".to_string()),
+        path: None,
+        required: true,
+        description: None,
+        metadata: Value::Null,
+    }
+}
+
+struct ConceptPacketExecutor {
+    observed: Arc<Mutex<Vec<AgentTaskRequest>>>,
+    emit_concept_packet: bool,
+}
+
+impl AgentTaskExecutorAdapter for ConceptPacketExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        self.observed
+            .lock()
+            .expect("observed requests")
+            .push(request.clone());
+
+        AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: request.task_id,
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: Some("ok".to_string()),
+            failure_classification: None,
+            artifacts: Vec::new(),
+            typed_artifacts: if self.emit_concept_packet {
+                vec![AgentTaskTypedArtifact {
+                    name: "concept_packet".to_string(),
+                    artifact_type: Some("concept_packet".to_string()),
+                    artifact_schema: Some("wp-site-generator/ConceptPacket/v1".to_string()),
+                    payload: json!({ "title": "Typed concept" }),
+                    artifact: None,
+                    metadata: json!({ "source": "wp-codebox/artifact-result-envelope/v1" }),
+                }]
+            } else {
+                Vec::new()
+            },
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- resolve scheduler artifact bindings from canonical typed artifact DTO fields before file artifacts
- bind typed artifact payloads into downstream task inputs
- include typed artifacts in generic artifact lineage for controller/fanout handoff
- add tests for required `concept_packet` handoff success/failure and durable fanout lineage

## Verification
- `cargo test artifact_binding_tests --lib`
- `cargo test required_concept_packet_binding --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** tracing generic aggregate artifact handoff, drafting Rust scheduler changes/tests, running verification, and preparing this PR description.
