### PR TITLE
Fix runner secret env preflight for non-secret commands

### DIFF
--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -168,31 +168,60 @@ pub(crate) fn prepare_runner_process(
         },
     )?;
 
-    let mut env = runner.env.clone();
-    env.extend(request.env);
+    let raw_runner_env = runner.env.clone();
+    let request_env = request.env.clone();
+    let mut env = raw_runner_env.clone();
+    env.extend(request_env.clone());
     if runner.kind != RunnerKind::Local {
         env.insert(RUNNER_HOSTED_EXEC_ENV.to_string(), "1".to_string());
         env.insert(RUNNER_ID_ENV.to_string(), runner.id.clone());
     }
-    let mut secret_env_plan =
-        SecretEnvPlan::from_secret_env_names(request.secret_env_names.iter().cloned());
-    secret_env_plan.allow_inherited_env_names([RUNTIME_SECRET_ENV_ALLOWLIST_ENV.to_string()]);
+    let secret_env_plan =
+        runner_exec_secret_env_plan(&request.command, None, &request.secret_env_names, &env);
 
     if runner.kind == RunnerKind::Local {
+        validate_runner_inherited_secret_env(
+            &secret_env_plan,
+            &request_env,
+            "local controller env",
+            true,
+        )?;
+        let runner_env = validated_runner_inherited_env(
+            &secret_env_plan,
+            raw_runner_env,
+            "local controller runner.env",
+            false,
+        )?;
+        env = runner_env;
+        env.extend(request_env.clone());
         env.extend(resolve_runner_secret_env_for_plan(
             &runner.secret_env,
             &secret_env_plan,
             &env,
         )?);
-        validate_runner_inherited_secret_env(&secret_env_plan, &env)?;
         normalize_runner_command_env(&mut env);
     } else {
+        validate_runner_inherited_secret_env(
+            &secret_env_plan,
+            &request_env,
+            "local controller env",
+            true,
+        )?;
+        let runner_env = validated_runner_inherited_env(
+            &secret_env_plan,
+            raw_runner_env,
+            "local controller runner.env",
+            false,
+        )?;
+        env = runner_env;
+        env.extend(request_env.clone());
+        env.insert(RUNNER_HOSTED_EXEC_ENV.to_string(), "1".to_string());
+        env.insert(RUNNER_ID_ENV.to_string(), runner.id.clone());
         env.extend(resolve_controller_secret_env_for_command(
             &runner.secret_env,
             &request.secret_env_names,
             &env,
         )?);
-        validate_runner_inherited_secret_env(&secret_env_plan, &env)?;
     }
 
     let source_snapshot = request
@@ -276,17 +305,31 @@ pub(crate) fn prepare_daemon_local_process(
         request.validate_require_paths_on_host,
     )?;
 
-    let mut env = runner.env.clone();
-    env.extend(request.env);
-    let mut secret_env_plan =
-        SecretEnvPlan::from_secret_env_names(request.secret_env_names.iter().cloned());
-    secret_env_plan.allow_inherited_env_names([RUNTIME_SECRET_ENV_ALLOWLIST_ENV.to_string()]);
+    let raw_runner_env = runner.env.clone();
+    let request_env = request.env.clone();
+    let mut env = raw_runner_env.clone();
+    env.extend(request_env.clone());
+    let secret_env_plan =
+        runner_exec_secret_env_plan(&request.command, None, &request.secret_env_names, &env);
+    validate_runner_inherited_secret_env(
+        &secret_env_plan,
+        &request_env,
+        "local controller env",
+        true,
+    )?;
+    let runner_env = validated_runner_inherited_env(
+        &secret_env_plan,
+        raw_runner_env,
+        "remote runner daemon env",
+        false,
+    )?;
+    env = runner_env;
+    env.extend(request_env.clone());
     env.extend(resolve_runner_secret_env_for_plan(
         &runner.secret_env,
         &secret_env_plan,
         &env,
     )?);
