### PR TITLE
chore: trim cargo warning surface

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1178,6 +1178,7 @@ pub(super) fn fuzz_evidence_followups(
     followups
 }
 
+#[cfg(test)]
 pub(super) fn default_runner_contract() -> FuzzRunnerContract {
     fuzz_runner_contract(None)
 }

--- a/src/core/agent_task_controller_service/artifacts.rs
+++ b/src/core/agent_task_controller_service/artifacts.rs
@@ -920,7 +920,7 @@ mod evidence_index {
         )
     }
 
-    pub fn record_controller_evidence_index(
+    fn record_controller_evidence_index(
         record: &mut AgentTaskLoopControllerRecord,
         entity_id: Option<&str>,
         index: ControllerEvidenceIndex,
@@ -957,7 +957,7 @@ mod evidence_index {
         Ok(())
     }
 
-    pub fn evidence_index_entry(
+    fn evidence_index_entry(
         task_id: &str,
         artifacts: Vec<AgentTaskArtifact>,
         evidence_refs: Vec<AgentTaskEvidenceRef>,

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -207,11 +207,6 @@ pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRu
     })
 }
 
-#[cfg(test)]
-pub(crate) fn write_run_record_for_test(record: &AgentTaskRunRecord) -> Result<()> {
-    store::write_record(record)
-}
-
 pub fn list_records() -> Result<Vec<AgentTaskRunRecord>> {
     let mut records = Vec::new();
     for record in store::read_records()? {

--- a/src/core/agent_task_loop_controller/gate.rs
+++ b/src/core/agent_task_loop_controller/gate.rs
@@ -1,6 +1,8 @@
 use super::*;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+#[cfg(test)]
+use serde_json::json;
+use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskGateBundle {

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use serde_json::{json, Value};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use super::apply::{
@@ -25,8 +25,7 @@ use crate::core::agent_task::{
     AGENT_TASK_OUTCOME_SCHEMA,
 };
 use crate::core::agent_task_gate::{
-    AgentTaskGateEnvironment, AgentTaskGateReport, AgentTaskGateRevealPolicy,
-    AgentTaskGateVisibility, VerifyGateOptions,
+    AgentTaskGateReport, AgentTaskGateRevealPolicy, AgentTaskGateVisibility, VerifyGateOptions,
 };
 use crate::core::command_invocation::CommandInvocation;
 use crate::core::{Error, Result};

--- a/src/core/git/github_types.rs
+++ b/src/core/git/github_types.rs
@@ -271,8 +271,6 @@ mod outputs {
 }
 
 mod options {
-    use super::*;
-
     /// Parameters for creating a new issue.
     #[derive(Debug, Clone, Default)]
     pub struct IssueCreateOptions {

--- a/src/core/io/mod.rs
+++ b/src/core/io/mod.rs
@@ -10,6 +10,4 @@ pub(crate) mod copy_tree;
 pub mod output_file;
 
 pub(crate) use copy_tree::{copy_tree, EntryPolicy};
-pub use output_file::{
-    write_output_file, write_output_file_atomically, OutputWriteOptions, TrailingNewline,
-};
+pub use output_file::{write_output_file_atomically, OutputWriteOptions};

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -415,22 +415,6 @@ mod tests {
     use crate::core::extension::ExtensionManifest;
     use crate::core::release::types::ReleaseState;
     use crate::core::release::{ReleaseArtifact, ReleaseStepStatus};
-    use std::process::Command;
-
-    fn git(path: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: {}",
-            args,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
     fn test_repo() -> GitHubRepo {
         GitHubRepo {
             host: "github.com".to_string(),

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -458,16 +458,6 @@ fn secret_env_handoff_remediation(entry: &SecretEnvHandoffEntry) -> String {
     }
 }
 
-fn declared_agent_task_controller_secret_env(args: &[String]) -> Vec<String> {
-    if subcommand_index(args, "agent-task").is_none() {
-        return Vec::new();
-    }
-
-    let executor = ExtensionProviderAgentTaskExecutor::discover();
-    declared_agent_task_controller_secret_env_with_providers(args, executor.providers())
-        .unwrap_or_default()
-}
-
 fn declared_agent_task_controller_secret_env_with_providers(
     args: &[String],
     providers: &[AgentTaskExecutorProvider],


### PR DESCRIPTION
## Summary
- Remove unused imports, test-only helpers, and dead wrappers that were producing Cargo warnings.
- Tighten private helper visibility for controller evidence indexing.
- Keep CLI behavior unchanged; this is warning-surface cleanup only.

## Tests
- cargo check
- cargo test fuzz_runner_contract_includes_extension_declared_env_settings
- cargo test declared_agent_task_controller_dispatch_provider_defaults_include_controller_sources
- cargo test output_file
- cargo test controller_evidence (0 matching tests; test targets built)
- cargo check --tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Warning-surface investigation, targeted cleanup edits, verification, and PR preparation.