### PR TITLE
fix(release): allow default-head worktree releases

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -142,10 +142,12 @@ pub(super) fn execute_release_plan_step(
                 .tag
                 .clone()
                 .or_else(|| context.state.version.as_deref().map(|v| format!("v{v}")));
+            let push_branch = step.inputs.get("branch").and_then(|value| value.as_str());
             executor::run_git_push(
                 context.component,
                 context.component_id,
                 release_tag.as_deref(),
+                push_branch,
             )
             .map(Some)
         }

--- a/src/core/release/executor/git_push.rs
+++ b/src/core/release/executor/git_push.rs
@@ -17,18 +17,30 @@ pub(crate) fn run_git_push(
     component: &Component,
     component_id: &str,
     release_tag: Option<&str>,
+    target_branch: Option<&str>,
 ) -> Result<ReleaseStepResult> {
-    let branch = crate::core::git::current_branch(std::path::Path::new(&component.local_path))
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "branch",
-                "Release push requires a checked-out branch",
-                Some(component.local_path.clone()),
-                Some(vec![
-                    "Check out the release branch before running `homeboy release`.".to_string(),
-                ]),
-            )
-        })?;
+    let current_branch = crate::core::git::current_branch(std::path::Path::new(
+        &component.local_path,
+    ))
+    .ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "branch",
+            "Release push requires a checked-out branch",
+            Some(component.local_path.clone()),
+            Some(vec![
+                "Check out the release branch before running `homeboy release`.".to_string(),
+            ]),
+        )
+    })?;
+    let branch = target_branch.unwrap_or(&current_branch);
+    if branch != current_branch {
+        log_status!(
+            "release",
+            "Pushing release commit from local branch '{}' to default branch '{}'.",
+            current_branch,
+            branch
+        );
+    }
     let output = push_release_branch(component, component_id, &branch)?;
     let data = serde_json::to_value(&output)
         .map_err(|e| Error::internal_json(e.to_string(), Some("git push output".to_string())))?;
@@ -252,8 +264,8 @@ mod tests {
             ..Component::default()
         };
 
-        let result =
-            run_git_push(&component, "fixture", None).expect("push step should return result");
+        let result = run_git_push(&component, "fixture", None, None)
+            .expect("push step should return result");
 
         assert_eq!(result.status, ReleaseStepStatus::Failed);
         assert!(!result.error.unwrap().trim().is_empty());
@@ -310,12 +322,70 @@ mod tests {
             ..Component::default()
         };
 
-        let result = run_git_push(&component, "fixture", Some("v1.0.0"))
+        let result = run_git_push(&component, "fixture", Some("v1.0.0"), None)
             .expect("push step should return result");
 
         assert_eq!(result.status, ReleaseStepStatus::Success);
         git(remote.path(), &["show-ref", "--verify", "refs/heads/main"]);
         git(remote.path(), &["show-ref", "--verify", "refs/tags/v1.0.0"]);
+    }
+
+    #[test]
+    fn run_git_push_can_push_release_worktree_head_to_default_branch() {
+        let local = tempfile::tempdir().expect("local tempdir");
+        let remote = tempfile::tempdir().expect("remote tempdir");
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
+        git(
+            local.path(),
+            &["clone", remote.path().to_str().unwrap(), "."],
+        );
+        git(local.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            local.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        std::fs::write(local.path().join("README.md"), "base").expect("write fixture");
+        git(local.path(), &["add", "."]);
+        git(local.path(), &["commit", "-m", "base"]);
+        git(local.path(), &["push", "origin", "main"]);
+
+        git(local.path(), &["checkout", "-q", "-b", "release/v1.0.0"]);
+        std::fs::write(local.path().join("release.txt"), "release").expect("write release");
+        git(local.path(), &["add", "."]);
+        git(local.path(), &["commit", "-m", "release: v1.0.0"]);
+        git(
+            local.path(),
+            &["tag", "-a", "v1.0.0", "-m", "Release v1.0.0"],
+        );
+
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: local.path().to_string_lossy().to_string(),
+            ..Component::default()
+        };
+
+        let result = run_git_push(&component, "fixture", Some("v1.0.0"), Some("main"))
+            .expect("push step should return result");
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        git(remote.path(), &["show-ref", "--verify", "refs/heads/main"]);
+        git(remote.path(), &["show-ref", "--verify", "refs/tags/v1.0.0"]);
+        git(local.path(), &["fetch", "origin"]);
+        let remote_main_subjects = Command::new("git")
+            .args(["log", "--format=%s", "origin/main"])
+            .current_dir(local.path())
+            .output()
+            .expect("git log");
+        assert!(String::from_utf8_lossy(&remote_main_subjects.stdout).contains("release: v1.0.0"));
+        assert_eq!(
+            Command::new("git")
+                .args(["branch", "--show-current"])
+                .current_dir(local.path())
+                .output()
+                .expect("git branch")
+                .stdout,
+            b"release/v1.0.0\n".to_vec()
+        );
     }
 
     #[test]
@@ -393,7 +463,7 @@ mod tests {
             ..Component::default()
         };
 
-        let result = run_git_push(&component, "fixture", Some("v1.0.0"))
+        let result = run_git_push(&component, "fixture", Some("v1.0.0"), None)
             .expect("push step returns a result");
 
         assert_eq!(

--- a/src/core/release/plan_steps/release.rs
+++ b/src/core/release/plan_steps/release.rs
@@ -136,12 +136,15 @@ pub(in crate::core::release) fn build_release_steps(
         string_config("name", tag_name),
     ));
 
