### PR TITLE
Keep runtime replay summaries provider-owned

### DIFF
--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -265,13 +265,13 @@ fn replay_provider_boundary_projects_latest_executor_input() {
             serde_json::to_string(&json!({
                 "task_id": "task-a",
                 "executor": {
-                    "backend": "codebox",
+                    "backend": "sample-runtime",
                     "config": {
                         "runtime_component_paths": {
                             "agent_runtime": "/runner/data-machine-patched"
                         },
                         "runtime_env": {
-                            "WP_CODEBOX_DATA_MACHINE_PATH": "/runner/data-machine-patched"
+                            "SAMPLE_RUNTIME_DATA_MACHINE_PATH": "/runner/data-machine-patched"
                         }
                     }
                 },

--- a/src/core/agent_task_controller_service/actions.rs
+++ b/src/core/agent_task_controller_service/actions.rs
@@ -308,6 +308,8 @@ fn controller_action_failure_summary(
         phase: Some(record.phase.clone()),
         provider: context.provider,
         failure_phase: context.failure_phase,
+        runtime_context: context.runtime_context,
+        replay_command: context.replay_command,
         diagnostic: context
             .diagnostic
             .or_else(|| first_action_diagnostic_message(record, &action.action_id))
@@ -359,6 +361,8 @@ struct FailureContext {
     task_id: Option<String>,
     provider: Option<String>,
     failure_phase: Option<String>,
+    runtime_context: Option<Value>,
+    replay_command: Option<String>,
 }
 
 fn find_failure_context(value: &Value) -> Option<FailureContext> {
@@ -391,6 +395,15 @@ fn find_failure_context(value: &Value) -> Option<FailureContext> {
                                         .and_then(Value::as_str)
                                         .map(str::to_string)
                                 }),
+                            runtime_context: diagnostic
+                                .get("data")
+                                .and_then(|data| data.get("runtime_context"))
+                                .cloned()
+                                .or_else(|| find_value_field(value, "runtime_context")),
+                            replay_command: diagnostic
+                                .get("data")
+                                .and_then(|data| string_field(data, "replay_command"))
+                                .or_else(|| find_string_field(value, "replay_command")),
                         });
                     }
                 }
@@ -427,6 +440,19 @@ fn find_string_field(value: &Value, field: &str) -> Option<String> {
         Value::Array(items) => items
             .iter()
             .find_map(|value| find_string_field(value, field)),
+        _ => None,
+    }
+}
+
+fn find_value_field(value: &Value, field: &str) -> Option<Value> {
+    match value {
+        Value::Object(map) => map.get(field).cloned().or_else(|| {
+            map.values()
+                .find_map(|value| find_value_field(value, field))
+        }),
+        Value::Array(items) => items
+            .iter()
+            .find_map(|value| find_value_field(value, field)),
         _ => None,
     }
 }

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -83,8 +83,8 @@ pub use proof::{
 pub use reports::*;
 pub use request::*;
 pub use run_failure_summary::{
-    build_run_failure_summary, ControllerRunCodeboxContext, ControllerRunEvidenceRef,
-    ControllerRunFailureSummary, CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA,
+    build_run_failure_summary, ControllerRunEvidenceRef, ControllerRunFailureSummary,
+    CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA,
 };
 pub use spec::*;
 #[cfg(test)]

--- a/src/core/agent_task_controller_service/reports.rs
+++ b/src/core/agent_task_controller_service/reports.rs
@@ -166,6 +166,10 @@ pub struct ControllerActionFailureSummary {
     pub provider: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_phase: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_context: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_command: Option<String>,
     pub diagnostic: String,
 }
 

--- a/src/core/agent_task_controller_service/run_failure_summary.rs
+++ b/src/core/agent_task_controller_service/run_failure_summary.rs
@@ -14,7 +14,7 @@
 //! hand-extract the root cause again.
 
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 /// Owner surface that a controller run blocker is attributed to.
 ///
@@ -58,21 +58,6 @@ pub struct ControllerRunEvidenceRef {
     pub label: Option<String>,
 }
 
-/// Effective WP Codebox runtime context surfaced from provider/result metadata.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct ControllerRunCodeboxContext {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub binary_path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub commit: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fingerprint: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub capabilities: Vec<String>,
-}
-
 /// Compact, operator-facing root-cause summary for a failed controller run.
 ///
 /// Built purely from the `run-from-spec` result envelope (resume results,
