### PR TITLE
Fix fuzz run action policy parity

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -5,8 +5,8 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 ## Synopsis
 
 ```bash
-homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
-homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
+homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
+homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
 homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>]
 homeboy fuzz validate <results-file>
@@ -142,7 +142,8 @@ requirements, selected gate profile, required artifact ids, gate ids, inventory
 provenance, and skipped target or operation reasons. The planner is product-neutral: it uses inventory-declared
 operation families and safety classes, not product-specific target names.
 
-`homeboy fuzz plan --action-model <path>` accepts a
+`homeboy fuzz plan --action-model <path>` and
+`homeboy fuzz run --action-model <path>` accept a
 `homeboy/fuzz-action-model/v1` JSON contract. The action model declares generic
 actions with ids, free-form kinds, optional canonical operation families,
 non-negative weights, opaque input generator refs, preconditions, effects, and
@@ -170,7 +171,8 @@ runner-owned.
 }
 ```
 
-`homeboy fuzz plan --exploration-policy <path>` accepts a
+`homeboy fuzz plan --exploration-policy <path>` and
+`homeboy fuzz run --exploration-policy <path>` accept a
 `homeboy/fuzz-exploration-policy/v1` JSON contract. The policy declares generic
 planning constraints such as action model refs, action weights, case and duration
 budgets, reset cadence, replay seed refs, corpus refs, and invariants. Homeboy

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1396,8 +1396,6 @@ pub(super) fn build_fuzz_execution_request(
         operation_families: Vec::new(),
         case_budget: None,
         duration_budget_seconds: None,
-        action_model: None,
-        exploration_policy: None,
     };
     let isolation_proof = super::planning::load_isolation_proof(args.isolation_proof.as_deref())?;
     let mut metadata =

--- a/src/commands/fuzz/planning.rs
+++ b/src/commands/fuzz/planning.rs
@@ -302,11 +302,13 @@ pub(super) fn plan_inventory_selection(
         .or_else(|| args.run.workload_id.clone())
         .map(|id| format!("{id}-sampling"));
     let action_model = args
+        .run
         .action_model
         .as_deref()
         .map(parse_fuzz_action_model_file)
         .transpose()?;
     let exploration_policy = args
+        .run
         .exploration_policy
         .as_deref()
         .map(parse_fuzz_exploration_policy_file)

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -34,6 +34,8 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             isolation: FuzzIsolationArg::Shared,
             isolation_proof: None,
             expect_metric: vec![],
+            action_model: None,
+            exploration_policy: None,
             args: vec![],
         };
         let results_path = home.path().join("fuzz-results.json");
@@ -226,6 +228,106 @@ fn fuzz_execution_request_artifact_records_runner_intent() {
             "HOMEBOY_FUZZ_EXECUTION_REQUEST_FILE"
         );
     });
+}
+
+#[test]
+fn fuzz_run_cli_preserves_action_model_and_exploration_policy_in_execution_request() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let action_model = temp.path().join("action-model.json");
+    let exploration_policy = temp.path().join("exploration-policy.json");
+    fs::write(
+        &action_model,
+        serde_json::json!({
+            "schema": "homeboy/fuzz-action-model/v1",
+            "version": 1,
+            "id": "generic-actions",
+            "actions": [
+                {
+                    "id": "resource.read",
+                    "kind": "read",
+                    "family": "read",
+                    "weight": 3.0,
+                    "input_generators": ["generator:resource-id"],
+                    "preconditions": ["resource.exists"],
+                    "effects": ["observation.recorded"],
+                    "invariants": ["resource.integrity"]
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .expect("write action model");
+    fs::write(
+        &exploration_policy,
+        serde_json::json!({
+            "schema": "homeboy/fuzz-exploration-policy/v1",
+            "version": 1,
+            "id": "bounded-exploration",
+            "action_model_ref": "generic-actions",
+            "action_weights": { "resource.read": 3.0 },
+            "case_budget": 50,
+            "duration_budget_seconds": 300,
+            "reset_cadence": "after_each_case",
+            "replay_seed_ref": "seed:stable-1",
+            "corpus_refs": ["corpus:generic-fixture"],
+            "invariants": ["resource.integrity"]
+        })
+        .to_string(),
+    )
+    .expect("write exploration policy");
+
+    let cli = FuzzCli::try_parse_from([
+        "fuzz",
+        "run",
+        "component-a",
+        "--workload",
+        "api-fuzz",
+        "--run-id",
+        "proof-1",
+        "--action-model",
+        action_model.to_str().expect("utf8 action model path"),
+        "--exploration-policy",
+        exploration_policy
+            .to_str()
+            .expect("utf8 exploration policy path"),
+    ])
+    .expect("parse fuzz run cli");
+    let Some(FuzzCommand::Run(args)) = cli.args.command else {
+        panic!("expected fuzz run command");
+    };
+
+    let request = build_fuzz_execution_request(
+        &args,
+        "component-a",
+        args.rig.as_deref(),
+        args.workload_id.clone(),
+        &planner_inventory(),
+    )
+    .expect("execution request");
+    let run_dir = RunDir::create().expect("run dir");
+    let request_path = persist_fuzz_execution_request(&run_dir, &request).expect("persist request");
+    let persisted: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&request_path).expect("read request artifact"))
+            .expect("request json");
+
+    assert_eq!(persisted["schema"], "homeboy/fuzz-execution-request/v1");
+    assert_eq!(persisted["id"], "proof-1");
+    assert_eq!(
+        persisted["metadata"]["action_model"]["schema"],
+        "homeboy/fuzz-action-model/v1"
+    );
+    assert_eq!(
+        persisted["metadata"]["action_model"]["actions"][0]["input_generators"],
+        serde_json::json!(["generator:resource-id"])
+    );
+    assert_eq!(
+        persisted["metadata"]["exploration_policy"]["schema"],
+        "homeboy/fuzz-exploration-policy/v1"
+    );
+    assert_eq!(
+        persisted["metadata"]["exploration_policy"]["corpus_refs"],
+        serde_json::json!(["corpus:generic-fixture"])
+    );
 }
 
 #[test]
@@ -960,6 +1062,8 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             isolation: FuzzIsolationArg::Shared,
             isolation_proof: None,
             expect_metric: vec![],
+            action_model: None,
+            exploration_policy: None,
             args: vec![],
         };
         let results_path = home.path().join("fuzz-results.json");

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -98,6 +98,8 @@ fn planner_args() -> FuzzPlanArgs {
             isolation: FuzzIsolationArg::Shared,
             isolation_proof: None,
             expect_metric: vec![],
+            action_model: None,
+            exploration_policy: None,
             args: Vec::new(),
         },
         request_id: None,
@@ -106,8 +108,6 @@ fn planner_args() -> FuzzPlanArgs {
         operation_families: Vec::new(),
         case_budget: None,
         duration_budget_seconds: None,
-        action_model: None,
-        exploration_policy: None,
     }
 }
 
