### PR TITLE
fix: clarify rig up lab remediation

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -441,7 +441,7 @@ impl LabLocalExecutionPolicy {
 
 pub const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
 pub(crate) const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
-pub(crate) const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
+pub(crate) const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror. For Lab/offloaded dependency preparation and verification, run `homeboy rig check <rig-id> --runner <runner-id>` or the rig's benchmark profile through `homeboy rig run <rig-id> --runner <runner-id>`.";
 const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
 

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -354,7 +354,9 @@ fn rig_check_supports_lab_runner_but_rig_up_stays_local_only() {
     assert!(!rig_up_descriptor.supports_lab_runner);
     assert!(rig_up_descriptor
         .lab_runner_unsupported_reason
-        .is_some_and(|reason| reason.contains("rig up")));
+        .is_some_and(|reason| reason.contains("rig up")
+            && reason.contains("rig check <rig-id> --runner <runner-id>")
+            && reason.contains("rig run <rig-id> --runner <runner-id>")));
 }
 
 #[test]
@@ -1156,6 +1158,10 @@ fn test_lab_runner_unsupported_hot_command_reasons() {
         .lab_runner_unsupported_reason()
         .expect("rig up reason")
         .contains("single-workspace Lab snapshot"));
+    assert!(parsed_command(&["homeboy", "rig", "up", "studio"])
+        .lab_runner_unsupported_reason()
+        .expect("rig up reason")
+        .contains("rig check <rig-id> --runner <runner-id>"));
     assert!(parsed_command(&[
         "homeboy", "fleet", "exec", "prod", "--apply", "wp", "plugin", "list",
     ])

--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -99,6 +99,41 @@ fn bare_json_output_format_is_rejected_as_footgun() {
 }
 
 #[test]
+fn rig_up_runner_error_points_to_offloadable_rig_paths() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let output = homeboy_command()
+        .args([
+            "--runner",
+            "homeboy-lab",
+            "rig",
+            "up",
+            "woocommerce-performance",
+        ])
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .output()
+        .expect("run homeboy");
+
+    assert_eq!(output.status.code(), Some(2));
+
+    let stdout_json: Value = serde_json::from_slice(&output.stdout).expect("stdout json");
+    let message = stdout_json["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("--runner is unavailable for this local-only resource-pressure command"),
+        "runner error should identify the unsupported local-only command: {message}"
+    );
+    assert!(
+        message.contains("homeboy rig check <rig-id> --runner <runner-id>"),
+        "runner error should point to offloadable rig check preparation: {message}"
+    );
+    assert!(
+        message.contains("homeboy rig run <rig-id> --runner <runner-id>"),
+        "runner error should point to offloadable rig run workflow: {message}"
+    );
+}
+
+#[test]
 fn command_owned_output_path_is_not_rejected_as_global_format() {
     let dir = tempfile::tempdir().expect("tempdir");
 


### PR DESCRIPTION
## Summary
- expand the `rig up` Lab unsupported reason with actionable offloadable rig paths
- cover the command contract and JSON error output so the remediation stays useful

Fixes #7134.

## Testing
- `rustfmt --check src/command_contract/lab.rs tests/command_contract/lab_test.rs tests/output_errors.rs`
- `cargo test rig_check_supports_lab_runner_but_rig_up_stays_local_only -- --nocapture`
- `cargo test test_lab_runner_unsupported_hot_command_reasons -- --nocapture`
- `cargo test --test output_errors rig_up_runner_error_points_to_offloadable_rig_paths -- --nocapture`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and testing the remediation wording and regression coverage.