### PR TITLE
Relax destructive fuzz isolation proof reset requirements

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -221,8 +221,6 @@ generic safety fields:
   "runtime_kind": "ephemeral-runner",
   "provider_ref": { "id": "opaque-provider-owned-ref" },
   "disposable": true,
-  "snapshot_ref": "snapshot://baseline-1",
-  "reset_supported": true,
   "teardown_required": true,
   "mutation_boundary": "runner-workspace",
   "proof_artifacts": [
@@ -232,11 +230,15 @@ generic safety fields:
 }
 ```
 
-For destructive planning or execution, `disposable`, `reset_supported`, and
-`teardown_required` must be `true`; `runtime_kind`, `snapshot_ref`,
-`mutation_boundary`, `verified_by`, and at least one `proof_artifacts` entry must
-be present. `homeboy fuzz plan` and `homeboy fuzz run` embed the accepted proof in
-the `homeboy/fuzz-execution-request/v1` request as `isolation_proof`.
+For destructive planning or execution, `disposable` and `teardown_required` must
+be `true`; `runtime_kind`, `mutation_boundary`, `verified_by`, and at least one
+`proof_artifacts` entry must be present. The teardown proof represents discard of
+the disposable mutation boundary, not restoration of a durable environment.
+Existing runner/provider capabilities such as `snapshot_ref` or `reset_supported`
+can be included as optional evidence, but Homeboy does not require rollback,
+restore, reset, or checkpoint support for destructive fuzzing inside an explicit
+disposable boundary. `homeboy fuzz plan` and `homeboy fuzz run` embed the accepted
+proof in the `homeboy/fuzz-execution-request/v1` request as `isolation_proof`.
 
 Operations keep the free-form `kind` string for product-owned semantics and can
 also carry a canonical `family` for cross-runner coverage reporting. When

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -356,7 +356,7 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
                 "replays a persisted fuzz case against local code and may write run artifacts";
         }
         ["fuzz"] | ["fuzz", "run"] | ["fuzz", "plan"] => {
-            metadata.output_notes = "read-only fuzz planning/execution contract by default; --allow-destructive requires explicit homeboy/isolation-proof/v1 input";
+            metadata.output_notes = "read-only fuzz planning/execution contract by default; --allow-destructive requires explicit disposable homeboy/isolation-proof/v1 input";
             metadata.dangerous_flags = vec!["--allow-destructive"];
         }
         ["db", "delete-row"] | ["db", "drop-table"] => {

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -389,7 +389,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         ..lab_command_spec_with_summary(
             "fuzz",
             CommandJsonFamily::Quality,
-            "fuzz is measurement-only by default; --allow-destructive requires explicit homeboy/isolation-proof/v1 input",
+            "fuzz is measurement-only by default; --allow-destructive requires explicit disposable homeboy/isolation-proof/v1 input",
             FUZZ_LAB_SUPPORT,
         )
     },

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -203,8 +203,6 @@ fn isolation_proof() -> IsolationProof {
         "runtime_kind": "ephemeral-runner",
         "provider_ref": { "id": "provider-opaque-ref" },
         "disposable": true,
-        "snapshot_ref": "snapshot://baseline-1",
-        "reset_supported": true,
         "teardown_required": true,
         "mutation_boundary": "runner-workspace",
         "proof_artifacts": [

--- a/src/core/fuzz/envelope.rs
+++ b/src/core/fuzz/envelope.rs
@@ -118,8 +118,10 @@ pub struct IsolationProof {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_ref: Option<Value>,
     pub disposable: bool,
-    pub snapshot_ref: String,
-    pub reset_supported: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_supported: Option<bool>,
     pub teardown_required: bool,
     pub mutation_boundary: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -147,15 +149,16 @@ impl IsolationProof {
             ));
         }
         self.runtime_kind = required_trimmed("isolation_proof.runtime_kind", &self.runtime_kind)?;
-        self.snapshot_ref = required_trimmed("isolation_proof.snapshot_ref", &self.snapshot_ref)?;
+        self.snapshot_ref = self
+            .snapshot_ref
+            .as_deref()
+            .map(|snapshot_ref| required_trimmed("isolation_proof.snapshot_ref", snapshot_ref))
+            .transpose()?;
         self.mutation_boundary =
             required_trimmed("isolation_proof.mutation_boundary", &self.mutation_boundary)?;
         self.verified_by = required_trimmed("isolation_proof.verified_by", &self.verified_by)?;
         if !self.disposable {
             return Err("isolation_proof.disposable must be true".to_string());
-        }
-        if !self.reset_supported {
-            return Err("isolation_proof.reset_supported must be true".to_string());
         }
         if !self.teardown_required {
             return Err("isolation_proof.teardown_required must be true".to_string());

--- a/src/core/fuzz/tests/contract_tests.rs
+++ b/src/core/fuzz/tests/contract_tests.rs
@@ -171,8 +171,6 @@ fn isolation_proof_requires_explicit_destructive_safety_fields() {
         "runtime_kind": "ephemeral-runner",
         "provider_ref": { "opaque": "provider-owned" },
         "disposable": true,
-        "snapshot_ref": "snapshot://baseline-1",
-        "reset_supported": true,
         "teardown_required": true,
         "mutation_boundary": "runner-workspace",
         "proof_artifacts": [{ "kind": "log", "ref": "artifact://proof" }],
@@ -183,8 +181,30 @@ fn isolation_proof_requires_explicit_destructive_safety_fields() {
     assert_eq!(proof.schema, ISOLATION_PROOF_SCHEMA);
     assert_eq!(proof.runtime_kind, "ephemeral-runner");
     assert!(proof.disposable);
-    assert!(proof.reset_supported);
     assert!(proof.teardown_required);
+    assert_eq!(proof.snapshot_ref, None);
+    assert_eq!(proof.reset_supported, None);
+}
+
+#[test]
+fn isolation_proof_preserves_optional_reset_evidence_when_present() {
+    let proof = IsolationProof::from_value(json!({
+        "schema": ISOLATION_PROOF_SCHEMA,
+        "version": FUZZ_CONTRACT_VERSION,
+        "runtime_kind": "ephemeral-runner",
+        "provider_ref": { "opaque": "provider-owned" },
+        "disposable": true,
+        "snapshot_ref": "snapshot://baseline-1",
+        "reset_supported": false,
+        "teardown_required": true,
+        "mutation_boundary": "runner-workspace",
+        "proof_artifacts": [{ "kind": "log", "ref": "artifact://proof" }],
+        "verified_by": "test-suite"
+    }))
+    .expect("valid proof with optional reset evidence");
+
+    assert_eq!(proof.snapshot_ref.as_deref(), Some("snapshot://baseline-1"));
+    assert_eq!(proof.reset_supported, Some(false));
 }
 
 #[test]
@@ -194,8 +214,6 @@ fn isolation_proof_rejects_missing_required_proof_artifacts() {
         "version": FUZZ_CONTRACT_VERSION,
         "runtime_kind": "ephemeral-runner",
         "disposable": true,
-        "snapshot_ref": "snapshot://baseline-1",
-        "reset_supported": true,
         "teardown_required": true,
         "mutation_boundary": "runner-workspace",
         "verified_by": "test-suite"


### PR DESCRIPTION
## Summary
- Treat destructive fuzz isolation proof as a disposable boundary + teardown/discard contract instead of requiring reset/restore support.
- Make isolation proof `snapshot_ref` and `reset_supported` optional evidence while preserving them when provided.
- Update fuzz docs, command safety notes, and public fuzz contract tests.

## Tests
- `cargo test core::fuzz::tests::contract_tests`
- `cargo test fuzz_plan_includes_destructive_operations_with_explicit_isolation_proof`
- `cargo test fuzz_execution_request_artifact_records_runner_intent`
- `cargo test --test command_surface_test`
- `cargo test --test output_contracts_test`

## Notes
- `cargo test --test runtime_product_boundary_test` and `cargo test --test architecture_core_agnostic_test` currently fail on existing unrelated baseline findings outside this PR diff.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Contract update, tests, docs, and PR preparation.