### PR TITLE
Classify daemon polling disconnects as runner recovery

### DIFF
--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -512,17 +512,56 @@ pub(super) fn fetch_daemon_events(
 }
 
 pub(super) fn daemon_job_context_error(runner_id: &str, job_id: &str, err: Error) -> Error {
+    let runner_exec_prefix = format!("homeboy runner exec {runner_id} --");
+    let runner_runs_list =
+        format!("{runner_exec_prefix} homeboy runs list --status running --limit 20");
+    let runner_job_logs = format!("homeboy runner job logs {runner_id} {job_id} --follow");
+    let runner_job_cancel = format!("homeboy runner job cancel {runner_id} {job_id}");
+    let runner_run_show = format!("{runner_exec_prefix} homeboy runs show <run-id>");
+    let runner_run_evidence = format!("{runner_exec_prefix} homeboy runs evidence <run-id>");
+    let runner_run_artifacts = format!("{runner_exec_prefix} homeboy runs artifacts <run-id>");
+    let source_code = err.code.as_str();
+    let source_message = err.message;
+    let source_details = err.details;
+    let source_hints = err.hints;
     let mut with_context = Error::new(
-        err.code,
-        err.message,
+        ErrorCode::RunnerControllerDisconnected,
+        format!(
+            "Lost contact with runner `{runner_id}` daemon while polling known job `{job_id}`: {source_message}"
+        ),
         json!({
+            "status": "recoverable_followup_required",
             "runner_id": runner_id,
             "job_id": job_id,
-            "source": err.details,
+            "reason": "daemon_job_poll_failed",
+            "recovery": {
+                "mode": "durable_runner_job",
+                "job_logs": runner_job_logs,
+                "job_cancel": runner_job_cancel,
+                "runner_runs_list": runner_runs_list,
+                "runner_run_show": runner_run_show,
+                "runner_run_evidence": runner_run_evidence,
+                "runner_run_artifacts": runner_run_artifacts,
+            },
+            "source": {
+                "code": source_code,
+                "message": source_message,
+                "details": source_details,
+            },
         }),
     );
-    with_context.hints = err.hints;
-    with_context.retryable = err.retryable.or(Some(true));
+    with_context.hints = source_hints;
+    for hint in lab_offload_handoff_hints(
+        runner_id,
+        None,
+        job_id,
+        None,
+        DaemonJobHandoffState::InFlight,
+        true,
+    ) {
+        with_context = with_context.with_hint(hint);
+    }
+    with_context.retryable = Some(true);
     with_context
 }
 

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -945,6 +945,50 @@ fn terminal_lab_result_transport_error_preserves_recovery_ids() {
 }
 
 #[test]
+fn daemon_polling_error_for_known_job_is_recoverable_runner_disconnect() {
+    let job_id = "8ae584d4-3395-4b76-8e83-14f2e8c4c1eb";
+    let source = Error::internal_unexpected(format!(
+        "query runner daemon: error sending request for url (http://127.0.0.1:1234/jobs/{job_id})"
+    ));
+
+    let err = daemon_job_context_error("lab", job_id, source);
+
+    assert_eq!(err.code, ErrorCode::RunnerControllerDisconnected);
+    assert_eq!(err.retryable, Some(true));
+    assert!(err
+        .message
+        .contains("Lost contact with runner `lab` daemon"));
+    assert!(!err.message.contains("internal.unexpected"));
+    assert_eq!(err.details["status"], "recoverable_followup_required");
+    assert_eq!(err.details["runner_id"], "lab");
+    assert_eq!(err.details["job_id"], job_id);
+    assert_eq!(err.details["source"]["code"], "internal.unexpected");
+    assert_eq!(
+        err.details["recovery"]["job_logs"],
+        format!("homeboy runner job logs lab {job_id} --follow")
+    );
+    assert_eq!(
+        err.details["recovery"]["job_cancel"],
+        format!("homeboy runner job cancel lab {job_id}")
+    );
+    assert_eq!(
+        err.details["recovery"]["runner_runs_list"],
+        "homeboy runner exec lab -- homeboy runs list --status running --limit 20"
+    );
+    let hints = err
+        .hints
+        .iter()
+        .map(|hint| hint.message.as_str())
+        .collect::<Vec<_>>();
+    assert!(hints
+        .iter()
+        .any(|hint| hint.contains(&format!("homeboy runner job logs lab {job_id} --follow"))));
+    assert!(hints
+        .iter()
+        .any(|hint| hint.contains(&format!("homeboy runner job cancel lab {job_id}"))));
+}
+
+#[test]
 fn daemon_exec_request_failed_error_handles_null_payload_with_reconnect_hint() {
     // The historical #3631/#3624 symptom: a stale/restarting daemon answers
     // with an empty/null error payload. We must never surface a bare `null`,


### PR DESCRIPTION
## Summary
- Normalize known-job daemon polling/contact failures to `runner.controller_disconnected` instead of preserving lower-level `internal.unexpected` as the top-level classification.
- Include runner id, job id, retryable marker, durable runner-job recovery commands, and existing Lab handoff hints.
- Add focused regression coverage for issue #7290's polling failure shape.

Fixes #7290

## Verification
- `cargo test daemon_polling_error_for_known_job_is_recoverable_runner_disconnect` passed
- `cargo check` passed with existing warnings about `RunnerWorkspaceMaterializationPlan` unused import and `is_missing_source_checkout_error` dead code

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated the daemon polling error path, implemented the recovery classification change, added focused regression coverage, and ran verification.