### PR TITLE
Emit runner job heartbeat progress

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::time::UNIX_EPOCH;
 
 use crate::command_contract::RunnerWorkload;
@@ -16,7 +16,7 @@ use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnal
 use crate::core::paths;
 use crate::core::process::pid_is_running;
 use crate::core::runner::{
-    execute_runner_process_until_cancelled, prepare_daemon_local_process, Runner,
+    execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process, Runner,
     RunnerProcessRequest,
 };
 use crate::core::source_snapshot::SourceSnapshot;
@@ -538,8 +538,15 @@ fn enqueue_exec_job(
             } else {
                 None
             };
-            let process_output =
-                execute_runner_process_until_cancelled(&plan, || job.is_cancelled())?;
+            let progress_job = job.clone();
+            let progress_sink = Arc::new(move |data| {
+                let _ = progress_job.progress(data);
+            });
+            let process_output = execute_runner_process_until_cancelled_with_progress(
+                &plan,
+                || job.is_cancelled(),
+                Some(progress_sink),
+            )?;
             let stdout = process_output.stdout.clone();
             let stderr = process_output.stderr.clone();
             let exit_code = process_output.exit_code;

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -77,9 +77,11 @@ pub(crate) use failure::{
     runner_exec_failure_context_remediation_hint,
 };
 pub(crate) use handoff::lab_offload_handoff_hints;
-pub(crate) use process::{execute_runner_process_until_cancelled, prepare_daemon_local_process};
+pub(crate) use process::{
+    execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
+};
 pub(crate) use secrets::runner_exec_secret_env_names;
-pub(crate) use worker::exec_worker_local_until_cancelled;
+pub(crate) use worker::exec_worker_local_until_cancelled_with_progress;
 
 // Public surface re-exported by the parent `runner` module. These mirror the
 // pre-split `pub` items so external callers keep referencing them unchanged.

--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -9,7 +9,8 @@ use crate::core::source_snapshot::SourceSnapshot;
 
 use super::super::normalize_runner_command_env;
 use super::super::resource_metrics::{
-    measured_command_output, measured_command_output_until_cancelled,
+    measured_command_output, measured_command_output_until_cancelled_with_progress,
+    RunnerCommandProgressSink,
 };
 use super::super::{load, Runner, RunnerKind};
 
@@ -302,15 +303,16 @@ pub(crate) fn execute_runner_process(plan: &PreparedRunnerProcess) -> Result<Pro
     command_output(&mut command)
 }
 
-pub(crate) fn execute_runner_process_until_cancelled(
+pub(crate) fn execute_runner_process_until_cancelled_with_progress(
     plan: &PreparedRunnerProcess,
     is_cancelled: impl FnMut() -> bool,
+    progress_sink: Option<RunnerCommandProgressSink>,
 ) -> Result<ProcessOutput> {
     let mut command = std::process::Command::new(&plan.command[0]);
     command.args(&plan.command[1..]).current_dir(&plan.cwd);
     apply_runner_process_env(&mut command, plan);
 
-    command_output_until_cancelled(&mut command, is_cancelled)
+    command_output_until_cancelled_with_progress(&mut command, is_cancelled, progress_sink)
 }
 
 pub(super) fn apply_runner_process_env(
@@ -347,11 +349,16 @@ pub(super) fn command_output(command: &mut std::process::Command) -> Result<Proc
     })
 }
 
