### PR TITLE
Reduce runner-resident read polling noise

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -51,6 +51,9 @@ pub struct LabRoutingPolicy {
     /// Whether the command requires extension parity between controller and
     /// runner before offloading.
     pub requires_extension_parity: bool,
+    /// Whether runner-resident reads should avoid durable mirror runs and
+    /// handoff boilerplate unless the command itself emits them.
+    pub read_only_polling: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
@@ -561,7 +564,9 @@ impl Commands {
                             agent_task::AgentTaskFanoutCommand::Status(_)
                             | agent_task::AgentTaskFanoutCommand::Artifacts(_),
                     }),
-            }) => LabCommandContract::runner_resident(AGENT_TASK_FANOUT_STATUS_LAB_LABEL),
+            }) => LabCommandContract::runner_resident_read_polling(
+                AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
+            ),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Controller(agent_task::AgentTaskControllerArgs {
@@ -588,9 +593,12 @@ impl Commands {
             }) => LabCommandContract::runner_resident(AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
+                    agent_task::AgentTaskCommand::Run(_)
+                    | agent_task::AgentTaskCommand::RunNext,
+            }) => LabCommandContract::runner_resident(AGENT_TASK_STATUS_LAB_LABEL),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command:
                     agent_task::AgentTaskCommand::Status(_)
-                    | agent_task::AgentTaskCommand::Run(_)
-                    | agent_task::AgentTaskCommand::RunNext
                     | agent_task::AgentTaskCommand::Logs(_)
                     | agent_task::AgentTaskCommand::Artifacts(_)
                     | agent_task::AgentTaskCommand::Evidence(_)
@@ -603,7 +611,7 @@ impl Commands {
                     | agent_task::AgentTaskCommand::List(_)
                     | agent_task::AgentTaskCommand::Active(_)
                     | agent_task::AgentTaskCommand::Latest(_),
-            }) => LabCommandContract::runner_resident(AGENT_TASK_STATUS_LAB_LABEL),
+            }) => LabCommandContract::runner_resident_read_polling(AGENT_TASK_STATUS_LAB_LABEL),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Auth(agent_task::AgentTaskAuthArgs {
@@ -789,6 +797,7 @@ impl LabCommandContract {
                 infer_source_path_tools: true,
                 release_gate: false,
                 requires_extension_parity,
+                read_only_polling: false,
             },
         }
     }
@@ -857,6 +866,17 @@ impl LabCommandContract {
         }
     }
 
+    pub(crate) fn runner_resident_read_polling(hot_label: &'static str) -> Self {
+        let base = Self::runner_resident(hot_label);
+        Self {
+            routing_policy: LabRoutingPolicy {
+                read_only_polling: true,
+                ..base.routing_policy
+            },
+            ..base
+        }
+    }
+
     pub(crate) fn local_only(hot_label: &'static str, reason: &'static str) -> Self {
         Self {
             hot_label,
@@ -871,6 +891,7 @@ impl LabCommandContract {
                 infer_source_path_tools: false,
                 release_gate: false,
                 requires_extension_parity: false,
+                read_only_polling: false,
             },
         }
     }
