### PR TITLE
Fix fuzz Lab rig component materialization

### DIFF
--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -350,14 +350,20 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
                 "creates/reuses DMC worktrees and can run the generated fanout unless --dry-run is passed";
             metadata.dangerous_flags = vec!["--run-plan"];
         }
-        ["fuzz", "replay"] => {
+        ["fuzz", "replay"] | ["fuzz", "minimize"] => {
             metadata.mutates = true;
             metadata.output_notes =
-                "replays a persisted fuzz case against local code and may write run artifacts";
+                "replays or minimizes a persisted fuzz case against local code and may write run artifacts";
         }
         ["fuzz"] | ["fuzz", "run"] | ["fuzz", "plan"] => {
             metadata.output_notes = "read-only fuzz planning/execution contract by default; --allow-destructive requires explicit disposable homeboy/isolation-proof/v1 input";
             metadata.dangerous_flags = vec!["--allow-destructive"];
+        }
+        ["rig", "release-lock"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.output_notes = "releases a local rig active-run lease; --force can reclaim a live holder's guardrail";
+            metadata.dangerous_flags = vec!["--force"];
         }
         ["db", "delete-row"] | ["db", "drop-table"] => {
             metadata.mutates = true;

--- a/src/commands/fuzz/replay.rs
+++ b/src/commands/fuzz/replay.rs
@@ -32,9 +32,13 @@ fn run_replay_like(
     args: ReplayLikeArgs,
     mode: ReplayLikeMode,
 ) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
+    let artifact_ref = replay_artifact_ref(&args);
     let artifact_file = match replay_artifact_path(&args) {
         Some(path) => Some(path),
-        None => resolve_run_replay_artifact_path(args.run_id.as_deref()).transpose()?,
+        None if artifact_ref.is_none() => {
+            resolve_run_replay_artifact_path(args.run_id.as_deref()).transpose()?
+        }
+        None => None,
     };
     let positional_case = args.artifact_or_case.as_ref().and_then(|value| {
         if artifact_file.is_some() && !Path::new(value).exists() {
@@ -44,6 +48,12 @@ fn run_replay_like(
         }
     });
     let requested_case_id = args.case_id.clone().or(positional_case);
+
+    if artifact_ref.is_some() && !args.dry_run {
+        return Err(runner_artifact_replay_requires_local_bytes(
+            artifact_ref.as_deref().unwrap_or_default(),
+        ));
+    }
 
     let resolved = if let Some(path) = artifact_file.as_ref() {
         Some(resolve_replay_artifact(path, requested_case_id.as_deref())?)
@@ -62,6 +72,7 @@ fn run_replay_like(
         case_id.as_deref(),
         replay.as_ref(),
         args.run_id.as_ref(),
+        artifact_ref.as_deref(),
     );
     let replay_context = resolve_replay_context(&args, mode)?;
     let replay_command = replay_context
@@ -70,7 +81,7 @@ fn run_replay_like(
         .map(|command| render_replay_command(&command, &env, args.args.as_slice()));
 
     if args.dry_run {
-        let status = if artifact_file.is_some() {
+        let status = if artifact_file.is_some() || artifact_ref.is_some() {
             "dry_run"
         } else {
             "needs_artifact"
@@ -81,7 +92,9 @@ fn run_replay_like(
                 command: mode.command_name().to_string(),
                 status: status.to_string(),
                 message: replay_message(replay_command.as_ref(), true, mode),
-                artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
+                artifact_file: artifact_file
+                    .map(|path| path.to_string_lossy().to_string())
+                    .or(artifact_ref.clone()),
                 campaign_id: resolved
                     .as_ref()
                     .and_then(|resolved| resolved.campaign_id.clone()),
@@ -106,7 +119,9 @@ fn run_replay_like(
             command: mode.command_name().to_string(),
             status: "unsupported".to_string(),
             message: format!("Generic fuzz {} execution requires a component/rig extension context with fuzz.{}; use --dry-run to inspect metadata only.", mode.label(), mode.manifest_key()),
-            artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
+            artifact_file: artifact_file
+                .map(|path| path.to_string_lossy().to_string())
+                .or(artifact_ref.clone()),
             campaign_id: resolved.as_ref().and_then(|resolved| resolved.campaign_id.clone()),
             envelope_id: resolved.as_ref().and_then(|resolved| resolved.envelope_id.clone()),
             case_id,
@@ -130,7 +145,9 @@ fn run_replay_like(
                 mode.manifest_key(),
                 mode.label()
             ),
-            artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
+            artifact_file: artifact_file
+                .map(|path| path.to_string_lossy().to_string())
+                .or(artifact_ref.clone()),
             campaign_id: resolved.as_ref().and_then(|resolved| resolved.campaign_id.clone()),
             envelope_id: resolved.as_ref().and_then(|resolved| resolved.envelope_id.clone()),
             case_id,
@@ -164,7 +181,9 @@ fn run_replay_like(
             command: mode.command_name().to_string(),
             status: if output.success { "passed" } else { "failed" }.to_string(),
             message: replay_message(Some(&command), false, mode),
-            artifact_file: artifact_file.map(|path| path.to_string_lossy().to_string()),
+            artifact_file: artifact_file
+                .map(|path| path.to_string_lossy().to_string())
+                .or(artifact_ref.clone()),
             campaign_id: resolved
                 .as_ref()
                 .and_then(|resolved| resolved.campaign_id.clone()),
@@ -399,11 +418,34 @@ struct ResolvedReplayArtifact {
 fn replay_artifact_path(args: &ReplayLikeArgs) -> Option<PathBuf> {
     args.artifact.clone().or_else(|| {
         args.artifact_or_case.as_ref().and_then(|value| {
+            if value.starts_with("runner-artifact://") {
+                return None;
+            }
             let path = PathBuf::from(value);
             (path.exists() || value.contains(std::path::MAIN_SEPARATOR) || value.ends_with(".json"))
                 .then_some(path)
         })
     })
+}
+
+fn replay_artifact_ref(args: &ReplayLikeArgs) -> Option<String> {
+    args.artifact_or_case
+        .as_deref()
+        .filter(|value| value.starts_with("runner-artifact://"))
+        .map(str::to_string)
+}
+
+fn runner_artifact_replay_requires_local_bytes(reference: &str) -> homeboy::core::Error {
+    Error::validation_invalid_argument(
+        "artifact",
+        "fuzz replay requires local artifact bytes unless --dry-run is used",
+        Some(reference.to_string()),
+        Some(vec![
+            format!("Runner artifact ref: {reference}"),
+            "Use `homeboy fuzz replay --dry-run <runner-artifact://...>` to inspect replay intent without local bytes.".to_string(),
+            "Download the artifact first with `homeboy runs artifact get <run-id> <artifact-id> --output <path>`, then replay that local path.".to_string(),
+        ]),
+    )
 }
 
 fn resolve_run_replay_artifact_path(
@@ -594,6 +636,7 @@ fn fuzz_replay_env(
     case_id: Option<&str>,
     replay: Option<&FuzzReplayMetadata>,
     run_id: Option<&String>,
+    artifact_ref: Option<&str>,
 ) -> Vec<FuzzReplayEnv> {
     let mut env = Vec::new();
     if let Some(path) = artifact_file {
@@ -601,6 +644,12 @@ fn fuzz_replay_env(
             &mut env,
             "HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE",
             path.to_string_lossy().to_string(),
+        );
+    } else if let Some(reference) = artifact_ref {
+        push_replay_env(
+            &mut env,
+            "HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE",
+            reference.to_string(),
         );
     }
     if let Some(case_id) = case_id.filter(|case_id| !case_id.trim().is_empty()) {

--- a/src/commands/fuzz/tests/replay_tests.rs
+++ b/src/commands/fuzz/tests/replay_tests.rs
@@ -170,6 +170,68 @@ fn fuzz_replay_resolves_persisted_run_artifact_without_path() {
 }
 
 #[test]
+fn fuzz_replay_dry_run_accepts_runner_artifact_ref_without_local_bytes() {
+    let reference = "runner-artifact://lab-runner/proof-run/fuzz-result-envelope";
+
+    let (output, exit) = run_replay(FuzzReplayArgs {
+        component: None,
+        path: None,
+        rig: None,
+        extension_override: ExtensionOverrideArgs::default(),
+        setting_args: SettingArgs::default(),
+        artifact_or_case: Some(reference.to_string()),
+        artifact: None,
+        case_id: Some("case-1".to_string()),
+        run_id: Some("proof-run".to_string()),
+        dry_run: true,
+        args: Vec::new(),
+    })
+    .expect("runner artifact dry-run");
+
+    assert_eq!(exit, 0);
+    assert_eq!(output.status, "dry_run");
+    assert_eq!(output.artifact_file.as_deref(), Some(reference));
+    assert_eq!(output.case_id.as_deref(), Some("case-1"));
+    assert!(output
+        .env
+        .iter()
+        .any(|env| { env.name == "HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE" && env.value == reference }));
+}
+
+#[test]
+fn fuzz_replay_runner_artifact_ref_without_dry_run_is_actionable() {
+    let result = run_replay(FuzzReplayArgs {
+        component: None,
+        path: None,
+        rig: None,
+        extension_override: ExtensionOverrideArgs::default(),
+        setting_args: SettingArgs::default(),
+        artifact_or_case: Some(
+            "runner-artifact://lab-runner/proof-run/fuzz-result-envelope".to_string(),
+        ),
+        artifact: None,
+        case_id: Some("case-1".to_string()),
+        run_id: Some("proof-run".to_string()),
+        dry_run: false,
+        args: Vec::new(),
+    });
+    let err = match result {
+        Ok(_) => panic!("local bytes required for execution"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.details["field"], "artifact");
+    assert!(err.message.contains("requires local artifact bytes"));
+    assert!(err.details["tried"]
+        .as_array()
+        .expect("tried entries")
+        .iter()
+        .any(|entry| entry
+            .as_str()
+            .is_some_and(|value| value.contains("--dry-run"))));
+}
+
+#[test]
 fn fuzz_replay_executes_manifest_replay_command_with_env() {
     with_isolated_home(|home| {
         let component_dir = tempfile::tempdir().expect("component dir");

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -485,14 +485,15 @@ mod tests {
             &mut env,
             &mapping,
             [(
-                "HOMEBOY_TEST_COMPONENT_PATH".to_string(),
+                "HOMEBOY_RIG_COMPONENT_PATH__TEST_RIG__COMPONENT".to_string(),
                 "/Users/user/Developer/example-component/includes".to_string(),
             )],
         )
         .expect("forward env");
 
         assert_eq!(
-            env.get("HOMEBOY_TEST_COMPONENT_PATH").map(String::as_str),
+            env.get("HOMEBOY_RIG_COMPONENT_PATH__TEST_RIG__COMPONENT")
+                .map(String::as_str),
             Some("/home/user/Developer/example-component/includes")
         );
         assert_eq!(
@@ -509,15 +510,18 @@ mod tests {
             &mut env,
             &[],
             [(
-                "HOMEBOY_UNSYNCED_COMPONENT_PATH".to_string(),
+                "HOMEBOY_RIG_COMPONENT_PATH__TEST_RIG__COMPONENT".to_string(),
                 "/Users/user/Developer/unsynced-component".to_string(),
             )],
         )
         .expect_err("unsynced path");
 
-        assert_eq!(err.details["field"], "HOMEBOY_UNSYNCED_COMPONENT_PATH");
+        assert_eq!(
+            err.details["field"],
+            "HOMEBOY_RIG_COMPONENT_PATH__TEST_RIG__COMPONENT"
+        );
         assert!(err.message.contains("was not synced to the runner"));
-        assert!(!env.contains_key("HOMEBOY_UNSYNCED_COMPONENT_PATH"));
+        assert!(!env.contains_key("HOMEBOY_RIG_COMPONENT_PATH__TEST_RIG__COMPONENT"));
     }
 
     #[test]

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -943,7 +943,7 @@ fn rig_component_path_env_extra_workspaces_from_entries(
 }
 
 pub(super) fn is_rig_component_path_env_name(name: &str) -> bool {
-    name.starts_with("HOMEBOY_") && name.ends_with("_COMPONENT_PATH")
+    name.starts_with("HOMEBOY_RIG_COMPONENT_PATH__")
 }
 
 pub(super) fn preflight_provider_config_source_cli_dependencies(
@@ -2179,7 +2179,7 @@ mod provider_config_candidate_paths_tests {
             let workspaces = rig_component_path_env_extra_workspaces_from_entries(
                 &source,
                 [(
-                    "HOMEBOY_TEST_COMPONENT_PATH".to_string(),
+                    "HOMEBOY_RIG_COMPONENT_PATH__TEST_RIG__PLUGIN".to_string(),
                     component_path.display().to_string(),
                 )],
             )
@@ -2199,13 +2199,16 @@ mod provider_config_candidate_paths_tests {
             let err = rig_component_path_env_extra_workspaces_from_entries(
                 home.path(),
                 [(
-                    "HOMEBOY_MISSING_COMPONENT_PATH".to_string(),
+                    "HOMEBOY_RIG_COMPONENT_PATH__TEST_RIG__PLUGIN".to_string(),
                     missing.display().to_string(),
                 )],
             )
             .expect_err("missing path");
 
-            assert_eq!(err.details["field"], "HOMEBOY_MISSING_COMPONENT_PATH");
+            assert_eq!(
+                err.details["field"],
+                "HOMEBOY_RIG_COMPONENT_PATH__TEST_RIG__PLUGIN"
+            );
             assert!(err.message.contains("controller-side path does not exist"));
         });
     }

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -546,17 +546,8 @@ pub(super) fn lab_offload_rig_component_checkout_root(args: &[String]) -> Result
     let Some((component_id, component)) = spec.components.iter().next() else {
         return Ok(None);
     };
-    let resolved_component_path = rig::resolve_component_path(&spec, component_id)?;
-    let declared_checkout_root = component
-        .checkout_root
-        .as_deref()
-        .unwrap_or(resolved_component_path.as_str());
-    let declared_required_subpath = required_component_subpath(
-        Path::new(&expanded_local_path(&spec, declared_checkout_root)),
-        Path::new(&resolved_component_path),
-        &rig_ids[0],
-        component_id,
-    )?;
+    let declared_required_subpath =
+        declared_required_component_subpath(&spec, component_id, component)?;
     Ok(Some(PathBuf::from(
         checkout_root_for_component_path_override(
             &expanded_local_path(&spec, &path_override),
@@ -576,21 +567,10 @@ pub(super) fn lab_offload_rig_component_dependencies(
         let spec = rig::load(&rig_id)?;
         let single_component = spec.components.len() == 1;
         for (component_id, component) in &spec.components {
-            let resolved_component_path = rig::resolve_component_path(&spec, component_id)?;
-            let declared_checkout_root = component
-                .checkout_root
-                .clone()
-                .unwrap_or_else(|| resolved_component_path.clone());
-            let declared_local_checkout_root = expanded_local_path(&spec, &declared_checkout_root);
-            let declared_local_component_path = resolved_component_path;
-            let declared_required_subpath = required_component_subpath(
-                Path::new(&declared_local_checkout_root),
-                Path::new(&declared_local_component_path),
-                &rig_id,
-                component_id,
-            )?;
             let (checkout_root, local_checkout_root, local_component_path) = if single_component {
                 if let Some(path_override) = component_path_override.as_deref() {
+                    let declared_required_subpath =
+                        declared_required_component_subpath(&spec, component_id, component)?;
                     let local_component_path = expanded_local_path(&spec, path_override);
                     let local_checkout_root = checkout_root_for_component_path_override(
                         &local_component_path,
@@ -602,17 +582,31 @@ pub(super) fn lab_offload_rig_component_dependencies(
                         local_component_path,
                     )
                 } else {
+                    let resolved_component_path = rig::resolve_component_path(&spec, component_id)?;
+                    let declared_checkout_root = component
+                        .checkout_root
+                        .clone()
+                        .unwrap_or_else(|| resolved_component_path.clone());
+                    let declared_local_checkout_root =
+                        expanded_local_path(&spec, &declared_checkout_root);
                     (
                         declared_checkout_root.to_string(),
                         declared_local_checkout_root,
-                        declared_local_component_path,
+                        resolved_component_path,
                     )
                 }
             } else {
+                let resolved_component_path = rig::resolve_component_path(&spec, component_id)?;
+                let declared_checkout_root = component
+                    .checkout_root
+                    .clone()
+                    .unwrap_or_else(|| resolved_component_path.clone());
+                let declared_local_checkout_root =
+                    expanded_local_path(&spec, &declared_checkout_root);
                 (
                     declared_checkout_root,
                     declared_local_checkout_root,
-                    declared_local_component_path,
+                    resolved_component_path,
                 )
             };
             let required_subpath = required_component_subpath(
@@ -639,6 +633,25 @@ pub(super) fn lab_offload_rig_component_dependencies(
         }
     }
     Ok(dependencies)
+}
+
+fn declared_required_component_subpath(
+    spec: &rig::RigSpec,
+    component_id: &str,
+    component: &rig::ComponentSpec,
+) -> Result<Option<String>> {
+    let Some(declared_checkout_root) = component.checkout_root.as_deref() else {
+        return Ok(None);
+    };
+    let Ok(resolved_component_path) = rig::resolve_component_path(spec, component_id) else {
+        return Ok(None);
+    };
+    required_component_subpath(
+        Path::new(&expanded_local_path(spec, declared_checkout_root)),
+        Path::new(&resolved_component_path),
+        &spec.id,
+        component_id,
+    )
 }
 
 fn component_path_override(args: &[String]) -> Option<String> {
@@ -1320,6 +1333,61 @@ mod tests {
             remap_bench_rig_default_component_to_primary_snapshot(&args, "/snapshot"),
             args
         );
+    }
+
+    #[test]
+    fn explicit_single_component_rig_path_materializes_without_declared_path() {
+        crate::test_support::with_isolated_home(|home| {
+            let component_path = home.path().join("Developer/component/plugins/package");
+            std::fs::create_dir_all(&component_path).expect("component path");
+            let rig_dir = home.path().join(".config/homeboy/rigs");
+            std::fs::create_dir_all(&rig_dir).expect("rig dir");
+            std::fs::write(
+                rig_dir.join("proof-rig.json"),
+                serde_json::json!({
+                    "id": "proof-rig",
+                    "components": {
+                        "package": {
+                            "component_id": "registered-package",
+                            "default_ref": "origin/main"
+                        }
+                    },
+                    "fuzz": { "default_component": "package" }
+                })
+                .to_string(),
+            )
+            .expect("rig spec");
+
+            let dependencies = lab_offload_rig_component_dependencies(
+                &[
+                    "homeboy".to_string(),
+                    "fuzz".to_string(),
+                    "run".to_string(),
+                    "--rig".to_string(),
+                    "proof-rig".to_string(),
+                    "--path".to_string(),
+                    component_path.display().to_string(),
+                ],
+                Some((
+                    &component_path.display().to_string(),
+                    "/home/runner/Developer/_lab_workspaces/package-proof",
+                )),
+                Some("/home/runner/Developer"),
+            )
+            .expect("explicit path should satisfy rig component materialization");
+
+            assert_eq!(dependencies.len(), 1);
+            assert_eq!(dependencies[0].component_id, "package");
+            assert_eq!(
+                dependencies[0].local_checkout_root,
+                component_path.display().to_string()
+            );
+            assert_eq!(
+                dependencies[0].remote_checkout_root,
+                "/home/runner/Developer/_lab_workspaces/package-proof"
+            );
+            assert_eq!(dependencies[0].required_subpath, None);
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Honor explicit single-component rig path materialization for fuzz Lab runs without requiring the rig-declared component path to resolve first.
- Recognize documented HOMEBOY_RIG_COMPONENT_PATH__<RIG>__<COMPONENT> env overrides when syncing and forwarding rig component paths.
- Allow fuzz replay dry-runs to render runner-artifact:// evidence refs without local bytes, while giving an actionable error for non-dry-run execution.
- Add safety metadata for fuzz minimize and rig release-lock so command safety checks remain explicit.

## Tests
- cargo test fuzz_replay
- cargo test explicit_single_component_rig_path_materializes_without_declared_path
- cargo test rig_component_path_env
- cargo test suspicious_command_paths_require_safety_classification
- cargo test (local full suite still has unrelated baseline/local failures; see PR notes)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Homeboy fuzz Lab proof-run blockers, implementing the fix, adding regression coverage, and preparing this PR.