### PR TITLE
Improve fuzz evidence replay portability

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -35,8 +35,9 @@ homeboy fuzz list --rig <rig-id>
 ```
 
 `fuzz list` is the declared-workload view. It is not proof that a workload ran.
-Use the listed workload id in `fuzz run`, then use `runs show` or `runs evidence`
-to inspect the executable/proven state and recorded artifacts.
+Use the listed workload id in `fuzz run`, then use `runs show`, `runs evidence`,
+or run-backed replay/minimize to inspect the executable/proven state and recorded
+artifacts.
 
 Run one workload through the fuzz command surface:
 
@@ -50,12 +51,22 @@ through `homeboy runs` instead of opening temporary runner paths directly:
 ```bash
 homeboy runs show <run-id>
 homeboy runs artifact get <run-id> <artifact-id> --output <path>
+homeboy fuzz replay --run-id <run-id> --case-id <case-id> --dry-run
 ```
 
 `homeboy runs show` renders the compact summary, coverage metadata when the
 runner provides it, and fetch commands for recorded artifacts such as failing
 cases, repro cases, and coverage reports. Use `homeboy runs artifact get` for
 artifact bytes that are stored locally or mirrored from a runner.
+
+`homeboy fuzz replay --run-id <run-id> --case-id <case-id>` and
+`homeboy fuzz minimize --run-id <run-id> --case-id <case-id>` resolve the
+persisted fuzz campaign/result-envelope artifact from the run when no explicit
+artifact path is supplied. `--dry-run` prints the canonical replay environment
+and resolved extension command without executing it. If the selected extension
+does not declare `fuzz.replay_command` or `fuzz.minimize_command`, Homeboy returns
+`unsupported` with the resolved contract instead of pretending replay or
+minimization ran.
 
 Runner scripts receive `HOMEBOY_FUZZ_RESULTS_FILE` pointing at
 `fuzz-results.json` in the command run directory. When a runner writes a
@@ -72,6 +83,14 @@ reference those files from the campaign `artifacts` list or `metadata.artifact_r
 validates local refs that point inside it when possible. Homeboy core owns the
 path contract; extensions own artifact meaning and any runner/offload upload
 implementation beyond the persisted fuzz result envelope.
+
+`homeboy runs export --run <run-id> --output <bundle-dir>` includes file artifact
+bytes and directory artifact zip archives in `artifact_bytes.json`, with SHA-256
+and byte size recorded in the bundle and artifact metadata. `homeboy runs import`
+validates the checksums before importing, rehydrates directory artifacts from the
+zip archive into the bundle directory, and records the imported artifact as a
+directory rather than metadata-only evidence. This keeps reviewer-facing fuzz
+evidence portable after disposable runner or sandbox teardown.
 
 When a runner or extension promotes an artifact directory through `runner exec
 --artifact-dir`, Homeboy records each direct file or directory child as a generic

--- a/src/commands/fuzz/replay.rs
+++ b/src/commands/fuzz/replay.rs
@@ -6,6 +6,8 @@ use homeboy::core::fuzz::{
     FuzzCampaign, FuzzReplayMetadata, FuzzResultEnvelope, FUZZ_CAMPAIGN_SCHEMA,
     FUZZ_RESULT_ENVELOPE_SCHEMA,
 };