@@ -286,6 +286,8 @@ fn fuzz_run_args_with_run_id(run_id: &str) -> FuzzRunArgs {
         isolation: FuzzIsolationArg::Shared,
         isolation_proof: None,
         expect_metric: vec![],
+        action_model: None,
+        exploration_policy: None,
         args: vec![],
     }
 }

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -127,6 +127,8 @@ fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_cont
         isolation: FuzzIsolationArg::Shared,
         isolation_proof: None,
         expect_metric: vec![],
+        action_model: None,
+        exploration_policy: None,
         args: vec![],
     };
     let workload = FuzzWorkloadOutput {
@@ -300,6 +302,8 @@ fn fuzz_runner_env_expands_rig_workload_and_injects_runtime_context() {
         isolation: FuzzIsolationArg::Shared,
         isolation_proof: None,
         expect_metric: vec![],
+        action_model: None,
+        exploration_policy: None,
         args: vec![],
     };
     let workload = FuzzWorkloadOutput {

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -213,6 +213,14 @@ pub struct FuzzRunArgs {
     #[arg(long = "expect-metric", value_name = "METRIC=VALUE", value_parser = crate::commands::parse_key_val)]
     pub(crate) expect_metric: Vec<(String, String)>,
 
+    /// Generic action model contract JSON (`homeboy/fuzz-action-model/v1`) to include in the execution request.
+    #[arg(long = "action-model", value_name = "PATH")]
+    pub(crate) action_model: Option<PathBuf>,
+
+    /// Generic exploration policy contract JSON (`homeboy/fuzz-exploration-policy/v1`) to include in the execution request.
+    #[arg(long = "exploration-policy", value_name = "PATH")]
+    pub(crate) exploration_policy: Option<PathBuf>,
+
     /// Additional runner arguments reserved for the fuzz extension script.
     #[arg(last = true)]
     pub(crate) args: Vec<String>,
@@ -266,14 +274,6 @@ pub(crate) struct FuzzPlanArgs {
     /// Maximum execution budget in seconds for downstream runners.
     #[arg(long = "duration-budget-seconds", value_name = "SECONDS")]
     pub(crate) duration_budget_seconds: Option<u64>,
-
-    /// Generic action model contract JSON (`homeboy/fuzz-action-model/v1`) to include in the plan.
-    #[arg(long = "action-model", value_name = "PATH")]
-    pub(crate) action_model: Option<PathBuf>,
-
-    /// Generic exploration policy contract JSON (`homeboy/fuzz-exploration-policy/v1`) to include in the plan.
-    #[arg(long = "exploration-policy", value_name = "PATH")]
-    pub(crate) exploration_policy: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]


### PR DESCRIPTION
## Summary
- Move generic action model and exploration policy inputs onto the shared fuzz run args so both `fuzz plan` and `fuzz run` accept the same contract files.
- Preserve validated action/exploration metadata in the `homeboy/fuzz-execution-request/v1` artifact emitted for runs.
- Document the `fuzz run` action model and exploration policy flags.

## Tests
- `cargo test commands::fuzz`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fuzz run/plan metadata parity fix, updating tests/docs, and preparing this PR.