### PR TITLE
fix: guide lab version drift recovery

### DIFF
--- a/src/core/runner/lab/offload/metadata.rs
+++ b/src/core/runner/lab/offload/metadata.rs
@@ -4,6 +4,7 @@
 use super::*;
 #[cfg(test)]
 use crate::core::secret_env_plan::SECRET_ENV_PLAN_ENV_DELTA_SOURCE;
+use std::path::{Path, PathBuf};
 
 const ENV_RESOLUTION_SCHEMA: &str = "homeboy/env-resolution/v1";
 const REDACTED_ENV_VALUE: &str = "<redacted>";
@@ -207,7 +208,13 @@ pub(crate) fn lab_runner_homeboy_metadata(
         format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
         format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
     ];
-    let primary_remediation_command = runner_homeboy_primary_remediation_command(runner_id, status);
+    let primary_remediation_command =
+        runner_homeboy_primary_remediation_command(runner_id, configured_executable, status);
+    let topology_recovery_command =
+        runner_homeboy_topology_recovery_command(runner_id, configured_executable, status);
+    let controller_binary = std::env::current_exe()
+        .ok()
+        .map(|path| path.display().to_string());
     let stale_daemon = status.stale_daemon.as_ref();
     serde_json::json!({
         "schema": "homeboy/lab-runner-homeboy/v1",
@@ -224,6 +231,8 @@ pub(crate) fn lab_runner_homeboy_metadata(
         "stale_daemon": status.stale_daemon,
         "version_drift": lab_runner_homeboy_version_drift(status),
         "primary_remediation_command": primary_remediation_command,
+        "topology_recovery_command": topology_recovery_command,
+        "controller_binary": controller_binary,
         "refresh_commands": refresh_commands,
         "local_upgrade_command": "homeboy upgrade",
         "upgrade_command": format!("homeboy upgrade --force --upgrade-runner {}", shell::quote_arg(runner_id)),
@@ -406,10 +415,16 @@ fn runner_daemon_newer_than_controller(status: &RunnerStatusReport) -> bool {
 
 fn runner_homeboy_primary_remediation_command(
     runner_id: &str,
+    configured_executable: &str,
     status: &RunnerStatusReport,
 ) -> String {
     if runner_daemon_newer_than_controller(status) {
-        return "homeboy upgrade".to_string();
+        return controller_homeboy_recovery_command();
+    }
+
+    if let Some(command) = runner_configured_binary_select_command(runner_id, configured_executable)
+    {
+        return command;
     }
 
     runner_homeboy_refresh_commands(runner_id, status)
@@ -421,6 +436,80 @@ fn runner_homeboy_primary_remediation_command(
                 shell::quote_arg(runner_id)
             )
         })
+}
+
+fn runner_homeboy_topology_recovery_command(
+    runner_id: &str,
+    configured_executable: &str,
+    status: &RunnerStatusReport,
+) -> String {
+    if runner_daemon_newer_than_controller(status) {
+        return controller_homeboy_recovery_command();
+    }
+    runner_configured_binary_select_command(runner_id, configured_executable).unwrap_or_else(|| {
+        runner_homeboy_primary_remediation_command(runner_id, configured_executable, status)
+    })
+}
+
+fn runner_configured_binary_select_command(
+    runner_id: &str,
+    configured_executable: &str,
+) -> Option<String> {
+    let configured_executable = configured_executable.trim();
+    if configured_executable.is_empty() || configured_executable == "homeboy" {
+        return None;
+    }
+    Some(format!(
+        "homeboy runner refresh-homeboy {} --select {} --reconnect",
+        shell::quote_arg(runner_id),
+        shell::quote_arg(configured_executable)
+    ))
+}
+
+fn controller_homeboy_recovery_command() -> String {
+    let Ok(exe) = std::env::current_exe() else {
+        return "homeboy upgrade".to_string();
+    };
+    controller_homeboy_recovery_command_for_binary(&exe)
+}
+
+pub(super) fn controller_homeboy_recovery_command_for_binary(exe: &Path) -> String {
+    if let Some(source_checkout) = source_checkout_for_binary(exe) {
+        return format!(
+            "homeboy upgrade --method source --source-path {} --force",
+            shell::quote_arg(&source_checkout.display().to_string())
+        );
+    }
+    let exe_display = exe.display().to_string();
+    if exe_display.contains("/Homebrew/")
+        || exe_display.contains("/homebrew/")
+        || exe_display.contains("/Cellar/homeboy/")
+        || exe_display.contains("/.linuxbrew/")
+    {
+        return "homeboy upgrade --method homebrew --force".to_string();
+    }
+    if exe_display.contains(&format!(
+        "/.{}/bin/",
+        crate::core::defaults::secondary_install_method_key()
+    )) {
+        return format!(
+            "homeboy upgrade --method {} --force",
+            crate::core::defaults::secondary_install_method_key()
+        );
+    }
+    "homeboy upgrade".to_string()
+}
+
+fn source_checkout_for_binary(binary: &Path) -> Option<PathBuf> {
+    for ancestor in binary.ancestors() {
+        if ancestor.file_name().and_then(|name| name.to_str()) == Some("target") {
+            return ancestor.parent().map(Path::to_path_buf);
+        }
+        if ancestor.join("Cargo.toml").is_file() && ancestor.join("src/main.rs").is_file() {
+            return Some(ancestor.to_path_buf());
+        }
+    }
+    None
 }
 
 pub(crate) fn lab_source_checkout_metadata(source_path: &Path) -> serde_json::Value {
@@ -564,9 +653,13 @@ pub(crate) fn stale_runner_homeboy_error(
     if runner_daemon_newer_than_controller(status) {
         tried.push(format!(
             "Upgrade this local Homeboy controller before retrying Lab offload: {}",
-            runner_homeboy_primary_remediation_command(runner_id, status)
+            runner_homeboy_primary_remediation_command(runner_id, configured_executable, status)
         ));
     }
+    tried.push(format!(
+        "One-command topology recovery: {}",
+        runner_homeboy_topology_recovery_command(runner_id, configured_executable, status)
+    ));
     tried.extend([
         format!("Reconnect runner `{runner_id}` before retrying Lab offload: {refresh}"),
         format!("If the runner binary itself is stale, refresh or select a clean runner binary with `homeboy runner refresh-homeboy {} --ref main --reconnect`.", shell::quote_arg(runner_id)),

--- a/src/core/runner/lab/offload/tests/capability_metadata.rs
+++ b/src/core/runner/lab/offload/tests/capability_metadata.rs
@@ -387,7 +387,13 @@ fn newer_runner_than_controller_points_to_local_upgrade_first() {
     let status = status_with_runner_version("homeboy-lab", &higher_minor_version());
 
     let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
-    assert_eq!(metadata["primary_remediation_command"], "homeboy upgrade");
+    assert!(metadata["primary_remediation_command"]
+        .as_str()
+        .is_some_and(|command| command.contains("homeboy upgrade")));
+    assert!(metadata["topology_recovery_command"]
+        .as_str()
+        .is_some_and(|command| command.contains("homeboy upgrade")));
+    assert!(metadata["controller_binary"].as_str().is_some());
     assert_eq!(metadata["local_upgrade_command"], "homeboy upgrade");
 
     let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
@@ -411,7 +417,9 @@ fn newer_stale_daemon_control_plane_points_to_local_upgrade_first() {
     ));
 
     let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
-    assert_eq!(metadata["primary_remediation_command"], "homeboy upgrade");
+    assert!(metadata["primary_remediation_command"]
+        .as_str()
+        .is_some_and(|command| command.contains("homeboy upgrade")));
 
     let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
     let tried = err.details["tried"].as_array().expect("tried hints");
@@ -419,6 +427,9 @@ fn newer_stale_daemon_control_plane_points_to_local_upgrade_first() {
         .first()
         .and_then(|hint| hint.as_str())
         .is_some_and(|hint| hint.contains("homeboy upgrade")));
+    assert!(tried.iter().any(|hint| hint
+        .as_str()
+        .is_some_and(|hint| hint.contains("One-command topology recovery"))));
 }
 
 #[test]
@@ -438,6 +449,70 @@ fn older_runner_than_controller_points_to_runner_refresh_first() {
         .and_then(|hint| hint.as_str())
         .is_some_and(|hint| hint
             .contains("homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect")));
+}
+
+#[test]
+fn configured_runner_binary_drift_selects_known_runner_binary() {
+    let status = status_with_runner_version("homeboy-lab", "0.0.0");
+    let configured = "/srv/homeboy-current/target/release/homeboy";
+
+    let metadata = lab_runner_homeboy_metadata("homeboy-lab", configured, &status);
+
+    assert_eq!(
+        metadata["primary_remediation_command"],
+        "homeboy runner refresh-homeboy homeboy-lab --select /srv/homeboy-current/target/release/homeboy --reconnect"
+    );
+    assert_eq!(
+        metadata["topology_recovery_command"],
+        metadata["primary_remediation_command"]
+    );
+
+    let err = stale_runner_homeboy_error("homeboy-lab", configured, &status);
+    let tried = err.details["tried"].as_array().expect("tried hints");
+    assert!(tried.iter().any(|hint| hint.as_str().is_some_and(|hint| hint.contains(
+        "homeboy runner refresh-homeboy homeboy-lab --select /srv/homeboy-current/target/release/homeboy --reconnect"
+    ))));
+}
+
+#[test]
+fn controller_recovery_command_uses_source_checkout_for_current_build_binary() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::create_dir_all(dir.path().join("src")).expect("src dir");
+    std::fs::create_dir_all(dir.path().join("target/release")).expect("target dir");
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"homeboy\"",
+    )
+    .expect("cargo manifest");
+    std::fs::write(dir.path().join("src/main.rs"), "fn main() {}").expect("main source");
+
+    let command =
+        controller_homeboy_recovery_command_for_binary(&dir.path().join("target/release/homeboy"));
+
+    assert_eq!(
+        command,
+        format!(
+            "homeboy upgrade --method source --source-path {} --force",
+            shell::quote_arg(&dir.path().display().to_string())
+        )
+    );
+}
+
+#[test]
+fn controller_recovery_command_uses_install_method_for_known_binary_locations() {
+    assert_eq!(
+        controller_homeboy_recovery_command_for_binary(std::path::Path::new(
+            "/opt/homebrew/Cellar/homeboy/0.276.0/bin/homeboy"
+        )),
+        "homeboy upgrade --method homebrew --force"
+    );
+
+    assert_eq!(
+        controller_homeboy_recovery_command_for_binary(std::path::Path::new(
+            "/Users/user/.cargo/bin/homeboy"
+        )),
+        "homeboy upgrade --method cargo --force"
+    );
 }
 
 #[test]
@@ -555,8 +630,9 @@ fn stale_runner_homeboy_error_blocks_offload_with_reconnect_guidance() {
     assert!(tried
         .first()
         .and_then(|hint| hint.as_str())
-        .is_some_and(|hint| hint
-            .contains("homeboy runner refresh-homeboy 'homeboy lab' --ref main --reconnect")));
+        .is_some_and(|hint| hint.contains(
+            "homeboy runner refresh-homeboy 'homeboy lab' --select /home/user/Developer/_lab_workspaces/homeboy-post-4583-proof/target/debug/homeboy --reconnect"
+        )));
     assert!(tried
         .iter()
         .any(|hint| hint.as_str().is_some_and(|hint| hint


### PR DESCRIPTION
## Summary
- Add topology-aware Lab runner Homeboy recovery commands to runner metadata and pre-execution drift errors.
- Prefer controller-side recovery when the runner daemon is newer, including source/Homebrew/cargo install method commands when detectable.
- Prefer selecting the configured runner binary when the runner-side binary path is known.

## Tests
- cargo test core::runner::lab::offload::tests::capability_metadata
- homeboy runner workspace sync homeboy-lab --path /Users/chubes/Developer/homeboy@issue-7160-version-drift-guidance --mode snapshot
- homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-issue-7160-version-drift-guidance-084e3907b07f-3080b864-ea55-4fc9-837d-14760a6efeac-1782949007683449000 -- homeboy build homeboy

Fixes #7160

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing Lab version drift recovery guidance, focused tests, and PR preparation.