### PR TITLE
Add host mutation lifecycle contract

### DIFF
--- a/src/command_contract/constants.rs
+++ b/src/command_contract/constants.rs
@@ -26,6 +26,7 @@ pub enum ContractConstants {
     Loop(LoopConstants),
     SecretEnvPlan(SecretEnvPlanConstants),
     ResourceLifecycleIndex(ResourceLifecycleIndexConstants),
+    HostMutationLifecycle(HostMutationLifecycleConstants),
     RunLocationIndex(RunLocationIndexConstants),
     ReviewerFacingRef(ReviewerFacingRefConstants),
 }
@@ -37,6 +38,7 @@ pub struct AllContractConstants {
     pub loop_contracts: LoopConstants,
     pub secret_env_plan: SecretEnvPlanConstants,
     pub resource_lifecycle_index: ResourceLifecycleIndexConstants,
+    pub host_mutation_lifecycle: HostMutationLifecycleConstants,
     pub run_location_index: RunLocationIndexConstants,
     pub reviewer_facing_ref: ReviewerFacingRefConstants,
 }
@@ -71,6 +73,11 @@ pub struct ResourceLifecycleIndexConstants {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HostMutationLifecycleConstants {
+    pub schema_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RunLocationIndexConstants {
     pub schema_id: String,
 }
@@ -89,6 +96,7 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
             loop_contracts: loop_constants(),
             secret_env_plan: secret_env_plan_constants(),
             resource_lifecycle_index: resource_lifecycle_index_constants(),
+            host_mutation_lifecycle: host_mutation_lifecycle_constants(),
             run_location_index: run_location_index_constants(),
             reviewer_facing_ref: reviewer_facing_ref_constants(),
         }),
@@ -100,6 +108,9 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
         "secret-env-plan" => ContractConstants::SecretEnvPlan(secret_env_plan_constants()),
         "resource-lifecycle-index" => {
             ContractConstants::ResourceLifecycleIndex(resource_lifecycle_index_constants())
+        }
+        "host-mutation-lifecycle" => {
+            ContractConstants::HostMutationLifecycle(host_mutation_lifecycle_constants())
         }
         "run-location-index" => ContractConstants::RunLocationIndex(run_location_index_constants()),
         "reviewer-facing-ref" | "reviewer-ref" => {
@@ -146,6 +157,12 @@ pub fn secret_env_plan_constants() -> SecretEnvPlanConstants {
 pub fn resource_lifecycle_index_constants() -> ResourceLifecycleIndexConstants {
     ResourceLifecycleIndexConstants {
         schema_id: registry_schema_id("resource-lifecycle-index"),
+    }
+}
+
+pub fn host_mutation_lifecycle_constants() -> HostMutationLifecycleConstants {
+    HostMutationLifecycleConstants {
+        schema_id: registry_schema_id("host-mutation-lifecycle"),
     }
 }
 

--- a/src/command_contract/registry.rs
+++ b/src/command_contract/registry.rs
@@ -115,6 +115,14 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         rust_type: "homeboy::core::resource_lifecycle_index::ResourceLifecycleIndex",
     },
     ContractRegistryEntry {
+        schema_id: crate::core::host_mutation_lifecycle::HOST_MUTATION_LIFECYCLE_SCHEMA,
+        name: "host-mutation-lifecycle",
+        title: "Host mutation lifecycle",
+        owner: "homeboy-core",
+        summary: "Declares reversible host mutations such as symlinks, temp dirs, file backups, and package manifest rewrites without product-specific semantics.",
+        rust_type: "homeboy::core::host_mutation_lifecycle::HostMutationLifecycle",
+    },
+    ContractRegistryEntry {
         schema_id: crate::command_contract::RUN_LOCATION_INDEX_SCHEMA,
         name: "run-location-index",
         title: "Run location index",

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -19,6 +19,10 @@ use crate::commands::{adapter, CmdResult, GlobalArgs};
 use crate::core::artifact_ref::{validate_reviewer_facing_artifact_ref, ArtifactReference};
 use crate::core::artifacts::validate_artifact_postprocess_plan;
 use crate::core::fuzz::{FuzzWorkload, FUZZ_WORKLOAD_SCHEMA};
+use crate::core::host_mutation_lifecycle::{
+    HostMutationLifecycle, HostMutationRevertStrategy, HostMutationStatus,
+    HOST_MUTATION_LIFECYCLE_SCHEMA,
+};
 use crate::core::loop_lifecycle::{
     LoopEvidenceRecord, LoopIterationRecord, LoopRunRecord, LOOP_EVIDENCE_SCHEMA,
     LOOP_ITERATION_SCHEMA, LOOP_RUN_SCHEMA,
@@ -63,7 +67,7 @@ pub enum ContractCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct ContractConstantsArgs {
-    /// Contract ID: all, artifact-manifest, loop, secret-env-plan, resource-lifecycle-index, run-location-index, reviewer-facing-ref.
+    /// Contract ID: all, artifact-manifest, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, reviewer-facing-ref.
     pub contract_id: String,
 }
 
@@ -404,7 +408,7 @@ fn constants(contract_id: &str) -> CmdResult<ContractOutput> {
             format!("unknown contract constants id `{contract_id}`"),
             None,
             Some(vec![
-                    "Use one of: all, artifact-manifest, artifact-postprocess, loop, secret-env-plan, resource-lifecycle-index, run-location-index, reviewer-facing-ref".to_string(),
+                    "Use one of: all, artifact-manifest, artifact-postprocess, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, reviewer-facing-ref".to_string(),
             ]),
         )
     })?;
@@ -912,6 +916,29 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
                 required: vec!["schema", "resources"],
                 example: resource_lifecycle_index_example(),
             },
