### PR TITLE
Use workspace materializer for direct git sync

### DIFF
--- a/src/core/runner/workspace/git.rs
+++ b/src/core/runner/workspace/git.rs
@@ -5,14 +5,9 @@ use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 
 use super::super::{Runner, RunnerKind};
-use super::materializer::{
-    dirty_git_workspace_guard, WorkspaceMaterializationOperation, WorkspaceMaterializer,
-};
+use super::materializer::{WorkspaceMaterializationOperation, WorkspaceMaterializer};
 use super::types::GitSnapshot;
-use super::util::{
-    git_output, owner_capture_shell, owner_restore_shell, parent_remote_path, run_shell_command,
-    ssh_args, ssh_client_for_runner,
-};
+use super::util::{git_output, run_shell_command, ssh_args, ssh_client_for_runner};
 
 pub(super) fn git_snapshot(
     local_path: &Path,
@@ -281,39 +276,16 @@ pub(super) fn materialize_git_command(
     git_fetch_refs: &[String],
     allow_dirty_lab_workspace: bool,
 ) -> String {
-    let parent = parent_remote_path(remote_path);
-    let dest = shell::quote_arg(remote_path);
-    let fetch_changed_since = changed_since_base
-        .map(|base| {
-            format!(
-                " && (git -C {dest} rev-parse --verify -q {} >/dev/null || git -C {dest} fetch origin {})",
-                shell::quote_arg(&format!("{base}^{{commit}}")),
-                shell::quote_arg(base)
-            )
+    WorkspaceMaterializer::new(remote_path)
+        .capture_owner()
+        .op(WorkspaceMaterializationOperation::EnsureParent)
+        .op(WorkspaceMaterializationOperation::SyncGitCheckout {
+            remote_url: remote_url.to_string(),
+            head: head.to_string(),
+            changed_since_base: changed_since_base.map(str::to_string),
+            fetch_refs: git_fetch_refs.to_vec(),
+            allow_dirty: allow_dirty_lab_workspace,
         })
-        .unwrap_or_default();
-    let fetch_extra_refs = git_fetch_refs
-        .iter()
-        .map(|git_ref| {
-            format!(
-                " && git -C {dest} fetch origin {}",
-                shell::quote_arg(git_ref)
-            )
-        })
-        .collect::<String>();
-
-    let dirty_guard = dirty_git_workspace_guard("$dest", allow_dirty_lab_workspace);
-
-    format!(
-        "parent={parent}; dest={dest}; {owner_capture}; mkdir -p \"$parent\" && if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git clone {url} \"$dest\" && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_extra_refs}{fetch_changed_since} && git -C \"$dest\" checkout --detach {head} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx && {owner_restore}",
-        parent = shell::quote_arg(parent.as_str()),
-        dest = dest,
-        url = shell::quote_arg(remote_url),
-        head = shell::quote_arg(head),
-        fetch_changed_since = fetch_changed_since,
-        fetch_extra_refs = fetch_extra_refs,
-        dirty_guard = dirty_guard,
-        owner_capture = owner_capture_shell("$parent"),
-        owner_restore = owner_restore_shell("$parent", "$dest"),
-    )
+        .restore_owner()
+        .command()
 }

--- a/src/core/runner/workspace/materializer.rs
+++ b/src/core/runner/workspace/materializer.rs
@@ -21,6 +21,13 @@ pub(super) enum WorkspaceMaterializationOperation {
     GuardCleanGitWorkspace {
         allow_dirty: bool,
     },
+    SyncGitCheckout {
+        remote_url: String,
+        head: String,
+        changed_since_base: Option<String>,
+        fetch_refs: Vec<String>,
+        allow_dirty: bool,
+    },
     AtomicReplaceTemp,
 }
 
@@ -121,6 +128,19 @@ impl WorkspaceMaterializationOperation {
             Self::GuardCleanGitWorkspace { allow_dirty } => {
                 dirty_git_workspace_guard("$dest", *allow_dirty)
             }
+            Self::SyncGitCheckout {
+                remote_url,
+                head,
+                changed_since_base,
+                fetch_refs,
+                allow_dirty,
+            } => sync_git_checkout_command(
+                remote_url,
+                head,
+                changed_since_base.as_deref(),
+                fetch_refs,
+                *allow_dirty,
+            ),
             Self::AtomicReplaceTemp => "rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"".to_string(),
         }
     }
@@ -157,4 +177,38 @@ pub(super) fn dirty_git_workspace_guard(dest: &str, allow_dirty: bool) -> String
             status = status,
         )
     }