+use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore};
+use homeboy::core::Error;
 
 use super::super::utils::args::PositionalComponentArgs;
 use super::types::{
@@ -30,7 +32,10 @@ fn run_replay_like(
     args: ReplayLikeArgs,
     mode: ReplayLikeMode,
 ) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
-    let artifact_file = replay_artifact_path(&args);
+    let artifact_file = match replay_artifact_path(&args) {
+        Some(path) => Some(path),
+        None => resolve_run_replay_artifact_path(args.run_id.as_deref()).transpose()?,
+    };
     let positional_case = args.artifact_or_case.as_ref().and_then(|value| {
         if artifact_file.is_some() && !Path::new(value).exists() {
             Some(value.clone())
@@ -399,6 +404,66 @@ fn replay_artifact_path(args: &ReplayLikeArgs) -> Option<PathBuf> {
                 .then_some(path)
         })
     })
+}
+
+fn resolve_run_replay_artifact_path(
+    run_id: Option<&str>,
+) -> Option<homeboy::core::Result<PathBuf>> {
+    let run_id = run_id.filter(|run_id| !run_id.trim().is_empty())?;
+    Some(resolve_run_replay_artifact_path_inner(run_id))
+}
+
+fn resolve_run_replay_artifact_path_inner(run_id: &str) -> homeboy::core::Result<PathBuf> {
+    let store = ObservationStore::open_initialized()?;
+    let _run = runs_service::require_run(&store, run_id)?;
+    let mut candidates = runs_service::list_artifacts_for_run(&store, run_id)?
+        .into_iter()
+        .filter(|artifact| artifact.artifact_type == "file")
+        .filter(is_run_replay_artifact_candidate)
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(run_replay_artifact_rank);
+
+    candidates
+        .into_iter()
+        .map(|artifact| PathBuf::from(artifact.path))
+        .find(|path| path.is_file())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run-id",
+                format!("fuzz replay artifact not found for run: {run_id}"),
+                Some(run_id.to_string()),
+                Some(vec![
+                    format!("Run `homeboy runs artifacts {run_id}` to inspect recorded artifacts."),
+                    "Persist a fuzz campaign/result envelope artifact before replaying by run id."
+                        .to_string(),
+                ]),
+            )
+        })
+}
+
+fn is_run_replay_artifact_candidate(artifact: &ArtifactRecord) -> bool {
+    artifact.kind == "fuzz_result_envelope"
+        || artifact.kind == "fuzz_results"
+        || artifact
+            .metadata_json
+            .get("schema")
+            .and_then(serde_json::Value::as_str)
+            == Some(FUZZ_RESULT_ENVELOPE_SCHEMA)
+}
+
+fn run_replay_artifact_rank(artifact: &ArtifactRecord) -> u8 {
+    if artifact.kind == "fuzz_result_envelope" {
+        0
+    } else if artifact
+        .metadata_json
+        .get("schema")
+        .and_then(serde_json::Value::as_str)
+        == Some(FUZZ_RESULT_ENVELOPE_SCHEMA)
+    {
+        1
+    } else {
+        2
+    }
 }
 
 fn resolve_replay_artifact(

--- a/src/commands/fuzz/tests/replay_tests.rs
+++ b/src/commands/fuzz/tests/replay_tests.rs
@@ -126,6 +126,50 @@ fn fuzz_replay_resolves_campaign_metadata_without_executing() {
 }
 
 #[test]
+fn fuzz_replay_resolves_persisted_run_artifact_without_path() {
+    with_isolated_home(|home| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                homeboy::core::observation::NewRunRecord::builder("fuzz")
+                    .component_id("component-a")
+                    .command("homeboy fuzz run component-a")
+                    .cwd_path(home.path())
+                    .build(),
+            )
+            .expect("run");
+        let path = write_replay_campaign(home.path());
+        store
+            .record_artifact(&run.id, "fuzz_results", &path)
+            .expect("artifact");
+
+        let (output, exit) = run_replay(FuzzReplayArgs {
+            component: None,
+            path: None,
+            rig: None,
+            extension_override: ExtensionOverrideArgs::default(),
+            setting_args: SettingArgs::default(),
+            artifact_or_case: None,
+            artifact: None,
+            case_id: Some("case-1".to_string()),
+            run_id: Some(run.id.clone()),
+            dry_run: true,
+            args: Vec::new(),
+        })
+        .expect("resolve run-backed replay");
+
+        assert_eq!(exit, 0);
+        assert_eq!(output.status, "dry_run");
+        assert_eq!(output.campaign_id.as_deref(), Some("campaign-1"));
+        assert_eq!(output.case_id.as_deref(), Some("case-1"));
+        assert_eq!(output.run_id.as_deref(), Some(run.id.as_str()));
+        assert!(output.artifact_file.as_deref().is_some_and(|artifact| {
+            artifact.ends_with("fuzz-results.json") && artifact != path.to_string_lossy()
+        }));
+    });
+}
+
+#[test]
 fn fuzz_replay_executes_manifest_replay_command_with_env() {
     with_isolated_home(|home| {
         let component_dir = tempfile::tempdir().expect("component dir");

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
 
 use clap::Args;
@@ -103,8 +104,10 @@ struct ObservationBundleArtifactBytes {
     path: String,
     sha256: String,
     size_bytes: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    archive_format: Option<String>,
     #[serde(skip)]
-    source_path: Option<PathBuf>,
+    source_bytes: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -204,7 +207,7 @@ pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
     let mut artifacts = 0usize;
     let mut artifact_metadata_only = 0usize;
     for artifact in &bundle.artifacts {
-        let artifact = imported_artifact_record(artifact, &bundle, &input);
+        let artifact = imported_artifact_record(artifact, &bundle, &input)?;
         if artifact.artifact_type == "metadata-only" {
             artifact_metadata_only += 1;
         } else {
@@ -309,7 +312,7 @@ fn imported_artifact_record(
     artifact: &ArtifactRecord,
     bundle: &ObservationBundle,
     input: &Path,
-) -> ArtifactRecord {
+) -> homeboy::core::Result<ArtifactRecord> {
     if artifact.artifact_type == "file" {
         if let Some(bytes) = bundle.artifact_bytes.iter().find(|bytes| {
             bytes.artifact_id == artifact.id && artifact.path == bundle_artifact_uri(&bytes.path)
@@ -318,17 +321,32 @@ fn imported_artifact_record(
             imported.path = input.join(&bytes.path).to_string_lossy().to_string();
             imported.sha256 = Some(bytes.sha256.clone());
             imported.size_bytes = Some(bytes.size_bytes);
-            return imported;
+            return Ok(imported);
+        }
+    }
+
+    if artifact.artifact_type == "directory" {
+        if let Some(bytes) = bundle.artifact_bytes.iter().find(|bytes| {
+            bytes.artifact_id == artifact.id
+                && bytes.archive_format.as_deref() == Some("zip")
+                && artifact.path == bundle_artifact_uri(&bytes.path)
+        }) {
+            let extracted = extract_directory_artifact_archive(input, bytes)?;
+            let mut imported = artifact.clone();
+            imported.path = extracted.to_string_lossy().to_string();
+            imported.sha256 = Some(bytes.sha256.clone());
+            imported.size_bytes = Some(bytes.size_bytes);
+            return Ok(imported);
         }
     }
 
     if !matches!(artifact.artifact_type.as_str(), "file" | "directory") {
-        return artifact.clone();
+        return Ok(artifact.clone());
     }
     let mut imported = artifact.clone();
     imported.artifact_type = "metadata-only".to_string();
     imported.path = portable_artifact_label(&artifact.path, &artifact.id);
-    imported
+    Ok(imported)
 }
 
 fn portable_artifact_label(path: &str, fallback: &str) -> String {
@@ -435,31 +453,15 @@ fn portable_bundle_artifact_record(
                     Some(format!("read artifact bytes {}", source_path.display())),
                 )
             })?;
-            let sha256 = format!("{:x}", Sha256::digest(&bytes));
-            let size_bytes = i64::try_from(bytes.len()).map_err(|_| {
-                Error::internal_unexpected(format!(
-                    "artifact {} is too large to record a portable size",
-                    artifact.id
-                ))
-            })?;
-            let path = format!("artifact-bytes/{}", portable_artifact_file_name(&artifact));
-            let mut portable = artifact;
-            portable.path = bundle_artifact_uri(&path);
-            portable.sha256 = Some(sha256.clone());
-            portable.size_bytes = Some(size_bytes);
-            portable.metadata_json =
-                with_bundle_byte_metadata(portable.metadata_json, &path, &sha256, size_bytes);
-            let artifact_id = portable.id.clone();
-            return Ok((
-                portable,
-                Some(ObservationBundleArtifactBytes {
-                    artifact_id,
-                    path,
-                    sha256,
-                    size_bytes,
-                    source_path: Some(source_path),
-                }),
-            ));
+            return portable_artifact_with_bytes(artifact, bytes, None, None);
+        }
+    }
+
+    if artifact.artifact_type == "directory" {
+        let source_path = PathBuf::from(&artifact.path);
+        if source_path.is_dir() {
+            let bytes = zip_directory_artifact(&source_path)?;
+            return portable_artifact_with_bytes(artifact, bytes, Some("zip"), Some(".zip"));
         }
     }
 
@@ -473,6 +475,49 @@ fn portable_bundle_artifact_record(
         .artifacts
         .metadata_only_ref(&portable_artifact_label(&portable.path, &portable.id));
     Ok((portable, None))
+}
+
+fn portable_artifact_with_bytes(
+    artifact: ArtifactRecord,
+    bytes: Vec<u8>,
+    archive_format: Option<&str>,
+    extension: Option<&str>,
+) -> homeboy::core::Result<(ArtifactRecord, Option<ObservationBundleArtifactBytes>)> {
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let size_bytes = i64::try_from(bytes.len()).map_err(|_| {
+        Error::internal_unexpected(format!(
+            "artifact {} is too large to record a portable size",
+            artifact.id
+        ))
+    })?;
+    let mut file_name = portable_artifact_file_name(&artifact);
+    if let Some(extension) = extension {
+        file_name.push_str(extension);
+    }
+    let path = format!("artifact-bytes/{file_name}");
+    let mut portable = artifact;
+    portable.path = bundle_artifact_uri(&path);
+    portable.sha256 = Some(sha256.clone());
+    portable.size_bytes = Some(size_bytes);
+    portable.metadata_json = with_bundle_byte_metadata(
+        portable.metadata_json,
+        &path,
+        &sha256,
+        size_bytes,
+        archive_format,
+    );
+    let artifact_id = portable.id.clone();
+    Ok((
+        portable,
+        Some(ObservationBundleArtifactBytes {
+            artifact_id,
+            path,
+            sha256,
+            size_bytes,
+            archive_format: archive_format.map(str::to_string),
+            source_bytes: Some(bytes),
+        }),
+    ))
 }
 
 fn portable_artifact_file_name(artifact: &ArtifactRecord) -> String {
@@ -507,6 +552,7 @@ fn with_bundle_byte_metadata(
     path: &str,
     sha256: &str,
     size_bytes: i64,
+    archive_format: Option<&str>,
 ) -> serde_json::Value {
     let mut object = match metadata {
         serde_json::Value::Object(object) => object,
@@ -517,14 +563,15 @@ fn with_bundle_byte_metadata(
             object
         }
     };
-    object.insert(
-        "portable_bundle".to_string(),
-        serde_json::json!({
-            "byte_ref": path,
-            "sha256": sha256,
-            "size_bytes": size_bytes,
-        }),
-    );
+    let mut portable_bundle = serde_json::json!({
+        "byte_ref": path,
+        "sha256": sha256,
+        "size_bytes": size_bytes,
+    });
+    if let Some(archive_format) = archive_format {
+        portable_bundle["archive_format"] = serde_json::Value::String(archive_format.to_string());
+    }
+    object.insert("portable_bundle".to_string(), portable_bundle);
     serde_json::Value::Object(object)
 }
 
@@ -628,7 +675,7 @@ fn write_artifact_bytes(
     artifact_bytes: &[ObservationBundleArtifactBytes],
 ) -> homeboy::core::Result<()> {
     for bytes in artifact_bytes {
-        let Some(source_path) = bytes.source_path.as_ref() else {
+        let Some(source_bytes) = bytes.source_bytes.as_ref() else {
             continue;
         };
         let output = bundle_dir.join(&bytes.path);
@@ -640,18 +687,195 @@ fn write_artifact_bytes(
                 )
             })?;
         }
-        fs::copy(source_path, &output).map_err(|e| {
+        fs::write(&output, source_bytes).map_err(|e| {
             Error::internal_io(
                 e.to_string(),
-                Some(format!(
-                    "copy artifact bytes {} to {}",
-                    source_path.display(),
-                    output.display()
-                )),
+                Some(format!("write artifact bytes {}", output.display())),
             )
         })?;
     }
     Ok(())
+}
+
+fn zip_directory_artifact(path: &Path) -> homeboy::core::Result<Vec<u8>> {
+    let mut cursor = Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut cursor);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        for file in sorted_directory_files(path)? {
+            let relative = file.strip_prefix(path).map_err(|error| {
+                Error::internal_unexpected(format!(
+                    "failed to compute relative path for {}: {}",
+                    file.display(),
+                    error
+                ))
+            })?;
+            let relative = relative.to_string_lossy().replace('\\', "/");
+            zip.start_file(relative, options).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("archive directory artifact {}", path.display())),
+                )
+            })?;
+            let bytes = fs::read(&file).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read directory artifact file {}", file.display())),
+                )
+            })?;
+            zip.write_all(&bytes).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!(
+                        "write directory artifact archive {}",
+                        path.display()
+                    )),
+                )
+            })?;
+        }
+        zip.finish().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "finish directory artifact archive {}",
+                    path.display()
+                )),
+            )
+        })?;
+    }
+    Ok(cursor.into_inner())
+}
+
+fn sorted_directory_files(path: &Path) -> homeboy::core::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_directory_files(path, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_directory_files(path: &Path, files: &mut Vec<PathBuf>) -> homeboy::core::Result<()> {
+    for entry in fs::read_dir(path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read directory artifact {}", path.display())),
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read directory artifact entry {}", path.display())),
+            )
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "read directory artifact entry type {}",
+                    entry.path().display()
+                )),
+            )
+        })?;
+        if file_type.is_dir() {
+            collect_directory_files(&entry.path(), files)?;
+        } else if file_type.is_file() {
+            files.push(entry.path());
+        }
+    }
+    Ok(())
+}
+
+fn extract_directory_artifact_archive(
+    bundle_dir: &Path,
+    bytes: &ObservationBundleArtifactBytes,
+) -> homeboy::core::Result<PathBuf> {
+    let archive = bundle_dir.join(&bytes.path);
+    let output = bundle_dir.join(format!("{}-contents", bytes.path.trim_end_matches(".zip")));
+    fs::create_dir_all(&output).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "create extracted artifact directory {}",
+                output.display()
+            )),
+        )
+    })?;
+    let file = fs::File::open(&archive).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "open directory artifact archive {}",
+                archive.display()
+            )),
+        )
+    })?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| {
+        Error::validation_invalid_argument(
+            "artifact_bytes",
+            format!("directory artifact archive is not a valid zip: {error}"),
+            Some(bytes.path.clone()),
+            None,
+        )
+    })?;
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read directory artifact archive entry {index}")),
+            )
+        })?;
+        let Some(name) = entry.enclosed_name().map(Path::to_path_buf) else {
+            return Err(Error::validation_invalid_argument(
+                "artifact_bytes",
+                "directory artifact archive contains an unsafe path",
+                Some(bytes.path.clone()),
+                None,
+            ));
+        };
+        let target = output.join(name);
+        if entry.is_dir() {
+            fs::create_dir_all(&target).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!(
+                        "create artifact archive directory {}",
+                        target.display()
+                    )),
+                )
+            })?;
+            continue;
+        }
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!(
+                        "create artifact archive parent {}",
+                        parent.display()
+                    )),
+                )
+            })?;
+        }
+        let mut output_file = fs::File::create(&target).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "create extracted artifact file {}",
+                    target.display()
+                )),
+            )
+        })?;
+        std::io::copy(&mut entry, &mut output_file).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "extract artifact archive file {}",
+                    target.display()
+                )),
+            )
+        })?;
+    }
+    Ok(output)
 }
 
 fn validate_artifact_bytes(

--- a/src/commands/runs/bundle_import_tests.rs
+++ b/src/commands/runs/bundle_import_tests.rs
@@ -257,6 +257,95 @@ fn runs_export_import_preserves_file_artifact_bytes_with_checksum_refs() {
     });
 }
 
