### PR TITLE
Report relative fuzz hotspot convergence

### DIFF
--- a/src/core/fuzz/cohorts.rs
+++ b/src/core/fuzz/cohorts.rs
@@ -2,6 +2,10 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 
+use super::FuzzHotspotSet;
+
+const CONVERGENCE_TOP_WINDOW: usize = 3;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct FuzzHotspotCohortItem {
     pub key: String,
@@ -17,12 +21,24 @@ pub struct FuzzHotspotCohortComparison {
     pub baseline_id: String,
     pub candidate_id: String,
     pub item_count: usize,
+    pub baseline_drift: FuzzHotspotCohortBaselineDrift,
     pub new_items: usize,
     pub resolved_items: usize,
     pub increased_items: usize,
     pub decreased_items: usize,
     pub unchanged_items: usize,
+    pub collapsed_top_items: Vec<String>,
+    pub emerging_top_items: Vec<String>,
     pub items: Vec<FuzzHotspotCohortDelta>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct FuzzHotspotCohortBaselineDrift {
+    pub baseline_score_total: f64,
+    pub candidate_score_total: f64,
+    pub score_total_delta: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score_total_relative_delta: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -37,6 +53,8 @@ pub struct FuzzHotspotCohortDelta {
     pub candidate_score: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score_delta: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relative_score_delta: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relative_lift: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -53,6 +71,18 @@ pub struct FuzzHotspotCohortDelta {
     pub baseline_run_count: usize,
     pub candidate_run_count: usize,
     pub run_count_delta: i64,
+}
+
+pub fn compare_fuzz_hotspot_sets(
+    baseline: &FuzzHotspotSet,
+    candidate: &FuzzHotspotSet,
+) -> FuzzHotspotCohortComparison {
+    compare_fuzz_hotspot_cohorts(
+        baseline.id.clone(),
+        candidate.id.clone(),
+        &cohort_items_from_hotspot_set(baseline),
+        &cohort_items_from_hotspot_set(candidate),
+    )
 }
 
 pub fn compare_fuzz_hotspot_cohorts(
@@ -107,10 +137,40 @@ pub fn compare_fuzz_hotspot_cohorts(
             .then_with(|| a.key.cmp(&b.key))
     });
 
+    let baseline_score_total = baseline.iter().map(|item| item.score).sum::<f64>();
+    let candidate_score_total = candidate.iter().map(|item| item.score).sum::<f64>();
+    let score_total_delta = candidate_score_total - baseline_score_total;
+    let score_total_relative_delta =
+        (baseline_score_total != 0.0).then_some(score_total_delta / baseline_score_total.abs());
+    let collapsed_top_items = items
+        .iter()
+        .filter(|item| {
+            item.baseline_rank
+                .is_some_and(|rank| rank <= CONVERGENCE_TOP_WINDOW)
+        })
+        .filter(|item| item.change_kind == "resolved" || item.change_kind == "decreased")
+        .map(|item| item.key.clone())
+        .collect::<Vec<_>>();
+    let emerging_top_items = items
+        .iter()
+        .filter(|item| {
+            item.candidate_rank
+                .is_some_and(|rank| rank <= CONVERGENCE_TOP_WINDOW)
+        })
+        .filter(|item| item.change_kind == "new" || item.change_kind == "increased")
+        .map(|item| item.key.clone())
+        .collect::<Vec<_>>();
+
     FuzzHotspotCohortComparison {
         baseline_id: baseline_id.into(),
         candidate_id: candidate_id.into(),
         item_count: items.len(),
+        baseline_drift: FuzzHotspotCohortBaselineDrift {
+            baseline_score_total,
+            candidate_score_total,
+            score_total_delta,
+            score_total_relative_delta,
+        },
         new_items: items
             .iter()
             .filter(|item| item.change_kind == "new")
@@ -131,8 +191,25 @@ pub fn compare_fuzz_hotspot_cohorts(
             .iter()
             .filter(|item| item.change_kind == "unchanged")
             .count(),
+        collapsed_top_items,
+        emerging_top_items,
         items,
     }
+}
+
+fn cohort_items_from_hotspot_set(set: &FuzzHotspotSet) -> Vec<FuzzHotspotCohortItem> {
+    set.items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| FuzzHotspotCohortItem {
+            key: item.id.clone(),
+            label: item.label.clone(),
+            score: item.relative_score.unwrap_or(item.value),
+            occurrences: item.sample_count.unwrap_or(1),
+            run_count: 1,
+            rank: item.rank.unwrap_or(index as u64 + 1) as usize,
+        })
+        .collect()
 }
 
 fn cohort_delta(
@@ -177,6 +254,7 @@ fn cohort_delta(
         baseline_score,
         candidate_score,
         score_delta,
+        relative_score_delta: score_delta,
         relative_lift,
         normalized_score_delta,
         baseline_rank: before.map(|item| item.rank),

--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -25,8 +25,8 @@ pub use artifact_envelope::{
     FuzzResultEnvelopeArtifactSummary,
 };
 pub use cohorts::{
-    compare_fuzz_hotspot_cohorts, FuzzHotspotCohortComparison, FuzzHotspotCohortDelta,
-    FuzzHotspotCohortItem,
+    compare_fuzz_hotspot_cohorts, compare_fuzz_hotspot_sets, FuzzHotspotCohortBaselineDrift,
+    FuzzHotspotCohortComparison, FuzzHotspotCohortDelta, FuzzHotspotCohortItem,
 };
 pub use contract::{
     canonical_operation_family, fuzz_core_contract, FuzzContractSchemas, FuzzCoreContract,

--- a/src/core/fuzz/tests/hotspot_tests.rs
+++ b/src/core/fuzz/tests/hotspot_tests.rs
@@ -1,8 +1,8 @@
 use serde_json::json;
 
 use crate::core::fuzz::{
-    parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots, FuzzObservationSet,
-    FUZZ_HOTSPOT_SET_SCHEMA, FUZZ_OBSERVATION_SET_SCHEMA,
+    compare_fuzz_hotspot_sets, parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots,
+    FuzzHotspotSet, FuzzObservationSet, FUZZ_HOTSPOT_SET_SCHEMA, FUZZ_OBSERVATION_SET_SCHEMA,
 };
 
 #[test]
@@ -136,4 +136,121 @@ fn ranks_observation_set_hotspots_deterministically() {
     assert_eq!(hotspots.items[2].rank, Some(3));
     assert_eq!(hotspots.items[2].relative_score, Some(0.5));
     assert_eq!(hotspots.items[2].evidence_refs, vec!["slow-query"]);
+}
+
+#[test]
+fn compares_fixture_hotspot_sets_for_relative_convergence() {
+    let baseline = FuzzHotspotSet::from_value(json!({
+        "schema": FUZZ_HOTSPOT_SET_SCHEMA,
+        "version": 1,
+        "id": "baseline-hotspots",
+        "items": [
+            {
+                "id": "route:checkout",
+                "dimension": "route",
+                "metric": "duration",
+                "value": 900.0,
+                "unit": "ms",
+                "rank": 1,
+                "relative_score": 1.0,
+                "label": "Checkout route"
+            },
+            {
+                "id": "route:search",
+                "dimension": "route",
+                "metric": "duration",
+                "value": 450.0,
+                "unit": "ms",
+                "rank": 2,
+                "relative_score": 0.5,
+                "label": "Search route"
+            },
+            {
+                "id": "route:account",
+                "dimension": "route",
+                "metric": "duration",
+                "value": 225.0,
+                "unit": "ms",
+                "rank": 3,
+                "relative_score": 0.25,
+                "label": "Account route"
+            }
+        ]
+    }))
+    .expect("baseline hotspot set");
+    let candidate = FuzzHotspotSet::from_value(json!({
+        "schema": FUZZ_HOTSPOT_SET_SCHEMA,
+        "version": 1,
+        "id": "candidate-hotspots",
+        "items": [
+            {
+                "id": "route:search",
+                "dimension": "route",
+                "metric": "duration",
+                "value": 400.0,
+                "unit": "ms",
+                "rank": 1,
+                "relative_score": 1.0,
+                "label": "Search route"
+            },
+            {
+                "id": "route:checkout",
+                "dimension": "route",
+                "metric": "duration",
+                "value": 120.0,
+                "unit": "ms",
+                "rank": 2,
+                "relative_score": 0.3,
+                "label": "Checkout route"
+            },
+            {
+                "id": "route:feed",
+                "dimension": "route",
+                "metric": "duration",
+                "value": 100.0,
+                "unit": "ms",
+                "rank": 3,
+                "relative_score": 0.25,
+                "label": "Feed route"
+            }
+        ]
+    }))
+    .expect("candidate hotspot set");
+
+    let comparison = compare_fuzz_hotspot_sets(&baseline, &candidate);
+
+    assert_eq!(comparison.baseline_drift.baseline_score_total, 1.75);
+    assert_eq!(comparison.baseline_drift.candidate_score_total, 1.55);
+    assert!((comparison.baseline_drift.score_total_delta + 0.2).abs() < f64::EPSILON);
+    assert_eq!(comparison.new_items, 1);
+    assert_eq!(comparison.resolved_items, 1);
+    assert_eq!(
+        comparison.collapsed_top_items,
+        vec!["route:account", "route:checkout"]
+    );
+    assert_eq!(
+        comparison.emerging_top_items,
+        vec!["route:feed", "route:search"]
+    );
+
+    let checkout = comparison
+        .items
+        .iter()
+        .find(|item| item.key == "route:checkout")
+        .expect("checkout delta");
+    assert_eq!(checkout.change_kind, "decreased");
+    assert_eq!(checkout.rank_movement, Some(-1));
+    assert_eq!(checkout.relative_score_delta, Some(-0.7));
+
+    let feed = comparison
+        .items
+        .iter()
+        .find(|item| item.key == "route:feed")
+        .expect("emerging delta");
+    assert_eq!(feed.change_kind, "new");
+    assert_eq!(feed.candidate_rank, Some(3));
+
+    let serialized = serde_json::to_value(&comparison).expect("serialize comparison");
+    assert!(serialized.get("threshold").is_none());
+    assert!(serialized.get("status").is_none());
 }


### PR DESCRIPTION
## Summary
- Add generic fuzz hotspot set comparison output for baseline drift, collapsed top hotspots, and emerging top hotspots.
- Preserve relative ranking and score movement as measurement output without threshold/gate semantics.
- Add fixture hotspot-set coverage for convergence reporting.

## Tests
- cargo test core::fuzz::tests
- cargo test commands::runs::hotspots

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing generic fuzz hotspot convergence reporting, fixture tests, and PR preparation.