### PR TITLE
Add fuzz campaign execution dispatch

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -8,7 +8,8 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
 homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
-homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--campaign-manifest <path>] [--campaign-workload <id>] [--lab-runner <id>] [--required-artifact <id>] [--allow-destructive --isolation isolated --isolation-proof <path>]
+homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--campaign-manifest <path>] [--campaign-workload <id>] [--lab-runner <id>] [--required-artifact <id>] [--execute|--dry-run] [--resume] [--allow-destructive --isolation isolated --isolation-proof <path>]
+homeboy fuzz run-campaign [<component>] [--rig <id>] [--campaign-manifest <path>] [--campaign-workload <id>] [--dry-run] [--resume] [fuzz run options]
 homeboy fuzz validate <results-file>
 homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--output-envelope <path>]
 homeboy fuzz compare <baseline-envelope> <candidate-envelope> [--hotspot-policy <advisory|blocking|off>]
@@ -164,10 +165,14 @@ provenance, and skipped target or operation reasons. The planner is product-neut
 operation families and safety classes, not product-specific target names.
 
 `homeboy fuzz plan --campaign-manifest <path>` adds a deterministic
-`homeboy/fuzz-campaign-plan/v1` object beside the single execution request. This
-is a planning primitive only: it emits structured entries and canonical
+`homeboy/fuzz-campaign-plan/v1` object beside the single execution request. The
+default is still planning-only: it emits structured entries and canonical
 `homeboy fuzz run` command vectors without running or rewriting the fuzz executor.
-The manifest is product-neutral and may contain `id`, `workloads`,
+Pass `--execute` or use `homeboy fuzz run-campaign` to execute the same entries
+sequentially through the existing `fuzz run` primitive. Pass `--dry-run` to emit
+the structured campaign dispatch records without execution, and `--resume` to
+skip entries whose planned run id is already persisted. The manifest is
+product-neutral and may contain `id`, `workloads`,
 `workload_ids`, `lab_runner`, and `required_artifacts`; product-specific details
 belong in manifest metadata that downstream runners consume, not in Homeboy core.
 Repeat `--campaign-workload <id>` to add workload ids without a manifest,
@@ -204,6 +209,12 @@ The resulting `campaign_plan.entries[]` are sorted by workload id, deduplicated,
 and include `run_id`, `tracker_refs`, `artifact_requirements`, `lab_runner`, a
 request copy scoped to the workload, and a command vector suitable for a caller
 or Lab orchestration layer to schedule explicitly.
+
+Campaign execution returns `variant: "run_campaign"` with `dispatch_records[]`.
+Each record includes the planned entry id, workload id, run id, command vector,
+status, optional exit code, optional result ref, and persisted evidence refs from
+the underlying `fuzz run`. Heavy campaigns should still use the normal Lab routing
+flags so the existing fuzz run offload policy owns where execution happens.
 
 `homeboy fuzz plan --action-model <path>` and
 `homeboy fuzz run --action-model <path>` accept a

--- a/src/commands/fuzz/dispatch.rs
+++ b/src/commands/fuzz/dispatch.rs
@@ -13,7 +13,7 @@ use super::compare::run_compare;
 use super::doctor::run_doctor;
 use super::execution::{fuzz_prepare_failure_message, run_run};
 use super::inspect::run_inspect;
-use super::planning::run_plan;
+use super::planning::{run_campaign, run_plan};
 use super::replay::{run_minimize, run_replay};
 use super::report::{run_report, run_validate};
 use super::types::{
@@ -32,7 +32,18 @@ pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
             Ok((FuzzOutput::Discover(run_discover(discover_args)?), 0))
         }
         Some(FuzzCommand::List(list_args)) => Ok((FuzzOutput::List(run_list(list_args)?), 0)),
+        Some(FuzzCommand::Plan(plan_args)) if plan_args.execute || plan_args.dry_run => {
+            let (output, exit) = run_campaign(plan_args)?;
+            Ok((FuzzOutput::RunCampaign(output), exit))
+        }
         Some(FuzzCommand::Plan(plan_args)) => Ok((FuzzOutput::Plan(run_plan(plan_args)?), 0)),
