### PR TITLE
Fix empty cook patch promotion outcome

### DIFF
--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -12,7 +12,9 @@ use crate::core::agent_task_gate::{
     AgentTaskGateRevealPolicy, AgentTaskGateStatus, AgentTaskGateVisibility,
 };
 use crate::core::agent_task_scheduler::{AgentTaskAggregate, AGENT_TASK_AGGREGATE_SCHEMA};
-use crate::core::agent_task_timeout_artifacts::is_actionable_patch_artifact;
+use crate::core::agent_task_timeout_artifacts::{
+    is_actionable_patch_artifact, is_empty_patch_artifact,
+};
 use crate::core::gate::HomeboyGateResult;
 use crate::core::{Error, Result};
 
@@ -66,6 +68,44 @@ pub(crate) fn promote_with_provider(
         )
     })?;
     validate_artifact_content(&artifact, &patch)?;
+    if patch.trim().is_empty() {
+        let status = AgentTaskPromotionStatus::NoChanges;
+        let target = AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), None);
+        let operator_notification = promotion_notification(status, &target);
+
+        return Ok(AgentTaskPromotionReport {
+            schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+            status,
+            source: AgentTaskPromotionSource {
+                kind: source_kind,
+                task_id: outcome.task_id.clone(),
+                run_id: options.source_run_id,
+                path: options
+                    .source_path
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+            },
+            to_worktree: options.to_worktree,
+            target,
+            patch_artifact: AgentTaskPromotionArtifactRef {
+                id: artifact.id,
+                kind: artifact.kind,
+                path: patch_path.display().to_string(),
+                sha256: artifact.sha256,
+            },
+            changed_files: Vec::new(),
+            command_evidence: Vec::new(),
+            deterministic_gates: Vec::new(),
+            gate_results: Vec::new(),
+            provenance: json!({
+                "source_schema": outcome.schema,
+                "artifact_metadata": artifact.metadata,
+                "worktree_path": null,
+                "dependencies_materialized": false,
+            }),
+            operator_notification,
+        });
+    }
     let normalized_patch = normalize_promotion_patch(&patch, &options.to_worktree)?;
     let changed_files = normalized_patch.changed_files.clone();
 
@@ -223,6 +263,12 @@ fn promotion_notification(
                 target.worktree
             )),
         },
+        AgentTaskPromotionStatus::NoChanges => AgentTaskPromotionNotification {
+            status: "completed".to_string(),
+            message: "provider completed successfully but produced an empty patch; nothing was promoted".to_string(),
+            resumable_blocker: None,
+            next_command: None,
+        },
     }
 }
 
@@ -292,15 +338,34 @@ pub(crate) fn select_patch_artifact(
         .artifacts
         .iter()
         .filter(|artifact| artifact_id.is_none_or(|expected| artifact.id == expected))
+        .filter(|artifact| {
+            is_actionable_patch_artifact(artifact) || is_empty_patch_artifact(artifact)
+        })
+        .cloned()
+        .collect();
+
+    let actionable_artifacts: Vec<AgentTaskArtifact> = artifacts
+        .iter()
         .filter(|artifact| is_actionable_patch_artifact(artifact))
         .cloned()
         .collect();
+    if !actionable_artifacts.is_empty() {
+        return match actionable_artifacts.len() {
+            1 => Ok(actionable_artifacts.into_iter().next().unwrap()),
+            _ => Err(Error::validation_invalid_argument(
+                "artifact_id",
+                "multiple patch artifacts were found; pass --artifact-id to select one",
+                None,
+                None,
+            )),
+        };
+    }
 
     match artifacts.len() {
         1 => Ok(artifacts.into_iter().next().unwrap()),
         0 => Err(Error::validation_invalid_argument(
             "artifact_id",
-            "no matching non-empty patch artifact was found; inspect the agent result or transcript for diagnosis",
+            "no matching patch artifact was found; inspect the agent result or transcript for diagnosis",
             None,
             None,
         )),

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -178,7 +178,11 @@ fn validate_patch_rejects_empty_patch() {
 }
 
 #[test]
-fn select_patch_artifact_rejects_empty_patch_metadata() {
+fn promote_reports_no_changes_for_empty_patch_metadata() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let patch_path = temp.path().join("patch.diff");
+    std::fs::write(&patch_path, "").expect("write empty patch");
+    let source_path = temp.path().join("outcome.json");
     let outcome = AgentTaskOutcome {
         schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
         task_id: "task-1".to_string(),
@@ -210,11 +214,35 @@ fn select_patch_artifact_rejects_empty_patch_metadata() {
         follow_up: None,
         metadata: Value::Null,
     };
+    let source = serde_json::to_string(&outcome).expect("serialize outcome");
+    std::fs::write(&source_path, &source).expect("write source");
 
-    let err = select_patch_artifact(&outcome, None).expect_err("empty patch rejected");
+    let mut provider = FakePromotionWorkspaceProvider::default();
 
-    assert!(err.message.contains("non-empty patch artifact"));
-    assert!(err.message.contains("agent result or transcript"));
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run-empty".to_string()),
+            source_path: Some(source_path),
+            to_worktree: "repo@promoted-task".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["cargo test".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: None,
+        },
+        &mut provider,
+    )
+    .expect("empty patch reports no changes");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::NoChanges);
+    assert!(report.changed_files.is_empty());
+    assert!(provider.apply_calls.is_empty());
+    assert!(provider.verify_calls.is_empty());
 }
 
 #[test]

--- a/src/core/agent_task_promotion/types.rs
+++ b/src/core/agent_task_promotion/types.rs
@@ -58,6 +58,7 @@ pub enum AgentTaskPromotionStatus {
     DryRun,
     Applied,
     GateFailed,
+    NoChanges,
 }
 
 impl AgentTaskPromotionStatus {
@@ -78,6 +79,7 @@ impl AgentTaskPromotionStatus {
             Self::Applied => "patch_promoted_no_pr",
             Self::GateFailed => "patch_promoted_gates_failed",
             Self::DryRun => "patch_not_promoted_dry_run",
+            Self::NoChanges => "patch_not_promoted_no_changes",
         }
     }
 }


### PR DESCRIPTION
## Summary
- Treat a successful empty patch artifact as an explicit agent-task promotion no-changes outcome.
- Prefer actionable patch artifacts when present, while allowing a single empty patch artifact to flow through cook feedback as no_changes.
- Cover the empty-patch promotion path without applying a worktree patch or running verify gates.

## Verification
- cargo test --locked core::agent_task_promotion::tests::
- cargo test --locked core::agent_task_cook_loop::tests::
- git diff --check origin/main..HEAD -- src/core/agent_task_promotion/promote.rs src/core/agent_task_promotion/types.rs src/core/agent_task_promotion/tests.rs

Note: cargo fmt --check currently reports unrelated formatting drift on origin/main outside this PR's files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the cook promotion contract gap, implementing the no-changes outcome, and drafting tests/PR notes.