### PR TITLE
Add runtime package refresh command

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -23,7 +23,7 @@ use super::spec::{
     AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL,
     AGENT_TASK_RUN_LAB_LABEL, AGENT_TASK_STATUS_LAB_LABEL, AUDIT_LAB_LABEL, BENCH_LAB_LABEL,
     COMMAND_SPECS, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REFACTOR_LAB_LABEL, REVIEW_LAB_LABEL,
-    RIG_CHECK_LAB_LABEL, TEST_LAB_LABEL, TRACE_LAB_LABEL,
+    RIG_CHECK_LAB_LABEL, RUNTIME_REFRESH_LAB_LABEL, TEST_LAB_LABEL, TRACE_LAB_LABEL,
 };
 
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
@@ -616,6 +616,9 @@ impl Commands {
             Commands::Extension(args) if args.is_update_command() => {
                 LabCommandContract::explicit_runner_simple(args.update_command_label())
             }
+            Commands::Runtime(args) if args.is_refresh_command() => {
+                LabCommandContract::explicit_runner_simple(RUNTIME_REFRESH_LAB_LABEL)
+            }
             Commands::Fleet(args) => {
                 let contract = crate::commands::fleet::adapter(CommandOutputFileMode::None)
                     .lab_contract(args);
@@ -890,7 +893,7 @@ impl RunnerWorkloadCommandFamily {
             label if label.starts_with("agent-task") => Self::AgentTask,
             LINT_LAB_LABEL | TEST_LAB_LABEL | AUDIT_LAB_LABEL | REVIEW_LAB_LABEL
             | BENCH_LAB_LABEL | FUZZ_LAB_LABEL | TRACE_LAB_LABEL => Self::Quality,
-            REFACTOR_LAB_LABEL | RIG_CHECK_LAB_LABEL => Self::Workspace,
+            REFACTOR_LAB_LABEL | RIG_CHECK_LAB_LABEL | RUNTIME_REFRESH_LAB_LABEL => Self::Workspace,
             label if label.starts_with("tunnel") => Self::Service,
             _ => Self::Unknown,
         }

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -274,6 +274,10 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
                 "mutates installed extension files or extension manifest metadata";
             metadata.dangerous_flags = vec!["--force"];
         }
+        ["runtime", "refresh"] => {
+            metadata.mutates = true;
+            metadata.output_notes = "mutates installed runtime package files";
+        }
         ["extension", "uninstall"] => {
             metadata.mutates = true;
             metadata.output_notes =

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -72,6 +72,7 @@ pub(crate) const FUZZ_LAB_LABEL: &str = "fuzz";
 pub(crate) const TRACE_LAB_LABEL: &str = "trace";
 pub(crate) const REFACTOR_LAB_LABEL: &str = "refactor";
 pub(crate) const RIG_CHECK_LAB_LABEL: &str = "rig check";
+pub(crate) const RUNTIME_REFRESH_LAB_LABEL: &str = "runtime refresh";
 pub(crate) const TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL: &str = "tunnel preview-consumer run";
 pub(crate) const TUNNEL_SERVICE_EXPOSE_LAB_LABEL: &str = "tunnel service expose";
 pub(crate) const TUNNEL_SERVICE_START_LAB_LABEL: &str = "tunnel service start";
@@ -294,6 +295,12 @@ const RIG_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary 
     hint_label: RIG_CHECK_LAB_LABEL,
 }];
 
