### PR TITLE
Gate mutating file mkdir and rename behind apply

### DIFF
--- a/docs/commands/file.md
+++ b/docs/commands/file.md
@@ -11,9 +11,9 @@ homeboy file <COMMAND>
 - `list <project_id> <path>`
 - `read <project_id> <path>`
 - `write <project_id> <path> [--apply]` (reads content from stdin)
-- `mkdir <project_id> <path>` (create a directory)
+- `mkdir <project_id> <path> [--apply]` (create a directory)
 - `delete <project_id> <path> [-r|--recursive] [--apply]` (delete files or directories)
-- `rename <project_id> <old_path> <new_path>`
+- `rename <project_id> <old_path> <new_path> [--apply]`
 - `find <project_id> <path> [options]` (search for files by name)
 - `grep <project_id> <path> <pattern> [options]` (search file contents)
 - `download <project_id> <path> [local_path] [-r|--recursive]`
@@ -23,15 +23,19 @@ homeboy file <COMMAND>
 
 `copy` and `sync` targets use `local/path` or `server_id:/path` syntax. `sync` is recursive and non-deleting by default; it does not expose a delete mode.
 
-### `write` and `delete`
+### `write`, `mkdir`, `delete`, and `rename`
 
-`write` and `delete` default to non-mutating plan output. Pass `--apply` to perform the remote mutation.
+`write`, `mkdir`, `delete`, and `rename` default to non-mutating plan output. Pass `--apply` to perform the remote mutation.
 
 ```sh
 printf 'content' | homeboy file write mysite /tmp/example.txt
 printf 'content' | homeboy file write mysite /tmp/example.txt --apply
 homeboy file delete mysite /tmp/example.txt
 homeboy file delete mysite /tmp/example.txt --apply
+homeboy file mkdir mysite /tmp/example-dir
+homeboy file mkdir mysite /tmp/example-dir --apply
+homeboy file rename mysite /tmp/example.txt /tmp/example-renamed.txt
+homeboy file rename mysite /tmp/example.txt /tmp/example-renamed.txt --apply
 ```
 
 ### `find`
@@ -151,7 +155,7 @@ Fields:
 - `entries`: for `list` (parsed from `ls -la`)
 - `content`: for `read`
 - `bytes_written`: for `write` (number of bytes written after stripping one trailing `\n` if present)
-- `dry_run`, `action_required`: for guarded `write` and `delete` plans
+- `dry_run`, `action_required`: for guarded `write`, `mkdir`, `delete`, and `rename` plans
 - `stdout`, `stderr`: included for error context when applicable
 - `exit_code`, `success`
 

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -374,16 +374,19 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.operator = true;
             metadata.output_notes = "default output is a non-mutating plan; pass --apply to mutate";
         }
