### PR TITLE
fix: remap lab passthrough source paths

### DIFF
--- a/src/core/runner/command_path.rs
+++ b/src/core/runner/command_path.rs
@@ -800,6 +800,36 @@ mod tests {
     }
 
     #[test]
+    fn preflight_rejects_untranslated_source_path_after_passthrough() {
+        let controller = tempfile::tempdir().expect("controller");
+        let source = controller.path().join("static-site-importer@fix");
+        fs::create_dir_all(&source).expect("source");
+        let command = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "static-site-importer".to_string(),
+            "--path".to_string(),
+            "/runner/workspaces/static-site-importer@fix".to_string(),
+            "--".to_string(),
+            "--static-site-importer-path".to_string(),
+            source.display().to_string(),
+        ];
+
+        let err = preflight_remote_argv_path_translation(
+            "Lab offload",
+            "lab-runner",
+            &command,
+            &source,
+            "/runner/workspaces/static-site-importer@fix",
+        )
+        .expect_err("untranslated passthrough source path must fail before dispatch");
+
+        assert!(err.message.contains("remote argv argument"));
+        assert!(err.message.contains("controller-local source path"));
+        assert!(err.details.to_string().contains("path-translation defect"));
+    }
+
+    #[test]
     fn preflight_accepts_mapped_remote_paths_and_non_path_settings() {
         let controller = tempfile::tempdir().expect("controller");
         let source = controller.path().join("primary");

--- a/src/core/runner/lab_arg_tests.rs
+++ b/src/core/runner/lab_arg_tests.rs
@@ -155,7 +155,7 @@ fn strips_controller_artifact_root_from_runner_resident_command() {
 }
 
 #[test]
-fn leaves_passthrough_path_args_untouched() {
+fn leaves_relative_passthrough_path_args_untouched() {
     let input = args(&[
         "homeboy",
         "test",
@@ -178,6 +178,83 @@ fn leaves_passthrough_path_args_untouched() {
             "test-fixture",
         ])
     );
+}
+
+#[test]
+fn remaps_synced_source_paths_in_passthrough_args() {
+    use super::super::lab_args::LabPathRemap;
+
+    let input = args(&[
+        "homeboy",
+        "bench",
+        "static-site-importer",
+        "--path",
+        "/Users/user/Developer/static-site-importer@fix",
+        "--runner",
+        "homeboy-lab",
+        "--lab-only",
+        "--rig",
+        "static-site-importer-fixture-matrix",
+        "--",
+        EXPLICIT_PASSTHROUGH_SENTINEL,
+        "--static-site-importer-path",
+        "/Users/user/Developer/static-site-importer@fix",
+        "--batch-size",
+        "1",
+    ]);
+    let mappings = vec![LabPathRemap {
+        local: "/Users/user/Developer/static-site-importer@fix".to_string(),
+        remote: "/home/user/_lab_workspaces/static-site-importer@fix".to_string(),
+    }];
+
+    assert_eq!(
+        rewrite_lab_offload_args(
+            &input,
+            "/home/user/_lab_workspaces/static-site-importer@fix",
+            &mappings,
+            None,
+        ),
+        args(&[
+            "homeboy",
+            "--force-hot",
+            "bench",
+            "static-site-importer",
+            "--path",
+            "/home/user/_lab_workspaces/static-site-importer@fix",
+            "--rig",
+            "static-site-importer-fixture-matrix",
+            "--",
+            "--static-site-importer-path",
+            "/home/user/_lab_workspaces/static-site-importer@fix",
+            "--batch-size",
+            "1",
+        ])
+    );
+}
+
+#[test]
+fn leaves_unmapped_passthrough_source_paths_for_safety_guard() {
+    let input = args(&[
+        "homeboy",
+        "bench",
+        "static-site-importer",
+        "--path",
+        "/Users/user/Developer/static-site-importer@fix",
+        "--",
+        "--static-site-importer-path",
+        "/Users/user/Developer/static-site-importer@fix",
+    ]);
+
+    let rewritten = rewrite_lab_offload_args(
+        &input,
+        "/home/user/_lab_workspaces/static-site-importer@fix",
+        &[],
+        None,
+    );
+
+    assert!(rewritten
+        .iter()
+        .any(|arg| arg == "/Users/user/Developer/static-site-importer@fix"));
 }
 
 #[test]

--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -75,7 +75,7 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
             continue;
         }
         if passthrough {
-            stripped.push(arg.clone());
+            stripped.push(remap_lab_offload_arg(arg, &ordered));
             continue;
         }
         if arg == "--" {


### PR DESCRIPTION
## Summary
- Remap known synced controller-local source paths even when they appear in Lab passthrough argv after `--`.
- Keep the existing preflight guard that rejects untranslated controller-local source paths before dispatch.
- Add focused coverage for SSI-shaped passthrough args and guard rejection.

Fixes #7184.

## Verification
- `rustfmt --check src/core/runner/lab_args/offload.rs src/core/runner/lab_arg_tests.rs src/core/runner/command_path.rs`
- `cargo test remaps_synced_source_paths_in_passthrough_args`
- `cargo test preflight_rejects_untranslated_source_path_after_passthrough`
- `git diff --check -- src/core/runner/lab_args/offload.rs src/core/runner/lab_arg_tests.rs src/core/runner/command_path.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode; subagent coding workflow
- **Used for:** Reproducing the Lab offload blocker context, drafting the fix and focused tests, and preparing this PR for review.
