### PR TITLE
Export runtime artifact contract constants

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -32,10 +32,12 @@ pub use constants::{
     artifact_manifest_constants, artifact_postprocess_constants, contract_constants,
     loop_constants, path_materialization_plan_constants, resource_lifecycle_index_constants,
     reviewer_facing_ref_constants, run_location_index_constants, runner_execution_record_constants,
-    secret_env_plan_constants, AllContractConstants, ArtifactManifestConstants,
-    ArtifactPostprocessConstants, ContractConstants, ContractConstantsOutput, LoopConstants,
+    runtime_artifact_constants, secret_env_plan_constants, AllContractConstants,
+    ArtifactManifestConstants, ArtifactPostprocessConstants, ContractConstants,
+    ContractConstantsOutput, ExecutorEvidenceConstants, LoopConstants,
     PathMaterializationPlanConstants, ResourceLifecycleIndexConstants, ReviewerFacingRefConstants,
-    RunLocationIndexConstants, RunnerExecutionRecordConstants, SecretEnvPlanConstants,
+    RunLocationIndexConstants, RunnerExecutionRecordConstants, RuntimeAgentArtifactPaths,
+    RuntimeArtifactConstants, RuntimeArtifactFilenames, SecretEnvPlanConstants,
     CONTRACT_CONSTANTS_SCHEMA,
 };
 pub use lab::{
@@ -50,8 +52,10 @@ pub use lab::{
     RunnerWorkloadCommandFamily, RunnerWorkloadExtensionRevision, RunnerWorkloadKind,
     RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
     RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, LAB_TRACE_EXTRA_TOOLS,
-    RUNNER_ARTIFACT_MANIFEST_FILE, RUNNER_ARTIFACT_MANIFEST_SCHEMA, RUNNER_HANDOFF_ENVELOPE_SCHEMA,
-    RUNNER_WORKLOAD_SCHEMA, RUN_LOCATION_INDEX_SCHEMA,
+    RUNNER_ARTIFACT_MANIFEST_FILE, RUNNER_ARTIFACT_MANIFEST_REF_NAME,
+    RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+    RUNNER_ARTIFACT_ROOT_DIR_SUFFIX, RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA,
+    RUN_LOCATION_INDEX_SCHEMA,
 };
 pub(crate) use lab::{LAB_NO_EXTRA_TOOLS, RIG_UP_LAB_UNSUPPORTED_REASON};
 pub use output::{
@@ -80,7 +84,10 @@ pub use crate::core::artifacts::{
     ArtifactPostprocessAction, ArtifactPostprocessPlan, ArtifactPostprocessPlanDescription,
     ArtifactPostprocessResult, ArtifactPostprocessReviewerRef, ArtifactPostprocessRoot,
     ARTIFACT_POSTPROCESS_PLAN_SCHEMA, ARTIFACT_POSTPROCESS_RESULT_SCHEMA,
-    ARTIFACT_POSTPROCESS_SCHEMA,
+    ARTIFACT_POSTPROCESS_SCHEMA, RUNTIME_AGENT_FINAL_OUTPUT_ARTIFACT_PATH,
+    RUNTIME_AGENT_PATCH_DIFF_ARTIFACT_FILE, RUNTIME_AGENT_PATCH_PATCH_ARTIFACT_FILE,
+    RUNTIME_AGENT_RESULT_ARTIFACT_FILE, RUNTIME_AGENT_RESULT_ARTIFACT_FILE_LEGACY_UNDERSCORE,
+    RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_FILE, RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_PATH,
 };
 pub use crate::core::run_lifecycle_status::{RunLifecycleStatus, RUN_LIFECYCLE_STATUS_SCHEMA};
 pub use crate::core::run_outcome_envelope::{

--- a/src/command_contract/constants.rs
+++ b/src/command_contract/constants.rs
@@ -1,12 +1,39 @@
 use serde::Serialize;
 
-use crate::command_contract::{registered_contract, RUNNER_ARTIFACT_MANIFEST_FILE};
+use crate::command_contract::{
+    registered_contract, RUNNER_ARTIFACT_MANIFEST_FILE, RUNNER_ARTIFACT_MANIFEST_REF_NAME,
+    RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+    RUNNER_ARTIFACT_ROOT_DIR_SUFFIX,
+};
+use crate::core::agent_task::AGENT_TASK_ARTIFACT_SCHEMA;
+use crate::core::agent_task_batch::AGENT_TASK_BATCH_ARTIFACTS_SCHEMA;
 use crate::core::agent_task_contract::AGENT_TASK_LOOP_ACTION_SCHEMA;
+use crate::core::agent_task_executor_evidence::{
+    EXECUTOR_INPUT_EVIDENCE_KIND, EXECUTOR_INPUT_FILE, EXECUTOR_RESULT_EVIDENCE_KIND,
+    EXECUTOR_RESULT_FILE,
+};
 use crate::core::agent_task_loop_controller::{
     AGENT_TASK_LOOP_CONTROLLER_SCHEMA, AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA,
 };
 use crate::core::agent_task_loop_definition::AGENT_TASK_LOOP_DEFINITION_SCHEMA;
-use crate::core::artifact_ref::{HOMEBOY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME};
+use crate::core::artifact_address::ARTIFACT_ADDRESS_SCHEMA;
+use crate::core::artifact_contract::{ARTIFACT_CONTRACT_SCHEMA, EVIDENCE_CONTRACT_SCHEMA};
+use crate::core::artifact_dom_boxes::ARTIFACT_DOM_BOXES_SCHEMA;
+use crate::core::artifact_ref::{
+    ARTIFACT_REF_SCHEMA, HOMEBOY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
+};
+use crate::core::artifacts::{
+    ARTIFACT_POSTPROCESS_PLAN_SCHEMA, ARTIFACT_POSTPROCESS_RESULT_SCHEMA,
+    ARTIFACT_POSTPROCESS_SCHEMA, RUNTIME_AGENT_FINAL_OUTPUT_ARTIFACT_PATH,
+    RUNTIME_AGENT_PATCH_DIFF_ARTIFACT_FILE, RUNTIME_AGENT_PATCH_PATCH_ARTIFACT_FILE,
+    RUNTIME_AGENT_RESULT_ARTIFACT_FILE, RUNTIME_AGENT_RESULT_ARTIFACT_FILE_LEGACY_UNDERSCORE,
+    RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_FILE, RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_PATH,
+};
+use crate::core::change_artifact::CHANGE_ARTIFACT_SCHEMA;
+use crate::core::fuzz::FUZZ_ARTIFACT_SCHEMA;
+use crate::core::matrix_artifact_summary::{
+    GENERIC_MATRIX_SUMMARY_SCHEMA, MATRIX_ARTIFACT_SUMMARY_SCHEMA,
+};
 use crate::core::runner_execution_envelope::{
     PATH_MATERIALIZATION_MODE_EXISTING_REMOTE, PATH_MATERIALIZATION_MODE_GIT,
     PATH_MATERIALIZATION_MODE_SNAPSHOT, PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS,
@@ -37,6 +64,7 @@ pub enum ContractConstants {
     RunLocationIndex(RunLocationIndexConstants),
     RunnerExecutionRecord(RunnerExecutionRecordConstants),
     PathMaterializationPlan(PathMaterializationPlanConstants),
+    RuntimeArtifacts(RuntimeArtifactConstants),
     ReviewerFacingRef(ReviewerFacingRefConstants),
 }
 
@@ -51,6 +79,7 @@ pub struct AllContractConstants {
     pub run_location_index: RunLocationIndexConstants,
     pub runner_execution_record: RunnerExecutionRecordConstants,
     pub path_materialization_plan: PathMaterializationPlanConstants,
+    pub runtime_artifacts: RuntimeArtifactConstants,
     pub reviewer_facing_ref: ReviewerFacingRefConstants,
 }
 
@@ -58,6 +87,10 @@ pub struct AllContractConstants {
 pub struct ArtifactManifestConstants {
     pub schema_id: String,
     pub file_name: String,
+    pub runner_manifest_ref_schema_id: String,
+    pub runner_manifest_ref_name: String,
+    pub runner_artifact_root_dir_suffix: String,
+    pub represented_artifact_schema_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -109,6 +142,36 @@ pub struct PathMaterializationPlanConstants {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeArtifactConstants {
+    pub runtime_agent_paths: RuntimeAgentArtifactPaths,
+    pub canonical_filenames: RuntimeArtifactFilenames,
+    pub executor_evidence: ExecutorEvidenceConstants,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeAgentArtifactPaths {
+    pub transcript: String,
+    pub final_output: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeArtifactFilenames {
+    pub transcript: String,
+    pub agent_result: String,
+    pub agent_result_legacy_underscore: String,
+    pub patch_diff: String,
+    pub patch_patch: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExecutorEvidenceConstants {
+    pub input_kind: String,
+    pub input_file_name: String,
+    pub result_kind: String,
+    pub result_file_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ReviewerFacingRefConstants {
     pub accepted_schemes: Vec<String>,
 }
@@ -126,6 +189,7 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
             run_location_index: run_location_index_constants(),
             runner_execution_record: runner_execution_record_constants(),
             path_materialization_plan: path_materialization_plan_constants(),
+            runtime_artifacts: runtime_artifact_constants(),
             reviewer_facing_ref: reviewer_facing_ref_constants(),
         }),
         "artifact-manifest" => ContractConstants::ArtifactManifest(artifact_manifest_constants()),
@@ -147,6 +211,9 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
         "path-materialization-plan" => {
             ContractConstants::PathMaterializationPlan(path_materialization_plan_constants())
         }
+        "runtime-artifacts" | "runtime-agent-artifacts" => {
+            ContractConstants::RuntimeArtifacts(runtime_artifact_constants())
+        }
         "reviewer-facing-ref" | "reviewer-ref" => {
             ContractConstants::ReviewerFacingRef(reviewer_facing_ref_constants())
         }
@@ -164,6 +231,10 @@ pub fn artifact_manifest_constants() -> ArtifactManifestConstants {
     ArtifactManifestConstants {
         schema_id: registry_schema_id("artifact-manifest"),
         file_name: RUNNER_ARTIFACT_MANIFEST_FILE.to_string(),
+        runner_manifest_ref_schema_id: RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA.to_string(),
+        runner_manifest_ref_name: RUNNER_ARTIFACT_MANIFEST_REF_NAME.to_string(),
+        runner_artifact_root_dir_suffix: RUNNER_ARTIFACT_ROOT_DIR_SUFFIX.to_string(),
+        represented_artifact_schema_ids: represented_artifact_schema_ids(),
     }
 }
 
@@ -249,6 +320,29 @@ pub fn path_materialization_plan_constants() -> PathMaterializationPlanConstants
     }
 }
 
+pub fn runtime_artifact_constants() -> RuntimeArtifactConstants {
+    RuntimeArtifactConstants {
+        runtime_agent_paths: RuntimeAgentArtifactPaths {
+            transcript: RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_PATH.to_string(),
+            final_output: RUNTIME_AGENT_FINAL_OUTPUT_ARTIFACT_PATH.to_string(),
+        },
+        canonical_filenames: RuntimeArtifactFilenames {
+            transcript: RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_FILE.to_string(),
+            agent_result: RUNTIME_AGENT_RESULT_ARTIFACT_FILE.to_string(),
+            agent_result_legacy_underscore: RUNTIME_AGENT_RESULT_ARTIFACT_FILE_LEGACY_UNDERSCORE
+                .to_string(),
+            patch_diff: RUNTIME_AGENT_PATCH_DIFF_ARTIFACT_FILE.to_string(),
+            patch_patch: RUNTIME_AGENT_PATCH_PATCH_ARTIFACT_FILE.to_string(),
+        },
+        executor_evidence: ExecutorEvidenceConstants {
+            input_kind: EXECUTOR_INPUT_EVIDENCE_KIND.to_string(),
+            input_file_name: EXECUTOR_INPUT_FILE.to_string(),
+            result_kind: EXECUTOR_RESULT_EVIDENCE_KIND.to_string(),
+            result_file_name: EXECUTOR_RESULT_FILE.to_string(),
+        },
+    }
+}
+
 pub fn reviewer_facing_ref_constants() -> ReviewerFacingRefConstants {
     ReviewerFacingRefConstants {
         accepted_schemes: vec![
@@ -265,4 +359,24 @@ fn registry_schema_id(name: &str) -> String {
         .expect("contract constants must reference registered contracts")
         .schema_id
         .to_string()
+}
+
+fn represented_artifact_schema_ids() -> Vec<String> {
+    vec![
+        RUNNER_ARTIFACT_MANIFEST_SCHEMA.to_string(),
+        ARTIFACT_CONTRACT_SCHEMA.to_string(),
+        EVIDENCE_CONTRACT_SCHEMA.to_string(),
+        ARTIFACT_REF_SCHEMA.to_string(),
+        ARTIFACT_ADDRESS_SCHEMA.to_string(),
+        ARTIFACT_DOM_BOXES_SCHEMA.to_string(),
+        ARTIFACT_POSTPROCESS_SCHEMA.to_string(),
+        ARTIFACT_POSTPROCESS_PLAN_SCHEMA.to_string(),
+        ARTIFACT_POSTPROCESS_RESULT_SCHEMA.to_string(),
+        AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+        AGENT_TASK_BATCH_ARTIFACTS_SCHEMA.to_string(),
+        CHANGE_ARTIFACT_SCHEMA.to_string(),
+        FUZZ_ARTIFACT_SCHEMA.to_string(),
+        GENERIC_MATRIX_SUMMARY_SCHEMA.to_string(),
+        MATRIX_ARTIFACT_SUMMARY_SCHEMA.to_string(),
+    ]
 }

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -30,8 +30,11 @@ use super::spec::{
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
 pub const RUNNER_HANDOFF_ENVELOPE_SCHEMA: &str = "homeboy/runner-exec-handoff/v1";
 pub const RUN_LOCATION_INDEX_SCHEMA: &str = "homeboy/run-location-index/v1";
+pub const RUNNER_ARTIFACT_MANIFEST_REF_NAME: &str = "runner-artifact-manifest-ref";
+pub const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA: &str = "homeboy/runner-artifact-manifest-ref/v1";
 pub const RUNNER_ARTIFACT_MANIFEST_SCHEMA: &str = crate::core::artifacts::ARTIFACT_MANIFEST_SCHEMA;
 pub const RUNNER_ARTIFACT_MANIFEST_FILE: &str = crate::core::artifacts::ARTIFACT_MANIFEST_FILE;
+pub const RUNNER_ARTIFACT_ROOT_DIR_SUFFIX: &str = "-homeboy-artifacts";
 
 /// Routing-policy flags shared by every Lab command representation
 /// (`LabCommandContract`, `LabRoutePlan`, `LabOffloadCommand`). These four
@@ -450,10 +453,10 @@ impl RunnerHandoffEnvelope {
 impl RunnerHandoffArtifactManifestRef {
     pub fn for_remote_cwd(remote_cwd: &str) -> Self {
         Self {
-            schema: "homeboy/runner-artifact-manifest-ref/v1".to_string(),
+            schema: RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA.to_string(),
             manifest_schema: RUNNER_ARTIFACT_MANIFEST_SCHEMA.to_string(),
             path: format!(
-                "{}-homeboy-artifacts/{RUNNER_ARTIFACT_MANIFEST_FILE}",
+                "{}{RUNNER_ARTIFACT_ROOT_DIR_SUFFIX}/{RUNNER_ARTIFACT_MANIFEST_FILE}",
                 remote_cwd.trim_end_matches('/')
             ),
         }

--- a/src/command_contract/registry.rs
+++ b/src/command_contract/registry.rs
@@ -131,6 +131,14 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         rust_type: "homeboy::command_contract::RunLocationIndex",
     },
     ContractRegistryEntry {
+        schema_id: crate::command_contract::RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+        name: crate::command_contract::RUNNER_ARTIFACT_MANIFEST_REF_NAME,
+        title: "Runner artifact manifest reference",
+        owner: "homeboy-core",
+        summary: "Points to a runner-resident artifact manifest and declares the manifest schema it contains.",
+        rust_type: "homeboy::command_contract::RunnerHandoffArtifactManifestRef",
+    },
+    ContractRegistryEntry {
         schema_id: crate::core::extension::EXTENSION_MATERIALIZATION_SOURCE_SCHEMA,
         name: "extension-materialization-source",
         title: "Extension materialization source",
@@ -163,6 +171,14 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         rust_type: "homeboy::core::run_outcome_envelope::RunOutcomeEnvelope",
     },
     ContractRegistryEntry {
+        schema_id: crate::core::runner_execution_envelope::RUNNER_EXECUTION_ENVELOPE_SCHEMA,
+        name: "runner-execution-envelope",
+        title: "Runner execution envelope",
+        owner: "homeboy-core",
+        summary: "Generic planned runner execution request with source, secret, artifact, mutation, publication, and result-ref policy.",
+        rust_type: "homeboy::core::runner_execution_envelope::RunnerExecutionEnvelope",
+    },
+    ContractRegistryEntry {
         schema_id: crate::core::runner_execution_envelope::RUNNER_EXECUTION_RECORD_SCHEMA,
         name: "runner-execution-record",
         title: "Runner execution record",
@@ -177,6 +193,14 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         owner: "homeboy-core",
         summary: "Generic runner-side path materialization entries for source snapshots and required remote paths.",
         rust_type: "homeboy::core::runner_execution_envelope::PathMaterializationPlan",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::core::runner_execution_envelope::ORCHESTRATION_TARGET_PROVENANCE_SCHEMA,
+        name: "orchestration-target-provenance",
+        title: "Orchestration target provenance",
+        owner: "homeboy-core",
+        summary: "Captures the controller, runner daemon, runner command, source snapshot, and extension provenance for a selected runner target.",
+        rust_type: "homeboy::core::runner_execution_envelope::OrchestrationTargetProvenance",
     },
 ];
 
@@ -221,12 +245,15 @@ mod tests {
             "resource-cleanup-intent",
             "resource-lifecycle-index",
             "run-location-index",
+            "runner-artifact-manifest-ref",
             "extension-materialization-source",
             "resolved-agent-runtime-execution-contract",
             "reviewer-facing-artifact-ref",
             "run-outcome-envelope",
+            "runner-execution-envelope",
             "runner-execution-record",
             "path-materialization-plan",
+            "orchestration-target-provenance",
         ] {
             assert!(names.contains(name), "missing {name}");
         }

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -12,12 +12,14 @@ use crate::command_contract::{
     CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
     CommandRawOutputMode, CommandResponseMode, CommandStdoutMode, ContractConstantsOutput,
     ContractRegistryEntry, ARTIFACT_POSTPROCESS_SCHEMA, COMMAND_REGISTRY,
-    PUBLIC_OUTPUT_VARIANT_CONTRACTS, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
-    RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA, RUN_LOCATION_INDEX_SCHEMA,
+    PUBLIC_OUTPUT_VARIANT_CONTRACTS, RUNNER_ARTIFACT_MANIFEST_FILE,
+    RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+    RUNNER_ARTIFACT_ROOT_DIR_SUFFIX, RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA,
+    RUN_LOCATION_INDEX_SCHEMA,
 };
 use crate::commands::{adapter, CmdResult, GlobalArgs};
 use crate::core::artifact_ref::{validate_reviewer_facing_artifact_ref, ArtifactReference};
-use crate::core::artifacts::validate_artifact_postprocess_plan;
+use crate::core::artifacts::{validate_artifact_postprocess_plan, ArtifactManifest};
 use crate::core::fuzz::{FuzzWorkload, FUZZ_WORKLOAD_SCHEMA};
 use crate::core::host_mutation_lifecycle::{
     HostMutationLifecycle, HostMutationRevertStrategy, HostMutationStatus,
@@ -39,8 +41,9 @@ use crate::core::run_outcome_envelope::{
     RunOutcomeEnvelope, RunOutcomeProjection, RUN_OUTCOME_ENVELOPE_SCHEMA,
 };
 use crate::core::runner_execution_envelope::{
-    PathMaterializationPlan, RunnerExecutionProjection, RunnerExecutionRecord,
-    PATH_MATERIALIZATION_PLAN_SCHEMA, RUNNER_EXECUTION_RECORD_SCHEMA,
+    PathMaterializationPlan, RunnerExecutionEnvelope, RunnerExecutionProjection,
+    RunnerExecutionRecord, PATH_MATERIALIZATION_PLAN_SCHEMA, RUNNER_EXECUTION_ENVELOPE_SCHEMA,
+    RUNNER_EXECUTION_RECORD_SCHEMA,
 };
 use crate::core::secret_env_plan::{SecretEnvPlan, SECRET_ENV_PLAN_SCHEMA};
 use crate::core::{Error, Result};
@@ -74,7 +77,7 @@ pub enum ContractCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct ContractConstantsArgs {
-    /// Contract ID: all, artifact-manifest, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, runner-execution-record, path-materialization-plan, reviewer-facing-ref.
+    /// Contract ID: all, artifact-manifest, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, runner-execution-record, path-materialization-plan, runtime-artifacts, reviewer-facing-ref.
     pub contract_id: String,
 }
 
@@ -419,7 +422,7 @@ fn constants(contract_id: &str) -> CmdResult<ContractOutput> {
             format!("unknown contract constants id `{contract_id}`"),
             None,
             Some(vec![
-                    "Use one of: all, artifact-manifest, artifact-postprocess, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, runner-execution-record, path-materialization-plan, reviewer-facing-ref".to_string(),
+                    "Use one of: all, artifact-manifest, artifact-postprocess, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, runner-execution-record, path-materialization-plan, runtime-artifacts, reviewer-facing-ref".to_string(),
             ]),
         )
     })?;
@@ -744,6 +747,45 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
             "Homeboy-owned schema IDs and canonical examples for cross-language contract tests.",
         contracts: vec![
             ContractSchemaEntry {
+                id: RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+                version: 1,
+                description: "Generic artifact manifest emitted under a runner/controller artifact root.",
+                fields: vec![
+                    field("schema", "string", "Schema ID for the artifact manifest.", true),
+                    field("artifacts", "array", "Manifest entries for produced artifact files.", false),
+                    field("artifacts[].path", "string", "Artifact-root-relative file path.", true),
+                    field("artifacts[].kind", "string", "Generic artifact kind.", true),
+                ],
+                required: vec!["schema", "artifacts"],
+                example: artifact_manifest_example(),
+            },
+            ContractSchemaEntry {
+                id: RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+                version: 1,
+                description: "Runner artifact manifest reference returned in handoff/location contracts.",
+                fields: vec![
+                    field("schema", "string", "Schema ID for the manifest reference.", true),
+                    field("manifest_schema", "string", "Schema ID expected inside the referenced manifest file.", true),
+                    field("path", "string", "Runner-resident manifest path.", true),
+                ],
+                required: vec!["schema", "manifest_schema", "path"],
+                example: runner_artifact_manifest_ref_example(),
+            },
+            ContractSchemaEntry {
+                id: RUNNER_EXECUTION_ENVELOPE_SCHEMA,
+                version: 1,
+                description: "Planned generic runner execution request.",
+                fields: vec![
+                    field("schema", "string", "Schema ID for the runner execution envelope.", true),
+                    field("envelope_id", "string", "Stable envelope identifier.", true),
+                    field("source", "object", "Source contract identity for this execution envelope.", false),
+                    field("artifact_declarations", "array", "Runtime artifacts expected from the execution.", false),
+                    field("result_refs", "object", "Durable result reference fields.", false),
+                ],
+                required: vec!["schema", "envelope_id"],
+                example: runner_execution_envelope_example(),
+            },
+            ContractSchemaEntry {
                 id: ARTIFACT_POSTPROCESS_SCHEMA,
                 version: 1,
                 description:
@@ -994,6 +1036,57 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
     }
 }
 
+fn artifact_manifest_example() -> Value {
+    json!({
+        "schema": RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+        "artifacts": [
+            {
+                "id": "transcript",
+                "path": crate::command_contract::RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_PATH,
+                "kind": "transcript",
+                "label": "Runtime transcript",
+                "content_type": "application/json",
+                "metadata": {}
+            },
+            {
+                "id": "final_output",
+                "path": crate::command_contract::RUNTIME_AGENT_FINAL_OUTPUT_ARTIFACT_PATH,
+                "kind": "final_output",
+                "label": "Final runtime output",
+                "content_type": "text/markdown",
+                "metadata": {}
+            }
+        ]
+    })
+}
+
+fn runner_artifact_manifest_ref_example() -> Value {
+    json!({
+        "schema": RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+        "manifest_schema": RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+        "path": runner_artifact_manifest_example_path()
+    })
+}
+
+fn runner_execution_envelope_example() -> Value {
+    json!({
+        "schema": RUNNER_EXECUTION_ENVELOPE_SCHEMA,
+        "envelope_id": "execution-1",
+        "source": { "kind": "agent_task", "ref_id": "task-1" },
+        "artifact_declarations": [
+            {
+                "name": "transcript",
+                "type": "file",
+                "path": crate::command_contract::RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_PATH,
+                "required": false,
+                "metadata": {}
+            }
+        ],
+        "result_refs": { "task_id": "task-1", "artifacts": [] },
+        "metadata": {}
+    })
+}
+
 fn artifact_postprocess_example() -> Value {
     json!({
         "schema": ARTIFACT_POSTPROCESS_SCHEMA,
@@ -1003,7 +1096,7 @@ fn artifact_postprocess_example() -> Value {
                 "id": "primary",
                 "path": "artifacts",
                 "persisted_ref": "runner-artifact://run-1/artifacts",
-                "manifest_path": "homeboy-artifact-manifest.json"
+                "manifest_path": RUNNER_ARTIFACT_MANIFEST_FILE
             }
         ],
         "actions": [
@@ -1071,9 +1164,9 @@ fn runner_handoff_example() -> Value {
         "mirror_run_id": "run-1",
         "remote_cwd": "/home/runner/workspace",
         "artifact_manifest": {
-            "schema": "homeboy/runner-artifact-manifest-ref/v1",
+            "schema": RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
             "manifest_schema": RUNNER_ARTIFACT_MANIFEST_SCHEMA,
-            "path": "/home/runner/workspace-homeboy-artifacts/manifest.json"
+            "path": runner_artifact_manifest_example_path()
         },
         "evidence": {
             "schema": "homeboy/runner-handoff-evidence/v1",
@@ -1085,14 +1178,14 @@ fn runner_handoff_example() -> Value {
             "mirror_run_id": "run-1",
             "remote_cwd": "/home/runner/workspace",
             "artifact_manifest": {
-                "schema": "homeboy/runner-artifact-manifest-ref/v1",
+                "schema": RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
                 "manifest_schema": RUNNER_ARTIFACT_MANIFEST_SCHEMA,
-                "path": "/home/runner/workspace-homeboy-artifacts/manifest.json"
+                "path": runner_artifact_manifest_example_path()
             },
             "artifact_refs": [{
                 "id": "artifact_manifest",
                 "name": "runner artifact manifest",
-                "path": "/home/runner/workspace-homeboy-artifacts/manifest.json"
+                "path": runner_artifact_manifest_example_path()
             }],
             "next_commands": [{
                 "label": "runner_job_logs",
@@ -1120,12 +1213,18 @@ fn run_location_index_example() -> Value {
         "runner_id": "runner-1",
         "remote_job_id": "job-1",
         "artifact_manifest_ref": {
-            "schema": "homeboy/runner-artifact-manifest-ref/v1",
+            "schema": RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
             "manifest_schema": RUNNER_ARTIFACT_MANIFEST_SCHEMA,
-            "path": "/home/runner/workspace-homeboy-artifacts/manifest.json"
+            "path": runner_artifact_manifest_example_path()
         },
         "liveness_heartbeat_timestamp": "2026-01-01T00:00:00Z"
     })
+}
+
+fn runner_artifact_manifest_example_path() -> String {
+    format!(
+        "/home/runner/workspace{RUNNER_ARTIFACT_ROOT_DIR_SUFFIX}/{RUNNER_ARTIFACT_MANIFEST_FILE}"
+    )
 }
 
 fn resource_lifecycle_index_example() -> Value {
@@ -1299,6 +1398,10 @@ fn resolve_schema(schema_id: &str) -> homeboy::core::Result<&'static ContractSch
 
 static CONTRACT_SCHEMAS: &[ContractSchema] = &[
     ContractSchema {
+        id: RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+        validate_json: validate_artifact_manifest,
+    },
+    ContractSchema {
         id: ARTIFACT_POSTPROCESS_SCHEMA,
         validate_json: validate_artifact_postprocess,
     },
@@ -1335,6 +1438,10 @@ static CONTRACT_SCHEMAS: &[ContractSchema] = &[
         validate_json: validate_loop_evidence,
     },
     ContractSchema {
+        id: RUNNER_EXECUTION_ENVELOPE_SCHEMA,
+        validate_json: validate_runner_execution_envelope,
+    },
+    ContractSchema {
         id: RUNNER_EXECUTION_RECORD_SCHEMA,
         validate_json: validate_runner_execution_record,
     },
@@ -1356,6 +1463,11 @@ fn validate_secret_env_plan(raw: &str) -> homeboy::core::Result<()> {
 fn validate_artifact_postprocess(raw: &str) -> homeboy::core::Result<()> {
     let plan: ArtifactPostprocessPlan = deserialize_contract(raw, ARTIFACT_POSTPROCESS_SCHEMA)?;
     validate_artifact_postprocess_plan(&plan)
+}
+
+fn validate_artifact_manifest(raw: &str) -> homeboy::core::Result<()> {
+    let manifest: ArtifactManifest = deserialize_contract(raw, RUNNER_ARTIFACT_MANIFEST_SCHEMA)?;
+    manifest.validate_shape()
 }
 
 fn validate_fuzz_workload(raw: &str) -> homeboy::core::Result<()> {
@@ -1410,6 +1522,12 @@ fn validate_loop_evidence(raw: &str) -> homeboy::core::Result<()> {
 fn validate_runner_execution_record(raw: &str) -> homeboy::core::Result<()> {
     let record: RunnerExecutionRecord = deserialize_contract(raw, RUNNER_EXECUTION_RECORD_SCHEMA)?;
     validate_schema_field(RUNNER_EXECUTION_RECORD_SCHEMA, &record.schema)
+}
+
+fn validate_runner_execution_envelope(raw: &str) -> homeboy::core::Result<()> {
+    let envelope: RunnerExecutionEnvelope =
+        deserialize_contract(raw, RUNNER_EXECUTION_ENVELOPE_SCHEMA)?;
+    validate_schema_field(RUNNER_EXECUTION_ENVELOPE_SCHEMA, &envelope.schema)
 }
 
 fn validate_path_materialization_plan(raw: &str) -> homeboy::core::Result<()> {
@@ -1527,6 +1645,21 @@ mod tests {
         )
         .unwrap();
         assert_eq!(catalog["schema"], CONTRACT_SCHEMA_CATALOG_SCHEMA);
+        assert!(catalog["contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|contract| contract["id"] == RUNNER_ARTIFACT_MANIFEST_SCHEMA));
+        assert!(catalog["contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|contract| contract["id"] == RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA));
+        assert!(catalog["contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|contract| contract["id"] == RUNNER_EXECUTION_ENVELOPE_SCHEMA));
         assert!(catalog["contracts"]
             .as_array()
             .unwrap()
@@ -1766,6 +1899,47 @@ mod tests {
         let output = validate_file(RUNNER_EXECUTION_RECORD_SCHEMA, file).unwrap();
 
         assert_eq!(output.schema, RUNNER_EXECUTION_RECORD_SCHEMA);
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn validates_artifact_manifest_json_file() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "homeboy-artifact-manifest.json",
+            json!({
+                "schema": RUNNER_ARTIFACT_MANIFEST_SCHEMA,
+                "artifacts": [
+                    {
+                        "path": "artifacts/agent-loop/transcript.json",
+                        "kind": "transcript"
+                    }
+                ]
+            }),
+        );
+
+        let output = validate_file(RUNNER_ARTIFACT_MANIFEST_SCHEMA, file).unwrap();
+
+        assert_eq!(output.schema, RUNNER_ARTIFACT_MANIFEST_SCHEMA);
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn validates_runner_execution_envelope_json_file() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "runner-execution-envelope.json",
+            json!({
+                "schema": RUNNER_EXECUTION_ENVELOPE_SCHEMA,
+                "envelope_id": "execution-1"
+            }),
+        );
+
+        let output = validate_file(RUNNER_EXECUTION_ENVELOPE_SCHEMA, file).unwrap();
+
+        assert_eq!(output.schema, RUNNER_EXECUTION_ENVELOPE_SCHEMA);
         assert!(output.valid);
     }
 

--- a/src/core/agent_task_executor_evidence.rs
+++ b/src/core/agent_task_executor_evidence.rs
@@ -35,10 +35,10 @@ pub const EXECUTOR_INPUT_EVIDENCE_KIND: &str = "executor-input";
 pub const EXECUTOR_RESULT_EVIDENCE_KIND: &str = "executor-result";
 
 /// File name for the persisted latest raw executor request.
-const EXECUTOR_INPUT_FILE: &str = "executor-input.json";
+pub const EXECUTOR_INPUT_FILE: &str = "executor-input.json";
 
 /// File name for the persisted latest raw executor result.
-const EXECUTOR_RESULT_FILE: &str = "executor-result.json";
+pub const EXECUTOR_RESULT_FILE: &str = "executor-result.json";
 
 /// Persist the latest raw executor request and result for `request`/`outcome`
 /// and append linking evidence refs onto the outcome.

--- a/src/core/artifact_manifest.rs
+++ b/src/core/artifact_manifest.rs
@@ -12,6 +12,18 @@ use std::path::{Component, Path, PathBuf};
 pub const ARTIFACT_MANIFEST_FILE: &str = "homeboy-artifact-manifest.json";
 pub const ARTIFACT_MANIFEST_SCHEMA: &str = "homeboy/artifact-manifest/v1";
 
+/// Stable runtime-agent artifact path for an agent execution transcript.
+pub const RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_PATH: &str = "artifacts/agent-loop/transcript.json";
+
+/// Stable runtime-agent artifact path for the final agent response/output.
+pub const RUNTIME_AGENT_FINAL_OUTPUT_ARTIFACT_PATH: &str = "artifacts/agent-loop/final.md";
+
+pub const RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_FILE: &str = "transcript.json";
+pub const RUNTIME_AGENT_RESULT_ARTIFACT_FILE: &str = "agent-result.json";
+pub const RUNTIME_AGENT_RESULT_ARTIFACT_FILE_LEGACY_UNDERSCORE: &str = "agent_result.json";
+pub const RUNTIME_AGENT_PATCH_DIFF_ARTIFACT_FILE: &str = "patch.diff";
+pub const RUNTIME_AGENT_PATCH_PATCH_ARTIFACT_FILE: &str = "patch.patch";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArtifactManifest {
     #[serde(default = "default_schema")]

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -26,7 +26,10 @@ pub use super::artifact_manifest::{
     read_manifest_from_root, write_manifest_to_root, ArtifactManifest, ArtifactManifestEntry,
     ArtifactManifestProvenance, ArtifactManifestPublicUrlState, ArtifactManifestViewer,
     ArtifactManifestViewerLink, ArtifactRedactionState, ValidatedArtifactManifestEntry,
-    ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA,
+    ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA, RUNTIME_AGENT_FINAL_OUTPUT_ARTIFACT_PATH,
+    RUNTIME_AGENT_PATCH_DIFF_ARTIFACT_FILE, RUNTIME_AGENT_PATCH_PATCH_ARTIFACT_FILE,
+    RUNTIME_AGENT_RESULT_ARTIFACT_FILE, RUNTIME_AGENT_RESULT_ARTIFACT_FILE_LEGACY_UNDERSCORE,
+    RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_FILE, RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_PATH,
 };
 pub use super::artifact_origin::{
     inspect, serve, status, status_with_command, ArtifactOriginInspect, ArtifactOriginServeSpec,

--- a/tests/contract_constants_test.rs
+++ b/tests/contract_constants_test.rs
@@ -20,6 +20,21 @@ fn contract_constants_exports_homeboy_owned_contract_ids() {
         "homeboy-artifact-manifest.json"
     );
     assert_eq!(
+        value["constants"]["artifact_manifest"]["runner_manifest_ref_schema_id"],
+        "homeboy/runner-artifact-manifest-ref/v1"
+    );
+    assert_eq!(
+        value["constants"]["artifact_manifest"]["runner_manifest_ref_name"],
+        "runner-artifact-manifest-ref"
+    );
+    assert!(
+        value["constants"]["artifact_manifest"]["represented_artifact_schema_ids"]
+            .as_array()
+            .expect("represented schema IDs")
+            .iter()
+            .any(|schema| schema == "homeboy/agent-task-artifact/v1")
+    );
+    assert_eq!(
         value["constants"]["artifact_postprocess"]["schema_id"],
         "homeboy/artifact-postprocess/v1"
     );
@@ -52,6 +67,22 @@ fn contract_constants_exports_homeboy_owned_contract_ids() {
             .expect("materialization modes")
             .iter()
             .any(|mode| mode == "snapshot")
+    );
+    assert_eq!(
+        value["constants"]["runtime_artifacts"]["runtime_agent_paths"]["transcript"],
+        "artifacts/agent-loop/transcript.json"
+    );
+    assert_eq!(
+        value["constants"]["runtime_artifacts"]["runtime_agent_paths"]["final_output"],
+        "artifacts/agent-loop/final.md"
+    );
+    assert_eq!(
+        value["constants"]["runtime_artifacts"]["canonical_filenames"]["agent_result"],
+        "agent-result.json"
+    );
+    assert_eq!(
+        value["constants"]["runtime_artifacts"]["executor_evidence"]["input_file_name"],
+        "executor-input.json"
     );
     assert_eq!(
         value["constants"]["host_mutation_lifecycle"]["schema_id"],


### PR DESCRIPTION
## Summary
- export runtime artifact path and canonical filename constants from Homeboy core
- publish runner artifact manifest ref metadata through contract constants
- add contract registry/list/show/validate coverage for artifact-related contracts

## Verification
- cargo test --lib commands::contract::tests
- cargo test --test contract_constants_test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated duplicated runtime artifact constants, drafted the contract export slice, and coordinated verification.