### PR TITLE
Add generic fuzz sequence plan handoff

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -5,10 +5,10 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 ## Synopsis
 
 ```bash
-homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
-homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
+homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
+homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
-homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>]
+homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>]
 homeboy fuzz validate <results-file>
 homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--output-envelope <path>]
 homeboy fuzz compare <baseline-envelope> <candidate-envelope> [--hotspot-policy <advisory|blocking|off>]
@@ -189,6 +189,38 @@ validates and embeds the policy without implementing downstream exploration.
   "replay_seed_ref": "seed:stable-1",
   "corpus_refs": ["corpus:generic-fixture"],
   "invariants": ["resource.integrity"]
+}
+```
+
+`homeboy fuzz plan --sequence-plan <path>` and `homeboy fuzz run --sequence-plan
+<path>` accept a `homeboy/fuzz-sequence-plan/v1` JSON contract. This is an
+explicit handoff for the exact generated sequence identity produced by an
+extension or external generator. Homeboy validates the schema/version and embeds
+the plan in the `homeboy/fuzz-execution-request/v1` request; `fuzz run` also
+exposes the normalized run-directory copy to runners as
+`HOMEBOY_FUZZ_SEQUENCE_PLAN_FILE` and persists it as a `fuzz_sequence_plan` run artifact. Homeboy core
+does not generate product actions or interpret product-specific step semantics.
+
+```json
+{
+  "schema": "homeboy/fuzz-sequence-plan/v1",
+  "version": 1,
+  "id": "sequence-plan-123",
+  "cases": [
+    {
+      "id": "case-1",
+      "target_id": "target-1",
+      "operation_id": "operation-1",
+      "steps": [
+        {
+          "id": "step-1",
+          "kind": "exercise",
+          "operation_id": "operation-1",
+          "input": { "value": 1 }
+        }
+      ]
+    }
+  ]
 }
 ```
 

--- a/src/commands/fuzz/compare.rs
+++ b/src/commands/fuzz/compare.rs
@@ -1018,6 +1018,7 @@ mod tests {
                 required_artifacts: default_fuzz_required_artifacts(),
                 gates: default_fuzz_gates(),
                 sampling: Default::default(),
+                sequence_plan: None,
                 isolation_proof: None,
                 metadata: serde_json::Value::Null,
                 extra: BTreeMap::new(),

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -12,15 +12,15 @@ use homeboy::core::extension::{self, ExtensionCapability, ExtensionRunner, FuzzC
 use homeboy::core::fuzz::{
     fuzz_gate_profile_contract, parse_fuzz_results_file, FuzzArtifact, FuzzCampaign,
     FuzzCoverageReconciliation, FuzzExecutionRequest, FuzzFindingStatus, FuzzGateProfile,
-    FuzzSamplingRequest, FuzzTargetInventory, FUZZ_CONTRACT_VERSION,
-    FUZZ_COVERAGE_RECONCILIATION_SCHEMA, FUZZ_EXECUTION_REQUEST_SCHEMA,
+    FuzzSamplingRequest, FuzzSequencePlan, FuzzTargetInventory, FUZZ_CONTRACT_VERSION,
+    FUZZ_COVERAGE_RECONCILIATION_SCHEMA, FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_SEQUENCE_PLAN_SCHEMA,
 };
 use homeboy::core::lifecycle::LifecyclePhaseStatus;
 use homeboy::core::observation::{ObservationStore, RunRecord, RunStatus};
 use homeboy::core::rig::{self, FuzzPrepareReport, RigSpec};
 use uuid::Uuid;
 
-use super::planning::plan_inventory_selection;
+use super::planning::{load_sequence_plan, plan_inventory_selection, with_sequence_plan_metadata};
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates_for_profile, fuzz_coverage_completeness,
     fuzz_result_envelope_evidence_ref, fuzz_result_envelope_from_campaign, gate_status,
@@ -101,6 +101,8 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         workload_id.clone(),
         &target_inventory,
     )?;
+    let sequence_plan_path =
+        persist_fuzz_sequence_plan(&run_dir, execution_request.sequence_plan.as_ref())?;
     let execution_request_path = persist_fuzz_execution_request(&run_dir, &execution_request)?;
     let runner_output = run_fuzz_extension_script(
         &ctx,
@@ -110,6 +112,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         invocation_requirements,
         &run_dir,
         &execution_request_path,
+        sequence_plan_path.as_deref(),
     )?;
     let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
     let artifacts_dir =
@@ -164,6 +167,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         success,
         args: &args,
         execution_request_path: Some(&execution_request_path),
+        sequence_plan_path: sequence_plan_path.as_deref(),
         results_path: &results_path,
         artifacts_dir: &artifacts_dir,
         results: results.as_ref(),
@@ -192,6 +196,10 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
             seed: args.seed.clone(),
             inventory_file: args
                 .inventory
+                .clone()
+                .map(|path| path.to_string_lossy().to_string()),
+            sequence_plan_file: args
+                .sequence_plan
                 .clone()
                 .map(|path| path.to_string_lossy().to_string()),
             max_duration: args.max_duration.clone(),
@@ -726,6 +734,7 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) success: bool,
     pub(super) args: &'a FuzzRunArgs,
     pub(super) execution_request_path: Option<&'a Path>,
