### PR TITLE
test: cover rig check lab path offload

### DIFF
--- a/src/core/runner/lab_arg_tests.rs
+++ b/src/core/runner/lab_arg_tests.rs
@@ -244,3 +244,35 @@ fn detects_lab_offload_source_path_from_path_flag() {
         std::path::PathBuf::from("/Users/user/Developer/project")
     );
 }
+
+#[test]
+fn rig_check_lab_offload_uses_explicit_component_path_as_source() {
+    let input = args(&[
+        "homeboy",
+        "rig",
+        "check",
+        "woocommerce-performance",
+        "--path",
+        "/Users/user/Developer/woocommerce",
+        "--runner",
+        "homeboy-lab",
+        "--lab-only",
+    ]);
+
+    assert_eq!(
+        lab_offload_source_path(&input).expect("rig check source path"),
+        std::path::PathBuf::from("/Users/user/Developer/woocommerce")
+    );
+    assert_eq!(
+        rewrite_lab_offload_args(&input, "/home/user/Developer/woocommerce", &[], None),
+        args(&[
+            "homeboy",
+            "--force-hot",
+            "rig",
+            "check",
+            "woocommerce-performance",
+            "--path",
+            "/home/user/Developer/woocommerce",
+        ])
+    );
+}


### PR DESCRIPTION
## Summary
- add regression coverage proving `homeboy rig check --path ... --runner ...` uses the explicit component path as the Lab source
- verify the remote offload args rewrite `--path` to the runner workspace path

Fixes #7138.

## Testing
- `cargo test rig_check_lab_offload_uses_explicit_component_path_as_source`
- `cargo test check_path_override`
- `git diff --check -- src/core/runner/lab_arg_tests.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Adding regression coverage for the Lab offload argument contract.