### PR TITLE
Clarify agent task provider identity

### DIFF
--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -334,6 +334,7 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
                 "version": catalog_version,
             },
             "dispatch_config_layers": dispatch_config_layers(providers),
+            "provider_identity_catalog": provider_identity_catalog(providers),
             "capability_contract": homeboy::core::agent_tasks::provider::provider_capability_contract(),
             "providers": providers,
             "readiness_validation": {
@@ -346,6 +347,24 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
         }),
         0,
     ))
+}
+
+fn provider_identity_catalog(providers: &[AgentTaskExecutorProvider]) -> Vec<Value> {
+    providers
+        .iter()
+        .map(|provider| {
+            let ai_provider_ids = provider.provider_defaults.keys().cloned().collect::<Vec<_>>();
+            serde_json::json!({
+                "executor_provider_id": provider.id,
+                "executor_backend": provider.backend,
+                "runtime_id": provider.runtime_id,
+                "runtime_package_source": provider.runtime_package_source.as_ref().or(provider.extension_id.as_ref()),
+                "runtime_path": provider.runtime_path,
+                "ai_provider_ids": ai_provider_ids,
+                "model": null,
+            })
+        })
+        .collect()
 }
 
 /// Operator-facing explanation of the two distinct dispatch configuration
@@ -739,6 +758,10 @@ mod tests {
             "id": "wordpress.sandbox-agent-task-executor",
             "backend": "wordpress",
             "extension_id": "wordpress.sandbox",
+            "runtime_id": "sandbox-runtime",
+            "provider_defaults": {
+                "codex": { "secret_env": ["CODEX_TOKEN"] }
+            }
         }))
         .expect("provider fixture");
 
@@ -776,6 +799,37 @@ mod tests {
             .as_str()
             .expect("common mistake")
             .contains("codex"));
