### PR TITLE
Tighten runner secret env inheritance

### DIFF
--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 use crate::core::redaction::{redact_argv, RedactionPolicy};
+use crate::core::secret_env_plan::SecretEnvPlan;
 use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
 
@@ -173,14 +174,17 @@ pub(crate) fn prepare_runner_process(
         env.insert(RUNNER_HOSTED_EXEC_ENV.to_string(), "1".to_string());
         env.insert(RUNNER_ID_ENV.to_string(), runner.id.clone());
     }
+    let mut secret_env_plan =
+        SecretEnvPlan::from_secret_env_names(request.secret_env_names.iter().cloned());
+    secret_env_plan.allow_inherited_env_names([RUNTIME_SECRET_ENV_ALLOWLIST_ENV.to_string()]);
+
     if runner.kind == RunnerKind::Local {
         env.extend(resolve_runner_secret_env_for_plan(
             &runner.secret_env,
-            &crate::core::secret_env_plan::SecretEnvPlan::from_secret_env_names(
-                request.secret_env_names.iter().cloned(),
-            ),
+            &secret_env_plan,
             &env,
         )?);
+        validate_runner_inherited_secret_env(&secret_env_plan, &env)?;
         normalize_runner_command_env(&mut env);
     } else {
         env.extend(resolve_controller_secret_env_for_command(
@@ -188,6 +192,7 @@ pub(crate) fn prepare_runner_process(
             &request.secret_env_names,
             &env,
         )?);
+        validate_runner_inherited_secret_env(&secret_env_plan, &env)?;
     }
 
     let source_snapshot = request
@@ -273,13 +278,15 @@ pub(crate) fn prepare_daemon_local_process(
 
     let mut env = runner.env.clone();
     env.extend(request.env);
+    let mut secret_env_plan =
+        SecretEnvPlan::from_secret_env_names(request.secret_env_names.iter().cloned());
+    secret_env_plan.allow_inherited_env_names([RUNTIME_SECRET_ENV_ALLOWLIST_ENV.to_string()]);
     env.extend(resolve_runner_secret_env_for_plan(
         &runner.secret_env,
-        &crate::core::secret_env_plan::SecretEnvPlan::from_secret_env_names(
-            request.secret_env_names.iter().cloned(),
-        ),
+        &secret_env_plan,
         &env,
     )?);
+    validate_runner_inherited_secret_env(&secret_env_plan, &env)?;
     normalize_runner_command_env(&mut env);
     let source_snapshot = request.source_snapshot.unwrap_or_else(|| {
         SourceSnapshot::collect_local(&runner.id, Path::new(&cwd), Some(&cwd), "existing_remote")
@@ -331,6 +338,29 @@ pub(super) fn apply_runner_process_env(
         crate::core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
         serde_json::to_string(&plan.source_snapshot).unwrap_or_default(),
     );
+}
+
+fn validate_runner_inherited_secret_env(
+    plan: &SecretEnvPlan,
+    env: &HashMap<String, String>,
+) -> Result<()> {
+    let env = env
+        .iter()
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect::<BTreeMap<_, _>>();
+    plan.diagnose_inherited_env(&env, "runner.env")
+        .map(|_| ())
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "env",
+                error.message,
+                None,
+                Some(vec![
+                    "Declare secret-bearing runtime env names in secret_env or HOMEBOY_AGENT_RUNTIME_SECRET_ENV before runner execution.".to_string(),
+                    "Keep non-secret runtime configuration in explicit public env; Homeboy rejects inherited sensitive env names that are neither public nor secret-declared.".to_string(),
+                ]),
+            )
+        })
 }
 
 pub(super) fn inherited_runner_process_env_keys() -> &'static [&'static str] {

--- a/src/core/runner/execution/secrets.rs
+++ b/src/core/runner/execution/secrets.rs
@@ -15,6 +15,8 @@ use super::super::{Runner, RunnerCapabilityPreflight};
 #[allow(unused_imports)]
 use super::*;
 
+pub(super) const RUNTIME_SECRET_ENV_ALLOWLIST_ENV: &str = "HOMEBOY_AGENT_RUNTIME_SECRET_ENV";
+
 pub(super) fn resolve_runner_secret_env_for_plan(
     secret_env: &HashMap<String, server::RunnerSecretEnvRef>,
     plan: &SecretEnvPlan,
@@ -347,7 +349,9 @@ pub(crate) fn runner_exec_secret_env_plan(
         command,
     ));
     names.extend(declared_runtime_provider_secret_env(env));
-    SecretEnvPlan::from_secret_env_names(names)
+    let mut plan = SecretEnvPlan::from_secret_env_names(names);
+    plan.allow_inherited_env_names([RUNTIME_SECRET_ENV_ALLOWLIST_ENV.to_string()]);
+    plan
 }
 
 /// Runtime/extension-declared secret env names for a hosted agent run.
