### PR TITLE
feat: scope rig bench checks by scenario

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -480,9 +480,13 @@ Rig specs can pin benchmark dispatch for `homeboy bench --rig <id>`.
 | `bench.components` | array | Components to benchmark as a rig-pinned matrix. |
 | `bench.default_baseline_rig` | string | Implicit baseline rig for branch-vs-main comparisons. |
 | `bench.warmup_iterations` | integer | Warmup iterations forwarded to bench runners. |
+| `bench.check_groups` | array | Common check-pipeline groups required before scenario-scoped bench runs. |
+| `bench.scenario_check_groups` | object | Additional check-pipeline groups keyed by bench scenario ID. |
 | `bench_workloads` | object | Out-of-tree workloads keyed by extension ID. |
 | `trace_workloads` | object | Out-of-tree trace workloads keyed by extension ID. |
 | `bench_profiles` | object | Named scenario lists used by `homeboy bench --profile <name>`. |
+
+When `homeboy bench --scenario <id>` selects scenarios and every selected scenario has a `bench.scenario_check_groups` entry, Homeboy runs `bench.check_groups` plus those scenario-specific groups instead of the full `rig check`. Runs without selected scenarios, or with an unmapped selected scenario, preserve the full rig check.
 
 `bench_workloads` and `trace_workloads` entries must use object form with a `path` field. Optional `check_groups` scope workload preflights; when every workload for the selected extension declares `check_groups`, workload commands run only those grouped check-pipeline steps. Workloads that omit `check_groups` run the full rig check. Trace workload objects can also declare `trace_phase_presets` and `trace_default_phase_preset`.
 
