### PR TITLE
Fix fanout cook-batch Lab label

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -19,11 +19,12 @@ use std::collections::BTreeSet;
 use super::spec::{
     CommandLabSupportSummary, AGENT_TASK_AUTH_STATUS_LAB_LABEL,
     AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL, AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL,
-    AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL, AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
-    AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL,
-    AGENT_TASK_RUN_LAB_LABEL, AGENT_TASK_STATUS_LAB_LABEL, AUDIT_LAB_LABEL, BENCH_LAB_LABEL,
-    COMMAND_SPECS, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REFACTOR_LAB_LABEL, REVIEW_LAB_LABEL,
-    RIG_CHECK_LAB_LABEL, RUNTIME_REFRESH_LAB_LABEL, TEST_LAB_LABEL, TRACE_LAB_LABEL,
+    AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL, AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
+    AGENT_TASK_FANOUT_STATUS_LAB_LABEL, AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
+    AGENT_TASK_PROVIDERS_LAB_LABEL, AGENT_TASK_RUN_LAB_LABEL, AGENT_TASK_STATUS_LAB_LABEL,
+    AUDIT_LAB_LABEL, BENCH_LAB_LABEL, COMMAND_SPECS, FUZZ_LAB_LABEL, LINT_LAB_LABEL,
+    REFACTOR_LAB_LABEL, REVIEW_LAB_LABEL, RIG_CHECK_LAB_LABEL, RUNTIME_REFRESH_LAB_LABEL,
+    TEST_LAB_LABEL, TRACE_LAB_LABEL,
 };
 
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
@@ -563,12 +564,21 @@ impl Commands {
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
-                        command:
-                            agent_task::AgentTaskFanoutCommand::RunPlan(_)
-                            | agent_task::AgentTaskFanoutCommand::CookBatch(_),
+                        command: agent_task::AgentTaskFanoutCommand::RunPlan(_),
                     }),
             }) => LabCommandContract::portable(
                 AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
+                None,
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command:
+                    agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
+                        command: agent_task::AgentTaskFanoutCommand::CookBatch(_),
+                    }),
+            }) => LabCommandContract::portable(
+                AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
                 None,
                 true,
                 LAB_NO_EXTRA_TOOLS,

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -59,6 +59,7 @@ pub(crate) const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task cont
 pub(crate) const AGENT_TASK_STATUS_LAB_LABEL: &str =
     "agent-task run/run-next/status/logs/artifacts/review/list/active/latest";
 pub(crate) const AGENT_TASK_PROVIDERS_LAB_LABEL: &str = "agent-task providers";
+pub(crate) const AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL: &str = "agent-task fanout cook-batch";
 pub(crate) const AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL: &str = "agent-task fanout run-plan";
 pub(crate) const AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL: &str = "agent-task fanout submit-batch";
 pub(crate) const AGENT_TASK_FANOUT_STATUS_LAB_LABEL: &str = "agent-task fanout status/artifacts";
@@ -227,12 +228,13 @@ const AGENT_TASK_LAB_SUPPORT: &[CommandLabSupportSummary] = &[
     },
     CommandLabSupportSummary {
         contract_labels: &[
+            AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
             AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
             AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
             AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
         ],
-        message_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
-        hint_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
+        message_label: "agent-task fanout cook-batch/run-plan/submit-batch/status/artifacts",
+        hint_label: "agent-task fanout cook-batch/run-plan/submit-batch/status/artifacts",
     },
     CommandLabSupportSummary {
         contract_labels: &[AGENT_TASK_AUTH_STATUS_LAB_LABEL],

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1817,6 +1817,40 @@ mod tests {
     }
 
     #[test]
+    fn agent_task_fanout_cook_batch_run_plan_supports_lab_runner_routing() {
+        let normalized = vec![
+            "homeboy".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "--lab-only".to_string(),
+            "agent-task".to_string(),
+            "fanout".to_string(),
+            "cook-batch".to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+            "--verify".to_string(),
+            "cargo test --locked agent_task".to_string(),
+            "--run-plan".to_string(),
+            "https://github.com/Extra-Chill/homeboy/issues/7011".to_string(),
+        ];
+        let cli = Cli::parse_from(&normalized);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+        let local_policy = runners::LabLocalExecutionPolicy::from_flags(
+            cli.allow_local_hot,
+            cli.allow_local_fallback,
+            cli.lab_only,
+        );
+
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        assert!(local_policy.deny_local_execution());
+        assert_eq!(command.hot_label, "agent-task fanout cook-batch");
+        assert!(command.portable);
+        assert!(command.routing_policy.default_lab_offload);
+        assert!(command.routing_policy.requires_extension_parity);
+    }
+
+    #[test]
     fn agent_task_fanout_state_reads_are_runner_resident() {
         for args in [
             [

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -806,6 +806,47 @@ mod tests {
     }
 
     #[test]
+    fn runner_workload_validation_accepts_fanout_cook_batch_command_label() {
+        let plan = plan();
+        let mut command = command();
+        command.hot_label = "agent-task fanout cook-batch";
+        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &command,
+            capture_patch: true,
+            mutation_flag: None,
+            allow_dirty_lab_workspace: false,
+            runner_id: "lab-a",
+            runner_mode: "direct_ssh",
+            assignment_source: "explicit",
+            status: "offloaded",
+            remote_workspace: Some("/srv/homeboy/work"),
+            fallback_reason: None,
+            workspace_mapping_ref: None,
+            proof_id: None,
+        });
+
+        validate_runner_workload_dispatch(
+            Some(&workload),
+            "lab-a",
+            Some("/srv/homeboy/work"),
+            &[
+                "homeboy".to_string(),
+                "--force-hot".to_string(),
+                "agent-task".to_string(),
+                "fanout".to_string(),
+                "cook-batch".to_string(),
+                "--repo".to_string(),
+                "homeboy".to_string(),
+                "--run-plan".to_string(),
+            ],
+            &["HOMEBODY_TRACE_SECRET".to_string()],
+            true,
+        )
+        .expect("matching fanout cook-batch argv is valid");
+    }
+
+    #[test]
     fn runner_workload_validation_rejects_required_secret_categories_without_named_handoff() {
         let plan = plan();
         let command = command();


### PR DESCRIPTION
## Summary

- Add a distinct Lab command label for `agent-task fanout cook-batch`.
- Route `cook-batch --run-plan` through that label instead of the internal `run-plan` label.
- Cover both command routing and runner workload validation for the observed mismatch.

Fixes #7024.

## Tests

- `cargo test --locked fanout_cook_batch`
- `cargo build --release --locked`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Diagnosing the dogfood blocker, implementing the command-label fix, and adding regression coverage.
