### PR TITLE
Add structured runner handoff evidence

### DIFF
--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -127,6 +127,49 @@ is parsed from standard Homeboy JSON error envelopes (`error.details.field`,
 `error.field`, or `contract_field`) when present; otherwise it is omitted and the
 raw execution evidence remains under `execution`.
 
+## Detached handoff evidence
+
+Detached Lab offload handoffs return a `homeboy/runner-exec-handoff/v1`
+envelope. Orchestrators should read the `evidence` object for the stable,
+machine-readable handoff summary instead of parsing human command strings.
+
+Shape:
+
+```json
+{
+  "schema": "homeboy/runner-handoff-evidence/v1",
+  "status": "handoff_complete",
+  "runner_id": "homeboy-lab",
+  "runner_job_id": "runner-job-123",
+  "run_id": "agent-task-run-123",
+  "persisted_run_id": "agent-task-run-123",
+  "mirror_run_id": "agent-task-run-123",
+  "remote_cwd": "/srv/homeboy/checkouts/component",
+  "artifact_manifest": {
+    "schema": "homeboy/runner-artifact-manifest-ref/v1",
+    "manifest_schema": "homeboy/artifact-manifest/v1",
+    "path": "/srv/homeboy/checkouts/component-homeboy-artifacts/homeboy-artifact-manifest.json"
+  },
+  "artifact_refs": [{
+    "id": "artifact_manifest",
+    "name": "runner artifact manifest",
+    "path": "/srv/homeboy/checkouts/component-homeboy-artifacts/homeboy-artifact-manifest.json"
+  }],
+  "next_commands": [{
+    "label": "runner_job_logs",
+    "command": ["homeboy", "runner", "job", "logs", "homeboy-lab", "runner-job-123", "--follow"]
+  }]
+}
+```
+
+`runner_job_id` is the runner daemon or reverse-broker job id. `run_id`,
+`persisted_run_id`, and `mirror_run_id` are present when durable mirrored run
+evidence exists. `remote_cwd` and `artifact_refs` identify runner-side evidence
+paths; local persistence or download remains an explicit follow-up action.
+`next_commands` is intentionally argv-shaped so controllers can inspect or
+render commands without shell parsing. The legacy top-level IDs and
+`follow_commands` strings remain for operator readability.
+
 Trace runners also receive trace-specific variables when invoked by `homeboy trace`:
 
 | Variable | Source | Meaning |

--- a/docs/workflows/use-runners.md
+++ b/docs/workflows/use-runners.md
@@ -68,6 +68,12 @@ homeboy runs artifacts <run-id>
 
 For matrix and static-output workflows, follow [Artifact loop for runner and matrix workflows](../operations/artifact-loop-runner-matrix.md).
 
+Detached Lab handoffs also include a structured `evidence` object in the
+handoff JSON. Use it to inspect `runner_id`, `runner_job_id`, mirrored
+`run_id` values, `remote_cwd`, artifact manifest paths, artifact refs, status,
+and argv-shaped `next_commands` without parsing human-readable follow-up
+strings.
+
 ## 5. Repair Before Bypassing
 
 If runner routing fails because the runner is stale, missing secrets, or has a dirty workspace, fix the runner state before claiming proof. Local-hot bypass flags are debugging aids, not release-gate proof.

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -254,6 +254,7 @@ pub struct RunnerHandoffEnvelope {
     pub mirror_run_id: Option<String>,
     pub remote_cwd: String,
     pub artifact_manifest: RunnerHandoffArtifactManifestRef,
+    pub evidence: RunnerHandoffEvidence,
     pub follow_commands: RunnerHandoffFollowCommands,
 }
 