+            ContractSchemaEntry {
+                id: HOST_MUTATION_LIFECYCLE_SCHEMA,
+                version: 1,
+                description: "Generic reversible host mutation lifecycle for symlinks, temp dirs, file backups, and package manifest rewrites.",
+                fields: vec![
+                    field(
+                        "schema",
+                        "string",
+                        "Schema ID for the host mutation lifecycle contract.",
+                        true,
+                    ),
+                    field("owner", "string", "System that declared the host mutations.", true),
+                    field("run_id", "string", "Run that owns the host mutations.", true),
+                    field("mutations", "array", "Host mutation lifecycle records.", true),
+                    field("mutations[].id", "string", "Stable mutation ID.", true),
+                    field("mutations[].actor", "string", "Tool or service that applied or declared the mutation.", true),
+                    field("mutations[].kind", "string", "Mutation kind enum: symlink, temp_dir, file_backup, package_manifest_rewrite.", true),
+                    field("mutations[].status", "string", "Mutation lifecycle status enum.", true),
+                    field("mutations[].revert.strategy", "string", "Compatible revert strategy and required restore metadata.", true),
+                ],
+                required: vec!["schema", "owner", "run_id", "mutations"],
+                example: host_mutation_lifecycle_example(),
+            },
         ],
     }
 }
@@ -1070,6 +1097,46 @@ fn resource_lifecycle_index_example() -> Value {
     })
 }
 