@@ -1042,6 +1063,56 @@ mod extension_ids {
         let context = resolve_for(Some(ExtensionCapability::Test))?;
 
         Ok(context.extension_id.into_iter().collect())
+    }
+}
+
+#[cfg(test)]
+mod low_noise_polling_tests {
+    use super::*;
+    use crate::cli_surface::Cli;
+    use clap::Parser;
+
+    fn parsed_command(args: &[&str]) -> Commands {
+        Cli::try_parse_from(args)
+            .expect("CLI args should parse")
+            .command
+    }
+
+    #[test]
+    fn runner_resident_agent_task_reads_are_low_noise_polling() {
+        for args in [
+            ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "list"].as_slice(),
+            ["homeboy", "agent-task", "active"].as_slice(),
+            ["homeboy", "agent-task", "latest"].as_slice(),
+        ] {
+            let contract = parsed_command(args)
+                .lab_contract()
+                .expect("runner-resident read polling contract");
+            assert_eq!(contract.source_path_mode, LabSourcePathMode::RunnerResident);
+            assert_eq!(
+                contract.workspace_mode_policy,
+                LabWorkspaceModePolicy::RunnerResident
+            );
+            assert!(contract.routing_policy.read_only_polling);
+        }
+    }
+
+    #[test]
+    fn runner_resident_agent_task_execution_keeps_full_runner_evidence() {
+        for args in [
+            ["homeboy", "agent-task", "run", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "run-next"].as_slice(),
+            ["homeboy", "agent-task", "controller", "resume", "loop-123"].as_slice(),
+        ] {
+            let contract = parsed_command(args)
+                .lab_contract()
+                .expect("runner-resident execution contract");
+            assert_eq!(contract.source_path_mode, LabSourcePathMode::RunnerResident);
+            assert!(!contract.routing_policy.read_only_polling);
+        }
     }
 }
 pub(crate) use extension_ids::*;

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -109,6 +109,10 @@ pub fn route_after_parse(
             active_run_id: active_run_id.as_deref(),
             detach_after_handoff: cli.detach_after_handoff,
             output_file_requested: output_file.is_some(),
+            read_only_polling: cli
+                .command
+                .lab_route_contract()?
+                .is_some_and(|contract| contract.command.routing_policy.read_only_polling),
             local_output_file: output_file,
             job_overrides,
         },
@@ -481,6 +485,8 @@ fn run_rig_source_management_on_runner(
             runner_workload: None,
             run_id: None,
             detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
         },
     )?;
 

--- a/src/commands/runner/exec.rs
+++ b/src/commands/runner/exec.rs
@@ -99,6 +99,8 @@ pub(super) fn exec(
             runner_workload: None,
             run_id: validated_run_id.clone(),
             detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
         },
     )?;
     if let Some(run_id) = validated_run_id.as_deref() {

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -38,6 +38,7 @@ pub struct LabRoutingRequest<'a> {
     pub active_run_id: Option<&'a str>,
     pub detach_after_handoff: bool,
     pub output_file_requested: bool,
+    pub read_only_polling: bool,
     /// Controller-local `--output` path forwarded to the offload executor so the
     /// durable agent-task run id can be persisted before long execution (#5684).
     pub local_output_file: Option<&'a str>,
@@ -62,6 +63,7 @@ pub(crate) fn route_lab_offload(
         mutation_flag: request.mutation_flag,
         detach_after_handoff: request.detach_after_handoff,
         output_file_requested: request.output_file_requested,
+        read_only_polling: request.read_only_polling,
         local_output_file: request.local_output_file,
         job_overrides: request.job_overrides,
     })
@@ -416,6 +418,7 @@ fn execute_lab_offload_with_timeout(
     let mutation_flag = request.mutation_flag.map(str::to_string);
     let detach_after_handoff = request.detach_after_handoff;
     let output_file_requested = request.output_file_requested;
+    let read_only_polling = request.read_only_polling;
     let local_output_file = request.local_output_file.map(str::to_string);
     let job_overrides = request.job_overrides;
     let (tx, rx) = std::sync::mpsc::channel();
@@ -431,6 +434,7 @@ fn execute_lab_offload_with_timeout(
             mutation_flag: mutation_flag.as_deref(),
             detach_after_handoff,
             output_file_requested,
+            read_only_polling,
             local_output_file: local_output_file.as_deref(),
             job_overrides,
         });
@@ -514,6 +518,7 @@ mod tests {
                 infer_source_path_tools: false,
                 release_gate: false,
                 requires_extension_parity: true,
+                read_only_polling: false,
             },
         }
     }
@@ -595,6 +600,7 @@ mod tests {
             active_run_id: None,
             detach_after_handoff: false,
             output_file_requested: false,
+            read_only_polling: false,
             local_output_file: None,
             job_overrides: runners::LabJobOverrides::default(),
         })
@@ -766,6 +772,7 @@ mod tests {
                 active_run_id: None,
                 detach_after_handoff: false,
                 output_file_requested: false,
+                read_only_polling: false,
                 local_output_file: None,
                 job_overrides: runners::LabJobOverrides::default(),
             },