@@ -262,6 +263,32 @@ pub struct RunnerHandoffArtifactManifestRef {
     pub schema: String,
     pub manifest_schema: String,
     pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerHandoffEvidence {
+    pub schema: String,
+    pub status: String,
+    pub runner_id: String,
+    pub runner_job_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persisted_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mirror_run_id: Option<String>,
+    pub remote_cwd: String,
+    pub artifact_manifest: RunnerHandoffArtifactManifestRef,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<RunnerWorkloadArtifactRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_commands: Vec<RunnerHandoffNextCommand>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunnerHandoffNextCommand {
+    pub label: String,
+    pub command: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -306,6 +333,83 @@ impl RunnerHandoffEnvelope {
         remote_cwd: String,
         mirror_run_id: Option<String>,
     ) -> Self {
+        let job_logs_command = vec![
+            "homeboy".to_string(),
+            "runner".to_string(),
+            "job".to_string(),
+            "logs".to_string(),
+            runner_id.to_string(),
+            job_id.to_string(),
+            "--follow".to_string(),
+        ];
+        let job_cancel_command = vec![
+            "homeboy".to_string(),
+            "runner".to_string(),
+            "job".to_string(),
+            "cancel".to_string(),
+            runner_id.to_string(),
+            job_id.to_string(),
+        ];
+        let mut next_commands = vec![
+            RunnerHandoffNextCommand {
+                label: "runner_job_logs".to_string(),
+                command: job_logs_command.clone(),
+            },
+            RunnerHandoffNextCommand {
+                label: "runner_job_cancel".to_string(),
+                command: job_cancel_command.clone(),
+            },
+        ];
+        if let Some(run_id) = mirror_run_id.as_ref() {
+            next_commands.extend([
+                RunnerHandoffNextCommand {
+                    label: "run_status".to_string(),
+                    command: vec![
+                        "homeboy".to_string(),
+                        "agent-task".to_string(),
+                        "status".to_string(),
+                        run_id.clone(),
+                    ],
+                },
+                RunnerHandoffNextCommand {
+                    label: "run_logs".to_string(),
+                    command: vec![
+                        "homeboy".to_string(),
+                        "agent-task".to_string(),
+                        "logs".to_string(),
+                        run_id.clone(),
+                    ],
+                },
+                RunnerHandoffNextCommand {
+                    label: "run_artifacts".to_string(),
+                    command: vec![
+                        "homeboy".to_string(),
+                        "agent-task".to_string(),
+                        "artifacts".to_string(),
+                        run_id.clone(),
+                    ],
+                },
+            ]);
+        }
+        let artifact_manifest = RunnerHandoffArtifactManifestRef::for_remote_cwd(&remote_cwd);
+        let evidence = RunnerHandoffEvidence {
+            schema: "homeboy/runner-handoff-evidence/v1".to_string(),
+            status: "handoff_complete".to_string(),
+            runner_id: runner_id.to_string(),
+            runner_job_id: job_id.to_string(),
+            run_id: mirror_run_id.clone(),
+            persisted_run_id: mirror_run_id.clone(),
+            mirror_run_id: mirror_run_id.clone(),
+            remote_cwd: remote_cwd.clone(),
+            artifact_manifest: artifact_manifest.clone(),
+            artifact_refs: vec![RunnerWorkloadArtifactRef {
+                id: "artifact_manifest".to_string(),
+                name: Some("runner artifact manifest".to_string()),
+                path: Some(artifact_manifest.path.clone()),
+                url: None,
+            }],
+            next_commands,
+        };
         let follow_commands = RunnerHandoffFollowCommands {
             job_logs: format!("homeboy runner job logs {runner_id} {job_id} --follow"),
             job_cancel: format!("homeboy runner job cancel {runner_id} {job_id}"),
@@ -335,8 +439,9 @@ impl RunnerHandoffEnvelope {
             durable_run_id: mirror_run_id.clone(),
             persisted_run_id: mirror_run_id.clone(),
             mirror_run_id,
-            artifact_manifest: RunnerHandoffArtifactManifestRef::for_remote_cwd(&remote_cwd),
+            artifact_manifest,
             remote_cwd,
+            evidence,
             follow_commands,
         }
     }

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -813,6 +813,12 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
                         true,
                     ),
                     field(
+                        "evidence",
+                        "object",
+                        "Structured runner handoff evidence for orchestrators, including runner/job/run IDs, remote paths, artifact refs, status, and typed next commands.",
+                        true,
+                    ),
+                    field(
                         "follow_commands",
                         "object",
                         "Operator follow-up commands.",
@@ -827,6 +833,7 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
                     "job_id",
                     "remote_cwd",
                     "artifact_manifest",
+                    "evidence",
                     "follow_commands",
                 ],
                 example: runner_handoff_example(),
@@ -959,6 +966,33 @@ fn runner_handoff_example() -> Value {
             "schema": "homeboy/runner-artifact-manifest-ref/v1",
             "manifest_schema": RUNNER_ARTIFACT_MANIFEST_SCHEMA,
             "path": "/home/runner/workspace-homeboy-artifacts/manifest.json"
+        },
+        "evidence": {
+            "schema": "homeboy/runner-handoff-evidence/v1",
+            "status": "handoff_complete",
+            "runner_id": "runner-1",
+            "runner_job_id": "job-1",
+            "run_id": "run-1",
+            "persisted_run_id": "run-1",
+            "mirror_run_id": "run-1",
+            "remote_cwd": "/home/runner/workspace",
+            "artifact_manifest": {
+                "schema": "homeboy/runner-artifact-manifest-ref/v1",
+                "manifest_schema": RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+                "path": "/home/runner/workspace-homeboy-artifacts/manifest.json"
+            },
+            "artifact_refs": [{
+                "id": "artifact_manifest",
+                "name": "runner artifact manifest",
+                "path": "/home/runner/workspace-homeboy-artifacts/manifest.json"
+            }],
+            "next_commands": [{
+                "label": "runner_job_logs",
+                "command": ["homeboy", "runner", "job", "logs", "runner-1", "job-1", "--follow"]
+            }, {
+                "label": "run_artifacts",
+                "command": ["homeboy", "agent-task", "artifacts", "run-1"]
+            }]
         },
         "follow_commands": {
             "job_logs": "homeboy runner job logs runner-1 job-1 --follow",

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -269,6 +269,9 @@ fn attach_handoff_metadata(metadata: &mut serde_json::Value, stdout: &str) {
     if let Some(commands) = value.get("follow_commands") {
         object.insert("follow_commands".to_string(), commands.clone());
     }
+    if let Some(evidence) = value.get("evidence") {
+        object.insert("evidence".to_string(), evidence.clone());
+    }
 }
 
 fn metadata_path_string(value: &serde_json::Value, path: &[&str]) -> Option<String> {

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -508,6 +508,27 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             envelope.artifact_manifest.path,
             "/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json"
         );
+        assert_eq!(envelope.evidence.status, "handoff_complete");
+        assert_eq!(envelope.evidence.runner_id, "lab");
+        assert_eq!(envelope.evidence.runner_job_id, job_id);
+        assert_eq!(
+            envelope.evidence.run_id.as_deref(),
+            Some("agent-task-run-6454")
+        );
+        assert_eq!(envelope.evidence.remote_cwd, "/srv/homeboy/project");
+        assert_eq!(envelope.evidence.artifact_refs.len(), 1);
+        assert_eq!(envelope.evidence.artifact_refs[0].id, "artifact_manifest");
+        assert_eq!(
+            envelope.evidence.artifact_refs[0].path.as_deref(),
+            Some("/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json")
+        );
+        assert!(envelope
+            .evidence
+            .next_commands
+            .iter()
+            .any(|command| command.label == "run_artifacts"
+                && command.command
+                    == ["homeboy", "agent-task", "artifacts", "agent-task-run-6454"]));
         assert_eq!(
             envelope.durable_run_id.as_deref(),
             Some("agent-task-run-6454")
@@ -532,6 +553,17 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
         assert_eq!(
             json["artifact_manifest"]["path"],
             "/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json"
+        );
+        assert_eq!(json["evidence"]["runner_id"], "lab");
+        assert_eq!(json["evidence"]["runner_job_id"], job_id);
+        assert_eq!(json["evidence"]["run_id"], "agent-task-run-6454");
+        assert_eq!(
+            json["evidence"]["artifact_refs"][0]["path"],
+            "/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json"
+        );
+        assert_eq!(
+            json["evidence"]["next_commands"][0]["command"],
+            serde_json::json!(["homeboy", "runner", "job", "logs", "lab", job_id, "--follow"])
         );
         assert_eq!(json["job_id"], job_id);
         assert_eq!(json["durable_run_id"], "agent-task-run-6454");
@@ -573,6 +605,18 @@ fn runner_handoff_envelope_omits_agent_task_followups_without_run_id() {
         json["artifact_manifest"]["path"],
         "/srv/homeboy/project-homeboy-artifacts/homeboy-artifact-manifest.json"
     );
+    assert_eq!(json["evidence"]["runner_id"], "lab");
+    assert_eq!(json["evidence"]["runner_job_id"], "job-123");
+    assert_eq!(json["evidence"]["remote_cwd"], "/srv/homeboy/project");
+    assert_eq!(
+        json["evidence"]["artifact_refs"][0]["id"],
+        "artifact_manifest"
+    );
+    assert_eq!(
+        json["evidence"]["next_commands"][1]["command"],
+        serde_json::json!(["homeboy", "runner", "job", "cancel", "lab", "job-123"])
+    );
+    assert!(json["evidence"].get("run_id").is_none());
     assert!(json["identity"].get("persisted_run_id").is_none());
     assert!(json["identity"].get("run_id").is_none());
     assert_eq!(json["durable_run_id"], Value::Null);


### PR DESCRIPTION
## Summary
- Add a structured `evidence` object to detached Lab runner handoff envelopes with runner/job/run IDs, status, remote cwd, artifact manifest refs, artifact refs, and argv-shaped next commands.
- Propagate handoff evidence into Lab dispatch metadata so orchestrators can inspect it alongside existing follow-up command strings.
- Document the handoff evidence contract and update focused handoff assertions.

## Verification
- `rustfmt --check src/command_contract/lab.rs src/commands/contract.rs src/core/lab_routing.rs src/core/runner/execution/tests/handoff.rs`
- `cargo check --lib`
- `cargo check --tests`

Note: repo-wide `cargo fmt --check` reports pre-existing formatting drift outside this PR, so formatting verification was scoped to touched Rust files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated runner/offload handoff contracts, implemented the structured evidence fields, updated docs/tests, and ran verification checks.