### PR TITLE
Register artifact postprocess contract

### DIFF
--- a/docs/architecture/artifact-postprocess-runner-contract.md
+++ b/docs/architecture/artifact-postprocess-runner-contract.md
@@ -2,7 +2,7 @@
 
 Homeboy core owns a product-neutral artifact postprocess contract for persisted artifact roots.
 
-The contract schema is `homeboy/artifact-postprocess-plan/v1`. A plan declares:
+The contract schema is `homeboy/artifact-postprocess/v1`. A plan declares:
 
 - `artifact_roots`: persisted artifact roots or runner artifact refs the postprocess action reads from.
 - `actions`: helper/action invocations with optional inputs, parameters, required flags, and output paths confined under the artifact root.

--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -29,9 +29,10 @@ pub use crate::core::artifact_ref::{
     validate_reviewer_facing_artifact_ref, ArtifactReference, ReviewerFacingArtifactRefError,
 };
 pub use constants::{
-    artifact_manifest_constants, contract_constants, loop_constants, reviewer_facing_ref_constants,
-    run_location_index_constants, secret_env_plan_constants, AllContractConstants,
-    ArtifactManifestConstants, ContractConstants, ContractConstantsOutput, LoopConstants,
+    artifact_manifest_constants, artifact_postprocess_constants, contract_constants,
+    loop_constants, reviewer_facing_ref_constants, run_location_index_constants,
+    secret_env_plan_constants, AllContractConstants, ArtifactManifestConstants,
+    ArtifactPostprocessConstants, ContractConstants, ContractConstantsOutput, LoopConstants,
     ReviewerFacingRefConstants, RunLocationIndexConstants, SecretEnvPlanConstants,
     CONTRACT_CONSTANTS_SCHEMA,
 };
@@ -76,5 +77,6 @@ pub use crate::core::artifacts::{
     ArtifactPostprocessAction, ArtifactPostprocessPlan, ArtifactPostprocessPlanDescription,
     ArtifactPostprocessResult, ArtifactPostprocessReviewerRef, ArtifactPostprocessRoot,
     ARTIFACT_POSTPROCESS_PLAN_SCHEMA, ARTIFACT_POSTPROCESS_RESULT_SCHEMA,
+    ARTIFACT_POSTPROCESS_SCHEMA,
 };
 pub use crate::core::run_lifecycle_status::{RunLifecycleStatus, RUN_LIFECYCLE_STATUS_SCHEMA};

