### PR TITLE
Add extension contract producer manifest surface

### DIFF
--- a/docs/reference/schemas/extension-manifest-schema.md
+++ b/docs/reference/schemas/extension-manifest-schema.md
@@ -18,6 +18,7 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
   "platform": {},
   "structured_sidecars": {},
   "materialization_source": {},
+  "contract_producers": [],
   "commands": {},
   "actions": [],
   "hooks": {},
@@ -46,6 +47,7 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
 - **`platform`** (object): Platform behavior definitions (database, deployment, version patterns)
 - **`structured_sidecars`** (object): Declares public machine-readable run-directory sidecar contracts
 - **`materialization_source`** (object): Declares runner-resolvable source metadata for materializing this extension away from controller-local paths
+- **`contract_producers`** (array): Declares generic producer invocations Homeboy can call at explicit lifecycle phases
 - **`fuzz`** (object): Declares fuzz workload metadata, optional runner script, and optional campaign portability metadata
 - **`commands`** (object): Additional CLI commands provided by extension
 - **`actions`** (array): Action definitions for `homeboy extension action`; release actions are normal actions whose IDs start with `release.`
@@ -252,6 +254,78 @@ Extensions can declare a small runner-facing source contract for rapid local ite
 - **`materialization_source.helper_manifest_refs[].purpose`** (string): Optional human-readable reason the helper manifest is relevant.
 
 `homeboy extension show <id>` includes `materialization_source` when the extension declares it, allowing runner parity tooling to consume the contract without reading controller-local extension files directly.
+
+## Extension Contract Producers
+
+Extensions can declare generic producer invocations for the times when Homeboy needs extension-owned data but must not learn the extension's domain. This is a declaration surface only: Homeboy can inspect the producer IDs, phases, invocation protocol, and advertised output kinds without embedding product, language, framework, or runner-specific behavior.
+
+```json
+{
+  "contract_producers": [
+    {
+      "schema": "homeboy/extension-contract-producer/v1",
+      "id": "capabilities",
+      "phase": "discovery",
+      "invocation": {
+        "script": "contracts/discovery.sh",
+        "args": ["--json"],
+        "env": ["HOMEBOY_COMPONENT_ROOT"],
+        "input_schema": "homeboy/extension-discovery-request/v1",
+        "output_schema": "homeboy/extension-discovery-response/v1"
+      },
+      "produces": [
+        {
+          "kind": "capability",
+          "name": "capabilities",
+          "schema": "homeboy/extension-capabilities/v1"
+        }
+      ]
+    },
+    {
+      "id": "plans",
+      "phase": "planning",
+      "invocation": { "script": "contracts/planning.sh" },
+      "produces": [
+        { "kind": "execution_plan" },
+        { "kind": "materialization_plan" },
+        { "kind": "secret_plan" }
+      ]
+    },
+    {
+      "id": "handoff-envelope",
+      "phase": "handoff",
+      "invocation": { "script": "contracts/handoff.sh" },
+      "produces": [{ "kind": "runner_envelope_addition" }]
+    },
+    {
+      "id": "results",
+      "phase": "result",
+      "invocation": { "script": "contracts/result.sh" },
+      "produces": [
+        { "kind": "artifact" },
+        { "kind": "status" },
+        { "kind": "evidence" }
+      ]
+    }
+  ]
+}
+```
+
+### Contract Producer Fields
+
+- **`contract_producers[].schema`** (string): Producer declaration schema. Defaults to `homeboy/extension-contract-producer/v1` when omitted.
+- **`contract_producers[].id`** (string): Stable producer identifier within the extension.
+- **`contract_producers[].phase`** (string): Explicit lifecycle phase when Homeboy may ask for data. Supported values are `discovery`, `planning`, `handoff`, and `result`.
+- **`contract_producers[].invocation.script`** (string): Extension-relative executable that produces the declared data.
+- **`contract_producers[].invocation.args`** (array): Optional static arguments for the invocation.
+- **`contract_producers[].invocation.env`** (array): Optional environment variable names the invocation consumes.
+- **`contract_producers[].invocation.input_schema`** (string): Optional schema identifier for the request payload Homeboy sends to the producer.
+- **`contract_producers[].invocation.output_schema`** (string): Optional schema identifier for the response payload emitted by the producer.
+- **`contract_producers[].produces[]`** (array): Generic payloads the producer can return. Supported `kind` values are `capability`, `execution_plan`, `materialization_plan`, `secret_plan`, `runner_envelope_addition`, `artifact`, `status`, and `evidence`.
+- **`contract_producers[].produces[].name`** (string): Optional stable logical output name.
+- **`contract_producers[].produces[].schema`** (string): Optional schema identifier for this specific output.
+
+`homeboy extension show <id>` includes `contract_producers` when the extension declares them, allowing orchestrators and runners to inspect available lifecycle data without reading extension files directly.
 
 ## Fuzz Capability
 

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -426,6 +426,8 @@ pub struct ExtensionDetail {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub materialization_source:
         Option<homeboy::core::extension::ExtensionMaterializationSourceContract>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub contract_producers: Vec<homeboy::core::extension::ExtensionContractProducer>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<RequiresDetail>,
 }
