### PR TITLE
Fix runner exec script-file env handling

### DIFF
--- a/src/commands/runner/exec.rs
+++ b/src/commands/runner/exec.rs
@@ -19,7 +19,6 @@ use homeboy::core::stream_capture::StreamCaptureMetadata;
 use homeboy::core::{server, Error};
 
 use super::super::CmdResult;
-use super::types::RUNNER_EXEC_SCRIPT_ENV;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn exec(
@@ -82,11 +81,7 @@ pub(super) fn exec(
             allow_diagnostic_ssh,
             command: prepared_command,
             env,
-            secret_env_names: script_file
-                .is_some()
-                .then(|| RUNNER_EXEC_SCRIPT_ENV.to_string())
-                .into_iter()
-                .collect(),
+            secret_env_names: Vec::new(),
             capture_patch,
             raw_exec: true,
             source_snapshot,
@@ -295,7 +290,10 @@ pub(super) fn prepare_runner_exec_command(
         (true, true) => Ok(vec![
             "bash".to_string(),
             "-c".to_string(),
-            "printf '%s' \"$HOMEBOY_RUNNER_EXEC_SCRIPT\" | bash -s".to_string(),
+            format!(
+                "printf '%s' {} | bash -s",
+                shell::quote_arg(script.expect("script is present"))
+            ),
         ]),
         (false, false) => Ok(command),
     }
@@ -303,7 +301,7 @@ pub(super) fn prepare_runner_exec_command(
 
 pub(super) fn prepare_runner_exec_env(
     env: Vec<String>,
-    script: Option<&str>,
+    _script: Option<&str>,
 ) -> homeboy::core::Result<HashMap<String, String>> {
     let mut values = HashMap::new();
     for assignment in env {
@@ -324,9 +322,6 @@ pub(super) fn prepare_runner_exec_env(
             ));
         }
         values.insert(key.to_string(), value.to_string());
-    }
-    if let Some(script) = script {
-        values.insert(RUNNER_EXEC_SCRIPT_ENV.to_string(), script.to_string());
     }
     Ok(values)
 }

--- a/src/commands/runner/tests/exec.rs
+++ b/src/commands/runner/tests/exec.rs
@@ -4,7 +4,6 @@ use super::super::exec::{
     promote_runner_exec_artifact_dirs, promote_runner_exec_artifacts, read_bounded,
     read_runner_exec_script, RUNNER_EXEC_SCRIPT_LIMIT_BYTES,
 };
-use super::super::types::RUNNER_EXEC_SCRIPT_ENV;
 
 use homeboy::core::observation::{NewRunRecord, ObservationStore};
 use homeboy::core::runners::{self as runner, RunnerExecMode, RunnerExecOutput};
@@ -110,12 +109,15 @@ fn read_runner_exec_script_rejects_oversized_script() {
 
 #[test]
 fn script_file_prepares_bash_stdin_command() {
-    let command = prepare_runner_exec_command(Some(&"echo hi".to_string()), Vec::new())
+    let command = prepare_runner_exec_command(Some(&"echo '$GREETING'".to_string()), Vec::new())
         .expect("script command");
 
     assert_eq!(command[0], "bash");
     assert_eq!(command[1], "-c");
-    assert!(command[2].contains(RUNNER_EXEC_SCRIPT_ENV));
+    assert!(command[2].contains("printf '%s'"));
+    assert!(command[2].contains("bash -s"));
+    assert!(!command[2].contains("HOMEBOY_RUNNER_EXEC_SCRIPT"));
+    assert!(command[2].contains("'echo '\\''$GREETING'\\'''"));
 }
 
 #[test]
@@ -137,7 +139,7 @@ fn env_parser_injects_script_body_without_shell_quoting() {
     .expect("env");
 
     assert_eq!(env["GREETING"], "hello world");
-    assert_eq!(env[RUNNER_EXEC_SCRIPT_ENV], "echo \"$GREETING\"");
+    assert!(!env.contains_key("HOMEBOY_RUNNER_EXEC_SCRIPT"));
 }
 
 #[test]

--- a/src/commands/runner/types.rs
+++ b/src/commands/runner/types.rs
@@ -253,7 +253,6 @@ pub enum RunnerConnectionOutput {
 pub type RunnerOutput = EntityCrudOutput<Runner, RunnerExtra>;
 
 pub(super) const REDACTED_ENV_VALUE: &str = "[redacted]";
-pub(super) const RUNNER_EXEC_SCRIPT_ENV: &str = "HOMEBOY_RUNNER_EXEC_SCRIPT";
 
 #[derive(Debug, Serialize)]
 #[serde(untagged)]


### PR DESCRIPTION
## Summary
- Stop carrying runner exec script bodies through HOMEBOY_RUNNER_EXEC_SCRIPT env.
- Build the script-file bash command with a quoted inline printf pipeline instead, so secret-env stdin handling cannot parse script lines as env exports.
- Remove the stale script env constant and update focused runner exec tests.

## Tests
- cargo test script_file_prepares_bash_stdin_command
- cargo test env_parser_injects_script_body_without_shell_quoting

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Reproducing the runner exec script/env failure, implementing the upstream fix, and running targeted verification.