### PR TITLE
Add workspace materializer primitive

### DIFF
--- a/src/core/runner/workspace/git.rs
+++ b/src/core/runner/workspace/git.rs
@@ -5,6 +5,9 @@ use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 
 use super::super::{Runner, RunnerKind};
+use super::materializer::{
+    dirty_git_workspace_guard, WorkspaceMaterializationOperation, WorkspaceMaterializer,
+};
 use super::types::GitSnapshot;
 use super::util::{
     git_output, owner_capture_shell, owner_restore_shell, parent_remote_path, run_shell_command,
@@ -242,32 +245,32 @@ fn git_bundle_install_command(
     remote_url: &str,
     allow_dirty_lab_workspace: bool,
 ) -> String {
-    let parent = parent_remote_path(remote_path);
-    let checkout = if let Some(branch) = branch {
-        format!(
-            "git -C \"$tmp\" checkout -B {branch} {head} && git -C \"$tmp\" config branch.{branch}.remote origin && git -C \"$tmp\" config branch.{branch}.merge refs/heads/{branch}",
-            branch = shell::quote_arg(branch),
-            head = shell::quote_arg(head),
-        )
-    } else {
-        format!(
-            "git -C \"$tmp\" checkout --detach {head}",
-            head = shell::quote_arg(head)
-        )
-    };
-
-    let dirty_guard = dirty_lab_workspace_guard("$dest", allow_dirty_lab_workspace);
-    format!(
-        "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"; bundle=\"${{dest}}.bundle.$$\"; {owner_capture}; mkdir -p \"$parent\" && trap 'rm -rf \"$tmp\" \"$bundle\"' EXIT; rm -rf \"$tmp\" \"$bundle\" && cat > \"$bundle\" && git clone \"$bundle\" \"$tmp\" && git -C \"$tmp\" remote set-url origin {remote_url} && {checkout} && git -C \"$tmp\" reset --hard {head} && git -C \"$tmp\" clean -ffdqx && {dirty_guard} && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\" && {owner_restore}",
-        parent = shell::quote_arg(parent.as_str()),
-        dest = shell::quote_arg(remote_path),
-        remote_url = shell::quote_arg(remote_url),
-        checkout = checkout,
-        head = shell::quote_arg(head),
-        dirty_guard = dirty_guard,
-        owner_capture = owner_capture_shell("$parent"),
-        owner_restore = owner_restore_shell("$parent", "$dest"),
-    )
+    WorkspaceMaterializer::new(remote_path)
+        .with_bundle_file()
+        .capture_owner()
+        .op(WorkspaceMaterializationOperation::EnsureParent)
+        .op(WorkspaceMaterializationOperation::CleanupOnExit(vec![
+            "\"$tmp\"".to_string(),
+            "\"$bundle\"".to_string(),
+        ]))
+        .op(WorkspaceMaterializationOperation::WriteStdinToBundle)
+        .op(WorkspaceMaterializationOperation::CloneBundleToTemp)
+        .op(WorkspaceMaterializationOperation::SetGitOrigin(
+            remote_url.to_string(),
+        ))
+        .op(WorkspaceMaterializationOperation::CheckoutGitRef {
+            head: head.to_string(),
+            branch: branch.map(str::to_string),
+        })
+        .op(WorkspaceMaterializationOperation::ResetAndCleanGit {
+            head: head.to_string(),
+        })
+        .op(WorkspaceMaterializationOperation::GuardCleanGitWorkspace {
+            allow_dirty: allow_dirty_lab_workspace,
+        })
+        .op(WorkspaceMaterializationOperation::AtomicReplaceTemp)
+        .restore_owner()
+        .command()
 }
 
 pub(super) fn materialize_git_command(
@@ -299,7 +302,7 @@ pub(super) fn materialize_git_command(
         })
         .collect::<String>();
 
-    let dirty_guard = dirty_lab_workspace_guard("$dest", allow_dirty_lab_workspace);
+    let dirty_guard = dirty_git_workspace_guard("$dest", allow_dirty_lab_workspace);
 
     format!(
         "parent={parent}; dest={dest}; {owner_capture}; mkdir -p \"$parent\" && if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git clone {url} \"$dest\" && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_extra_refs}{fetch_changed_since} && git -C \"$dest\" checkout --detach {head} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx && {owner_restore}",
@@ -313,22 +316,4 @@ pub(super) fn materialize_git_command(
         owner_capture = owner_capture_shell("$parent"),
         owner_restore = owner_restore_shell("$parent", "$dest"),
     )
-}
-
-fn dirty_lab_workspace_guard(dest: &str, allow_dirty_lab_workspace: bool) -> String {
-    let status = format!(
-        "git -C {dest} status --porcelain=v1 2>/dev/null | while IFS= read -r line; do path=${{line#???}}; if [ \"$path\" = .homeboy ] || [ \"${{path#.homeboy/}}\" != \"$path\" ]; then :; else printf '%s\\n' \"$line\"; fi; done || true",
-        dest = dest,
-    );
-    if allow_dirty_lab_workspace {
-        format!(
-            "dirty=$({status}); if [ -n \"$dirty\" ]; then printf '%s\\n' 'Homeboy Lab warning: --allow-dirty-lab-workspace is overwriting uncommitted runner workspace changes.' >&2; printf '%s\\n' \"$dirty\" >&2; fi",
-            status = status,
-        )
-    } else {
-        format!(
-            "dirty=$({status}); if [ -n \"$dirty\" ]; then printf '%s\\n' 'Homeboy Lab refused to overwrite a dirty runner workspace.' >&2; printf '%s\\n' \"$dirty\" >&2; printf '%s\\n' 'Commit, stash, clean, or remove the runner workspace before retrying. Pass --allow-dirty-lab-workspace only for noisy investigation that may discard runner-side changes.' >&2; exit 97; fi",
-            status = status,
-        )
-    }
 }

--- a/src/core/runner/workspace/materializer.rs
+++ b/src/core/runner/workspace/materializer.rs
@@ -1,0 +1,160 @@
+use crate::core::engine::shell;
+
+use super::util::{owner_capture_shell, owner_restore_shell, parent_remote_path};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum WorkspaceMaterializationOperation {
+    EnsureParent,
+    CleanupOnExit(Vec<String>),
+    RecreateTempDir,
+    ExtractTarStdinToTemp,
+    WriteStdinToBundle,
+    CloneBundleToTemp,
+    SetGitOrigin(String),
+    CheckoutGitRef {
+        head: String,
+        branch: Option<String>,
+    },
+    ResetAndCleanGit {
+        head: String,
+    },
+    GuardCleanGitWorkspace {
+        allow_dirty: bool,
+    },
+    AtomicReplaceTemp,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct WorkspaceMaterializer {
+    remote_path: String,
+    bundle: bool,
+    capture_owner: bool,
+    restore_owner: bool,
+    operations: Vec<WorkspaceMaterializationOperation>,
+}
+
+impl WorkspaceMaterializer {
+    pub(super) fn new(remote_path: impl Into<String>) -> Self {
+        Self {
+            remote_path: remote_path.into(),
+            bundle: false,
+            capture_owner: false,
+            restore_owner: false,
+            operations: Vec::new(),
+        }
+    }
+
+    pub(super) fn with_bundle_file(mut self) -> Self {
+        self.bundle = true;
+        self
+    }
+
+    pub(super) fn capture_owner(mut self) -> Self {
+        self.capture_owner = true;
+        self
+    }
+
+    pub(super) fn restore_owner(mut self) -> Self {
+        self.restore_owner = true;
+        self
+    }
+
+    pub(super) fn op(mut self, operation: WorkspaceMaterializationOperation) -> Self {
+        self.operations.push(operation);
+        self
+    }
+
+    pub(super) fn command(&self) -> String {
+        let parent = parent_remote_path(&self.remote_path);
+        let mut prefix = format!(
+            "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"",
+            parent = shell::quote_arg(parent.as_str()),
+            dest = shell::quote_arg(&self.remote_path),
+        );
+        if self.bundle {
+            prefix.push_str("; bundle=\"${dest}.bundle.$$\"");
+        }
+        if self.capture_owner {
+            prefix.push_str("; ");
+            prefix.push_str(&owner_capture_shell("$parent"));
+        }
+
+        let mut commands = Vec::new();
+        for operation in &self.operations {
+            commands.push(operation.shell());
+        }
+        if self.restore_owner {
+            commands.push(owner_restore_shell("$parent", "$dest"));
+        }
+
+        format!("{prefix}; {}", commands.join(" && "))
+    }
+}
+
+impl WorkspaceMaterializationOperation {
+    fn shell(&self) -> String {
+        match self {
+            Self::EnsureParent => "mkdir -p \"$parent\"".to_string(),
+            Self::CleanupOnExit(paths) => format!(
+                "trap 'rm -rf {}' EXIT",
+                paths
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ),
+            Self::RecreateTempDir => "rm -rf \"$tmp\" && mkdir -p \"$tmp\"".to_string(),
+            Self::ExtractTarStdinToTemp => "tar -C \"$tmp\" -xf -".to_string(),
+            Self::WriteStdinToBundle => {
+                "rm -rf \"$tmp\" \"$bundle\" && cat > \"$bundle\"".to_string()
+            }
+            Self::CloneBundleToTemp => "git clone \"$bundle\" \"$tmp\"".to_string(),
+            Self::SetGitOrigin(remote_url) => format!(
+                "git -C \"$tmp\" remote set-url origin {remote_url}",
+                remote_url = shell::quote_arg(remote_url)
+            ),
+            Self::CheckoutGitRef { head, branch } => git_checkout_command(head, branch.as_deref()),
+            Self::ResetAndCleanGit { head } => format!(
+                "git -C \"$tmp\" reset --hard {head} && git -C \"$tmp\" clean -ffdqx",
+                head = shell::quote_arg(head)
+            ),
+            Self::GuardCleanGitWorkspace { allow_dirty } => {
+                dirty_git_workspace_guard("$dest", *allow_dirty)
+            }
+            Self::AtomicReplaceTemp => "rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"".to_string(),
+        }
+    }
+}
+
+fn git_checkout_command(head: &str, branch: Option<&str>) -> String {
+    if let Some(branch) = branch {
+        format!(
+            "git -C \"$tmp\" checkout -B {branch} {head} && git -C \"$tmp\" config branch.{branch}.remote origin && git -C \"$tmp\" config branch.{branch}.merge refs/heads/{branch}",
+            branch = shell::quote_arg(branch),
+            head = shell::quote_arg(head),
+        )
+    } else {
+        format!(
+            "git -C \"$tmp\" checkout --detach {head}",
+            head = shell::quote_arg(head)
+        )
+    }
+}
+
+pub(super) fn dirty_git_workspace_guard(dest: &str, allow_dirty: bool) -> String {
+    let status = format!(
+        "git -C {dest} status --porcelain=v1 2>/dev/null | while IFS= read -r line; do path=${{line#???}}; if [ \"$path\" = .homeboy ] || [ \"${{path#.homeboy/}}\" != \"$path\" ]; then :; else printf '%s\\n' \"$line\"; fi; done || true",
+        dest = dest,
+    );
+    if allow_dirty {
+        format!(
+            "dirty=$({status}); if [ -n \"$dirty\" ]; then printf '%s\\n' 'Homeboy Lab warning: --allow-dirty-lab-workspace is overwriting uncommitted runner workspace changes.' >&2; printf '%s\\n' \"$dirty\" >&2; fi",
+            status = status,
+        )
+    } else {
+        format!(
+            "dirty=$({status}); if [ -n \"$dirty\" ]; then printf '%s\\n' 'Homeboy Lab refused to overwrite a dirty runner workspace.' >&2; printf '%s\\n' \"$dirty\" >&2; printf '%s\\n' 'Commit, stash, clean, or remove the runner workspace before retrying. Pass --allow-dirty-lab-workspace only for noisy investigation that may discard runner-side changes.' >&2; exit 97; fi",
+            status = status,
+        )
+    }
+}

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -8,6 +8,7 @@
 
 mod git;
 mod materialized;
+mod materializer;
 mod pull;
 mod snapshot;
 mod sync;

--- a/src/core/runner/workspace/snapshot.rs
+++ b/src/core/runner/workspace/snapshot.rs
@@ -8,10 +8,11 @@ use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 
 use super::super::{Runner, RunnerKind};
+use super::materializer::{WorkspaceMaterializationOperation, WorkspaceMaterializer};
 use super::types::SnapshotStats;
 use super::util::{
-    git_output, hex_prefix, owner_capture_shell, owner_restore_shell, parent_remote_path,
-    run_shell_capture, run_shell_command, ssh_args, ssh_client_for_runner, tar_exclude_args,
+    git_output, hex_prefix, run_shell_capture, run_shell_command, ssh_args, ssh_client_for_runner,
+    tar_exclude_args,
 };
 
 pub(crate) fn snapshot_identity(
@@ -404,12 +405,15 @@ fn includes_override_exclude(includes: &[String], exclude: &str) -> bool {
 }
 
 pub(super) fn snapshot_install_command(remote_path: &str) -> String {
-    let parent = parent_remote_path(remote_path);
-    format!(
-        "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"; {owner_capture}; mkdir -p \"$parent\" && trap 'rm -rf \"$tmp\"' EXIT; rm -rf \"$tmp\" && mkdir -p \"$tmp\" && tar -C \"$tmp\" -xf - && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\" && {owner_restore}",
-        parent = shell::quote_arg(parent.as_str()),
-        dest = shell::quote_arg(remote_path),
-        owner_capture = owner_capture_shell("$parent"),
-        owner_restore = owner_restore_shell("$parent", "$dest"),
-    )
+    WorkspaceMaterializer::new(remote_path)
+        .capture_owner()
+        .op(WorkspaceMaterializationOperation::EnsureParent)
+        .op(WorkspaceMaterializationOperation::CleanupOnExit(vec![
+            "\"$tmp\"".to_string(),
+        ]))
+        .op(WorkspaceMaterializationOperation::RecreateTempDir)
+        .op(WorkspaceMaterializationOperation::ExtractTarStdinToTemp)
+        .op(WorkspaceMaterializationOperation::AtomicReplaceTemp)
+        .restore_owner()
+        .command()
 }

--- a/src/core/runner/workspace/tests/materializer.rs
+++ b/src/core/runner/workspace/tests/materializer.rs
@@ -1,0 +1,64 @@
+use crate::core::runner::workspace::materializer::{
+    WorkspaceMaterializationOperation, WorkspaceMaterializer,
+};
+
+#[test]
+fn workspace_materializer_builds_snapshot_atomic_replace_command() {
+    let command = WorkspaceMaterializer::new("/srv/homeboy/_lab_workspaces/homeboy-abc")
+        .capture_owner()
+        .op(WorkspaceMaterializationOperation::EnsureParent)
+        .op(WorkspaceMaterializationOperation::CleanupOnExit(vec![
+            "\"$tmp\"".to_string(),
+        ]))
+        .op(WorkspaceMaterializationOperation::RecreateTempDir)
+        .op(WorkspaceMaterializationOperation::ExtractTarStdinToTemp)
+        .op(WorkspaceMaterializationOperation::AtomicReplaceTemp)
+        .restore_owner()
+        .command();
+
+    assert!(command.contains("parent=/srv/homeboy/_lab_workspaces"));
+    assert!(command.contains("dest=/srv/homeboy/_lab_workspaces/homeboy-abc"));
+    assert!(command.contains("trap 'rm -rf \"$tmp\"' EXIT"));
+    assert!(command.contains("tar -C \"$tmp\" -xf -"));
+    assert!(command.contains("rm -rf \"$dest\" && mv \"$tmp\" \"$dest\""));
+    assert!(command.contains("owner_path=$parent"));
+    assert!(command.contains("chown -R \"$owner\" $dest"));
+}
+
+#[test]
+fn workspace_materializer_builds_git_bundle_checkout_command() {
+    let command = WorkspaceMaterializer::new("/srv/homeboy/_lab_workspaces/homeboy-abc")
+        .with_bundle_file()
+        .capture_owner()
+        .op(WorkspaceMaterializationOperation::EnsureParent)
+        .op(WorkspaceMaterializationOperation::CleanupOnExit(vec![
+            "\"$tmp\"".to_string(),
+            "\"$bundle\"".to_string(),
+        ]))
+        .op(WorkspaceMaterializationOperation::WriteStdinToBundle)
+        .op(WorkspaceMaterializationOperation::CloneBundleToTemp)
+        .op(WorkspaceMaterializationOperation::SetGitOrigin(
+            "https://github.com/Extra-Chill/homeboy.git".to_string(),
+        ))
+        .op(WorkspaceMaterializationOperation::CheckoutGitRef {
+            head: "abc123".to_string(),
+            branch: Some("main".to_string()),
+        })
+        .op(WorkspaceMaterializationOperation::ResetAndCleanGit {
+            head: "abc123".to_string(),
+        })
+        .op(WorkspaceMaterializationOperation::GuardCleanGitWorkspace { allow_dirty: false })
+        .op(WorkspaceMaterializationOperation::AtomicReplaceTemp)
+        .restore_owner()
+        .command();
+
+    assert!(command.contains("bundle=\"${dest}.bundle.$$\""));
+    assert!(command.contains("cat > \"$bundle\""));
+    assert!(command.contains("git clone \"$bundle\" \"$tmp\""));
+    assert!(command.contains("remote set-url origin https://github.com/Extra-Chill/homeboy.git"));
+    assert!(command.contains("checkout -B main abc123"));
+    assert!(command.contains("config branch.main.merge refs/heads/main"));
+    assert!(command.contains("git -C \"$tmp\" reset --hard abc123"));
+    assert!(command.contains("Homeboy Lab refused to overwrite a dirty runner workspace"));
+    assert!(command.contains("exit 97"));
+}

--- a/src/core/runner/workspace/tests/mod.rs
+++ b/src/core/runner/workspace/tests/mod.rs
@@ -1,5 +1,6 @@
 mod deterministic;
 mod git;
+mod materializer;
 mod prune;
 mod reap;
 mod snapshot;


### PR DESCRIPTION
## Summary
- Add a typed WorkspaceMaterializer builder for runner workspace materialization shell construction.
- Model first operations for parent prep, stdin upload, temp cleanup, git checkout/reset/clean, dirty-workspace guard, and atomic replacement.
- Route snapshot install and controller-routed git bundle install command construction through the new primitive without broad behavior changes.
- Add focused command-construction tests for snapshot atomic replace and git bundle checkout materialization.

## Tests
- rustfmt on touched Rust files
- cargo check
- homeboy audit --profile pr --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted and implemented the typed workspace materializer primitive, migrated small command-construction paths, added focused tests, and ran safe verification.