### PR TITLE
Add core contract registry CLI

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -120,7 +120,7 @@ pub enum Commands {
     Component(component::ComponentArgs),
     /// Manage global Homeboy configuration
     Config(config::ConfigArgs),
-    /// Export machine-consumable Homeboy contract metadata
+    /// Inspect and export machine-consumable Homeboy contract metadata
     Contract(contract::ContractArgs),
     /// Run the local-only HTTP API daemon
     Daemon(daemon::DaemonArgs),

--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -20,6 +20,7 @@
 mod lab;
 mod output;
 mod public_variants;
+mod registry;
 pub mod safety_manifest;
 mod spec;
 
@@ -45,6 +46,9 @@ pub use output::{
     CommandResponsePlan, CommandStdoutMode,
 };
 pub use public_variants::{PublicOutputVariantContract, PUBLIC_OUTPUT_VARIANT_CONTRACTS};
+pub use registry::{
+    registered_contract, registered_contracts, ContractRegistryEntry, ContractRegistrySummary,
+};
 pub use spec::{
     registered_command, registered_command_dispatch_family, registered_command_json_family,
     CommandLabSupportSummary, CommandRegistryEntry, CommandSafetySpec, CommandSpec,

--- a/src/command_contract/registry.rs
+++ b/src/command_contract/registry.rs
@@ -1,0 +1,181 @@
+//! Core-owned data contract registry.
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ContractRegistryEntry {
+    pub schema_id: &'static str,
+    pub name: &'static str,
+    pub title: &'static str,
+    pub owner: &'static str,
+    pub summary: &'static str,
+    pub rust_type: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ContractRegistrySummary {
+    pub schema_id: &'static str,
+    pub name: &'static str,
+    pub title: &'static str,
+}
+
+impl ContractRegistryEntry {
+    pub const fn summary(&self) -> ContractRegistrySummary {
+        ContractRegistrySummary {
+            schema_id: self.schema_id,
+            name: self.name,
+            title: self.title,
+        }
+    }
+
+    pub fn matches(&self, value: &str) -> bool {
+        self.schema_id == value || self.name == value
+    }
+}
+
+pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
+    ContractRegistryEntry {
+        schema_id: crate::core::lifecycle::LIFECYCLE_CONTRACT_SCHEMA,
+        name: "lifecycle-contract",
+        title: "Loop lifecycle contract",
+        owner: "homeboy-core",
+        summary: "Declares generic mutable-workload lifecycle phases such as prepare, seed, snapshot, reset, rollback, and teardown.",
+        rust_type: "homeboy::core::lifecycle::LifecycleContract",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::lifecycle::LIFECYCLE_RESULT_SCHEMA,
+        name: "lifecycle-result",
+        title: "Loop lifecycle result",
+        owner: "homeboy-core",
+        summary: "Records lifecycle phase outcomes and optional snapshot references for generic workload execution.",
+        rust_type: "homeboy::core::lifecycle::LifecycleResultMetadata",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::lifecycle::LIFECYCLE_SNAPSHOT_REF_SCHEMA,
+        name: "lifecycle-snapshot-ref",
+        title: "Loop lifecycle snapshot reference",
+        owner: "homeboy-core",
+        summary: "Identifies a snapshot captured during a lifecycle phase without coupling to a product runtime.",
+        rust_type: "homeboy::core::lifecycle::LifecycleSnapshotRef",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::run_lifecycle_status::RUN_LIFECYCLE_STATUS_SCHEMA,
+        name: "run-lifecycle-status",
+        title: "Run lifecycle status",
+        owner: "homeboy-core",
+        summary: "Canonical generic status vocabulary for persisted or runner-backed runs.",
+        rust_type: "homeboy::core::run_lifecycle_status::RunLifecycleStatus",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::artifacts::ARTIFACT_MANIFEST_SCHEMA,
+        name: "artifact-manifest",
+        title: "Artifact manifest",
+        owner: "homeboy-core",
+        summary: "Indexes produced artifacts, provenance, redaction state, and reviewer-viewer links.",
+        rust_type: "homeboy::core::artifact_manifest::ArtifactManifest",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA,
+        name: "secret-env-plan",
+        title: "Secret environment plan",
+        owner: "homeboy-core",
+        summary: "Describes required secret environment variables while keeping values out of serialized plans.",
+        rust_type: "homeboy::core::secret_env_plan::SecretEnvPlan",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::fuzz::FUZZ_WORKLOAD_SCHEMA,
+        name: "fuzz-workload",
+        title: "Fuzz workload",
+        owner: "homeboy-core",
+        summary: "Generic fuzz workload declaration consumed by Homeboy fuzz orchestration.",
+        rust_type: "homeboy::core::fuzz::FuzzWorkload",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::resource_cleanup_intent::RESOURCE_CLEANUP_INTENT_SCHEMA,
+        name: "resource-cleanup-intent",
+        title: "Resource cleanup intent",
+        owner: "homeboy-core",
+        summary: "Declares dry-run versus apply cleanup intent and ownership metadata for removable resources.",
+        rust_type: "homeboy::core::resource_cleanup_intent::ResourceCleanupIntentContract",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::command_contract::RUN_LOCATION_INDEX_SCHEMA,
+        name: "run-location-index",
+        title: "Run location index",
+        owner: "homeboy-core",
+        summary: "Maps a runner-resident run to its cwd, artifact directory, and artifact manifest reference.",
+        rust_type: "homeboy::command_contract::RunLocationIndex",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::extension::EXTENSION_MATERIALIZATION_SOURCE_SCHEMA,
+        name: "extension-materialization-source",
+        title: "Extension materialization source",
+        owner: "homeboy-core",
+        summary: "Records where an installed extension was materialized from in a generic source contract.",
+        rust_type: "homeboy::core::extension::ExtensionMaterializationSourceContract",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::agent_task_provider::RESOLVED_AGENT_RUNTIME_EXECUTION_CONTRACT_SCHEMA,
+        name: "resolved-agent-runtime-execution-contract",
+        title: "Resolved agent runtime execution contract",
+        owner: "homeboy-core",
+        summary: "Captures the selected agent runtime provider, materialization, secrets, readiness, and capabilities.",
+        rust_type: "homeboy::core::agent_task_provider::ResolvedAgentRuntimeExecutionContract",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::artifact_ref::ARTIFACT_REF_SCHEMA,
+        name: "reviewer-facing-artifact-ref",
+        title: "Reviewer-facing artifact reference",
+        owner: "homeboy-core",
+        summary: "Stable artifact reference vocabulary suitable for reviewer-facing evidence links.",
+        rust_type: "homeboy::core::artifact_ref::ArtifactReference",
+    },
+];
+
+pub fn registered_contracts() -> &'static [ContractRegistryEntry] {
+    CONTRACT_REGISTRY
+}
+
+pub fn registered_contract(value: &str) -> Option<&'static ContractRegistryEntry> {
+    CONTRACT_REGISTRY.iter().find(|entry| entry.matches(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_resolves_by_schema_id_or_name() {
+        let by_schema = registered_contract(crate::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA)
+            .expect("schema lookup");
+        let by_name = registered_contract("secret-env-plan").expect("name lookup");
+
+        assert_eq!(by_schema, by_name);
+        assert_eq!(by_name.title, "Secret environment plan");
+    }
+
+    #[test]
+    fn registry_covers_first_slice_contracts() {
+        let names = CONTRACT_REGISTRY
+            .iter()
+            .map(|entry| entry.name)
+            .collect::<std::collections::BTreeSet<_>>();
+
+        for name in [
+            "lifecycle-contract",
+            "lifecycle-result",
+            "lifecycle-snapshot-ref",
+            "run-lifecycle-status",
+            "artifact-manifest",
+            "secret-env-plan",
+            "fuzz-workload",
+            "resource-cleanup-intent",
+            "run-location-index",
+            "extension-materialization-source",
+            "resolved-agent-runtime-execution-contract",
+            "reviewer-facing-artifact-ref",
+        ] {
+            assert!(names.contains(name), "missing {name}");
+        }
+    }
+}

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -444,7 +444,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     command_spec_with_output_notes(
         "contract",
         CommandJsonFamily::Workspace,
-        "exports stable machine-consumable contract JSON files for downstream non-Rust consumers",
+        "lists, shows, and exports Homeboy-owned contract metadata for downstream consumers",
     ),
     command_spec("daemon", CommandJsonFamily::Ops),
     command_spec("extension", CommandJsonFamily::Workspace),

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -6,10 +6,11 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::command_contract::{
-    CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
-    CommandRawOutputMode, CommandResponseMode, CommandStdoutMode, COMMAND_REGISTRY,
-    PUBLIC_OUTPUT_VARIANT_CONTRACTS, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
-    RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA, RUN_LOCATION_INDEX_SCHEMA,
+    registered_contract, registered_contracts, CommandDispatchFamily, CommandJsonFamily,
+    CommandOutputContractKind, CommandOutputFileMode, CommandRawOutputMode, CommandResponseMode,
+    CommandStdoutMode, ContractRegistryEntry, COMMAND_REGISTRY, PUBLIC_OUTPUT_VARIANT_CONTRACTS,
+    RUNNER_ARTIFACT_MANIFEST_SCHEMA, RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA,
+    RUN_LOCATION_INDEX_SCHEMA,
 };
 use crate::commands::{CmdResult, GlobalArgs};
 
@@ -26,8 +27,78 @@ pub struct ContractArgs {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum ContractCommand {
+    /// List core-owned data contracts.
+    List,
+    /// Show one core-owned data contract by schema id or registry name.
+    Show(ContractShowArgs),
     /// Export machine-consumable Homeboy contract JSON files.
     Export(ContractExportArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ContractShowArgs {
+    /// Schema id or short registry name.
+    pub schema_id_or_name: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum ContractOutput {
+    Export(ContractExportOutput),
+    List(ContractListOutput),
+    Show(ContractShowOutput),
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct ContractListOutput {
+    pub kind: &'static str,
+    pub contracts: Vec<ContractListEntry>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct ContractShowOutput {
+    pub kind: &'static str,
+    pub contract: ContractDetail,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct ContractListEntry {
+    pub schema_id: &'static str,
+    pub name: &'static str,
+    pub title: &'static str,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct ContractDetail {
+    pub schema_id: &'static str,
+    pub name: &'static str,
+    pub title: &'static str,
+    pub owner: &'static str,
+    pub summary: &'static str,
+    pub rust_type: &'static str,
+}
+
+impl From<&'static ContractRegistryEntry> for ContractListEntry {
+    fn from(entry: &'static ContractRegistryEntry) -> Self {
+        Self {
+            schema_id: entry.schema_id,
+            name: entry.name,
+            title: entry.title,
+        }
+    }
+}
+
+impl From<&'static ContractRegistryEntry> for ContractDetail {
+    fn from(entry: &'static ContractRegistryEntry) -> Self {
+        Self {
+            schema_id: entry.schema_id,
+            name: entry.name,
+            title: entry.title,
+            owner: entry.owner,
+            summary: entry.summary,
+            rust_type: entry.rust_type,
+        }
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -153,9 +224,41 @@ struct FieldMetadata {
     required: bool,
 }
 
-pub fn run(args: ContractArgs, _global: &GlobalArgs) -> CmdResult<ContractExportOutput> {
+pub fn run(args: ContractArgs, _global: &GlobalArgs) -> CmdResult<ContractOutput> {
     match args.command {
-        ContractCommand::Export(args) => export_contracts(args),
+        ContractCommand::List => Ok((
+            ContractOutput::List(ContractListOutput {
+                kind: "list",
+                contracts: registered_contracts()
+                    .iter()
+                    .map(ContractListEntry::from)
+                    .collect(),
+            }),
+            0,
+        )),
+        ContractCommand::Show(args) => {
+            let contract = registered_contract(&args.schema_id_or_name).ok_or_else(|| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "schema_id_or_name",
+                    format!("unknown Homeboy core contract `{}`", args.schema_id_or_name),
+                    Some(args.schema_id_or_name.clone()),
+                    Some(vec![
+                        "Run `homeboy contract list` to inspect registered contracts.".to_string(),
+                    ]),
+                )
+            })?;
+
+            Ok((
+                ContractOutput::Show(ContractShowOutput {
+                    kind: "show",
+                    contract: contract.into(),
+                }),
+                0,
+            ))
+        }
+        ContractCommand::Export(args) => {
+            export_contracts(args).map(|(output, code)| (ContractOutput::Export(output), code))
+        }
     }
 }
 
@@ -647,6 +750,9 @@ mod tests {
         let (output, exit_code) = run(args, &GlobalArgs {}).expect("contract export");
 
         assert_eq!(exit_code, 0);
+        let ContractOutput::Export(output) = output else {
+            panic!("expected export output");
+        };
         assert_eq!(output.schema, CONTRACT_EXPORT_INDEX_SCHEMA);
         assert_eq!(output.files.len(), 3);
 
@@ -682,5 +788,64 @@ mod tests {
         });
 
         assert_eq!(command.top_level_name(), "contract");
+    }
+
+    #[test]
+    fn list_returns_registered_contracts() {
+        let (output, exit_code) = run(
+            ContractArgs {
+                command: ContractCommand::List,
+            },
+            &GlobalArgs {},
+        )
+        .expect("list contracts");
+
+        assert_eq!(exit_code, 0);
+        let ContractOutput::List(output) = output else {
+            panic!("expected list output");
+        };
+        assert_eq!(output.kind, "list");
+        assert!(output
+            .contracts
+            .iter()
+            .any(|contract| contract.name == "secret-env-plan"));
+    }
+
+    #[test]
+    fn show_resolves_by_name() {
+        let (output, exit_code) = run(
+            ContractArgs {
+                command: ContractCommand::Show(ContractShowArgs {
+                    schema_id_or_name: "secret-env-plan".to_string(),
+                }),
+            },
+            &GlobalArgs {},
+        )
+        .expect("show contract");
+
+        assert_eq!(exit_code, 0);
+        let ContractOutput::Show(output) = output else {
+            panic!("expected show output");
+        };
+        assert_eq!(output.kind, "show");
+        assert_eq!(
+            output.contract.schema_id,
+            crate::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA
+        );
+    }
+
+    #[test]
+    fn show_rejects_unknown_contract() {
+        let err = run(
+            ContractArgs {
+                command: ContractCommand::Show(ContractShowArgs {
+                    schema_id_or_name: "missing-contract".to_string(),
+                }),
+            },
+            &GlobalArgs {},
+        )
+        .expect_err("unknown contract should fail");
+
+        assert!(err.to_string().contains("missing-contract"));
     }
 }


### PR DESCRIPTION
## Summary
- Add a central Homeboy core contract registry for first-slice generic schema contracts.
- Add `homeboy contract list` and `homeboy contract show <schema-id-or-name>` JSON-envelope CLI output.
- Register command metadata/output routing and focused registry/command tests.

## Tests
- `cargo test commands::contract`
- `cargo test command_contract::registry`
- `cargo test command_registry_covers_top_level_parser_surface`
- `cargo test command_spec_output_descriptor_uses_shared_contract_shape`
- `cargo run --quiet -- contract list`
- `cargo run --quiet -- contract show secret-env-plan`

## Notes
- Broad `cargo test contract` was intentionally not used as final evidence because it matches many unrelated existing tests; that broad run compiled but hit two unrelated provider-manifest failures.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the contract registry/CLI slice, tests, verification, and PR preparation.
