### PR TITLE
fix: prepare rig dependencies before bench checks

### DIFF
--- a/src/core/rig/pipeline/mod.rs
+++ b/src/core/rig/pipeline/mod.rs
@@ -60,6 +60,80 @@ pub fn run_pipeline_check_groups(
     run_ordered_steps(rig, "check", &steps, ordered_indices, fail_fast, &[])
 }
 
+pub fn run_prepare_requirement_steps(
+    rig: &RigSpec,
+    phase: &str,
+    settings: &[(String, String)],
+) -> Result<PipelineOutcome> {
+    let mut outcomes = Vec::new();
+    let mut failed = 0;
+    let mut passed = 0;
+
+    for (pipeline_name, steps) in &rig.pipeline {
+        if pipeline_name == phase {
+            continue;
+        }
+
+        for (idx, step) in steps.iter().enumerate() {
+            if !is_prepare_requirement_step(step, phase) {
+                continue;
+            }
+
+            let label = labels::step_label(rig, step, idx);
+            crate::log_status!("rig", "{}: {}", phase, label);
+            let result = requirement_step::run_requirement_step(rig, phase, step, settings);
+            let outcome = match &result {
+                Ok(()) => PipelineStepOutcome {
+                    kind: labels::step_kind(step).to_string(),
+                    label: label.clone(),
+                    status: "pass".to_string(),
+                    error: None,
+                },
+                Err(error) => PipelineStepOutcome {
+                    kind: labels::step_kind(step).to_string(),
+                    label: label.clone(),
+                    status: "fail".to_string(),
+                    error: Some(error.to_string()),
+                },
+            };
+
+            match result {
+                Ok(()) => passed += 1,
+                Err(_) => {
+                    failed += 1;
+                    outcomes.push(outcome);
+                    return Ok(PipelineOutcome {
+                        name: phase.to_string(),
+                        steps: outcomes,
+                        passed,
+                        failed,
+                    });
+                }
+            }
+
+            outcomes.push(outcome);
+        }
+    }
+
+    Ok(PipelineOutcome {
+        name: phase.to_string(),
+        steps: outcomes,
+        passed,
+        failed,
+    })
+}
+
+fn is_prepare_requirement_step(step: &PipelineStep, phase: &str) -> bool {
+    matches!(
+        step,
+        PipelineStep::Requirement {
+            prepare_command: Some(_),
+            prepare_phases,
+            ..
+        } if prepare_phases.iter().any(|candidate| candidate == phase)
+    )
+}
+
 pub fn cleanup_shared_paths(rig: &RigSpec) -> Result<()> {
     fs_step::cleanup_shared_paths(rig)
 }

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -17,7 +17,8 @@ use super::lease::acquire_active_run_lease;
 use super::lint::run_package_lint;
 use super::pipeline::{
     cleanup_shared_paths, run_command_step, run_pipeline, run_pipeline_check_groups,
-    run_pipeline_with_settings, PipelineOutcome, PipelineStepOutcome,
+    run_pipeline_with_settings, run_prepare_requirement_steps, PipelineOutcome,
+    PipelineStepOutcome,
 };
 use super::service::{self, ServiceStatus};
 use super::spec::{DependencyMaterializationOutputKind, RigSpec, ServiceKind, SymlinkSpec};
@@ -299,11 +300,23 @@ pub fn run_bench_prepare(
     rig: &RigSpec,
     settings: &[(String, String)],
 ) -> Result<Option<BenchPrepareReport>> {
-    if !rig.pipeline.contains_key("bench_prepare") {
+    let prepare_requirements = run_prepare_requirement_steps(rig, "bench_prepare", settings)?;
+    if !rig.pipeline.contains_key("bench_prepare") && prepare_requirements.steps.is_empty() {
         return Ok(None);
     }
 
-    let outcome = run_pipeline_with_settings(rig, "bench_prepare", true, settings)?;
+    let pipeline_outcome =
+        if prepare_requirements.is_success() && rig.pipeline.contains_key("bench_prepare") {
+            run_pipeline_with_settings(rig, "bench_prepare", true, settings)?
+        } else {
+            PipelineOutcome {
+                name: "bench_prepare".to_string(),
+                steps: Vec::new(),
+                passed: 0,
+                failed: 0,
+            }
+        };
+    let outcome = merge_prepare_outcomes("bench_prepare", prepare_requirements, pipeline_outcome);
     Ok(Some(BenchPrepareReport {
         rig_id: rig.id.clone(),
         success: outcome.is_success(),

--- a/tests/core/rig/bench_prepare_pipeline_test.rs
+++ b/tests/core/rig/bench_prepare_pipeline_test.rs
@@ -240,6 +240,62 @@ fn failing_bench_prepare_requirement_reports_context() {
 }
 
 #[test]
+fn bench_prepare_materializes_check_requirement_prepare_commands_before_check() {
+    with_isolated_home(|home| {
+        let component = tempfile::TempDir::new().expect("component");
+        let log_dir = tempfile::TempDir::new().expect("log dir");
+        let log_path = log_dir.path().join("order.log");
+        let marker = component.path().join("ready.marker");
+        write_logging_bench_extension(home, &log_path);
+
+        let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+        fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+        let spec = serde_json::json!({
+            "components": {
+                "studio": {
+                    "path": component.path(),
+                    "extensions": { "fixture-bench": {} }
+                }
+            },
+            "bench": { "default_component": "studio" },
+            "pipeline": {
+                "check": [{
+                    "kind": "requirement",
+                    "label": "fixture marker",
+                    "file": marker,
+                    "prepare_command": format!(
+                        "printf 'prepare\\n' >> '{}'; printf ready > '{}'",
+                        log_path.display(),
+                        marker.display()
+                    ),
+                    "prepare_phases": ["up", "bench_prepare"],
+                    "remediation": "prepare the fixture marker before benchmarking"
+                }]
+            }
+        });
+        fs::write(
+            rig_dir.join("check-requirement-prepare-rig.json"),
+            serde_json::to_string(&spec).expect("serialize rig"),
+        )
+        .expect("write rig");
+
+        let (_output, exit_code) = run(
+            run_args(
+                None,
+                vec!["check-requirement-prepare-rig".to_string()],
+                Vec::new(),
+            ),
+            &GlobalArgs {},
+        )
+        .expect("bench should run");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(log_lines(&log_path), vec!["prepare", "workload"]);
+        assert_eq!(fs::read_to_string(marker).expect("marker"), "ready");
+    });
+}
+
+#[test]
 fn bench_list_rig_discovers_scenarios_without_preflight_or_bench_prepare() {
     with_isolated_home(|home| {
         let component = tempfile::TempDir::new().expect("component");


### PR DESCRIPTION
## Summary
- run `prepare_command` requirements that declare `bench_prepare` before the final bench check
- merge prepare requirement outcomes into the bench prepare report
- add regression coverage for check requirement materialization before benchmark workload execution

Fixes #7135.

## Testing
- `cargo test bench_prepare_pipeline_test`
- `cargo test requirement_prepare`
- `cargo test bench_prepare`
- `cargo test pipeline_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the rig prepare/check flow and regression tests.