### PR TITLE
Add secret env plan materialization contract

### DIFF
--- a/docs/commands/contract.md
+++ b/docs/commands/contract.md
@@ -16,6 +16,7 @@ homeboy contract <COMMAND>
 - `export --dir <dir>` - write machine-consumable contract JSON files
 - `validate <schema-id> --file <path>` - validate a JSON file against a registered contract
 - `normalize <kind>` - validate and normalize contract values from JSON input
+- `materialize <kind>` - assemble generic contract envelopes from declarative JSON input
 
 ## Constants
 
@@ -69,3 +70,20 @@ homeboy contract normalize run-lifecycle-status --input '{"status":"timed_out"}'
 
 Use `normalize` when automation needs to validate contract values and receive a
 canonical classification in the standard JSON envelope.
+
+## Materialize
+
+```sh
+homeboy contract materialize secret-env-plan --input '{
+  "secret_env_names": ["DIRECT_SECRET"],
+  "public_env": { "PUBLIC_FLAG": "1" },
+  "source_env_map": { "TARGET_SECRET": ["PRIMARY_TARGET_SECRET", "FALLBACK_TARGET_SECRET"] },
+  "env_name_mapping": { "source_refs": ["MAPPED_SECRET"] },
+  "inherited_allowed_env_names": ["HOMEBOY_AGENT_RUNTIME_SECRET_ENV"]
+}'
+```
+
+`materialize secret-env-plan` returns a `homeboy/secret-env-plan/v1` envelope plus
+name-only diagnostics. It accepts generic declarations only: public env values,
+secret env names, target-to-source env maps, grouping maps, and inheritance
+allowlists/policy. Secret values are not accepted or emitted.

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -42,8 +42,11 @@ use crate::core::runner_execution_envelope::{
     PathMaterializationPlan, RunnerExecutionProjection, RunnerExecutionRecord,
     PATH_MATERIALIZATION_PLAN_SCHEMA, RUNNER_EXECUTION_RECORD_SCHEMA,
 };
-use crate::core::secret_env_plan::{SecretEnvPlan, SECRET_ENV_PLAN_SCHEMA};
-use crate::core::{Error, Result};
+use crate::core::secret_env_plan::{
+    SecretEnvPlan, SecretEnvPlanMaterialization, SecretEnvPlanMaterializeRequest,
+    SECRET_ENV_PLAN_SCHEMA,
+};
+use crate::core::{Error, ErrorCode, Result};
 
 const CONTRACT_EXPORT_INDEX_SCHEMA: &str = "homeboy/contract-export-index/v1";
 const COMMAND_REGISTRY_EXPORT_SCHEMA: &str = "homeboy/command-registry-export/v1";
