### PR TITLE
Tighten Lab handoff artifact manifest contract

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -30,11 +30,12 @@ pub use lab::{
     LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabCommandRouteContract,
     LabLocalExecutionPolicy, LabLocalHotPolicy, LabRoutingPolicy, LabRunnerSupportSummary,
     LabSelectedRunnerFallbackPolicy, LabSourcePathMode, LabWorkspaceModePolicy,
-    RunnerHandoffEnvelope, RunnerHandoffFollowCommands, RunnerWorkload, RunnerWorkloadArtifactRef,
-    RunnerWorkloadAssignment, RunnerWorkloadCapability, RunnerWorkloadCommandFamily,
-    RunnerWorkloadExtensionRevision, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
-    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
-    RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS, RUNNER_HANDOFF_ENVELOPE_SCHEMA,
+    RunnerHandoffArtifactManifestRef, RunnerHandoffEnvelope, RunnerHandoffFollowCommands,
+    RunnerWorkload, RunnerWorkloadArtifactRef, RunnerWorkloadAssignment, RunnerWorkloadCapability,
+    RunnerWorkloadCommandFamily, RunnerWorkloadExtensionRevision, RunnerWorkloadKind,
+    RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
+    RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS,
+    RUNNER_ARTIFACT_MANIFEST_FILE, RUNNER_ARTIFACT_MANIFEST_SCHEMA, RUNNER_HANDOFF_ENVELOPE_SCHEMA,
     RUNNER_WORKLOAD_SCHEMA,
 };
 pub(crate) use lab::{LAB_NO_EXTRA_TOOLS, RIG_UP_LAB_UNSUPPORTED_REASON};

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -28,6 +28,8 @@ use super::spec::{
 
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
 pub const RUNNER_HANDOFF_ENVELOPE_SCHEMA: &str = "homeboy/runner-exec-handoff/v1";
+pub const RUNNER_ARTIFACT_MANIFEST_SCHEMA: &str = "homeboy/artifact-manifest/v1";
+pub const RUNNER_ARTIFACT_MANIFEST_FILE: &str = "homeboy-artifact-manifest.json";
 
 /// Routing-policy flags shared by every Lab command representation
 /// (`LabCommandContract`, `LabRoutePlan`, `LabOffloadCommand`). These four
@@ -249,7 +251,15 @@ pub struct RunnerHandoffEnvelope {
     pub persisted_run_id: Option<String>,
     pub mirror_run_id: Option<String>,
     pub remote_cwd: String,
+    pub artifact_manifest: RunnerHandoffArtifactManifestRef,
     pub follow_commands: RunnerHandoffFollowCommands,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerHandoffArtifactManifestRef {
+    pub schema: String,
+    pub manifest_schema: String,
+    pub path: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -312,8 +322,22 @@ impl RunnerHandoffEnvelope {
             durable_run_id: mirror_run_id.clone(),
             persisted_run_id: mirror_run_id.clone(),
             mirror_run_id,
+            artifact_manifest: RunnerHandoffArtifactManifestRef::for_remote_cwd(&remote_cwd),
             remote_cwd,
             follow_commands,
+        }
+    }
+}
+
+impl RunnerHandoffArtifactManifestRef {
+    pub fn for_remote_cwd(remote_cwd: &str) -> Self {
+        Self {
+            schema: "homeboy/runner-artifact-manifest-ref/v1".to_string(),
+            manifest_schema: RUNNER_ARTIFACT_MANIFEST_SCHEMA.to_string(),
+            path: format!(
+                "{}-homeboy-artifacts/{RUNNER_ARTIFACT_MANIFEST_FILE}",
+                remote_cwd.trim_end_matches('/')
+            ),
         }
     }
 }

--- a/src/core/artifact_manifest.rs
+++ b/src/core/artifact_manifest.rs
@@ -165,14 +165,7 @@ impl ArtifactManifest {
         &self,
         root: impl AsRef<Path>,
     ) -> Result<Vec<ValidatedArtifactManifestEntry>> {
-        if self.schema != ARTIFACT_MANIFEST_SCHEMA {
-            return Err(Error::validation_invalid_argument(
-                "schema",
-                format!("expected {ARTIFACT_MANIFEST_SCHEMA}"),
-                Some(self.schema.clone()),
-                None,
-            ));
-        }
+        self.validate_shape()?;
 
         let root = root.as_ref();
         let root_canonical = canonicalize_existing_dir(root, "artifact_root")?;
@@ -235,6 +228,27 @@ impl ArtifactManifest {
             });
         }
         Ok(validated)
