### PR TITLE
Refactor runner materialization contracts

### DIFF
--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -53,8 +53,6 @@ pub use types::{RunsArgs, RunsOutput, HOSTED_BLUEPRINT_VIEWER};
 // `use` (still reachable by descendant submodules) so the re-export never
 // widens their visibility.
 pub(crate) use common::RunSummary;
-#[cfg(test)]
-pub(crate) use handlers::artifact_get;
 use handlers::require_run;
 pub(crate) use handlers::run_summary;
 pub(crate) use hotspots::fuzz_hotspot_lines;

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
+use crate::core::agent_task_provider::WorkspaceCwdMode;
 use crate::core::agent_task_provider::{
     AgentTaskExecutorProvider, AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
     AgentTaskProviderWorkspaceMaterialization,
@@ -721,7 +723,7 @@ mod tests {
                     },
                     "env_passthrough": ["EXAMPLE_RUNTIME_BIN", "EXAMPLE_RUNTIME_TOKEN", "EXAMPLE_RUNTIME_BIN"],
                     "workspace": {
-                        "cwd": "git_checkout",
+                        "cwd": WorkspaceCwdMode::GitCheckout.to_string(),
                         "requires_git": true
                     }
                 },
@@ -825,7 +827,7 @@ mod tests {
                         "request_schema": AGENT_TASK_REQUEST_SCHEMA,
                         "outcome_schema": AGENT_TASK_OUTCOME_SCHEMA,
                         "workspace_materialization": {
-                            "cwd": "git_checkout",
+                            "cwd": WorkspaceCwdMode::GitCheckout.to_string(),
                             "requires_git": true,
                             "write_scope": "artifacts",
                             "artifact_paths": [".homeboy/example"]

--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -611,6 +611,7 @@ pub(super) fn provider_command_env(
         .clone()
         .or_else(|| provider.extension_path.clone())
         .unwrap_or_default();
+    let secret_env_plan = provider_secret_env_plan_with_status(provider, request);
     let mut env = vec![
         (
             "HOMEBOY_AGENT_TASK_PROVIDER_ID".to_string(),
@@ -620,11 +621,7 @@ pub(super) fn provider_command_env(
             "HOMEBOY_AGENT_TASK_EXECUTOR_CONFIG_JSON".to_string(),
             serde_json::to_string(&request.executor.config).unwrap_or_else(|_| "null".to_string()),
         ),
-        (
-            "HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON".to_string(),
-            serde_json::to_string(&provider_secret_env_plan_with_status(provider, request))
-                .unwrap_or_else(|_| "null".to_string()),
-        ),
+        secret_env_plan.json_env_pair(),
         (
             "HOMEBOY_AGENT_TOOL_POLICY_JSON".to_string(),
             serde_json::to_string(&request.policy.tools).unwrap_or_else(|_| "null".to_string()),

--- a/src/core/agent_task_provider/runtime_types.rs
+++ b/src/core/agent_task_provider/runtime_types.rs
@@ -1,4 +1,38 @@
 use super::*;
+use std::fmt;
+use std::str::FromStr;
+
+pub const AGENT_TASK_APPLY_BACK_STRATEGY_MUTATION_ARTIFACTS: &str = "mutation_artifacts";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentTaskApplyBackStrategy {
+    MutationArtifacts,
+}
+
+impl AgentTaskApplyBackStrategy {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MutationArtifacts => AGENT_TASK_APPLY_BACK_STRATEGY_MUTATION_ARTIFACTS,
+        }
+    }
+}
+
+impl fmt::Display for AgentTaskApplyBackStrategy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for AgentTaskApplyBackStrategy {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            AGENT_TASK_APPLY_BACK_STRATEGY_MUTATION_ARTIFACTS => Ok(Self::MutationArtifacts),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AgentTaskRuntimeContract {
@@ -147,6 +181,40 @@ impl AgentTaskRuntimeApplyBack {
         self.mutation_artifacts.is_empty()
             && self.requires_git_checkout.is_none()
             && self.strategy.is_none()
+    }
+
+    pub fn strategy(&self) -> Option<AgentTaskApplyBackStrategy> {
+        self.strategy
+            .as_deref()
+            .and_then(|value| AgentTaskApplyBackStrategy::from_str(value).ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_back_strategy_parses_known_contract_value() {
+        let apply_back = AgentTaskRuntimeApplyBack {
+            strategy: Some(AgentTaskApplyBackStrategy::MutationArtifacts.to_string()),
+            ..AgentTaskRuntimeApplyBack::default()
+        };
+
+        assert_eq!(
+            apply_back.strategy(),
+            Some(AgentTaskApplyBackStrategy::MutationArtifacts)
+        );
+    }
+
+    #[test]
+    fn apply_back_strategy_keeps_unknown_strings_non_breaking() {
+        let apply_back = AgentTaskRuntimeApplyBack {
+            strategy: Some("provider_owned_strategy".to_string()),
+            ..AgentTaskRuntimeApplyBack::default()
+        };
+
+        assert_eq!(apply_back.strategy(), None);
     }
 }
 

--- a/src/core/agent_task_provider/tests/manifest_tests.rs
+++ b/src/core/agent_task_provider/tests/manifest_tests.rs
@@ -161,7 +161,7 @@ fn provider_manifest_preserves_unknown_metadata_on_export() {
             }
         },
         "workspace_materialization": {
-            "cwd": "git_checkout",
+            "cwd": WorkspaceCwdMode::GitCheckout.to_string(),
             "provider_workspace_mode": "linked"
         }
     }))

--- a/src/core/agent_task_provider/tests/scheduler_tests.rs
+++ b/src/core/agent_task_provider/tests/scheduler_tests.rs
@@ -240,7 +240,8 @@ fn provider_command_receives_canonical_secret_env_plan_without_values() {
     let command = format!(
         "node {}",
         script(&format!(
-            "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let plan=JSON.parse(process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON); let mapped=(plan.env_name_mapping['test.provider']||[]).includes('{secret_name}'); let configured=(plan.status||[]).some((item)=>item.name==='{secret_name}'&&item.configured===true&&item.source==='env'); let leaked=JSON.stringify(plan).includes('hydrated-secret'); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:mapped&&configured&&!leaked?'succeeded':'failed',summary:JSON.stringify(plan)}}));"
+            "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let plan=JSON.parse(process.env.{}); let mapped=(plan.env_name_mapping['test.provider']||[]).includes('{secret_name}'); let configured=(plan.status||[]).some((item)=>item.name==='{secret_name}'&&item.configured===true&&item.source==='env'); let leaked=JSON.stringify(plan).includes('hydrated-secret'); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:mapped&&configured&&!leaked?'succeeded':'failed',summary:JSON.stringify(plan)}}));",
+            crate::core::secret_env_plan::AGENT_TASK_SECRET_ENV_PLAN_JSON_ENV
         ))
     );
     let (mut request, mut provider) = request("task-secret-env-plan", command);

--- a/src/core/agent_task_provider/tests/workspace_secrets_tests.rs
+++ b/src/core/agent_task_provider/tests/workspace_secrets_tests.rs
@@ -5,7 +5,7 @@ use super::*;
 fn provider_workspace_materialization_declares_cwd_git_checkout_requirement() {
     let (_request, mut provider) = request("task-a", "node provider-a.js".to_string());
     provider.workspace_materialization = Some(AgentTaskProviderWorkspaceMaterialization {
-        cwd: Some("git_checkout".to_string()),
+        cwd: Some(WorkspaceCwdMode::GitCheckout.to_string()),
         requires_git: None,
         write_scope: None,
         artifact_paths: Vec::new(),
@@ -239,7 +239,7 @@ fn provider_apply_back_contract_declares_git_checkout_requirement() {
     provider.workspace_materialization = Some(AgentTaskProviderWorkspaceMaterialization {
         apply_back: AgentTaskRuntimeApplyBack {
             requires_git_checkout: Some(true),
-            strategy: Some("mutation_artifacts".to_string()),
+            strategy: Some(AgentTaskApplyBackStrategy::MutationArtifacts.to_string()),
             mutation_artifacts: vec![AgentTaskRuntimeMutationArtifact {
                 name: "patch".to_string(),
                 path: "outputs.runtime.artifacts.patch".to_string(),
@@ -262,7 +262,7 @@ fn provider_apply_back_contract_declares_git_checkout_requirement() {
 fn provider_workspace_materialization_ignores_unselected_provider() {
     let (_request, mut provider) = request("task-a", "node provider-a.js".to_string());
     provider.workspace_materialization = Some(AgentTaskProviderWorkspaceMaterialization {
-        cwd: Some("git_checkout".to_string()),
+        cwd: Some(WorkspaceCwdMode::GitCheckout.to_string()),
         requires_git: None,
         write_scope: None,
         artifact_paths: Vec::new(),

--- a/src/core/agent_task_provider/workspace_types.rs
+++ b/src/core/agent_task_provider/workspace_types.rs
@@ -1,4 +1,110 @@
 use super::*;
+use std::fmt;
+use std::str::FromStr;
+
+pub const WORKSPACE_CWD_MODE_GIT_CHECKOUT: &str = "git_checkout";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceCwdMode {
+    GitCheckout,
+}
+
+impl WorkspaceCwdMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::GitCheckout => WORKSPACE_CWD_MODE_GIT_CHECKOUT,
+        }
+    }
+}
+
+impl fmt::Display for WorkspaceCwdMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for WorkspaceCwdMode {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            WORKSPACE_CWD_MODE_GIT_CHECKOUT => Ok(Self::GitCheckout),
+            _ => Err(()),
+        }
+    }
+}
+
+pub const WORKSPACE_WRITE_SCOPE_PATCH: &str = "patch";
+pub const WORKSPACE_WRITE_SCOPE_WORKSPACE: &str = "workspace";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceWriteScope {
+    Patch,
+    Workspace,
+}
+
+impl WorkspaceWriteScope {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Patch => WORKSPACE_WRITE_SCOPE_PATCH,
+            Self::Workspace => WORKSPACE_WRITE_SCOPE_WORKSPACE,
+        }
+    }
+}
+
+impl fmt::Display for WorkspaceWriteScope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for WorkspaceWriteScope {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            WORKSPACE_WRITE_SCOPE_PATCH => Ok(Self::Patch),
+            WORKSPACE_WRITE_SCOPE_WORKSPACE => Ok(Self::Workspace),
+            _ => Err(()),
+        }
+    }
+}
+
+pub const WORKSPACE_MATERIALIZATION_MODE_GIT: &str = "git";
+pub const WORKSPACE_MATERIALIZATION_MODE_SNAPSHOT: &str = "snapshot";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceMaterializationMode {
+    Git,
+    Snapshot,
+}
+
+impl WorkspaceMaterializationMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Git => WORKSPACE_MATERIALIZATION_MODE_GIT,
+            Self::Snapshot => WORKSPACE_MATERIALIZATION_MODE_SNAPSHOT,
+        }
+    }
+}
+
+impl fmt::Display for WorkspaceMaterializationMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for WorkspaceMaterializationMode {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            WORKSPACE_MATERIALIZATION_MODE_GIT => Ok(Self::Git),
+            WORKSPACE_MATERIALIZATION_MODE_SNAPSHOT => Ok(Self::Snapshot),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AgentTaskProviderWorkspaceMaterialization {
@@ -24,7 +130,15 @@ impl AgentTaskProviderWorkspaceMaterialization {
     pub fn requires_cwd_git_checkout(&self) -> bool {
         self.apply_back.requires_git_checkout == Some(true)
             || self.requires_git == Some(true)
-            || self.cwd.as_deref() == Some("git_checkout")
+            || self.cwd_mode() == Some(WorkspaceCwdMode::GitCheckout)
+    }
+
+    pub fn cwd_mode(&self) -> Option<WorkspaceCwdMode> {
+        parse_optional_contract_value(self.cwd.as_deref())
+    }
+
+    pub fn write_scope(&self) -> Option<WorkspaceWriteScope> {
+        parse_optional_contract_value(self.write_scope.as_deref())
     }
 
     pub fn validate(&self) -> Result<(), Vec<String>> {
@@ -106,6 +220,14 @@ impl WorkspaceMaterializationSpec {
         }
         errors
     }
+
+    pub fn mode(&self) -> Option<WorkspaceMaterializationMode> {
+        parse_optional_contract_value(self.mode.as_deref())
+    }
+
+    pub fn materialization(&self) -> Option<WorkspaceMaterializationMode> {
+        parse_optional_contract_value(self.materialization.as_deref())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -151,6 +273,18 @@ impl WorkspaceMountSpec {
             self.materialization.as_deref(),
         )
     }
+
+    pub fn mode(&self) -> Option<WorkspaceMaterializationMode> {
+        parse_optional_contract_value(self.mode.as_deref())
+    }
+
+    pub fn materialization(&self) -> Option<WorkspaceMaterializationMode> {
+        parse_optional_contract_value(self.materialization.as_deref())
+    }
+}
+
+fn parse_optional_contract_value<T: FromStr>(value: Option<&str>) -> Option<T> {
+    value.and_then(|value| T::from_str(value).ok())
 }
 
 fn workspace_mount_like_validation_errors(
@@ -177,5 +311,63 @@ fn workspace_mount_like_validation_errors(
 fn validate_non_blank_optional(field: &str, value: Option<&str>, errors: &mut Vec<String>) {
     if value.is_some_and(|value| value.trim().is_empty()) {
         errors.push(format!("{field} must not be blank"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_materialization_uses_typed_cwd_contract_for_git_checkout() {
+        let materialization = AgentTaskProviderWorkspaceMaterialization {
+            cwd: Some(WorkspaceCwdMode::GitCheckout.to_string()),
+            ..AgentTaskProviderWorkspaceMaterialization::default()
+        };
+
+        assert_eq!(
+            materialization.cwd_mode(),
+            Some(WorkspaceCwdMode::GitCheckout)
+        );
+        assert!(materialization.requires_cwd_git_checkout());
+    }
+
+    #[test]
+    fn workspace_materialization_keeps_unknown_strings_non_breaking() {
+        let materialization = AgentTaskProviderWorkspaceMaterialization {
+            cwd: Some("provider_owned_workspace".to_string()),
+            write_scope: Some("provider_owned_scope".to_string()),
+            ..AgentTaskProviderWorkspaceMaterialization::default()
+        };
+
+        assert_eq!(materialization.cwd_mode(), None);
+        assert_eq!(materialization.write_scope(), None);
+        assert!(!materialization.requires_cwd_git_checkout());
+        assert!(materialization.validate().is_ok());
+    }
+
+    #[test]
+    fn workspace_mount_modes_parse_known_contract_values() {
+        let spec = WorkspaceMaterializationSpec {
+            mode: Some(WorkspaceMaterializationMode::Git.to_string()),
+            materialization: Some(WorkspaceMaterializationMode::Snapshot.to_string()),
+            ..WorkspaceMaterializationSpec::default()
+        };
+        let mount = WorkspaceMountSpec {
+            mode: Some(WorkspaceMaterializationMode::Snapshot.to_string()),
+            materialization: Some(WorkspaceMaterializationMode::Git.to_string()),
+            ..WorkspaceMountSpec::default()
+        };
+
+        assert_eq!(spec.mode(), Some(WorkspaceMaterializationMode::Git));
+        assert_eq!(
+            spec.materialization(),
+            Some(WorkspaceMaterializationMode::Snapshot)
+        );
+        assert_eq!(mount.mode(), Some(WorkspaceMaterializationMode::Snapshot));
+        assert_eq!(
+            mount.materialization(),
+            Some(WorkspaceMaterializationMode::Git)
+        );
     }
 }

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -17,6 +17,7 @@ use crate::core::error::{Error, Result};
 use crate::core::runner_execution_envelope::{
     PathMaterializationEntry, PathMaterializationPlan, RunnerExecutionArtifactRef,
     RunnerExecutionNextAction, RunnerExecutionRecord,
+    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
 };
 use crate::core::source_snapshot::SourceSnapshot;
 
@@ -227,22 +228,9 @@ fn path_materialization_plan(
         if trimmed.is_empty() {
             return None;
         }
-        Some(PathMaterializationEntry {
-            role: "required_path".to_string(),
-            owner: "runner_exec.require_paths".to_string(),
-            local_path: None,
-            remote_path: trimmed.to_string(),
-            materialization_mode: "existing_remote".to_string(),
-            validation_status: "validated".to_string(),
-        })
+        Some(PathMaterializationEntry::required_existing_remote(trimmed))
     }));
-    if entries.is_empty() {
-        return None;
-    }
-    Some(PathMaterializationPlan {
-        schema: "homeboy/path-materialization-plan/v1".to_string(),
-        entries,
-    })
+    PathMaterializationPlan::non_empty(entries)
 }
 
 fn path_materialization_entry_from_snapshot(
@@ -252,14 +240,12 @@ fn path_materialization_entry_from_snapshot(
     if remote_path.is_empty() {
         return None;
     }
-    Some(PathMaterializationEntry {
-        role: "primary_workspace".to_string(),
-        owner: "runner_exec.source_snapshot".to_string(),
-        local_path: snapshot.local_path.clone(),
-        remote_path: remote_path.to_string(),
-        materialization_mode: snapshot.sync_mode.clone(),
-        validation_status: "materialized".to_string(),
-    })
+    Some(PathMaterializationEntry::primary_workspace_materialized(
+        PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
+        snapshot.local_path.clone(),
+        remote_path,
+        snapshot.sync_mode.clone(),
+    ))
 }
 
 fn job_artifact_refs(artifacts: &[JobArtifactMetadata]) -> Vec<RunnerExecutionArtifactRef> {

--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 use crate::core::redaction::{redact_argv, RedactionPolicy};
+use crate::core::runner_execution_envelope::PATH_MATERIALIZATION_MODE_EXISTING_REMOTE;
 use crate::core::secret_env_plan::SecretEnvPlan;
 use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
@@ -233,7 +234,7 @@ pub(crate) fn prepare_runner_process(
                 &runner.id,
                 Path::new(&cwd),
                 Some(&cwd),
-                "existing_remote",
+                PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
             ),
             RunnerKind::Ssh => {
                 SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref())
@@ -335,7 +336,12 @@ pub(crate) fn prepare_daemon_local_process(
     )?);
     normalize_runner_command_env(&mut env);
     let source_snapshot = request.source_snapshot.unwrap_or_else(|| {
-        SourceSnapshot::collect_local(&runner.id, Path::new(&cwd), Some(&cwd), "existing_remote")
+        SourceSnapshot::collect_local(
+            &runner.id,
+            Path::new(&cwd),
+            Some(&cwd),
+            PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
+        )
     });
 
     Ok(PreparedRunnerProcess {

--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -463,7 +463,10 @@ fn test_exec_runs_local_runner_command() {
         }
         let source_snapshot = output.source_snapshot.expect("source snapshot");
         assert_eq!(source_snapshot.runner_id, "lab-local");
-        assert_eq!(source_snapshot.sync_mode, "existing_remote");
+        assert_eq!(
+            source_snapshot.sync_mode,
+            crate::core::runner_execution_envelope::PATH_MATERIALIZATION_MODE_EXISTING_REMOTE
+        );
         assert!(source_snapshot.snapshot_hash.starts_with("sha256:"));
         assert!(output.job_id.is_none());
     });

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -2,6 +2,7 @@
 //! output-file download, and stream-truncation guard.
 
 use super::*;
+use crate::core::secret_env_plan::SECRET_ENV_PLAN_ENV_DELTA_SOURCE;
 
 /// Homeboy-owned Lab artifact directory for a given runner checkout root.
 ///
@@ -652,7 +653,7 @@ pub(crate) fn run_lab_offload_inner(
             secret_names: Vec::new(),
         },
         LabEnvResolutionLayer {
-            source: "secret_env_plan_env_delta",
+            source: SECRET_ENV_PLAN_ENV_DELTA_SOURCE,
             env: secret_env_delta,
             secret_names: secret_env_handoff.secret_env_names.clone(),
         },

--- a/src/core/runner/lab/offload/metadata.rs
+++ b/src/core/runner/lab/offload/metadata.rs
@@ -2,6 +2,8 @@
 //! rig component path overrides, and the stale-runner-homeboy error.
 
 use super::*;
+#[cfg(test)]
+use crate::core::secret_env_plan::SECRET_ENV_PLAN_ENV_DELTA_SOURCE;
 
 const ENV_RESOLUTION_SCHEMA: &str = "homeboy/env-resolution/v1";
 const REDACTED_ENV_VALUE: &str = "<redacted>";
@@ -690,7 +692,7 @@ mod tests {
                 secret_names: Vec::new(),
             },
             LabEnvResolutionLayer {
-                source: "secret_env_plan_env_delta",
+                source: SECRET_ENV_PLAN_ENV_DELTA_SOURCE,
                 env: std::collections::HashMap::from([
                     ("SHARED".to_string(), "from-secret-plan".to_string()),
                     ("API_TOKEN".to_string(), "super-secret".to_string()),
@@ -717,7 +719,11 @@ mod tests {
         assert_eq!(shared["winning_source_layer"], "job_override");
         assert_eq!(
             shared["shadowed_source_layers"],
-            serde_json::json!(["env_delta", "runtime_overlay", "secret_env_plan_env_delta"])
+            serde_json::json!([
+                "env_delta",
+                "runtime_overlay",
+                SECRET_ENV_PLAN_ENV_DELTA_SOURCE
+            ])
         );
         assert_eq!(shared["classification"], "public");
         assert_eq!(shared["value_preview"], REDACTED_ENV_VALUE);
@@ -728,7 +734,7 @@ mod tests {
             .expect("api token entry");
         assert_eq!(
             api_token["winning_source_layer"],
-            "secret_env_plan_env_delta"
+            SECRET_ENV_PLAN_ENV_DELTA_SOURCE
         );
         assert_eq!(api_token["classification"], "secret");
         assert_eq!(api_token["value_status"], "secret_redacted");

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -1,6 +1,7 @@
 //! Runner-resident Lab offload path and managed-source refresh.
 
 use super::*;
+use crate::core::secret_env_plan::SECRET_ENV_PLAN_ENV_DELTA_SOURCE;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn run_runner_resident_lab_offload(
@@ -133,7 +134,7 @@ pub(crate) fn run_runner_resident_lab_offload(
             secret_names: Vec::new(),
         },
         LabEnvResolutionLayer {
-            source: "secret_env_plan_env_delta",
+            source: SECRET_ENV_PLAN_ENV_DELTA_SOURCE,
             env: secret_env_handoff.env_delta.clone(),
             secret_names: secret_env_handoff.secret_env_names.clone(),
         },

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fmt;
+use std::str::FromStr;
 
 use crate::command_contract::{RunnerWorkload, RunnerWorkloadArtifactRef};
 use crate::core::agent_task::{AgentTaskArtifactDeclaration, AgentTaskRequest};
@@ -7,6 +9,53 @@ use crate::core::secret_env_plan::SecretEnvPlan;
 
 pub const RUNNER_EXECUTION_ENVELOPE_SCHEMA: &str = "homeboy/runner-execution-envelope/v1";
 pub const RUNNER_EXECUTION_RECORD_SCHEMA: &str = "homeboy/runner-execution-record/v1";
+pub const PATH_MATERIALIZATION_PLAN_SCHEMA: &str = "homeboy/path-materialization-plan/v1";
+pub const PATH_MATERIALIZATION_MODE_EXISTING_REMOTE: &str = "existing_remote";
+pub const PATH_MATERIALIZATION_MODE_GIT: &str = "git";
+pub const PATH_MATERIALIZATION_MODE_SNAPSHOT: &str = "snapshot";
+pub const PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE: &str = "primary_workspace";
+pub const PATH_MATERIALIZATION_ROLE_REQUIRED_PATH: &str = "required_path";
+pub const PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT: &str =
+    "runner_exec.source_snapshot";
+pub const PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS: &str = "runner_exec.require_paths";
+pub const PATH_MATERIALIZATION_STATUS_MATERIALIZED: &str = "materialized";
+pub const PATH_MATERIALIZATION_STATUS_VALIDATED: &str = "validated";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathMaterializationMode {
+    ExistingRemote,
+    Git,
+    Snapshot,
+}
+
+impl PathMaterializationMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExistingRemote => PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
+            Self::Git => PATH_MATERIALIZATION_MODE_GIT,
+            Self::Snapshot => PATH_MATERIALIZATION_MODE_SNAPSHOT,
+        }
+    }
+}
+
+impl fmt::Display for PathMaterializationMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PathMaterializationMode {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            PATH_MATERIALIZATION_MODE_EXISTING_REMOTE => Ok(Self::ExistingRemote),
+            PATH_MATERIALIZATION_MODE_GIT => Ok(Self::Git),
+            PATH_MATERIALIZATION_MODE_SNAPSHOT => Ok(Self::Snapshot),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RunnerExecutionEnvelope {
@@ -71,6 +120,24 @@ pub struct PathMaterializationPlan {
     pub entries: Vec<PathMaterializationEntry>,
 }
 
+impl PathMaterializationPlan {
+    pub fn new(entries: impl IntoIterator<Item = PathMaterializationEntry>) -> Self {
+        Self {
+            schema: PATH_MATERIALIZATION_PLAN_SCHEMA.to_string(),
+            entries: entries.into_iter().collect(),
+        }
+    }
+
+    pub fn non_empty(entries: impl IntoIterator<Item = PathMaterializationEntry>) -> Option<Self> {
+        let plan = Self::new(entries);
+        if plan.entries.is_empty() {
+            None
+        } else {
+            Some(plan)
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PathMaterializationEntry {
     pub role: String,
@@ -80,6 +147,75 @@ pub struct PathMaterializationEntry {
     pub remote_path: String,
     pub materialization_mode: String,
     pub validation_status: String,
+}
+
+impl PathMaterializationEntry {
+    pub fn new(
+        role: impl Into<String>,
+        owner: impl Into<String>,
+        local_path: Option<String>,
+        remote_path: impl Into<String>,
+        materialization_mode: impl Into<String>,
+        validation_status: impl Into<String>,
+    ) -> Self {
+        Self {
+            role: role.into(),
+            owner: owner.into(),
+            local_path,
+            remote_path: remote_path.into(),
+            materialization_mode: materialization_mode.into(),
+            validation_status: validation_status.into(),
+        }
+    }
+
+    pub fn with_mode(
+        role: impl Into<String>,
+        owner: impl Into<String>,
+        local_path: Option<String>,
+        remote_path: impl Into<String>,
+        materialization_mode: PathMaterializationMode,
+        validation_status: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            role,
+            owner,
+            local_path,
+            remote_path,
+            materialization_mode.to_string(),
+            validation_status,
+        )
+    }
+
+    pub fn required_existing_remote(remote_path: impl Into<String>) -> Self {
+        Self::with_mode(
+            PATH_MATERIALIZATION_ROLE_REQUIRED_PATH,
+            PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS,
+            None,
+            remote_path,
+            PathMaterializationMode::ExistingRemote,
+            PATH_MATERIALIZATION_STATUS_VALIDATED,
+        )
+    }
+
+    pub fn primary_workspace_materialized(
+        owner: impl Into<String>,
+        local_path: Option<String>,
+        remote_path: impl Into<String>,
+        materialization_mode: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE,
+            owner,
+            local_path,
+            remote_path,
+            materialization_mode,
+            PATH_MATERIALIZATION_STATUS_MATERIALIZED,
+        )
+    }
+
+    pub fn mode(&self) -> Option<PathMaterializationMode> {
+        PathMaterializationMode::from_str(&self.materialization_mode).ok()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -401,7 +537,7 @@ fn runner_execution_record_schema() -> String {
 }
 
 fn path_materialization_plan_schema() -> String {
-    "homeboy/path-materialization-plan/v1".to_string()
+    PATH_MATERIALIZATION_PLAN_SCHEMA.to_string()
 }
 
 #[cfg(test)]
@@ -495,14 +631,12 @@ mod tests {
             }])
             .with_path_materialization_plan(Some(PathMaterializationPlan {
                 schema: path_materialization_plan_schema(),
-                entries: vec![PathMaterializationEntry {
-                    role: "primary_workspace".to_string(),
-                    owner: "runner_exec.source_snapshot".to_string(),
-                    local_path: Some("/local/project".to_string()),
-                    remote_path: "/runner/project".to_string(),
-                    materialization_mode: "snapshot".to_string(),
-                    validation_status: "materialized".to_string(),
-                }],
+                entries: vec![PathMaterializationEntry::primary_workspace_materialized(
+                    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
+                    Some("/local/project".to_string()),
+                    "/runner/project",
+                    PathMaterializationMode::Snapshot.to_string(),
+                )],
             }))
             .with_next_actions(vec![RunnerExecutionNextAction {
                 label: "runner_job_logs".to_string(),
@@ -526,7 +660,7 @@ mod tests {
         assert_eq!(value["remote_run_id"], "run-1");
         assert_eq!(
             value["path_materialization_plan"]["schema"],
-            "homeboy/path-materialization-plan/v1"
+            PATH_MATERIALIZATION_PLAN_SCHEMA
         );
         assert_eq!(
             value["path_materialization_plan"]["entries"][0]["remote_path"],
@@ -534,6 +668,48 @@ mod tests {
         );
         assert_eq!(value["artifact_refs"][0]["id"], "artifact-1");
         assert_eq!(value["next_actions"][0]["label"], "runner_job_logs");
+    }
+
+    #[test]
+    fn path_materialization_entry_parses_known_modes_without_rejecting_unknowns() {
+        let entry = PathMaterializationEntry::primary_workspace_materialized(
+            PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
+            None,
+            "/runner/project",
+            PathMaterializationMode::Snapshot.to_string(),
+        );
+        let provider_owned = PathMaterializationEntry {
+            materialization_mode: "provider_owned_mode".to_string(),
+            ..entry.clone()
+        };
+
+        assert_eq!(entry.mode(), Some(PathMaterializationMode::Snapshot));
+        assert_eq!(provider_owned.mode(), None);
+    }
+
+    #[test]
+    fn path_materialization_plan_helpers_emit_canonical_shape() {
+        let plan = PathMaterializationPlan::non_empty(vec![
+            PathMaterializationEntry::required_existing_remote("/runner/cache"),
+        ])
+        .expect("non-empty plan");
+
+        assert_eq!(plan.schema, PATH_MATERIALIZATION_PLAN_SCHEMA);
+        assert_eq!(plan.entries[0].role, PATH_MATERIALIZATION_ROLE_REQUIRED_PATH);
+        assert_eq!(
+            plan.entries[0].owner,
+            PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS
+        );
+        assert_eq!(plan.entries[0].remote_path, "/runner/cache");
+        assert_eq!(
+            plan.entries[0].mode(),
+            Some(PathMaterializationMode::ExistingRemote)
+        );
+        assert_eq!(
+            plan.entries[0].validation_status,
+            PATH_MATERIALIZATION_STATUS_VALIDATED
+        );
+        assert!(PathMaterializationPlan::non_empty(Vec::new()).is_none());
     }
 
     #[test]

--- a/src/core/secret_env_plan.rs
+++ b/src/core/secret_env_plan.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::core::redaction::RedactionPolicy;
 
 pub const SECRET_ENV_PLAN_SCHEMA: &str = "homeboy/secret-env-plan/v1";
+pub const AGENT_TASK_SECRET_ENV_PLAN_JSON_ENV: &str = "HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON";
+pub const SECRET_ENV_PLAN_ENV_DELTA_SOURCE: &str = "secret_env_plan_env_delta";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SecretEnvPlan {
@@ -226,6 +228,13 @@ impl SecretEnvPlan {
             .map(|requirement| requirement.name.clone())
             .collect();
         plan
+    }
+
+    pub fn json_env_pair(&self) -> (String, String) {
+        (
+            AGENT_TASK_SECRET_ENV_PLAN_JSON_ENV.to_string(),
+            serde_json::to_string(self).unwrap_or_else(|_| "null".to_string()),
+        )
     }
 
     pub fn secret_env_names(&self) -> Vec<String> {
@@ -701,6 +710,17 @@ mod tests {
                 "MAPPED_SECRET".to_string()
             ])
         );
+    }
+
+    #[test]
+    fn secret_env_plan_json_env_pair_uses_canonical_handoff_name() {
+        let plan = SecretEnvPlan::from_secret_env_names(["API_TOKEN".to_string()]);
+
+        let (name, value) = plan.json_env_pair();
+
+        assert_eq!(name, AGENT_TASK_SECRET_ENV_PLAN_JSON_ENV);
+        let decoded: SecretEnvPlan = serde_json::from_str(&value).expect("secret plan json");
+        assert_eq!(decoded.secret_env_names(), vec!["API_TOKEN".to_string()]);
     }
 
     #[test]

--- a/src/core/source_snapshot.rs
+++ b/src/core/source_snapshot.rs
@@ -4,6 +4,10 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::core::runner_execution_envelope::PATH_MATERIALIZATION_MODE_EXISTING_REMOTE;
+#[cfg(test)]
+use crate::core::runner_execution_envelope::PATH_MATERIALIZATION_MODE_SNAPSHOT;
+
 use crate::core::git;
 
 const SOURCE_SYNC_EXCLUDES_ENV: &str = "HOMEBOY_SOURCE_SYNC_EXCLUDES";
@@ -142,7 +146,8 @@ impl SourceSnapshot {
         policy: &SourceSnapshotPolicy,
     ) -> Self {
         let mut hasher = Sha256::new();
-        hasher.update(b"existing_remote\0");
+        hasher.update(PATH_MATERIALIZATION_MODE_EXISTING_REMOTE.as_bytes());
+        hasher.update(b"\0");
         hasher.update(runner_id.as_bytes());
         hasher.update(b"\0");
         hasher.update(remote_path.as_bytes());
@@ -159,7 +164,7 @@ impl SourceSnapshot {
             git_branch: None,
             git_sha: None,
             dirty: false,
-            sync_mode: "existing_remote".to_string(),
+            sync_mode: PATH_MATERIALIZATION_MODE_EXISTING_REMOTE.to_string(),
             workspace_snapshot_identity: None,
             snapshot_hash: format!("sha256:{:x}", hasher.finalize()),
             synced_at: chrono::Utc::now().to_rfc3339(),
@@ -296,12 +301,12 @@ mod tests {
             "lab-local",
             source_path,
             Some("/srv/homeboy/repo"),
-            "snapshot",
+            PATH_MATERIALIZATION_MODE_SNAPSHOT,
         );
 
         assert_eq!(snapshot.runner_id, "lab-local");
         assert_eq!(snapshot.remote_path.as_deref(), Some("/srv/homeboy/repo"));
-        assert_eq!(snapshot.sync_mode, "snapshot");
+        assert_eq!(snapshot.sync_mode, PATH_MATERIALIZATION_MODE_SNAPSHOT);
         assert_eq!(
             snapshot.local_path.as_deref(),
             Some(source_path.to_str().unwrap())
@@ -330,7 +335,7 @@ mod tests {
             "lab-local",
             tempdir.path(),
             Some("/srv/homeboy/repo"),
-            "snapshot",
+            PATH_MATERIALIZATION_MODE_SNAPSHOT,
         );
 
         assert_eq!(
@@ -352,7 +357,10 @@ mod tests {
         assert_eq!(snapshot.runner_id, "lab");
         assert_eq!(snapshot.remote_path.as_deref(), Some("/srv/homeboy/repo"));
         assert_eq!(snapshot.workspace_root.as_deref(), Some("/srv/homeboy"));
-        assert_eq!(snapshot.sync_mode, "existing_remote");
+        assert_eq!(
+            snapshot.sync_mode,
+            PATH_MATERIALIZATION_MODE_EXISTING_REMOTE
+        );
         assert!(!snapshot.dirty);
         assert!(snapshot.snapshot_hash.starts_with("sha256:"));
         assert!(snapshot.sync_excludes.contains(&".git/".to_string()));


### PR DESCRIPTION
## Summary
- Add typed helpers/constants for agent-task workspace materialization, apply-back strategy, runner path materialization, and secret-env handoff names.
- Replace core call sites that were copying contract string sentinels with canonical helpers.
- Add focused tests for known contract values while keeping provider-owned unknown values non-breaking.

## Testing
- cargo test secret_env_plan
- cargo test path_materialization

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, focused test selection, and PR preparation.