+    }
+
+    #[test]
+    fn provider_identity_catalog_uses_explicit_runtime_vocabulary() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "opencode.agent-task-executor",
+            "backend": "opencode",
+            "extension_id": "wp-codebox",
+            "runtime_package_source": "wp-codebox",
+            "runtime_id": "opencode-local-runtime",
+            "provider_defaults": {
+                "openai": {},
+                "anthropic": {}
+            }
+        }))
+        .expect("provider fixture");
+
+        let catalog = provider_identity_catalog(&[provider]);
+
+        assert_eq!(
+            catalog[0]["executor_provider_id"],
+            "opencode.agent-task-executor"
+        );
+        assert_eq!(catalog[0]["executor_backend"], "opencode");
+        assert_eq!(catalog[0]["runtime_id"], "opencode-local-runtime");
+        assert_eq!(catalog[0]["runtime_package_source"], "wp-codebox");
+        assert_eq!(
+            catalog[0]["ai_provider_ids"],
+            serde_json::json!(["anthropic", "openai"])
+        );
+        assert!(catalog[0]["model"].is_null());
     }
 
     #[test]

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -476,6 +476,9 @@ fn agent_task_executor_providers_from_runtime_manifests(
         for mut provider in runtime_manifest.agent_task_executors {
             provider.extension_id = runtime_manifest.extension_id.clone();
             provider.extension_path = runtime_manifest.extension_path.clone();
+            if provider.runtime_package_source.is_none() {
+                provider.runtime_package_source = runtime_manifest.extension_id.clone();
+            }
             provider.runtime_id = Some(runtime_manifest.id.clone());
             provider.runtime_path = runtime_manifest.runtime_path.clone();
             if let Ok(value) = serde_json::to_value(&materialization_plan) {

--- a/src/core/agent_task/executor.rs
+++ b/src/core/agent_task/executor.rs
@@ -31,8 +31,8 @@ pub struct AgentTaskRuntimeSelection {
         skip_serializing_if = "Option::is_none"
     )]
     pub executor_provider_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider: Option<String>,
+    #[serde(default, alias = "provider", skip_serializing_if = "Option::is_none")]
+    pub ai_provider_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -50,8 +50,8 @@ impl AgentTaskExecutor {
             executor_provider_id: explicit
                 .executor_provider_id
                 .or_else(|| self.selector.clone()),
-            provider: explicit
-                .provider
+            ai_provider_id: explicit
+                .ai_provider_id
                 .or_else(|| config_string(&self.config, "provider")),
             model: explicit.model.or_else(|| self.model.clone()),
             substrate_ref: explicit.substrate_ref,
@@ -82,7 +82,7 @@ impl AgentTaskExecutor {
     pub fn provider(&self) -> Option<&str> {
         self.runtime_selection
             .as_ref()
-            .and_then(|selection| selection.provider.as_deref())
+            .and_then(|selection| selection.ai_provider_id.as_deref())
             .or_else(|| config_str(&self.config, "provider"))
     }
 

--- a/src/core/agent_task/tests.rs
+++ b/src/core/agent_task/tests.rs
@@ -196,7 +196,7 @@ fn executor_runtime_selection_synthesizes_legacy_fields() {
         selection.executor_provider_id.as_deref(),
         Some("claude-code")
     );
-    assert_eq!(selection.provider.as_deref(), Some("claude-code"));
+    assert_eq!(selection.ai_provider_id.as_deref(), Some("claude-code"));
     assert_eq!(selection.model.as_deref(), Some("opus-4.7"));
     assert_eq!(selection.substrate_ref, None);
     assert_eq!(executor.executor_backend(), "sample-runtime");
@@ -248,6 +248,10 @@ fn executor_runtime_selection_round_trips_aliases() {
     assert_eq!(
         serialized["runtime_selection"]["executor_provider_id"],
         "runtime-selector"
+    );
+    assert_eq!(
+        serialized["runtime_selection"]["ai_provider_id"],
+        "example-oauth"
     );
     assert!(serialized.get("runtime").is_none());
 }

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -10,8 +10,8 @@ use serde_json::Value;
 
 use crate::core::agent_task::{
     AgentTaskComponentContract, AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy,
-    AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkspace, AgentTaskWorkspaceMode,
-    AGENT_TASK_REQUEST_SCHEMA,
+    AgentTaskRequest, AgentTaskRuntimeSelection, AgentTaskSourceRef, AgentTaskWorkspace,
+    AgentTaskWorkspaceMode, AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
 use crate::core::agent_task_prompts;
@@ -127,7 +127,14 @@ pub fn build_dispatch_plan_with_provider_requirements(
             executor: AgentTaskExecutor {
                 backend: request.backend.clone(),
                 selector: request.selector.clone(),
-                runtime_selection: None,
+                runtime_selection: Some(AgentTaskRuntimeSelection {
+                    runtime_id: None,
+                    executor_backend: Some(request.backend.clone()),
+                    executor_provider_id: request.selector.clone(),
+                    ai_provider_id: config_string(&provider_config, "provider"),
+                    model: request.model.clone(),
+                    substrate_ref: None,
+                }),
                 required_capabilities: request.required_capabilities.clone(),
                 secret_env: secret_env.clone(),
                 model: request.model.clone(),
@@ -242,6 +249,10 @@ fn validate_dispatch_workspace_target(
             "Use a provider without a git-checkout materialization requirement only if it has an explicit non-git apply-back artifact contract.".to_string(),
         ]),
     ))
+}
+
+fn config_string(config: &Value, key: &str) -> Option<String> {
+    config.get(key).and_then(Value::as_str).map(str::to_string)
 }
 
 fn is_git_checkout(path: &std::path::Path) -> bool {
@@ -857,6 +868,54 @@ mod tests {
         assert!(!serialized.contains("kimaki"));
         assert!(!serialized.contains("channel"));
         assert!(!serialized.contains("thread"));
+    }
+
+    #[test]
+    fn dispatch_plan_records_executor_and_ai_provider_vocabulary_separately() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let request = dispatch_request(DispatchRequestOverrides {
+            prompt: Some("Cook the issue cleanly.".to_string()),
+            cwd: Some(workspace.path().display().to_string()),
+            backend: Some("opencode".to_string()),
+            selector: Some("opencode.agent-task-executor".to_string()),
+            model: Some("gpt-5.5".to_string()),
+            core: DispatchCoreInputs {
+                provider_config: Some(r#"{"provider":"openai"}"#.to_string()),
+                ..DispatchCoreInputs::default()
+            },
+            ..DispatchRequestOverrides::default()
+        });
+        let plan =
+            build_dispatch_plan_with_provider_requirements(&request, |_backend, _selector| false)
+                .expect("dispatch plan");
+
+        let executor = &plan.tasks[0].executor;
+        let selection = executor
+            .runtime_selection
+            .as_ref()
+            .expect("runtime selection");
+        assert_eq!(executor.backend, "opencode");
+        assert_eq!(
+            executor.selector.as_deref(),
+            Some("opencode.agent-task-executor")
+        );
+        assert_eq!(selection.executor_backend.as_deref(), Some("opencode"));
+        assert_eq!(
+            selection.executor_provider_id.as_deref(),
+            Some("opencode.agent-task-executor")
+        );
+        assert_eq!(selection.ai_provider_id.as_deref(), Some("openai"));
+        assert_eq!(selection.model.as_deref(), Some("gpt-5.5"));
+
+        let serialized = serde_json::to_value(&plan).expect("serialize plan");
+        assert_eq!(
+            serialized["tasks"][0]["executor"]["runtime_selection"]["executor_provider_id"],
+            "opencode.agent-task-executor"
+        );
+        assert_eq!(
+            serialized["tasks"][0]["executor"]["runtime_selection"]["ai_provider_id"],
+            "openai"
+        );
     }
 
     #[test]
@@ -1494,6 +1553,8 @@ mod tests {
         run_id: Option<String>,
         task_id: Option<String>,
         backend: Option<String>,
+        selector: Option<String>,
+        model: Option<String>,
         core: DispatchCoreInputs,
     }
 
@@ -1506,8 +1567,8 @@ mod tests {
             repo: overrides.repo,
             task_url: overrides.task_url,
             backend: overrides.backend.unwrap_or_else(|| "fixture".to_string()),
-            selector: None,
-            model: None,
+            selector: overrides.selector,
+            model: overrides.model,
             required_capabilities: overrides.required_capabilities,
             secret_env: overrides.secret_env,
             concurrency: if overrides.concurrency == 0 {

--- a/src/core/agent_task_provider/tests/common.rs
+++ b/src/core/agent_task_provider/tests/common.rs
@@ -40,6 +40,7 @@ pub(super) fn request(
         runtime_contract: AgentTaskRuntimeContract::default(),
         extension_id: None,
         extension_path: None,
+        runtime_package_source: None,
         runtime_id: None,
         runtime_path: None,
         extra: BTreeMap::new(),

--- a/src/core/agent_task_provider/types.rs
+++ b/src/core/agent_task_provider/types.rs
@@ -98,6 +98,8 @@ pub struct AgentTaskExecutorProvider {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_package_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_path: Option<String>,

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -2200,6 +2200,7 @@ HOMEBOY_SHARED_MISSING_SECRET_TEST, HOMEBOY_OTHER_MISSING_SECRET_TEST"
             runtime_contract: Default::default(),
             extension_id: None,
             extension_path: None,
+            runtime_package_source: None,
             runtime_id: None,
             runtime_path: None,
             extra: std::collections::BTreeMap::new(),


### PR DESCRIPTION
## Summary
- separate executor/runtime provider identity from nested AI provider/model selection in dispatch plans
- add a provider identity catalog with explicit runtime vocabulary
- expose runtime package source metadata from runtime manifests

Fixes #7048.

## Tests
- cargo test --locked agent_task_dispatch_plan::tests::dispatch_plan_records_executor_and_ai_provider_vocabulary_separately
- cargo test --locked agent_task::tests::executor_runtime_selection_round_trips_aliases
- cargo test --locked provider_identity_catalog_uses_explicit_runtime_vocabulary
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode native subagents
- **Used for:** Investigating the agent-task provider identity surfaces, drafting the code/test changes, and verifying focused tests. Chris remains responsible for review and landing.