--- a/src/core/runner/execution/broker.rs
+++ b/src/core/runner/execution/broker.rs
@@ -30,6 +30,8 @@ pub(super) fn exec_via_reverse_broker(
     runner_workload: Option<RunnerWorkload>,
     run_id: Option<String>,
     detach_after_handoff: bool,
+    mirror_evidence: bool,
+    print_handoff_output: bool,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
         .timeout(Duration::from_secs(10))
@@ -87,8 +89,9 @@ pub(super) fn exec_via_reverse_broker(
             Some("parse reverse broker job".to_string()),
         )
     })?;
-    let persisted_run_id =
-        persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref());
+    let persisted_run_id = mirror_evidence
+        .then(|| persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref()))
+        .flatten();
     if detach_after_handoff {
         return Ok(detached_handoff_output(
             runner,
@@ -148,28 +151,34 @@ pub(super) fn exec_via_reverse_broker(
         &redaction_secret_env_names,
     );
 
-    let mirror = mirror_reverse_broker_evidence(
-        runner,
-        broker_url,
-        &cwd,
-        &command,
-        &job,
-        &events,
-        &result,
-        run_id.as_deref(),
-    )?;
+    let mirror = if mirror_evidence {
+        mirror_reverse_broker_evidence(
+            runner,
+            broker_url,
+            &cwd,
+            &command,
+            &job,
+            &events,
+            &result,
+            run_id.as_deref(),
+        )?
+    } else {
+        None
+    };
     let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
     let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.clone());
     let artifacts = job.artifacts.clone();
     let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
 
-    print_lab_offload_handoff(
-        &runner.id,
-        Some(&cwd),
-        &job.id.to_string(),
-        mirror_run_id.as_deref(),
-        DaemonJobHandoffState::Terminal(job.status),
-    );
+    if print_handoff_output {
+        print_lab_offload_handoff(
+            &runner.id,
+            Some(&cwd),
+            &job.id.to_string(),
+            mirror_run_id.as_deref(),
+            DaemonJobHandoffState::Terminal(job.status),
+        );
+    }
 
     let runner_job = RunnerJob::from_job(&runner.id, "broker", &command, Some(cwd.clone()), &job);
     let runner_result = runner_result(

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -41,6 +41,8 @@ pub(super) fn exec_via_daemon(
     runner_workload: Option<RunnerWorkload>,
     run_id: Option<String>,
     detach_after_handoff: bool,
+    mirror_evidence: bool,
+    print_handoff_output: bool,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
         .no_proxy()
@@ -97,8 +99,9 @@ pub(super) fn exec_via_daemon(
     let mut job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
         Error::internal_json(err.to_string(), Some("parse daemon exec job".to_string()))
     })?;
-    let persisted_run_id =
-        persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref());
+    let persisted_run_id = mirror_evidence
+        .then(|| persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref()))
+        .flatten();
     if detach_after_handoff {
         return Ok(detached_handoff_output(
             runner,
@@ -155,26 +158,32 @@ pub(super) fn exec_via_daemon(
         exit_code,
     } = runner_job_result_fields(&events, job.status, &env, &secret_env_names);
 
-    let mirror = mirror_daemon_evidence(
-        runner,
-        &cwd,
-        &command,
-        &job,
-        &events,
-        &result,
-        run_id.as_deref(),
-    )?;
+    let mirror = if mirror_evidence {
+        mirror_daemon_evidence(
+            runner,
+            &cwd,
+            &command,
+            &job,
+            &events,
+            &result,
+            run_id.as_deref(),
+        )?
+    } else {
+        None
+    };
     let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
     let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.clone());
     let artifacts = job.artifacts.clone();
     let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
-    print_lab_offload_handoff(
-        &runner.id,
-        Some(&cwd),
-        &job.id.to_string(),
-        mirror_run_id.as_deref(),
-        DaemonJobHandoffState::Terminal(job.status),
-    );
+    if print_handoff_output {
+        print_lab_offload_handoff(
+            &runner.id,
+            Some(&cwd),
+            &job.id.to_string(),
+            mirror_run_id.as_deref(),
+            DaemonJobHandoffState::Terminal(job.status),
+        );
+    }
 
     let runner_job = RunnerJob::from_job(&runner.id, "daemon", &command, Some(cwd.clone()), &job);
     let runner_result = runner_result(

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -104,6 +104,8 @@ pub struct RunnerExecOptions {
     pub runner_workload: Option<RunnerWorkload>,
     pub run_id: Option<String>,
     pub detach_after_handoff: bool,
+    pub mirror_evidence: bool,
+    pub print_handoff: bool,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -555,6 +557,8 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 options.runner_workload,
                 options.run_id,
                 options.detach_after_handoff,
+                options.mirror_evidence,
+                options.print_handoff,
             )
         }
         RunnerTransport::ReverseBroker(handle) => {
@@ -573,6 +577,8 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 options.runner_workload,
                 options.run_id,
                 options.detach_after_handoff,
+                options.mirror_evidence,
+                options.print_handoff,
             )
         }
         RunnerTransport::Local => exec_local(plan),

--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -396,6 +396,8 @@ fn worker_local_workload_validation_uses_implicit_command_secret_names() {
                 runner_workload: Some(workload),
                 run_id: None,
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
             |_plan| {
                 Ok(ProcessOutput {
@@ -437,6 +439,8 @@ fn test_exec_runs_local_runner_command() {
                 runner_workload: None,
                 run_id: None,
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
         )
         .expect("exec local runner");
@@ -494,6 +498,8 @@ fn test_exec_does_not_leak_ambient_process_env() {
                 runner_workload: None,
                 run_id: None,
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
         )
         .expect("exec local runner");
@@ -531,6 +537,8 @@ fn test_exec_preserves_explicit_request_env() {
                 runner_workload: None,
                 run_id: None,
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
         )
         .expect("exec local runner");
@@ -582,6 +590,8 @@ fn runner_exec_explicit_run_id_overrides_conflicting_run_id_env() {
                 runner_workload: None,
                 run_id: Some("explicit-run".to_string()),
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
         )
         .expect("exec local runner");
@@ -640,6 +650,8 @@ fn test_exec_rejects_missing_required_local_runner_path() {
                 runner_workload: None,
                 run_id: None,
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
         )
         .expect_err("missing required path rejects before command");
@@ -684,6 +696,8 @@ fn test_exec_reports_required_path_diagnostics() {
                 runner_workload: None,
                 run_id: None,
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
         )
         .expect("exec with required path");
@@ -739,6 +753,8 @@ fn test_exec_rejects_disconnected_ssh_runner_without_diagnostic_fallback() {
                 runner_workload: None,
                 run_id: None,
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
         )
         .expect_err("disconnected ssh runner needs daemon or diagnostic fallback");
@@ -778,6 +794,8 @@ fn explicit_diagnostic_ssh_wins_for_ssh_runners() {
         runner_workload: None,
         run_id: None,
         detach_after_handoff: false,
+        mirror_evidence: true,
+        print_handoff: true,
     };
 
     assert!(should_force_diagnostic_ssh(&ssh_runner(), &options));

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -128,10 +128,7 @@ fn opt_in_cancels_remote_job_on_wait_timeout() {
 
         // The opt-in cancel primitive fired exactly once, targeting this job.
         assert_eq!(calls.borrow().len(), 1);
-        assert_eq!(
-            calls.borrow()[0],
-            ("lab".to_string(), job_id.to_string())
-        );
+        assert_eq!(calls.borrow()[0], ("lab".to_string(), job_id.to_string()));
         // The timeout still surfaces, but no longer claims the job was left running.
         assert!(!err.message.contains("was not cancelled"));
         assert!(err.message.contains("remote cancellation was requested"));
@@ -208,9 +205,10 @@ fn opt_in_surfaces_remote_cancel_failure_on_wait_timeout() {
         assert!(err.message.contains("but failed"));
         assert!(err.message.contains("runner is not connected"));
         assert_eq!(err.details["cancel_on_wait_timeout"], "failed");
-        assert!(err.hints.iter().any(|hint| hint
-            .message
-            .contains("remote cancellation failed")));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("remote cancellation failed")));
     });
 }
 
@@ -388,6 +386,8 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
             Vec::new(),
             None,
             Some(stable_run_id.to_string()),
+            true,
+            true,
             true,
         )
         .expect("reverse broker detached exec");
@@ -662,6 +662,8 @@ fn reverse_broker_exec_submits_job_and_polls_result() {
             None,
             None,
             false,
+            true,
+            true,
         )
         .expect("reverse broker exec");
         worker.join().expect("worker joins");
@@ -777,6 +779,8 @@ fn daemon_exec_failure_without_error_field_is_actionable() {
         None,
         None,
         false,
+        true,
+        true,
     )
     .expect_err("daemon exec failure");
 
@@ -937,6 +941,8 @@ fn daemon_exec_empty_envelope_over_http_is_actionable_not_null() {
         None,
         None,
         false,
+        true,
+        true,
     )
     .expect_err("daemon exec failure");
 

--- a/src/core/runner/execution/tests/policy.rs
+++ b/src/core/runner/execution/tests/policy.rs
@@ -41,6 +41,8 @@ fn test_runner_policy_denies_raw_ssh_exec_by_default() {
         runner_workload: None,
         run_id: None,
         detach_after_handoff: false,
+        mirror_evidence: true,
+        print_handoff: true,
     };
 
     let err = validate_runner_policy(&runner, "/srv/homeboy/project", policy_request(&options))
@@ -78,6 +80,8 @@ fn test_runner_policy_enforces_projects_commands_workspace_and_artifacts() {
         runner_workload: None,
         run_id: None,
         detach_after_handoff: false,
+        mirror_evidence: true,
+        print_handoff: true,
     };
     validate_runner_policy(
         &runner,

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -173,6 +173,8 @@ pub fn refresh_homeboy_binary(
             runner_workload: None,
             run_id: None,
             detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
         },
     )?;
     if exit_code != 0 {

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -744,6 +744,8 @@ pub(crate) fn run_lab_offload_inner(
             runner_workload: Some(runner_workload),
             run_id: agent_task_run_id.clone(),
             detach_after_handoff: request.detach_after_handoff,
+            mirror_evidence: true,
+            print_handoff: true,
         },
     );
     overhead.record(LabOffloadPhase::RemoteExec, remote_exec_started.elapsed());

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -98,12 +98,14 @@ pub(crate) fn run_runner_resident_lab_offload(
         runner_workspace_root,
     )?;
 
-    eprintln!(
-        "Lab offload: running runner-resident `{}` on runner `{}` in `{}`.",
-        redact_argv_display(&command),
-        runner_id,
-        runner_workspace_root
-    );
+    if !request.read_only_polling {
+        eprintln!(
+            "Lab offload: running runner-resident `{}` on runner `{}` in `{}`.",
+            redact_argv_display(&command),
+            runner_id,
+            runner_workspace_root
+        );
+    }
     let mut lab_metadata = lab_offload_metadata(
         &plan,
         selection.source.metadata_value(),
@@ -152,6 +154,8 @@ pub(crate) fn run_runner_resident_lab_offload(
     secret_env_names.dedup();
     preflight_lab_secret_env_handoff(runner_id, None, &env, &secret_env_handoff)?;
 
+    let (mirror_evidence, print_handoff) =
+        runner_resident_exec_noise_policy(request.read_only_polling);
     let exec_timer = overhead.phase(LabOffloadPhase::RemoteExec);
     let (exec_output, exit_code) = exec(
         runner_id,
@@ -171,6 +175,8 @@ pub(crate) fn run_runner_resident_lab_offload(
             runner_workload: None,
             run_id: agent_task_run_id,
             detach_after_handoff: false,
+            mirror_evidence,
+            print_handoff,
         },
     )?;
     exec_timer.finish();
@@ -188,7 +194,7 @@ pub(crate) fn run_runner_resident_lab_offload(
         .inputs(PlanValues::new().json("exit_code", exit_code))
         .build(),
     );
-    if !exec_output.stderr.is_empty() {
+    if !request.read_only_polling && !exec_output.stderr.is_empty() {
         messages.push(format!(
             "Lab offload: runner-resident command wrote {} stderr bytes.",
             exec_output.stderr.len()
@@ -196,9 +202,11 @@ pub(crate) fn run_runner_resident_lab_offload(
     }
 
     let mut stderr = String::new();
-    for message in messages {
-        stderr.push_str(&message);
-        stderr.push('\n');
+    if !request.read_only_polling {
+        for message in messages {
+            stderr.push_str(&message);
+            stderr.push('\n');
+        }
     }
     stderr.push_str(&exec_output.stderr);
     if exit_code != 0 {
@@ -225,6 +233,25 @@ pub(crate) fn run_runner_resident_lab_offload(
         exit_code,
         output_file_content,
     })
+}
+
+fn runner_resident_exec_noise_policy(read_only_polling: bool) -> (bool, bool) {
+    (!read_only_polling, !read_only_polling)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::runner_resident_exec_noise_policy;
+
+    #[test]
+    fn read_only_polling_skips_runner_exec_mirror_and_handoff_output() {
+        assert_eq!(runner_resident_exec_noise_policy(true), (false, false));
+    }
+
+    #[test]
+    fn runner_resident_execution_preserves_runner_exec_evidence() {
+        assert_eq!(runner_resident_exec_noise_policy(false), (true, true));
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -266,6 +293,8 @@ pub(crate) fn refresh_managed_runner_sources(
                 runner_workload: None,
                 run_id: None,
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
         )?;
         if exit_code != 0 {

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -343,6 +343,7 @@ fn plan_records_skipped_auto_offload() {
         mutation_flag: None,
         detach_after_handoff: false,
         output_file_requested: false,
+        read_only_polling: false,
         local_output_file: None,
         job_overrides: LabJobOverrides::default(),
     })
@@ -370,6 +371,7 @@ fn lab_only_refuses_local_execution_without_lab_contract() {
         mutation_flag: None,
         detach_after_handoff: false,
         output_file_requested: false,
+        read_only_polling: false,
         local_output_file: None,
         job_overrides: LabJobOverrides::default(),
     });
@@ -398,6 +400,7 @@ fn build_runner_error_gives_managed_runner_replacement() {
         mutation_flag: None,
         detach_after_handoff: false,
         output_file_requested: false,
+        read_only_polling: false,
         local_output_file: None,
         job_overrides: LabJobOverrides::default(),
     });
@@ -439,6 +442,7 @@ fn build_lab_only_error_gives_managed_runner_replacement() {
         mutation_flag: None,
         detach_after_handoff: false,
         output_file_requested: false,
+        read_only_polling: false,
         local_output_file: None,
         job_overrides: LabJobOverrides::default(),
     });
@@ -482,6 +486,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
         mutation_flag: None,
         detach_after_handoff: false,
         output_file_requested: false,
+        read_only_polling: false,
         local_output_file: None,
         job_overrides: LabJobOverrides::default(),
     });

--- a/src/core/runner/lab/offload/tests/mod.rs
+++ b/src/core/runner/lab/offload/tests/mod.rs
@@ -39,6 +39,7 @@ pub(super) fn portable_lab_command(label: &'static str) -> LabOffloadCommand {
             infer_source_path_tools: true,
             release_gate: false,
             requires_extension_parity: true,
+            read_only_polling: false,
         },
     }
 }

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -20,6 +20,7 @@ pub struct LabOffloadRequest<'a> {
     pub mutation_flag: Option<&'a str>,
     pub detach_after_handoff: bool,
     pub output_file_requested: bool,
+    pub read_only_polling: bool,
     /// Controller-local `--output` path, when the operator requested the global
     /// JSON envelope be written to a file. Used to persist the durable agent-task
     /// run id immediately (before long-running provider execution starts) so the

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -274,6 +274,8 @@ fn probe_agent_task_providers_on_runner(
             runner_workload: None,
             run_id: None,
             detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
         },
     )?;
 

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -547,6 +547,8 @@ fn run_runtime_overlay_install_step(
             runner_workload: None,
             run_id: None,
             detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
         },
     )?;
     if exit_code == 0 {

--- a/src/core/runner/lab_workspaces_deps.rs
+++ b/src/core/runner/lab_workspaces_deps.rs
@@ -490,6 +490,8 @@ pub(super) fn bootstrap_source_cli_node_dependencies(
             runner_workload: None,
             run_id: None,
             detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
         },
     )?;
     if exit_code == 0 {

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -275,6 +275,8 @@ pub(super) fn sync_lab_offload_rigs(
                 runner_workload: None,
                 run_id: None,
                 detach_after_handoff: false,
+                mirror_evidence: true,
+                print_handoff: true,
             },
         )?;
 

--- a/src/core/runner/rig_materialization/rig_source_install.rs
+++ b/src/core/runner/rig_materialization/rig_source_install.rs
@@ -81,6 +81,8 @@ fn exec_runner_rig_sources_command(
             runner_workload: None,
             run_id: None,
             detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
         },
     )
 }

