### PR TITLE
test: align release blockers with current contracts

### DIFF
--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -360,6 +360,14 @@ mod tests {
             "review" => Some(&["homeboy", "review"]),
             "audit" => Some(&["homeboy", "audit"]),
             "refactor" => Some(&["homeboy", "refactor", "--all"]),
+            "runtime" => Some(&[
+                "homeboy",
+                "runtime",
+                "refresh",
+                "example-runtime",
+                "--source",
+                ".",
+            ]),
             "rig" => Some(&["homeboy", "rig", "check", "example-rig"]),
             "tunnel" => Some(&[
                 "homeboy",

--- a/src/commands/runs/corpus_tests.rs
+++ b/src/commands/runs/corpus_tests.rs
@@ -236,7 +236,7 @@ fn import_from_gh_actions_requires_workflow_or_run_id() {
 }
 
 #[test]
-fn bundle_import_marks_file_artifacts_metadata_only_and_query_reports_skip() {
+fn bundle_import_restores_file_artifacts_and_query_reads_embedded_bytes() {
     let bundle_dir = tempfile::tempdir().expect("bundle dir");
     let mut run_id = String::new();
     let mut source_home_path = String::new();
@@ -273,15 +273,15 @@ fn bundle_import_marks_file_artifacts_metadata_only_and_query_reports_skip() {
         let RunsOutput::Import(output) = output else {
             panic!("expected import output");
         };
-        assert_eq!(output.imported.artifacts, 0);
-        assert_eq!(output.imported.artifact_metadata_only, 1);
+        assert_eq!(output.imported.artifacts, 1);
+        assert_eq!(output.imported.artifact_metadata_only, 0);
 
         let store = ObservationStore::open_initialized().expect("store");
         let artifacts = store.list_artifacts(&run_id).expect("artifacts");
         assert_eq!(artifacts.len(), 1);
-        assert_eq!(artifacts[0].artifact_type, "metadata-only");
+        assert_eq!(artifacts[0].artifact_type, "file");
         assert!(!artifacts[0].path.contains(&source_home_path));
-        assert!(!std::path::Path::new(&artifacts[0].path).is_absolute());
+        assert!(std::path::Path::new(&artifacts[0].path).is_absolute());
 
         let (output, _) = query::runs_query(query::RunsQueryArgs {
             component_id: Some("homeboy".into()),
@@ -297,24 +297,9 @@ fn bundle_import_marks_file_artifacts_metadata_only_and_query_reports_skip() {
         let RunsOutput::Query(output) = output else {
             panic!("expected query output");
         };
-        assert_eq!(output.matched_artifact_count, 0);
-        assert_eq!(output.skipped_artifact_count, 1);
-        assert_eq!(output.skipped_artifacts[0].artifact_type, "metadata-only");
-        assert!(output.skipped_artifacts[0]
-            .reason
-            .contains("artifact bytes are not available"));
-
-        let err = super::artifact_get(super::RunsArtifactGetArgs {
-            run_id,
-            artifact_id: artifacts[0].id.clone(),
-            runner: None,
-            output: None,
-            field: Vec::new(),
-        })
-        .err()
-        .expect("metadata-only artifact get must fail");
-        assert_eq!(err.code.as_str(), "validation.invalid_argument");
-        assert!(err.message.contains("metadata only"));
+        assert_eq!(output.matched_artifact_count, 1);
+        assert_eq!(output.skipped_artifact_count, 0);
+        assert_eq!(output.rows[0].values[0], "homeboy");
     });
 }
 

--- a/src/commands/runs/tests/export_import.rs
+++ b/src/commands/runs/tests/export_import.rs
@@ -146,7 +146,7 @@ fn export_since_writes_multiple_runs() {
 }
 
 #[test]
-fn export_artifacts_is_metadata_only() {
+fn export_embeds_local_file_artifact_bytes() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();
         let store = ObservationStore::open_initialized().expect("store");
@@ -168,8 +168,15 @@ fn export_artifacts_is_metadata_only() {
         .expect("export");
 
         let artifacts: Vec<ArtifactRecord> = read_bundle_test_json(&output.join("artifacts.json"));
-        assert_eq!(artifacts, vec![artifact]);
-        assert!(!output.join("files").exists());
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].id, artifact.id);
+        assert_eq!(artifacts[0].artifact_type, "file");
+        assert!(artifacts[0].path.starts_with("bundle://artifact-bytes/"));
+        assert_eq!(artifacts[0].size_bytes, Some(11));
+        assert!(artifacts[0].sha256.is_some());
+        assert!(artifacts[0].metadata_json.get("portable_bundle").is_some());
+        assert!(output.join("artifact_bytes.json").exists());
+        assert!(output.join("artifact-bytes").exists());
     });
 }
 

--- a/src/core/release/executor/github_release/tests/repair_tests.rs
+++ b/src/core/release/executor/github_release/tests/repair_tests.rs
@@ -157,14 +157,19 @@ fn repair_commands_include_configured_enterprise_proxy_env() {
         Some("build/v1.2.3-release-notes.md"),
     );
 
-    assert!(repair.create_command.starts_with(
-        "GH_HOST=github.enterprise.test HTTP_PROXY=http://proxy.example.test:8080 ALL_PROXY=socks5://127.0.0.1:8080 gh release create v1.2.3"
-    ));
     assert!(repair
-        .env_hint
-        .as_deref()
-        .unwrap_or_default()
-        .contains("HTTP_PROXY, ALL_PROXY"));
+        .create_command
+        .contains("GH_HOST=github.enterprise.test"));
+    assert!(repair
+        .create_command
+        .contains("HTTP_PROXY=http://proxy.example.test:8080"));
+    assert!(repair
+        .create_command
+        .contains("ALL_PROXY=socks5://127.0.0.1:8080"));
+    assert!(repair.create_command.contains("gh release create v1.2.3"));
+    let env_hint = repair.env_hint.as_deref().unwrap_or_default();
+    assert!(env_hint.contains("HTTP_PROXY"));
+    assert!(env_hint.contains("ALL_PROXY"));
 }
 
 #[test]

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -754,7 +754,17 @@ mod tests {
             )
             .expect_err("failed dependency build should fail sync");
 
-            assert!(err.message.contains("build lifecycle failed"));
+            assert_eq!(err.code.as_str(), "dependency_step_failed");
+            assert_eq!(
+                err.details.get("step_id").and_then(|value| value.as_str()),
+                Some("dependency.build")
+            );
+            assert_eq!(
+                err.details
+                    .get("component_id")
+                    .and_then(|value| value.as_str()),
+                Some("shared-runtime")
+            );
             assert!(!dependency.join(".homeboy-build").exists());
             let output = Command::new("git")
                 .args(["status", "--porcelain=v1"])
@@ -901,7 +911,8 @@ mod tests {
                 .map(|entries| entries.filter_map(|entry| entry.ok()).count())
                 .unwrap_or(0);
             assert_eq!(
-                leftovers, 0,
+                leftovers,
+                0,
                 "partial sync must not leave an orphaned remote checkout under {}",
                 lab_workspaces.display()
             );


### PR DESCRIPTION
## Summary
- Add a parseable runtime sample for Lab-supported command registry coverage.
- Update portable observation bundle tests for embedded artifact bytes.
- Make GitHub release repair proxy-env assertions order-insensitive.
- Assert structured validation dependency build-failure details.

## Verification
- cargo test command_registry_lab_metadata_matches_command_support_for_parseable_samples
- cargo test export_embeds_local_file_artifact_bytes
- cargo test bundle_import_restores_file_artifacts_and_query_reads_embedded_bytes
- cargo test repair_commands_include_configured_enterprise_proxy_env
- cargo test sync_workspace_failed_validation_dependency_build_keeps_source_clean
- cargo build --release

Local full `cargo test` still reports broader failures outside this scoped patch: extension fixture resolution, lab env contamination, SIGTERM/SIGKILL timing, audit snapshot output, and annotation-path setup.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the release-test failures, updating scoped test contracts, and running local verification.