### PR TITLE
Export generic contract constants

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -14,6 +14,7 @@
 - [cleanup](cleanup.md) — declared reconstructable artifact cleanup across managed worktrees
 - [component](component.md)
 - [config](config.md)
+- [contract](contract.md) — core-owned contract registry, constants, exports, and normalization
 - [daemon](daemon.md) — local-only HTTP API daemon
 - [db](db.md)
 - [deploy](deploy.md)

--- a/docs/commands/contract.md
+++ b/docs/commands/contract.md
@@ -1,0 +1,71 @@
+# `homeboy contract`
+
+Inspect and export Homeboy-owned generic contract metadata.
+
+## Synopsis
+
+```sh
+homeboy contract <COMMAND>
+```
+
+## Subcommands
+
+- `list` - list registered core-owned data contracts
+- `show <schema-id-or-name>` - show one registered contract by schema ID or registry name
+- `constants <contract-id>` - export stable constants for one contract surface
+- `export --dir <dir>` - write machine-consumable contract JSON files
+- `validate <schema-id> --file <path>` - validate a JSON file against a registered contract
+- `normalize <kind>` - validate and normalize contract values from JSON input
+
+## Constants
+
+```sh
+homeboy contract constants artifact-manifest
+homeboy contract constants all
+```
+
+`constants` returns the standard Homeboy JSON envelope. The payload exposes stable
+schema IDs, artifact file names, and accepted reviewer-facing reference schemes
+without requiring downstream consumers to link Rust.
+
+Accepted contract IDs include `all`, `artifact-manifest`, `loop`,
+`secret-env-plan`, `run-location-index`, and `reviewer-facing-ref`.
+
+## Registry
+
+```sh
+homeboy contract list
+homeboy contract show secret-env-plan
+```
+
+The registry is the central source for contract names, schema IDs, titles,
+owners, summaries, and Rust type anchors.
+
+## Export
+
+```sh
+homeboy contract export --dir ./contracts
+```
+
+Writes contract registry, public output variants, and schema catalog JSON files
+for cross-language contract tests and automation.
+
+## Validate
+
+```sh
+homeboy contract validate homeboy/secret-env-plan/v1 --file ./secret-env-plan.json
+```
+
+Use `validate` to check a JSON file against one of the registered generic
+Homeboy contracts and receive a standard JSON envelope with the validation
+result.
+
+## Normalize
+
+```sh
+homeboy contract normalize artifact-ref --input '"https://example.com/artifact.json"'
+homeboy contract normalize run-lifecycle-status --input '{"status":"timed_out"}'
+```
+
+Use `normalize` when automation needs to validate contract values and receive a
+canonical classification in the standard JSON envelope.

--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -17,6 +17,7 @@
 //!   [`PUBLIC_OUTPUT_VARIANT_CONTRACTS`] table that anchors public output
 //!   variants to discriminators and golden fixtures.
 
+mod constants;
 mod lab;
 mod output;
 mod public_variants;