+const RUNTIME_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
+    contract_labels: &[RUNTIME_REFRESH_LAB_LABEL],
+    message_label: RUNTIME_REFRESH_LAB_LABEL,
+    hint_label: RUNTIME_REFRESH_LAB_LABEL,
+}];
+
 const TUNNEL_LAB_SUPPORT: &[CommandLabSupportSummary] = &[
     CommandLabSupportSummary {
         contract_labels: &[TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL],
@@ -499,7 +506,12 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         RIG_LAB_SUPPORT,
     ),
     command_spec("runner", CommandJsonFamily::Workspace),
-    command_spec("runtime", CommandJsonFamily::Workspace),
+    lab_command_spec_with_summary(
+        "runtime",
+        CommandJsonFamily::Workspace,
+        "Lab runner routing covers runtime package refresh workflows",
+        RUNTIME_LAB_SUPPORT,
+    ),
     command_spec("worktree", CommandJsonFamily::Workspace),
     lab_command_spec_with_summary(
         "tunnel",

--- a/src/commands/infra/runtime.rs
+++ b/src/commands/infra/runtime.rs
@@ -16,6 +16,19 @@ enum RuntimeCommand {
         #[command(subcommand)]
         command: RuntimeHelperCommand,
     },
+    /// Refresh a shared runtime package from a source repository or directory.
+    Refresh {
+        /// Runtime package ID to materialize.
+        runtime_id: String,
+
+        /// Git URL, repo root, or runtime package directory to install from.
+        #[arg(long)]
+        source: String,
+
+        /// Git ref to check out for URL sources (branch, tag, or commit).
+        #[arg(long = "ref")]
+        revision: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -35,6 +48,7 @@ enum RuntimeHelperCommand {
 #[serde(untagged)]
 pub enum RuntimeOutput {
     HelperPath(RuntimeHelperPathOutput),
+    RuntimePackageRefresh(RuntimePackageRefreshOutput),
 }
 
 #[derive(Serialize)]
@@ -44,11 +58,27 @@ pub struct RuntimeHelperPathOutput {
     path: String,
 }
 
+#[derive(Serialize)]
+pub struct RuntimePackageRefreshOutput {
+    command: String,
+    runtime_id: String,
+    source: String,
+    path: String,
+    manifest_path: String,
+    source_revision: Option<String>,
+    replaced_existing: bool,
+}
+
 pub fn run(args: RuntimeArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<RuntimeOutput> {
     match args.command {
         RuntimeCommand::Helper { command } => match command {
             RuntimeHelperCommand::Path { helper, .. } => helper_path(&helper),
         },
+        RuntimeCommand::Refresh {
+            runtime_id,
+            source,
+            revision,
+        } => refresh_runtime_package(&runtime_id, &source, revision.as_deref()),
     }
 }
 
@@ -57,6 +87,13 @@ pub fn is_plain_mode(args: &RuntimeArgs) -> bool {
         RuntimeCommand::Helper { command } => match command {
             RuntimeHelperCommand::Path { plain, .. } => *plain,
         },
+        RuntimeCommand::Refresh { .. } => false,
+    }
+}
+
+impl RuntimeArgs {
+    pub(crate) fn is_refresh_command(&self) -> bool {
+        matches!(self.command, RuntimeCommand::Refresh { .. })
     }
 }
 
@@ -68,6 +105,7 @@ pub fn run_plain_text(args: RuntimeArgs) -> homeboy::core::Result<(String, i32)>
                 Ok((format!("{}\n", path.to_string_lossy()), 0))
             }
         },
+        RuntimeCommand::Refresh { .. } => unreachable!("runtime refresh has no plain mode"),
     }
 }
 
@@ -84,6 +122,27 @@ fn helper_path(helper: &str) -> CmdResult<RuntimeOutput> {
     ))
 }
 
