### PR TITLE
fix: stage codebox fuzz workload files

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1547,6 +1547,7 @@ fn fuzz_runner_workload_path(
 
     expand_fuzz_workload_strings(&mut value, rig_context);
     inject_fuzz_runtime_context(&mut value, rig_context);
+    stage_codebox_workload_file_refs(&mut value, source_path)?;
 
     let output_file = format!(
         "fuzz-workload-{}.json",
@@ -1652,6 +1653,130 @@ fn inject_fuzz_runtime_context(value: &mut serde_json::Value, rig_context: &Fuzz
             "components": components,
         }),
     );
+}
+
+fn stage_codebox_workload_file_refs(
+    value: &mut serde_json::Value,
+    source_path: &Path,
+) -> homeboy::core::Result<()> {
+    if value.get("schema").and_then(serde_json::Value::as_str)
+        != Some("wp-codebox/wordpress-workload-run/v1")
+    {
+        return Ok(());
+    }
+
+    let Some(root) = value.as_object_mut() else {
+        return Ok(());
+    };
+    let mut staged_files = root
+        .get("staged_files")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    for phase in ["before", "steps", "after"] {
+        let Some(steps) = root
+            .get_mut(phase)
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+        for step in steps {
+            stage_codebox_step_file_refs(step, source_path, &mut staged_files)?;
+        }
+    }
+
+    if !staged_files.is_empty() {
+        root.insert(
+            "staged_files".to_string(),
+            serde_json::Value::Array(staged_files),
+        );
+    }
+    Ok(())
+}
+
+fn stage_codebox_step_file_refs(
+    step: &mut serde_json::Value,
+    source_path: &Path,
+    staged_files: &mut Vec<serde_json::Value>,
+) -> homeboy::core::Result<()> {
+    let Some(step) = step.as_object_mut() else {
+        return Ok(());
+    };
+    let command = step
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    if command != "wordpress.run-workload" && command != "wordpress.run-declarative-fuzz" {
+        return Ok(());
+    }
+    let Some(args) = step
+        .get_mut("args")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return Ok(());
+    };
+
+    for arg in args {
+        let Some(raw) = arg.as_str() else {
+            continue;
+        };
+        let Some(path) = raw.strip_prefix("path=") else {
+            continue;
+        };
+        if !codebox_workload_ref_needs_staging(path) {
+            continue;
+        }
+        let host_path = Path::new(path);
+        if !host_path.is_file() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "fuzz_workload",
+                format!(
+                    "WP Codebox fuzz workload references a local file that cannot be staged: {}",
+                    host_path.display()
+                ),
+                Some(source_path.display().to_string()),
+                None,
+            ));
+        }
+        let target = codebox_staged_workload_target(host_path);
+        if !staged_files.iter().any(|entry| {
+            entry.get("source").and_then(serde_json::Value::as_str) == Some(path)
+                && entry.get("target").and_then(serde_json::Value::as_str) == Some(target.as_str())
+        }) {
+            staged_files.push(serde_json::json!({
+                "source": path,
+                "target": target.clone(),
+            }));
+        }
+        *arg = serde_json::Value::String(format!("path={target}"));
+    }
+    Ok(())
+}
+
+fn codebox_workload_ref_needs_staging(path: &str) -> bool {
+    let path = Path::new(path);
+    path.is_absolute()
+        && path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| matches!(extension, "php" | "json" | "mjs" | "js"))
+}
+
+fn codebox_staged_workload_target(path: &Path) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("workload");
+    let extension = path
+        .extension()
+        .and_then(|name| name.to_str())
+        .unwrap_or("php");
+    format!(
+        "/tmp/homeboy-fuzz-workloads/{}.{}",
+        sanitize_workload_file_segment(stem),
+        sanitize_workload_file_segment(extension)
+    )
 }
 
 fn expanded_fuzz_component_path(

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -726,3 +726,115 @@ fn fuzz_runner_env_expands_rig_workload_and_injects_runtime_context() {
         key == "HOMEBOY_FUZZ_WORKLOAD_ROOT" && value == &temp.path().to_string_lossy()
     }));
 }