@@ -360,7 +364,7 @@ pub(crate) fn runner_exec_secret_env_plan(
 /// working by exporting the same allowlist it already owns, and any new provider
 /// is supported without a core change (generic-core rule, #6676).
 fn declared_runtime_provider_secret_env(env: &HashMap<String, String>) -> Vec<String> {
-    env.get("HOMEBOY_AGENT_RUNTIME_SECRET_ENV")
+    env.get(RUNTIME_SECRET_ENV_ALLOWLIST_ENV)
         .into_iter()
         .flat_map(|value| value.split(','))
         .map(str::trim)

--- a/src/core/runner/execution/tests/prepare.rs
+++ b/src/core/runner/execution/tests/prepare.rs
@@ -175,6 +175,68 @@ fn local_runner_prep_does_not_mark_commands_as_runner_hosted() {
 }
 
 #[test]
+fn runner_prep_rejects_undeclared_sensitive_env() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("project");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+
+        let err = prepare_runner_process(RunnerProcessRequest {
+            runner_id: "local".to_string(),
+            runner: Some(local_runner(workspace.display().to_string())),
+            cwd: Some(workspace.display().to_string()),
+            project_id: None,
+            command: vec!["env".to_string()],
+            env: HashMap::from([(
+                "UNDECLARED_API_TOKEN".to_string(),
+                "secret-value".to_string(),
+            )]),
+            secret_env_names: Vec::new(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: false,
+        })
+        .expect_err("undeclared sensitive env should fail closed");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("UNDECLARED_API_TOKEN"));
+        assert!(!format!("{err:?}").contains("secret-value"));
+    });
+}
+
+#[test]
+fn runner_prep_allows_declared_sensitive_env() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("project");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+
+        let plan = prepare_runner_process(RunnerProcessRequest {
+            runner_id: "local".to_string(),
+            runner: Some(local_runner(workspace.display().to_string())),
+            cwd: Some(workspace.display().to_string()),
+            project_id: None,
+            command: vec!["env".to_string()],
+            env: HashMap::from([("DECLARED_API_TOKEN".to_string(), "secret-value".to_string())]),
+            secret_env_names: vec!["DECLARED_API_TOKEN".to_string()],
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: false,
+        })
+        .expect("declared sensitive env is allowed");
+
+        assert_eq!(
+            plan.env.get("DECLARED_API_TOKEN").map(String::as_str),
+            Some("secret-value")
+        );
+    });
+}
+
+#[test]
 fn daemon_local_prep_normalizes_default_path_on_runner_side() {
     crate::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/src/core/secret_env_plan.rs
+++ b/src/core/secret_env_plan.rs
@@ -27,6 +27,11 @@ pub struct SecretEnvPlan {
         skip_serializing_if = "SecretEnvRedactionPolicy::is_default_policy"
     )]
     pub redaction: SecretEnvRedactionPolicy,
