### PR TITLE
runs: -q/--field JSONPath selector + harden artifact get --output (#6947)

### DIFF
--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -116,7 +116,9 @@ pub fn run_command_output(
             let summarize_proof = runs_proof_summary_eligible(&args);
             let (stdout_result, exit_code) = dispatch(Commands::Runs(args), global);
             let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
-                if summarize_show {
+                if let Some(rendered) = super::runs_summary::render_runs_field_selection(payload) {
+                    Some(rendered)
+                } else if summarize_show {
                     super::runs_summary::render_runs_show_summary(payload)
                 } else if summarize_dossier {
                     super::runs_dossier_summary::render_runs_dossier_summary(payload)

--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -147,6 +147,38 @@ pub fn eval_jsonpath(path: &serde_json_path::JsonPath, value: &Value) -> Vec<Val
     path.query(value).all().into_iter().cloned().collect()
 }
 
+/// Project one or more JSONPath selectors over `root`, returning a
+/// `(selector, value)` pair per expression. Each value collapses the matched
+/// nodes: `null` for no match, the single match, or an array for many. Backs
+/// the `-q`/`--field` selectors on `runs show` and `runs artifact get` so a
+/// caller extracts only the fields it needs instead of the whole structure.
+pub fn select_fields(
+    root: &Value,
+    exprs: &[String],
+) -> homeboy::core::Result<Vec<(String, Value)>> {
+    let mut selected = Vec::with_capacity(exprs.len());
+    for expr in exprs {
+        let trimmed = expr.trim();
+        if trimmed.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "field",
+                "--field/-q selector must not be empty",
+                None,
+                None,
+            ));
+        }
+        let path = compile_jsonpath(trimmed)?;
+        let matches = eval_jsonpath(&path, root);
+        let value = match matches.len() {
+            0 => Value::Null,
+            1 => matches.into_iter().next().unwrap(),
+            _ => Value::Array(matches),
+        };
+        selected.push((trimmed.to_string(), value));
+    }
+    Ok(selected)
+}
+
 /// Render a JSON value as a flat scalar string suitable for grouping or
 /// table display. Returns `None` for objects, arrays, and `null`.
 ///
@@ -386,6 +418,39 @@ mod tests {
         assert!(parse_duration("0s").is_err());
         assert!(parse_duration("10x").is_err());
         assert!(parse_duration("h").is_err());
+    }
+
+    #[test]
+    fn select_fields_collapses_matches_per_selector() {
+        let root = serde_json::json!({
+            "status": "pass",
+            "metadata": { "run_dir": "/tmp/run" },
+            "tags": ["a", "b"]
+        });
+        let selected = select_fields(
+            &root,
+            &[
+                "$.status".to_string(),
+                "$.metadata.run_dir".to_string(),
+                "$.tags[*]".to_string(),
+                "$.missing".to_string(),
+            ],
+        )
+        .expect("select");
+        assert_eq!(selected[0], ("$.status".to_string(), Value::String("pass".into())));
+        assert_eq!(
+            selected[1],
+            ("$.metadata.run_dir".to_string(), Value::String("/tmp/run".into()))
+        );
+        assert_eq!(selected[2].1, serde_json::json!(["a", "b"]));
+        assert_eq!(selected[3].1, Value::Null);
+    }
+
+    #[test]
+    fn select_fields_rejects_empty_and_invalid_selectors() {
+        let root = serde_json::json!({ "a": 1 });
+        assert!(select_fields(&root, &["   ".to_string()]).is_err());
+        assert!(select_fields(&root, &["$[".to_string()]).is_err());
     }
 
     #[test]

--- a/src/commands/runs/corpus_tests.rs
+++ b/src/commands/runs/corpus_tests.rs
@@ -309,6 +309,7 @@ fn bundle_import_marks_file_artifacts_metadata_only_and_query_reports_skip() {
             artifact_id: artifacts[0].id.clone(),
             runner: None,
             output: None,
+            field: Vec::new(),
         })
         .err()
         .expect("metadata-only artifact get must fail");

--- a/src/commands/runs/dispatch.rs
+++ b/src/commands/runs/dispatch.rs
@@ -145,7 +145,18 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::FuzzCompare(args) => fuzz_compare::fuzz_compare_from_args(args),
         RunsCommand::Hotspots(args) => hotspots::runs_hotspots(args),
         RunsCommand::Reconcile(args) => reconcile::reconcile_runs(args),
