### PR TITLE
Neutralize generic extension runtime fixtures

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -820,11 +820,11 @@ mod tests {
         std::fs::write(
             extension_dir.join(format!("{id}.json")),
             serde_json::json!({
-                "name": "WordPress Extension",
+                "name": "Sample Runtime Extension",
                 "version": "0.0.0",
                 "cli": {
                     "tool": tool,
-                    "display_name": "WordPress CLI",
+                    "display_name": "Sample CLI",
                     "command_template": "{{cliPath}} {{args}}"
                 }
             })
@@ -886,19 +886,22 @@ mod tests {
             startup_fast_path(&args(&["homeboy", "status", "--help"])),
             None
         );
-        assert_eq!(startup_fast_path(&args(&["homeboy", "wp", "--help"])), None);
+        assert_eq!(
+            startup_fast_path(&args(&["homeboy", "sample-cli", "--help"])),
+            None
+        );
     }
 
     #[test]
     fn root_help_lists_extension_provided_commands() {
         let mut command = build_augmented_command(
-            &[sample_extension_info("wp")],
+            &[sample_extension_info("sample-cli")],
             &ExtensionCliHealth::default(),
         );
 
         let help = command.render_help().to_string();
 
-        assert!(help.contains("Extension-provided commands: wp"));
+        assert!(help.contains("Extension-provided commands: sample-cli"));
     }
 
     #[cfg(unix)]
@@ -906,16 +909,18 @@ mod tests {
     fn root_help_warns_about_broken_extension_links_without_paths() {
         let health = ExtensionCliHealth {
             load_error: None,
-            broken_link_ids: vec!["wordpress".to_string()],
+            broken_link_ids: vec!["sample-runtime".to_string()],
         };
         let mut command = build_augmented_command(&[], &health);
 
         let help = command.render_help().to_string();
 
-        assert!(help.contains("Extension health warning: 1 broken extension link(s): wordpress"));
+        assert!(
+            help.contains("Extension health warning: 1 broken extension link(s): sample-runtime")
+        );
         assert!(help.contains("homeboy extension list"));
         assert!(help.contains("homeboy extension relink <id> <path>"));
-        assert!(!help.contains("/missing-wordpress"));
+        assert!(!help.contains("/missing-sample-runtime"));
     }
 
     #[cfg(unix)]
@@ -923,17 +928,17 @@ mod tests {
     fn invalid_dynamic_command_points_to_extension_health_when_links_are_broken() {
         let command = build_augmented_command(&[], &ExtensionCliHealth::default());
         let err = command
-            .try_get_matches_from(["homeboy", "wp"])
-            .expect_err("wp should not parse without extension command metadata");
+            .try_get_matches_from(["homeboy", "sample-cli"])
+            .expect_err("sample-cli should not parse without extension command metadata");
         let health = ExtensionCliHealth {
             load_error: None,
-            broken_link_ids: vec!["wordpress".to_string()],
+            broken_link_ids: vec!["sample-runtime".to_string()],
         };
 
         let output = try_augment_clap_error(&err, &health).expect("extension health hint");
 
         assert!(output.contains("extension-provided commands may be unavailable"));
-        assert!(output.contains("broken extension link(s): wordpress"));
+        assert!(output.contains("broken extension link(s): sample-runtime"));
         assert!(output.contains("homeboy extension list"));
     }
 
@@ -941,41 +946,48 @@ mod tests {
     #[test]
     fn extension_discovery_reports_dynamic_commands_and_broken_links() {
         crate::test_support::with_isolated_home(|home| {
-            write_cli_extension(home.path(), "wordpress", "wp");
+            write_cli_extension(home.path(), "sample-runtime", "sample-cli");
             let extensions_dir = home.path().join(".config/homeboy/extensions");
-            let link = extensions_dir.join("nodejs");
-            let target = extensions_dir.join("missing-nodejs");
+            let link = extensions_dir.join("stale-runtime");
+            let target = extensions_dir.join("missing-stale-runtime");
             std::os::unix::fs::symlink(&target, &link).unwrap();
 
             let discovery = collect_extension_cli_info();
 
             assert_eq!(discovery.info.len(), 1);
-            assert_eq!(discovery.info[0].tool, "wp");
-            assert_eq!(discovery.health.broken_link_ids, vec!["nodejs"]);
+            assert_eq!(discovery.info[0].tool, "sample-cli");
+            assert_eq!(discovery.health.broken_link_ids, vec!["stale-runtime"]);
         });
     }
 
     #[test]
     fn augmented_manifest_includes_extension_command_contract_and_health() {
         crate::test_support::with_isolated_home(|home| {
-            write_cli_extension(home.path(), "wordpress", "wp");
-            write_extension_command_docs(home.path(), "wordpress", "wp");
+            write_cli_extension(home.path(), "sample-runtime", "sample-cli");
+            write_extension_command_docs(home.path(), "sample-runtime", "sample-cli");
 
             let manifest = current_augmented_command_safety_manifest();
-            let wp = manifest.find_path(&["wp"]).expect("wp command manifest");
+            let sample_cli = manifest
+                .find_path(&["sample-cli"])
+                .expect("sample-cli command manifest");
 
-            assert!(wp.mutates);
-            assert!(wp.operator);
-            assert_eq!(wp.docs.path.as_deref(), Some("docs/commands/wp.md"));
-            assert!(wp.dangerous_flags.contains(&"passthrough args".to_string()));
-            assert!(wp
+            assert!(sample_cli.mutates);
+            assert!(sample_cli.operator);
+            assert_eq!(
+                sample_cli.docs.path.as_deref(),
+                Some("docs/commands/sample-cli.md")
+            );
+            assert!(sample_cli
+                .dangerous_flags
+                .contains(&"passthrough args".to_string()));
+            assert!(sample_cli
                 .output
                 .notes
                 .contains("extension-provided CLI passthrough"));
 
-            let extension = wp.extension.as_ref().expect("extension metadata");
-            assert_eq!(extension.extension_id, "wordpress");
-            assert_eq!(extension.tool_name, "wp");
+            let extension = sample_cli.extension.as_ref().expect("extension metadata");
+            assert_eq!(extension.extension_id, "sample-runtime");
+            assert_eq!(extension.tool_name, "sample-cli");
             assert_eq!(extension.args_contract.project_id.name, "project_id");
             assert!(extension.args_contract.project_id.required);
             assert_eq!(extension.args_contract.args.name, "args");

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -1124,7 +1124,7 @@ mod tests {
             "id": "roadie",
             "local_path": "/tmp/roadie",
             "extensions": {
-                "wordpress": {
+                "sample-runtime": {
                     "settings": {
                         "test_backend": "host-smoke"
                     }
@@ -1137,7 +1137,7 @@ mod tests {
                 { "id": "test_backend", "default": "custom-provider" }
             ]
         });
-        let extension_settings = extract_component_extension_settings(&component, "wordpress");
+        let extension_settings = extract_component_extension_settings(&component, "sample-runtime");
 
         let json = build_settings_json_from_manifest(&manifest, &extension_settings, &[], &[])
             .expect("settings json");

--- a/src/core/extension/registry.rs
+++ b/src/core/extension/registry.rs
@@ -218,24 +218,23 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             let extensions_dir = paths::extensions().unwrap();
             std::fs::create_dir_all(&extensions_dir).unwrap();
-            let link = extensions_dir.join("wordpress");
-            let target = extensions_dir.join("missing-wordpress");
+            let link = extensions_dir.join("sample-runtime");
+            let target = extensions_dir.join("missing-sample-runtime");
             std::os::unix::fs::symlink(&target, &link).unwrap();
 
-            let broken = broken_extension_link("wordpress").expect("broken link");
-            assert_eq!(broken.id, "wordpress");
+            let broken = broken_extension_link("sample-runtime").expect("broken link");
+            assert_eq!(broken.id, "sample-runtime");
             assert_eq!(broken.path, link);
             assert_eq!(broken.target, target);
-            assert!(is_extension_linked("wordpress"));
+            assert!(is_extension_linked("sample-runtime"));
 
-            let err = load_extension("wordpress").expect_err("broken link error");
+            let err = load_extension("sample-runtime").expect_err("broken link error");
             assert_eq!(err.code, ErrorCode::ExtensionNotFound);
             assert_eq!(err.details["error"], "target_missing");
             assert!(err.message.contains("target is missing"));
-            assert!(err
-                .hints
-                .iter()
-                .any(|hint| hint.message.contains("homeboy extension relink wordpress")));
+            assert!(err.hints.iter().any(|hint| hint
+                .message
+                .contains("homeboy extension relink sample-runtime")));
         });
     }
 
@@ -245,13 +244,13 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             let extensions_dir = paths::extensions().unwrap();
             std::fs::create_dir_all(&extensions_dir).unwrap();
-            let link = extensions_dir.join("wordpress");
-            let target = extensions_dir.join("missing-wordpress");
+            let link = extensions_dir.join("sample-runtime");
+            let target = extensions_dir.join("missing-sample-runtime");
             std::os::unix::fs::symlink(&target, &link).unwrap();
 
             let broken = broken_extension_links();
             assert_eq!(broken.len(), 1);
-            assert_eq!(broken[0].id, "wordpress");
+            assert_eq!(broken[0].id, "sample-runtime");
             assert_eq!(broken[0].target, target);
         });
     }

--- a/src/core/extension/setup_env.rs
+++ b/src/core/extension/setup_env.rs
@@ -134,7 +134,7 @@ mod tests {
         // rather than racing under a private lock (#6804).
         with_isolated_home(|_| {
             persist(
-                "wordpress",
+                "sample-runtime",
                 &[
                     (
                         "HOMEBOY_SAMPLE_RUNTIME_CORE_MODULE".to_string(),
@@ -145,7 +145,7 @@ mod tests {
             )
             .expect("persist");
 
-            let loaded = load("wordpress");
+            let loaded = load("sample-runtime");
             assert_eq!(
                 loaded,
                 vec![
@@ -169,20 +169,24 @@ mod tests {
     #[test]
     fn persist_empty_clears_previous_document() {
         with_isolated_home(|_| {
-            persist("wordpress", &[("KEY".to_string(), "value".to_string())]).expect("persist");
-            assert!(!load("wordpress").is_empty());
+            persist(
+                "sample-runtime",
+                &[("KEY".to_string(), "value".to_string())],
+            )
+            .expect("persist");
+            assert!(!load("sample-runtime").is_empty());
 
-            persist("wordpress", &[]).expect("clear");
-            assert!(load("wordpress").is_empty());
+            persist("sample-runtime", &[]).expect("clear");
+            assert!(load("sample-runtime").is_empty());
         });
     }
 
     #[test]
     fn sanitizes_extension_id_for_filesystem_safety() {
         // The sanitizer maps every filesystem-unsafe character (here `/`) to
-        // `_`; `wp/sandbox` therefore becomes `wp_sandbox`. (#6705's mechanical
+        // `_`; `sample/runtime` therefore becomes `sample_runtime`. (#6705's mechanical
         // term rename left a stale expected literal here.)
-        assert_eq!(sanitize_extension_id("wp/sandbox"), "wp_sandbox");
-        assert_eq!(sanitize_extension_id("wordpress"), "wordpress");
+        assert_eq!(sanitize_extension_id("sample/runtime"), "sample_runtime");
+        assert_eq!(sanitize_extension_id("sample-runtime"), "sample-runtime");
     }
 }

--- a/src/core/extension/summary.rs
+++ b/src/core/extension/summary.rs
@@ -162,14 +162,14 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             let extensions_dir = paths::extensions().unwrap();
             std::fs::create_dir_all(&extensions_dir).unwrap();
-            let link = extensions_dir.join("wordpress");
-            let target = extensions_dir.join("missing-wordpress");
+            let link = extensions_dir.join("sample-runtime");
+            let target = extensions_dir.join("missing-sample-runtime");
             std::os::unix::fs::symlink(&target, &link).unwrap();
 
             let summaries = list_summaries(None);
 
             assert_eq!(summaries.len(), 1);
-            assert_eq!(summaries[0].id, "wordpress");
+            assert_eq!(summaries[0].id, "sample-runtime");
             assert!(!summaries[0].ready);
             assert!(summaries[0].linked);
             assert_eq!(summaries[0].error.as_deref(), Some("target_missing"));

--- a/tests/deps_test.rs
+++ b/tests/deps_test.rs
@@ -198,7 +198,7 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
                 update: None,
                 rebuild: false,
                 post_update: vec!["composer build".to_string()],
-                test: vec!["homeboy test --path . --extension wordpress".to_string()],
+                test: vec!["homeboy test --path . --extension sample-runtime".to_string()],
             }],
         ),
         stack_component(
@@ -211,7 +211,7 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
                 update: Some("composer update example-org/block-format-bridge".to_string()),
                 rebuild: false,
                 post_update: Vec::new(),
-                test: vec!["homeboy test --path . --extension wordpress".to_string()],
+                test: vec!["homeboy test --path . --extension sample-runtime".to_string()],
             }],
         ),
     ];


### PR DESCRIPTION
## Summary
- Replace WordPress/wp-specific sample extension ids and CLI names in generic core extension/CLI runtime tests with neutral sample-runtime/sample-cli fixtures.
- Keep assertions focused on the same parser, manifest, symlink, settings, env persistence, and dependency-stack behavior.

## Tests
- cargo test cli_runtime
- cargo test summary::tests::list_summaries_includes_broken_extension_symlinks
- cargo test setup_env::tests
- cargo test execution::tests::build_settings_json_includes_nested_homeboy_json_extension_settings
- cargo test registry::tests::test_broken_extension_link_detects_missing_symlink_target
- cargo test registry::tests::test_broken_extension_links_lists_missing_symlink_targets
- cargo test --test deps_test stack_plan_walks_declared_downstream_edges_in_order
- git diff --check

## Residual risk
- The broader core_agnostic_test guards currently fail on existing unrelated baseline drift outside this PR scope; focused tests for the edited generic fixtures pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Fixture cleanup implementation, focused test execution, PR drafting.