### PR TITLE
Add rig host mutation pipeline step

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -350,6 +350,38 @@ Executable requirements are provider-agnostic. If `executable_env` is set and th
 
 Applies or verifies an idempotent local-only patch. `marker` must appear in `content`; when the marker is already present, `apply` is a no-op. If `after` is set and not found, the step fails rather than guessing where to insert. Use `op: "verify"` in `check` pipelines.
 
+### `host-mutation`
+
+```jsonc
+{
+  "kind": "host-mutation",
+  "op": "apply",
+  "dry_run": false,
+  "lifecycle": {
+    "schema": "homeboy/host-mutation-lifecycle/v1",
+    "owner": "example-rig",
+    "run_id": "example-rig-up",
+    "mutations": [
+      {
+        "id": "link-tool",
+        "actor": "rig.pipeline.up",
+        "kind": "symlink",
+        "link_path": "~/bin/example-tool",
+        "target_path": "${components.app.path}/bin/example-tool",
+        "status": "declared",
+        "revert": { "strategy": "remove_path" }
+      }
+    ]
+  }
+}
+```
+
+Consumes the generic `homeboy/host-mutation-lifecycle/v1` contract from rig pipelines. `op` defaults to `validate`; supported values are `validate`, `apply`, and `revert`. `validate` is read-only. `dry_run: true` validates and expands the lifecycle without changing files, regardless of `op`.
+
+Supported mutation kinds are the contract kinds: `symlink`, `temp_dir`, `file_backup`, and `package_manifest_rewrite`. Revert runs mutations in reverse order using each record's `revert` plan. Path fields support normal rig expansion (`~`, `${env.NAME}`, `${components.<id>.path}`, `${package.root}`).
+
+Package manifest rewrites operate on JSON package manifests and update common dependency sections (`dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`) using each change's `before`/`after` guard. Declare `revert.backup_path` with `strategy: "restore_package_manifest"` so `op: "revert"` can restore the original file.
+
 ### `command`
 
 ```jsonc

--- a/src/core/rig/pipeline/host_mutation_step.rs
+++ b/src/core/rig/pipeline/host_mutation_step.rs
@@ -1,0 +1,428 @@
+//! Host mutation lifecycle pipeline step execution.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::super::expand::expand_vars;
+use super::super::spec::{HostMutationOp, RigSpec};
+use crate::core::error::{Error, Result};
+use crate::core::host_mutation_lifecycle::{
+    HostMutation, HostMutationLifecycle, HostMutationRecord, HostMutationRevertStrategy,
+    HostMutationStatus,
+};
+
+pub(super) fn run_host_mutation_step(
+    rig: &RigSpec,
+    op: HostMutationOp,
+    dry_run: bool,
+    lifecycle: &HostMutationLifecycle,
+) -> Result<()> {
+    let lifecycle = expand_lifecycle(rig, lifecycle);
+    lifecycle.validate()?;
+
+    if dry_run || op == HostMutationOp::Validate {
+        return Ok(());
+    }
+
+    match op {
+        HostMutationOp::Validate => Ok(()),
+        HostMutationOp::Apply => {
+            for record in &lifecycle.mutations {
+                apply_record(rig, record)?;
+            }
+            Ok(())
+        }
+        HostMutationOp::Revert => {
+            for record in lifecycle.mutations.iter().rev() {
+                revert_record(rig, record)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn expand_lifecycle(rig: &RigSpec, lifecycle: &HostMutationLifecycle) -> HostMutationLifecycle {
+    let mut lifecycle = lifecycle.clone();
+    for record in &mut lifecycle.mutations {
+        record.actor = expand_vars(rig, &record.actor);
+        record.mutation = expand_mutation(rig, &record.mutation);
+        record.revert.backup_path = record
+            .revert
+            .backup_path
+            .as_deref()
+            .map(|value| expand_vars(rig, value));
+        record.revert.target_path = record
+            .revert
+            .target_path
+            .as_deref()
+            .map(|value| expand_vars(rig, value));
+    }
+    lifecycle
+}
+
+fn expand_mutation(rig: &RigSpec, mutation: &HostMutation) -> HostMutation {
+    match mutation {
+        HostMutation::Symlink {
+            link_path,
+            target_path,
+            previous_target_path,
+        } => HostMutation::Symlink {
+            link_path: expand_vars(rig, link_path),
+            target_path: expand_vars(rig, target_path),
+            previous_target_path: previous_target_path
+                .as_deref()
+                .map(|value| expand_vars(rig, value)),
+        },
+        HostMutation::TempDir { path, purpose } => HostMutation::TempDir {
+            path: expand_vars(rig, path),
+            purpose: purpose.clone(),
+        },
+        HostMutation::FileBackup {
+            original_path,
+            backup_path,
+        } => HostMutation::FileBackup {
+            original_path: expand_vars(rig, original_path),
+            backup_path: expand_vars(rig, backup_path),
+        },
+        HostMutation::PackageManifestRewrite {
+            manifest_path,
+            package_manager,
+            changes,
+        } => HostMutation::PackageManifestRewrite {
+            manifest_path: expand_vars(rig, manifest_path),
+            package_manager: package_manager.clone(),
+            changes: changes.clone(),
+        },
+    }
+}
+
+fn apply_record(rig: &RigSpec, record: &HostMutationRecord) -> Result<()> {
+    if matches!(
+        record.status,
+        HostMutationStatus::Reverted | HostMutationStatus::Failed
+    ) {
+        return Err(step_error(
+            rig,
+            format!(
+                "mutation '{}' has status {:?} and cannot be applied",
+                record.id, record.status
+            ),
+        ));
+    }
+
+    match &record.mutation {
+        HostMutation::Symlink {
+            link_path,
+            target_path,
+            ..
+        } => apply_symlink(rig, Path::new(link_path), Path::new(target_path)),
+        HostMutation::TempDir { path, .. } => std::fs::create_dir_all(path)
+            .map_err(|e| step_error(rig, format!("create temp dir {}: {}", path, e))),
+        HostMutation::FileBackup {
+            original_path,
+            backup_path,
+        } => {
+            if Path::new(backup_path).exists() {
+                Ok(())
+            } else {
+                copy_file(rig, original_path, backup_path, "backup file")
+            }
+        }
+        HostMutation::PackageManifestRewrite { manifest_path, .. } => {
+            let backup_path = record.revert.backup_path.as_deref().ok_or_else(|| {
+                step_error(
+                    rig,
+                    format!(
+                        "mutation '{}' requires revert.backup_path before package manifest rewrite",
+                        record.id
+                    ),
+                )
+            })?;
+            if !Path::new(backup_path).exists() {
+                copy_file(rig, manifest_path, backup_path, "backup package manifest")?;
+            }
+            rewrite_package_manifest(rig, record)
+        }
+    }
+}
+
+fn revert_record(rig: &RigSpec, record: &HostMutationRecord) -> Result<()> {
+    match record.revert.strategy {
+        HostMutationRevertStrategy::RemovePath => match &record.mutation {
+            HostMutation::Symlink { link_path, .. } => remove_path(rig, link_path),
+            HostMutation::TempDir { path, .. } => remove_path(rig, path),
+            _ => Err(step_error(
+                rig,
+                format!(
+                    "mutation '{}' cannot be reverted by removing a path",
+                    record.id
+                ),
+            )),
+        },
+        HostMutationRevertStrategy::RestoreBackup => match &record.mutation {
+            HostMutation::FileBackup { original_path, .. } => {
+                let backup_path = record.revert.backup_path.as_deref().ok_or_else(|| {
+                    step_error(
+                        rig,
+                        format!("mutation '{}' is missing backup_path", record.id),
+                    )
+                })?;
+                copy_file(rig, backup_path, original_path, "restore backup")
+            }
+            _ => Err(step_error(
+                rig,
+                format!("mutation '{}' is not a file backup", record.id),
+            )),
+        },
+        HostMutationRevertStrategy::RestoreSymlink => match &record.mutation {
+            HostMutation::Symlink {
+                link_path,
+                previous_target_path,
+                ..
+            } => {
+                let target_path = record
+                    .revert
+                    .target_path
+                    .as_deref()
+                    .or(previous_target_path.as_deref())
+                    .ok_or_else(|| {
+                        step_error(
+                            rig,
+                            format!("mutation '{}' is missing target_path", record.id),
+                        )
+                    })?;
+                apply_symlink(rig, Path::new(link_path), Path::new(target_path))
+            }
+            _ => Err(step_error(
+                rig,
+                format!("mutation '{}' is not a symlink", record.id),
+            )),
+        },
+        HostMutationRevertStrategy::RestorePackageManifest => match &record.mutation {
+            HostMutation::PackageManifestRewrite { manifest_path, .. } => {
+                let backup_path = record.revert.backup_path.as_deref().ok_or_else(|| {
+                    step_error(
+                        rig,
+                        format!("mutation '{}' is missing backup_path", record.id),
+                    )
+                })?;
+                copy_file(rig, backup_path, manifest_path, "restore package manifest")
+            }
+            _ => Err(step_error(
+                rig,
+                format!("mutation '{}' is not a package manifest rewrite", record.id),
+            )),
+        },
+        HostMutationRevertStrategy::Manual => Err(step_error(
+            rig,
+            format!(
+                "mutation '{}' requires manual revert: {}",
+                record.id,
+                record.revert.notes.as_deref().unwrap_or("no notes")
+            ),
+        )),
+    }
+}
+
+fn apply_symlink(rig: &RigSpec, link_path: &Path, target_path: &Path) -> Result<()> {
+    if let Some(parent) = link_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            step_error(
+                rig,
+                format!("create parent of {}: {}", link_path.display(), e),
+            )
+        })?;
+    }
+
+    match std::fs::symlink_metadata(link_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let current = std::fs::read_link(link_path)
+                .map_err(|e| step_error(rig, format!("read {}: {}", link_path.display(), e)))?;
+            if current == target_path {
+                return Ok(());
+            }
+            std::fs::remove_file(link_path)
+                .map_err(|e| step_error(rig, format!("remove {}: {}", link_path.display(), e)))?;
+        }
+        Ok(_) => {
+            return Err(step_error(
+                rig,
+                format!(
+                    "{} exists and is not a symlink; refusing to replace it",
+                    link_path.display()
+                ),
+            ));
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(step_error(
+                rig,
+                format!("stat {}: {}", link_path.display(), e),
+            ));
+        }
+    }
+
+    create_symlink(target_path, link_path).map_err(|e| {
+        step_error(
+            rig,
+            format!(
+                "create {} -> {}: {}",
+                link_path.display(),
+                target_path.display(),
+                e
+            ),
+        )
+    })
+}
+
+#[cfg(unix)]
+fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(not(unix))]
+fn create_symlink(_target: &Path, _link: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "host mutation symlinks are not supported on this platform",
+    ))
+}
+
+fn remove_path(rig: &RigSpec, path: &str) -> Result<()> {
+    let path = PathBuf::from(path);
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || metadata.is_file() => {
+            std::fs::remove_file(&path)
+                .map_err(|e| step_error(rig, format!("remove {}: {}", path.display(), e)))
+        }
+        Ok(metadata) if metadata.is_dir() => std::fs::remove_dir_all(&path)
+            .map_err(|e| step_error(rig, format!("remove directory {}: {}", path.display(), e))),
+        Ok(_) => Err(step_error(
+            rig,
+            format!(
+                "{} exists but is not a file, symlink, or directory",
+                path.display()
+            ),
+        )),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(step_error(rig, format!("stat {}: {}", path.display(), e))),
+    }
+}
+
+fn copy_file(rig: &RigSpec, from: &str, to: &str, action: &str) -> Result<()> {
+    let from = Path::new(from);
+    let to = Path::new(to);
+    if let Some(parent) = to.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| step_error(rig, format!("create parent of {}: {}", to.display(), e)))?;
+    }
+    std::fs::copy(from, to).map(|_| ()).map_err(|e| {
+        step_error(
+            rig,
+            format!("{} {} -> {}: {}", action, from.display(), to.display(), e),
+        )
+    })
+}
+
+fn rewrite_package_manifest(rig: &RigSpec, record: &HostMutationRecord) -> Result<()> {
+    let HostMutation::PackageManifestRewrite {
+        manifest_path,
+        changes,
+        ..
+    } = &record.mutation
+    else {
+        return Err(step_error(
+            rig,
+            "mutation is not a package manifest rewrite",
+        ));
+    };
+
+    let raw = std::fs::read_to_string(manifest_path)
+        .map_err(|e| step_error(rig, format!("read {}: {}", manifest_path, e)))?;
+    let mut manifest: Value = serde_json::from_str(&raw)
+        .map_err(|e| step_error(rig, format!("parse {} as JSON: {}", manifest_path, e)))?;
+
+    for change in changes {
+        apply_package_change(rig, record, &mut manifest, change)?;
+    }
+
+    let rendered = serde_json::to_string_pretty(&manifest)
+        .map_err(|e| step_error(rig, format!("serialize {}: {}", manifest_path, e)))?;
+    std::fs::write(manifest_path, format!("{}\n", rendered))
+        .map_err(|e| step_error(rig, format!("write {}: {}", manifest_path, e)))
+}
+
+fn apply_package_change(
+    rig: &RigSpec,
+    record: &HostMutationRecord,
+    manifest: &mut Value,
+    change: &crate::core::host_mutation_lifecycle::PackageManifestChange,
+) -> Result<()> {
+    const SECTIONS: &[&str] = &[
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ];
+
+    for section in SECTIONS {
+        let Some(dependencies) = manifest.get_mut(*section).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        if !dependencies.contains_key(&change.package) {
+            continue;
+        }
+        let current = dependencies
+            .get(&change.package)
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if change.before.as_ref() != current.as_ref() {
+            return Err(step_error(
+                rig,
+                format!(
+                    "mutation '{}' expected {} in {} to be {:?}, found {:?}",
+                    record.id, change.package, section, change.before, current
+                ),
+            ));
+        }
+        match &change.after {
+            Some(after) => {
+                dependencies.insert(change.package.clone(), Value::String(after.clone()));
+            }
+            None => {
+                dependencies.remove(&change.package);
+            }
+        }
+        return Ok(());
+    }
+
+    if change.before.is_some() {
+        return Err(step_error(
+            rig,
+            format!(
+                "mutation '{}' expected package {} to exist before rewrite",
+                record.id, change.package
+            ),
+        ));
+    }
+
+    let dependencies = manifest
+        .as_object_mut()
+        .ok_or_else(|| step_error(rig, "package manifest root must be a JSON object"))?
+        .entry("dependencies")
+        .or_insert_with(|| Value::Object(Default::default()))
+        .as_object_mut()
+        .ok_or_else(|| step_error(rig, "package manifest dependencies must be a JSON object"))?;
+    match &change.after {
+        Some(after) => {
+            dependencies.insert(change.package.clone(), Value::String(after.clone()));
+            Ok(())
+        }
+        None => Ok(()),
+    }
+}
+
+fn step_error(rig: &RigSpec, reason: impl Into<String>) -> Error {
+    Error::rig_pipeline_failed(&rig.id, "host-mutation", reason)
+}

--- a/src/core/rig/pipeline/labels.rs
+++ b/src/core/rig/pipeline/labels.rs
@@ -2,7 +2,8 @@
 
 use super::super::expand::expand_vars;
 use super::super::spec::{
-    GitOp, PatchOp, PipelineStep, RigSpec, ServiceOp, SharedPathOp, StackOp, SymlinkOp,
+    GitOp, HostMutationOp, PatchOp, PipelineStep, RigSpec, ServiceOp, SharedPathOp, StackOp,
+    SymlinkOp,
 };
 
 pub(super) fn step_kind(step: &PipelineStep) -> &'static str {
@@ -18,6 +19,7 @@ pub(super) fn step_kind(step: &PipelineStep) -> &'static str {
         PipelineStep::Symlink { .. } => "symlink",
         PipelineStep::SharedPath { .. } => "shared-path",
         PipelineStep::Patch { .. } => "patch",
+        PipelineStep::HostMutation { .. } => "host-mutation",
         PipelineStep::Check { .. } => "check",
     }
 }
@@ -114,6 +116,18 @@ pub(super) fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> Stri
                 truncate(file, 60)
             )
         }),
+        PipelineStep::HostMutation {
+            op,
+            lifecycle,
+            label,
+            ..
+        } => label.clone().unwrap_or_else(|| {
+            format!(
+                "host-mutation {} {}",
+                serialize_host_mutation_op(*op),
+                truncate(&lifecycle.run_id, 60)
+            )
+        }),
         PipelineStep::Check { label, .. } => label
             .clone()
             .unwrap_or_else(|| format!("check #{}", idx + 1)),
@@ -166,6 +180,14 @@ fn serialize_patch_op(op: PatchOp) -> &'static str {
     match op {
         PatchOp::Apply => "apply",
         PatchOp::Verify => "verify",
+    }
+}
+
+fn serialize_host_mutation_op(op: HostMutationOp) -> &'static str {
+    match op {
+        HostMutationOp::Validate => "validate",
+        HostMutationOp::Apply => "apply",
+        HostMutationOp::Revert => "revert",
     }
 }
 

--- a/src/core/rig/pipeline/mod.rs
+++ b/src/core/rig/pipeline/mod.rs
@@ -10,6 +10,7 @@ mod command_step;
 mod component;
 mod fs_step;
 mod git_step;
+mod host_mutation_step;
 mod labels;
 mod ordering;
 mod outcome;
@@ -324,6 +325,12 @@ fn run_step(
         } => {
             patch_step::run_patch_step(rig, component, file, marker, after.as_deref(), content, *op)
         }
+        PipelineStep::HostMutation {
+            op,
+            dry_run,
+            lifecycle,
+            ..
+        } => host_mutation_step::run_host_mutation_step(rig, *op, *dry_run, lifecycle),
         PipelineStep::Check { spec, .. } => check::evaluate(rig, spec),
     }
 }

--- a/src/core/rig/pipeline/ordering.rs
+++ b/src/core/rig/pipeline/ordering.rs
@@ -180,6 +180,7 @@ fn step_id(step: &PipelineStep) -> Option<&str> {
         | PipelineStep::Symlink { step_id, .. }
         | PipelineStep::SharedPath { step_id, .. }
         | PipelineStep::Patch { step_id, .. }
+        | PipelineStep::HostMutation { step_id, .. }
         | PipelineStep::Check { step_id, .. } => step_id.as_deref(),
     }
 }
@@ -197,6 +198,7 @@ fn step_dependencies(step: &PipelineStep) -> &[String] {
         | PipelineStep::Symlink { depends_on, .. }
         | PipelineStep::SharedPath { depends_on, .. }
         | PipelineStep::Patch { depends_on, .. }
+        | PipelineStep::HostMutation { depends_on, .. }
         | PipelineStep::Check { depends_on, .. } => depends_on,
     }
 }

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -25,7 +25,9 @@ pub use dependencies::{
     DependencyMaterializationSafety, DependencyMaterializationStepSpec,
     NormalizedDependencyMaterializationStep,
 };
-pub use pipeline::{GitOp, PatchOp, PipelineStep, ServiceOp, SharedPathOp, StackOp, SymlinkOp};
+pub use pipeline::{
+    GitOp, HostMutationOp, PatchOp, PipelineStep, ServiceOp, SharedPathOp, StackOp, SymlinkOp,
+};
 pub use trace::{
     TraceDependencySpec, TraceExperimentArtifactSpec, TraceExperimentCommandSpec,
     TraceExperimentSpec, TraceGuardrailSpec, TraceNativePublicPreviewSpec,

--- a/src/core/rig/spec/pipeline.rs
+++ b/src/core/rig/spec/pipeline.rs
@@ -4,6 +4,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::core::host_mutation_lifecycle::HostMutationLifecycle;
+
 use super::CheckSpec;
 
 /// A pipeline step. Flat enum via `kind` discriminator so specs stay readable.
@@ -342,6 +344,27 @@ pub enum PipelineStep {
         label: Option<String>,
     },
 
+    /// Validate, apply, or revert a generic reversible host mutation lifecycle.
+    HostMutation {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
+        /// Operation: `validate`, `apply`, or `revert`.
+        #[serde(default = "default_host_mutation_op")]
+        op: HostMutationOp,
+        /// Validate and plan without mutating files.
+        #[serde(default)]
+        dry_run: bool,
+        /// Host mutation lifecycle contract payload.
+        lifecycle: HostMutationLifecycle,
+        /// Human-readable label shown during execution.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+    },
+
     /// Pre-flight / health check. Non-fatal in `up` (warns), fatal in `check`.
     Check {
         /// Optional stable node ID for dependency-aware pipeline ordering.
@@ -366,6 +389,10 @@ pub enum PipelineStep {
 
 fn default_patch_op() -> PatchOp {
     PatchOp::Apply
+}
+
+fn default_host_mutation_op() -> HostMutationOp {
+    HostMutationOp::Validate
 }
 
 /// Git operation supported by a rig `git` step.
@@ -444,4 +471,16 @@ pub enum PatchOp {
     /// Read-only: pass if the marker is present, fail otherwise. Use in
     /// `check` pipelines to surface stale or unpatched checkouts.
     Verify,
+}
+
+/// Host mutation lifecycle operation supported by a rig `host-mutation` step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HostMutationOp {
+    /// Validate the embedded lifecycle contract without touching the host.
+    Validate,
+    /// Apply each declared mutation.
+    Apply,
+    /// Revert each mutation using its declared revert plan.
+    Revert,
 }

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -266,6 +266,303 @@ fn test_bootstrap_step_provides_required_runner_capability_before_consumer() {
     );
 }
 
+#[test]
+fn test_host_mutation_step_reports_contract_validation_failure() {
+    let rig: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "host-mutation-invalid",
+            "pipeline": {
+                "up": [{
+                    "kind": "host-mutation",
+                    "op": "validate",
+                    "lifecycle": {
+                        "schema": "homeboy/host-mutation-lifecycle/v0",
+                        "owner": "fixture",
+                        "run_id": "run-1",
+                        "mutations": []
+                    }
+                }]
+            }
+        }"#,
+    )
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+
+    assert!(!out.is_success());
+    assert_eq!(out.steps[0].kind, "host-mutation");
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(error.contains("expected homeboy/host-mutation-lifecycle/v1"));
+}
+
+#[test]
+fn test_host_mutation_step_dry_run_does_not_mutate_filesystem() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let temp_dir = tmp.path().join("created-by-mutation");
+    let temp_dir_arg = temp_dir.to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "host-mutation-dry-run",
+            "pipeline": {{
+                "up": [{{
+                    "kind": "host-mutation",
+                    "op": "apply",
+                    "dry_run": true,
+                    "lifecycle": {{
+                        "schema": "homeboy/host-mutation-lifecycle/v1",
+                        "owner": "fixture",
+                        "run_id": "run-1",
+                        "mutations": [{{
+                            "id": "temp-dir",
+                            "actor": "test",
+                            "kind": "temp_dir",
+                            "path": "{}",
+                            "status": "declared",
+                            "revert": {{ "strategy": "remove_path" }}
+                        }}]
+                    }}
+                }}]
+            }}
+        }}"#,
+        temp_dir_arg
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+    assert!(
+        !temp_dir.exists(),
+        "dry-run host mutation should not create path"
+    );
+}
+
+#[test]
+fn test_host_mutation_step_applies_and_reverts_package_manifest_rewrite() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let manifest = tmp.path().join("package.json");
+    let backup = tmp.path().join("package.json.homeboy-backup");
+    std::fs::write(
+        &manifest,
+        r#"{
+  "dependencies": {
+    "demo-package": "1.0.0"
+  }
+}
+"#,
+    )
+    .expect("write manifest");
+    let manifest_arg = manifest.to_string_lossy();
+    let backup_arg = backup.to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "host-mutation-package-manifest",
+            "pipeline": {{
+                "up": [{{
+                    "kind": "host-mutation",
+                    "op": "apply",
+                    "lifecycle": {{
+                        "schema": "homeboy/host-mutation-lifecycle/v1",
+                        "owner": "fixture",
+                        "run_id": "run-1",
+                        "mutations": [{{
+                            "id": "rewrite-package",
+                            "actor": "test",
+                            "kind": "package_manifest_rewrite",
+                            "manifest_path": "{}",
+                            "changes": [{{
+                                "package": "demo-package",
+                                "before": "1.0.0",
+                                "after": "2.0.0"
+                            }}],
+                            "status": "declared",
+                            "revert": {{
+                                "strategy": "restore_package_manifest",
+                                "backup_path": "{}"
+                            }}
+                        }}]
+                    }}
+                }}],
+                "down": [{{
+                    "kind": "host-mutation",
+                    "op": "revert",
+                    "lifecycle": {{
+                        "schema": "homeboy/host-mutation-lifecycle/v1",
+                        "owner": "fixture",
+                        "run_id": "run-1",
+                        "mutations": [{{
+                            "id": "rewrite-package",
+                            "actor": "test",
+                            "kind": "package_manifest_rewrite",
+                            "manifest_path": "{}",
+                            "changes": [{{
+                                "package": "demo-package",
+                                "before": "1.0.0",
+                                "after": "2.0.0"
+                            }}],
+                            "status": "applied",
+                            "revert": {{
+                                "strategy": "restore_package_manifest",
+                                "backup_path": "{}"
+                            }}
+                        }}]
+                    }}
+                }}]
+            }}
+        }}"#,
+        manifest_arg, backup_arg, manifest_arg, backup_arg
+    ))
+    .expect("parse rig");
+
+    let up = run_pipeline(&rig, "up", true).expect("up pipeline runs");
+    assert!(up.is_success(), "outcomes: {:?}", up.steps);
+    let rewritten = std::fs::read_to_string(&manifest).expect("read rewritten");
+    assert!(rewritten.contains("2.0.0"), "manifest: {rewritten}");
+    assert!(backup.exists(), "apply should create revert backup");
+
+    let down = run_pipeline(&rig, "down", true).expect("down pipeline runs");
+    assert!(down.is_success(), "outcomes: {:?}", down.steps);
+    let restored = std::fs::read_to_string(&manifest).expect("read restored");
+    assert!(restored.contains("1.0.0"), "manifest: {restored}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_host_mutation_step_applies_and_reverts_filesystem_mutations() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let target = tmp.path().join("target-bin");
+    let link = tmp.path().join("bin/tool");
+    let temp_dir = tmp.path().join("runtime-temp");
+    let original = tmp.path().join("config.json");
+    let backup = tmp.path().join("config.json.homeboy-backup");
+    std::fs::write(&target, "tool").expect("write target");
+    std::fs::write(&original, "original").expect("write original");
+    let target_arg = target.to_string_lossy();
+    let link_arg = link.to_string_lossy();
+    let temp_dir_arg = temp_dir.to_string_lossy();
+    let original_arg = original.to_string_lossy();
+    let backup_arg = backup.to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "host-mutation-filesystem",
+            "pipeline": {{
+                "up": [{{
+                    "kind": "host-mutation",
+                    "op": "apply",
+                    "lifecycle": {{
+                        "schema": "homeboy/host-mutation-lifecycle/v1",
+                        "owner": "fixture",
+                        "run_id": "run-1",
+                        "mutations": [
+                            {{
+                                "id": "link-tool",
+                                "actor": "test",
+                                "kind": "symlink",
+                                "link_path": "{}",
+                                "target_path": "{}",
+                                "status": "declared",
+                                "revert": {{ "strategy": "remove_path" }}
+                            }},
+                            {{
+                                "id": "temp-dir",
+                                "actor": "test",
+                                "kind": "temp_dir",
+                                "path": "{}",
+                                "status": "declared",
+                                "revert": {{ "strategy": "remove_path" }}
+                            }},
+                            {{
+                                "id": "file-backup",
+                                "actor": "test",
+                                "kind": "file_backup",
+                                "original_path": "{}",
+                                "backup_path": "{}",
+                                "status": "declared",
+                                "revert": {{
+                                    "strategy": "restore_backup",
+                                    "backup_path": "{}"
+                                }}
+                            }}
+                        ]
+                    }}
+                }}],
+                "down": [{{
+                    "kind": "host-mutation",
+                    "op": "revert",
+                    "lifecycle": {{
+                        "schema": "homeboy/host-mutation-lifecycle/v1",
+                        "owner": "fixture",
+                        "run_id": "run-1",
+                        "mutations": [
+                            {{
+                                "id": "link-tool",
+                                "actor": "test",
+                                "kind": "symlink",
+                                "link_path": "{}",
+                                "target_path": "{}",
+                                "status": "applied",
+                                "revert": {{ "strategy": "remove_path" }}
+                            }},
+                            {{
+                                "id": "temp-dir",
+                                "actor": "test",
+                                "kind": "temp_dir",
+                                "path": "{}",
+                                "status": "applied",
+                                "revert": {{ "strategy": "remove_path" }}
+                            }},
+                            {{
+                                "id": "file-backup",
+                                "actor": "test",
+                                "kind": "file_backup",
+                                "original_path": "{}",
+                                "backup_path": "{}",
+                                "status": "applied",
+                                "revert": {{
+                                    "strategy": "restore_backup",
+                                    "backup_path": "{}"
+                                }}
+                            }}
+                        ]
+                    }}
+                }}]
+            }}
+        }}"#,
+        link_arg,
+        target_arg,
+        temp_dir_arg,
+        original_arg,
+        backup_arg,
+        backup_arg,
+        link_arg,
+        target_arg,
+        temp_dir_arg,
+        original_arg,
+        backup_arg,
+        backup_arg
+    ))
+    .expect("parse rig");
+
+    let up = run_pipeline(&rig, "up", true).expect("up pipeline runs");
+    assert!(up.is_success(), "outcomes: {:?}", up.steps);
+    assert_eq!(std::fs::read_link(&link).expect("read link"), target);
+    assert!(temp_dir.is_dir(), "temp dir should be created");
+    assert_eq!(
+        std::fs::read_to_string(&backup).expect("read backup"),
+        "original"
+    );
+
+    std::fs::write(&original, "changed").expect("change original");
+    let down = run_pipeline(&rig, "down", true).expect("down pipeline runs");
+    assert!(down.is_success(), "outcomes: {:?}", down.steps);
+    assert!(!link.exists(), "revert should remove symlink");
+    assert!(!temp_dir.exists(), "revert should remove temp dir");
+    assert_eq!(
+        std::fs::read_to_string(&original).expect("read restored"),
+        "original"
+    );
+}
+
 struct EnvRestore {
     name: &'static str,
     previous: Option<String>,


### PR DESCRIPTION
## Summary
- Add a generic `host-mutation` rig pipeline step that consumes `homeboy/host-mutation-lifecycle/v1` payloads.
- Support `validate`, `apply`, and `revert` operations with `dry_run` validation-only behavior.
- Apply/revert symlink, temp dir, file backup, and JSON package manifest rewrite mutations through the shared contract.
- Document the new rig spec shape and add targeted pipeline tests for validation, dry-run, filesystem mutations, and package manifest rewrite rollback.

## Tests
- `cargo check`
- `cargo test core::rig::pipeline::pipeline_test::test_host_mutation_step --lib`
- `cargo test core::host_mutation_lifecycle::tests --lib`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the rig pipeline schema/executor/docs/tests and ran verification in collaboration with Chris.