### PR TITLE
Register non-core command docs

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -630,7 +630,9 @@ mod surface {
     }
 
     fn runtime_extension_doc_commands() -> BTreeSet<String> {
-        BTreeSet::from(["cargo".to_string(), "wp".to_string()])
+        crate::command_contract::runtime_extension_command_doc_slugs()
+            .map(str::to_string)
+            .collect()
     }
 
     fn sorted_difference(left: &BTreeSet<String>, right: &BTreeSet<String>) -> Vec<String> {
@@ -854,7 +856,7 @@ mod tests {
             .filter_map(|entry| entry.docs_slug)
             .collect::<BTreeSet<_>>();
         let extension_or_support_docs =
-            BTreeSet::from(["audit-rules", "cargo", "commands-index", "rig-spec", "wp"]);
+            crate::command_contract::non_core_command_doc_slugs().collect::<BTreeSet<_>>();
 
         for doc in
             std::fs::read_dir(root.join("docs/commands")).expect("failed to read docs/commands")
@@ -871,6 +873,28 @@ mod tests {
             assert!(
                 registered_docs.contains(slug) || extension_or_support_docs.contains(slug),
                 "docs/commands/{slug}.md is not registered as a core command doc or known extension/support doc"
+            );
+        }
+    }
+
+    #[test]
+    fn non_core_command_doc_registry_paths_exist() {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let index = commands_index();
+
+        for slug in crate::command_contract::non_core_command_doc_slugs() {
+            assert!(
+                root.join("docs/commands")
+                    .join(format!("{slug}.md"))
+                    .is_file(),
+                "non-core command doc registry points at missing docs/commands/{slug}.md"
+            );
+        }
+
+        for slug in crate::command_contract::runtime_extension_command_doc_slugs() {
+            assert!(
+                index.contains(&format!("[{slug}]({slug}.md)")),
+                "docs/commands/commands-index.md is missing runtime extension command doc `{slug}`"
             );
         }
     }

--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -62,9 +62,10 @@ pub use registry::{
     registered_contract, registered_contracts, ContractRegistryEntry, ContractRegistrySummary,
 };
 pub use spec::{
-    registered_command, registered_command_dispatch_family, registered_command_json_family,
-    CommandLabSupportSummary, CommandRegistryEntry, CommandSafetySpec, CommandSpec,
-    COMMAND_REGISTRY, COMMAND_SPECS,
+    non_core_command_doc_slugs, registered_command, registered_command_dispatch_family,
+    registered_command_json_family, runtime_extension_command_doc_slugs, support_command_doc_slugs,
+    CommandDocKind, CommandDocSpec, CommandLabSupportSummary, CommandRegistryEntry,
+    CommandSafetySpec, CommandSpec, COMMAND_DOC_REGISTRY, COMMAND_REGISTRY, COMMAND_SPECS,
 };
 pub(crate) use spec::{
     AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REVIEW_LAB_LABEL,

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -30,6 +30,18 @@ pub struct CommandLabSupportSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandDocSpec {
+    pub slug: &'static str,
+    pub kind: CommandDocKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandDocKind {
+    RuntimeExtensionCommand,
+    Support,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CommandSafetySpec {
     pub mutates: bool,
     pub operator: bool,
@@ -568,6 +580,29 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
 
 pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = COMMAND_SPECS;
 
+pub const COMMAND_DOC_REGISTRY: &[CommandDocSpec] = &[
+    CommandDocSpec {
+        slug: "audit-rules",
+        kind: CommandDocKind::Support,
+    },
+    CommandDocSpec {
+        slug: "cargo",
+        kind: CommandDocKind::RuntimeExtensionCommand,
+    },
+    CommandDocSpec {
+        slug: "commands-index",
+        kind: CommandDocKind::Support,
+    },
+    CommandDocSpec {
+        slug: "rig-spec",
+        kind: CommandDocKind::Support,
+    },
+    CommandDocSpec {
+        slug: "wp",
+        kind: CommandDocKind::RuntimeExtensionCommand,
+    },
+];
+
 pub fn registered_command(name: &str) -> Option<&'static CommandSpec> {
     COMMAND_SPECS.iter().find(|entry| entry.name == name)
 }
@@ -578,4 +613,22 @@ pub fn registered_command_json_family(name: &str) -> Option<CommandJsonFamily> {
 
 pub fn registered_command_dispatch_family(name: &str) -> Option<CommandDispatchFamily> {
     registered_command(name).map(CommandSpec::dispatch_family)
+}
+
+pub fn runtime_extension_command_doc_slugs() -> impl Iterator<Item = &'static str> {
+    COMMAND_DOC_REGISTRY
+        .iter()
+        .filter(|entry| entry.kind == CommandDocKind::RuntimeExtensionCommand)
+        .map(|entry| entry.slug)
+}
+
+pub fn support_command_doc_slugs() -> impl Iterator<Item = &'static str> {
+    COMMAND_DOC_REGISTRY
+        .iter()
+        .filter(|entry| entry.kind == CommandDocKind::Support)
+        .map(|entry| entry.slug)
+}
+
+pub fn non_core_command_doc_slugs() -> impl Iterator<Item = &'static str> {
+    COMMAND_DOC_REGISTRY.iter().map(|entry| entry.slug)
 }


### PR DESCRIPTION
## Summary
- Add a command-doc metadata registry for non-core command docs.
- Derive runtime extension docs and support docs drift checks from that registry instead of duplicated hardcoded exception lists.
- Add coverage that registered non-core command docs exist and runtime extension command docs stay indexed.

## Testing
- 
- 
- {
  "success": true,
  "data": {
    "component": "homeboy",
    "exit_code": 0,
    "hints": [
      "No impacted tests found for --changed-since fb41aba0e043830c0191f9798875acda86ef831e",
      "Run full suite if needed: homeboy test homeboy"
    ],
    "passed": true,
    "phase": {
      "exit_code": 0,
      "phase": "test",
      "status": "passed",
      "summary": "test phase passed"
    },
    "status": "passed",
    "test_scope": {
      "changed_since": "fb41aba0e043830c0191f9798875acda86ef831e",
      "mode": "changed",
      "selected_count": 0
    }
  }
} (Lab run succeeded; changed scope selected 0 impacted tests)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the metadata refactor, added drift coverage, and ran verification with Chris responsible for review and submission.