--- a/src/command_contract/constants.rs
+++ b/src/command_contract/constants.rs
@@ -22,6 +22,7 @@ pub struct ContractConstantsOutput {
 pub enum ContractConstants {
     All(AllContractConstants),
     ArtifactManifest(ArtifactManifestConstants),
+    ArtifactPostprocess(ArtifactPostprocessConstants),
     Loop(LoopConstants),
     SecretEnvPlan(SecretEnvPlanConstants),
     RunLocationIndex(RunLocationIndexConstants),
@@ -31,6 +32,7 @@ pub enum ContractConstants {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AllContractConstants {
     pub artifact_manifest: ArtifactManifestConstants,
+    pub artifact_postprocess: ArtifactPostprocessConstants,
     pub loop_contracts: LoopConstants,
     pub secret_env_plan: SecretEnvPlanConstants,
     pub run_location_index: RunLocationIndexConstants,
@@ -41,6 +43,11 @@ pub struct AllContractConstants {
 pub struct ArtifactManifestConstants {
     pub schema_id: String,
     pub file_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactPostprocessConstants {
+    pub schema_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -71,12 +78,16 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
     let constants = match normalized {
         "all" => ContractConstants::All(AllContractConstants {
             artifact_manifest: artifact_manifest_constants(),
+            artifact_postprocess: artifact_postprocess_constants(),
             loop_contracts: loop_constants(),
             secret_env_plan: secret_env_plan_constants(),
             run_location_index: run_location_index_constants(),
             reviewer_facing_ref: reviewer_facing_ref_constants(),
         }),
         "artifact-manifest" => ContractConstants::ArtifactManifest(artifact_manifest_constants()),
+        "artifact-postprocess" => {
+            ContractConstants::ArtifactPostprocess(artifact_postprocess_constants())
+        }
         "loop" | "loop-contracts" => ContractConstants::Loop(loop_constants()),
         "secret-env-plan" => ContractConstants::SecretEnvPlan(secret_env_plan_constants()),
         "run-location-index" => ContractConstants::RunLocationIndex(run_location_index_constants()),
@@ -97,6 +108,12 @@ pub fn artifact_manifest_constants() -> ArtifactManifestConstants {
     ArtifactManifestConstants {
         schema_id: registry_schema_id("artifact-manifest"),
         file_name: RUNNER_ARTIFACT_MANIFEST_FILE.to_string(),
+    }
+}
+
+pub fn artifact_postprocess_constants() -> ArtifactPostprocessConstants {
+    ArtifactPostprocessConstants {
+        schema_id: registry_schema_id("artifact-postprocess"),
     }
 }
 

--- a/src/command_contract/registry.rs
+++ b/src/command_contract/registry.rs
@@ -75,6 +75,14 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         rust_type: "homeboy::core::artifact_manifest::ArtifactManifest",
     },
     ContractRegistryEntry {
+        schema_id: crate::core::artifacts::ARTIFACT_POSTPROCESS_SCHEMA,
+        name: "artifact-postprocess",
+        title: "Artifact postprocess plan",
+        owner: "homeboy-core",
+        summary: "Declares generic helper-driven postprocessing actions for produced artifacts without product-specific semantics.",
+        rust_type: "homeboy::core::artifact_postprocess::ArtifactPostprocessPlan",
+    },
+    ContractRegistryEntry {
         schema_id: crate::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA,
         name: "secret-env-plan",
         title: "Secret environment plan",
@@ -167,6 +175,7 @@ mod tests {
             "lifecycle-snapshot-ref",
             "run-lifecycle-status",
             "artifact-manifest",
+            "artifact-postprocess",
             "secret-env-plan",
             "fuzz-workload",
             "resource-cleanup-intent",

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -8,14 +8,16 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::command_contract::{
-    contract_constants, registered_contract, registered_contracts, CommandDispatchFamily,
-    CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode, CommandRawOutputMode,
-    CommandResponseMode, CommandStdoutMode, ContractConstantsOutput, ContractRegistryEntry,
-    COMMAND_REGISTRY, PUBLIC_OUTPUT_VARIANT_CONTRACTS, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+    contract_constants, registered_contract, registered_contracts, ArtifactPostprocessPlan,
+    CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+    CommandRawOutputMode, CommandResponseMode, CommandStdoutMode, ContractConstantsOutput,
+    ContractRegistryEntry, ARTIFACT_POSTPROCESS_SCHEMA, COMMAND_REGISTRY,
+    PUBLIC_OUTPUT_VARIANT_CONTRACTS, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
     RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA, RUN_LOCATION_INDEX_SCHEMA,
 };
 use crate::commands::{adapter, CmdResult, GlobalArgs};
 use crate::core::artifact_ref::{validate_reviewer_facing_artifact_ref, ArtifactReference};
+use crate::core::artifacts::validate_artifact_postprocess_plan;
 use crate::core::fuzz::{FuzzWorkload, FUZZ_WORKLOAD_SCHEMA};
 use crate::core::loop_lifecycle::{
     LoopEvidenceRecord, LoopIterationRecord, LoopRunRecord, LOOP_EVIDENCE_SCHEMA,
@@ -398,7 +400,7 @@ fn constants(contract_id: &str) -> CmdResult<ContractOutput> {
             format!("unknown contract constants id `{contract_id}`"),
             None,
             Some(vec![
-                "Use one of: all, artifact-manifest, loop, secret-env-plan, run-location-index, reviewer-facing-ref".to_string(),
+                    "Use one of: all, artifact-manifest, artifact-postprocess, loop, secret-env-plan, run-location-index, reviewer-facing-ref".to_string(),
             ]),
         )
     })?;
@@ -683,6 +685,42 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
             "Homeboy-owned schema IDs and canonical examples for cross-language contract tests.",
         contracts: vec![
             ContractSchemaEntry {
+                id: ARTIFACT_POSTPROCESS_SCHEMA,
+                version: 1,
+                description:
+                    "Generic artifact postprocess plan consumed by Homeboy artifact runners.",
+                fields: vec![
+                    field(
+                        "schema",
+                        "string",
+                        "Schema ID for the artifact postprocess plan.",
+                        true,
+                    ),
+                    field("plan_id", "string", "Stable plan identifier.", true),
+                    field(
+                        "artifact_roots",
+                        "array",
+                        "Persisted artifact roots available to postprocess actions.",
+                        true,
+                    ),
+                    field(
+                        "actions",
+                        "array",
+                        "Helper/action declarations to run against artifacts.",
+                        false,
+                    ),
+                    field(
+                        "reviewer_refs",
+                        "array",
+                        "Optional reviewer-facing references emitted with the result.",
+                        false,
+                    ),
+                    field("metadata", "object|null", "Generic plan metadata.", false),
+                ],
+                required: vec!["schema", "plan_id", "artifact_roots"],
+                example: artifact_postprocess_example(),
+            },
+            ContractSchemaEntry {
                 id: RUNNER_WORKLOAD_SCHEMA,
                 version: 1,
                 description: "Runner-resident workload request consumed by Lab runners.",
@@ -839,6 +877,34 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
             },
         ],
     }
+}
+
+fn artifact_postprocess_example() -> Value {
+    json!({
+        "schema": ARTIFACT_POSTPROCESS_SCHEMA,
+        "plan_id": "artifact-postprocess-1",
+        "artifact_roots": [
+            {
+                "id": "primary",
+                "path": "artifacts",
+                "persisted_ref": "runner-artifact://run-1/artifacts",
+                "manifest_path": "homeboy-artifact-manifest.json"
+            }
+        ],
+        "actions": [
+            {
+                "id": "summarize",
+                "helper": "artifact-helper",
+                "action": "summarize",
+                "input": "artifacts/input.json",
+                "output": "artifact-postprocess/summary.json",
+                "parameters": {},
+                "required": true
+            }
+        ],
+        "reviewer_refs": [],
+        "metadata": {}
+    })
 }
 
 fn runner_workload_example() -> Value {
@@ -1031,6 +1097,10 @@ fn resolve_schema(schema_id: &str) -> homeboy::core::Result<&'static ContractSch
 
 static CONTRACT_SCHEMAS: &[ContractSchema] = &[
     ContractSchema {
+        id: ARTIFACT_POSTPROCESS_SCHEMA,
+        validate_json: validate_artifact_postprocess,
+    },
+    ContractSchema {
         id: SECRET_ENV_PLAN_SCHEMA,
         validate_json: validate_secret_env_plan,
     },
@@ -1059,6 +1129,11 @@ static CONTRACT_SCHEMAS: &[ContractSchema] = &[
 fn validate_secret_env_plan(raw: &str) -> homeboy::core::Result<()> {
     let plan: SecretEnvPlan = deserialize_contract(raw, SECRET_ENV_PLAN_SCHEMA)?;
     validate_schema_field(SECRET_ENV_PLAN_SCHEMA, &plan.schema)
+}
+
+fn validate_artifact_postprocess(raw: &str) -> homeboy::core::Result<()> {
+    let plan: ArtifactPostprocessPlan = deserialize_contract(raw, ARTIFACT_POSTPROCESS_SCHEMA)?;
+    validate_artifact_postprocess_plan(&plan)
 }
 
 fn validate_fuzz_workload(raw: &str) -> homeboy::core::Result<()> {
@@ -1207,6 +1282,11 @@ mod tests {
             .unwrap()
             .iter()
             .any(|contract| contract["id"] == RUNNER_WORKLOAD_SCHEMA));
+        assert!(catalog["contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|contract| contract["id"] == ARTIFACT_POSTPROCESS_SCHEMA));
     }
 
     #[test]
@@ -1262,6 +1342,27 @@ mod tests {
             output.contract.schema_id,
             crate::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA
         );
+    }
+
+    #[test]
+    fn show_resolves_artifact_postprocess_contract_by_schema_id() {
+        let (output, exit_code) = run(
+            ContractArgs {
+                command: ContractCommand::Show(ContractShowArgs {
+                    schema_id_or_name: ARTIFACT_POSTPROCESS_SCHEMA.to_string(),
+                }),
+            },
+            &GlobalArgs {},
+        )
+        .expect("show artifact postprocess contract");
+
+        assert_eq!(exit_code, 0);
+        let ContractOutput::Show(output) = output else {
+            panic!("expected show output");
+        };
+        assert_eq!(output.kind, "show");
+        assert_eq!(output.contract.schema_id, ARTIFACT_POSTPROCESS_SCHEMA);
+        assert_eq!(output.contract.name, "artifact-postprocess");
     }
 
     #[test]
@@ -1333,6 +1434,50 @@ mod tests {
 
         assert_eq!(output.schema, SECRET_ENV_PLAN_SCHEMA);
         assert!(output.valid);
+    }
+
+    #[test]
+    fn validates_artifact_postprocess_json_file() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "artifact-postprocess.json",
+            json!({
+                "schema": ARTIFACT_POSTPROCESS_SCHEMA,
+                "plan_id": "postprocess-1",
+                "artifact_roots": [
+                    {
+                        "id": "primary",
+                        "path": "artifacts"
+                    }
+                ],
+                "actions": []
+            }),
+        );
+
+        let output = validate_file(ARTIFACT_POSTPROCESS_SCHEMA, file).unwrap();
+
+        assert_eq!(output.schema, ARTIFACT_POSTPROCESS_SCHEMA);
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn rejects_invalid_artifact_postprocess_json_file() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "artifact-postprocess-invalid.json",
+            json!({
+                "schema": ARTIFACT_POSTPROCESS_SCHEMA,
+                "plan_id": "postprocess-1",
+                "artifact_roots": []
+            }),
+        );
+
+        let err = validate_file(ARTIFACT_POSTPROCESS_SCHEMA, file)
+            .expect_err("empty artifact roots should fail");
+
+        assert!(err.message.contains("artifact postprocess plan"));
     }
 
     #[test]

--- a/src/core/artifact_postprocess.rs
+++ b/src/core/artifact_postprocess.rs
@@ -14,7 +14,8 @@ use crate::core::artifact_manifest::{self, ARTIFACT_MANIFEST_FILE};
 use crate::core::error::{Error, Result};
 use crate::core::observation::{ArtifactRecord, ObservationStore};
 
-pub const ARTIFACT_POSTPROCESS_PLAN_SCHEMA: &str = "homeboy/artifact-postprocess-plan/v1";
+pub const ARTIFACT_POSTPROCESS_SCHEMA: &str = "homeboy/artifact-postprocess/v1";
+pub const ARTIFACT_POSTPROCESS_PLAN_SCHEMA: &str = ARTIFACT_POSTPROCESS_SCHEMA;
 pub const ARTIFACT_POSTPROCESS_RESULT_SCHEMA: &str = "homeboy/artifact-postprocess-result/v1";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -39,6 +39,7 @@ pub use super::artifact_postprocess::{
     ArtifactPostprocessOutput, ArtifactPostprocessPlan, ArtifactPostprocessPlanDescription,
     ArtifactPostprocessProducedArtifact, ArtifactPostprocessResult, ArtifactPostprocessReviewerRef,
     ArtifactPostprocessRoot, ARTIFACT_POSTPROCESS_PLAN_SCHEMA, ARTIFACT_POSTPROCESS_RESULT_SCHEMA,
+    ARTIFACT_POSTPROCESS_SCHEMA,
 };
 pub use super::artifact_preview::{html_preview_entrypoints, ArtifactPreviewEntrypoint};
 pub use super::artifact_ref::{

--- a/tests/contract_constants_test.rs
+++ b/tests/contract_constants_test.rs
@@ -20,6 +20,10 @@ fn contract_constants_exports_homeboy_owned_contract_ids() {
         "homeboy-artifact-manifest.json"
     );
     assert_eq!(
+        value["constants"]["artifact_postprocess"]["schema_id"],
+        "homeboy/artifact-postprocess/v1"
+    );
+    assert_eq!(
         value["constants"]["secret_env_plan"]["schema_id"],
         "homeboy/secret-env-plan/v1"
     );


### PR DESCRIPTION
## Summary
- Registers the generic `homeboy/artifact-postprocess/v1` contract in the core contract registry.
- Adds schema catalog/export metadata, constants exposure, and validation using the existing artifact postprocess plan validator.
- Updates focused tests for show, export inclusion, constants, and valid/invalid artifact postprocess payloads.

## Tests
- `cargo test commands::contract::tests --lib`
- `cargo test --test contract_constants_test`
- `cargo test command_contract::registry::tests --lib`
- `target/debug/homeboy contract show homeboy/artifact-postprocess/v1`
- `target/debug/homeboy contract list`
- `git diff --check`

## Notes
- `cargo fmt --check` reports pre-existing formatting drift outside this PR's touched files, so only touched Rust files were formatted with `rustfmt`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the contract registration, validation/catalog wiring, focused tests, and PR preparation.