### PR TITLE
Support component execution environment config

### DIFF
--- a/docs/reference/schemas/component-schema.md
+++ b/docs/reference/schemas/component-schema.md
@@ -42,6 +42,9 @@ Component configuration defines buildable and deployable units stored in `compon
     "bench": ["shell command"],
     "trace": ["shell command"]
   },
+  "env": {
+    "KEY": "value"
+  },
   "extensions": {},
   "release": {}
 }
@@ -76,6 +79,11 @@ Component configuration defines buildable and deployable units stored in `compon
   - Resolution order is `scripts.<capability>` first, then linked extension support, then not-applicable
   - Scripts receive the same runner env paths (`HOMEBOY_COMPONENT_ID`, `HOMEBOY_COMPONENT_PATH`, `HOMEBOY_RUN_DIR` and sidecar file vars when relevant) as extension runners, with `HOMEBOY_EXTENSION_ID=component-script`
   - Use `scripts.build`, not `build_command`; `build_command` is still only a diagnostic output field.
+- **`env`** (object): Component-scoped environment variables applied to Homeboy-managed capability runs for the component
+  - Applies to component scripts and extension runners for managed build/test/lint/bench/trace/deps-style capability execution.
+  - Per-run environment variables supplied by command workflows are applied after component config and win on key conflicts.
+  - `homeboy build` reports configured keys as `active_env_keys` so cache/debug configuration is visible without exposing values.
+  - Example: set `"CARGO_TARGET_DIR": "/path/to/shared/rebuildable/cargo-target"` for a Rust component without adding Rust-specific Homeboy behavior.
 - **`artifact_inputs`** (array): Producer artifacts to resolve and compose into this component's build artifact after this component builds
   - **`component`** (string): Producer component ID to build before composition
   - **`artifact`** (string): Producer artifact path or glob, resolved relative to the producer `local_path`
@@ -160,6 +168,9 @@ Setting `local_path` to the same directory as the deploy target is a misconfigur
     "post:release": [
       "echo 'Release complete!'"
     ]