+    let push_branch = super::super::planning_git::release_push_branch(component)?;
     steps.push(ready_step(
         "git.push",
         "git.push",
-        "Push to remote",
+        format!("Push to remote {}", push_branch),
         vec!["git.tag".to_string()],
-        StepConfig::new().bool("tags", true),
+        StepConfig::new()
+            .bool("tags", true)
+            .string("branch", push_branch),
     ));
 
     if !options.skip_github_release && github_release_applies(component) {

--- a/src/core/release/plan_steps/tests/mod.rs
+++ b/src/core/release/plan_steps/tests/mod.rs
@@ -371,6 +371,7 @@ fn test_build_release_steps() {
     let version_index = step_index(&ids, "version");
     let prepare_index = step_index(&ids, "release.prepare");
     let commit_index = step_index(&ids, "git.commit");
+    let push_index = step_index(&ids, "git.push");
 
     assert!(changelog_policy_index < changelog_index);
     assert!(changelog_index < version_index);
@@ -385,6 +386,13 @@ fn test_build_release_steps() {
     assert_eq!(steps[version_index].needs, vec!["changelog.finalize"]);
     assert_eq!(steps[prepare_index].needs, vec!["version"]);
     assert_eq!(steps[commit_index].needs, vec!["release.prepare"]);
+    assert_eq!(
+        steps[push_index]
+            .inputs
+            .get("branch")
+            .and_then(|value| value.as_str()),
+        Some("main")
+    );
 }
 
 #[test]

--- a/src/core/release/planning_git.rs
+++ b/src/core/release/planning_git.rs
@@ -30,6 +30,16 @@ pub(super) fn validate_default_branch(component: &Component) -> Result<()> {
         return Ok(());
     }
 
+    if head_matches_remote_default(component, &default_branch)? {
+        log_status!(
+            "release",
+            "Local branch '{}' matches the remote default branch tip; release will push HEAD to '{}'.",
+            current_branch,
+            default_branch
+        );
+        return Ok(());
+    }
+
     Err(Error::validation_invalid_argument(
         "release",
         format!(
@@ -48,6 +58,36 @@ pub(super) fn validate_default_branch(component: &Component) -> Result<()> {
             ),
             "If you only want a preview, use --dry-run".to_string(),
         ]),
+    ))
+}
+
+pub(super) fn release_push_branch(component: &Component) -> Result<String> {
+    let default_branch = default_branch(component);
+    if !git::is_git_repo(&component.local_path) {
+        return Ok(default_branch);
+    }
+
+    let current_branch = current_branch(component)?;
+
+    if current_branch == default_branch {
+        return Ok(current_branch);
+    }
+
+    if head_matches_remote_default(component, &default_branch)? {
+        return Ok(default_branch);
+    }
+
+    Err(Error::validation_invalid_argument(
+        "release",
+        format!(
+            "Refusing to plan release push from branch '{}' because the repo default branch is '{}'",
+            current_branch, default_branch
+        ),
+        None,
+        Some(vec![format!(
+            "Check out '{}' or rerun preflight after fast-forwarding the release worktree to the remote default branch tip",
+            default_branch
+        )]),
     ))
 }
 
@@ -167,6 +207,60 @@ pub(super) fn validate_head_reachable_from_default_branch(component: &Component)
     ))
 }
 