--- a/src/core/runner/worker/run.rs
+++ b/src/core/runner/worker/run.rs
@@ -296,6 +296,8 @@ fn run_once_output(
             runner_workload: claim.request.runner_workload.clone(),
             run_id: claimed_run_id,
             detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
         },
         || {
             if cancel_seen || last_cancel_poll.elapsed() < BROKER_CANCEL_POLL_INTERVAL {

--- a/src/core/upgrade/runners/commands.rs
+++ b/src/core/upgrade/runners/commands.rs
@@ -159,6 +159,8 @@ pub fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecO
         runner_workload: None,
         run_id: None,
         detach_after_handoff: false,
+        mirror_evidence: true,
+        print_handoff: true,
     }
 }
 

--- a/src/core/upgrade/runners/source_checkout.rs
+++ b/src/core/upgrade/runners/source_checkout.rs
@@ -112,6 +112,8 @@ pub fn runner_source_checkout_prepare_options(
         runner_workload: None,
         run_id: None,
         detach_after_handoff: false,
+        mirror_evidence: true,
+        print_handoff: true,
     }
 }
 

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -579,6 +579,55 @@ fn test_lab_command_contracts_cover_hot_commands() {
         assert!(!contract.routing_policy.default_lab_offload);
     }
 
+    for args in [
+        ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
+        ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
+        ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
+        ["homeboy", "agent-task", "list"].as_slice(),
+        ["homeboy", "agent-task", "active"].as_slice(),
+        ["homeboy", "agent-task", "latest"].as_slice(),
+        [
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "status",
+            "fanout-batch-123",
+        ]
+        .as_slice(),
+        [
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "artifacts",
+            "fanout-batch-123",
+        ]
+        .as_slice(),
+    ] {
+        assert!(
+            parsed_command(args)
+                .lab_contract()
+                .expect("runner-resident read polling contract")
+                .routing_policy
+                .read_only_polling,
+            "{args:?} should use low-noise read polling"
+        );
+    }
+
+    for args in [
+        ["homeboy", "agent-task", "run", "agent-task-123"].as_slice(),
+        ["homeboy", "agent-task", "run-next"].as_slice(),
+        ["homeboy", "agent-task", "controller", "resume", "loop-123"].as_slice(),
+    ] {
+        assert!(
+            !parsed_command(args)
+                .lab_contract()
+                .expect("runner-resident execution contract")
+                .routing_policy
+                .read_only_polling,
+            "{args:?} should preserve full runner execution evidence"
+        );
+    }
+
     let fanout_submit_batch = parsed_command(&[
         "homeboy",
         "agent-task",

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1194,6 +1194,8 @@ fn runner_exec_rejects_requests_that_violate_runner_policy_before_daemon_dispatc
             runner_workload: None,
             run_id: None,
             detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
         },
     )
     .expect_err("policy denied");


### PR DESCRIPTION
## Summary
- Mark runner-resident agent-task read polling commands with a generic low-noise routing policy.
- Suppress runner-exec mirror evidence and handoff boilerplate for those read-only polling calls while preserving full evidence for runner-resident execution commands.
- Keep existing runner exec evidence behavior explicit at all other call sites.

Fixes #6999

## Tests
- cargo check
- cargo test runner_resident
- cargo test read_only

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.