@@ -26,6 +27,13 @@ mod spec;
 
 pub use crate::core::artifact_ref::{
     validate_reviewer_facing_artifact_ref, ArtifactReference, ReviewerFacingArtifactRefError,
+};
+pub use constants::{
+    artifact_manifest_constants, contract_constants, loop_constants, reviewer_facing_ref_constants,
+    run_location_index_constants, secret_env_plan_constants, AllContractConstants,
+    ArtifactManifestConstants, ContractConstants, ContractConstantsOutput, LoopConstants,
+    ReviewerFacingRefConstants, RunLocationIndexConstants, SecretEnvPlanConstants,
+    CONTRACT_CONSTANTS_SCHEMA,
 };
 pub use lab::{
     lab_runner_support_summary, lab_runner_supported_contract_labels, lab_runner_supported_labels,

--- a/src/command_contract/constants.rs
+++ b/src/command_contract/constants.rs
@@ -1,0 +1,140 @@
+use serde::Serialize;
+
+use crate::command_contract::{registered_contract, RUNNER_ARTIFACT_MANIFEST_FILE};
+use crate::core::agent_task_contract::AGENT_TASK_LOOP_ACTION_SCHEMA;
+use crate::core::agent_task_loop_controller::{
+    AGENT_TASK_LOOP_CONTROLLER_SCHEMA, AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA,
+};
+use crate::core::agent_task_loop_definition::AGENT_TASK_LOOP_DEFINITION_SCHEMA;
+use crate::core::artifact_ref::{HOMEBOY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME};
+
+pub const CONTRACT_CONSTANTS_SCHEMA: &str = "homeboy/contract-constants/v1";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ContractConstantsOutput {
+    pub schema: &'static str,
+    pub contract_id: String,
+    pub constants: ContractConstants,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ContractConstants {
+    All(AllContractConstants),
+    ArtifactManifest(ArtifactManifestConstants),
+    Loop(LoopConstants),
+    SecretEnvPlan(SecretEnvPlanConstants),
+    RunLocationIndex(RunLocationIndexConstants),
+    ReviewerFacingRef(ReviewerFacingRefConstants),
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AllContractConstants {
+    pub artifact_manifest: ArtifactManifestConstants,
+    pub loop_contracts: LoopConstants,
+    pub secret_env_plan: SecretEnvPlanConstants,
+    pub run_location_index: RunLocationIndexConstants,
+    pub reviewer_facing_ref: ReviewerFacingRefConstants,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactManifestConstants {
+    pub schema_id: String,
+    pub file_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct LoopConstants {
+    pub controller_schema_id: String,
+    pub controller_status_schema_id: String,
+    pub definition_schema_id: String,
+    pub action_schema_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SecretEnvPlanConstants {
+    pub schema_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunLocationIndexConstants {
+    pub schema_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReviewerFacingRefConstants {
+    pub accepted_schemes: Vec<String>,
+}
+
+pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> {
+    let normalized = contract_id.trim();
+    let constants = match normalized {
+        "all" => ContractConstants::All(AllContractConstants {
+            artifact_manifest: artifact_manifest_constants(),
+            loop_contracts: loop_constants(),
+            secret_env_plan: secret_env_plan_constants(),
+            run_location_index: run_location_index_constants(),
+            reviewer_facing_ref: reviewer_facing_ref_constants(),
+        }),
+        "artifact-manifest" => ContractConstants::ArtifactManifest(artifact_manifest_constants()),
+        "loop" | "loop-contracts" => ContractConstants::Loop(loop_constants()),
+        "secret-env-plan" => ContractConstants::SecretEnvPlan(secret_env_plan_constants()),
+        "run-location-index" => ContractConstants::RunLocationIndex(run_location_index_constants()),
+        "reviewer-facing-ref" | "reviewer-ref" => {
+            ContractConstants::ReviewerFacingRef(reviewer_facing_ref_constants())
+        }
+        _ => return None,
+    };
+
+    Some(ContractConstantsOutput {
+        schema: CONTRACT_CONSTANTS_SCHEMA,
+        contract_id: normalized.to_string(),
+        constants,
+    })
+}
+
+pub fn artifact_manifest_constants() -> ArtifactManifestConstants {
+    ArtifactManifestConstants {
+        schema_id: registry_schema_id("artifact-manifest"),
+        file_name: RUNNER_ARTIFACT_MANIFEST_FILE.to_string(),
+    }
+}
+
+pub fn loop_constants() -> LoopConstants {
+    LoopConstants {
+        controller_schema_id: AGENT_TASK_LOOP_CONTROLLER_SCHEMA.to_string(),
+        controller_status_schema_id: AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA.to_string(),
+        definition_schema_id: AGENT_TASK_LOOP_DEFINITION_SCHEMA.to_string(),
+        action_schema_id: AGENT_TASK_LOOP_ACTION_SCHEMA.to_string(),
+    }
+}
+
+pub fn secret_env_plan_constants() -> SecretEnvPlanConstants {
+    SecretEnvPlanConstants {
+        schema_id: registry_schema_id("secret-env-plan"),
+    }
+}
+
+pub fn run_location_index_constants() -> RunLocationIndexConstants {
+    RunLocationIndexConstants {
+        schema_id: registry_schema_id("run-location-index"),
+    }
+}
+
+pub fn reviewer_facing_ref_constants() -> ReviewerFacingRefConstants {
+    ReviewerFacingRefConstants {
+        accepted_schemes: vec![
+            "http://".to_string(),
+            "https://".to_string(),
+            HOMEBOY_REF_SCHEME.to_string(),
+            RUNNER_ARTIFACT_REF_SCHEME.to_string(),
+        ],
+    }
+}
+
+fn registry_schema_id(name: &str) -> String {
+    registered_contract(name)
+        .expect("contract constants must reference registered contracts")
+        .schema_id
+        .to_string()
+}

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -226,11 +226,13 @@ impl Commands {
                 CommandOutputContractKind::JsonEnvelope,
             ),
             Commands::Version(_) => version::adapter(output_file_mode).output_descriptor(),
+            Commands::Contract(_) => {
+                crate::commands::contract::adapter(output_file_mode).output_descriptor()
+            }
             Commands::AgentTask(_)
             | Commands::Project(_)
             | Commands::Component(_)
             | Commands::Config(_)
-            | Commands::Contract(_)
             | Commands::Extension(_)
             | Commands::Manifest(_)
             | Commands::Changelog(_)

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -452,7 +452,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     command_spec_with_output_notes(
         "contract",
         CommandJsonFamily::Workspace,
-        "lists, shows, exports, validates, and normalizes Homeboy-owned contract metadata through the central contract surface",
+        "lists, shows, exports constants, exports schemas, validates, and normalizes Homeboy-owned contract metadata through the central contract surface",
     ),
     command_spec("daemon", CommandJsonFamily::Ops),
     command_spec("extension", CommandJsonFamily::Workspace),

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -8,13 +8,13 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::command_contract::{
-    registered_contract, registered_contracts, CommandDispatchFamily, CommandJsonFamily,
-    CommandOutputContractKind, CommandOutputFileMode, CommandRawOutputMode, CommandResponseMode,
-    CommandStdoutMode, ContractRegistryEntry, COMMAND_REGISTRY, PUBLIC_OUTPUT_VARIANT_CONTRACTS,
-    RUNNER_ARTIFACT_MANIFEST_SCHEMA, RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA,
-    RUN_LOCATION_INDEX_SCHEMA,
+    contract_constants, registered_contract, registered_contracts, CommandDispatchFamily,
+    CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode, CommandRawOutputMode,
+    CommandResponseMode, CommandStdoutMode, ContractConstantsOutput, ContractRegistryEntry,
+    COMMAND_REGISTRY, PUBLIC_OUTPUT_VARIANT_CONTRACTS, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+    RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA, RUN_LOCATION_INDEX_SCHEMA,
 };
-use crate::commands::{CmdResult, GlobalArgs};
+use crate::commands::{adapter, CmdResult, GlobalArgs};
 use crate::core::artifact_ref::{validate_reviewer_facing_artifact_ref, ArtifactReference};
 use crate::core::fuzz::{FuzzWorkload, FUZZ_WORKLOAD_SCHEMA};
 use crate::core::loop_lifecycle::{
@@ -49,8 +49,16 @@ pub enum ContractCommand {
     Export(ContractExportArgs),
     /// Validate a JSON file against a registered generic Homeboy contract.
     Validate(ContractValidateArgs),
+    /// Export Homeboy-owned constants for a generic contract surface.
+    Constants(ContractConstantsArgs),
     /// Validate and normalize generic contract values.
     Normalize(ContractNormalizeArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ContractConstantsArgs {
+    /// Contract ID: all, artifact-manifest, loop, secret-env-plan, run-location-index, reviewer-facing-ref.
+    pub contract_id: String,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -63,6 +71,7 @@ pub struct ContractShowArgs {
 #[serde(untagged)]
 pub enum ContractOutput {
     Export(ContractExportOutput),
+    Constants(ContractConstantsOutput),
     List(ContractListOutput),
     Show(ContractShowOutput),
     Validate(ContractValidateOutput),
@@ -345,6 +354,7 @@ pub fn run(args: ContractArgs, _global: &GlobalArgs) -> CmdResult<ContractOutput
             export_contracts(args).map(|(output, code)| (ContractOutput::Export(output), code))
         }
         ContractCommand::Validate(args) => Ok((ContractOutput::Validate(validate(args)?), 0)),
+        ContractCommand::Constants(args) => constants(&args.contract_id),
         ContractCommand::Normalize(args) => Ok((ContractOutput::Normalize(normalize(args)?), 0)),
     }
 }
@@ -365,6 +375,35 @@ fn validate(args: ContractValidateArgs) -> Result<ContractValidateOutput> {
         file: display_path(&args.file),
         valid: true,
     })
+}
+
+pub(crate) fn adapter(
+    output_file_mode: CommandOutputFileMode,
+) -> adapter::TypedCommandAdapter<ContractArgs> {
+    adapter::TypedCommandAdapter::json_only(
+        CommandJsonFamily::Workspace,
+        output_file_mode,
+        run_json,
+    )
+}
+
+fn run_json(args: ContractArgs, global: &GlobalArgs) -> adapter::JsonCommandRun {
+    crate::commands::utils::response::map_cmd_result_to_json(run(args, global))
+}
+
+fn constants(contract_id: &str) -> CmdResult<ContractOutput> {
+    let output = contract_constants(contract_id).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "contract_id",
+            format!("unknown contract constants id `{contract_id}`"),
+            None,
+            Some(vec![
+                "Use one of: all, artifact-manifest, loop, secret-env-plan, run-location-index, reviewer-facing-ref".to_string(),
+            ]),
+        )
+    })?;
+
+    Ok((ContractOutput::Constants(output), 0))
 }
 
 fn normalize(args: ContractNormalizeArgs) -> Result<ContractNormalizeOutput> {

--- a/src/commands/infra/adapter.rs
+++ b/src/commands/infra/adapter.rs
@@ -6,7 +6,7 @@ use crate::command_contract::{
 
 use crate::cli_surface::Commands;
 
-use crate::commands::{fleet, observe, version, GlobalArgs};
+use crate::commands::{contract, fleet, observe, version, GlobalArgs};
 
 pub(crate) type JsonCommandRun = (homeboy::core::Result<Value>, i32);
 pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonCommandRun;
@@ -126,6 +126,12 @@ pub(crate) fn command_adapter(
             let executor = observe::adapter(output_file_mode)
                 .execute_json
                 .expect("observe adapter supports JSON execution");
+            Ok(BoundCommandAdapter::bind(args, executor))
+        }
+        Commands::Contract(args) => {
+            let executor = contract::adapter(output_file_mode)
+                .execute_json
+                .expect("contract adapter supports JSON execution");
             Ok(BoundCommandAdapter::bind(args, executor))
         }
         command => Err(command),

--- a/tests/contract_constants_test.rs
+++ b/tests/contract_constants_test.rs
@@ -1,0 +1,94 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use homeboy::command_contract::{contract_constants, CONTRACT_CONSTANTS_SCHEMA};
+use serde_json::Value;
+
+#[test]
+fn contract_constants_exports_homeboy_owned_contract_ids() {
+    let output = contract_constants("all").expect("all constants");
+    let value = serde_json::to_value(output).expect("constants json");
+
+    assert_eq!(value["schema"], CONTRACT_CONSTANTS_SCHEMA);
+    assert_eq!(value["contract_id"], "all");
+    assert_eq!(
+        value["constants"]["artifact_manifest"]["schema_id"],
+        "homeboy/artifact-manifest/v1"
+    );
+    assert_eq!(
+        value["constants"]["artifact_manifest"]["file_name"],
+        "homeboy-artifact-manifest.json"
+    );
+    assert_eq!(
+        value["constants"]["secret_env_plan"]["schema_id"],
+        "homeboy/secret-env-plan/v1"
+    );
+    assert_eq!(
+        value["constants"]["run_location_index"]["schema_id"],
+        "homeboy/run-location-index/v1"
+    );
+    assert_eq!(
+        value["constants"]["loop_contracts"]["controller_schema_id"],
+        "homeboy/agent-task-loop-controller/v1"
+    );
+    assert!(
+        value["constants"]["reviewer_facing_ref"]["accepted_schemes"]
+            .as_array()
+            .expect("accepted schemes")
+            .iter()
+            .any(|scheme| scheme == "runner-artifact://")
+    );
+}
+
+#[test]
+fn contract_constants_cli_returns_json_envelope() {
+    let output = homeboy_command()
+        .args(["contract", "constants", "artifact-manifest"])
+        .output()
+        .expect("run homeboy");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: Value = serde_json::from_slice(&output.stdout).expect("json stdout");
+    assert_eq!(value["success"], true);
+    assert_eq!(value["data"]["schema"], CONTRACT_CONSTANTS_SCHEMA);
+    assert_eq!(value["data"]["contract_id"], "artifact-manifest");
+    assert_eq!(
+        value["data"]["constants"]["schema_id"],
+        "homeboy/artifact-manifest/v1"
+    );
+    assert_eq!(
+        value["data"]["constants"]["file_name"],
+        "homeboy-artifact-manifest.json"
+    );
+}
+
+#[test]
+fn contract_constants_cli_rejects_unknown_contract_id() {
+    let output = homeboy_command()
+        .args(["contract", "constants", "missing"])
+        .output()
+        .expect("run homeboy");
+
+    assert_eq!(output.status.code(), Some(2));
+
+    let value: Value = serde_json::from_slice(&output.stdout).expect("json stdout");
+    assert_eq!(value["success"], false);
+    assert_eq!(value["error"]["code"], "validation.invalid_argument");
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}
+
+fn homeboy_command() -> Command {
+    let mut command = Command::new(homeboy_bin());
+    command.env("HOMEBOY_NO_UPDATE_CHECK", "1");
+    command
+}


### PR DESCRIPTION
## Summary
- Add a generic `homeboy contract constants <contract-id>` JSON command for Homeboy-owned contract constants.
- Export constants for artifact manifests, loop schema IDs, secret env plans, run location indexes, and reviewer-facing ref schemes.
- Add focused CLI and contract tests.

## Tests
- `cargo test contract_constants --test contract_constants_test`
- `cargo test command_adapter_recognizes_migrated_json_commands --lib`
- `cargo test json_dispatch_family_comes_from_command_registry --lib`
- `cargo test --test command_surface_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the generic contract constants command, tests, and PR preparation.