### PR TITLE
Use generic dependency path handoff

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -581,8 +581,8 @@ pub(crate) fn run_lab_offload_inner(
     let mut env_delta = std::collections::HashMap::new();
     let rig_component_path_env =
         forward_rig_component_path_env(&mut env_delta, &workspace_mapping)?;
-    let wordpress_dependency_paths_env =
-        forward_wordpress_dependency_paths_env(&mut env_delta, &workspace_mapping);
+    let declared_dependency_paths_env =
+        forward_declared_dependency_paths_env(&mut env_delta, &workspace_mapping);
     apply_rig_component_path_overrides(&mut env_delta, &rig_component_path_overrides);
     // Surface synced runtime-overlay remote paths into the command env so a hot
     // command (e.g. a CLI-runner env entry) points at the real remote runtime
@@ -597,7 +597,7 @@ pub(crate) fn run_lab_offload_inner(
         build_lab_secret_env_handoff_plan(&changed_since_preflight.args, env_delta)?;
     lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
     lab_metadata["rig_component_path_env"] = rig_component_path_env;
-    lab_metadata["wordpress_dependency_paths_env"] = wordpress_dependency_paths_env;
+    lab_metadata["declared_dependency_paths_env"] = declared_dependency_paths_env;
     lab_metadata["rig_component_path_overrides"] =
         rig_component_path_overrides_metadata(&rig_component_path_overrides);
     lab_metadata["settings_env"] =

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -71,8 +71,8 @@ use super::super::lab_args::{
 use super::super::lab_capabilities::lab_runner_capability_contract;
 use super::super::lab_command::lab_offload_command_prefix;
 use super::super::lab_env::{
-    build_lab_offload_env_with_passthroughs, forward_rig_component_path_env,
-    forward_wordpress_dependency_paths_env, misplaced_runner_exec_wait_timeout_warning,
+    build_lab_offload_env_with_passthroughs, forward_declared_dependency_paths_env,
+    forward_rig_component_path_env, misplaced_runner_exec_wait_timeout_warning,
     settings_env_diagnostics,
 };
 use super::super::lab_plan::{base_lab_plan, disabled_select_runner_plan, with_step};

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -10,8 +10,8 @@ use crate::core::observation::{
 };
 
 const SETTINGS_DIAGNOSTICS_SCHEMA: &str = "homeboy/lab-offload-settings-env/v1";
-pub(super) const WORDPRESS_DEPENDENCY_PATHS_ENV: &str = "HOMEBOY_WORDPRESS_DEPENDENCY_PATHS";
-const WORDPRESS_DEPENDENCY_PATHS_SCHEMA: &str = "homeboy/lab-offload-wordpress-dependency-paths/v1";
+pub(super) const DECLARED_DEPENDENCY_PATHS_ENV: &str = "HOMEBOY_DECLARED_DEPENDENCY_PATHS";
+const DECLARED_DEPENDENCY_PATHS_SCHEMA: &str = "homeboy/lab-offload-declared-dependency-paths/v1";
 
 pub(super) fn forward_env_if_present(env: &mut HashMap<String, String>, name: &str) {
     if let Ok(value) = std::env::var(name) {
@@ -60,28 +60,28 @@ pub(super) fn forward_rig_component_path_env(
     forward_rig_component_path_env_entries(env, workspace_mapping, std::env::vars())
 }
 
-pub(super) fn forward_wordpress_dependency_paths_env(
+pub(super) fn forward_declared_dependency_paths_env(
     env: &mut HashMap<String, String>,
     workspace_mapping: &[LabWorkspaceMappingEntry],
 ) -> serde_json::Value {
-    let dependencies = wordpress_dependency_paths(workspace_mapping);
+    let dependencies = declared_dependency_paths(workspace_mapping);
     if !dependencies.is_empty() {
         env.insert(
-            WORDPRESS_DEPENDENCY_PATHS_ENV.to_string(),
+            DECLARED_DEPENDENCY_PATHS_ENV.to_string(),
             serde_json::to_string(&dependencies).unwrap_or_else(|_| "{}".to_string()),
         );
     }
 
     serde_json::json!({
-        "schema": WORDPRESS_DEPENDENCY_PATHS_SCHEMA,
-        "env_name": WORDPRESS_DEPENDENCY_PATHS_ENV,
+        "schema": DECLARED_DEPENDENCY_PATHS_SCHEMA,
+        "env_name": DECLARED_DEPENDENCY_PATHS_ENV,
         "forwarded_to_runner": !dependencies.is_empty(),
         "count": dependencies.len(),
         "dependencies": dependencies,
     })
 }
 
-fn wordpress_dependency_paths(
+fn declared_dependency_paths(
     workspace_mapping: &[LabWorkspaceMappingEntry],
 ) -> serde_json::Map<String, serde_json::Value> {
     workspace_mapping
@@ -536,7 +536,7 @@ mod tests {
     }
 
     #[test]
-    fn wordpress_dependency_paths_env_exports_validation_dependency_mapping() {
+    fn declared_dependency_paths_env_exports_validation_dependency_mapping() {
         let mapping = vec![
             crate::core::runner::lab_workspaces::workspace_mapping_entry_for_validation_dependency(
                 &crate::core::runner::RunnerValidationDependencySyncOutput {
@@ -598,14 +598,14 @@ mod tests {
         ];
         let mut env = HashMap::new();
 
-        let metadata = forward_wordpress_dependency_paths_env(&mut env, &mapping);
+        let metadata = forward_declared_dependency_paths_env(&mut env, &mapping);
         let exported: serde_json::Value = serde_json::from_str(
-            env.get(WORDPRESS_DEPENDENCY_PATHS_ENV)
+            env.get(DECLARED_DEPENDENCY_PATHS_ENV)
                 .expect("dependency paths env"),
         )
         .expect("env json");
 
-        assert_eq!(metadata["schema"], WORDPRESS_DEPENDENCY_PATHS_SCHEMA);
+        assert_eq!(metadata["schema"], DECLARED_DEPENDENCY_PATHS_SCHEMA);
         assert_eq!(metadata["forwarded_to_runner"], true);
         assert_eq!(metadata["count"], 1);
         assert_eq!(
@@ -620,14 +620,14 @@ mod tests {
     }
 
     #[test]
-    fn wordpress_dependency_paths_env_is_absent_without_dependencies() {
+    fn declared_dependency_paths_env_is_absent_without_dependencies() {
         let mut env = HashMap::new();
 
-        let metadata = forward_wordpress_dependency_paths_env(&mut env, &[]);
+        let metadata = forward_declared_dependency_paths_env(&mut env, &[]);
 
         assert_eq!(metadata["forwarded_to_runner"], false);
         assert_eq!(metadata["count"], 0);
-        assert!(!env.contains_key(WORDPRESS_DEPENDENCY_PATHS_ENV));
+        assert!(!env.contains_key(DECLARED_DEPENDENCY_PATHS_ENV));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace the WordPress-specific Lab dependency paths env contract with a generic declared dependency paths contract.
- Rename the Lab offload metadata field from `wordpress_dependency_paths_env` to `declared_dependency_paths_env`.
- Keep validation dependency path payload behavior unchanged while removing the WordPress-specific env/schema naming.

## Verification
- `rustfmt --check src/core/runner/lab_env.rs src/core/runner/lab/offload/mod.rs src/core/runner/lab/offload/inner.rs`
- `cargo check`

## Notes
- Did not run `cargo test`; repo/site rules treat local `cargo test` as hot.
- Full `cargo fmt --check` reports pre-existing formatting diffs outside this PR touched files, so verification used scoped `rustfmt --check` on touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Implemented the env contract rename, scoped verification, and PR preparation in collaboration with Chris.