### PR TITLE
Keep cook agents out of git finalization

### DIFF
--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -748,7 +748,7 @@ fn render_prompt(
     worktree: &str,
 ) -> String {
     let template = template.unwrap_or(
-        "Fix {issue_url}. Inspect the issue, implement the smallest correct change in {repo}, run the requested verification gates, push {branch}, and open/update the PR with reviewer-ready evidence.",
+        "Fix {issue_url}. Inspect the issue, implement the smallest correct change in {repo}, run the requested verification gates, and report the changed files plus verification results. Homeboy deterministic finalization is enabled: Homeboy will commit, push {branch}, open/update the PR, add AI disclosure, and finalize reviewer-ready evidence after gates pass. Do not inspect credentials, configure git identity, commit, push, or open/update the PR yourself.",
     );
     template
         .replace("{issue_url}", &issue.url)
@@ -1058,6 +1058,11 @@ mod tests {
             .as_deref()
             .expect("prompt")
             .contains("https://github.com/Extra-Chill/homeboy/issues/6453"));
+        let prompt = plan.cooks[0].prompt.as_deref().expect("prompt");
+        assert!(prompt.contains("Homeboy will commit, push fix/issue-6453-homeboy"));
+        assert!(prompt.contains("open/update the PR"));
+        assert!(prompt.contains("add AI disclosure"));
+        assert!(prompt.contains("Do not inspect credentials, configure git identity, commit, push"));
         assert_eq!(plan.cooks[0].verify, vec!["cargo test --lib"]);
         assert_eq!(plan.cooks[0].backend.as_deref(), Some("sandbox"));
 
@@ -1067,6 +1072,23 @@ mod tests {
         assert_eq!(
             invocation.dispatch.workspace.as_deref(),
             Some("homeboy@fix-issue-6453-homeboy")
+        );
+    }
+
+    #[test]
+    fn cook_batch_preserves_explicit_prompt_template_for_manual_pr_modes() {
+        let mut args = cook_batch_args();
+        args.prompt_template = Some(
+            "Fix {issue_ref} on {branch}; push manually and open the pull request.".to_string(),
+        );
+
+        let plan = build_cook_batch_plan(&args).expect("cook batch plan");
+
+        assert_eq!(
+            plan.cooks[0].prompt.as_deref(),
+            Some(
+                "Fix Extra-Chill/homeboy#6453 on fix/issue-6453-homeboy; push manually and open the pull request."
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
- Update generated cook-batch prompts so agents edit, test, and report instead of committing, pushing, or opening PRs.
- Make Homeboy finalization responsibilities explicit in the default prompt.
- Preserve explicit prompt templates for manual PR modes.

## Why
Homeboy owns deterministic finalization. Agent prompts should not encourage credential inspection, git identity setup, commits, pushes, or PR creation from provider runtimes.

## Verification
- cargo test cook_batch_preserves_explicit_prompt_template_for_manual_pr_modes
- cargo test cook_batch
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting the prompt contract update and regression tests.