### PR TITLE
Remove legacy component create flags

### DIFF
--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -31,9 +31,8 @@ Options:
 - `--extension <extension>`: extension this component uses (repeatable)
 - `--project <project>`: attach the component to a project after creation
 
-Legacy JSON bulk create flags are rejected. `component create` now initializes
-repo-owned `homeboy.json` from explicit flags, then registers the component for
-ID-based discovery.
+`component create` initializes repo-owned `homeboy.json` from explicit flags,
+then registers the component for ID-based discovery.
 
 #### Extract Command Execution Context
 

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -21,14 +21,6 @@ pub struct ComponentArgs {
 enum ComponentCommand {
     /// Initialize portable component config for a repo
     Create {
-        /// Legacy JSON input spec. Hidden because create now writes repo-owned homeboy.json from flags.
-        #[arg(long, hide = true)]
-        json: Option<String>,
-
-        /// Legacy JSON-mode flag. Hidden because JSON bulk create is no longer supported.
-        #[arg(long, hide = true)]
-        skip_existing: bool,
-
         /// Absolute path to local source directory (writes homeboy.json there)
         #[arg(long)]
         local_path: Option<String>,
@@ -199,8 +191,6 @@ pub fn run(
 ) -> CmdResult<ComponentOutput> {
     match args.command {
         ComponentCommand::Create {
-            json,
-            skip_existing,
             local_path,
             remote_path,
             build_artifact,
@@ -211,18 +201,6 @@ pub fn run(
             extensions,
             project,
         } => {
-            if json.is_some() || skip_existing {
-                return Err(homeboy::core::Error::validation_invalid_argument(
-                    "component.create",
-                    "component create now initializes repo-owned homeboy.json from flags; JSON bulk create is legacy and no longer supported here",
-                    None,
-                    Some(vec![
-                        "Use: homeboy component create --local-path <path> [flags]".to_string(),
-                        "Then attach it to a project with: homeboy project components attach-path <project> <path>".to_string(),
-                    ]),
-                ));
-            }
-
             let local_path = local_path.ok_or_else(|| {
                 homeboy::core::Error::validation_invalid_argument(
                     "local_path",
@@ -924,7 +902,7 @@ fn shared(id: Option<&str>) -> CmdResult<ComponentOutput> {
 mod tests {
     use super::*;
     use crate::cli_surface::Cli;
-    use clap::CommandFactory;
+    use clap::{CommandFactory, Parser};
     use std::fs;
 
     #[test]
@@ -1020,6 +998,26 @@ mod tests {
             !help.contains("unzip -o {artifact} && rm {artifact}"),
             "component help should not document single-brace placeholders: {help}"
         );
+    }
+
+    #[test]
+    fn component_create_rejects_removed_legacy_bulk_flags_at_parse_time() {
+        for args in [
+            [
+                "homeboy",
+                "component",
+                "create",
+                "--json",
+                r#"{"id":"demo"}"#,
+            ],
+            ["homeboy", "component", "create", "--skip-existing", ""],
+        ] {
+            let args = args.into_iter().filter(|arg| !arg.is_empty());
+            assert!(
+                Cli::try_parse_from(args).is_err(),
+                "removed legacy component create flag should not parse"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove hidden legacy component create --json and --skip-existing flags.
- Drop the runtime-only rejection path for those removed flags.
- Update component command docs and parser regression coverage.

## Testing
- cargo test commands::component::tests
- cargo test command_surface

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, focused test selection, and PR preparation.