### PR TITLE
Add generic relative hotspot dimensions

### DIFF
--- a/src/core/fuzz/hotspots.rs
+++ b/src/core/fuzz/hotspots.rs
@@ -58,11 +58,15 @@ impl FuzzHotspotSet {
 pub struct FuzzHotspot {
     pub id: String,
     pub dimension: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dimensions: Vec<FuzzHotspotDimension>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     pub metric: String,
     pub value: f64,
     pub unit: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub metrics: Vec<FuzzHotspotMetric>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub basis: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -93,12 +97,18 @@ impl FuzzHotspot {
     fn normalize(&mut self) -> std::result::Result<(), String> {
         self.id = required_trimmed("hotspot.id", &self.id)?;
         self.dimension = required_trimmed("hotspot.dimension", &self.dimension)?;
+        for dimension in &mut self.dimensions {
+            dimension.normalize(&self.id)?;
+        }
         self.kind = normalize_optional_string(self.kind.take());
         self.metric = required_trimmed("hotspot.metric", &self.metric)?;
         if !self.value.is_finite() {
             return Err(format!("hotspot.value must be finite for `{}`", self.id));
         }
         self.unit = required_trimmed("hotspot.unit", &self.unit)?;
+        for metric in &mut self.metrics {
+            metric.normalize(&self.id)?;
+        }
         self.basis = normalize_optional_string(self.basis.take());
         if let Some(relative_score) = self.relative_score {
             if !relative_score.is_finite() {
@@ -113,6 +123,80 @@ impl FuzzHotspot {
         self.evidence_refs = normalize_string_vec(std::mem::take(&mut self.evidence_refs));
         self.artifact_refs = normalize_string_vec(std::mem::take(&mut self.artifact_refs));
         self.source_refs = normalize_string_vec(std::mem::take(&mut self.source_refs));
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FuzzHotspotDimension {
+    pub name: String,
+    pub value: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl FuzzHotspotDimension {
+    fn normalize(&mut self, hotspot_id: &str) -> std::result::Result<(), String> {
+        self.name = required_trimmed("hotspot.dimension.name", &self.name)
+            .map_err(|err| format!("{err} for `{hotspot_id}`"))?;
+        self.value = required_trimmed("hotspot.dimension.value", &self.value)
+            .map_err(|err| format!("{err} for `{hotspot_id}`"))?;
+        self.kind = normalize_optional_string(self.kind.take());
+        self.label = normalize_optional_string(self.label.take());
+        self.labels = normalize_string_vec(std::mem::take(&mut self.labels));
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FuzzHotspotMetric {
+    pub name: String,
+    pub value: f64,
+    pub unit: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub basis: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rank: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relative_score: Option<f64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl FuzzHotspotMetric {
+    fn normalize(&mut self, hotspot_id: &str) -> std::result::Result<(), String> {
+        self.name = required_trimmed("hotspot.metric.name", &self.name)
+            .map_err(|err| format!("{err} for `{hotspot_id}`"))?;
+        if !self.value.is_finite() {
+            return Err(format!(
+                "hotspot.metric.value must be finite for `{hotspot_id}`"
+            ));
+        }
+        self.unit = required_trimmed("hotspot.metric.unit", &self.unit)
+            .map_err(|err| format!("{err} for `{hotspot_id}`"))?;
+        self.basis = normalize_optional_string(self.basis.take());
+        if let Some(relative_score) = self.relative_score {
+            if !relative_score.is_finite() {
+                return Err(format!(
+                    "hotspot.metric.relative_score must be finite for `{hotspot_id}`"
+                ));
+            }
+        }
+        self.labels = normalize_string_vec(std::mem::take(&mut self.labels));
         Ok(())
     }
 }
@@ -194,10 +278,12 @@ fn hotspot_from_observation(observation: &FuzzObservation) -> FuzzHotspot {
             .join(":")
         }),
         dimension,
+        dimensions: observation_dimensions(observation),
         kind: Some("observation".to_string()),
         metric: observation.metric.clone(),
         value: observation.value,
         unit: observation.unit.clone(),
+        metrics: Vec::new(),
         basis: Some("fuzz_observation_set".to_string()),
         sample_count: observation.sample_count,
         rank: None,
@@ -211,6 +297,34 @@ fn hotspot_from_observation(observation: &FuzzObservation) -> FuzzHotspot {
         metadata: observation.metadata.clone(),
         extra: observation.extra.clone(),
     }
+}
+
+fn observation_dimensions(observation: &FuzzObservation) -> Vec<FuzzHotspotDimension> {
+    [
+        (
+            "family",
+            Some(observation_family_dimension(observation.family)),
+        ),
+        ("subject", Some(observation.subject.as_str())),
+        ("case", observation.case_id.as_deref()),
+        ("target", observation.target_id.as_deref()),
+        ("operation", observation.operation_id.as_deref()),
+        ("phase", observation.phase.as_deref()),
+        ("fingerprint", observation.fingerprint.as_deref()),
+    ]
+    .into_iter()
+    .filter_map(|(name, value)| {
+        value.map(|value| FuzzHotspotDimension {
+            name: name.to_string(),
+            value: value.to_string(),
+            kind: None,
+            label: None,
+            labels: Vec::new(),
+            metadata: Value::Null,
+            extra: BTreeMap::new(),
+        })
+    })
+    .collect()
 }
 
 fn observation_family_dimension(family: FuzzObservationFamily) -> &'static str {

--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -47,7 +47,8 @@ pub use envelope::{
     FuzzTargetInventory, IsolationProof,
 };
 pub use hotspots::{
-    parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots, FuzzHotspot, FuzzHotspotSet,
+    parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots, FuzzHotspot,
+    FuzzHotspotDimension, FuzzHotspotMetric, FuzzHotspotSet,
 };
 pub use observations::{
     parse_fuzz_observation_set_value, FuzzObservation, FuzzObservationFamily, FuzzObservationSet,

--- a/src/core/fuzz/tests/hotspot_tests.rs
+++ b/src/core/fuzz/tests/hotspot_tests.rs
@@ -1,8 +1,9 @@
 use serde_json::json;
 
 use crate::core::fuzz::{
-    parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots, FuzzObservationSet,
-    FUZZ_HOTSPOT_SET_SCHEMA, FUZZ_OBSERVATION_SET_SCHEMA,
+    parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots, FuzzHotspot,
+    FuzzHotspotDimension, FuzzHotspotMetric, FuzzHotspotSet, FuzzObservationSet,
+    FUZZ_CONTRACT_VERSION, FUZZ_HOTSPOT_SET_SCHEMA, FUZZ_OBSERVATION_SET_SCHEMA,
 };
 
 #[test]
@@ -17,10 +18,27 @@ fn parses_typed_hotspot_set_from_result_envelope_metadata() {
                 {
                     "id": "action:checkout",
                     "dimension": "action",
+                    "dimensions": [
+                        { "name": "operation", "value": "checkout" },
+                        { "name": "storage_target", "value": "orders", "kind": "collection" },
+                        { "name": "cache_target", "value": "product-prices", "kind": "keyspace" },
+                        { "name": "query_fingerprint", "value": "read-items-by-owner" },
+                        { "name": "write_amplification", "value": "line-item-fanout" },
+                        { "name": "duplicate_work_group", "value": "totals-recalculation" },
+                        { "name": "task_unit", "value": "post-submit-handler" },
+                        { "name": "page_screen", "value": "checkout" },
+                        { "name": "browser_step", "value": "submit-order" },
+                        { "name": "extension_label", "value": "provider-specific-bucket" }
+                    ],
                     "kind": "handler",
                     "metric": "duration",
                     "value": 481.5,
                     "unit": "ms",
+                    "metrics": [
+                        { "name": "duration", "value": 481.5, "unit": "ms", "relative_score": 0.98 },
+                        { "name": "write_amplification", "value": 8, "unit": "writes_per_action" },
+                        { "name": "cache_miss_rate", "value": 0.42, "unit": "ratio" }
+                    ],
                     "basis": "p95_per_case",
                     "sample_count": 144,
                     "rank": 1,
@@ -41,10 +59,19 @@ fn parses_typed_hotspot_set_from_result_envelope_metadata() {
     assert_eq!(set.items.len(), 1);
     assert_eq!(set.items[0].id, "action:checkout");
     assert_eq!(set.items[0].dimension, "action");
+    assert_eq!(set.items[0].dimensions.len(), 10);
+    assert_eq!(set.items[0].dimensions[1].name, "storage_target");
+    assert_eq!(
+        set.items[0].dimensions[1].kind.as_deref(),
+        Some("collection")
+    );
     assert_eq!(set.items[0].kind.as_deref(), Some("handler"));
     assert_eq!(set.items[0].metric, "duration");
     assert_eq!(set.items[0].value, 481.5);
     assert_eq!(set.items[0].unit, "ms");
+    assert_eq!(set.items[0].metrics.len(), 3);
+    assert_eq!(set.items[0].metrics[0].name, "duration");
+    assert_eq!(set.items[0].metrics[0].relative_score, Some(0.98));
     assert_eq!(set.items[0].basis.as_deref(), Some("p95_per_case"));
     assert_eq!(set.items[0].sample_count, Some(144));
     assert_eq!(set.items[0].rank, Some(1));
@@ -52,6 +79,89 @@ fn parses_typed_hotspot_set_from_result_envelope_metadata() {
     assert_eq!(set.items[0].labels, vec!["production", "p95"]);
     assert_eq!(set.items[0].evidence_refs, vec!["case-log:case-1"]);
     assert_eq!(set.items[0].artifact_refs, vec!["profile.json"]);
+}
+
+#[test]
+fn serializes_generic_hotspot_dimensions_metrics_and_labels_without_gate_fields() {
+    let set = FuzzHotspotSet {
+        schema: FUZZ_HOTSPOT_SET_SCHEMA.to_string(),
+        version: FUZZ_CONTRACT_VERSION,
+        id: "rich-hotspots".to_string(),
+        label: None,
+        items: vec![FuzzHotspot {
+            id: "operation:checkout".to_string(),
+            dimension: "operation".to_string(),
+            dimensions: vec![
+                dimension("operation", "checkout"),
+                dimension("query_fingerprint", "fetch-related-items"),
+                dimension("storage_target", "items"),
+                dimension("cache_target", "price-cache"),
+                dimension("write_amplification", "metadata-fanout"),
+                dimension("duplicate_work_group", "recalculate-summary"),
+                dimension("task_unit", "submit-handler"),
+                dimension("page_screen", "checkout"),
+                dimension("browser_step", "place-order"),
+                dimension("extension_label", "runtime-owned-label"),
+            ],
+            kind: Some("relative_hotspot".to_string()),
+            metric: "duration".to_string(),
+            value: 42.0,
+            unit: "ms".to_string(),
+            metrics: vec![
+                metric("duration", 42.0, "ms"),
+                metric("duplicate_work", 6.0, "count"),
+                metric("writes_per_operation", 3.5, "ratio"),
+            ],
+            basis: Some("relative_rank".to_string()),
+            sample_count: Some(12),
+            rank: Some(1),
+            relative_score: Some(1.0),
+            label: Some("Checkout operation".to_string()),
+            labels: vec!["production".to_string(), "candidate".to_string()],
+            evidence_refs: Vec::new(),
+            artifact_refs: Vec::new(),
+            source_refs: Vec::new(),
+            provenance: None,
+            metadata: serde_json::Value::Null,
+            extra: Default::default(),
+        }],
+        provenance: None,
+        metadata: serde_json::Value::Null,
+        extra: Default::default(),
+    };
+
+    let serialized = serde_json::to_value(&set).expect("serialize hotspot set");
+    let parsed = parse_fuzz_hotspot_set_value(&serialized).expect("parse serialized hotspot set");
+
+    assert_eq!(parsed, set);
+    assert!(serialized.pointer("/items/0/dimensions").is_some());
+    assert!(serialized.pointer("/items/0/metrics").is_some());
+    assert_no_nested_gate_fields(&serialized);
+}
+
+#[test]
+fn preserves_minimal_hotspot_artifact_compatibility() {
+    let minimal = json!({
+        "schema": FUZZ_HOTSPOT_SET_SCHEMA,
+        "id": "legacy-hotspots",
+        "items": [
+            {
+                "id": "action:save",
+                "dimension": "action",
+                "metric": "duration",
+                "value": 12.0,
+                "unit": "ms"
+            }
+        ]
+    });
+
+    let set = parse_fuzz_hotspot_set_value(&minimal).expect("minimal hotspot set");
+    let serialized = serde_json::to_value(&set).expect("serialize minimal hotspot set");
+
+    assert!(set.items[0].dimensions.is_empty());
+    assert!(set.items[0].metrics.is_empty());
+    assert!(serialized.pointer("/items/0/dimensions").is_none());
+    assert!(serialized.pointer("/items/0/metrics").is_none());
 }
 
 #[test]
@@ -66,6 +176,28 @@ fn rejects_invalid_hotspot_metric_values() {
                 "metric": "duration",
                 "value": "not-a-number",
                 "unit": "ms"
+            }
+        ]
+    });
+
+    assert!(parse_fuzz_hotspot_set_value(&invalid).is_none());
+}
+
+#[test]
+fn rejects_invalid_nested_hotspot_metric_values() {
+    let invalid = json!({
+        "schema": FUZZ_HOTSPOT_SET_SCHEMA,
+        "id": "hotspots",
+        "items": [
+            {
+                "id": "action:slow",
+                "dimension": "action",
+                "metric": "duration",
+                "value": 10,
+                "unit": "ms",
+                "metrics": [
+                    { "name": "cache_miss_rate", "value": "not-a-number", "unit": "ratio" }
+                ]
             }
         ]
     });
@@ -99,7 +231,11 @@ fn ranks_observation_set_hotspots_deterministically() {
                 "metric": "duration",
                 "value": 25.0,
                 "unit": "ms",
-                "fingerprint": "query-a:duration"
+                "fingerprint": "query-a:duration",
+                "operation_id": "read-items",
+                "target_id": "items-store",
+                "case_id": "catalog-page",
+                "phase": "load"
             },
             {
                 "id": "counter-spike",
@@ -136,4 +272,62 @@ fn ranks_observation_set_hotspots_deterministically() {
     assert_eq!(hotspots.items[2].rank, Some(3));
     assert_eq!(hotspots.items[2].relative_score, Some(0.5));
     assert_eq!(hotspots.items[2].evidence_refs, vec!["slow-query"]);
+    assert_eq!(hotspots.items[2].dimensions[0].name, "family");
+    assert_eq!(hotspots.items[2].dimensions[0].value, "query");
+    assert!(hotspots.items[2]
+        .dimensions
+        .iter()
+        .any(|dimension| dimension.name == "operation" && dimension.value == "read-items"));
+    assert!(hotspots.items[2]
+        .dimensions
+        .iter()
+        .any(|dimension| dimension.name == "target" && dimension.value == "items-store"));
+}
+
+fn dimension(name: &str, value: &str) -> FuzzHotspotDimension {
+    FuzzHotspotDimension {
+        name: name.to_string(),
+        value: value.to_string(),
+        kind: None,
+        label: None,
+        labels: Vec::new(),
+        metadata: serde_json::Value::Null,
+        extra: Default::default(),
+    }
+}
+
+fn metric(name: &str, value: f64, unit: &str) -> FuzzHotspotMetric {
+    FuzzHotspotMetric {
+        name: name.to_string(),
+        value,
+        unit: unit.to_string(),
+        basis: None,
+        sample_count: None,
+        rank: None,
+        relative_score: None,
+        labels: Vec::new(),
+        metadata: serde_json::Value::Null,
+        extra: Default::default(),
+    }
+}
+
+fn assert_no_nested_gate_fields(value: &serde_json::Value) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for (key, value) in object {
+                assert_ne!(key, "threshold");
+                assert_ne!(key, "budget");
+                assert_ne!(key, "status");
+                assert_ne!(key, "passed");
+                assert_ne!(key, "failed");
+                assert_no_nested_gate_fields(value);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                assert_no_nested_gate_fields(item);
+            }
+        }
+        _ => {}
+    }
 }


### PR DESCRIPTION
## Summary
- Add optional generic hotspot dimensions and nested metric observations to the fuzz hotspot artifact contract.
- Preserve existing minimal hotspot artifacts by defaulting and omitting empty dimensions/metrics.
- Carry observation family/subject/case/target/operation/phase/fingerprint into derived hotspot dimensions for richer relative ranking inputs.

## Testing
- `rustfmt --check src/core/fuzz/hotspots.rs src/core/fuzz/mod.rs src/core/fuzz/tests/hotspot_tests.rs`
- `cargo test core::fuzz::tests::hotspot_tests`
- `cargo test core::fuzz::tests::cohort_tests`
- `cargo test commands::runs::hotspots`
- `cargo test --test core_agnostic_test` fails on existing unrelated core-boundary baseline debt outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted and tested the hotspot artifact contract changes and PR description.