+
+#[test]
+fn fuzz_runner_env_stages_codebox_workload_file_refs() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(temp.path().join("bench")).expect("create bench dir");
+    let php_path = temp.path().join("bench/rest-product-batch-import.php");
+    std::fs::write(&php_path, "<?php return array( 'ok' => true );\n").expect("write php workload");
+    let workload_path = temp
+        .path()
+        .join("bench/rest-product-batch-import.workload.json");
+    std::fs::write(
+        &workload_path,
+        r#"{
+          "schema": "wp-codebox/wordpress-workload-run/v1",
+          "steps": [
+            {
+              "command": "wordpress.run-workload",
+              "args": [
+                "path=${package.root}/bench/rest-product-batch-import.php",
+                "type=php"
+              ]
+            }
+          ]
+        }"#,
+    )
+    .expect("write workload");
+    let spec: RigSpec = serde_json::from_value(serde_json::json!({
+        "id": "package-fuzz",
+        "components": {
+            "package": {
+                "path": "${package.root}/plugins/package",
+                "branch": "main"
+            }
+        }
+    }))
+    .expect("parse rig spec");
+    let context = FuzzRigContext {
+        spec,
+        package_root: Some(temp.path().to_path_buf()),
+    };
+    let args = FuzzRunArgs {
+        comp: PositionalComponentArgs {
+            component: Some("package".to_string()),
+            path: None,
+        },
+        rig: Some("package-fuzz".to_string()),
+        extension_override: ExtensionOverrideArgs { extensions: vec![] },
+        setting_args: SettingArgs {
+            setting: vec![],
+            setting_json: vec![],
+        },
+        workload_id: Some("rest-product-batch-import".to_string()),
+        run_id: Some("proof-1".to_string()),
+        tracker_refs: vec![],
+        seed: None,
+        inventory: None,
+        sequence_plan: None,
+        require_case_log: false,
+        require_coverage_summary: false,
+        require_result_envelope: false,
+        max_duration: None,
+        gate_profile: FuzzGateProfileArg::Measurement,
+        allow_destructive: false,
+        isolation: FuzzIsolationArg::Shared,
+        isolation_proof: None,
+        expect_metric: vec![],
+        action_model: None,
+        exploration_policy: None,
+        args: vec![],
+    };
+    let workload = FuzzWorkloadOutput {
+        id: "rest-product-batch-import".to_string(),
+        label: None,
+        description: None,
+        source: format!("rig_workloads:generic:{}", workload_path.display()),
+        manifest_path: Some(workload_path.to_string_lossy().to_string()),
+    };
+    let run_dir = RunDir::create().expect("run dir");
+    let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
+
+    let env = fuzz_runner_env(
+        &args,
+        Some(&context),
+        Some(&workload),
+        &results_path,
+        &run_dir,
+        None,
+        None,
+    )
+    .expect("fuzz runner env");
+    let expanded_path = env
+        .iter()
+        .find_map(|(key, value)| (key == "HOMEBOY_FUZZ_WORKLOAD_PATH").then_some(value))
+        .expect("expanded workload path");
+    let expanded: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(expanded_path).expect("read expanded workload"),
+    )
+    .expect("parse expanded workload");
+
+    assert_eq!(
+        expanded["steps"][0]["args"][0].as_str(),
+        Some("path=/tmp/homeboy-fuzz-workloads/rest-product-batch-import.php")
+    );
+    assert_eq!(
+        expanded["staged_files"][0]["source"].as_str(),
+        Some(php_path.to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        expanded["staged_files"][0]["target"].as_str(),
+        Some("/tmp/homeboy-fuzz-workloads/rest-product-batch-import.php")
+    );
+}


### PR DESCRIPTION
## Summary
- stage WP Codebox fuzz workload file references into sandbox-visible `/tmp/homeboy-fuzz-workloads` targets
- rewrite supported absolute workload file args before execution
- fail preflight when a referenced local workload file cannot be staged

Fixes #7136.

## Testing
- `rustfmt --check src/commands/fuzz/execution.rs src/commands/fuzz/tests/workload_tests.rs`
- `cargo test commands::fuzz::tests::workload_tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing workload staging and unit coverage.