@@ -105,13 +90,12 @@ pub struct ControllerRunFailureSummary {
     /// Durable evidence refs (runner job logs, run evidence, artifact bundles).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub evidence_refs: Vec<ControllerRunEvidenceRef>,
-    /// Effective WP Codebox context, when the failed run delegated through a
-    /// Codebox-backed provider and the provider emitted runtime metadata.
+    /// Provider-owned runtime context for the failed run.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub codebox_context: Option<ControllerRunCodeboxContext>,
-    /// Direct WP Codebox recipe replay command for generated recipes.
+    pub runtime_context: Option<Value>,
+    /// Provider-owned replay command for reproducing the failed runtime action.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub codebox_replay_command: Option<String>,
+    pub replay_command: Option<String>,
     /// Next recommended Homeboy command to investigate or resume.
     pub next_command: String,
 }
@@ -178,12 +162,13 @@ pub fn build_run_failure_summary(
     );
 
     let evidence_refs = collect_evidence_refs(loop_id, failed_action, status);
-    let codebox_context = failed_action.and_then(extract_codebox_context);
-    let codebox_replay_command = failed_action.and_then(|action| {
-        codebox_context.as_ref().and_then(|context| {
-            codebox_replay_command(loop_id, action_id.as_deref(), action, context)
-        })
-    });
+    let runtime_context = failure_summary
+        .and_then(|summary| summary.get("runtime_context"))
+        .cloned()
+        .or_else(|| failed_action.and_then(provider_owned_runtime_context));
+    let replay_command = failure_summary
+        .and_then(|summary| string_field(summary, "replay_command"))
+        .or_else(|| failed_action.and_then(provider_owned_replay_command));
 
     let next_command = next_command(loop_id, owner_surface, action_status.as_deref());
 
@@ -198,8 +183,8 @@ pub fn build_run_failure_summary(
         provider,
         failure_phase,
         evidence_refs,
-        codebox_context,
-        codebox_replay_command,
+        runtime_context,
+        replay_command,
         next_command,
     }
 }
@@ -571,214 +556,42 @@ fn best_diagnostic_message(value: Option<&Value>) -> Option<String> {
         .map(|candidate| candidate.message)
 }
 
