### PR TITLE
Clarify blocked controller backend status

### DIFF
--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -215,6 +215,13 @@ pub struct AgentTaskControllerPlanArgs {
 pub struct AgentTaskControllerStatusArgs {
     /// Durable loop id returned by `agent-task controller init`.
     pub loop_id: String,
+
+    /// Optional repo loop spec JSON, @file, or - to compare against persisted controller state.
+    #[arg(long, value_name = "SPEC")]
+    pub spec: Option<String>,
+
+    #[command(flatten)]
+    pub dispatch: AgentTaskControllerDispatchArgs,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -4,7 +4,8 @@
 use serde_json::Value;
 
 use homeboy::core::agent_task_controller_service::{
-    build_run_failure_summary, init_from_spec_for_resume_with_resolution,
+    build_run_failure_summary, controller_spec_fingerprint_for_status,
+    init_from_spec_for_resume_with_resolution, spec_fingerprint_for_status,
     ControllerResumeStateResolution,
 };
 use homeboy::core::agent_task_loop_definition::{
@@ -31,8 +32,9 @@ use super::args::{
     AgentTaskControllerDispatchArgs, AgentTaskControllerFromSpecArgs,
     AgentTaskControllerMaterializeArgs, AgentTaskControllerPlanArgs, AgentTaskControllerProofArgs,
     AgentTaskControllerRunArgs, AgentTaskControllerRunFromSpecArgs, AgentTaskControllerRunNextArgs,
-    AgentTaskControllerValidateProofArgs, AgentTaskLoopArgs, AgentTaskLoopCommand,
-    AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs, AgentTaskLoopStatusArgs,
+    AgentTaskControllerStatusArgs, AgentTaskControllerValidateProofArgs, AgentTaskLoopArgs,
+    AgentTaskLoopCommand, AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs,
+    AgentTaskLoopStatusArgs,
 };
 use super::command_json_value;
 
@@ -56,21 +58,24 @@ pub(super) fn controller(args: AgentTaskControllerArgs) -> CmdResult<Value> {
         }
         AgentTaskControllerCommand::Plan(plan_args) => controller_plan(plan_args),
         AgentTaskControllerCommand::Status(status_args) => {
-            let report = homeboy::core::agent_tasks::loop_controller::controller_status_report(
-                &status_args.loop_id,
-            )?;
-            Ok((command_json_value(report)?, 0))
+            let value = controller_status_report_value(status_args)?;
+            Ok((command_json_value(value)?, 0))
         }
         AgentTaskControllerCommand::Diagnose(status_args) => {
-            let report = homeboy::core::agent_tasks::loop_controller::controller_status_report(
-                &status_args.loop_id,
-            )?;
+            let report = controller_status_report_value(status_args)?;
+            let loop_id = report["controller"]["loop_id"]
+                .as_str()
+                .unwrap_or("<loop-id>");
             Ok((
                 command_json_value(serde_json::json!({
                     "schema": "homeboy/agent-task-loop-controller-diagnose-result/v1",
-                    "loop_id": status_args.loop_id,
-                    "failed_child_actions": report.diagnostics.failed_child_actions,
-                    "next_command": format!("homeboy agent-task controller status {}", status_args.loop_id),
+                    "loop_id": loop_id,
+                    "controller_state": report["diagnostics"]["controller_state"].clone(),
+                    "relevant_action": report["diagnostics"]["relevant_action"].clone(),
+                    "requested_context": report["diagnostics"]["requested_context"].clone(),
+                    "failed_child_actions": report["diagnostics"]["failed_child_actions"].clone(),
+                    "next_commands": report["diagnostics"]["next_commands"].clone(),
+                    "next_command": format!("homeboy agent-task controller status {}", loop_id),
                 }))?,
                 0,
             ))
@@ -95,6 +100,108 @@ pub(super) fn controller(args: AgentTaskControllerArgs) -> CmdResult<Value> {
         }
         AgentTaskControllerCommand::Proof(proof_args) => controller_proof(proof_args),
     }
+}
+
+fn controller_status_report_value(
+    args: AgentTaskControllerStatusArgs,
+) -> homeboy::core::Result<Value> {
+    let report =
+        homeboy::core::agent_tasks::loop_controller::controller_status_report(&args.loop_id)?;
+    let mut value = serde_json::to_value(report)
+        .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
+    if args.spec.is_some()
+        || args.dispatch.dispatch_backend.is_some()
+        || args.dispatch.dispatch_selector.is_some()
+        || args.dispatch.dispatch_model.is_some()
+        || args.dispatch.dispatch_provider_config.is_some()
+    {
+        let requested = requested_controller_status_context(&value, &args)?;
+        if let Some(diagnostics) = value.get_mut("diagnostics").and_then(Value::as_object_mut) {
+            diagnostics.insert("requested_context".to_string(), requested);
+        }
+    }
+    Ok(value)
+}
+
+fn requested_controller_status_context(
+    report: &Value,
+    args: &AgentTaskControllerStatusArgs,
+) -> homeboy::core::Result<Value> {
+    let persisted_spec_fingerprint = report.get("controller").and_then(|controller| {
+        serde_json::from_value(controller.clone())
+            .ok()
+            .and_then(|record| controller_spec_fingerprint_for_status(&record))
+    });
+    let requested_spec_fingerprint = if let Some(spec_source) = &args.spec {
+        let raw = config::read_json_spec_to_string(spec_source)?;
+        let spec: AgentTaskRepoLoopSpec = serde_json::from_str(&raw).map_err(|error| {
+            homeboy::core::Error::validation_invalid_argument(
+                "spec",
+                error.to_string(),
+                Some(spec_source.to_string()),
+                None,
+            )
+        })?;
+        Some(spec_fingerprint_for_status(&spec)?)
+    } else {
+        None
+    };
+    let persisted_executor = report
+        .pointer("/diagnostics/relevant_action/selected_executor")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let requested_executor = serde_json::json!({
+        "backend": args.dispatch.dispatch_backend,
+        "selector": args.dispatch.dispatch_selector,
+        "model": args.dispatch.dispatch_model,
+        "provider_config_summary": requested_provider_config_summary(args.dispatch.dispatch_provider_config.as_deref()),
+    });
+    let stale_spec = requested_spec_fingerprint.is_some()
+        && persisted_spec_fingerprint != requested_spec_fingerprint;
+    let executor_mismatch = requested_executor_mismatch(&persisted_executor, &requested_executor);
+
+    Ok(serde_json::json!({
+        "schema": "homeboy/agent-task-loop-controller-requested-context/v1",
+        "persisted_spec_fingerprint": persisted_spec_fingerprint,
+        "requested_spec_fingerprint": requested_spec_fingerprint,
+        "stale_spec": stale_spec,
+        "persisted_executor": persisted_executor,
+        "requested_executor": requested_executor,
+        "executor_mismatch": executor_mismatch,
+        "guidance": requested_context_guidance(stale_spec, executor_mismatch),
+    }))
+}
+
+fn requested_executor_mismatch(persisted: &Value, requested: &Value) -> bool {
+    ["backend", "selector", "model"].into_iter().any(|key| {
+        let requested_value = requested.get(key).and_then(Value::as_str);
+        requested_value.is_some() && requested_value != persisted.get(key).and_then(Value::as_str)
+    })
+}
+
+fn requested_context_guidance(stale_spec: bool, executor_mismatch: bool) -> Vec<String> {
+    if stale_spec || executor_mismatch {
+        return vec![
+            "Use --fork to launch the requested spec/backend without mutating persisted state.".to_string(),
+            "Use --replace to discard persisted state and run the requested spec/backend under this loop id.".to_string(),
+            "Use --resume-existing only when intentionally continuing the persisted state/backend.".to_string(),
+        ];
+    }
+    vec!["Persisted state matches the supplied status context; resume is the safe continuation path.".to_string()]
+}
+
+fn requested_provider_config_summary(raw: Option<&str>) -> Value {
+    let Some(raw) = raw else {
+        return Value::Null;
+    };
+    let parsed = serde_json::from_str::<Value>(raw).unwrap_or(Value::Null);
+    let mut summary = serde_json::Map::new();
+    for key in ["provider", "model", "runtime", "backend", "selector"] {
+        if let Some(value) = parsed.get(key).and_then(Value::as_str) {
+            summary.insert(key.to_string(), Value::String(value.to_string()));
+        }
+    }
+    Value::Object(summary)
 }
 
 pub(super) fn loop_command(args: AgentTaskLoopArgs) -> CmdResult<Value> {

--- a/src/commands/agent_task_summary/controller.rs
+++ b/src/commands/agent_task_summary/controller.rs
@@ -29,6 +29,16 @@ pub(super) fn render_controller_summary(payload: &Value) -> Option<String> {
         format!("Artifacts: {}", totals.artifacts),
     ];
 
+    if let Some(state) = string_value(payload, &["diagnostics", "controller_state", "label"]) {
+        let reason = string_value(payload, &["diagnostics", "controller_state", "reason"])
+            .unwrap_or("no diagnostic reason recorded");
+        lines.push(format!("Controller state: {state} ({reason})"));
+    }
+
+    if let Some(executor) = controller_selected_executor(payload) {
+        lines.push(format!("Selected executor: {executor}"));
+    }
+
     if let Some(failure) = controller_last_failure(payload, controller) {
         lines.push(format!("Last failure: {failure}"));
     }
@@ -287,6 +297,13 @@ fn collect_controller_artifact_lines(value: &Value, path: &[&str], artifacts: &m
 }
 
 fn first_controller_recovery_command(payload: &Value) -> Option<&str> {
+    if let Some(command) = first_string(
+        value_at(payload, &["diagnostics"]).unwrap_or(payload),
+        &["next_commands"],
+    ) {
+        return Some(command);
+    }
+
     if let Some(command) = first_failed_child_action(payload)
         .and_then(|action| string_value(action, &["next_command"]))
     {
@@ -301,4 +318,22 @@ fn first_controller_recovery_command(payload: &Value) -> Option<&str> {
         })?
         .iter()
         .find_map(|action| first_string(action, &["recovery_commands"]))
+}
+
+fn controller_selected_executor(payload: &Value) -> Option<String> {
+    let executor = value_at(
+        payload,
+        &["diagnostics", "relevant_action", "selected_executor"],
+    )?;
+    let mut parts = Vec::new();
+    if let Some(value) = string_value(executor, &["backend"]) {
+        parts.push(format!("backend={value}"));
+    }
+    if let Some(value) = string_value(executor, &["selector"]) {
+        parts.push(format!("selector={value}"));
+    }
+    if let Some(value) = string_value(executor, &["model"]) {
+        parts.push(format!("model={value}"));
+    }
+    (!parts.is_empty()).then(|| parts.join(" / "))
 }

--- a/src/commands/agent_task_summary/mod.rs
+++ b/src/commands/agent_task_summary/mod.rs
@@ -1030,6 +1030,56 @@ mod tests {
     }
 
     #[test]
+    fn controller_status_summary_surfaces_blocked_state_and_selected_executor() {
+        let payload = json!({
+            "schema": "homeboy/agent-task-loop-controller-status/v1",
+            "controller": {
+                "loop_id": "loop-123",
+                "phase": "triage",
+                "state": "running",
+                "entities": {},
+                "task_lineage": [],
+                "next_actions": [{
+                    "action_id": "action-1",
+                    "action": { "action": "spawn_task" },
+                    "status": "failed"
+                }]
+            },
+            "diagnostics": {
+                "controller_state": {
+                    "state": "running_blocked_failed_action",
+                    "label": "running but blocked on failed action",
+                    "actionable": true,
+                    "reason": "controller is marked running, but a failed or blocked action must be resolved before ordinary progress is safe"
+                },
+                "relevant_action": {
+                    "action_id": "action-1",
+                    "action": "spawn_task",
+                    "status": "failed",
+                    "selected_executor": {
+                        "backend": "old-backend",
+                        "selector": "old-selector",
+                        "model": "old-model"
+                    }
+                },
+                "next_commands": ["homeboy agent-task controller diagnose loop-123  # inspect failed action evidence"]
+            }
+        });
+
+        let summary =
+            render_agent_task_summary(AgentTaskSummaryKind::Controller, &payload).unwrap();
+
+        assert!(summary.contains("State: running\n"));
+        assert!(summary.contains("Controller state: running but blocked on failed action"));
+        assert!(summary.contains(
+            "Selected executor: backend=old-backend / selector=old-selector / model=old-model\n"
+        ));
+        assert!(summary.contains(
+            "Next: homeboy agent-task controller diagnose loop-123  # inspect failed action evidence\n"
+        ));
+    }
+
+    #[test]
     fn controller_resume_summary_surfaces_last_failure_and_generic_resume_command() {
         let payload = json!({
             "schema": "homeboy/agent-task-loop-controller-resume-result/v1",

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -247,6 +247,18 @@ pub fn init_from_spec_for_resume(
     init_from_spec_for_resume_with_resolution(request, ControllerResumeStateResolution::default())
 }
 
+/// Compute the stable repo-loop spec fingerprint for operator diagnostics.
+pub fn spec_fingerprint_for_status(spec: &AgentTaskRepoLoopSpec) -> Result<String> {
+    repo_loop_spec_fingerprint(spec)
+}
+
+/// Read the persisted repo-loop spec fingerprint from a controller record.
+pub fn controller_spec_fingerprint_for_status(
+    record: &AgentTaskLoopControllerRecord,
+) -> Option<String> {
+    repo_loop_spec_fingerprint_from_metadata(record)
+}
+
 /// Initialize a controller for resume, applying an explicit stale-state resolution.
 ///
 /// When the supplied spec fingerprint matches the persisted controller (or no

--- a/src/core/agent_task_loop_controller/diagnostics.rs
+++ b/src/core/agent_task_loop_controller/diagnostics.rs
@@ -37,12 +37,48 @@ pub struct AgentTaskLoopControllerDiagnostics {
     pub schema: String,
     pub stale_pending_threshold_seconds: i64,
     pub summary: AgentTaskLoopControllerDiagnosticSummary,
+    pub controller_state: AgentTaskLoopControllerStateDiagnostic,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relevant_action: Option<AgentTaskLoopRelevantActionDiagnostic>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_commands: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub failed_child_actions: Vec<AgentTaskLoopFailedChildActionDiagnostic>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pending_actions: Vec<AgentTaskLoopPendingActionDiagnostic>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub acceptance_gates: Vec<AgentTaskLoopAcceptanceGateDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskLoopControllerStateDiagnostic {
+    pub state: String,
+    pub label: String,
+    pub actionable: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskLoopRelevantActionDiagnostic {
+    pub action_id: String,
+    pub action: String,
+    pub status: AgentTaskLoopActionStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dedupe_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_executor: Option<AgentTaskLoopSelectedExecutorDiagnostic>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub referenced_run_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskLoopSelectedExecutorDiagnostic {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/agent_task_loop_controller/service.rs
+++ b/src/core/agent_task_loop_controller/service.rs
@@ -40,6 +40,10 @@ where
     let mut orphaned_pending_action_count = 0;
     let acceptance_gates = acceptance_gate_diagnostics(record);
     let failed_child_actions = failed_child_action_diagnostics(record);
+    let controller_state = controller_state_diagnostic(record);
+    let relevant_action = relevant_action_diagnostic(record);
+    let next_commands =
+        controller_next_commands(record, &controller_state, relevant_action.as_ref());
     let missing_acceptance_gate_count = acceptance_gates
         .iter()
         .filter(|gate| gate.status == AgentTaskLoopAcceptanceGateStatus::Missing)
@@ -119,10 +123,171 @@ where
             failed_acceptance_gate_count,
             pending_acceptance_gate_count,
         },
+        controller_state,
+        relevant_action,
+        next_commands,
         failed_child_actions,
         pending_actions,
         acceptance_gates,
     })
+}
+
+fn controller_state_diagnostic(
+    record: &AgentTaskLoopControllerRecord,
+) -> AgentTaskLoopControllerStateDiagnostic {
+    if runtime_is_off(&record.metadata) {
+        return AgentTaskLoopControllerStateDiagnostic {
+            state: "paused_off".to_string(),
+            label: "paused/off".to_string(),
+            actionable: true,
+            reason:
+                "loop runtime metadata is off; resume only after intentionally turning the loop on"
+                    .to_string(),
+        };
+    }
+
+    if record
+        .next_actions
+        .iter()
+        .any(|action| action.status == AgentTaskLoopActionStatus::Running)
+    {
+        return AgentTaskLoopControllerStateDiagnostic {
+            state: "running_active_work".to_string(),
+            label: "running with active work".to_string(),
+            actionable: false,
+            reason: "at least one controller action is currently running".to_string(),
+        };
+    }
+
+    if record.next_actions.iter().any(is_failed_or_blocked_action) {
+        return AgentTaskLoopControllerStateDiagnostic {
+            state: "running_blocked_failed_action".to_string(),
+            label: "running but blocked on failed action".to_string(),
+            actionable: true,
+            reason: "controller is marked running, but a failed or blocked action must be resolved before ordinary progress is safe".to_string(),
+        };
+    }
+
+    if record
+        .next_actions
+        .iter()
+        .any(|action| action.status == AgentTaskLoopActionStatus::Pending)
+    {
+        return AgentTaskLoopControllerStateDiagnostic {
+            state: "running_pending_work".to_string(),
+            label: "running with pending work".to_string(),
+            actionable: true,
+            reason: "pending controller actions are available to run".to_string(),
+        };
+    }
+
+    AgentTaskLoopControllerStateDiagnostic {
+        state: format!("{:?}", record.state).to_ascii_lowercase(),
+        label: format!("{:?}", record.state).to_ascii_lowercase(),
+        actionable: !matches!(record.state, AgentTaskLoopControllerState::Completed),
+        reason: "no failed, running, or pending action is recorded".to_string(),
+    }
+}
+
+fn runtime_is_off(metadata: &Value) -> bool {
+    metadata
+        .get("runtime")
+        .and_then(|runtime| runtime.get("on"))
+        .and_then(Value::as_bool)
+        == Some(false)
+}
+
+fn relevant_action_diagnostic(
+    record: &AgentTaskLoopControllerRecord,
+) -> Option<AgentTaskLoopRelevantActionDiagnostic> {
+    let action = record
+        .next_actions
+        .iter()
+        .rev()
+        .find(|action| is_failed_or_blocked_action(action))
+        .or_else(|| {
+            record
+                .next_actions
+                .iter()
+                .find(|action| action.status == AgentTaskLoopActionStatus::Running)
+        })
+        .or_else(|| {
+            record
+                .next_actions
+                .iter()
+                .find(|action| action.status == AgentTaskLoopActionStatus::Pending)
+        })?;
+    let action_value = action_value(action);
+    Some(AgentTaskLoopRelevantActionDiagnostic {
+        action_id: action.action_id.clone(),
+        action: action_name(&action.action).to_string(),
+        status: action.status,
+        dedupe_key: action.dedupe_key.clone(),
+        selected_executor: selected_executor_diagnostic(action_value.as_ref(), &record.metadata),
+        referenced_run_id: action_referenced_run_id(action, record),
+    })
+}
+
+fn selected_executor_diagnostic(
+    action: Option<&Value>,
+    metadata: &Value,
+) -> Option<AgentTaskLoopSelectedExecutorDiagnostic> {
+    let executor = AgentTaskLoopSelectedExecutorDiagnostic {
+        backend: first_dispatch_backend(action, metadata),
+        selector: first_dispatch_selector(action, metadata),
+        model: first_dispatch_model(action, metadata),
+    };
+    (executor.backend.is_some() || executor.selector.is_some() || executor.model.is_some())
+        .then_some(executor)
+}
+
+fn controller_next_commands(
+    record: &AgentTaskLoopControllerRecord,
+    controller_state: &AgentTaskLoopControllerStateDiagnostic,
+    relevant_action: Option<&AgentTaskLoopRelevantActionDiagnostic>,
+) -> Vec<String> {
+    let loop_id = shell_arg(&record.loop_id);
+    match controller_state.state.as_str() {
+        "paused_off" => vec![format!(
+            "homeboy agent-task loop resume {loop_id}  # turns the loop back on and resumes pending work"
+        )],
+        "running_active_work" => vec![format!(
+            "homeboy agent-task controller status {loop_id}  # active work is still running"
+        )],
+        "running_blocked_failed_action" => {
+            let mut commands = vec![format!(
+                "homeboy agent-task controller diagnose {loop_id}  # inspect failed action evidence"
+            )];
+            if let Some(action) = relevant_action {
+                commands.push(format!(
+                    "homeboy agent-task controller run {loop_id} --action-id {}  # retry this persisted action",
+                    shell_arg(&action.action_id)
+                ));
+            }
+            commands.push(format!(
+                "homeboy agent-task controller from-spec <spec> --resume --fork  # start fresh with a new backend/spec without changing this state"
+            ));
+            commands.push(format!(
+                "homeboy agent-task controller from-spec <spec> --resume --replace  # discard this persisted controller state"
+            ));
+            commands.push(format!(
+                "homeboy agent-task controller from-spec <spec> --resume-existing  # intentionally continue this persisted state"
+            ));
+            commands
+        }
+        "running_pending_work" => vec![format!("homeboy agent-task controller resume {loop_id}")],
+        _ => vec![format!("homeboy agent-task controller status {loop_id}")],
+    }
+}
+
+fn is_failed_or_blocked_action(action: &AgentTaskLoopPolicyActionRecord) -> bool {
+    matches!(
+        action.status,
+        AgentTaskLoopActionStatus::Failed
+            | AgentTaskLoopActionStatus::BlockedRunnerUnavailable
+            | AgentTaskLoopActionStatus::BlockedRemoteMaterialization
+            | AgentTaskLoopActionStatus::BlockedLocalFallbackDenied
+    )
 }
 
 fn failed_child_action_diagnostics(

--- a/src/core/agent_task_loop_controller/tests.rs
+++ b/src/core/agent_task_loop_controller/tests.rs
@@ -176,6 +176,87 @@ fn status_diagnostics_resume_commands_use_action_executor_selector() {
 }
 
 #[test]
+fn status_diagnostics_classify_paused_active_and_blocked_controller_states() {
+    let mut paused = AgentTaskLoopControllerRecord::new("paused-loop", "repair", "v1");
+    paused.metadata = json!({ "runtime": { "on": false, "state": "off" } });
+    let paused_diagnostics = controller_status_diagnostics_with(&paused, Utc::now(), |_| Ok(true))
+        .expect("paused diagnostics");
+    assert_eq!(paused_diagnostics.controller_state.state, "paused_off");
+    assert_eq!(paused_diagnostics.controller_state.label, "paused/off");
+    assert!(paused_diagnostics.next_commands[0].contains("agent-task loop resume paused-loop"));
+
+    let mut active = AgentTaskLoopControllerRecord::new("active-loop", "repair", "v1");
+    active.record_action(
+        AgentTaskLoopPolicyAction::SpawnTask {
+            dedupe_key: "finding:active:repair".to_string(),
+            entity_id: None,
+            request: json!({ "task": "repair" }),
+        },
+        "finding emitted",
+    );
+    active.next_actions[0].status = AgentTaskLoopActionStatus::Running;
+    let active_diagnostics = controller_status_diagnostics_with(&active, Utc::now(), |_| Ok(true))
+        .expect("active diagnostics");
+    assert_eq!(
+        active_diagnostics.controller_state.state,
+        "running_active_work"
+    );
+    assert!(!active_diagnostics.controller_state.actionable);
+
+    let mut blocked = AgentTaskLoopControllerRecord::new("blocked-loop", "repair", "v1");
+    blocked.record_action(
+        AgentTaskLoopPolicyAction::SpawnTask {
+            dedupe_key: "finding:blocked:repair".to_string(),
+            entity_id: None,
+            request: json!({
+                "mode": "run_plan",
+                "plan": {
+                    "tasks": [{
+                        "executor": {
+                            "backend": "old-backend",
+                            "selector": "old-selector",
+                            "model": "old-model"
+                        }
+                    }]
+                }
+            }),
+        },
+        "finding emitted",
+    );
+    blocked.next_actions[0].status = AgentTaskLoopActionStatus::Failed;
+    let blocked_diagnostics =
+        controller_status_diagnostics_with(&blocked, Utc::now(), |_| Ok(true))
+            .expect("blocked diagnostics");
+
+    assert_eq!(
+        blocked_diagnostics.controller_state.state,
+        "running_blocked_failed_action"
+    );
+    assert!(blocked_diagnostics.controller_state.actionable);
+    let relevant = blocked_diagnostics
+        .relevant_action
+        .expect("blocked action surfaced");
+    assert_eq!(relevant.action_id, "action-1");
+    assert_eq!(relevant.status, AgentTaskLoopActionStatus::Failed);
+    let executor = relevant.selected_executor.expect("selected executor");
+    assert_eq!(executor.backend.as_deref(), Some("old-backend"));
+    assert_eq!(executor.selector.as_deref(), Some("old-selector"));
+    assert_eq!(executor.model.as_deref(), Some("old-model"));
+    assert!(blocked_diagnostics
+        .next_commands
+        .iter()
+        .any(|command| command.contains("--fork")));
+    assert!(blocked_diagnostics
+        .next_commands
+        .iter()
+        .any(|command| command.contains("--replace")));
+    assert!(blocked_diagnostics
+        .next_commands
+        .iter()
+        .any(|command| command.contains("--resume-existing")));
+}
+
+#[test]
 fn status_diagnostics_flag_missing_referenced_run_records() {
     let mut record = AgentTaskLoopControllerRecord::new("loop", "repair", "v1");
     record.record_action(


### PR DESCRIPTION
## Summary
- classify controller status as paused, active, blocked, or pending
- surface relevant action executor/backend/model where available
- add requested-context diagnostics for spec/backend mismatch and summary output

Fixes #6977.

## Tests
- `cargo test status_diagnostics_classify_paused_active_and_blocked_controller_states --locked`
- `cargo test controller_status_summary_surfaces_blocked_state_and_selected_executor --locked`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.