-    validate_runner_inherited_secret_env(&secret_env_plan, &env)?;
     normalize_runner_command_env(&mut env);
     let source_snapshot = request.source_snapshot.unwrap_or_else(|| {
         SourceSnapshot::collect_local(&runner.id, Path::new(&cwd), Some(&cwd), "existing_remote")
@@ -343,17 +386,22 @@ pub(super) fn apply_runner_process_env(
 fn validate_runner_inherited_secret_env(
     plan: &SecretEnvPlan,
     env: &HashMap<String, String>,
+    source: &str,
+    enforce_without_secret_contract: bool,
 ) -> Result<()> {
+    if env.is_empty() || (!enforce_without_secret_contract && plan.secret_env_names().is_empty()) {
+        return Ok(());
+    }
     let env = env
         .iter()
         .map(|(name, value)| (name.clone(), value.clone()))
         .collect::<BTreeMap<_, _>>();
-    plan.diagnose_inherited_env(&env, "runner.env")
+    plan.diagnose_inherited_env(&env, source)
         .map(|_| ())
         .map_err(|error| {
             Error::validation_invalid_argument(
                 "env",
-                error.message,
+                format!("{} in {source}", error.message),
                 None,
                 Some(vec![
                     "Declare secret-bearing runtime env names in secret_env or HOMEBOY_AGENT_RUNTIME_SECRET_ENV before runner execution.".to_string(),
@@ -361,6 +409,24 @@ fn validate_runner_inherited_secret_env(
                 ]),
             )
         })
+}
+
+fn validated_runner_inherited_env(
+    plan: &SecretEnvPlan,
+    env: HashMap<String, String>,
+    source: &str,
+    enforce_without_secret_contract: bool,
+) -> Result<HashMap<String, String>> {
+    validate_runner_inherited_secret_env(plan, &env, source, enforce_without_secret_contract)?;
+    if enforce_without_secret_contract || !plan.secret_env_names().is_empty() {
+        return Ok(env);
+    }
+
+    let policy = RedactionPolicy::default();
+    Ok(env
+        .into_iter()
+        .filter(|(name, _)| !policy.is_sensitive_key(name))
+        .collect())
 }
 
 pub(super) fn inherited_runner_process_env_keys() -> &'static [&'static str] {

--- a/src/core/runner/execution/tests/prepare.rs
+++ b/src/core/runner/execution/tests/prepare.rs
@@ -237,6 +237,146 @@ fn runner_prep_allows_declared_sensitive_env() {
 }
 
 #[test]
+fn daemon_prep_allows_unrelated_runner_side_secret_for_non_secret_command() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("project");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+
+        let mut runner = ssh_runner();
+        runner.workspace_root = Some(workspace.display().to_string());
+        runner.env.insert(
+            "OPENAI_API_KEY".to_string(),
+            "runner-side-secret".to_string(),
+        );
+
+        let plan = prepare_daemon_local_process(RunnerProcessRequest {
+            runner_id: "lab".to_string(),
+            runner: Some(runner),
+            cwd: Some(workspace.display().to_string()),
+            project_id: None,
+            command: vec![
+                "homeboy".to_string(),
+                "refactor".to_string(),
+                "--help".to_string(),
+            ],
+            env: Default::default(),
+            secret_env_names: Vec::new(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: false,
+        })
+        .expect("unrelated runner-side secret should not block non-secret command");
+
+        assert!(!plan.env.contains_key("OPENAI_API_KEY"));
+    });
+}
+
+#[test]
+fn runner_prep_runtime_secret_env_allowlist_declares_sensitive_env() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("project");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+
+        let plan = prepare_runner_process(RunnerProcessRequest {
+            runner_id: "local".to_string(),
+            runner: Some(local_runner(workspace.display().to_string())),
+            cwd: Some(workspace.display().to_string()),
+            project_id: None,
+            command: vec!["node".to_string(), "run-headless-loop.cjs".to_string()],
+            env: HashMap::from([
+                (
+                    "HOMEBOY_AGENT_RUNTIME_SECRET_ENV".to_string(),
+                    "OPENAI_API_KEY".to_string(),
+                ),
+                ("OPENAI_API_KEY".to_string(), "secret-value".to_string()),
+            ]),
+            secret_env_names: Vec::new(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: false,
+        })
+        .expect("runtime secret env allowlist should satisfy preflight declaration");
+
+        assert_eq!(
+            plan.env.get("OPENAI_API_KEY").map(String::as_str),
+            Some("secret-value")
+        );
+    });
+}
+
+#[test]
+fn runner_prep_diagnostic_identifies_local_controller_secret_source() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("project");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+
+        let err = prepare_runner_process(RunnerProcessRequest {
+            runner_id: "local".to_string(),
+            runner: Some(local_runner(workspace.display().to_string())),
+            cwd: Some(workspace.display().to_string()),
+            project_id: None,
+            command: vec!["env".to_string()],
+            env: HashMap::from([("OPENAI_API_KEY".to_string(), "secret-value".to_string())]),
+            secret_env_names: Vec::new(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: false,
+        })
+        .expect_err("undeclared local controller secret should fail closed");
+
+        assert!(err.message.contains("OPENAI_API_KEY"));
+        assert!(err.message.contains("local controller env"));
+    });
+}
+
+#[test]
+fn daemon_prep_diagnostic_identifies_remote_runner_daemon_secret_source() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("project");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+
+        let mut runner = ssh_runner();
+        runner.workspace_root = Some(workspace.display().to_string());
+        runner.env.insert(
+            "OPENAI_API_KEY".to_string(),
+            "runner-side-secret".to_string(),
+        );
+
+        let err = prepare_daemon_local_process(RunnerProcessRequest {
+            runner_id: "lab".to_string(),
+            runner: Some(runner),
+            cwd: Some(workspace.display().to_string()),
+            project_id: None,
+            command: vec!["node".to_string(), "run-headless-loop.cjs".to_string()],
+            env: HashMap::from([(
+                "HOMEBOY_AGENT_RUNTIME_SECRET_ENV".to_string(),
+                "AI_PROVIDER_TOKEN".to_string(),
+            )]),
+            secret_env_names: Vec::new(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: false,
+        })
+        .expect_err("undeclared runner daemon secret should identify source");
+
+        assert!(err.message.contains("OPENAI_API_KEY"));
+        assert!(err.message.contains("remote runner daemon env"));
+    });
+}
+
+#[test]
 fn daemon_local_prep_normalizes_default_path_on_runner_side() {
     crate::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary
- Build runner secret-env preflight plans from command/runtime env declarations, including HOMEBOY_AGENT_RUNTIME_SECRET_ENV.
- Treat request env as explicit controller input, while treating runner/daemon env as inherited context.
- Drop unrelated inherited sensitive runner env for commands with no secret contract instead of blocking or forwarding it.
- Include source-specific diagnostics for local controller env vs remote runner daemon env.

Fixes https://github.com/Extra-Chill/homeboy/issues/7053

## Verification
- rustfmt --check src/core/runner/execution/process.rs src/core/runner/execution/tests/prepare.rs
- cargo test core::runner::execution::tests --lib
- cargo clippy --lib --no-deps -- -A unused-imports

## Notes
- Repository-wide cargo fmt --check still reports pre-existing formatting diffs outside this PR.
- cargo clippy completes but reports existing warning debt outside this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigating the runner secret-env preflight path, implementing the fix, adding tests, and preparing this PR.