### PR TITLE
Allow pruneable provider plugin paths in lab preflight

### DIFF
--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -247,6 +247,11 @@ fn collect_unmaterialized_path_strings(
 ) {
     match value {
         Value::String(text) if is_controller_path_like(text) => {
+            if is_provider_plugin_path_location(location)
+                && provider_plugin_path_is_pruneable_before_offload(text, mappings)
+            {
+                return;
+            }
             if let Some(reason) = unmaterialized_path_reason(text, mappings) {
                 failures.push(UnmaterializedPath {
                     location: location.to_string(),
@@ -292,6 +297,15 @@ fn is_materializable_provider_config_path_key(key: &str) -> bool {
             | "component_contracts"
             | "path"
     )
+}
+
+fn is_provider_plugin_path_location(location: &str) -> bool {
+    location.contains(".provider_plugin_paths")
+}
+
+fn provider_plugin_path_is_pruneable_before_offload(path: &str, mappings: &[LabPathRemap]) -> bool {
+    let ordered = super::path_remap::order_mappings_by_specificity(mappings);
+    remap_local_path(path, &ordered).is_none() && !path_is_under_remote_mapping(path, mappings)
 }
 
 fn unmaterialized_path_reason(path: &str, mappings: &[LabPathRemap]) -> Option<&'static str> {

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -242,6 +242,27 @@ mod provider_config_materialization_tests {
     }
 
     #[test]
+    fn provider_config_materialization_preflight_allows_pruneable_provider_plugin_paths() {
+        let config = serde_json::json!({
+            "provider": "example-oauth",
+            "provider_plugin_paths": [
+                "/Users/user/Developer/stale-provider-plugin"
+            ]
+        })
+        .to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--provider-config".to_string(),
+            config,
+        ];
+
+        preflight_provider_config_paths_materialized_in_args(&args, &[])
+            .expect("stale provider plugin paths are pruned before remote dispatch");
+    }
+
+    #[test]
     fn provider_config_runtime_manifest_records_effective_paths() {
         let args = vec![
             "homeboy".to_string(),


### PR DESCRIPTION
## Summary
- let provider-config preflight allow stale absolute `provider_plugin_paths` that the remap step prunes before remote dispatch
- keep real runtime/component path misses fail-closed
- add regression coverage for the preflight/prune behavior

Fixes #6985.

## Tests
- `cargo test provider_config_materialization_preflight --locked`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.