### PR TITLE
Normalize runner terminal outcomes

### DIFF
--- a/src/command_contract/registry.rs
+++ b/src/command_contract/registry.rs
@@ -175,7 +175,7 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         name: "run-outcome-envelope",
         title: "Run outcome envelope",
         owner: "homeboy-core",
-        summary: "Generic inspectable run outcome envelope that normalizes artifact, evidence, handoff, result, fuzz, and agent-task proof references.",
+        summary: "Canonical terminal run outcome envelope for runner and Lab executions, including status, exit code, artifact/evidence references, handoffs, and result payloads.",
         rust_type: "homeboy::core::run_outcome_envelope::RunOutcomeEnvelope",
     },
     ContractRegistryEntry {
@@ -191,7 +191,7 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         name: "runner-execution-record",
         title: "Runner execution record",
         owner: "homeboy-core",
-        summary: "Generic terminal runner execution record with stable IDs, materialized paths, artifact references, and follow-up actions.",
+        summary: "Durable runner execution record for orchestration identity, materialized paths, provenance, and follow-up actions; terminal command output should project through run-outcome-envelope.",
         rust_type: "homeboy::core::runner_execution_envelope::RunnerExecutionRecord",
     },
     ContractRegistryEntry {

--- a/src/core/run_outcome_envelope.rs
+++ b/src/core/run_outcome_envelope.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use crate::core::api_jobs::JobArtifactMetadata;
 use crate::core::artifact_ref::{artifact_uri, ArtifactRef, EvidenceRef, ARTIFACT_REF_SCHEMA};
 use crate::core::runner::{RunnerArtifactRef, RunnerHandoff};
+use crate::core::runner_execution_envelope::{RunnerExecutionArtifactRef, RunnerExecutionRecord};
 
 pub const RUN_OUTCOME_ENVELOPE_SCHEMA: &str = "homeboy/run-outcome-envelope/v1";
 
@@ -81,6 +82,15 @@ impl RunOutcomeEnvelope {
         self
     }
 
+    pub fn from_runner_execution_record(record: &RunnerExecutionRecord) -> Self {
+        let run_id = runner_execution_record_run_id(record);
+        let mut envelope = Self::new(record.status.clone())
+            .with_run_id(Some(run_id.clone()))
+            .with_runner_id(Some(record.runner_id.clone()));
+        envelope.add_runner_execution_artifact_refs(&run_id, record.artifact_refs.clone());
+        envelope
+    }
+
     pub fn add_job_artifact_refs(
         &mut self,
         run_id: &str,
@@ -98,6 +108,16 @@ impl RunOutcomeEnvelope {
     ) {
         for artifact in artifacts {
             self.push_artifact_ref(runner_artifact_ref(run_id, artifact));
+        }
+    }
+
+    pub fn add_runner_execution_artifact_refs(
+        &mut self,
+        run_id: &str,
+        artifacts: impl IntoIterator<Item = RunnerExecutionArtifactRef>,
+    ) {
+        for artifact in artifacts {
+            self.push_artifact_ref(runner_execution_artifact_ref(run_id, artifact));
         }
     }
 
@@ -217,6 +237,39 @@ fn runner_artifact_ref(run_id: &str, artifact: RunnerArtifactRef) -> ArtifactRef
     }
 }
 