+}
+
+fn sync_git_checkout_command(
+    remote_url: &str,
+    head: &str,
+    changed_since_base: Option<&str>,
+    fetch_refs: &[String],
+    allow_dirty: bool,
+) -> String {
+    let fetch_changed_since = changed_since_base
+        .map(|base| {
+            format!(
+                " && (git -C \"$dest\" rev-parse --verify -q {} >/dev/null || git -C \"$dest\" fetch origin {})",
+                shell::quote_arg(&format!("{base}^{{commit}}")),
+                shell::quote_arg(base)
+            )
+        })
+        .unwrap_or_default();
+    let fetch_extra_refs = fetch_refs
+        .iter()
+        .map(|git_ref| {
+            format!(
+                " && git -C \"$dest\" fetch origin {}",
+                shell::quote_arg(git_ref)
+            )
+        })
+        .collect::<String>();
+    let dirty_guard = dirty_git_workspace_guard("$dest", allow_dirty);
+
+    format!(
+        "if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git clone {remote_url} \"$dest\" && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_extra_refs}{fetch_changed_since} && git -C \"$dest\" checkout --detach {head} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx",
+        remote_url = shell::quote_arg(remote_url),
+        head = shell::quote_arg(head),
+    )
 }

--- a/src/core/runner/workspace/tests/materializer.rs
+++ b/src/core/runner/workspace/tests/materializer.rs
@@ -62,3 +62,32 @@ fn workspace_materializer_builds_git_bundle_checkout_command() {
     assert!(command.contains("Homeboy Lab refused to overwrite a dirty runner workspace"));
     assert!(command.contains("exit 97"));
 }
+
+#[test]
+fn workspace_materializer_builds_direct_git_checkout_command() {
+    let command = WorkspaceMaterializer::new("/srv/homeboy/_lab_workspaces/homeboy-abc")
+        .capture_owner()
+        .op(WorkspaceMaterializationOperation::EnsureParent)
+        .op(WorkspaceMaterializationOperation::SyncGitCheckout {
+            remote_url: "https://github.com/Extra-Chill/homeboy.git".to_string(),
+            head: "abc123".to_string(),
+            changed_since_base: Some("origin/main".to_string()),
+            fetch_refs: vec!["refs/pull/123/head:refs/remotes/pull/123".to_string()],
+            allow_dirty: false,
+        })
+        .restore_owner()
+        .command();
+
+    assert!(command.contains("parent=/srv/homeboy/_lab_workspaces"));
+    assert!(command.contains("dest=/srv/homeboy/_lab_workspaces/homeboy-abc"));
+    assert!(command.contains("mkdir -p \"$parent\""));
+    assert!(command.contains("if [ -d \"$dest\"/.git ]; then"));
+    assert!(command.contains("Homeboy Lab refused to overwrite a dirty runner workspace"));
+    assert!(command.contains("git clone https://github.com/Extra-Chill/homeboy.git \"$dest\""));
+    assert!(command.contains("fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'"));
+    assert!(command.contains("fetch origin refs/pull/123/head:refs/remotes/pull/123"));
+    assert!(command.contains("rev-parse --verify -q 'origin/main^{commit}'"));
+    assert!(command.contains("checkout --detach abc123"));
+    assert!(command.contains("git -C \"$dest\" clean -ffdqx"));
+    assert!(command.contains("chown -R \"$owner\" $dest"));
+}


### PR DESCRIPTION
## Summary
- Route direct Lab git workspace sync through the Wave 2 `WorkspaceMaterializer` builder.
- Add a typed `SyncGitCheckout` materialization operation preserving clone/update, dirty guard, extra refs, changed-since fetch, checkout, reset/clean, and ownership restore behavior.
- Add materializer command coverage for the direct git checkout path.

## Verification
- `rustfmt src/core/runner/workspace/materializer.rs src/core/runner/workspace/git.rs src/core/runner/workspace/tests/materializer.rs`
- `cargo check`
- `cargo check --tests`
- `homeboy audit --profile pr --changed-since origin/main` failed on pre-existing/global baseline findings outside this change scope: structural findings in `src/commands/agent_task/fanout.rs`, `src/core/extension/lifecycle/mod.rs`, `src/core/runner_execution_envelope.rs`, and a vacuous-test finding in `src/core/server/client/tests.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated the runner workspace materialization paths, migrated the direct git sync command construction onto `WorkspaceMaterializer`, added command-builder coverage, and ran verification.