-fn extract_codebox_context(value: &Value) -> Option<ControllerRunCodeboxContext> {
-    if !contains_codebox_marker(value) {
-        return None;
-    }
-
-    let context = ControllerRunCodeboxContext {
-        binary_path: first_string_field(
-            value,
-            &[
-                "codebox_binary_path",
-                "wp_codebox_binary_path",
-                "wp_codebox_binary",
-                "codebox_binary",
-            ],
-        )
-        .or_else(|| {
-            first_codebox_scoped_string_field(value, &["binary_path", "executable_path", "path"])
-        }),
-        version: first_string_field(value, &["codebox_version", "wp_codebox_version"])
-            .or_else(|| first_codebox_scoped_string_field(value, &["version"])),
-        commit: first_string_field(value, &["codebox_commit", "wp_codebox_commit"]).or_else(|| {
-            first_codebox_scoped_string_field(value, &["commit", "git_commit", "revision"])
-        }),
-        fingerprint: first_string_field(value, &["codebox_fingerprint", "wp_codebox_fingerprint"])
-            .or_else(|| first_codebox_scoped_string_field(value, &["fingerprint"])),
-        capabilities: first_codebox_capabilities(value),
-    };
-
-    if context.binary_path.is_some()
-        || context.version.is_some()
-        || context.commit.is_some()
-        || context.fingerprint.is_some()
-        || !context.capabilities.is_empty()
-    {
-        Some(context)
-    } else {
-        Some(ControllerRunCodeboxContext {
-            binary_path: Some("wp-codebox".to_string()),
-            version: None,
-            commit: None,
-            fingerprint: None,
-            capabilities: Vec::new(),
-        })
-    }
+fn provider_owned_runtime_context(value: &Value) -> Option<Value> {
+    find_value_field(value, "runtime_context")
 }
 
-fn contains_codebox_marker(value: &Value) -> bool {
+fn provider_owned_replay_command(value: &Value) -> Option<String> {
+    find_string_field(value, "replay_command")
+}
+
+fn find_value_field(value: &Value, field: &str) -> Option<Value> {
     match value {
-        Value::String(text) => is_codebox_marker(text),
-        Value::Array(items) => items.iter().any(contains_codebox_marker),
-        Value::Object(map) => map
+        Value::Object(map) => map.get(field).cloned().or_else(|| {
+            map.values()
+                .find_map(|value| find_value_field(value, field))
+        }),
+        Value::Array(items) => items
             .iter()
-            .any(|(key, nested)| is_codebox_marker(key) || contains_codebox_marker(nested)),
-        _ => false,
-    }
-}
-
-fn is_codebox_marker(value: &str) -> bool {
-    value.to_ascii_lowercase().contains("codebox")
-}
-
-fn first_string_field(value: &Value, fields: &[&str]) -> Option<String> {
-    find_all_strings(value, fields).into_iter().next()
-}
-
-fn first_codebox_scoped_string_field(value: &Value, fields: &[&str]) -> Option<String> {
-    first_codebox_scoped_string_field_inner(value, fields, false)
-}
-
-fn first_codebox_scoped_string_field_inner(
-    value: &Value,
-    fields: &[&str],
-    codebox_scoped: bool,
-) -> Option<String> {
-    match value {
-        Value::Object(map) => {
-            let scoped = codebox_scoped || object_has_codebox_marker(map);
-            if scoped {
-                for field in fields {
-                    if let Some(found) = string_field(value, field) {
-                        return Some(found);
-                    }
-                }
-            }
-            map.iter().find_map(|(key, nested)| {
-                first_codebox_scoped_string_field_inner(
-                    nested,
-                    fields,
-                    scoped || is_codebox_marker(key),
-                )
-            })
-        }
-        Value::Array(items) => items.iter().find_map(|nested| {
-            first_codebox_scoped_string_field_inner(nested, fields, codebox_scoped)
-        }),
+            .find_map(|value| find_value_field(value, field)),
         _ => None,
     }
 }
 
-fn object_has_codebox_marker(map: &Map<String, Value>) -> bool {
-    map.iter().any(|(key, value)| {
-        is_codebox_marker(key) || matches!(value, Value::String(text) if is_codebox_marker(text))
-    })
-}
-
-fn first_codebox_capabilities(value: &Value) -> Vec<String> {
-    let mut out = Vec::new();
-    collect_codebox_capabilities(value, false, &mut out);
-    out.truncate(40);
-    out
-}
-
-fn collect_codebox_capabilities(value: &Value, codebox_scoped: bool, out: &mut Vec<String>) {
+fn find_string_field(value: &Value, field: &str) -> Option<String> {
     match value {
-        Value::Object(map) => {
-            let scoped = codebox_scoped || object_has_codebox_marker(map);
-            if scoped {
-                for key in [
-                    "capabilities",
-                    "commands",
-                    "supported_commands",
-                    "recipe_commands",
-                    "supported_recipe_commands",
-                ] {
-                    if let Some(Value::Array(items)) = map.get(key) {
-                        for item in items {
-                            push_capability(item, out);
-                        }
-                    }
-                }
-            }
-            for (key, nested) in map {
-                collect_codebox_capabilities(nested, scoped || is_codebox_marker(key), out);
-            }
-        }
-        Value::Array(items) => {
-            for nested in items {
-                collect_codebox_capabilities(nested, codebox_scoped, out);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn push_capability(value: &Value, out: &mut Vec<String>) {
-    let capability = value
-        .as_str()
-        .map(str::to_string)
-        .or_else(|| string_field(value, "id"))
-        .or_else(|| string_field(value, "name"))
-        .or_else(|| string_field(value, "command"));
-    if let Some(capability) = capability.filter(|capability| !capability.trim().is_empty()) {
-        if !out.iter().any(|seen| seen == &capability) {
-            out.push(capability);
-        }
-    }
-}
-
-fn codebox_replay_command(
-    loop_id: &str,
-    action_id: Option<&str>,
-    value: &Value,
-    context: &ControllerRunCodeboxContext,
-) -> Option<String> {
-    let recipe = first_string_field(
-        value,
-        &[
-            "generated_recipe_path",
-            "recipe_path",
-            "recipe_file",
-            "recipe",
-        ],
-    )?;
-    let binary = context.binary_path.as_deref().unwrap_or("wp-codebox");
-    let artifact_dir = format!(
-        "/tmp/homeboy-codebox-replay/{}/{}",
-        safe_shell_path_segment(loop_id),
-        safe_shell_path_segment(action_id.unwrap_or("failed-action"))
-    );
-    Some(format!(
-        "{} recipe-run --recipe {} --artifacts {} --json",
-        shell_quote(binary),
-        shell_quote(&recipe),
-        shell_quote(&artifact_dir)
-    ))
-}
-
-fn safe_shell_path_segment(value: &str) -> String {
-    value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
-                ch
-            } else {
-                '-'
-            }
-        })
-        .collect()
-}
-
-fn shell_quote(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | ':' | '='))
-    {
-        value.to_string()
-    } else {
-        format!("'{}'", value.replace('\'', "'\\''"))
+        Value::Object(map) => map
+            .get(field)
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                map.values()
+                    .find_map(|value| find_string_field(value, field))
+            }),
+        Value::Array(items) => items
+            .iter()
+            .find_map(|value| find_string_field(value, field)),
+        _ => None,
     }
 }
 

