### PR TITLE
fix: resolve runner capability error collision

### DIFF
--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -147,7 +147,6 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         | ErrorCode::RigServiceFailed
         | ErrorCode::RigResourceConflict
         | ErrorCode::RunnerLabTransportFailure
-        | ErrorCode::RunnerCapabilityMissing
         | ErrorCode::RunnerControllerDisconnected
         | ErrorCode::StackApplyConflict
         | ErrorCode::DependencyStepFailed

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -41,7 +41,6 @@ pub enum ErrorCode {
     RigResourceConflict,
     RigSchemaUnsupported,
     RunnerLabTransportFailure,
-    RunnerCapabilityMissing,
     StackNotFound,
     StackApplyConflict,
     RunnerControllerDisconnected,
@@ -100,7 +99,6 @@ impl ErrorCode {
             ErrorCode::RigResourceConflict => "rig.resource_conflict",
             ErrorCode::RigSchemaUnsupported => "rig.schema_unsupported",
             ErrorCode::RunnerLabTransportFailure => "runner.lab_transport_failure",
-            ErrorCode::RunnerCapabilityMissing => "runner_capability_missing",
             ErrorCode::StackNotFound => "stack.not_found",
             ErrorCode::StackApplyConflict => "stack.apply_conflict",
             ErrorCode::RunnerControllerDisconnected => "runner.controller_disconnected",
@@ -508,29 +506,6 @@ impl Error {
                 status: None,
                 logs: Vec::new(),
                 artifact_refs,
-                next_machine_action,
-                cause: None,
-            }),
-        )
-    }
-
-    pub fn runner_capability_missing(
-        step_id: impl Into<String>,
-        component_id: impl Into<String>,
-        next_machine_action: Option<String>,
-    ) -> Self {
-        let step_id = step_id.into();
-        let component_id = component_id.into();
-        Self::new(
-            ErrorCode::RunnerCapabilityMissing,
-            format!("Runner capability '{step_id}' is missing for component '{component_id}'"),
-            to_details(DependencyFailureDetails {
-                step_id,
-                component_id,
-                output_path_ref: None,
-                status: None,
-                logs: Vec::new(),
-                artifact_refs: Vec::new(),
                 next_machine_action,
                 cause: None,
             }),

--- a/src/core/rig/spec/dependencies.rs
+++ b/src/core/rig/spec/dependencies.rs
@@ -333,6 +333,7 @@ mod tests {
                     r#ref: None,
                     default_ref: None,
                     extensions: None,
+                    dependency_cache: None,
                 },
             )]),
             requirements: crate::core::rig::spec::RigRequirementsSpec {


### PR DESCRIPTION
## Summary
- Remove the duplicate RunnerCapabilityMissing enum entry and obsolete helper shape
- Keep the structured runner capability error used by rig pipeline validation
- Update the dependency materialization test fixture for the dependency_cache field

## Verification
- cargo check
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the compile regression, applying the minimal Rust fix, and verifying the branch.