-        ["file", "write"] | ["file", "delete"] => {
+        ["file", "write"] | ["file", "delete"] | ["file", "mkdir"] | ["file", "rename"] => {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.output_notes = "default output is a non-mutating plan; pass --apply to mutate";
+            metadata.dangerous_flags = vec!["--apply"];
         }
-        ["file", "copy"]
-        | ["file", "edit"]
-        | ["file", "mkdir"]
-        | ["file", "rename"]
-        | ["file", "sync"] => {
+        ["file", "edit"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.dry_run_flag = Some("--dry-run");
+            metadata.output_notes = "mutates file content unless --dry-run is passed";
+        }
+        ["file", "copy"] | ["file", "sync"] => {
             metadata.mutates = true;
         }
         ["fleet", "exec"] => {
@@ -863,6 +866,9 @@ mod tests {
             ["db", "drop-table"].as_slice(),
             ["file", "write"].as_slice(),
             ["file", "delete"].as_slice(),
+            ["file", "mkdir"].as_slice(),
+            ["file", "rename"].as_slice(),
+            ["file", "edit"].as_slice(),
             ["docs", "map"].as_slice(),
             ["runs", "reconcile"].as_slice(),
             ["runs", "import"].as_slice(),
@@ -914,6 +920,9 @@ mod tests {
             ["self", "cleanup-runtime-tmp"].as_slice(),
             ["db", "delete-row"].as_slice(),
             ["file", "delete"].as_slice(),
+            ["file", "mkdir"].as_slice(),
+            ["file", "rename"].as_slice(),
+            ["file", "edit"].as_slice(),
             ["server", "set"].as_slice(),
             ["api", "post"].as_slice(),
             ["http", "request"].as_slice(),
@@ -950,6 +959,22 @@ mod tests {
 
         let file_write = manifest.find_path(&["file", "write"]).unwrap();
         assert!(file_write.output.notes.contains("--apply"));
+        assert!(file_write.dangerous_flags.contains(&"--apply".to_string()));
+
+        let file_delete = manifest.find_path(&["file", "delete"]).unwrap();
+        assert!(file_delete.output.notes.contains("--apply"));
+        assert!(file_delete.dangerous_flags.contains(&"--apply".to_string()));
+
+        let file_mkdir = manifest.find_path(&["file", "mkdir"]).unwrap();
+        assert!(file_mkdir.output.notes.contains("--apply"));
+        assert!(file_mkdir.dangerous_flags.contains(&"--apply".to_string()));
+
+        let file_rename = manifest.find_path(&["file", "rename"]).unwrap();
+        assert!(file_rename.output.notes.contains("--apply"));
+        assert!(file_rename.dangerous_flags.contains(&"--apply".to_string()));
+
+        let file_edit = manifest.find_path(&["file", "edit"]).unwrap();
+        assert_eq!(file_edit.dry_run.flag.as_deref(), Some("--dry-run"));
 
         let api_post = manifest.find_path(&["api", "post"]).unwrap();
         assert!(api_post.output.notes.contains("--apply"));

--- a/src/commands/file/args.rs
+++ b/src/commands/file/args.rs
@@ -51,6 +51,9 @@ pub(crate) enum FileCommand {
         project_id: String,
         /// Remote directory path
         path: String,
+        /// Apply the directory creation. Without this flag, prints a plan only.
+        #[arg(long)]
+        apply: bool,
     },
     /// Delete a file or directory
     Delete {
@@ -73,6 +76,9 @@ pub(crate) enum FileCommand {
         old_path: String,
         /// New path
         new_path: String,
+        /// Apply the rename/move. Without this flag, prints a plan only.
+        #[arg(long)]
+        apply: bool,
     },
     /// Find files by name pattern
     Find {

--- a/src/commands/file/mod.rs
+++ b/src/commands/file/mod.rs
@@ -55,38 +55,13 @@ pub fn run(args: FileArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<F
             let (out, code) = write(&project_id, &path, apply)?;
             Ok((FileCommandOutput::Standard(out), code))
         }
-        FileCommand::Mkdir { project_id, path } => {
-            let project = project::load(&project_id)?;
-            let project_base_path = require_project_base_path(&project_id, &project)?;
-            let full_path = join_remote_path(Some(&project_base_path), &path)?;
-            let output = executor::execute_for_project(
-                &project,
-                &format!("mkdir {}", shell::quote_path(&full_path)),
-            )?;
-            command::require_success(output.success, &output.stderr, "MKDIR")?;
-
-            Ok((
-                FileCommandOutput::Standard(FileOutput {
-                    command: "file.mkdir".to_string(),
-                    project_id,
-                    base_path: Some(project_base_path),
-                    path: Some(full_path),
-                    old_path: None,
-                    new_path: None,
-                    recursive: None,
-                    entries: None,
-                    content: None,
-                    size: None,
-                    bytes_written: None,
-                    dry_run: false,
-                    action_required: None,
-                    stdout: None,
-                    stderr: None,
-                    exit_code: 0,
-                    success: true,
-                }),
-                0,
-            ))
+        FileCommand::Mkdir {
+            project_id,
+            path,
+            apply,
+        } => {
+            let (out, code) = mkdir(&project_id, &path, apply)?;
+            Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Delete {
             project_id,
@@ -101,8 +76,9 @@ pub fn run(args: FileArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<F
             project_id,
             old_path,
             new_path,
+            apply,
         } => {
-            let (out, code) = rename(&project_id, &old_path, &new_path)?;
+            let (out, code) = rename(&project_id, &old_path, &new_path, apply)?;
             Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Find {
@@ -344,7 +320,101 @@ fn delete(project_id: &str, path: &str, recursive: bool, apply: bool) -> CmdResu
     ))
 }
 
-fn rename(project_id: &str, old_path: &str, new_path: &str) -> CmdResult<FileOutput> {
+fn mkdir(project_id: &str, path: &str, apply: bool) -> CmdResult<FileOutput> {
+    let project = project::load(project_id)?;
+    let project_base_path = require_project_base_path(project_id, &project)?;
+    let full_path = join_remote_path(Some(&project_base_path), path)?;
+
+    if !apply {
+        return Ok((
+            FileOutput {
+                command: "file.mkdir".to_string(),
+                project_id: project_id.to_string(),
+                base_path: Some(project_base_path),
+                path: Some(full_path),
+                old_path: None,
+                new_path: None,
+                recursive: None,
+                entries: None,
+                content: None,
+                size: None,
+                bytes_written: None,
+                dry_run: true,
+                action_required: Some(
+                    "Re-run with --apply to create the remote directory.".to_string(),
+                ),
+                stdout: None,
+                stderr: None,
+                exit_code: 0,
+                success: true,
+            },
+            0,
+        ));
+    }
+
+    let output = executor::execute_for_project(
+        &project,
+        &format!("mkdir {}", shell::quote_path(&full_path)),
+    )?;
+    command::require_success(output.success, &output.stderr, "MKDIR")?;
+
+    Ok((
+        FileOutput {
+            command: "file.mkdir".to_string(),
+            project_id: project_id.to_string(),
+            base_path: Some(project_base_path),
+            path: Some(full_path),
+            old_path: None,
+            new_path: None,
+            recursive: None,
+            entries: None,
+            content: None,
+            size: None,
+            bytes_written: None,
+            dry_run: false,
+            action_required: None,
+            stdout: None,
+            stderr: None,
+            exit_code: 0,
+            success: true,
+        },
+        0,
+    ))
+}
+
+fn rename(project_id: &str, old_path: &str, new_path: &str, apply: bool) -> CmdResult<FileOutput> {
+    if !apply {
+        let project = project::load(project_id)?;
+        let project_base_path = require_project_base_path(project_id, &project)?;
+        let full_old = join_remote_path(Some(&project_base_path), old_path)?;
+        let full_new = join_remote_path(Some(&project_base_path), new_path)?;
+
+        return Ok((
+            FileOutput {
+                command: "file.rename".to_string(),
+                project_id: project_id.to_string(),
+                base_path: Some(project_base_path),
+                path: None,
+                old_path: Some(full_old),
+                new_path: Some(full_new),
+                recursive: None,
+                entries: None,
+                content: None,
+                size: None,
+                bytes_written: None,
+                dry_run: true,
+                action_required: Some(
+                    "Re-run with --apply to rename or move the remote path.".to_string(),
+                ),
+                stdout: None,
+                stderr: None,
+                exit_code: 0,
+                success: true,
+            },
+            0,
+        ));
+    }
+
     let result = files::rename(project_id, old_path, new_path)?;
 
     Ok((

--- a/tests/commands/file_test.rs
+++ b/tests/commands/file_test.rs
@@ -100,6 +100,82 @@ fn file_delete_without_apply_returns_plan_and_preserves_file() {
 }
 
 #[test]
+fn file_mkdir_without_apply_returns_plan_and_preserves_filesystem() {
+    let project_root = tempfile::tempdir().expect("project tempdir");
+    let project_id = "local-file-mkdir-plan";
+    let dir_path = project_root.path().join("new-dir");
+
+    let result = with_isolated_home(|home| {
+        write_project_config(home.path(), project_id, project_root.path());
+
+        run(
+            FileArgs {
+                command: FileCommand::Mkdir {
+                    project_id: project_id.to_string(),
+                    path: "new-dir".to_string(),
+                    apply: false,
+                },
+            },
+            &GlobalArgs {},
+        )
+    });
+
+    let (output, code) = result.expect("run homeboy file mkdir");
+    let FileCommandOutput::Standard(payload) = output else {
+        panic!("expected standard file output");
+    };
+
+    assert_eq!(code, 0);
+    assert_eq!(payload.command, "file.mkdir");
+    assert!(payload.dry_run);
+    assert_eq!(
+        payload.action_required.as_deref(),
+        Some("Re-run with --apply to create the remote directory.")
+    );
+    assert!(!dir_path.exists());
+}
+
+#[test]
+fn file_rename_without_apply_returns_plan_and_preserves_filesystem() {
+    let project_root = tempfile::tempdir().expect("project tempdir");
+    let project_id = "local-file-rename-plan";
+    let old_path = project_root.path().join("old.txt");
+    let new_path = project_root.path().join("new.txt");
+    std::fs::write(&old_path, "keep me").expect("write sample file");
+
+    let result = with_isolated_home(|home| {
+        write_project_config(home.path(), project_id, project_root.path());
+
+        run(
+            FileArgs {
+                command: FileCommand::Rename {
+                    project_id: project_id.to_string(),
+                    old_path: "old.txt".to_string(),
+                    new_path: "new.txt".to_string(),
+                    apply: false,
+                },
+            },
+            &GlobalArgs {},
+        )
+    });
+
+    let (output, code) = result.expect("run homeboy file rename");
+    let FileCommandOutput::Standard(payload) = output else {
+        panic!("expected standard file output");
+    };
+
+    assert_eq!(code, 0);
+    assert_eq!(payload.command, "file.rename");
+    assert!(payload.dry_run);
+    assert_eq!(
+        payload.action_required.as_deref(),
+        Some("Re-run with --apply to rename or move the remote path.")
+    );
+    assert!(old_path.exists());
+    assert!(!new_path.exists());
+}
+
+#[test]
 fn file_edit_dry_run_returns_preview_and_preserves_file() {
     let project_root = tempfile::tempdir().expect("project tempdir");
     let project_id = "local-file-edit-dry-run";


### PR DESCRIPTION
## Summary
- Add explicit `--apply` gates to `homeboy file mkdir` and `homeboy file rename` so default execution returns non-mutating plan output.
- Keep documented `file edit` behavior intact, while recording its existing `--dry-run` guard in the safety manifest.
- Add file command tests and safety manifest assertions proving the mutating file commands have explicit guard metadata.
- Update `docs/commands/file.md` for the new `mkdir`/`rename` apply contract.

## Tests
- `rustfmt --check src/commands/file/args.rs src/commands/file/mod.rs tests/commands/file_test.rs src/command_contract/safety_manifest.rs`
- `cargo check`
- `git diff --check`

## Notes
- Did not run `cargo test` locally per the hot-command rule.
- Whole-tree `cargo fmt --check` reports unrelated pre-existing formatting drift outside this PR's files, so formatting verification was scoped to touched Rust files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, test updates, documentation updates, and verification.