### PR TITLE
Fix monorepo release scope handling

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -245,13 +245,10 @@ fn planned_release_tag_name(context: &ReleaseExecutionContext) -> Result<String>
                     ]),
                 )
             })?;
-    let monorepo =
-        super::planning_semver::release_monorepo_context(context.component, context.component_id);
+    let release_scope =
+        super::scope::ReleaseScope::resolve(context.component, context.component_id)?;
 
-    Ok(monorepo
-        .as_ref()
-        .map(|ctx| ctx.format_tag(&new_version))
-        .unwrap_or_else(|| format!("v{}", new_version)))
+    Ok(release_scope.tag_name(&new_version))
 }
 
 fn run_default_branch_preflight(

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -129,16 +129,13 @@ fn initial_release_state(
     }
 
     let version_info = super::version::read_component_version(component)?;
-    let monorepo = super::planning_semver::release_monorepo_context(component, component_id);
-    let expected_tag = match monorepo.as_ref() {
-        Some(ctx) => ctx.format_tag(&version_info.version),
-        None => format!("v{}", version_info.version),
-    };
+    let release_scope = super::scope::ReleaseScope::resolve(component, component_id)?;
+    let expected_tag = release_scope.tag_name(&version_info.version);
 
     let (tag, version) = resolve_head_release(
         &component.local_path,
         &expected_tag,
-        monorepo.as_ref().map(|ctx| ctx.tag_prefix.as_str()),
+        release_scope.tag_prefix(),
         component_id,
     )?;
     let notes = read_current_release_notes(component)?;
@@ -489,6 +486,25 @@ mod tests {
 
         assert_eq!(tag, "v0.11.11");
         assert_eq!(version, "0.11.11");
+    }
+
+    #[test]
+    fn head_release_uses_package_tag_namespace() {
+        let (_remote, checkout) = release_repo_with_remote_tag("3.22.1", "wordpress-v3.22.1");
+        run_in(checkout.path(), &["git", "tag", "v2.10.0"]);
+        run_in(checkout.path(), &["git", "tag", "nodejs-v2.2.0"]);
+        run_in(checkout.path(), &["git", "tag", "wordpress-v3.22.1"]);
+
+        let (tag, version) = resolve_head_release(
+            checkout.path().to_str().expect("checkout path"),
+            "wordpress-v3.22.1",
+            Some("wordpress"),
+            "wordpress",
+        )
+        .expect("package release tag at HEAD should be used");
+
+        assert_eq!(tag, "wordpress-v3.22.1");
+        assert_eq!(version, "3.22.1");
     }
 
     #[test]

--- a/src/core/release/executor/github_release/notes.rs
+++ b/src/core/release/executor/github_release/notes.rs
@@ -151,7 +151,13 @@ pub(crate) fn github_changelog_url(
     tag: &str,
 ) -> Option<String> {
     let changelog_path = changelog::resolve_changelog_path(component).ok()?;
-    let local_path = std::path::Path::new(&component.local_path);
+    let release_scope =
+        crate::core::release::scope::ReleaseScope::resolve(component, &component.id).ok();
+    let component_path = release_scope
+        .as_ref()
+        .map(|scope| scope.component_path.as_str())
+        .unwrap_or(component.local_path.as_str());
+    let local_path = std::path::Path::new(component_path);
     let component_relative = changelog_path
         .strip_prefix(local_path)
         .unwrap_or(&changelog_path)
@@ -164,19 +170,14 @@ pub(crate) fn github_changelog_url(
     // component's path prefix so the link points at the real file
     // (`php-transformer/CHANGELOG.md`) instead of a root-level `CHANGELOG.md`
     // that does not exist (issue #6146).
-    let repo_relative =
-        match crate::core::git::MonorepoContext::detect(&component.local_path, &component.id) {
-            Some(ctx) => {
-                let prefix = ctx.path_prefix.replace('\\', "/");
-                let prefix = prefix.trim_matches('/');
-                if prefix.is_empty() {
-                    component_relative
-                } else {
-                    format!("{}/{}", prefix, component_relative)
-                }
-            }
-            None => component_relative,
-        };
+    let repo_relative = match release_scope {
+        Some(scope) if !scope.path_prefix.is_empty() => {
+            let prefix = scope.path_prefix.replace('\\', "/");
+            let prefix = prefix.trim_matches('/');
+            format!("{}/{}", prefix, component_relative)
+        }
+        _ => component_relative,
+    };
 
     Some(format!(
         "https://{}/{}/{}/blob/{}/{}",
@@ -207,23 +208,19 @@ pub(crate) fn github_generated_notes_start_tag(
     component: &Component,
     tag: &str,
 ) -> Result<Option<String>> {
-    let monorepo = crate::core::git::MonorepoContext::detect(&component.local_path, &component.id);
-    let (git_root, tag_prefix) = match monorepo.as_ref() {
-        Some(ctx) => (ctx.git_root.as_str(), Some(ctx.tag_prefix.as_str())),
-        None => (component.local_path.as_str(), None),
-    };
-    let previous =
-        crate::core::git::get_previous_tag_before_any_with_prefix(git_root, tag, tag_prefix)?;
+    let release_scope =
+        crate::core::release::scope::ReleaseScope::resolve(component, &component.id)?;
+    let previous = release_scope.previous_tag_before_any(tag)?;
 
     if let Some(previous_tag) = previous.as_deref() {
-        if !crate::core::git::is_ancestor(git_root, previous_tag, tag)? {
+        if !crate::core::git::is_ancestor(&release_scope.git_root, previous_tag, tag)? {
             return Err(Error::validation_invalid_argument(
                 "release-notes-range",
                 format!(
                     "Previous release tag {} is not reachable from release tag {}. Refusing to generate GitHub release notes because using an older reachable tag would duplicate prior release ranges.",
                     previous_tag, tag
                 ),
-                Some(format!("Repository: {}", git_root)),
+                Some(format!("Repository: {}", release_scope.git_root)),
                 Some(vec![
                     format!(
                         "Merge or recover the {} release commit onto the selected release base/default branch, then rerun the release.",

--- a/src/core/release/executor/github_release/tests/mod.rs
+++ b/src/core/release/executor/github_release/tests/mod.rs
@@ -56,6 +56,9 @@ pub(super) fn run_git(dir: &std::path::Path, args: &[&str]) {
 }
 
 pub(super) fn commit_file(dir: &std::path::Path, name: &str, content: &str, message: &str) {
+    if let Some(parent) = dir.join(name).parent() {
+        std::fs::create_dir_all(parent).expect("create fixture parent");
+    }
     std::fs::write(dir.join(name), content).expect("write fixture file");
     run_git(dir, &["add", name]);
     run_git(dir, &["commit", "-q", "-m", message]);

--- a/src/core/release/executor/github_release/tests/start_tag_tests.rs
+++ b/src/core/release/executor/github_release/tests/start_tag_tests.rs
@@ -2,6 +2,7 @@
 
 use super::super::{github_generated_notes_start_tag, github_release_notes_start_tag};
 use super::{commit_file, component_for_repo, git_repo, run_git};
+use crate::core::component::Component;
 
 #[test]
 fn generated_notes_start_tag_fails_closed_when_prior_release_tag_is_off_branch() {
@@ -106,4 +107,39 @@ fn generated_notes_start_tag_uses_prior_release_tag_when_reachable() {
         .expect("reachable previous tag should resolve");
 
     assert_eq!(start_tag.as_deref(), Some("v0.2.0"));
+}
+
+#[test]
+fn generated_notes_start_tag_uses_package_tag_namespace() {
+    let temp = git_repo();
+    let dir = temp.path();
+    commit_file(dir, "README.md", "initial", "chore: initial");
+    run_git(dir, &["tag", "v2.10.0"]);
+    run_git(dir, &["tag", "nodejs-v2.2.0"]);
+    run_git(dir, &["tag", "wordpress-v3.22.1"]);
+    commit_file(
+        dir,
+        "packages/nodejs/src/index.ts",
+        "nodejs",
+        "fix: update nodejs package",
+    );
+    run_git(dir, &["tag", "nodejs-v2.2.1"]);
+    commit_file(
+        dir,
+        "packages/wordpress/src/index.ts",
+        "wordpress",
+        "fix: update wordpress package",
+    );
+    run_git(dir, &["tag", "wordpress-v3.22.2"]);
+
+    let component = Component {
+        id: "wordpress".to_string(),
+        local_path: dir.join("packages/wordpress").to_string_lossy().to_string(),
+        ..Default::default()
+    };
+
+    let start_tag = github_generated_notes_start_tag(&component, "wordpress-v3.22.2")
+        .expect("package previous tag should resolve");
+
+    assert_eq!(start_tag.as_deref(), Some("wordpress-v3.22.1"));
 }

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -21,6 +21,7 @@ mod planning_policy;
 mod planning_quality;
 mod planning_semver;
 mod planning_worktree;
+mod scope;
 mod types;
 mod utils;
 pub mod version;

--- a/src/core/release/plan_steps/release.rs
+++ b/src/core/release/plan_steps/release.rs
@@ -3,11 +3,11 @@ use super::changelog::build_changelog_steps;
 use super::hints::{github_release_applies, push_publish_vs_github_release_hints};
 use crate::core::component::Component;
 use crate::core::extension::ExtensionManifest;
-use crate::core::git;
 use crate::core::plan::PlanStep;
 use crate::core::release::pipeline_capabilities::{
     get_publish_targets, has_package_capability, has_prepare_capability,
 };
+use crate::core::release::scope::ReleaseScope;
 use crate::core::release::types::{ReleaseChangelogPlan, ReleaseOptions};
 use crate::core::Result;
 
@@ -20,7 +20,7 @@ pub(in crate::core::release) fn build_release_steps(
     new_version: &str,
     changelog_plan: &ReleaseChangelogPlan,
     options: &ReleaseOptions,
-    monorepo: Option<&git::MonorepoContext>,
+    release_scope: &ReleaseScope,
     warnings: &mut Vec<String>,
     hints: &mut Vec<String>,
 ) -> Result<Vec<PlanStep>> {
@@ -37,7 +37,7 @@ pub(in crate::core::release) fn build_release_steps(
             extensions,
             new_version,
             options,
-            monorepo,
+            release_scope,
             &publish_targets,
             warnings,
         ));
@@ -59,10 +59,7 @@ pub(in crate::core::release) fn build_release_steps(
         "preflight.changelog_bootstrap",
     );
 
-    let tag_name = match monorepo {
-        Some(ctx) => ctx.format_tag(new_version),
-        None => format!("v{}", new_version),
-    };
+    let tag_name = release_scope.tag_name(new_version);
 
     let tag_preflight_needs = package_preflight_step_id
         .as_deref()
@@ -237,7 +234,7 @@ fn build_head_release_steps(
     extensions: &[ExtensionManifest],
     version: &str,
     options: &ReleaseOptions,
-    monorepo: Option<&git::MonorepoContext>,
+    release_scope: &ReleaseScope,
     publish_targets: &[String],
     warnings: &mut Vec<String>,
 ) -> Vec<PlanStep> {
@@ -284,10 +281,7 @@ fn build_head_release_steps(
     }
 
     if !options.skip_github_release && github_release_applies(component) {
-        let tag_name = match monorepo {
-            Some(ctx) => ctx.format_tag(version),
-            None => format!("v{}", version),
-        };
+        let tag_name = release_scope.tag_name(version);
         steps.push(ready_step(
             "github.release",
             "github.release",

--- a/src/core/release/plan_steps/tests/mod.rs
+++ b/src/core/release/plan_steps/tests/mod.rs
@@ -4,6 +4,7 @@ use super::release::build_release_steps;
 use crate::core::component::{Component, ScopedExtensionConfig};
 use crate::core::extension::ExtensionManifest;
 use crate::core::plan::PlanStepStatus;
+use crate::core::release::scope::ReleaseScope;
 use crate::core::release::types::{
     ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleasePipelineOptions,
     ReleaseSemverRecommendation,
@@ -344,6 +345,7 @@ fn test_build_release_steps() {
     .expect("extension manifest");
     let mut warnings = Vec::new();
     let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
     let options = ReleaseOptions {
         bump_type: "patch".to_string(),
         ..Default::default()
@@ -356,7 +358,7 @@ fn test_build_release_steps() {
         "1.0.1",
         &fixture_changelog_plan(),
         &options,
-        None,
+        &release_scope,
         &mut warnings,
         &mut hints,
     )
@@ -414,6 +416,7 @@ fn release_plan_runs_package_preflight_before_mutating_release_steps() {
     extension.id = "fixture-packager".to_string();
     let mut warnings = Vec::new();
     let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
     let options = ReleaseOptions {
         bump_type: "patch".to_string(),
         ..Default::default()
@@ -426,7 +429,7 @@ fn release_plan_runs_package_preflight_before_mutating_release_steps() {
         "1.0.1",
         &fixture_changelog_plan(),
         &options,
-        None,
+        &release_scope,
         &mut warnings,
         &mut hints,
     )
@@ -474,6 +477,7 @@ fn release_plan_records_changelog_contract() {
     let component = fixture_component();
     let mut warnings = Vec::new();
     let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
     let options = ReleaseOptions {
         bump_type: "patch".to_string(),
         ..Default::default()
@@ -487,7 +491,7 @@ fn release_plan_records_changelog_contract() {
         "1.0.1",
         &changelog_plan,
         &options,
-        None,
+        &release_scope,
         &mut warnings,
         &mut hints,
     )
@@ -542,6 +546,7 @@ fn release_plan_includes_deploy_intent_when_requested() {
     let component = fixture_component();
     let mut warnings = Vec::new();
     let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
     let options = ReleaseOptions {
         bump_type: "patch".to_string(),
         pipeline: ReleasePipelineOptions {
@@ -558,7 +563,7 @@ fn release_plan_includes_deploy_intent_when_requested() {
         "1.0.1",
         &fixture_changelog_plan(),
         &options,
-        None,
+        &release_scope,
         &mut warnings,
         &mut hints,
     )
@@ -598,6 +603,7 @@ fn head_release_plan_skips_mutation_steps_and_uses_existing_artifacts() {
     extension.id = "wordpress".to_string();
     let mut warnings = Vec::new();
     let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
     let options = ReleaseOptions {
         bump_type: "head".to_string(),
         pipeline: ReleasePipelineOptions {
@@ -615,7 +621,7 @@ fn head_release_plan_skips_mutation_steps_and_uses_existing_artifacts() {
         "1.0.1",
         &fixture_changelog_plan(),
         &options,
-        None,
+        &release_scope,
         &mut warnings,
         &mut hints,
     )
@@ -664,6 +670,7 @@ fn head_release_skip_publish_still_uploads_existing_artifacts() {
     extension.id = "package-runtime".to_string();
     let mut warnings = Vec::new();
     let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
     let options = ReleaseOptions {
         bump_type: "head".to_string(),
         pipeline: ReleasePipelineOptions {
@@ -682,7 +689,7 @@ fn head_release_skip_publish_still_uploads_existing_artifacts() {
         "1.0.1",
         &fixture_changelog_plan(),
         &options,
-        None,
+        &release_scope,
         &mut warnings,
         &mut hints,
     )
@@ -716,6 +723,7 @@ fn release_plan_warns_when_configured_extensions_have_no_publish_action() {
     extension.id = "wordpress".to_string();
     let mut warnings = Vec::new();
     let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
     let options = ReleaseOptions {
         bump_type: "patch".to_string(),
         ..Default::default()
@@ -728,7 +736,7 @@ fn release_plan_warns_when_configured_extensions_have_no_publish_action() {
         "1.0.1",
         &fixture_changelog_plan(),
         &options,
-        None,
+        &release_scope,
         &mut warnings,
         &mut hints,
     )

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -10,10 +10,10 @@ use super::planning_changelog::{build_changelog_plan, generate_changelog_entries
 use super::planning_policy::release_skip_plan;
 use super::planning_semver::{
     build_semver_recommendation, current_version_tag_at_head, current_version_tag_name,
-    release_monorepo_context, validate_current_version_tag_reachable,
-    validate_release_version_floor,
+    validate_current_version_tag_reachable, validate_release_version_floor,
 };
 use super::planning_worktree::validate_release_worktree;
+use super::scope::ReleaseScope;
 use super::types::{
     ReleaseChangelogPlan, ReleaseOptions, ReleasePlan, ReleaseSemverRecommendation,
 };
@@ -31,21 +31,17 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
 
     let mut v = ValidationCollector::new();
 
-    let monorepo = release_monorepo_context(&component, component_id);
+    let release_scope = ReleaseScope::resolve(&component, component_id)?;
     let version_info = v.capture(version::read_component_version(&component), "version");
     if let Some(ref info) = version_info {
         if let Some(message) = v
             .capture(
-                validate_current_version_tag_reachable(
-                    &component.local_path,
-                    monorepo.as_ref(),
-                    &info.version,
-                ),
+                validate_current_version_tag_reachable(&release_scope, &info.version),
                 "tag",
             )
             .flatten()
         {
-            let tag_name = current_version_tag_name(monorepo.as_ref(), &info.version);
+            let tag_name = current_version_tag_name(&release_scope, &info.version);
             v.push(
                 "tag",
                 &message,
@@ -65,7 +61,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let mut semver_recommendation = if options.pipeline.head {
         None
     } else {
-        build_semver_recommendation(&component, &options.bump_type, monorepo.as_ref())?
+        build_semver_recommendation(&component, &options.bump_type, &release_scope)?
     };
 
     if !options.pipeline.head {
@@ -74,7 +70,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         // skip plan instead of a downstream changelog contract error for the
         // next version (issue #4316).
         let release_already_at_head = version_info.as_ref().and_then(|info| {
-            current_version_tag_at_head(&component.local_path, monorepo.as_ref(), &info.version)
+            current_version_tag_at_head(&release_scope, &info.version)
                 .ok()
                 .flatten()
         });
@@ -93,7 +89,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         Default::default()
     } else {
         v.capture(
-            generate_changelog_entries(&component, component_id, options, monorepo.as_ref()),
+            generate_changelog_entries(&component, component_id, options, &release_scope),
             "commits",
         )
         .unwrap_or_default()
@@ -167,7 +163,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         &new_version,
         &changelog_plan,
         options,
-        monorepo.as_ref(),
+        &release_scope,
         &mut warnings,
         &mut hints,
     )?);

--- a/src/core/release/planning_changelog.rs
+++ b/src/core/release/planning_changelog.rs
@@ -5,6 +5,7 @@ use crate::core::git;
 use crate::core::release::changelog;
 
 use super::planning_semver::resolve_tag_and_commits;
+use super::scope::ReleaseScope;
 use super::types::{ReleaseChangelogPlan, ReleaseOptions};
 
 pub(super) fn build_changelog_plan(
@@ -32,9 +33,9 @@ pub(super) fn generate_changelog_entries(
     component: &Component,
     component_id: &str,
     options: &ReleaseOptions,
-    monorepo: Option<&git::MonorepoContext>,
+    release_scope: &ReleaseScope,
 ) -> Result<std::collections::HashMap<String, Vec<String>>> {
-    let (latest_tag, commits) = resolve_tag_and_commits(&component.local_path, monorepo)?;
+    let (latest_tag, commits) = resolve_tag_and_commits(release_scope)?;
 
     if commits.is_empty() {
         if options.bump_policy.force_empty_release {
@@ -233,6 +234,7 @@ mod tests {
     };
     use crate::core::component::Component;
     use crate::core::git::{CommitCategory, CommitInfo};
+    use crate::core::release::scope::ReleaseScope;
     use crate::core::release::types::ReleaseOptions;
 
     fn commit(subject: &str, category: CommitCategory) -> CommitInfo {
@@ -400,10 +402,15 @@ mod tests {
             "feat: add release planner (#2478)",
         );
         let component = component_with_changelog_target(&temp, Some("CHANGELOG.md"));
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
 
-        let entries =
-            generate_changelog_entries(&component, "fixture", &ReleaseOptions::default(), None)
-                .expect("changelog entries should generate");
+        let entries = generate_changelog_entries(
+            &component,
+            "fixture",
+            &ReleaseOptions::default(),
+            &release_scope,
+        )
+        .expect("changelog entries should generate");
 
         assert_eq!(entries["added"], vec!["add release planner"]);
     }

--- a/src/core/release/planning_semver.rs
+++ b/src/core/release/planning_semver.rs
@@ -1,15 +1,16 @@
-use crate::core::component::{resolve_component_scope, Component, ScopeCommand};
+use crate::core::component::Component;
 use crate::core::error::{Error, Result};
 use crate::core::git;
 
+use super::scope::ReleaseScope;
 use super::types::{ReleaseSemverCommit, ReleaseSemverRecommendation};
 
 pub(super) fn build_semver_recommendation(
-    component: &Component,
+    _component: &Component,
     requested_bump: &str,
-    monorepo: Option<&git::MonorepoContext>,
+    scope: &ReleaseScope,
 ) -> Result<Option<ReleaseSemverRecommendation>> {
-    let (latest_tag, commits) = resolve_tag_and_commits(&component.local_path, monorepo)?;
+    let (latest_tag, commits) = resolve_tag_and_commits(scope)?;
 
     if commits.is_empty() {
         return Ok(None);
@@ -64,129 +65,6 @@ pub(super) fn build_semver_recommendation(
     }))
 }
 
-pub(super) fn release_monorepo_context(
-    component: &Component,
-    component_id: &str,
-) -> Option<git::MonorepoContext> {
-    let mut context = git::MonorepoContext::detect(&component.local_path, component_id);
-    let extra_prefixes = release_scope_prefixes(component);
-
-    if let Some(ctx) = context.as_mut() {
-        for prefix in extra_prefixes {
-            let component_prefix = ctx.path_prefix.trim_end_matches('/');
-            let scoped = if prefix == component_prefix
-                || prefix.starts_with(&format!("{}/", component_prefix))
-            {
-                prefix
-            } else {
-                format!("{}/{}", component_prefix, prefix)
-            };
-            if !ctx.path_prefixes.contains(&scoped) {
-                ctx.path_prefixes.push(scoped);
-            }
-        }
-        return context;
-    }
-
-    if extra_prefixes.is_empty() {
-        return None;
-    }
-
-    let git_root = git::get_git_root(&component.local_path).ok()?;
-    Some(git::MonorepoContext {
-        git_root,
-        path_prefix: extra_prefixes[0].clone(),
-        path_prefixes: extra_prefixes,
-        tag_prefix: component_id.to_string(),
-    })
-}
-
-fn release_scope_prefixes(component: &Component) -> Vec<String> {
-    let scope = resolve_component_scope(component, ScopeCommand::Release);
-    let mut prefixes: Vec<String> = scope
-        .include
-        .iter()
-        .filter_map(|path| normalize_release_scope_path(path))
-        .collect();
-
-    if prefixes.is_empty() {
-        if let Some(prefix) = infer_common_release_prefix(component) {
-            prefixes.push(prefix);
-        }
-    }
-
-    prefixes.sort();
-    prefixes.dedup();
-    prefixes
-}
-
-fn infer_common_release_prefix(component: &Component) -> Option<String> {
-    let mut paths = Vec::new();
-
-    if let Some(targets) = component.version_targets.as_ref() {
-        paths.extend(
-            targets
-                .iter()
-                .filter_map(|target| normalize_release_scope_path(&target.file)),
-        );
-    }
-
-    if let Some(target) = component.changelog_target.as_ref() {
-        if let Some(path) = normalize_release_scope_path(target) {
-            paths.push(path);
-        }
-    }
-
-    common_directory_prefix(&paths)
-}
-
-fn normalize_release_scope_path(path: &str) -> Option<String> {
-    let mut value = path.trim().trim_start_matches("./").trim_matches('/');
-    if value.is_empty() || value == "." {
-        return None;
-    }
-
-    if let Some(wildcard) = value.find('*') {
-        value = value[..wildcard].trim_end_matches('/');
-    }
-
-    if value.is_empty() || value == "." {
-        return None;
-    }
-
-    Some(value.to_string())
-}
-
-fn common_directory_prefix(paths: &[String]) -> Option<String> {
-    let mut iter = paths.iter();
-    let first = iter.next()?;
-    let mut prefix: Vec<&str> = first.split('/').collect();
-    if prefix.len() <= 1 {
-        return None;
-    }
-    prefix.pop();
-
-    for path in iter {
-        let mut dirs: Vec<&str> = path.split('/').collect();
-        if dirs.len() <= 1 {
-            return None;
-        }
-        dirs.pop();
-
-        let keep = prefix
-            .iter()
-            .zip(dirs.iter())
-            .take_while(|(left, right)| left == right)
-            .count();
-        prefix.truncate(keep);
-        if prefix.is_empty() {
-            return None;
-        }
-    }
-
-    Some(prefix.join("/"))
-}
-
 pub(super) fn validate_release_version_floor(
     latest_tag: Option<&str>,
     current_version: &str,
@@ -216,22 +94,18 @@ pub(super) fn validate_release_version_floor(
 }
 
 pub(super) fn validate_current_version_tag_reachable(
-    local_path: &str,
-    monorepo: Option<&git::MonorepoContext>,
+    scope: &ReleaseScope,
     current_version: &str,
 ) -> Result<Option<String>> {
-    let git_root = monorepo
-        .map(|ctx| ctx.git_root.as_str())
-        .unwrap_or(local_path);
-    let tag_name = current_version_tag_name(monorepo, current_version);
+    let tag_name = current_version_tag_name(scope, current_version);
 
-    if !git::tag_exists_locally(git_root, &tag_name)? {
+    if !git::tag_exists_locally(&scope.git_root, &tag_name)? {
         return Ok(None);
     }
 
-    let tag_commit = git::get_tag_commit(git_root, &tag_name)?;
+    let tag_commit = git::get_tag_commit(&scope.git_root, &tag_name)?;
     let output = git::execute_git_for_release(
-        git_root,
+        &scope.git_root,
         &["merge-base", "--is-ancestor", &tag_commit, "HEAD"],
     )
     .map_err(|err| Error::git_command_failed(format!("git merge-base failed: {}", err)))?;
@@ -245,13 +119,8 @@ pub(super) fn validate_current_version_tag_reachable(
     )))
 }
 
-pub(super) fn current_version_tag_name(
-    monorepo: Option<&git::MonorepoContext>,
-    current_version: &str,
-) -> String {
-    monorepo
-        .map(|ctx| ctx.format_tag(current_version))
-        .unwrap_or_else(|| format!("v{}", current_version))
+pub(super) fn current_version_tag_name(scope: &ReleaseScope, current_version: &str) -> String {
+    scope.tag_name(current_version)
 }
 
 /// Detect whether the release for `current_version` is already published at
@@ -262,21 +131,17 @@ pub(super) fn current_version_tag_name(
 /// "release already exists" message instead of a downstream changelog
 /// contract error for the next version (issue #4316).
 pub(super) fn current_version_tag_at_head(
-    local_path: &str,
-    monorepo: Option<&git::MonorepoContext>,
+    scope: &ReleaseScope,
     current_version: &str,
 ) -> Result<Option<String>> {
-    let git_root = monorepo
-        .map(|ctx| ctx.git_root.as_str())
-        .unwrap_or(local_path);
-    let tag_name = current_version_tag_name(monorepo, current_version);
+    let tag_name = current_version_tag_name(scope, current_version);
 
-    if !git::tag_exists_locally(git_root, &tag_name)? {
+    if !git::tag_exists_locally(&scope.git_root, &tag_name)? {
         return Ok(None);
     }
 
-    let tag_commit = git::get_tag_commit(git_root, &tag_name)?;
-    let head_commit = git::get_head_commit(git_root)?;
+    let tag_commit = git::get_tag_commit(&scope.git_root, &tag_name)?;
+    let head_commit = git::get_head_commit(&scope.git_root)?;
 
     if tag_commit == head_commit {
         Ok(Some(tag_name))
@@ -290,8 +155,7 @@ pub(super) fn current_version_tag_at_head(
 /// In a monorepo, uses component-prefixed tags and path-scoped commits.
 /// In a single-repo, uses standard global tags and all commits.
 pub(super) fn resolve_tag_and_commits(
-    local_path: &str,
-    monorepo: Option<&git::MonorepoContext>,
+    scope: &ReleaseScope,
 ) -> Result<(Option<String>, Vec<git::CommitInfo>)> {
     // Make release tags (and connecting history) available before the
     // reachability/changelog-range guard inspects them. A tagless or shallow
@@ -299,42 +163,16 @@ pub(super) fn resolve_tag_and_commits(
     // reachable from HEAD" and refuse (issue #6916). Best-effort: offline
     // checkouts still fall through to the guard against local history, so a tag
     // that is truly not an ancestor of HEAD is still refused.
-    let guard_root = monorepo
-        .map(|ctx| ctx.git_root.as_str())
-        .unwrap_or(local_path);
-    git::fetch_tags(guard_root)?;
-
-    match monorepo {
-        Some(ctx) => {
-            let latest_tag = git::get_latest_tag_with_prefix(&ctx.git_root, Some(&ctx.tag_prefix))?;
-            validate_latest_release_tag_reachable(
-                &ctx.git_root,
-                latest_tag.as_deref(),
-                Some(&ctx.tag_prefix),
-            )?;
-            let path_prefixes: Vec<&str> = ctx.path_prefixes.iter().map(String::as_str).collect();
-            let commits = git::get_commits_since_tag_for_paths(
-                &ctx.git_root,
-                latest_tag.as_deref(),
-                &path_prefixes,
-            )?;
-            Ok((latest_tag, commits))
-        }
-        None => {
-            let latest_tag = git::get_latest_tag(local_path)?;
-            validate_latest_release_tag_reachable(local_path, latest_tag.as_deref(), None)?;
-            let commits = git::get_commits_since_tag(local_path, latest_tag.as_deref())?;
-            Ok((latest_tag, commits))
-        }
-    }
+    let (latest_tag, commits) = scope.commits_since_latest_tag()?;
+    validate_latest_release_tag_reachable(scope, latest_tag.as_deref())?;
+    Ok((latest_tag, commits))
 }
 
 fn validate_latest_release_tag_reachable(
-    git_root: &str,
+    scope: &ReleaseScope,
     latest_reachable_tag: Option<&str>,
-    tag_prefix: Option<&str>,
 ) -> Result<()> {
-    let Some(latest_any_tag) = git::get_latest_tag_any_with_prefix(git_root, tag_prefix)? else {
+    let Some(latest_any_tag) = scope.latest_tag_any()? else {
         return Ok(());
     };
 
@@ -342,7 +180,7 @@ fn validate_latest_release_tag_reachable(
         return Ok(());
     }
 
-    if git::is_ancestor(git_root, &latest_any_tag, "HEAD")? {
+    if git::is_ancestor(&scope.git_root, &latest_any_tag, "HEAD")? {
         return Ok(());
     }
 
@@ -353,7 +191,7 @@ fn validate_latest_release_tag_reachable(
             latest_any_tag,
             latest_reachable_tag.unwrap_or("the initial commit")
         ),
-        Some(format!("Repository: {}", git_root)),
+        Some(format!("Repository: {}", scope.git_root)),
         Some(vec![
             format!(
                 "Merge or recover the {} release commit onto the selected release base/default branch, then rerun the release.",
@@ -434,10 +272,11 @@ fn commit_range(latest_tag: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_semver_recommendation, release_monorepo_context, resolve_tag_and_commits,
+        build_semver_recommendation, resolve_tag_and_commits,
         validate_current_version_tag_reachable, validate_release_version_floor,
     };
     use crate::core::component::{CommandScopeConfig, Component, ScopeConfig, VersionTarget};
+    use crate::core::release::scope::ReleaseScope;
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
         let output = std::process::Command::new("git")
@@ -484,7 +323,8 @@ mod tests {
             ..Default::default()
         };
 
-        let recommendation = build_semver_recommendation(&component, "patch", None)
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let recommendation = build_semver_recommendation(&component, "patch", &release_scope)
             .expect("recommendation should build")
             .expect("feature commit should recommend a release");
 
@@ -510,7 +350,8 @@ mod tests {
             ..Default::default()
         };
 
-        let recommendation = build_semver_recommendation(&component, "2.0.0", None)
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let recommendation = build_semver_recommendation(&component, "2.0.0", &release_scope)
             .expect("recommendation should build")
             .expect("breaking commit should recommend a release");
 
@@ -537,7 +378,8 @@ mod tests {
             ..Default::default()
         };
 
-        let recommendation = build_semver_recommendation(&component, "none", None)
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let recommendation = build_semver_recommendation(&component, "none", &release_scope)
             .expect("no-op recommendation should be valid");
 
         assert!(
@@ -554,8 +396,13 @@ mod tests {
         run_git(dir, &["tag", "v1.0.0"]);
         commit_file(dir, "fix.txt", "fix", "fix: patch bug");
 
-        let (latest_tag, commits) = resolve_tag_and_commits(&dir.to_string_lossy(), None)
-            .expect("tag and commits should resolve");
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let (latest_tag, commits) =
+            resolve_tag_and_commits(&release_scope).expect("tag and commits should resolve");
 
         assert_eq!(latest_tag.as_deref(), Some("v1.0.0"));
         assert_eq!(commits.len(), 1);
@@ -592,10 +439,10 @@ mod tests {
             ..Default::default()
         });
 
-        let monorepo = release_monorepo_context(&component, "package-a")
-            .expect("release scope should create monorepo context");
-        let (latest_tag, commits) = resolve_tag_and_commits(&component.local_path, Some(&monorepo))
-            .expect("scoped commits should resolve");
+        let release_scope =
+            ReleaseScope::resolve(&component, "package-a").expect("release scope should resolve");
+        let (latest_tag, commits) =
+            resolve_tag_and_commits(&release_scope).expect("scoped commits should resolve");
 
         assert_eq!(latest_tag.as_deref(), Some("package-a-v1.0.0"));
         assert_eq!(commits.len(), 1);
@@ -631,11 +478,11 @@ mod tests {
             ..Default::default()
         };
 
-        let monorepo = release_monorepo_context(&component, "package-a")
-            .expect("release files should create monorepo context");
-        assert_eq!(monorepo.path_prefixes, vec!["packages/package-a"]);
-        let (latest_tag, commits) = resolve_tag_and_commits(&component.local_path, Some(&monorepo))
-            .expect("scoped commits should resolve");
+        let release_scope = ReleaseScope::resolve(&component, "package-a")
+            .expect("release files should create release scope");
+        assert_eq!(release_scope.path_prefixes, vec!["packages/package-a"]);
+        let (latest_tag, commits) =
+            resolve_tag_and_commits(&release_scope).expect("scoped commits should resolve");
 
         assert_eq!(latest_tag.as_deref(), Some("package-a-v1.0.0"));
         assert_eq!(commits.len(), 1);
@@ -667,7 +514,12 @@ mod tests {
             "fix: second release work",
         );
 
-        let err = resolve_tag_and_commits(&dir.to_string_lossy(), None)
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let err = resolve_tag_and_commits(&release_scope)
             .expect_err("off-branch latest release tag should fail closed");
 
         assert!(err.message.contains("Latest release tag v0.2.0"));
@@ -711,7 +563,12 @@ mod tests {
         run_git(dir, &["tag", "v0.1.1"]);
         run_git(dir, &["checkout", "main"]);
 
-        let message = validate_current_version_tag_reachable(&dir.to_string_lossy(), None, "0.1.1")
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let message = validate_current_version_tag_reachable(&release_scope, "0.1.1")
             .expect("validation should run")
             .expect("orphaned current-version tag should block release");
 
@@ -728,7 +585,12 @@ mod tests {
         commit_file(dir, "VERSION", "0.1.1", "release: v0.1.1");
         run_git(dir, &["tag", "v0.1.1"]);
 
-        let message = validate_current_version_tag_reachable(&dir.to_string_lossy(), None, "0.1.1")
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let message = validate_current_version_tag_reachable(&release_scope, "0.1.1")
             .expect("validation should run");
 
         assert!(message.is_none());
@@ -781,7 +643,12 @@ mod tests {
 
         // resolve_tag_and_commits fetches tags from origin before the guard, so
         // the now-reachable tag is found and the call proceeds.
-        let (latest_tag, commits) = resolve_tag_and_commits(&work_dir.to_string_lossy(), None)
+        let component = Component {
+            local_path: work_dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let (latest_tag, commits) = resolve_tag_and_commits(&release_scope)
             .expect("tag reachable on origin should let the release proceed past the guard");
 
         assert_eq!(latest_tag.as_deref(), Some("v0.1.18"));
@@ -829,7 +696,12 @@ mod tests {
         run_git(work_dir, &["config", "user.email", "homeboy@example.com"]);
         run_git(work_dir, &["config", "user.name", "Homeboy Test"]);
 
-        let err = resolve_tag_and_commits(&work_dir.to_string_lossy(), None)
+        let component = Component {
+            local_path: work_dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let err = resolve_tag_and_commits(&release_scope)
             .expect_err("off-branch tag must still fail closed after fetching tags");
 
         assert!(err.message.contains("Latest release tag v0.2.0"));

--- a/src/core/release/scope.rs
+++ b/src/core/release/scope.rs
@@ -1,0 +1,347 @@
+use crate::core::component::{resolve_component_scope, Component, ScopeCommand};
+use crate::core::error::Result;
+use crate::core::git;
+
+#[derive(Debug, Clone)]
+pub(super) struct ReleaseScope {
+    pub git_root: String,
+    pub component_path: String,
+    pub path_prefix: String,
+    pub tag_prefix: Option<String>,
+    pub path_prefixes: Vec<String>,
+}
+
+impl ReleaseScope {
+    pub fn resolve(component: &Component, component_id: &str) -> Result<Self> {
+        let git_root = git::get_git_root(&component.local_path)
+            .unwrap_or_else(|_| component.local_path.clone());
+        let detected_prefix = git::get_component_path_prefix(&component.local_path);
+        let mut path_prefixes = release_scope_prefixes(component);
+
+        if let Some(prefix) = detected_prefix.as_ref() {
+            for scoped_prefix in &mut path_prefixes {
+                let component_prefix = prefix.trim_end_matches('/');
+                if *scoped_prefix == component_prefix
+                    || scoped_prefix.starts_with(&format!("{}/", component_prefix))
+                {
+                    continue;
+                }
+                *scoped_prefix = format!("{}/{}", component_prefix, scoped_prefix);
+            }
+            if !path_prefixes.contains(prefix) {
+                path_prefixes.push(prefix.clone());
+            }
+        }
+
+        path_prefixes.sort();
+        path_prefixes.dedup();
+
+        let path_prefix = detected_prefix
+            .or_else(|| path_prefixes.first().cloned())
+            .unwrap_or_default();
+        let tag_prefix = (!path_prefix.is_empty()).then(|| component_id.to_string());
+
+        Ok(Self {
+            git_root,
+            component_path: component.local_path.clone(),
+            path_prefix,
+            tag_prefix,
+            path_prefixes,
+        })
+    }
+
+    pub fn tag_name(&self, version: &str) -> String {
+        match self.tag_prefix.as_deref() {
+            Some(prefix) => format!("{}-v{}", prefix, version),
+            None => format!("v{}", version),
+        }
+    }
+
+    pub fn tag_prefix(&self) -> Option<&str> {
+        self.tag_prefix.as_deref()
+    }
+
+    pub fn latest_tag(&self) -> Result<Option<String>> {
+        git::get_latest_tag_with_prefix(&self.git_root, self.tag_prefix())
+    }
+
+    pub fn latest_tag_any(&self) -> Result<Option<String>> {
+        git::get_latest_tag_any_with_prefix(&self.git_root, self.tag_prefix())
+    }
+
+    #[allow(dead_code)]
+    pub fn previous_tag_before(&self, tag: &str) -> Result<Option<String>> {
+        git::get_previous_tag_before_with_prefix(&self.git_root, tag, self.tag_prefix())
+    }
+
+    pub fn previous_tag_before_any(&self, tag: &str) -> Result<Option<String>> {
+        git::get_previous_tag_before_any_with_prefix(&self.git_root, tag, self.tag_prefix())
+    }
+
+    pub fn commits_since_latest_tag(&self) -> Result<(Option<String>, Vec<git::CommitInfo>)> {
+        git::fetch_tags(&self.git_root)?;
+        let latest_tag = self.latest_tag()?;
+        let path_prefixes: Vec<&str> = self.path_prefixes.iter().map(String::as_str).collect();
+        let commits = git::get_commits_since_tag_for_paths(
+            &self.git_root,
+            latest_tag.as_deref(),
+            &path_prefixes,
+        )?;
+        Ok((latest_tag, commits))
+    }
+}
+
+fn release_scope_prefixes(component: &Component) -> Vec<String> {
+    let scope = resolve_component_scope(component, ScopeCommand::Release);
+    let mut prefixes: Vec<String> = scope
+        .include
+        .iter()
+        .filter_map(|path| normalize_release_scope_path(path))
+        .collect();
+
+    if prefixes.is_empty() {
+        if let Some(prefix) = infer_common_release_prefix(component) {
+            prefixes.push(prefix);
+        }
+    }
+
+    prefixes.sort();
+    prefixes.dedup();
+    prefixes
+}
+
+fn infer_common_release_prefix(component: &Component) -> Option<String> {
+    let mut paths = Vec::new();
+
+    if let Some(targets) = component.version_targets.as_ref() {
+        paths.extend(
+            targets
+                .iter()
+                .filter_map(|target| normalize_release_scope_path(&target.file)),
+        );
+    }
+
+    if let Some(target) = component.changelog_target.as_ref() {
+        if let Some(path) = normalize_release_scope_path(target) {
+            paths.push(path);
+        }
+    }
+
+    common_directory_prefix(&paths)
+}
+
+fn normalize_release_scope_path(path: &str) -> Option<String> {
+    let mut value = path.trim().trim_start_matches("./").trim_matches('/');
+    if value.is_empty() || value == "." {
+        return None;
+    }
+
+    if let Some(wildcard) = value.find('*') {
+        value = value[..wildcard].trim_end_matches('/');
+    }
+
+    if value.is_empty() || value == "." {
+        return None;
+    }
+
+    Some(value.to_string())
+}
+
+fn common_directory_prefix(paths: &[String]) -> Option<String> {
+    let mut iter = paths.iter();
+    let first = iter.next()?;
+    let mut prefix: Vec<&str> = first.split('/').collect();
+    if prefix.len() <= 1 {
+        return None;
+    }
+    prefix.pop();
+
+    for path in iter {
+        let mut dirs: Vec<&str> = path.split('/').collect();
+        if dirs.len() <= 1 {
+            return None;
+        }
+        dirs.pop();
+
+        let keep = prefix
+            .iter()
+            .zip(dirs.iter())
+            .take_while(|(left, right)| left == right)
+            .count();
+        prefix.truncate(keep);
+        if prefix.is_empty() {
+            return None;
+        }
+    }
+
+    Some(prefix.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReleaseScope;
+    use crate::core::component::{CommandScopeConfig, Component, ScopeConfig};
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: stdout={} stderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn commit_file(dir: &std::path::Path, name: &str, content: &str, message: &str) {
+        if let Some(parent) = dir.join(name).parent() {
+            std::fs::create_dir_all(parent).expect("create fixture parent");
+        }
+        std::fs::write(dir.join(name), content).expect("write fixture file");
+        run_git(dir, &["add", name]);
+        run_git(dir, &["commit", "-q", "-m", message]);
+    }
+
+    fn git_repo() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_git(dir, &["init", "-q"]);
+        run_git(dir, &["config", "user.email", "homeboy@example.com"]);
+        run_git(dir, &["config", "user.name", "Homeboy Test"]);
+        temp
+    }
+
+    #[test]
+    fn blocks_engine_style_package_scope_uses_package_tags_and_ignores_siblings() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "php-transformer-v0.2.2"]);
+        run_git(dir, &["tag", "figma-transformer-v0.1.2"]);
+        run_git(dir, &["tag", "blocks-engine-v0.2.2"]);
+        commit_file(
+            dir,
+            "figma-transformer/src/index.ts",
+            "figma",
+            "fix: update figma transformer",
+        );
+        commit_file(
+            dir,
+            "php-transformer/src/index.php",
+            "php",
+            "fix: update php transformer",
+        );
+
+        let component = Component {
+            id: "php-transformer".to_string(),
+            local_path: dir.join("php-transformer").to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        let scope = ReleaseScope::resolve(&component, "php-transformer").expect("release scope");
+        let (latest_tag, commits) = scope.commits_since_latest_tag().expect("commits");
+
+        assert_eq!(scope.component_path, component.local_path);
+        assert_eq!(scope.path_prefix, "php-transformer");
+        assert_eq!(scope.tag_name("0.2.3"), "php-transformer-v0.2.3");
+        assert_eq!(latest_tag.as_deref(), Some("php-transformer-v0.2.2"));
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].subject, "fix: update php transformer");
+    }
+
+    #[test]
+    fn homeboy_extensions_style_root_and_package_tags_stay_in_their_namespaces() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "v2.9.3"]);
+        run_git(dir, &["tag", "wordpress-v3.22.1"]);
+        run_git(dir, &["tag", "nodejs-v2.2.0"]);
+        run_git(dir, &["tag", "rust-v1.22.3"]);
+        commit_file(dir, "README.md", "root", "fix: update root package");
+        run_git(dir, &["tag", "v2.10.0"]);
+        commit_file(
+            dir,
+            "packages/wordpress/src/index.ts",
+            "wordpress",
+            "fix: update wordpress package",
+        );
+
+        let root = Component {
+            id: "homeboy-extensions".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let wordpress = Component {
+            id: "wordpress".to_string(),
+            local_path: dir.join("packages/wordpress").to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        let root_scope = ReleaseScope::resolve(&root, "homeboy-extensions").expect("root scope");
+        let wordpress_scope =
+            ReleaseScope::resolve(&wordpress, "wordpress").expect("package scope");
+
+        assert_eq!(root_scope.latest_tag().unwrap().as_deref(), Some("v2.10.0"));
+        assert_eq!(
+            root_scope
+                .previous_tag_before("v2.10.0")
+                .unwrap()
+                .as_deref(),
+            Some("v2.9.3")
+        );
+        assert_eq!(root_scope.tag_name("2.10.1"), "v2.10.1");
+        assert_eq!(
+            wordpress_scope.latest_tag().unwrap().as_deref(),
+            Some("wordpress-v3.22.1")
+        );
+        assert_eq!(wordpress_scope.tag_name("3.22.2"), "wordpress-v3.22.2");
+        assert_eq!(
+            wordpress_scope
+                .previous_tag_before_any("wordpress-v3.22.2")
+                .unwrap()
+                .as_deref(),
+            Some("wordpress-v3.22.1")
+        );
+    }
+
+    #[test]
+    fn repo_root_component_with_release_scope_gets_package_tag_namespace() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "blocks-engine-v0.2.2"]);
+        commit_file(
+            dir,
+            "packages/blocks-engine/src/index.ts",
+            "blocks-engine",
+            "fix: update blocks engine package",
+        );
+
+        let component = Component {
+            id: "blocks-engine".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            scopes: Some(ScopeConfig {
+                release: Some(CommandScopeConfig {
+                    include: vec!["packages/blocks-engine/**".to_string()],
+                    exclude: vec![],
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let scope = ReleaseScope::resolve(&component, "blocks-engine").expect("release scope");
+        let (latest_tag, commits) = scope.commits_since_latest_tag().expect("commits");
+
+        assert_eq!(scope.path_prefix, "packages/blocks-engine");
+        assert_eq!(scope.tag_name("0.2.3"), "blocks-engine-v0.2.3");
+        assert_eq!(latest_tag.as_deref(), Some("blocks-engine-v0.2.2"));
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].subject, "fix: update blocks engine package");
+    }
+}

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -2,7 +2,7 @@ use crate::core::error::{Error, Result};
 use crate::core::git;
 
 use super::context::load_component;
-use super::planning_semver::release_monorepo_context;
+use super::scope::ReleaseScope;
 use super::types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseBumpPolicyOptions,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseExecutionPlan, ReleaseOptions, ReleasePlan,
@@ -65,11 +65,11 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         },
     )?;
 
-    let monorepo = release_monorepo_context(&component, &input.component_id);
+    let release_scope = ReleaseScope::resolve(&component, &input.component_id)?;
     let resolved_bump = if input.pipeline.head {
         None
     } else {
-        resolve_bump(&component.local_path, monorepo.as_ref())?
+        resolve_bump(&release_scope)?
     };
     let (auto_bump_type, releasable_count) = resolved_bump
         .clone()
@@ -187,9 +187,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
             } else {
                 extract_new_version_from_plan(&plan)
             };
-            let tag = new_version
-                .as_ref()
-                .map(|v| format_tag(v, monorepo.as_ref()));
+            let tag = new_version.as_ref().map(|v| release_scope.tag_name(v));
 
             return Ok((
                 ReleaseCommandResult {
@@ -244,9 +242,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         } else {
             extract_new_version_from_plan(&plan)
         };
-        let tag = new_version
-            .as_ref()
-            .map(|v| format_tag(v, monorepo.as_ref()));
+        let tag = new_version.as_ref().map(|v| release_scope.tag_name(v));
         let deployment = dry_run_deployment_plan(&input.component_id, input.pipeline.deploy, &plan);
         let skipped_reason = skipped_reason_from_plan(&plan);
         let dry_run_exit_code = release_command_exit_code(skipped_reason.as_deref(), 0, 0, 0);
@@ -279,9 +275,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     } else {
         extract_new_version_from_run(&run_result)
     };
-    let tag = new_version
-        .as_ref()
-        .map(|v| format_tag(v, monorepo.as_ref()));
+    let tag = new_version.as_ref().map(|v| release_scope.tag_name(v));
     let release_step_exit = release_run_failure_exit(&run_result);
     let post_release_exit = if has_post_release_warnings(&run_result) {
         3
@@ -400,12 +394,8 @@ fn current_component_version(
     super::version::read_component_version(component).map(|info| Some(info.version))
 }
 
-fn resolve_bump(
-    local_path: &str,
-    monorepo: Option<&git::MonorepoContext>,
-) -> Result<Option<(String, usize)>> {
-    let (_latest_tag, commits) =
-        super::planning_semver::resolve_tag_and_commits(local_path, monorepo)?;
+fn resolve_bump(release_scope: &ReleaseScope) -> Result<Option<(String, usize)>> {
+    let (_latest_tag, commits) = super::planning_semver::resolve_tag_and_commits(release_scope)?;
 
     if commits.is_empty() {
         return Ok(None);
@@ -420,14 +410,6 @@ fn resolve_bump(
             Ok(Some((bump.as_str().to_string(), releasable)))
         }
         None => Ok(None),
-    }
-}
-
-/// Format a version string as a tag name, using component prefix in monorepos.
-pub(super) fn format_tag(version: &str, monorepo: Option<&git::MonorepoContext>) -> String {
-    match monorepo {
-        Some(ctx) => ctx.format_tag(version),
-        None => format!("v{}", version),
     }
 }
 

--- a/src/core/release/workflow_recover.rs
+++ b/src/core/release/workflow_recover.rs
@@ -10,8 +10,9 @@ use crate::core::plan::PlanStep;
 
 use super::advanced_remote;
 use super::context::load_component;
+use super::scope::ReleaseScope;
 use super::types::{ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePlan};
-use super::workflow::{format_tag, release_execution_plan, short_sha};
+use super::workflow::{release_execution_plan, short_sha};
 
 pub(super) fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
     let component = load_component(
@@ -28,11 +29,10 @@ pub(super) fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommand
         git::configure_identity(&component.local_path, &identity)?;
     }
 
-    let monorepo =
-        super::planning_semver::release_monorepo_context(&component, &input.component_id);
+    let release_scope = ReleaseScope::resolve(&component, &input.component_id)?;
     let version_info = crate::core::release::version::read_component_version(&component)?;
     let current_version = &version_info.version;
-    let tag_name = format_tag(current_version, monorepo.as_ref());
+    let tag_name = release_scope.tag_name(current_version);
 
     // Create the annotated release tag, surfacing `err_label` on failure. Shared
     // by the retag-to-HEAD and first-time create paths below, which issue the
@@ -78,7 +78,7 @@ pub(super) fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommand
     // loudly so the operator can decide whether to delete the orphan tag, hand
     // back-fill a release: commit, or run `--recover` to commit the version
     // files at the tagged commit.
-    if let Some(latest_tag) = latest_release_tag(&component.local_path, monorepo.as_ref()) {
+    if let Some(latest_tag) = latest_release_tag(&release_scope) {
         if let Some(diagnostic) = diagnose_orphan_tag(&component.local_path, &latest_tag) {
             log_status!("recover", "{}", diagnostic);
         }
@@ -545,11 +545,8 @@ fn recovery_step(id: &str, label: impl Into<String>, needed: bool, needs: Vec<St
 
 /// Resolve the most recent release-shaped tag for the component, honoring
 /// monorepo prefixes. Returns `None` if no matching tag is found.
-fn latest_release_tag(local_path: &str, monorepo: Option<&git::MonorepoContext>) -> Option<String> {
-    match monorepo {
-        Some(ctx) => git::get_latest_tag_with_prefix(&ctx.git_root, Some(&ctx.tag_prefix)).ok()?,
-        None => git::get_latest_tag(local_path).ok()?,
-    }
+fn latest_release_tag(release_scope: &ReleaseScope) -> Option<String> {
+    release_scope.latest_tag().ok()?
 }
 
 /// Inspect the latest release tag for the orphan-tag pattern (#2234): a tag


### PR DESCRIPTION
## Summary
- Add a release-owned `ReleaseScope` that centralizes git root, component path, path prefix, and tag namespace for releases.
- Thread the scope through semver/changelog planning, tag naming, `--head`, recovery, tag state checks, and GitHub generated release notes.
- Add monorepo regression coverage for package-scoped tags and sibling-commit isolation using blocks-engine/homeboy-extensions-shaped fixtures.

## Testing
- `cargo test -q release:: --lib`
- `git diff --check origin/main...HEAD`

## Notes
- `cargo test -q --test release_workflow_test` has one stale workflow assertion failure on this branch/main unrelated to release scope.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the ReleaseScope refactor, wiring release planning/execution call sites, and adding synthetic monorepo release-scope tests.