-        RunsCommand::Show { run_id, json: _ } => handlers::show_run(&run_id),
+        RunsCommand::Show {
+            run_id,
+            json: _,
+            field,
+        } => {
+            let (output, exit_code) = handlers::show_run(&run_id)?;
+            if field.is_empty() {
+                Ok((output, exit_code))
+            } else {
+                handlers::apply_field_selection(output, &field)
+            }
+        }
         RunsCommand::Proof { run_id, json: _ } => proof::proof(&run_id),
         RunsCommand::Dossier { run_id, json: _ } => dossier::runs_dossier(&run_id),
         RunsCommand::ResumePlan { run_id } => handlers::resume_plan(&run_id),

--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -20,7 +20,8 @@ use super::types::{
     RunDetail, RunsArtifactArgs, RunsArtifactCommand, RunsArtifactGetArgs, RunsArtifactGetOutput,
     RunsArtifactPathGuide, RunsArtifactPullEntry, RunsArtifactPullSummary, RunsArtifactsArgs,
     RunsArtifactsOutput, RunsEnvKeyOutput, RunsEnvOutput, RunsEnvSourceLayerOutput, RunsEnvSummary,
-    RunsListArgs, RunsListOutput, RunsOutput, RunsResumePlanOutput, RunsShowOutput,
+    RunsFieldSelectionOutput, RunsListArgs, RunsListOutput, RunsOutput, RunsResumePlanOutput,
+    RunsSelectedField, RunsShowOutput,
 };
 use super::{reconcile, remote, remote_artifact, CmdResult};
 
@@ -525,6 +526,15 @@ pub fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
 }
 
 pub(crate) fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
+    let fields = args.field.clone();
+    let (output, exit_code) = artifact_get_inner(args)?;
+    if fields.is_empty() {
+        return Ok((output, exit_code));
+    }
+    apply_field_selection(output, &fields)
+}
+
+fn artifact_get_inner(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
     if let Some(runner_id) = args.runner.clone() {
         return remote::runner_artifact_get(&runner_id, args);
     }
@@ -571,6 +581,64 @@ pub(crate) fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
             None,
         )),
     }
+}
+
+/// Project `--field`/`-q` selectors over a `show` or `artifact get` result,
+/// returning a compact [`RunsOutput::FieldSelection`] carrying only the
+/// requested fields. Show selectors are rooted at the run detail; artifact-get
+/// selectors at the artifact-get result. Unsupported variants are returned
+/// unchanged so the selector never silently swallows other output.
+pub(super) fn apply_field_selection(
+    output: RunsOutput,
+    fields: &[String],
+) -> CmdResult<RunsOutput> {
+    let value = serde_json::to_value(&output).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("serialize runs output for field selection".to_string()),
+        )
+    })?;
+    let variant = value.get("variant").and_then(Value::as_str).unwrap_or_default();
+    let payload = value.get("payload").cloned().unwrap_or(Value::Null);
+    let (root, run_id, artifact_id) = match variant {
+        "show" => {
+            let run = payload.get("run").cloned().unwrap_or(Value::Null);
+            let run_id = run
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            (run, run_id, None)
+        }
+        "artifact_get" => {
+            let run_id = payload
+                .get("run_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let artifact_id = payload
+                .get("artifact_id")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            (payload.clone(), run_id, artifact_id)
+        }
+        _ => return Ok((output, 0)),
+    };
+
+    let selected = super::common::select_fields(&root, fields)?
+        .into_iter()
+        .map(|(field, value)| RunsSelectedField { field, value })
+        .collect();
+
+    Ok((
+        RunsOutput::FieldSelection(RunsFieldSelectionOutput {
+            command: "runs.field",
+            run_id,
+            artifact_id,
+            fields: selected,
+        }),
+        0,
+    ))
 }
 
 pub(super) fn require_run(

--- a/src/commands/runs/tests/mod.rs
+++ b/src/commands/runs/tests/mod.rs
@@ -781,6 +781,7 @@ fn artifact_get_copies_registered_file_without_raw_path_lookup() {
             artifact_id: artifact.id.clone(),
             runner: None,
             output: Some(output_path.clone()),
+            field: Vec::new(),
         })
         .expect("get artifact");
 
@@ -799,11 +800,82 @@ fn artifact_get_copies_registered_file_without_raw_path_lookup() {
             artifact_id: artifact_path.display().to_string(),
             runner: None,
             output: Some(home.path().join("bad.json")),
+            field: Vec::new(),
         }) {
             Ok(_) => panic!("raw paths are not accepted as artifact ids"),
             Err(err) => err,
         };
         assert!(err.to_string().contains("artifact record not found"));