--- a/src/core/agent_task_controller_service/tests/failure_summary_tests.rs
+++ b/src/core/agent_task_controller_service/tests/failure_summary_tests.rs
@@ -114,32 +114,28 @@ fn run_failure_summary_falls_back_to_stopped_reason() {
 }
 
 #[test]
-fn run_failure_summary_surfaces_codebox_context_and_recipe_replay() {
+fn run_failure_summary_surfaces_provider_runtime_context_and_replay() {
     let results = vec![serde_json::json!({
         "schema": ACTION_RESULT_SCHEMA,
         "status": "failed",
-        "action_id": "validate-recipe",
+        "action_id": "validate-runtime-input",
         "failure_summary": {
-            "action_id": "validate-recipe",
-            "provider": "wp-codebox",
+            "action_id": "validate-runtime-input",
+            "provider": "sample-runtime",
             "failure_phase": "schema_validation",
-            "diagnostic": "unsupported recipe command `wordpress.editor-validate-blocks`",
+            "diagnostic": "unsupported runtime operation `render.preview`",
+            "runtime_context": {
+                "binary_path": "/opt/sample-runtime/bin/runtime",
+                "version": "0.9.1",
+                "fingerprint": "sha256:runtime",
+                "capabilities": ["render.preview"]
+            },
+            "replay_command": "/opt/sample-runtime/bin/runtime replay --input '/tmp/generated input.json' --json"
         },
         "execution": {
             "outputs": {
                 "provider_run_result": {
-                    "source": "wp-codebox/artifact-result-envelope/v1",
-                    "generated_recipe_path": "/tmp/generated recipe.json",
-                    "codebox": {
-                        "binary_path": "/opt/wp-codebox/bin/wp-codebox",
-                        "version": "0.9.1",
-                        "commit": "abc1234",
-                        "fingerprint": "sha256:codebox",
-                        "supported_recipe_commands": [
-                            "wordpress.load",
-                            "wordpress.editor-validate-blocks"
-                        ]
-                    }
+                    "source": "sample-runtime/result-envelope/v1"
                 }
             }
         }
@@ -148,28 +144,23 @@ fn run_failure_summary_surfaces_codebox_context_and_recipe_replay() {
 
     let summary = build_run_failure_summary("loop/9", "action_failed", &results, &status);
     let context = summary
-        .codebox_context
+        .runtime_context
         .as_ref()
-        .expect("codebox context is surfaced");
+        .expect("provider runtime context is surfaced");
 
     assert_eq!(
-        context.binary_path.as_deref(),
-        Some("/opt/wp-codebox/bin/wp-codebox")
+        context["binary_path"].as_str(),
+        Some("/opt/sample-runtime/bin/runtime")
     );
-    assert_eq!(context.version.as_deref(), Some("0.9.1"));
-    assert_eq!(context.commit.as_deref(), Some("abc1234"));
-    assert_eq!(context.fingerprint.as_deref(), Some("sha256:codebox"));
-    assert!(context
-        .capabilities
-        .iter()
-        .any(|capability| capability == "wordpress.editor-validate-blocks"));
+    assert_eq!(context["version"].as_str(), Some("0.9.1"));
+    assert_eq!(context["fingerprint"].as_str(), Some("sha256:runtime"));
 
     let replay = summary
-        .codebox_replay_command
+        .replay_command
         .as_deref()
-        .expect("codebox replay command is surfaced");
+        .expect("provider replay command is surfaced");
     assert_eq!(
         replay,
-        "/opt/wp-codebox/bin/wp-codebox recipe-run --recipe '/tmp/generated recipe.json' --artifacts /tmp/homeboy-codebox-replay/loop-9/validate-recipe --json"
+        "/opt/sample-runtime/bin/runtime replay --input '/tmp/generated input.json' --json"
     );
 }

--- a/src/core/agent_task_scheduler/tests/scheduling_tests.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests.rs
@@ -856,20 +856,14 @@ mod artifact_binding_tests {
         child_runs.sort_by(|left, right| left.task_id.cmp(&right.task_id));
         assert_eq!(child_runs[0].task_id, "case-a");
         assert_eq!(child_runs[0].run_id, "child-case-a");
-        assert_eq!(
-            child_runs[0].provider.as_deref(),
-            Some("generic-fuzz")
-        );
+        assert_eq!(child_runs[0].provider.as_deref(), Some("generic-fuzz"));
         assert_eq!(child_runs[0].state, AgentTaskState::Succeeded);
         assert_eq!(aggregate.artifact_bindings.len(), 2);
         let mut artifact_bindings = aggregate.artifact_bindings.clone();
         artifact_bindings.sort_by(|left, right| left.task_id.cmp(&right.task_id));
         assert_eq!(artifact_bindings[0].task_id, "case-a");
         assert_eq!(artifact_bindings[0].run_id, "child-case-a");
-        assert_eq!(
-            artifact_bindings[0].artifact_id,
-            "artifact-case-a"
-        );
+        assert_eq!(artifact_bindings[0].artifact_id, "artifact-case-a");
         assert_eq!(artifact_bindings[0].kind, "fuzz-report");
         assert_eq!(
             artifact_bindings[0].path.as_deref(),
@@ -1425,7 +1419,7 @@ impl AgentTaskExecutorAdapter for ConceptPacketExecutor {
                     artifact_schema: Some("wp-site-generator/ConceptPacket/v1".to_string()),
                     payload: json!({ "title": "Typed concept" }),
                     artifact: None,
-                    metadata: json!({ "source": "wp-codebox/artifact-result-envelope/v1" }),
+                    metadata: json!({ "source": "sample-runtime/artifact-result-envelope/v1" }),
                 }]
             } else {
                 Vec::new()

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -768,7 +768,11 @@ mod install_flows {
     fn run_lint_reports_package_conflict_markers() {
         let _home = HomeGuard::new();
         let package = tempfile::tempdir().expect("package");
-        write_rig(package.path(), "lint-conflict", &minimal_rig("lint-conflict"));
+        write_rig(
+            package.path(),
+            "lint-conflict",
+            &minimal_rig("lint-conflict"),
+        );
         fs::write(package.path().join("conflicted.txt"), "<<<<<<< ours\n")
             .expect("conflict fixture");
 
@@ -834,7 +838,7 @@ mod install_flows {
             "pipeline": {
                 "check": [
                     { "$merge": "append" },
-                    { "kind": "check", "label": "wp codebox cli exists", "command": "wp-codebox --version" }
+                    { "kind": "check", "label": "sample runtime cli exists", "command": "sample-runtime --version" }
                 ]
             }
         }"#,
@@ -855,7 +859,7 @@ mod install_flows {
             .iter()
             .map(|step| step["label"].as_str().expect("label"))
             .collect();
-        assert_eq!(labels, vec!["npm available", "wp codebox cli exists"]);
+        assert_eq!(labels, vec!["npm available", "sample runtime cli exists"]);
 
         // The materialized spec still parses as a rig (directive fully removed).
         load("appender").expect("load appended rig");

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -48,7 +48,7 @@ fn test_env_provider_extensions_for_extension_workloads_are_deduplicated() {
         r#"{
             "id": "fixture-bench",
             "bench_workloads": {
-                "nodejs": [
+                "fixture-runtime": [
                     {
                         "path": "/tmp/one.bench.mjs",
                         "env_provider_extensions": ["fixture-runtime", "fixture-runtime"]
@@ -67,7 +67,7 @@ fn test_env_provider_extensions_for_extension_workloads_are_deduplicated() {
         env_provider_extensions_for_extension_workloads(
             &rig_spec,
             RigWorkloadKind::Bench,
-            "nodejs",
+            "fixture-runtime",
         ),
         vec!["artifact-helper".to_string(), "fixture-runtime".to_string()]
     );

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -40,10 +40,20 @@ const CORE_EXTENSION_BOUNDARY_ROOTS: &[&str] =
 // Concrete extension IDs belong in extension-owned fixtures/config, not in
 // Homeboy core or core-owned tests. Keep this list to IDs provided by external
 // extensions so the guard stays independent of any one regression site.
-const CONCRETE_EXTENSION_IDS: &[Term] = &[Term {
-    name: "nodejs",
-    kind: MatchKind::Token,
-}];
+const CONCRETE_EXTENSION_IDS: &[Term] = &[
+    Term {
+        name: "nodejs",
+        kind: MatchKind::Token,
+    },
+    Term {
+        name: "codebox",
+        kind: MatchKind::Token,
+    },
+    Term {
+        name: "wp-codebox",
+        kind: MatchKind::Literal,
+    },
+];
 
 const TERMS: &[Term] = &[
     Term {


### PR DESCRIPTION
## Summary
- replace Homeboy core's WP Codebox-specific failure-summary parsing with generic provider-owned `runtime_context` and `replay_command` fields
- pass those fields through controller action failure summaries so providers/extensions own product-specific replay details
- strengthen the core agnostic guard so concrete extension IDs including Codebox are caught in core-owned source/tests
- neutralize existing core-owned fixtures that used concrete extension IDs

## Verification
- `cargo test run_failure_summary`
- `cargo test core_content_stays_free_of_concrete_extension_ids`

## Related
- Follow-up to Extra-Chill/homeboy#7016
- Provider-side Codebox implementation merged in Extra-Chill/homeboy-extensions#2040

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and applying the generic Homeboy primitive, core-boundary guard hardening, fixture cleanup, and regression tests.