+        Some(FuzzCommand::RunCampaign(mut plan_args)) => {
+            if !plan_args.dry_run {
+                plan_args.execute = true;
+            }
+            let (output, exit) = run_campaign(plan_args)?;
+            Ok((FuzzOutput::RunCampaign(output), exit))
+        }
         Some(FuzzCommand::Run(run_args)) => {
             let (output, exit) = run_run(run_args)?;
             Ok((FuzzOutput::Run(output), exit))

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1460,6 +1460,9 @@ pub(super) fn build_fuzz_execution_request(
         campaign_workloads: Vec::new(),
         lab_runner: None,
         required_artifacts: Vec::new(),
+        execute: false,
+        dry_run: false,
+        resume: false,
     };
     let isolation_proof = super::planning::load_isolation_proof(args.isolation_proof.as_deref())?;
     let sequence_plan = load_sequence_plan(args.sequence_plan.as_deref())?;

--- a/src/commands/fuzz/planning.rs
+++ b/src/commands/fuzz/planning.rs
@@ -12,7 +12,11 @@ use homeboy::core::fuzz::{
 };
 
 use super::execution::fuzz_runner_contract;
-use super::types::{FuzzPlanArgs, FuzzPlanOutput, FuzzPlanStrategy};
+use super::execution::run_run;
+use super::types::{
+    FuzzCampaignDispatchRecordOutput, FuzzCampaignRunOutput, FuzzPlanArgs, FuzzPlanOutput,
+    FuzzPlanStrategy,
+};
 use super::types_extra::{
     FuzzCampaignPlanEntryOutput, FuzzCampaignPlanIsolationOutput, FuzzCampaignPlanOutput,
 };
@@ -119,6 +123,161 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
         campaign_plan,
         runner_contract: fuzz_runner_contract(fuzz_config.as_ref()),
     })
