### PR TITLE
Add dependency-aware release cascade (homeboy release --cascade)

### DIFF
--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -132,6 +132,13 @@ pub struct ReleaseArgs {
     /// When set, configures git user.name and user.email before committing.
     #[arg(long)]
     git_identity: Option<String>,
+
+    /// After releasing the component, release every dependent that declares a
+    /// dependency on it: update the dependent's declared dependency pin and
+    /// release it with an automatic patch bump, transitively. Single-component
+    /// releases only.
+    #[arg(long)]
+    cascade: bool,
 }
 
 #[derive(Serialize)]
@@ -139,6 +146,10 @@ pub struct ReleaseArgs {
 pub struct ReleaseOutput {
     pub variant: &'static str,
     pub result: ReleaseCommandResult,
+    /// Dependency-aware cascade result, present when `--cascade` released
+    /// dependents after this component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cascade: Option<release::CascadeResult>,
 }
 
 #[derive(Serialize)]
@@ -290,6 +301,7 @@ impl ReleaseArgs {
             no_github_release: false,
             i_know_ci_creates_the_github_release: false,
             git_identity: None,
+            cascade: false,
         }
     }
 }
@@ -313,7 +325,7 @@ pub fn run(
     // Single component: use the original single-release flow
     if component_ids.len() == 1 {
         let component_id = &component_ids[0];
-        let (result, exit_code) = release::run_command(ReleaseCommandInput {
+        let input = ReleaseCommandInput {
             component_id: component_id.clone(),
             path_override: args.path.clone(),
             dry_run: args.dry_run_args.dry_run,
@@ -328,14 +340,27 @@ pub fn run(
             skip_github_release: args.no_github_release,
             git_identity: args.git_identity.clone(),
             execution: Some(execution.clone()),
-        })?;
+        };
+        let (result, exit_code) = release::run_command(input.clone())?;
+
+        let cascade = run_cascade_if_requested(&args, component_id, &result, &input)?;
 
         return Ok((
             ReleaseCommandOutput::Single(ReleaseOutput {
                 variant: "single",
                 result,
+                cascade,
             }),
             exit_code,
+        ));
+    }
+
+    if args.cascade {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "cascade",
+            "--cascade releases dependents of a single component; run one component at a time",
+            None,
+            None,
         ));
     }
 
@@ -415,6 +440,45 @@ pub fn run(
         }),
         exit_code,
     ))
+}
+
+/// Run the dependency-aware cascade after a single-component release, when
+/// `--cascade` was requested and the component actually released.
+fn run_cascade_if_requested(
+    args: &ReleaseArgs,
+    component_id: &str,
+    result: &ReleaseCommandResult,
+    input: &ReleaseCommandInput,
+) -> Result<Option<release::CascadeResult>, homeboy::core::Error> {
+    if !args.cascade {
+        return Ok(None);
+    }
+
+    if args.dry_run_args.dry_run {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "cascade",
+            "--cascade mutates and releases dependents; it cannot be combined with --dry-run",
+            None,
+            None,
+        ));
+    }
+
+    // Only cascade when the upstream actually produced a release; a skipped or
+    // failed upstream has no new coordinates to propagate.
+    if result.status != "released" {
+        return Ok(None);
+    }
+
+    let component = component::resolve_effective(Some(component_id), args.path.as_deref(), None)?;
+    let sha = homeboy::core::git::get_head_commit(&component.local_path).unwrap_or_default();
+    let root = release::ReleasedCoordinates {
+        component_id: component_id.to_string(),
+        version: result.new_version.clone().unwrap_or_default(),
+        tag: result.tag.clone().unwrap_or_default(),
+        sha,
+    };
+
+    Ok(Some(release::run_cascade(&root, input)?))
 }
 
 fn run_package_only(
@@ -741,6 +805,7 @@ mod tests {
             no_github_release: false,
             i_know_ci_creates_the_github_release: false,
             git_identity: None,
+            cascade: false,
         }
     }
 