-pub(super) fn command_output_until_cancelled(
+pub(super) fn command_output_until_cancelled_with_progress(
     command: &mut std::process::Command,
     is_cancelled: impl FnMut() -> bool,
+    progress_sink: Option<RunnerCommandProgressSink>,
 ) -> Result<ProcessOutput> {
-    let measured = measured_command_output_until_cancelled(command, is_cancelled)?;
+    let measured = measured_command_output_until_cancelled_with_progress(
+        command,
+        is_cancelled,
+        progress_sink,
+    )?;
     let output = measured.output;
     Ok(ProcessOutput {
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),

--- a/src/core/runner/execution/worker.rs
+++ b/src/core/runner/execution/worker.rs
@@ -13,14 +13,15 @@ use super::policy::{validate_runner_policy, RunnerPolicyRequest};
 #[allow(unused_imports)]
 use super::*;
 
-pub(crate) fn exec_worker_local_until_cancelled(
+pub(crate) fn exec_worker_local_until_cancelled_with_progress(
     runner_id: &str,
     options: RunnerExecOptions,
     is_cancelled: impl FnMut() -> bool,
+    progress_sink: Option<super::super::RunnerCommandProgressSink>,
 ) -> Result<(RunnerExecOutput, i32)> {
     let mut is_cancelled = is_cancelled;
     exec_worker_local_with_process_output(runner_id, options, |plan| {
-        execute_runner_process_until_cancelled(plan, &mut is_cancelled)
+        execute_runner_process_until_cancelled_with_progress(plan, &mut is_cancelled, progress_sink)
     })
 }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -87,8 +87,9 @@ pub use evidence::{
     RemoteArtifactDownload, RunnerJobLogSnapshot,
 };
 pub(crate) use execution::{
-    daemon_api_get, execute_runner_process_until_cancelled, prepare_daemon_local_process,
-    runner_exec_secret_env_names, RunnerProcessRequest, RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV,
+    daemon_api_get, execute_runner_process_until_cancelled_with_progress,
+    prepare_daemon_local_process, runner_exec_secret_env_names, RunnerProcessRequest,
+    RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV,
 };
 pub use execution::{
     daemon_api_post, exec, runner_exec_failure_error, runner_job_cancel, RunnerExecDiagnostics,
@@ -117,6 +118,7 @@ pub use offload_metadata::{
     lab_offload_metadata_with_workspace_mapping,
     lab_offload_metadata_with_workspace_mapping_and_runner_workload,
 };
+pub(crate) use resource_metrics::RunnerCommandProgressSink;
 pub use resource_metrics::RunnerResourceMetrics;
 pub use session::{
     ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,

--- a/src/core/runner/resource_metrics.rs
+++ b/src/core/runner/resource_metrics.rs
@@ -4,6 +4,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 
 use crate::core::engine::command::{
     isolate_process_tree, wait_with_bounded_output, wait_with_bounded_output_until_cancelled,
@@ -12,6 +13,7 @@ use crate::core::engine::command::{
 use crate::core::error::{Error, Result};
 
 const SAMPLE_INTERVAL: Duration = Duration::from_millis(1000);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerResourceMetrics {
@@ -35,6 +37,8 @@ pub(crate) struct MeasuredOutput {
     pub metrics: RunnerResourceMetrics,
 }
 
+pub(crate) type RunnerCommandProgressSink = Arc<dyn Fn(Value) + Send + Sync + 'static>;
+
 #[derive(Debug, Default)]
 struct MetricsState {
     sample_count: u64,
@@ -51,7 +55,7 @@ pub(crate) fn measured_command_output(command: &mut Command) -> Result<MeasuredO
         Error::internal_io(err.to_string(), Some("execute runner command".to_string()))
     })?;
     let pid = child.id();
-    let collector = ResourceMetricsCollector::start(pid);
+    let collector = ResourceMetricsCollector::start(pid, started, None);
     let bounded_output =
         wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES).map_err(|err| {
             Error::internal_io(err.to_string(), Some("wait for runner command".to_string()))
@@ -66,9 +70,10 @@ pub(crate) fn measured_command_output(command: &mut Command) -> Result<MeasuredO
     })
 }
 
-pub(crate) fn measured_command_output_until_cancelled(
+pub(crate) fn measured_command_output_until_cancelled_with_progress(
     command: &mut Command,
     is_cancelled: impl FnMut() -> bool,
+    progress_sink: Option<RunnerCommandProgressSink>,
 ) -> Result<MeasuredOutput> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
     isolate_process_tree(command);
@@ -77,7 +82,7 @@ pub(crate) fn measured_command_output_until_cancelled(
         Error::internal_io(err.to_string(), Some("execute runner command".to_string()))
     })?;
     let pid = child.id();
-    let collector = ResourceMetricsCollector::start(pid);
+    let collector = ResourceMetricsCollector::start(pid, started, progress_sink);
     let bounded_output = wait_with_bounded_output_until_cancelled(
         &mut child,
         DEFAULT_CAPTURE_LIMIT_BYTES,
@@ -104,10 +109,14 @@ struct ResourceMetricsCollector {
 }
 
 impl ResourceMetricsCollector {
-    fn start(root_pid: u32) -> Self {
+    fn start(
+        root_pid: u32,
+        started: Instant,
+        progress_sink: Option<RunnerCommandProgressSink>,
+    ) -> Self {
         let supported = cfg!(target_os = "linux") && std::path::Path::new("/proc").exists();
         let state = Arc::new(Mutex::new(MetricsState::default()));
-        if !supported {
+        if !supported && progress_sink.is_none() {
             return Self {
                 supported,
                 stop: None,
@@ -119,8 +128,19 @@ impl ResourceMetricsCollector {
         let (stop, stop_rx) = mpsc::channel();
         sample(root_pid, &state);
         let thread_state = Arc::clone(&state);
+        let mut last_heartbeat = Instant::now();
         let handle = thread::spawn(move || loop {
             sample(root_pid, &thread_state);
+            if let Some(progress) = progress_sink.as_ref() {
+                if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
+                    progress(runner_command_heartbeat_data(
+                        started.elapsed(),
+                        root_pid,
+                        process_tree_resource_summary(root_pid),
+                    ));
+                    last_heartbeat = Instant::now();
+                }
+            }
             if stop_rx.recv_timeout(SAMPLE_INTERVAL).is_ok() {
                 break;
             }
@@ -157,6 +177,39 @@ impl ResourceMetricsCollector {
             },
         }
     }
+}
+
+pub(crate) fn runner_command_heartbeat_data(
+    elapsed: Duration,
+    root_pid: u32,
+    resources: Option<Value>,
+) -> Value {
+    json!({
+        "phase": "heartbeat",
+        "elapsed_ms": elapsed.as_millis(),
+        "process": {
+            "root_pid": root_pid,
+            "resources": resources,
+        },
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn process_tree_resource_summary(root_pid: u32) -> Option<Value> {
+    let snapshot = process_tree_snapshot(root_pid)?;
+    Some(json!({
+        "source": "linux_procfs_process_tree",
+        "process_count": snapshot.process_count,
+        "child_process_count": snapshot.process_count.saturating_sub(1),
+        "rss_bytes": snapshot.rss_bytes,
+        "cpu_user_ms": snapshot.cpu_user_ms,
+        "cpu_system_ms": snapshot.cpu_system_ms,
+    }))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_tree_resource_summary(_root_pid: u32) -> Option<Value> {
+    None
 }
 
 #[cfg(target_os = "linux")]
@@ -281,6 +334,40 @@ fn clock_ticks_per_second() -> u64 {
     static CLOCK_TICKS_PER_SECOND: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
 
     *CLOCK_TICKS_PER_SECOND.get_or_init(|| command_u64("getconf", &["CLK_TCK"]).unwrap_or(100))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn heartbeat_payload_includes_elapsed_pid_and_optional_resources() {
+        let payload = runner_command_heartbeat_data(
+            Duration::from_millis(42_000),
+            1234,
+            Some(json!({
+                "source": "fixture",
+                "process_count": 3,
+                "child_process_count": 2,
+            })),
+        );
+
+        assert_eq!(payload["phase"], "heartbeat");
+        assert_eq!(payload["elapsed_ms"], 42_000);
+        assert_eq!(payload["process"]["root_pid"], 1234);
+        assert_eq!(payload["process"]["resources"]["process_count"], 3);
+        assert_eq!(payload["process"]["resources"]["child_process_count"], 2);
+    }
+
+    #[test]
+    fn heartbeat_payload_allows_missing_resource_summary() {
+        let payload = runner_command_heartbeat_data(Duration::from_millis(5), 9, None);
+
+        assert_eq!(payload["phase"], "heartbeat");
+        assert_eq!(payload["elapsed_ms"], 5);
+        assert_eq!(payload["process"]["root_pid"], 9);
+        assert!(payload["process"]["resources"].is_null());
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/src/core/runner/worker/broker.rs
+++ b/src/core/runner/worker/broker.rs
@@ -64,6 +64,31 @@ pub(super) fn append_progress(
     Ok(())
 }
 
+pub(super) fn append_progress_data(
+    client: &Client,
+    broker_url: &str,
+    token: Option<&str>,
+    runner_id: &str,
+    job: &Job,
+    data: serde_json::Value,
+) -> Result<()> {
+    let claim_id = remote_runner_claim_id(job)?;
+    broker_http::post_json(
+        client,
+        broker_url,
+        &format!("/runner/jobs/{}/events", job.id),
+        json!({
+            "runner_id": runner_id,
+            "claim_id": claim_id,
+            "kind": "progress",
+            "data": data,
+        }),
+        "append reverse runner progress event",
+        token,
+    )?;
+    Ok(())
+}
+
 pub(super) fn finish_job(
     client: &Client,
     broker_url: &str,

--- a/src/core/runner/worker/run.rs
+++ b/src/core/runner/worker/run.rs
@@ -11,9 +11,10 @@ use serde_json::json;
 use crate::core::api_jobs::{RemoteRunnerJobRequest, RemoteRunnerJobResult};
 use crate::core::error::{Error, Result};
 
-use super::super::execution::{exec_worker_local_until_cancelled, RunnerExecOptions};
+use super::super::execution::{exec_worker_local_until_cancelled_with_progress, RunnerExecOptions};
 use super::broker::{
-    append_progress, cancelled_job_snapshot, claim_job, finish_job, start_claim_heartbeat,
+    append_progress, append_progress_data, cancelled_job_snapshot, claim_job, finish_job,
+    start_claim_heartbeat,
 };
 use super::result::{
     cancelled_output, claimed_output, log_worker_event, remote_runner_result_from_exec_output,
@@ -278,7 +279,20 @@ fn run_once_output(
     let mut cancel_seen = false;
     let mut last_cancel_poll = Instant::now();
     let claimed_run_id = claimed_job_run_id(&claim.request);
-    let exec_result = exec_worker_local_until_cancelled(
+    let progress_client = client.clone();
+    let progress_options = options.clone();
+    let progress_job = claim.job.clone();
+    let progress_sink = Arc::new(move |data| {
+        let _ = append_progress_data(
+            &progress_client,
+            &progress_options.broker_url,
+            progress_options.broker_token.as_deref(),
+            &progress_options.runner_id,
+            &progress_job,
+            data,
+        );
+    });
+    let exec_result = exec_worker_local_until_cancelled_with_progress(
         &options.runner_id,
         RunnerExecOptions {
             cwd: claim.request.cwd.clone(),
@@ -307,6 +321,7 @@ fn run_once_output(
                 .unwrap_or(false);
             cancel_seen
         },
+        Some(progress_sink),
     );
     let (exec_output, exit_code) = match exec_result {
         Ok(result) => result,


### PR DESCRIPTION
## Summary
- Emit generic runner command heartbeat progress events for long-running child processes.
- Include elapsed milliseconds, root PID, and process/resource summary when available.
- Wire heartbeat progress into both direct daemon jobs and reverse broker jobs without runtime/provider-specific logic.

Fixes #6998

## Tests
- cargo test core::runner::resource_metrics::tests --lib
- cargo test core::runner::execution::tests --lib
- cargo test core::runner::worker --lib
- rustfmt --check src/core/daemon.rs src/core/runner/execution/process.rs src/core/runner/resource_metrics.rs src/core/runner/worker/broker.rs src/core/runner/worker/run.rs

## Notes
- Repository-wide cargo fmt --check still reports pre-existing formatting drift outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Code inspection, implementation, tests, and PR drafting.