### PR TITLE
Give cook attempts unique run IDs

### DIFF
--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -9,6 +9,7 @@ use homeboy::core::agent_tasks::dispatch_service::{
     self, AgentTaskDispatchCommand, DispatchCoreInputs,
 };
 use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
+use homeboy::core::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::core::agent_tasks::provider;
 use homeboy::core::agent_tasks::service::{
     self as agent_task_service, AgentTaskCookServiceOptions,
@@ -55,6 +56,7 @@ fn submit_batch_cook_fanout(args: AgentTaskFanoutSubmitArgs) -> CmdResult<Value>
             serde_json::json!({
                 "cook_id": cook.cook_id,
                 "run_id": cook.run_id(),
+                "run_id_semantics": "stable cook id; executed attempts use unique durable run ids",
                 "worktree": cook.to_worktree,
                 "head": cook.head,
                 "workspace_materialization": cook.workspace_materialization,
@@ -504,7 +506,7 @@ impl BatchCookSpec {
             required_capabilities: Vec::new(),
             secret_env: self.secret_env.clone(),
             concurrency: self.concurrency,
-            run_id: Some(self.run_id()),
+            run_id: Some(agent_task_lifecycle::cook_attempt_run_id(&self.run_id(), 1)),
             task_id: None,
             core: DispatchCoreInputs {
                 tasks_json: None,
@@ -525,7 +527,7 @@ impl BatchCookSpec {
         Ok(BatchCookInvocation {
             dispatch,
             options: AgentTaskCookServiceOptions {
-                cook_id: self.cook_id.clone(),
+                cook_id: self.run_id(),
                 initial_run_id: self.run_id(),
                 to_worktree: self.to_worktree.clone(),
                 provider_command: self.provider_command.clone(),

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -4,6 +4,7 @@
 use serde_json::Value;
 
 use homeboy::core::agent_tasks::dispatch_service;
+use homeboy::core::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_tasks::scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan,
@@ -50,6 +51,10 @@ where
     if dispatch_args.prompt.is_none() {
         dispatch_args.prompt = args.goal.clone();
     }
+    let requested_cook_id = dispatch_args.run_id.clone();
+    if let Some(cook_id) = requested_cook_id.as_deref() {
+        dispatch_args.run_id = Some(agent_task_lifecycle::cook_attempt_run_id(cook_id, 1));
+    }
     dispatch_args.core.queue_only = false;
     let (dispatch_value, _dispatch_exit) =
         dispatch_service::run_dispatch_command(dispatch_args.into(), executor.clone())?;
@@ -61,7 +66,7 @@ where
             )
         })?
         .to_string();
-    let cook_id = run_id.clone();
+    let cook_id = requested_cook_id.unwrap_or_else(|| run_id.clone());
     let title = args
         .title
         .clone()

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -165,8 +165,17 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
         assert_eq!(exit_code, 1);
         assert_eq!(value["schema"], "homeboy/agent-task-cook/v1");
         assert_eq!(value["cook_id"], "cook-missing-provider");
+        assert_ne!(value["latest_run_id"], "cook-missing-provider");
+        assert!(value["latest_run_id"]
+            .as_str()
+            .expect("latest run id")
+            .starts_with("cook-missing-provider-attempt-1-"));
+        assert_eq!(
+            value["history_run_ids"].as_array().expect("history").len(),
+            1
+        );
         assert_eq!(value["status"], "policy_failure");
-        assert_eq!(value["attempts"][0]["run_id"], "cook-missing-provider");
+        assert_eq!(value["attempts"][0]["run_id"], value["latest_run_id"]);
         assert!(value["stop_reason"]
             .as_str()
             .expect("stop reason")

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -53,7 +53,7 @@ pub fn record_completed_run(
 }
 
 pub fn load_plan(run_id: &str) -> Result<AgentTaskPlan> {
-    let record = store::read_record(&sanitize_run_id(run_id))?;
+    let record = store::read_record(&resolve_run_id(run_id)?)?;
     store::read_plan_path(&record.plan_path)
 }
 
@@ -146,7 +146,9 @@ pub fn record_run_aggregate(
 }
 
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let requested_run_id = sanitize_run_id(run_id);
+    let resolved_run_id = resolve_run_id(run_id)?;
+    let mut record = store::read_record(&resolved_run_id)?;
     if let (Ok(aggregate), Ok(plan)) = (
         store::read_aggregate(&record.run_id),
         store::read_plan_path(&record.plan_path),
@@ -168,6 +170,16 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
         }
     }
     record.annotate_stale_running();
+    if requested_run_id != record.run_id {
+        if let Ok(index) = store::read_cook_index(&requested_run_id) {
+            let metadata = record.ensure_metadata_object();
+            metadata.insert("cook_alias".to_string(), json!(requested_run_id));
+            metadata.insert(
+                "cook_index".to_string(),
+                serde_json::to_value(index).unwrap_or(Value::Null),
+            );
+        }
+    }
     Ok(record)
 }
 
@@ -261,7 +273,7 @@ pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
 }
 
 pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRunRecord> {
-    let source = store::read_record(&sanitize_run_id(run_id))?;
+    let source = store::read_record(&resolve_run_id(run_id)?)?;
     let plan = store::read_plan_path(&source.plan_path)?;
     let mut retry = submit_plan(&plan, requested_run_id)?;
     let metadata = retry.ensure_metadata_object();
@@ -272,7 +284,7 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
 }
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
-    let run_id = sanitize_run_id(run_id);
+    let run_id = resolve_run_id(run_id)?;
     let record = store::read_record(&run_id)?;
     let (events, artifact_refs) = match store::read_aggregate(&run_id) {
         Ok(aggregate) => {
@@ -291,7 +303,7 @@ pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
 }
 
 pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
-    let run_id = sanitize_run_id(run_id);
+    let run_id = resolve_run_id(run_id)?;
     let record = store::read_record(&run_id)?;
     let aggregate = store::read_aggregate(&run_id).ok();
     let latest_executor_evidence = record.latest_executor_evidence.as_ref();
@@ -304,7 +316,7 @@ pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
 }
 
 pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
-    let record = store::read_record(&sanitize_run_id(run_id))?;
+    let record = store::read_record(&resolve_run_id(run_id)?)?;
     record.aggregate_path.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "run_id",
@@ -325,6 +337,32 @@ pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
     })?;
     let path = store::aggregate_path(&record.run_id)?;
     Ok((raw, path))
+}
+
+pub fn record_cook_attempt(
+    cook_id: &str,
+    attempt: u32,
+    run_id: &str,
+) -> Result<AgentTaskCookIndex> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let recorded_at = now_timestamp();
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("cook_id".to_string(), json!(sanitize_run_id(cook_id)));
+    metadata.insert("cook_attempt".to_string(), json!(attempt));
+    store::write_record(&record)?;
+    store::write_cook_index_attempt(cook_id, attempt, run_id, recorded_at)
+}
+
+pub fn cook_index(cook_id: &str) -> Result<AgentTaskCookIndex> {
+    store::read_cook_index(&sanitize_run_id(cook_id))
+}
+
+fn resolve_run_id(run_id: &str) -> Result<String> {
+    let run_id = sanitize_run_id(run_id);
+    match store::read_cook_index(&run_id) {
+        Ok(index) => Ok(index.latest_run_id),
+        Err(_) => Ok(run_id),
+    }
 }
 
 pub fn record_promotion(run_id: &str, promotion: Value) -> Result<AgentTaskRunRecord> {

--- a/src/core/agent_task_lifecycle/lifecycle_record_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_record_ops.rs
@@ -133,6 +133,13 @@ pub(crate) fn default_run_id() -> String {
     format!("agent-task-{}", Uuid::new_v4())
 }
 
+pub fn cook_attempt_run_id(cook_id: &str, attempt: u32) -> String {
+    let cook_id = sanitize_run_id(cook_id);
+    let suffix = Uuid::new_v4().simple().to_string();
+    let suffix = &suffix[..8];
+    format!("{cook_id}-attempt-{attempt}-{suffix}")
+}
+
 pub(crate) fn now_timestamp() -> String {
     Utc::now().to_rfc3339()
 }

--- a/src/core/agent_task_lifecycle/mod.rs
+++ b/src/core/agent_task_lifecycle/mod.rs
@@ -39,6 +39,7 @@ mod records;
 pub use cancellation::*;
 pub use failure_recording::*;
 pub use lifecycle_ops::*;
+pub use lifecycle_record_ops::cook_attempt_run_id;
 pub use records::*;
 
 pub(crate) use conversion::*;

--- a/src/core/agent_task_lifecycle/records.rs
+++ b/src/core/agent_task_lifecycle/records.rs
@@ -6,6 +6,7 @@ pub(crate) mod schemas {
     pub(crate) const EVENT: &str = "homeboy/agent-task-event/v1";
     pub(crate) const RUN_STATUS: &str = "homeboy/agent-task-run-status/v1";
     pub(crate) const RUN_ARTIFACTS: &str = "homeboy/agent-task-run-artifacts/v1";
+    pub(crate) const COOK_INDEX: &str = "homeboy/agent-task-cook-index/v1";
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -34,6 +35,27 @@ pub struct AgentTaskRunRecord {
     pub lifecycle: RunLifecycleRecord,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskCookIndex {
+    #[serde(default = "cook_index_schema")]
+    pub schema: String,
+    pub cook_id: String,
+    pub latest_run_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attempts: Vec<AgentTaskCookIndexAttempt>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskCookIndexAttempt {
+    pub attempt: u32,
+    pub run_id: String,
+    pub recorded_at: String,
+}
+
+fn cook_index_schema() -> String {
+    schemas::COOK_INDEX.to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -69,6 +69,40 @@ fn submit_plan_persists_queued_status() {
 }
 
 #[test]
+fn cook_index_keeps_repeated_attempts_unique_with_stable_latest_alias() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let aggregate = succeeded_aggregate(&plan);
+        let first_run_id = cook_attempt_run_id("cook-issue-6978", 1);
+        let second_run_id = cook_attempt_run_id("cook-issue-6978", 1);
+
+        assert_ne!(first_run_id, second_run_id);
+
+        record_completed_run(&plan, &aggregate, Some(&first_run_id)).expect("first run recorded");
+        record_cook_attempt("cook-issue-6978", 1, &first_run_id).expect("first cook indexed");
+        record_completed_run(&plan, &aggregate, Some(&second_run_id)).expect("second run recorded");
+        record_cook_attempt("cook-issue-6978", 1, &second_run_id).expect("second cook indexed");
+
+        let index = cook_index("cook-issue-6978").expect("cook index loaded");
+        assert_eq!(index.latest_run_id, second_run_id);
+        assert_eq!(index.attempts.len(), 2);
+        assert_eq!(index.attempts[0].run_id, first_run_id);
+        assert_eq!(index.attempts[1].run_id, second_run_id);
+
+        let latest = status("cook-issue-6978").expect("stable cook id resolves");
+        assert_eq!(latest.run_id, second_run_id);
+        assert_eq!(latest.metadata["cook_alias"], "cook-issue-6978");
+        assert_eq!(
+            latest.metadata["cook_index"]["latest_run_id"],
+            second_run_id
+        );
+
+        let (_raw, path) = aggregate_source("cook-issue-6978").expect("latest aggregate resolves");
+        assert!(path.display().to_string().contains(&second_run_id));
+    });
+}
+
+#[test]
 fn record_promotion_persists_latest_event_on_run_metadata() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -49,6 +49,10 @@ pub struct AgentTaskCookServiceOptions {
 pub struct AgentTaskCookReport {
     pub schema: &'static str,
     pub cook_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub history_run_ids: Vec<String>,
     pub status: String,
     pub attempts: Vec<AgentTaskCookAttemptReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -83,6 +87,7 @@ where
     let cook_id = options.cook_id.clone();
 
     for attempt in 1..=max_attempts {
+        agent_task_lifecycle::record_cook_attempt(&cook_id, attempt, &run_id)?;
         let record = agent_task_lifecycle::status(&run_id)?;
         let plan = agent_task_lifecycle::load_plan(&run_id)?;
         let Some(source_request) = plan.tasks.first().cloned() else {
@@ -232,7 +237,7 @@ where
                         1,
                     ));
                 };
-                let next_run_id = format!("{cook_id}-attempt-{}", attempt + 1);
+                let next_run_id = agent_task_lifecycle::cook_attempt_run_id(&cook_id, attempt + 1);
                 let follow_up_plan = AgentTaskPlan::new(
                     format!("{cook_id}-cook-attempt-{}", attempt + 1),
                     vec![follow_up_request],
@@ -391,10 +396,24 @@ fn cook_report(
     stop_reason: Option<String>,
     exit_code: i32,
 ) -> AgentTaskRunResult<AgentTaskCookReport> {
+    let (latest_run_id, history_run_ids) = agent_task_lifecycle::cook_index(&cook_id)
+        .map(|index| {
+            (
+                Some(index.latest_run_id),
+                index
+                    .attempts
+                    .into_iter()
+                    .map(|attempt| attempt.run_id)
+                    .collect(),
+            )
+        })
+        .unwrap_or((None, Vec::new()));
     AgentTaskRunResult {
         value: AgentTaskCookReport {
             schema: "homeboy/agent-task-cook/v1",
             cook_id,
+            latest_run_id,
+            history_run_ids,
             status: status.to_string(),
             attempts,
             finalization,

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -233,14 +233,15 @@ pub mod gate {
 /// Durable run lifecycle: submit, run-record state, log/artifact loaders.
 pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
-        aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run, list_records,
-        load_plan, logs, mark_resuming, mark_running, record_completed_run,
-        record_pre_dispatch_failure, record_promotion, record_remote_dispatch_failure,
-        record_run_aggregate, retry, run_record_exists, run_status, status, submit_plan,
-        AgentTaskArtifactRef, AgentTaskEventEnvelope, AgentTaskPreDispatchFailure,
-        AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts, AgentTaskRunLog,
-        AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState, AgentTaskRunStatus,
-        AgentTaskRunTask,
+        aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
+        cook_attempt_run_id, cook_index, list_records, load_plan, logs, mark_resuming,
+        mark_running, record_completed_run, record_cook_attempt, record_pre_dispatch_failure,
+        record_promotion, record_remote_dispatch_failure, record_run_aggregate, retry,
+        run_record_exists, run_status, status, submit_plan, AgentTaskArtifactRef,
+        AgentTaskCookIndex, AgentTaskCookIndexAttempt, AgentTaskEventEnvelope,
+        AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts,
+        AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState,
+        AgentTaskRunStatus, AgentTaskRunTask,
     };
 }
 

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -4,7 +4,10 @@ use std::path::PathBuf;
 use serde::Serialize;
 use serde_json::{json, Value};
 
-use super::{sanitize_run_id, AgentTaskRunRecord, AgentTaskRunState};
+use super::{
+    sanitize_run_id, AgentTaskCookIndex, AgentTaskCookIndexAttempt, AgentTaskRunRecord,
+    AgentTaskRunState,
+};
 use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use crate::core::observation::{ObservationStore, RunListFilter, RunRecord, RunStatus};
 use crate::core::{paths, Error, ErrorCode, Result};
@@ -65,6 +68,36 @@ pub(super) fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {
         )
     })?;
     record_from_run(&run)
+}
+
+pub(super) fn write_cook_index_attempt(
+    cook_id: &str,
+    attempt: u32,
+    run_id: &str,
+    recorded_at: String,
+) -> Result<AgentTaskCookIndex> {
+    let cook_id = sanitize_run_id(cook_id);
+    let run_id = sanitize_run_id(run_id);
+    let mut index = read_cook_index(&cook_id).unwrap_or_else(|_| AgentTaskCookIndex {
+        schema: super::records::schemas::COOK_INDEX.to_string(),
+        cook_id: cook_id.clone(),
+        latest_run_id: run_id.clone(),
+        attempts: Vec::new(),
+    });
+    index.cook_id = cook_id;
+    index.latest_run_id = run_id.clone();
+    index.attempts.retain(|entry| entry.run_id != run_id);
+    index.attempts.push(AgentTaskCookIndexAttempt {
+        attempt,
+        run_id,
+        recorded_at,
+    });
+    write_json(&cook_index_path(&index.cook_id)?, &index)?;
+    Ok(index)
+}
+
+pub(super) fn read_cook_index(cook_id: &str) -> Result<AgentTaskCookIndex> {
+    read_json(&cook_index_path(cook_id)?)
 }
 
 pub(super) fn record_exists(run_id: &str) -> Result<bool> {
@@ -241,4 +274,11 @@ fn run_dir(run_id: &str) -> Result<PathBuf> {
     Ok(paths::homeboy_data()?
         .join("agent-task-runs")
         .join(sanitize_run_id(run_id)))
+}
+
+fn cook_index_path(cook_id: &str) -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?
+        .join("agent-task-cooks")
+        .join(sanitize_run_id(cook_id))
+        .join("index.json"))
 }


### PR DESCRIPTION
## Summary
- Give each cook attempt a unique durable run ID while keeping a stable cook ID alias.
- Persist a cook index with latest run and attempt history.
- Resolve stable cook IDs through the index for status/log/artifact flows, while preserving old direct run IDs.

## Why
Repeated dogfood runs reused cook-issue style IDs, making stale aggregates easy to confuse with current attempts. Stable aliases should point to history; durable attempt IDs should be unique.

## Verification
- cargo test agent_task_lifecycle::tests
- cargo test cook_returns_durable_id_when_promotion_provider_is_missing
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing cook attempt indexing, updating lifecycle resolution, and adding regression coverage.