### PR TITLE
Label extension refresh lab offloads correctly

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -614,7 +614,7 @@ impl Commands {
             Commands::Bench(args) => return args.portability_contract(),
             Commands::Fuzz(args) => return CommandPortabilityContract::lab_optional(args.lab_contract()),
             Commands::Extension(args) if args.is_update_command() => {
-                LabCommandContract::explicit_runner_simple("extension update")
+                LabCommandContract::explicit_runner_simple(args.update_command_label())
             }
             Commands::Fleet(args) => {
                 let contract = crate::commands::fleet::adapter(CommandOutputFileMode::None)

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -251,6 +251,13 @@ impl ExtensionArgs {
             ExtensionCommand::Update { .. } | ExtensionCommand::Refresh { .. }
         )
     }
+
+    pub(crate) fn update_command_label(&self) -> &'static str {
+        match self.command {
+            ExtensionCommand::Refresh { .. } => "extension refresh",
+            _ => "extension update",
+        }
+    }
 }
 
 #[derive(Serialize)]

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1413,7 +1413,7 @@ mod tests {
 
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
-        assert_eq!(command.hot_label, "extension update");
+        assert_eq!(command.hot_label, "extension refresh");
         assert!(command.portable);
         assert!(!command.routing_policy.default_lab_offload);
         assert!(command.unsupported_reason.is_none());


### PR DESCRIPTION
## Summary
- label `extension refresh` lab offloads as `extension refresh` instead of `extension update`
- keep `extension update` lab offloads labeled as `extension update`
- update route coverage for the refresh command label

Fixes #6992.

## Testing
- `cargo test --locked --lib extension_`

Note: `cargo test --locked extension_` also ran `tests/core_agnostic_test.rs` and hit an existing unrelated failure for concrete `nodejs` fixture references in `tests/core/rig/workloads_test.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the lab offload command-label mismatch, implementing the small route-label fix, and running targeted verification.
