### PR TITLE
Send runner snapshot to daemon exec jobs

### DIFF
--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -61,6 +61,7 @@ pub(super) fn exec_via_daemon(
     };
     let payload = json!({
         "runner_id": runner.id,
+        "runner": runner,
         "project_id": project_id,
         "cwd": cwd,
         "command": command,


### PR DESCRIPTION
## Summary
- Include the controller runner snapshot in daemon exec requests
- Allows daemon-side process preparation to see configured runner settings, including `homeboy_path`
- Completes the #7260 PATH fix for real daemon jobs, not just process-prep tests

## Verification
- `cargo check -q`
- `cargo run -q --bin homeboy -- runner exec homeboy-lab -- homeboy --version`
- Persisted run: `runner-exec-generic-homeboy-lab-1c715f47-0960-469a-aaef-b3fb295cf383`
- Result: bare daemon job `homeboy --version` returned `homeboy 0.280.2+f63bc1995789` with controller, daemon, and configured job binary all fresh

Follow-up for #7254 and #7260.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Diagnosed the remaining daemon payload gap, implemented the minimal fix, and verified with a real runner daemon job.