@@ -70,6 +73,8 @@ pub enum ContractCommand {
     Constants(ContractConstantsArgs),
     /// Validate and normalize generic contract values.
     Normalize(ContractNormalizeArgs),
+    /// Materialize generic contract envelopes from declarative inputs.
+    Materialize(ContractMaterializeArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -93,6 +98,7 @@ pub enum ContractOutput {
     Show(ContractShowOutput),
     Validate(ContractValidateOutput),
     Normalize(ContractNormalizeOutput),
+    Materialize(ContractMaterializeOutput),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -119,6 +125,27 @@ pub struct ContractNormalizeArgs {
     /// Read JSON value to normalize from a file.
     #[arg(long, value_name = "PATH")]
     pub input_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ContractMaterializeArgs {
+    /// Contract value kind to materialize
+    #[arg(value_enum)]
+    pub kind: ContractMaterializeKind,
+
+    /// JSON request to materialize. If omitted, stdin is read.
+    #[arg(long, conflicts_with = "input_file", value_name = "JSON")]
+    pub input: Option<String>,
+
+    /// Read JSON request to materialize from a file.
+    #[arg(long, value_name = "PATH")]
+    pub input_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum ContractMaterializeKind {
+    SecretEnvPlan,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -173,6 +200,12 @@ pub enum ContractNormalizeOutput {
     RunLifecycleStatus(RunLifecycleStatusNormalizeOutput),
     RunnerExecutionRecord(RunnerExecutionProjection),
     RunOutcomeEnvelope(RunOutcomeProjection),
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ContractMaterializeOutput {
+    SecretEnvPlan(SecretEnvPlanMaterialization),
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -377,6 +410,9 @@ pub fn run(args: ContractArgs, _global: &GlobalArgs) -> CmdResult<ContractOutput
         ContractCommand::Validate(args) => Ok((ContractOutput::Validate(validate(args)?), 0)),
         ContractCommand::Constants(args) => constants(&args.contract_id),
         ContractCommand::Normalize(args) => Ok((ContractOutput::Normalize(normalize(args)?), 0)),
+        ContractCommand::Materialize(args) => {
+            Ok((ContractOutput::Materialize(materialize(args)?), 0))
+        }
     }
 }
 
@@ -443,6 +479,38 @@ fn normalize(args: ContractNormalizeArgs) -> Result<ContractNormalizeOutput> {
             normalize_run_outcome_envelope(value).map(ContractNormalizeOutput::RunOutcomeEnvelope)
         }
     }
+}
+
+fn materialize(args: ContractMaterializeArgs) -> Result<ContractMaterializeOutput> {
+    let value = read_json_value(args.input.as_deref(), args.input_file.as_ref())?;
+
+    match args.kind {
+        ContractMaterializeKind::SecretEnvPlan => {
+            materialize_secret_env_plan(value).map(ContractMaterializeOutput::SecretEnvPlan)
+        }
+    }
+}
+
+fn materialize_secret_env_plan(value: Value) -> Result<SecretEnvPlanMaterialization> {
+    let request: SecretEnvPlanMaterializeRequest = deserialize_contract_value(
+        value,
+        "secret-env-plan-materialize-request",
+        "expected a secret env plan materialization request JSON object",
+    )?;
+
+    SecretEnvPlan::materialize_request(request).map_err(|err| {
+        Error::new(
+            ErrorCode::ValidationInvalidArgument,
+            format!("Invalid argument 'secret-env-plan': {}", err.message),
+            json!({
+                "field": "secret-env-plan",
+                "problem": err.message,
+                "missing_required_secret_env": err.missing_required_secret_env,
+                "undeclared_inherited_secret_env": err.undeclared_inherited_secret_env,
+                "diagnostics": err.diagnostics,
+            }),
+        )
+    })
 }
 
 fn normalize_artifact_ref(value: Value) -> Result<ArtifactRefNormalizeOutput> {

--- a/src/core/secret_env_plan.rs
+++ b/src/core/secret_env_plan.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::core::redaction::RedactionPolicy;
 
 pub const SECRET_ENV_PLAN_SCHEMA: &str = "homeboy/secret-env-plan/v1";
+pub const SECRET_ENV_PLAN_MATERIALIZATION_SCHEMA: &str =
+    "homeboy/secret-env-plan-materialization/v1";
 pub const AGENT_TASK_SECRET_ENV_PLAN_JSON_ENV: &str = "HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON";
 pub const SECRET_ENV_PLAN_ENV_DELTA_SOURCE: &str = "secret_env_plan_env_delta";
 
@@ -90,6 +92,40 @@ pub struct SecretEnvPlanDiagnosticError {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub undeclared_inherited_secret_env: Vec<String>,
     pub message: String,
+    pub diagnostics: SecretEnvPlanDiagnostics,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SecretEnvPlanMaterializeRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_plan: Option<SecretEnvPlan>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub public_env: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_env_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requirements: Vec<SecretEnvRequirement>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub source_env_map: BTreeMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env_name_mapping: BTreeMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inherited_allowed_env_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inherited_env_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inheritance: Option<SecretEnvInheritancePolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction: Option<SecretEnvRedactionPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic_source: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvPlanMaterialization {
+    pub schema: String,
+    pub valid: bool,
+    pub plan: SecretEnvPlan,
     pub diagnostics: SecretEnvPlanDiagnostics,
 }
 
@@ -287,6 +323,76 @@ impl Default for SecretEnvPlan {
 }
 
 impl SecretEnvPlan {
+    pub fn materialize_request(
+        request: SecretEnvPlanMaterializeRequest,
+    ) -> Result<SecretEnvPlanMaterialization, SecretEnvPlanDiagnosticError> {
+        let mut plan = request.base_plan.unwrap_or_default();
+        plan.schema = SECRET_ENV_PLAN_SCHEMA.to_string();
+        plan.public_env.extend(request.public_env);
+        plan.extend_secret_env_names(request.secret_env_names);
+
+        if !request.requirements.is_empty() {
+            plan.requirements =
+                normalize_requirements(plan.requirements.into_iter().chain(request.requirements));
+        }
+
+        for (name, source_env_names) in request.source_env_map {
+            let name = name.trim().to_string();
+            if name.is_empty() {
+                continue;
+            }
+            let source_env_names = normalize_ordered_names(source_env_names);
+            upsert_requirement(
+                &mut plan.requirements,
+                SecretEnvRequirement {
+                    name: name.clone(),
+                    required: true,
+                    source_env_names,
+                    refresh: None,
+                },
+            );
+            plan.extend_secret_env_names([name]);
+        }
+
+        for (key, names) in request.env_name_mapping {
+            plan.map_env_names(key, names);
+        }
+
+        if let Some(inheritance) = request.inheritance {
+            plan.inheritance = SecretEnvInheritancePolicy {
+                require_declaration: inheritance.require_declaration,
+                allowed_env_names: normalize_names(
+                    inheritance
+                        .allowed_env_names
+                        .into_iter()
+                        .chain(request.inherited_allowed_env_names),
+                ),
+            };
+        } else {
+            plan.allow_inherited_env_names(request.inherited_allowed_env_names);
+        }
+
+        if let Some(redaction) = request.redaction {
+            plan.redaction = redaction;
+        }
+
+        plan.requirements = normalize_requirements(plan.secret_env_requirements());
+
+        let diagnostics = plan.diagnose_materialized_declarations(
+            request.inherited_env_names,
+            request
+                .diagnostic_source
+                .unwrap_or_else(|| "materialize-request".to_string()),
+        )?;
+
+        Ok(SecretEnvPlanMaterialization {
+            schema: SECRET_ENV_PLAN_MATERIALIZATION_SCHEMA.to_string(),
+            valid: true,
+            plan,
+            diagnostics,
+        })
+    }
+
     pub fn from_secret_env_names(names: impl IntoIterator<Item = String>) -> Self {
         Self {
             secret_env_names: normalize_names(names),
@@ -434,6 +540,46 @@ impl SecretEnvPlan {
         }
     }
 
+    pub fn diagnose_inherited_env_names(
+        &self,
+        names: impl IntoIterator<Item = String>,
+        source: impl Into<String>,
+    ) -> Result<SecretEnvPlanDiagnostics, SecretEnvPlanDiagnosticError> {
+        let env = normalize_names(names)
+            .into_iter()
+            .map(|name| (name, String::new()))
+            .collect::<BTreeMap<_, _>>();
+        self.diagnose_inherited_env(&env, source)
+    }
+
+    fn diagnose_materialized_declarations(
+        &self,
+        inherited_env_names: impl IntoIterator<Item = String>,
+        inherited_source: impl Into<String>,
+    ) -> Result<SecretEnvPlanDiagnostics, SecretEnvPlanDiagnosticError> {
+        let status = self
+            .secret_env_requirements()
+            .into_iter()
+            .map(|requirement| {
+                secret_env_status_with_sources(requirement.name, true, "declared", None, Vec::new())
+            })
+            .collect::<Vec<_>>();
+        let mut diagnostics = self.diagnose(status)?;
+        let inherited = self.diagnose_inherited_env_names(inherited_env_names, inherited_source);
+        match inherited {
+            Ok(inherited_diagnostics) => {
+                diagnostics.inherited_env = inherited_diagnostics.inherited_env;
+                Ok(diagnostics)
+            }
+            Err(mut error) => {
+                error.diagnostics.status = diagnostics.status;
+                error.diagnostics.passthrough_secret_env_names =
+                    diagnostics.passthrough_secret_env_names;
+                Err(error)
+            }
+        }
+    }
+
     pub fn remove_undeclared_inherited_secret_env(
         &self,
         env: &mut HashMap<String, String>,
@@ -569,6 +715,33 @@ impl SecretEnvPlan {
             .chain(self.inheritance.allowed_env_names.iter().cloned())
             .collect()
     }
+}
+
+fn upsert_requirement(
+    requirements: &mut Vec<SecretEnvRequirement>,
+    requirement: SecretEnvRequirement,
+) {
+    let mut merged = requirements
+        .drain(..)
+        .map(|entry| (entry.name.clone(), entry))
+        .collect::<BTreeMap<_, _>>();
+    merged
+        .entry(requirement.name.clone())
+        .and_modify(|entry| {
+            entry.required = entry.required || requirement.required;
+            entry.source_env_names = normalize_ordered_names(
+                entry
+                    .source_env_names
+                    .iter()
+                    .cloned()
+                    .chain(requirement.source_env_names.iter().cloned()),
+            );
+            if entry.refresh.is_none() {
+                entry.refresh = requirement.refresh.clone();
+            }
+        })
+        .or_insert(requirement);
+    *requirements = merged.into_values().collect();
 }
 
 impl SecretEnvRequirement {
@@ -1190,5 +1363,78 @@ mod tests {
             .diagnostics;
 
         assert_eq!(diagnostics.status[0].refresh, Some(refresh));
+    }
+
+    #[test]
+    fn materialize_request_builds_plan_from_declarations_and_source_maps() {
+        let output = SecretEnvPlan::materialize_request(SecretEnvPlanMaterializeRequest {
+            public_env: BTreeMap::from([("PUBLIC_FLAG".to_string(), "1".to_string())]),
+            secret_env_names: vec!["DIRECT_SECRET".to_string()],
+            source_env_map: BTreeMap::from([(
+                "TARGET_SECRET".to_string(),
+                vec![
+                    "PRIMARY_TARGET_SECRET".to_string(),
+                    "FALLBACK_TARGET_SECRET".to_string(),
+                ],
+            )]),
+            env_name_mapping: BTreeMap::from([(
+                "source_refs".to_string(),
+                vec!["MAPPED_SECRET".to_string()],
+            )]),
+            inherited_allowed_env_names: vec!["HOMEBOY_AGENT_RUNTIME_SECRET_ENV".to_string()],
+            inherited_env_names: vec!["TARGET_SECRET".to_string()],
+            ..SecretEnvPlanMaterializeRequest::default()
+        })
+        .expect("materialized secret env plan");
+
+        assert_eq!(output.schema, SECRET_ENV_PLAN_MATERIALIZATION_SCHEMA);
+        assert!(output.valid);
+        assert_eq!(output.plan.schema, SECRET_ENV_PLAN_SCHEMA);
+        assert_eq!(
+            output.plan.secret_env_names(),
+            vec![
+                "DIRECT_SECRET".to_string(),
+                "FALLBACK_TARGET_SECRET".to_string(),
+                "MAPPED_SECRET".to_string(),
+                "PRIMARY_TARGET_SECRET".to_string(),
+                "TARGET_SECRET".to_string(),
+            ]
+        );
+        assert_eq!(
+            output.diagnostics.passthrough_secret_env_names,
+            vec![
+                "DIRECT_SECRET".to_string(),
+                "MAPPED_SECRET".to_string(),
+                "TARGET_SECRET".to_string(),
+            ]
+        );
+        assert_eq!(output.diagnostics.status[2].name, "TARGET_SECRET");
+        assert_eq!(
+            output.diagnostics.status[2].source_env_names,
+            vec![
+                "PRIMARY_TARGET_SECRET".to_string(),
+                "FALLBACK_TARGET_SECRET".to_string(),
+            ]
+        );
+        assert!(!serde_json::to_string(&output)
+            .expect("materialization json")
+            .contains("secret-value"));
+    }
+
+    #[test]
+    fn materialize_request_rejects_undeclared_inherited_secret_env_names() {
+        let error = SecretEnvPlan::materialize_request(SecretEnvPlanMaterializeRequest {
+            inherited_env_names: vec!["UNDECLARED_API_TOKEN".to_string()],
+            ..SecretEnvPlanMaterializeRequest::default()
+        })
+        .expect_err("undeclared sensitive inherited env is rejected");
+
+        assert_eq!(
+            error.undeclared_inherited_secret_env,
+            vec!["UNDECLARED_API_TOKEN".to_string()]
+        );
+        assert!(!serde_json::to_string(&error)
+            .expect("error json")
+            .contains("secret-value"));
     }
 }


### PR DESCRIPTION
## Summary
- add `homeboy contract materialize secret-env-plan`
- materialize `homeboy/secret-env-plan/v1` from generic declarations, source maps, env mappings, and inheritance policy
- return redacted diagnostics for success and validation failures

## Verification
- `rustfmt --check src/core/secret_env_plan.rs src/commands/contract.rs`
- `cargo check --bin homeboy`
- `cargo test materialize_request --lib`
- CLI materialization success and failure-path checks

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the Extensions secret-plan duplication, drafted the core primitive, and coordinated verification.