+fn host_mutation_lifecycle_example() -> Value {
+    json!({
+        "schema": HOST_MUTATION_LIFECYCLE_SCHEMA,
+        "owner": "homeboy-core",
+        "run_id": "run-1",
+        "mutations": [
+            {
+                "id": "link-current-release",
+                "actor": "host-materializer",
+                "kind": "symlink",
+                "link_path": "/tmp/homeboy/current",
+                "target_path": "/tmp/homeboy/releases/run-1",
+                "status": HostMutationStatus::Applied,
+                "revert": {
+                    "strategy": HostMutationRevertStrategy::RemovePath
+                }
+            },
+            {
+                "id": "rewrite-package-manifest",
+                "actor": "dependency-materializer",
+                "kind": "package_manifest_rewrite",
+                "manifest_path": "package.json",
+                "package_manager": "npm",
+                "changes": [
+                    {
+                        "package": "example-package",
+                        "before": "^1.0.0",
+                        "after": "^1.1.0"
+                    }
+                ],
+                "status": HostMutationStatus::Applied,
+                "revert": {
+                    "strategy": HostMutationRevertStrategy::RestorePackageManifest,
+                    "backup_path": "package.json.homeboy-backup"
+                }
+            }
+        ]
+    })
+}
+
 fn field(
     name: &'static str,
     kind: &'static str,
@@ -1201,6 +1268,10 @@ static CONTRACT_SCHEMAS: &[ContractSchema] = &[
         validate_json: validate_resource_lifecycle_index,
     },
     ContractSchema {
+        id: HOST_MUTATION_LIFECYCLE_SCHEMA,
+        validate_json: validate_host_mutation_lifecycle,
+    },
+    ContractSchema {
         id: LOOP_RUN_SCHEMA,
         validate_json: validate_loop_run,
     },
@@ -1249,6 +1320,12 @@ fn validate_resource_cleanup_intent(raw: &str) -> homeboy::core::Result<()> {
 fn validate_resource_lifecycle_index(raw: &str) -> homeboy::core::Result<()> {
     let contract: ResourceLifecycleIndex =
         deserialize_contract(raw, RESOURCE_LIFECYCLE_INDEX_SCHEMA)?;
+    contract.validate()
+}
+
+fn validate_host_mutation_lifecycle(raw: &str) -> homeboy::core::Result<()> {
+    let contract: HostMutationLifecycle =
+        deserialize_contract(raw, HOST_MUTATION_LIFECYCLE_SCHEMA)?;
     contract.validate()
 }
 
@@ -1381,6 +1458,11 @@ mod tests {
             .unwrap()
             .iter()
             .any(|contract| contract["id"] == ARTIFACT_POSTPROCESS_SCHEMA));
+        assert!(catalog["contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|contract| contract["id"] == HOST_MUTATION_LIFECYCLE_SCHEMA));
     }
 
     #[test]
@@ -1553,6 +1635,85 @@ mod tests {
 
         assert_eq!(output.schema, ARTIFACT_POSTPROCESS_SCHEMA);
         assert!(output.valid);
+    }
+
+    #[test]
+    fn validates_host_mutation_lifecycle_json_file() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "host-mutation-lifecycle.json",
+            json!({
+                "schema": HOST_MUTATION_LIFECYCLE_SCHEMA,
+                "owner": "homeboy-test",
+                "run_id": "run-1",
+                "mutations": [
+                    {
+                        "id": "temp-workspace",
+                        "actor": "test",
+                        "kind": "temp_dir",
+                        "path": "/tmp/homeboy-run-1",
+                        "status": "applied",
+                        "revert": { "strategy": "remove_path" }
+                    },
+                    {
+                        "id": "manifest-rewrite",
+                        "actor": "test",
+                        "kind": "package_manifest_rewrite",
+                        "manifest_path": "package.json",
+                        "package_manager": "npm",
+                        "changes": [
+                            {
+                                "package": "example-package",
+                                "before": "^1.0.0",
+                                "after": "^1.1.0"
+                            }
+                        ],
+                        "status": "applied",
+                        "revert": {
+                            "strategy": "restore_package_manifest",
+                            "backup_path": "package.json.homeboy-backup"
+                        }
+                    }
+                ]
+            }),
+        );
+
+        let output = validate_file(HOST_MUTATION_LIFECYCLE_SCHEMA, file).unwrap();
+
+        assert_eq!(output.schema, HOST_MUTATION_LIFECYCLE_SCHEMA);
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn rejects_host_mutation_lifecycle_without_reversible_manifest_backup() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "host-mutation-lifecycle.json",
+            json!({
+                "schema": HOST_MUTATION_LIFECYCLE_SCHEMA,
+                "owner": "homeboy-test",
+                "run_id": "run-1",
+                "mutations": [
+                    {
+                        "id": "manifest-rewrite",
+                        "actor": "test",
+                        "kind": "package_manifest_rewrite",
+                        "manifest_path": "package.json",
+                        "changes": [
+                            { "package": "example-package", "after": "^1.1.0" }
+                        ],
+                        "status": "applied",
+                        "revert": { "strategy": "restore_package_manifest" }
+                    }
+                ]
+            }),
+        );
+
+        let error = validate_file(HOST_MUTATION_LIFECYCLE_SCHEMA, file).unwrap_err();
+
+        assert_eq!(error.details["field"], "mutations[0].revert.strategy");
     }
 
     #[test]

