### PR TITLE
Promote committed agent-task changes

### DIFF
--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -3,7 +3,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
-use std::path::PathBuf;
 
 use homeboy::core::agent_tasks::batch;
 use homeboy::core::agent_tasks::dispatch_service::{
@@ -523,16 +522,10 @@ impl BatchCookSpec {
             .commit_message
             .clone()
             .unwrap_or_else(|| default_cook_commit_message(self));
-        let source_worktree_path = self
-            .cwd
-            .clone()
-            .or_else(|| {
-                self.workspace.as_ref().and_then(|workspace| {
-                    let path = PathBuf::from(workspace);
-                    path.exists().then(|| workspace.clone())
-                })
-            })
-            .map(PathBuf::from);
+        let source_worktree_path = agent_task_service::source_worktree_path(
+            self.cwd.clone(),
+            self.workspace.clone(),
+        );
         Ok(BatchCookInvocation {
             dispatch,
             options: AgentTaskCookServiceOptions {

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
+use std::path::PathBuf;
 
 use homeboy::core::agent_tasks::batch;
 use homeboy::core::agent_tasks::dispatch_service::{
@@ -522,12 +523,23 @@ impl BatchCookSpec {
             .commit_message
             .clone()
             .unwrap_or_else(|| default_cook_commit_message(self));
+        let source_worktree_path = self
+            .cwd
+            .clone()
+            .or_else(|| {
+                self.workspace.as_ref().and_then(|workspace| {
+                    let path = PathBuf::from(workspace);
+                    path.exists().then(|| workspace.clone())
+                })
+            })
+            .map(PathBuf::from);
         Ok(BatchCookInvocation {
             dispatch,
             options: AgentTaskCookServiceOptions {
                 cook_id: self.cook_id.clone(),
                 initial_run_id: self.run_id(),
                 to_worktree: self.to_worktree.clone(),
+                source_worktree_path,
                 provider_command: self.provider_command.clone(),
                 gates: VerifyGateOptions {
                     verify: self.verify.clone(),

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -551,18 +551,11 @@ impl BatchCookSpec {
                 ai_model: self
                     .model
                     .clone()
-                    .or_else(|| ai_model_from_tool(&self.ai_tool)),
+                    .or_else(|| agent_task_service::ai_model_from_tool(&self.ai_tool)),
                 ai_used_for: self.ai_used_for.clone(),
             },
         })
     }
-}
-
-fn ai_model_from_tool(ai_tool: &str) -> Option<String> {
-    let start = ai_tool.find('(')?;
-    let end = ai_tool[start + 1..].find(')')? + start + 1;
-    let model = ai_tool[start + 1..end].trim();
-    (!model.is_empty()).then(|| model.to_string())
 }
 
 fn default_cook_title(cook: &BatchCookSpec) -> String {

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -200,6 +200,8 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
         source: raw,
         source_run_id: source_run_id.clone(),
         source_path,
+        source_worktree_path: None,
+        base_ref: None,
         to_worktree: args.to_worktree,
         task_id: args.task_id,
         artifact_id: args.artifact_id,

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -2,6 +2,7 @@
 //! resume, and retry.
 
 use serde_json::Value;
+use std::path::PathBuf;
 
 use homeboy::core::agent_tasks::dispatch_service;
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
@@ -70,11 +71,23 @@ where
         .commit_message
         .clone()
         .unwrap_or_else(|| default_loop_commit_message(&args));
+    let source_worktree_path = args
+        .dispatch
+        .cwd
+        .clone()
+        .or_else(|| {
+            args.dispatch.workspace.as_ref().and_then(|workspace| {
+                let path = PathBuf::from(workspace);
+                path.exists().then(|| workspace.clone())
+            })
+        })
+        .map(PathBuf::from);
     let result = agent_task_service::run_cook(
         agent_task_service::AgentTaskCookServiceOptions {
             cook_id,
             initial_run_id: run_id,
             to_worktree: args.to_worktree,
+            source_worktree_path,
             provider_command: args.provider_command,
             gates: args.gates.into(),
             max_attempts: args.max_attempts,

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -2,7 +2,6 @@
 //! resume, and retry.
 
 use serde_json::Value;
-use std::path::PathBuf;
 
 use homeboy::core::agent_tasks::dispatch_service;
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
@@ -71,17 +70,10 @@ where
         .commit_message
         .clone()
         .unwrap_or_else(|| default_loop_commit_message(&args));
-    let source_worktree_path = args
-        .dispatch
-        .cwd
-        .clone()
-        .or_else(|| {
-            args.dispatch.workspace.as_ref().and_then(|workspace| {
-                let path = PathBuf::from(workspace);
-                path.exists().then(|| workspace.clone())
-            })
-        })
-        .map(PathBuf::from);
+    let source_worktree_path = agent_task_service::source_worktree_path(
+        args.dispatch.cwd.clone(),
+        args.dispatch.workspace.clone(),
+    );
     let result = agent_task_service::run_cook(
         agent_task_service::AgentTaskCookServiceOptions {
             cook_id,

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -94,7 +94,7 @@ where
             ai_model: args
                 .dispatch
                 .model
-                .or_else(|| ai_model_from_tool(&args.ai_tool)),
+                .or_else(|| agent_task_service::ai_model_from_tool(&args.ai_tool)),
             ai_used_for: args.ai_used_for,
         },
         executor,
@@ -103,13 +103,6 @@ where
         serde_json::to_value(result.value).unwrap_or(Value::Null),
         result.exit_code,
     ))
-}
-
-fn ai_model_from_tool(ai_tool: &str) -> Option<String> {
-    let start = ai_tool.find('(')?;
-    let end = ai_tool[start + 1..].find(')')? + start + 1;
-    let model = ai_tool[start + 1..end].trim();
-    (!model.is_empty()).then(|| model.to_string())
 }
 
 fn default_loop_title(args: &AgentTaskCookArgs) -> String {

--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -8,16 +8,12 @@
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::path::{Path, PathBuf};
 
 use homeboy::core::agent_task_service as agent_task_service_direct;
 use homeboy::core::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::core::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use homeboy::core::agent_tasks::service as agent_task_service;
 use homeboy::core::agent_tasks::{AgentTaskEvidenceRef, AgentTaskOutcomeStatus};
-use homeboy::core::observation::ObservationStore;
-use homeboy::core::redaction::{self, RedactionPolicy};
 
 use super::super::CmdResult;
 use super::args::{CancelArgs, DiagnoseArgs, EvidenceArgs, ReplayProviderBoundaryArgs, StatusArgs};
@@ -26,7 +22,6 @@ use super::args::{CancelArgs, DiagnoseArgs, EvidenceArgs, ReplayProviderBoundary
 /// aggregate cannot flood recovery output. Overflow is reported as an
 /// `omitted` count rather than dropped silently.
 const COMPACT_REF_LIMIT: usize = 12;
-const EVIDENCE_TEXT_LIMIT: usize = 16 * 1024;
 
 pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     if args.bridge {
@@ -40,7 +35,9 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     let record = match agent_task_service::status(&args.run_id) {
         Ok(record) => record,
         Err(error) if is_missing_agent_task_run_metadata_error(&error) => {
-            if let Some(remediation) = offloaded_status_remediation(&args.run_id)? {
+            if let Some(remediation) =
+                agent_task_service::offloaded_status_remediation(&args.run_id)?
+            {
                 return Ok((remediation, 1));
             }
             return Err(error);
@@ -59,72 +56,6 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
 fn is_missing_agent_task_run_metadata_error(error: &homeboy::core::Error) -> bool {
     error.code == homeboy::core::ErrorCode::InternalJsonError
         && error.message.contains("is missing agent_task_run metadata")
-}
-
-fn offloaded_status_remediation(run_id: &str) -> homeboy::core::Result<Option<Value>> {
-    let Some(run) = ObservationStore::open_initialized()?.get_run(run_id)? else {
-        return Ok(None);
-    };
-    let Some(runner_id) = metadata_string(
-        &run.metadata_json,
-        &[&["runner_id"], &["identity", "runner_id"]],
-    )
-    .filter(|runner_id| !runner_id.trim().is_empty()) else {
-        return Ok(None);
-    };
-    let runner_job_id = metadata_string(
-        &run.metadata_json,
-        &[
-            &["runner_job_id"],
-            &["job_id"],
-            &["identity", "runner_job_id"],
-        ],
-    );
-
-    Ok(Some(runner_status_remediation(
-        run_id,
-        &runner_id,
-        runner_job_id.as_deref(),
-    )))
-}
-
-fn runner_status_remediation(run_id: &str, runner_id: &str, runner_job_id: Option<&str>) -> Value {
-    let command_prefix = format!("homeboy --runner {runner_id} agent-task");
-    let mut commands = vec![
-        format!("{command_prefix} status {run_id}"),
-        format!("{command_prefix} logs {run_id} --full"),
-        format!("{command_prefix} artifacts {run_id}"),
-    ];
-    if let Some(job_id) = runner_job_id.filter(|job_id| !job_id.trim().is_empty()) {
-        commands.push(format!(
-            "homeboy runner job logs {runner_id} {job_id} --full"
-        ));
-    }
-
-    json!({
-        "schema": "homeboy/agent-task-status-remediation/v1",
-        "status": "runner_status_required",
-        "run_id": run_id,
-        "runner_id": runner_id,
-        "runner_job_id": runner_job_id,
-        "message": "Local observation metadata does not contain an agent-task run record; query the runner that owns this durable run.",
-        "commands": commands,
-        "remediation": {
-            "status": format!("{command_prefix} status {run_id}"),
-            "logs": format!("{command_prefix} logs {run_id} --full"),
-            "artifacts": format!("{command_prefix} artifacts {run_id}"),
-        },
-    })
-}
-
-fn metadata_string(metadata: &Value, paths: &[&[&str]]) -> Option<String> {
-    paths.iter().find_map(|path| {
-        let mut current = metadata;
-        for segment in *path {
-            current = current.get(*segment)?;
-        }
-        current.as_str().map(str::to_string)
-    })
 }
 
 pub(super) fn list_runs(
@@ -250,7 +181,7 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
             continue;
         }
 
-        hydrated.push(hydrate_evidence_ref(
+        hydrated.push(agent_task_service::hydrate_evidence_ref(
             &args.run_id,
             &evidence_ref,
             task_id.as_deref(),
@@ -285,7 +216,9 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
     if let Some(aggregate) = aggregate.as_ref() {
         for outcome in &aggregate.outcomes {
             for evidence in &outcome.evidence_refs {
-                if let Some(summary) = hydrate_evidence_summary(&outcome.task_id, evidence) {
+                if let Some(summary) =
+                    agent_task_service::hydrate_evidence_summary(&outcome.task_id, evidence)
+                {
                     collect_nested_diagnostics(
                         &outcome.task_id,
                         summary.get("summary").unwrap_or(&Value::Null),
@@ -366,7 +299,7 @@ pub(super) fn replay_provider_boundary(args: ReplayProviderBoundaryArgs) -> CmdR
         ));
     };
 
-    let hydrated = hydrate_evidence_ref(
+    let hydrated = agent_task_service::hydrate_evidence_ref(
         &args.run_id,
         &evidence_ref,
         task_id.as_deref(),
@@ -390,7 +323,7 @@ pub(super) fn replay_provider_boundary(args: ReplayProviderBoundaryArgs) -> CmdR
         },
         "normalized_provider_boundary": boundary,
     });
-    let evidence_uri = persist_provider_boundary_replay_evidence(&report);
+    let evidence_uri = agent_task_service::persist_provider_boundary_replay_evidence(&report);
     let report = match evidence_uri {
         Some(uri) => {
             let mut report = report;
@@ -414,7 +347,9 @@ pub(super) fn cancel(args: CancelArgs) -> CmdResult<Value> {
     Ok((value, 0))
 }
 
-fn hydrated_executor_input_value(result: &HydratedEvidence) -> homeboy::core::Result<Value> {
+fn hydrated_executor_input_value(
+    result: &agent_task_service::AgentTaskHydratedEvidence,
+) -> homeboy::core::Result<Value> {
     if result.status != "ok" {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "executor-input evidence",
@@ -470,49 +405,13 @@ fn provider_boundary_projection(input: &Value) -> Value {
     })
 }
 
-fn persist_provider_boundary_replay_evidence(report: &Value) -> Option<String> {
-    let run_id = report.get("run_id")?.as_str().unwrap_or("unknown-run");
-    let task_id = report
-        .get("task_id")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown-task");
-    let dir = std::env::temp_dir()
-        .join("homeboy-agent-task-evidence")
-        .join(sanitize_evidence_path_part(run_id));
-    fs::create_dir_all(&dir).ok()?;
-    let path = dir.join(format!(
-        "provider-boundary-replay-{}.json",
-        sanitize_evidence_path_part(task_id)
-    ));
-    fs::write(&path, serde_json::to_vec_pretty(report).ok()?).ok()?;
-    Some(format!("file://{}", path.display()))
-}
-
-fn sanitize_evidence_path_part(value: &str) -> String {
-    let sanitized: String = value
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
-                character
-            } else {
-                '-'
-            }
-        })
-        .collect();
-    if sanitized.is_empty() {
-        "unknown".to_string()
-    } else {
-        sanitized
-    }
-}
-
 #[derive(Serialize)]
 struct AgentTaskEvidenceReport {
     schema: &'static str,
     run_id: String,
     filters: AgentTaskEvidenceFilters,
     count: usize,
-    evidence: Vec<HydratedEvidence>,
+    evidence: Vec<agent_task_service::AgentTaskHydratedEvidence>,
 }
 
 #[derive(Serialize)]
@@ -522,236 +421,7 @@ struct AgentTaskEvidenceFilters {
     failure_only: bool,
 }
 
-#[derive(Serialize)]
-struct HydratedEvidence {
-    kind: String,
-    label: Option<String>,
-    task_id: Option<String>,
-    uri: String,
-    source: String,
-    status: String,
-    truncated: bool,
-    bytes_read: Option<usize>,
-    omitted_bytes: Option<u64>,
-    content: Value,
-    error: Option<String>,
-}
-
-fn hydrate_evidence_ref(
-    run_id: &str,
-    evidence_ref: &AgentTaskEvidenceRef,
-    task_id: Option<&str>,
-    plan: Option<&AgentTaskPlan>,
-    aggregate: Option<&AgentTaskAggregate>,
-) -> HydratedEvidence {
-    let hydrated = if evidence_ref.uri.starts_with("homeboy://agent-task/") {
-        hydrate_homeboy_evidence_ref(run_id, &evidence_ref.uri, task_id, plan, aggregate)
-    } else if evidence_ref.uri.starts_with("file://") {
-        hydrate_file_evidence_ref(&evidence_ref.uri)
-    } else if let Some(path) = local_evidence_path(&evidence_ref.uri) {
-        hydrate_local_path_evidence_ref(&path)
-    } else {
-        Ok(HydratedContent {
-            source: "unsupported".to_string(),
-            truncated: false,
-            bytes_read: None,
-            omitted_bytes: None,
-            content: json!({
-                "summary": "Evidence ref is recorded but this URI scheme is not hydratable by agent-task evidence yet.",
-                "unsupported_ref": evidence_ref.uri,
-                "supported_refs": ["homeboy://agent-task/run/<run-id>/<section>", "file://<absolute-path>", "local filesystem path"],
-                "next_action": "Use a file:// URI or local path for evidence stored on this machine; otherwise inspect the producing provider or artifact store for this ref.",
-            }),
-        })
-    };
-
-    match hydrated {
-        Ok(content) => HydratedEvidence {
-            kind: evidence_ref.kind.clone(),
-            label: evidence_ref.label.clone(),
-            task_id: task_id.map(str::to_string),
-            uri: evidence_ref.uri.clone(),
-            source: content.source,
-            status: "ok".to_string(),
-            truncated: content.truncated,
-            bytes_read: content.bytes_read,
-            omitted_bytes: content.omitted_bytes,
-            content: redaction::redact_json(&content.content),
-            error: None,
-        },
-        Err(error) => HydratedEvidence {
-            kind: evidence_ref.kind.clone(),
-            label: evidence_ref.label.clone(),
-            task_id: task_id.map(str::to_string),
-            uri: evidence_ref.uri.clone(),
-            source: "error".to_string(),
-            status: "error".to_string(),
-            truncated: false,
-            bytes_read: None,
-            omitted_bytes: None,
-            content: Value::Null,
-            error: Some(redaction::redact_string(&error.message)),
-        },
-    }
-}
-
-struct HydratedContent {
-    source: String,
-    truncated: bool,
-    bytes_read: Option<usize>,
-    omitted_bytes: Option<u64>,
-    content: Value,
-}
-
-fn hydrate_homeboy_evidence_ref(
-    run_id: &str,
-    uri: &str,
-    task_id: Option<&str>,
-    plan: Option<&AgentTaskPlan>,
-    aggregate: Option<&AgentTaskAggregate>,
-) -> homeboy::core::Result<HydratedContent> {
-    let parsed = parse_agent_task_homeboy_uri(uri)?;
-    if parsed.run_id != run_id {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "evidence_ref",
-            format!(
-                "evidence ref points at run {} but command is hydrating run {run_id}",
-                parsed.run_id
-            ),
-            Some(uri.to_string()),
-            None,
-        ));
-    }
-
-    let content = match parsed.section.as_str() {
-        "plan" => match (plan, task_id.or(parsed.task.as_deref())) {
-            (Some(plan), Some(task_id)) => plan
-                .tasks
-                .iter()
-                .find(|task| task.task_id == task_id)
-                .map(|task| json!(task))
-                .unwrap_or_else(|| json!({ "missing_task": task_id })),
-            (Some(plan), None) => json!(plan),
-            (None, _) => json!({ "summary": "plan is not available for this run" }),
-        },
-        "aggregate" => match (aggregate, parsed.outcome.as_deref().or(task_id)) {
-            (Some(aggregate), Some(task_id)) => aggregate
-                .outcomes
-                .iter()
-                .find(|outcome| outcome.task_id == task_id)
-                .map(|outcome| json!(outcome))
-                .unwrap_or_else(|| json!({ "missing_outcome": task_id })),
-            (Some(aggregate), None) => json!(aggregate),
-            (None, _) => json!({ "summary": "aggregate is not available for this run" }),
-        },
-        "artifacts" => match (aggregate, task_id.or(parsed.task.as_deref())) {
-            (Some(aggregate), Some(task_id)) => aggregate
-                .outcomes
-                .iter()
-                .find(|outcome| outcome.task_id == task_id)
-                .map(|outcome| {
-                    json!({
-                        "task_id": outcome.task_id,
-                        "status": outcome.status,
-                        "summary": outcome.summary,
-                        "artifacts": outcome.artifacts,
-                        "typed_artifacts": outcome.typed_artifacts,
-                        "evidence_refs": outcome.evidence_refs,
-                        "diagnostics": outcome.diagnostics,
-                    })
-                })
-                .unwrap_or_else(|| json!({ "missing_outcome": task_id })),
-            _ => json!({ "summary": "outcome artifacts are not available for this run" }),
-        },
-        "logs" => serde_json::to_value(agent_task_service::logs(run_id)?)
-            .unwrap_or_else(|_| json!({ "summary": "logs could not be serialized" })),
-        "status" => serde_json::to_value(agent_task_service::status(run_id)?)
-            .unwrap_or_else(|_| json!({ "summary": "status could not be serialized" })),
-        section => json!({
-            "summary": format!("homeboy agent-task evidence does not hydrate section '{section}' yet"),
-        }),
-    };
-
-    Ok(HydratedContent {
-        source: "homeboy".to_string(),
-        truncated: false,
-        bytes_read: None,
-        omitted_bytes: None,
-        content,
-    })
-}
-
-fn hydrate_file_evidence_ref(uri: &str) -> homeboy::core::Result<HydratedContent> {
-    let path = file_uri_path(uri)?;
-    hydrate_local_path_evidence_ref(&path)
-}
-
-fn hydrate_local_path_evidence_ref(path: &Path) -> homeboy::core::Result<HydratedContent> {
-    let metadata = fs::metadata(&path)
-        .map_err(|error| homeboy::core::Error::internal_io(error.to_string(), None))?;
-    if !metadata.is_file() {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "evidence_ref",
-            "file evidence ref does not point at a regular file",
-            None,
-            None,
-        ));
-    }
-
-    let bytes = fs::read(&path)
-        .map_err(|error| homeboy::core::Error::internal_io(error.to_string(), None))?;
-    let truncated = bytes.len() > EVIDENCE_TEXT_LIMIT;
-    let visible = &bytes[..bytes.len().min(EVIDENCE_TEXT_LIMIT)];
-    let text = String::from_utf8_lossy(visible);
-    let redacted_text = redaction::redact_string(&text);
-    let content = serde_json::from_str::<Value>(&redacted_text)
-        .map(|value| json!({ "format": "json", "value": value }))
-        .unwrap_or_else(|_| json!({ "format": "text", "text": redacted_text }));
-
-    Ok(HydratedContent {
-        source: "file".to_string(),
-        truncated,
-        bytes_read: Some(visible.len()),
-        omitted_bytes: truncated.then_some(bytes.len().saturating_sub(EVIDENCE_TEXT_LIMIT) as u64),
-        content,
-    })
-}
-
-fn local_evidence_path(uri: &str) -> Option<PathBuf> {
-    if uri.contains("://") || uri.contains('\0') || uri.trim().is_empty() {
-        return None;
-    }
-    let path = Path::new(uri);
-    if path.is_absolute() || path.exists() {
-        Some(path.to_path_buf())
-    } else {
-        None
-    }
-}
-
-fn file_uri_path(uri: &str) -> homeboy::core::Result<PathBuf> {
-    let raw = uri.strip_prefix("file://").ok_or_else(|| {
-        homeboy::core::Error::validation_invalid_argument(
-            "evidence_ref",
-            "file evidence ref must start with file://",
-            Some(uri.to_string()),
-            None,
-        )
-    })?;
-    if raw.is_empty() || raw.contains('\0') {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "evidence_ref",
-            "file evidence ref path is empty or invalid",
-            Some(uri.to_string()),
-            None,
-        ));
-    }
-    Ok(Path::new(raw).to_path_buf())
-}
-
 struct ParsedAgentTaskUri {
-    run_id: String,
-    section: String,
     task: Option<String>,
     outcome: Option<String>,
 }
@@ -781,8 +451,6 @@ fn parse_agent_task_homeboy_uri(uri: &str) -> homeboy::core::Result<ParsedAgentT
     }
 
     Ok(ParsedAgentTaskUri {
-        run_id: run_id.to_string(),
-        section: section.to_string(),
         task: fragment_value(fragment, "task"),
         outcome: fragment_value(fragment, "outcome"),
     })
@@ -1403,118 +1071,6 @@ fn evidence_is_test(kind: &str, uri: &str) -> bool {
         || uri.contains("transcript")
 }
 
-fn hydrate_evidence_summary(
-    task_id: &str,
-    evidence: &homeboy::core::agent_tasks::AgentTaskEvidenceRef,
-) -> Option<Value> {
-    let path = evidence.uri.strip_prefix("file://")?;
-    if !path.ends_with(".json") {
-        return None;
-    }
-    let raw = std::fs::read_to_string(path).ok()?;
-    let value: Value = serde_json::from_str(&raw).ok()?;
-    let redacted = RedactionPolicy::default().redact_json(&value);
-    Some(json!({
-        "task_id": task_id,
-        "kind": evidence.kind,
-        "label": evidence.label,
-        "uri": evidence.uri,
-        "summary": evidence_json_summary(&redacted),
-    }))
-}
-
-fn evidence_json_summary(value: &Value) -> Value {
-    json!({
-        "status": find_string_field(value, &["status", "state"]),
-        "failure_classification": find_string_field(value, &["failure_classification", "failure_class", "classification", "class", "code", "kind"]),
-        "message": find_string_field(value, &["message", "summary", "error", "detail", "reason"]),
-        "command": find_string_field(value, &["command", "cmd", "failing_command"]),
-        "exit_code": find_number_field(value, &["exit_code", "exit_status", "status_code"]),
-        "stderr_excerpt": find_string_field(value, &["stderr", "stderr_excerpt"]).map(|text| excerpt(&text)),
-        "stdout_excerpt": find_string_field(value, &["stdout", "stdout_excerpt"]).map(|text| excerpt(&text)),
-        "diagnostics": first_diagnostics(value),
-    })
-}
-
-fn find_string_field(value: &Value, names: &[&str]) -> Option<String> {
-    match value {
-        Value::Object(map) => {
-            for name in names {
-                if let Some(text) = map.get(*name).and_then(Value::as_str) {
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() {
-                        return Some(trimmed.to_string());
-                    }
-                }
-            }
-            map.values()
-                .find_map(|nested| find_string_field(nested, names))
-        }
-        Value::Array(items) => items
-            .iter()
-            .find_map(|nested| find_string_field(nested, names)),
-        _ => None,
-    }
-}
-
-fn find_number_field(value: &Value, names: &[&str]) -> Option<i64> {
-    match value {
-        Value::Object(map) => {
-            for name in names {
-                if let Some(number) = map.get(*name).and_then(Value::as_i64) {
-                    return Some(number);
-                }
-            }
-            map.values()
-                .find_map(|nested| find_number_field(nested, names))
-        }
-        Value::Array(items) => items
-            .iter()
-            .find_map(|nested| find_number_field(nested, names)),
-        _ => None,
-    }
-}
-
-fn first_diagnostics(value: &Value) -> Value {
-    match value {
-        Value::Object(map) => {
-            if let Some(Value::Array(items)) = map.get("diagnostics") {
-                return Value::Array(items.iter().take(5).cloned().collect());
-            }
-            map.values()
-                .find_map(|nested| {
-                    let diagnostics = first_diagnostics(nested);
-                    diagnostics
-                        .as_array()
-                        .is_some_and(|items| !items.is_empty())
-                        .then_some(diagnostics)
-                })
-                .unwrap_or_else(|| Value::Array(Vec::new()))
-        }
-        Value::Array(items) => items
-            .iter()
-            .find_map(|nested| {
-                let diagnostics = first_diagnostics(nested);
-                diagnostics
-                    .as_array()
-                    .is_some_and(|items| !items.is_empty())
-                    .then_some(diagnostics)
-            })
-            .unwrap_or_else(|| Value::Array(Vec::new())),
-        _ => Value::Array(Vec::new()),
-    }
-}
-
-fn excerpt(text: &str) -> String {
-    const MAX_CHARS: usize = 1200;
-    let trimmed = text.trim();
-    if trimmed.chars().count() <= MAX_CHARS {
-        return trimmed.to_string();
-    }
-    let truncated: String = trimmed.chars().take(MAX_CHARS).collect();
-    format!("{truncated}…")
-}
-
 fn collected_diagnostic_value(item: CollectedDiagnostic) -> Value {
     json!({
         "task_id": item.task_id,
@@ -1590,88 +1146,6 @@ fn diagnose_next_commands(run_id: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::with_isolated_home;
-    use homeboy::core::observation::{RunRecord, RunStatus};
-
-    #[test]
-    fn status_returns_runner_remediation_for_offloaded_record_without_agent_task_metadata() {
-        with_isolated_home(|_| {
-            ObservationStore::open_initialized()
-                .expect("observation store")
-                .upsert_imported_run(&RunRecord {
-                    id: "agent-task-offloaded".to_string(),
-                    kind: "agent-task".to_string(),
-                    component_id: None,
-                    started_at: "2026-06-30T00:00:00Z".to_string(),
-                    finished_at: None,
-                    status: RunStatus::Running.as_str().to_string(),
-                    command: Some("homeboy agent-task".to_string()),
-                    cwd: None,
-                    homeboy_version: None,
-                    git_sha: None,
-                    rig_id: None,
-                    metadata_json: json!({
-                        "runner_id": "homeboy-lab",
-                        "runner_job_id": "job-123",
-                    }),
-                })
-                .expect("raw offload mirror written");
-
-            let (value, exit_code) = status(StatusArgs {
-                run_id: "agent-task-offloaded".to_string(),
-                bridge: false,
-                since_cursor: None,
-                full: false,
-            })
-            .expect("status remediation");
-
-            assert_eq!(exit_code, 1);
-            assert_eq!(value["schema"], "homeboy/agent-task-status-remediation/v1");
-            assert_eq!(value["status"], "runner_status_required");
-            assert_eq!(value["runner_id"], "homeboy-lab");
-            assert_eq!(value["runner_job_id"], "job-123");
-            assert_eq!(
-                value["remediation"]["status"],
-                "homeboy --runner homeboy-lab agent-task status agent-task-offloaded"
-            );
-            assert!(value["commands"]
-                .as_array()
-                .expect("commands")
-                .iter()
-                .any(|command| command
-                    == "homeboy --runner homeboy-lab agent-task logs agent-task-offloaded --full"));
-        });
-    }
-
-    #[test]
-    fn runner_status_remediation_uses_nested_identity_runner_metadata() {
-        let metadata = json!({
-            "identity": {
-                "runner_id": "lab-nested",
-                "runner_job_id": "job-nested",
-            }
-        });
-        let runner_id = metadata_string(&metadata, &[&["runner_id"], &["identity", "runner_id"]])
-            .expect("runner id");
-        let runner_job_id = metadata_string(
-            &metadata,
-            &[
-                &["runner_job_id"],
-                &["job_id"],
-                &["identity", "runner_job_id"],
-            ],
-        );
-        let remediation =
-            runner_status_remediation("agent-task-run", &runner_id, runner_job_id.as_deref());
-
-        assert_eq!(remediation["runner_id"], "lab-nested");
-        assert_eq!(remediation["runner_job_id"], "job-nested");
-        assert!(remediation["commands"]
-            .as_array()
-            .expect("commands")
-            .iter()
-            .any(|command| command == "homeboy runner job logs lab-nested job-nested --full"));
-    }
 
     #[test]
     fn compact_status_surfaces_latest_promotion() {

--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -421,54 +421,6 @@ struct AgentTaskEvidenceFilters {
     failure_only: bool,
 }
 
-struct ParsedAgentTaskUri {
-    task: Option<String>,
-    outcome: Option<String>,
-}
-
-fn parse_agent_task_homeboy_uri(uri: &str) -> homeboy::core::Result<ParsedAgentTaskUri> {
-    let rest = uri
-        .strip_prefix("homeboy://agent-task/run/")
-        .ok_or_else(|| {
-            homeboy::core::Error::validation_invalid_argument(
-                "evidence_ref",
-                "unsupported homeboy agent-task evidence ref",
-                Some(uri.to_string()),
-                None,
-            )
-        })?;
-    let (path, fragment) = rest.split_once('#').unwrap_or((rest, ""));
-    let mut parts = path.split('/');
-    let run_id = parts.next().unwrap_or_default();
-    let section = parts.next().unwrap_or_default();
-    if run_id.is_empty() || section.is_empty() {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "evidence_ref",
-            "homeboy agent-task evidence ref must include run id and section",
-            Some(uri.to_string()),
-            None,
-        ));
-    }
-
-    Ok(ParsedAgentTaskUri {
-        task: fragment_value(fragment, "task"),
-        outcome: fragment_value(fragment, "outcome"),
-    })
-}
-
-fn fragment_value(fragment: &str, key: &str) -> Option<String> {
-    fragment.split('&').find_map(|part| {
-        let (candidate, value) = part.split_once('=')?;
-        (candidate == key && !value.trim().is_empty()).then(|| value.to_string())
-    })
-}
-
-fn evidence_ref_task_id(evidence_ref: &AgentTaskEvidenceRef) -> Option<String> {
-    parse_agent_task_homeboy_uri(&evidence_ref.uri)
-        .ok()
-        .and_then(|parsed| parsed.task.or(parsed.outcome))
-}
-
 fn failed_task_statuses(
     aggregate: Option<&AgentTaskAggregate>,
 ) -> HashMap<String, AgentTaskOutcomeStatus> {
@@ -514,7 +466,10 @@ fn evidence_refs_with_tasks(
     }
     for evidence_ref in refs {
         if seen.insert((evidence_ref.kind.clone(), evidence_ref.uri.clone())) {
-            entries.push((evidence_ref.clone(), evidence_ref_task_id(evidence_ref)));
+            entries.push((
+                evidence_ref.clone(),
+                agent_task_service::evidence_ref_task_id(evidence_ref),
+            ));
         }
     }
     entries

--- a/src/core/agent_task_promotion/apply.rs
+++ b/src/core/agent_task_promotion/apply.rs
@@ -276,12 +276,43 @@ pub(crate) fn run_provider_command(
         ));
     }
 
+    let workspace_path = PathBuf::from(response.workspace_path);
+    validate_provider_workspace_path(&workspace_path)?;
+
     let mut command_evidence = response.command_evidence;
     if command_evidence.is_empty() {
         command_evidence.push(report);
     }
     Ok(AgentTaskPromotionWorkspace {
-        path: PathBuf::from(response.workspace_path),
+        path: workspace_path,
         command_evidence,
     })
+}
+
+fn validate_provider_workspace_path(path: &Path) -> Result<()> {
+    match git_output(path, &["rev-parse", "--is-inside-work-tree"]) {
+        Some(value) if value == "true" => Ok(()),
+        _ => Err(Error::validation_invalid_argument(
+            "promotion_provider.response.workspace_path",
+            format!(
+                "promotion provider response workspace_path is not a git worktree: {}",
+                path.display()
+            ),
+            None,
+            None,
+        )),
+    }
+}
+
+fn git_output(cwd: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -71,62 +71,17 @@ pub(crate) fn promote_with_provider(
     validate_artifact_content(&artifact, &patch)?;
     if patch.trim().is_empty() {
         if let Some(committed_patch) = committed_changes_patch(&options)? {
-            let mut deterministic_gates = Vec::new();
-            let mut dependencies_materialized = false;
-            if !options.dry_run
-                && (!options.gates.verify.is_empty() || !options.gates.private_verify.is_empty())
-            {
-                dependencies_materialized =
-                    crate::core::hygiene::materialize_worktree_dependencies(
-                        &committed_patch.worktree_path,
-                    )?;
-                for (index, command) in options.gates.verify.iter().enumerate() {
-                    deterministic_gates.push(provider.verify(
-                        &committed_patch.worktree_path,
-                        index + 1,
-                        command,
-                        AgentTaskGateVisibility::Visible,
-                        AgentTaskGateRevealPolicy::FullEvidence,
-                    )?);
-                }
-                let private_offset = deterministic_gates.len();
-                for (index, command) in options.gates.private_verify.iter().enumerate() {
-                    deterministic_gates.push(provider.verify(
-                        &committed_patch.worktree_path,
-                        private_offset + index + 1,
-                        command,
-                        AgentTaskGateVisibility::Private,
-                        options.gates.private_gate_reveal,
-                    )?);
-                }
-            }
-            let has_gate_failure = deterministic_gates
-                .iter()
-                .any(|gate| gate.status == AgentTaskGateStatus::Failed);
-            let gate_results = deterministic_gates
-                .iter()
-                .cloned()
-                .map(HomeboyGateResult::from)
-                .collect();
-            let status = status_for_report(options.dry_run, has_gate_failure);
+            let gates = run_promotion_gates(&options, provider, &committed_patch.worktree_path)?;
             let target = AgentTaskPromotionTarget::from_worktree(
                 options.to_worktree.clone(),
                 Some(&committed_patch.worktree_path),
             );
-            let operator_notification = promotion_notification(status, &target);
+            let operator_notification = promotion_notification(gates.status, &target);
 
             return Ok(AgentTaskPromotionReport {
                 schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
-                status,
-                source: AgentTaskPromotionSource {
-                    kind: source_kind,
-                    task_id: outcome.task_id.clone(),
-                    run_id: options.source_run_id,
-                    path: options
-                        .source_path
-                        .as_ref()
-                        .map(|path| path.display().to_string()),
-                },
+                status: gates.status,
+                source: promotion_source(&source_kind, &outcome, &options),
                 to_worktree: options.to_worktree,
                 target,
                 patch_artifact: AgentTaskPromotionArtifactRef {
@@ -137,13 +92,13 @@ pub(crate) fn promote_with_provider(
                 },
                 changed_files: committed_patch.changed_files,
                 command_evidence: Vec::new(),
-                deterministic_gates,
-                gate_results,
+                deterministic_gates: gates.deterministic_gates,
+                gate_results: gates.gate_results,
                 provenance: json!({
                     "source_schema": outcome.schema,
                     "artifact_metadata": artifact.metadata,
                     "worktree_path": committed_patch.worktree_path,
-                    "dependencies_materialized": dependencies_materialized,
+                    "dependencies_materialized": gates.dependencies_materialized,
                     "change_source": "local_commits",
                     "base_ref": committed_patch.base_ref,
                 }),
@@ -157,15 +112,7 @@ pub(crate) fn promote_with_provider(
         return Ok(AgentTaskPromotionReport {
             schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
             status,
-            source: AgentTaskPromotionSource {
-                kind: source_kind,
-                task_id: outcome.task_id.clone(),
-                run_id: options.source_run_id,
-                path: options
-                    .source_path
-                    .as_ref()
-                    .map(|path| path.display().to_string()),
-            },
+            source: promotion_source(&source_kind, &outcome, &options),
             to_worktree: options.to_worktree,
             target,
             patch_artifact: AgentTaskPromotionArtifactRef {
@@ -210,74 +157,21 @@ pub(crate) fn promote_with_provider(
         applied_worktree_path = Some(target.path);
     }
 
-    let mut deterministic_gates = Vec::new();
-    let mut dependencies_materialized = false;
-    if !options.dry_run
-        && (!options.gates.verify.is_empty() || !options.gates.private_verify.is_empty())
-    {
-        let worktree_path = applied_worktree_path.as_deref().ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "to_worktree",
-                format!("managed worktree {} was not found", options.to_worktree),
-                None,
-                None,
-            )
-        })?;
-        // Materialize dependencies via the component's resolved dependency
-        // providers (install + build steps) in the freshly created worktree
-        // before running the verify gates. Without this, a fresh worktree has
-        // no installed dependency artifacts and gates fatal on missing
-        // dependencies, masking the real pass/fail signal (#3771).
-        dependencies_materialized =
-            crate::core::hygiene::materialize_worktree_dependencies(Path::new(worktree_path))?;
-        for (index, command) in options.gates.verify.iter().enumerate() {
-            deterministic_gates.push(provider.verify(
-                worktree_path,
-                index + 1,
-                command,
-                AgentTaskGateVisibility::Visible,
-                AgentTaskGateRevealPolicy::FullEvidence,
-            )?);
-        }
-        let private_offset = deterministic_gates.len();
-        for (index, command) in options.gates.private_verify.iter().enumerate() {
-            deterministic_gates.push(provider.verify(
-                worktree_path,
-                private_offset + index + 1,
-                command,
-                AgentTaskGateVisibility::Private,
-                options.gates.private_gate_reveal,
-            )?);
-        }
-    }
-    let has_gate_failure = deterministic_gates
-        .iter()
-        .any(|gate| gate.status == AgentTaskGateStatus::Failed);
-    let gate_results = deterministic_gates
-        .iter()
-        .cloned()
-        .map(HomeboyGateResult::from)
-        .collect();
-
-    let status = status_for_report(options.dry_run, has_gate_failure);
+    let gates = if let Some(worktree_path) = applied_worktree_path.as_deref() {
+        run_promotion_gates(&options, provider, worktree_path)?
+    } else {
+        PromotionGateRun::without_gates(options.dry_run)
+    };
     let target = AgentTaskPromotionTarget::from_worktree(
         options.to_worktree.clone(),
         applied_worktree_path.as_deref(),
     );
-    let operator_notification = promotion_notification(status, &target);
+    let operator_notification = promotion_notification(gates.status, &target);
 
     Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
-        status,
-        source: AgentTaskPromotionSource {
-            kind: source_kind,
-            task_id: outcome.task_id.clone(),
-            run_id: options.source_run_id,
-            path: options
-                .source_path
-                .as_ref()
-                .map(|path| path.display().to_string()),
-        },
+        status: gates.status,
+        source: promotion_source(&source_kind, &outcome, &options),
         to_worktree: options.to_worktree,
         target,
         patch_artifact: AgentTaskPromotionArtifactRef {
@@ -288,16 +182,101 @@ pub(crate) fn promote_with_provider(
         },
         changed_files,
         command_evidence,
-        deterministic_gates,
-        gate_results,
+        deterministic_gates: gates.deterministic_gates,
+        gate_results: gates.gate_results,
         provenance: json!({
             "source_schema": outcome.schema,
             "artifact_metadata": artifact.metadata,
             "worktree_path": applied_worktree_path,
-            "dependencies_materialized": dependencies_materialized,
+            "dependencies_materialized": gates.dependencies_materialized,
         }),
         operator_notification,
     })
+}
+
+struct PromotionGateRun {
+    status: AgentTaskPromotionStatus,
+    deterministic_gates: Vec<crate::core::agent_task_gate::AgentTaskGateReport>,
+    gate_results: Vec<HomeboyGateResult>,
+    dependencies_materialized: bool,
+}
+
+impl PromotionGateRun {
+    fn without_gates(dry_run: bool) -> Self {
+        Self {
+            status: status_for_report(dry_run, false),
+            deterministic_gates: Vec::new(),
+            gate_results: Vec::new(),
+            dependencies_materialized: false,
+        }
+    }
+}
+
+fn run_promotion_gates(
+    options: &AgentTaskPromotionOptions,
+    provider: &mut impl AgentTaskPromotionWorkspaceProvider,
+    worktree_path: &Path,
+) -> Result<PromotionGateRun> {
+    if options.dry_run
+        || (options.gates.verify.is_empty() && options.gates.private_verify.is_empty())
+    {
+        return Ok(PromotionGateRun::without_gates(options.dry_run));
+    }
+
+    // Materialize dependencies via the component's resolved dependency providers
+    // before running verify gates so dependency misses do not mask gate signal.
+    crate::core::hygiene::materialize_worktree_dependencies(worktree_path)?;
+    let mut deterministic_gates = Vec::new();
+    for (index, command) in options.gates.verify.iter().enumerate() {
+        deterministic_gates.push(provider.verify(
+            worktree_path,
+            index + 1,
+            command,
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+        )?);
+    }
+    let private_offset = deterministic_gates.len();
+    for (index, command) in options.gates.private_verify.iter().enumerate() {
+        deterministic_gates.push(provider.verify(
+            worktree_path,
+            private_offset + index + 1,
+            command,
+            AgentTaskGateVisibility::Private,
+            options.gates.private_gate_reveal,
+        )?);
+    }
+    let has_gate_failure = deterministic_gates
+        .iter()
+        .any(|gate| gate.status == AgentTaskGateStatus::Failed);
+    let gate_results = deterministic_gates
+        .iter()
+        .cloned()
+        .map(HomeboyGateResult::from)
+        .collect();
+
+    Ok(PromotionGateRun {
+        status: status_for_report(options.dry_run, has_gate_failure),
+        deterministic_gates,
+        gate_results,
+        dependencies_materialized: true,
+    })
+}
+
+fn promotion_source(
+    source_kind: &str,
+    outcome: &AgentTaskOutcome,
+    options: &AgentTaskPromotionOptions,
+) -> AgentTaskPromotionSource {
+    AgentTaskPromotionSource {
+        kind: source_kind.to_string(),
+        task_id: outcome.task_id.clone(),
+        run_id: options.source_run_id.clone(),
+        path: options
+            .source_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+    }
 }
 
 struct CommittedChangesPatch {

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -69,6 +70,86 @@ pub(crate) fn promote_with_provider(
     })?;
     validate_artifact_content(&artifact, &patch)?;
     if patch.trim().is_empty() {
+        if let Some(committed_patch) = committed_changes_patch(&options)? {
+            let mut deterministic_gates = Vec::new();
+            let mut dependencies_materialized = false;
+            if !options.dry_run
+                && (!options.gates.verify.is_empty() || !options.gates.private_verify.is_empty())
+            {
+                dependencies_materialized =
+                    crate::core::hygiene::materialize_worktree_dependencies(
+                        &committed_patch.worktree_path,
+                    )?;
+                for (index, command) in options.gates.verify.iter().enumerate() {
+                    deterministic_gates.push(provider.verify(
+                        &committed_patch.worktree_path,
+                        index + 1,
+                        command,
+                        AgentTaskGateVisibility::Visible,
+                        AgentTaskGateRevealPolicy::FullEvidence,
+                    )?);
+                }
+                let private_offset = deterministic_gates.len();
+                for (index, command) in options.gates.private_verify.iter().enumerate() {
+                    deterministic_gates.push(provider.verify(
+                        &committed_patch.worktree_path,
+                        private_offset + index + 1,
+                        command,
+                        AgentTaskGateVisibility::Private,
+                        options.gates.private_gate_reveal,
+                    )?);
+                }
+            }
+            let has_gate_failure = deterministic_gates
+                .iter()
+                .any(|gate| gate.status == AgentTaskGateStatus::Failed);
+            let gate_results = deterministic_gates
+                .iter()
+                .cloned()
+                .map(HomeboyGateResult::from)
+                .collect();
+            let status = status_for_report(options.dry_run, has_gate_failure);
+            let target = AgentTaskPromotionTarget::from_worktree(
+                options.to_worktree.clone(),
+                Some(&committed_patch.worktree_path),
+            );
+            let operator_notification = promotion_notification(status, &target);
+
+            return Ok(AgentTaskPromotionReport {
+                schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+                status,
+                source: AgentTaskPromotionSource {
+                    kind: source_kind,
+                    task_id: outcome.task_id.clone(),
+                    run_id: options.source_run_id,
+                    path: options
+                        .source_path
+                        .as_ref()
+                        .map(|path| path.display().to_string()),
+                },
+                to_worktree: options.to_worktree,
+                target,
+                patch_artifact: AgentTaskPromotionArtifactRef {
+                    id: "committed-changes".to_string(),
+                    kind: "patch".to_string(),
+                    path: committed_patch.patch_path.display().to_string(),
+                    sha256: Some(committed_patch.sha256),
+                },
+                changed_files: committed_patch.changed_files,
+                command_evidence: Vec::new(),
+                deterministic_gates,
+                gate_results,
+                provenance: json!({
+                    "source_schema": outcome.schema,
+                    "artifact_metadata": artifact.metadata,
+                    "worktree_path": committed_patch.worktree_path,
+                    "dependencies_materialized": dependencies_materialized,
+                    "change_source": "local_commits",
+                    "base_ref": committed_patch.base_ref,
+                }),
+                operator_notification,
+            });
+        }
         let status = AgentTaskPromotionStatus::NoChanges;
         let target = AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), None);
         let operator_notification = promotion_notification(status, &target);
@@ -217,6 +298,136 @@ pub(crate) fn promote_with_provider(
         }),
         operator_notification,
     })
+}
+
+struct CommittedChangesPatch {
+    worktree_path: PathBuf,
+    base_ref: String,
+    patch_path: PathBuf,
+    sha256: String,
+    changed_files: Vec<String>,
+}
+
+fn committed_changes_patch(
+    options: &AgentTaskPromotionOptions,
+) -> Result<Option<CommittedChangesPatch>> {
+    let Some(worktree_path) = options.source_worktree_path.as_deref() else {
+        return Ok(None);
+    };
+    if !worktree_path.is_dir() {
+        return Ok(None);
+    }
+    let Some(base_ref) =
+        resolve_committed_changes_base(worktree_path, options.base_ref.as_deref())?
+    else {
+        return Ok(None);
+    };
+    let changed_files = git_lines(worktree_path, &["diff", "--name-only", &base_ref, "HEAD"])?;
+    if changed_files.is_empty() {
+        return Ok(None);
+    }
+    let patch = git_output(
+        worktree_path,
+        &[
+            "diff",
+            "--binary",
+            "--full-index",
+            "--find-renames",
+            &base_ref,
+            "HEAD",
+        ],
+    )?;
+    if patch.trim().is_empty() {
+        return Ok(None);
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(patch.as_bytes());
+    let sha256 = format!("{:x}", hasher.finalize());
+    let patch_path = committed_changes_patch_path(options, &sha256)?;
+    std::fs::write(&patch_path, patch.as_bytes()).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "write committed changes promotion patch {}",
+                patch_path.display()
+            )),
+        )
+    })?;
+    Ok(Some(CommittedChangesPatch {
+        worktree_path: worktree_path.to_path_buf(),
+        base_ref,
+        patch_path,
+        sha256,
+        changed_files,
+    }))
+}
+
+fn committed_changes_patch_path(
+    options: &AgentTaskPromotionOptions,
+    sha256: &str,
+) -> Result<PathBuf> {
+    if let Some(parent) = options.source_path.as_deref().and_then(Path::parent) {
+        return Ok(parent.join(format!("committed-changes-{sha256}.patch")));
+    }
+    let dir = std::env::temp_dir().join("homeboy-agent-task-promotions");
+    std::fs::create_dir_all(&dir).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "create committed changes promotion artifact directory {}",
+                dir.display()
+            )),
+        )
+    })?;
+    Ok(dir.join(format!("committed-changes-{sha256}.patch")))
+}
+
+fn resolve_committed_changes_base(cwd: &Path, requested: Option<&str>) -> Result<Option<String>> {
+    let mut candidates = Vec::new();
+    if let Some(requested) = requested.filter(|value| !value.trim().is_empty()) {
+        candidates.push(requested.to_string());
+        if !requested.contains('/') {
+            candidates.push(format!("origin/{requested}"));
+        }
+    }
+    candidates.push("@{upstream}".to_string());
+    for candidate in candidates {
+        if git_output(
+            cwd,
+            &["rev-parse", "--verify", &format!("{candidate}^{{commit}}")],
+        )
+        .is_ok()
+        {
+            let merge_base = git_output(cwd, &["merge-base", &candidate, "HEAD"])?;
+            return Ok(Some(merge_base.trim().to_string()));
+        }
+    }
+    Ok(None)
+}
+
+fn git_lines(cwd: &Path, args: &[&str]) -> Result<Vec<String>> {
+    Ok(git_output(cwd, args)?
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn git_output(cwd: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 fn status_for_report(dry_run: bool, has_gate_failure: bool) -> AgentTaskPromotionStatus {

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -136,6 +137,42 @@ fn write_patch_source(temp: &tempfile::TempDir) -> (PathBuf, String) {
     (source_path, source)
 }
 
+fn write_empty_patch_source(temp: &tempfile::TempDir) -> (PathBuf, String) {
+    let patch_path = temp.path().join("empty.patch");
+    std::fs::write(&patch_path, "").expect("write empty patch");
+    let source_path = temp.path().join("outcome.json");
+    let source = serde_json::json!({
+        "schema": AGENT_TASK_OUTCOME_SCHEMA,
+        "task_id": "task-1",
+        "status": "succeeded",
+        "artifacts": [{
+            "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+            "id": "patch",
+            "kind": "patch",
+            "path": "empty.patch",
+            "size_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }]
+    })
+    .to_string();
+    std::fs::write(&source_path, &source).expect("write source");
+    (source_path, source)
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn validate_patch_extracts_safe_changed_files() {
     let patch = normalize_promotion_patch(VALID_PATCH, "repo@promoted-task").expect("valid patch");
@@ -224,6 +261,8 @@ fn promote_reports_no_changes_for_empty_patch_metadata() {
             source,
             source_run_id: Some("run-empty".to_string()),
             source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
             to_worktree: "repo@promoted-task".to_string(),
             task_id: None,
             artifact_id: None,
@@ -243,6 +282,64 @@ fn promote_reports_no_changes_for_empty_patch_metadata() {
     assert!(report.changed_files.is_empty());
     assert!(provider.apply_calls.is_empty());
     assert!(provider.verify_calls.is_empty());
+}
+
+#[test]
+fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "homeboy@example.test"]);
+    git(&repo, &["config", "user.name", "Homeboy Test"]);
+    git(&repo, &["checkout", "-b", "main"]);
+    std::fs::create_dir(repo.join("src")).expect("create src");
+    std::fs::write(repo.join("src/lib.rs"), "old\n").expect("write base file");
+    git(&repo, &["add", "src/lib.rs"]);
+    git(&repo, &["commit", "-m", "base"]);
+    git(&repo, &["checkout", "-b", "fix/committed"]);
+    std::fs::write(repo.join("src/lib.rs"), "new\n").expect("write committed change");
+    git(&repo, &["commit", "-am", "fix: committed change"]);
+
+    let (source_path, source) = write_empty_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider::default();
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run-committed".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: Some("main".to_string()),
+            to_worktree: "repo@fix-committed".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: None,
+        },
+        &mut provider,
+    )
+    .expect("committed changes are promoted");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(report.changed_files, vec!["src/lib.rs"]);
+    assert_eq!(report.patch_artifact.id, "committed-changes");
+    assert!(Path::new(&report.patch_artifact.path).is_file());
+    assert!(std::fs::read_to_string(&report.patch_artifact.path)
+        .expect("read committed patch")
+        .contains("+new"));
+    assert_eq!(
+        report.provenance["change_source"].as_str(),
+        Some("local_commits")
+    );
+    assert_eq!(provider.apply_calls.len(), 0);
+    assert_eq!(provider.verify_calls.len(), 1);
+    assert_eq!(provider.verify_calls[0].0, repo);
 }
 
 #[test]
@@ -353,6 +450,8 @@ fn promote_dry_run_reports_selected_patch_without_provider_mutation() {
         source,
         source_run_id: None,
         source_path: Some(source_path),
+        source_worktree_path: None,
+        base_ref: None,
         to_worktree: "repo@promoted-task".to_string(),
         task_id: None,
         artifact_id: None,
@@ -389,6 +488,8 @@ fn promote_applies_patch_with_fake_workspace_provider() {
             source,
             source_run_id: Some("run-1".to_string()),
             source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
             to_worktree: "repo@controlled-worktree".to_string(),
             task_id: None,
             artifact_id: None,
@@ -486,6 +587,8 @@ fn promote_materializes_worktree_dependencies_before_verify_gate() {
                 source,
                 source_run_id: Some("run-3771".to_string()),
                 source_path: Some(source_path),
+                source_worktree_path: None,
+                base_ref: None,
                 to_worktree: "repo@worktree".to_string(),
                 task_id: None,
                 artifact_id: None,
@@ -547,6 +650,8 @@ fn promote_applies_normalized_lab_sandbox_patch_with_fake_workspace_provider() {
             source,
             source_run_id: None,
             source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
             to_worktree: "homeboy@promoted-task".to_string(),
             task_id: None,
             artifact_id: None,
@@ -582,6 +687,8 @@ fn promote_requires_provider_for_apply() {
         source,
         source_run_id: None,
         source_path: Some(source_path),
+        source_worktree_path: None,
+        base_ref: None,
         to_worktree: "repo@controlled-worktree".to_string(),
         task_id: None,
         artifact_id: None,
@@ -607,6 +714,8 @@ fn promotion_options_keep_flat_verify_gate_serialized_shape() {
         source: "source.json".to_string(),
         source_run_id: Some("run-1".to_string()),
         source_path: None,
+        source_worktree_path: None,
+        base_ref: None,
         to_worktree: "repo@flatten".to_string(),
         task_id: None,
         artifact_id: None,

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -822,12 +822,20 @@ fn promotion_report_serializes_generic_command_evidence() {
 #[test]
 fn provider_command_response_supplies_workspace_and_evidence() {
     let temp = tempfile::tempdir().expect("tempdir");
+    let workspace_path = temp.path().join("workspace");
+    std::fs::create_dir(&workspace_path).expect("create workspace");
+    assert!(std::process::Command::new("git")
+        .arg("init")
+        .arg(&workspace_path)
+        .status()
+        .expect("git init")
+        .success());
     let response_path = temp.path().join("response.json");
     std::fs::write(
         &response_path,
         serde_json::json!({
             "schema": AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
-            "workspace_path": temp.path().join("workspace").display().to_string(),
+            "workspace_path": workspace_path.display().to_string(),
             "command_evidence": [{
                 "command": ["provider", "apply"],
                 "exit_code": 0

--- a/src/core/agent_task_promotion/types.rs
+++ b/src/core/agent_task_promotion/types.rs
@@ -16,6 +16,10 @@ pub struct AgentTaskPromotionOptions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_run_id: Option<String>,
     pub source_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_worktree_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<String>,
     pub to_worktree: String,
     pub task_id: Option<String>,
     pub artifact_id: Option<String>,

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -277,6 +277,13 @@ pub fn source_worktree_path(cwd: Option<String>, workspace: Option<String>) -> O
     .map(PathBuf::from)
 }
 
+pub fn ai_model_from_tool(ai_tool: &str) -> Option<String> {
+    let start = ai_tool.find('(')?;
+    let end = ai_tool[start + 1..].find(')')? + start + 1;
+    let model = ai_tool[start + 1..end].trim();
+    (!model.is_empty()).then(|| model.to_string())
+}
+
 pub fn promotion_source(spec: &str) -> Result<(String, Option<PathBuf>)> {
     if spec != "-" {
         let path = PathBuf::from(spec.strip_prefix('@').unwrap_or(spec));

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -267,6 +267,16 @@ where
     ))
 }
 
+pub fn source_worktree_path(cwd: Option<String>, workspace: Option<String>) -> Option<PathBuf> {
+    cwd.or_else(|| {
+        workspace.and_then(|workspace| {
+            let path = PathBuf::from(&workspace);
+            path.exists().then_some(workspace)
+        })
+    })
+    .map(PathBuf::from)
+}
+
 pub fn promotion_source(spec: &str) -> Result<(String, Option<PathBuf>)> {
     if spec != "-" {
         let path = PathBuf::from(spec.strip_prefix('@').unwrap_or(spec));

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -28,6 +28,7 @@ pub struct AgentTaskCookServiceOptions {
     pub cook_id: String,
     pub initial_run_id: String,
     pub to_worktree: String,
+    pub source_worktree_path: Option<PathBuf>,
     pub provider_command: Option<String>,
     /// Shared deterministic verification gate fields, factored out of the
     /// per-field duplication that previously spanned the loop/promote types.
@@ -302,6 +303,8 @@ fn promote_attempt(
         source,
         source_run_id: Some(run_id.to_string()),
         source_path,
+        source_worktree_path: options.source_worktree_path.clone(),
+        base_ref: Some(options.base.clone()),
         to_worktree: options.to_worktree.clone(),
         task_id: None,
         artifact_id: None,

--- a/src/core/agent_task_service/mod.rs
+++ b/src/core/agent_task_service/mod.rs
@@ -9,11 +9,13 @@ mod cook;
 mod discovery;
 mod execution;
 mod reconcile;
+mod status_support;
 
 pub use cook::*;
 pub use discovery::*;
 pub use execution::*;
 pub use reconcile::*;
+pub use status_support::*;
 
 #[cfg(test)]
 mod tests;

--- a/src/core/agent_task_service/status_support.rs
+++ b/src/core/agent_task_service/status_support.rs
@@ -1,0 +1,491 @@
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
+use crate::core::agent_tasks::AgentTaskEvidenceRef;
+use crate::core::observation::ObservationStore;
+use crate::core::redaction::{self, RedactionPolicy};
+use crate::core::Result;
+
+const EVIDENCE_TEXT_LIMIT: usize = 16 * 1024;
+
+pub fn offloaded_status_remediation(run_id: &str) -> Result<Option<Value>> {
+    let Some(run) = ObservationStore::open_initialized()?.get_run(run_id)? else {
+        return Ok(None);
+    };
+    let Some(runner_id) = metadata_string(
+        &run.metadata_json,
+        &[&["runner_id"], &["identity", "runner_id"]],
+    )
+    .filter(|runner_id| !runner_id.trim().is_empty()) else {
+        return Ok(None);
+    };
+    let runner_job_id = metadata_string(
+        &run.metadata_json,
+        &[
+            &["runner_job_id"],
+            &["job_id"],
+            &["identity", "runner_job_id"],
+        ],
+    );
+
+    Ok(Some(runner_status_remediation(
+        run_id,
+        &runner_id,
+        runner_job_id.as_deref(),
+    )))
+}
+
+fn runner_status_remediation(run_id: &str, runner_id: &str, runner_job_id: Option<&str>) -> Value {
+    let command_prefix = format!("homeboy --runner {runner_id} agent-task");
+    let mut commands = vec![
+        format!("{command_prefix} status {run_id}"),
+        format!("{command_prefix} logs {run_id} --full"),
+        format!("{command_prefix} artifacts {run_id}"),
+    ];
+    if let Some(job_id) = runner_job_id.filter(|job_id| !job_id.trim().is_empty()) {
+        commands.push(format!(
+            "homeboy runner job logs {runner_id} {job_id} --full"
+        ));
+    }
+
+    json!({
+        "schema": "homeboy/agent-task-status-remediation/v1",
+        "status": "runner_status_required",
+        "run_id": run_id,
+        "runner_id": runner_id,
+        "runner_job_id": runner_job_id,
+        "message": "Local observation metadata does not contain an agent-task run record; query the runner that owns this durable run.",
+        "commands": commands,
+        "remediation": {
+            "status": format!("{command_prefix} status {run_id}"),
+            "logs": format!("{command_prefix} logs {run_id} --full"),
+            "artifacts": format!("{command_prefix} artifacts {run_id}"),
+        },
+    })
+}
+
+fn metadata_string(metadata: &Value, paths: &[&[&str]]) -> Option<String> {
+    paths.iter().find_map(|path| {
+        let mut current = metadata;
+        for segment in *path {
+            current = current.get(*segment)?;
+        }
+        current.as_str().map(str::to_string)
+    })
+}
+
+pub fn persist_provider_boundary_replay_evidence(report: &Value) -> Option<String> {
+    let run_id = report.get("run_id")?.as_str().unwrap_or("unknown-run");
+    let task_id = report
+        .get("task_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown-task");
+    let dir = std::env::temp_dir()
+        .join("homeboy-agent-task-evidence")
+        .join(sanitize_evidence_path_part(run_id));
+    fs::create_dir_all(&dir).ok()?;
+    let path = dir.join(format!(
+        "provider-boundary-replay-{}.json",
+        sanitize_evidence_path_part(task_id)
+    ));
+    fs::write(&path, serde_json::to_vec_pretty(report).ok()?).ok()?;
+    Some(format!("file://{}", path.display()))
+}
+
+fn sanitize_evidence_path_part(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "unknown".to_string()
+    } else {
+        sanitized
+    }
+}
+
+#[derive(Serialize)]
+pub struct AgentTaskHydratedEvidence {
+    pub kind: String,
+    pub label: Option<String>,
+    pub task_id: Option<String>,
+    pub uri: String,
+    pub source: String,
+    pub status: String,
+    pub truncated: bool,
+    pub bytes_read: Option<usize>,
+    pub omitted_bytes: Option<u64>,
+    pub content: Value,
+    pub error: Option<String>,
+}
+
+pub fn hydrate_evidence_ref(
+    run_id: &str,
+    evidence_ref: &AgentTaskEvidenceRef,
+    task_id: Option<&str>,
+    plan: Option<&AgentTaskPlan>,
+    aggregate: Option<&AgentTaskAggregate>,
+) -> AgentTaskHydratedEvidence {
+    let hydrated = if evidence_ref.uri.starts_with("homeboy://agent-task/") {
+        hydrate_homeboy_evidence_ref(run_id, &evidence_ref.uri, task_id, plan, aggregate)
+    } else if evidence_ref.uri.starts_with("file://") {
+        hydrate_file_evidence_ref(&evidence_ref.uri)
+    } else if let Some(path) = local_evidence_path(&evidence_ref.uri) {
+        hydrate_local_path_evidence_ref(&path)
+    } else {
+        Ok(HydratedContent {
+            source: "unsupported".to_string(),
+            truncated: false,
+            bytes_read: None,
+            omitted_bytes: None,
+            content: json!({
+                "summary": "Evidence ref is recorded but this URI scheme is not hydratable by agent-task evidence yet.",
+                "unsupported_ref": evidence_ref.uri,
+                "supported_refs": ["homeboy://agent-task/run/<run-id>/<section>", "file://<absolute-path>", "local filesystem path"],
+                "next_action": "Use a file:// URI or local path for evidence stored on this machine; otherwise inspect the producing provider or artifact store for this ref.",
+            }),
+        })
+    };
+
+    match hydrated {
+        Ok(content) => AgentTaskHydratedEvidence {
+            kind: evidence_ref.kind.clone(),
+            label: evidence_ref.label.clone(),
+            task_id: task_id.map(str::to_string),
+            uri: evidence_ref.uri.clone(),
+            source: content.source,
+            status: "ok".to_string(),
+            truncated: content.truncated,
+            bytes_read: content.bytes_read,
+            omitted_bytes: content.omitted_bytes,
+            content: redaction::redact_json(&content.content),
+            error: None,
+        },
+        Err(error) => AgentTaskHydratedEvidence {
+            kind: evidence_ref.kind.clone(),
+            label: evidence_ref.label.clone(),
+            task_id: task_id.map(str::to_string),
+            uri: evidence_ref.uri.clone(),
+            source: "error".to_string(),
+            status: "error".to_string(),
+            truncated: false,
+            bytes_read: None,
+            omitted_bytes: None,
+            content: Value::Null,
+            error: Some(redaction::redact_string(&error.message)),
+        },
+    }
+}
+
+struct HydratedContent {
+    source: String,
+    truncated: bool,
+    bytes_read: Option<usize>,
+    omitted_bytes: Option<u64>,
+    content: Value,
+}
+
+fn hydrate_homeboy_evidence_ref(
+    run_id: &str,
+    uri: &str,
+    task_id: Option<&str>,
+    plan: Option<&AgentTaskPlan>,
+    aggregate: Option<&AgentTaskAggregate>,
+) -> Result<HydratedContent> {
+    let parsed = parse_agent_task_homeboy_uri(uri)?;
+    if parsed.run_id != run_id {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "evidence_ref",
+            format!(
+                "evidence ref points at run {} but command is hydrating run {run_id}",
+                parsed.run_id
+            ),
+            Some(uri.to_string()),
+            None,
+        ));
+    }
+
+    let content = match parsed.section.as_str() {
+        "plan" => match (plan, task_id.or(parsed.task.as_deref())) {
+            (Some(plan), Some(task_id)) => plan
+                .tasks
+                .iter()
+                .find(|task| task.task_id == task_id)
+                .map(|task| json!(task))
+                .unwrap_or_else(|| json!({ "missing_task": task_id })),
+            (Some(plan), None) => json!(plan),
+            (None, _) => json!({ "summary": "plan is not available for this run" }),
+        },
+        "aggregate" => match (aggregate, parsed.outcome.as_deref().or(task_id)) {
+            (Some(aggregate), Some(task_id)) => aggregate
+                .outcomes
+                .iter()
+                .find(|outcome| outcome.task_id == task_id)
+                .map(|outcome| json!(outcome))
+                .unwrap_or_else(|| json!({ "missing_outcome": task_id })),
+            (Some(aggregate), None) => json!(aggregate),
+            (None, _) => json!({ "summary": "aggregate is not available for this run" }),
+        },
+        "artifacts" => match (aggregate, task_id.or(parsed.task.as_deref())) {
+            (Some(aggregate), Some(task_id)) => aggregate
+                .outcomes
+                .iter()
+                .find(|outcome| outcome.task_id == task_id)
+                .map(|outcome| {
+                    json!({
+                        "task_id": outcome.task_id,
+                        "status": outcome.status,
+                        "summary": outcome.summary,
+                        "artifacts": outcome.artifacts,
+                        "typed_artifacts": outcome.typed_artifacts,
+                        "evidence_refs": outcome.evidence_refs,
+                        "diagnostics": outcome.diagnostics,
+                    })
+                })
+                .unwrap_or_else(|| json!({ "missing_outcome": task_id })),
+            _ => json!({ "summary": "outcome artifacts are not available for this run" }),
+        },
+        "logs" => serde_json::to_value(super::logs(run_id)?)
+            .unwrap_or_else(|_| json!({ "summary": "logs could not be serialized" })),
+        "status" => serde_json::to_value(super::status(run_id)?)
+            .unwrap_or_else(|_| json!({ "summary": "status could not be serialized" })),
+        section => json!({
+            "summary": format!("homeboy agent-task evidence does not hydrate section '{section}' yet"),
+        }),
+    };
+
+    Ok(HydratedContent {
+        source: "homeboy".to_string(),
+        truncated: false,
+        bytes_read: None,
+        omitted_bytes: None,
+        content,
+    })
+}
+
+fn hydrate_file_evidence_ref(uri: &str) -> Result<HydratedContent> {
+    let path = file_uri_path(uri)?;
+    hydrate_local_path_evidence_ref(&path)
+}
+
+fn hydrate_local_path_evidence_ref(path: &Path) -> Result<HydratedContent> {
+    let metadata = fs::metadata(path)
+        .map_err(|error| crate::core::Error::internal_io(error.to_string(), None))?;
+    if !metadata.is_file() {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "evidence_ref",
+            "file evidence ref does not point at a regular file",
+            None,
+            None,
+        ));
+    }
+
+    let bytes =
+        fs::read(path).map_err(|error| crate::core::Error::internal_io(error.to_string(), None))?;
+    let truncated = bytes.len() > EVIDENCE_TEXT_LIMIT;
+    let visible = &bytes[..bytes.len().min(EVIDENCE_TEXT_LIMIT)];
+    let text = String::from_utf8_lossy(visible);
+    let redacted_text = redaction::redact_string(&text);
+    let content = serde_json::from_str::<Value>(&redacted_text)
+        .map(|value| json!({ "format": "json", "value": value }))
+        .unwrap_or_else(|_| json!({ "format": "text", "text": redacted_text }));
+
+    Ok(HydratedContent {
+        source: "file".to_string(),
+        truncated,
+        bytes_read: Some(visible.len()),
+        omitted_bytes: truncated.then_some(bytes.len().saturating_sub(EVIDENCE_TEXT_LIMIT) as u64),
+        content,
+    })
+}
+
+fn local_evidence_path(uri: &str) -> Option<PathBuf> {
+    if uri.contains("://") || uri.contains('\0') || uri.trim().is_empty() {
+        return None;
+    }
+    let path = Path::new(uri);
+    if path.is_absolute() || path.exists() {
+        Some(path.to_path_buf())
+    } else {
+        None
+    }
+}
+
+fn file_uri_path(uri: &str) -> Result<PathBuf> {
+    let raw = uri.strip_prefix("file://").ok_or_else(|| {
+        crate::core::Error::validation_invalid_argument(
+            "evidence_ref",
+            "file evidence ref must start with file://",
+            Some(uri.to_string()),
+            None,
+        )
+    })?;
+    if raw.is_empty() || raw.contains('\0') {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "evidence_ref",
+            "file evidence ref path is empty or invalid",
+            Some(uri.to_string()),
+            None,
+        ));
+    }
+    Ok(Path::new(raw).to_path_buf())
+}
+
+struct ParsedAgentTaskUri {
+    run_id: String,
+    section: String,
+    task: Option<String>,
+    outcome: Option<String>,
+}
+
+fn parse_agent_task_homeboy_uri(uri: &str) -> Result<ParsedAgentTaskUri> {
+    let rest = uri
+        .strip_prefix("homeboy://agent-task/run/")
+        .ok_or_else(|| {
+            crate::core::Error::validation_invalid_argument(
+                "evidence_ref",
+                "unsupported homeboy agent-task evidence ref",
+                Some(uri.to_string()),
+                None,
+            )
+        })?;
+    let (path, fragment) = rest.split_once('#').unwrap_or((rest, ""));
+    let mut parts = path.split('/');
+    let run_id = parts.next().unwrap_or_default();
+    let section = parts.next().unwrap_or_default();
+    if run_id.is_empty() || section.is_empty() {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "evidence_ref",
+            "homeboy agent-task evidence ref must include run id and section",
+            Some(uri.to_string()),
+            None,
+        ));
+    }
+
+    Ok(ParsedAgentTaskUri {
+        run_id: run_id.to_string(),
+        section: section.to_string(),
+        task: fragment_value(fragment, "task"),
+        outcome: fragment_value(fragment, "outcome"),
+    })
+}
+
+fn fragment_value(fragment: &str, key: &str) -> Option<String> {
+    fragment.split('&').find_map(|part| {
+        let (candidate, value) = part.split_once('=')?;
+        (candidate == key && !value.trim().is_empty()).then(|| value.to_string())
+    })
+}
+
+pub fn hydrate_evidence_summary(task_id: &str, evidence: &AgentTaskEvidenceRef) -> Option<Value> {
+    let path = evidence.uri.strip_prefix("file://")?;
+    if !path.ends_with(".json") {
+        return None;
+    }
+    let raw = fs::read_to_string(path).ok()?;
+    let value: Value = serde_json::from_str(&raw).ok()?;
+    let redacted = RedactionPolicy::default().redact_json(&value);
+    Some(json!({
+        "task_id": task_id,
+        "kind": evidence.kind,
+        "label": evidence.label,
+        "uri": evidence.uri,
+        "summary": evidence_json_summary(&redacted),
+    }))
+}
+
+fn evidence_json_summary(value: &Value) -> Value {
+    json!({
+        "status": find_string_field(value, &["status", "state"]),
+        "failure_classification": find_string_field(value, &["failure_classification", "failure_class", "classification", "class", "code", "kind"]),
+        "message": find_string_field(value, &["message", "summary", "error", "detail", "reason"]),
+        "command": find_string_field(value, &["command", "cmd", "failing_command"]),
+        "exit_code": find_number_field(value, &["exit_code", "exit_status", "status_code"]),
+        "stderr_excerpt": find_string_field(value, &["stderr", "stderr_excerpt"]).map(|text| excerpt(&text)),
+        "stdout_excerpt": find_string_field(value, &["stdout", "stdout_excerpt"]).map(|text| excerpt(&text)),
+        "diagnostics": first_diagnostics(value),
+    })
+}
+
+fn find_string_field(value: &Value, names: &[&str]) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            for name in names {
+                if let Some(text) = map.get(*name).and_then(Value::as_str) {
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        return Some(trimmed.to_string());
+                    }
+                }
+            }
+            map.values()
+                .find_map(|nested| find_string_field(nested, names))
+        }
+        Value::Array(items) => items
+            .iter()
+            .find_map(|nested| find_string_field(nested, names)),
+        _ => None,
+    }
+}
+
+fn find_number_field(value: &Value, names: &[&str]) -> Option<i64> {
+    match value {
+        Value::Object(map) => {
+            for name in names {
+                if let Some(number) = map.get(*name).and_then(Value::as_i64) {
+                    return Some(number);
+                }
+            }
+            map.values()
+                .find_map(|nested| find_number_field(nested, names))
+        }
+        Value::Array(items) => items
+            .iter()
+            .find_map(|nested| find_number_field(nested, names)),
+        _ => None,
+    }
+}
+
+fn first_diagnostics(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::Array(items)) = map.get("diagnostics") {
+                return Value::Array(items.iter().take(3).cloned().collect());
+            }
+            map.values()
+                .find_map(|nested| match first_diagnostics(nested) {
+                    Value::Array(items) if !items.is_empty() => Some(Value::Array(items)),
+                    _ => None,
+                })
+                .unwrap_or_else(|| Value::Array(Vec::new()))
+        }
+        Value::Array(items) => items
+            .iter()
+            .find_map(|nested| match first_diagnostics(nested) {
+                Value::Array(items) if !items.is_empty() => Some(Value::Array(items)),
+                _ => None,
+            })
+            .unwrap_or_else(|| Value::Array(Vec::new())),
+        _ => Value::Array(Vec::new()),
+    }
+}
+
+fn excerpt(text: &str) -> String {
+    const LIMIT: usize = 600;
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= LIMIT {
+        trimmed.to_string()
+    } else {
+        let prefix: String = trimmed.chars().take(LIMIT).collect();
+        format!("{prefix}...")
+    }
+}

--- a/src/core/agent_task_service/status_support.rs
+++ b/src/core/agent_task_service/status_support.rs
@@ -386,6 +386,12 @@ fn fragment_value(fragment: &str, key: &str) -> Option<String> {
     })
 }
 
+pub fn evidence_ref_task_id(evidence_ref: &AgentTaskEvidenceRef) -> Option<String> {
+    parse_agent_task_homeboy_uri(&evidence_ref.uri)
+        .ok()
+        .and_then(|parsed| parsed.task.or(parsed.outcome))
+}
+
 pub fn hydrate_evidence_summary(task_id: &str, evidence: &AgentTaskEvidenceRef) -> Option<Value> {
     let path = evidence.uri.strip_prefix("file://")?;
     if !path.ends_with(".json") {

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -346,12 +346,14 @@ pub mod secrets {
 /// High-level service entry points combining lifecycle and scheduling.
 pub mod service {
     pub use super::super::agent_task_service::{
-        aggregate_exit_code, ai_model_from_tool, artifacts, cancel, discover_runs, logs,
-        normalize_plan_workspaces, promotion_source, read_plan, resume, retry, run_cook,
-        run_loaded_plan, run_next, run_status, run_submitted, source_worktree_path, status,
-        submit_plan_spec, AgentTaskCookAttemptReport, AgentTaskCookReport,
-        AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts,
-        AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport, AgentTaskDiscoveryRun,
-        AgentTaskRetryServiceResult, AgentTaskRunResult,
+        aggregate_exit_code, ai_model_from_tool, artifacts, cancel, discover_runs,
+        hydrate_evidence_ref, hydrate_evidence_summary, logs, normalize_plan_workspaces,
+        offloaded_status_remediation, persist_provider_boundary_replay_evidence, promotion_source,
+        read_plan, resume, retry, run_cook, run_loaded_plan, run_next, run_status, run_submitted,
+        source_worktree_path, status, submit_plan_spec, AgentTaskCookAttemptReport,
+        AgentTaskCookReport, AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands,
+        AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
+        AgentTaskDiscoveryRun, AgentTaskHydratedEvidence, AgentTaskRetryServiceResult,
+        AgentTaskRunResult,
     };
 }

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -348,9 +348,10 @@ pub mod service {
     pub use super::super::agent_task_service::{
         aggregate_exit_code, artifacts, cancel, discover_runs, logs, normalize_plan_workspaces,
         promotion_source, read_plan, resume, retry, run_cook, run_loaded_plan, run_next,
-        run_status, run_submitted, status, submit_plan_spec, AgentTaskCookAttemptReport,
-        AgentTaskCookReport, AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands,
-        AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
-        AgentTaskDiscoveryRun, AgentTaskRetryServiceResult, AgentTaskRunResult,
+        run_status, run_submitted, source_worktree_path, status, submit_plan_spec,
+        AgentTaskCookAttemptReport, AgentTaskCookReport, AgentTaskCookServiceOptions,
+        AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter,
+        AgentTaskDiscoveryReport, AgentTaskDiscoveryRun, AgentTaskRetryServiceResult,
+        AgentTaskRunResult,
     };
 }

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -347,13 +347,13 @@ pub mod secrets {
 pub mod service {
     pub use super::super::agent_task_service::{
         aggregate_exit_code, ai_model_from_tool, artifacts, cancel, discover_runs,
-        hydrate_evidence_ref, hydrate_evidence_summary, logs, normalize_plan_workspaces,
-        offloaded_status_remediation, persist_provider_boundary_replay_evidence, promotion_source,
-        read_plan, resume, retry, run_cook, run_loaded_plan, run_next, run_status, run_submitted,
-        source_worktree_path, status, submit_plan_spec, AgentTaskCookAttemptReport,
-        AgentTaskCookReport, AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands,
-        AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
-        AgentTaskDiscoveryRun, AgentTaskHydratedEvidence, AgentTaskRetryServiceResult,
-        AgentTaskRunResult,
+        evidence_ref_task_id, hydrate_evidence_ref, hydrate_evidence_summary, logs,
+        normalize_plan_workspaces, offloaded_status_remediation,
+        persist_provider_boundary_replay_evidence, promotion_source, read_plan, resume, retry,
+        run_cook, run_loaded_plan, run_next, run_status, run_submitted, source_worktree_path,
+        status, submit_plan_spec, AgentTaskCookAttemptReport, AgentTaskCookReport,
+        AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts,
+        AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport, AgentTaskDiscoveryRun,
+        AgentTaskHydratedEvidence, AgentTaskRetryServiceResult, AgentTaskRunResult,
     };
 }

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -346,12 +346,12 @@ pub mod secrets {
 /// High-level service entry points combining lifecycle and scheduling.
 pub mod service {
     pub use super::super::agent_task_service::{
-        aggregate_exit_code, artifacts, cancel, discover_runs, logs, normalize_plan_workspaces,
-        promotion_source, read_plan, resume, retry, run_cook, run_loaded_plan, run_next,
-        run_status, run_submitted, source_worktree_path, status, submit_plan_spec,
-        AgentTaskCookAttemptReport, AgentTaskCookReport, AgentTaskCookServiceOptions,
-        AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter,
-        AgentTaskDiscoveryReport, AgentTaskDiscoveryRun, AgentTaskRetryServiceResult,
-        AgentTaskRunResult,
+        aggregate_exit_code, ai_model_from_tool, artifacts, cancel, discover_runs, logs,
+        normalize_plan_workspaces, promotion_source, read_plan, resume, retry, run_cook,
+        run_loaded_plan, run_next, run_status, run_submitted, source_worktree_path, status,
+        submit_plan_spec, AgentTaskCookAttemptReport, AgentTaskCookReport,
+        AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts,
+        AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport, AgentTaskDiscoveryRun,
+        AgentTaskRetryServiceResult, AgentTaskRunResult,
     };
 }


### PR DESCRIPTION
## Summary
- Detect committed provider changes when a patch artifact is empty.
- Export a deterministic committed-changes patch from the source worktree relative to the intended base.
- Classify committed provider work as promotable changes instead of no_changes.
- Preserve true no-change behavior for empty patches without local commits.

## Why
OpenCode dogfood proved the agent can implement and test a change, but if the agent commits before Homeboy promotion, the worktree diff is clean and Homeboy previously reported no_changes. Promotion now handles committed local changes as first-class provider output.

## Verification
- cargo test agent_task_promotion --lib
- cargo test agent_task_cook --lib
- cargo test agent_task_fanout --lib
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing committed-change promotion, adding regression tests, and running targeted verification.