### PR TITLE
Add runner execution contract projections

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -30,11 +30,12 @@ pub use crate::core::artifact_ref::{
 };
 pub use constants::{
     artifact_manifest_constants, artifact_postprocess_constants, contract_constants,
-    loop_constants, resource_lifecycle_index_constants, reviewer_facing_ref_constants,
-    run_location_index_constants, secret_env_plan_constants, AllContractConstants,
-    ArtifactManifestConstants, ArtifactPostprocessConstants, ContractConstants,
-    ContractConstantsOutput, LoopConstants, ResourceLifecycleIndexConstants,
-    ReviewerFacingRefConstants, RunLocationIndexConstants, SecretEnvPlanConstants,
+    loop_constants, path_materialization_plan_constants, resource_lifecycle_index_constants,
+    reviewer_facing_ref_constants, run_location_index_constants, runner_execution_record_constants,
+    secret_env_plan_constants, AllContractConstants, ArtifactManifestConstants,
+    ArtifactPostprocessConstants, ContractConstants, ContractConstantsOutput, LoopConstants,
+    PathMaterializationPlanConstants, ResourceLifecycleIndexConstants, ReviewerFacingRefConstants,
+    RunLocationIndexConstants, RunnerExecutionRecordConstants, SecretEnvPlanConstants,
     CONTRACT_CONSTANTS_SCHEMA,
 };
 pub use lab::{
@@ -83,5 +84,16 @@ pub use crate::core::artifacts::{
 };
 pub use crate::core::run_lifecycle_status::{RunLifecycleStatus, RUN_LIFECYCLE_STATUS_SCHEMA};
 pub use crate::core::run_outcome_envelope::{
-    RunOutcomeEnvelope, RunOutcomeHandoffRef, RUN_OUTCOME_ENVELOPE_SCHEMA,
+    RunOutcomeEnvelope, RunOutcomeHandoffRef, RunOutcomeProjection, RUN_OUTCOME_ENVELOPE_SCHEMA,
+};
+pub use crate::core::runner_execution_envelope::{
+    PathMaterializationEntry, PathMaterializationMode, PathMaterializationPlan,
+    PathMaterializationProjection, RunnerExecutionArtifactRef, RunnerExecutionNextAction,
+    RunnerExecutionProjection, RunnerExecutionRecord, PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
+    PATH_MATERIALIZATION_MODE_GIT, PATH_MATERIALIZATION_MODE_SNAPSHOT,
+    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS,
+    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT, PATH_MATERIALIZATION_PLAN_SCHEMA,
+    PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE, PATH_MATERIALIZATION_ROLE_REQUIRED_PATH,
+    PATH_MATERIALIZATION_STATUS_MATERIALIZED, PATH_MATERIALIZATION_STATUS_VALIDATED,
+    RUNNER_EXECUTION_RECORD_SCHEMA,
 };

--- a/src/command_contract/constants.rs
+++ b/src/command_contract/constants.rs
@@ -7,6 +7,13 @@ use crate::core::agent_task_loop_controller::{
 };
 use crate::core::agent_task_loop_definition::AGENT_TASK_LOOP_DEFINITION_SCHEMA;
 use crate::core::artifact_ref::{HOMEBOY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME};
+use crate::core::runner_execution_envelope::{
+    PATH_MATERIALIZATION_MODE_EXISTING_REMOTE, PATH_MATERIALIZATION_MODE_GIT,
+    PATH_MATERIALIZATION_MODE_SNAPSHOT, PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS,
+    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT, PATH_MATERIALIZATION_PLAN_SCHEMA,
+    PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE, PATH_MATERIALIZATION_ROLE_REQUIRED_PATH,
+    PATH_MATERIALIZATION_STATUS_MATERIALIZED, PATH_MATERIALIZATION_STATUS_VALIDATED,
+};
 
 pub const CONTRACT_CONSTANTS_SCHEMA: &str = "homeboy/contract-constants/v1";
 
@@ -28,6 +35,8 @@ pub enum ContractConstants {
     ResourceLifecycleIndex(ResourceLifecycleIndexConstants),
     HostMutationLifecycle(HostMutationLifecycleConstants),
     RunLocationIndex(RunLocationIndexConstants),
+    RunnerExecutionRecord(RunnerExecutionRecordConstants),
+    PathMaterializationPlan(PathMaterializationPlanConstants),
     ReviewerFacingRef(ReviewerFacingRefConstants),
 }
 
@@ -40,6 +49,8 @@ pub struct AllContractConstants {
     pub resource_lifecycle_index: ResourceLifecycleIndexConstants,
     pub host_mutation_lifecycle: HostMutationLifecycleConstants,
     pub run_location_index: RunLocationIndexConstants,
+    pub runner_execution_record: RunnerExecutionRecordConstants,
+    pub path_materialization_plan: PathMaterializationPlanConstants,
     pub reviewer_facing_ref: ReviewerFacingRefConstants,
 }
 
@@ -83,6 +94,21 @@ pub struct RunLocationIndexConstants {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerExecutionRecordConstants {
+    pub schema_id: String,
+    pub projection_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PathMaterializationPlanConstants {
+    pub schema_id: String,
+    pub roles: Vec<String>,
+    pub owners: Vec<String>,
+    pub materialization_modes: Vec<String>,
+    pub validation_statuses: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ReviewerFacingRefConstants {
     pub accepted_schemes: Vec<String>,
 }
@@ -98,6 +124,8 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
             resource_lifecycle_index: resource_lifecycle_index_constants(),
             host_mutation_lifecycle: host_mutation_lifecycle_constants(),
             run_location_index: run_location_index_constants(),
+            runner_execution_record: runner_execution_record_constants(),
+            path_materialization_plan: path_materialization_plan_constants(),
             reviewer_facing_ref: reviewer_facing_ref_constants(),
         }),
         "artifact-manifest" => ContractConstants::ArtifactManifest(artifact_manifest_constants()),
@@ -113,6 +141,12 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
             ContractConstants::HostMutationLifecycle(host_mutation_lifecycle_constants())
         }
         "run-location-index" => ContractConstants::RunLocationIndex(run_location_index_constants()),
+        "runner-execution-record" => {
+            ContractConstants::RunnerExecutionRecord(runner_execution_record_constants())
+        }
+        "path-materialization-plan" => {
+            ContractConstants::PathMaterializationPlan(path_materialization_plan_constants())
+        }
         "reviewer-facing-ref" | "reviewer-ref" => {
             ContractConstants::ReviewerFacingRef(reviewer_facing_ref_constants())
         }
@@ -169,6 +203,49 @@ pub fn host_mutation_lifecycle_constants() -> HostMutationLifecycleConstants {
 pub fn run_location_index_constants() -> RunLocationIndexConstants {
     RunLocationIndexConstants {
         schema_id: registry_schema_id("run-location-index"),
+    }
+}
+
+pub fn runner_execution_record_constants() -> RunnerExecutionRecordConstants {
+    RunnerExecutionRecordConstants {
+        schema_id: registry_schema_id("runner-execution-record"),
+        projection_fields: vec![
+            "execution_id".to_string(),
+            "runner_id".to_string(),
+            "transport".to_string(),
+            "status".to_string(),
+            "job_id".to_string(),
+            "local_run_id".to_string(),
+            "remote_run_id".to_string(),
+            "agent_task_run_id".to_string(),
+            "mirror_run_id".to_string(),
+            "materialized_paths".to_string(),
+            "artifact_refs".to_string(),
+            "next_actions".to_string(),
+        ],
+    }
+}
+
+pub fn path_materialization_plan_constants() -> PathMaterializationPlanConstants {
+    PathMaterializationPlanConstants {
+        schema_id: PATH_MATERIALIZATION_PLAN_SCHEMA.to_string(),
+        roles: vec![
+            PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE.to_string(),
+            PATH_MATERIALIZATION_ROLE_REQUIRED_PATH.to_string(),
+        ],
+        owners: vec![
+            PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT.to_string(),
+            PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS.to_string(),
+        ],
+        materialization_modes: vec![
+            PATH_MATERIALIZATION_MODE_EXISTING_REMOTE.to_string(),
+            PATH_MATERIALIZATION_MODE_GIT.to_string(),
+            PATH_MATERIALIZATION_MODE_SNAPSHOT.to_string(),
+        ],
+        validation_statuses: vec![
+            PATH_MATERIALIZATION_STATUS_MATERIALIZED.to_string(),
+            PATH_MATERIALIZATION_STATUS_VALIDATED.to_string(),
+        ],
     }
 }
 

--- a/src/command_contract/registry.rs
+++ b/src/command_contract/registry.rs
@@ -162,6 +162,22 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         summary: "Generic inspectable run outcome envelope that normalizes artifact, evidence, handoff, result, fuzz, and agent-task proof references.",
         rust_type: "homeboy::core::run_outcome_envelope::RunOutcomeEnvelope",
     },
+    ContractRegistryEntry {
+        schema_id: crate::core::runner_execution_envelope::RUNNER_EXECUTION_RECORD_SCHEMA,
+        name: "runner-execution-record",
+        title: "Runner execution record",
+        owner: "homeboy-core",
+        summary: "Generic terminal runner execution record with stable IDs, materialized paths, artifact references, and follow-up actions.",
+        rust_type: "homeboy::core::runner_execution_envelope::RunnerExecutionRecord",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::runner_execution_envelope::PATH_MATERIALIZATION_PLAN_SCHEMA,
+        name: "path-materialization-plan",
+        title: "Path materialization plan",
+        owner: "homeboy-core",
+        summary: "Generic runner-side path materialization entries for source snapshots and required remote paths.",
+        rust_type: "homeboy::core::runner_execution_envelope::PathMaterializationPlan",
+    },
 ];
 
 pub fn registered_contracts() -> &'static [ContractRegistryEntry] {
