### PR TITLE
Remove stale CLI compatibility surfaces

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -613,7 +613,6 @@ homeboy runner exec <runner-id> --ssh --cwd /runner/workspace/project -- <comman
 homeboy runner exec <runner-id> --run-id ssi-fixture-matrix-summary -- <command...>
 homeboy runner exec <runner-id> --cwd /runner/workspace/project --require-path /runner/workspace/project -- <command...>
 homeboy runner env <runner-id>
-homeboy runner env <runner-id> --show-values
 ```
 
 `exec` submits the command to the connected runner daemon when `homeboy runner connect <runner-id>` has established a live loopback tunnel. If no daemon session is connected, local runners execute directly and SSH runners require explicit diagnostic `--ssh`. SSH runner raw exec is policy-denied by default until `policy.allow_raw_exec` is explicitly true.
@@ -650,7 +649,7 @@ This is the generic one-command form for “run my local patch on the runner”:
 Runner job environment:
 
 - `homeboy runner env <runner-id>` shows configured public runner env plus `secret_env` keys/references for runner jobs. It does not resolve or print secret values.
-- Public `env` values are redacted by default because legacy configs may still contain tokens. Use `--show-values` only in trusted local/operator contexts; `secret_env` remains references-only even with `--show-values`.
+- Public `env` values are redacted because legacy configs may still contain tokens; `secret_env` remains references-only.
 - `homeboy ssh <server> -- printenv NAME` inspects the server login shell environment. It does not include runner job env unless the variable is also configured on the server shell.
 - Use `homeboy runner exec <runner-id> -- printenv NAME` for final execution-time proof when debugging resolved runner job environment.
 

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -147,7 +147,6 @@ homeboy runs list --kind bench --component <component> [--scenario <id>] [--rig 
 homeboy runs dossier <run-id>
 homeboy runs distribution --kind bench --component <component> --field <metadata.path> [--scenario <id>] [--rig <id>] [--status <status>] [--limit 20]
 homeboy runs bench-compare --from-run <run-id> --to-run <run-id>
-homeboy rig runs <id> [--limit 20]
 ```
 
 ## Portable Bundles

--- a/docs/internals/developer-guide/architecture-cleanup-map.md
+++ b/docs/internals/developer-guide/architecture-cleanup-map.md
@@ -62,7 +62,6 @@ docs cleanup PR.
 
 | Compatibility surface | Current owner | Current shape | Retirement criteria |
 | --- | --- | --- | --- |
-| Hidden `homeboy list` command | `src/cli_surface.rs`, `src/command_contract/output.rs` | Hidden raw Markdown/help alias with optional JSON safety manifest. | Remove after command-surface manifest consumers use `homeboy --help`, `homeboy docs list`, or the explicit safety manifest surface. |
 | Global `--no-local-execution` alias | `src/cli_surface.rs` | Visible alias for `--lab-only`. | Remove after operator docs and automation uniformly use `--lab-only` and no active scripts reference the alias. |
 | Legacy component fields such as `build_command` | `src/commands/component.rs`, `src/core/extension/build/mod.rs`, `src/core/extension/capability.rs` | Rejected with targeted errors while modern config uses extension/build script contracts. | Remove parse-time compatibility handling after persisted configs have been migrated and error telemetry shows the legacy field is no longer encountered. |
 | Hidden JSON self-check flags | `src/commands/lint.rs`, `src/commands/test.rs`, `src/commands/review/mod.rs` | Hidden `--self-checks-json`-style command inputs used by internal checks. | Replace with explicit core/test harness contracts, then remove hidden flags once self-check callers are migrated. |

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -169,14 +169,6 @@ enum RigCommand {
         /// Rig ID
         rig_id: String,
     },