+fn refresh_runtime_package(
+    runtime_id: &str,
+    source: &str,
+    revision: Option<&str>,
+) -> CmdResult<RuntimeOutput> {
+    let result = homeboy::core::runtime_package::refresh(runtime_id, source, revision)?;
+
+    Ok((
+        RuntimeOutput::RuntimePackageRefresh(RuntimePackageRefreshOutput {
+            command: "runtime.refresh".to_string(),
+            runtime_id: result.runtime_id,
+            source: result.source,
+            path: result.path.to_string_lossy().to_string(),
+            manifest_path: result.manifest_path.to_string_lossy().to_string(),
+            source_revision: result.source_revision,
+            replaced_existing: result.replaced_existing,
+        }),
+        0,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,7 +153,9 @@ mod tests {
             let (output, exit_code) = helper_path("command-capture.sh").unwrap();
 
             assert_eq!(exit_code, 0);
-            let RuntimeOutput::HelperPath(output) = output;
+            let RuntimeOutput::HelperPath(output) = output else {
+                panic!("expected helper path output");
+            };
             assert!(output.path.ends_with("command-capture.sh"));
             assert!(std::path::Path::new(&output.path).is_file());
         });
@@ -117,6 +178,35 @@ mod tests {
             assert_eq!(exit_code, 0);
             assert!(output.ends_with("runner-prelude.sh\n"));
             assert!(std::path::Path::new(output.trim()).is_file());
+        });
+    }
+
+    #[test]
+    fn refresh_runtime_package_reports_materialized_path() {
+        crate::test_support::with_isolated_home(|_| {
+            let source = tempfile::TempDir::new().expect("source tempdir");
+            let package = source.path().join("agent-runtimes/neutral-runtime");
+            std::fs::create_dir_all(&package).expect("runtime package dir");
+            std::fs::write(
+                package.join("neutral-runtime.json"),
+                r#"{
+  "schema": "homeboy/agent-runtime-manifest/v1",
+  "id": "neutral-runtime"
+}"#,
+            )
+            .expect("runtime package manifest");
+
+            let (output, exit_code) =
+                refresh_runtime_package("neutral-runtime", &source.path().to_string_lossy(), None)
+                    .expect("refresh runtime package");
+
+            assert_eq!(exit_code, 0);
+            let RuntimeOutput::RuntimePackageRefresh(output) = output else {
+                panic!("expected runtime package refresh output");
+            };
+            assert_eq!(output.runtime_id, "neutral-runtime");
+            assert!(output.path.ends_with("agent-runtimes/neutral-runtime"));
+            assert!(std::path::Path::new(&output.manifest_path).is_file());
         });
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -128,6 +128,7 @@ pub mod rig;
 pub mod run_lifecycle_record;
 pub mod runner;
 pub mod runner_execution_envelope;
+pub mod runtime_package;
 pub mod scope;
 pub mod secret_env_plan;
 pub mod self_status;

