### PR TITLE
Add fuzz campaign planner

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -8,7 +8,7 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
 homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
-homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>]
+homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--campaign-manifest <path>] [--campaign-workload <id>] [--lab-runner <id>] [--required-artifact <id>] [--allow-destructive --isolation isolated --isolation-proof <path>]
 homeboy fuzz validate <results-file>
 homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--output-envelope <path>]
 homeboy fuzz compare <baseline-envelope> <candidate-envelope> [--hotspot-policy <advisory|blocking|off>]
@@ -162,6 +162,48 @@ families, selected operation ids, seed/corpus refs, effective budgets, isolation
 requirements, selected gate profile, required artifact ids, gate ids, inventory
 provenance, and skipped target or operation reasons. The planner is product-neutral: it uses inventory-declared
 operation families and safety classes, not product-specific target names.
+
+`homeboy fuzz plan --campaign-manifest <path>` adds a deterministic
+`homeboy/fuzz-campaign-plan/v1` object beside the single execution request. This
+is a planning primitive only: it emits structured entries and canonical
+`homeboy fuzz run` command vectors without running or rewriting the fuzz executor.
+The manifest is product-neutral and may contain `id`, `workloads`,
+`workload_ids`, `lab_runner`, and `required_artifacts`; product-specific details
+belong in manifest metadata that downstream runners consume, not in Homeboy core.
+Repeat `--campaign-workload <id>` to add workload ids without a manifest,
+`--tracker-ref KIND:ID` to anchor every entry, `--lab-runner <id>` to record the
+preferred offload target, and `--required-artifact <id>` for reviewer-facing
+artifacts each planned run must produce.
+
+Example campaign manifest:
+
+```json
+{
+  "id": "full-surface",
+  "workloads": ["api-fuzz", { "id": "db-fuzz" }],
+  "lab_runner": "lab-a",
+  "required_artifacts": [
+    { "id": "coverage-gap-report", "kind": "coverage_gap_report" },
+    "performance-hotspots-summary"
+  ]
+}
+```
+
+Example planner command:
+
+```bash
+homeboy fuzz plan my-component \
+  --campaign-manifest manifests/full-surface-fuzz.json \
+  --campaign-workload browser-fuzz \
+  --tracker-ref github_issue:owner/repo#123 \
+  --lab-runner lab-a \
+  --required-artifact fuzz-result-envelope
+```
+
+The resulting `campaign_plan.entries[]` are sorted by workload id, deduplicated,
+and include `run_id`, `tracker_refs`, `artifact_requirements`, `lab_runner`, a
+request copy scoped to the workload, and a command vector suitable for a caller
+or Lab orchestration layer to schedule explicitly.
 
 `homeboy fuzz plan --action-model <path>` and
 `homeboy fuzz run --action-model <path>` accept a

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1456,6 +1456,10 @@ pub(super) fn build_fuzz_execution_request(
         operation_families: Vec::new(),
         case_budget: None,
         duration_budget_seconds: None,
+        campaign_manifest: None,
+        campaign_workloads: Vec::new(),
+        lab_runner: None,
+        required_artifacts: Vec::new(),
     };
     let isolation_proof = super::planning::load_isolation_proof(args.isolation_proof.as_deref())?;
     let sequence_plan = load_sequence_plan(args.sequence_plan.as_deref())?;

