### PR TITLE
Add fuzz minimize and portable bundle bytes

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -13,6 +13,7 @@ homeboy fuzz validate <results-file>
 homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--output-envelope <path>]
 homeboy fuzz compare <baseline-envelope> <candidate-envelope> [--hotspot-policy <advisory|blocking|off>]
 homeboy fuzz replay [<artifact-or-case>] [--artifact <path>] [--case-id <id>] [--run-id <id>] [-- <runner-args>]
+homeboy fuzz minimize [<artifact-or-case>] [--artifact <path>] [--case-id <id>] [--run-id <id>] [--dry-run] [-- <runner-args>]
 ```
 
 ## Description
@@ -245,10 +246,10 @@ homeboy fuzz replay fuzz-results.json --case-id case-1
 homeboy fuzz replay case-1 --artifact fuzz-results.json
 ```
 
-Replay currently returns a validated `dry_run` contract rather than executing a
-runner. The output includes the campaign/envelope ids, selected case id, matching
-`replay` metadata when present, passthrough args, and environment variables for
-the originating extension-owned replay runner:
+Replay and minimize resolve a validated contract before execution. The output
+includes the campaign/envelope ids, selected case id, matching `replay` metadata
+when present, passthrough args, and environment variables for the originating
+extension-owned replay or minimization runner:
 
 ```text
 HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE
@@ -257,10 +258,40 @@ HOMEBOY_FUZZ_REPLAY_ID
 HOMEBOY_FUZZ_REPLAY_SEED
 HOMEBOY_FUZZ_REPLAY_ARTIFACT_ID
 HOMEBOY_FUZZ_RUN_ID
+HOMEBOY_FUZZ_REPLAY_RUN_ID
 ```
 
-Homeboy does not fake replay execution without a resolved component/extension
-context. Extension scripts own concrete replay execution.
+`homeboy fuzz replay` executes extension-owned `fuzz.replay_command` when a
+component/rig extension context declares one. `homeboy fuzz minimize` executes
+extension-owned `fuzz.minimize_command` using the same artifact, case, replay
+metadata, env, placeholder, and passthrough-argument contract. Both commands
+support `--dry-run` to inspect metadata and command generation without execution.
+
+Homeboy does not fake replay or minimization without a resolved
+component/extension context. If the extension manifest omits the relevant command,
+the CLI returns `unsupported` and prints the resolved contract. Concrete replay
+and minimization behavior belongs to extension scripts.
+
+Manifest commands support placeholders that Homeboy shell-quotes before
+execution: `{artifact}`, `{artifact_file}`, `{case}`, `{case_id}`, `{run_id}`,
+`{replay}`, `{replay_id}`, `{seed}`, `{replay_seed}`, `{artifact_id}`,
+`{case_artifact}`, and `{replay_artifact_id}`. Additional CLI args after `--`
+are appended to the rendered extension command.
+
+## Portable Fuzz Evidence Bundles
+
+`homeboy runs export --run <run-id> --output <dir>` exports runs, artifacts,
+trace spans, findings, and test failures as a portable observation bundle. When a
+file artifact is available locally, the bundle includes its bytes under
+`artifact-bytes/`, records refs/checksums/sizes in `artifact_bytes.json`, and
+stamps the exported artifact with `bundle://...`, SHA-256, size, and
+`metadata_json.portable_bundle`. Missing local files and directories remain
+metadata-only refs.
+
+`homeboy runs import <dir>` validates bundled artifact byte checksums and sizes
+before importing. Imported artifacts with valid bundle bytes point at the bundled
+file path, preserving bytes for downstream inspection without relying on the
+producer machine's original local path.
 
 Full-coverage claims need persisted proof artifacts. A neutral coverage summary
 can report declared, executable, and proven counts; operation totals; skipped
@@ -416,8 +447,8 @@ Rigs can add private fuzz workloads keyed by extension id:
 
 ## Output
 
-`contract`, `list`, `plan`, `run`, `validate`, `report`, and `replay` return
-JSON envelopes with stable `variant` values.
+`contract`, `list`, `plan`, `run`, `validate`, `report`, `replay`, and
+`minimize` return JSON envelopes with stable `variant` values.
 
 `run.execution.results_file` is the path advertised to the runner through
 `HOMEBOY_FUZZ_RESULTS_FILE`. `run.results` is present only when the runner wrote

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -35,11 +35,13 @@ rig package / local spec
 | `show <id>` | Print one rig spec as JSON. |
 | `up <id>` | Run the rig's `up` pipeline and materialize the environment. |
 | `check <id>` | Run the rig's `check` pipeline and report all failures. |
+| `lint <target>` | Lint a rig ID, package path, or `rig.json` without touching the environment. |
 | `down <id>` | Run the rig's `down` pipeline and stop managed services. |
 | `repair <id>` | Repair safe declared drift without running the full `up` pipeline. |
 | `sync <id>` | Sync every stack declared by the rig's components. |
 | `status <id>` | Show running services and last `up` / `check` state. |
 | `runs <id>` | List persisted observation runs for the rig. |
+| `release-lock <id>` | Release a stuck active-run rig lease after verifying no owner is active. |
 | `install <source>` | Install rigs from a local package path or git URL. |
 | `update [id]` | Pull and refresh git-backed installed rig packages. |
 | `sources ...` | Inspect, refresh, or remove installed rig source packages. |
@@ -101,6 +103,19 @@ homeboy rig check studio
 ```
 
 Runs the `check` pipeline and reports every failing step instead of stopping at the first failure. Use this as the preflight for a local environment.
+
+### `lint`
+
+```sh
+homeboy rig lint studio
+homeboy rig lint ./packages/studio --id studio
+homeboy rig lint ./packages/studio/rigs/studio/rig.json
+```
+
+Runs env-independent rig package lint only: conflict markers, JSON validity, and
+`extends` template materialization. It does not run requirements, component
+checkout probes, services, or live `check` steps, so CI can validate rig packages
+before a full environment exists.
 
 ### `down`
 
@@ -208,6 +223,16 @@ homeboy rig sync studio --dry-run
   }
 }
 ```