@@ -209,6 +225,8 @@ mod tests {
             "resolved-agent-runtime-execution-contract",
             "reviewer-facing-artifact-ref",
             "run-outcome-envelope",
+            "runner-execution-record",
+            "path-materialization-plan",
         ] {
             assert!(names.contains(name), "missing {name}");
         }

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -35,6 +35,13 @@ use crate::core::resource_lifecycle_index::{
     ResourceLifecycleResourceStatus, RESOURCE_LIFECYCLE_INDEX_SCHEMA,
 };
 use crate::core::run_lifecycle_status::{RunLifecycleStatus, RUN_LIFECYCLE_STATUS_SCHEMA};
+use crate::core::run_outcome_envelope::{
+    RunOutcomeEnvelope, RunOutcomeProjection, RUN_OUTCOME_ENVELOPE_SCHEMA,
+};
+use crate::core::runner_execution_envelope::{
+    PathMaterializationPlan, RunnerExecutionProjection, RunnerExecutionRecord,
+    PATH_MATERIALIZATION_PLAN_SCHEMA, RUNNER_EXECUTION_RECORD_SCHEMA,
+};
 use crate::core::secret_env_plan::{SecretEnvPlan, SECRET_ENV_PLAN_SCHEMA};
 use crate::core::{Error, Result};
 