+fn head_matches_remote_default(component: &Component, default_branch: &str) -> Result<bool> {
+    let remote = source_remote(component);
+    let remote_default_ref = format!("{remote}/{default_branch}");
+    let Ok(remote_default_revision) = remote_default_revision(component, &remote_default_ref)
+    else {
+        return Ok(false);
+    };
+    let head_revision = git::run_git(
+        std::path::Path::new(&component.local_path),
+        &["rev-parse", "HEAD"],
+        "git rev-parse HEAD",
+    )
+    .map(|value| value.trim().to_string())
+    .map_err(|_| {
+        Error::validation_invalid_argument(
+            "release",
+            "Refusing to release because HEAD could not be resolved",
+            None,
+            Some(vec![
+                "Ensure the checkout has at least one commit before releasing".to_string(),
+            ]),
+        )
+    })?;
+
+    Ok(head_revision == remote_default_revision)
+}
+
+fn remote_default_revision(component: &Component, remote_default_ref: &str) -> Result<String> {
+    git::run_git(
+        std::path::Path::new(&component.local_path),
+        &["rev-parse", remote_default_ref],
+        "git rev-parse remote default branch",
+    )
+    .ok()
+    .map(|value| value.trim().to_string())
+    .filter(|value| !value.is_empty())
+    .ok_or_else(|| {
+        let current_branch =
+            current_branch(component).unwrap_or_else(|_| "detached HEAD".to_string());
+        Error::validation_invalid_argument(
+            "release",
+            format!(
+                "Refusing to release from branch '{}' because the repo default branch is not available as '{}'",
+                current_branch, remote_default_ref
+            ),
+            None,
+            Some(vec![format!(
+                "Fetch the default branch before running `homeboy release --apply`: git fetch {}",
+                source_remote(component)
+            )]),
+        )
+    })
+}
+
 fn current_branch(component: &Component) -> Result<String> {
     command::run_in_optional(
         &component.local_path,
@@ -198,7 +292,7 @@ fn source_remote(component: &Component) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        validate_default_branch, validate_default_branch_ancestry,
+        release_push_branch, validate_default_branch, validate_default_branch_ancestry,
         validate_head_reachable_from_default_branch, validate_remote_sync,
     };
     use crate::core::component::Component;
@@ -288,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_default_branch_blocks_release_branch_at_remote_default_tip() {
+    fn test_validate_default_branch_allows_release_branch_at_remote_default_tip() {
         let temp = tempfile::tempdir().expect("tempdir");
         let remote = temp.path().join("remote.git");
         let seed = temp.path().join("seed");
@@ -309,13 +403,12 @@ mod tests {
         run_git(temp.path(), &["clone", &remote_str, "checkout"]);
         run_git(&checkout, &["checkout", "-q", "-b", "release-local"]);
 
-        let err = validate_default_branch(&git_component(&checkout))
-            .expect_err("release branch at origin/main tip should fail");
-
-        assert!(err
-            .message
-            .contains("branch 'release-local' because the repo default branch is 'main'"));
-        assert!(err.details.to_string().contains("homeboy release --apply"));
+        validate_default_branch(&git_component(&checkout))
+            .expect("release branch at origin/main tip should pass");
+        assert_eq!(
+            release_push_branch(&git_component(&checkout)).expect("push branch"),
+            "main"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow clean non-default release worktree branches when HEAD matches the remote default branch tip
- record the resolved release push branch in the plan and push HEAD explicitly to the default branch
- add regression coverage for release-branch preflight and push behavior

Fixes #7278

## Tests
- cargo test planning_git
- cargo test run_git_push
- cargo test test_build_release_steps
- rustfmt --check src/core/release/planning_git.rs src/core/release/plan_steps/release.rs src/core/release/execution_dispatch.rs src/core/release/executor/git_push.rs src/core/release/plan_steps/tests/mod.rs
- git diff --check origin/main..HEAD

Note: full Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/commands/agent_task/fanout.rs:524:
             .commit_message
             .clone()
             .unwrap_or_else(|| default_cook_commit_message(self));
-        let source_worktree_path = agent_task_service::source_worktree_path(
-            self.cwd.clone(),
-            self.workspace.clone(),
-        );
+        let source_worktree_path =
+            agent_task_service::source_worktree_path(self.cwd.clone(), self.workspace.clone());
         Ok(BatchCookInvocation {
             dispatch,
             options: AgentTaskCookServiceOptions {
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/commands/review/mod.rs:174:
     }
 }
 
-fn dispatch_review_plan_step( // homeboy-audit: allow-thin-command-adapter
+fn dispatch_review_plan_step(
+    // homeboy-audit: allow-thin-command-adapter
     step: &PlanStep,
     args: &ReviewArgs,
     global: &GlobalArgs,
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/commands/review/mod.rs:304:
     let mut lint_stage = None;
     let mut test_stage = None;
 
-    let stage_run = match review::execute_review_plan_steps(&quality_plan.steps, |step| { // homeboy-audit: allow-thin-command-adapter
-        dispatch_review_plan_step(step, &args, global, &component_label, &review_context) // homeboy-audit: allow-thin-command-adapter
+    let stage_run = match review::execute_review_plan_steps(&quality_plan.steps, |step| {
+        // homeboy-audit: allow-thin-command-adapter
+        dispatch_review_plan_step(step, &args, global, &component_label, &review_context)
+        // homeboy-audit: allow-thin-command-adapter
     }) {
         Ok(run) => run,
         Err(error) => {
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/commands/runs/common.rs:437:
             ],
         )
         .expect("select");
-        assert_eq!(selected[0], ("$.status".to_string(), Value::String("pass".into())));
         assert_eq!(
+            selected[0],
+            ("$.status".to_string(), Value::String("pass".into()))
+        );
+        assert_eq!(
             selected[1],
-            ("$.metadata.run_dir".to_string(), Value::String("/tmp/run".into()))
+            (
+                "$.metadata.run_dir".to_string(),
+                Value::String("/tmp/run".into())
+            )
         );
         assert_eq!(selected[2].1, serde_json::json!(["a", "b"]));
         assert_eq!(selected[3].1, Value::Null);
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/commands/runs/proof.rs:210:
         assert_eq!(proof.passed, Some(false));
         assert_eq!(proof.exit_code, Some(2));
         assert_eq!(proof.error.as_deref(), Some("gate exceeded"));
-        assert_eq!(proof.gate_failures, vec!["p95_ms exceeded", "rss_mb exceeded"]);
+        assert_eq!(
+            proof.gate_failures,
+            vec!["p95_ms exceeded", "rss_mb exceeded"]
+        );
 
         // Declared container flattened to dotted scalar leaves.
-        assert_eq!(proof.signals.get("proof.rendered_contains_marker"), Some(&json!(true)));
+        assert_eq!(
+            proof.signals.get("proof.rendered_contains_marker"),
+            Some(&json!(true))
+        );
         assert_eq!(proof.signals.get("proof.opfs_resume"), Some(&json!(false)));
         assert_eq!(proof.signals.get("proof.http_status"), Some(&json!(200)));
         assert_eq!(proof.signals.get("proof.nested.value"), Some(&json!("ok")));
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/commands/runs/proof.rs:220:
         // Top-level boolean proof signal and known scalar status signal.
         assert_eq!(proof.signals.get("marker_present"), Some(&json!(true)));
-        assert_eq!(proof.signals.get("observation_status"), Some(&json!("failed")));
+        assert_eq!(
+            proof.signals.get("observation_status"),
+            Some(&json!("failed"))
+        );
         // Per-scenario bench metrics + passed flag.
         assert_eq!(proof.signals.get("cold.passed"), Some(&json!(false)));
         assert_eq!(proof.signals.get("cold.p95_ms"), Some(&json!(42.0)));
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/commands/runs/watch.rs:302:
 
     /// Drive the loop with a virtual clock: each simulated sleep advances time,
     /// so timeouts are exercised without real waiting.
-    fn run_loop(
-        poller: &ScriptedPoller,
-        cfg: &WatchConfig,
-    ) -> homeboy::core::Result<WatchResult> {
+    fn run_loop(poller: &ScriptedPoller, cfg: &WatchConfig) -> homeboy::core::Result<WatchResult> {
         let clock = Cell::new(Duration::ZERO);
         let advance = |by: Duration| clock.set(clock.get() + by);
         run_watch_loop(
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/commands/upgrade.rs:258:
                     .to_string(),
             ),
             recovery_commands: vec![
-                "homeboy upgrade --force --upgrade-runner homeboy-lab".to_string(),
+                "homeboy upgrade --force --upgrade-runner homeboy-lab".to_string()
             ],
             extensions_synced: Vec::new(),
             extensions_skipped: Vec::new(),
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/commands/utils/resource_policy.rs:396:
 mod tests {
     use super::*;
     use crate::cli_surface::Cli;
-    use crate::commands::resources::{
-        LoadSummary, MemorySummary, ProcessSummary, RigLeaseSummary,
-    };
+    use crate::commands::resources::{LoadSummary, MemorySummary, ProcessSummary, RigLeaseSummary};
     use clap::Parser;
     fn resources(recommendation: ResourceRecommendation) -> DoctorOutput {
         DoctorOutput {
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/agent_task_controller_service/tests/resume_tests.rs:749:
             .controller
             .next_actions
             .iter()
-            .find(|action| {
-                matches!(
-                    action.action,
-                    AgentTaskLoopPolicyAction::RunGates { .. }
-                )
-            })
+            .find(|action| matches!(action.action, AgentTaskLoopPolicyAction::RunGates { .. }))
             .expect("run-gates action present");
         assert_eq!(gate_action.status, AgentTaskLoopActionStatus::Failed);
         assert!(result
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/agent_task_controller_service/tests/resume_tests.rs:762:
             .controller
             .next_actions
             .iter()
-            .any(|action| matches!(action.action, AgentTaskLoopPolicyAction::Complete { .. })
-                && action.status == AgentTaskLoopActionStatus::Pending));
+            .any(
+                |action| matches!(action.action, AgentTaskLoopPolicyAction::Complete { .. })
+                    && action.status == AgentTaskLoopActionStatus::Pending
+            ));
         assert!(result
             .value
             .controller
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/core_fingerprint/mod.rs:1295:
     let compiled: Vec<(Option<regex::Regex>, bool)> = cfg
         .patterns
         .iter()
-        .map(|pattern| (grammar::cached_regex(&pattern.regex), pattern.apply_skip_calls))
+        .map(|pattern| {
+            (
+                grammar::cached_regex(&pattern.regex),
+                pattern.apply_skip_calls,
+            )
+        })
         .collect();
 
     let mut sites = Vec::new();
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/core_fingerprint/tests.rs:885:
 fn rust_aggregate_grammar() -> Grammar {
     let mut grammar = rust_grammar();
     grammar.fingerprint.aggregate_seams = Some(AggregateSeamConfig {
-        method_names: vec!["new".to_string(), "builder".to_string(), "default".to_string()],
+        method_names: vec![
+            "new".to_string(),
+            "builder".to_string(),
+            "default".to_string(),
+        ],
         method_prefixes: vec!["from_".to_string(), "for_".to_string(), "with_".to_string()],
         type_method_templates: vec!["build_{type}".to_string(), "create_{type}".to_string()],
     });
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/core_fingerprint/tests.rs:906:
     // Match the WordPress grammar's PHP call skip set so free-function call
     // sites mirror the reference script.
     grammar.fingerprint.skip_calls = [
-        "if", "while", "for", "foreach", "switch", "match", "catch", "return", "echo", "print",
-        "isset", "unset", "empty", "list", "array", "function", "class", "interface", "trait",
-        "new", "require", "require_once", "include", "include_once", "define", "defined", "die",
-        "exit", "eval", "compact", "extract", "var_dump", "print_r", "var_export",
+        "if",
+        "while",
+        "for",
+        "foreach",
+        "switch",
+        "match",
+        "catch",
+        "return",
+        "echo",
+        "print",
+        "isset",
+        "unset",
+        "empty",
+        "list",
+        "array",
+        "function",
+        "class",
+        "interface",
+        "trait",
+        "new",
+        "require",
+        "require_once",
+        "include",
+        "include_once",
+        "define",
+        "defined",
+        "die",
+        "exit",
+        "eval",
+        "compact",
+        "extract",
+        "var_dump",
+        "print_r",
+        "var_export",
     ]
     .iter()
     .map(|s| s.to_string())
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/descriptor_runtime.rs:103:
             Some(snapshot) => field_patterns::run(snapshot, &config.detector_profile),
             None => Vec::new(),
         },
-        GenericDetectorRunner::DeprecationAge => {
-            deprecation_age::run(context.all_fingerprints, context.root, &config.detector_profile)
-        }
+        GenericDetectorRunner::DeprecationAge => deprecation_age::run(
+            context.all_fingerprints,
+            context.root,
+            &config.detector_profile,
+        ),
         GenericDetectorRunner::DeadGuard => {
             dead_guard::run(context.per_file_fingerprints, context.root, config)
         }
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/descriptor_runtime.rs:136:
         GenericDetectorRunner::ParallelRunnerSetup => {
             parallel_runner_setup::run(context.all_fingerprints)
         }
-        GenericDetectorRunner::RemoteExecutionPreflight => {
-            remote_execution_preflight::run(context.all_fingerprints, &config.remote_execution_safety)
-        }
+        GenericDetectorRunner::RemoteExecutionPreflight => remote_execution_preflight::run(
+            context.all_fingerprints,
+            &config.remote_execution_safety,
+        ),
         GenericDetectorRunner::EnumDispatchContracts => match context.source_snapshot {
             Some(snapshot) => enum_dispatch_contracts::run(snapshot),
             None => Vec::new(),
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/descriptor_runtime.rs:145:
         },
-        GenericDetectorRunner::PublicRegistryExposure => {
-            public_registry_exposure::run(context.all_fingerprints, &config.public_registry_exposure)
-        }
+        GenericDetectorRunner::PublicRegistryExposure => public_registry_exposure::run(
+            context.all_fingerprints,
+            &config.public_registry_exposure,
+        ),
         GenericDetectorRunner::CommandStatusContracts => {
             command_status_contracts::run(context.root, &config.command_status_contracts)
         }
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/detectors/source_policy.rs:518:
     fn core_boundary_default_config_emits_nothing() {
         let fp = rust_fp("src/core/engine.rs", "fn dispatch() {}");
 
-        assert!(
-            run_core_boundary(&[&fp], &crate::core::component::CoreBoundaryLeakConfig::default())
-                .is_empty()
-        );
+        assert!(run_core_boundary(
+            &[&fp],
+            &crate::core::component::CoreBoundaryLeakConfig::default()
+        )
+        .is_empty());
     }
 
     #[test]
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/detectors/upstream_workaround.rs:285:
                 &ext.version_guard_constants,
                 DetectorProfileField::VersionGuardConstant,
             );
-            profile.extend_owned_regexes(&ext.version_guard_regexes, DetectorRegexKind::VersionGuard);
+            profile
+                .extend_owned_regexes(&ext.version_guard_regexes, DetectorRegexKind::VersionGuard);
             profile.extend_owned_regexes(
                 &ext.tracker_reference_regexes,
                 DetectorRegexKind::TrackerReference,
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/engine.rs:368:
     // packs, the fingerprint/root families, etc. — is dispatched by the
     // descriptor table in one pass. Adding a detector is a descriptor row plus a
     // `run_generic_descriptor` arm, never a new block here.
-    run_descriptor_detectors(plan, &mut timing, &mut all_findings, &detector_context, None);
+    run_descriptor_detectors(
+        plan,
+        &mut timing,
+        &mut all_findings,
+        &detector_context,
+        None,
+    );
 
     // `artifact_portability` stays hand-sequenced: it logs scan statistics (runs,
     // artifacts, metadata fields) even when it produces no findings.
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/code_audit/engine.rs:589:
     // whole-tree detectors below (structural, field patterns) consume a single
     // walk/read instead of each re-walking and re-reading the tree. Built only
     // when at least one snapshot-backed detector is enabled.
-    let source_snapshot = if plan.detector_enabled("structural")
-        || plan.detector_enabled("field_patterns")
-    {
-        let snapshot_started = std::time::Instant::now();
-        let snapshot = build_shared_source_snapshot(root, &audit_config);
-        timing.push_ok("source_snapshot", snapshot_started.elapsed());
-        Some(snapshot)
-    } else {
-        None
-    };
+    let source_snapshot =
+        if plan.detector_enabled("structural") || plan.detector_enabled("field_patterns") {
+            let snapshot_started = std::time::Instant::now();
+            let snapshot = build_shared_source_snapshot(root, &audit_config);
+            timing.push_ok("source_snapshot", snapshot_started.elapsed());
+            Some(snapshot)
+        } else {
+            None
+        };
 
     let detector_context = DetectorRunContext {
         root,
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/daemon.rs:320:
 fn list_running_run_ids(store: &crate::core::observation::ObservationStore) -> Vec<String> {
     store
         .list_runs(crate::core::observation::RunListFilter {
-            status: Some(crate::core::observation::RunStatus::Running.as_str().to_string()),
+            status: Some(
+                crate::core::observation::RunStatus::Running
+                    .as_str()
+                    .to_string(),
+            ),
             limit: Some(1000),
             ..Default::default()
         })
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/deps/dependency_graph.rs:1:
 use crate::core::component::{self, Component, DependencyStackEdge};
+use crate::core::deps::provider;
 use crate::core::deps::{update, DependencyUpdateOptions};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use crate::core::{Error, Result};
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/deps/dependency_graph.rs:5:
-use crate::core::deps::provider;
 use serde::ser::Error as SerializeError;
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::{BTreeMap, BTreeSet};
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/extension/grammar/mod.rs:30:
 pub use super::grammar_strings::find_unclosed_raw_string_on_line;
 use super::grammar_strings::{line_closes_regular_string, line_has_unclosed_regular_string};
 
-pub use extract::{extract, namespace, Symbol};
 pub(crate) use extract::cached_regex;
+pub use extract::{extract, namespace, Symbol};
 pub use loading::{load_for_extension_path, load_grammar, load_grammar_json};
 pub use parser::{ContextualLine, Region, StructuralContext};
 pub use types::{
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/extension/lifecycle/install_sources.rs:334:
     source_root: Option<&Path>,
 ) -> Result<()> {
     if let Some(source_root) = source_root {
-        return install_shared_assets_from_root(source_root, extension_dir, SharedAssetMode::Symlink);
+        return install_shared_assets_from_root(
+            source_root,
+            extension_dir,
+            SharedAssetMode::Symlink,
+        );
     }
 
     if let Some(parent) = source.parent() {
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/extension/lifecycle/mod.rs:1003:
             // Edit the shared asset in the source worktree after install. Because
             // the install symlinks the tree, the edit must be visible at the live
             // install path with no reinstall — the iteration-blocker fix.
-            let source_contract = source.join("agent-task-contracts/agent-task-provider-contract.js");
-            fs::write(&source_contract, "module.exports = { contract: 'edited-live' };\n")
-                .expect("edit shared source file");
+            let source_contract =
+                source.join("agent-task-contracts/agent-task-provider-contract.js");
+            fs::write(
+                &source_contract,
+                "module.exports = { contract: 'edited-live' };\n",
+            )
+            .expect("edit shared source file");
 
             let installed_contract =
                 home.join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js");
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/extension/lifecycle/mod.rs:1012:
-            let observed = fs::read_to_string(&installed_contract).expect("read installed contract");
+            let observed =
+                fs::read_to_string(&installed_contract).expect("read installed contract");
             assert!(
                 observed.contains("edited-live"),
                 "edit to the symlinked shared tree should be visible to the install, got: {observed}"
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/extension/lint/mod.rs:65:
             &exclude_sniffs.map(str::to_string),
         )
         .env_opt("HOMEBOY_CATEGORY", &category.map(str::to_string))
-        .env_opt(
-            "HOMEBOY_LINT_CHANGED_FILES_FILE",
-            &changed_files_file,
-        ))
+        .env_opt("HOMEBOY_LINT_CHANGED_FILES_FILE", &changed_files_file))
 }
 
 /// Write core's resolved changed-file list to a newline-delimited manifest in
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/extension/lint/mod.rs:86:
         return Ok(None);
     };
 
-    let manifest_path =
-        run_dir.step_file(crate::core::engine::run_dir::files::LINT_CHANGED_FILES);
+    let manifest_path = run_dir.step_file(crate::core::engine::run_dir::files::LINT_CHANGED_FILES);
     let mut contents = changed_files.join("\n");
     contents.push('\n');
     std::fs::write(&manifest_path, contents).map_err(|error| {
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/extension/lint/mod.rs:168:
     fn changed_files_manifest_unset_when_no_list_supplied() {
         let run_dir = RunDir::create().expect("run dir");
 
-        assert_eq!(write_changed_files_manifest(&run_dir, None).expect("none"), None);
+        assert_eq!(
+            write_changed_files_manifest(&run_dir, None).expect("none"),
+            None
+        );
         assert_eq!(
             write_changed_files_manifest(&run_dir, Some(&[])).expect("empty"),
             None
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/extension/validation.rs:108:
                     // active iteration isn't rejected and steered to a re-clone via
                     // `homeboy extension update`. Cloned/copied installs still
                     // enforce, so genuinely incompatible non-dev versions are caught.
-                    if !constraint.matches(&installed_version)
-                        && !is_extension_linked(extension_id)
+                    if !constraint.matches(&installed_version) && !is_extension_linked(extension_id)
                     {
                         errors.push(format!(
                             "'{}' requires {}, but {} is installed",
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/github/checks.rs:103:
 
     #[test]
     fn classifies_terminal_outcomes() {
-        assert_eq!(classify_check(&check("COMPLETED", "SUCCESS")), CheckClass::Passed);
-        assert_eq!(classify_check(&check("COMPLETED", "NEUTRAL")), CheckClass::Passed);
-        assert_eq!(classify_check(&check("COMPLETED", "SKIPPED")), CheckClass::Skipped);
-        assert_eq!(classify_check(&check("COMPLETED", "FAILURE")), CheckClass::Failed);
         assert_eq!(
+            classify_check(&check("COMPLETED", "SUCCESS")),
+            CheckClass::Passed
+        );
+        assert_eq!(
+            classify_check(&check("COMPLETED", "NEUTRAL")),
+            CheckClass::Passed
+        );
+        assert_eq!(
+            classify_check(&check("COMPLETED", "SKIPPED")),
+            CheckClass::Skipped
+        );
+        assert_eq!(
+            classify_check(&check("COMPLETED", "FAILURE")),
+            CheckClass::Failed
+        );
+        assert_eq!(
             classify_check(&check("COMPLETED", "ACTION_REQUIRED")),
             CheckClass::Failed
         );
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/github/checks.rs:119:
             classify_check(&check("COMPLETED", "TIMED_OUT")),
             CheckClass::Rerunnable
         );
-        assert_eq!(classify_check(&check("COMPLETED", "BOGUS")), CheckClass::Unknown);
+        assert_eq!(
+            classify_check(&check("COMPLETED", "BOGUS")),
+            CheckClass::Unknown
+        );
     }
 
     #[test]
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/github/checks.rs:126:
     fn classifies_waiting_outcomes() {
         assert_eq!(classify_check(&check("QUEUED", "")), CheckClass::Queued);
         assert_eq!(classify_check(&check("REQUESTED", "")), CheckClass::Queued);
-        assert_eq!(classify_check(&check("IN_PROGRESS", "")), CheckClass::Running);
-        assert_eq!(classify_check(&check("PENDING", "")), CheckClass::Pending);
         assert_eq!(
-            classify_check(&serde_json::json!({})),
-            CheckClass::Pending
+            classify_check(&check("IN_PROGRESS", "")),
+            CheckClass::Running
         );
+        assert_eq!(classify_check(&check("PENDING", "")), CheckClass::Pending);
+        assert_eq!(classify_check(&serde_json::json!({})), CheckClass::Pending);
     }
 
     #[test]
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/github/checks.rs:151:
 
     #[test]
     fn matches_are_case_insensitive() {
-        assert_eq!(classify_check(&check("completed", "failure")), CheckClass::Failed);
-        assert_eq!(classify_check(&check("in_progress", "")), CheckClass::Running);
+        assert_eq!(
+            classify_check(&check("completed", "failure")),
+            CheckClass::Failed
+        );
+        assert_eq!(
+            classify_check(&check("in_progress", "")),
+            CheckClass::Running
+        );
     }
 
     #[test]
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/operations_push.rs:185:
 
     #[test]
     fn token_push_injects_token_for_enterprise_https_remote() {
-        let url = resolve_push_remote_url(Some("https://github.a8c.com/owner/repo.git"), Some("tok"))
-            .expect("enterprise https remote should be accepted");
+        let url =
+            resolve_push_remote_url(Some("https://github.a8c.com/owner/repo.git"), Some("tok"))
+                .expect("enterprise https remote should be accepted");
         assert_eq!(
             url.as_deref(),
             Some("https://x-access-token:tok@github.a8c.com/owner/repo.git")
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/operations_push.rs:195:
 
     #[test]
     fn token_push_rejects_ssh_remote() {
-        assert!(resolve_push_remote_url(Some("git@github.com:owner/repo.git"), Some("tok")).is_err());
+        assert!(
+            resolve_push_remote_url(Some("git@github.com:owner/repo.git"), Some("tok")).is_err()
+        );
     }
 }
 
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/operations_tags.rs:166:
     // Fetch tags from the remote so the latest release tag and its commits are
     // present locally. Best-effort: offline/no-remote checkouts fall through to
     // the guard with whatever local history exists.
-    let _ = crate::core::engine::command::run_in_optional(
-        path,
-        "git",
-        &["fetch", "--tags", &remote],
-    );
+    let _ =
+        crate::core::engine::command::run_in_optional(path, "git", &["fetch", "--tags", &remote]);
 
     Ok(())
 }
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/primitives.rs:237:
 pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
     let remote = resolve_default_remote(git_root);
     let old_branch = current_branch(git_root);
-    run_git(git_root, &["fetch", &remote], &format!("git fetch {remote}"))?;
+    run_git(
+        git_root,
+        &["fetch", &remote],
+        &format!("git fetch {remote}"),
+    )?;
     let mut detached_default_branch: Option<String> = None;
 
     if let Some(remote_branch) = default_remote_branch(git_root) {
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/primitives.rs:454:
         );
         git(
             tmp.path(),
-            &["clone", "-q", remote.to_str().unwrap(), seed.to_str().unwrap()],
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                seed.to_str().unwrap(),
+            ],
         );
         git(&seed, &["config", "user.email", "t@x.test"]);
         git(&seed, &["config", "user.name", "T"]);
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/git/primitives.rs:468:
         // is deliberately NOT named origin.
         git(
             tmp.path(),
-            &["clone", "-q", remote.to_str().unwrap(), clone.to_str().unwrap()],
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                clone.to_str().unwrap(),
+            ],
         );
         git(&clone, &["remote", "rename", "origin", "upstream"]);
 
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/hygiene.rs:6:
 use serde_json::Value;
 
 use crate::core::component::{self, Component};
+use crate::core::deps::provider;
 use crate::core::error::{Error, ErrorCode, Result, ValidationErrorItem};
 use crate::core::extension::{build, ExtensionCapability};
-use crate::core::deps::provider;
 
 const LAB_SOURCE_EVIDENCE_FILE: &str = ".homeboy/lab-source-evidence.json";
 const DEPENDENCY_LIFECYCLE_ARTIFACT_DIR: &str = ".homeboy/dependency-lifecycle";
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/notify.rs:125:
         .or_else(configured_command);
 
     let Some(template) = template else {
-        eprintln!(
-            "homeboy notify [{}]: {}",
-            event.status,
-            event.message()
-        );
+        eprintln!("homeboy notify [{}]: {}", event.status, event.message());
         return NotifyOutcome {
             delivered: true,
             delivery: NotifyDelivery::Stderr,
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/notify.rs:206:
         assert_eq!(argv[0], "logger");
         assert_eq!(argv[1], "-t");
         assert_eq!(argv[2], "homeboy-pass");
-        assert_eq!(argv[3], "homeboy run pass — Run run-123 finished with status pass");
+        assert_eq!(
+            argv[3],
+            "homeboy run pass — Run run-123 finished with status pass"
+        );
     }
 
     #[test]
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/observation/runs_service.rs:1357:
 
         // The hydrated record now parses into a non-zero matrix summary, where
         // the un-hydrated `remote_file` record would have summarized 0.
-        let summary =
-            crate::core::artifacts::summarize_matrix_artifacts("run-1", &hydrated, &[])
-                .expect("summary");
+        let summary = crate::core::artifacts::summarize_matrix_artifacts("run-1", &hydrated, &[])
+            .expect("summary");
         assert_eq!(summary.finding_count, 1);
         assert_eq!(summary.top_diagnostic_kinds[0].key, "missing_title");
         assert_eq!(summary.top_fixtures[0].key, "home");
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/observation/runs_service.rs:1366:
 
-        let zero =
-            crate::core::artifacts::summarize_matrix_artifacts("run-1", &[remote], &[])
-                .expect("summary");
+        let zero = crate::core::artifacts::summarize_matrix_artifacts("run-1", &[remote], &[])
+            .expect("summary");
         assert_eq!(zero.finding_count, 0);
     }
 
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/observation/runs_service.rs:1437:
             "homeboy bench run homeboy",
             serde_json::json!({ "lab": { "run_label": "meta-label" } }),
         );
-        let runs = vec![by_command.clone(), by_command_eq.clone(), by_metadata.clone()];
+        let runs = vec![
+            by_command.clone(),
+            by_command_eq.clone(),
+            by_metadata.clone(),
+        ];
 
         // Human label carried in the command resolves to its observation UUID.
         assert_eq!(
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/release/cascade.rs:256:
     })?;
 
     let extension_id = find_update_dependency_extension(downstream)?;
-    let payload =
-        build_update_dependency_payload(&target.downstream, &target.downstream_path, package, upstream);
+    let payload = build_update_dependency_payload(
+        &target.downstream,
+        &target.downstream_path,
+        package,
+        upstream,
+    );
 
     extension::execute_action(
         &extension_id,
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/release/cascade.rs:323:
     #[test]
     fn cascade_targets_preserve_topological_order() {
         let steps = vec![
-            step(1, "php-transformer", "static-site-importer", "chubes/php-transformer"),
-            step(2, "static-site-importer", "site-builder", "chubes/static-site-importer"),
+            step(
+                1,
+                "php-transformer",
+                "static-site-importer",
+                "chubes/php-transformer",
+            ),
+            step(
+                2,
+                "static-site-importer",
+                "site-builder",
+                "chubes/static-site-importer",
+            ),
         ];
 
         let targets = cascade_targets(&steps);
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/release/cascade.rs:373:
 
     #[test]
     fn cascade_targets_dedupe_identical_edges() {
-        let steps = vec![
-            step(1, "a", "b", "pkg/a"),
-            step(2, "a", "b", "pkg/a"),
-        ];
+        let steps = vec![step(1, "a", "b", "pkg/a"), step(2, "a", "b", "pkg/a")];
 
         let targets = cascade_targets(&steps);
 
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/release/cascade.rs:402:
 
         // The action runs against the dependent's checkout.
         assert_eq!(payload["release"]["component_id"], "static-site-importer");
-        assert_eq!(payload["release"]["local_path"], "/work/static-site-importer");
+        assert_eq!(
+            payload["release"]["local_path"],
+            "/work/static-site-importer"
+        );
 
         // The dependency block carries everything an extension needs to repin.
         assert_eq!(payload["dependency"]["released_id"], "php-transformer");
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/rig/../../../tests/core/rig/lease_test.rs:404:
                 forced,
                 ..
             } => {
-                assert!(!was_reclaimable, "live holder was not otherwise reclaimable");
+                assert!(
+                    !was_reclaimable,
+                    "live holder was not otherwise reclaimable"
+                );
                 assert!(forced, "force was required");
             }
             other => panic!("expected Released, got {other:?}"),
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/rig/discovery.rs:82:
                         continue;
                     }
                 }
-                rigs.push(discovered_from_path(&rig_path, path.file_name(), package_path)?);
+                rigs.push(discovered_from_path(
+                    &rig_path,
+                    path.file_name(),
+                    package_path,
+                )?);
             }
         }
     }
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/rig/mod.rs:700:
             error.message
         );
         assert!(
-            error.hints.iter().any(|h| h.message.contains("homeboy upgrade")),
+            error
+                .hints
+                .iter()
+                .any(|h| h.message.contains("homeboy upgrade")),
             "should hint to upgrade"
         );
     }
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/rig/mod.rs:708:
     #[test]
     fn syntax_error_stays_invalid_json() {
         let err = serde_json::from_str::<serde_json::Value>("{ not json").unwrap_err();
-        assert!(matches!(err.classify(), serde_json::error::Category::Syntax));
+        assert!(matches!(
+            err.classify(),
+            serde_json::error::Category::Syntax
+        ));
 
         let path = Path::new("/tmp/broken/rig.json");
         let error = rig_spec_parse_error(err, path, None, Some("{ not json".to_string()));
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/runner/execution/handoff.rs:124:
 /// the opt-in is on, the existing `runner_job_cancel` primitive is invoked and
 /// any error is captured rather than propagated (the controller still needs to
 /// surface the timeout).
-pub(super) fn attempt_wait_timeout_cancel(runner_id: &str, job_id: &str) -> WaitTimeoutCancelOutcome {
+pub(super) fn attempt_wait_timeout_cancel(
+    runner_id: &str,
+    job_id: &str,
+) -> WaitTimeoutCancelOutcome {
     if !cancel_on_wait_timeout_enabled() {
         return WaitTimeoutCancelOutcome::Disabled;
     }
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/runner/execution/handoff.rs:173:
     }
 
     pub(super) fn take_invoke(runner_id: &str, job_id: &str) -> Option<Result<()>> {
-        HOOK.with(|cell| cell.borrow_mut().as_mut().map(|hook| hook(runner_id, job_id)))
+        HOOK.with(|cell| {
+            cell.borrow_mut()
+                .as_mut()
+                .map(|hook| hook(runner_id, job_id))
+        })
     }
 }
 
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/runner/runtime_overlay_freshness.rs:277:
 
     use super::{
         assess_runtime_overlay_build_freshness, require_fresh_runtime_overlay,
-        stale_runtime_overlay_warning, RuntimeOverlayBuildStatus, REQUIRE_FRESH_RUNTIME_OVERLAY_ENV,
+        stale_runtime_overlay_warning, RuntimeOverlayBuildStatus,
+        REQUIRE_FRESH_RUNTIME_OVERLAY_ENV,
     };
 
     fn git(path: &Path, args: &[&str]) {
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/runner/workspace/tests/reap.rs:2:
 use std::path::Path;
 
 use crate::core::runner::workspace::sync::{reap_run_workspace, sync_workspace};
-use crate::core::runner::workspace::types::{
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
-};
+use crate::core::runner::workspace::types::{RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
 use crate::core::runner::{MaterializedWorkspace, WorkspaceCleanupPolicy};
 
 fn sync_options(path: String) -> RunnerWorkspaceSyncOptions {
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/runner/workspace/tests/reap.rs:79:
         let outside = runner_root.path().join("not-a-lab-workspace");
         fs::create_dir_all(&outside).expect("outside dir");
 
-        let result = reap_run_workspace(
-            "lab-local-reap-guard",
-            &outside.display().to_string(),
-            None,
-        );
+        let result =
+            reap_run_workspace("lab-local-reap-guard", &outside.display().to_string(), None);
 
         assert!(
             result.is_err(),
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/server/client/tests.rs:11:
     execute_local_command_passthrough, execute_local_command_stderr_passthrough,
 };
 use super::ssh_client::{
-    build_secret_env_stdin_block, wrap_command_with_secret_env_read_loop,
-    SECRET_ENV_STDIN_SENTINEL,
+    build_secret_env_stdin_block, wrap_command_with_secret_env_read_loop, SECRET_ENV_STDIN_SENTINEL,
 };
 use super::{CommandOutput, SshClient};
 
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/core/server/client/tests.rs:63:
 
 #[test]
 fn empty_secret_env_block_carries_only_the_sentinel() {
-    let block =
-        String::from_utf8(build_secret_env_stdin_block(&std::collections::BTreeMap::new()))
-            .expect("utf8 block");
+    let block = String::from_utf8(build_secret_env_stdin_block(
+        &std::collections::BTreeMap::new(),
+    ))
+    .expect("utf8 block");
     assert_eq!(block, format!("{SECRET_ENV_STDIN_SENTINEL}\n"));
 }
 
Diff in /Users/chubes/Developer/homeboy@fix-7278-release-default-head-worktree/src/extensions/mod.rs:1:
+
+ currently reports unrelated upstream formatting drift outside this PR's release files.