### PR TITLE
Use workspace materializer for dependency cache commands

### DIFF
--- a/src/core/runner/git_dependency_materialization.rs
+++ b/src/core/runner/git_dependency_materialization.rs
@@ -10,10 +10,11 @@ use crate::core::rig::spec::DependencyCacheSpec;
 
 use super::{
     workspace::{
-        canonical_workspace_path, effective_snapshot_excludes, git_output, local_snapshot_stats,
-        materialize_snapshot, materialize_snapshot_git, parent_remote_path, run_shell_capture,
-        run_shell_command, shell_command_for_runner, snapshot_identity, ByteFileCounts,
-        DEFAULT_EXCLUDES,
+        canonical_workspace_path, dependency_cache_manifest_command,
+        dependency_cache_restore_command, dependency_cache_save_command,
+        effective_snapshot_excludes, git_output, local_snapshot_stats, materialize_snapshot,
+        materialize_snapshot_git, parent_remote_path, run_shell_capture, run_shell_command,
+        shell_command_for_runner, snapshot_identity, ByteFileCounts, DEFAULT_EXCLUDES,
     },
     Runner, RunnerKind, RunnerWorkspaceSyncMode,
 };
@@ -333,12 +334,7 @@ fn restore_dependency_cache_paths(
             missing.push(path.clone());
             continue;
         }
