### PR TITLE
Add runner dependency cache primitives

### DIFF
--- a/src/commands/trace/rig_tests.rs
+++ b/src/commands/trace/rig_tests.rs
@@ -149,6 +149,7 @@ fn rig_component_path_and_trace_env_are_threaded() {
             r#ref: None,
             default_ref: None,
             extensions: Some(extensions),
+            dependency_cache: None,
         },
     );
     let spec = RigSpec {

--- a/src/core/rig/component_resolution.rs
+++ b/src/core/rig/component_resolution.rs
@@ -181,6 +181,7 @@ mod tests {
             r#ref: None,
             default_ref: None,
             extensions: None,
+            dependency_cache: None,
         }
     }
 

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -1111,6 +1111,27 @@ pub struct ComponentSpec {
     /// components or repo-owned `homeboy.json` files.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extensions: Option<HashMap<String, ScopedExtensionConfig>>,
+
+    /// Optional generic runner-side dependency cache declaration. Rigs declare
+    /// inputs and cache paths; Homeboy owns key computation, restore, and save.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dependency_cache: Option<DependencyCacheSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DependencyCacheSpec {
+    /// Stable dependency materialization step ID supplied by the rig/extension.
+    pub step_id: String,
+    /// Relative paths inside the materialized checkout to restore/save.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+    /// Relative lockfile paths whose contents participate in the cache key.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lockfiles: Vec<String>,
+    /// Relative package/dependency metadata paths whose contents participate in
+    /// the cache key. The name is generic: Homeboy does not interpret contents.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub package_metadata: Vec<String>,
 }
 
 /// A background service the rig manages.

--- a/src/core/runner/git_dependency_materialization.rs
+++ b/src/core/runner/git_dependency_materialization.rs
@@ -1,18 +1,24 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
+use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
+use crate::core::rig::spec::DependencyCacheSpec;
 
 use super::{
     workspace::{
         canonical_workspace_path, effective_snapshot_excludes, git_output, local_snapshot_stats,
-        materialize_snapshot, materialize_snapshot_git, snapshot_identity, ByteFileCounts,
+        materialize_snapshot, materialize_snapshot_git, parent_remote_path, run_shell_capture,
+        run_shell_command, shell_command_for_runner, snapshot_identity, ByteFileCounts,
         DEFAULT_EXCLUDES,
     },
-    Runner, RunnerWorkspaceSyncMode,
+    Runner, RunnerKind, RunnerWorkspaceSyncMode,
 };