@@ -67,7 +74,7 @@ pub enum ContractCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct ContractConstantsArgs {
-    /// Contract ID: all, artifact-manifest, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, reviewer-facing-ref.
+    /// Contract ID: all, artifact-manifest, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, runner-execution-record, path-materialization-plan, reviewer-facing-ref.
     pub contract_id: String,
 }
 
@@ -119,6 +126,8 @@ pub struct ContractNormalizeArgs {
 pub enum ContractNormalizeKind {
     ArtifactRef,
     RunLifecycleStatus,
+    RunnerExecutionRecord,
+    RunOutcomeEnvelope,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -162,6 +171,8 @@ pub struct ContractValidateOutput {
 pub enum ContractNormalizeOutput {
     ArtifactRef(ArtifactRefNormalizeOutput),
     RunLifecycleStatus(RunLifecycleStatusNormalizeOutput),
+    RunnerExecutionRecord(RunnerExecutionProjection),
+    RunOutcomeEnvelope(RunOutcomeProjection),
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -408,7 +419,7 @@ fn constants(contract_id: &str) -> CmdResult<ContractOutput> {
             format!("unknown contract constants id `{contract_id}`"),
             None,
             Some(vec![
-                    "Use one of: all, artifact-manifest, artifact-postprocess, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, reviewer-facing-ref".to_string(),
+                    "Use one of: all, artifact-manifest, artifact-postprocess, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, runner-execution-record, path-materialization-plan, reviewer-facing-ref".to_string(),
             ]),
         )
     })?;
@@ -425,6 +436,11 @@ fn normalize(args: ContractNormalizeArgs) -> Result<ContractNormalizeOutput> {
         }
         ContractNormalizeKind::RunLifecycleStatus => {
             normalize_run_lifecycle_status(value).map(ContractNormalizeOutput::RunLifecycleStatus)
+        }
+        ContractNormalizeKind::RunnerExecutionRecord => normalize_runner_execution_record(value)
+            .map(ContractNormalizeOutput::RunnerExecutionRecord),
+        ContractNormalizeKind::RunOutcomeEnvelope => {
+            normalize_run_outcome_envelope(value).map(ContractNormalizeOutput::RunOutcomeEnvelope)
         }
     }
 }
