### PR TITLE
Prefer configured runner homeboy path in job env

### DIFF
--- a/src/core/runner/command_path.rs
+++ b/src/core/runner/command_path.rs
@@ -26,6 +26,40 @@ pub(crate) fn normalize_runner_command_env(env: &mut HashMap<String, String>) {
     }
 }
 
+pub(crate) fn normalize_runner_command_env_for_homeboy_path(
+    env: &mut HashMap<String, String>,
+    homeboy_path: Option<&str>,
+) {
+    normalize_runner_command_env(env);
+
+    let Some(homeboy_path) = homeboy_path else {
+        return;
+    };
+    let homeboy_path = Path::new(homeboy_path);
+    if !homeboy_path.is_absolute() {
+        return;
+    }
+    let Some(parent) = homeboy_path.parent() else {
+        return;
+    };
+    let Some(parent) = parent.to_str() else {
+        return;
+    };
+    prepend_path_entry(env, parent);
+}
+
+fn prepend_path_entry(env: &mut HashMap<String, String>, entry: &str) {
+    let path = env.entry("PATH".to_string()).or_default();
+    if path.split(':').any(|part| part == entry) {
+        return;
+    }
+    if path.is_empty() {
+        path.push_str(entry);
+    } else {
+        *path = format!("{entry}:{path}");
+    }
+}
+
 pub(crate) fn remote_shell_path_preamble() -> &'static str {
     concat!(
         "export PATH=\"$HOME/.local/bin:$HOME/.",

--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -9,7 +9,7 @@ use crate::core::secret_env_plan::SecretEnvPlan;
 use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
 
-use super::super::normalize_runner_command_env;
+use super::super::normalize_runner_command_env_for_homeboy_path;
 use super::super::resource_metrics::{
     measured_command_output, measured_command_output_until_cancelled_with_progress,
     RunnerCommandProgressSink,
@@ -201,7 +201,10 @@ pub(crate) fn prepare_runner_process(
             &secret_env_plan,
             &env,
         )?);
-        normalize_runner_command_env(&mut env);
+        normalize_runner_command_env_for_homeboy_path(
+            &mut env,
+            runner.settings.homeboy_path.as_deref(),
+        );
     } else {
         validate_runner_inherited_secret_env(
             &secret_env_plan,
@@ -334,7 +337,10 @@ pub(crate) fn prepare_daemon_local_process(
         &secret_env_plan,
         &env,
     )?);
-    normalize_runner_command_env(&mut env);
+    normalize_runner_command_env_for_homeboy_path(
+        &mut env,
+        runner.settings.homeboy_path.as_deref(),
+    );
     let source_snapshot = request.source_snapshot.unwrap_or_else(|| {
         SourceSnapshot::collect_local(
             &runner.id,

--- a/src/core/runner/execution/tests/prepare.rs
+++ b/src/core/runner/execution/tests/prepare.rs
@@ -408,3 +408,41 @@ fn daemon_local_prep_normalizes_default_path_on_runner_side() {
         );
     });
 }
+
+#[test]
+fn daemon_local_prep_prefers_configured_homeboy_path_for_nested_homeboy() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("project");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        let workspace = workspace.display().to_string();
+        let mut runner = ssh_runner();
+        runner.settings.homeboy_path = Some("/opt/homeboy/current/homeboy".to_string());
+        runner.env.insert(
+            "PATH".to_string(),
+            "/usr/local/bin:/usr/bin:/bin".to_string(),
+        );
+
+        let plan = prepare_daemon_local_process(RunnerProcessRequest {
+            runner_id: "lab".to_string(),
+            runner: Some(runner),
+            cwd: Some(workspace),
+            project_id: None,
+            command: vec!["homeboy".to_string(), "--version".to_string()],
+            env: Default::default(),
+            secret_env_names: Vec::new(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: false,
+        })
+        .expect("prepare daemon-local runner process");
+
+        assert_eq!(
+            plan.env.get("PATH").map(String::as_str),
+            Some("/opt/homeboy/current:/usr/local/bin:/usr/bin:/bin"),
+            "daemon-side nested `homeboy` commands should resolve through configured homeboy_path first"
+        );
+    });
+}

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -73,7 +73,8 @@ pub use capabilities::{
 };
 pub use command_path::preflight_remote_argv_path_translation;
 pub(crate) use command_path::{
-    normalize_runner_command_env, quote_runner_env_value, remote_shell_path_preamble,
+    normalize_runner_command_env, normalize_runner_command_env_for_homeboy_path,
+    quote_runner_env_value, remote_shell_path_preamble,
 };
 pub use connection::{
     connect, connect_reverse, disconnect, reverse_broker_artifact, reverse_broker_reconcile,


### PR DESCRIPTION
## Summary
- Prepend the configured absolute `runner.homeboy_path` directory to runner job `PATH`
- Keep relative/bare `homeboy_path` behavior unchanged
- Add a daemon-side regression test for nested bare `homeboy` commands

## Verification
- `cargo check -q`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-7254-runner-source-upgrade-verification --lab-only --runner homeboy-lab --skip-lint -- daemon_local_prep_prefers_configured_homeboy_path_for_nested_homeboy`
- Persisted run: `runner-exec-generic-homeboy-lab-8d380553-3c58-4daa-bfca-28e3e2ea60a8`

Fixes follow-up evidence on #7254.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Diagnosed the runner PATH split-brain, implemented the scoped fix, and ran verification.