+  },
+  "env": {
+    "SHARED_BUILD_CACHE": "/path/to/shared/rebuildable-cache"
   },
   "extensions": {
     "wordpress": {

--- a/src/core/component/model.rs
+++ b/src/core/component/model.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use super::audit::AuditConfig;
 use super::config::{
@@ -108,6 +108,10 @@ pub struct Component {
     /// then extension-claimed behavior, then not-applicable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scripts: Option<ComponentScriptsConfig>,
+    /// Component-scoped environment variables applied to Homeboy-managed
+    /// capability runs for this component. Per-run env overrides win on conflict.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audit: Option<AuditConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -208,6 +212,8 @@ struct RawComponent {
     scopes: Option<ScopeConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     scripts: Option<ComponentScriptsConfig>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    env: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     audit: Option<AuditConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -259,6 +265,7 @@ impl From<RawComponent> for Component {
             docs_dirs: raw.docs_dirs,
             scopes: raw.scopes,
             scripts: raw.scripts,
+            env: raw.env,
             audit: raw.audit,
             dependency_stack: raw.dependency_stack,
             deploy_together: raw.deploy_together,
@@ -303,6 +310,7 @@ impl From<Component> for RawComponent {
             docs_dirs: c.docs_dirs,
             scopes: c.scopes,
             scripts: c.scripts,
+            env: c.env,
             audit: c.audit,
             dependency_stack: c.dependency_stack,
             deploy_together: c.deploy_together,
@@ -352,6 +360,7 @@ impl Component {
             docs_dirs: Vec::new(),
             scopes: None,
             scripts: None,
+            env: BTreeMap::new(),
             audit: None,
             dependency_stack: Vec::new(),
             deploy_together: Vec::new(),

--- a/src/core/component/tests.rs
+++ b/src/core/component/tests.rs
@@ -137,6 +137,29 @@ fn component_priority_labels_serialization_roundtrip() {
 }
 
 #[test]
+fn component_env_serialization_roundtrip() {
+    let component: Component = serde_json::from_value(serde_json::json!({
+        "id": "fixture",
+        "env": {
+            "CARGO_TARGET_DIR": "/tmp/homeboy/cargo-target",
+            "SHARED_CACHE_DIR": "/tmp/homeboy/shared-cache"
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(
+        component.env.get("CARGO_TARGET_DIR").map(String::as_str),
+        Some("/tmp/homeboy/cargo-target")
+    );
+
+    let json = serde_json::to_value(&component).unwrap();
+    assert_eq!(
+        json["env"]["SHARED_CACHE_DIR"],
+        serde_json::json!("/tmp/homeboy/shared-cache")
+    );
+}
+
+#[test]
 fn component_deploy_config_reads_legacy_flat_fields() {
     let component: Component = serde_json::from_value(serde_json::json!({
         "id": "sample-plugin",

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -156,6 +156,8 @@ pub struct BuildOutput {
     pub command: String,
     pub component_id: String,
     pub build_command: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_env_keys: Vec<String>,
     #[serde(flatten)]
     pub output: CapturedOutput,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -436,6 +438,7 @@ fn execute_build_component(
 
     let resolved = resolve_build_command(comp)?;
     let build_cmd = resolved.command().to_string();
+    let active_env_keys = configured_env_keys(comp);
     let build_context = match &resolved {
         ResolvedBuildCommand::ComponentScript { .. } => None,
         ResolvedBuildCommand::ExtensionProvided { context, .. } => Some(context),
@@ -452,6 +455,7 @@ fn execute_build_component(
                 command: "build.run".to_string(),
                 component_id: comp.id.clone(),
                 build_command: build_cmd,
+                active_env_keys,
                 output: CapturedOutput::new(String::new(), String::new()),
                 artifact_inputs: Vec::new(),
                 extension_phase_timings: Vec::new(),
@@ -479,6 +483,7 @@ fn execute_build_component(
                     command: "build.run".to_string(),
                     component_id: comp.id.clone(),
                     build_command: build_cmd,
+                    active_env_keys,
                     output: CapturedOutput::new(String::new(), stderr),
                     artifact_inputs: Vec::new(),
                     extension_phase_timings: Vec::new(),
@@ -546,6 +551,7 @@ fn execute_build_component(
             command: "build.run".to_string(),
             component_id: comp.id.clone(),
             build_command: build_cmd,
+            active_env_keys,
             output: CapturedOutput::new(runner_output.stdout, runner_output.stderr),
             artifact_inputs,
             extension_phase_timings: runner_output.extension_phase_timings,
@@ -697,6 +703,10 @@ fn build_env(
     env
 }
 
+fn configured_env_keys(comp: &Component) -> Vec<String> {
+    comp.env.keys().cloned().collect()
+}
+
 fn command_with_args(command: &str, args: &[String]) -> String {
     if args.is_empty() {
         return command.to_string();
@@ -756,17 +766,37 @@ fn run_pre_build_scripts(
     }
 
     let extension_path_lossy = build_context.extension_path.to_string_lossy().to_string();
-    let env: [(&str, &str); 4] = [
-        (exec_context::EXTENSION_PATH, &extension_path_lossy),
-        (exec_context::COMPONENT_ID, &build_context.component.id),
+    let mut env: Vec<(String, String)> = vec![
         (
-            exec_context::COMPONENT_PATH,
-            &build_context.component.local_path,
+            exec_context::EXTENSION_PATH.to_string(),
+            extension_path_lossy,
         ),
-        ("HOMEBOY_PLUGIN_PATH", &build_context.component.local_path),
+        (
+            exec_context::COMPONENT_ID.to_string(),
+            build_context.component.id.clone(),
+        ),
+        (
+            exec_context::COMPONENT_PATH.to_string(),
+            build_context.component.local_path.clone(),
+        ),
+        (
+            "HOMEBOY_PLUGIN_PATH".to_string(),
+            build_context.component.local_path.clone(),
+        ),
     ];
+    env.extend(
+        crate::core::extension::component_script::component_env_vars(&build_context.component),
+    );
+    let env_refs: Vec<(&str, &str)> = env
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
 
-    let output = execute_local_command_in_dir(&script_path.to_string_lossy(), None, Some(&env));
+    let output = execute_local_command_in_dir(
+        &script_path.to_string_lossy(),
+        None,
+        Some(env_refs.as_slice()),
+    );
 
     if !output.success {
         let combined = if output.stderr.is_empty() {

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -189,12 +189,14 @@ fn component_script_env(
         (exec_context::COMPONENT_PATH.to_string(), source_path_value),
         (exec_context::SETTINGS_JSON.to_string(), "{}".to_string()),
     ];
+    let component_env = component_env_vars(component);
     if let Some(extensions) = &component.extensions {
         let mut extension_ids = extensions.keys().collect::<Vec<_>>();
         extension_ids.sort();
         for extension_id in extension_ids {
             let extension = load_extension(extension_id)?;
             let mut provider_env = env.clone();
+            provider_env.extend(component_env.iter().cloned());
             provider_env.extend(extra_env.iter().cloned());
             env.extend(env_provider::env_vars(
                 &extension,
@@ -203,8 +205,17 @@ fn component_script_env(
             )?);
         }
     }
+    env.extend(component_env);
     env.extend(extra_env.iter().cloned());
     Ok(env)
+}
+
+pub(crate) fn component_env_vars(component: &Component) -> Vec<(String, String)> {
+    component
+        .env
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
 }
 
 fn command_with_args(command: &str, script_args: &[String]) -> String {

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -233,7 +233,9 @@ impl ExtensionRunner {
 
         let project_path = PathBuf::from(&prepared.execution.component.local_path);
         let invocation = self.acquire_invocation_guard()?;
-        let mut extra_env_vars = self.env_vars.clone();
+        let mut extra_env_vars =
+            super::component_script::component_env_vars(&prepared.execution.component);
+        extra_env_vars.extend(self.env_vars.clone());
         if let Some(invocation) = invocation.as_ref() {
             extra_env_vars.extend(invocation.env_vars());
         }

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -105,6 +105,95 @@ fn test_run_component_scripts_with_env() {
 }
 
 #[test]
+fn component_config_env_is_available_to_component_scripts_and_extra_env_wins() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let mut component = script_component(
+        dir.path(),
+        "printf '%s:%s' \"$SHARED_CACHE_DIR\" \"$OVERRIDE_ME\" > marker",
+    );
+    component.env.insert(
+        "SHARED_CACHE_DIR".to_string(),
+        "/tmp/homeboy-shared-cache".to_string(),
+    );
+    component
+        .env
+        .insert("OVERRIDE_ME".to_string(), "configured".to_string());
+
+    let output = run_component_scripts_with_env(
+        &component,
+        ExtensionCapability::Test,
+        dir.path(),
+        false,
+        &[("OVERRIDE_ME".to_string(), "runtime".to_string())],
+        &[],
+    )
+    .expect("component script should run with configured env");
+
+    assert!(output.success);
+    assert_eq!(
+        fs::read_to_string(dir.path().join("marker")).unwrap(),
+        "/tmp/homeboy-shared-cache:runtime"
+    );
+}
+
+#[test]
+fn component_config_env_is_visible_to_env_providers() {
+    with_isolated_home(|_| {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let extension_dir = crate::core::paths::extensions()
+            .expect("extensions path")
+            .join("fixture-provider-env");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("fixture-provider-env.json"),
+            r#"{
+                "name": "Fixture Provider Env",
+                "version": "1.0.0",
+                "env_provider": { "script": "env.sh" }
+            }"#,
+        )
+        .expect("extension manifest");
+        fs::write(
+            extension_dir.join("env.sh"),
+            "#!/bin/sh\nprintf '{\"PROVIDER_SAW\":\"%s\"}' \"$SHARED_CACHE_DIR\"\n",
+        )
+        .expect("extension env script");
+        let mut permissions = fs::metadata(extension_dir.join("env.sh"))
+            .expect("extension env metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(extension_dir.join("env.sh"), permissions)
+            .expect("extension env executable");
+
+        let mut component = script_component(dir.path(), "printf '%s' \"$PROVIDER_SAW\" > marker");
+        component.env.insert(
+            "SHARED_CACHE_DIR".to_string(),
+            "/tmp/homeboy-provider-cache".to_string(),
+        );
+        component.extensions = Some(HashMap::from([(
+            "fixture-provider-env".to_string(),
+            ScopedExtensionConfig::default(),
+        )]));
+
+        let output = run_component_scripts_with_env(
+            &component,
+            ExtensionCapability::Test,
+            dir.path(),
+            false,
+            &[],
+            &[],
+        )
+        .expect("component script should run");
+
+        assert!(output.success);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("marker")).unwrap(),
+            "/tmp/homeboy-provider-cache"
+        );
+    });
+}
+
+#[test]
 fn component_scripts_include_linked_extension_env_provider_output() {
     with_isolated_home(|_| {
         let dir = tempfile::tempdir().expect("temp dir");


### PR DESCRIPTION
Closes #7268

## Summary
- Add generic top-level component `env` configuration.
- Apply configured env to Homeboy-managed component execution paths.
- Include active env key names in build output for debuggability without exposing values.

## Testing
- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- Not run: `cargo test` per local hot-command policy.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Issue triage, implementation, cleanup of generated diffs, and PR preparation.