+fn runner_execution_artifact_ref(
+    run_id: &str,
+    artifact: RunnerExecutionArtifactRef,
+) -> ArtifactRef {
+    let id = artifact.id.clone();
+    ArtifactRef {
+        schema: ARTIFACT_REF_SCHEMA.to_string(),
+        id: id.clone(),
+        run_id: run_id.to_string(),
+        kind: artifact
+            .name
+            .clone()
+            .unwrap_or_else(|| "artifact".to_string()),
+        artifact_type: artifact_type(artifact.path.as_deref(), artifact.url.as_deref()),
+        path: artifact.path.unwrap_or_else(|| artifact_uri(run_id, &id)),
+        url: artifact.url,
+        public_url: None,
+        role: None,
+        semantic_key: artifact.name,
+    }
+}
+
+fn runner_execution_record_run_id(record: &RunnerExecutionRecord) -> String {
+    record
+        .remote_run_id
+        .clone()
+        .or_else(|| record.mirror_run_id.clone())
+        .or_else(|| record.agent_task_run_id.clone())
+        .or_else(|| record.local_run_id.clone())
+        .or_else(|| record.job_id.clone())
+        .unwrap_or_else(|| record.execution_id.clone())
+}
+
 fn artifact_type(path: Option<&str>, url: Option<&str>) -> String {
     if path.is_some() || url.is_some() {
         "file".to_string()
@@ -301,5 +354,34 @@ mod tests {
         assert_eq!(value["runner_id"], "runner-1");
         assert_eq!(value["artifact_refs"][0]["id"], "summary");
         assert!(value.get("result").is_none());
+    }
+
+    #[test]
+    fn run_outcome_envelope_projects_terminal_runner_execution_record() {
+        let record = RunnerExecutionRecord::terminal("job-1", "lab-a", "daemon", 0)
+            .with_job_id("job-1")
+            .with_mirror_run_id(Some("run-1".to_string()))
+            .with_artifact_refs(vec![RunnerExecutionArtifactRef {
+                id: "report".to_string(),
+                name: Some("summary".to_string()),
+                path: Some("artifacts/summary.json".to_string()),
+                url: None,
+            }]);
+
+        let value = serde_json::to_value(RunOutcomeEnvelope::from_runner_execution_record(&record))
+            .expect("outcome json");
+
+        assert_eq!(value["schema"], RUN_OUTCOME_ENVELOPE_SCHEMA);
+        assert_eq!(value["status"], "succeeded");
+        assert_eq!(value["run_id"], "run-1");
+        assert_eq!(value["runner_id"], "lab-a");
+        assert_eq!(value["artifact_refs"][0]["id"], "report");
+        assert_eq!(
+            value["evidence_refs"][0]["target"],
+            "homeboy://run/run-1/artifact/report"
+        );
+        assert!(value.get("transport").is_none());
+        assert!(value.get("materialized_paths").is_none());
+        assert!(value.get("next_actions").is_none());
     }
 }

--- a/src/core/runner/worker/result.rs
+++ b/src/core/runner/worker/result.rs
@@ -40,7 +40,8 @@ pub(super) fn remote_runner_result_from_exec_output(
         data["resource_guard_violation"] =
             serde_json::to_value(resource_guard_violation).unwrap_or(serde_json::Value::Null);
     }
-    if let Some(execution_record) = exec_output.execution_record.clone() {
+    let execution_record = exec_output.execution_record.clone();
+    if let Some(execution_record) = execution_record.clone() {
         data["execution_record"] =
             serde_json::to_value(&execution_record).unwrap_or(serde_json::Value::Null);
         if let Some(provenance) = execution_record.orchestration_provenance {
@@ -77,19 +78,27 @@ pub(super) fn remote_runner_result_from_exec_output(
             ))
             .unwrap_or(serde_json::Value::Null);
     }
-    let outcome_run_id = exec_output
+    let fallback_outcome_run_id = exec_output
         .mirror_run_id
         .clone()
         .or_else(|| exec_output.job_id.clone())
         .unwrap_or_else(|| exec_output.runner_id.clone());
-    let mut outcome = RunOutcomeEnvelope::new(if exit_code == 0 {
-        "succeeded"
+    let mut outcome = if let Some(execution_record) = execution_record.as_ref() {
+        RunOutcomeEnvelope::from_runner_execution_record(execution_record)
     } else {
-        "failed"
-    })
-    .with_run_id(Some(outcome_run_id.clone()))
-    .with_runner_id(Some(exec_output.runner_id.clone()))
+        RunOutcomeEnvelope::new(if exit_code == 0 {
+            "succeeded"
+        } else {
+            "failed"
+        })
+        .with_run_id(Some(fallback_outcome_run_id.clone()))
+        .with_runner_id(Some(exec_output.runner_id.clone()))
+    }
     .with_exit_code(exit_code);
+    let outcome_run_id = outcome
+        .run_id
+        .clone()
+        .unwrap_or_else(|| fallback_outcome_run_id.clone());
     outcome.add_job_artifact_refs(&outcome_run_id, exec_output.artifacts.clone());
     if let Some(result) = exec_output.runner_result.clone() {
         outcome.add_runner_artifact_refs(&outcome_run_id, result.artifact_refs.clone());

--- a/src/core/runner/worker/tests/result_tests.rs
+++ b/src/core/runner/worker/tests/result_tests.rs
@@ -154,6 +154,13 @@ fn reverse_worker_result_preserves_execution_provenance() {
 
     let data = result.data.as_ref().expect("data");
     assert_eq!(data["execution_record"]["runner_id"], "lab");
+    assert_eq!(data["outcome"]["schema"], "homeboy/run-outcome-envelope/v1");
+    assert_eq!(data["outcome"]["status"], "succeeded");
+    assert_eq!(data["outcome"]["runner_id"], "lab");
+    assert_eq!(data["outcome"]["run_id"], "job-1");
+    assert_eq!(data["outcome"]["exit_code"], 0);
+    assert!(data["outcome"].get("transport").is_none());
+    assert!(data["outcome"].get("materialized_paths").is_none());
     assert_eq!(
         data["orchestration_provenance"]["selected_runner_id"],
         "lab"


### PR DESCRIPTION
## Summary
- Make RunOutcomeEnvelope the explicit terminal projection for runner/Lab execution records.
- Add conversion from RunnerExecutionRecord artifact/status identities into run outcome artifacts/evidence.
- Build reverse-runner job result data.outcome from the execution record when available while preserving orchestration provenance for existing consumers.
- Update contract registry summaries to clarify the boundary between terminal outcome and execution orchestration metadata.

## Verification
- rustfmt src/command_contract/registry.rs src/core/run_outcome_envelope.rs src/core/runner/worker/result.rs src/core/runner/worker/tests/result_tests.rs
- cargo check --lib

Note: cargo fmt --check was not used as a pass/fail gate because this fresh worktree contains unrelated pre-existing formatting diffs outside this PR's files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Drafted and verified the focused code/test/docs changes with Chris's requested scope.