### PR TITLE
Fix nested Lab fuzz replay case lookup

### DIFF
--- a/src/commands/fuzz/replay.rs
+++ b/src/commands/fuzz/replay.rs
@@ -900,16 +900,29 @@ fn resolve_replay_artifact(
         .unwrap_or_default();
 
     if schema == FUZZ_RESULT_ENVELOPE_SCHEMA {
-        let envelope: FuzzResultEnvelope = serde_json::from_value(value).map_err(|error| {
-            homeboy::core::Error::validation_invalid_argument(
-                "artifact",
-                format!("failed to decode fuzz result envelope: {error}"),
-                Some(path.display().to_string()),
-                None,
-            )
-        })?;
+        let envelope: FuzzResultEnvelope =
+            serde_json::from_value(value.clone()).map_err(|error| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "artifact",
+                    format!("failed to decode fuzz result envelope: {error}"),
+                    Some(path.display().to_string()),
+                    None,
+                )
+            })?;
         let campaign = envelope.campaign.as_ref();
-        let (case_id, replay) = resolve_replay_metadata(campaign, requested_case_id)?;
+        let resolved = resolve_replay_metadata(campaign, requested_case_id);
+        if let Err(error) = &resolved {
+            if requested_case_id.is_some() && error.details["field"] == "case-id" {
+                if let Some(mut nested) = resolve_nested_replay_artifact(&value, requested_case_id)
+                {
+                    if nested.envelope_id.is_none() {
+                        nested.envelope_id = Some(envelope.id.clone());
+                    }
+                    return Ok(nested);
+                }
+            }
+        }
+        let (case_id, replay) = resolved?;
         return Ok(ResolvedReplayArtifact {
             campaign_id: campaign.map(|campaign| campaign.id.clone()),
             envelope_id: Some(envelope.id),
@@ -919,7 +932,7 @@ fn resolve_replay_artifact(
     }
 
     if schema == FUZZ_CAMPAIGN_SCHEMA {
-        let campaign: FuzzCampaign = serde_json::from_value(value).map_err(|error| {
+        let campaign: FuzzCampaign = serde_json::from_value(value.clone()).map_err(|error| {
             homeboy::core::Error::validation_invalid_argument(
                 "artifact",
                 format!("failed to decode fuzz campaign: {error}"),
@@ -927,13 +940,25 @@ fn resolve_replay_artifact(
                 None,
             )
         })?;
-        let (case_id, replay) = resolve_replay_metadata(Some(&campaign), requested_case_id)?;
+        let resolved = resolve_replay_metadata(Some(&campaign), requested_case_id);
+        if let Err(error) = &resolved {
+            if requested_case_id.is_some() && error.details["field"] == "case-id" {
+                if let Some(nested) = resolve_nested_replay_artifact(&value, requested_case_id) {
+                    return Ok(nested);
+                }
+            }
+        }
+        let (case_id, replay) = resolved?;
         return Ok(ResolvedReplayArtifact {
             campaign_id: Some(campaign.id),
             envelope_id: None,
             case_id,
             replay,
         });
+    }
+
+    if let Some(nested) = resolve_nested_replay_artifact(&value, requested_case_id) {
+        return Ok(nested);
     }
 
     Err(homeboy::core::Error::validation_invalid_argument(
@@ -944,6 +969,104 @@ fn resolve_replay_artifact(
         Some(path.display().to_string()),
         None,
     ))
+}
+
+fn resolve_nested_replay_artifact(
+    value: &serde_json::Value,
+    requested_case_id: Option<&str>,
+) -> Option<ResolvedReplayArtifact> {
+    let requested_case_id = requested_case_id?;
+    let mut stack = Vec::new();
+    push_child_values(value, &mut stack);
+
+    while let Some(candidate) = stack.pop() {
+        if let Some(resolved) = resolve_nested_replay_candidate(candidate, requested_case_id) {
+            return Some(resolved);
+        }
+        push_child_values(candidate, &mut stack);
+    }
+
+    None
+}
+
+fn resolve_nested_replay_candidate(
+    value: &serde_json::Value,
+    requested_case_id: &str,
+) -> Option<ResolvedReplayArtifact> {
+    let schema = value.get("schema").and_then(|schema| schema.as_str());
+    if schema == Some(FUZZ_RESULT_ENVELOPE_SCHEMA) {
+        if let Ok(envelope) = serde_json::from_value::<FuzzResultEnvelope>(value.clone()) {
+            if let Ok((Some(case_id), replay)) =
+                resolve_replay_metadata(envelope.campaign.as_ref(), Some(requested_case_id))
+            {
+                return Some(ResolvedReplayArtifact {
+                    campaign_id: envelope
+                        .campaign
+                        .as_ref()
+                        .map(|campaign| campaign.id.clone()),
+                    envelope_id: Some(envelope.id),
+                    case_id: Some(case_id),
+                    replay,
+                });
+            }
+        }
+    }
+
+    if schema == Some(FUZZ_CAMPAIGN_SCHEMA) {
+        if let Ok(campaign) = serde_json::from_value::<FuzzCampaign>(value.clone()) {
+            if let Ok((Some(case_id), replay)) =
+                resolve_replay_metadata(Some(&campaign), Some(requested_case_id))
+            {
+                return Some(ResolvedReplayArtifact {
+                    campaign_id: Some(campaign.id),
+                    envelope_id: None,
+                    case_id: Some(case_id),
+                    replay,
+                });
+            }
+        }
+    }
+
+    resolve_normalized_case_payload(value, requested_case_id)
+}
+
+fn resolve_normalized_case_payload(
+    value: &serde_json::Value,
+    requested_case_id: &str,
+) -> Option<ResolvedReplayArtifact> {
+    let object = value.as_object()?;
+    let cases = object.get("cases")?.as_array()?;
+    let case = cases.iter().find(|case| {
+        case.get("id")
+            .or_else(|| case.get("case_id"))
+            .and_then(|id| id.as_str())
+            == Some(requested_case_id)
+    })?;
+    let case_id = case
+        .get("id")
+        .or_else(|| case.get("case_id"))
+        .and_then(|id| id.as_str())?
+        .to_string();
+    let campaign_id = object
+        .get("id")
+        .or_else(|| object.get("campaign_id"))
+        .and_then(|id| id.as_str())
+        .map(str::to_string);
+
+    Some(ResolvedReplayArtifact {
+        campaign_id,
+        envelope_id: None,
+        case_id: Some(case_id),
+        replay: None,
+    })
+}
+
+fn push_child_values<'a>(value: &'a serde_json::Value, stack: &mut Vec<&'a serde_json::Value>) {
+    match value {
+        serde_json::Value::Array(items) => stack.extend(items.iter().rev()),
+        serde_json::Value::Object(object) => stack.extend(object.values().rev()),
+        _ => {}
+    }
 }
 
 fn resolve_replay_metadata(

--- a/src/commands/fuzz/tests/replay_tests.rs
+++ b/src/commands/fuzz/tests/replay_tests.rs
@@ -170,6 +170,220 @@ fn fuzz_replay_resolves_persisted_run_artifact_without_path() {
 }
 
 #[test]
+fn fuzz_replay_resolves_case_from_nested_lab_normalized_result_payload() {
+    with_isolated_home(|home| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                homeboy::core::observation::NewRunRecord::builder("fuzz")
+                    .component_id("component-a")
+                    .command("homeboy fuzz run component-a")
+                    .cwd_path(home.path())
+                    .build(),
+            )
+            .expect("run");
+        let path = home.path().join("lab-fuzz-envelope.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "schema": homeboy::core::fuzz::FUZZ_RESULT_ENVELOPE_SCHEMA,
+                "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+                "id": "lab-envelope-1",
+                "status": "passed",
+                "request": {
+                    "schema": homeboy::core::fuzz::FUZZ_EXECUTION_REQUEST_SCHEMA,
+                    "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+                    "id": "request-1",
+                    "component": "component-a"
+                },
+                "campaign": {
+                    "schema": homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA,
+                    "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+                    "id": "campaign-with-artifact-payloads",
+                    "safety_class": "read_only",
+                    "metadata": {
+                        "artifact_refs": [{
+                            "artifact_ref": "artifact:fuzz.result.normalized",
+                            "content": {
+                                "cases": [{
+                                    "id": "rest-db-query-profile:default",
+                                    "status": "passed"
+                                }]
+                            }
+                        }]
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("write lab envelope");
+        store
+            .record_artifact(&run.id, "fuzz_result_envelope", &path)
+            .expect("artifact");
+
+        let (output, exit) = run_replay(FuzzReplayArgs {
+            component: None,
+            path: None,
+            rig: None,
+            extension_override: ExtensionOverrideArgs::default(),
+            setting_args: SettingArgs::default(),
+            artifact_or_case: None,
+            artifact: None,
+            case_id: Some("rest-db-query-profile:default".to_string()),
+            run_id: Some(run.id.clone()),
+            dry_run: true,
+            args: Vec::new(),
+        })
+        .expect("resolve nested normalized case");
+
+        assert_eq!(exit, 0);
+        assert_eq!(output.status, "dry_run");
+        assert_eq!(output.run_id.as_deref(), Some(run.id.as_str()));
+        assert_eq!(output.envelope_id.as_deref(), Some("lab-envelope-1"));
+        assert_eq!(
+            output.case_id.as_deref(),
+            Some("rest-db-query-profile:default")
+        );
+        assert!(output.replay.is_none());
+        assert!(output.env.iter().any(|env| {
+            env.name == "HOMEBOY_FUZZ_REPLAY_CASE_ID"
+                && env.value == "rest-db-query-profile:default"
+        }));
+    });
+}
+
+#[test]
+fn fuzz_minimize_resolves_case_from_nested_lab_fuzz_result_artifact_payload() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("lab-artifact-wrapper.json");
+    std::fs::write(
+        &path,
+        serde_json::json!({
+            "schema": "homeboy/lab-artifact-wrapper/v1",
+            "id": "wrapper-1",
+            "artifact": {
+                "payload": {
+                    "fuzz_result_envelope": {
+                        "schema": homeboy::core::fuzz::FUZZ_RESULT_ENVELOPE_SCHEMA,
+                        "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+                        "id": "nested-envelope-1",
+                        "status": "passed",
+                        "request": {
+                            "schema": homeboy::core::fuzz::FUZZ_EXECUTION_REQUEST_SCHEMA,
+                            "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+                            "id": "request-1",
+                            "component": "component-a"
+                        },
+                        "campaign": {
+                            "schema": homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA,
+                            "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+                            "id": "nested-campaign-1",
+                            "safety_class": "read_only",
+                            "cases": [{
+                                "schema": homeboy::core::fuzz::FUZZ_CASE_SCHEMA,
+                                "id": "case-from-nested-envelope",
+                                "replay_id": "replay-1"
+                            }],
+                            "replay": {
+                                "schema": homeboy::core::fuzz::FUZZ_REPLAY_SCHEMA,
+                                "id": "replay-1",
+                                "seed": "nested-seed",
+                                "artifact_id": "nested-artifact"
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write lab wrapper");
+
+    let (output, exit) = run_minimize(FuzzMinimizeArgs {
+        component: None,
+        path: None,
+        rig: None,
+        extension_override: ExtensionOverrideArgs::default(),
+        setting_args: SettingArgs::default(),
+        artifact_or_case: Some(path.to_string_lossy().to_string()),
+        artifact: None,
+        case_id: Some("case-from-nested-envelope".to_string()),
+        run_id: Some("lab-run-1".to_string()),
+        dry_run: true,
+        args: Vec::new(),
+    })
+    .expect("resolve nested envelope case");
+
+    assert_eq!(exit, 0);
+    assert_eq!(output.command, "fuzz.minimize");
+    assert_eq!(output.status, "dry_run");
+    assert_eq!(output.campaign_id.as_deref(), Some("nested-campaign-1"));
+    assert_eq!(output.envelope_id.as_deref(), Some("nested-envelope-1"));
+    assert_eq!(output.case_id.as_deref(), Some("case-from-nested-envelope"));
+    assert_eq!(
+        output.replay.as_ref().map(|replay| replay.seed.as_deref()),
+        Some(Some("nested-seed"))
+    );
+}
+
+#[test]
+fn fuzz_replay_preserves_clear_error_when_nested_case_is_absent() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("lab-fuzz-envelope.json");
+    std::fs::write(
+        &path,
+        serde_json::json!({
+            "schema": homeboy::core::fuzz::FUZZ_RESULT_ENVELOPE_SCHEMA,
+            "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+            "id": "lab-envelope-1",
+            "status": "passed",
+            "request": {
+                "schema": homeboy::core::fuzz::FUZZ_EXECUTION_REQUEST_SCHEMA,
+                "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+                "id": "request-1",
+                "component": "component-a"
+            },
+            "campaign": {
+                "schema": homeboy::core::fuzz::FUZZ_CAMPAIGN_SCHEMA,
+                "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+                "id": "campaign-with-artifact-payloads",
+                "safety_class": "read_only",
+                "metadata": {
+                    "normalized_result": {
+                        "cases": [{ "id": "different-case" }]
+                    }
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write lab envelope");
+
+    let result = run_replay(FuzzReplayArgs {
+        component: None,
+        path: None,
+        rig: None,
+        extension_override: ExtensionOverrideArgs::default(),
+        setting_args: SettingArgs::default(),
+        artifact_or_case: Some(path.to_string_lossy().to_string()),
+        artifact: None,
+        case_id: Some("missing-case".to_string()),
+        run_id: Some("lab-run-1".to_string()),
+        dry_run: true,
+        args: Vec::new(),
+    });
+    let error = match result {
+        Ok(_) => panic!("missing nested case remains invalid"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.details["field"], "case-id");
+    assert!(error
+        .message
+        .contains("does not contain case 'missing-case'"));
+}
+
+#[test]
 fn fuzz_replay_dry_run_resolves_persisted_homeboy_artifact_ref_without_local_bytes() {
     with_isolated_home(|home| {
         let store = ObservationStore::open_initialized().expect("store");


### PR DESCRIPTION
## Summary
- Search nested fuzz result envelopes and campaign payloads when top-level replay case lookup misses a requested case.
- Resolve generic normalized Lab payloads with cases arrays so replay/minimize dry-runs can bind case ids from embedded artifact content.
- Preserve the existing clear case-id validation error when the requested case is absent.

## Tests
- Remote Lab runner: `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-replay-nested-lab-fuzz-cases-41c6236bd18b-c132c290-61c0-4263-8f2b-a4dad0e9e29b-1782956117223204000 -- cargo test replay_tests`
- Persisted run evidence: `runner-exec-cargo-test-replay_tests-homeboy-lab-cb31ba94-2fc7-4fb6-a6ae-dcfdef8d4bc2`

## Notes
- `homeboy test --lab-only` was blocked before execution by local controller/runner version drift: local controller `0.278.1`, connected runner `0.279.0`. Validation still ran off-machine through the managed runner exec path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed the replay case resolver gap, implemented the generic nested lookup, added tests, and ran remote validation.