### PR TITLE
Surface runner workspace prune bytes

### DIFF
--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -542,7 +542,7 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         ["runner", "workspace", "prune"] => {
             metadata.mutates = true;
             metadata.operator = true;
-            metadata.output_notes = "default output is a non-mutating orphan cleanup plan; pass --apply to delete exact runner workspace paths";
+            metadata.output_notes = "default output is a non-mutating orphan cleanup plan with candidate/remaining bytes; pass --apply to delete exact runner workspace paths and --passes to drain bounded pages";
             metadata.dangerous_flags = vec!["--apply"];
         }
         ["http", "request"] => {

--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -657,9 +657,14 @@ pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
             purpose: "Run a managed follow-up command through Homeboy instead of opening an ad-hoc shell.".to_string(),
         },
         LabFollowup {
-            label: "workspace_prune".to_string(),
-            command: format!("homeboy runner workspace prune {runner_arg} --apply"),
-            purpose: "Reclaim safe orphaned Lab workspaces when the runner workspace filesystem is under disk pressure.".to_string(),
+            label: "workspace_prune_preview".to_string(),
+            command: format!("homeboy runner workspace prune {runner_arg}"),
+            purpose: "Report safe orphaned Lab workspace counts and bytes before deleting anything.".to_string(),
+        },
+        LabFollowup {
+            label: "workspace_prune_drain".to_string(),
+            command: format!("homeboy runner workspace prune {runner_arg} --apply --passes 10"),
+            purpose: "Reclaim safe orphaned Lab workspaces in bounded passes when the runner workspace filesystem is under disk pressure.".to_string(),
         },
     ]);
     followups.extend(declared_followups_for_legacy(

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -140,7 +140,11 @@ fn runner_followups_include_workspace_prune_for_disk_pressure_recovery() {
     let followups = runner_followups(Some("homeboy-lab"));
     let serialized = serde_json::to_string(&followups).expect("serialize followups");
 
-    assert!(serialized.contains("homeboy runner workspace prune homeboy-lab --apply"));
+    assert!(serialized.contains("workspace_prune_preview"));
+    assert!(serialized.contains("homeboy runner workspace prune homeboy-lab"));
+    assert!(serialized.contains("workspace_prune_drain"));
+    assert!(serialized.contains("homeboy runner workspace prune homeboy-lab --apply --passes 10"));
+    assert!(serialized.contains("counts and bytes"));
     assert!(serialized.contains("disk pressure"));
 }
 

--- a/src/commands/runner/workspace/mod.rs
+++ b/src/commands/runner/workspace/mod.rs
@@ -119,6 +119,10 @@ pub(super) enum RunnerWorkspaceCommand {
         /// Maximum number of orphan candidates to report or remove.
         #[arg(long, default_value_t = 25)]
         limit: usize,
+
+        /// Maximum apply passes to run. Each pass re-scans and removes at most --limit candidates.
+        #[arg(long, default_value_t = 1)]
+        passes: usize,
     },
 }
 
@@ -186,12 +190,14 @@ pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceO
             apply,
             min_age_hours,
             limit,
+            passes,
         } => runner::prune_workspaces(
             &runner_id,
             runner::RunnerWorkspacePruneOptions {
                 apply,
                 min_age_hours,
                 limit,
+                passes,
             },
         )
         .map(|(output, exit_code)| (RunnerWorkspaceOutput::Prune(output), exit_code)),

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -266,16 +266,30 @@ pub fn prune_workspaces(
     validate_absolute_path("workspace_root", workspace_root)?;
     let lab_workspaces_root = format!("{}/_lab_workspaces", workspace_root.trim_end_matches('/'));
     let limit = options.limit.max(1);
-    let candidates = match runner.kind {
-        RunnerKind::Local => prune_candidates_local(Path::new(&lab_workspaces_root), &options)?,
-        RunnerKind::Ssh => prune_candidates_ssh(&runner, &lab_workspaces_root, &options)?,
+    let passes = if options.apply {
+        options.passes.max(1)
+    } else {
+        1
     };
-
     let mut removed = Vec::new();
     let mut skipped = Vec::new();
     let mut candidate_entries = Vec::new();
-    for candidate in candidates.into_iter().take(limit) {
-        if options.apply {
+    let mut total_candidate_count = 0;
+    let mut total_candidate_bytes = 0;
+    for pass in 0..passes {
+        let candidates = prune_candidates_for_runner(&runner, &lab_workspaces_root, &options)?;
+        if pass == 0 {
+            total_candidate_count = candidates.len();
+            total_candidate_bytes = candidates.iter().map(|entry| entry.bytes).sum();
+        }
+        if candidates.is_empty() {
+            break;
+        }
+        for candidate in candidates.into_iter().take(limit) {
+            if !options.apply {
+                candidate_entries.push(candidate);
+                continue;
+            }
             match remove_workspace(&runner, &lab_workspaces_root, &candidate.remote_path) {
                 Ok(()) => removed.push(candidate),
                 Err(err) => skipped.push(RunnerWorkspacePruneSkippedEntry {
@@ -283,30 +297,78 @@ pub fn prune_workspaces(
                     reason: err.to_string(),
                 }),
             }
-        } else {
-            candidate_entries.push(candidate);
+        }
+        if !options.apply || total_candidate_count <= limit {
+            break;
         }
     }
 
-    let total_candidate_bytes = candidate_entries.iter().map(|entry| entry.bytes).sum();
+    let remaining_candidates = if options.apply {
+        prune_candidates_for_runner(&runner, &lab_workspaces_root, &options)?
+    } else {
+        prune_candidates_for_runner(&runner, &lab_workspaces_root, &options)?
+            .into_iter()
+            .skip(limit)
+            .collect()
+    };
+    let remaining_candidate_count = remaining_candidates.len();
+    let remaining_candidate_bytes = remaining_candidates.iter().map(|entry| entry.bytes).sum();
+    let has_more = remaining_candidate_count > 0;
+    let runner_arg = shell_arg(&runner.id);
+    let next_command = has_more.then(|| {
+        if options.apply {
+            format!(
+                "homeboy runner workspace prune {runner_arg} --apply --min-age-hours {} --limit {limit} --passes {passes}",
+                options.min_age_hours
+            )
+        } else {
+            format!(
+                "homeboy runner workspace prune {runner_arg} --min-age-hours {} --limit {limit}",
+                options.min_age_hours
+            )
+        }
+    });
+    let drain_command = format!(
+        "homeboy runner workspace prune {runner_arg} --apply --min-age-hours {} --limit {limit} --passes 10",
+        options.min_age_hours
+    );
     let total_removed_bytes = removed.iter().map(|entry| entry.bytes).sum();
+    let runner_id = runner.id.clone();
+    let workspace_root = workspace_root.to_string();
     Ok((
         RunnerWorkspacePruneOutput {
             variant: "workspace_prune",
             command: "runner.workspace.prune",
-            runner_id: runner.id,
+            runner_id,
             dry_run: !options.apply,
-            workspace_root: workspace_root.to_string(),
+            workspace_root,
             lab_workspaces_root,
             min_age_hours: options.min_age_hours,
             candidates: candidate_entries,
             removed,
             skipped,
+            total_candidate_count,
             total_candidate_bytes,
             total_removed_bytes,
+            remaining_candidate_count,
+            remaining_candidate_bytes,
+            has_more,
+            next_command,
+            drain_command,
         },
         0,
     ))
+}
+
+fn prune_candidates_for_runner(
+    runner: &super::super::Runner,
+    lab_workspaces_root: &str,
+    options: &RunnerWorkspacePruneOptions,
+) -> Result<Vec<RunnerWorkspacePruneEntry>> {
+    match runner.kind {
+        RunnerKind::Local => prune_candidates_local(Path::new(lab_workspaces_root), options),
+        RunnerKind::Ssh => prune_candidates_ssh(runner, lab_workspaces_root, options),
+    }
 }
 
 /// Reap a single run-scoped materialized workspace (and its sibling Homeboy

--- a/src/core/runner/workspace/tests/prune.rs
+++ b/src/core/runner/workspace/tests/prune.rs
@@ -36,6 +36,7 @@ fn prune_workspaces_previews_orphans_without_deleting_by_default() {
                 apply: false,
                 min_age_hours: 0,
                 limit: 10,
+                passes: 1,
             },
         )
         .expect("prune preview");
@@ -43,6 +44,13 @@ fn prune_workspaces_previews_orphans_without_deleting_by_default() {
         assert_eq!(exit_code, 0);
         assert!(output.dry_run);
         assert_eq!(output.candidates.len(), 1);
+        assert_eq!(output.total_candidate_count, 1);
+        assert!(output.total_candidate_bytes > 0);
+        assert_eq!(output.remaining_candidate_count, 0);
+        assert_eq!(output.remaining_candidate_bytes, 0);
+        assert!(!output.has_more);
+        assert!(output.next_command.is_none());
+        assert!(output.drain_command.contains("--apply --min-age-hours 0"));
         assert_eq!(output.candidates[0].remote_path, synced.remote_path);
         assert_eq!(output.candidates[0].reason, "source_path_missing");
         assert!(Path::new(&synced.remote_path).exists());
@@ -92,6 +100,7 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
                 apply: true,
                 min_age_hours: 0,
                 limit: 10,
+                passes: 1,
             },
         )
         .expect("prune apply");
@@ -99,6 +108,10 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
         assert_eq!(exit_code, 0);
         assert!(!output.dry_run);
         assert_eq!(output.removed.len(), 1);
+        assert_eq!(output.total_candidate_count, 1);
+        assert!(output.total_candidate_bytes >= output.total_removed_bytes);
+        assert_eq!(output.remaining_candidate_count, 0);
+        assert!(!output.has_more);
         assert_eq!(output.removed[0].remote_path, orphan.remote_path);
         assert!(!Path::new(&orphan.remote_path).exists());
         assert!(Path::new(&live.remote_path).exists());
@@ -145,6 +158,7 @@ fn prune_workspaces_preview_reports_synthetic_odd_path_without_deleting() {
                 apply: false,
                 min_age_hours: 0,
                 limit: 10,
+                passes: 1,
             },
         )
         .expect("prune preview");
@@ -162,6 +176,124 @@ fn prune_workspaces_preview_reports_synthetic_odd_path_without_deleting() {
         assert_eq!(output.candidates[0].reason, "source_path_missing");
         assert!(workspace.exists());
         assert!(output.removed.is_empty());
+    });
+}
+
+#[test]
+fn prune_workspaces_reports_remaining_bytes_and_drain_command_when_limited() {
+    crate::test_support::with_isolated_home(|_| {
+        let source_parent = tempfile::tempdir().expect("source parent");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let source_a = source_parent.path().join("orphan-source-a");
+        let source_b = source_parent.path().join("orphan-source-b");
+        fs::create_dir_all(&source_a).expect("source a dir");
+        fs::create_dir_all(&source_b).expect("source b dir");
+        fs::write(source_a.join("file.txt"), "a\n").expect("source a file");
+        fs::write(source_b.join("file.txt"), "larger b\n").expect("source b file");
+        crate::core::runner::create(
+            &format!(
+                r#"{{"id":"lab-local-prune-limited","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        sync_workspace(
+            "lab-local-prune-limited",
+            sync_options(source_a.display().to_string()),
+        )
+        .expect("sync source a");
+        sync_workspace(
+            "lab-local-prune-limited",
+            sync_options(source_b.display().to_string()),
+        )
+        .expect("sync source b");
+        fs::remove_dir_all(&source_a).expect("remove source a");
+        fs::remove_dir_all(&source_b).expect("remove source b");
+
+        let (output, exit_code) = prune_workspaces(
+            "lab-local-prune-limited",
+            RunnerWorkspacePruneOptions {
+                apply: false,
+                min_age_hours: 0,
+                limit: 1,
+                passes: 1,
+            },
+        )
+        .expect("prune preview");
+
+        assert_eq!(exit_code, 0);
+        assert!(output.dry_run);
+        assert_eq!(output.candidates.len(), 1);
+        assert_eq!(output.total_candidate_count, 2);
+        assert!(output.total_candidate_bytes > output.candidates[0].bytes);
+        assert_eq!(output.remaining_candidate_count, 1);
+        assert!(output.remaining_candidate_bytes > 0);
+        assert!(output.has_more);
+        assert_eq!(
+            output.next_command.as_deref(),
+            Some("homeboy runner workspace prune lab-local-prune-limited --min-age-hours 0 --limit 1")
+        );
+        assert_eq!(
+            output.drain_command,
+            "homeboy runner workspace prune lab-local-prune-limited --apply --min-age-hours 0 --limit 1 --passes 10"
+        );
+    });
+}
+
+#[test]
+fn prune_workspaces_apply_passes_drain_until_empty() {
+    crate::test_support::with_isolated_home(|_| {
+        let source_parent = tempfile::tempdir().expect("source parent");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let source_a = source_parent.path().join("drain-source-a");
+        let source_b = source_parent.path().join("drain-source-b");
+        fs::create_dir_all(&source_a).expect("source a dir");
+        fs::create_dir_all(&source_b).expect("source b dir");
+        fs::write(source_a.join("file.txt"), "a\n").expect("source a file");
+        fs::write(source_b.join("file.txt"), "b\n").expect("source b file");
+        crate::core::runner::create(
+            &format!(
+                r#"{{"id":"lab-local-prune-drain","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let (workspace_a, _) = sync_workspace(
+            "lab-local-prune-drain",
+            sync_options(source_a.display().to_string()),
+        )
+        .expect("sync source a");
+        let (workspace_b, _) = sync_workspace(
+            "lab-local-prune-drain",
+            sync_options(source_b.display().to_string()),
+        )
+        .expect("sync source b");
+        fs::remove_dir_all(&source_a).expect("remove source a");
+        fs::remove_dir_all(&source_b).expect("remove source b");
+
+        let (output, exit_code) = prune_workspaces(
+            "lab-local-prune-drain",
+            RunnerWorkspacePruneOptions {
+                apply: true,
+                min_age_hours: 0,
+                limit: 1,
+                passes: 10,
+            },
+        )
+        .expect("prune drain");
+
+        assert_eq!(exit_code, 0);
+        assert!(!output.dry_run);
+        assert_eq!(output.total_candidate_count, 2);
+        assert_eq!(output.removed.len(), 2);
+        assert_eq!(output.remaining_candidate_count, 0);
+        assert_eq!(output.remaining_candidate_bytes, 0);
+        assert!(!output.has_more);
+        assert!(output.next_command.is_none());
+        assert!(!Path::new(&workspace_a.remote_path).exists());
+        assert!(!Path::new(&workspace_b.remote_path).exists());
     });
 }
 

--- a/src/core/runner/workspace/types.rs
+++ b/src/core/runner/workspace/types.rs
@@ -148,6 +148,7 @@ pub struct RunnerWorkspacePruneOptions {
     pub apply: bool,
     pub min_age_hours: u64,
     pub limit: usize,
+    pub passes: usize,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -162,8 +163,15 @@ pub struct RunnerWorkspacePruneOutput {
     pub candidates: Vec<RunnerWorkspacePruneEntry>,
     pub removed: Vec<RunnerWorkspacePruneEntry>,
     pub skipped: Vec<RunnerWorkspacePruneSkippedEntry>,
+    pub total_candidate_count: usize,
     pub total_candidate_bytes: u64,
     pub total_removed_bytes: u64,
+    pub remaining_candidate_count: usize,
+    pub remaining_candidate_bytes: u64,
+    pub has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_command: Option<String>,
+    pub drain_command: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- report total and remaining orphan workspace candidate counts/bytes from runner workspace prune
- add bounded apply passes with next/drain follow-up commands
- update runner status follow-ups to preview bytes first and offer bounded prune drain

Fixes #7164

## Verification
- cargo test prune_workspaces --lib
- cargo test runner_followups_include_workspace_prune_for_disk_pressure_recovery --lib
- rustfmt --check src/command_contract/safety_manifest.rs src/commands/runner/status.rs src/commands/runner/tests/status.rs src/commands/runner/workspace/mod.rs src/core/runner/workspace/sync.rs src/core/runner/workspace/tests/prune.rs src/core/runner/workspace/types.rs

Note: repository-wide cargo fmt --check still reports unrelated baseline formatting drift outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Resuming the interrupted implementation, reviewing the existing diff, focused test verification, and preparing the PR.