### PR TITLE
Prepare fuzz rig dependencies before list validation

### DIFF
--- a/src/commands/fuzz/dispatch.rs
+++ b/src/commands/fuzz/dispatch.rs
@@ -11,7 +11,7 @@ use homeboy::core::fuzz::{
 use super::super::{CmdResult, GlobalArgs};
 use super::compare::run_compare;
 use super::doctor::run_doctor;
-use super::execution::run_run;
+use super::execution::{fuzz_prepare_failure_message, run_run};
 use super::inspect::run_inspect;
 use super::planning::run_plan;
 use super::replay::{run_minimize, run_replay};
@@ -149,8 +149,22 @@ pub(super) fn run_contract() -> FuzzContractOutput {
     }
 }
 
-fn run_list(args: FuzzListArgs) -> homeboy::core::Result<FuzzListOutput> {
+pub(super) fn run_list(args: FuzzListArgs) -> homeboy::core::Result<FuzzListOutput> {
     let rig_context = load_rig(args.rig.as_deref(), &args.setting_args)?;
+    if let Some(context) = rig_context.as_ref() {
+        let prepare_settings = fuzz_list_prepare_settings(&args);
+        if let Some(prepare) =
+            homeboy::core::rig::run_fuzz_prepare(&context.spec, &prepare_settings)?
+        {
+            if !prepare.success {
+                return Err(homeboy::core::Error::rig_pipeline_failed(
+                    &context.spec.id,
+                    "fuzz_prepare",
+                    fuzz_prepare_failure_message(&prepare),
+                ));
+            }
+        }
+    }
     let effective_id = resolve_component_id(
         &args.comp,
         rig_context.as_ref().map(|context| &context.spec),
@@ -177,4 +191,18 @@ fn run_list(args: FuzzListArgs) -> homeboy::core::Result<FuzzListOutput> {
         workloads,
         run_hint: "Select one workload with `homeboy fuzz run <component> --workload <id>`; offload heavy campaigns with the global `--runner <id>` flag when configured.".to_string(),
     })
+}
+
+fn fuzz_list_prepare_settings(args: &FuzzListArgs) -> Vec<(String, String)> {
+    args.setting_args
+        .setting
+        .iter()
+        .cloned()
+        .chain(
+            args.setting_args
+                .setting_json
+                .iter()
+                .map(|(key, value)| (key.clone(), value.to_string())),
+        )
+        .collect()
 }

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -369,7 +369,7 @@ fn fuzz_prepare_settings(args: &FuzzRunArgs) -> Vec<(String, String)> {
         .collect()
 }
 
-fn fuzz_prepare_failure_message(prepare: &FuzzPrepareReport) -> String {
+pub(super) fn fuzz_prepare_failure_message(prepare: &FuzzPrepareReport) -> String {
     let failed_steps = prepare
         .pipeline
         .steps

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use super::super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
+use super::dispatch::run_list;
 use super::execution::{
     build_fuzz_execution_request, default_runner_contract, fuzz_artifact_ref_validation,
     fuzz_campaign_contract, fuzz_evidence_followups, fuzz_expected_metric_error, fuzz_max_duration,
@@ -18,9 +19,9 @@ use super::report::{
 };
 use super::types::{
     FuzzCommand, FuzzDiscoverArgs, FuzzExecutionOutput, FuzzGateProfileArg, FuzzIsolationArg,
-    FuzzListOutput, FuzzMinimizeArgs, FuzzOutput, FuzzPlanArgs, FuzzPlanStrategy, FuzzReplayArgs,
-    FuzzReportArgs, FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract, FuzzValidateArgs,
-    FuzzWorkloadOutput,
+    FuzzListArgs, FuzzListOutput, FuzzMinimizeArgs, FuzzOutput, FuzzPlanArgs, FuzzPlanStrategy,
+    FuzzReplayArgs, FuzzReportArgs, FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract,
+    FuzzValidateArgs, FuzzWorkloadOutput,
 };
 use super::workloads::{
     fuzz_workloads, resolve_component_id, resolve_fuzz_context, rig_component_for_fuzz,

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -170,6 +170,127 @@ fn resolve_fuzz_context_preserves_rig_extensions_with_explicit_path_when_registr
 }
 
 #[test]
+fn fuzz_list_materializes_prepare_dependencies_before_workload_validation() {
+    with_isolated_home(|home| {
+        let component_dir = home.path().join("component");
+        fs::create_dir_all(&component_dir).expect("component dir");
+        write_generic_fuzz_extension(home.path());
+        write_fuzz_prepare_rig(
+            home.path(),
+            &component_dir,
+            r#"mkdir -p runtime && printf ready > runtime/ready.txt"#,
+            "runtime/ready.txt",
+            "materialize runtime dependency",
+        );
+
+        let output = run_list(fuzz_list_args()).expect("fuzz list");
+
+        assert_eq!(output.count, 1);
+        assert!(component_dir.join("runtime/ready.txt").is_file());
+    });
+}
+
+#[test]
+fn fuzz_list_reports_structured_prepare_step_failure() {
+    with_isolated_home(|home| {
+        let component_dir = home.path().join("component");
+        fs::create_dir_all(&component_dir).expect("component dir");
+        write_generic_fuzz_extension(home.path());
+        write_fuzz_prepare_rig(
+            home.path(),
+            &component_dir,
+            "false",
+            "runtime/ready.txt",
+            "materialize runtime dependency",
+        );
+
+        let error = match run_list(fuzz_list_args()) {
+            Ok(_) => panic!("prepare should fail"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+
+        assert!(message.contains("fuzz_prepare"));
+        assert!(message.contains("requirement `materialize runtime dependency` failed"));
+        assert!(message.contains("prepare command failed"));
+    });
+}
+
+fn fuzz_list_args() -> FuzzListArgs {
+    FuzzListArgs {
+        comp: PositionalComponentArgs {
+            component: None,
+            path: None,
+        },
+        rig: Some("package-fuzz".to_string()),
+        extension_override: ExtensionOverrideArgs::default(),
+        setting_args: SettingArgs::default(),
+    }
+}
+
+fn write_generic_fuzz_extension(home: &Path) {
+    let extension_dir = home.join(".config/homeboy/extensions/generic");
+    fs::create_dir_all(&extension_dir).expect("extension dir");
+    fs::write(
+        extension_dir.join("generic.json"),
+        serde_json::json!({
+            "name": "generic",
+            "version": "0.0.0",
+            "fuzz": {
+                "workloads": [{ "id": "fixture" }]
+            }
+        })
+        .to_string(),
+    )
+    .expect("extension manifest");
+}
+
+fn write_fuzz_prepare_rig(
+    home: &Path,
+    component_dir: &Path,
+    prepare_command: &str,
+    required_file: &str,
+    label: &str,
+) {
+    let rig_dir = home.join(".config/homeboy/rigs");
+    fs::create_dir_all(&rig_dir).expect("rig dir");
+    fs::write(
+        rig_dir.join("package-fuzz.json"),
+        serde_json::json!({
+            "id": "package-fuzz",
+            "components": {
+                "package": {
+                    "path": component_dir.to_string_lossy(),
+                    "extensions": {
+                        "generic": {
+                            "settings": {}
+                        }
+                    }
+                }
+            },
+            "fuzz": {
+                "default_component": "package"
+            },
+            "pipeline": {
+                "fuzz_prepare": [
+                    {
+                        "kind": "requirement",
+                        "id": "runtime-ready",
+                        "file": required_file,
+                        "cwd": component_dir.to_string_lossy(),
+                        "prepare_command": prepare_command,
+                        "prepare_phases": ["fuzz_prepare"],
+                        "label": label
+                    }
+                ]
+            }
+        })
+        .to_string(),
+    )
+    .expect("rig config");
+}
+
+#[test]
 fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_contract() {
     let args = FuzzRunArgs {
         comp: PositionalComponentArgs {


### PR DESCRIPTION
## Summary
- Run rig `fuzz_prepare` before `homeboy fuzz list --rig ...` resolves component/workload context, matching `fuzz run` prepare behavior.
- Reuse the existing generic rig `requirement.prepare_command` / `prepare_phases` contract as the compatible dependency-materialization fixture shape; this stays product/tool agnostic and does not hardcode Composer, WooCommerce, WordPress, or package managers.
- Share structured `fuzz_prepare` failure messaging between list and run so failed materialization steps fail loudly before workload validation/execution.

## Tests
- `cargo test commands::fuzz::tests::workload_tests --lib`
- `cargo test commands::fuzz::tests --lib`
- `cargo test command_contract::lab --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fuzz prepare wiring, adding tests, running verification, and drafting this PR body.
