### PR TITLE
Add resource lifecycle index contract

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -30,9 +30,10 @@ pub use crate::core::artifact_ref::{
 };
 pub use constants::{
     artifact_manifest_constants, artifact_postprocess_constants, contract_constants,
-    loop_constants, reviewer_facing_ref_constants, run_location_index_constants,
-    secret_env_plan_constants, AllContractConstants, ArtifactManifestConstants,
-    ArtifactPostprocessConstants, ContractConstants, ContractConstantsOutput, LoopConstants,
+    loop_constants, resource_lifecycle_index_constants, reviewer_facing_ref_constants,
+    run_location_index_constants, secret_env_plan_constants, AllContractConstants,
+    ArtifactManifestConstants, ArtifactPostprocessConstants, ContractConstants,
+    ContractConstantsOutput, LoopConstants, ResourceLifecycleIndexConstants,
     ReviewerFacingRefConstants, RunLocationIndexConstants, SecretEnvPlanConstants,
     CONTRACT_CONSTANTS_SCHEMA,
 };

--- a/src/command_contract/constants.rs
+++ b/src/command_contract/constants.rs
@@ -25,6 +25,7 @@ pub enum ContractConstants {
     ArtifactPostprocess(ArtifactPostprocessConstants),
     Loop(LoopConstants),
     SecretEnvPlan(SecretEnvPlanConstants),
+    ResourceLifecycleIndex(ResourceLifecycleIndexConstants),
     RunLocationIndex(RunLocationIndexConstants),
     ReviewerFacingRef(ReviewerFacingRefConstants),
 }
@@ -35,6 +36,7 @@ pub struct AllContractConstants {
     pub artifact_postprocess: ArtifactPostprocessConstants,
     pub loop_contracts: LoopConstants,
     pub secret_env_plan: SecretEnvPlanConstants,
+    pub resource_lifecycle_index: ResourceLifecycleIndexConstants,
     pub run_location_index: RunLocationIndexConstants,
     pub reviewer_facing_ref: ReviewerFacingRefConstants,
 }
@@ -64,6 +66,11 @@ pub struct SecretEnvPlanConstants {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ResourceLifecycleIndexConstants {
+    pub schema_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RunLocationIndexConstants {
     pub schema_id: String,
 }
@@ -81,6 +88,7 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
             artifact_postprocess: artifact_postprocess_constants(),
             loop_contracts: loop_constants(),
             secret_env_plan: secret_env_plan_constants(),
+            resource_lifecycle_index: resource_lifecycle_index_constants(),
             run_location_index: run_location_index_constants(),
             reviewer_facing_ref: reviewer_facing_ref_constants(),
         }),
@@ -90,6 +98,9 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
         }
         "loop" | "loop-contracts" => ContractConstants::Loop(loop_constants()),
         "secret-env-plan" => ContractConstants::SecretEnvPlan(secret_env_plan_constants()),