+    pub(super) sequence_plan_path: Option<&'a Path>,
     pub(super) results_path: &'a Path,
     pub(super) artifacts_dir: &'a Path,
     pub(super) results: Option<&'a FuzzCampaign>,
@@ -759,6 +768,7 @@ pub(super) fn persist_fuzz_run_evidence(
         "max_duration": input.args.max_duration.clone(),
         "passthrough_args": input.args.args.clone(),
         "execution_request_file": input.execution_request_path.map(|path| path.to_string_lossy().to_string()),
+        "sequence_plan_file": input.sequence_plan_path.map(|path| path.to_string_lossy().to_string()),
         "tracker_refs": input.args.tracker_refs,
         "exit_code": input.exit_code,
         "success": input.success,
@@ -818,6 +828,19 @@ pub(super) fn persist_fuzz_run_evidence(
                 serde_json::json!({
                     "schema": FUZZ_EXECUTION_REQUEST_SCHEMA,
                     "source": "HOMEBOY_FUZZ_EXECUTION_REQUEST_FILE",
+                }),
+            )?;
+        }
+    }
+    if let Some(sequence_plan_path) = input.sequence_plan_path {
+        if sequence_plan_path.is_file() {
+            store.record_artifact_with_metadata(
+                &run_id,
+                "fuzz_sequence_plan",
+                sequence_plan_path,
+                serde_json::json!({
+                    "schema": FUZZ_SEQUENCE_PLAN_SCHEMA,
+                    "source": "--sequence-plan",
                 }),
             )?;
         }
@@ -1097,6 +1120,12 @@ fn fuzz_run_command(
     if let Some(seed) = args.seed.as_ref() {
         parts.extend(["--seed".to_string(), seed.clone()]);
     }
+    if let Some(sequence_plan) = args.sequence_plan.as_ref() {
+        parts.extend([
+            "--sequence-plan".to_string(),
+            sequence_plan.to_string_lossy().to_string(),
+        ]);
+    }
     if let Some(max_duration) = args.max_duration.as_ref() {
         parts.extend(["--max-duration".to_string(), max_duration.clone()]);
     }
@@ -1157,6 +1186,7 @@ pub(super) fn fuzz_runner_contract(config: Option<&FuzzConfig>) -> FuzzRunnerCon
     let mut env: Vec<String> = [
         "HOMEBOY_FUZZ_RESULTS_FILE",
         "HOMEBOY_FUZZ_EXECUTION_REQUEST_FILE",
+        "HOMEBOY_FUZZ_SEQUENCE_PLAN_FILE",
         "HOMEBOY_FUZZ_ARTIFACTS_DIR",
         "HOMEBOY_FUZZ_WORKLOAD_ID",
         "HOMEBOY_FUZZ_WORKLOAD_PATH",
@@ -1204,6 +1234,7 @@ fn run_fuzz_extension_script(
     invocation_requirements: InvocationRequirements,
     run_dir: &RunDir,
     execution_request_path: &Path,
+    sequence_plan_path: Option<&Path>,
 ) -> homeboy::core::Result<homeboy::core::extension::RunnerOutput> {
     let execution_context =
         extension::resolve_execution_context(&ctx.component, ExtensionCapability::Fuzz)?;
@@ -1239,6 +1270,7 @@ fn run_fuzz_extension_script(
         &results_path,
         run_dir,
         Some(execution_request_path),
+        sequence_plan_path,
     )?;
     for (key, value) in env {
         runner = runner.env(&key, &value);
@@ -1301,6 +1333,7 @@ pub(super) fn fuzz_runner_env(
     results_path: &Path,
     run_dir: &RunDir,
     execution_request_path: Option<&Path>,
+    sequence_plan_path: Option<&Path>,
 ) -> homeboy::core::Result<Vec<(String, String)>> {
     let mut env = vec![(
         "HOMEBOY_FUZZ_RESULTS_FILE".to_string(),
@@ -1344,6 +1377,12 @@ pub(super) fn fuzz_runner_env(
             path.to_string_lossy().to_string(),
         ));
     }
+    if let Some(path) = sequence_plan_path.or(args.sequence_plan.as_deref()) {
+        env.push((
+            "HOMEBOY_FUZZ_SEQUENCE_PLAN_FILE".to_string(),
+            path.to_string_lossy().to_string(),
+        ));
+    }
     push_opt_env(
         &mut env,
         "HOMEBOY_FUZZ_MAX_DURATION",
@@ -1381,6 +1420,26 @@ pub(super) fn persist_fuzz_execution_request(
     Ok(path)
 }
 
+pub(super) fn persist_fuzz_sequence_plan(
+    run_dir: &RunDir,
+    plan: Option<&FuzzSequencePlan>,
+) -> homeboy::core::Result<Option<PathBuf>> {
+    let Some(plan) = plan else {
+        return Ok(None);
+    };
+    let path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_SEQUENCE_PLAN);
+    let raw = serde_json::to_vec_pretty(plan).map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some("serialize fuzz sequence plan".to_string()),
+        )
+    })?;
+    std::fs::write(&path, raw).map_err(|error| {
+        homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+    })?;
+    Ok(Some(path))
+}
+
 pub(super) fn build_fuzz_execution_request(
     args: &FuzzRunArgs,
     component_id: &str,
@@ -1400,8 +1459,14 @@ pub(super) fn build_fuzz_execution_request(
         exploration_policy: None,
     };
     let isolation_proof = super::planning::load_isolation_proof(args.isolation_proof.as_deref())?;
+    let sequence_plan = load_sequence_plan(args.sequence_plan.as_deref())?;
     let mut metadata =
         plan_inventory_selection(&plan_args, target_inventory, isolation_proof.as_ref())?;
+    metadata = with_sequence_plan_metadata(
+        metadata,
+        args.sequence_plan.as_deref(),
+        sequence_plan.as_ref(),
+    )?;
     if let Some(object) = metadata.as_object_mut() {
         object.insert(
             "target_inventory".to_string(),
@@ -1446,6 +1511,7 @@ pub(super) fn build_fuzz_execution_request(
         required_artifacts,
         gates,
         sampling,
+        sequence_plan,
         isolation_proof,
         metadata,
         extra: std::collections::BTreeMap::new(),

--- a/src/commands/fuzz/planning.rs
+++ b/src/commands/fuzz/planning.rs
@@ -3,10 +3,10 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use homeboy::core::fuzz::{
     fuzz_gate_profile_contract, parse_fuzz_action_model_file, parse_fuzz_exploration_policy_file,
-    FuzzExecutionRequest, FuzzOperation, FuzzOperationFamily, FuzzSafetyClass,
-    FuzzSamplingCorpusRef, FuzzSamplingReplayDeterminism, FuzzSamplingRequest, FuzzSamplingStratum,
-    FuzzTargetInventory, IsolationProof, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
-    FUZZ_SAMPLING_REQUEST_SCHEMA,
+    parse_fuzz_sequence_plan_file, FuzzExecutionRequest, FuzzOperation, FuzzOperationFamily,
+    FuzzSafetyClass, FuzzSamplingCorpusRef, FuzzSamplingReplayDeterminism, FuzzSamplingRequest,
+    FuzzSamplingStratum, FuzzTargetInventory, IsolationProof, FUZZ_CONTRACT_VERSION,
+    FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_SAMPLING_REQUEST_SCHEMA, FUZZ_SEQUENCE_PLAN_SCHEMA,
 };
 
 use super::execution::fuzz_runner_contract;
@@ -61,8 +61,14 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
         args.run.inventory.as_deref(),
     )?;
     let isolation_proof = load_isolation_proof(args.run.isolation_proof.as_deref())?;
+    let sequence_plan = load_sequence_plan(args.run.sequence_plan.as_deref())?;
     let planning_metadata =
         plan_inventory_selection(&args, &target_inventory, isolation_proof.as_ref())?;
+    let planning_metadata = with_sequence_plan_metadata(
+        planning_metadata,
+        args.run.sequence_plan.as_deref(),
+        sequence_plan.as_ref(),
+    )?;
     let sampling: FuzzSamplingRequest = serde_json::from_value(
         planning_metadata
             .get("sampling")
@@ -97,6 +103,7 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
             required_artifacts,
             gates,
             sampling,
+            sequence_plan,
             isolation_proof,
             metadata: planning_metadata,
             extra: std::collections::BTreeMap::new(),
@@ -104,6 +111,39 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
         runner_contract: fuzz_runner_contract(fuzz_config.as_ref()),
     })
 }
+
+pub(super) fn load_sequence_plan(
+    path: Option<&std::path::Path>,
+) -> homeboy::core::Result<Option<homeboy::core::fuzz::FuzzSequencePlan>> {
+    path.map(parse_fuzz_sequence_plan_file).transpose()
+}
+
+pub(super) fn with_sequence_plan_metadata(
+    mut metadata: serde_json::Value,
+    path: Option<&std::path::Path>,
+    plan: Option<&homeboy::core::fuzz::FuzzSequencePlan>,
+) -> homeboy::core::Result<serde_json::Value> {
+    let Some(plan) = plan else {
+        return Ok(metadata);
+    };
+    if !metadata.is_object() {
+        metadata = serde_json::json!({});
+    }
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert(
+            "sequence_plan_ref".to_string(),
+            serde_json::json!({
+                "schema": FUZZ_SEQUENCE_PLAN_SCHEMA,
+                "id": plan.id,
+                "path": path.map(|path| path.to_string_lossy().to_string()),
+                "case_count": plan.cases.len(),
+                "source": "--sequence-plan"
+            }),
+        );
+    }
+    Ok(metadata)
+}
+
 pub(super) fn plan_inventory_selection(
     args: &FuzzPlanArgs,
     inventory: &FuzzTargetInventory,

--- a/src/commands/fuzz/report.rs
+++ b/src/commands/fuzz/report.rs
@@ -156,6 +156,7 @@ pub(super) fn fuzz_result_envelope_from_campaign(
                 },
                 ..Default::default()
             },
+            sequence_plan: None,
             isolation_proof: None,
             metadata: serde_json::Value::Null,
             extra: std::collections::BTreeMap::new(),

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -25,6 +25,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             }],
             seed: Some("1234".to_string()),
             inventory: None,
+            sequence_plan: None,
             require_case_log: false,
             require_coverage_summary: false,
             require_result_envelope: false,
@@ -52,6 +53,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             success: true,
             args: &args,
             execution_request_path: None,
+            sequence_plan_path: None,
             results_path: &results_path,
             artifacts_dir: &artifacts_dir,
             results: None,
@@ -140,6 +142,7 @@ fn fuzz_execution_request_artifact_records_runner_intent() {
             &results_path,
             &run_dir,
             Some(&request_path),
+            None,
         )
         .expect("runner env");
 
@@ -195,6 +198,7 @@ fn fuzz_execution_request_artifact_records_runner_intent() {
             success: true,
             args: &args,
             execution_request_path: Some(&request_path),
+            sequence_plan_path: None,
             results_path: &results_path,
             artifacts_dir: &artifacts_dir,
             results: None,
@@ -244,6 +248,141 @@ fn fuzz_execution_request_rejects_destructive_without_isolation_proof() {
     .expect_err("missing isolation proof should fail");
 
     assert!(error.to_string().contains("homeboy/isolation-proof/v1"));
+}
+
+#[test]
+fn fuzz_sequence_plan_flag_records_request_env_and_artifact() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let sequence_plan_path = run_dir.step_file("caller-sequence-plan.json");
+        std::fs::write(
+            &sequence_plan_path,
+            serde_json::json!({
+                "schema": "homeboy/fuzz-sequence-plan/v1",
+                "version": 1,
+                "id": "plan-123",
+                "cases": [{
+                    "id": "case-1",
+                    "target_id": "target-1",
+                    "operation_id": "operation-1",
+                    "steps": [{
+                        "id": "step-1",
+                        "kind": "exercise",
+                        "operation_id": "operation-1",
+                        "input": { "value": 1 }
+                    }]
+                }]
+            })
+            .to_string(),
+        )
+        .expect("sequence plan file");
+        let parsed = FuzzCli::try_parse_from([
+            "fuzz",
+            "run",
+            "component-a",
+            "--run-id",
+            "proof-sequence",
+            "--sequence-plan",
+            sequence_plan_path.to_str().expect("utf8 path"),
+        ])
+        .expect("parse fuzz run cli");
+        let Some(FuzzCommand::Run(mut args)) = parsed.args.command else {
+            panic!("expected fuzz run args");
+        };
+        args.rig = Some("package-fuzz".to_string());
+        args.workload_id = Some("parser".to_string());
+
+        let request = build_fuzz_execution_request(
+            &args,
+            "component-a",
+            args.rig.as_deref(),
+            args.workload_id.clone(),
+            &planner_inventory(),
+        )
+        .expect("execution request");
+        assert_eq!(
+            request.sequence_plan.as_ref().expect("sequence plan").id,
+            "plan-123"
+        );
+        assert_eq!(
+            request.metadata["sequence_plan_ref"]["schema"],
+            "homeboy/fuzz-sequence-plan/v1"
+        );
+        assert_eq!(request.metadata["sequence_plan_ref"]["case_count"], 1);
+
+        let request_path = persist_fuzz_execution_request(&run_dir, &request).expect("request");
+        let persisted_plan_path =
+            persist_fuzz_sequence_plan(&run_dir, request.sequence_plan.as_ref())
+                .expect("persist sequence plan")
+                .expect("sequence plan path");
+        let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
+        let artifacts_dir =
+            run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_ARTIFACTS_DIR);
+        std::fs::write(&results_path, "{}").expect("results file");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
+
+        let env = fuzz_runner_env(
+            &args,
+            None,
+            None,
+            &results_path,
+            &run_dir,
+            Some(&request_path),
+            Some(&persisted_plan_path),
+        )
+        .expect("runner env");
+        assert!(env.contains(&(
+            "HOMEBOY_FUZZ_SEQUENCE_PLAN_FILE".to_string(),
+            persisted_plan_path.to_string_lossy().to_string()
+        )));
+
+        persist_fuzz_run_evidence(FuzzRunEvidenceInput {
+            run_id: args.run_id.as_deref(),
+            component_id: "component-a",
+            rig_id: args.rig.as_deref(),
+            workload_id: args.workload_id.as_deref(),
+            workload_path: Some("/tmp/fuzz/parser.json"),
+            status: "passed",
+            exit_code: 0,
+            success: true,
+            args: &args,
+            execution_request_path: Some(&request_path),
+            sequence_plan_path: Some(&persisted_plan_path),
+            results_path: &results_path,
+            artifacts_dir: &artifacts_dir,
+            results: None,
+            expected_metric_gates: &[],
+            results_error: None,
+            missing_artifact_refs: &[],
+            postprocess: &[],
+        })
+        .expect("persist fuzz run");
+
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .get_run("proof-sequence")
+            .expect("get run")
+            .expect("run record");
+        assert_eq!(
+            run.metadata_json["sequence_plan_file"],
+            persisted_plan_path.to_string_lossy().to_string()
+        );
+        let artifacts = store.list_artifacts("proof-sequence").expect("artifacts");
+        let sequence_artifact = artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "fuzz_sequence_plan")
+            .expect("sequence plan artifact");
+        assert_eq!(sequence_artifact.artifact_type, "file");
+        assert_eq!(
+            sequence_artifact.metadata_json["schema"],
+            "homeboy/fuzz-sequence-plan/v1"
+        );
+        let persisted_plan: FuzzSequencePlan = serde_json::from_str(
+            &std::fs::read_to_string(&sequence_artifact.path).expect("read sequence artifact"),
+        )
+        .expect("parse persisted plan");
+        assert_eq!(persisted_plan.id, "plan-123");
+    });
 }
 
 #[test]