+    });
+}
+
+#[test]
+fn artifact_get_field_selector_projects_only_requested_fields() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+            .expect("run");
+        let artifact_path = home.path().join("bench-results.json");
+        std::fs::write(&artifact_path, br#"{"ok":true}"#).expect("artifact");
+        let artifact = store
+            .record_artifact(&run.id, "bench_results", &artifact_path)
+            .expect("record artifact");
+        let output_path = home.path().join("downloaded.json");
+
+        let (output, _) = artifact_get(RunsArtifactGetArgs {
+            run_id: run.id.clone(),
+            artifact_id: artifact.id.clone(),
+            runner: None,
+            output: Some(output_path.clone()),
+            field: vec!["$.output_path".to_string(), "$.artifact_id".to_string()],
+        })
+        .expect("get artifact with field selector");
+
+        // The artifact bytes are still written even when fields are projected.
+        assert_eq!(
+            std::fs::read(&output_path).expect("downloaded"),
+            br#"{"ok":true}"#
+        );
+
+        let RunsOutput::FieldSelection(selection) = output else {
+            panic!("expected field-selection output");
+        };
+        assert_eq!(selection.command, "runs.field");
+        assert_eq!(selection.run_id, run.id);
+        assert_eq!(selection.artifact_id.as_deref(), Some(artifact.id.as_str()));
+        assert_eq!(selection.fields.len(), 2);
+        assert_eq!(selection.fields[0].field, "$.output_path");
+        assert_eq!(
+            selection.fields[0].value,
+            Value::String(output_path.display().to_string())
+        );
+        assert_eq!(selection.fields[1].field, "$.artifact_id");
+        assert_eq!(selection.fields[1].value, Value::String(artifact.id.clone()));
+    });
+}
+
+#[test]
+fn show_run_field_selector_projects_run_detail_fields() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+            .expect("run");
+
+        let (output, _) = show_run(&run.id).expect("show");
+        let (selection_output, _) =
+            super::handlers::apply_field_selection(output, &["$.status".to_string()])
+                .expect("apply field selection");
+        let RunsOutput::FieldSelection(selection) = selection_output else {
+            panic!("expected field-selection output");
+        };
+        assert_eq!(selection.run_id, run.id);
+        assert!(selection.artifact_id.is_none());
+        assert_eq!(selection.fields[0].field, "$.status");
+        assert_eq!(selection.fields[0].value, Value::String("running".into()));
     });
 }
 
@@ -859,6 +931,7 @@ fn artifact_get_fetches_nested_publication_artifact_store_ref() {
             artifact_id: "nested-result".to_string(),
             runner: None,
             output: Some(output_path.clone()),
+            field: Vec::new(),
         })
         .expect("get nested artifact");
 

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -84,6 +84,12 @@ pub(super) enum RunsCommand {
         /// always available with this flag or via `--output <file>`.
         #[arg(long)]
         json: bool,
+        /// JSONPath selector(s) projected over the run detail so callers
+        /// extract only specific fields instead of the whole structure.
+        /// Repeat or comma-separate. Rooted at the run detail, e.g.
+        /// `-q '$.status'`, `-q '$.metadata.run_dir'`.
+        #[arg(long = "field", short = 'q', value_delimiter = ',')]
+        field: Vec<String>,
     },
     /// Show only the compact proof signals for one run: verdict, gate
     /// failures, and declared proof/scorecard signal fields. Full evidence