+        "resource-lifecycle-index" => {
+            ContractConstants::ResourceLifecycleIndex(resource_lifecycle_index_constants())
+        }
         "run-location-index" => ContractConstants::RunLocationIndex(run_location_index_constants()),
         "reviewer-facing-ref" | "reviewer-ref" => {
             ContractConstants::ReviewerFacingRef(reviewer_facing_ref_constants())
@@ -129,6 +140,12 @@ pub fn loop_constants() -> LoopConstants {
 pub fn secret_env_plan_constants() -> SecretEnvPlanConstants {
     SecretEnvPlanConstants {
         schema_id: registry_schema_id("secret-env-plan"),
+    }
+}
+
+pub fn resource_lifecycle_index_constants() -> ResourceLifecycleIndexConstants {
+    ResourceLifecycleIndexConstants {
+        schema_id: registry_schema_id("resource-lifecycle-index"),
     }
 }
 

--- a/src/command_contract/registry.rs
+++ b/src/command_contract/registry.rs
@@ -107,6 +107,14 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         rust_type: "homeboy::core::resource_cleanup_intent::ResourceCleanupIntentContract",
     },
     ContractRegistryEntry {
+        schema_id: crate::core::resource_lifecycle_index::RESOURCE_LIFECYCLE_INDEX_SCHEMA,
+        name: "resource-lifecycle-index",
+        title: "Resource lifecycle index",
+        owner: "homeboy-core",
+        summary: "Indexes run-owned resources, retention policy, cleanup intent, and lifecycle status without runtime-specific semantics.",
+        rust_type: "homeboy::core::resource_lifecycle_index::ResourceLifecycleIndex",
+    },
+    ContractRegistryEntry {
         schema_id: crate::command_contract::RUN_LOCATION_INDEX_SCHEMA,
         name: "run-location-index",
         title: "Run location index",
@@ -179,6 +187,7 @@ mod tests {
             "secret-env-plan",
             "fuzz-workload",
             "resource-cleanup-intent",
+            "resource-lifecycle-index",
             "run-location-index",
             "extension-materialization-source",
             "resolved-agent-runtime-execution-contract",

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -26,6 +26,10 @@ use crate::core::loop_lifecycle::{
 use crate::core::resource_cleanup_intent::{
     ResourceCleanupIntentContract, RESOURCE_CLEANUP_INTENT_SCHEMA,
 };
+use crate::core::resource_lifecycle_index::{
+    ResourceCleanupPolicy, ResourceEvidenceRetention, ResourceLifecycleIndex,
+    ResourceLifecycleResourceStatus, RESOURCE_LIFECYCLE_INDEX_SCHEMA,
+};
 use crate::core::run_lifecycle_status::{RunLifecycleStatus, RUN_LIFECYCLE_STATUS_SCHEMA};
 use crate::core::secret_env_plan::{SecretEnvPlan, SECRET_ENV_PLAN_SCHEMA};
 use crate::core::{Error, Result};
@@ -59,7 +63,7 @@ pub enum ContractCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct ContractConstantsArgs {
-    /// Contract ID: all, artifact-manifest, loop, secret-env-plan, run-location-index, reviewer-facing-ref.
+    /// Contract ID: all, artifact-manifest, loop, secret-env-plan, resource-lifecycle-index, run-location-index, reviewer-facing-ref.
     pub contract_id: String,
 }
 
@@ -400,7 +404,7 @@ fn constants(contract_id: &str) -> CmdResult<ContractOutput> {
             format!("unknown contract constants id `{contract_id}`"),
             None,
             Some(vec![
-                    "Use one of: all, artifact-manifest, artifact-postprocess, loop, secret-env-plan, run-location-index, reviewer-facing-ref".to_string(),
+                    "Use one of: all, artifact-manifest, artifact-postprocess, loop, secret-env-plan, resource-lifecycle-index, run-location-index, reviewer-facing-ref".to_string(),
             ]),
         )
     })?;
@@ -875,6 +879,32 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
                 ],
                 example: run_location_index_example(),
             },
+            ContractSchemaEntry {
+                id: RESOURCE_LIFECYCLE_INDEX_SCHEMA,
+                version: 1,
+                description: "Generic run-owned resource lifecycle index for cleanup and retention consumers.",
+                fields: vec![
+                    field(
+                        "schema",
+                        "string",
+                        "Schema ID for the resource lifecycle index.",
+                        true,
+                    ),
+                    field("resources", "array", "Run-owned resource records.", true),
+                    field("resources[].owner", "string", "System that declared the resource.", true),
+                    field("resources[].run_id", "string", "Run that owns the resource.", true),
+                    field("resources[].runner_id", "string|null", "Runner that hosts or produced the resource.", false),
+                    field("resources[].path", "string", "Resource path or stable resource address.", true),
+                    field("resources[].kind", "string", "Generic resource kind such as artifact, workspace, or temp_dir.", true),
+                    field("resources[].ttl", "string|null", "Retention duration or deadline understood by the producer/consumer.", false),
+                    field("resources[].cleanup_policy", "string", "Cleanup policy enum.", true),
+                    field("resources[].evidence_retention", "string", "Evidence retention enum.", true),
+                    field("resources[].cleanup_intent", "string", "Dry-run/apply cleanup intent.", true),
+                    field("resources[].status", "string", "Resource lifecycle status enum.", true),
+                ],
+                required: vec!["schema", "resources"],
+                example: resource_lifecycle_index_example(),
+            },
         ],
     }
 }
@@ -983,6 +1013,26 @@ fn run_location_index_example() -> Value {
             "path": "/home/runner/workspace-homeboy-artifacts/manifest.json"
         },
         "liveness_heartbeat_timestamp": "2026-01-01T00:00:00Z"