-    /// Compatibility alias for `homeboy runs list --rig <rig-id>`
-    Runs {
-        /// Rig ID
-        rig_id: String,
-        /// Maximum runs to return
-        #[arg(long, default_value_t = 20)]
-        limit: i64,
-    },
     /// Release a stuck active-run lock (rig lease) so a new run can proceed.
     ///
     /// By default the lock is only released when its holder is provably gone or
@@ -317,7 +309,6 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
         RigCommand::Run(args) => run_profile(args),
         RigCommand::Status { rig_id } => status(&rig_id),
-        RigCommand::Runs { rig_id, limit } => runs(&rig_id, limit),
         RigCommand::ReleaseLock { rig_id, force } => release_lock(&rig_id, force),
         RigCommand::Install {
             source,
@@ -340,18 +331,6 @@ fn release_lock(rig_id: &str, force: bool) -> CmdResult<RigCommandOutput> {
         }),
         0,
     ))
-}
-
-fn runs(rig_id: &str, limit: i64) -> CmdResult<RigCommandOutput> {
-    let (output, exit_code) = super::runs::list_runs(
-        super::runs::RunsListArgs {
-            rig: Some(rig_id.to_string()),
-            limit,
-            ..Default::default()
-        },
-        "rig.runs",
-    )?;
-    Ok((RigCommandOutput::Runs(output), exit_code))
 }
 
 fn list() -> CmdResult<RigCommandOutput> {

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -6,7 +6,6 @@
 use serde::Serialize;
 
 use crate::commands::bench::{BenchOutput, RigRunBenchPlan};
-use crate::commands::runs::RunsOutput;
 use homeboy::core::rig::{self, RigResourcesSpec, RigSpec};
 
 /// Tagged union of every rig command's output.
@@ -26,7 +25,6 @@ pub enum RigCommandOutput {
     Update(RigUpdateOutput),
     Sources(RigSourcesOutput),
     App(RigAppOutput),
-    Runs(RunsOutput),
     ReleaseLock(RigReleaseLockOutput),
     Run(RigRunOutput),
 }

--- a/src/commands/runs/artifact_index_tests.rs
+++ b/src/commands/runs/artifact_index_tests.rs
@@ -58,7 +58,7 @@ fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> 
 }
 
 #[test]
-fn rig_runs_list_surfaces_compact_artifact_index() {
+fn runs_list_rig_filter_surfaces_compact_artifact_index() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();
         let store = ObservationStore::open_initialized().expect("store");
@@ -103,14 +103,14 @@ fn rig_runs_list_surfaces_compact_artifact_index() {
                 limit: 20,
                 include_active_runner_jobs: false,
             },
-            "rig.runs",
+            "runs.list",
         )
-        .expect("rig runs");
+        .expect("runs list");
 
         let RunsOutput::List(output) = output else {
             panic!("expected list output");
         };
-        assert_eq!(output.command, "rig.runs");
+        assert_eq!(output.command, "runs.list");
         assert_eq!(output.runs.len(), 1);
         let artifact_index = output.runs[0]
             .artifact_index

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -421,14 +421,6 @@ fn runner_exec_flags_parse_before_trailing_command() {
 }
 
 #[test]
-fn runner_env_rejects_legacy_show_values_flag() {
-    assert!(
-        Cli::try_parse_from(["homeboy", "runner", "env", "homeboy-lab", "--show-values"]).is_err(),
-        "runner env must not expose raw environment values"
-    );
-}
-
-#[test]
 fn agent_task_auth_status_accepts_global_runner_and_secret_env() {
     Cli::try_parse_from([
         "homeboy",


### PR DESCRIPTION
## Summary
- Remove the rig runs compatibility alias.
- Delete stale runner env --show-values docs and negative parser test.
- Remove the deleted homeboy list cleanup-map entry.

## Verification
- rustfmt --check on touched Rust files
- git diff --check
- cargo check --test command_surface_test --test architecture_core_agnostic_test --test output_contracts_test
- cargo check --tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Identified stale CLI compatibility surfaces, removed dead paths/docs, and ran targeted checks.