### PR TITLE
test: remove obsolete legacy flag rejection tests

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -902,7 +902,7 @@ fn shared(id: Option<&str>) -> CmdResult<ComponentOutput> {
 mod tests {
     use super::*;
     use crate::cli_surface::Cli;
-    use clap::{CommandFactory, Parser};
+    use clap::CommandFactory;
     use std::fs;
 
     #[test]
@@ -998,26 +998,6 @@ mod tests {
             !help.contains("unzip -o {artifact} && rm {artifact}"),
             "component help should not document single-brace placeholders: {help}"
         );
-    }
-
-    #[test]
-    fn component_create_rejects_removed_legacy_bulk_flags_at_parse_time() {
-        for args in [
-            [
-                "homeboy",
-                "component",
-                "create",
-                "--json",
-                r#"{"id":"demo"}"#,
-            ],
-            ["homeboy", "component", "create", "--skip-existing", ""],
-        ] {
-            let args = args.into_iter().filter(|arg| !arg.is_empty());
-            assert!(
-                Cli::try_parse_from(args).is_err(),
-                "removed legacy component create flag should not parse"
-            );
-        }
     }
 
     #[test]

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -374,45 +374,6 @@ mod normalize_tests {
     }
 
     #[test]
-    fn legacy_cli_aliases_are_rejected() {
-        let cases = [
-            &["homeboy", "components", "list"][..],
-            &["homeboy", "component", "edit", "example", "--json", "{}"][..],
-            &["homeboy", "component", "merge", "example", "--json", "{}"][..],
-            &[
-                "homeboy",
-                "extension",
-                "install",
-                "https://example.test/ext.git",
-                "--revision",
-                "main",
-            ][..],
-            &[
-                "homeboy",
-                "refactor",
-                "propagate",
-                "--struct",
-                "FileFingerprint",
-            ][..],
-            &[
-                "homeboy",
-                "trace",
-                "overlay-locks",
-                "cleanup",
-                "--stale",
-                "--force-stale-lock-cleanup",
-            ][..],
-        ];
-
-        for case in cases {
-            assert!(
-                Cli::try_parse_from(normalize(argv(case))).is_err(),
-                "legacy alias should be rejected: {case:?}"
-            );
-        }
-    }
-
-    #[test]
     fn test_owned_flag_after_component_and_explicit_passthrough_stay_distinct() {
         let input = argv(&[
             "homeboy",


### PR DESCRIPTION
## Summary
- Remove low-value tests that only assert removed legacy CLI aliases and component-create bulk flags fail to parse.
- Leave production clap definitions and parse rejection behavior unchanged.

## Tests
- cargo test commands::utils::args::normalize_tests
- cargo test commands::component::tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting legacy flag references, deleting obsolete tests, running targeted Rust tests, and drafting this PR.