### PR TITLE
Add run location index contract

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -29,14 +29,14 @@ pub use lab::{
     lab_runner_unsupported_message, AgentTaskDispatchIdentity, CommandPortabilityContract,
     LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabCommandRouteContract,
     LabLocalExecutionPolicy, LabLocalHotPolicy, LabRoutingPolicy, LabRunnerSupportSummary,
-    LabSelectedRunnerFallbackPolicy, LabSourcePathMode, LabWorkspaceModePolicy,
+    LabSelectedRunnerFallbackPolicy, LabSourcePathMode, LabWorkspaceModePolicy, RunLocationIndex,
     RunnerHandoffArtifactManifestRef, RunnerHandoffEnvelope, RunnerHandoffFollowCommands,
     RunnerWorkload, RunnerWorkloadArtifactRef, RunnerWorkloadAssignment, RunnerWorkloadCapability,
     RunnerWorkloadCommandFamily, RunnerWorkloadExtensionRevision, RunnerWorkloadKind,
     RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
     RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS,
     RUNNER_ARTIFACT_MANIFEST_FILE, RUNNER_ARTIFACT_MANIFEST_SCHEMA, RUNNER_HANDOFF_ENVELOPE_SCHEMA,
-    RUNNER_WORKLOAD_SCHEMA,
+    RUNNER_WORKLOAD_SCHEMA, RUN_LOCATION_INDEX_SCHEMA,
 };
 pub(crate) use lab::{LAB_NO_EXTRA_TOOLS, RIG_UP_LAB_UNSUPPORTED_REASON};
 pub use output::{

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -29,6 +29,7 @@ use super::spec::{
 
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
 pub const RUNNER_HANDOFF_ENVELOPE_SCHEMA: &str = "homeboy/runner-exec-handoff/v1";
+pub const RUN_LOCATION_INDEX_SCHEMA: &str = "homeboy/run-location-index/v1";
 pub const RUNNER_ARTIFACT_MANIFEST_SCHEMA: &str = "homeboy/artifact-manifest/v1";
 pub const RUNNER_ARTIFACT_MANIFEST_FILE: &str = "homeboy-artifact-manifest.json";
 
@@ -285,6 +286,17 @@ pub struct RunnerHandoffFollowCommands {
     pub logs: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifacts: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunLocationIndex {
+    pub schema: String,
+    pub run_id: String,
+    pub controller_location: String,
+    pub runner_id: String,
+    pub remote_job_id: String,
+    pub artifact_manifest_ref: RunnerHandoffArtifactManifestRef,
+    pub liveness_heartbeat_timestamp: String,
 }
 
 impl RunnerHandoffEnvelope {

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -1249,3 +1249,41 @@ fn lab_mutation_patch_capture_is_descriptor_owned() {
     assert!(!read_only_descriptor.lab_offload_captures_mutation_patch);
     assert_eq!(read_only_descriptor.lab_offload_mutation_flag, None);
 }
+
+#[test]
+fn run_location_index_contract_serializes_required_fields() {
+    let index = RunLocationIndex {
+        schema: RUN_LOCATION_INDEX_SCHEMA.to_string(),
+        run_id: "agent-task-run-6454".to_string(),
+        controller_location: "controller:mac.lan".to_string(),
+        runner_id: "lab".to_string(),
+        remote_job_id: "job-123".to_string(),
+        artifact_manifest_ref: RunnerHandoffArtifactManifestRef {
+            schema: "homeboy/runner-artifact-manifest-ref/v1".to_string(),
+            manifest_schema: RUNNER_ARTIFACT_MANIFEST_SCHEMA.to_string(),
+            path: "/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json"
+                .to_string(),
+        },
+        liveness_heartbeat_timestamp: "2026-06-30T15:58:00Z".to_string(),
+    };
+
+    let json = serde_json::to_value(&index).expect("serialize run location index");
+    assert_eq!(json["schema"], RUN_LOCATION_INDEX_SCHEMA);
+    assert_eq!(json["run_id"], "agent-task-run-6454");
+    assert_eq!(json["controller_location"], "controller:mac.lan");
+    assert_eq!(json["runner_id"], "lab");
+    assert_eq!(json["remote_job_id"], "job-123");
+    assert_eq!(
+        json["artifact_manifest_ref"]["manifest_schema"],
+        RUNNER_ARTIFACT_MANIFEST_SCHEMA
+    );
+    assert_eq!(
+        json["artifact_manifest_ref"]["path"],
+        "/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json"
+    );
+    assert_eq!(json["liveness_heartbeat_timestamp"], "2026-06-30T15:58:00Z");
+
+    let round_trip: RunLocationIndex =
+        serde_json::from_value(json).expect("deserialize run location index");
+    assert_eq!(round_trip, index);
+}


### PR DESCRIPTION
## Summary
- Add an exported `homeboy/run-location-index/v1` schema constant.
- Add `RunLocationIndex` with run id, controller location, runner id, remote job id, artifact manifest ref, and liveness heartbeat timestamp.
- Add focused serialization/deserialization coverage for the contract shape.

## Tests
- `rustfmt --check src/command_contract/lab.rs tests/command_contract/lab_test.rs`
- `cargo test --lib command_contract::lab::tests::run_location_index_contract_serializes_required_fields`
- `cargo test --lib command_contract::lab::tests`

## Notes
- Contract-only change; no run discovery/runtime behavior migration.
- Full `cargo fmt --check` currently reports unrelated pre-existing formatting drift outside this PR's touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the additive Rust contract, focused test, and PR description.