### PR TITLE
Deduplicate conventional rig bench workloads

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::thread;
 
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
@@ -694,6 +694,10 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
             })
         })
         .unwrap_or_default();
+    let extra_workloads = filter_component_conventional_bench_workloads(
+        extra_workloads,
+        path_override.as_deref(),
+    );
 
     let run_dir = RunDir::create()?;
     let resource_run = homeboy::core::engine::resource::ResourceSummaryRun::start(Some(format!(
@@ -733,6 +737,35 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
     let output = output?;
 
     Ok((BenchOutput::List(output), 0))
+}
+
+pub(crate) fn filter_component_conventional_bench_workloads(
+    workloads: Vec<PathBuf>,
+    component_root: Option<&str>,
+) -> Vec<PathBuf> {
+    let Some(component_root) = component_root else {
+        return workloads;
+    };
+    let component_root = Path::new(component_root);
+
+    workloads
+        .into_iter()
+        .filter(|path| !is_component_conventional_bench_workload(path, component_root))
+        .collect()
+}
+
+fn is_component_conventional_bench_workload(path: &Path, component_root: &Path) -> bool {
+    let Ok(relative) = path.strip_prefix(component_root) else {
+        return false;
+    };
+    let mut components = relative.components();
+    if components.next().and_then(|component| component.as_os_str().to_str()) != Some("bench") {
+        return false;
+    }
+    relative
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.contains(".bench."))
 }
 
 fn report_list_rig_source(context: &ListRigContext) {

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -646,6 +646,10 @@ fn run_component_with_rig_context(
 
     let (extra_workloads, env_provider_extensions, invocation_requirements) =
         rig_workload_runtime_inputs(rig_context, rig_spec, ctx.extension_id.as_deref());
+    let extra_workloads = super::filter_component_conventional_bench_workloads(
+        extra_workloads,
+        path_override.as_deref(),
+    );
 
     let selected_scenarios = selected_scenario_ids(args, rig_spec)?;
     let observation = observation::start(BenchObservationStart {


### PR DESCRIPTION
## Summary
- Deduplicates conventional component bench workloads when a rig already supplies the same workload path.
- Applies the filter in bench list and matrix execution paths.
- Prevents duplicate scenario IDs for repo-local rig benches such as Static Site Importer’s fixture matrix.

## Test Plan
- `cargo test bench::`
- Verified SSI fixture-matrix runner path no longer fails on duplicate scenario IDs when using the patched Homeboy binary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing duplicate rig bench workload discovery, drafting the fix, running verification, and preparing this PR description.