+    }
+
+    /// Validate the portable manifest contract without requiring local files.
+    ///
+    /// Lab handoffs can carry a durable artifact manifest before the controller
+    /// has imported the files locally. This check enforces the typed manifest
+    /// shape while leaving byte-level validation to [`Self::validate_under`]
+    /// once an artifact root is available.
+    pub fn validate_shape(&self) -> Result<()> {
+        if self.schema != ARTIFACT_MANIFEST_SCHEMA {
+            return Err(Error::validation_invalid_argument(
+                "schema",
+                format!("expected {ARTIFACT_MANIFEST_SCHEMA}"),
+                Some(self.schema.clone()),
+                None,
+            ));
+        }
+        for entry in &self.artifacts {
+            validate_entry_shape(entry)?;
+        }
+        Ok(())
     }
 }
 
@@ -391,6 +405,7 @@ fn validate_entry_shape(entry: &ArtifactManifestEntry) -> Result<()> {
         validate_non_empty("id", id)?;
     }
     validate_non_empty("path", &entry.path)?;
+    validate_relative_artifact_path(&entry.path)?;
     validate_non_empty("kind", &entry.kind)?;
     if let Some(role) = &entry.role {
         validate_non_empty("role", role)?;
@@ -452,6 +467,19 @@ fn validate_entry_shape(entry: &ArtifactManifestEntry) -> Result<()> {
     Ok(())
 }
 
+fn validate_relative_artifact_path(relative: &str) -> Result<()> {
+    let relative_path = Path::new(relative);
+    if relative_path.is_absolute() || relative_path.components().any(disallowed_component) {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "artifact path must be relative and stay within the artifact root",
+            Some(relative.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
 fn validate_optional_non_empty(field: &str, value: Option<&str>) -> Result<()> {
     if let Some(value) = value {
         validate_non_empty(field, value)?;
@@ -472,16 +500,9 @@ fn validate_non_empty(field: &str, value: &str) -> Result<()> {
 }
 
 fn confined_existing_file(root_canonical: &Path, relative: &str) -> Result<PathBuf> {
-    let relative_path = Path::new(relative);
-    if relative_path.is_absolute() || relative_path.components().any(disallowed_component) {
-        return Err(Error::validation_invalid_argument(
-            "path",
-            "artifact path must be relative and stay within the artifact root",
-            Some(relative.to_string()),
-            None,
-        ));
-    }
+    validate_relative_artifact_path(relative)?;
 
+    let relative_path = Path::new(relative);
     let candidate = root_canonical.join(relative_path);
     let canonical = candidate.canonicalize().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -497,6 +497,18 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
         assert_eq!(envelope.job_id, job_id);
         assert_eq!(envelope.remote_cwd, "/srv/homeboy/project");
         assert_eq!(
+            envelope.artifact_manifest.schema,
+            "homeboy/runner-artifact-manifest-ref/v1"
+        );
+        assert_eq!(
+            envelope.artifact_manifest.manifest_schema,
+            crate::command_contract::RUNNER_ARTIFACT_MANIFEST_SCHEMA
+        );
+        assert_eq!(
+            envelope.artifact_manifest.path,
+            "/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json"
+        );
+        assert_eq!(
             envelope.durable_run_id.as_deref(),
             Some("agent-task-run-6454")
         );
@@ -516,6 +528,10 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
         assert_eq!(
             json["identity"]["handoff_id"],
             format!("runner:lab:job:{job_id}")
+        );
+        assert_eq!(
+            json["artifact_manifest"]["path"],
+            "/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json"
         );
         assert_eq!(json["job_id"], job_id);
         assert_eq!(json["durable_run_id"], "agent-task-run-6454");
@@ -553,6 +569,10 @@ fn runner_handoff_envelope_omits_agent_task_followups_without_run_id() {
     assert_eq!(json["identity"]["runner_id"], "lab");
     assert_eq!(json["identity"]["runner_job_id"], "job-123");
     assert_eq!(json["identity"]["handoff_id"], "runner:lab:job:job-123");
+    assert_eq!(
+        json["artifact_manifest"]["path"],
+        "/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json"
+    );
     assert!(json["identity"].get("persisted_run_id").is_none());
     assert!(json["identity"].get("run_id").is_none());
     assert_eq!(json["durable_run_id"], Value::Null);

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -24,6 +24,7 @@ use crate::core::agent_tasks::scheduler::{
 use crate::core::api_jobs::JobEvent;
 #[cfg(test)]
 use crate::core::api_jobs::JobEventKind;
+use crate::core::artifact_manifest::ArtifactManifest;
 use crate::core::runner::agent_task_lifecycle_event::{
     agent_task_run_plan_lifecycle_event_from_job_events, is_agent_task_run_plan_envelope,
     parse_offloaded_run_plan_envelope,
@@ -170,13 +171,13 @@ pub(super) fn parse_offloaded_agent_task_handoff(
     output: &str,
 ) -> Result<Option<AgentTaskLabHandoff>> {
     if let Ok(value) = serde_json::from_str::<Value>(output) {
-        return Ok(agent_task_handoff_value(&value));
+        return agent_task_handoff_value(&value);
     }
 
     for (index, _) in output.match_indices('{') {
         let mut stream = serde_json::Deserializer::from_str(&output[index..]).into_iter();
         if let Some(Ok(value)) = stream.next() {
-            if let Some(handoff) = agent_task_handoff_value(&value) {
+            if let Some(handoff) = agent_task_handoff_value(&value)? {
                 return Ok(Some(handoff));
             }
         }
@@ -199,6 +200,8 @@ pub(super) struct AgentTaskLabHandoff {
     pub aggregate_summary: Option<AgentTaskAggregateHandoffSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_refs: Vec<AgentTaskArtifactRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_manifest: Option<ArtifactManifest>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evidence_refs: Vec<AgentTaskEvidenceRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -233,16 +236,22 @@ fn agent_task_lab_handoff_schema() -> String {
     AGENT_TASK_LAB_HANDOFF_SCHEMA.to_string()
 }
 
-fn agent_task_handoff_value(value: &Value) -> Option<AgentTaskLabHandoff> {
+fn agent_task_handoff_value(value: &Value) -> Result<Option<AgentTaskLabHandoff>> {
     if let Some(handoff_value) = typed_agent_task_handoff_value(value) {
-        let mut handoff =
-            serde_json::from_value::<AgentTaskLabHandoff>(handoff_value.clone()).ok()?;
+        let mut handoff = serde_json::from_value::<AgentTaskLabHandoff>(handoff_value.clone())
+            .map_err(|err| {
+                Error::internal_json(
+                    err.to_string(),
+                    Some("parse typed agent-task Lab handoff".to_string()),
+                )
+            })?;
+        finalize_typed_agent_task_handoff(&mut handoff)?;
         if handoff.envelope.is_null() {
             handoff.envelope = handoff_envelope_from_typed_handoff(&handoff);
         }
-        return Some(handoff);
+        return Ok(Some(handoff));
     }
-    agent_task_dispatch_envelope_value(value).map(AgentTaskLabHandoff::from_dispatch_envelope)
+    Ok(agent_task_dispatch_envelope_value(value).map(AgentTaskLabHandoff::from_dispatch_envelope))
 }
 
 fn typed_agent_task_handoff_value(value: &Value) -> Option<&Value> {
@@ -273,7 +282,23 @@ fn handoff_envelope_from_typed_handoff(handoff: &AgentTaskLabHandoff) -> Value {
             envelope.insert("aggregate".to_string(), value);
         }
     }
+    if let Some(manifest) = handoff.artifact_manifest.as_ref() {
+        if let Ok(value) = serde_json::to_value(manifest) {
+            envelope.insert("artifact_manifest".to_string(), value);
+        }
+    }
     Value::Object(envelope)
+}
+
+fn finalize_typed_agent_task_handoff(handoff: &mut AgentTaskLabHandoff) -> Result<()> {
+    let Some(manifest) = handoff.artifact_manifest.as_ref() else {
+        return Ok(());
+    };
+    manifest.validate_shape()?;
+    let run_id = handoff.run_id.as_deref().unwrap_or("lab-offload");
+    let manifest_refs = collect_manifest_artifact_refs(manifest, run_id);
+    append_unique_artifact_refs(&mut handoff.artifact_refs, manifest_refs);
+    Ok(())
 }
 
 impl AgentTaskLabHandoff {
@@ -297,6 +322,7 @@ impl AgentTaskLabHandoff {
                 .as_ref()
                 .map(AgentTaskAggregateHandoffSummary::from_aggregate),
             artifact_refs: collect_handoff_artifact_refs(record.as_ref(), aggregate.as_ref()),
+            artifact_manifest: None,
             evidence_refs: collect_handoff_evidence_refs(aggregate.as_ref()),
             record,
             aggregate,
@@ -356,6 +382,51 @@ fn collect_handoff_artifact_refs(
         }
     }
     refs
+}
+
+fn collect_manifest_artifact_refs(
+    manifest: &ArtifactManifest,
+    run_id: &str,
+) -> Vec<AgentTaskArtifactRef> {
+    manifest
+        .artifacts
+        .iter()
+        .map(|entry| AgentTaskArtifactRef {
+            task_id: entry
+                .metadata
+                .get("task_id")
+                .or_else(|| entry.metadata.get("taskId"))
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or(run_id)
+                .to_string(),
+            kind: entry.kind.clone(),
+            uri: entry
+                .public_url
+                .as_deref()
+                .unwrap_or(&entry.path)
+                .to_string(),
+            role: entry.role.clone(),
+            label: entry.label.clone(),
+            semantic_key: entry.semantic_key.clone(),
+            size_bytes: entry.size_bytes,
+        })
+        .collect()
+}
+
+fn append_unique_artifact_refs(
+    artifact_refs: &mut Vec<AgentTaskArtifactRef>,
+    incoming: Vec<AgentTaskArtifactRef>,
+) {
+    for artifact_ref in incoming {
+        if artifact_refs
+            .iter()
+            .any(|existing| existing == &artifact_ref)
+        {
+            continue;
+        }
+        artifact_refs.push(artifact_ref);
+    }
 }
 
 fn collect_handoff_evidence_refs(
@@ -744,6 +815,61 @@ mod tests {
         );
         assert_eq!(handoff.envelope["run_id"], "run-typed");
         assert!(handoff.envelope.get("aggregate").is_none());
+    }
+
+    #[test]
+    fn typed_handoff_imports_valid_artifact_manifest_refs() {
+        let stdout = concat!(
+            "runner chatter\n",
+            "{\"schema\":\"homeboy/agent-task-lab-handoff/v1\",",
+            "\"run_id\":\"run-manifest\",",
+            "\"artifact_manifest\":{",
+            "\"schema\":\"homeboy/artifact-manifest/v1\",",
+            "\"artifacts\":[{",
+            "\"path\":\"logs/output.log\",",
+            "\"kind\":\"log\",",
+            "\"role\":\"execution-log\",",
+            "\"label\":\"Runner output\",",
+            "\"semantic_key\":\"runner.output\",",
+            "\"size_bytes\":42,",
+            "\"metadata\":{\"task_id\":\"task-from-manifest\"}",
+            "}]}}\n"
+        );
+
+        let handoff = parse_offloaded_agent_task_handoff(stdout)
+            .expect("parse handoff")
+            .expect("handoff found");
+
+        assert_eq!(handoff.artifact_refs.len(), 1);
+        let artifact_ref = &handoff.artifact_refs[0];
+        assert_eq!(artifact_ref.task_id, "task-from-manifest");
+        assert_eq!(artifact_ref.kind, "log");
+        assert_eq!(artifact_ref.uri, "logs/output.log");
+        assert_eq!(artifact_ref.role.as_deref(), Some("execution-log"));
+        assert_eq!(artifact_ref.label.as_deref(), Some("Runner output"));
+        assert_eq!(artifact_ref.semantic_key.as_deref(), Some("runner.output"));
+        assert_eq!(artifact_ref.size_bytes, Some(42));
+        assert_eq!(
+            handoff.envelope["artifact_manifest"]["schema"],
+            "homeboy/artifact-manifest/v1"
+        );
+    }
+
+    #[test]
+    fn typed_handoff_rejects_malformed_artifact_manifest() {
+        let stdout = concat!(
+            "{\"schema\":\"homeboy/agent-task-lab-handoff/v1\",",
+            "\"run_id\":\"run-bad-manifest\",",
+            "\"artifact_manifest\":{",
+            "\"schema\":\"homeboy/artifact-manifest/v1\",",
+            "\"artifacts\":[{\"path\":\"../secret.log\",\"kind\":\"log\"}]",
+            "}}\n"
+        );
+
+        let err = parse_offloaded_agent_task_handoff(stdout).expect_err("invalid manifest");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("artifact path must be relative"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a typed runner handoff artifact manifest reference to the generic Lab contract
- add shape-only validation for portable artifact manifests before local file import
- import validated typed agent-task Lab handoff manifests into artifact refs

## Tests
- cargo test typed_handoff --lib
- cargo test detached_handoff_output_includes_runner_job_and_agent_task_followups --lib
- cargo test runner_handoff_envelope_omits_agent_task_followups_without_run_id --lib
- cargo test validates_confined_relative_file_entries --lib
- cargo test rejects_parent_path_escape_before_touching_filesystem --lib
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Scoped implementation, test updates, and verification.