### PR TITLE
Fix lab runner version remediation direction

### DIFF
--- a/src/core/runner/lab/offload/metadata.rs
+++ b/src/core/runner/lab/offload/metadata.rs
@@ -205,6 +205,7 @@ pub(crate) fn lab_runner_homeboy_metadata(
         format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
         format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
     ];
+    let primary_remediation_command = runner_homeboy_primary_remediation_command(runner_id, status);
     let stale_daemon = status.stale_daemon.as_ref();
     serde_json::json!({
         "schema": "homeboy/lab-runner-homeboy/v1",
@@ -220,7 +221,9 @@ pub(crate) fn lab_runner_homeboy_metadata(
         "stale_daemon_refresh_command": stale_daemon.map(|warning| warning.refresh_command.clone()),
         "stale_daemon": status.stale_daemon,
         "version_drift": lab_runner_homeboy_version_drift(status),
+        "primary_remediation_command": primary_remediation_command,
         "refresh_commands": refresh_commands,
+        "local_upgrade_command": "homeboy upgrade",
         "upgrade_command": format!("homeboy upgrade --force --upgrade-runner {}", shell::quote_arg(runner_id)),
     })
 }
@@ -253,9 +256,7 @@ pub(crate) enum RunnerHomeboyVersionDrift {
 /// opt into strict exact-match either per-runner (the
 /// `require_exact_homeboy_version` runner setting) or for a single run via the
 /// `HOMEBOY_REQUIRE_EXACT_RUNNER_VERSION` env var.
-pub(crate) fn require_exact_runner_version(
-    settings: &crate::core::server::RunnerSettings,
-) -> bool {
+pub(crate) fn require_exact_runner_version(settings: &crate::core::server::RunnerSettings) -> bool {
     if std::env::var(REQUIRE_EXACT_RUNNER_VERSION_ENV)
         .ok()
         .is_some_and(|value| {
@@ -274,21 +275,26 @@ pub(crate) fn require_exact_runner_version(
 /// leading label (e.g. `homeboy 0.266.1`) and trailing build/prerelease
 /// metadata (e.g. `0.266.1+abc`). Mirrors the lenient parsing already used by
 /// the runner version probe so the gate accepts the same shapes.
-fn parse_major_minor(version: &str) -> Option<(u64, u64)> {
+fn parse_version_triplet(version: &str) -> Option<(u64, u64, u64)> {
     let candidate = version
         .split_whitespace()
         .find(|token| token.chars().next().is_some_and(|c| c.is_ascii_digit()))
         .unwrap_or_else(|| version.trim());
     let mut parts = candidate.split('.');
-    let major = parts.next()?.parse::<u64>().ok()?;
-    let minor: u64 = parts
-        .next()?
-        .chars()
-        .take_while(|c| c.is_ascii_digit())
-        .collect::<String>()
-        .parse()
-        .ok()?;
-    Some((major, minor))
+    let mut parse_part = || {
+        parts
+            .next()?
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect::<String>()
+            .parse()
+            .ok()
+    };
+    Some((parse_part()?, parse_part()?, parse_part()?))
+}
+
+fn parse_major_minor(version: &str) -> Option<(u64, u64)> {
+    parse_version_triplet(version).map(|(major, minor, _patch)| (major, minor))
 }
 
 /// Classify controller↔runner Homeboy version drift using the same drift
@@ -375,6 +381,44 @@ pub(crate) fn lab_runner_homeboy_compatible_drift_warning(
 
 fn lab_runner_homeboy_version_drift(status: &RunnerStatusReport) -> bool {
     classify_runner_homeboy_version_drift(status) != RunnerHomeboyVersionDrift::None
+}
+
+fn runner_daemon_newer_than_controller(status: &RunnerStatusReport) -> bool {
+    let Some(controller) = parse_version_triplet(env!("CARGO_PKG_VERSION")) else {
+        return false;
+    };
+    status
+        .stale_daemon
+        .as_ref()
+        .map(|warning| warning.active_daemon_control_plane_version.as_str())
+        .into_iter()
+        .chain(
+            status
+                .session
+                .as_ref()
+                .map(|session| session.homeboy_version.as_str()),
+        )
+        .filter_map(parse_version_triplet)
+        .any(|runner| runner > controller)
+}
+
+fn runner_homeboy_primary_remediation_command(
+    runner_id: &str,
+    status: &RunnerStatusReport,
+) -> String {
+    if runner_daemon_newer_than_controller(status) {
+        return "homeboy upgrade".to_string();
+    }
+
+    runner_homeboy_refresh_commands(runner_id, status)
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| {
+            format!(
+                "homeboy runner refresh-homeboy {} --ref main --reconnect",
+                shell::quote_arg(runner_id)
+            )
+        })
 }
 
 pub(crate) fn lab_source_checkout_metadata(source_path: &Path) -> serde_json::Value {
@@ -514,17 +558,25 @@ pub(crate) fn stale_runner_homeboy_error(
             )
         });
     let refresh = refresh_commands.join(" && ");
+    let mut tried = Vec::new();
+    if runner_daemon_newer_than_controller(status) {
+        tried.push(format!(
+            "Upgrade this local Homeboy controller before retrying Lab offload: {}",
+            runner_homeboy_primary_remediation_command(runner_id, status)
+        ));
+    }
+    tried.extend([
+        format!("Reconnect runner `{runner_id}` before retrying Lab offload: {refresh}"),
+        format!("If the runner binary itself is stale, refresh or select a clean runner binary with `homeboy runner refresh-homeboy {} --ref main --reconnect`.", shell::quote_arg(runner_id)),
+        "Use --force-hot --allow-local-hot only if you intentionally want to bypass Lab offload and run locally.".to_string(),
+    ]);
     Error::validation_invalid_argument(
         "runner",
         format!(
-            "Lab offload refused runner `{runner_id}` because its active daemon control plane differs from the configured job command binary `{configured_executable}`. Active daemon control plane: {active_daemon}; job command binary: {current_homeboy}. {drift_message} Stale runner runtimes can return malformed or misleading provider output; reconnect the runner before retrying."
+            "Lab offload refused runner `{runner_id}` because its active daemon control plane differs from the configured job command binary `{configured_executable}`. Active daemon control plane: {active_daemon}; job command binary: {current_homeboy}. {drift_message} Stale runner runtimes can return malformed or misleading provider output; follow the first remediation hint before retrying."
         ),
         Some(runner_id.to_string()),
-        Some(vec![
-            format!("Reconnect runner `{runner_id}` before retrying Lab offload: {refresh}"),
-            format!("If the runner binary itself is stale, refresh or select a clean runner binary with `homeboy runner refresh-homeboy {} --ref main --reconnect`.", shell::quote_arg(runner_id)),
-            "Use --force-hot --allow-local-hot only if you intentionally want to bypass Lab offload and run locally.".to_string(),
-        ]),
+        Some(tried),
     )
 }
 

--- a/src/core/runner/lab/offload/tests/capability_metadata.rs
+++ b/src/core/runner/lab/offload/tests/capability_metadata.rs
@@ -338,10 +338,8 @@ fn same_minor_patch_drift_version(prefix: &str) -> String {
 
 #[test]
 fn same_minor_patch_drift_is_compatible_and_proceeds_with_warning() {
-    let status = status_with_runner_version(
-        "homeboy-lab",
-        &same_minor_patch_drift_version("homeboy "),
-    );
+    let status =
+        status_with_runner_version("homeboy-lab", &same_minor_patch_drift_version("homeboy "));
 
     assert_eq!(
         classify_runner_homeboy_version_drift(&status),
@@ -357,8 +355,7 @@ fn same_minor_patch_drift_is_compatible_and_proceeds_with_warning() {
 
 #[test]
 fn same_minor_patch_drift_is_refused_under_strict_mode() {
-    let status =
-        status_with_runner_version("homeboy-lab", &same_minor_patch_drift_version(""));
+    let status = status_with_runner_version("homeboy-lab", &same_minor_patch_drift_version(""));
 
     // Strict override restores exact-match: patch drift now refuses.
     assert!(lab_runner_homeboy_has_blocking_drift(&status, true));
@@ -372,10 +369,7 @@ fn minor_version_drift_is_incompatible_and_refused() {
     let controller = env!("CARGO_PKG_VERSION");
     let mut parts = controller.split('.');
     let major = parts.next().unwrap_or("0");
-    let minor: u64 = parts
-        .next()
-        .and_then(|p| p.parse().ok())
-        .unwrap_or(0);
+    let minor: u64 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
     let drifted = format!("{major}.{}.0", minor.wrapping_add(1));
     let status = status_with_runner_version("homeboy-lab", &drifted);
 
@@ -386,6 +380,64 @@ fn minor_version_drift_is_incompatible_and_refused() {
     assert!(lab_runner_homeboy_has_blocking_drift(&status, false));
     assert!(lab_runner_homeboy_has_blocking_drift(&status, true));
     assert!(lab_runner_homeboy_compatible_drift_warning(&status, false).is_none());
+}
+
+#[test]
+fn newer_runner_than_controller_points_to_local_upgrade_first() {
+    let status = status_with_runner_version("homeboy-lab", &higher_minor_version());
+
+    let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
+    assert_eq!(metadata["primary_remediation_command"], "homeboy upgrade");
+    assert_eq!(metadata["local_upgrade_command"], "homeboy upgrade");
+
+    let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
+    let tried = err.details["tried"].as_array().expect("tried hints");
+    assert!(tried
+        .first()
+        .and_then(|hint| hint.as_str())
+        .is_some_and(|hint| hint.contains("homeboy upgrade")));
+}
+
+#[test]
+fn newer_stale_daemon_control_plane_points_to_local_upgrade_first() {
+    let mut status = status_with_runner_version("homeboy-lab", env!("CARGO_PKG_VERSION"));
+    let runner_version = higher_minor_version();
+    status.stale_daemon = Some(RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        runner_version,
+        env!("CARGO_PKG_VERSION").to_string(),
+        None,
+        None,
+    ));
+
+    let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
+    assert_eq!(metadata["primary_remediation_command"], "homeboy upgrade");
+
+    let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
+    let tried = err.details["tried"].as_array().expect("tried hints");
+    assert!(tried
+        .first()
+        .and_then(|hint| hint.as_str())
+        .is_some_and(|hint| hint.contains("homeboy upgrade")));
+}
+
+#[test]
+fn older_runner_than_controller_points_to_runner_refresh_first() {
+    let status = status_with_runner_version("homeboy-lab", "0.0.0");
+
+    let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
+    assert_eq!(
+        metadata["primary_remediation_command"],
+        "homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect"
+    );
+
+    let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
+    let tried = err.details["tried"].as_array().expect("tried hints");
+    assert!(tried
+        .first()
+        .and_then(|hint| hint.as_str())
+        .is_some_and(|hint| hint
+            .contains("homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect")));
 }
 
 #[test]
@@ -501,12 +553,25 @@ fn stale_runner_homeboy_error_blocks_offload_with_reconnect_guidance() {
         .contains("malformed or misleading provider output"));
     let tried = err.details["tried"].as_array().expect("tried hints");
     assert!(tried
+        .first()
+        .and_then(|hint| hint.as_str())
+        .is_some_and(|hint| hint
+            .contains("homeboy runner refresh-homeboy 'homeboy lab' --ref main --reconnect")));
+    assert!(tried
         .iter()
         .any(|hint| hint.as_str().is_some_and(|hint| hint
             .contains("homeboy runner refresh-homeboy 'homeboy lab' --ref main --reconnect"))));
     assert!(tried.iter().any(|hint| hint
         .as_str()
         .is_some_and(|hint| hint.contains("refresh or select a clean runner binary"))));
+}
+
+fn higher_minor_version() -> String {
+    let controller = env!("CARGO_PKG_VERSION");
+    let mut parts = controller.split('.');
+    let major = parts.next().unwrap_or("0");
+    let minor: u64 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+    format!("{major}.{}.0", minor + 1)
 }
 
 #[test]

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -505,16 +505,21 @@ fn refresh_hint(
 }
 
 fn refresh_command(runner_id: &str, runner_homeboy: &serde_json::Value) -> String {
-    runner_homeboy["refresh_commands"]
-        .as_array()
-        .and_then(|commands| {
-            commands
-                .iter()
-                .filter_map(|command| command.as_str())
-                .next()
-        })
+    runner_homeboy["primary_remediation_command"]
+        .as_str()
         .map(str::to_string)
         .filter(|command| !command.is_empty())
+        .or_else(|| {
+            runner_homeboy["refresh_commands"]
+                .as_array()
+                .and_then(|commands| {
+                    commands
+                        .iter()
+                        .filter_map(|command| command.as_str())
+                        .next()
+                })
+                .map(str::to_string)
+        })
         .or_else(|| {
             runner_homeboy["upgrade_command"]
                 .as_str()


### PR DESCRIPTION
## Summary
- Add a primary Lab runner Homeboy remediation command that points to local `homeboy upgrade` when the runner daemon/control plane is newer than the local controller.
- Keep runner refresh/reconnect as the first remediation when the runner or configured runner binary is stale.
- Teach provider preflight diagnostics to prefer the primary remediation command from runner metadata.

Fixes https://github.com/Extra-Chill/homeboy/issues/7052

## Verification
- `rustfmt --check src/core/runner/lab/offload/metadata.rs src/core/runner/lab/provider_preflight.rs src/core/runner/lab/offload/tests/capability_metadata.rs`
- `cargo test -q core::runner::lab::offload::tests::capability_metadata`
- `cargo test -q core::runner::lab::provider_preflight`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Diagnosing runner-version remediation flow, implementing the Rust changes, and adding targeted tests.