--- a/src/core/release/cascade.rs
+++ b/src/core/release/cascade.rs
@@ -1,0 +1,414 @@
+//! Generic, dependency-aware release cascade.
+//!
+//! After an upstream component is released, the cascade releases every dependent
+//! that declares a dependency on it: it updates the dependent's declared
+//! dependency pin through a generic extension action ([`UPDATE_DEPENDENCY_ACTION`])
+//! and then releases the dependent with an automatic patch bump.
+//!
+//! The cascade is framework-agnostic. Core carries only generic dependency
+//! coordinates — the released component id, the package name that links the two
+//! components, and the released version/tag/sha. Package-manager specifics (e.g.
+//! rewriting a Composer custom-package's `dist.url`/`source.reference` or
+//! regenerating a lockfile) live entirely in extensions, behind the
+//! `release.update_dependency` action. No package-manager strings appear here.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use crate::core::component::{self, Component};
+use crate::core::deps::{self, DependencyStackPlanStep};
+use crate::core::error::{Error, Result};
+use crate::core::extension;
+use crate::core::git;
+
+use super::types::ReleaseCommandInput;
+
+/// Generic extension action a dependent's extension implements to update its
+/// declared pin on a just-released upstream. Receives the released coordinates
+/// in the action payload's `dependency` block (see
+/// [`build_update_dependency_payload`]).
+pub const UPDATE_DEPENDENCY_ACTION: &str = "release.update_dependency";
+
+/// Bump type used for a dependent released purely because an upstream changed.
+/// Passing this as the release bump override also permits a release with no new
+/// commits since the last tag (a pure dependency bump), instead of skipping
+/// with "no releasable commits".
+pub const DEPENDENCY_BUMP: &str = "patch";
+
+/// Released coordinates for one component in the cascade.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReleasedCoordinates {
+    pub component_id: String,
+    pub version: String,
+    pub tag: String,
+    pub sha: String,
+}
+
+/// One incoming dependency edge into a downstream dependent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CascadeEdge {
+    /// The upstream (released) component this edge depends on.
+    pub upstream: String,
+    /// The package name that links upstream → downstream.
+    pub package: String,
+}
+
+/// A downstream dependent to update and release, with every incoming dependency
+/// edge collapsed so the dependent is released at most once per cascade.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CascadeTarget {
+    pub downstream: String,
+    pub downstream_path: String,
+    pub incoming: Vec<CascadeEdge>,
+}
+
+/// Per-dependent outcome of a cascade run.
+#[derive(Debug, Clone, Serialize)]
+pub struct CascadeStepResult {
+    pub downstream: String,
+    /// Packages whose pin was updated on this dependent.
+    pub updated_packages: Vec<String>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+}
+
+/// Aggregate result of a cascade run.
+#[derive(Debug, Clone, Serialize)]
+pub struct CascadeResult {
+    pub upstream: String,
+    pub released: Vec<CascadeStepResult>,
+}
+
+/// Collapse an ordered (BFS / topological) dependency stack plan into a
+/// deduplicated, first-seen-ordered list of downstream targets.
+///
+/// Each downstream appears once, with all of its incoming edges grouped, so a
+/// dependent that consumes two cascaded upstreams is released a single time
+/// rather than once per edge. Pure — performs no IO — so the dedupe/order
+/// contract is unit-testable without a live dependency graph.
+pub fn cascade_targets(steps: &[DependencyStackPlanStep]) -> Vec<CascadeTarget> {
+    let mut order: Vec<String> = Vec::new();
+    let mut by_downstream: BTreeMap<String, CascadeTarget> = BTreeMap::new();
+
+    for step in steps {
+        let target = by_downstream
+            .entry(step.downstream.clone())
+            .or_insert_with(|| {
+                order.push(step.downstream.clone());
+                CascadeTarget {
+                    downstream: step.downstream.clone(),
+                    downstream_path: step.downstream_path.clone(),
+                    incoming: Vec::new(),
+                }
+            });
+        let edge = CascadeEdge {
+            upstream: step.upstream.clone(),
+            package: step.package.clone(),
+        };
+        if !target.incoming.contains(&edge) {
+            target.incoming.push(edge);
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|id| by_downstream.remove(&id))
+        .collect()
+}
+
+/// Build the generic payload handed to a dependent's
+/// [`UPDATE_DEPENDENCY_ACTION`].
+///
+/// `release.{component_id,local_path}` target the *dependent* (so the action
+/// runs against the dependent's checkout via `HOMEBOY_COMPONENT_PATH`), while
+/// the `dependency` block carries the *upstream* release coordinates the
+/// extension needs to repin: released component id, package name, version, tag,
+/// and commit sha. The field names are package-manager-agnostic on purpose.
+pub fn build_update_dependency_payload(
+    downstream_id: &str,
+    downstream_path: &str,
+    package: &str,
+    upstream: &ReleasedCoordinates,
+) -> serde_json::Value {
+    serde_json::json!({
+        "release": {
+            "component_id": downstream_id,
+            "local_path": downstream_path,
+            "version": upstream.version,
+            "tag": upstream.tag,
+        },
+        "dependency": {
+            "released_id": upstream.component_id,
+            "package": package,
+            "version": upstream.version,
+            "tag": upstream.tag,
+            "sha": upstream.sha,
+        }
+    })
+}
+
+/// Run the dependency-aware cascade for a just-released `root` component.
+///
+/// Enumerates dependents through the existing dependency stack graph, and for
+/// each dependent (in topological order): updates every in-cascade upstream pin
+/// via the generic extension action, then releases the dependent with an
+/// automatic patch bump. The freshly released dependent's coordinates feed
+/// transitive dependents deeper in the graph.
+///
+/// `base_input` supplies the shared release flags (apply, skip-checks,
+/// git-identity, …) captured from the originating `homeboy release` invocation;
+/// per-dependent fields (`component_id`, `bump_override`, `path_override`) are
+/// overridden here.
+pub fn run_cascade(
+    root: &ReleasedCoordinates,
+    base_input: &ReleaseCommandInput,
+) -> Result<CascadeResult> {
+    let components = component::list()?;
+    let plan = deps::stack_plan_from_components(&root.component_id, &components)?;
+    let targets = cascade_targets(&plan.planned_steps());
+
+    let components_by_id: BTreeMap<String, Component> = components
+        .into_iter()
+        .map(|component| (component.id.clone(), component))
+        .collect();
+
+    let mut released: BTreeMap<String, ReleasedCoordinates> = BTreeMap::new();
+    released.insert(root.component_id.clone(), root.clone());
+
+    let mut steps = Vec::new();
+    for target in targets {
+        let mut updated_packages = Vec::new();
+        for edge in &target.incoming {
+            let Some(upstream) = released.get(&edge.upstream) else {
+                // The upstream was not (yet) released in this cascade — skip the
+                // edge rather than pin to a stale coordinate.
+                continue;
+            };
+            update_dependency(&components_by_id, &target, &edge.package, upstream)?;
+            updated_packages.push(edge.package.clone());
+        }
+
+        if updated_packages.is_empty() {
+            continue;
+        }
+
+        let mut input = base_input.clone();
+        input.component_id = target.downstream.clone();
+        input.path_override = None;
+        // A dependency-only release has no new commits; the patch override both
+        // selects the bump and permits the otherwise-empty release.
+        input.bump_override = Some(DEPENDENCY_BUMP.to_string());
+
+        let (result, _exit) = super::run_command(input)?;
+
+        if result.status == "released" {
+            if let Some(version) = result.new_version.clone() {
+                let sha = git::get_head_commit(&target.downstream_path).unwrap_or_default();
+                released.insert(
+                    target.downstream.clone(),
+                    ReleasedCoordinates {
+                        component_id: target.downstream.clone(),
+                        version,
+                        tag: result.tag.clone().unwrap_or_default(),
+                        sha,
+                    },
+                );
+            }
+        }
+
+        steps.push(CascadeStepResult {
+            downstream: target.downstream.clone(),
+            updated_packages,
+            status: result.status,
+            new_version: result.new_version,
+            tag: result.tag,
+        });
+    }
+
+    Ok(CascadeResult {
+        upstream: root.component_id.clone(),
+        released: steps,
+    })
+}
+
+/// Update one dependent's pin on a released upstream via the dependent's
+/// extension that implements [`UPDATE_DEPENDENCY_ACTION`].
+fn update_dependency(
+    components_by_id: &BTreeMap<String, Component>,
+    target: &CascadeTarget,
+    package: &str,
+    upstream: &ReleasedCoordinates,
+) -> Result<serde_json::Value> {
+    let downstream = components_by_id.get(&target.downstream).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "cascade.downstream",
+            format!(
+                "Dependent '{}' is not a known component; cannot update its dependency on '{}'",
+                target.downstream, upstream.component_id
+            ),
+            Some(target.downstream.clone()),
+            None,
+        )
+    })?;
+
+    let extension_id = find_update_dependency_extension(downstream)?;
+    let payload =
+        build_update_dependency_payload(&target.downstream, &target.downstream_path, package, upstream);
+
+    extension::execute_action(
+        &extension_id,
+        UPDATE_DEPENDENCY_ACTION,
+        None,
+        None,
+        Some(&payload),
+    )
+}
+
+/// Find the dependent's extension that declares [`UPDATE_DEPENDENCY_ACTION`].
+fn find_update_dependency_extension(downstream: &Component) -> Result<String> {
+    let extensions = super::context::resolve_extensions(downstream)?;
+    extensions
+        .into_iter()
+        .find(|manifest| {
+            manifest
+                .actions
+                .iter()
+                .any(|action| action.id == UPDATE_DEPENDENCY_ACTION)
+        })
+        .map(|manifest| manifest.id)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cascade.update_dependency",
+                format!(
+                    "Dependent '{}' has no extension providing the '{}' action; cannot auto-update its dependency pin",
+                    downstream.id, UPDATE_DEPENDENCY_ACTION
+                ),
+                Some(downstream.id.clone()),
+                Some(vec![format!(
+                    "Add an extension that implements the '{}' action to the dependent's homeboy.json",
+                    UPDATE_DEPENDENCY_ACTION
+                )]),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn step(
+        sequence: usize,
+        upstream: &str,
+        downstream: &str,
+        package: &str,
+    ) -> DependencyStackPlanStep {
+        DependencyStackPlanStep {
+            sequence,
+            declaring_component_id: downstream.to_string(),
+            upstream: upstream.to_string(),
+            downstream: downstream.to_string(),
+            downstream_path: format!("/work/{downstream}"),
+            package: package.to_string(),
+            update_command: String::new(),
+            rebuild: false,
+            post_update: Vec::new(),
+            test: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn cascade_targets_preserve_topological_order() {
+        let steps = vec![
+            step(1, "php-transformer", "static-site-importer", "chubes/php-transformer"),
+            step(2, "static-site-importer", "site-builder", "chubes/static-site-importer"),
+        ];
+
+        let targets = cascade_targets(&steps);
+
+        let ids: Vec<_> = targets.iter().map(|t| t.downstream.as_str()).collect();
+        assert_eq!(ids, vec!["static-site-importer", "site-builder"]);
+        assert_eq!(targets[0].downstream_path, "/work/static-site-importer");
+        assert_eq!(targets[0].incoming[0].upstream, "php-transformer");
+        assert_eq!(targets[0].incoming[0].package, "chubes/php-transformer");
+    }
+
+    #[test]
+    fn cascade_targets_collapse_a_diamond_into_one_release_per_dependent() {
+        // a -> b, a -> c, b -> d, c -> d: `d` depends on both `b` and `c`.
+        let steps = vec![
+            step(1, "a", "b", "pkg/a"),
+            step(2, "a", "c", "pkg/a"),
+            step(3, "b", "d", "pkg/b"),
+            step(4, "c", "d", "pkg/c"),
+        ];
+
+        let targets = cascade_targets(&steps);
+
+        let ids: Vec<_> = targets.iter().map(|t| t.downstream.as_str()).collect();
+        assert_eq!(ids, vec!["b", "c", "d"], "each dependent released once");
+
+        let d = targets
+            .iter()
+            .find(|t| t.downstream == "d")
+            .expect("d target");
+        assert_eq!(
+            d.incoming,
+            vec![
+                CascadeEdge {
+                    upstream: "b".to_string(),
+                    package: "pkg/b".to_string()
+                },
+                CascadeEdge {
+                    upstream: "c".to_string(),
+                    package: "pkg/c".to_string()
+                },
+            ],
+            "both incoming edges are grouped onto the single dependent",
+        );
+    }
+
+    #[test]
+    fn cascade_targets_dedupe_identical_edges() {
+        let steps = vec![
+            step(1, "a", "b", "pkg/a"),
+            step(2, "a", "b", "pkg/a"),
+        ];
+
+        let targets = cascade_targets(&steps);
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].incoming.len(), 1);
+    }
+
+    #[test]
+    fn update_dependency_payload_carries_generic_upstream_coordinates() {
+        let upstream = ReleasedCoordinates {
+            component_id: "php-transformer".to_string(),
+            version: "1.4.0".to_string(),
+            tag: "v1.4.0".to_string(),
+            sha: "abc123def456".to_string(),
+        };
+
+        let payload = build_update_dependency_payload(
+            "static-site-importer",
+            "/work/static-site-importer",
+            "chubes/php-transformer",
+            &upstream,
+        );
+
+        // The action runs against the dependent's checkout.
+        assert_eq!(payload["release"]["component_id"], "static-site-importer");
+        assert_eq!(payload["release"]["local_path"], "/work/static-site-importer");
+
+        // The dependency block carries everything an extension needs to repin.
+        assert_eq!(payload["dependency"]["released_id"], "php-transformer");
+        assert_eq!(payload["dependency"]["package"], "chubes/php-transformer");
+        assert_eq!(payload["dependency"]["version"], "1.4.0");
+        assert_eq!(payload["dependency"]["tag"], "v1.4.0");
+        assert_eq!(payload["dependency"]["sha"], "abc123def456");
+    }
+}

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -1,4 +1,5 @@
 mod advanced_remote;
