### PR TITLE
Validate dependency materialization env prefixes

### DIFF
--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -12,6 +12,8 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
+use super::spec::{validate_dependency_materialization_steps, RigSpec};
+
 const EXTENDS_FIELD: &str = "extends";
 
 pub use super::discovery::{discover_rigs, discover_stacks, DiscoveredRig, DiscoveredStack};
@@ -129,7 +131,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
     let mut installed = Vec::new();
     for rig in selected {
         let target = paths::rig_config(&rig.id)?;
-        materialize_rig_spec(&rig.rig_path, &prepared.source_root)?;
+        validate_rig_spec_file(&rig.rig_path, &prepared.source_root, &rig.id)?;
         if target.exists() || fs::symlink_metadata(&target).is_ok() {
             ensure_rig_refreshable(&rig, &target)?;
             remove_existing_config(&target, "replace rig config link")?;
@@ -197,6 +199,52 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
         installed,
         installed_stacks,
     })
+}
+
+fn validate_rig_spec_file(path: &Path, source_root: &Path, rig_id: &str) -> Result<()> {
+    let value = match materialize_rig_spec(path, source_root)? {
+        Some(value) => value,
+        None => {
+            let content = fs::read_to_string(path).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("read rig spec {}", path.display())),
+                )
+            })?;
+            serde_json::from_str(&content).map_err(|e| {
+                Error::validation_invalid_json(
+                    e,
+                    Some(format!("parse rig spec {}", path.display())),
+                    Some(content.chars().take(200).collect()),
+                )
+            })?
+        }
+    };
+    let mut spec: RigSpec = serde_json::from_value(value).map_err(|e| {
+        Error::rig_schema_unsupported(
+            e.to_string(),
+            format!("parse rig spec {}", path.display()),
+            None,
+        )
+    })?;
+    if spec.id.is_empty() {
+        spec.id = rig_id.to_string();
+    }
+
+    let errors = validate_dependency_materialization_steps(&spec);
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "rig",
+        format!(
+            "Rig `{}` has invalid dependency materialization configuration",
+            spec.id
+        ),
+        Some(spec.id),
+        Some(errors),
+    ))
 }
 
 pub(crate) fn write_rig_config_from_source(

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -330,6 +330,7 @@ fn read_config(id: &str) -> Result<(RigSpec, Option<String>)> {
     apply_trace_workload_defaults(&mut spec)?;
     let declared_id = (!spec.id.is_empty() && spec.id != id).then(|| spec.id.clone());
     spec.id = id.to_string();
+    validate_rig_spec(&spec)?;
     forget_local_package_root(id);
     Ok((spec, declared_id))
 }
@@ -361,7 +362,25 @@ fn read_spec_from_path(path: &Path, id_hint: Option<&str>, package_root: &Path) 
     spec.id = crate::core::extension::slugify_id(&spec.id)?;
     remember_local_package_root(&spec.id, package_root);
     apply_trace_workload_defaults(&mut spec)?;
+    validate_rig_spec(&spec)?;
     Ok(spec)
+}
+
+fn validate_rig_spec(spec: &RigSpec) -> Result<()> {
+    let errors = validate_dependency_materialization_steps(spec);
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "rig",
+        format!(
+            "Rig `{}` has invalid dependency materialization configuration",
+            spec.id
+        ),
+        Some(spec.id.clone()),
+        Some(errors),
+    ))
 }
 
 fn local_package_root_for_rig_json(path: &Path) -> PathBuf {
@@ -636,6 +655,7 @@ pub fn list_ids() -> Result<Vec<String>> {
 mod schema_error_tests {
     use super::*;
     use crate::core::error::ErrorCode;
+    use std::fs;
 
     /// A rig declaring the `component_id` component schema, with one component
     /// that uses neither `path` nor `component_id` — the shape an older binary
@@ -712,5 +732,41 @@ mod schema_error_tests {
             component_with_unrecognized_schema(&value),
             Some("legacy".to_string())
         );
+    }
+
+    #[test]
+    fn local_source_load_rejects_dependency_materialization_env_prefix_command() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let rig_dir = tmp.path().join("rigs/env-prefix");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "env-prefix",
+                "requirements": {
+                    "dependency_materialization": [
+                        {
+                            "id": "prepare-deps",
+                            "command": "RUNTIME_MODE=off deps.prepare",
+                            "safety": "network_access"
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .expect("rig spec");
+
+        let error = load_local_source(tmp.path().to_str().unwrap(), Some("env-prefix"))
+            .expect_err("env-prefix command should be rejected");
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(error.message.contains("dependency materialization"));
+        assert!(error
+            .details
+            .get("tried")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|details| details.iter().any(|detail| detail
+                .as_str()
+                .is_some_and(|value| value.contains("env instead")))));
     }
 }

--- a/src/core/rig/spec/dependencies.rs
+++ b/src/core/rig/spec/dependencies.rs
@@ -190,6 +190,13 @@ pub fn validate_dependency_materialization_steps(rig: &RigSpec) -> Vec<String> {
             (None, None) => errors.push(format!(
                 "{context} must declare exactly one of command or provider"
             )),
+            (Some(command), None) => {
+                if command_starts_with_env_assignment(command) {
+                    errors.push(format!(
+                        "{context} command must not start with shell-style environment assignments; declare environment values in env instead"
+                    ));
+                }
+            }
             _ => {}
         }
 
@@ -253,6 +260,20 @@ fn normalized_optional_ref(value: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+fn command_starts_with_env_assignment(command: &str) -> bool {
+    let Some(first) = command.split_whitespace().next() else {
+        return false;
+    };
+    let Some((name, value)) = first.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && !value.is_empty()
+        && name.chars().enumerate().all(|(index, ch)| {
+            ch == '_' || ch.is_ascii_alphabetic() || (index > 0 && ch.is_ascii_digit())
+        })
 }
 
 #[cfg(test)]
@@ -369,6 +390,7 @@ mod tests {
                         { "id": "missing-executor", "safety": "read_only" },
                         { "id": "ambiguous", "command": "deps.prepare", "provider": "deps.provider", "safety": "network_access" },
                         { "id": "missing-safety", "command": "deps.prepare" },
+                        { "id": "env-prefix", "command": "RUNTIME_MODE=off deps.prepare", "safety": "network_access" },
                         { "id": "bad-output", "provider": "deps.provider", "safety": "writes_working_tree", "expected_outputs": [{ "path": "" }] },
                         { "id": "bad-component", "provider": "deps.provider", "safety": "writes_cache", "component": "missing" }
                     ]
@@ -387,6 +409,9 @@ mod tests {
         assert!(errors.iter().any(
             |error| error.contains("missing-safety") && error.contains("safety classification")
         ));
+        assert!(errors.iter().any(|error| error.contains("env-prefix")
+            && error.contains("environment assignments")
+            && error.contains("env instead")));
         assert!(errors
             .iter()
             .any(|error| error.contains("bad-output") && error.contains("expected output path")));


### PR DESCRIPTION
## Summary
- Reject dependency materialization command strings that start with shell-style env assignments.
- Validate dependency materialization specs when rigs are loaded or installed.
- Add focused unit coverage for the validator and local-source load path.

## Tests
- `cargo test core::rig::spec::dependencies::tests::validates_executor_and_safety_classification`
- `cargo test core::rig::schema_error_tests::local_source_load_rejects_dependency_materialization_env_prefix_command`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the dependency materialization command shape, implementing validation, and drafting focused tests.