### PR TITLE
Wire lifecycle records for promoted artifacts

### DIFF
--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -12,6 +12,7 @@ use homeboy::core::artifact_address::ArtifactAddress;
 use homeboy::core::observation::evidence_report::directory_publication_guidance;
 use homeboy::core::observation::runs_service;
 use homeboy::core::observation::{FindingListFilter, ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::resource_lifecycle_index::resource_lifecycle_index_from_artifacts;
 use homeboy::core::validation_progress::ValidationProgressLedger;
 use homeboy::core::Error;
 use homeboy::core::{api_jobs, runners as runner};
@@ -203,6 +204,7 @@ pub fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutput> {
         .filter_map(homeboy::core::fuzz::inspect_fuzz_result_envelope_artifact)
         .collect();
     let directory_publication = directory_publication_guidance_for_artifacts(&artifacts);
+    let resource_lifecycle_index = resource_lifecycle_index_from_artifacts(&artifacts)?;
     let pull = if args.pull {
         Some(pull_artifacts_to_local(
             &artifacts,
@@ -218,6 +220,7 @@ pub fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutput> {
             runner_id: None,
             path_guide: RunsArtifactPathGuide::for_listing(&args.run_id, None),
             artifacts,
+            resource_lifecycle_index,
             directory_publication,
             preview_entrypoints,
             matrix_summary,

--- a/src/commands/runs/remote.rs
+++ b/src/commands/runs/remote.rs
@@ -2,6 +2,7 @@ use homeboy::core::artifact_address::ArtifactAddress;
 use homeboy::core::execution_contract::{encode_uri_component, EXECUTION_CONTRACT};
 use homeboy::core::observation::evidence_report::directory_publication_guidance;
 use homeboy::core::observation::ArtifactRecord;
+use homeboy::core::resource_lifecycle_index::resource_lifecycle_index_from_artifacts;
 use homeboy::core::runners as runner;
 use homeboy::core::Error;
 
@@ -53,6 +54,7 @@ pub fn runner_artifacts(runner_id: &str, run_id: &str) -> CmdResult<RunsOutput> 
     )?;
     let artifacts = parse_runner_artifacts(&data)?;
     let directory_publication = directory_publication_guidance_for_artifacts(&artifacts);
+    let resource_lifecycle_index = resource_lifecycle_index_from_artifacts(&artifacts)?;
 
     Ok((
         RunsOutput::Artifacts(RunsArtifactsOutput {
@@ -61,6 +63,7 @@ pub fn runner_artifacts(runner_id: &str, run_id: &str) -> CmdResult<RunsOutput> 
             runner_id: Some(runner_id.to_string()),
             path_guide: RunsArtifactPathGuide::for_listing(run_id, Some(runner_id)),
             artifacts,
+            resource_lifecycle_index,
             directory_publication,
             preview_entrypoints: Vec::new(),
             matrix_summary: None,

--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -12,6 +12,11 @@ use homeboy::core::observation::runs_service::{
 };
 use homeboy::core::observation::ArtifactRecord;
 use homeboy::core::observation::ObservationStore;
+use homeboy::core::resource_cleanup_intent::ResourceCleanupIntent;
+use homeboy::core::resource_lifecycle_index::{
+    ResourceCleanupPolicy, ResourceEvidenceRetention, ResourceLifecycleRecord,
+    ResourceLifecycleResourceStatus,
+};
 use homeboy::core::runners::{self as runner, Runner, RunnerKind};
 use homeboy::core::{server, Error};
 
@@ -80,6 +85,10 @@ pub fn attach(args: RunsArtifactAttachArgs) -> CmdResult<RunsOutput> {
             metadata,
         )?,
     };
+    let artifact = store.update_artifact_metadata(
+        &artifact.id,
+        metadata_with_resource_lifecycle(artifact.metadata_json.clone(), &artifact, &args.runner),
+    )?;
     if source.temporary {
         match source.artifact_type {
             RunnerAttachArtifactType::File => {
@@ -101,6 +110,31 @@ pub fn attach(args: RunsArtifactAttachArgs) -> CmdResult<RunsOutput> {
         }),
         0,
     ))
+}
+
+fn metadata_with_resource_lifecycle(
+    mut metadata: serde_json::Value,
+    artifact: &ArtifactRecord,
+    runner_id: &str,
+) -> serde_json::Value {
+    if !metadata.is_object() {
+        metadata = serde_json::json!({});
+    }
+    let resource = ResourceLifecycleRecord {
+        owner: "homeboy-runs".to_string(),
+        run_id: artifact.run_id.clone(),
+        runner_id: Some(runner_id.to_string()),
+        path: artifact.path.clone(),
+        kind: format!("artifact_{}", artifact.artifact_type),
+        ttl: Some("P30D".to_string()),
+        cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
+        evidence_retention: ResourceEvidenceRetention::Full,
+        cleanup_intent: ResourceCleanupIntent::DryRun,
+        status: ResourceLifecycleResourceStatus::Retained,
+    };
+    metadata["resource_lifecycle"] =
+        serde_json::to_value(resource).expect("resource lifecycle records are serializable");
+    metadata
 }
 
 pub fn preview(args: RunsArtifactPreviewArgs) -> CmdResult<RunsOutput> {
@@ -910,6 +944,18 @@ mod tests {
                 output.artifact.metadata_json["runner_path"],
                 source.display().to_string()
             );
+            assert_eq!(
+                output.artifact.metadata_json["resource_lifecycle"]["cleanup_policy"],
+                "delete_after_ttl"
+            );
+            assert_eq!(
+                output.artifact.metadata_json["resource_lifecycle"]["evidence_retention"],
+                "full"
+            );
+            assert_eq!(
+                output.artifact.metadata_json["resource_lifecycle"]["path"],
+                output.artifact.path
+            );
             assert!(PathBuf::from(&output.artifact.path).exists());
             let artifacts = store.list_artifacts(&run.id).expect("artifacts");
             assert_eq!(artifacts.len(), 1);
@@ -983,6 +1029,16 @@ mod tests {
                 .preview_entrypoints
                 .iter()
                 .any(|entrypoint| entrypoint.path == "case-a/index.html"));
+            let lifecycle_index = artifacts_output
+                .resource_lifecycle_index
+                .expect("resource lifecycle index");
+            assert_eq!(lifecycle_index.resources.len(), 1);
+            assert_eq!(lifecycle_index.resources[0].run_id, run.id);
+            assert_eq!(
+                lifecycle_index.resources[0].runner_id.as_deref(),
+                Some("issue-6462-local")
+            );
+            assert_eq!(lifecycle_index.resources[0].kind, "artifact_directory");
         });
     }
 

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -15,6 +15,7 @@ use homeboy::core::fuzz::FuzzResultEnvelopeArtifactInspection;
 use homeboy::core::observation::evidence_report::DirectoryArtifactPublicationGuidance;
 use homeboy::core::observation::runs_service;
 use homeboy::core::observation::ArtifactRecord;
+use homeboy::core::resource_lifecycle_index::ResourceLifecycleIndex;
 use homeboy::core::runners::RunnerArtifactRef;
 use homeboy::core::validation_progress::ValidationCommandSummary;
 
@@ -257,6 +258,8 @@ pub struct RunsArtifactsOutput {
     pub runner_id: Option<String>,
     pub path_guide: RunsArtifactPathGuide,
     pub artifacts: Vec<ArtifactRecord>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_lifecycle_index: Option<ResourceLifecycleIndex>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub directory_publication: Vec<RunsDirectoryArtifactPublicationGuidance>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/core/observation/store/artifacts.rs
+++ b/src/core/observation/store/artifacts.rs
@@ -326,6 +326,38 @@ impl ObservationStore {
         collect_rows(rows, "collect artifact records")
     }
 
+    pub fn update_artifact_metadata(
+        &self,
+        artifact_id: &str,
+        metadata_json: serde_json::Value,
+    ) -> Result<ArtifactRecord> {
+        validate_required("artifact_id", artifact_id)?;
+        let serialized = serialize_metadata(&metadata_json)?;
+        let rows = execute_with_retry("update artifact metadata", || {
+            self.connection.execute(
+                r#"
+                UPDATE artifacts
+                SET metadata_json = ?1
+                WHERE id = ?2
+                "#,
+                params![serialized, artifact_id],
+            )
+        })?;
+        if rows == 0 {
+            return Err(Error::validation_invalid_argument(
+                "artifact_id",
+                format!("artifact record not found: {artifact_id}"),
+                Some(artifact_id.to_string()),
+                None,
+            ));
+        }
+        self.get_artifact(artifact_id)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "Updated artifact record {artifact_id} but could not read it back"
+            ))
+        })
+    }
+
     pub fn list_artifacts_for_runs(
         &self,
         run_ids: &[String],

--- a/src/core/resource_lifecycle_index.rs
+++ b/src/core/resource_lifecycle_index.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::core::observation::ArtifactRecord;
 use crate::core::resource_cleanup_intent::ResourceCleanupIntent;
 use crate::core::{Error, Result};
 
@@ -91,6 +92,38 @@ pub fn validate_resource_lifecycle_index(index: &ResourceLifecycleIndex) -> Resu
     }
 
     Ok(())
+}
+
+pub fn resource_lifecycle_index_from_artifacts(
+    artifacts: &[ArtifactRecord],
+) -> Result<Option<ResourceLifecycleIndex>> {
+    let mut resources = Vec::new();
+    for artifact in artifacts {
+        let Some(value) = artifact.metadata_json.get("resource_lifecycle") else {
+            continue;
+        };
+        let record: ResourceLifecycleRecord =
+            serde_json::from_value(value.clone()).map_err(|err| {
+                Error::internal_json(
+                    err.to_string(),
+                    Some(format!(
+                        "parse resource lifecycle metadata for artifact {}",
+                        artifact.id
+                    )),
+                )
+            })?;
+        resources.push(record);
+    }
+    if resources.is_empty() {
+        return Ok(None);
+    }
+
+    let index = ResourceLifecycleIndex {
+        schema: RESOURCE_LIFECYCLE_INDEX_SCHEMA.to_string(),
+        resources,
+    };
+    index.validate()?;
+    Ok(Some(index))
 }
 
 pub fn validate_resource_lifecycle_record(


### PR DESCRIPTION
## Summary
- Annotate `runs artifact attach` promoted artifacts with a persisted `resource_lifecycle` record.
- Project artifact lifecycle metadata into `runs artifacts` as a validated `resource_lifecycle_index` for local and runner artifact listings.
- Add artifact metadata update support in the observation store so producers can persist post-copy lifecycle paths.

## Verification
- `rustfmt --check src/core/observation/store/artifacts.rs src/core/resource_lifecycle_index.rs src/commands/runs/types.rs src/commands/runs/handlers.rs src/commands/runs/remote.rs src/commands/runs/remote_artifact.rs`
- `cargo check -q`

Note: repo-wide `cargo fmt --check` reports pre-existing formatting drift in unrelated files, so I used targeted rustfmt checks to avoid unrelated churn. I did not run `cargo test` or benchmarks locally per hot-command guidance.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the lifecycle producer wiring, targeted verification, commit, and PR drafting under Chris's direction.
