### PR TITLE
Allow replay dry-run artifact refs without component context

### DIFF
--- a/src/commands/fuzz/replay.rs
+++ b/src/commands/fuzz/replay.rs
@@ -7,7 +7,7 @@ use homeboy::core::fuzz::{
     FUZZ_RESULT_ENVELOPE_SCHEMA,
 };
 use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore};
-use homeboy::core::Error;
+use homeboy::core::{Error, ErrorCode};
 
 use super::super::utils::args::PositionalComponentArgs;
 use super::types::{
@@ -83,7 +83,13 @@ fn run_replay_like(
         args.run_id.as_ref(),
         artifact_ref.as_deref(),
     );
-    let replay_context = resolve_replay_context(&args, mode)?;
+    let replay_context = match resolve_replay_context(&args, mode) {
+        Ok(context) => context,
+        Err(error) if args.dry_run && artifact_ref.is_some() && replay_context_optional(&error) => {
+            None
+        }
+        Err(error) => return Err(error),
+    };
     let replay_command = replay_context
         .as_ref()
         .and_then(|context| context.command.clone())
@@ -354,6 +360,13 @@ fn replay_component_args(args: &ReplayLikeArgs) -> PositionalComponentArgs {
         component: args.component.clone(),
         path: args.path.clone(),
     }
+}
+
+fn replay_context_optional(error: &Error) -> bool {
+    matches!(
+        error.code,
+        ErrorCode::ComponentNotFound | ErrorCode::ExtensionNotFound
+    )
 }
 
 fn replay_message(command: Option<&String>, dry_run: bool, mode: ReplayLikeMode) -> String {

--- a/src/commands/fuzz/tests/replay_tests.rs
+++ b/src/commands/fuzz/tests/replay_tests.rs
@@ -206,11 +206,35 @@ fn fuzz_replay_dry_run_resolves_persisted_homeboy_artifact_ref_without_local_byt
                 created_at: chrono::Utc::now().to_rfc3339(),
             })
             .expect("import artifact ref");
+        let rig_dir = home.path().join(".config/homeboy/rigs");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("fixture-rig.json"),
+            serde_json::json!({
+                "id": "fixture-rig",
+                "components": {
+                    "component-a": {
+                        "path": "${env.HOMEBOY_EMPTY_COMPONENT_PATH}",
+                        "extensions": {
+                            "fixture-fuzz": { "settings": {} }
+                        }
+                    }
+                },
+                "fuzz": {
+                    "default_component": "component-a"
+                }
+            })
+            .to_string(),
+        )
+        .expect("rig spec");
+        unsafe {
+            std::env::remove_var("HOMEBOY_EMPTY_COMPONENT_PATH");
+        }
 
         let (output, exit) = run_replay(FuzzReplayArgs {
-            component: None,
+            component: Some("component-a".to_string()),
             path: None,
-            rig: None,
+            rig: Some("fixture-rig".to_string()),
             extension_override: ExtensionOverrideArgs::default(),
             setting_args: SettingArgs::default(),
             artifact_or_case: None,


### PR DESCRIPTION
## Summary
- let fuzz replay dry-run render persisted artifact-ref intent when component or extension context cannot be resolved locally
- keep non-dry-run behavior unchanged; execution still requires local bytes and valid context
- cover the run-id + component + rig shape where the persisted artifact ref exists but the rig component path is not locally materialized

## Tests
- cargo test replay_tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the remaining replay dry-run context edge, implementing the Rust change, adding coverage, and preparing this PR description.
