### PR TITLE
Expose fuzz workload structural validation

### DIFF
--- a/src/core/fuzz/mod.rs
+++ b/src/core/fuzz/mod.rs
@@ -57,6 +57,7 @@ pub use parse::{
     merge_fuzz_target_inventory, parse_fuzz_action_model_file, parse_fuzz_case_log_contents,
     parse_fuzz_case_log_file, parse_fuzz_exploration_policy_file, parse_fuzz_result_envelope_file,
     parse_fuzz_results_file, parse_fuzz_sequence_plan_file, parse_fuzz_target_inventory_file,
+    parse_fuzz_workload_file,
 };
 pub use schemas::{
     standardized_fuzz_skip_reason_codes, FUZZ_ACTION_MODEL_SCHEMA, FUZZ_ARTIFACT_SCHEMA,

--- a/src/core/fuzz/parse.rs
+++ b/src/core/fuzz/parse.rs
@@ -10,6 +10,7 @@ use super::envelope::{FuzzResultEnvelope, FuzzTargetInventory};
 use super::schemas::{FUZZ_CAMPAIGN_SCHEMA, FUZZ_RESULT_ENVELOPE_SCHEMA};
 use super::types::{
     FuzzActionModel, FuzzCampaign, FuzzCaseLogEntry, FuzzExplorationPolicy, FuzzSequencePlan,
+    FuzzWorkload,
 };
 
 pub fn parse_fuzz_results_file(path: &Path) -> Result<FuzzCampaign> {
@@ -166,6 +167,26 @@ pub fn parse_fuzz_action_model_file(path: &Path) -> Result<FuzzActionModel> {
     FuzzActionModel::from_value(value).map_err(|message| {
         Error::validation_invalid_argument(
             "action_model",
+            message,
+            Some(path.display().to_string()),
+            None,
+        )
+    })
+}
+
+pub fn parse_fuzz_workload_file(path: &Path) -> Result<FuzzWorkload> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+    let value: Value = serde_json::from_str(&contents).map_err(|err| {
+        Error::validation_invalid_json(
+            err,
+            Some(format!("parse fuzz workload file {}", path.display())),
+            Some(contents.clone()),
+        )
+    })?;
+    FuzzWorkload::from_value(value).map_err(|message| {
+        Error::validation_invalid_argument(
+            "workload",
             message,
             Some(path.display().to_string()),
             None,

--- a/src/core/fuzz/tests/mod.rs
+++ b/src/core/fuzz/tests/mod.rs
@@ -8,3 +8,4 @@ mod observation_tests;
 mod parse_tests;
 mod sequence_tests;
 mod surface_tests;
+mod workload_tests;

--- a/src/core/fuzz/tests/workload_tests.rs
+++ b/src/core/fuzz/tests/workload_tests.rs
@@ -1,0 +1,52 @@
+use serde_json::json;
+
+use crate::core::fuzz::*;
+
+#[test]
+fn workload_from_value_normalizes_structural_fields() {
+    let workload = FuzzWorkload::from_value(json!({
+        "id": " default ",
+        "label": " ",
+        "safety_class": "read_only",
+        "surface_ids": [" api ", " "],
+        "operations": [" read ", ""],
+        "seed_ids": [" seed-1 "],
+        "custom": { "owner": "extension" }
+    }))
+    .expect("workload contract");
+
+    assert_eq!(workload.schema, FUZZ_WORKLOAD_SCHEMA);
+    assert_eq!(workload.id, "default");
+    assert_eq!(workload.label, None);
+    assert_eq!(workload.safety_class, FuzzSafetyClass::ReadOnly);
+    assert_eq!(workload.surface_ids, vec!["api"]);
+    assert_eq!(workload.operations, vec!["read"]);
+    assert_eq!(workload.seed_ids, vec!["seed-1"]);
+    assert_eq!(workload.extra["custom"]["owner"], "extension");
+}
+
+#[test]
+fn workload_from_value_rejects_wrong_schema() {
+    let error = FuzzWorkload::from_value(json!({
+        "schema": "example/custom/v1",
+        "id": "default",
+        "safety_class": "read_only"
+    }))
+    .expect_err("schema mismatch should fail");
+
+    assert!(
+        error.contains("fuzz workload schema must be homeboy/fuzz-workload/v1"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn workload_from_value_requires_non_empty_id() {
+    let error = FuzzWorkload::from_value(json!({
+        "id": " ",
+        "safety_class": "read_only"
+    }))
+    .expect_err("blank id should fail");
+
+    assert_eq!(error, "workload.id must be non-empty");
+}

--- a/src/core/fuzz/types.rs
+++ b/src/core/fuzz/types.rs
@@ -193,6 +193,12 @@ pub struct FuzzWorkload {
 }
 
 impl FuzzWorkload {
+    pub fn from_value(value: Value) -> std::result::Result<Self, String> {
+        let mut workload: Self = serde_json::from_value(value).map_err(|err| err.to_string())?;
+        workload.normalize()?;
+        Ok(workload)
+    }
+
     pub(super) fn normalize(&mut self) -> std::result::Result<(), String> {
         self.schema = trim_or_default(&self.schema, FUZZ_WORKLOAD_SCHEMA);
         require_schema(&self.schema, FUZZ_WORKLOAD_SCHEMA, "fuzz workload")?;


### PR DESCRIPTION
## Summary
- Add public core validation for `homeboy/fuzz-workload/v1` via `FuzzWorkload::from_value`.
- Export `parse_fuzz_workload_file` alongside the existing fuzz parse helpers.
- Add structural-only tests for default schema normalization, required id validation, wrong-schema rejection, and string-list normalization.

## Tests
- `cargo test core::fuzz::tests::workload_tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the additive core validation/export and focused structural tests.