### PR TITLE
feat: expose bench passthrough args env

### DIFF
--- a/src/core/extension/bench/run/list.rs
+++ b/src/core/extension/bench/run/list.rs
@@ -146,6 +146,15 @@ pub(crate) fn bench_component_script_list_env(
 ) -> Result<Vec<(String, String)>> {
     let mut env = vec![("HOMEBOY_BENCH_LIST_ONLY".to_string(), "1".to_string())];
     env.push((
+        "HOMEBOY_BENCH_ARGS_JSON".to_string(),
+        serde_json::to_string(&args.passthrough_args).map_err(|e| {
+            Error::internal_json(
+                e.to_string(),
+                Some("serialize bench passthrough args".to_string()),
+            )
+        })?,
+    ));
+    env.push((
         "HOMEBOY_SETTINGS_JSON".to_string(),
         crate::core::extension::build_settings_json_from_manifest(
             &serde_json::json!({}),

--- a/src/core/extension/bench/run/mod.rs
+++ b/src/core/extension/bench/run/mod.rs
@@ -207,6 +207,40 @@ mod tests {
     }
 
     #[test]
+    fn component_script_bench_env_serializes_passthrough_args() {
+        let run_dir = RunDir::create().expect("run dir");
+        let mut args = bench_run_workflow_args_fixture();
+        args.passthrough_args = vec![
+            "--workload-option".to_string(),
+            "value with spaces".to_string(),
+        ];
+
+        let env = bench_component_script_env(&args, &run_dir).expect("component-script env");
+
+        assert_eq!(
+            env.iter()
+                .find_map(|(key, value)| (key == "HOMEBOY_BENCH_ARGS_JSON").then_some(value)),
+            Some(&r#"["--workload-option","value with spaces"]"#.to_string())
+        );
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn component_script_bench_env_serializes_empty_passthrough_args() {
+        let run_dir = RunDir::create().expect("run dir");
+        let args = bench_run_workflow_args_fixture();
+
+        let env = bench_component_script_env(&args, &run_dir).expect("component-script env");
+
+        assert_eq!(
+            env.iter()
+                .find_map(|(key, value)| (key == "HOMEBOY_BENCH_ARGS_JSON").then_some(value)),
+            Some(&"[]".to_string())
+        );
+        run_dir.cleanup();
+    }
+
+    #[test]
     fn component_script_bench_env_omits_run_id_when_absent_or_blank() {
         let run_dir = RunDir::create().expect("run dir");
 
@@ -291,6 +325,29 @@ mod tests {
         assert_eq!(
             parsed["workflow_bench_env"]["WORKFLOW_BENCH_SCENARIO"],
             "plain-site-sample-plugin"
+        );
+    }
+
+    #[test]
+    fn component_script_bench_list_env_serializes_passthrough_args() {
+        let env = bench_component_script_list_env(&BenchListWorkflowArgs {
+            component_label: "studio-web".to_string(),
+            component_id: "studio-web".to_string(),
+            path_override: None,
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            passthrough_args: vec!["--scenario-filter".to_string(), "plain".to_string()],
+            scenario_ids: Vec::new(),
+            extra_workloads: Vec::new(),
+            env_provider_extensions: Vec::new(),
+            rig_package: None,
+        })
+        .expect("component-script list env");
+
+        assert_eq!(
+            env.iter()
+                .find_map(|(key, value)| (key == "HOMEBOY_BENCH_ARGS_JSON").then_some(value)),
+            Some(&r#"["--scenario-filter","plain"]"#.to_string())
         );
     }
 

--- a/src/core/extension/bench/run/runner.rs
+++ b/src/core/extension/bench/run/runner.rs
@@ -178,6 +178,15 @@ pub(crate) fn build_runner(
     )
     .env("HOMEBOY_BENCH_PROGRESS", bench_progress_env_value())
     .env("HOMEBOY_BENCH_PROGRESS_STREAM", "stderr")
+    .env(
+        "HOMEBOY_BENCH_ARGS_JSON",
+        &serde_json::to_string(&args.passthrough_args).map_err(|e| {
+            Error::internal_json(
+                e.to_string(),
+                Some("serialize bench passthrough args".to_string()),
+            )
+        })?,
+    )
     .script_args(&args.passthrough_args)
     .passthrough(false)
     .stderr_passthrough(bench_progress_enabled());

--- a/src/core/extension/bench/run/workflow.rs
+++ b/src/core/extension/bench/run/workflow.rs
@@ -489,6 +489,15 @@ pub(crate) fn bench_component_script_env(
             args.scenario_ids.join(","),
         ),
         (
+            "HOMEBOY_BENCH_ARGS_JSON".to_string(),
+            serde_json::to_string(&args.passthrough_args).map_err(|e| {
+                Error::internal_json(
+                    e.to_string(),
+                    Some("serialize bench passthrough args".to_string()),
+                )
+            })?,
+        ),
+        (
             "HOMEBOY_SETTINGS_JSON".to_string(),
             crate::core::extension::build_settings_json_from_manifest(
                 &serde_json::json!({}),


### PR DESCRIPTION
## Summary
- Add `HOMEBOY_BENCH_ARGS_JSON` as a generic bench runtime env contract for passthrough args.
- Include the env contract for component-script run/list env and extension runner env.
- Preserve existing child argv passthrough behavior.

This gives imported bench workloads a stable way to consume `homeboy bench ... -- <args>` without relying on process argv.

## Verification
- `cargo test component_script_bench --lib`
- `rustfmt --check src/core/extension/bench/run/list.rs src/core/extension/bench/run/mod.rs src/core/extension/bench/run/runner.rs src/core/extension/bench/run/workflow.rs`
- `git diff --check -- src/core/extension/bench/run/list.rs src/core/extension/bench/run/mod.rs src/core/extension/bench/run/runner.rs src/core/extension/bench/run/workflow.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode; subagent coding workflow
- **Used for:** Designing and implementing the generic bench passthrough-args env contract with focused tests.
