### PR TITLE
Fix rig fuzz lab paths and replay artifact refs

### DIFF
--- a/src/commands/fuzz/replay.rs
+++ b/src/commands/fuzz/replay.rs
@@ -32,11 +32,20 @@ fn run_replay_like(
     args: ReplayLikeArgs,
     mode: ReplayLikeMode,
 ) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
-    let artifact_ref = replay_artifact_ref(&args);
+    let mut artifact_ref = replay_artifact_ref(&args);
     let artifact_file = match replay_artifact_path(&args) {
         Some(path) => Some(path),
         None if artifact_ref.is_none() => {
-            resolve_run_replay_artifact_path(args.run_id.as_deref()).transpose()?
+            match resolve_run_replay_artifact_source(args.run_id.as_deref(), args.dry_run)
+                .transpose()?
+            {
+                Some(ReplayArtifactSource::Local(path)) => Some(path),
+                Some(ReplayArtifactSource::Reference(reference)) => {
+                    artifact_ref = Some(reference);
+                    None
+                }
+                None => None,
+            }
         }
         None => None,
     };
@@ -418,7 +427,7 @@ struct ResolvedReplayArtifact {
 fn replay_artifact_path(args: &ReplayLikeArgs) -> Option<PathBuf> {
     args.artifact.clone().or_else(|| {
         args.artifact_or_case.as_ref().and_then(|value| {
-            if value.starts_with("runner-artifact://") {
+            if is_replay_artifact_ref(value) {
                 return None;
             }
             let path = PathBuf::from(value);
@@ -431,8 +440,12 @@ fn replay_artifact_path(args: &ReplayLikeArgs) -> Option<PathBuf> {
 fn replay_artifact_ref(args: &ReplayLikeArgs) -> Option<String> {
     args.artifact_or_case
         .as_deref()
-        .filter(|value| value.starts_with("runner-artifact://"))
+        .filter(|value| is_replay_artifact_ref(value))
         .map(str::to_string)
+}
+
+fn is_replay_artifact_ref(value: &str) -> bool {
+    value.starts_with("runner-artifact://") || value.starts_with("homeboy://run/")
 }
 
 fn runner_artifact_replay_requires_local_bytes(reference: &str) -> homeboy::core::Error {
@@ -448,14 +461,26 @@ fn runner_artifact_replay_requires_local_bytes(reference: &str) -> homeboy::core
     )
 }
 
-fn resolve_run_replay_artifact_path(
-    run_id: Option<&str>,
-) -> Option<homeboy::core::Result<PathBuf>> {
-    let run_id = run_id.filter(|run_id| !run_id.trim().is_empty())?;
-    Some(resolve_run_replay_artifact_path_inner(run_id))
+enum ReplayArtifactSource {
+    Local(PathBuf),
+    Reference(String),
 }
 
-fn resolve_run_replay_artifact_path_inner(run_id: &str) -> homeboy::core::Result<PathBuf> {
+fn resolve_run_replay_artifact_source(
+    run_id: Option<&str>,
+    allow_ref_without_bytes: bool,
+) -> Option<homeboy::core::Result<ReplayArtifactSource>> {
+    let run_id = run_id.filter(|run_id| !run_id.trim().is_empty())?;
+    Some(resolve_run_replay_artifact_source_inner(
+        run_id,
+        allow_ref_without_bytes,
+    ))
+}
+
+fn resolve_run_replay_artifact_source_inner(
+    run_id: &str,
+    allow_ref_without_bytes: bool,
+) -> homeboy::core::Result<ReplayArtifactSource> {
     let store = ObservationStore::open_initialized()?;
     let _run = runs_service::require_run(&store, run_id)?;
     let mut candidates = runs_service::list_artifacts_for_run(&store, run_id)?
@@ -465,22 +490,32 @@ fn resolve_run_replay_artifact_path_inner(run_id: &str) -> homeboy::core::Result
         .collect::<Vec<_>>();
     candidates.sort_by_key(run_replay_artifact_rank);
 
-    candidates
-        .into_iter()
-        .map(|artifact| PathBuf::from(artifact.path))
-        .find(|path| path.is_file())
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "run-id",
-                format!("fuzz replay artifact not found for run: {run_id}"),
-                Some(run_id.to_string()),
-                Some(vec![
-                    format!("Run `homeboy runs artifacts {run_id}` to inspect recorded artifacts."),
-                    "Persist a fuzz campaign/result envelope artifact before replaying by run id."
-                        .to_string(),
-                ]),
-            )
-        })
+    for artifact in &candidates {
+        let path = PathBuf::from(&artifact.path);
+        if path.is_file() {
+            return Ok(ReplayArtifactSource::Local(path));
+        }
+    }
+
+    if allow_ref_without_bytes {
+        if let Some(artifact) = candidates.first() {
+            return Ok(ReplayArtifactSource::Reference(format!(
+                "homeboy://run/{run_id}/artifact/{}",
+                artifact.id
+            )));
+        }
+    }
+
+    Err(Error::validation_invalid_argument(
+        "run-id",
+        format!("fuzz replay artifact not found for run: {run_id}"),
+        Some(run_id.to_string()),
+        Some(vec![
+            format!("Run `homeboy runs artifacts {run_id}` to inspect recorded artifacts."),
+            "Persist a fuzz campaign/result envelope artifact before replaying by run id."
+                .to_string(),
+        ]),
+    ))
 }
 
 fn is_run_replay_artifact_candidate(artifact: &ArtifactRecord) -> bool {

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -23,7 +23,8 @@ use super::types::{
     FuzzWorkloadOutput,
 };
 use super::workloads::{
-    fuzz_workloads, resolve_component_id, rig_component_for_fuzz, select_workload, FuzzRigContext,
+    fuzz_workloads, resolve_component_id, resolve_fuzz_context, rig_component_for_fuzz,
+    select_workload, FuzzRigContext,
 };
 use super::{run_contract, run_discover, FuzzArgs};
 use clap::Parser;

--- a/src/commands/fuzz/tests/replay_tests.rs
+++ b/src/commands/fuzz/tests/replay_tests.rs
@@ -170,6 +170,69 @@ fn fuzz_replay_resolves_persisted_run_artifact_without_path() {
 }
 
 #[test]
+fn fuzz_replay_dry_run_resolves_persisted_homeboy_artifact_ref_without_local_bytes() {
+    with_isolated_home(|home| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                homeboy::core::observation::NewRunRecord::builder("fuzz")
+                    .component_id("component-a")
+                    .command("homeboy fuzz run component-a")
+                    .cwd_path(home.path())
+                    .build(),
+            )
+            .expect("run");
+        store
+            .import_artifact(&homeboy::core::observation::ArtifactRecord {
+                id: "artifact-1".to_string(),
+                run_id: run.id.clone(),
+                kind: "fuzz_result_envelope".to_string(),
+                artifact_type: "file".to_string(),
+                path: home
+                    .path()
+                    .join("missing-envelope.json")
+                    .to_string_lossy()
+                    .to_string(),
+                url: None,
+                public_url: None,
+                viewer_url: None,
+                viewer_links: Vec::new(),
+                sha256: None,
+                size_bytes: None,
+                mime: Some("application/json".to_string()),
+                metadata_json: serde_json::json!({
+                    "schema": homeboy::core::fuzz::FUZZ_RESULT_ENVELOPE_SCHEMA
+                }),
+                created_at: chrono::Utc::now().to_rfc3339(),
+            })
+            .expect("import artifact ref");
+
+        let (output, exit) = run_replay(FuzzReplayArgs {
+            component: None,
+            path: None,
+            rig: None,
+            extension_override: ExtensionOverrideArgs::default(),
+            setting_args: SettingArgs::default(),
+            artifact_or_case: None,
+            artifact: None,
+            case_id: Some("case-1".to_string()),
+            run_id: Some(run.id.clone()),
+            dry_run: true,
+            args: Vec::new(),
+        })
+        .expect("resolve homeboy artifact ref dry-run");
+
+        assert_eq!(exit, 0);
+        assert_eq!(output.status, "dry_run");
+        let expected_ref = format!("homeboy://run/{}/artifact/artifact-1", run.id);
+        assert_eq!(output.artifact_file.as_deref(), Some(expected_ref.as_str()));
+        assert!(output.env.iter().any(|env| {
+            env.name == "HOMEBOY_FUZZ_REPLAY_ARTIFACT_FILE" && env.value == expected_ref
+        }));
+    });
+}
+
+#[test]
 fn fuzz_replay_dry_run_accepts_runner_artifact_ref_without_local_bytes() {
     let reference = "runner-artifact://lab-runner/proof-run/fuzz-result-envelope";
 

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -101,6 +101,75 @@ fn resolve_component_id_uses_fuzz_default_component() {
 }
 
 #[test]
+fn resolve_fuzz_context_preserves_rig_extensions_with_explicit_path_when_registry_missing() {
+    with_isolated_home(|home| {
+        let extension_dir = home.path().join(".config/homeboy/extensions/generic");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("generic.json"),
+            serde_json::json!({
+                "name": "generic",
+                "version": "0.0.0",
+                "fuzz": {
+                    "workloads": [{ "id": "fixture" }]
+                }
+            })
+            .to_string(),
+        )
+        .expect("extension manifest");
+        let component_dir = tempfile::tempdir().expect("component dir");
+        let spec: RigSpec = serde_json::from_value(serde_json::json!({
+            "id": "package-fuzz",
+            "components": {
+                "package": {
+                    "path": "${env.HOMEBOY_EMPTY_PACKAGE_PATH}",
+                    "extensions": {
+                        "generic": {
+                            "settings": {}
+                        }
+                    }
+                }
+            },
+            "fuzz": {
+                "default_component": "package"
+            }
+        }))
+        .expect("parse rig spec");
+        unsafe {
+            std::env::remove_var("HOMEBOY_EMPTY_PACKAGE_PATH");
+        }
+        let context = FuzzRigContext {
+            spec,
+            package_root: None,
+        };
+        let comp = PositionalComponentArgs {
+            component: Some("package".to_string()),
+            path: Some(component_dir.path().to_string_lossy().to_string()),
+        };
+
+        let resolved = resolve_fuzz_context(
+            "package",
+            &comp,
+            &SettingArgs::default(),
+            &ExtensionOverrideArgs::default(),
+            homeboy::core::extension::ExtensionCapability::Fuzz,
+            Some(&context),
+        )
+        .expect("resolve fuzz context");
+
+        assert_eq!(
+            resolved.component.local_path,
+            component_dir.path().to_string_lossy()
+        );
+        assert!(resolved
+            .component
+            .extensions
+            .as_ref()
+            .is_some_and(|extensions| extensions.contains_key("generic")));
+    });
+}
+
+#[test]
 fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_contract() {
     let args = FuzzRunArgs {
         comp: PositionalComponentArgs {

--- a/src/commands/fuzz/workloads.rs
+++ b/src/commands/fuzz/workloads.rs
@@ -131,7 +131,13 @@ pub(super) fn resolve_fuzz_context(
         .path
         .clone()
         .or_else(|| rig_spec.and_then(|spec| rig_component_path(spec, component_id)));
-    let component_override = rig_spec.and_then(|spec| rig_component_for_fuzz(spec, component_id));
+    let component_override = rig_spec.and_then(|spec| {
+        rig_component_for_fuzz(spec, component_id).or_else(|| {
+            path_override
+                .as_ref()
+                .and_then(|path| rig_component_for_fuzz_with_path(spec, component_id, path))
+        })
+    });
 
     let mut resolve_options = ResolveOptions::with_capability_and_json(
         component_id,
@@ -156,6 +162,31 @@ pub(super) fn rig_component_for_fuzz(spec: &RigSpec, component_id: &str) -> Opti
     let mut component = rig::resolve_component(spec, component_id).ok()?;
     component.remote_url = rig_component.remote_url.clone().or(component.remote_url);
     component.extensions = Some(extensions);
+    component.resolve_remote_path();
+    Some(component)
+}
+
+fn rig_component_for_fuzz_with_path(
+    spec: &RigSpec,
+    component_id: &str,
+    path: &str,
+) -> Option<Component> {
+    let rig_component = spec.components.get(component_id)?;
+    let mut extensions = rig_component.extensions.clone()?;
+    expand_rig_extension_settings(spec, &mut extensions);
+    let mut component = Component {
+        id: rig_component
+            .component_id
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(component_id)
+            .to_string(),
+        local_path: path.to_string(),
+        remote_url: rig_component.remote_url.clone(),
+        triage_remote_url: rig_component.triage_remote_url.clone(),
+        extensions: Some(extensions),
+        ..Component::default()
+    };
     component.resolve_remote_path();
     Some(component)
 }

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -364,7 +364,7 @@ fn prepare_lab_offload_workspace_stage_inner(
     let path_remaps = path_remaps_from_workspace_mapping(&workspace_mapping);
     preflight_provider_config_source_cli_dependencies(&offload_args, &synced.excludes)?;
     preflight_provider_config_paths_materialized_in_args(&offload_args, &path_remaps)?;
-    let remapped_args = rig_materialization::remap_bench_rig_default_component_to_primary_snapshot(
+    let remapped_args = rig_materialization::remap_rig_default_component_to_primary_snapshot(
         &offload_args,
         &remote_cwd,
     );

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -365,11 +365,11 @@ fn installed_rig_path_from_stdout(stdout: &str, rig_id: &str) -> Option<String> 
         .map(str::to_string)
 }
 
-pub(super) fn remap_bench_rig_default_component_to_primary_snapshot(
+pub(super) fn remap_rig_default_component_to_primary_snapshot(
     args: &[String],
     primary_remote_path: &str,
 ) -> Vec<String> {
-    if !is_bench_rig_run(args) || has_path_arg(args) {
+    if !is_bench_or_fuzz_rig_component_command(args) || has_path_arg(args) {
         return args.to_vec();
     }
 
@@ -405,9 +405,15 @@ fn primary_source_rig_ids(primary_local_path: &str) -> Result<HashSet<String>> {
         .collect())
 }
 
-fn is_bench_rig_run(args: &[String]) -> bool {
-    matches!(args.get(1).map(String::as_str), Some("bench"))
-        && !lab_offload_rig_ids(args).is_empty()
+fn is_bench_or_fuzz_rig_component_command(args: &[String]) -> bool {
+    match args.get(1).map(String::as_str) {
+        Some("bench") => !lab_offload_rig_ids(args).is_empty(),
+        Some("fuzz") => {
+            matches!(args.get(2).map(String::as_str), Some("list" | "run"))
+                && !lab_offload_rig_ids(args).is_empty()
+        }
+        _ => false,
+    }
 }
 
 fn has_path_arg(args: &[String]) -> bool {
@@ -1242,7 +1248,7 @@ mod tests {
             "editable_preview_ready".to_string(),
         ];
 
-        let rewritten = remap_bench_rig_default_component_to_primary_snapshot(
+        let rewritten = remap_rig_default_component_to_primary_snapshot(
             &args,
             "/home/user/Developer/_lab_workspaces/studio-web-release-clean-abc",
         );
@@ -1258,6 +1264,37 @@ mod tests {
                 "editable_preview_ready",
                 "--path",
                 "/home/user/Developer/_lab_workspaces/studio-web-release-clean-abc",
+            ]
+        );
+    }
+
+    #[test]
+    fn fuzz_rig_list_args_receive_primary_snapshot_path() {
+        let args = vec![
+            "homeboy".to_string(),
+            "fuzz".to_string(),
+            "list".to_string(),
+            "woocommerce".to_string(),
+            "--rig".to_string(),
+            "woocommerce-performance".to_string(),
+        ];
+
+        let rewritten = remap_rig_default_component_to_primary_snapshot(
+            &args,
+            "/home/user/Developer/_lab_workspaces/woocommerce-abc",
+        );
+
+        assert_eq!(
+            rewritten,
+            vec![
+                "homeboy",
+                "fuzz",
+                "list",
+                "woocommerce",
+                "--rig",
+                "woocommerce-performance",
+                "--path",
+                "/home/user/Developer/_lab_workspaces/woocommerce-abc",
             ]
         );
     }
@@ -1299,7 +1336,7 @@ mod tests {
             "--runner-owned".to_string(),
         ];
 
-        let rewritten = remap_bench_rig_default_component_to_primary_snapshot(
+        let rewritten = remap_rig_default_component_to_primary_snapshot(
             &args,
             "/home/user/Developer/_lab_workspaces/studio-web-release-clean-abc",
         );
@@ -1330,7 +1367,7 @@ mod tests {
         ];
 
         assert_eq!(
-            remap_bench_rig_default_component_to_primary_snapshot(&args, "/snapshot"),
+            remap_rig_default_component_to_primary_snapshot(&args, "/snapshot"),
             args
         );
     }


### PR DESCRIPTION
## Summary
- inject the synced runner workspace path for lab-offloaded rig fuzz list/run commands, matching the existing bench path handoff
- preserve rig extension config when fuzz context resolution uses an explicit component path instead of the global component registry
- allow fuzz replay dry-run to render intent from persisted Homeboy artifact refs when local artifact bytes are unavailable

## Tests
- cargo test workload_tests
- cargo test replay_tests
- cargo test rig_materialization
- cargo test -- --test-threads=1 (fails on existing unrelated local baseline failures: runs bundle metadata-only import/export assertions and agent task lifecycle SIGTERM/SIGKILL assertion)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the lab fuzz/replay blockers, implementing the Rust changes, adding tests, and preparing this PR description.
