### PR TITLE
Add compact runs proof signal surface (closes #6945)

### DIFF
--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -113,12 +113,15 @@ pub fn run_command_output(
         Commands::Runs(args) => {
             let summarize_show = runs_show_summary_eligible(&args);
             let summarize_dossier = runs_dossier_summary_eligible(&args);
+            let summarize_proof = runs_proof_summary_eligible(&args);
             let (stdout_result, exit_code) = dispatch(Commands::Runs(args), global);
             let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
                 if summarize_show {
                     super::runs_summary::render_runs_show_summary(payload)
                 } else if summarize_dossier {
                     super::runs_dossier_summary::render_runs_dossier_summary(payload)
+                } else if summarize_proof {
+                    super::runs_proof_summary::render_runs_proof_summary(payload)
                 } else {
                     None
                 }
@@ -254,6 +257,10 @@ fn runs_show_summary_eligible(args: &crate::commands::runs::RunsArgs) -> bool {
 
 fn runs_dossier_summary_eligible(args: &crate::commands::runs::RunsArgs) -> bool {
     args.dossier_summary_eligible() && !homeboy::core::lab_routing::is_lab_offload_subprocess()
+}
+
+fn runs_proof_summary_eligible(args: &crate::commands::runs::RunsArgs) -> bool {
+    args.proof_summary_eligible() && !homeboy::core::lab_routing::is_lab_offload_subprocess()
 }
 
 fn ci_triage_summary_eligible(args: &crate::commands::ci::CiArgs) -> bool {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -224,6 +224,7 @@ pub mod review;
 pub mod rig;
 pub mod runner;
 pub mod runs;
+pub(crate) mod runs_proof_summary;
 pub(crate) mod runs_summary;
 pub mod self_cmd;
 pub mod server;

--- a/src/commands/runs/dispatch.rs
+++ b/src/commands/runs/dispatch.rs
@@ -8,7 +8,7 @@ use homeboy::core::Error;
 use super::types::{RunsArgs, RunsArtifactArgs, RunsArtifactCommand, RunsCommand, RunsOutput};
 use super::{
     bench, compare, distribution, dossier, drift, evidence, findings, fuzz_compare, handlers,
-    hotspots, latest, loop_sync, query, reconcile, refs,
+    hotspots, latest, loop_sync, proof, query, reconcile, refs,
 };
 use super::{CmdResult, GlobalArgs};
 
@@ -21,6 +21,12 @@ impl RunsArgs {
 
     pub fn dossier_summary_eligible(&self) -> bool {
         matches!(self.command, RunsCommand::Dossier { json: false, .. })
+    }
+
+    /// Whether this is a `runs proof <id>` invocation eligible for the compact
+    /// human summary (i.e. the caller did not pass `--json`).
+    pub fn proof_summary_eligible(&self) -> bool {
+        matches!(self.command, RunsCommand::Proof { json: false, .. })
     }
 
     pub fn absorb_global_runner_for_list(&mut self, runner: Option<String>) -> Option<String> {
@@ -83,6 +89,7 @@ impl RunsArgs {
                 ],
             ),
             RunsCommand::Show { run_id, .. }
+            | RunsCommand::Proof { run_id, .. }
             | RunsCommand::Dossier { run_id, .. }
             | RunsCommand::ResumePlan { run_id }
             | RunsCommand::Evidence { run_id }
@@ -139,6 +146,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Hotspots(args) => hotspots::runs_hotspots(args),
         RunsCommand::Reconcile(args) => reconcile::reconcile_runs(args),
         RunsCommand::Show { run_id, json: _ } => handlers::show_run(&run_id),
+        RunsCommand::Proof { run_id, json: _ } => proof::proof(&run_id),
         RunsCommand::Dossier { run_id, json: _ } => dossier::runs_dossier(&run_id),
         RunsCommand::ResumePlan { run_id } => handlers::resume_plan(&run_id),
         RunsCommand::Evidence { run_id } => evidence::evidence(&run_id),

--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -29,6 +29,7 @@ mod handlers;
 mod hotspots;
 mod latest;
 mod loop_sync;
+mod proof;
 mod query;
 mod reconcile;
 mod refs;

--- a/src/commands/runs/proof.rs
+++ b/src/commands/runs/proof.rs
@@ -1,0 +1,250 @@
+//! Compact, signal-only projection for `homeboy runs proof <run-id>`.
+//!
+//! Verifying a bench/recipe run otherwise forces reading the full evidence or
+//! `runs show` payload (tens of KB) to extract a handful of signals. This
+//! projection returns only the verdict (status + passed/failed), gate
+//! failures, and the run's declared proof/scorecard signal fields flattened to
+//! scalar `key:value` pairs. The full JSON stays behind `runs show --json` and
+//! `runs evidence`; `runs proof --json` returns this same compact payload.
+//!
+//! Generic across run kinds: it reuses the shared
+//! [`evidence_failure_summary`](homeboy::core::observation::evidence_report::evidence_failure_summary)
+//! for the verdict and flattens any declared signal container
+//! (`proof`/`scorecard`/`signals`), per-scenario bench metrics, and top-level
+//! boolean proof signals — without baking in bench-specific field names.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use homeboy::core::observation::evidence_report::evidence_failure_summary;
+use homeboy::core::observation::{runs_service, ObservationStore, RunRecord};
+
+use super::{reconcile, CmdResult, RunsOutput};
+
+/// Declared proof/scorecard signal containers. Any of these objects/arrays in
+/// run metadata are flattened to scalar `key:value` signal leaves.
+const SIGNAL_CONTAINERS: &[&str] = &["proof", "scorecard", "signals", "proof_signals"];
+
+/// Generic top-level scalar (non-boolean) signals worth surfacing even when a
+/// run does not nest them under a declared container.
+const TOP_LEVEL_SCALAR_SIGNALS: &[&str] = &["observation_status", "http_status", "baseline_status"];
+
+#[derive(Serialize)]
+pub struct RunsProofOutput {
+    pub command: &'static str,
+    pub run_id: String,
+    pub kind: String,
+    pub status: String,
+    /// `Some(true)` for a passing run, `Some(false)` for fail/error/stale, and
+    /// `None` while the run is still running or otherwise indeterminate.
+    pub passed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gate_failures: Vec<String>,
+    /// Flattened scalar proof/scorecard signal fields, deterministic by key.
+    pub signals: BTreeMap<String, Value>,
+}
+
+pub fn proof(run_id: &str) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
+    runs_service::require_run(&store, run_id)?;
+    runs_service::refresh_mirrored_daemon_evidence_best_effort(run_id);
+    let run = runs_service::require_run(&store, run_id)?;
+    Ok((RunsOutput::Proof(build_proof(&run)), 0))
+}
+
+/// Project a loaded run into its compact proof signals. Pure over the run
+/// record so non-CLI callers and tests can reuse it without an observation
+/// store.
+pub fn build_proof(run: &RunRecord) -> RunsProofOutput {
+    let failure = evidence_failure_summary(run);
+    let passed = if failure.failed {
+        Some(false)
+    } else if matches!(run.status.as_str(), "pass" | "passed") {
+        Some(true)
+    } else {
+        None
+    };
+
+    let mut signals = BTreeMap::new();
+    collect_signals(&run.metadata_json, &mut signals);
+
+    RunsProofOutput {
+        command: "runs.proof",
+        run_id: run.id.clone(),
+        kind: run.kind.clone(),
+        status: run.status.clone(),
+        passed,
+        exit_code: failure.exit_code,
+        error: failure.error,
+        gate_failures: failure.gate_failures,
+        signals,
+    }
+}
+
+fn collect_signals(metadata: &Value, out: &mut BTreeMap<String, Value>) {
+    let Some(map) = metadata.as_object() else {
+        return;
+    };
+
+    // 1. Declared proof/scorecard signal containers.
+    for key in SIGNAL_CONTAINERS {
+        if let Some(value) = map.get(*key) {
+            flatten_scalars(key, value, out);
+        }
+    }
+
+    // 2. Per-scenario bench scorecard metrics.
+    if let Some(scenarios) = map.get("scenario_metrics").and_then(Value::as_array) {
+        for scenario in scenarios {
+            let id = scenario
+                .get("scenario_id")
+                .and_then(Value::as_str)
+                .unwrap_or("scenario");
+            if let Some(passed @ Value::Bool(_)) = scenario.get("passed") {
+                out.insert(format!("{id}.passed"), passed.clone());
+            }
+            if let Some(metrics) = scenario.get("metrics") {
+                flatten_scalars(id, metrics, out);
+            }
+        }
+    }
+
+    // 3. Top-level boolean proof signals (e.g. probe `rendered_contains_marker`,
+    //    `opfs_resume`) plus known scalar status signals.
+    for (key, value) in map {
+        if (value.is_boolean() || TOP_LEVEL_SCALAR_SIGNALS.contains(&key.as_str()))
+            && is_scalar(value)
+        {
+            out.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+/// Recursively record scalar (bool/number/string) leaves under a dotted key
+/// path. Objects and arrays recurse; `null` is dropped so the projection only
+/// carries decided signals.
+fn flatten_scalars(prefix: &str, value: &Value, out: &mut BTreeMap<String, Value>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                flatten_scalars(&format!("{prefix}.{key}"), child, out);
+            }
+        }
+        Value::Array(items) => {
+            for (idx, child) in items.iter().enumerate() {
+                flatten_scalars(&format!("{prefix}[{idx}]"), child, out);
+            }
+        }
+        Value::Null => {}
+        scalar => {
+            out.insert(prefix.to_string(), scalar.clone());
+        }
+    }
+}
+
+fn is_scalar(value: &Value) -> bool {
+    matches!(value, Value::Bool(_) | Value::Number(_) | Value::String(_))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn run_with(status: &str, metadata: Value) -> RunRecord {
+        RunRecord {
+            id: "run-proof-1".to_string(),
+            kind: "bench".to_string(),
+            component_id: Some("homeboy".to_string()),
+            started_at: "2026-06-29T00:00:00Z".to_string(),
+            finished_at: Some("2026-06-29T00:01:00Z".to_string()),
+            status: status.to_string(),
+            command: Some("homeboy bench homeboy".to_string()),
+            cwd: Some("/tmp/homeboy-fixture".to_string()),
+            homeboy_version: Some("test-version".to_string()),
+            git_sha: Some("abc123".to_string()),
+            rig_id: None,
+            metadata_json: metadata,
+        }
+    }
+
+    #[test]
+    fn build_proof_flattens_declared_and_bench_signals() {
+        let run = run_with(
+            "fail",
+            json!({
+                "exit_code": 2,
+                "error": "gate exceeded",
+                "gate_failures": ["p95_ms exceeded", "rss_mb exceeded"],
+                "observation_status": "failed",
+                "baseline_status": null,
+                // Declared probe-style proof signals (booleans + nested scalar).
+                "proof": {
+                    "rendered_contains_marker": true,
+                    "opfs_resume": false,
+                    "http_status": 200,
+                    "nested": { "value": "ok" }
+                },
+                // Top-level boolean proof signal not nested in a container.
+                "marker_present": true,
+                // Bench scorecard metrics.
+                "scenario_metrics": [{
+                    "scenario_id": "cold",
+                    "passed": false,
+                    "metrics": { "p95_ms": 42.0, "rss_mb": 5496.3 }
+                }]
+            }),
+        );
+
+        let proof = build_proof(&run);
+
+        assert_eq!(proof.command, "runs.proof");
+        assert_eq!(proof.status, "fail");
+        assert_eq!(proof.passed, Some(false));
+        assert_eq!(proof.exit_code, Some(2));
+        assert_eq!(proof.error.as_deref(), Some("gate exceeded"));
+        assert_eq!(proof.gate_failures, vec!["p95_ms exceeded", "rss_mb exceeded"]);
+
+        // Declared container flattened to dotted scalar leaves.
+        assert_eq!(proof.signals.get("proof.rendered_contains_marker"), Some(&json!(true)));
+        assert_eq!(proof.signals.get("proof.opfs_resume"), Some(&json!(false)));
+        assert_eq!(proof.signals.get("proof.http_status"), Some(&json!(200)));
+        assert_eq!(proof.signals.get("proof.nested.value"), Some(&json!("ok")));
+        // Top-level boolean proof signal and known scalar status signal.
+        assert_eq!(proof.signals.get("marker_present"), Some(&json!(true)));
+        assert_eq!(proof.signals.get("observation_status"), Some(&json!("failed")));
+        // Per-scenario bench metrics + passed flag.
+        assert_eq!(proof.signals.get("cold.passed"), Some(&json!(false)));
+        assert_eq!(proof.signals.get("cold.p95_ms"), Some(&json!(42.0)));
+        assert_eq!(proof.signals.get("cold.rss_mb"), Some(&json!(5496.3)));
+
+        // Null signal is dropped; non-signal scalars (exit_code/error) are not
+        // duplicated into the signal map.
+        assert!(!proof.signals.contains_key("baseline_status"));
+        assert!(!proof.signals.contains_key("exit_code"));
+        assert!(!proof.signals.contains_key("error"));
+    }
+
+    #[test]
+    fn build_proof_marks_running_run_pending_with_no_signals() {
+        let run = run_with("running", json!({ "phase": "warmup" }));
+        let proof = build_proof(&run);
+        assert_eq!(proof.passed, None);
+        assert!(proof.gate_failures.is_empty());
+        assert!(proof.signals.is_empty());
+    }
+
+    #[test]
+    fn build_proof_marks_pass() {
+        let run = run_with("pass", json!({ "scenario_metrics": [] }));
+        let proof = build_proof(&run);
+        assert_eq!(proof.passed, Some(true));
+    }
+}

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -32,6 +32,7 @@ use super::gh_actions::GhActionsImportOutput;
 use super::hotspots::{RunsHotspotsArgs, RunsHotspotsOutput};
 use super::latest::{RunsLatestFindingOutput, RunsLatestRunArgs, RunsLatestRunOutput};
 use super::loop_sync::{RunsLoopSyncArgs, RunsLoopSyncOutput};
+use super::proof::RunsProofOutput;
 use super::query::{RunsQueryArgs, RunsQueryOutput};
 use super::reconcile::{RunsReconcileArgs, RunsReconcileOutput};
 use super::refs::{RunsRefsArgs, RunsRefsOutput};
@@ -81,6 +82,15 @@ pub(super) enum RunsCommand {
         /// The compact summary surfaces status, key metadata, and artifact
         /// pointers with inspect commands; the full payload is unchanged and
         /// always available with this flag or via `--output <file>`.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show only the compact proof signals for one run: verdict, gate
+    /// failures, and declared proof/scorecard signal fields. Full evidence
+    /// stays behind `runs show --json` / `runs evidence`.
+    Proof {
+        run_id: String,
+        /// Print the full JSON output instead of the compact human summary.
         #[arg(long)]
         json: bool,
     },
@@ -158,6 +168,7 @@ pub enum RunsOutput {
     LatestRun(RunsLatestRunOutput),
     Compare(RunsCompareOutput),
     Show(RunsShowOutput),
+    Proof(RunsProofOutput),
     Dossier(RunsDossierOutput),
     ResumePlan(RunsResumePlanOutput),
     Evidence(RunsEvidenceOutput),

--- a/src/commands/runs_proof_summary.rs
+++ b/src/commands/runs_proof_summary.rs
@@ -1,0 +1,145 @@
+//! Compact human-readable summary for `homeboy runs proof`.
+//!
+//! `runs proof` already returns a small signal-only payload. This renderer
+//! presents it as ~10 lines of `key: value` text so an agent verifying a run
+//! reads the verdict and declared proof/scorecard signals without parsing
+//! JSON. The full payload remains available via `runs proof <id> --json`.
+
+use serde_json::Value;
+
+use super::summary_json::{string_value, value_at};
+
+/// Render a compact summary for a serialized `RunsOutput` value. Returns `None`
+/// for any variant other than `proof`.
+pub(crate) fn render_runs_proof_summary(payload: &Value) -> Option<String> {
+    if payload.get("variant").and_then(Value::as_str)? != "proof" {
+        return None;
+    }
+    let proof = value_at(payload, &["payload"])?;
+    Some(render(proof))
+}
+
+fn render(proof: &Value) -> String {
+    let run_id = string_value(proof, &["run_id"]).unwrap_or("<unknown>");
+    let kind = string_value(proof, &["kind"]).unwrap_or("run");
+    let status = string_value(proof, &["status"]).unwrap_or("unknown");
+    let verdict = match proof.get("passed") {
+        Some(Value::Bool(true)) => "PASS",
+        Some(Value::Bool(false)) => "FAIL",
+        _ => "PENDING",
+    };
+
+    let mut lines = vec![
+        format!("Proof {run_id} ({kind})"),
+        format!("Verdict: {verdict} (status: {status})"),
+    ];
+
+    if let Some(code) = proof.get("exit_code").and_then(Value::as_i64) {
+        lines.push(format!("Exit code: {code}"));
+    }
+    if let Some(error) = string_value(proof, &["error"]) {
+        lines.push(format!("Error: {error}"));
+    }
+
+    let gate_failures = proof
+        .get("gate_failures")
+        .and_then(Value::as_array)
+        .filter(|gates| !gates.is_empty());
+    if let Some(gates) = gate_failures {
+        lines.push(format!("Gate failures ({}):", gates.len()));
+        for gate in gates.iter().filter_map(Value::as_str) {
+            lines.push(format!("  {gate}"));
+        }
+    }
+
+    match proof.get("signals").and_then(Value::as_object) {
+        Some(signals) if !signals.is_empty() => {
+            lines.push(format!("Signals ({}):", signals.len()));
+            for (key, value) in signals {
+                lines.push(format!("  {key}: {}", scalar_display(value)));
+            }
+        }
+        _ => lines.push("Signals: none declared".to_string()),
+    }
+
+    lines.push(format!("Full output: homeboy runs proof {run_id} --json"));
+
+    let mut output = lines.join("\n");
+    output.push('\n');
+    output
+}
+
+fn scalar_display(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn non_proof_variant_returns_none() {
+        let payload = json!({ "variant": "show", "payload": {} });
+        assert!(render_runs_proof_summary(&payload).is_none());
+    }
+
+    #[test]
+    fn proof_summary_surfaces_verdict_gates_and_signals() {
+        let payload = json!({
+            "variant": "proof",
+            "payload": {
+                "command": "runs.proof",
+                "run_id": "bench-run-42",
+                "kind": "bench",
+                "status": "fail",
+                "passed": false,
+                "exit_code": 2,
+                "error": "gate exceeded",
+                "gate_failures": ["p95_ms exceeded"],
+                "signals": {
+                    "cold.p95_ms": 42.0,
+                    "proof.opfs_resume": false,
+                    "observation_status": "failed"
+                }
+            }
+        });
+
+        let summary = render_runs_proof_summary(&payload).expect("summary");
+
+        assert!(summary.starts_with("Proof bench-run-42 (bench)\n"));
+        assert!(summary.contains("Verdict: FAIL (status: fail)\n"));
+        assert!(summary.contains("Exit code: 2\n"));
+        assert!(summary.contains("Error: gate exceeded\n"));
+        assert!(summary.contains("Gate failures (1):\n"));
+        assert!(summary.contains("  p95_ms exceeded\n"));
+        assert!(summary.contains("Signals (3):\n"));
+        assert!(summary.contains("  cold.p95_ms: 42.0\n"));
+        assert!(summary.contains("  proof.opfs_resume: false\n"));
+        assert!(summary.contains("  observation_status: failed\n"));
+        assert!(summary.contains("Full output: homeboy runs proof bench-run-42 --json\n"));
+        // Compact: no raw JSON braces.
+        assert!(!summary.contains("{\n"));
+    }
+
+    #[test]
+    fn proof_summary_reports_pending_and_no_signals() {
+        let payload = json!({
+            "variant": "proof",
+            "payload": {
+                "run_id": "run-1",
+                "kind": "bench",
+                "status": "running",
+                "passed": null,
+                "signals": {}
+            }
+        });
+
+        let summary = render_runs_proof_summary(&payload).expect("summary");
+        assert!(summary.contains("Verdict: PENDING (status: running)\n"));
+        assert!(summary.contains("Signals: none declared\n"));
+    }
+}


### PR DESCRIPTION
## Summary

Verifying a bench/recipe run forced reading the full `runs show` / `runs evidence` JSON (tens of KB) to extract a handful of signals (pass/fail, gate failures, a few proof booleans). This adds a compact, signal-only surface so an agent reads ~10 lines instead.

`homeboy runs proof <run-id>` returns only:
- run `status` + `passed` (`true`/`false`/`null` while running)
- `exit_code` / `error`
- `gate_failures`
- `signals`: the run's declared proof/scorecard signal fields flattened to scalar `key:value` pairs

The full JSON stays behind `--json` (same compact payload, machine-readable) and the unchanged `runs show --json` / `runs evidence`.

### Generic, not bench-specific
The projection reuses the shared `evidence_failure_summary` for the verdict, and collects signals from:
- any declared signal container in metadata (`proof` / `scorecard` / `signals` / `proof_signals`), recursively flattened to scalar leaves;
- per-scenario bench metrics (`scenario_metrics[].metrics` + `passed`);
- top-level boolean proof signals (e.g. probe `rendered_contains_marker` / `opfs_resume`) and known scalar status signals.

No bench-specific field names are baked in. Compact human output is the default, matching the existing `runs show` / `runs dossier` compact-default + `--json` convention.

### Verification
- `cargo build -p homeboy --lib` clean.
- New focused unit tests for the projection (`build_proof_*`) and the human renderer (`render_runs_proof_summary`) pass: `cargo test -p homeboy --lib proof`.
- Ran `homeboy runs proof <id>` against a real persisted bench run: prints 13 flattened signals + verdict (~16 lines) vs the full payload.

Closes #6945.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Investigating the `runs` command surface and run-store/evidence structures, implementing the compact `runs proof` projection + human renderer, wiring the subcommand, and adding unit tests.