@@ -689,6 +691,7 @@ fn show_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {
         settings: extension.settings.clone(),
         structured_sidecars: extension.structured_sidecars(),
         materialization_source: extension.materialization_source.clone(),
+        contract_producers: extension.contract_producers.clone(),
         requires,
     };
 
@@ -1235,6 +1238,55 @@ mod tests {
             assert_eq!(
                 source.helper_manifest_refs[0].path,
                 "runtime/local-runtime.json"
+            );
+        });
+    }
+
+    #[test]
+    fn extension_show_emits_contract_producers() {
+        with_isolated_home(|home| {
+            let extension_id = "contract-producer";
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions")
+                .join(extension_id);
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join(format!("{extension_id}.json")),
+                r#"{
+  "name": "Contract producer extension",
+  "version": "1.0.0",
+  "contract_producers": [{
+    "id": "handoff-envelope",
+    "phase": "handoff",
+    "invocation": {
+      "script": "contracts/handoff.sh",
+      "output_schema": "homeboy/runner-envelope-additions/v1"
+    },
+    "produces": [{
+      "kind": "runner_envelope_addition",
+      "schema": "homeboy/runner-envelope-additions/v1"
+    }]
+  }]
+}"#,
+            )
+            .expect("extension manifest");
+
+            let (output, exit_code) = show_extension(extension_id).expect("show extension");
+            assert_eq!(exit_code, 0);
+            let ExtensionOutput::Show { extension } = output else {
+                panic!("expected extension show output");
+            };
+
+            assert_eq!(extension.contract_producers.len(), 1);
+            assert_eq!(extension.contract_producers[0].id, "handoff-envelope");
+            assert_eq!(
+                extension.contract_producers[0].phase,
+                homeboy::core::extension::ExtensionContractProducerPhase::Handoff
+            );
+            assert_eq!(
+                extension.contract_producers[0].produces[0].kind,
+                homeboy::core::extension::ExtensionContractProducerOutputKind::RunnerEnvelopeAddition
             );
         });
     }

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -649,6 +649,7 @@ mod tests {
             autofix_verify: None,
             structured_sidecars: Default::default(),
             materialization_source: None,
+            contract_producers: Vec::new(),
             release_preflights: Vec::new(),
             agent_runtimes: Vec::new(),
             agent_task: None,

--- a/src/core/code_audit/detectors/test_topology.rs
+++ b/src/core/code_audit/detectors/test_topology.rs
@@ -390,6 +390,7 @@ JSON
             trace: None,
             structured_sidecars: std::collections::BTreeMap::new(),
             materialization_source: None,
+            contract_producers: vec![],
             release_preflights: vec![],
             agent_runtimes: vec![],
             agent_task: None,

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 pub const EXTENSION_MATERIALIZATION_SOURCE_SCHEMA: &str =
     "homeboy/extension-materialization-source/v1";
+pub const EXTENSION_CONTRACT_PRODUCER_SCHEMA: &str = "homeboy/extension-contract-producer/v1";
 
 // Keep broad manifest wiring here while leaf config structs live in focused files.
 pub use super::manifest_action_config::{
@@ -558,6 +559,68 @@ fn default_extension_materialization_source_schema() -> String {
     EXTENSION_MATERIALIZATION_SOURCE_SCHEMA.to_string()
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionContractProducerPhase {
+    Discovery,
+    Planning,
+    Handoff,
+    Result,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionContractProducerOutputKind {
+    Capability,
+    ExecutionPlan,
+    MaterializationPlan,
+    SecretPlan,
+    RunnerEnvelopeAddition,
+    Artifact,
+    Status,
+    Evidence,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionContractProducerOutput {
+    pub kind: ExtensionContractProducerOutputKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionContractProducerInvocation {
+    pub script: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionContractProducer {
+    #[serde(default = "default_extension_contract_producer_schema")]
+    pub schema: String,
+    pub id: String,
+    pub phase: ExtensionContractProducerPhase,
+    pub invocation: ExtensionContractProducerInvocation,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub produces: Vec<ExtensionContractProducerOutput>,
+}
+
+fn default_extension_contract_producer_schema() -> String {
+    EXTENSION_CONTRACT_PRODUCER_SCHEMA.to_string()
+}
+
 /// Unified extension manifest decomposed into capability groups.
 ///
 /// Extension JSON files use nested capability groups that map directly to these fields.
@@ -643,6 +706,11 @@ pub struct ExtensionManifest {
     /// extension on a runner without depending on controller-local paths.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub materialization_source: Option<ExtensionMaterializationSourceContract>,
+
+    /// Extension-owned producers Homeboy can invoke at explicit lifecycle times
+    /// to obtain generic contracts without learning domain-specific behavior.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub contract_producers: Vec<ExtensionContractProducer>,
 
     /// Release preflights supplied by this extension.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -71,7 +71,9 @@ pub use manifest::{
     CiJobSpec, CiLocalContext, CiProfileSpec, CliAutoFlag, CliAutoFlagCondition, CliConfig,
     CliHelpConfig, ComponentEnvConfig, DatabaseCliConfig, DatabaseConfig, DeployCapability,
     DeployOverride, DeployOwnerHint, DeployVerification, DepsConfig, DiscoveryConfig,
-    DiscoveryMarkerConfig, DocTarget, ExecutableCapability, ExtensionManifest,
+    DiscoveryMarkerConfig, DocTarget, ExecutableCapability, ExtensionContractProducer,
+    ExtensionContractProducerInvocation, ExtensionContractProducerOutput,
+    ExtensionContractProducerOutputKind, ExtensionContractProducerPhase, ExtensionManifest,
     ExtensionMaterializationHelperManifestRef, ExtensionMaterializationSourceContract,
     ExtensionMaterializationSourceKind, FeatureContextRule, FileContainsCondition, FuzzConfig,
     HttpMethod, IncludeWrapperPolicy, InputConfig, LintChangedFileRoute, LintConfig, OutputConfig,
@@ -83,7 +85,8 @@ pub use manifest::{
     TestPassthroughFilter, TestPassthroughFilterStrategy, TestVacuityPolicy,
     TraceBrowserArtifactMapConfig, TraceBrowserEvidenceAdapterConfig,
     TraceBrowserMetricAliasConfig, TraceBrowserSummaryAliasConfig, TraceConfig,
-    VersionPatternConfig, EXTENSION_MATERIALIZATION_SOURCE_SCHEMA,
+    VersionPatternConfig, EXTENSION_CONTRACT_PRODUCER_SCHEMA,
+    EXTENSION_MATERIALIZATION_SOURCE_SCHEMA,
 };
 pub use manifest_deploy_config::{DeployArchiveInstallPolicy, DeployRequiredHeader};
 pub use refactor_protocol::{

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -277,6 +277,118 @@ fn manifest_parses_extension_materialization_source_contract() {
 }
 
 #[test]
+fn manifest_parses_extension_contract_producers() {
+    let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+        "name": "Example",
+        "version": "0.0.0",
+        "contract_producers": [
+            {
+                "id": "capabilities",
+                "phase": "discovery",
+                "invocation": {
+                    "script": "contracts/discovery.sh",
+                    "args": ["--json"],
+                    "env": ["HOMEBOY_COMPONENT_ROOT"],
+                    "input_schema": "homeboy/extension-discovery-request/v1",
+                    "output_schema": "homeboy/extension-discovery-response/v1"
+                },
+                "produces": [{
+                    "kind": "capability",
+                    "name": "capabilities",
+                    "schema": "homeboy/extension-capabilities/v1"
+                }]
+            },
+            {
+                "id": "plans",
+                "phase": "planning",
+                "invocation": { "script": "contracts/planning.sh" },
+                "produces": [
+                    { "kind": "execution_plan" },
+                    { "kind": "materialization_plan" },
+                    { "kind": "secret_plan" }
+                ]
+            },
+            {
+                "id": "handoff",
+                "phase": "handoff",
+                "invocation": { "script": "contracts/handoff.sh" },
+                "produces": [{ "kind": "runner_envelope_addition" }]
+            },
+            {
+                "id": "results",
+                "phase": "result",
+                "invocation": { "script": "contracts/result.sh" },
+                "produces": [
+                    { "kind": "artifact" },
+                    { "kind": "status" },
+                    { "kind": "evidence" }
+                ]
+            }
+        ]
+    }))
+    .unwrap();
+
+    assert_eq!(manifest.contract_producers.len(), 4);
+    assert_eq!(
+        manifest.contract_producers[0].schema,
+        EXTENSION_CONTRACT_PRODUCER_SCHEMA
+    );
+    assert_eq!(
+        manifest.contract_producers[0].phase,
+        ExtensionContractProducerPhase::Discovery
+    );
+    assert_eq!(
+        manifest.contract_producers[0].invocation.script,
+        "contracts/discovery.sh"
+    );
+    assert_eq!(
+        manifest.contract_producers[0].invocation.args,
+        vec!["--json"]
+    );
+    assert_eq!(
+        manifest.contract_producers[0].produces[0].name.as_deref(),
+        Some("capabilities")
+    );
+    assert_eq!(
+        manifest.contract_producers[1].produces[0].kind,
+        ExtensionContractProducerOutputKind::ExecutionPlan
+    );
+    assert_eq!(
+        manifest.contract_producers[1].produces[1].kind,
+        ExtensionContractProducerOutputKind::MaterializationPlan
+    );
+    assert_eq!(
+        manifest.contract_producers[1].produces[2].kind,
+        ExtensionContractProducerOutputKind::SecretPlan
+    );
+    assert_eq!(
+        manifest.contract_producers[2].produces[0].kind,
+        ExtensionContractProducerOutputKind::RunnerEnvelopeAddition
+    );
+    assert_eq!(
+        manifest.contract_producers[3].produces[2].kind,
+        ExtensionContractProducerOutputKind::Evidence
+    );
+}
+
+#[test]
+fn contract_producers_reject_unknown_fields() {
+    let err = serde_json::from_value::<ExtensionManifest>(serde_json::json!({
+        "name": "Example",
+        "version": "0.0.0",
+        "contract_producers": [{
+            "id": "capabilities",
+            "phase": "discovery",
+            "domain": "wordpress",
+            "invocation": { "script": "contracts/discovery.sh" }
+        }]
+    }))
+    .expect_err("contract producers should stay explicit and generic");
+
+    assert!(err.to_string().contains("unknown field"));
+}
+
+#[test]
 fn legacy_sidecar_schema_fields_do_not_declare_structured_contracts() {
     let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
         "name": "Example",

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -360,6 +360,7 @@ fn extension_show_output_contracts_use_top_level_structured_sidecars() {
                 producer: Some("lint".to_string()),
             }],
             materialization_source: None,
+            contract_producers: Vec::new(),
             requires: None,
         },
     });


### PR DESCRIPTION
## Summary
- Add a generic extension `contract_producers` manifest surface with lifecycle phases for discovery, planning, handoff, and result time.
- Model invocation metadata and produced payload kinds without domain behavior or execution wiring.
- Surface declared producers through `homeboy extension show` and document the schema.

## Tests
- `cargo test contract_producers`
- `cargo test extension_show_output_contracts_use_top_level_structured_sidecars`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the manifest structs, command output wiring, documentation, tests, and PR preparation.