### PR TITLE
Make worktree artifact cleanup explicit

### DIFF
--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -2,6 +2,8 @@
 
 Remove or inspect reconstructable artifacts that Homeboy can safely recreate.
 
+This is the canonical artifact cleanup path. Worktree lifecycle cleanup is handled by `homeboy worktree cleanup`; artifact removal stays dry-run here until `--apply` is passed.
+
 ## `homeboy cleanup artifacts`
 
 Scans the current repository and its managed Git worktrees for declared artifact paths. The command defaults to dry-run JSON output and only removes files when `--apply` is passed.

--- a/docs/commands/worktree.md
+++ b/docs/commands/worktree.md
@@ -8,8 +8,10 @@ Manage component-backed task worktrees for generic Homeboy workflows.
 - `homeboy worktree list`
 - `homeboy worktree status <id>`
 - `homeboy worktree remove <id> [--force]`
-- `homeboy worktree cleanup [--force]`
+- `homeboy worktree cleanup [--force] [--cleanup-artifacts]`
 
 ## Safety
 
 Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. `--force` only bypasses dirty/unpushed checks; primary checkout and containment gates always apply.
+
+`worktree cleanup` is task-worktree cleanup by default. Use `homeboy cleanup artifacts` to plan rebuildable artifact cleanup, then pass `--apply` when the plan is acceptable. `worktree cleanup --cleanup-artifacts` is an explicit combined operator path for also removing declared rebuildable artifacts from the Homeboy checkout that built the active binary.

--- a/docs/workflows/manage-local-environments.md
+++ b/docs/workflows/manage-local-environments.md
@@ -92,6 +92,13 @@ homeboy worktree cleanup
 
 Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. Treat `--force` as an explicit operator decision, not routine cleanup.
 
+Use artifact cleanup separately so it stays plan-first:
+
+```bash
+homeboy cleanup artifacts
+homeboy cleanup artifacts --apply
+```
+
 ## 6. Connect To Agent Workflows
 
 Agent-task cooks can target a managed worktree:

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -579,8 +579,8 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.dry_run_flag = Some("--dry-run");
             metadata.output_notes =
-                "removes cleanup-eligible task worktrees and rebuildable artifacts; pass --dry-run to report candidates without removing";
-            metadata.dangerous_flags = vec!["--force"];
+                "removes cleanup-eligible task worktrees; pass --cleanup-artifacts to also remove rebuildable Homeboy artifacts";
+            metadata.dangerous_flags = vec!["--force", "--cleanup-artifacts"];
         }
         ["tunnel", "service", "expose"]
         | ["tunnel", "service", "set"]

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -113,9 +113,9 @@ enum WorktreeCommand {
         /// Report cleanup candidates without removing worktrees or artifacts.
         #[arg(long)]
         dry_run: bool,
-        /// Skip the automatic rebuildable artifact cleanup pass.
+        /// Also remove declared rebuildable artifacts from the Homeboy checkout that built this binary.
         #[arg(long)]
-        skip_artifact_cleanup: bool,
+        cleanup_artifacts: bool,
     },
 }
 
@@ -218,12 +218,10 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
         WorktreeCommand::Cleanup {
             force,
             dry_run,
-            skip_artifact_cleanup,
+            cleanup_artifacts,
         } => {
             let worktrees = worktree::cleanup(WorktreeCleanupOptions { force, dry_run })?;
-            let artifact_cleanup = if skip_artifact_cleanup {
-                None
-            } else {
+            let artifact_cleanup = if cleanup_artifacts {
                 Some(artifact_cleanup::cleanup_artifacts(
                     ArtifactCleanupOptions {
                         path: None,
@@ -235,6 +233,8 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
                         merged_only: false,
                     },
                 )?)
+            } else {
+                None
             };
             WorktreeOutput::Cleanup(WorktreeCleanupCommandOutput {
                 worktrees,
@@ -243,4 +243,47 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
         }
     };
     Ok((output, 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::cli_surface::{Cli, Commands};
+
+    use super::WorktreeCommand;
+
+    #[test]
+    fn worktree_cleanup_does_not_cleanup_artifacts_by_default() {
+        let cli = Cli::parse_from(["homeboy", "worktree", "cleanup"]);
+
+        let Commands::Worktree(args) = cli.command else {
+            panic!("expected worktree command");
+        };
+        let WorktreeCommand::Cleanup {
+            cleanup_artifacts, ..
+        } = args.command
+        else {
+            panic!("expected worktree cleanup command");
+        };
+
+        assert!(!cleanup_artifacts);
+    }
+
+    #[test]
+    fn worktree_cleanup_artifact_cleanup_requires_explicit_flag() {
+        let cli = Cli::parse_from(["homeboy", "worktree", "cleanup", "--cleanup-artifacts"]);
+
+        let Commands::Worktree(args) = cli.command else {
+            panic!("expected worktree command");
+        };
+        let WorktreeCommand::Cleanup {
+            cleanup_artifacts, ..
+        } = args.command
+        else {
+            panic!("expected worktree cleanup command");
+        };
+
+        assert!(cleanup_artifacts);
+    }
 }


### PR DESCRIPTION
## Summary
- Stop running artifact cleanup implicitly from worktree cleanup.
- Add explicit worktree cleanup --cleanup-artifacts for the combined mutating path.
- Update safety metadata and docs for the canonical cleanup contract.

## Verification
- homeboy test --lab-only --skip-lint -- worktree_cleanup, run f3da329b-ac8e-4ee3-9fd4-26456861f33b
- homeboy test --lab-only --skip-lint -- command_safety_manifest_records_guard_flags_and_dry_run_flags, run runner-exec-generic-homeboy-lab-f309dfac-f621-41fb-a742-aaaa20d1e954

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated cleanup surface fragmentation, drafted the explicit cleanup contract, and routed targeted tests through Homeboy lab.