+    })
+}
+
+fn resource_lifecycle_index_example() -> Value {
+    json!({
+        "schema": RESOURCE_LIFECYCLE_INDEX_SCHEMA,
+        "resources": [
+            {
+                "owner": "homeboy-core",
+                "run_id": "run-1",
+                "runner_id": "runner-1",
+                "path": "/home/runner/workspace-homeboy-artifacts",
+                "kind": "artifact_dir",
+                "ttl": "P7D",
+                "cleanup_policy": ResourceCleanupPolicy::DeleteAfterTtl,
+                "evidence_retention": ResourceEvidenceRetention::Manifest,
+                "cleanup_intent": "dry_run",
+                "status": ResourceLifecycleResourceStatus::Active
+            }
+        ]
     })
 }
 
@@ -1113,6 +1163,10 @@ static CONTRACT_SCHEMAS: &[ContractSchema] = &[
         validate_json: validate_resource_cleanup_intent,
     },
     ContractSchema {
+        id: RESOURCE_LIFECYCLE_INDEX_SCHEMA,
+        validate_json: validate_resource_lifecycle_index,
+    },
+    ContractSchema {
         id: LOOP_RUN_SCHEMA,
         validate_json: validate_loop_run,
     },
@@ -1155,6 +1209,12 @@ fn validate_fuzz_workload(raw: &str) -> homeboy::core::Result<()> {
 fn validate_resource_cleanup_intent(raw: &str) -> homeboy::core::Result<()> {
     let contract: ResourceCleanupIntentContract =
         deserialize_contract(raw, RESOURCE_CLEANUP_INTENT_SCHEMA)?;
+    contract.validate()
+}
+
+fn validate_resource_lifecycle_index(raw: &str) -> homeboy::core::Result<()> {
+    let contract: ResourceLifecycleIndex =
+        deserialize_contract(raw, RESOURCE_LIFECYCLE_INDEX_SCHEMA)?;
     contract.validate()
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -125,6 +125,7 @@ pub mod release;
 pub mod report_compare;
 pub(crate) mod report_compare_render;
 pub mod resource_cleanup_intent;
+pub mod resource_lifecycle_index;
 pub mod resources;
 pub mod review;
 pub mod rig;

--- a/src/core/resource_lifecycle_index.rs
+++ b/src/core/resource_lifecycle_index.rs
@@ -1,0 +1,217 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::resource_cleanup_intent::ResourceCleanupIntent;
+use crate::core::{Error, Result};
+
+pub const RESOURCE_LIFECYCLE_INDEX_SCHEMA: &str = "homeboy/resource-lifecycle-index/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceLifecycleIndex {
+    #[serde(default = "resource_lifecycle_index_schema")]
+    pub schema: String,
+    #[serde(default)]
+    pub resources: Vec<ResourceLifecycleRecord>,
+}
+
+impl ResourceLifecycleIndex {
+    pub fn validate(&self) -> Result<()> {
+        validate_resource_lifecycle_index(self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceLifecycleRecord {
+    pub owner: String,
+    pub run_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
+    pub path: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<String>,
+    pub cleanup_policy: ResourceCleanupPolicy,
+    pub evidence_retention: ResourceEvidenceRetention,
+    #[serde(default)]
+    pub cleanup_intent: ResourceCleanupIntent,
+    pub status: ResourceLifecycleResourceStatus,
+}
+
+impl ResourceLifecycleRecord {
+    pub fn validate(&self, index: usize) -> Result<()> {
+        validate_resource_lifecycle_record(index, self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceCleanupPolicy {
+    Preserve,
+    Manual,
+    DeleteAfterTtl,
+    DeleteOnSuccess,
+    DeleteOnTerminal,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceEvidenceRetention {
+    None,
+    Metadata,
+    Manifest,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceLifecycleResourceStatus {
+    Declared,
+    Active,
+    Retained,
+    CleanupPending,
+    Cleaned,
+    Missing,
+    Failed,
+}
+
+pub fn validate_resource_lifecycle_index(index: &ResourceLifecycleIndex) -> Result<()> {
+    if index.schema != RESOURCE_LIFECYCLE_INDEX_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "schema",
+            format!(
+                "expected {RESOURCE_LIFECYCLE_INDEX_SCHEMA}, received {}",
+                index.schema
+            ),
+            Some(index.schema.clone()),
+            None,
+        ));
+    }
+
+    for (resource_index, resource) in index.resources.iter().enumerate() {
+        validate_resource_lifecycle_record(resource_index, resource)?;
+    }
+
+    Ok(())
+}
+
+pub fn validate_resource_lifecycle_record(
+    index: usize,
+    record: &ResourceLifecycleRecord,
+) -> Result<()> {
+    let prefix = format!("resources[{index}]");
+    validate_required_field(&format!("{prefix}.owner"), &record.owner)?;
+    validate_required_field(&format!("{prefix}.run_id"), &record.run_id)?;
+    validate_required_field(&format!("{prefix}.path"), &record.path)?;
+    validate_required_field(&format!("{prefix}.kind"), &record.kind)?;
+
+    if let Some(runner_id) = &record.runner_id {
+        validate_required_field(&format!("{prefix}.runner_id"), runner_id)?;
+    }
+
+    if let Some(ttl) = &record.ttl {
+        validate_required_field(&format!("{prefix}.ttl"), ttl)?;
+    } else if matches!(record.cleanup_policy, ResourceCleanupPolicy::DeleteAfterTtl) {
+        return Err(Error::validation_invalid_argument(
+            format!("{prefix}.ttl"),
+            "delete_after_ttl cleanup policy requires ttl",
+            None,
+            None,
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_required_field(field: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            field,
+            "must not be blank",
+            None,
+            None,
+        ));
+    }
+
+    Ok(())
+}
+
+fn resource_lifecycle_index_schema() -> String {
+    RESOURCE_LIFECYCLE_INDEX_SCHEMA.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ErrorCode;
+
+    fn record() -> ResourceLifecycleRecord {
+        ResourceLifecycleRecord {
+            owner: "homeboy-test".to_string(),
+            run_id: "run-1".to_string(),
+            runner_id: Some("runner-1".to_string()),
+            path: "/tmp/homeboy/run-1/workspace".to_string(),
+            kind: "workspace".to_string(),
+            ttl: Some("P7D".to_string()),
+            cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
+            evidence_retention: ResourceEvidenceRetention::Manifest,
+            cleanup_intent: ResourceCleanupIntent::DryRun,
+            status: ResourceLifecycleResourceStatus::Active,
+        }
+    }
+
+    fn index() -> ResourceLifecycleIndex {
+        ResourceLifecycleIndex {
+            schema: RESOURCE_LIFECYCLE_INDEX_SCHEMA.to_string(),
+            resources: vec![record()],
+        }
+    }
+
+    #[test]
+    fn validates_resource_lifecycle_index() {
+        index().validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_wrong_schema() {
+        let mut index = index();
+        index.schema = "homeboy/resource-lifecycle-index/v0".to_string();
+
+        let error = index.validate().unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "schema");
+    }
+
+    #[test]
+    fn rejects_blank_required_resource_fields() {
+        let mut index = index();
+        index.resources[0].path = "  ".to_string();
+
+        let error = index.validate().unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "resources[0].path");
+    }
+
+    #[test]
+    fn delete_after_ttl_requires_ttl() {
+        let mut index = index();
+        index.resources[0].ttl = None;
+
+        let error = index.validate().unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "resources[0].ttl");
+    }
+
+    #[test]
+    fn serializes_stable_snake_case_policy_values() {
+        assert_eq!(
+            serde_json::to_string(&ResourceCleanupPolicy::DeleteAfterTtl).unwrap(),
+            "\"delete_after_ttl\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ResourceLifecycleResourceStatus::CleanupPending).unwrap(),
+            "\"cleanup_pending\""
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a generic `homeboy/resource-lifecycle-index/v1` contract for run-owned resource records.
- Defines resource fields for owner, run ID, optional runner ID, path, kind, TTL, cleanup policy, evidence retention, cleanup intent, and lifecycle status.
- Registers the contract in the core registry, constants export, schema catalog, and contract validation path.

## Testing
- `cargo check --lib`
- `cargo check --bin homeboy`
- `git diff --check`

## Notes
- Did not intentionally run `cargo test` because local test runs are a hot command in this environment. During PR creation, an initial shell quoting mistake interpreted backticked body text as commands and started `cargo test`; it timed out while listing tests with a broken pipe before completing.
- `cargo fmt --check` is currently blocked by pre-existing formatting drift outside this PR; only intended files were retained in the commit.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated existing Homeboy cleanup/artifact contracts, implemented the resource lifecycle index contract, ran safe checks, and prepared this PR.
