### PR TITLE
Add artifact manifest path helpers

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -30,8 +30,8 @@ use super::spec::{
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
 pub const RUNNER_HANDOFF_ENVELOPE_SCHEMA: &str = "homeboy/runner-exec-handoff/v1";
 pub const RUN_LOCATION_INDEX_SCHEMA: &str = "homeboy/run-location-index/v1";
-pub const RUNNER_ARTIFACT_MANIFEST_SCHEMA: &str = "homeboy/artifact-manifest/v1";
-pub const RUNNER_ARTIFACT_MANIFEST_FILE: &str = "homeboy-artifact-manifest.json";
+pub const RUNNER_ARTIFACT_MANIFEST_SCHEMA: &str = crate::core::artifacts::ARTIFACT_MANIFEST_SCHEMA;
+pub const RUNNER_ARTIFACT_MANIFEST_FILE: &str = crate::core::artifacts::ARTIFACT_MANIFEST_FILE;
 
 /// Routing-policy flags shared by every Lab command representation
 /// (`LabCommandContract`, `LabRoutePlan`, `LabOffloadCommand`). These four

--- a/src/core/artifact_manifest.rs
+++ b/src/core/artifact_manifest.rs
@@ -317,8 +317,24 @@ fn serialize_extra_field<T: Serialize>(value: &T, context: &str) -> Result<Value
         .map_err(|e| Error::internal_json(e.to_string(), Some(format!("serialize {context}"))))
 }
 
-fn manifest_path(root: impl AsRef<Path>) -> PathBuf {
+pub fn manifest_path(root: impl AsRef<Path>) -> PathBuf {
     root.as_ref().join(ARTIFACT_MANIFEST_FILE)
+}
+
+pub fn normalize_relative_artifact_path(relative: impl AsRef<Path>) -> Result<String> {
+    let relative = relative.as_ref();
+    if relative.as_os_str().is_empty()
+        || relative.is_absolute()
+        || relative.components().any(disallowed_component)
+    {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "artifact path must be relative and stay within the artifact root",
+            Some(relative.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+    Ok(slash_path(relative))
 }
 
 pub fn read_manifest_from_root(root: impl AsRef<Path>) -> Result<ArtifactManifest> {
@@ -468,15 +484,7 @@ fn validate_entry_shape(entry: &ArtifactManifestEntry) -> Result<()> {
 }
 
 fn validate_relative_artifact_path(relative: &str) -> Result<()> {
-    let relative_path = Path::new(relative);
-    if relative_path.is_absolute() || relative_path.components().any(disallowed_component) {
-        return Err(Error::validation_invalid_argument(
-            "path",
-            "artifact path must be relative and stay within the artifact root",
-            Some(relative.to_string()),
-            None,
-        ));
-    }
+    normalize_relative_artifact_path(relative)?;
     Ok(())
 }
 
@@ -729,6 +737,33 @@ mod tests {
             manifest.artifacts[0].content_type.as_deref(),
             Some("application/json")
         );
+    }
+
+    #[test]
+    fn exposes_manifest_path_from_canonical_filename() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        assert_eq!(
+            manifest_path(dir.path()),
+            dir.path().join(ARTIFACT_MANIFEST_FILE)
+        );
+    }
+
+    #[test]
+    fn normalizes_safe_relative_artifact_paths_to_slashes() {
+        assert_eq!(
+            normalize_relative_artifact_path(Path::new("logs").join("output.txt"))
+                .expect("normalized path"),
+            "logs/output.txt"
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_relative_artifact_paths() {
+        for path in ["", ".", "logs/../secret.txt", "/tmp/output.txt"] {
+            let err = normalize_relative_artifact_path(path).expect_err("unsafe path");
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        }
     }
 
     #[test]

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -22,10 +22,11 @@ pub use super::artifact_links::{
     PublicArtifactUrlValidation, PUBLIC_ARTIFACT_BASE_URL_ENV,
 };
 pub use super::artifact_manifest::{
-    manifest_for_existing_files, read_manifest_from_root, write_manifest_to_root, ArtifactManifest,
-    ArtifactManifestEntry, ArtifactManifestProvenance, ArtifactManifestPublicUrlState,
-    ArtifactManifestViewer, ArtifactManifestViewerLink, ArtifactRedactionState,
-    ValidatedArtifactManifestEntry, ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA,
+    manifest_for_existing_files, manifest_path, normalize_relative_artifact_path,
+    read_manifest_from_root, write_manifest_to_root, ArtifactManifest, ArtifactManifestEntry,
+    ArtifactManifestProvenance, ArtifactManifestPublicUrlState, ArtifactManifestViewer,
+    ArtifactManifestViewerLink, ArtifactRedactionState, ValidatedArtifactManifestEntry,
+    ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA,
 };
 pub use super::artifact_origin::{
     inspect, serve, status, status_with_command, ArtifactOriginInspect, ArtifactOriginServeSpec,


### PR DESCRIPTION
## Summary
- Export core artifact manifest path and safe relative artifact path normalization helpers.
- Re-export the helpers through the stable artifact facade.
- Point lab runner artifact manifest constants at the core artifact manifest constants to avoid duplicate literals.

## Tests
- cargo test --lib core::artifact_manifest
- cargo test --lib core::runner::execution::tests::handoff

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the scoped helper export, deduplicating lab constants, adding focused tests, and running verification.