@@ -169,6 +175,7 @@ pub enum RunsOutput {
     Compare(RunsCompareOutput),
     Show(RunsShowOutput),
     Proof(RunsProofOutput),
+    FieldSelection(RunsFieldSelectionOutput),
     Dossier(RunsDossierOutput),
     ResumePlan(RunsResumePlanOutput),
     Evidence(RunsEvidenceOutput),
@@ -206,6 +213,28 @@ pub struct RunsListOutput {
 pub struct RunsShowOutput {
     pub command: &'static str,
     pub run: RunDetail,
+}
+
+/// Field-projection result for `runs show -q` / `runs artifact get -q`.
+///
+/// Carries only the selected fields so callers extract a few values without
+/// fetching and grepping the entire run/artifact structure.
+#[derive(Serialize)]
+pub struct RunsFieldSelectionOutput {
+    pub command: &'static str,
+    pub run_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_id: Option<String>,
+    pub fields: Vec<RunsSelectedField>,
+}
+
+/// One projected `(selector, value)` pair. `value` is the JSON matched at the
+/// selector: `null` when nothing matched, the single match, or an array when
+/// the selector matched multiple nodes.
+#[derive(Serialize)]
+pub struct RunsSelectedField {
+    pub field: String,
+    pub value: Value,
 }
 
 #[derive(Serialize)]
@@ -426,6 +455,13 @@ pub struct RunsArtifactGetArgs {
     /// Destination file path. Defaults to the recorded artifact filename.
     #[arg(long, short = 'o')]
     pub output: Option<PathBuf>,
+    /// JSONPath selector(s) projected over the artifact-get result so callers
+    /// extract only specific fields (e.g. `sha256`, `output_path`) instead of
+    /// the whole structure. Repeat or comma-separate. Field selection still
+    /// writes the artifact bytes when `--output` is set. Example:
+    /// `-q '$.sha256'`, `-q '$.output_path'`.
+    #[arg(long = "field", short = 'q', value_delimiter = ',')]
+    pub field: Vec<String>,
 }
 
 #[derive(Serialize)]

--- a/src/commands/runs_summary.rs
+++ b/src/commands/runs_summary.rs
@@ -27,6 +27,31 @@ pub(crate) fn render_runs_show_summary(payload: &Value) -> Option<String> {
     Some(render_run_detail(run))
 }
 
+/// Render a `runs show -q` / `runs artifact get -q` field projection as plain
+/// lines so the selectors work as a grep replacement. One value per selector,
+/// in selector order; strings print raw, other JSON prints compactly. The full
+/// labeled `{field, value}` structure stays available in the JSON output and in
+/// `--output <file>`. Returns `None` for any other variant.
+pub(crate) fn render_runs_field_selection(payload: &Value) -> Option<String> {
+    if payload.get("variant").and_then(Value::as_str)? != "field_selection" {
+        return None;
+    }
+    let fields = value_at(payload, &["payload", "fields"])?.as_array()?;
+    let lines = fields
+        .iter()
+        .map(|field| field_value_line(field.get("value").unwrap_or(&Value::Null)))
+        .collect::<Vec<_>>();
+    Some(format!("{}\n", lines.join("\n")))
+}
+
+fn field_value_line(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
 fn render_run_detail(run: &Value) -> String {
     let run_id = string_value(run, &["id"]).unwrap_or("<unknown>");
     let kind = string_value(run, &["kind"]).unwrap_or("run");

--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -17,7 +17,7 @@
 //! into `RunsOutput` variants.
 
 use std::fs::{self, File};
-use std::io;
+use std::io::{self, Write};
 use std::path::{Component, Path, PathBuf};
 
 use chrono::{Duration, Utc};
@@ -324,16 +324,12 @@ mod artifact_resolve {
     ) -> Result<ArtifactRecord> {
         require_run(store, run_id)?;
         crate::core::artifacts::index_remote_published_artifact_refs_for_run(store, run_id)?;
-        let artifact = store
-            .get_artifact_for_run_token(run_id, artifact_id)?
-            .ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "artifact_id",
-                    format!("artifact record not found: {artifact_id}"),
-                    Some(artifact_id.to_string()),
-                    None,
-                )
-            })?;
+        let artifact = match store.get_artifact_for_run_token(run_id, artifact_id)? {
+            Some(artifact) => artifact,
+            None => {
+                return Err(unknown_artifact_error(store, run_id, artifact_id));
+            }
+        };
 
         if artifact.run_id != run_id {
             return Err(Error::validation_invalid_argument(
@@ -344,6 +340,45 @@ mod artifact_resolve {
             ));
         }
         Ok(artifact)
+    }
+
+    /// Build a clear "artifact not found" error that lists the artifact names
+    /// (kinds and ids) actually recorded for the run, so callers fix the token
+    /// instead of guessing which name matches.
+    fn unknown_artifact_error(store: &ObservationStore, run_id: &str, artifact_id: &str) -> Error {
+        let available = store.list_artifacts(run_id).unwrap_or_default();
+        let mut names: Vec<String> = Vec::new();
+        for artifact in &available {
+            for token in [artifact.kind.as_str(), artifact.id.as_str()] {
+                if !token.is_empty() && !names.iter().any(|name| name == token) {
+                    names.push(token.to_string());
+                }
+            }
+        }
+        let (problem, hints) = if names.is_empty() {
+            (
+                format!("artifact record not found: {artifact_id}; run `{run_id}` has no recorded artifacts yet"),
+                vec!["Run `homeboy runs artifacts <run-id>` after the source command records artifacts.".to_string()],
+            )
+        } else {
+            (
+                format!(
+                    "artifact record not found: {artifact_id}; available artifact names for run `{run_id}`: {}",
+                    names.join(", ")
+                ),
+                vec![
+                    "Pass an artifact id, kind, or name from the available list.".to_string(),
+                    "Run `homeboy runs artifacts <run-id>` to inspect all recorded artifacts."
+                        .to_string(),
+                ],
+            )
+        };
+        Error::validation_invalid_argument(
+            "artifact_id",
+            problem,
+            Some(artifact_id.to_string()),
+            Some(hints),
+        )
     }
 
     /// Copy a recorded file artifact's bytes to `output`.
@@ -415,6 +450,26 @@ mod artifact_resolve {
                 )),
             )
         })?;
