### PR TITLE
Drop undeclared inherited secret env before runner dispatch

### DIFF
--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -177,6 +177,7 @@ pub(crate) fn prepare_runner_process(
     let mut secret_env_plan =
         SecretEnvPlan::from_secret_env_names(request.secret_env_names.iter().cloned());
     secret_env_plan.allow_inherited_env_names([RUNTIME_SECRET_ENV_ALLOWLIST_ENV.to_string()]);
+    secret_env_plan.remove_undeclared_inherited_secret_env(&mut env);
 
     if runner.kind == RunnerKind::Local {
         env.extend(resolve_runner_secret_env_for_plan(
@@ -281,6 +282,7 @@ pub(crate) fn prepare_daemon_local_process(
     let mut secret_env_plan =
         SecretEnvPlan::from_secret_env_names(request.secret_env_names.iter().cloned());
     secret_env_plan.allow_inherited_env_names([RUNTIME_SECRET_ENV_ALLOWLIST_ENV.to_string()]);
+    secret_env_plan.remove_undeclared_inherited_secret_env(&mut env);
     env.extend(resolve_runner_secret_env_for_plan(
         &runner.secret_env,
         &secret_env_plan,

--- a/src/core/runner/execution/tests/prepare.rs
+++ b/src/core/runner/execution/tests/prepare.rs
@@ -175,13 +175,13 @@ fn local_runner_prep_does_not_mark_commands_as_runner_hosted() {
 }
 
 #[test]
-fn runner_prep_rejects_undeclared_sensitive_env() {
+fn runner_prep_drops_undeclared_sensitive_env() {
     crate::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("project");
         std::fs::create_dir_all(&workspace).expect("workspace");
 
-        let err = prepare_runner_process(RunnerProcessRequest {
+        let plan = prepare_runner_process(RunnerProcessRequest {
             runner_id: "local".to_string(),
             runner: Some(local_runner(workspace.display().to_string())),
             cwd: Some(workspace.display().to_string()),
@@ -198,11 +198,10 @@ fn runner_prep_rejects_undeclared_sensitive_env() {
             require_paths: Vec::new(),
             validate_require_paths_on_host: false,
         })
-        .expect_err("undeclared sensitive env should fail closed");
+        .expect("undeclared sensitive env is dropped before execution");
 
-        assert_eq!(err.code.as_str(), "validation.invalid_argument");
-        assert!(err.message.contains("UNDECLARED_API_TOKEN"));
-        assert!(!format!("{err:?}").contains("secret-value"));
+        assert!(!plan.env.contains_key("UNDECLARED_API_TOKEN"));
+        assert!(!format!("{plan:?}").contains("secret-value"));
     });
 }
 

--- a/src/core/secret_env_plan.rs
+++ b/src/core/secret_env_plan.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 
@@ -346,6 +346,27 @@ impl SecretEnvPlan {
                 diagnostics,
             })
         }
+    }
+
+    pub fn remove_undeclared_inherited_secret_env(
+        &self,
+        env: &mut HashMap<String, String>,
+    ) -> Vec<String> {
+        let declared = self.declared_inherited_env_names();
+        let policy = self.redaction.to_policy();
+        let mut removed = env
+            .keys()
+            .filter(|name| policy.is_sensitive_key(name) && !declared.contains(*name))
+            .cloned()
+            .collect::<Vec<_>>();
+        removed.sort();
+        removed.dedup();
+
+        for name in &removed {
+            env.remove(name);
+        }
+
+        removed
     }
 
     fn secret_env_requirements(&self) -> Vec<SecretEnvRequirement> {


### PR DESCRIPTION
## Summary
- Drop sensitive inherited/request env keys that are not declared by the runner secret env plan before runner dispatch.
- Keep declared secret env names forwarded and validated.
- Update runner preparation coverage so undeclared sensitive env is removed without leaking values.

## Tests
- cargo test core::runner::execution::tests::prepare::
- cargo test core::secret_env_plan::tests::
- cargo test core::runner::execution::
- OPENAI_API_KEY=ambient-test-secret cargo run --manifest-path /Users/chubes/Developer/homeboy@fix-lab-drop-ambient-secrets/Cargo.toml -- --lab-only --runner homeboy-lab fuzz list woocommerce --rig woocommerce-performance

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the Lab runner env handoff path, implementing the generic secret-env sanitization change, updating tests, and running verification.