@@ -308,6 +447,7 @@ fn fuzz_run_persists_coverage_reconciliation_artifact() {
             success: true,
             args: &args,
             execution_request_path: Some(&request_path),
+            sequence_plan_path: None,
             results_path: &results_path,
             artifacts_dir: &artifacts_dir,
             results: Some(&campaign),
@@ -382,6 +522,7 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
             success: true,
             args: &args,
             execution_request_path: None,
+            sequence_plan_path: None,
             results_path: &results_path,
             artifacts_dir: &artifacts_dir,
             results: None,
@@ -432,6 +573,7 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
             success: true,
             args: &args,
             execution_request_path: None,
+            sequence_plan_path: None,
             results_path: &results_path,
             artifacts_dir: &artifacts_dir,
             results: Some(&campaign),
@@ -951,6 +1093,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             tracker_refs: vec![],
             seed: None,
             inventory: None,
+            sequence_plan: None,
             require_case_log: false,
             require_coverage_summary: false,
             require_result_envelope: false,
@@ -982,6 +1125,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             success: false,
             args: &args,
             execution_request_path: None,
+            sequence_plan_path: None,
             results_path: &results_path,
             artifacts_dir: &artifacts_dir,
             results: None,

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -6,7 +6,8 @@ use super::execution::{
     fuzz_campaign_contract, fuzz_evidence_followups, fuzz_expected_metric_error, fuzz_max_duration,
     fuzz_postprocess_error, fuzz_run_artifact_validation_error, fuzz_run_outcome,
     fuzz_runner_contract, fuzz_runner_env, persist_fuzz_execution_request,
-    persist_fuzz_run_evidence, run_fuzz_artifact_postprocess, FuzzRunEvidenceInput,
+    persist_fuzz_run_evidence, persist_fuzz_sequence_plan, run_fuzz_artifact_postprocess,
+    FuzzRunEvidenceInput,
 };
 use super::planning::plan_inventory_selection;
 use super::replay::{run_minimize, run_replay};
@@ -30,7 +31,7 @@ use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::FuzzConfig;
 use homeboy::core::fuzz::{
     FuzzCampaign, FuzzCase, FuzzCoverageSkip, FuzzCoverageSummary, FuzzExecutionRequest,
-    FuzzFinding, FuzzFindingStatus, FuzzTargetInventory, IsolationProof,
+    FuzzFinding, FuzzFindingStatus, FuzzSequencePlan, FuzzTargetInventory, IsolationProof,
 };
 use homeboy::core::lifecycle::{
     LifecyclePhaseKind, LifecyclePhaseResult, LifecyclePhaseStatus, LifecycleResultMetadata,
@@ -89,6 +90,7 @@ fn planner_args() -> FuzzPlanArgs {
             tracker_refs: vec![],
             seed: None,
             inventory: None,
+            sequence_plan: None,
             require_case_log: false,
             require_coverage_summary: false,
             require_result_envelope: false,
@@ -277,6 +279,7 @@ fn fuzz_run_args_with_run_id(run_id: &str) -> FuzzRunArgs {
         tracker_refs: vec![],
         seed: Some("1234".to_string()),
         inventory: None,
+        sequence_plan: None,
         require_case_log: false,
         require_coverage_summary: false,
         require_result_envelope: false,

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -731,6 +731,7 @@ fn fuzz_output_contract_has_stable_variant_discriminators() {
         run_id: None,
         seed: None,
         inventory_file: None,
+        sequence_plan_file: None,
         max_duration: None,
         passthrough_args: Vec::new(),
         requested_settings: serde_json::Value::Null,

--- a/src/commands/fuzz/tests/report_tests.rs
+++ b/src/commands/fuzz/tests/report_tests.rs
@@ -35,6 +35,7 @@ fn fuzz_output_contract_includes_results_file_and_parsed_campaign() {
         run_id: None,
         seed: None,
         inventory_file: None,
+        sequence_plan_file: None,
         max_duration: None,
         passthrough_args: Vec::new(),
         requested_settings: serde_json::Value::Null,

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -118,6 +118,7 @@ fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_cont
         tracker_refs: vec![],
         seed: Some("1234".to_string()),
         inventory: Some(PathBuf::from("/tmp/fuzz-inventory.json")),
+        sequence_plan: None,
         require_case_log: false,
         require_coverage_summary: false,
         require_result_envelope: false,
@@ -149,6 +150,7 @@ fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_cont
         &results_path,
         &run_dir,
         Some(&execution_request_path),
+        None,
     )
     .expect("fuzz runner env");
 
@@ -291,6 +293,7 @@ fn fuzz_runner_env_expands_rig_workload_and_injects_runtime_context() {
         tracker_refs: vec![],
         seed: None,
         inventory: None,
+        sequence_plan: None,
         require_case_log: false,
         require_coverage_summary: false,
         require_result_envelope: false,
@@ -324,6 +327,7 @@ fn fuzz_runner_env_expands_rig_workload_and_injects_runtime_context() {
         Some(&workload),
         &results_path,
         &run_dir,
+        None,
         None,
     )
     .expect("fuzz runner env");

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -176,6 +176,10 @@ pub struct FuzzRunArgs {
     #[arg(long = "inventory", value_name = "PATH")]
     pub(crate) inventory: Option<PathBuf>,
 
+    /// Exact generated generic sequence plan JSON (`homeboy/fuzz-sequence-plan/v1`) to hand to the runner.
+    #[arg(long = "sequence-plan", value_name = "PATH")]
+    pub(crate) sequence_plan: Option<PathBuf>,
+
     /// Fail the run unless the campaign links case-level execution evidence.
     #[arg(long = "require-case-log")]
     pub(crate) require_case_log: bool,

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -159,6 +159,7 @@ pub struct FuzzRunOutput {
     pub run_id: Option<String>,
     pub seed: Option<String>,
     pub inventory_file: Option<String>,
+    pub sequence_plan_file: Option<String>,
     pub max_duration: Option<String>,
     pub passthrough_args: Vec<String>,
     pub requested_settings: serde_json::Value,

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -40,6 +40,7 @@ pub mod files {
     pub const BENCH_RESPONSIVENESS: &str = "bench-responsiveness.jsonl";
     pub const FUZZ_RESULTS: &str = "fuzz-results.json";
     pub const FUZZ_EXECUTION_REQUEST: &str = "fuzz-execution-request.json";
+    pub const FUZZ_SEQUENCE_PLAN: &str = "fuzz-sequence-plan.json";
     pub const FUZZ_COVERAGE_RECONCILIATION: &str = "fuzz-coverage-reconciliation.json";
     pub const FUZZ_ARTIFACTS_DIR: &str = "fuzz-artifacts";
     pub const TRACE_RESULTS: &str = "trace.json";

--- a/src/core/fuzz/envelope.rs
+++ b/src/core/fuzz/envelope.rs
@@ -13,7 +13,9 @@ use super::schema_defaults::{
     fuzz_target_inventory_schema, isolation_proof_schema,
 };
 use super::schemas::{FUZZ_CONTRACT_VERSION, FUZZ_TARGET_INVENTORY_SCHEMA, ISOLATION_PROOF_SCHEMA};
-use super::types::{FuzzCampaign, FuzzSeed, FuzzSurface, FuzzTarget, FuzzWorkload};
+use super::types::{
+    FuzzCampaign, FuzzSeed, FuzzSequencePlan, FuzzSurface, FuzzTarget, FuzzWorkload,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FuzzTargetInventory {
@@ -100,6 +102,8 @@ pub struct FuzzExecutionRequest {
     pub gates: Vec<FuzzGate>,
     #[serde(default)]
     pub sampling: FuzzSamplingRequest,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sequence_plan: Option<FuzzSequencePlan>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub isolation_proof: Option<IsolationProof>,
     #[serde(default, skip_serializing_if = "Value::is_null")]

--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -55,7 +55,7 @@ pub use observations::{
 pub use parse::{
     merge_fuzz_target_inventory, parse_fuzz_action_model_file, parse_fuzz_case_log_contents,
     parse_fuzz_case_log_file, parse_fuzz_exploration_policy_file, parse_fuzz_result_envelope_file,
-    parse_fuzz_results_file, parse_fuzz_target_inventory_file,
+    parse_fuzz_results_file, parse_fuzz_sequence_plan_file, parse_fuzz_target_inventory_file,
 };
 pub use schemas::{
     standardized_fuzz_skip_reason_codes, FUZZ_ACTION_MODEL_SCHEMA, FUZZ_ARTIFACT_SCHEMA,

--- a/src/core/fuzz/parse.rs
+++ b/src/core/fuzz/parse.rs
@@ -8,7 +8,9 @@ use crate::core::{Error, Result};
 
 use super::envelope::{FuzzResultEnvelope, FuzzTargetInventory};
 use super::schemas::{FUZZ_CAMPAIGN_SCHEMA, FUZZ_RESULT_ENVELOPE_SCHEMA};
-use super::types::{FuzzActionModel, FuzzCampaign, FuzzCaseLogEntry, FuzzExplorationPolicy};
+use super::types::{
+    FuzzActionModel, FuzzCampaign, FuzzCaseLogEntry, FuzzExplorationPolicy, FuzzSequencePlan,
+};
 
 pub fn parse_fuzz_results_file(path: &Path) -> Result<FuzzCampaign> {
     let contents = std::fs::read_to_string(path)
@@ -187,6 +189,26 @@ pub fn parse_fuzz_exploration_policy_file(path: &Path) -> Result<FuzzExploration
     FuzzExplorationPolicy::from_value(value).map_err(|message| {
         Error::validation_invalid_argument(
             "exploration_policy",
+            message,
+            Some(path.display().to_string()),
+            None,
+        )
+    })
+}
+
+pub fn parse_fuzz_sequence_plan_file(path: &Path) -> Result<FuzzSequencePlan> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+    let value: Value = serde_json::from_str(&contents).map_err(|err| {
+        Error::validation_invalid_json(
+            err,
+            Some(format!("parse fuzz sequence plan file {}", path.display())),
+            Some(contents.clone()),
+        )
+    })?;
+    FuzzSequencePlan::from_value(value).map_err(|message| {
+        Error::validation_invalid_argument(
+            "sequence_plan",
             message,
             Some(path.display().to_string()),
             None,


### PR DESCRIPTION
## Summary
- Add `--sequence-plan <path>` to generic `fuzz plan` / `fuzz run` inputs via the existing `homeboy/fuzz-sequence-plan/v1` contract.
- Validate and embed the exact sequence plan in `homeboy/fuzz-execution-request/v1` without generating product actions in Homeboy core.
- Persist the normalized plan as a `fuzz_sequence_plan` artifact and hand runners `HOMEBOY_FUZZ_SEQUENCE_PLAN_FILE`.
- Document the generic handoff and add public CLI/request/env/artifact tests.

## Tests
- `cargo test fuzz` passed.
- `cargo test` ran and failed in unrelated existing/environment-sensitive tests: `command_contract::safety_manifest::tests::suspicious_command_paths_require_safety_classification`, `commands::infra::route::tests::explicit_runner_for_changed_scope_test_is_lab_portable`, `commands::infra::route::tests::linked_local_rig_check_stays_local_without_runner`, `commands::runs::corpus_tests::bundle_import_marks_file_artifacts_metadata_only_and_query_reports_skip`, `commands::runs::tests::export_import::export_artifacts_is_metadata_only`, `core::agent_task_lifecycle::tests::cancel_run_signals_live_running_record`, `core::code_audit::entry::audit_runtime_regression_test::audit_runtime_regression_matches_snapshot`, and `core::refactor::plan::generate::module_surface::tests::build_uses_snapshot_content_for_module_surfaces`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing the generic fuzz sequence-plan handoff, tests, docs, and PR preparation.