--- a/src/commands/fuzz/planning.rs
+++ b/src/commands/fuzz/planning.rs
@@ -1,16 +1,21 @@
+use serde::Deserialize;
 use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet};
 
 use homeboy::core::fuzz::{
     fuzz_gate_profile_contract, parse_fuzz_action_model_file, parse_fuzz_exploration_policy_file,
     parse_fuzz_sequence_plan_file, FuzzExecutionRequest, FuzzOperation, FuzzOperationFamily,
-    FuzzSafetyClass, FuzzSamplingCorpusRef, FuzzSamplingReplayDeterminism, FuzzSamplingRequest,
-    FuzzSamplingStratum, FuzzTargetInventory, IsolationProof, FUZZ_CONTRACT_VERSION,
-    FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_SAMPLING_REQUEST_SCHEMA, FUZZ_SEQUENCE_PLAN_SCHEMA,
+    FuzzRequiredArtifact, FuzzSafetyClass, FuzzSamplingCorpusRef, FuzzSamplingReplayDeterminism,
+    FuzzSamplingRequest, FuzzSamplingStratum, FuzzTargetInventory, IsolationProof,
+    FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_REQUIRED_ARTIFACT_SCHEMA,
+    FUZZ_SAMPLING_REQUEST_SCHEMA, FUZZ_SEQUENCE_PLAN_SCHEMA,
 };
 
 use super::execution::fuzz_runner_contract;
 use super::types::{FuzzPlanArgs, FuzzPlanOutput, FuzzPlanStrategy};
+use super::types_extra::{
+    FuzzCampaignPlanEntryOutput, FuzzCampaignPlanIsolationOutput, FuzzCampaignPlanOutput,
+};
 use super::workloads::{
     build_target_inventory, fuzz_workloads, load_rig, resolve_component_id, resolve_fuzz_context,
     select_workload,
@@ -84,32 +89,344 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
         )
     })?;
 
+    let request = FuzzExecutionRequest {
+        schema: FUZZ_EXECUTION_REQUEST_SCHEMA.to_string(),
+        version: FUZZ_CONTRACT_VERSION,
+        id: request_id,
+        component: ctx.component_id.clone(),
+        rig_id: rig_id.clone(),
+        workload_id,
+        case_ids: Vec::new(),
+        seed: args.run.seed.clone(),
+        max_duration: args.run.max_duration.clone(),
+        args: args.run.args.clone(),
+        required_artifacts,
+        gates,
+        sampling,
+        sequence_plan,
+        isolation_proof,
+        metadata: planning_metadata,
+        extra: std::collections::BTreeMap::new(),
+    };
+    let campaign_plan = build_campaign_plan(&args, &ctx.component_id, rig_id.as_deref(), &request)?;
+
     Ok(FuzzPlanOutput {
         command: "fuzz.plan".to_string(),
         component: ctx.component_id.clone(),
         rig_id: rig_id.clone(),
         target_inventory,
-        request: FuzzExecutionRequest {
-            schema: FUZZ_EXECUTION_REQUEST_SCHEMA.to_string(),
-            version: FUZZ_CONTRACT_VERSION,
-            id: request_id,
-            component: ctx.component_id,
-            rig_id,
-            workload_id,
-            case_ids: Vec::new(),
-            seed: args.run.seed,
-            max_duration: args.run.max_duration,
-            args: args.run.args,
-            required_artifacts,
-            gates,
-            sampling,
-            sequence_plan,
-            isolation_proof,
-            metadata: planning_metadata,
-            extra: std::collections::BTreeMap::new(),
-        },
+        request,
+        campaign_plan,
         runner_contract: fuzz_runner_contract(fuzz_config.as_ref()),
     })