+pub mod cascade;
 pub mod changelog;
 mod checkout_guard;
 mod context;
@@ -26,6 +27,7 @@ pub mod version;
 mod workflow;
 mod workflow_recover;
 
+pub use cascade::{run_cascade, CascadeResult, CascadeStepResult, ReleasedCoordinates};
 pub use package_recovery::{package_existing_tag, ReleasePackageResult};
 pub use pipeline::run;
 pub use planner::plan;


### PR DESCRIPTION
## Summary

`homeboy release <component> --cascade` releases the component and then releases every dependent that declares a dependency on it — updating each dependent's pin and patch-bumping it, transitively. This eliminates the manual composer-pin / re-pin / patch-bump spelunking operators do by hand (release upstream → get tag+sha → rewrite the dependent's custom-package → regen lock → re-pin → release dependent).

Implements Extra-Chill/homeboy#6938. Core orchestration is **framework-agnostic**; all Composer/WordPress specifics live in the homeboy-extensions hook (Extra-Chill/homeboy-extensions#2015).

## How it works

New `src/core/release/cascade.rs`:

- **Enumerate dependents** via the existing dependency stack graph (`deps::stack_plan_from_components`), which already derives edges from declared `dependency_stack` entries *and* auto-detected package constraints (so `static-site-importer` → `php-transformer` is known from composer metadata).
- **`cascade_targets`** collapses the BFS plan into a deduplicated, topologically ordered list of dependents so a dependent consuming two cascaded upstreams is released once (diamond-safe). Pure function, unit-tested.
- For each dependent: update every in-cascade upstream pin via the generic `release.update_dependency` extension action — carrying only generic dependency coordinates (`released_id`, `package`, `version`, `tag`, `sha`) — then release the dependent. The freshly-released coordinates propagate to transitive dependents.
- **Auto patch bump** for dependency-only releases reuses existing release semantics: passing `bump_override = "patch"` both selects the bump and permits an otherwise-empty release (no new commits), so no change to the shared bump-decision logic is needed.

No package-manager strings appear in core. The hook discovery scans the dependent's linked extensions for one providing `release.update_dependency`.

## Wiring

- `--cascade` flag on `homeboy release` (single-component only; rejected with `--dry-run` and with batch releases).
- Runs after a successful single release; results surface under `ReleaseOutput.cascade`.

## Generic-core boundary (project rule)

Cascade orchestration, dependent enumeration, ordering, and the patch decision are generic. The Composer custom-package rewrite (dist.url/source.reference/dist.reference/constraint + lock regen) lives entirely in the wordpress extension behind `release.update_dependency` — see Extra-Chill/homeboy-extensions#2015.

## Tests

Unit tests on the deterministic pieces: target dedup/ordering (chain, diamond, duplicate edges) and the generic update-dependency payload shape. Full `cargo build` clean; `cargo test --lib core::release::cascade` and existing `commands::release` tests green.

**Note for reviewers:** the deterministic pieces (target planning, payload shape, the extension's composer rewrite) are unit-tested in isolation. The end-to-end multi-repo cascade (live `run_command` per dependent + the extension hook) was not exercised against real repos locally and should be validated in an integration run before relying on it — homeboy is release-critical.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Investigation of release/deps/extension internals, design, implementation, and tests.

DO NOT MERGE without review.