### PR TITLE
Keep refresh-homeboy binary and PATH aligned

### DIFF
--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -4,7 +4,10 @@ use serde_json::Value;
 use crate::core::error::{Error, Result};
 use crate::core::output::MergeOutput;
 
-use super::{connect, disconnect, exec, load, merge, RunnerCapabilityPreflight, RunnerExecOptions};
+use super::{
+    connect, disconnect, exec, load, merge, normalize_runner_command_env_for_homeboy_path,
+    RunnerCapabilityPreflight, RunnerExecOptions,
+};
 
 const DEFAULT_HOMEBOY_REMOTE: &str = "https://github.com/Extra-Chill/homeboy.git";
 const DEFAULT_HOMEBOY_REF: &str = "main";
@@ -202,7 +205,11 @@ pub fn refresh_homeboy_binary(
     }
 
     let identity = parse_identity(&exec_output.stdout)?;
-    let patch = serde_json::json!({ "homeboy_path": plan.binary_path });
+    let env = refreshed_runner_env(&plan.runner_id, &plan.binary_path)?;
+    let patch = serde_json::json!({
+        "homeboy_path": plan.binary_path,
+        "env": env,
+    });
     let updated_fields = match merge(Some(&plan.runner_id), &patch.to_string(), &[])? {
         MergeOutput::Single(result) => result.updated_fields,
         MergeOutput::Bulk(_) => Vec::new(),
@@ -266,6 +273,16 @@ fn parse_identity(stdout: &str) -> Result<Value> {
             Some("parse runner Homeboy identity output".to_string()),
         )
     })
+}
+
+fn refreshed_runner_env(
+    runner_id: &str,
+    homeboy_path: &str,
+) -> Result<std::collections::HashMap<String, String>> {
+    let runner = load(runner_id)?;
+    let mut env = runner.env;
+    normalize_runner_command_env_for_homeboy_path(&mut env, Some(homeboy_path));
+    Ok(env)
 }
 
 fn default_target_dir(workspace_root: &str, git_ref: &str) -> String {
@@ -344,6 +361,7 @@ fn shell_arg(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support;
 
     #[test]
     fn materialize_plan_uses_clean_runner_cache() {
@@ -407,5 +425,34 @@ mod tests {
         .expect("identity parses");
 
         assert_eq!(identity["data"]["version"], "0.263.0");
+    }
+
+    #[test]
+    fn refreshed_runner_env_prepends_selected_homeboy_dir_to_path() {
+        test_support::with_isolated_home(|_| {
+            crate::core::runner::create(
+                r#"{
+                    "id": "lab-local",
+                    "kind": "local",
+                    "workspace_root": "/runner/ws",
+                    "homeboy_path": "/old/homeboy",
+                    "env": {"PATH": "/usr/bin:/bin", "RUST_LOG": "info"}
+                }"#,
+                false,
+            )
+            .expect("create runner");
+
+            let env = refreshed_runner_env(
+                "lab-local",
+                "/runner/ws/_homeboy_binaries/homeboy-main/target/release/homeboy",
+            )
+            .expect("refresh env");
+
+            assert_eq!(
+                env.get("PATH").map(String::as_str),
+                Some("/runner/ws/_homeboy_binaries/homeboy-main/target/release:/usr/bin:/bin")
+            );
+            assert_eq!(env.get("RUST_LOG").map(String::as_str), Some("info"));
+        });
     }
 }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -73,8 +73,8 @@ pub use capabilities::{
 };
 pub use command_path::preflight_remote_argv_path_translation;
 pub(crate) use command_path::{
-    normalize_runner_command_env, normalize_runner_command_env_for_homeboy_path,
-    quote_runner_env_value, remote_shell_path_preamble,
+    normalize_runner_command_env_for_homeboy_path, quote_runner_env_value,
+    remote_shell_path_preamble,
 };
 pub use connection::{
     connect, connect_reverse, disconnect, reverse_broker_artifact, reverse_broker_reconcile,
@@ -222,7 +222,10 @@ impl RunnerSpec {
 
     pub fn effective_env(&self) -> HashMap<String, String> {
         let mut env = self.env.clone();
-        normalize_runner_command_env(&mut env);
+        normalize_runner_command_env_for_homeboy_path(
+            &mut env,
+            self.settings.homeboy_path.as_deref(),
+        );
         env
     }
 }
@@ -997,7 +1000,10 @@ mod tests {
         assert_eq!(runner.policy.allowed_commands, vec!["test"]);
 
         let env = spec.effective_env();
-        assert_eq!(env.get("PATH").map(String::as_str), Some("/runner/bin"));
+        assert_eq!(
+            env.get("PATH").map(String::as_str),
+            Some("/usr/local/bin:/runner/bin")
+        );
         assert_eq!(env.get("RUST_LOG").map(String::as_str), Some("info"));
     }
 


### PR DESCRIPTION
## Summary
- Persist runner env PATH during refresh-homeboy so the selected homeboy_path directory is prepended to PATH.
- Make runner effective_env use the same homeboy_path-aware PATH normalization that execution already uses.
- Add regression coverage for refresh env mutation and effective-env PATH alignment.

Fixes #7297

## Tests
- homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-refresh-homeboy-path-consistency --lab-only --skip-lint -- refreshed_runner_env_prepends_selected_homeboy_dir_to_path runner_spec_preserves_server_runner_fields_and_effective_env

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated runner refresh/config/PATH handling, implemented the consistency fix, added focused regression coverage, and ran targeted Lab-backed verification.