### PR TITLE
Add rig run bench primitive

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -309,6 +309,124 @@ pub struct BenchRunArgs {
     ignore_default_baseline: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RigRunBenchPlan {
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RigRunBenchOptions {
+    pub rig_id: String,
+    pub profile: String,
+    pub component: Option<String>,
+    pub path: Option<String>,
+    pub iterations: u64,
+    pub warmup: Option<u64>,
+    pub runs: u64,
+    pub run_id: Option<String>,
+    pub shared_state: Option<PathBuf>,
+    pub concurrency: u32,
+    pub settings: SettingArgs,
+    pub json_summary: bool,
+    pub passthrough_args: Vec<String>,
+}
+
+impl RigRunBenchOptions {
+    pub(crate) fn bench_plan(&self) -> RigRunBenchPlan {
+        let mut command = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--rig".to_string(),
+            self.rig_id.clone(),
+            "--profile".to_string(),
+            self.profile.clone(),
+            "--iterations".to_string(),
+            self.iterations.to_string(),
+        ];
+        if let Some(component) = &self.component {
+            command.push(component.clone());
+        }
+        if let Some(path) = &self.path {
+            command.extend(["--path".to_string(), path.clone()]);
+        }
+        if let Some(warmup) = self.warmup {
+            command.extend(["--warmup".to_string(), warmup.to_string()]);
+        }
+        if self.runs != 1 {
+            command.extend(["--runs".to_string(), self.runs.to_string()]);
+        }
+        if let Some(run_id) = &self.run_id {
+            command.extend(["--run-id".to_string(), run_id.clone()]);
+        }
+        if let Some(shared_state) = &self.shared_state {
+            command.extend([
+                "--shared-state".to_string(),
+                shared_state.to_string_lossy().to_string(),
+            ]);
+        }
+        if self.concurrency != 1 {
+            command.extend(["--concurrency".to_string(), self.concurrency.to_string()]);
+        }
+        for (key, value) in &self.settings.setting {
+            command.extend(["--setting".to_string(), format!("{key}={value}")]);
+        }
+        for (key, value) in &self.settings.setting_json {
+            command.extend(["--setting-json".to_string(), format!("{key}={value}")]);
+        }
+        if self.json_summary {
+            command.push("--json-summary".to_string());
+        }
+        if !self.passthrough_args.is_empty() {
+            command.push("--".to_string());
+            command.extend(self.passthrough_args.iter().cloned());
+        }
+        RigRunBenchPlan { command }
+    }
+
+    fn into_bench_args(self) -> BenchArgs {
+        BenchArgs {
+            command: None,
+            json: false,
+            run: BenchRunArgs {
+                comp: PositionalComponentArgs {
+                    component: self.component,
+                    path: self.path,
+                },
+                extension_override: ExtensionOverrideArgs::default(),
+                iterations: self.iterations,
+                warmup: self.warmup,
+                runs: self.runs,
+                run_id: self.run_id,
+                shared_state: self.shared_state,
+                concurrency: self.concurrency,
+                matrix: Vec::new(),
+                runner_pool: None,
+                matrix_max_tasks: None,
+                matrix_max_queue_depth: None,
+                expected_artifact: Vec::new(),
+                baseline_args: BaselineArgs::default(),
+                regression_threshold: DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                setting_args: self.settings,
+                args: self.passthrough_args,
+                json_summary: self.json_summary,
+                status_file: None,
+                report: Vec::new(),
+                rig: vec![self.rig_id],
+                rig_order: BenchRigOrder::Input,
+                rig_concurrency: 1,
+                scenario_ids: Vec::new(),
+                profile: Some(self.profile),
+                ci_profile: None,
+                ignore_default_baseline: false,
+            },
+        }
+    }
+}
+
+pub(crate) fn run_rig_profile(options: RigRunBenchOptions) -> CmdResult<BenchOutput> {
+    run(options.into_bench_args(), &GlobalArgs {})
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub enum BenchRigOrder {
     Input,
@@ -694,10 +812,8 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
             })
         })
         .unwrap_or_default();
