### PR TITLE
Add resolved agent runtime execution contract

### DIFF
--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -19,6 +19,7 @@ use crate::core::agent_task_promotion::AGENT_TASK_PROMOTION_REPORT_SCHEMA;
 use crate::core::agent_task_provider::{
     provider_capability_contract, ProviderSchemaContract, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
     AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
+    RESOLVED_AGENT_RUNTIME_EXECUTION_CONTRACT_SCHEMA,
 };
 use crate::core::agent_task_schedule::{
     AgentTaskAggregateStatus, AgentTaskState, AGENT_TASK_PLAN_SCHEMA,
@@ -85,6 +86,7 @@ pub struct AgentTaskCoreContractSchemas {
     pub secret_env_plan: String,
     pub secret_env_requirement: String,
     pub command_invocation: String,
+    pub resolved_agent_runtime_execution_contract: String,
     pub batch_cook_fanout_plan: String,
     pub batch_cook_fanout_run: String,
     pub batch_cook_fanout_submit: String,
@@ -165,6 +167,8 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
             secret_env_plan: SECRET_ENV_PLAN_SCHEMA.to_string(),
             secret_env_requirement: SECRET_ENV_REQUIREMENT_SCHEMA.to_string(),
             command_invocation: COMMAND_INVOCATION_SCHEMA.to_string(),
+            resolved_agent_runtime_execution_contract:
+                RESOLVED_AGENT_RUNTIME_EXECUTION_CONTRACT_SCHEMA.to_string(),
             batch_cook_fanout_plan: AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA.to_string(),
             batch_cook_fanout_run: AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA.to_string(),
             batch_cook_fanout_submit: AGENT_TASK_BATCH_COOK_FANOUT_SUBMIT_SCHEMA.to_string(),
@@ -395,6 +399,10 @@ mod tests {
         assert_eq!(
             contract.schemas.command_invocation,
             COMMAND_INVOCATION_SCHEMA
+        );
+        assert_eq!(
+            contract.schemas.resolved_agent_runtime_execution_contract,
+            RESOLVED_AGENT_RUNTIME_EXECUTION_CONTRACT_SCHEMA
         );
         assert_eq!(
             contract.schemas.batch_cook_fanout_plan,

--- a/src/core/agent_task_provider/runtime_types.rs
+++ b/src/core/agent_task_provider/runtime_types.rs
@@ -3,6 +3,72 @@ use std::fmt;
 use std::str::FromStr;
 
 pub const AGENT_TASK_APPLY_BACK_STRATEGY_MUTATION_ARTIFACTS: &str = "mutation_artifacts";
+pub const RESOLVED_AGENT_RUNTIME_EXECUTION_CONTRACT_SCHEMA: &str =
+    "homeboy/resolved-agent-runtime-execution-contract/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedAgentRuntimeExecutionContract {
+    #[serde(default = "resolved_agent_runtime_execution_contract_schema")]
+    pub schema: String,
+    pub provider_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_backend: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_materialization: Option<ResolvedAgentRuntimeWorkspaceMaterializationSummary>,
+    #[serde(
+        default,
+        skip_serializing_if = "ResolvedAgentRuntimeSecretEnvPlan::is_empty"
+    )]
+    pub secret_env_plan: ResolvedAgentRuntimeSecretEnvPlan,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub readiness_checks: Vec<AgentTaskProviderRunnerReadiness>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ResolvedAgentRuntimeWorkspaceMaterializationSummary {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_git: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub write_scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec: Option<WorkspaceMaterializationSpec>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mounts: Vec<WorkspaceMountSpec>,
+    #[serde(default, skip_serializing_if = "AgentTaskRuntimeApplyBack::is_empty")]
+    pub apply_back: AgentTaskRuntimeApplyBack,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ResolvedAgentRuntimeSecretEnvPlan {
+    #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
+    pub plan_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object: Option<SecretEnvPlan>,
+}
+
+impl ResolvedAgentRuntimeSecretEnvPlan {
+    pub fn is_empty(&self) -> bool {
+        self.plan_ref.is_none() && self.object.is_none()
+    }
+}
+
+fn resolved_agent_runtime_execution_contract_schema() -> String {
+    RESOLVED_AGENT_RUNTIME_EXECUTION_CONTRACT_SCHEMA.to_string()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentTaskApplyBackStrategy {
@@ -193,6 +259,78 @@ impl AgentTaskRuntimeApplyBack {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolved_runtime_execution_contract_serializes_canonical_shape() {
+        let contract = ResolvedAgentRuntimeExecutionContract {
+            schema: RESOLVED_AGENT_RUNTIME_EXECUTION_CONTRACT_SCHEMA.to_string(),
+            provider_id: "provider-1".to_string(),
+            provider_backend: Some("example-backend".to_string()),
+            runtime_id: Some("runtime-1".to_string()),
+            runtime_path: Some("/runtime/path".to_string()),
+            workspace_materialization: Some(ResolvedAgentRuntimeWorkspaceMaterializationSummary {
+                cwd: Some(WorkspaceCwdMode::GitCheckout.to_string()),
+                requires_git: Some(true),
+                write_scope: Some(WorkspaceWriteScope::Workspace.to_string()),
+                artifact_paths: vec!["artifacts".to_string()],
+                ..ResolvedAgentRuntimeWorkspaceMaterializationSummary::default()
+            }),
+            secret_env_plan: ResolvedAgentRuntimeSecretEnvPlan {
+                plan_ref: Some("runner-artifact://runner/run/secret-env-plan.json".to_string()),
+                object: Some(SecretEnvPlan::from_secret_env_names([
+                    "EXAMPLE_TOKEN".to_string()
+                ])),
+            },
+            readiness_checks: vec![AgentTaskProviderRunnerReadiness {
+                id: "example-token".to_string(),
+                label: "Example token".to_string(),
+                secret_env: vec!["EXAMPLE_TOKEN".to_string()],
+                env_path: None,
+                executable: None,
+                remediation: None,
+                extra: BTreeMap::new(),
+            }],
+            capabilities: vec!["apply_back".to_string()],
+            extra: BTreeMap::new(),
+        };
+
+        let value = serde_json::to_value(&contract).expect("serialize contract");
+
+        assert_eq!(
+            value["schema"],
+            RESOLVED_AGENT_RUNTIME_EXECUTION_CONTRACT_SCHEMA
+        );
+        assert_eq!(value["provider_id"], "provider-1");
+        assert_eq!(value["workspace_materialization"]["cwd"], "git_checkout");
+        assert_eq!(
+            value["secret_env_plan"]["ref"],
+            "runner-artifact://runner/run/secret-env-plan.json"
+        );
+        assert_eq!(
+            value["secret_env_plan"]["object"]["secret_env_names"][0],
+            "EXAMPLE_TOKEN"
+        );
+        assert_eq!(value["readiness_checks"][0]["id"], "example-token");
+        assert_eq!(value["capabilities"][0], "apply_back");
+    }
+
+    #[test]
+    fn resolved_runtime_execution_contract_defaults_schema_and_omits_empty_sections() {
+        let contract = serde_json::from_value::<ResolvedAgentRuntimeExecutionContract>(
+            serde_json::json!({ "provider_id": "provider-1" }),
+        )
+        .expect("deserialize minimal contract");
+
+        assert_eq!(
+            contract.schema,
+            RESOLVED_AGENT_RUNTIME_EXECUTION_CONTRACT_SCHEMA
+        );
+        assert!(contract.secret_env_plan.is_empty());
+
+        let value = serde_json::to_value(&contract).expect("serialize minimal contract");
+        assert!(value.get("secret_env_plan").is_none());
+        assert!(value.get("workspace_materialization").is_none());
+    }
 
     #[test]
     fn apply_back_strategy_parses_known_contract_value() {


### PR DESCRIPTION
## Summary
- Adds additive serde structs for `ResolvedAgentRuntimeExecutionContract` with provider id/backend, runtime identity, workspace materialization summary, secret env plan ref/object, readiness checks, capabilities, and extension fields.
- Exports the new schema id through the existing agent-task core contract discovery surface.
- Adds focused serde/default-shape tests for the new contract and a core contract schema assertion.

## Tests
- `rustfmt src/core/agent_task_provider/runtime_types.rs src/core/agent_task_contract.rs`
- `cargo fmt --check` was attempted, but the fresh `origin/main` worktree reports unrelated pre-existing formatting drift across many untouched files.
- `cargo test core::agent_task_provider::runtime_types::tests::resolved_runtime_execution_contract` was attempted serially after dependency compilation; local `homeboy` test compilation exceeded 10 minutes twice before tests ran.
- `cargo test core::agent_task_contract::tests::core_contract_exports_authoritative_agent_task_metadata` was attempted in the initial parallel run but waited on Cargo locks and timed out while compiling.

## Residual risk
- Focused Rust tests could not complete locally because `homeboy` test compilation did not finish within the available timeouts. The change is limited to additive serde structs/constants and schema export assertions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the additive contract structs/constants/tests, running local verification attempts, and preparing this PR.