+    #[serde(
+        default,
+        skip_serializing_if = "SecretEnvInheritancePolicy::is_default_policy"
+    )]
+    pub inheritance: SecretEnvInheritancePolicy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -49,7 +54,16 @@ pub struct SecretEnvRefreshHint {
 pub struct SecretEnvPlanDiagnostics {
     pub passthrough_secret_env_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inherited_env: Vec<SecretEnvInheritedEnvStatus>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub status: Vec<SecretEnvDiagnosticStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvInheritedEnvStatus {
+    pub name: String,
+    pub declared: bool,
+    pub source: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -65,6 +79,8 @@ pub struct SecretEnvDiagnosticStatus {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SecretEnvPlanDiagnosticError {
     pub missing_required_secret_env: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub undeclared_inherited_secret_env: Vec<String>,
     pub message: String,
     pub diagnostics: SecretEnvPlanDiagnostics,
 }
@@ -188,6 +204,7 @@ impl Default for SecretEnvPlan {
             env_name_mapping: BTreeMap::new(),
             status: Vec::new(),
             redaction: SecretEnvRedactionPolicy::default(),
+            inheritance: SecretEnvInheritancePolicy::default(),
         }
     }
 }
@@ -269,6 +286,7 @@ impl SecretEnvPlan {
 
         let diagnostics = SecretEnvPlanDiagnostics {
             passthrough_secret_env_names,
+            inherited_env: Vec::new(),
             status: diagnostic_status,
         };
 
@@ -281,6 +299,50 @@ impl SecretEnvPlan {
                     missing_required_secret_env.join(", ")
                 ),
                 missing_required_secret_env,
+                undeclared_inherited_secret_env: Vec::new(),
+                diagnostics,
+            })
+        }
+    }
+
+    pub fn diagnose_inherited_env(
+        &self,
+        env: &BTreeMap<String, String>,
+        source: impl Into<String>,
+    ) -> Result<SecretEnvPlanDiagnostics, SecretEnvPlanDiagnosticError> {
+        let source = source.into();
+        let declared = self.declared_inherited_env_names();
+        let policy = self.redaction.to_policy();
+        let mut undeclared = Vec::new();
+        let mut inherited_env = Vec::new();
+
+        for name in env.keys() {
+            if !policy.is_sensitive_key(name) {
+                continue;
+            }
+            let is_declared = declared.contains(name);
+            if self.inheritance.require_declaration && !is_declared {
+                undeclared.push(name.clone());
+            }
+            inherited_env.push(SecretEnvInheritedEnvStatus {
+                name: name.clone(),
+                declared: is_declared,
+                source: source.clone(),
+            });
+        }
+
+        let mut diagnostics = self
+            .diagnose(self.status.clone())
+            .unwrap_or_else(|error| error.diagnostics);
+        diagnostics.inherited_env = inherited_env;
+
+        if undeclared.is_empty() {
+            Ok(diagnostics)
+        } else {
+            Err(SecretEnvPlanDiagnosticError {
+                message: format!("undeclared inherited secret env: {}", undeclared.join(", ")),
+                missing_required_secret_env: Vec::new(),
+                undeclared_inherited_secret_env: undeclared,
                 diagnostics,
             })
         }
@@ -314,6 +376,16 @@ impl SecretEnvPlan {
 
     pub fn extend_secret_env_names(&mut self, names: impl IntoIterator<Item = String>) {
         self.secret_env_names = normalize_names(self.secret_env_names.iter().cloned().chain(names));
+    }
+
+    pub fn allow_inherited_env_names(&mut self, names: impl IntoIterator<Item = String>) {
+        self.inheritance.allowed_env_names = normalize_names(
+            self.inheritance
+                .allowed_env_names
+                .iter()
+                .cloned()
+                .chain(names),
+        );
     }
 
     pub fn map_env_names(
@@ -365,6 +437,37 @@ impl SecretEnvPlan {
             .map(|(name, value)| (name.clone(), policy.redact_env_value(value)))
             .collect();
         redacted
+    }
+
+    fn declared_inherited_env_names(&self) -> BTreeSet<String> {
+        self.secret_env_names()
+            .into_iter()
+            .chain(self.public_env.keys().cloned())
+            .chain(self.inheritance.allowed_env_names.iter().cloned())
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvInheritancePolicy {
+    #[serde(default = "default_require_declaration")]
+    pub require_declaration: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_env_names: Vec<String>,
+}
+
+impl Default for SecretEnvInheritancePolicy {
+    fn default() -> Self {
+        Self {
+            require_declaration: default_require_declaration(),
+            allowed_env_names: Vec::new(),
+        }
+    }
+}
+
+impl SecretEnvInheritancePolicy {
+    fn is_default_policy(&self) -> bool {
+        self == &Self::default()
     }
 }
 
@@ -467,6 +570,10 @@ fn default_replacement() -> String {
 }
 
 fn default_required() -> bool {
+    true
+}
+
+fn default_require_declaration() -> bool {
     true
 }
 
@@ -695,6 +802,63 @@ mod tests {
                 refresh: None,
             }]
         );
+        assert!(diagnostics.inherited_env.is_empty());
+    }
+
+    #[test]
+    fn diagnostics_reject_undeclared_inherited_secret_env() {
+        let plan = SecretEnvPlan::default();
+
+        let error = plan
+            .diagnose_inherited_env(
+                &BTreeMap::from([(
+                    "UNDECLARED_API_TOKEN".to_string(),
+                    "secret-value".to_string(),
+                )]),
+                "runner.env",
+            )
+            .expect_err("sensitive inherited env must be declared");
+
+        assert_eq!(
+            error.undeclared_inherited_secret_env,
+            vec!["UNDECLARED_API_TOKEN".to_string()]
+        );
+        assert_eq!(
+            error.diagnostics.inherited_env,
+            vec![SecretEnvInheritedEnvStatus {
+                name: "UNDECLARED_API_TOKEN".to_string(),
+                declared: false,
+                source: "runner.env".to_string(),
+            }]
+        );
+        assert!(!serde_json::to_string(&error)
+            .expect("error json")
+            .contains("secret-value"));
+    }
+
+    #[test]
+    fn diagnostics_allow_declared_or_allowlisted_inherited_secret_env() {
+        let mut plan = SecretEnvPlan::from_secret_env_names(["DECLARED_API_TOKEN".to_string()]);
+        plan.allow_inherited_env_names(["HOMEBOY_AGENT_RUNTIME_SECRET_ENV".to_string()]);
+
+        let diagnostics = plan
+            .diagnose_inherited_env(
+                &BTreeMap::from([
+                    ("DECLARED_API_TOKEN".to_string(), "secret-value".to_string()),
+                    (
+                        "HOMEBOY_AGENT_RUNTIME_SECRET_ENV".to_string(),
+                        "DECLARED_API_TOKEN".to_string(),
+                    ),
+                ]),
+                "request.env",
+            )
+            .expect("declared sensitive inherited env is allowed");
+
+        assert_eq!(diagnostics.inherited_env.len(), 2);
+        assert!(diagnostics
+            .inherited_env
+            .iter()
+            .all(|status| status.declared));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a typed secret env inheritance policy and redacted diagnostics to SecretEnvPlan.
- Validate runner materialized env so sensitive inherited env names must be declared as secret env or explicitly allowlisted.
- Treat HOMEBOY_AGENT_RUNTIME_SECRET_ENV as generic control-plane allowlist env while preserving provider-agnostic runtime secret declaration.

## Testing
- cargo test core::secret_env_plan::tests
- cargo test core::runner::execution::tests::prepare
- cargo test core::runner::execution::tests::exec::runner_exec_secret_env_names
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the upstream Homeboy runtime env/secret materialization contract changes, adding tests, and drafting this PR description.