+}
+
+pub(super) fn run_campaign(
+    mut args: FuzzPlanArgs,
+) -> homeboy::core::Result<(FuzzCampaignRunOutput, i32)> {
+    if args.execute && args.dry_run {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "execute",
+            "fuzz campaign execution cannot combine --execute and --dry-run".to_string(),
+            None,
+            None,
+        ));
+    }
+    args.execute = args.execute || !args.dry_run;
+    let plan_output = run_plan(args.clone())?;
+    let Some(plan) = plan_output.campaign_plan else {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "campaign-workload",
+            "fuzz campaign execution requires --campaign-manifest or at least one --campaign-workload".to_string(),
+            None,
+            None,
+        ));
+    };
+
+    let mut dispatch_records = Vec::new();
+    let mut run_ids = Vec::new();
+    let mut result_refs = Vec::new();
+    let mut exit_code = 0;
+    let store = if args.resume {
+        Some(homeboy::core::observation::ObservationStore::open_initialized()?)
+    } else {
+        None
+    };
+
+    for entry in &plan.entries {
+        run_ids.push(entry.run_id.clone());
+        if let Some(store) = store.as_ref() {
+            if store.get_run(&entry.run_id)?.is_some() {
+                dispatch_records.push(campaign_dispatch_record(
+                    entry,
+                    "skipped_existing",
+                    None,
+                    None,
+                    Vec::new(),
+                    Some("resume skipped existing persisted run id".to_string()),
+                ));
+                continue;
+            }
+        }
+        if !args.execute {
+            dispatch_records.push(campaign_dispatch_record(
+                entry,
+                "planned",
+                None,
+                None,
+                Vec::new(),
+                Some("dry run; not executed".to_string()),
+            ));
+            continue;
+        }
+
+        let mut run_args = args.run.clone();
+        run_args.workload_id = Some(entry.workload_id.clone());
+        run_args.run_id = Some(entry.run_id.clone());
+        let (run_output, entry_exit) = run_run(run_args)?;
+        if entry_exit != 0 && exit_code == 0 {
+            exit_code = entry_exit;
+        }
+        let entry_refs = run_output.evidence_refs.clone();
+        result_refs.extend(entry_refs.iter().cloned());
+        dispatch_records.push(campaign_dispatch_record(
+            entry,
+            &run_output.status,
+            Some(entry_exit),
+            entry_refs.first().map(|evidence| evidence.target.clone()),
+            entry_refs,
+            None,
+        ));
+    }
+
+    let status = campaign_run_status(&dispatch_records, args.execute);
+    Ok((
+        FuzzCampaignRunOutput {
+            command: if args.execute {
+                "fuzz.run-campaign"
+            } else {
+                "fuzz.run-campaign.dry-run"
+            }
+            .to_string(),
+            status: status.to_string(),
+            execute: args.execute,
+            dry_run: !args.execute,
+            resume: args.resume,
+            plan,
+            dispatch_records,
+            run_ids,
+            result_refs,
+            next_steps: campaign_next_steps(&status),
+        },
+        exit_code,
+    ))
+}
+
+fn campaign_dispatch_record(
+    entry: &FuzzCampaignPlanEntryOutput,
+    status: &str,
+    exit_code: Option<i32>,
+    result_ref: Option<String>,
+    evidence_refs: Vec<homeboy::core::artifact_ref::EvidenceRef>,
+    message: Option<String>,
+) -> FuzzCampaignDispatchRecordOutput {
+    FuzzCampaignDispatchRecordOutput {
+        index: entry.index,
+        entry_id: entry.id.clone(),
+        workload_id: entry.workload_id.clone(),
+        run_id: entry.run_id.clone(),
+        status: status.to_string(),
+        command: entry.command.clone(),
+        lab_runner: entry.lab_runner.clone(),
+        tracker_refs: entry.tracker_refs.clone(),
+        exit_code,
+        result_ref,
+        evidence_refs,
+        message,
+    }
+}
+
+fn campaign_run_status(
+    records: &[FuzzCampaignDispatchRecordOutput],
+    executed: bool,
+) -> &'static str {
+    if !executed {
+        return "planned";
+    }
+    if records
+        .iter()
+        .any(|record| matches!(record.status.as_str(), "failed" | "timeout"))
+    {
+        "failed"
+    } else if records
+        .iter()
+        .all(|record| record.status == "skipped_existing")
+    {
+        "skipped_existing"
+    } else {
+        "completed"
+    }
+}
+
+fn campaign_next_steps(status: &str) -> Vec<String> {
+    match status {
+        "planned" => vec!["Run the campaign with `homeboy fuzz plan --execute ...` or `homeboy fuzz run-campaign ...`.".to_string()],
+        "failed" => vec!["Inspect failed entry run ids with `homeboy runs show <run-id>` and `homeboy fuzz inspect <run-id>`.".to_string()],
+        _ => vec!["Inspect persisted campaign entry evidence with `homeboy runs show <run-id>` and `homeboy runs evidence <run-id>`.".to_string()],
+    }
 }
 
 const FUZZ_CAMPAIGN_PLAN_SCHEMA: &str = "homeboy/fuzz-campaign-plan/v1";

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -10,7 +10,7 @@ use super::execution::{
     persist_fuzz_run_evidence, persist_fuzz_sequence_plan, run_fuzz_artifact_postprocess,
     FuzzRunEvidenceInput,
 };
-use super::planning::{build_campaign_plan, plan_inventory_selection};
+use super::planning::{build_campaign_plan, plan_inventory_selection, run_campaign};
 use super::replay::{run_minimize, run_replay};
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,
@@ -117,6 +117,9 @@ fn planner_args() -> FuzzPlanArgs {
         campaign_workloads: Vec::new(),
         lab_runner: None,
         required_artifacts: Vec::new(),
+        execute: false,
+        dry_run: false,
+        resume: false,
     }
 }
 

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -409,6 +409,84 @@ fn fuzz_campaign_plan_cli_parses_manifest_workloads_lab_runner_and_artifacts() {
 }
 
 #[test]