+        // Flush and fsync so the reported `output_path` is durably on disk
+        // before we return success — never print fetch metadata for a write
+        // that did not actually land.
+        writer.flush().map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("flush {}", output.display())))
+        })?;
+        writer.sync_all().map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("sync {}", output.display())))
+        })?;
+        drop(writer);
+        if !output.is_file() {
+            return Err(Error::internal_io(
+                format!(
+                    "artifact {} copy reported success but no file exists at {}",
+                    artifact.id,
+                    output.display()
+                ),
+                Some(format!("verify artifact output {}", output.display())),
+            ));
+        }
 
         Ok(ArtifactFetchOutcome {
             run_id: artifact.run_id,
@@ -1134,6 +1189,33 @@ mod tests {
                 .expect_err("missing artifact");
             assert_eq!(err.code.as_str(), "validation.invalid_argument");
             assert!(err.message.contains("artifact record not found"));
+            // With no artifacts recorded, the error is explicit rather than
+            // listing phantom names.
+            assert!(err.message.contains("no recorded artifacts"));
+        });
+    }
+
+    #[test]
+    fn resolve_artifact_for_run_unknown_id_lists_available_names() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(sample_run("bench")).expect("run");
+            let source = home.path().join("bench-results.json");
+            std::fs::write(&source, br#"{"ok":true}"#).expect("source");
+            store
+                .record_artifact(&run.id, "bench_results", &source)
+                .expect("record");
+
+            let err = resolve_artifact_for_run(&store, &run.id, "does-not-exist")
+                .expect_err("unknown artifact");
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(
+                err.message.contains("available artifact names")
+                    && err.message.contains("bench_results"),
+                "expected available names listing the recorded kind, got: {}",
+                err.message
+            );
         });
     }
 


### PR DESCRIPTION
## What

Field-level extraction for `runs show` / `runs artifact get`, plus reliability fixes on `runs artifact get --output`. Closes #6947.

### `-q` / `--field` selector
- New `-q`/`--field` JSONPath selector on `runs show` and `runs artifact get` (repeatable / comma-separated).
- Reuses the existing `serde_json_path` engine already backing `runs query` (no new dependency, no bespoke path parser).
- Roots: `runs show` selectors evaluate against the run detail (`-q '$.status'`, `-q '$.metadata.run_dir'`); `runs artifact get` against the artifact-get result (`-q '$.sha256'`, `-q '$.output_path'`).
- Each selector collapses its matches to `null` (no match) / the value / an array (many).
- Output is a compact `RunsOutput::FieldSelection` payload (`{ run_id, artifact_id?, fields: [{field, value}] }`), always available as JSON and in `--output <file>`. A presentation renderer also prints the selected values as plain lines so `-q` works as a grep replacement.

### `runs artifact get --output` hardening
- Local-file copy now flushes + `fsync`s + verifies the destination file exists before returning fetch metadata, so success is never reported for a write that did not land.
- Unknown artifact names now produce a clear error that lists the artifact names actually recorded for the run (or states the run has none) instead of a bare not-found.

`runs artifact get -q` still writes the artifact bytes when `--output` is set; field projection is layered on top of the existing fetch.

## Verify
- `cargo build -p homeboy --lib` — clean (pre-existing warnings only).
- `cargo test -p homeboy --lib -- commands::runs::` — 127 passed. New tests: `select_fields_collapses_matches_per_selector`, `select_fields_rejects_empty_and_invalid_selectors`, `artifact_get_field_selector_projects_only_requested_fields` (verifies `--output` bytes written + projection), `show_run_field_selector_projects_run_detail_fields`, `resolve_artifact_for_run_unknown_id_lists_available_names`.
- Live: `homeboy runs show <id> -q '$.status'` → `pass`; `-q '$.status,$.kind'` → two lines.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (claude-opus-4-8) via Claude Code
- **Used for:** Investigating the `runs` command surface, implementing the `-q` selector + `--output` hardening, and writing unit tests. Chris reviewed and is responsible for every line.