@@ -484,6 +500,41 @@ fn normalize_run_lifecycle_status(value: Value) -> Result<RunLifecycleStatusNorm
         is_terminal: status.is_terminal(),
         is_success: status.is_success(),
         is_retryable: status.is_retryable(),
+    })
+}
+
+fn normalize_runner_execution_record(value: Value) -> Result<RunnerExecutionProjection> {
+    let record: RunnerExecutionRecord = deserialize_contract_value(
+        value,
+        "runner-execution-record",
+        "expected a runner execution record JSON object",
+    )?;
+
+    Ok(record.projection())
+}
+
+fn normalize_run_outcome_envelope(value: Value) -> Result<RunOutcomeProjection> {
+    let envelope: RunOutcomeEnvelope = deserialize_contract_value(
+        value,
+        "run-outcome-envelope",
+        "expected a run outcome envelope JSON object",
+    )?;
+
+    Ok(envelope.projection())
+}
+
+fn deserialize_contract_value<T: DeserializeOwned>(
+    value: Value,
+    field: &'static str,
+    hint: &'static str,
+) -> Result<T> {
+    serde_json::from_value(value).map_err(|err| {
+        Error::validation_invalid_argument(
+            field,
+            err.to_string(),
+            None,
+            Some(vec![hint.to_string()]),
+        )
     })
 }
 
@@ -1283,6 +1334,18 @@ static CONTRACT_SCHEMAS: &[ContractSchema] = &[
         id: LOOP_EVIDENCE_SCHEMA,
         validate_json: validate_loop_evidence,
     },
