### PR TITLE
Classify stale runner jobs after daemon restart

### DIFF
--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -416,11 +416,83 @@ mod tests {
         let events = reopened.events(job.id).expect("events persist");
         assert!(events.iter().any(|event| {
             event.kind == JobEventKind::Error
-                && event
-                    .data
-                    .as_ref()
-                    .is_some_and(|data| data["reason"] == json!("stale_after_daemon_restart"))
+                && event.data.as_ref().is_some_and(|data| {
+                    data["reason"] == json!("stale_after_daemon_restart")
+                        && data["classification"]["kind"]
+                            == json!("unrecoverable_child_after_control_plane_restart")
+                        && data["classification"]["recoverable"] == json!(false)
+                        && data["classification"]["child"]["output_observed"] == json!(false)
+                })
         }));
+    }
+
+    #[test]
+    fn durable_store_stale_restart_classification_preserves_last_child_evidence() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("durable store opens");
+        let job = store
+            .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+            .expect("remote runner job queues");
+        let claim = store
+            .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
+            .expect("claim succeeds")
+            .expect("job claimed");
+        let claim_id = claim.job.claim_id.expect("claim id");
+        store
+            .append_remote_runner_event(
+                job.id,
+                "homeboy-lab",
+                &claim_id,
+                JobEventKind::Stdout,
+                Some("running wp test".to_string()),
+                Some(json!({ "tail": "last child output" })),
+            )
+            .expect("runner appends child output");
+
+        let reopened = JobStore::open(&path).expect("durable store reopens");
+        let stale = reopened.get(job.id).expect("job persists");
+        assert_eq!(stale.status, JobStatus::Failed);
+
+        let events = reopened.events(job.id).expect("events persist");
+        assert!(events.iter().any(|event| {
+            event.kind == JobEventKind::Stdout
+                && event.message.as_deref() == Some("running wp test")
+        }));
+        let classification = events
+            .iter()
+            .find_map(|event| {
+                (event.kind == JobEventKind::Error)
+                    .then(|| event.data.as_ref()?.get("classification"))?
+            })
+            .expect("stale classification");
+
+        assert_eq!(
+            classification["kind"],
+            json!("unrecoverable_child_after_control_plane_restart")
+        );
+        assert_eq!(classification["recoverable"], json!(false));
+        assert_eq!(
+            classification["child"]["terminal_result_recorded"],
+            json!(false)
+        );
+        assert_eq!(classification["child"]["output_observed"], json!(true));
+        assert_eq!(
+            classification["child"]["last_known_event"]["kind"],
+            json!("stdout")
+        );
+        assert_eq!(
+            classification["child"]["last_known_event"]["message"],
+            json!("running wp test")
+        );
+        assert_eq!(
+            classification["remote_runner"]["runner_id"],
+            json!("homeboy-lab")
+        );
+        assert_eq!(
+            classification["remote_runner"]["claimed_by_runner_id"],
+            json!("homeboy-lab")
+        );
     }
 
     #[test]

--- a/src/core/api_jobs/persistence.rs
+++ b/src/core/api_jobs/persistence.rs
@@ -138,6 +138,7 @@ pub(super) fn reconcile_stale_jobs(
         } else {
             "daemon restarted before the job reached a terminal status".to_string()
         };
+        let classification = stale_after_restart_classification(stored);
         stored.job.status = JobStatus::Failed;
         stored.job.updated_at_ms = now;
         stored.job.finished_at_ms = Some(now);
@@ -150,7 +151,10 @@ pub(super) fn reconcile_stale_jobs(
             kind: JobEventKind::Error,
             timestamp_ms: now,
             message: Some(reason.clone()),
-            data: Some(serde_json::json!({ "reason": "stale_after_daemon_restart" })),
+            data: Some(serde_json::json!({
+                "reason": "stale_after_daemon_restart",
+                "classification": classification,
+            })),
         });
         next_sequence += 1;
         stored.events.push(JobEvent {
@@ -161,7 +165,8 @@ pub(super) fn reconcile_stale_jobs(
             message: Some("job marked failed after daemon restart".to_string()),
             data: Some(serde_json::json!({
                 "status": JobStatus::Failed,
-                "reason": "stale_after_daemon_restart"
+                "reason": "stale_after_daemon_restart",
+                "classification": classification,
             })),
         });
         apply_event_retention(&mut stored.events, event_retention_limit);
@@ -169,6 +174,64 @@ pub(super) fn reconcile_stale_jobs(
     }
 
     next_sequence
+}
+
+fn stale_after_restart_classification(stored: &StoredJob) -> Value {
+    let last_child_event = stored
+        .events
+        .iter()
+        .rev()
+        .find(|event| child_evidence_kind(event.kind));
+    let artifact_ids = stored
+        .job
+        .artifacts
+        .iter()
+        .map(|artifact| artifact.id.clone())
+        .collect::<Vec<_>>();
+
+    serde_json::json!({
+        "kind": "unrecoverable_child_after_control_plane_restart",
+        "recoverable": false,
+        "reason": "stale_after_daemon_restart",
+        "control_plane": {
+            "daemon_restarted": true,
+        },
+        "child": {
+            "terminal_result_recorded": false,
+            "last_known_event": last_child_event.map(last_known_child_event),
+            "output_observed": last_child_event.is_some(),
+        },
+        "remote_runner": stored.remote_runner.as_ref().map(|remote_runner| serde_json::json!({
+            "runner_id": remote_runner.request.runner_id.clone(),
+            "project_id": remote_runner.request.project_id.clone(),
+            "claim_id": stored.job.claim_id.clone(),
+            "claimed_by_runner_id": stored.job.claimed_by_runner_id.clone(),
+            "claimed_at_ms": stored.job.claimed_at_ms,
+            "claim_expires_at_ms": stored.job.claim_expires_at_ms,
+            "secret_execution_env_unrecoverable": remote_runner_job_has_unrecoverable_execution_env(stored),
+        })),
+        "artifacts": {
+            "count": artifact_ids.len(),
+            "ids": artifact_ids,
+        },
+    })
+}
+
+fn child_evidence_kind(kind: JobEventKind) -> bool {
+    matches!(
+        kind,
+        JobEventKind::Stdout | JobEventKind::Stderr | JobEventKind::Progress | JobEventKind::Result
+    )
+}
+
+fn last_known_child_event(event: &JobEvent) -> Value {
+    serde_json::json!({
+        "sequence": event.sequence,
+        "kind": event.kind,
+        "timestamp_ms": event.timestamp_ms,
+        "message": event.message.clone(),
+        "data": event.data.clone(),
+    })
 }
 
 fn remote_runner_job_has_unrecoverable_execution_env(stored: &StoredJob) -> bool {


### PR DESCRIPTION
## Summary
- Add structured stale-after-daemon-restart classification for unrecovered in-flight runner jobs.
- Preserve and surface the last known child evidence already in the durable job log when a restart leaves the child outcome unrecoverable.
- Keep existing terminal Result-event recovery behavior intact and covered.

Fixes https://github.com/Extra-Chill/homeboy/issues/7289

## Verification
- `rustfmt --check src/core/api_jobs/persistence.rs src/core/api_jobs/mod.rs`
- `git diff --check`
- `cargo test durable_store` (6 passed; first attempt timed out during initial dependency compilation, retry passed with warm artifacts)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Inspected runner job restart recovery, implemented the structured stale classification, added focused coverage, and ran verification.