+
+pub(crate) const DEPENDENCY_CACHE_SCHEMA: &str = "homeboy/runner-dependency-cache/v1";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) struct RunnerGitDependencyMaterializationOutput {
@@ -41,6 +47,8 @@ pub(crate) struct RunnerGitDependencyMaterializationOutput {
     /// a clean checkout at HEAD. Makes bench artifact provenance explicit.
     pub dirty_overlay: bool,
     pub sync_mode: RunnerWorkspaceSyncMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependency_cache: Option<RunnerDependencyCacheRestoreOutput>,
     #[serde(flatten)]
     pub counts: ByteFileCounts,
 }
@@ -56,6 +64,58 @@ pub(crate) struct RunnerGitDependencyMaterializationOptions {
     /// instead of being refused. The snapshot already tars the working tree, so
     /// the dirty overlay travels to the runner. Defaults to false (clean-HEAD).
     pub allow_dirty: bool,
+    pub dependency_cache: Option<DependencyCacheSpec>,
+    pub component_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RunnerDependencyCacheRestoreOutput {
+    pub schema: &'static str,
+    pub status: String,
+    pub key: String,
+    pub cache_path: String,
+    pub restored_paths: Vec<String>,
+    pub missing_paths: Vec<String>,
+    pub manifest: RunnerDependencyCacheManifest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RunnerDependencyCacheSaveOutput {
+    pub schema: &'static str,
+    pub status: String,
+    pub key: String,
+    pub cache_path: String,
+    pub saved_paths: Vec<String>,
+    pub missing_paths: Vec<String>,
+    pub manifest: RunnerDependencyCacheManifest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RunnerDependencyCacheManifest {
+    pub schema: &'static str,
+    pub key: String,
+    pub step_id: String,
+    pub component_ref: String,
+    pub runner_os: String,
+    pub runner_arch: String,
+    pub key_files: Vec<RunnerDependencyCacheKeyFile>,
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RunnerDependencyCacheKeyFile {
+    pub role: String,
+    pub path: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RunnerDependencyCacheSaveRequest {
+    pub remote_path: String,
+    pub cache_path: String,
+    pub manifest: RunnerDependencyCacheManifest,
 }
 
 pub(crate) fn materialize_git_dependency(
@@ -122,6 +182,24 @@ pub(crate) fn materialize_git_dependency(
             &snapshot,
         )?;
     }
+    let dependency_cache = options
+        .dependency_cache
+        .as_ref()
+        .map(|cache| {
+            dependency_cache_restore(
+                runner,
+                &local_path,
+                &options.remote_path,
+                cache,
+                options
+                    .component_ref
+                    .as_deref()
+                    .or(freshness.after_sha.as_deref())
+                    .or(freshness.pinned_ref.as_deref())
+                    .unwrap_or(&snapshot),
+            )
+        })
+        .transpose()?;
 
     Ok(RunnerGitDependencyMaterializationOutput {
         local_path: local_path.display().to_string(),
@@ -139,8 +217,305 @@ pub(crate) fn materialize_git_dependency(
         used_pinned_ref: freshness.used_pinned_ref,
         dirty_overlay,
         sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+        dependency_cache,
         counts: stats,
     })
+}
+
+pub(crate) fn dependency_cache_save(
+    runner: &Runner,
+    request: &RunnerDependencyCacheSaveRequest,
+) -> Result<RunnerDependencyCacheSaveOutput> {
+    save_dependency_cache_paths(
+        runner,
+        &request.remote_path,
+        &request.cache_path,
+        &request.manifest,
+    )
+}
+
+pub(crate) fn dependency_cache_save_request(
+    output: &RunnerGitDependencyMaterializationOutput,
+) -> Option<RunnerDependencyCacheSaveRequest> {
+    let cache = output.dependency_cache.as_ref()?;
+    Some(RunnerDependencyCacheSaveRequest {
+        remote_path: output.remote_path.clone(),
+        cache_path: cache.cache_path.clone(),
+        manifest: cache.manifest.clone(),
+    })
+}
+
+fn dependency_cache_restore(
+    runner: &Runner,
+    local_path: &Path,
+    remote_path: &str,
+    spec: &DependencyCacheSpec,
+    component_ref: &str,
+) -> Result<RunnerDependencyCacheRestoreOutput> {
+    let manifest = dependency_cache_manifest(runner, local_path, spec, component_ref)?;
+    let cache_path = dependency_cache_path(runner, remote_path, &manifest.key);
+    restore_dependency_cache_paths(runner, remote_path, &cache_path, &manifest)
+}
+
+fn dependency_cache_manifest(
+    runner: &Runner,
+    local_path: &Path,
+    spec: &DependencyCacheSpec,
+    component_ref: &str,
+) -> Result<RunnerDependencyCacheManifest> {
+    validate_dependency_cache_spec(spec)?;
+    let runner_os = runner_label(runner, "os", std::env::consts::OS);
+    let runner_arch = runner_label(runner, "arch", std::env::consts::ARCH);
+    let mut key_files = Vec::new();
+    for path in &spec.lockfiles {
+        key_files.push(cache_key_file(local_path, "lockfile", path)?);
+    }
+    for path in &spec.package_metadata {
+        key_files.push(cache_key_file(local_path, "package_metadata", path)?);
+    }
+    key_files.sort_by(|left, right| {
+        left.role
+            .cmp(&right.role)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let mut paths = spec
+        .paths
+        .iter()
+        .map(|path| normalize_relative_cache_path(path))
+        .collect::<Result<Vec<_>>>()?;
+    paths.sort();
+    paths.dedup();
+    let mut hasher = Sha256::new();
+    hasher.update(DEPENDENCY_CACHE_SCHEMA.as_bytes());
+    hasher.update(spec.step_id.trim().as_bytes());
+    hasher.update(component_ref.as_bytes());
+    hasher.update(runner_os.as_bytes());
+    hasher.update(runner_arch.as_bytes());
+    for file in &key_files {
+        hasher.update(file.role.as_bytes());
+        hasher.update(file.path.as_bytes());
+        hasher.update(file.status.as_bytes());
+        if let Some(sha) = &file.sha256 {
+            hasher.update(sha.as_bytes());
+        }
+    }
+    for path in &paths {
+        hasher.update(path.as_bytes());
+    }
+    let key = format!("dep-cache-{}", hex(&hasher.finalize()));
+    Ok(RunnerDependencyCacheManifest {
+        schema: DEPENDENCY_CACHE_SCHEMA,
+        key,
+        step_id: spec.step_id.trim().to_string(),
+        component_ref: component_ref.to_string(),
+        runner_os,
+        runner_arch,
+        key_files,
+        paths,
+    })
+}
+
+fn restore_dependency_cache_paths(
+    runner: &Runner,
+    remote_path: &str,
+    cache_path: &str,
+    manifest: &RunnerDependencyCacheManifest,
+) -> Result<RunnerDependencyCacheRestoreOutput> {
+    let mut restored = Vec::new();
+    let mut missing = Vec::new();
+    for path in &manifest.paths {
+        let archive = cache_archive_path(cache_path, path);
+        let probe = format!(
+            "if test -f {}; then printf yes; fi",
+            shell::quote_arg(&archive)
+        );
+        if run_shell_capture(&shell_command_for_runner(runner, &probe)?).is_none() {
+            missing.push(path.clone());
+            continue;
+        }
+        let command = format!(
+            "mkdir -p {dest} && rm -rf {target} && tar -C {dest} -xf {archive}",
+            dest = shell::quote_arg(remote_path),
+            target = shell::quote_arg(&Path::new(remote_path).join(path).display().to_string()),
+            archive = shell::quote_arg(&archive),
+        );
+        run_shell_command(
+            &shell_command_for_runner(runner, &command)?,
+            "restore runner dependency cache",
+        )?;
+        restored.push(path.clone());
+    }
+    Ok(RunnerDependencyCacheRestoreOutput {
+        schema: DEPENDENCY_CACHE_SCHEMA,
+        status: if restored.is_empty() { "miss" } else { "hit" }.to_string(),
+        key: manifest.key.clone(),
+        cache_path: cache_path.to_string(),
+        restored_paths: restored,
+        missing_paths: missing,
+        manifest: manifest.clone(),
+    })
+}
+
+fn save_dependency_cache_paths(
+    runner: &Runner,
+    remote_path: &str,
+    cache_path: &str,
+    manifest: &RunnerDependencyCacheManifest,
+) -> Result<RunnerDependencyCacheSaveOutput> {
+    let mut saved = Vec::new();
+    let mut missing = Vec::new();
+    for path in &manifest.paths {
+        let source = Path::new(remote_path).join(path).display().to_string();
+        let archive = cache_archive_path(cache_path, path);
+        let probe = format!(
+            "if test -e {}; then printf yes; fi",
+            shell::quote_arg(&source)
+        );
+        if run_shell_capture(&shell_command_for_runner(runner, &probe)?).is_none() {
+            missing.push(path.clone());
+            continue;
+        }
+        let command = format!(
+            "mkdir -p {cache} {archive_parent} && tar -C {remote} -cf {archive} {path}",
+            cache = shell::quote_arg(cache_path),
+            archive_parent = shell::quote_arg(&parent_remote_path(&archive)),
+            remote = shell::quote_arg(remote_path),
+            archive = shell::quote_arg(&archive),
+            path = shell::quote_arg(path),
+        );
+        run_shell_command(
+            &shell_command_for_runner(runner, &command)?,
+            "save runner dependency cache",
+        )?;
+        saved.push(path.clone());
+    }
+    let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_else(|_| "{}".to_string());
+    let write_manifest = format!(
+        "mkdir -p {cache} && printf %s {json} > {manifest}",
+        cache = shell::quote_arg(cache_path),
+        json = shell::quote_arg(&manifest_json),
+        manifest = shell::quote_arg(
+            &Path::new(cache_path)
+                .join("manifest.json")
+                .display()
+                .to_string()
+        ),
+    );
+    run_shell_command(
+        &shell_command_for_runner(runner, &write_manifest)?,
+        "write runner dependency cache manifest",
+    )?;
+    Ok(RunnerDependencyCacheSaveOutput {
+        schema: DEPENDENCY_CACHE_SCHEMA,
+        status: if saved.is_empty() { "empty" } else { "saved" }.to_string(),
+        key: manifest.key.clone(),
+        cache_path: cache_path.to_string(),
+        saved_paths: saved,
+        missing_paths: missing,
+        manifest: manifest.clone(),
+    })
+}
+
+fn validate_dependency_cache_spec(spec: &DependencyCacheSpec) -> Result<()> {
+    if spec.step_id.trim().is_empty() || spec.paths.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "dependency_cache",
+            "dependency cache requires a non-empty step_id and at least one path",
+            None,
+            None,
+        ));
+    }
+    for path in spec
+        .paths
+        .iter()
+        .chain(spec.lockfiles.iter())
+        .chain(spec.package_metadata.iter())
+    {
+        normalize_relative_cache_path(path)?;
+    }
+    Ok(())
+}
+
+fn cache_key_file(
+    local_path: &Path,
+    role: &str,
+    path: &str,
+) -> Result<RunnerDependencyCacheKeyFile> {
+    let normalized = normalize_relative_cache_path(path)?;
+    let full = local_path.join(&normalized);
+    if !full.is_file() {
+        return Ok(RunnerDependencyCacheKeyFile {
+            role: role.to_string(),
+            path: normalized,
+            status: "missing".to_string(),
+            sha256: None,
+        });
+    }
+    let bytes = std::fs::read(&full).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("read dependency cache key file {}", full.display())),
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(RunnerDependencyCacheKeyFile {
+        role: role.to_string(),
+        path: normalized,
+        status: "present".to_string(),
+        sha256: Some(hex(&hasher.finalize())),
+    })
+}
+
+fn normalize_relative_cache_path(path: &str) -> Result<String> {
+    let value = path.trim().trim_matches('/');
+    if value.is_empty()
+        || value.starts_with("../")
+        || value.contains("/../")
+        || Path::new(value).is_absolute()
+    {
+        return Err(Error::validation_invalid_argument(
+            "dependency_cache",
+            "dependency cache paths must be non-empty relative paths that stay inside the checkout",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn dependency_cache_path(runner: &Runner, remote_path: &str, key: &str) -> String {
+    let root = runner
+        .workspace_root
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| parent_remote_path(remote_path));
+    format!("{}/_dependency_cache/{}", root.trim_end_matches('/'), key)
+}
+
+fn cache_archive_path(cache_path: &str, path: &str) -> String {
+    PathBuf::from(cache_path)
+        .join(format!("{}.tar", path.replace('/', "__")))
+        .display()
+        .to_string()
+}
+
+fn runner_label(runner: &Runner, key: &str, fallback: &str) -> String {
+    runner
+        .resources
+        .get(key)
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| match runner.kind {
+            RunnerKind::Local => fallback.to_string(),
+            RunnerKind::Ssh => fallback.to_string(),
+        })
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -490,9 +865,13 @@ mod tests {
     use std::path::Path;
     use std::process::Command;
 
+    use crate::core::engine::shell;
+
     use super::{
-        ensure_git_dependency_fresh, materialize_git_dependency, DependencyUpdateStatus,
-        RunnerGitDependencyMaterializationOptions,
+        cache_archive_path, dependency_cache_manifest, ensure_git_dependency_fresh,
+        materialize_git_dependency, restore_dependency_cache_paths, save_dependency_cache_paths,
+        DependencyUpdateStatus, Runner, RunnerDependencyCacheManifest,
+        RunnerGitDependencyMaterializationOptions, RunnerKind, DEPENDENCY_CACHE_SCHEMA,
     };
 
     #[test]
@@ -535,6 +914,8 @@ mod tests {
                     required_subpath: None,
                     pinned_ref: None,
                     allow_dirty: false,
+                    dependency_cache: None,
+                    component_ref: None,
                 },
             )
             .expect("materialize git dependency");
@@ -726,6 +1107,113 @@ mod tests {
         assert_eq!(git_output(checkout.path(), &["rev-parse", "HEAD"]), before);
     }
 
+    #[test]
+    fn dependency_cache_key_changes_with_declared_inputs() {
+        let root = tempfile::tempdir().expect("root");
+        fs::write(root.path().join("lock.txt"), "one").expect("write lock");
+        fs::write(root.path().join("package.meta"), "meta").expect("write metadata");
+        let mut runner = test_runner(tempfile::tempdir().expect("runner root").path());
+        runner
+            .resources
+            .insert("os".to_string(), serde_json::json!("linux"));
+        runner
+            .resources
+            .insert("arch".to_string(), serde_json::json!("x86_64"));
+        let spec = crate::core::rig::spec::DependencyCacheSpec {
+            step_id: "deps".to_string(),
+            paths: vec!["vendor/cache".to_string()],
+            lockfiles: vec!["lock.txt".to_string()],
+            package_metadata: vec!["package.meta".to_string()],
+        };
+
+        let first =
+            dependency_cache_manifest(&runner, root.path(), &spec, "abc").expect("manifest");
+        fs::write(root.path().join("lock.txt"), "two").expect("update lock");
+        let second =
+            dependency_cache_manifest(&runner, root.path(), &spec, "abc").expect("manifest");
+
+        assert_ne!(first.key, second.key);
+        assert_eq!(first.step_id, "deps");
+        assert_eq!(first.runner_os, "linux");
+        assert_eq!(first.runner_arch, "x86_64");
+        assert_eq!(first.key_files.len(), 2);
+    }
+
+    #[test]
+    fn dependency_cache_restore_reports_miss_and_hit() {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        let remote = runner_root.path().join("checkout");
+        let cache = runner_root.path().join("cache");
+        fs::create_dir_all(&remote).expect("remote");
+        let runner = test_runner(runner_root.path());
+        let manifest = test_cache_manifest("key", vec!["deps".to_string()]);
+
+        let miss = restore_dependency_cache_paths(
+            &runner,
+            &remote.display().to_string(),
+            &cache.display().to_string(),
+            &manifest,
+        )
+        .expect("restore miss");
+        assert_eq!(miss.status, "miss");
+        assert_eq!(miss.missing_paths, vec!["deps"]);
+
+        fs::create_dir_all(cache.join("unused")).ok();
+        fs::create_dir_all(runner_root.path().join("source/deps")).expect("source deps");
+        fs::write(runner_root.path().join("source/deps/file.txt"), "cached").expect("cached file");
+        let archive = cache_archive_path(&cache.display().to_string(), "deps");
+        run_shell(&format!(
+            "mkdir -p {} && tar -C {} -cf {} deps",
+            shell::quote_arg(&cache.display().to_string()),
+            shell::quote_arg(&runner_root.path().join("source").display().to_string()),
+            shell::quote_arg(&archive),
+        ));
+
+        let hit = restore_dependency_cache_paths(
+            &runner,
+            &remote.display().to_string(),
+            &cache.display().to_string(),
+            &manifest,
+        )
+        .expect("restore hit");
+        assert_eq!(hit.status, "hit");
+        assert_eq!(hit.restored_paths, vec!["deps"]);
+        assert_eq!(
+            fs::read_to_string(remote.join("deps/file.txt")).expect("restored file"),
+            "cached"
+        );
+    }
+
+    #[test]
+    fn dependency_cache_save_writes_manifest_shape() {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        let remote = runner_root.path().join("checkout");
+        let cache = runner_root.path().join("cache");
+        fs::create_dir_all(remote.join("deps")).expect("deps");
+        fs::write(remote.join("deps/file.txt"), "saved").expect("saved file");
+        let runner = test_runner(runner_root.path());
+        let manifest =
+            test_cache_manifest("key-save", vec!["deps".to_string(), "missing".to_string()]);
+
+        let saved = save_dependency_cache_paths(
+            &runner,
+            &remote.display().to_string(),
+            &cache.display().to_string(),
+            &manifest,
+        )
+        .expect("save cache");
+
+        assert_eq!(saved.status, "saved");
+        assert_eq!(saved.saved_paths, vec!["deps"]);
+        assert_eq!(saved.missing_paths, vec!["missing"]);
+        assert!(Path::new(&cache_archive_path(&cache.display().to_string(), "deps")).is_file());
+        let manifest_json = fs::read_to_string(cache.join("manifest.json")).expect("manifest json");
+        let value: serde_json::Value = serde_json::from_str(&manifest_json).expect("json");
+        assert_eq!(value["schema"], DEPENDENCY_CACHE_SCHEMA);
+        assert_eq!(value["key"], "key-save");
+        assert_eq!(value["paths"].as_array().expect("paths").len(), 2);
+    }
+
     struct GitFixture {
         remote: tempfile::TempDir,
         work: tempfile::TempDir,
@@ -812,5 +1300,44 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
         String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn test_runner(workspace_root: &Path) -> Runner {
+        Runner {
+            id: "test-runner".to_string(),
+            kind: RunnerKind::Local,
+            server_id: None,
+            workspace_root: Some(workspace_root.display().to_string()),
+            settings: Default::default(),
+            env: Default::default(),
+            secret_env: Default::default(),
+            resources: Default::default(),
+            policy: Default::default(),
+        }
+    }
+
+    fn test_cache_manifest(key: &str, paths: Vec<String>) -> RunnerDependencyCacheManifest {
+        RunnerDependencyCacheManifest {
+            schema: DEPENDENCY_CACHE_SCHEMA,
+            key: key.to_string(),
+            step_id: "deps".to_string(),
+            component_ref: "abc".to_string(),
+            runner_os: "linux".to_string(),
+            runner_arch: "x86_64".to_string(),
+            key_files: Vec::new(),
+            paths,
+        }
+    }
+
+    fn run_shell(command: &str) {
+        let output = Command::new("sh")
+            .args(["-c", command])
+            .output()
+            .expect("run shell");
+        assert!(
+            output.status.success(),
+            "shell failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -467,6 +467,7 @@ pub(crate) fn run_lab_offload_inner(
         remote_output_file,
         synced_rigs,
         rig_component_path_overrides,
+        dependency_cache_saves,
         runtime_overlay_env,
         runtime_overlay_metadata,
     } = workspace_stage;
@@ -833,6 +834,19 @@ pub(crate) fn run_lab_offload_inner(
         )
     };
     plan = add_success_step(plan, "lab.exec");
+    let dependency_cache_save_outputs = save_dependency_caches(runner_id, &dependency_cache_saves)?;
+    if !dependency_cache_save_outputs.is_empty() {
+        plan = with_step(
+            plan,
+            PlanStep::ready("lab.save_dependency_caches", "lab.save_dependency_caches")
+                .inputs(
+                    PlanValues::new()
+                        .json("count", dependency_cache_save_outputs.len())
+                        .json("caches", &dependency_cache_save_outputs),
+                )
+                .build(),
+        );
+    }
     if exec_output.mirror_run_id.is_some() {
         plan = add_success_step(plan, "lab.mirror_evidence");
     }
@@ -1018,6 +1032,20 @@ pub(crate) fn ensure_lab_offload_streams_not_truncated(
     error.details["capture"] =
         serde_json::to_value(capture).unwrap_or_else(|_| serde_json::json!({}));
     Err(error)
+}
+
+fn save_dependency_caches(
+    runner_id: &str,
+    requests: &[RunnerDependencyCacheSaveRequest],
+) -> Result<Vec<RunnerDependencyCacheSaveOutput>> {
+    if requests.is_empty() {
+        return Ok(Vec::new());
+    }
+    let runner = load(runner_id)?;
+    requests
+        .iter()
+        .map(|request| dependency_cache_save(&runner, request))
+        .collect()
 }
 
 fn has_recoverable_fuzz_result_artifact(

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -39,7 +39,7 @@ pub use types::{
 
 // Shared external imports, re-exported so submodules can pull them via
 // `use super::*`.
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::command_contract::lab_runner_support_summary;
@@ -96,14 +96,15 @@ use super::super::lab_workspaces::{
 };
 use super::super::offload_changed_since::LabOffloadChangedSincePreflight;
 use super::super::{
-    evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_changed_since_ref,
-    lab_offload_metadata, lab_offload_metadata_with_workspace_mapping, load,
-    plan_managed_runner_source_syncs, preflight_lab_offload_changed_since,
-    prepare_git_lab_offload_changed_since, prepare_lab_runner_capability, rig_materialization,
-    status, sync_workspace, LabRunnerGateDecision, MaterializedWorkspace, RunnerCapabilityPreflight,
-    RunnerExecOptions, RunnerFileTransfer, RunnerStatusReport, RunnerWorkspaceApplyOutput,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
-    WorkspaceCleanupPolicy,
+    dependency_cache_save, evaluate_lab_runner_capabilities_for_runner, exec,
+    lab_offload_changed_since_ref, lab_offload_metadata,
+    lab_offload_metadata_with_workspace_mapping, load, plan_managed_runner_source_syncs,
+    preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
+    prepare_lab_runner_capability, rig_materialization, status, sync_workspace,
+    LabRunnerGateDecision, MaterializedWorkspace, RunnerCapabilityPreflight,
+    RunnerDependencyCacheSaveOutput, RunnerDependencyCacheSaveRequest, RunnerExecOptions,
+    RunnerFileTransfer, RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput, WorkspaceCleanupPolicy,
 };
 
 use super::super::workload::{build_runner_workload, RunnerWorkloadBuildInput};

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -17,6 +17,7 @@ pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) remote_output_file: Option<String>,
     pub(crate) synced_rigs: Vec<rig_materialization::LabOffloadRigSync>,
     pub(crate) rig_component_path_overrides: Vec<(String, String)>,
+    pub(crate) dependency_cache_saves: Vec<RunnerDependencyCacheSaveRequest>,
     /// Env-var overrides surfacing synced runtime-overlay remote paths to the
     /// hot command. Empty when no overlay declared `expose_remote_path_env`.
     pub(crate) runtime_overlay_env: Vec<(String, String)>,
@@ -333,6 +334,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         request.allow_dirty_lab_workspace,
     )?;
     let synced_rig_dependencies = rig_component_sync.materializations;
+    let dependency_cache_saves = rig_component_sync.dependency_cache_saves;
     let rig_component_path_overrides = rig_component_sync.component_path_env;
     if !synced_rig_dependencies.is_empty() {
         for dependency in &synced_rig_dependencies {
@@ -454,6 +456,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         remote_output_file,
         synced_rigs,
         rig_component_path_overrides,
+        dependency_cache_saves,
         runtime_overlay_env,
         runtime_overlay_metadata,
     })

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -2291,6 +2291,7 @@ mod provider_config_candidate_paths_tests {
             used_pinned_ref: false,
             dirty_overlay: false,
             sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+            dependency_cache: None,
             counts: ByteFileCounts {
                 files: 7,
                 bytes: 42,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -97,8 +97,9 @@ pub use execution::{
     RunnerExecStructuredSummary,
 };
 pub(crate) use git_dependency_materialization::{
-    materialize_git_dependency, RunnerGitDependencyMaterializationOptions,
-    RunnerGitDependencyMaterializationOutput,
+    dependency_cache_save, dependency_cache_save_request, materialize_git_dependency,
+    RunnerDependencyCacheSaveOutput, RunnerDependencyCacheSaveRequest,
+    RunnerGitDependencyMaterializationOptions, RunnerGitDependencyMaterializationOutput,
 };
 pub use homeboy_refresh::{
     plan_homeboy_binary_refresh, refresh_homeboy_binary, HomeboyBinaryRefreshMode,

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -6,9 +6,10 @@ use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
 
 use super::{
-    exec, load, materialize_git_dependency, preflight_remote_argv_path_translation, sync_workspace,
+    dependency_cache_save_request, exec, load, materialize_git_dependency,
+    preflight_remote_argv_path_translation, sync_workspace,
     workspace::{parent_remote_path, sanitize_path_segment},
-    RunnerExecOptions, RunnerGitDependencyMaterializationOptions,
+    RunnerDependencyCacheSaveRequest, RunnerExecOptions, RunnerGitDependencyMaterializationOptions,
     RunnerGitDependencyMaterializationOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 
@@ -28,6 +29,8 @@ pub(super) struct RigComponentDependency {
     pub required_subpath: Option<String>,
     pub remote_url: Option<String>,
     pub pinned_ref: Option<String>,
+    pub component_ref: Option<String>,
+    pub dependency_cache: Option<crate::core::rig::spec::DependencyCacheSpec>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -438,6 +441,7 @@ fn has_path_arg(args: &[String]) -> bool {
 pub(super) struct LabOffloadRigComponentSync {
     /// Per-dependency materialization outputs (remote paths, freshness, etc.).
     pub materializations: Vec<RunnerGitDependencyMaterializationOutput>,
+    pub dependency_cache_saves: Vec<RunnerDependencyCacheSaveRequest>,
     /// Generic `${components.<id>.path}` override env vars mapping each rig
     /// component to its runner-side materialized path, so checks that execute
     /// on the runner resolve component paths to the runner workspace instead of
@@ -461,6 +465,7 @@ pub(super) fn sync_lab_offload_rig_component_dependencies(
     if dependencies.is_empty() {
         return Ok(LabOffloadRigComponentSync {
             materializations: Vec::new(),
+            dependency_cache_saves: Vec::new(),
             component_path_env: Vec::new(),
         });
     }
@@ -488,7 +493,7 @@ pub(super) fn sync_lab_offload_rig_component_dependencies(
         if !seen.insert(dependency.remote_checkout_root.clone()) {
             continue;
         }
-        synced.push(materialize_git_dependency(
+        let materialization = materialize_git_dependency(
             &runner,
             RunnerGitDependencyMaterializationOptions {
                 local_path: dependency.local_checkout_root,
@@ -497,12 +502,20 @@ pub(super) fn sync_lab_offload_rig_component_dependencies(
                 required_subpath: dependency.required_subpath,
                 pinned_ref: dependency.pinned_ref,
                 allow_dirty: allow_dirty_lab_workspace,
+                dependency_cache: dependency.dependency_cache,
+                component_ref: dependency.component_ref,
             },
-        )?);
+        )?;
+        synced.push(materialization);
     }
+    let dependency_cache_saves = synced
+        .iter()
+        .filter_map(dependency_cache_save_request)
+        .collect();
 
     Ok(LabOffloadRigComponentSync {
         materializations: synced,
+        dependency_cache_saves,
         component_path_env,
     })
 }
@@ -638,6 +651,8 @@ pub(super) fn lab_offload_rig_component_dependencies(
                 required_subpath,
                 remote_url: component.remote_url.clone(),
                 pinned_ref: rig::component_ref(component),
+                component_ref: rig::component_ref(component),
+                dependency_cache: component.dependency_cache.clone(),
             });
         }
     }
@@ -1584,6 +1599,8 @@ mod tests {
             required_subpath: Some("projects/plugins/jetpack".to_string()),
             remote_url: None,
             pinned_ref: None,
+            component_ref: None,
+            dependency_cache: None,
         };
         let remote = effective_remote_component_path(
             &dependency,
@@ -1609,6 +1626,8 @@ mod tests {
             required_subpath: None,
             remote_url: None,
             pinned_ref: None,
+            component_ref: None,
+            dependency_cache: None,
         };
         let remote = effective_remote_component_path(
             &dependency,
@@ -1688,6 +1707,8 @@ mod tests {
             required_subpath: None,
             remote_url: Some("https://github.example.com/example-org/studio-web.git".to_string()),
             pinned_ref: None,
+            component_ref: None,
+            dependency_cache: None,
         }];
 
         assert!(dependencies

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -32,7 +32,10 @@ pub(crate) use snapshot::{
     materialize_snapshot, materialize_snapshot_git, snapshot_identity,
 };
 pub(crate) use types::{canonical_workspace_path, DEFAULT_EXCLUDES};
-pub(crate) use util::{git_output, parent_remote_path, sanitize_path_segment};
+pub(crate) use util::{
+    git_output, parent_remote_path, run_shell_capture, run_shell_command, sanitize_path_segment,
+    shell_command_for_runner,
+};
 
 #[cfg(test)]
 mod tests;

--- a/src/core/runner/workspace/util.rs
+++ b/src/core/runner/workspace/util.rs
@@ -98,7 +98,7 @@ pub(crate) fn ssh_client_for_runner(runner: &Runner) -> Result<(Server, SshClien
 /// spawn failure or non-zero exit. Used for advisory provenance reads (e.g.
 /// reading a synthetic snapshot checkout's HEAD over SSH) where a failure must
 /// not abort the surrounding operation.
-pub(super) fn run_shell_capture(command: &str) -> Option<String> {
+pub(crate) fn run_shell_capture(command: &str) -> Option<String> {
     let output = Command::new("sh").args(["-c", command]).output().ok()?;
     if !output.status.success() {
         return None;
@@ -111,7 +111,7 @@ pub(super) fn run_shell_capture(command: &str) -> Option<String> {
     }
 }
 
-pub(super) fn run_shell_command(command: &str, action: &str) -> Result<()> {
+pub(crate) fn run_shell_command(command: &str, action: &str) -> Result<()> {
     let output = Command::new("sh")
         .args(["-c", command])
         .output()
@@ -123,6 +123,25 @@ pub(super) fn run_shell_command(command: &str, action: &str) -> Result<()> {
         "{action} failed: {}",
         String::from_utf8_lossy(&output.stderr)
     )))
+}
+
+pub(crate) fn shell_command_for_runner(runner: &Runner, command: &str) -> Result<String> {
+    match runner.kind {
+        super::super::RunnerKind::Local => Ok(command.to_string()),
+        super::super::RunnerKind::Ssh => {
+            let (_server, client) = ssh_client_for_runner(runner)?;
+            if client.is_local {
+                return Ok(command.to_string());
+            }
+            let remote = format!("{}@{}", client.user, client.host);
+            Ok(format!(
+                "ssh {ssh_args} {remote} {command}",
+                ssh_args = ssh_args(&client),
+                remote = shell::quote_arg(&remote),
+                command = shell::quote_arg(command),
+            ))
+        }
+    }
 }
 
 pub(super) fn tar_exclude_args(excludes: &[String]) -> String {

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -26,6 +26,7 @@ fn rig_with_launcher(install_dir: &str) -> RigSpec {
             r#ref: None,
             default_ref: None,
             extensions: None,
+            dependency_cache: None,
         },
     );
 

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -63,6 +63,7 @@ fn test_expand_vars_component_path() {
             r#ref: None,
             default_ref: None,
             extensions: None,
+            dependency_cache: None,
         },
     );
     let rig = rig_with("t", components);
@@ -107,6 +108,7 @@ fn test_expand_vars_package_root_from_installed_source_metadata() {
                 r#ref: None,
                 default_ref: None,
                 extensions: None,
+                dependency_cache: None,
             },
         );
         let rig = rig_with("studio-web-product-matrix", components);
@@ -166,6 +168,7 @@ fn test_expand_resources_expands_string_entries() {
                 r#ref: None,
                 default_ref: None,
                 extensions: None,
+                dependency_cache: None,
             },
         );
         let mut rig = rig_with("t", components);

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -663,6 +663,7 @@ mod dag {
                 r#ref: None,
                 default_ref: None,
                 extensions: None,
+                dependency_cache: None,
             },
         );
         let rig = rig_with_steps(
@@ -710,6 +711,7 @@ mod dag {
                 r#ref: None,
                 default_ref: None,
                 extensions: None,
+                dependency_cache: None,
             },
         );
         components.insert(
@@ -726,6 +728,7 @@ mod dag {
                 r#ref: None,
                 default_ref: None,
                 extensions: None,
+                dependency_cache: None,
             },
         );
 
@@ -801,6 +804,7 @@ mod git_steps {
                 r#ref: None,
                 default_ref: None,
                 extensions: None,
+                dependency_cache: None,
             },
         );
 
@@ -928,6 +932,7 @@ mod extension_lifecycle {
                 r#ref: None,
                 default_ref: None,
                 extensions: Some(extensions),
+                dependency_cache: None,
             },
         );
 

--- a/tests/core/rig/pipeline_test/patch.rs
+++ b/tests/core/rig/pipeline_test/patch.rs
@@ -23,6 +23,7 @@ fn rig_with_patch(component_path: &str, step: PipelineStep) -> RigSpec {
             r#ref: None,
             default_ref: None,
             extensions: None,
+            dependency_cache: None,
         },
     );
     let mut pipeline = HashMap::new();

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -207,6 +207,7 @@ fn test_run_up_persists_step_order_source_and_component_snapshot() {
                 r#ref: None,
                 default_ref: None,
                 extensions: None,
+                dependency_cache: None,
             },
         );
         rig.pipeline.insert(

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -763,6 +763,7 @@ fn test_snapshot_state() {
             r#ref: None,
             default_ref: None,
             extensions: None,
+            dependency_cache: None,
         },
     );
     components.insert(
@@ -779,6 +780,7 @@ fn test_snapshot_state() {
             r#ref: None,
             default_ref: None,
             extensions: None,
+            dependency_cache: None,
         },
     );
     let rig = RigSpec {

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -22,6 +22,7 @@ fn component(path: &str, stack: Option<&str>) -> ComponentSpec {
         r#ref: None,
         default_ref: None,
         extensions: None,
+        dependency_cache: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- Add generic rig-declared dependency cache inputs for runner-side Lab component materialization.
- Compute deterministic cache keys from dependency step id, component ref, runner OS/arch labels, lockfiles, package metadata, and cache paths.
- Restore cache paths before remote workload execution and save cache archives plus manifest evidence after successful execution.

## Testing
- cargo test dependency_cache
- cargo test git_dependency_materialization --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented runner dependency cache primitives, tests, and PR preparation.