+
+## Active-Run Locks
+
+```sh
+homeboy rig release-lock studio
+```
+
+Releases a stuck active-run lock for a rig lease so a new local run can proceed.
+Use it only after verifying the recorded owner process or runner is no longer
+active; normal `up`, `check`, `down`, and `repair` flows release their own locks.
 
 ## App Launchers
 

--- a/src/commands/fuzz/dispatch.rs
+++ b/src/commands/fuzz/dispatch.rs
@@ -14,7 +14,7 @@ use super::doctor::run_doctor;
 use super::execution::run_run;
 use super::inspect::run_inspect;
 use super::planning::run_plan;
-use super::replay::run_replay;
+use super::replay::{run_minimize, run_replay};
 use super::report::{run_report, run_validate};
 use super::types::{
     FuzzArgs, FuzzCommand, FuzzContractOutput, FuzzDiscoverArgs, FuzzDiscoverOutput,
@@ -49,6 +49,10 @@ pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
         Some(FuzzCommand::Replay(replay_args)) => {
             let (output, exit) = run_replay(replay_args)?;
             Ok((FuzzOutput::Replay(output), exit))
+        }
+        Some(FuzzCommand::Minimize(minimize_args)) => {
+            let (output, exit) = run_minimize(minimize_args)?;
+            Ok((FuzzOutput::Minimize(output), exit))
         }
         Some(FuzzCommand::Inspect(inspect_args)) => {
             let output = run_inspect(inspect_args)?;

--- a/src/commands/fuzz/replay.rs
+++ b/src/commands/fuzz/replay.rs
@@ -8,10 +8,28 @@ use homeboy::core::fuzz::{
 };
 
 use super::super::utils::args::PositionalComponentArgs;
-use super::types::{FuzzReplayArgs, FuzzReplayEnv, FuzzReplayExecution, FuzzReplayOutput};
+use super::types::{
+    FuzzMinimizeArgs, FuzzReplayArgs, FuzzReplayEnv, FuzzReplayExecution, FuzzReplayOutput,
+};
 use super::workloads::{load_rig, resolve_component_id, resolve_fuzz_context};
 
 pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
+    run_replay_like(ReplayLikeArgs::from_replay(args), ReplayLikeMode::Replay)
+}
+
+pub(super) fn run_minimize(
+    args: FuzzMinimizeArgs,
+) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
+    run_replay_like(
+        ReplayLikeArgs::from_minimize(args),
+        ReplayLikeMode::Minimize,
+    )
+}
+
+fn run_replay_like(
+    args: ReplayLikeArgs,
+    mode: ReplayLikeMode,
+) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
     let artifact_file = replay_artifact_path(&args);
     let positional_case = args.artifact_or_case.as_ref().and_then(|value| {
         if artifact_file.is_some() && !Path::new(value).exists() {
@@ -40,10 +58,10 @@ pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzRep
         replay.as_ref(),
         args.run_id.as_ref(),
     );
-    let replay_context = resolve_replay_context(&args)?;
+    let replay_context = resolve_replay_context(&args, mode)?;
     let replay_command = replay_context
         .as_ref()
-        .and_then(|context| context.replay_command.clone())
+        .and_then(|context| context.command.clone())
         .map(|command| render_replay_command(&command, &env, args.args.as_slice()));
 
     if args.dry_run {
@@ -55,9 +73,9 @@ pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzRep
 
         return Ok((
             FuzzReplayOutput {
-                command: "fuzz.replay".to_string(),
+                command: mode.command_name().to_string(),
                 status: status.to_string(),
-                message: replay_message(replay_command.as_ref(), true),
+                message: replay_message(replay_command.as_ref(), true, mode),
                 artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
                 campaign_id: resolved
                     .as_ref()
@@ -80,10 +98,9 @@ pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzRep
 
     let Some(context) = replay_context else {
         return Ok((FuzzReplayOutput {
-            command: "fuzz.replay".to_string(),
+            command: mode.command_name().to_string(),
             status: "unsupported".to_string(),
-            message: "Generic fuzz replay execution requires a component/rig extension context with fuzz.replay_command; use --dry-run to inspect metadata only."
-                .to_string(),
+            message: format!("Generic fuzz {} execution requires a component/rig extension context with fuzz.{}; use --dry-run to inspect metadata only.", mode.label(), mode.manifest_key()),
             artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
             campaign_id: resolved.as_ref().and_then(|resolved| resolved.campaign_id.clone()),
             envelope_id: resolved.as_ref().and_then(|resolved| resolved.envelope_id.clone()),
@@ -100,11 +117,13 @@ pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzRep
 
     let Some(command) = replay_command.clone() else {
         return Ok((FuzzReplayOutput {
-            command: "fuzz.replay".to_string(),
+            command: mode.command_name().to_string(),
             status: "unsupported".to_string(),
             message: format!(
-                "Extension '{}' does not declare fuzz.replay_command; replay execution is unsupported for this context.",
-                context.execution_context.extension_id
+                "Extension '{}' does not declare fuzz.{}; {} execution is unsupported for this context.",
+                context.execution_context.extension_id,
+                mode.manifest_key(),
+                mode.label()
             ),
             artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
             campaign_id: resolved.as_ref().and_then(|resolved| resolved.campaign_id.clone()),
@@ -137,9 +156,9 @@ pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzRep
 
     Ok((
         FuzzReplayOutput {
-            command: "fuzz.replay".to_string(),
+            command: mode.command_name().to_string(),
             status: if output.success { "passed" } else { "failed" }.to_string(),
-            message: replay_message(Some(&command), false),
+            message: replay_message(Some(&command), false, mode),
             artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
             campaign_id: resolved
                 .as_ref()
@@ -153,7 +172,7 @@ pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzRep
             env,
             replay_command: Some(command),
             execution: Some(FuzzReplayExecution {
-                kind: "fuzz_replay".to_string(),
+                kind: mode.execution_kind().to_string(),
                 extension_id: context.execution_context.extension_id,
                 exit_code: output.exit_code,
                 success: output.success,
@@ -169,14 +188,100 @@ pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzRep
 }
 
 #[derive(Clone)]
+struct ReplayLikeArgs {
+    component: Option<String>,
+    path: Option<String>,
+    rig: Option<String>,
+    extension_override: super::super::utils::args::ExtensionOverrideArgs,
+    setting_args: super::super::utils::args::SettingArgs,
+    artifact_or_case: Option<String>,
+    artifact: Option<PathBuf>,
+    case_id: Option<String>,
+    run_id: Option<String>,
+    dry_run: bool,
+    args: Vec<String>,
+}
+
+impl ReplayLikeArgs {
+    fn from_replay(args: FuzzReplayArgs) -> Self {
+        Self {
+            component: args.component,
+            path: args.path,
+            rig: args.rig,
+            extension_override: args.extension_override,
+            setting_args: args.setting_args,
+            artifact_or_case: args.artifact_or_case,
+            artifact: args.artifact,
+            case_id: args.case_id,
+            run_id: args.run_id,
+            dry_run: args.dry_run,
+            args: args.args,
+        }
+    }
+
+    fn from_minimize(args: FuzzMinimizeArgs) -> Self {
+        Self {
+            component: args.component,
+            path: args.path,
+            rig: args.rig,
+            extension_override: args.extension_override,
+            setting_args: args.setting_args,
+            artifact_or_case: args.artifact_or_case,
+            artifact: args.artifact,
+            case_id: args.case_id,
+            run_id: args.run_id,
+            dry_run: args.dry_run,
+            args: args.args,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ReplayLikeMode {
+    Replay,
+    Minimize,
+}
+
+impl ReplayLikeMode {
+    fn command_name(self) -> &'static str {
+        match self {
+            Self::Replay => "fuzz.replay",
+            Self::Minimize => "fuzz.minimize",
+        }
+    }
+
+    fn manifest_key(self) -> &'static str {
+        match self {
+            Self::Replay => "replay_command",
+            Self::Minimize => "minimize_command",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Replay => "replay",
+            Self::Minimize => "minimize",
+        }
+    }
+
+    fn execution_kind(self) -> &'static str {
+        match self {
+            Self::Replay => "fuzz_replay",
+            Self::Minimize => "fuzz_minimize",
+        }
+    }
+}
+
+#[derive(Clone)]
 struct ResolvedReplayContext {
     execution_context: homeboy::core::extension::ExtensionExecutionContext,
     component: homeboy::core::component::Component,
-    replay_command: Option<String>,
+    command: Option<String>,
 }
 
 fn resolve_replay_context(
-    args: &FuzzReplayArgs,
+    args: &ReplayLikeArgs,
+    mode: ReplayLikeMode,
 ) -> homeboy::core::Result<Option<ResolvedReplayContext>> {
     let comp = replay_component_args(args);
     if comp.id().is_none() && args.rig.is_none() {
@@ -196,30 +301,33 @@ fn resolve_replay_context(
     )?;
     let execution_context =
         extension::resolve_execution_context(&ctx.component, ExtensionCapability::Fuzz)?;
-    let replay_command = extension::load_extension(&execution_context.extension_id)
+    let command = extension::load_extension(&execution_context.extension_id)
         .ok()
         .and_then(|manifest| manifest.fuzz)
-        .and_then(|fuzz| fuzz.replay_command);
+        .and_then(|fuzz| match mode {
+            ReplayLikeMode::Replay => fuzz.replay_command,
+            ReplayLikeMode::Minimize => fuzz.minimize_command,
+        });
 
     Ok(Some(ResolvedReplayContext {
         execution_context,
         component: ctx.component,
-        replay_command,
+        command,
     }))
 }
 
-fn replay_component_args(args: &FuzzReplayArgs) -> PositionalComponentArgs {
+fn replay_component_args(args: &ReplayLikeArgs) -> PositionalComponentArgs {
     PositionalComponentArgs {
         component: args.component.clone(),
         path: args.path.clone(),
     }
 }
 
-fn replay_message(command: Option<&String>, dry_run: bool) -> String {
+fn replay_message(command: Option<&String>, dry_run: bool, mode: ReplayLikeMode) -> String {
     match (command, dry_run) {
-        (Some(_), true) => "Generic fuzz replay resolved an extension replay_command and printed the execution environment without running it.".to_string(),
-        (Some(_), false) => "Generic fuzz replay executed the extension replay_command with canonical Homeboy fuzz replay environment.".to_string(),
-        (None, _) => "Generic fuzz replay resolved replay metadata and printed the extension-owned execution contract; no replay_command is available to execute.".to_string(),
+        (Some(_), true) => format!("Generic fuzz {} resolved an extension {} and printed the execution environment without running it.", mode.label(), mode.manifest_key()),
+        (Some(_), false) => format!("Generic fuzz {} executed the extension {} with canonical Homeboy fuzz replay environment.", mode.label(), mode.manifest_key()),
+        (None, _) => format!("Generic fuzz {} resolved replay metadata and printed the extension-owned execution contract; no {} is available to execute.", mode.label(), mode.manifest_key()),
     }
 }
 
@@ -249,6 +357,8 @@ fn render_replay_command(command: &str, env: &[FuzzReplayEnv], args: &[String]) 
         ("replay_id", "HOMEBOY_FUZZ_REPLAY_ID"),
         ("seed", "HOMEBOY_FUZZ_REPLAY_SEED"),
         ("replay_seed", "HOMEBOY_FUZZ_REPLAY_SEED"),
+        ("artifact_id", "HOMEBOY_FUZZ_REPLAY_ARTIFACT_ID"),
+        ("case_artifact", "HOMEBOY_FUZZ_REPLAY_ARTIFACT_ID"),
         ("replay_artifact_id", "HOMEBOY_FUZZ_REPLAY_ARTIFACT_ID"),
     ] {
         if let Some(value) = env_value(env, env_name) {
@@ -281,7 +391,7 @@ struct ResolvedReplayArtifact {
     replay: Option<FuzzReplayMetadata>,
 }
 
-fn replay_artifact_path(args: &FuzzReplayArgs) -> Option<PathBuf> {
+fn replay_artifact_path(args: &ReplayLikeArgs) -> Option<PathBuf> {
     args.artifact.clone().or_else(|| {
         args.artifact_or_case.as_ref().and_then(|value| {
             let path = PathBuf::from(value);

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -9,7 +9,7 @@ use super::execution::{
     persist_fuzz_run_evidence, run_fuzz_artifact_postprocess, FuzzRunEvidenceInput,
 };
 use super::planning::plan_inventory_selection;
-use super::replay::run_replay;
+use super::replay::{run_minimize, run_replay};
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,
     fuzz_observation_hotspots, fuzz_performance_hotspots, gate_status, run_report, run_validate,
@@ -17,8 +17,9 @@ use super::report::{
 };
 use super::types::{
     FuzzCommand, FuzzDiscoverArgs, FuzzExecutionOutput, FuzzGateProfileArg, FuzzIsolationArg,
-    FuzzListOutput, FuzzOutput, FuzzPlanArgs, FuzzPlanStrategy, FuzzReplayArgs, FuzzReportArgs,
-    FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract, FuzzValidateArgs, FuzzWorkloadOutput,
+    FuzzListOutput, FuzzMinimizeArgs, FuzzOutput, FuzzPlanArgs, FuzzPlanStrategy, FuzzReplayArgs,
+    FuzzReportArgs, FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract, FuzzValidateArgs,
+    FuzzWorkloadOutput,
 };
 use super::workloads::{
     fuzz_workloads, resolve_component_id, rig_component_for_fuzz, select_workload, FuzzRigContext,

--- a/src/commands/fuzz/tests/replay_tests.rs
+++ b/src/commands/fuzz/tests/replay_tests.rs
@@ -32,6 +32,37 @@ fn fuzz_replay_parses_artifact_and_case_id_flags() {
 }
 
 #[test]
+fn fuzz_minimize_parses_artifact_and_case_id_flags() {
+    let cli = FuzzCli::parse_from([
+        "fuzz",
+        "minimize",
+        "/tmp/fuzz-results.json",
+        "--component",
+        "component-a",
+        "--case-id",
+        "case-1",
+        "--run-id",
+        "proof-1",
+        "--",
+        "--runner-flag",
+    ]);
+
+    match cli.args.command {
+        Some(FuzzCommand::Minimize(minimize)) => {
+            assert_eq!(minimize.component.as_deref(), Some("component-a"));
+            assert_eq!(
+                minimize.artifact_or_case.as_deref(),
+                Some("/tmp/fuzz-results.json")
+            );
+            assert_eq!(minimize.case_id.as_deref(), Some("case-1"));
+            assert_eq!(minimize.run_id.as_deref(), Some("proof-1"));
+            assert_eq!(minimize.args, vec!["--runner-flag"]);
+        }
+        _ => panic!("expected fuzz minimize command"),
+    }
+}
+
+#[test]
 fn fuzz_replay_resolves_campaign_metadata_without_executing() {
     let temp = tempfile::tempdir().expect("tempdir");
     let path = temp.path().join("fuzz-results.json");
@@ -104,6 +135,7 @@ fn fuzz_replay_executes_manifest_replay_command_with_env() {
             Some(
                 r#"sh -c 'printf %s:%s:%s "$HOMEBOY_FUZZ_REPLAY_CASE_ID" "$HOMEBOY_FUZZ_REPLAY_SEED" "$1"' replay-runner {case}"#,
             ),
+            None,
         );
         write_fuzz_rig(
             home,
@@ -145,7 +177,7 @@ fn fuzz_replay_executes_manifest_replay_command_with_env() {
 fn fuzz_replay_reports_unsupported_when_manifest_has_no_replay_command() {
     with_isolated_home(|home| {
         let component_dir = tempfile::tempdir().expect("component dir");
-        write_fuzz_extension(home.path(), "fixture-fuzz", None);
+        write_fuzz_extension(home.path(), "fixture-fuzz", None, None);
         write_fuzz_rig(
             home,
             "fixture-rig",
@@ -179,7 +211,97 @@ fn fuzz_replay_reports_unsupported_when_manifest_has_no_replay_command() {
     });
 }
 
-fn write_fuzz_extension(home: &Path, id: &str, replay_command: Option<&str>) {
+#[test]
+fn fuzz_minimize_executes_manifest_minimize_command_with_replay_env() {
+    with_isolated_home(|home| {
+        let component_dir = tempfile::tempdir().expect("component dir");
+        write_fuzz_extension(
+            home.path(),
+            "fixture-fuzz",
+            None,
+            Some(
+                r#"sh -c 'printf min:%s:%s:%s "$HOMEBOY_FUZZ_REPLAY_CASE_ID" "$HOMEBOY_FUZZ_REPLAY_SEED" "$1"' minimize-runner {case}"#,
+            ),
+        );
+        write_fuzz_rig(
+            home,
+            "fixture-rig",
+            "component-a",
+            component_dir.path(),
+            "fixture-fuzz",
+        );
+        let path = write_replay_campaign(component_dir.path());
+
+        let (output, exit) = run_minimize(FuzzMinimizeArgs {
+            component: Some("component-a".to_string()),
+            path: None,
+            rig: Some("fixture-rig".to_string()),
+            extension_override: ExtensionOverrideArgs::default(),
+            setting_args: SettingArgs::default(),
+            artifact_or_case: Some(path.to_string_lossy().to_string()),
+            artifact: None,
+            case_id: Some("case-1".to_string()),
+            run_id: Some("proof-1".to_string()),
+            dry_run: false,
+            args: vec!["--extra".to_string()],
+        })
+        .expect("execute minimize");
+
+        assert_eq!(exit, 0);
+        assert_eq!(output.command, "fuzz.minimize");
+        assert_eq!(output.status, "passed");
+        assert!(output.replay_command.as_deref().unwrap().contains("case-1"));
+        let execution = output.execution.expect("execution");
+        assert_eq!(execution.kind, "fuzz_minimize");
+        assert_eq!(execution.stdout, "min:case-1:1234:case-1");
+    });
+}
+
+#[test]
+fn fuzz_minimize_reports_unsupported_without_minimize_command() {
+    with_isolated_home(|home| {
+        let component_dir = tempfile::tempdir().expect("component dir");
+        write_fuzz_extension(home.path(), "fixture-fuzz", Some("true"), None);
+        write_fuzz_rig(
+            home,
+            "fixture-rig",
+            "component-a",
+            component_dir.path(),
+            "fixture-fuzz",
+        );
+        let path = write_replay_campaign(component_dir.path());
+
+        let (output, exit) = run_minimize(FuzzMinimizeArgs {
+            component: Some("component-a".to_string()),
+            path: None,
+            rig: Some("fixture-rig".to_string()),
+            extension_override: ExtensionOverrideArgs::default(),
+            setting_args: SettingArgs::default(),
+            artifact_or_case: Some(path.to_string_lossy().to_string()),
+            artifact: None,
+            case_id: Some("case-1".to_string()),
+            run_id: Some("proof-1".to_string()),
+            dry_run: false,
+            args: Vec::new(),
+        })
+        .expect("resolve unsupported minimize");
+
+        assert_eq!(exit, 1);
+        assert_eq!(output.command, "fuzz.minimize");
+        assert_eq!(output.status, "unsupported");
+        assert!(output
+            .message
+            .contains("does not declare fuzz.minimize_command"));
+        assert!(output.execution.is_none());
+    });
+}
+
+fn write_fuzz_extension(
+    home: &Path,
+    id: &str,
+    replay_command: Option<&str>,
+    minimize_command: Option<&str>,
+) {
     let extension_dir = home.join(".config/homeboy/extensions").join(id);
     fs::create_dir_all(&extension_dir).expect("extension dir");
     let mut fuzz = serde_json::json!({
@@ -187,6 +309,9 @@ fn write_fuzz_extension(home: &Path, id: &str, replay_command: Option<&str>) {
     });
     if let Some(command) = replay_command {
         fuzz["replay_command"] = serde_json::Value::String(command.to_string());
+    }
+    if let Some(command) = minimize_command {
+        fuzz["minimize_command"] = serde_json::Value::String(command.to_string());
     }
     fs::write(
         extension_dir.join(format!("{id}.json")),

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -79,6 +79,8 @@ pub(crate) enum FuzzCommand {
     Compare(FuzzCompareArgs),
     /// Resolve replay metadata for persisted fuzz cases
     Replay(FuzzReplayArgs),
+    /// Resolve minimization metadata for persisted fuzz cases
+    Minimize(FuzzMinimizeArgs),
     /// Print the raw fuzz runner result for a run without spelunking runner logs
     Inspect(FuzzInspectArgs),
 }
@@ -441,6 +443,51 @@ pub(crate) struct FuzzReplayArgs {
     pub(crate) dry_run: bool,
 
     /// Additional arguments passed to the extension replay command.
+    #[arg(last = true)]
+    pub(crate) args: Vec<String>,
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct FuzzMinimizeArgs {
+    /// Component ID used to resolve the extension minimize_command.
+    #[arg(long = "component", value_name = "ID")]
+    pub(crate) component: Option<String>,
+
+    /// Override the component checkout path for minimize command execution.
+    #[arg(long)]
+    pub(crate) path: Option<String>,
+
+    /// Resolve minimization through a rig's component path and extension config.
+    #[arg(long, value_name = "RIG_ID")]
+    pub(crate) rig: Option<String>,
+
+    #[command(flatten)]
+    pub(crate) extension_override: ExtensionOverrideArgs,
+
+    #[command(flatten)]
+    pub(crate) setting_args: SettingArgs,
+
+    /// Fuzz campaign/result envelope path, or a case id when --artifact is used.
+    #[arg(value_name = "ARTIFACT_OR_CASE")]
+    pub(crate) artifact_or_case: Option<String>,
+
+    /// Fuzz campaign or result envelope artifact to inspect for minimization metadata.
+    #[arg(long = "artifact", value_name = "PATH")]
+    pub(crate) artifact: Option<PathBuf>,
+
+    /// Case id to minimize from the campaign/envelope artifact.
+    #[arg(long = "case-id", value_name = "ID")]
+    pub(crate) case_id: Option<String>,
+
+    /// Stable Homeboy run id associated with the persisted fuzz evidence.
+    #[arg(long = "run-id", value_name = "ID")]
+    pub(crate) run_id: Option<String>,
+
+    /// Resolve minimization metadata and command environment without executing minimize_command.
+    #[arg(long = "dry-run")]
+    pub(crate) dry_run: bool,
+
+    /// Additional arguments passed to the extension minimize command.
     #[arg(last = true)]
     pub(crate) args: Vec<String>,
 }

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -21,6 +21,7 @@ pub enum FuzzOutput {
     Report(FuzzReportOutput),
     Compare(FuzzCompareOutput),
     Replay(FuzzReplayOutput),
+    Minimize(FuzzReplayOutput),
     Inspect(FuzzInspectOutput),
 }
 

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -76,6 +76,8 @@ pub struct ObservationBundleManifest {
     pub homeboy_version: String,
     pub run_count: usize,
     pub artifact_count: usize,
+    #[serde(default)]
+    pub artifact_byte_count: usize,
     pub trace_span_count: usize,
     #[serde(default)]
     pub finding_count: usize,
@@ -88,9 +90,21 @@ struct ObservationBundle {
     manifest: ObservationBundleManifest,
     runs: Vec<RunRecord>,
     artifacts: Vec<ArtifactRecord>,
+    #[serde(default)]
+    artifact_bytes: Vec<ObservationBundleArtifactBytes>,
     trace_spans: Vec<TraceSpanRecord>,
     findings: Vec<RecordedHomeboyFinding>,
     test_failures: Vec<RecordedHomeboyFinding>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ObservationBundleArtifactBytes {
+    artifact_id: String,
+    path: String,
+    sha256: String,
+    size_bytes: i64,
+    #[serde(skip)]
+    source_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -110,6 +124,7 @@ pub struct RunsExportOutput {
     pub manifest: ObservationBundleManifest,
     pub run_count: usize,
     pub artifact_count: usize,
+    pub artifact_byte_count: usize,
     pub trace_span_count: usize,
     pub finding_count: usize,
     pub test_failure_count: usize,
@@ -158,6 +173,7 @@ pub(super) fn export_runs(args: RunsExportArgs) -> CmdResult<RunsOutput> {
             output: args.output.to_string_lossy().to_string(),
             run_count: bundle.runs.len(),
             artifact_count: bundle.artifacts.len(),
+            artifact_byte_count: bundle.artifact_bytes.len(),
             trace_span_count: bundle.trace_spans.len(),
             finding_count: bundle.findings.len(),
             test_failure_count: bundle.test_failures.len(),
@@ -188,7 +204,7 @@ pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
     let mut artifacts = 0usize;
     let mut artifact_metadata_only = 0usize;
     for artifact in &bundle.artifacts {
-        let artifact = imported_artifact_record(artifact);
+        let artifact = imported_artifact_record(artifact, &bundle, &input);
         if artifact.artifact_type == "metadata-only" {
             artifact_metadata_only += 1;
         } else {
@@ -239,8 +255,14 @@ fn import_bundle_run(
 fn rewrite_bundle_run_references(bundle: &mut ObservationBundle, from: &str, to: &str) {
     for artifact in &mut bundle.artifacts {
         if artifact.run_id == from {
+            let original_artifact_id = artifact.id.clone();
             artifact.id = remapped_child_record_id(&artifact.id, to);
             artifact.run_id = to.to_string();
+            for bytes in &mut bundle.artifact_bytes {
+                if bytes.artifact_id == original_artifact_id {
+                    bytes.artifact_id = artifact.id.clone();
+                }
+            }
         }
     }
     for span in &mut bundle.trace_spans {
@@ -283,7 +305,23 @@ fn remapped_lab_run_id(run: &RunRecord) -> homeboy::core::Result<String> {
     Ok(format!("{}-imported-{}", run.id, &hex[..16]))
 }
 
-fn imported_artifact_record(artifact: &ArtifactRecord) -> ArtifactRecord {
+fn imported_artifact_record(
+    artifact: &ArtifactRecord,
+    bundle: &ObservationBundle,
+    input: &Path,
+) -> ArtifactRecord {
+    if artifact.artifact_type == "file" {
+        if let Some(bytes) = bundle.artifact_bytes.iter().find(|bytes| {
+            bytes.artifact_id == artifact.id && artifact.path == bundle_artifact_uri(&bytes.path)
+        }) {
+            let mut imported = artifact.clone();
+            imported.path = input.join(&bytes.path).to_string_lossy().to_string();
+            imported.sha256 = Some(bytes.sha256.clone());
+            imported.size_bytes = Some(bytes.size_bytes);
+            return imported;
+        }
+    }
+
     if !matches!(artifact.artifact_type.as_str(), "file" | "directory") {
         return artifact.clone();
     }
@@ -334,15 +372,17 @@ fn build_bundle(
     runs: Vec<RunRecord>,
 ) -> homeboy::core::Result<ObservationBundle> {
     let mut artifacts = Vec::new();
+    let mut artifact_bytes = Vec::new();
     let mut trace_spans = Vec::new();
     let mut findings = Vec::new();
     for run in &runs {
-        artifacts.extend(
-            store
-                .list_artifacts(&run.id)?
-                .into_iter()
-                .map(portable_bundle_artifact_record),
-        );
+        for artifact in store.list_artifacts(&run.id)? {
+            let (artifact, bytes) = portable_bundle_artifact_record(artifact)?;
+            artifacts.push(artifact);
+            if let Some(bytes) = bytes {
+                artifact_bytes.push(bytes);
+            }
+        }
         trace_spans.extend(store.list_trace_spans(&run.id)?);
         findings.extend(
             store
@@ -363,6 +403,7 @@ fn build_bundle(
         homeboy_version: env!("CARGO_PKG_VERSION").to_string(),
         run_count: runs.len(),
         artifact_count: artifacts.len(),
+        artifact_byte_count: artifact_bytes.len(),
         trace_span_count: trace_spans.len(),
         finding_count: findings.len(),
         test_failure_count: test_failures.len(),
@@ -371,17 +412,59 @@ fn build_bundle(
         manifest,
         runs,
         artifacts,
+        artifact_bytes,
         trace_spans,
         findings,
         test_failures,
     })
 }
 
-fn portable_bundle_artifact_record(artifact: ArtifactRecord) -> ArtifactRecord {
-    if !matches!(artifact.artifact_type.as_str(), "file" | "directory")
-        || is_reportable_artifact_evidence_path(&artifact.path)
-    {
-        return artifact;
+fn portable_bundle_artifact_record(
+    artifact: ArtifactRecord,
+) -> homeboy::core::Result<(ArtifactRecord, Option<ObservationBundleArtifactBytes>)> {
+    if !matches!(artifact.artifact_type.as_str(), "file" | "directory") {
+        return Ok((artifact, None));
+    }
+
+    if artifact.artifact_type == "file" {
+        let source_path = PathBuf::from(&artifact.path);
+        if source_path.is_file() {
+            let bytes = fs::read(&source_path).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("read artifact bytes {}", source_path.display())),
+                )
+            })?;
+            let sha256 = format!("{:x}", Sha256::digest(&bytes));
+            let size_bytes = i64::try_from(bytes.len()).map_err(|_| {
+                Error::internal_unexpected(format!(
+                    "artifact {} is too large to record a portable size",
+                    artifact.id
+                ))
+            })?;
+            let path = format!("artifact-bytes/{}", portable_artifact_file_name(&artifact));
+            let mut portable = artifact;
+            portable.path = bundle_artifact_uri(&path);
+            portable.sha256 = Some(sha256.clone());
+            portable.size_bytes = Some(size_bytes);
+            portable.metadata_json =
+                with_bundle_byte_metadata(portable.metadata_json, &path, &sha256, size_bytes);
+            let artifact_id = portable.id.clone();
+            return Ok((
+                portable,
+                Some(ObservationBundleArtifactBytes {
+                    artifact_id,
+                    path,
+                    sha256,
+                    size_bytes,
+                    source_path: Some(source_path),
+                }),
+            ));
+        }
+    }
+
+    if is_reportable_artifact_evidence_path(&artifact.path) {
+        return Ok((artifact, None));
     }
 
     let mut portable = artifact;
@@ -389,7 +472,60 @@ fn portable_bundle_artifact_record(artifact: ArtifactRecord) -> ArtifactRecord {
     portable.path = EXECUTION_CONTRACT
         .artifacts
         .metadata_only_ref(&portable_artifact_label(&portable.path, &portable.id));
-    portable
+    Ok((portable, None))
+}
+
+fn portable_artifact_file_name(artifact: &ArtifactRecord) -> String {
+    let label = portable_artifact_label(&artifact.path, &artifact.id);
+    format!(
+        "{}-{}",
+        safe_bundle_segment(&artifact.id),
+        safe_bundle_segment(&label)
+    )
+}
+
+fn safe_bundle_segment(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    sanitized.trim_matches('-').to_string()
+}
+
+fn bundle_artifact_uri(path: &str) -> String {
+    format!("bundle://{path}")
+}
+
+fn with_bundle_byte_metadata(
+    metadata: serde_json::Value,
+    path: &str,
+    sha256: &str,
+    size_bytes: i64,
+) -> serde_json::Value {
+    let mut object = match metadata {
+        serde_json::Value::Object(object) => object,
+        other if other.is_null() => serde_json::Map::new(),
+        other => {
+            let mut object = serde_json::Map::new();
+            object.insert("original_metadata".to_string(), other);
+            object
+        }
+    };
+    object.insert(
+        "portable_bundle".to_string(),
+        serde_json::json!({
+            "byte_ref": path,
+            "sha256": sha256,
+            "size_bytes": size_bytes,
+        }),
+    );
+    serde_json::Value::Object(object)
 }
 
 fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::core::Result<()> {
@@ -410,6 +546,8 @@ fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::core::R
     write_json(path.join("manifest.json"), &bundle.manifest)?;
     write_json(path.join("runs.json"), &bundle.runs)?;
     write_json(path.join("artifacts.json"), &bundle.artifacts)?;
+    write_json(path.join("artifact_bytes.json"), &bundle.artifact_bytes)?;
+    write_artifact_bytes(path, &bundle.artifact_bytes)?;
     write_json(path.join("trace_spans.json"), &bundle.trace_spans)?;
     write_json(path.join("findings.json"), &bundle.findings)?;
     write_json(path.join("test_failures.json"), &bundle.test_failures)?;
@@ -448,6 +586,9 @@ fn read_bundle_dir(path: &Path) -> homeboy::core::Result<ObservationBundle> {
 
     let runs: Vec<RunRecord> = read_json(path.join("runs.json"))?;
     let artifacts: Vec<ArtifactRecord> = read_json(path.join("artifacts.json"))?;
+    let artifact_bytes: Vec<ObservationBundleArtifactBytes> =
+        read_optional_json(path.join("artifact_bytes.json"))?;
+    validate_artifact_bytes(path, &artifact_bytes)?;
     let trace_spans: Vec<TraceSpanRecord> = read_json(path.join("trace_spans.json"))?;
     let mut findings: Vec<RecordedHomeboyFinding> = read_optional_json(path.join("findings.json"))?;
     let test_failures: Vec<RecordedHomeboyFinding> =
@@ -459,6 +600,7 @@ fn read_bundle_dir(path: &Path) -> homeboy::core::Result<ObservationBundle> {
     }
     if manifest.run_count != runs.len()
         || manifest.artifact_count != artifacts.len()
+        || manifest.artifact_byte_count != artifact_bytes.len()
         || manifest.trace_span_count != trace_spans.len()
         || manifest.finding_count != findings.len()
         || manifest.test_failure_count != test_failures.len()
@@ -474,10 +616,76 @@ fn read_bundle_dir(path: &Path) -> homeboy::core::Result<ObservationBundle> {
         manifest,
         runs,
         artifacts,
+        artifact_bytes,
         trace_spans,
         findings,
         test_failures,
     })
+}
+
+fn write_artifact_bytes(
+    bundle_dir: &Path,
+    artifact_bytes: &[ObservationBundleArtifactBytes],
+) -> homeboy::core::Result<()> {
+    for bytes in artifact_bytes {
+        let Some(source_path) = bytes.source_path.as_ref() else {
+            continue;
+        };
+        let output = bundle_dir.join(&bytes.path);
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("create artifact byte dir {}", parent.display())),
+                )
+            })?;
+        }
+        fs::copy(source_path, &output).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!(
+                    "copy artifact bytes {} to {}",
+                    source_path.display(),
+                    output.display()
+                )),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn validate_artifact_bytes(
+    bundle_dir: &Path,
+    artifact_bytes: &[ObservationBundleArtifactBytes],
+) -> homeboy::core::Result<()> {
+    for bytes in artifact_bytes {
+        let path = bundle_dir.join(&bytes.path);
+        let raw = fs::read(&path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read bundled artifact bytes {}", path.display())),
+            )
+        })?;
+        let sha256 = format!("{:x}", Sha256::digest(&raw));
+        let size_bytes = i64::try_from(raw.len()).map_err(|_| {
+            Error::internal_unexpected(format!(
+                "bundled artifact {} is too large to record a portable size",
+                bytes.artifact_id
+            ))
+        })?;
+        if sha256 != bytes.sha256 || size_bytes != bytes.size_bytes {
+            return Err(Error::validation_invalid_argument(
+                "artifact_bytes",
+                format!(
+                    "bundled artifact bytes for {} do not match recorded checksum/size",
+                    bytes.artifact_id
+                ),
+                Some(path.to_string_lossy().to_string()),
+                None,
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn is_test_failure_finding(finding: &RecordedHomeboyFinding) -> bool {

--- a/src/commands/runs/bundle_import_tests.rs
+++ b/src/commands/runs/bundle_import_tests.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 
 use super::bundle::{export_runs, import_runs, RunsExportArgs, RunsImportArgs};
 use super::dead_owned_run;
+use super::RunsOutput;
 
 struct XdgGuard(Option<String>);
 
@@ -176,6 +177,83 @@ fn lab_bundle_run_id_conflicts_are_remapped_idempotently() {
                 .len(),
             1
         );
+    });
+}
+
+#[test]
+fn runs_export_import_preserves_file_artifact_bytes_with_checksum_refs() {
+    let bundle_root = tempfile::tempdir().expect("bundle root");
+    let bundle = bundle_root.path().join("fuzz-bundle");
+    let mut exported_run_id = String::new();
+    let mut bundled_bytes = std::path::PathBuf::new();
+    let mut exported_sha256 = None;
+    let mut exported_size_bytes = None;
+
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run("fuzz", "homeboy", "rig-a", Value::Null))
+            .expect("run");
+        exported_run_id = run.id.clone();
+        let artifact_path = home.path().join("fuzz-result-envelope.json");
+        std::fs::write(
+            &artifact_path,
+            br#"{"schema":"homeboy/fuzz-result-envelope/v1"}"#,
+        )
+        .expect("artifact file");
+        store
+            .record_artifact(&run.id, "fuzz_result_envelope", &artifact_path)
+            .expect("artifact");
+
+        let (output, exit) = export_runs(RunsExportArgs {
+            run: Some(run.id.clone()),
+            since: None,
+            output: bundle.clone(),
+        })
+        .expect("export");
+        assert_eq!(exit, 0);
+        let RunsOutput::Export(exported) = output else {
+            panic!("expected export output");
+        };
+        assert_eq!(exported.artifact_count, 1);
+        assert_eq!(exported.artifact_byte_count, 1);
+
+        let artifact_bytes: Vec<Value> = read_bundle_test_json(&bundle.join("artifact_bytes.json"));
+        assert_eq!(artifact_bytes.len(), 1);
+        let byte_ref = artifact_bytes[0]["path"].as_str().expect("byte path");
+        bundled_bytes = bundle.join(byte_ref);
+        assert_eq!(
+            std::fs::read(&bundled_bytes).expect("bundled bytes"),
+            br#"{"schema":"homeboy/fuzz-result-envelope/v1"}"#
+        );
+        assert!(artifact_bytes[0]["sha256"].as_str().is_some());
+        exported_sha256 = artifact_bytes[0]["sha256"].as_str().map(str::to_string);
+        exported_size_bytes = artifact_bytes[0]["size_bytes"].as_i64();
+        assert_eq!(
+            exported_size_bytes,
+            Some(br#"{"schema":"homeboy/fuzz-result-envelope/v1"}"#.len() as i64)
+        );
+    });
+
+    with_isolated_home(|_| {
+        let _xdg = XdgGuard::unset();
+        import_runs(RunsImportArgs {
+            input: Some(bundle.clone()),
+            ..RunsImportArgs::default()
+        })
+        .expect("import");
+        let store = ObservationStore::open_initialized().expect("store");
+        let imported_artifact = store
+            .list_artifacts(&exported_run_id)
+            .expect("artifacts")
+            .into_iter()
+            .next()
+            .expect("artifact");
+        assert_eq!(imported_artifact.artifact_type, "file");
+        assert_eq!(imported_artifact.path, bundled_bytes.to_string_lossy());
+        assert_eq!(imported_artifact.sha256, exported_sha256);
+        assert_eq!(imported_artifact.size_bytes, exported_size_bytes);
     });
 }
 


### PR DESCRIPTION
## Summary
- Add a generic `homeboy fuzz minimize` command backed by explicit extension `fuzz.minimize_command` support.
- Share replay/minimize artifact, case, env, placeholder, dry-run, and unsupported-contract behavior without faking minimization in core.
- Export/import available file artifact bytes in observation bundles with bundle refs, sizes, and SHA-256 validation.
- Document fuzz replay/minimize contracts, portable evidence bundles, and missing rig command-surface entries.

## Tests
- `cargo test commands::fuzz::tests::replay_tests`
- `cargo test commands::runs::bundle_import_tests`
- `cargo test command_surface`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the generic fuzz minimize CLI contract, portable bundle byte export/import support, docs, tests, and PR preparation.