+fn fuzz_plan_execute_cli_parses_campaign_execution_flags() {
+    let cli = FuzzCli::try_parse_from([
+        "fuzz",
+        "plan",
+        "component-a",
+        "--campaign-workload",
+        "api-fuzz",
+        "--execute",
+        "--resume",
+    ])
+    .expect("parse fuzz plan execute cli");
+
+    let Some(FuzzCommand::Plan(args)) = cli.args.command else {
+        panic!("expected fuzz plan command");
+    };
+    assert!(args.execute);
+    assert!(args.resume);
+    assert!(!args.dry_run);
+}
+
+#[test]
+fn fuzz_run_campaign_cli_parses_as_campaign_command() {
+    let cli = FuzzCli::try_parse_from([
+        "fuzz",
+        "run-campaign",
+        "component-a",
+        "--campaign-workload",
+        "api-fuzz",
+        "--dry-run",
+    ])
+    .expect("parse fuzz run-campaign cli");
+
+    let Some(FuzzCommand::RunCampaign(args)) = cli.args.command else {
+        panic!("expected fuzz run-campaign command");
+    };
+    assert!(args.dry_run);
+    assert!(!args.execute);
+}
+
+#[test]
+fn fuzz_run_campaign_dry_run_emits_structured_dispatch_records() {
+    let mut args = planner_args();
+    args.request_id = Some("campaign-1".to_string());
+    args.campaign_workloads = vec!["api-fuzz".to_string(), "db-fuzz".to_string()];
+    args.dry_run = true;
+
+    let (output, exit_code) = run_campaign(args).expect("dry-run campaign");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.status, "planned");
+    assert!(!output.execute);
+    assert!(output.dry_run);
+    assert_eq!(output.dispatch_records.len(), 2);
+    assert_eq!(output.dispatch_records[0].status, "planned");
+    assert_eq!(output.dispatch_records[0].run_id, "campaign-1-api-fuzz");
+    assert_eq!(output.dispatch_records[1].run_id, "campaign-1-db-fuzz");
+    assert_eq!(
+        output.dispatch_records[0]
+            .command
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec![
+            "homeboy",
+            "fuzz",
+            "run",
+            "component-a",
+            "--workload",
+            "api-fuzz",
+            "--run-id",
+            "campaign-1-api-fuzz",
+            "--gate-profile",
+            "measurement",
+        ]
+    );
+}
+
+#[test]
 fn fuzz_plan_operation_filter_limits_inventory_selection() {
     let mut args = planner_args();
     args.operations = vec!["read".to_string()];

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -45,8 +45,10 @@ impl FuzzArgs {
     pub fn is_lab_offload_command(&self) -> bool {
         matches!(
             self.command,
-            None | Some(FuzzCommand::Run(_)) | Some(FuzzCommand::List(_))
-        )
+            None | Some(FuzzCommand::Run(_))
+                | Some(FuzzCommand::RunCampaign(_))
+                | Some(FuzzCommand::List(_))
+        ) || matches!(&self.command, Some(FuzzCommand::Plan(plan)) if plan.execute)
     }
 
     pub fn extension_override_ids(&self) -> &[String] {
@@ -69,6 +71,8 @@ pub(crate) enum FuzzCommand {
     List(FuzzListArgs),
     /// Build a fuzz execution request without executing it
     Plan(FuzzPlanArgs),
+    /// Execute or dry-run a generated fuzz campaign plan
+    RunCampaign(FuzzPlanArgs),
     /// Execute the selected fuzz workload, persist fuzz evidence, and surface its campaign contract
     Run(FuzzRunArgs),
     /// Validate a fuzz result campaign file
@@ -294,6 +298,18 @@ pub(crate) struct FuzzPlanArgs {
     /// Additional required artifact id/kind expected from every campaign entry. Repeatable.
     #[arg(long = "required-artifact", value_name = "ID")]
     pub(crate) required_artifacts: Vec<String>,
+
+    /// Execute generated campaign entries through the existing `fuzz run` primitive.
+    #[arg(long = "execute")]
+    pub(crate) execute: bool,
+
+    /// Emit structured dispatch records without executing campaign entries.
+    #[arg(long = "dry-run")]
+    pub(crate) dry_run: bool,
+
+    /// Skip campaign entries whose run id already exists in the persisted run store.
+    #[arg(long = "resume")]
+    pub(crate) resume: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -525,12 +541,13 @@ pub(crate) struct FuzzMinimizeArgs {
 }
 
 pub use super::types_extra::{
-    FuzzArtifactPostprocessOutput, FuzzCampaignContract, FuzzCompareDeltas,
-    FuzzCompareHotspotDelta, FuzzCompareHotspotSnapshot, FuzzCompareHotspotSummary,
-    FuzzCompareOutput, FuzzCompareSnapshot, FuzzContractGateProfileOutput, FuzzContractOutput,
-    FuzzCoverageCompletenessOutput, FuzzCoverageSelectorSummaryOutput, FuzzDiscoverOutput,
-    FuzzDiscoverSummary, FuzzExecutionOutput, FuzzGateEvaluation, FuzzGateStatusChange,
-    FuzzInspectCandidate, FuzzInspectOutput, FuzzListOutput, FuzzOutput, FuzzPlanOutput,
-    FuzzReplayArtifactAccess, FuzzReplayEnv, FuzzReplayExecution, FuzzReplayOutput,
-    FuzzReportOutput, FuzzRunOutput, FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
+    FuzzArtifactPostprocessOutput, FuzzCampaignContract, FuzzCampaignDispatchRecordOutput,
+    FuzzCampaignRunOutput, FuzzCompareDeltas, FuzzCompareHotspotDelta, FuzzCompareHotspotSnapshot,
+    FuzzCompareHotspotSummary, FuzzCompareOutput, FuzzCompareSnapshot,
+    FuzzContractGateProfileOutput, FuzzContractOutput, FuzzCoverageCompletenessOutput,
+    FuzzCoverageSelectorSummaryOutput, FuzzDiscoverOutput, FuzzDiscoverSummary,
+    FuzzExecutionOutput, FuzzGateEvaluation, FuzzGateStatusChange, FuzzInspectCandidate,
+    FuzzInspectOutput, FuzzListOutput, FuzzOutput, FuzzPlanOutput, FuzzReplayArtifactAccess,
+    FuzzReplayEnv, FuzzReplayExecution, FuzzReplayOutput, FuzzReportOutput, FuzzRunOutput,
+    FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
 };

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -17,6 +17,7 @@ pub enum FuzzOutput {
     Discover(FuzzDiscoverOutput),
     List(FuzzListOutput),
     Plan(FuzzPlanOutput),
+    RunCampaign(FuzzCampaignRunOutput),
     Run(FuzzRunOutput),
     Validate(FuzzValidateOutput),
     Report(FuzzReportOutput),
@@ -238,6 +239,39 @@ pub struct FuzzCampaignPlanEntryOutput {
     pub artifact_requirements: Vec<FuzzRequiredArtifact>,
     pub command: Vec<String>,
     pub request: FuzzExecutionRequest,
+}
+
+#[derive(Serialize)]
+pub struct FuzzCampaignRunOutput {
+    pub command: String,
+    pub status: String,
+    pub execute: bool,
+    pub dry_run: bool,
+    pub resume: bool,
+    pub plan: FuzzCampaignPlanOutput,
+    pub dispatch_records: Vec<FuzzCampaignDispatchRecordOutput>,
+    pub run_ids: Vec<String>,
+    pub result_refs: Vec<EvidenceRef>,
+    pub next_steps: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct FuzzCampaignDispatchRecordOutput {
+    pub index: usize,
+    pub entry_id: String,
+    pub workload_id: String,
+    pub run_id: String,
+    pub status: String,
+    pub command: Vec<String>,
+    pub lab_runner: Option<String>,
+    pub tracker_refs: Vec<TrackerRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_ref: Option<String>,
+    pub evidence_refs: Vec<EvidenceRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary
- Adds `homeboy fuzz run-campaign` and `homeboy fuzz plan --execute` to execute Wave 2 campaign plan entries through existing `fuzz run` primitives.
- Emits structured campaign dispatch records with command vectors, run IDs, status, exit codes, result refs, and persisted evidence refs.
- Adds `--dry-run` dispatch preview and `--resume` skipping for already persisted planned run IDs.
- Documents the campaign execution contract and keeps heavy execution on existing Lab routing.

## Verification
- `cargo check`
- `cargo run --quiet -- fuzz --help`
- `cargo run --quiet -- fuzz plan --help`
- `cargo run --quiet -- fuzz run-campaign --help`
- `git diff --cached --check`

`cargo test` was not run per local resource policy against hot commands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the campaign execution dispatch path, updated tests/docs, and ran safe verification.