-    let extra_workloads = filter_component_conventional_bench_workloads(
-        extra_workloads,
-        path_override.as_deref(),
-    );
+    let extra_workloads =
+        filter_component_conventional_bench_workloads(extra_workloads, path_override.as_deref());
 
     let run_dir = RunDir::create()?;
     let resource_run = homeboy::core::engine::resource::ResourceSummaryRun::start(Some(format!(
@@ -759,7 +875,11 @@ fn is_component_conventional_bench_workload(path: &Path, component_root: &Path) 
         return false;
     };
     let mut components = relative.components();
-    if components.next().and_then(|component| component.as_os_str().to_str()) != Some("bench") {
+    if components
+        .next()
+        .and_then(|component| component.as_os_str().to_str())
+        != Some("bench")
+    {
         return false;
     }
     relative

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -11,14 +11,16 @@ use homeboy::core::rig;
 
 use self::output::{
     RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledStackSummary,
-    RigInstalledSummary, RigListOutput, RigReleaseLockOutput, RigRepairOutput, RigShowOutput,
-    RigSourceSummary, RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput, RigUpPlanOutput,
-    RigUpPlanStep, RigUpdateOutput,
+    RigInstalledSummary, RigListOutput, RigReleaseLockOutput, RigRepairOutput, RigRunOutput,
+    RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput,
+    RigUpPlanOutput, RigUpPlanStep, RigUpdateOutput,
 };
+use super::bench::RigRunBenchOptions;
+use super::utils::args::SettingArgs;
 use super::CmdResult;
 use crate::command_contract::{
-    CommandPortabilityContract, LabCommandContract, LAB_NO_EXTRA_TOOLS, RIG_CHECK_LAB_LABEL,
-    RIG_UP_LAB_UNSUPPORTED_REASON,
+    CommandPortabilityContract, LabCommandContract, BENCH_LAB_LABEL, LAB_NO_EXTRA_TOOLS,
+    RIG_CHECK_LAB_LABEL, RIG_UP_LAB_UNSUPPORTED_REASON,
 };
 
 #[derive(Args)]
@@ -74,6 +76,14 @@ impl RigArgs {
                 )
             };
             return CommandPortabilityContract::lab(contract);
+        }
+        if matches!(self.command, RigCommand::Run(_)) {
+            return CommandPortabilityContract::lab(LabCommandContract::portable(
+                BENCH_LAB_LABEL,
+                None,
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ));
         }
         if self.is_hot_resource_command() {
             return CommandPortabilityContract::lab(LabCommandContract::local_only(
@@ -152,6 +162,8 @@ enum RigCommand {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Refresh, sync, check, and benchmark a rig profile end-to-end
+    Run(RigRunArgs),
     /// Show current state of a rig: running services, last up/check
     Status {
         /// Rig ID
@@ -240,6 +252,59 @@ enum RigAppCommand {
     },
 }
 
+#[derive(Args)]
+struct RigRunArgs {
+    /// Rig ID
+    rig_id: String,
+
+    /// Rig-defined bench profile to run
+    #[arg(long, value_name = "PROFILE")]
+    profile: String,
+
+    /// Optional component ID override for rigs with multiple bench components
+    #[arg(long, value_name = "COMPONENT")]
+    component: Option<String>,
+
+    /// Override the component checkout path for this invocation
+    #[arg(long)]
+    path: Option<String>,
+
+    /// Iterations per scenario. Forwarded to the bench runner.
+    #[arg(long, default_value_t = 10)]
+    iterations: u64,
+
+    /// Warmup iterations to run before measured iterations.
+    #[arg(long, value_name = "N", allow_hyphen_values = true)]
+    warmup: Option<u64>,
+
+    /// Number of repetitions (independent substrate spawns).
+    #[arg(long, default_value_t = 1, value_name = "COUNT", value_parser = crate::commands::parse_runs_count)]
+    runs: u64,
+
+    /// Caller-supplied stable proof label for this run.
+    #[arg(long = "run-id", value_name = "ID")]
+    run_id: Option<String>,
+
+    /// Directory shared across bench runner instances.
+    #[arg(long, value_name = "DIR")]
+    shared_state: Option<std::path::PathBuf>,
+
+    /// Number of concurrent bench runner instances.
+    #[arg(long, default_value_t = 1)]
+    concurrency: u32,
+
+    #[command(flatten)]
+    setting_args: SettingArgs,
+
+    /// Print compact machine-readable bench summary.
+    #[arg(long)]
+    json_summary: bool,
+
+    /// Additional arguments to pass to the bench runner (must follow --)
+    #[arg(last = true)]
+    args: Vec<String>,
+}
+
 pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOutput> {
     match args.command {
         RigCommand::List => list(),
@@ -250,6 +315,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Down { rig_id } => down(&rig_id),
         RigCommand::Repair { rig_id } => repair(&rig_id),
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
+        RigCommand::Run(args) => run_profile(args),
         RigCommand::Status { rig_id } => status(&rig_id),
         RigCommand::Runs { rig_id, limit } => runs(&rig_id, limit),
         RigCommand::ReleaseLock { rig_id, force } => release_lock(&rig_id, force),
@@ -686,6 +752,74 @@ fn sync(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
     ))
 }
 
+fn run_profile(args: RigRunArgs) -> CmdResult<RigCommandOutput> {
+    let source_update = refresh_rig_source_if_materialized(&args.rig_id)?;
+    let rig = rig::load(&args.rig_id)?;
+    let sync_report = rig::run_sync(&rig, false)?;
+    let bench_options = rig_run_bench_options(args);
+    let profile = bench_options.profile.clone();
+    let bench_invocation = bench_options.bench_plan();
+
+    if !sync_report.success {
+        return Ok((
+            RigCommandOutput::Run(RigRunOutput {
+                command: "rig.run",
+                rig_id: rig.id,
+                profile,
+                source_update,
+                sync: sync_report,
+                bench_invocation,
+                bench: None,
+            }),
+            1,
+        ));
+    }
+
+    let (bench, bench_exit_code) = super::bench::run_rig_profile(bench_options)?;
+    Ok((
+        RigCommandOutput::Run(RigRunOutput {
+            command: "rig.run",
+            rig_id: rig.id,
+            profile,
+            source_update,
+            sync: sync_report,
+            bench_invocation,
+            bench: Some(bench),
+        }),
+        bench_exit_code,
+    ))
+}
+
+fn refresh_rig_source_if_materialized(
+    rig_id: &str,
+) -> homeboy::core::Result<Option<rig::RigSourceUpdateResult>> {
+    let Some(metadata) = rig::read_source_metadata(rig_id) else {
+        return Ok(None);
+    };
+    if metadata.linked {
+        return Ok(None);
+    }
+    Ok(Some(rig::update_source_for_rig(rig_id)?))
+}
+
+fn rig_run_bench_options(args: RigRunArgs) -> RigRunBenchOptions {
+    RigRunBenchOptions {
+        rig_id: args.rig_id,
+        profile: args.profile,
+        component: args.component,
+        path: args.path,
+        iterations: args.iterations,
+        warmup: args.warmup,
+        runs: args.runs,
+        run_id: args.run_id,
+        shared_state: args.shared_state,
+        concurrency: args.concurrency,
+        settings: args.setting_args,
+        json_summary: args.json_summary,
+        passthrough_args: args.args,
+    }
+}
+
 fn status(rig_id: &str) -> CmdResult<RigCommandOutput> {
     let rig = rig::load(rig_id)?;
     let report = rig::run_status(&rig)?;
@@ -785,6 +919,123 @@ mod tests {
         };
         assert_eq!(target, "studio-bfb");
         assert_eq!(path.as_deref(), Some("/tmp/studio"));
+    }
+
+    #[test]
+    fn parses_rig_run_profile_and_bench_settings() {
+        let cli = TestCli::try_parse_from([
+            "homeboy",
+            "run",
+            "static-site-importer-fixture-matrix",
+            "--profile",
+            "fixture-matrix",
+            "--iterations",
+            "1",
+            "--setting",
+            "bench_env.CORPUS_SIZE=44",
+            "--setting-json",
+            "artifact_env={\"KEEP\":\"1\"}",
+            "--json-summary",
+            "--",
+            "--full",
+        ])
+        .expect("rig run should parse profile and bench settings");
+
+        let RigCommand::Run(args) = cli.rig.command else {
+            panic!("expected rig run command");
+        };
+        assert_eq!(args.rig_id, "static-site-importer-fixture-matrix");
+        assert_eq!(args.profile, "fixture-matrix");
+        assert_eq!(args.iterations, 1);
+        assert_eq!(
+            args.setting_args.setting,
+            vec![("bench_env.CORPUS_SIZE".to_string(), "44".to_string())]
+        );
+        assert_eq!(args.args, vec!["--full".to_string()]);
+    }
+
+    #[test]
+    fn rig_run_accepts_global_runner_after_subcommand() {
+        let cli = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "rig",
+            "run",
+            "static-site-importer-fixture-matrix",
+            "--profile",
+            "fixture-matrix",
+            "--runner",
+            "homeboy-lab",
+        ])
+        .expect("global --runner should parse for rig run");
+
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        let crate::cli_surface::Commands::Rig(args) = cli.command else {
+            panic!("expected rig command");
+        };
+        assert!(matches!(args.command, RigCommand::Run(_)));
+    }
+
+    #[test]
+    fn rig_run_builds_canonical_bench_invocation() {
+        let args = RigRunArgs {
+            rig_id: "static-site-importer-fixture-matrix".to_string(),
+            profile: "fixture-matrix".to_string(),
+            component: None,
+            path: Some("/tmp/static-site-importer".to_string()),
+            iterations: 3,
+            warmup: Some(1),
+            runs: 2,
+            run_id: Some("proof-7118".to_string()),
+            shared_state: Some(std::path::PathBuf::from("/tmp/homeboy-shared")),
+            concurrency: 4,
+            setting_args: SettingArgs {
+                setting: vec![("bench_env.CORPUS_SIZE".to_string(), "44".to_string())],
+                setting_json: vec![(
+                    "artifact_env".to_string(),
+                    serde_json::json!({ "KEEP": "1" }),
+                )],
+            },
+            json_summary: true,
+            args: vec!["--full".to_string()],
+        };
+
+        let plan = rig_run_bench_options(args).bench_plan();
+
+        assert_eq!(
+            plan.command,
+            vec![
+                "homeboy",
+                "bench",
+                "--rig",
+                "static-site-importer-fixture-matrix",
+                "--profile",
+                "fixture-matrix",
+                "--iterations",
+                "3",
+                "--path",
+                "/tmp/static-site-importer",
+                "--warmup",
+                "1",
+                "--runs",
+                "2",
+                "--run-id",
+                "proof-7118",
+                "--shared-state",
+                "/tmp/homeboy-shared",
+                "--concurrency",
+                "4",
+                "--setting",
+                "bench_env.CORPUS_SIZE=44",
+                "--setting-json",
+                "artifact_env={\"KEEP\":\"1\"}",
+                "--json-summary",
+                "--",
+                "--full",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -5,6 +5,7 @@
 
 use serde::Serialize;
 
+use crate::commands::bench::{BenchOutput, RigRunBenchPlan};
 use crate::commands::runs::RunsOutput;
 use homeboy::core::rig::{self, RigResourcesSpec, RigSpec};
 
@@ -27,6 +28,20 @@ pub enum RigCommandOutput {
     App(RigAppOutput),
     Runs(RunsOutput),
     ReleaseLock(RigReleaseLockOutput),
+    Run(RigRunOutput),
+}
+
+#[derive(Serialize)]
+pub struct RigRunOutput {
+    pub command: &'static str,
+    pub rig_id: String,
+    pub profile: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_update: Option<rig::RigSourceUpdateResult>,
+    pub sync: rig::RigStackSyncReport,
+    pub bench_invocation: RigRunBenchPlan,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bench: Option<BenchOutput>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary
- Add `homeboy rig run <rig-id> --profile <profile>` as a first-class rig profile execution primitive.
- Refresh non-linked installed rig sources, sync declared rig stacks, then dispatch through existing bench internals for `bench --rig ... --profile ...` behavior.
- Include structured output with source update, sync report, canonical bench invocation, and bench result payload.

## Tests
- `cargo check`
- `cargo test commands::rig::tests::`
- `cargo test command_surface`

Closes #7118.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the rig run command, bench invocation helper, and tests.