+    ContractSchema {
+        id: RUNNER_EXECUTION_RECORD_SCHEMA,
+        validate_json: validate_runner_execution_record,
+    },
+    ContractSchema {
+        id: PATH_MATERIALIZATION_PLAN_SCHEMA,
+        validate_json: validate_path_materialization_plan,
+    },
+    ContractSchema {
+        id: RUN_OUTCOME_ENVELOPE_SCHEMA,
+        validate_json: validate_run_outcome_envelope,
+    },
 ];
 
 fn validate_secret_env_plan(raw: &str) -> homeboy::core::Result<()> {
@@ -1342,6 +1405,22 @@ fn validate_loop_iteration(raw: &str) -> homeboy::core::Result<()> {
 fn validate_loop_evidence(raw: &str) -> homeboy::core::Result<()> {
     let record: LoopEvidenceRecord = deserialize_contract(raw, LOOP_EVIDENCE_SCHEMA)?;
     validate_schema_field(LOOP_EVIDENCE_SCHEMA, &record.schema)
+}
+
+fn validate_runner_execution_record(raw: &str) -> homeboy::core::Result<()> {
+    let record: RunnerExecutionRecord = deserialize_contract(raw, RUNNER_EXECUTION_RECORD_SCHEMA)?;
+    validate_schema_field(RUNNER_EXECUTION_RECORD_SCHEMA, &record.schema)
+}
+
+fn validate_path_materialization_plan(raw: &str) -> homeboy::core::Result<()> {
+    let plan: PathMaterializationPlan =
+        deserialize_contract(raw, PATH_MATERIALIZATION_PLAN_SCHEMA)?;
+    validate_schema_field(PATH_MATERIALIZATION_PLAN_SCHEMA, &plan.schema)
+}
+
+fn validate_run_outcome_envelope(raw: &str) -> homeboy::core::Result<()> {
+    let envelope: RunOutcomeEnvelope = deserialize_contract(raw, RUN_OUTCOME_ENVELOPE_SCHEMA)?;
+    validate_schema_field(RUN_OUTCOME_ENVELOPE_SCHEMA, &envelope.schema)
 }
 
 fn deserialize_contract<T: DeserializeOwned>(
@@ -1595,6 +1674,63 @@ mod tests {
     }
 
     #[test]
+    fn runner_execution_record_normalizer_projects_materialized_paths() {
+        let output = normalize_runner_execution_record(json!({
+            "schema": RUNNER_EXECUTION_RECORD_SCHEMA,
+            "execution_id": "job-1",
+            "runner_id": "lab-a",
+            "transport": "daemon",
+            "status": "succeeded",
+            "job_id": "job-1",
+            "remote_run_id": "run-1",
+            "path_materialization_plan": {
+                "schema": PATH_MATERIALIZATION_PLAN_SCHEMA,
+                "entries": [
+                    {
+                        "role": "primary_workspace",
+                        "owner": "runner_exec.source_snapshot",
+                        "local_path": "/local/project",
+                        "remote_path": "/runner/project",
+                        "materialization_mode": "snapshot",
+                        "validation_status": "materialized"
+                    }
+                ]
+            },
+            "artifact_refs": [
+                { "id": "summary", "path": "artifacts/summary.json" }
+            ],
+            "next_actions": []
+        }))
+        .expect("runner execution record should normalize");
+
+        assert_eq!(output.execution_id, "job-1");
+        assert_eq!(output.remote_run_id.as_deref(), Some("run-1"));
+        assert_eq!(output.materialized_paths.len(), 1);
+        assert_eq!(output.materialized_paths[0].remote_path, "/runner/project");
+        assert_eq!(output.artifact_refs[0].id, "summary");
+    }
+
+    #[test]
+    fn run_outcome_envelope_normalizer_projects_inspection_fields() {
+        let output = normalize_run_outcome_envelope(json!({
+            "schema": RUN_OUTCOME_ENVELOPE_SCHEMA,
+            "status": "succeeded",
+            "run_id": "run-1",
+            "runner_id": "lab-a",
+            "exit_code": 0,
+            "artifact_refs": [],
+            "evidence_refs": [],
+            "handoffs": [],
+            "result": { "nested": "payload" }
+        }))
+        .expect("run outcome envelope should normalize");
+
+        assert_eq!(output.run_id.as_deref(), Some("run-1"));
+        assert_eq!(output.runner_id.as_deref(), Some("lab-a"));
+        assert_eq!(output.exit_code, Some(0));
+    }
+
+    #[test]
     fn validates_secret_env_plan_json_file() {
         let dir = TempDir::new().unwrap();
         let file = write_json(
@@ -1609,6 +1745,71 @@ mod tests {
         let output = validate_file(SECRET_ENV_PLAN_SCHEMA, file).unwrap();
 
         assert_eq!(output.schema, SECRET_ENV_PLAN_SCHEMA);
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn validates_runner_execution_record_json_file() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "runner-execution-record.json",
+            json!({
+                "schema": RUNNER_EXECUTION_RECORD_SCHEMA,
+                "execution_id": "job-1",
+                "runner_id": "lab-a",
+                "transport": "daemon",
+                "status": "succeeded"
+            }),
+        );
+
+        let output = validate_file(RUNNER_EXECUTION_RECORD_SCHEMA, file).unwrap();
+
+        assert_eq!(output.schema, RUNNER_EXECUTION_RECORD_SCHEMA);
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn validates_path_materialization_plan_json_file() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "path-materialization-plan.json",
+            json!({
+                "schema": PATH_MATERIALIZATION_PLAN_SCHEMA,
+                "entries": [
+                    {
+                        "role": "required_path",
+                        "owner": "runner_exec.require_paths",
+                        "remote_path": "/runner/cache",
+                        "materialization_mode": "existing_remote",
+                        "validation_status": "validated"
+                    }
+                ]
+            }),
+        );
+
+        let output = validate_file(PATH_MATERIALIZATION_PLAN_SCHEMA, file).unwrap();
+
+        assert_eq!(output.schema, PATH_MATERIALIZATION_PLAN_SCHEMA);
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn validates_run_outcome_envelope_json_file() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "run-outcome-envelope.json",
+            json!({
+                "schema": RUN_OUTCOME_ENVELOPE_SCHEMA,
+                "status": "succeeded"
+            }),
+        );
+
+        let output = validate_file(RUN_OUTCOME_ENVELOPE_SCHEMA, file).unwrap();
+
+        assert_eq!(output.schema, RUN_OUTCOME_ENVELOPE_SCHEMA);
         assert!(output.valid);
     }
 

--- a/src/core/run_outcome_envelope.rs
+++ b/src/core/run_outcome_envelope.rs
@@ -28,6 +28,24 @@ pub struct RunOutcomeEnvelope {
     pub result: Value,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunOutcomeProjection {
+    pub schema: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<ArtifactRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_refs: Vec<EvidenceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub handoffs: Vec<RunOutcomeHandoffRef>,
+}
+
 impl RunOutcomeEnvelope {
     pub fn new(status: impl Into<String>) -> Self {
         Self {
@@ -93,6 +111,19 @@ impl RunOutcomeEnvelope {
                 .unwrap_or_else(|| "unknown".to_string()),
             job_id: handoff.job.as_ref().map(|job| job.job_id.clone()),
         });
+    }
+
+    pub fn projection(&self) -> RunOutcomeProjection {
+        RunOutcomeProjection {
+            schema: self.schema.clone(),
+            status: self.status.clone(),
+            run_id: self.run_id.clone(),
+            runner_id: self.runner_id.clone(),
+            exit_code: self.exit_code,
+            artifact_refs: self.artifact_refs.clone(),
+            evidence_refs: self.evidence_refs.clone(),
+            handoffs: self.handoffs.clone(),
+        }
     }
 
     fn push_artifact_ref(&mut self, artifact: ArtifactRef) {
@@ -239,5 +270,36 @@ mod tests {
             "homeboy://run/run-1/artifact/summary"
         );
         assert_eq!(value["evidence_refs"][0]["role"], "summary");
+    }
+
+    #[test]
+    fn run_outcome_projection_exposes_inspection_fields_without_result_payload() {
+        let mut envelope = RunOutcomeEnvelope::new("succeeded")
+            .with_run_id(Some("run-1".to_string()))
+            .with_runner_id(Some("runner-1".to_string()))
+            .with_exit_code(0)
+            .with_result(json!({ "large": "payload" }));
+        envelope.add_job_artifact_refs(
+            "run-1",
+            vec![JobArtifactMetadata {
+                id: "summary".to_string(),
+                name: Some("summary.json".to_string()),
+                path: Some("summary.json".to_string()),
+                url: None,
+                mime: None,
+                size_bytes: None,
+                sha256: None,
+                content_base64: None,
+                metadata: None,
+            }],
+        );
+
+        let value = serde_json::to_value(envelope.projection()).expect("projection json");
+
+        assert_eq!(value["schema"], RUN_OUTCOME_ENVELOPE_SCHEMA);
+        assert_eq!(value["run_id"], "run-1");
+        assert_eq!(value["runner_id"], "runner-1");
+        assert_eq!(value["artifact_refs"][0]["id"], "summary");
+        assert!(value.get("result").is_none());
     }
 }

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -117,6 +117,42 @@ pub struct RunnerExecutionRecord {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerExecutionProjection {
+    pub schema: String,
+    pub execution_id: String,
+    pub runner_id: String,
+    pub transport: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_task_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mirror_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub materialized_paths: Vec<PathMaterializationProjection>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<RunnerExecutionArtifactRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_actions: Vec<RunnerExecutionNextAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathMaterializationProjection {
+    pub role: String,
+    pub owner: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_path: Option<String>,
+    pub remote_path: String,
+    pub materialization_mode: String,
+    pub validation_status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PathMaterializationPlan {
     #[serde(default = "path_materialization_plan_schema")]
     pub schema: String,
@@ -223,6 +259,13 @@ impl PathMaterializationPlan {
         } else {
             Some(plan)
         }
+    }
+
+    pub fn projection_entries(&self) -> Vec<PathMaterializationProjection> {
+        self.entries
+            .iter()
+            .map(PathMaterializationProjection::from)
+            .collect()
     }
 }
 
@@ -394,6 +437,41 @@ impl RunnerExecutionRecord {
     ) -> Self {
         self.next_actions = next_actions.into_iter().collect();
         self
+    }
+
+    pub fn projection(&self) -> RunnerExecutionProjection {
+        RunnerExecutionProjection {
+            schema: self.schema.clone(),
+            execution_id: self.execution_id.clone(),
+            runner_id: self.runner_id.clone(),
+            transport: self.transport.clone(),
+            status: self.status.clone(),
+            job_id: self.job_id.clone(),
+            local_run_id: self.local_run_id.clone(),
+            remote_run_id: self.remote_run_id.clone(),
+            agent_task_run_id: self.agent_task_run_id.clone(),
+            mirror_run_id: self.mirror_run_id.clone(),
+            materialized_paths: self
+                .path_materialization_plan
+                .as_ref()
+                .map(PathMaterializationPlan::projection_entries)
+                .unwrap_or_default(),
+            artifact_refs: self.artifact_refs.clone(),
+            next_actions: self.next_actions.clone(),
+        }
+    }
+}
+
+impl From<&PathMaterializationEntry> for PathMaterializationProjection {
+    fn from(entry: &PathMaterializationEntry) -> Self {
+        Self {
+            role: entry.role.clone(),
+            owner: entry.owner.clone(),
+            local_path: entry.local_path.clone(),
+            remote_path: entry.remote_path.clone(),
+            materialization_mode: entry.materialization_mode.clone(),
+            validation_status: entry.validation_status.clone(),
+        }
     }
 }
 
@@ -814,6 +892,38 @@ mod tests {
             PATH_MATERIALIZATION_STATUS_VALIDATED
         );
         assert!(PathMaterializationPlan::non_empty(Vec::new()).is_none());
+    }
+
+    #[test]
+    fn runner_execution_projection_flattens_materialized_paths() {
+        let record = RunnerExecutionRecord::terminal("job-1", "lab-a", "daemon", 0)
+            .with_job_id("job-1")
+            .with_mirror_run_id(Some("run-1".to_string()))
+            .with_path_materialization_plan(Some(PathMaterializationPlan::new(vec![
+                PathMaterializationEntry::primary_workspace_materialized(
+                    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
+                    Some("/local/project".to_string()),
+                    "/runner/project",
+                    PathMaterializationMode::Snapshot.to_string(),
+                ),
+                PathMaterializationEntry::required_existing_remote("/runner/cache"),
+            ])));
+
+        let projection = record.projection();
+
+        assert_eq!(projection.execution_id, "job-1");
+        assert_eq!(projection.runner_id, "lab-a");
+        assert_eq!(projection.job_id.as_deref(), Some("job-1"));
+        assert_eq!(projection.remote_run_id.as_deref(), Some("run-1"));
+        assert_eq!(projection.materialized_paths.len(), 2);
+        assert_eq!(
+            projection.materialized_paths[0].remote_path,
+            "/runner/project"
+        );
+        assert_eq!(
+            projection.materialized_paths[1].role,
+            PATH_MATERIALIZATION_ROLE_REQUIRED_PATH
+        );
     }
 
     #[test]

--- a/tests/contract_constants_test.rs
+++ b/tests/contract_constants_test.rs
@@ -32,6 +32,28 @@ fn contract_constants_exports_homeboy_owned_contract_ids() {
         "homeboy/run-location-index/v1"
     );
     assert_eq!(
+        value["constants"]["runner_execution_record"]["schema_id"],
+        "homeboy/runner-execution-record/v1"
+    );
+    assert!(
+        value["constants"]["runner_execution_record"]["projection_fields"]
+            .as_array()
+            .expect("projection fields")
+            .iter()
+            .any(|field| field == "materialized_paths")
+    );
+    assert_eq!(
+        value["constants"]["path_materialization_plan"]["schema_id"],
+        "homeboy/path-materialization-plan/v1"
+    );
+    assert!(
+        value["constants"]["path_materialization_plan"]["materialization_modes"]
+            .as_array()
+            .expect("materialization modes")
+            .iter()
+            .any(|mode| mode == "snapshot")
+    );
+    assert_eq!(
         value["constants"]["host_mutation_lifecycle"]["schema_id"],
         "homeboy/host-mutation-lifecycle/v1"
     );


### PR DESCRIPTION
## Summary
- add projection helpers for runner execution records, path materialization plans, and run outcome envelopes
- export runner execution/path materialization contracts through the contract registry and constants surfaces
- add contract normalize/validation coverage for downstream consumers

## Verification
- rustfmt --check on touched Rust files
- git diff --check
- subagent verification before rebase: targeted contract tests passed

## Notes
- This is the first upstream slice for downstream Extensions to consume runner execution/materialization data without scraping runtime-specific metadata.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the contract seams, drafted the implementation, and coordinated verification.