### PR TITLE
Allow empty patch artifacts

### DIFF
--- a/src/core/agent_task_scheduler/outcome.rs
+++ b/src/core/agent_task_scheduler/outcome.rs
@@ -110,6 +110,10 @@ fn invalid_typed_artifact_reason(
     path: Option<&str>,
     size_bytes: Option<u64>,
 ) -> Option<String> {
+    if is_empty_patch_artifact(typed_artifact) {
+        return None;
+    }
+
     if size_bytes == Some(0) {
         return Some("declared artifact size is zero bytes".to_string());
     }
@@ -127,6 +131,25 @@ fn invalid_typed_artifact_reason(
     }
 
     None
+}
+
+fn is_empty_patch_artifact(typed_artifact: &AgentTaskTypedArtifact) -> bool {
+    let is_patch = typed_artifact.name == "patch"
+        || typed_artifact.artifact_type.as_deref() == Some("patch")
+        || string_field(&typed_artifact.payload, "kind").as_deref() == Some("patch")
+        || typed_artifact
+            .artifact
+            .as_ref()
+            .map(|artifact| artifact.kind == "patch")
+            .unwrap_or(false);
+    let has_reference = typed_artifact
+        .artifact
+        .as_ref()
+        .and_then(|artifact| artifact.path.as_ref().or(artifact.url.as_ref()))
+        .is_some()
+        || string_field(&typed_artifact.payload, "path").is_some()
+        || string_field(&typed_artifact.payload, "url").is_some();
+    is_patch && has_reference
 }
 
 fn string_field(value: &Value, field: &str) -> Option<String> {

--- a/src/core/agent_task_scheduler/tests/fixtures.rs
+++ b/src/core/agent_task_scheduler/tests/fixtures.rs
@@ -33,6 +33,8 @@ pub(super) struct SuccessMissingRequiredArtifactsExecutor;
 
 pub(super) struct SuccessEmptyRequiredTypedArtifactExecutor {
     pub(super) artifact_path: std::path::PathBuf,
+    pub(super) artifact_name: &'static str,
+    pub(super) artifact_kind: &'static str,
 }
 
 impl AgentTaskExecutorAdapter for RetryOnceExecutor {
@@ -249,21 +251,21 @@ impl AgentTaskExecutorAdapter for SuccessEmptyRequiredTypedArtifactExecutor {
         let mut outcome = outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded);
         let artifact = AgentTaskArtifact {
             schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-            id: "empty-patch".to_string(),
-            kind: "patch".to_string(),
-            name: Some("patch.diff".to_string()),
+            id: format!("empty-{}", self.artifact_name),
+            kind: self.artifact_kind.to_string(),
+            name: Some(self.artifact_name.to_string()),
             label: None,
             role: None,
             semantic_key: None,
             path: Some(self.artifact_path.display().to_string()),
             url: None,
-            mime: Some("text/x-patch".to_string()),
+            mime: None,
             size_bytes: Some(0),
             sha256: None,
-            metadata: json!({ "role": "patch" }),
+            metadata: json!({ "role": self.artifact_name }),
         };
         outcome.typed_artifacts.push(AgentTaskTypedArtifact {
-            name: "patch".to_string(),
+            name: self.artifact_name.to_string(),
             artifact_type: Some("file".to_string()),
             artifact_schema: None,
             payload: json!({

--- a/src/core/agent_task_scheduler/tests/outcome_tests.rs
+++ b/src/core/agent_task_scheduler/tests/outcome_tests.rs
@@ -113,15 +113,42 @@ fn missing_required_typed_artifacts_fails_succeeded_outcome() {
 }
 
 #[test]
-fn empty_required_typed_artifact_fails_with_operator_pointer() {
+fn empty_required_patch_artifact_is_valid_no_diff_evidence() {
     let temp = tempfile::tempdir().expect("tempdir");
     let patch_path = temp.path().join("patch.diff");
     fs::write(&patch_path, "").expect("empty patch");
     let scheduler = AgentTaskScheduler::new(SuccessEmptyRequiredTypedArtifactExecutor {
         artifact_path: patch_path.clone(),
+        artifact_name: "patch",
+        artifact_kind: "patch",
     });
 
     let aggregate = scheduler.run(plan_with_required_artifacts(&["patch"]));
+
+    assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+    assert_eq!(aggregate.totals.succeeded, 1);
+    assert_eq!(
+        aggregate.outcomes[0].status,
+        AgentTaskOutcomeStatus::Succeeded
+    );
+    assert!(aggregate.outcomes[0]
+        .diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.class != "agent_task.required_typed_artifacts_invalid"));
+}
+
+#[test]
+fn empty_required_non_patch_typed_artifact_fails_with_operator_pointer() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let report_path = temp.path().join("report.json");
+    fs::write(&report_path, "").expect("empty report");
+    let scheduler = AgentTaskScheduler::new(SuccessEmptyRequiredTypedArtifactExecutor {
+        artifact_path: report_path.clone(),
+        artifact_name: "agent_result",
+        artifact_kind: "json",
+    });
+
+    let aggregate = scheduler.run(plan_with_required_artifacts(&["agent_result"]));
 
     assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
     assert_eq!(aggregate.totals.failed, 1);
@@ -136,14 +163,14 @@ fn empty_required_typed_artifact_fails_with_operator_pointer() {
         .find(|diagnostic| diagnostic.class == "agent_task.required_typed_artifacts_invalid")
         .expect("invalid required typed artifact diagnostic");
     assert_eq!(diagnostic.data["invalid"][0]["task_id"], json!("task-1"));
-    assert_eq!(diagnostic.data["invalid"][0]["name"], json!("patch"));
+    assert_eq!(diagnostic.data["invalid"][0]["name"], json!("agent_result"));
     assert_eq!(
         diagnostic.data["invalid"][0]["artifact_id"],
-        json!("empty-patch")
+        json!("empty-agent_result")
     );
     assert_eq!(
         diagnostic.data["invalid"][0]["path"],
-        json!(patch_path.display().to_string())
+        json!(report_path.display().to_string())
     );
     assert_eq!(diagnostic.data["invalid"][0]["size_bytes"], json!(0));
     assert_eq!(


### PR DESCRIPTION
## Summary
- allow zero-byte required typed artifacts when they are patch/diff artifacts with a real file or URL reference
- keep zero-byte non-patch required typed artifacts invalid
- update scheduler outcome coverage for no-diff patch evidence

Refs https://github.com/Extra-Chill/homeboy/issues/7070

## Evidence
- OpenCode now produces artifacts, but no-diff patch output is a zero-byte patch file.
- Homeboy classified the successful provider outcome as failed: `agent task produced invalid required typed artifacts: patch (... referenced artifact file is zero bytes)`.
- Failed child: `cook-issue-2035`
- Runner job: `homeboy runner job logs homeboy-lab 2e1c0255-0169-4b92-9ec7-4f46fa253a1d`

## Tests
- `cargo test --locked core::agent_task_scheduler::tests::outcome_tests::`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the no-diff patch artifact validation failure, drafting the targeted scheduler fix, and updating regression coverage.