### PR TITLE
Fix bench rig extension selection

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1133,9 +1133,7 @@ impl Commands {
             Commands::Audit(args) => {
                 extension_ids.extend(args.extension_override.extensions.clone())
             }
-            Commands::Bench(args) => {
-                extension_ids.extend(args.extension_override_ids().iter().cloned())
-            }
+            Commands::Bench(args) => extension_ids.extend(args.lab_required_extension_ids()?),
             Commands::Fuzz(args) => {
                 extension_ids.extend(args.extension_override_ids().iter().cloned())
             }

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::thread;
 
@@ -103,6 +103,25 @@ impl BenchArgs {
         self.run_args_for_lab_offload()
             .map(|run| run.extension_override.extensions.as_slice())
             .unwrap_or(&[])
+    }
+
+    pub(crate) fn lab_required_extension_ids(&self) -> homeboy::core::Result<Vec<String>> {
+        let Some(run) = self.run_args_for_lab_offload() else {
+            return Ok(Vec::new());
+        };
+        if !run.extension_override.extensions.is_empty() {
+            return Ok(run.extension_override.extensions.clone());
+        }
+
+        let mut extension_ids = BTreeSet::new();
+        for rig_id in &run.rig {
+            let spec = rig::load(rig_id)?;
+            extension_ids.extend(rig::extension_ids_for_workloads(
+                &spec,
+                rig::RigWorkloadKind::Bench,
+            ));
+        }
+        Ok(extension_ids.into_iter().collect())
     }
 
     fn run_args_for_lab_offload(&self) -> Option<&BenchRunArgs> {

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -391,6 +391,42 @@ fn lab_route_contract_carries_command_specific_requirements() {
 }
 
 #[test]
+fn bench_lab_route_prefers_rig_declared_workload_extension_over_ecosystem_fallback() {
+    crate::test_support::with_isolated_home(|_| {
+        let rig_path = crate::core::paths::rig_config("node-package-wordpress-bench")
+            .expect("rig path resolves");
+        std::fs::create_dir_all(rig_path.parent().expect("rig dir")).expect("create rig dir");
+        std::fs::write(
+            &rig_path,
+            r#"{
+                "id": "node-package-wordpress-bench",
+                "bench": { "default_component": "node-package" },
+                "bench_workloads": {
+                    "wordpress": [
+                        { "path": "${package.root}/bench/fixture.bench.mjs" }
+                    ]
+                }
+            }"#,
+        )
+        .expect("write rig spec");
+
+        let command = parsed_command(&[
+            "homeboy",
+            "bench",
+            "node-package",
+            "--rig",
+            "node-package-wordpress-bench",
+        ]);
+        let route_contract = command
+            .lab_route_contract()
+            .expect("route contract resolves")
+            .expect("bench has a Lab route contract");
+
+        assert_eq!(route_contract.required_extensions, vec!["wordpress"]);
+    });
+}
+
+#[test]
 fn local_execution_policy_names_legacy_flag_combinations() {
     let default_policy = LabLocalExecutionPolicy::default();
     assert!(!default_policy.allow_local_hot());


### PR DESCRIPTION
## Summary
- Use bench rig workload extension declarations when building Lab route required extensions for bench runs.
- Preserve explicit `--extension` precedence over rig-derived defaults.
- Add a regression for a Node package bench command whose rig declares a WordPress bench workload extension.

Fixes https://github.com/Extra-Chill/homeboy/issues/7296

## Tests
- `cargo test --lib bench_lab_route_prefers_rig_declared_workload_extension_over_ecosystem_fallback`
- `cargo test bench_lab_route_prefers_rig_declared_workload_extension_over_ecosystem_fallback` passed the targeted lib regression, then timed out while Cargo continued enumerating filtered integration test binaries.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated the bench Lab route extension-selection path, implemented the generic rig-declared extension selection fix, added the focused regression, and ran targeted verification.