--- a/src/core/host_mutation_lifecycle.rs
+++ b/src/core/host_mutation_lifecycle.rs
@@ -1,0 +1,414 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::{Error, Result};
+
+pub const HOST_MUTATION_LIFECYCLE_SCHEMA: &str = "homeboy/host-mutation-lifecycle/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HostMutationLifecycle {
+    #[serde(default = "host_mutation_lifecycle_schema")]
+    pub schema: String,
+    pub owner: String,
+    pub run_id: String,
+    #[serde(default)]
+    pub mutations: Vec<HostMutationRecord>,
+}
+
+impl HostMutationLifecycle {
+    pub fn validate(&self) -> Result<()> {
+        validate_host_mutation_lifecycle(self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HostMutationRecord {
+    pub id: String,
+    pub actor: String,
+    #[serde(flatten)]
+    pub mutation: HostMutation,
+    pub status: HostMutationStatus,
+    pub revert: HostMutationRevertPlan,
+}
+
+impl HostMutationRecord {
+    pub fn validate(&self, index: usize) -> Result<()> {
+        validate_host_mutation_record(index, self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HostMutation {
+    Symlink {
+        link_path: String,
+        target_path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_target_path: Option<String>,
+    },
+    TempDir {
+        path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        purpose: Option<String>,
+    },
+    FileBackup {
+        original_path: String,
+        backup_path: String,
+    },
+    PackageManifestRewrite {
+        manifest_path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        package_manager: Option<String>,
+        changes: Vec<PackageManifestChange>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PackageManifestChange {
+    pub package: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HostMutationStatus {
+    Declared,
+    Applied,
+    RevertPending,
+    Reverted,
+    Retained,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HostMutationRevertPlan {
+    pub strategy: HostMutationRevertStrategy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HostMutationRevertStrategy {
+    RemovePath,
+    RestoreBackup,
+    RestoreSymlink,
+    RestorePackageManifest,
+    Manual,
+}
+
+pub fn validate_host_mutation_lifecycle(contract: &HostMutationLifecycle) -> Result<()> {
+    if contract.schema != HOST_MUTATION_LIFECYCLE_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "schema",
+            format!(
+                "expected {HOST_MUTATION_LIFECYCLE_SCHEMA}, received {}",
+                contract.schema
+            ),
+            Some(contract.schema.clone()),
+            None,
+        ));
+    }
+
+    validate_required_field("owner", &contract.owner)?;
+    validate_required_field("run_id", &contract.run_id)?;
+
+    for (index, mutation) in contract.mutations.iter().enumerate() {
+        validate_host_mutation_record(index, mutation)?;
+    }
+
+    Ok(())
+}
+
+pub fn validate_host_mutation_record(index: usize, record: &HostMutationRecord) -> Result<()> {
+    let prefix = format!("mutations[{index}]");
+    validate_required_field(&format!("{prefix}.id"), &record.id)?;
+    validate_required_field(&format!("{prefix}.actor"), &record.actor)?;
+    validate_host_mutation(&prefix, &record.mutation)?;
+    validate_revert_plan(&prefix, &record.mutation, &record.revert)
+}
+
+fn validate_host_mutation(prefix: &str, mutation: &HostMutation) -> Result<()> {
+    match mutation {
+        HostMutation::Symlink {
+            link_path,
+            target_path,
+            previous_target_path,
+        } => {
+            validate_required_field(&format!("{prefix}.link_path"), link_path)?;
+            validate_required_field(&format!("{prefix}.target_path"), target_path)?;
+            validate_optional_field(
+                &format!("{prefix}.previous_target_path"),
+                previous_target_path,
+            )
+        }
+        HostMutation::TempDir { path, purpose } => {
+            validate_required_field(&format!("{prefix}.path"), path)?;
+            validate_optional_field(&format!("{prefix}.purpose"), purpose)
+        }
+        HostMutation::FileBackup {
+            original_path,
+            backup_path,
+        } => {
+            validate_required_field(&format!("{prefix}.original_path"), original_path)?;
+            validate_required_field(&format!("{prefix}.backup_path"), backup_path)
+        }
+        HostMutation::PackageManifestRewrite {
+            manifest_path,
+            package_manager,
+            changes,
+        } => {
+            validate_required_field(&format!("{prefix}.manifest_path"), manifest_path)?;
+            validate_optional_field(&format!("{prefix}.package_manager"), package_manager)?;
+            if changes.is_empty() {
+                return Err(Error::validation_invalid_argument(
+                    format!("{prefix}.changes"),
+                    "package manifest rewrites require at least one package change",
+                    None,
+                    None,
+                ));
+            }
+            for (change_index, change) in changes.iter().enumerate() {
+                let change_prefix = format!("{prefix}.changes[{change_index}]");
+                validate_required_field(&format!("{change_prefix}.package"), &change.package)?;
+                validate_optional_field(&format!("{change_prefix}.before"), &change.before)?;
+                validate_optional_field(&format!("{change_prefix}.after"), &change.after)?;
+                if change.before.is_none() && change.after.is_none() {
+                    return Err(Error::validation_invalid_argument(
+                        format!("{change_prefix}.before"),
+                        "package manifest change requires before or after value",
+                        None,
+                        None,
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn validate_revert_plan(
+    prefix: &str,
+    mutation: &HostMutation,
+    revert: &HostMutationRevertPlan,
+) -> Result<()> {
+    validate_optional_field(&format!("{prefix}.revert.notes"), &revert.notes)?;
+    validate_optional_field(&format!("{prefix}.revert.backup_path"), &revert.backup_path)?;
+    validate_optional_field(&format!("{prefix}.revert.target_path"), &revert.target_path)?;
+
+    let valid = match mutation {
+        HostMutation::Symlink {
+            previous_target_path,
+            ..
+        } => match revert.strategy {
+            HostMutationRevertStrategy::RemovePath => true,
+            HostMutationRevertStrategy::RestoreSymlink => previous_target_path.is_some(),
+            HostMutationRevertStrategy::Manual => revert.notes.is_some(),
+            _ => false,
+        },
+        HostMutation::TempDir { .. } => match revert.strategy {
+            HostMutationRevertStrategy::RemovePath => true,
+            HostMutationRevertStrategy::Manual => revert.notes.is_some(),
+            _ => false,
+        },
+        HostMutation::FileBackup { .. } => match revert.strategy {
+            HostMutationRevertStrategy::RestoreBackup => revert.backup_path.is_some(),
+            HostMutationRevertStrategy::Manual => revert.notes.is_some(),
+            _ => false,
+        },
+        HostMutation::PackageManifestRewrite { .. } => match revert.strategy {
+            HostMutationRevertStrategy::RestorePackageManifest => revert.backup_path.is_some(),
+            HostMutationRevertStrategy::Manual => revert.notes.is_some(),
+            _ => false,
+        },
+    };
+
+    if valid {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        format!("{prefix}.revert.strategy"),
+        "revert strategy must be compatible with the mutation kind and include required restore metadata",
+        None,
+        None,
+    ))
+}
+
+fn validate_required_field(field: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            field,
+            "must not be blank",
+            None,
+            None,
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_optional_field(field: &str, value: &Option<String>) -> Result<()> {
+    if value
+        .as_deref()
+        .is_some_and(|value| value.trim().is_empty())
+    {
+        return Err(Error::validation_invalid_argument(
+            field,
+            "must not be blank when present",
+            None,
+            None,
+        ));
+    }
+
+    Ok(())
+}
+
+fn host_mutation_lifecycle_schema() -> String {
+    HOST_MUTATION_LIFECYCLE_SCHEMA.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ErrorCode;
+
+    fn revert(strategy: HostMutationRevertStrategy) -> HostMutationRevertPlan {
+        HostMutationRevertPlan {
+            strategy,
+            backup_path: None,
+            target_path: None,
+            notes: None,
+        }
+    }
+
+    fn contract(mutation: HostMutation, revert: HostMutationRevertPlan) -> HostMutationLifecycle {
+        HostMutationLifecycle {
+            schema: HOST_MUTATION_LIFECYCLE_SCHEMA.to_string(),
+            owner: "homeboy-test".to_string(),
+            run_id: "run-1".to_string(),
+            mutations: vec![HostMutationRecord {
+                id: "mutation-1".to_string(),
+                actor: "test".to_string(),
+                mutation,
+                status: HostMutationStatus::Applied,
+                revert,
+            }],
+        }
+    }
+
+    #[test]
+    fn validates_symlink_mutation_with_remove_revert() {
+        contract(
+            HostMutation::Symlink {
+                link_path: "/tmp/current".to_string(),
+                target_path: "/tmp/releases/new".to_string(),
+                previous_target_path: None,
+            },
+            revert(HostMutationRevertStrategy::RemovePath),
+        )
+        .validate()
+        .unwrap();
+    }
+
+    #[test]
+    fn validates_package_manifest_rewrite_with_backup_restore() {
+        let mut restore = revert(HostMutationRevertStrategy::RestorePackageManifest);
+        restore.backup_path = Some("package.json.homeboy-backup".to_string());
+
+        contract(
+            HostMutation::PackageManifestRewrite {
+                manifest_path: "package.json".to_string(),
+                package_manager: Some("npm".to_string()),
+                changes: vec![PackageManifestChange {
+                    package: "example-package".to_string(),
+                    before: Some("^1.0.0".to_string()),
+                    after: Some("^1.1.0".to_string()),
+                }],
+            },
+            restore,
+        )
+        .validate()
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_wrong_schema() {
+        let mut contract = contract(
+            HostMutation::TempDir {
+                path: "/tmp/homeboy-run".to_string(),
+                purpose: None,
+            },
+            revert(HostMutationRevertStrategy::RemovePath),
+        );
+        contract.schema = "homeboy/host-mutation-lifecycle/v0".to_string();
+
+        let error = contract.validate().unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "schema");
+    }
+
+    #[test]
+    fn rejects_blank_mutation_path() {
+        let error = contract(
+            HostMutation::FileBackup {
+                original_path: "  ".to_string(),
+                backup_path: "file.homeboy-backup".to_string(),
+            },
+            HostMutationRevertPlan {
+                strategy: HostMutationRevertStrategy::RestoreBackup,
+                backup_path: Some("file.homeboy-backup".to_string()),
+                target_path: None,
+                notes: None,
+            },
+        )
+        .validate()
+        .unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "mutations[0].original_path");
+    }
+
+    #[test]
+    fn rejects_incompatible_revert_strategy() {
+        let error = contract(
+            HostMutation::TempDir {
+                path: "/tmp/homeboy-run".to_string(),
+                purpose: None,
+            },
+            revert(HostMutationRevertStrategy::RestoreBackup),
+        )
+        .validate()
+        .unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "mutations[0].revert.strategy");
+    }
+
+    #[test]
+    fn rejects_empty_manifest_rewrite_changes() {
+        let mut restore = revert(HostMutationRevertStrategy::RestorePackageManifest);
+        restore.backup_path = Some("package.json.homeboy-backup".to_string());
+
+        let error = contract(
+            HostMutation::PackageManifestRewrite {
+                manifest_path: "package.json".to_string(),
+                package_manager: None,
+                changes: vec![],
+            },
+            restore,
+        )
+        .validate()
+        .unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "mutations[0].changes");
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -88,6 +88,7 @@ pub mod fuzz;
 pub mod gate;
 pub mod gh_actions_cache;
 pub mod git;
+pub mod host_mutation_lifecycle;
 pub mod http_api;
 pub(crate) mod http_probe;
 pub mod http_request;

--- a/tests/contract_constants_test.rs
+++ b/tests/contract_constants_test.rs
@@ -32,6 +32,10 @@ fn contract_constants_exports_homeboy_owned_contract_ids() {
         "homeboy/run-location-index/v1"
     );
     assert_eq!(
+        value["constants"]["host_mutation_lifecycle"]["schema_id"],
+        "homeboy/host-mutation-lifecycle/v1"
+    );
+    assert_eq!(
         value["constants"]["loop_contracts"]["controller_schema_id"],
         "homeboy/agent-task-loop-controller/v1"
     );


### PR DESCRIPTION
## Summary
- Adds a generic typed host mutation lifecycle contract for reversible symlink, temp dir, file backup, and package manifest rewrite declarations.
- Registers the schema with contract list/show/export/validate and constants surfaces.
- Adds validation coverage for successful host mutation contracts and missing reversible manifest backup metadata.

## Verification
- cargo check --tests
- Local cargo test was intentionally not run because this environment marks local cargo test as a hot command.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implemented the contract, validation wiring, and verification workflow in collaboration with Chris.