-        let command = format!(
-            "mkdir -p {dest} && rm -rf {target} && tar -C {dest} -xf {archive}",
-            dest = shell::quote_arg(remote_path),
-            target = shell::quote_arg(&Path::new(remote_path).join(path).display().to_string()),
-            archive = shell::quote_arg(&archive),
-        );
+        let command = dependency_cache_restore_command(remote_path, path, &archive);
         run_shell_command(
             &shell_command_for_runner(runner, &command)?,
             "restore runner dependency cache",
@@ -375,14 +371,7 @@ fn save_dependency_cache_paths(
             missing.push(path.clone());
             continue;
         }
-        let command = format!(
-            "mkdir -p {cache} {archive_parent} && tar -C {remote} -cf {archive} {path}",
-            cache = shell::quote_arg(cache_path),
-            archive_parent = shell::quote_arg(&parent_remote_path(&archive)),
-            remote = shell::quote_arg(remote_path),
-            archive = shell::quote_arg(&archive),
-            path = shell::quote_arg(path),
-        );
+        let command = dependency_cache_save_command(remote_path, cache_path, path, &archive);
         run_shell_command(
             &shell_command_for_runner(runner, &command)?,
             "save runner dependency cache",
@@ -390,17 +379,7 @@ fn save_dependency_cache_paths(
         saved.push(path.clone());
     }
     let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_else(|_| "{}".to_string());
-    let write_manifest = format!(
-        "mkdir -p {cache} && printf %s {json} > {manifest}",
-        cache = shell::quote_arg(cache_path),
-        json = shell::quote_arg(&manifest_json),
-        manifest = shell::quote_arg(
-            &Path::new(cache_path)
-                .join("manifest.json")
-                .display()
-                .to_string()
-        ),
-    );
+    let write_manifest = dependency_cache_manifest_command(cache_path, &manifest_json);
     run_shell_command(
         &shell_command_for_runner(runner, &write_manifest)?,
         "write runner dependency cache manifest",

--- a/src/core/runner/workspace/materializer.rs
+++ b/src/core/runner/workspace/materializer.rs
@@ -2,6 +2,8 @@ use crate::core::engine::shell;
 
 use super::util::{owner_capture_shell, owner_restore_shell, parent_remote_path};
 
+const CACHE_MANIFEST_FILE: &str = "manifest.json";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum WorkspaceMaterializationOperation {
     EnsureParent,
@@ -27,6 +29,20 @@ pub(super) enum WorkspaceMaterializationOperation {
         changed_since_base: Option<String>,
         fetch_refs: Vec<String>,
         allow_dirty: bool,
+    },
+    EnsureDestDir,
+    EnsureParentOf(String),
+    RestoreDependencyCachePath {
+        path: String,
+        archive: String,
+    },
+    SaveDependencyCachePath {
+        remote_path: String,
+        path: String,
+        archive: String,
+    },
+    WriteDependencyCacheManifest {
+        json: String,
     },
     AtomicReplaceTemp,
 }
@@ -141,9 +157,84 @@ impl WorkspaceMaterializationOperation {
                 fetch_refs,
                 *allow_dirty,
             ),
+            Self::EnsureDestDir => "mkdir -p \"$dest\"".to_string(),
+            Self::EnsureParentOf(path) => format!(
+                "mkdir -p {parent}",
+                parent = shell::quote_arg(&parent_remote_path(path))
+            ),
+            Self::RestoreDependencyCachePath { path, archive } => format!(
+                "rm -rf {target} && tar -C \"$dest\" -xf {archive}",
+                target = dest_child_path(path),
+                archive = shell::quote_arg(archive)
+            ),
+            Self::SaveDependencyCachePath {
+                remote_path,
+                path,
+                archive,
+            } => format!(
+                "tar -C {remote} -cf {archive} {path}",
+                remote = shell::quote_arg(remote_path),
+                archive = shell::quote_arg(archive),
+                path = shell::quote_arg(path),
+            ),
+            Self::WriteDependencyCacheManifest { json } => format!(
+                "printf %s {json} > {manifest}",
+                json = shell::quote_arg(json),
+                manifest = dest_child_path(CACHE_MANIFEST_FILE),
+            ),
             Self::AtomicReplaceTemp => "rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"".to_string(),
         }
     }
+}
+
+pub(crate) fn dependency_cache_restore_command(
+    remote_path: &str,
+    path: &str,
+    archive: &str,
+) -> String {
+    WorkspaceMaterializer::new(remote_path)
+        .op(WorkspaceMaterializationOperation::EnsureDestDir)
+        .op(
+            WorkspaceMaterializationOperation::RestoreDependencyCachePath {
+                path: path.to_string(),
+                archive: archive.to_string(),
+            },
+        )
+        .command()
+}
+
+pub(crate) fn dependency_cache_save_command(
+    remote_path: &str,
+    cache_path: &str,
+    path: &str,
+    archive: &str,
+) -> String {
+    WorkspaceMaterializer::new(cache_path)
+        .op(WorkspaceMaterializationOperation::EnsureDestDir)
+        .op(WorkspaceMaterializationOperation::EnsureParentOf(
+            archive.to_string(),
+        ))
+        .op(WorkspaceMaterializationOperation::SaveDependencyCachePath {
+            remote_path: remote_path.to_string(),
+            path: path.to_string(),
+            archive: archive.to_string(),
+        })
+        .command()
+}
+
+pub(crate) fn dependency_cache_manifest_command(cache_path: &str, json: &str) -> String {
+    WorkspaceMaterializer::new(cache_path)
+        .op(WorkspaceMaterializationOperation::EnsureDestDir)
+        .op(
+            WorkspaceMaterializationOperation::WriteDependencyCacheManifest {
+                json: json.to_string(),
+            },
+        )
+        .command()
+}
+
+fn dest_child_path(path: &str) -> String {
+    format!("\"$dest\"/{}", shell::quote_arg(path))
 }
 
 fn git_checkout_command(head: &str, branch: Option<&str>) -> String {

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -28,6 +28,10 @@ pub use types::{
 };
 
 pub(crate) use materialized::{MaterializedWorkspace, WorkspaceCleanupPolicy};
+pub(crate) use materializer::{
+    dependency_cache_manifest_command, dependency_cache_restore_command,
+    dependency_cache_save_command,
+};
 pub(crate) use snapshot::{
     copy_snapshot_to_directory, effective_snapshot_excludes, local_snapshot_stats,
     materialize_snapshot, materialize_snapshot_git, snapshot_identity,

--- a/src/core/runner/workspace/tests/materializer.rs
+++ b/src/core/runner/workspace/tests/materializer.rs
@@ -1,5 +1,6 @@
 use crate::core::runner::workspace::materializer::{
-    WorkspaceMaterializationOperation, WorkspaceMaterializer,
+    dependency_cache_manifest_command, dependency_cache_restore_command,
+    dependency_cache_save_command, WorkspaceMaterializationOperation, WorkspaceMaterializer,
 };
 
 #[test]
@@ -90,4 +91,49 @@ fn workspace_materializer_builds_direct_git_checkout_command() {
     assert!(command.contains("checkout --detach abc123"));
     assert!(command.contains("git -C \"$dest\" clean -ffdqx"));
     assert!(command.contains("chown -R \"$owner\" $dest"));
+}
+
+#[test]
+fn workspace_materializer_builds_dependency_cache_restore_command() {
+    let command = dependency_cache_restore_command(
+        "/srv/homeboy/_lab_workspaces/homeboy-abc",
+        "vendor/cache with spaces",
+        "/srv/homeboy/_dependency_cache/key/vendor__cache.tar",
+    );
+
+    assert!(command.contains("dest=/srv/homeboy/_lab_workspaces/homeboy-abc"));
+    assert!(command.contains("mkdir -p \"$dest\""));
+    assert!(command.contains("rm -rf \"$dest\"/'vendor/cache with spaces'"));
+    assert!(command
+        .contains("tar -C \"$dest\" -xf /srv/homeboy/_dependency_cache/key/vendor__cache.tar"));
+}
+
+#[test]
+fn workspace_materializer_builds_dependency_cache_save_command() {
+    let command = dependency_cache_save_command(
+        "/srv/homeboy/_lab_workspaces/homeboy-abc",
+        "/srv/homeboy/_dependency_cache/key",
+        "vendor/cache with spaces",
+        "/srv/homeboy/_dependency_cache/key/vendor__cache.tar",
+    );
+
+    assert!(command.contains("dest=/srv/homeboy/_dependency_cache/key"));
+    assert!(command.contains("mkdir -p \"$dest\""));
+    assert!(command.contains("mkdir -p /srv/homeboy/_dependency_cache/key"));
+    assert!(command.contains(
+        "tar -C /srv/homeboy/_lab_workspaces/homeboy-abc -cf /srv/homeboy/_dependency_cache/key/vendor__cache.tar 'vendor/cache with spaces'"
+    ));
+}
+
+#[test]
+fn workspace_materializer_builds_dependency_cache_manifest_command() {
+    let command = dependency_cache_manifest_command(
+        "/srv/homeboy/_dependency_cache/key",
+        "{\n  \"key\": \"dep-cache\"\n}",
+    );
+
+    assert!(command.contains("dest=/srv/homeboy/_dependency_cache/key"));
+    assert!(command.contains("mkdir -p \"$dest\""));
+    assert!(command.contains("printf %s '{"));
+    assert!(command.contains("}' > \"$dest\"/manifest.json"));
 }


### PR DESCRIPTION
## Summary
- move dependency-cache restore/save/manifest shell command construction onto WorkspaceMaterializer helpers
- keep dependency-cache behavior unchanged while removing inline ad-hoc command assembly from the real git dependency materialization path
- add materializer builder coverage for restore, save, and manifest-writing commands, including quoted cache paths

## Verification
- PASS: homeboy test homeboy --runner homeboy-lab --lab-only --skip-lint -- core::runner::workspace::tests::materializer
- PASS: homeboy test homeboy --runner homeboy-lab --lab-only --skip-lint -- dependency_cache
- PASS: git diff --check
- NOTE: homeboy test without --skip-lint currently fails before tests because the branch/base has broad rustfmt drift reported as 71 files needing formatting; this PR keeps the diff scoped and does not reformat unrelated files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Implemented the scoped materializer migration, added focused tests, and ran runner-backed verification.