+#[test]
+fn runs_export_import_preserves_directory_artifact_as_checksumed_archive() {
+    let bundle_root = tempfile::tempdir().expect("bundle root");
+    let bundle = bundle_root.path().join("directory-bundle");
+    let mut exported_run_id = String::new();
+    let mut exported_sha256 = None;
+    let mut exported_size_bytes = None;
+
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run("fuzz", "homeboy", "rig-a", Value::Null))
+            .expect("run");
+        exported_run_id = run.id.clone();
+
+        let artifact_dir = home.path().join("fuzz-artifacts");
+        std::fs::create_dir_all(artifact_dir.join("cases")).expect("artifact dir");
+        std::fs::write(
+            artifact_dir.join("cases/case-1.json"),
+            br#"{"id":"case-1"}"#,
+        )
+        .expect("case file");
+        std::fs::write(artifact_dir.join("summary.txt"), "portable directory").expect("summary");
+        store
+            .record_directory_artifact(&run.id, "fuzz_artifacts", &artifact_dir)
+            .expect("directory artifact");
+
+        let (output, exit) = export_runs(RunsExportArgs {
+            run: Some(run.id.clone()),
+            since: None,
+            output: bundle.clone(),
+        })
+        .expect("export");
+        assert_eq!(exit, 0);
+        let RunsOutput::Export(exported) = output else {
+            panic!("expected export output");
+        };
+        assert_eq!(exported.artifact_count, 1);
+        assert_eq!(exported.artifact_byte_count, 1);
+
+        let artifacts: Vec<ArtifactRecord> = read_bundle_test_json(&bundle.join("artifacts.json"));
+        assert_eq!(artifacts[0].artifact_type, "directory");
+        assert!(artifacts[0].path.starts_with("bundle://artifact-bytes/"));
+        assert_eq!(
+            artifacts[0].metadata_json["portable_bundle"]["archive_format"].as_str(),
+            Some("zip")
+        );
+
+        let artifact_bytes: Vec<Value> = read_bundle_test_json(&bundle.join("artifact_bytes.json"));
+        assert_eq!(artifact_bytes.len(), 1);
+        assert_eq!(artifact_bytes[0]["archive_format"].as_str(), Some("zip"));
+        let byte_ref = artifact_bytes[0]["path"].as_str().expect("byte path");
+        assert!(bundle.join(byte_ref).is_file());
+        exported_sha256 = artifact_bytes[0]["sha256"].as_str().map(str::to_string);
+        exported_size_bytes = artifact_bytes[0]["size_bytes"].as_i64();
+        assert!(exported_size_bytes.is_some_and(|size| size > 0));
+    });
+
+    with_isolated_home(|_| {
+        let _xdg = XdgGuard::unset();
+        import_runs(RunsImportArgs {
+            input: Some(bundle.clone()),
+            ..RunsImportArgs::default()
+        })
+        .expect("import");
+        let store = ObservationStore::open_initialized().expect("store");
+        let imported_artifact = store
+            .list_artifacts(&exported_run_id)
+            .expect("artifacts")
+            .into_iter()
+            .next()
+            .expect("artifact");
+        assert_eq!(imported_artifact.artifact_type, "directory");
+        assert_eq!(imported_artifact.sha256, exported_sha256);
+        assert_eq!(imported_artifact.size_bytes, exported_size_bytes);
+        let imported_dir = Path::new(&imported_artifact.path);
+        assert!(imported_dir.is_dir());
+        assert_eq!(
+            std::fs::read_to_string(imported_dir.join("summary.txt")).expect("summary"),
+            "portable directory"
+        );
+        assert_eq!(
+            std::fs::read(imported_dir.join("cases/case-1.json")).expect("case"),
+            br#"{"id":"case-1"}"#
+        );
+    });
+}
+
 fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
     NewRunRecord::builder(kind)
         .component_id(component_id)


### PR DESCRIPTION
## Summary
- Resolve fuzz replay/minimize artifacts from persisted run evidence when `--run-id` is provided without an artifact path.
- Export directory artifacts in observation bundles as checksumed zip archive bytes and rehydrate them as directory artifacts on import.
- Document run-backed replay/minimize and portable directory bundle behavior.

## Tests
- `cargo test commands::fuzz::tests::replay_tests`
- `cargo test commands::runs::bundle_import_tests`
- `cargo test --test command_surface_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, documentation, and PR preparation.