--- a/src/core/runtime_package.rs
+++ b/src/core/runtime_package.rs
@@ -1,0 +1,278 @@
+use std::path::{Path, PathBuf};
+
+use crate::core::agent_runtime_manifest::AgentRuntimeManifest;
+use crate::core::config;
+use crate::core::engine::identifier;
+use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::error::{Error, Result};
+use crate::core::{git, paths};
+
+#[derive(Debug, Clone)]
+pub struct RuntimePackageRefreshResult {
+    pub runtime_id: String,
+    pub source: String,
+    pub path: PathBuf,
+    pub manifest_path: PathBuf,
+    pub source_revision: Option<String>,
+    pub replaced_existing: bool,
+}
+
+pub fn refresh(
+    runtime_id: &str,
+    source: &str,
+    revision: Option<&str>,
+) -> Result<RuntimePackageRefreshResult> {
+    let runtime_id = identifier::slugify_id(runtime_id, "runtime_id")?;
+    let runtime_root = paths::agent_runtimes()?;
+    local_files::ensure_app_dirs()?;
+    std::fs::create_dir_all(&runtime_root).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("prepare runtime package directory".to_string()),
+        )
+    })?;
+
+    let temp_dir = runtime_root.join(format!(".refresh-tmp-{runtime_id}"));
+    remove_path_if_exists(&temp_dir, "clean stale runtime package refresh temp")?;
+
+    let (source_root, source_revision) = if crate::core::extension::is_git_url(source) {
+        git::clone_repo_at_ref(source, &temp_dir, revision)?;
+        let source_revision = git::short_head_revision(&temp_dir);
+        (temp_dir.as_path(), source_revision)
+    } else {
+        if revision.is_some() {
+            return Err(Error::validation_invalid_argument(
+                "ref",
+                "--ref is only supported for git URL runtime package sources",
+                revision.map(str::to_string),
+                None,
+            ));
+        }
+        let source_path = Path::new(source);
+        let source_revision = git::short_head_revision(source_path);
+        (source_path, source_revision)
+    };
+
+    let package_source = resolve_runtime_package_source(source_root, &runtime_id)?;
+    validate_runtime_package(&package_source, &runtime_id)?;
+
+    let target = runtime_root.join(&runtime_id);
+    let staged = runtime_root.join(format!(".refresh-stage-{runtime_id}"));
+    let backup = runtime_root.join(format!(".refresh-backup-{runtime_id}"));
+    remove_path_if_exists(&staged, "clean stale runtime package refresh stage")?;
+    remove_path_if_exists(&backup, "clean stale runtime package refresh backup")?;
+
+    copy_dir_recursive(&package_source, &staged)?;
+    write_source_metadata(&staged, source, source_revision.as_deref())?;
+
+    let replaced_existing = path_exists_or_symlink(&target);
+    if replaced_existing {
+        rename_path(&target, &backup, "backup runtime package")?;
+    }
+
+    if let Err(err) = rename_path(&staged, &target, "install runtime package") {
+        if replaced_existing {
+            let _ = rename_path(&backup, &target, "restore runtime package backup");
+        }
+        let _ = remove_path_if_exists(&staged, "clean failed runtime package stage");
+        let _ = remove_path_if_exists(&temp_dir, "clean runtime package refresh temp");
+        return Err(err);
+    }
+
+    remove_path_if_exists(&backup, "remove runtime package backup")?;
+    remove_path_if_exists(&temp_dir, "clean runtime package refresh temp")?;
+
+    Ok(RuntimePackageRefreshResult {
+        runtime_id: runtime_id.clone(),
+        source: source.to_string(),
+        path: target.clone(),
+        manifest_path: target.join(format!("{runtime_id}.json")),
+        source_revision,
+        replaced_existing,
+    })
+}
+
+fn resolve_runtime_package_source<'a>(source_root: &'a Path, runtime_id: &str) -> Result<PathBuf> {
+    let direct_manifest = source_root.join(format!("{runtime_id}.json"));
+    if direct_manifest.is_file() {
+        return Ok(source_root.to_path_buf());
+    }
+
+    let monorepo_package = source_root.join("agent-runtimes").join(runtime_id);
+    if monorepo_package
+        .join(format!("{runtime_id}.json"))
+        .is_file()
+    {
+        return Ok(monorepo_package);
+    }
+
+    Err(Error::validation_invalid_argument(
+        "source",
+        format!(
+            "No runtime package manifest '{}.json' found at source root or agent-runtimes/{}",
+            runtime_id, runtime_id
+        ),
+        Some(source_root.display().to_string()),
+        None,
+    ))
+}
+
+fn validate_runtime_package(package_dir: &Path, runtime_id: &str) -> Result<()> {
+    let manifest_path = package_dir.join(format!("{runtime_id}.json"));
+    let content = local_files::local().read(&manifest_path)?;
+    let manifest: AgentRuntimeManifest = config::from_str(&content)?;
+    if manifest.id != runtime_id {
+        return Err(Error::validation_invalid_argument(
+            "runtime_id",
+            format!(
+                "Runtime package manifest id '{}' does not match requested id '{}'",
+                manifest.id, runtime_id
+            ),
+            Some(runtime_id.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn write_source_metadata(
+    package_dir: &Path,
+    source: &str,
+    source_revision: Option<&str>,
+) -> Result<()> {
+    std::fs::write(package_dir.join(".source-url"), source).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("write runtime package source".to_string()),
+        )
+    })?;
+    if let Some(revision) = source_revision {
+        std::fs::write(package_dir.join(".source-revision"), revision).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some("write runtime package source revision".to_string()),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
+    std::fs::create_dir_all(target).map_err(|e| {
+        Error::internal_io(e.to_string(), Some("create runtime package".to_string()))
+    })?;
+
+    for entry in std::fs::read_dir(source).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("read runtime package source".to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some("read runtime package entry".to_string()),
+            )
+        })?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let metadata = entry.metadata().map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some("inspect runtime package entry".to_string()),
+            )
+        })?;
+        if metadata.is_dir() {
+            copy_dir_recursive(&source_path, &target_path)?;
+        } else if metadata.is_file() {
+            std::fs::copy(&source_path, &target_path).map_err(|e| {
+                Error::internal_io(e.to_string(), Some("copy runtime package file".to_string()))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn rename_path(from: &Path, to: &Path, context: &str) -> Result<()> {
+    std::fs::rename(from, to)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(context.to_string())))
+}
+
+fn remove_path_if_exists(path: &Path, context: &str) -> Result<()> {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return Ok(());
+    };
+    let result = if metadata.file_type().is_symlink() || metadata.is_file() {
+        std::fs::remove_file(path)
+    } else {
+        std::fs::remove_dir_all(path)
+    };
+    result.map_err(|e| Error::internal_io(e.to_string(), Some(context.to_string())))
+}
+
+fn path_exists_or_symlink(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_isolated_home;
+
+    fn write_runtime_package(root: &Path, runtime_id: &str, marker: &str) {
+        let package = root.join("agent-runtimes").join(runtime_id);
+        std::fs::create_dir_all(&package).expect("runtime package dir");
+        std::fs::write(
+            package.join(format!("{runtime_id}.json")),
+            format!(
+                r#"{{
+  "schema": "homeboy/agent-runtime-manifest/v1",
+  "id": "{}"
+}}"#,
+                runtime_id
+            ),
+        )
+        .expect("runtime package manifest");
+        std::fs::write(package.join("marker.txt"), marker).expect("runtime package marker");
+    }
+
+    #[test]
+    fn refresh_installs_runtime_package_from_monorepo_source() {
+        with_isolated_home(|_| {
+            let source = tempfile::TempDir::new().expect("source tempdir");
+            write_runtime_package(source.path(), "neutral-runtime", "v1");
+
+            let result = refresh("neutral-runtime", &source.path().to_string_lossy(), None)
+                .expect("refresh runtime package");
+
+            assert_eq!(result.runtime_id, "neutral-runtime");
+            assert!(!result.replaced_existing);
+            assert!(result.path.ends_with("agent-runtimes/neutral-runtime"));
+            assert_eq!(
+                std::fs::read_to_string(result.path.join("marker.txt")).unwrap(),
+                "v1"
+            );
+        });
+    }
+
+    #[test]
+    fn refresh_replaces_existing_runtime_package() {
+        with_isolated_home(|_| {
+            let source = tempfile::TempDir::new().expect("source tempdir");
+            write_runtime_package(source.path(), "neutral-runtime", "v1");
+            refresh("neutral-runtime", &source.path().to_string_lossy(), None)
+                .expect("first refresh");
+
+            write_runtime_package(source.path(), "neutral-runtime", "v2");
+            let result = refresh("neutral-runtime", &source.path().to_string_lossy(), None)
+                .expect("second refresh");
+
+            assert!(result.replaced_existing);
+            assert_eq!(
+                std::fs::read_to_string(result.path.join("marker.txt")).unwrap(),
+                "v2"
+            );
+        });
+    }
+}

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -208,6 +208,19 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
         (
             parsed_command(&[
                 "homeboy",
+                "runtime",
+                "refresh",
+                "neutral-runtime",
+                "--source",
+                "https://example.test/runtime.git",
+                "--ref",
+                "main",
+            ]),
+            "runtime refresh",
+        ),
+        (
+            parsed_command(&[
+                "homeboy",
                 "tunnel",
                 "preview-consumer",
                 "run",


### PR DESCRIPTION
## Summary
- Add `homeboy runtime refresh <runtime-id> --source <source> --ref <ref>` for bounded shared runtime package refreshes.
- Materialize one runtime package into the generic `agent-runtimes/<runtime-id>` cache and report installed path, manifest path, source, source revision, and replacement status.
- Advertise `runtime refresh` through the existing Lab routing contract for runner offload.

Fixes #7001

## Tests
- `cargo test runtime_package -- --nocapture`
- `cargo test test_supports_lab_runner -- --nocapture`
- `cargo test test_lab_runner_supported_labels_are_contract_owned -- --nocapture`

## Known unrelated failures
- `cargo test --test architecture_core_agnostic_test -- --nocapture` fails on existing detector-domain term findings in `src/core/code_audit/detectors/upstream_workaround.rs`.
- `cargo test --test runtime_product_boundary_test -- --nocapture` fails on existing product-name references outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the runtime-package refresh command, tests, and PR preparation.