+}
+
+const FUZZ_CAMPAIGN_PLAN_SCHEMA: &str = "homeboy/fuzz-campaign-plan/v1";
+
+#[derive(Deserialize)]
+struct FuzzCampaignManifest {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    workloads: Vec<FuzzCampaignManifestWorkload>,
+    #[serde(default)]
+    workload_ids: Vec<String>,
+    #[serde(default)]
+    lab_runner: Option<String>,
+    #[serde(default)]
+    required_artifacts: Vec<FuzzCampaignManifestArtifact>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum FuzzCampaignManifestWorkload {
+    Id(String),
+    Object { id: String },
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum FuzzCampaignManifestArtifact {
+    Id(String),
+    Object { id: String, kind: Option<String> },
+}
+
+pub(super) fn build_campaign_plan(
+    args: &FuzzPlanArgs,
+    component: &str,
+    rig_id: Option<&str>,
+    base_request: &FuzzExecutionRequest,
+) -> homeboy::core::Result<Option<FuzzCampaignPlanOutput>> {
+    if args.campaign_manifest.is_none() && args.campaign_workloads.is_empty() {
+        return Ok(None);
+    }
+
+    let manifest = load_campaign_manifest(args.campaign_manifest.as_deref())?;
+    let mut workload_ids = manifest_workload_ids(manifest.as_ref());
+    workload_ids.extend(args.campaign_workloads.iter().cloned());
+    workload_ids.sort();
+    workload_ids.dedup();
+    if workload_ids.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "campaign-workload",
+            "campaign planning requires at least one workload id".to_string(),
+            None,
+            None,
+        ));
+    }
+
+    let manifest_artifacts = manifest
+        .as_ref()
+        .map(|manifest| manifest.required_artifacts.as_slice())
+        .unwrap_or(&[]);
+    let artifact_requirements = campaign_artifact_requirements(
+        &base_request.required_artifacts,
+        manifest_artifacts,
+        &args.required_artifacts,
+    );
+    let lab_runner = args.lab_runner.clone().or_else(|| {
+        manifest
+            .as_ref()
+            .and_then(|manifest| manifest.lab_runner.clone())
+    });
+    let campaign_id = args
+        .request_id
+        .clone()
+        .or_else(|| manifest.as_ref().and_then(|manifest| manifest.id.clone()))
+        .or_else(|| args.run.run_id.clone())
+        .unwrap_or_else(|| format!("{component}-fuzz-campaign"));
+
+    let entries = workload_ids
+        .iter()
+        .enumerate()
+        .map(|(index, workload_id)| {
+            let run_id = format!("{campaign_id}-{workload_id}");
+            let mut request = base_request.clone();
+            request.id = run_id.clone();
+            request.workload_id = Some(workload_id.clone());
+            request.required_artifacts = artifact_requirements.clone();
+            request.metadata = campaign_entry_metadata(&request.metadata, &campaign_id, index);
+            FuzzCampaignPlanEntryOutput {
+                index,
+                id: format!("{campaign_id}:{workload_id}"),
+                workload_id: workload_id.clone(),
+                run_id: run_id.clone(),
+                lab_runner: lab_runner.clone(),
+                tracker_refs: args.run.tracker_refs.clone(),
+                artifact_requirements: artifact_requirements.clone(),
+                command: campaign_run_command(args, component, workload_id, &run_id),
+                request,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Some(FuzzCampaignPlanOutput {
+        schema: FUZZ_CAMPAIGN_PLAN_SCHEMA.to_string(),
+        version: FUZZ_CONTRACT_VERSION,
+        id: campaign_id,
+        component: component.to_string(),
+        rig_id: rig_id.map(str::to_string),
+        source_manifest: args
+            .campaign_manifest
+            .as_ref()
+            .map(|path| path.to_string_lossy().to_string()),
+        lab_runner,
+        isolation: FuzzCampaignPlanIsolationOutput {
+            mode: args.run.isolation.as_str().to_string(),
+            allow_destructive: args.run.allow_destructive,
+            proof_required: args.run.allow_destructive || args.run.isolation.requests_isolation(),
+            proof_file: args
+                .run
+                .isolation_proof
+                .as_ref()
+                .map(|path| path.to_string_lossy().to_string()),
+        },
+        tracker_refs: args.run.tracker_refs.clone(),
+        artifact_requirements,
+        entries,
+    }))
+}
+
+fn load_campaign_manifest(
+    path: Option<&std::path::Path>,
+) -> homeboy::core::Result<Option<FuzzCampaignManifest>> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    let raw = std::fs::read_to_string(path).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "campaign-manifest",
+            format!("failed to read fuzz campaign manifest: {error}"),
+            Some(path.display().to_string()),
+            None,
+        )
+    })?;
+    serde_json::from_str(&raw).map(Some).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "campaign-manifest",
+            format!("invalid fuzz campaign manifest JSON: {error}"),
+            Some(path.display().to_string()),
+            None,
+        )
+    })
+}
+
+fn manifest_workload_ids(manifest: Option<&FuzzCampaignManifest>) -> Vec<String> {
+    let Some(manifest) = manifest else {
+        return Vec::new();
+    };
+    manifest
+        .workloads
+        .iter()
+        .map(|workload| match workload {
+            FuzzCampaignManifestWorkload::Id(id) => id.clone(),
+            FuzzCampaignManifestWorkload::Object { id } => id.clone(),
+        })
+        .chain(manifest.workload_ids.iter().cloned())
+        .filter_map(|id| {
+            let trimmed = id.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .collect()
+}
+
+fn campaign_artifact_requirements(
+    base: &[FuzzRequiredArtifact],
+    manifest: &[FuzzCampaignManifestArtifact],
+    extra: &[String],
+) -> Vec<FuzzRequiredArtifact> {
+    let mut artifacts = base.to_vec();
+    artifacts.extend(manifest.iter().filter_map(|artifact| match artifact {
+        FuzzCampaignManifestArtifact::Id(id) => required_artifact_from_id(id, None),
+        FuzzCampaignManifestArtifact::Object { id, kind } => {
+            required_artifact_from_id(id, kind.as_deref())
+        }
+    }));
+    artifacts.extend(
+        extra
+            .iter()
+            .filter_map(|id| required_artifact_from_id(id, None)),
+    );
+    artifacts.sort_by(|a, b| a.id.cmp(&b.id).then(a.kind.cmp(&b.kind)));
+    artifacts.dedup_by(|a, b| a.id == b.id && a.kind == b.kind);
+    artifacts
+}
+
+fn required_artifact_from_id(id: &str, kind: Option<&str>) -> Option<FuzzRequiredArtifact> {
+    let id = id.trim();
+    if id.is_empty() {
+        return None;
+    }
+    Some(FuzzRequiredArtifact {
+        schema: FUZZ_REQUIRED_ARTIFACT_SCHEMA.to_string(),
+        id: id.to_string(),
+        kind: kind.unwrap_or(id).trim().replace('-', "_"),
+        required: true,
+        description: None,
+        acceptable_artifact_kinds: Vec::new(),
+    })
+}
+
+fn campaign_entry_metadata(
+    base: &serde_json::Value,
+    campaign_id: &str,
+    index: usize,
+) -> serde_json::Value {
+    let mut metadata = base.clone();
+    if !metadata.is_object() {
+        metadata = json!({});
+    }
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert(
+            "campaign_plan".to_string(),
+            json!({
+                "schema": FUZZ_CAMPAIGN_PLAN_SCHEMA,
+                "id": campaign_id,
+                "entry_index": index,
+            }),
+        );
+    }
+    metadata
+}
+
+fn campaign_run_command(
+    args: &FuzzPlanArgs,
+    component: &str,
+    workload_id: &str,
+    run_id: &str,
+) -> Vec<String> {
+    let mut command = vec![
+        "homeboy".to_string(),
+        "fuzz".to_string(),
+        "run".to_string(),
+        component.to_string(),
+    ];
+    if let Some(rig) = args.run.rig.as_ref() {
+        command.extend(["--rig".to_string(), rig.clone()]);
+    }
+    command.extend([
+        "--workload".to_string(),
+        workload_id.to_string(),
+        "--run-id".to_string(),
+        run_id.to_string(),
+    ]);
+    for tracker_ref in &args.run.tracker_refs {
+        command.extend([
+            "--tracker-ref".to_string(),
+            format!("{}:{}", tracker_ref.kind, tracker_ref.id),
+        ]);
+    }
+    if let Some(seed) = args.run.seed.as_ref() {
+        command.extend(["--seed".to_string(), seed.clone()]);
+    }
+    if let Some(inventory) = args.run.inventory.as_ref() {
+        command.extend([
+            "--inventory".to_string(),
+            inventory.to_string_lossy().to_string(),
+        ]);
+    }
+    if let Some(sequence_plan) = args.run.sequence_plan.as_ref() {
+        command.extend([
+            "--sequence-plan".to_string(),
+            sequence_plan.to_string_lossy().to_string(),
+        ]);
+    }
+    command.extend([
+        "--gate-profile".to_string(),
+        args.run.gate_profile.as_str().to_string(),
+    ]);
+    if args.run.require_case_log {
+        command.push("--require-case-log".to_string());
+    }
+    if args.run.require_coverage_summary {
+        command.push("--require-coverage-summary".to_string());
+    }
+    if args.run.require_result_envelope {
+        command.push("--require-result-envelope".to_string());
+    }
+    if let Some(max_duration) = args.run.max_duration.as_ref() {
+        command.extend(["--max-duration".to_string(), max_duration.clone()]);
+    }
+    if args.run.allow_destructive {
+        command.push("--allow-destructive".to_string());
+    }
+    if args.run.isolation.requests_isolation() {
+        command.extend([
+            "--isolation".to_string(),
+            args.run.isolation.as_str().to_string(),
+        ]);
+    }
+    if let Some(isolation_proof) = args.run.isolation_proof.as_ref() {
+        command.extend([
+            "--isolation-proof".to_string(),
+            isolation_proof.to_string_lossy().to_string(),
+        ]);
+    }
+    if !args.run.args.is_empty() {
+        command.push("--".to_string());
+        command.extend(args.run.args.clone());
+    }
+    command
 }
 
 pub(super) fn load_sequence_plan(

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -10,7 +10,7 @@ use super::execution::{
     persist_fuzz_run_evidence, persist_fuzz_sequence_plan, run_fuzz_artifact_postprocess,
     FuzzRunEvidenceInput,
 };
-use super::planning::plan_inventory_selection;
+use super::planning::{build_campaign_plan, plan_inventory_selection};
 use super::replay::{run_minimize, run_replay};
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,
@@ -33,7 +33,8 @@ use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::FuzzConfig;
 use homeboy::core::fuzz::{
     FuzzCampaign, FuzzCase, FuzzCoverageSkip, FuzzCoverageSummary, FuzzExecutionRequest,
-    FuzzFinding, FuzzFindingStatus, FuzzSequencePlan, FuzzTargetInventory, IsolationProof,
+    FuzzFinding, FuzzFindingStatus, FuzzSamplingRequest, FuzzSequencePlan, FuzzTargetInventory,
+    IsolationProof,
 };
 use homeboy::core::lifecycle::{
     LifecyclePhaseKind, LifecyclePhaseResult, LifecyclePhaseStatus, LifecycleResultMetadata,
@@ -112,6 +113,32 @@ fn planner_args() -> FuzzPlanArgs {
         operation_families: Vec::new(),
         case_budget: None,
         duration_budget_seconds: None,
+        campaign_manifest: None,
+        campaign_workloads: Vec::new(),
+        lab_runner: None,
+        required_artifacts: Vec::new(),
+    }
+}
+
+fn campaign_base_request() -> FuzzExecutionRequest {
+    FuzzExecutionRequest {
+        schema: homeboy::core::fuzz::FUZZ_EXECUTION_REQUEST_SCHEMA.to_string(),
+        version: homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+        id: "base-request".to_string(),
+        component: "component-a".to_string(),
+        rig_id: Some("generic-rig".to_string()),
+        workload_id: Some("api-fuzz".to_string()),
+        case_ids: Vec::new(),
+        seed: Some("1234".to_string()),
+        max_duration: None,
+        args: Vec::new(),
+        required_artifacts: Vec::new(),
+        gates: Vec::new(),
+        sampling: FuzzSamplingRequest::default(),
+        sequence_plan: None,
+        isolation_proof: None,
+        metadata: serde_json::json!({ "planner": { "strategy": "all" } }),
+        extra: std::collections::BTreeMap::new(),
     }
 }
 

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -273,6 +273,142 @@ fn fuzz_plan_rejects_invalid_action_model_schema_from_cli_contract_path() {
 }
 
 #[test]
+fn fuzz_campaign_plan_emits_deterministic_run_entries_from_manifest_and_cli_workloads() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let manifest = temp.path().join("campaign.json");
+    fs::write(
+        &manifest,
+        serde_json::json!({
+            "id": "full-surface",
+            "workloads": [
+                { "id": "db-fuzz" },
+                "api-fuzz"
+            ],
+            "lab_runner": "lab-a",
+            "required_artifacts": [
+                { "id": "coverage-gap-report", "kind": "coverage_gap_report" }
+            ]
+        })
+        .to_string(),
+    )
+    .expect("write manifest");
+    let mut args = planner_args();
+    args.request_id = Some("campaign-1".to_string());
+    args.campaign_manifest = Some(manifest.clone());
+    args.campaign_workloads = vec!["browser-fuzz".to_string(), "api-fuzz".to_string()];
+    args.required_artifacts = vec!["performance-hotspots-summary".to_string()];
+    args.run.tracker_refs = vec![homeboy::core::evidence_manifest::TrackerRef {
+        kind: "github_issue".to_string(),
+        id: "Extra-Chill/homeboy#123".to_string(),
+        url: None,
+        title: None,
+        state: None,
+    }];
+    args.run.seed = Some("1234".to_string());
+
+    let plan = build_campaign_plan(
+        &args,
+        "component-a",
+        Some("generic-rig"),
+        &campaign_base_request(),
+    )
+    .expect("build campaign plan")
+    .expect("campaign plan");
+
+    assert_eq!(plan.schema, "homeboy/fuzz-campaign-plan/v1");
+    assert_eq!(plan.id, "campaign-1");
+    assert_eq!(plan.lab_runner.as_deref(), Some("lab-a"));
+    assert_eq!(plan.entries.len(), 3);
+    assert_eq!(plan.entries[0].workload_id, "api-fuzz");
+    assert_eq!(plan.entries[1].workload_id, "browser-fuzz");
+    assert_eq!(plan.entries[2].workload_id, "db-fuzz");
+    assert_eq!(plan.entries[0].run_id, "campaign-1-api-fuzz");
+    assert_eq!(plan.entries[0].request.id, "campaign-1-api-fuzz");
+    assert_eq!(
+        plan.entries[0].request.workload_id.as_deref(),
+        Some("api-fuzz")
+    );
+    assert_eq!(
+        plan.entries[0].request.metadata["campaign_plan"]["entry_index"],
+        0
+    );
+    assert!(plan
+        .artifact_requirements
+        .iter()
+        .any(|artifact| artifact.id == "coverage-gap-report"));
+    assert!(plan
+        .artifact_requirements
+        .iter()
+        .any(|artifact| artifact.id == "performance-hotspots-summary"));
+    assert_eq!(
+        plan.entries[0]
+            .command
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec![
+            "homeboy",
+            "fuzz",
+            "run",
+            "component-a",
+            "--workload",
+            "api-fuzz",
+            "--run-id",
+            "campaign-1-api-fuzz",
+            "--tracker-ref",
+            "github_issue:Extra-Chill/homeboy#123",
+            "--seed",
+            "1234",
+            "--gate-profile",
+            "measurement",
+        ]
+    );
+}
+
+#[test]
+fn fuzz_campaign_plan_cli_parses_manifest_workloads_lab_runner_and_artifacts() {
+    let cli = FuzzCli::try_parse_from([
+        "fuzz",
+        "plan",
+        "component-a",
+        "--campaign-manifest",
+        "/tmp/fuzz-campaign.json",
+        "--campaign-workload",
+        "api-fuzz",
+        "--campaign-workload",
+        "db-fuzz",
+        "--lab-runner",
+        "lab-a",
+        "--required-artifact",
+        "coverage-gap-report",
+    ])
+    .expect("parse fuzz campaign plan cli");
+
+    let Some(FuzzCommand::Plan(args)) = cli.args.command else {
+        panic!("expected fuzz plan command");
+    };
+    assert_eq!(
+        args.campaign_manifest.as_deref(),
+        Some(Path::new("/tmp/fuzz-campaign.json"))
+    );
+    assert_eq!(
+        args.campaign_workloads
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["api-fuzz", "db-fuzz"]
+    );
+    assert_eq!(args.lab_runner.as_deref(), Some("lab-a"));
+    assert_eq!(
+        args.required_artifacts
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["coverage-gap-report"]
+    );
+}
+
+#[test]
 fn fuzz_plan_operation_filter_limits_inventory_selection() {
     let mut args = planner_args();
     args.operations = vec!["read".to_string()];

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -278,6 +278,22 @@ pub(crate) struct FuzzPlanArgs {
     /// Maximum execution budget in seconds for downstream runners.
     #[arg(long = "duration-budget-seconds", value_name = "SECONDS")]
     pub(crate) duration_budget_seconds: Option<u64>,
+
+    /// Product-neutral campaign manifest containing workload ids and optional planning metadata.
+    #[arg(long = "campaign-manifest", value_name = "PATH")]
+    pub(crate) campaign_manifest: Option<PathBuf>,
+
+    /// Add a workload id to the generated campaign plan. Repeatable.
+    #[arg(long = "campaign-workload", value_name = "ID")]
+    pub(crate) campaign_workloads: Vec<String>,
+
+    /// Preferred Lab runner id to record in campaign plan entries without executing them.
+    #[arg(long = "lab-runner", value_name = "ID")]
+    pub(crate) lab_runner: Option<String>,
+
+    /// Additional required artifact id/kind expected from every campaign entry. Repeatable.
+    #[arg(long = "required-artifact", value_name = "ID")]
+    pub(crate) required_artifacts: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 
 use homeboy::core::artifact_ref::EvidenceRef;
+use homeboy::core::evidence_manifest::TrackerRef;
 use homeboy::core::fuzz::{
     FuzzCampaign, FuzzExecutionRequest, FuzzGate, FuzzHotspotSet, FuzzReplayMetadata,
     FuzzRequiredArtifact, FuzzResultEnvelope, FuzzTargetInventory,
@@ -198,7 +199,45 @@ pub struct FuzzPlanOutput {
     pub rig_id: Option<String>,
     pub target_inventory: FuzzTargetInventory,
     pub request: FuzzExecutionRequest,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub campaign_plan: Option<FuzzCampaignPlanOutput>,
     pub runner_contract: FuzzRunnerContract,
+}
+
+#[derive(Serialize)]
+pub struct FuzzCampaignPlanOutput {
+    pub schema: String,
+    pub version: u32,
+    pub id: String,
+    pub component: String,
+    pub rig_id: Option<String>,
+    pub source_manifest: Option<String>,
+    pub lab_runner: Option<String>,
+    pub isolation: FuzzCampaignPlanIsolationOutput,
+    pub tracker_refs: Vec<TrackerRef>,
+    pub artifact_requirements: Vec<FuzzRequiredArtifact>,
+    pub entries: Vec<FuzzCampaignPlanEntryOutput>,
+}
+
+#[derive(Serialize)]
+pub struct FuzzCampaignPlanIsolationOutput {
+    pub mode: String,
+    pub allow_destructive: bool,
+    pub proof_required: bool,
+    pub proof_file: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct FuzzCampaignPlanEntryOutput {
+    pub index: usize,
+    pub id: String,
+    pub workload_id: String,
+    pub run_id: String,
+    pub lab_runner: Option<String>,
+    pub tracker_refs: Vec<TrackerRef>,
+    pub artifact_requirements: Vec<FuzzRequiredArtifact>,
+    pub command: Vec<String>,
+    pub request: FuzzExecutionRequest,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary
- Add product-neutral fuzz campaign planning to `homeboy fuzz plan` via campaign manifests and explicit workload lists.
- Emit deterministic `homeboy/fuzz-campaign-plan/v1` entries with scoped run ids, canonical `homeboy fuzz run` command vectors, tracker refs, Lab runner metadata, isolation metadata, and required artifact expectations.
- Document the manifest shape and add compile-checked planner tests for deterministic ordering and CLI parsing.

## Tests
- `cargo check`
- `cargo check --tests`
- Did not run local `cargo test` because this environment marks it as a hot command.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the existing fuzz planning contracts, implemented the campaign planning primitive, updated tests/docs, and ran safe checks.