@@ -493,7 +497,12 @@ Workload paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and `${pac
   "bench": {
     "components": ["studio", "playground"],
     "default_baseline_rig": "studio-main",
-    "warmup_iterations": 2
+    "warmup_iterations": 2,
+    "check_groups": ["common"],
+    "scenario_check_groups": {
+      "admin-first-load": ["admin-assets"],
+      "rest-product-batch-import": ["rest-api"]
+    }
   },
   "bench_workloads": {
     "wordpress": [

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -634,10 +634,6 @@ fn run_component_with_rig_context(
         });
     }
 
-    if let Some(spec) = rig_spec {
-        run_rig_workload_preflight(spec, ctx.extension_id.as_deref())?;
-    }
-
     let run_dir = RunDir::create()?;
     let resource_run = homeboy::core::engine::resource::ResourceSummaryRun::start(Some(format!(
         "bench {}",
@@ -652,6 +648,11 @@ fn run_component_with_rig_context(
     );
 
     let selected_scenarios = selected_scenario_ids(args, rig_spec)?;
+
+    if let Some(spec) = rig_spec {
+        run_rig_workload_preflight(spec, ctx.extension_id.as_deref(), &selected_scenarios)?;
+    }
+
     let observation = observation::start(BenchObservationStart {
         component_id: &ctx.component_id,
         component_label: &effective_id,
@@ -796,9 +797,12 @@ fn rig_workload_runtime_inputs(
 fn run_rig_workload_preflight(
     spec: &RigSpec,
     extension_id: Option<&str>,
+    scenario_ids: &[String],
 ) -> homeboy::core::Result<()> {
-    let groups = extension_id.and_then(|id| {
-        rig::check_groups_for_extension_workloads(spec, rig::RigWorkloadKind::Bench, id)
+    let groups = rig::check_groups_for_bench_scenarios(spec, scenario_ids).or_else(|| {
+        extension_id.and_then(|id| {
+            rig::check_groups_for_extension_workloads(spec, rig::RigWorkloadKind::Bench, id)
+        })
     });
     let check = match groups {
         Some(groups) => rig::run_check_groups(spec, &groups)?,
@@ -968,6 +972,98 @@ mod tests {
 
         assert_eq!(rig_spec.components["primary"].path, "/src/primary");
         assert_eq!(rig_spec.components["candidate"].path, "/tmp/candidate");
+    }
+
+    #[test]
+    fn rig_bench_preflight_uses_scenario_scoped_check_groups() {
+        with_isolated_home(|_| {
+            let rig_spec: RigSpec = serde_json::from_str(
+                r#"{
+                    "id": "woocommerce-performance",
+                    "bench": {
+                        "check_groups": ["common"],
+                        "scenario_check_groups": {
+                            "rest-product-batch-import": ["rest"],
+                            "admin-page-assets": ["admin"]
+                        }
+                    },
+                    "pipeline": {
+                        "check": [
+                            {
+                                "kind": "check",
+                                "label": "common rig health",
+                                "groups": ["common"],
+                                "command": "true"
+                            },
+                            {
+                                "kind": "check",
+                                "label": "REST endpoint healthy",
+                                "groups": ["rest"],
+                                "command": "true"
+                            },
+                            {
+                                "kind": "check",
+                                "label": "Woo admin asset registries",
+                                "groups": ["admin"],
+                                "command": "false"
+                            }
+                        ]
+                    }
+                }"#,
+            )
+            .expect("parse rig spec");
+
+            run_rig_workload_preflight(&rig_spec, None, &["rest-product-batch-import".to_string()])
+                .expect("REST scenario should skip unrelated admin checks");
+
+            assert!(run_rig_workload_preflight(
+                &rig_spec,
+                None,
+                &["admin-page-assets".to_string()],
+            )
+            .is_err());
+
+            assert!(run_rig_workload_preflight(&rig_spec, None, &[]).is_err());
+        });
+    }
+
+    #[test]
+    fn rig_bench_preflight_falls_back_to_full_check_for_unmapped_scenario() {
+        with_isolated_home(|_| {
+            let rig_spec: RigSpec = serde_json::from_str(
+                r#"{
+                    "id": "woocommerce-performance",
+                    "bench": {
+                        "check_groups": ["common"],
+                        "scenario_check_groups": {
+                            "rest-product-batch-import": ["rest"]
+                        }
+                    },
+                    "pipeline": {
+                        "check": [
+                            {
+                                "kind": "check",
+                                "label": "REST endpoint healthy",
+                                "groups": ["rest"],
+                                "command": "true"
+                            },
+                            {
+                                "kind": "check",
+                                "label": "unmapped surface still enforced by full check",
+                                "groups": ["admin"],
+                                "command": "false"
+                            }
+                        ]
+                    }
+                }"#,
+            )
+            .expect("parse rig spec");
+
+            assert!(
+                run_rig_workload_preflight(&rig_spec, None, &["unknown-scenario".to_string()],)
+                    .is_err()
+            );
+        });
     }
 
     #[test]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -94,11 +94,12 @@ pub use state::{
     ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot, ServiceState,
 };
 pub use workloads::{
-    check_groups_for_extension_workloads, env_provider_extensions_for_extension_workloads,
-    extension_ids_for_workloads, extension_workload_inputs,
-    invocation_requirements_for_extension_workloads, runner_capabilities_for_extension,
-    trace_dependencies_for_extension, workload_path_expansions_for_extension,
-    workloads_for_extension, RigExtensionWorkloadInputs, RigWorkloadKind, RigWorkloadPathExpansion,
+    check_groups_for_bench_scenarios, check_groups_for_extension_workloads,
+    env_provider_extensions_for_extension_workloads, extension_ids_for_workloads,
+    extension_workload_inputs, invocation_requirements_for_extension_workloads,
+    runner_capabilities_for_extension, trace_dependencies_for_extension,
+    workload_path_expansions_for_extension, workloads_for_extension, RigExtensionWorkloadInputs,
+    RigWorkloadKind, RigWorkloadPathExpansion,
 };
 
 use crate::core::error::{Error, Result};

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -423,6 +423,14 @@ pub struct BenchSpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accepted_settings: Vec<String>,
 
+    /// Check-pipeline groups required before any scenario-scoped bench run.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub check_groups: Vec<String>,
+
+    /// Additional check-pipeline groups keyed by bench scenario id.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub scenario_check_groups: BTreeMap<String, Vec<String>>,
+
     /// Optional matrix axes for cross-rig bench comparison reporting.
     ///
     /// Example: `{ "runtime": "sdk", "substrate": "bfb" }`. When

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -194,6 +194,41 @@ pub fn check_groups_for_extension_workloads(
     Some(groups.into_iter().collect())
 }
 
+/// Return scenario-scoped bench preflight groups.
+///
+/// `None` preserves full `rig check` when no scenario is selected or any
+/// selected scenario has no explicit mapping. `Some(groups)` means the bench
+/// spec opted every selected scenario into scoped preflight checks.
+pub fn check_groups_for_bench_scenarios(
+    rig_spec: &RigSpec,
+    scenario_ids: &[String],
+) -> Option<Vec<String>> {
+    if scenario_ids.is_empty() {
+        return None;
+    }
+    let bench = rig_spec.bench.as_ref()?;
+
+    let mut groups = BTreeSet::new();
+    groups.extend(
+        bench
+            .check_groups
+            .iter()
+            .filter(|group| !group.is_empty())
+            .cloned(),
+    );
+    for scenario_id in scenario_ids {
+        let scenario_groups = bench.scenario_check_groups.get(scenario_id)?;
+        groups.extend(
+            scenario_groups
+                .iter()
+                .filter(|group| !group.is_empty())
+                .cloned(),
+        );
+    }
+
+    Some(groups.into_iter().collect())
+}
+
 pub fn invocation_requirements_for_extension_workloads(
     rig_spec: &RigSpec,
     kind: RigWorkloadKind,


### PR DESCRIPTION
## Summary
- add `bench.check_groups` and `bench.scenario_check_groups` to rig specs
- make `homeboy bench --scenario` run scoped check groups only when every selected scenario is mapped
- preserve full rig checks for unmapped scenarios and non-scenario runs
- document the new rig spec fields

Fixes #7137.

## Testing
- `cargo test rig_bench_preflight`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Designing the minimal scenario-scoped preflight schema, implementation, docs, and tests.