### PR TITLE
Fix fanout worktree creation without DMC

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -19,11 +19,12 @@ use std::collections::BTreeSet;
 use super::spec::{
     CommandLabSupportSummary, AGENT_TASK_AUTH_STATUS_LAB_LABEL,
     AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL, AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL,
-    AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL, AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
-    AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL,
-    AGENT_TASK_RUN_LAB_LABEL, AGENT_TASK_STATUS_LAB_LABEL, AUDIT_LAB_LABEL, BENCH_LAB_LABEL,
-    COMMAND_SPECS, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REFACTOR_LAB_LABEL, REVIEW_LAB_LABEL,
-    RIG_CHECK_LAB_LABEL, RUNTIME_REFRESH_LAB_LABEL, TEST_LAB_LABEL, TRACE_LAB_LABEL,
+    AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL, AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
+    AGENT_TASK_FANOUT_STATUS_LAB_LABEL, AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
+    AGENT_TASK_PROVIDERS_LAB_LABEL, AGENT_TASK_RUN_LAB_LABEL, AGENT_TASK_STATUS_LAB_LABEL,
+    AUDIT_LAB_LABEL, BENCH_LAB_LABEL, COMMAND_SPECS, FUZZ_LAB_LABEL, LINT_LAB_LABEL,
+    REFACTOR_LAB_LABEL, REVIEW_LAB_LABEL, RIG_CHECK_LAB_LABEL, RUNTIME_REFRESH_LAB_LABEL,
+    TEST_LAB_LABEL, TRACE_LAB_LABEL,
 };
 
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
@@ -563,12 +564,21 @@ impl Commands {
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
-                        command:
-                            agent_task::AgentTaskFanoutCommand::RunPlan(_)
-                            | agent_task::AgentTaskFanoutCommand::CookBatch(_),
+                        command: agent_task::AgentTaskFanoutCommand::RunPlan(_),
                     }),
             }) => LabCommandContract::portable(
                 AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
+                None,
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command:
+                    agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
+                        command: agent_task::AgentTaskFanoutCommand::CookBatch(_),
+                    }),
+            }) => LabCommandContract::portable(
+                AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
                 None,
                 true,
                 LAB_NO_EXTRA_TOOLS,

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -351,7 +351,7 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.operator = true;
             metadata.dry_run_flag = Some("--dry-run");
             metadata.output_notes =
-                "creates/reuses DMC worktrees and can run the generated fanout unless --dry-run is passed";
+                "creates/reuses task worktrees and can run the generated fanout unless --dry-run is passed";
             metadata.dangerous_flags = vec!["--run-plan"];
         }
         ["fuzz", "replay"] | ["fuzz", "minimize"] => {
@@ -555,7 +555,7 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         ["worktree", "queue-create"] => {
             metadata.mutates = true;
             metadata.dry_run_flag = Some("--dry-run");
-            metadata.output_notes = "default output creates DMC worktrees one-at-a-time; pass --dry-run to plan without creating";
+            metadata.output_notes = "default output creates task worktrees one-at-a-time; pass --dry-run to plan without creating";
         }
         ["worktree", "create"] => {
             metadata.mutates = true;

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -59,6 +59,7 @@ pub(crate) const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task cont
 pub(crate) const AGENT_TASK_STATUS_LAB_LABEL: &str =
     "agent-task run/run-next/status/logs/artifacts/review/list/active/latest";
 pub(crate) const AGENT_TASK_PROVIDERS_LAB_LABEL: &str = "agent-task providers";
+pub(crate) const AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL: &str = "agent-task fanout cook-batch";
 pub(crate) const AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL: &str = "agent-task fanout run-plan";
 pub(crate) const AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL: &str = "agent-task fanout submit-batch";
 pub(crate) const AGENT_TASK_FANOUT_STATUS_LAB_LABEL: &str = "agent-task fanout status/artifacts";
@@ -227,12 +228,13 @@ const AGENT_TASK_LAB_SUPPORT: &[CommandLabSupportSummary] = &[
     },
     CommandLabSupportSummary {
         contract_labels: &[
+            AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
             AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
             AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
             AGENT_TASK_FANOUT_STATUS_LAB_LABEL,
         ],
-        message_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
-        hint_label: "agent-task fanout run-plan/submit-batch/status/artifacts",
+        message_label: "agent-task fanout cook-batch/run-plan/submit-batch/status/artifacts",
+        hint_label: "agent-task fanout cook-batch/run-plan/submit-batch/status/artifacts",
     },
     CommandLabSupportSummary {
         contract_labels: &[AGENT_TASK_AUTH_STATUS_LAB_LABEL],

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -34,7 +34,7 @@ pub struct AgentTaskFanoutArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum AgentTaskFanoutCommand {
-    /// Build an operator-ready batch-cook fanout from issue URLs and create/reuse DMC worktrees.
+    /// Build an operator-ready batch-cook fanout from issue URLs and create/reuse task worktrees.
     CookBatch(AgentTaskFanoutCookBatchArgs),
     /// Normalize a batch-cook fanout plan with independent cooks, worktrees, and PR targets.
     Plan(AgentTaskFanoutPlanArgs),
@@ -114,10 +114,6 @@ pub struct AgentTaskFanoutCookBatchArgs {
     /// Run the generated batch-cook plan immediately after worktree creation succeeds.
     #[arg(long = "run-plan")]
     pub run_plan: bool,
-
-    /// Path to the `studio`/DMC wrapper binary.
-    #[arg(long = "dmc-bin", default_value = "studio", value_name = "BIN")]
-    pub dmc_bin: String,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -56,7 +56,7 @@ pub struct AgentTaskFanoutCookBatchArgs {
     #[arg(value_name = "ISSUE_URL", required = true)]
     pub issues: Vec<String>,
 
-    /// Repo/workspace slug managed by Workspace Registry.
+    /// Registered component/repo handle.
     #[arg(long = "repo", value_name = "REPO")]
     pub repo: String,
 

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -254,7 +254,6 @@ fn queue_or_reuse_worktrees(
             task_ref: None,
             dry_run,
             retry_after_seconds: 30,
-            dmc_bin: args.dmc_bin.clone(),
         })
     };
 
@@ -277,7 +276,7 @@ fn queue_or_reuse_worktrees(
                     branch: branch.clone(),
                     handle: handle.clone(),
                     status: worktree::WorktreeQueueCreateStatus::Created,
-                    command: dmc_add_command(args, branch),
+                    command: worktree_create_command(args, branch),
                     retry_after_seconds: None,
                     active_lock_holder: None,
                     path: Some(status.record.worktree_path),
@@ -775,17 +774,15 @@ fn provider_readiness_command(args: &AgentTaskFanoutCookBatchArgs) -> Vec<String
     command
 }
 
-fn dmc_add_command(args: &AgentTaskFanoutCookBatchArgs, branch: &str) -> Vec<String> {
+fn worktree_create_command(args: &AgentTaskFanoutCookBatchArgs, branch: &str) -> Vec<String> {
     vec![
-        args.dmc_bin.clone(),
-        "wp".to_string(),
-        "workspace-registry".to_string(),
-        "workspace".to_string(),
         "worktree".to_string(),
-        "add".to_string(),
+        "create".to_string(),
         args.repo.clone(),
+        "--branch".to_string(),
         branch.to_string(),
-        format!("--from={}", args.from),
+        "--from".to_string(),
+        args.from.clone(),
     ]
 }
 
@@ -1032,7 +1029,6 @@ mod tests {
             },
             dry_run: true,
             run_plan: false,
-            dmc_bin: "studio".to_string(),
         }
     }
 

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1817,6 +1817,40 @@ mod tests {
     }
 
     #[test]
+    fn agent_task_fanout_cook_batch_run_plan_supports_lab_runner_routing() {
+        let normalized = vec![
+            "homeboy".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "--lab-only".to_string(),
+            "agent-task".to_string(),
+            "fanout".to_string(),
+            "cook-batch".to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+            "--verify".to_string(),
+            "cargo test --locked agent_task".to_string(),
+            "--run-plan".to_string(),
+            "https://github.com/Extra-Chill/homeboy/issues/7011".to_string(),
+        ];
+        let cli = Cli::parse_from(&normalized);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+        let local_policy = runners::LabLocalExecutionPolicy::from_flags(
+            cli.allow_local_hot,
+            cli.allow_local_fallback,
+            cli.lab_only,
+        );
+
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        assert!(local_policy.deny_local_execution());
+        assert_eq!(command.hot_label, "agent-task fanout cook-batch");
+        assert!(command.portable);
+        assert!(command.routing_policy.default_lab_offload);
+        assert!(command.routing_policy.requires_extension_parity);
+    }
+
+    #[test]
     fn agent_task_fanout_state_reads_are_runner_resident() {
         for args in [
             [

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -53,9 +53,9 @@ enum WorktreeCommand {
         #[arg(long)]
         provenance_json: Option<String>,
     },
-    /// Create multiple DMC worktrees one-at-a-time with lock-aware queue status JSON
+    /// Create multiple task worktrees one-at-a-time with queue status JSON
     QueueCreate {
-        /// DMC workspace repo handle, e.g. homeboy
+        /// Registered component/repo handle, e.g. homeboy
         repo: String,
         /// Branch to create. Repeat for fanout batches.
         #[arg(long = "branch", value_name = "BRANCH", required = true)]
@@ -66,18 +66,15 @@ enum WorktreeCommand {
         /// Task or issue URL associated with these worktrees
         #[arg(long)]
         task_url: Option<String>,
-        /// Short task reference recorded by DMC, e.g. Extra-Chill/homeboy#5786
+        /// Short task reference associated with these worktrees, e.g. Extra-Chill/homeboy#5786
         #[arg(long)]
         task_ref: Option<String>,
         /// Print the queue plan/status without creating worktrees
         #[arg(long)]
         dry_run: bool,
-        /// Suggested orchestrator wait when DMC reports an active lock but no retry-after value
+        /// Suggested orchestrator wait when queueing is blocked but no retry-after value is available
         #[arg(long, default_value_t = 60)]
         retry_after_seconds: u64,
-        /// Executable used for DMC calls. Defaults to `studio`.
-        #[arg(long, default_value = "studio")]
-        dmc_bin: String,
     },
     /// List persisted task worktrees
     List,
@@ -187,7 +184,6 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
             task_ref,
             dry_run,
             retry_after_seconds,
-            dmc_bin,
         } => WorktreeOutput::QueueCreate(worktree::queue_create(WorktreeQueueCreateOptions {
             repo,
             branches,
@@ -196,7 +192,6 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
             task_ref,
             dry_run,
             retry_after_seconds,
-            dmc_bin,
         })?),
         WorktreeCommand::List => WorktreeOutput::List(worktree::list()?),
         WorktreeCommand::Status { id } => WorktreeOutput::Status(worktree::status(&id)?),

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -806,6 +806,47 @@ mod tests {
     }
 
     #[test]
+    fn runner_workload_validation_accepts_fanout_cook_batch_command_label() {
+        let plan = plan();
+        let mut command = command();
+        command.hot_label = "agent-task fanout cook-batch";
+        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &command,
+            capture_patch: true,
+            mutation_flag: None,
+            allow_dirty_lab_workspace: false,
+            runner_id: "lab-a",
+            runner_mode: "direct_ssh",
+            assignment_source: "explicit",
+            status: "offloaded",
+            remote_workspace: Some("/srv/homeboy/work"),
+            fallback_reason: None,
+            workspace_mapping_ref: None,
+            proof_id: None,
+        });
+
+        validate_runner_workload_dispatch(
+            Some(&workload),
+            "lab-a",
+            Some("/srv/homeboy/work"),
+            &[
+                "homeboy".to_string(),
+                "--force-hot".to_string(),
+                "agent-task".to_string(),
+                "fanout".to_string(),
+                "cook-batch".to_string(),
+                "--repo".to_string(),
+                "homeboy".to_string(),
+                "--run-plan".to_string(),
+            ],
+            &["HOMEBODY_TRACE_SECRET".to_string()],
+            true,
+        )
+        .expect("matching fanout cook-batch argv is valid");
+    }
+
+    #[test]
     fn runner_workload_validation_rejects_required_secret_categories_without_named_handoff() {
         let plan = plan();
         let command = command();

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -1,8 +1,5 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
-
-use serde_json::Value;
 
 use crate::core::component::{self, TargetSpec};
 use crate::core::error::{Error, Result};
@@ -185,7 +182,6 @@ mod types {
         pub task_ref: Option<String>,
         pub dry_run: bool,
         pub retry_after_seconds: u64,
-        pub dmc_bin: String,
     }
 
     #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -712,8 +708,8 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
     let mut rows = Vec::new();
     let total = options.branches.len();
     for (index, branch) in options.branches.iter().enumerate() {
-        let command = dmc_add_command(&options, branch);
-        let handle = dmc_worktree_handle(&options.repo, branch);
+        let command = worktree_create_command(&options, branch);
+        let handle = worktree_handle(&options.repo, branch);
 
         if options.dry_run {
             rows.push(queue_row(
@@ -725,74 +721,34 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
             continue;
         }
 
-        if let Some(holder) = active_lock_holder(&options.dmc_bin, &options.repo)? {
-            let mut row = queue_row(
-                branch,
-                handle,
-                command,
-                WorktreeQueueCreateStatus::ActiveLockHolder,
-            );
-            row.retry_after_seconds = Some(options.retry_after_seconds);
-            row.active_lock_holder = Some(holder);
-            rows.push(row);
-            for queued_branch in options.branches.iter().take(total).skip(index + 1) {
-                rows.push(queue_row(
-                    queued_branch,
-                    dmc_worktree_handle(&options.repo, queued_branch),
-                    dmc_add_command(&options, queued_branch),
-                    WorktreeQueueCreateStatus::Queued,
-                ));
+        match create(WorktreeCreateOptions {
+            component_id: options.repo.clone(),
+            branch: branch.clone(),
+            from: Some(options.from.clone()),
+            task_url: options.task_url.clone(),
+            run_id: None,
+            cleanup_policy: None,
+        }) {
+            Ok(created) => {
+                let mut row =
+                    queue_row(branch, handle, command, WorktreeQueueCreateStatus::Created);
+                row.path = Some(created.record.worktree_path);
+                rows.push(row);
             }
-            break;
-        }
-
-        let output = Command::new(&options.dmc_bin)
-            .args(dmc_add_args(&options, branch))
-            .output()
-            .map_err(|err| Error::internal_io(err.to_string(), Some(command.join(" "))))?;
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let mut row = queue_row(branch, handle, command, WorktreeQueueCreateStatus::Created);
-            row.path = parse_prefixed_line(&stdout, "Path:");
-            let path = row.path.as_deref().ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "dmc_output",
-                    "DMC worktree add succeeded but did not report a Path line",
-                    Some(stdout.to_string()),
-                    None,
-                )
-            })?;
-            record_queued_worktree(&options, branch, &row.handle, path)?;
-            rows.push(row);
-        } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let status_error = format_command_error(&stdout, &stderr);
-            let mut row = if let Some(holder) = active_lock_holder(&options.dmc_bin, &options.repo)?
-            {
-                let mut row = queue_row(
-                    branch,
-                    handle,
-                    command,
-                    WorktreeQueueCreateStatus::ActiveLockHolder,
-                );
-                row.retry_after_seconds = Some(options.retry_after_seconds);
-                row.active_lock_holder = Some(holder);
-                row
-            } else {
-                queue_row(branch, handle, command, WorktreeQueueCreateStatus::Failed)
-            };
-            row.error = Some(status_error);
-            rows.push(row);
-            for queued_branch in options.branches.iter().take(total).skip(index + 1) {
-                rows.push(queue_row(
-                    queued_branch,
-                    dmc_worktree_handle(&options.repo, queued_branch),
-                    dmc_add_command(&options, queued_branch),
-                    WorktreeQueueCreateStatus::Queued,
-                ));
+            Err(error) => {
+                let mut row = queue_row(branch, handle, command, WorktreeQueueCreateStatus::Failed);
+                row.error = Some(error.message);
+                rows.push(row);
+                for queued_branch in options.branches.iter().take(total).skip(index + 1) {
+                    rows.push(queue_row(
+                        queued_branch,
+                        worktree_handle(&options.repo, queued_branch),
+                        worktree_create_command(&options, queued_branch),
+                        WorktreeQueueCreateStatus::Queued,
+                    ));
+                }
+                break;
             }
-            break;
         }
     }
 
@@ -826,177 +782,29 @@ mod queue_ops {
         }
     }
 
-    pub(super) fn record_queued_worktree(
-        options: &WorktreeQueueCreateOptions,
-        branch: &str,
-        handle: &str,
-        path: &str,
-    ) -> Result<()> {
-        let worktree_path = PathBuf::from(path).canonicalize().map_err(|err| {
-            Error::internal_io(err.to_string(), Some(format!("DMC worktree path {path}")))
-        })?;
-        let source_checkout = registered_component_git_root(&options.repo)?;
-        let record = TaskWorktreeRecord {
-            id: handle.to_string(),
-            component_id: options.repo.clone(),
-            source_checkout: source_checkout.to_string_lossy().to_string(),
-            worktree_path: worktree_path.to_string_lossy().to_string(),
-            branch: branch.to_string(),
-            base_ref: options.from.clone(),
-            task_url: options.task_url.clone(),
-            run_id: None,
-            cleanup_policy: CleanupPolicy::RemoveWhenSafe,
-            created_at: chrono::Utc::now().to_rfc3339(),
-            state: TaskWorktreeState::Active,
-        };
-        write_record(&metadata_dir()?, &record)
-    }
-
-    pub(super) fn registered_component_git_root(repo: &str) -> Result<PathBuf> {
-        let component = component::load(repo)?;
-        let git_root = git::get_git_root(&component.local_path).map_err(|_| {
-            Error::validation_invalid_argument(
-                "repo",
-                "DMC worktree queue source component is not inside a git checkout",
-                Some(repo.to_string()),
-                None,
-            )
-        })?;
-        PathBuf::from(git_root)
-            .canonicalize()
-            .map_err(|err| Error::internal_io(err.to_string(), Some(repo.to_string())))
-    }
-
-    pub(super) fn dmc_add_command(
+    pub(super) fn worktree_create_command(
         options: &WorktreeQueueCreateOptions,
         branch: &str,
     ) -> Vec<String> {
-        let mut command = vec![options.dmc_bin.clone()];
-        command.extend(dmc_add_args(options, branch));
-        command
-    }
-
-    pub(super) fn dmc_add_args(options: &WorktreeQueueCreateOptions, branch: &str) -> Vec<String> {
         let mut args = vec![
-            "wp".to_string(),
-            "workspace-registry".to_string(),
-            "workspace".to_string(),
+            "homeboy".to_string(),
             "worktree".to_string(),
-            "add".to_string(),
+            "create".to_string(),
             options.repo.clone(),
+            "--branch".to_string(),
             branch.to_string(),
-            format!("--from={}", options.from),
+            "--from".to_string(),
+            options.from.clone(),
         ];
         if let Some(task_url) = &options.task_url {
-            args.push(format!("--task-url={task_url}"));
-        }
-        if let Some(task_ref) = &options.task_ref {
-            args.push(format!("--task-ref={task_ref}"));
+            args.push("--task-url".to_string());
+            args.push(task_url.clone());
         }
         args
     }
 
-    pub(super) fn dmc_worktree_handle(repo: &str, branch: &str) -> String {
+    pub(super) fn worktree_handle(repo: &str, branch: &str) -> String {
         format!("{}@{}", repo, branch_slug(branch))
-    }
-
-    pub(super) fn active_lock_holder(
-        dmc_bin: &str,
-        repo: &str,
-    ) -> Result<Option<WorktreeQueueLockHolder>> {
-        let output = Command::new(dmc_bin)
-            .args([
-                "wp",
-                "workspace-registry",
-                "workspace",
-                "worktree",
-                "locks",
-                "--format=json",
-            ])
-            .output()
-            .map_err(|err| {
-                Error::internal_io(err.to_string(), Some("DMC lock status".to_string()))
-            })?;
-        if !output.status.success() {
-            return Ok(None);
-        }
-        let value: Value = serde_json::from_slice(&output.stdout).map_err(|err| {
-            Error::internal_json(err.to_string(), Some("DMC lock status".to_string()))
-        })?;
-        Ok(active_lock_holder_from_status(&value, repo))
-    }
-
-    pub(super) fn active_lock_holder_from_status(
-        value: &Value,
-        repo: &str,
-    ) -> Option<WorktreeQueueLockHolder> {
-        let lock_key = format!("worktree-{repo}");
-        for section in ["database", "filesystem"] {
-            let Some(section_value) = value.get(section) else {
-                continue;
-            };
-            let active_keys = section_value
-                .get("active_keys")
-                .and_then(Value::as_array)
-                .map(|keys| keys.iter().filter_map(Value::as_str).collect::<Vec<_>>())
-                .unwrap_or_default();
-            let Some(locks) = section_value.get("locks").and_then(Value::as_array) else {
-                continue;
-            };
-            for lock in locks {
-                let key = lock
-                    .get("lock_key")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default();
-                let scope = lock
-                    .get("scope")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default();
-                let state = lock
-                    .get("state")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default();
-                let active = state == "active"
-                    || active_keys.iter().any(|active_key| {
-                        *active_key == key || *active_key == scope || *active_key == lock_key
-                    });
-                if (key == lock_key || scope == repo) && active {
-                    return Some(WorktreeQueueLockHolder {
-                        lock_key: key.to_string(),
-                        scope: scope.to_string(),
-                        path: lock.get("path").and_then(Value::as_str).map(str::to_string),
-                        command: lock
-                            .get("command")
-                            .and_then(Value::as_str)
-                            .map(str::to_string),
-                    });
-                }
-            }
-        }
-        None
-    }
-
-    pub(super) fn parse_prefixed_line(output: &str, prefix: &str) -> Option<String> {
-        output.lines().find_map(|line| {
-            line.trim()
-                .strip_prefix(prefix)
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_string)
-        })
-    }
-
-    pub(super) fn format_command_error(stdout: &str, stderr: &str) -> String {
-        let message = [stderr.trim(), stdout.trim()]
-            .into_iter()
-            .filter(|part| !part.is_empty())
-            .collect::<Vec<_>>()
-            .join("\n");
-        if message.is_empty() {
-            "DMC worktree add failed without output".to_string()
-        } else {
-            message
-        }
     }
 }
 use queue_ops::*;
@@ -1211,12 +1019,11 @@ mod tests {
             task_ref: Some("Extra-Chill/homeboy#5786".to_string()),
             dry_run: true,
             retry_after_seconds: 30,
-            dmc_bin: "studio".to_string(),
         }
     }
 
     #[test]
-    fn queue_create_dry_run_returns_queued_rows_with_exact_dmc_commands() {
+    fn queue_create_dry_run_returns_queued_rows_with_exact_homeboy_commands() {
         let output = queue_create(queue_options()).unwrap();
 
         assert_eq!(output.schema, "homeboy/worktree-queue-create/v1");
@@ -1226,124 +1033,73 @@ mod tests {
         assert_eq!(
             output.rows[0].command,
             vec![
-                "studio",
-                "wp",
-                "workspace-registry",
-                "workspace",
-                "worktree",
-                "add",
                 "homeboy",
+                "worktree",
+                "create",
+                "homeboy",
+                "--branch",
                 "cook/one",
-                "--from=origin/main",
-                "--task-url=https://github.com/Extra-Chill/homeboy/issues/5786",
-                "--task-ref=Extra-Chill/homeboy#5786",
+                "--from",
+                "origin/main",
+                "--task-url",
+                "https://github.com/Extra-Chill/homeboy/issues/5786",
             ]
         );
     }
 
     #[test]
-    #[cfg(unix)]
-    fn queue_create_records_successful_dmc_worktree() {
+    fn queue_create_records_successful_homeboy_worktree() {
         use crate::test_support::with_isolated_home;
-        use std::os::unix::fs::PermissionsExt;
 
         with_isolated_home(|home| {
             let parent = home.path().join("Developer");
-            let source = parent.join("homeboy");
-            let worktree_path = parent.join("homeboy@cook-one");
+            let source = parent.join("queue-fixture");
+            let worktree_path = parent.join("queue-fixture@cook-one");
+            if parent.exists() {
+                fs::remove_dir_all(&parent).unwrap();
+            }
             fs::create_dir_all(&parent).unwrap();
             fs::create_dir_all(&source).unwrap();
             run_git(&source, &["init", "-q"]);
             run_git(&source, &["config", "user.email", "homeboy@example.com"]);
             run_git(&source, &["config", "user.name", "Homeboy Test"]);
             fs::write(source.join("README.md"), "initial\n").unwrap();
-            fs::write(source.join("homeboy.json"), r#"{"id":"homeboy"}"#).unwrap();
+            fs::write(source.join("homeboy.json"), r#"{"id":"queue-fixture"}"#).unwrap();
             run_git(&source, &["add", "."]);
             run_git(&source, &["commit", "-q", "-m", "initial"]);
-            write_component_registration(home.path(), "homeboy", &source);
-
-            let dmc = home.path().join("fake-dmc");
-            fs::write(
-                &dmc,
-                format!(
-                    "#!/bin/sh\nif [ \"$5\" = \"locks\" ]; then\n  printf '{{\"database\":{{\"locks\":[]}},\"filesystem\":{{\"locks\":[]}}}}\\n'\n  exit 0\nfi\nmkdir -p '{}'\nprintf 'Path: {}\\n'\n",
-                    worktree_path.display(),
-                    worktree_path.display()
-                ),
-            )
-            .unwrap();
-            let mut perms = fs::metadata(&dmc).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&dmc, perms).unwrap();
+            write_component_registration(home.path(), "queue-fixture", &source);
 
             let output = queue_create(WorktreeQueueCreateOptions {
-                repo: "homeboy".to_string(),
+                repo: "queue-fixture".to_string(),
                 branches: vec!["cook/one".to_string()],
-                from: "origin/main".to_string(),
+                from: "HEAD".to_string(),
                 task_url: Some("https://github.com/Extra-Chill/homeboy/issues/5924".to_string()),
                 task_ref: None,
                 dry_run: false,
                 retry_after_seconds: 30,
-                dmc_bin: dmc.display().to_string(),
             })
             .unwrap();
 
-            assert_eq!(output.rows[0].status, WorktreeQueueCreateStatus::Created);
-            let record = resolve("homeboy@cook-one").expect("queued worktree record");
             assert_eq!(
-                std::fs::canonicalize(&record.worktree_path).unwrap(),
-                std::fs::canonicalize(&worktree_path).unwrap()
+                output.rows[0].status,
+                WorktreeQueueCreateStatus::Created,
+                "queue row failed: {:?}",
+                output.rows[0].error
+            );
+            assert_eq!(output.rows[0].handle, "queue-fixture@cook-one");
+            assert!(output.rows[0].path.is_some());
+            let record = resolve("queue-fixture@cook-one").expect("queued worktree record");
+            assert!(Path::new(&record.worktree_path).exists());
+            assert_eq!(
+                PathBuf::from(&record.worktree_path).canonicalize().unwrap(),
+                worktree_path.canonicalize().unwrap()
             );
             assert_eq!(record.branch, "cook/one");
-            assert_eq!(record.base_ref, "origin/main");
+            assert_eq!(record.base_ref, "HEAD");
             assert_eq!(
                 record.task_url.as_deref(),
                 Some("https://github.com/Extra-Chill/homeboy/issues/5924")
             );
         });
-    }
-
-    #[test]
-    fn active_lock_status_distinguishes_holder_for_repo() {
-        let status = serde_json::json!({
-            "database": { "locks": [{
-                "lock_key": "worktree-homeboy",
-                "scope": "homeboy",
-                "state": "active",
-                "path": "/tmp/worktree-homeboy.lock",
-                "command": "wp workspace-registry workspace worktree add homeboy cook/one"
-            }]},
-            "filesystem": { "locks": [] }
-        });
-
-        let holder = active_lock_holder_from_status(&status, "homeboy").unwrap();
-
-        assert_eq!(holder.lock_key, "worktree-homeboy");
-        assert_eq!(holder.scope, "homeboy");
-        assert_eq!(holder.path.as_deref(), Some("/tmp/worktree-homeboy.lock"));
-        assert_eq!(
-            holder.command.as_deref(),
-            Some("wp workspace-registry workspace worktree add homeboy cook/one")
-        );
-    }
-
-    #[test]
-    fn active_lock_status_checks_filesystem_when_database_section_is_absent() {
-        let status = serde_json::json!({
-            "filesystem": {
-                "active_keys": ["worktree-homeboy"],
-                "locks": [{
-                    "lock_key": "worktree-homeboy",
-                    "scope": "homeboy",
-                    "path": "/tmp/worktree-homeboy.lock"
-                }]
-            }
-        });
-
-        let holder = active_lock_holder_from_status(&status, "homeboy").unwrap();
-
-        assert_eq!(holder.lock_key, "worktree-homeboy");
-        assert_eq!(holder.scope, "homeboy");
-        assert_eq!(holder.path.as_deref(), Some("/tmp/worktree-homeboy.lock"));
     }
 }

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -60,6 +60,31 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
             parsed_command(&[
                 "homeboy",
                 "agent-task",
+                "fanout",
+                "cook-batch",
+                "--repo",
+                "homeboy",
+                "--verify",
+                "true",
+                "https://github.com/Extra-Chill/homeboy/issues/6453",
+            ]),
+            "agent-task fanout cook-batch/run-plan/submit-batch/status/artifacts",
+        ),
+        (
+            parsed_command(&[
+                "homeboy",
+                "agent-task",
+                "fanout",
+                "run-plan",
+                "--input",
+                "fanout.json",
+            ]),
+            "agent-task fanout cook-batch/run-plan/submit-batch/status/artifacts",
+        ),
+        (
+            parsed_command(&[
+                "homeboy",
+                "agent-task",
                 "cook",
                 "--to-worktree",
                 "homeboy@cook",
@@ -131,7 +156,7 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
                 "--input",
                 "fanout.json",
             ]),
-            "agent-task fanout run-plan/submit-batch/status/artifacts",
+            "agent-task fanout cook-batch/run-plan/submit-batch/status/artifacts",
         ),
         (
             parsed_command(&[
@@ -141,7 +166,7 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
                 "status",
                 "fanout-batch-123",
             ]),
-            "agent-task fanout run-plan/submit-batch/status/artifacts",
+            "agent-task fanout cook-batch/run-plan/submit-batch/status/artifacts",
         ),
         (
             parsed_command(&[
@@ -151,7 +176,7 @@ fn supported_lab_command_cases() -> Vec<(Commands, &'static str)> {
                 "artifacts",
                 "fanout-batch-123",
             ]),
-            "agent-task fanout submit-batch/status/artifacts",
+            "agent-task fanout cook-batch/run-plan/submit-batch/status/artifacts",
         ),
         (
             parsed_command(&[

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -149,6 +149,24 @@ fn agent_task_controller_events_command_parses() {
 }
 
 #[test]
+fn agent_task_fanout_cook_batch_help_uses_generic_worktree_terms() {
+    let mut root = Cli::command();
+    let help = root
+        .find_subcommand_mut("agent-task")
+        .and_then(|command| command.find_subcommand_mut("fanout"))
+        .and_then(|command| command.find_subcommand_mut("cook-batch"))
+        .expect("agent-task fanout cook-batch command")
+        .render_long_help()
+        .to_string();
+
+    assert!(help.contains("task worktrees"));
+    assert!(!help.contains("DMC"));
+    assert!(!help.contains("dmc"));
+    assert!(!help.contains("studio"));
+    assert!(!help.contains("workspace-registry"));
+}
+
+#[test]
 fn agent_task_controller_resume_dispatch_defaults_parse() {
     Cli::try_parse_from([
         "homeboy",
@@ -301,25 +319,65 @@ fn runner_exec_flags_parse_before_trailing_command() {
     // distinct flags that share this ordering invariant in one place.
     for args in [
         [
-            "homeboy", "runner", "exec", "homeboy-lab", "--raw", "--cwd", "/runner/workspaces",
-            "python3", "-c", "print('hello')",
+            "homeboy",
+            "runner",
+            "exec",
+            "homeboy-lab",
+            "--raw",
+            "--cwd",
+            "/runner/workspaces",
+            "python3",
+            "-c",
+            "print('hello')",
         ]
         .as_slice(),
         [
-            "homeboy", "runner", "exec", "homeboy-lab", "--run-id", "ssi-fixture-matrix-summary",
-            "--cwd", "/runner/workspaces", "homeboy", "trace", "matrix", "summary",
+            "homeboy",
+            "runner",
+            "exec",
+            "homeboy-lab",
+            "--run-id",
+            "ssi-fixture-matrix-summary",
+            "--cwd",
+            "/runner/workspaces",
+            "homeboy",
+            "trace",
+            "matrix",
+            "summary",
         ]
         .as_slice(),
         [
-            "homeboy", "runner", "exec", "homeboy-lab", "--run-id", "runner-exec-artifact-fixture",
-            "--artifact", "output/report.json", "--cwd", "/runner/workspaces", "homeboy", "trace",
-            "matrix", "summary",
+            "homeboy",
+            "runner",
+            "exec",
+            "homeboy-lab",
+            "--run-id",
+            "runner-exec-artifact-fixture",
+            "--artifact",
+            "output/report.json",
+            "--cwd",
+            "/runner/workspaces",
+            "homeboy",
+            "trace",
+            "matrix",
+            "summary",
         ]
         .as_slice(),
         [
-            "homeboy", "runner", "exec", "homeboy-lab", "--run-id",
-            "runner-exec-artifact-dir-fixture", "--artifact-dir", "output", "--cwd",
-            "/runner/workspaces", "homeboy", "trace", "matrix", "summary",
+            "homeboy",
+            "runner",
+            "exec",
+            "homeboy-lab",
+            "--run-id",
+            "runner-exec-artifact-dir-fixture",
+            "--artifact-dir",
+            "output",
+            "--cwd",
+            "/runner/workspaces",
+            "homeboy",
+            "trace",
+            "matrix",
+            "summary",
         ]
         .as_slice(),
     ] {

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -163,6 +163,7 @@ fn agent_task_fanout_cook_batch_help_uses_generic_worktree_terms() {
     assert!(!help.contains("DMC"));
     assert!(!help.contains("dmc"));
     assert!(!help.contains("studio"));
+    assert!(!help.contains("Workspace Registry"));
     assert!(!help.contains("workspace-registry"));
 }
 


### PR DESCRIPTION
## Summary
- remove the fanout cook-batch public DMC/studio option and wording
- route queued task worktree creation through Homeboy's own worktree creation primitive
- cover generic help text, queue creation, and Lab command labels

Fixes #7033.

## Verification
- cargo test --locked queue_create
- cargo test --locked fanout_cook_batch
- cargo test --locked supported_lab_commands_are_registered
- cargo build --release --locked
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the worktree queue refactor, updating tests, and running verification.