### PR TITLE
Carry runner secret requirements as plans

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -189,6 +189,8 @@ mod runner_workload_types {
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub struct RunnerWorkloadSecrets {
         pub categories: Vec<String>,
+        #[serde(default)]
+        pub secret_env_plan: crate::core::secret_env_plan::SecretEnvPlan,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/core/api_jobs/remote_runner.rs
+++ b/src/core/api_jobs/remote_runner.rs
@@ -159,18 +159,23 @@ impl JobStore {
                 None,
             ));
         }
-        request.secret_env_names = crate::core::runner::runner_exec_secret_env_names(
+        let secret_env_plan = crate::core::runner::runner_exec_secret_env_plan(
             &request.command,
             None,
             &request.secret_env_names,
             &request.env,
+            request
+                .runner_workload
+                .as_ref()
+                .map(|workload| workload.required_secrets.secret_env_plan.clone()),
         );
+        request.secret_env_names = secret_env_plan.secret_env_names();
         crate::core::runner::workload::validate_runner_workload_dispatch(
             request.runner_workload.as_ref(),
             &request.runner_id,
             request.cwd.as_deref(),
             &request.command,
-            &request.secret_env_names,
+            &secret_env_plan,
             request.capture_patch,
         )?;
 

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -481,18 +481,23 @@ fn enqueue_exec_job(
                 None,
             )
         })?;
-    request.secret_env_names = crate::core::runner::runner_exec_secret_env_names(
+    let secret_env_plan = crate::core::runner::runner_exec_secret_env_plan(
         &request.command,
         None,
         &request.secret_env_names,
         &request.env,
+        request
+            .runner_workload
+            .as_ref()
+            .map(|workload| workload.required_secrets.secret_env_plan.clone()),
     );
+    request.secret_env_names = secret_env_plan.secret_env_names();
     crate::core::runner::workload::validate_runner_workload_dispatch(
         request.runner_workload.as_ref(),
         &request.runner_id,
         request.cwd.as_deref(),
         &request.command,
-        &request.secret_env_names,
+        &secret_env_plan,
         request.capture_patch,
     )?;
     let plan = prepare_daemon_local_process(RunnerProcessRequest {

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -86,7 +86,9 @@ pub(crate) use handoff::lab_offload_handoff_hints;
 pub(crate) use process::{
     execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
 };
+#[cfg(test)]
 pub(crate) use secrets::runner_exec_secret_env_names;
+pub(crate) use secrets::runner_exec_secret_env_plan;
 pub(crate) use worker::exec_worker_local_until_cancelled_with_progress;
 
 // Public surface re-exported by the parent `runner` module. These mirror the
@@ -562,7 +564,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
         runner_id,
         Some(&cwd),
         &options.command,
-        &secret_env_names,
+        &secret_env_plan,
         options.capture_patch,
     )?;
     let required_extensions = required_extensions_for_command(

--- a/src/core/runner/execution/secrets.rs
+++ b/src/core/runner/execution/secrets.rs
@@ -319,6 +319,7 @@ pub(super) fn resolve_controller_secret_env_for_command(
     Ok(resolved)
 }
 
+#[cfg(test)]
 pub(crate) fn runner_exec_secret_env_names(
     command: &[String],
     preflight: Option<&RunnerCapabilityPreflight>,
@@ -335,20 +336,23 @@ pub(crate) fn runner_exec_secret_env_plan(
     env: &HashMap<String, String>,
     base_plan: Option<SecretEnvPlan>,
 ) -> SecretEnvPlan {
+    let has_base_plan = base_plan.is_some();
     let mut names = Vec::new();
     names.extend(explicit_names.iter().cloned());
     if let Some(preflight) = preflight {
         names.extend(preflight.required_env.iter().cloned());
     }
-    names.extend(super::super::lab::secrets::declared_agent_task_secret_env(
-        command,
-    ));
-    names.extend(super::super::lab::secrets::declared_trace_secret_env(
-        command,
-    ));
-    names.extend(super::super::lab::secrets::declared_tunnel_secret_env(
-        command,
-    ));
+    if !has_base_plan {
+        names.extend(super::super::lab::secrets::declared_agent_task_secret_env(
+            command,
+        ));
+        names.extend(super::super::lab::secrets::declared_trace_secret_env(
+            command,
+        ));
+        names.extend(super::super::lab::secrets::declared_tunnel_secret_env(
+            command,
+        ));
+    }
     names.extend(declared_runtime_provider_secret_env(env));
     let mut plan = SecretEnvPlan::from_secret_env_names(names);
     plan.allow_inherited_env_names([RUNTIME_SECRET_ENV_ALLOWLIST_ENV.to_string()]);

--- a/src/core/runner/execution/worker.rs
+++ b/src/core/runner/execution/worker.rs
@@ -66,7 +66,7 @@ pub(super) fn exec_worker_local_with_process_output(
         runner_id,
         Some(&plan.cwd),
         &options.command,
-        &secret_env_names,
+        &secret_env_plan,
         options.capture_patch,
     )?;
     let required_extensions = required_extensions_for_command(

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -537,26 +537,6 @@ pub(crate) fn run_lab_offload_inner(
         None,
         Some(&workspace_mapping_metadata),
     );
-    let runner_workload = build_runner_workload(RunnerWorkloadBuildInput {
-        plan: &plan,
-        command: &contract,
-        capture_patch: request.capture_patch,
-        mutation_flag: request.mutation_flag,
-        allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
-        runner_id,
-        runner_mode: status_tunnel_mode(&runner_status).metadata_value(),
-        assignment_source: selection.source.metadata_value(),
-        status: "offloaded",
-        remote_workspace: Some(&remote_cwd),
-        fallback_reason: None,
-        workspace_mapping_ref: Some("workspace_mapping"),
-        proof_id: lab_metadata
-            .get("proof")
-            .and_then(|proof| proof.get("id"))
-            .and_then(|id| id.as_str()),
-    });
-    lab_metadata["runner_workload"] =
-        serde_json::to_value(&runner_workload).unwrap_or(serde_json::json!(null));
     lab_metadata["source_snapshot"] =
         serde_json::to_value(&source_snapshot).unwrap_or(serde_json::json!(null));
     lab_metadata["workspace_materialization_plan"] =
@@ -596,6 +576,27 @@ pub(crate) fn run_lab_offload_inner(
     let secret_env_handoff =
         build_lab_secret_env_handoff_plan(&changed_since_preflight.args, env_delta)?;
     lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
+    let mut runner_workload = build_runner_workload(RunnerWorkloadBuildInput {
+        plan: &plan,
+        command: &contract,
+        capture_patch: request.capture_patch,
+        mutation_flag: request.mutation_flag,
+        allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+        runner_id,
+        runner_mode: status_tunnel_mode(&runner_status).metadata_value(),
+        assignment_source: selection.source.metadata_value(),
+        status: "offloaded",
+        remote_workspace: Some(&remote_cwd),
+        fallback_reason: None,
+        workspace_mapping_ref: Some("workspace_mapping"),
+        proof_id: lab_metadata
+            .get("proof")
+            .and_then(|proof| proof.get("id"))
+            .and_then(|id| id.as_str()),
+    });
+    runner_workload.required_secrets.secret_env_plan = secret_env_handoff.secret_env_plan.clone();
+    lab_metadata["runner_workload"] =
+        serde_json::to_value(&runner_workload).unwrap_or(serde_json::json!(null));
     lab_metadata["rig_component_path_env"] = rig_component_path_env;
     lab_metadata["wordpress_dependency_paths_env"] = wordpress_dependency_paths_env;
     lab_metadata["rig_component_path_overrides"] =

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -90,7 +90,7 @@ pub use evidence::{
 };
 pub(crate) use execution::{
     daemon_api_get, execute_runner_process_until_cancelled_with_progress,
-    prepare_daemon_local_process, runner_exec_secret_env_names, RunnerProcessRequest,
+    prepare_daemon_local_process, runner_exec_secret_env_plan, RunnerProcessRequest,
     RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV,
 };
 pub use execution::{

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -359,6 +359,7 @@ mod tests {
             required_capabilities: Vec::new(),
             required_secrets: RunnerWorkloadSecrets {
                 categories: Vec::new(),
+                secret_env_plan: crate::core::secret_env_plan::SecretEnvPlan::default(),
             },
             required_extensions: vec!["browser".to_string()],
             required_extension_revisions: vec![RunnerWorkloadExtensionRevision {

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -6,6 +6,7 @@ use crate::command_contract::{
 };
 use crate::core::error::{Error, Result};
 use crate::core::plan::HomeboyPlan;
+use crate::core::secret_env_plan::SecretEnvPlan;
 
 use super::{
     LabOffloadCommand, LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy,
@@ -48,6 +49,7 @@ pub(crate) fn build_runner_workload(input: RunnerWorkloadBuildInput<'_>) -> Runn
         required_capabilities: required_capabilities(input.command),
         required_secrets: RunnerWorkloadSecrets {
             categories: required_secret_categories(input.command.hot_label),
+            secret_env_plan: SecretEnvPlan::default(),
         },
         required_extensions: input.command.required_extensions.clone(),
         required_extension_revisions: required_extension_revisions(
@@ -108,7 +110,7 @@ pub(crate) fn validate_runner_workload_dispatch(
     runner_id: &str,
     cwd: Option<&str>,
     command: &[String],
-    secret_env_names: &[String],
+    secret_env_plan: &SecretEnvPlan,
     capture_patch: bool,
 ) -> Result<()> {
     let Some(workload) = workload else {
@@ -116,7 +118,7 @@ pub(crate) fn validate_runner_workload_dispatch(
     };
     validate_runner_workload_dispatch_identity(workload, runner_id, cwd)?;
     validate_runner_workload_mutation_policy(workload, capture_patch)?;
-    validate_runner_workload_required_secrets(workload, command, secret_env_names)?;
+    validate_runner_workload_required_secrets(workload, secret_env_plan)?;
     validate_runner_workload_required_capabilities(workload)?;
     validate_runner_workload_command_present(command)?;
     validate_runner_workload_command(workload, command)?;
@@ -167,21 +169,13 @@ fn validate_runner_workload_mutation_policy(
 
 fn validate_runner_workload_required_secrets(
     workload: &RunnerWorkload,
-    command: &[String],
-    secret_env_names: &[String],
+    secret_env_plan: &SecretEnvPlan,
 ) -> Result<()> {
-    let expected = expected_required_secret_env_names(workload, command);
-    for category in &workload.required_secrets.categories {
-        if !matches!(category.as_str(), "agent_task" | "trace" | "tunnel") {
-            return Err(workload_error(
-                "runner_workload.required_secrets",
-                format!("runner workload declares unsupported secret category `{category}`"),
-            ));
-        }
-    }
+    let expected = workload.required_secrets.secret_env_plan.secret_env_names();
+    let declared = secret_env_plan.secret_env_names();
     let missing = expected
         .iter()
-        .filter(|name| !secret_env_names.contains(name))
+        .filter(|name| !declared.contains(name))
         .cloned()
         .collect::<Vec<_>>();
     if !missing.is_empty() {
@@ -194,27 +188,6 @@ fn validate_runner_workload_required_secrets(
         ));
     }
     Ok(())
-}
-
-fn expected_required_secret_env_names(
-    workload: &RunnerWorkload,
-    command: &[String],
-) -> Vec<String> {
-    let command = dispatch_workload_command_args(command);
-    let mut names = Vec::new();
-    for category in &workload.required_secrets.categories {
-        match category.as_str() {
-            "agent_task" => {
-                names.extend(super::lab::secrets::declared_agent_task_secret_env(command))
-            }
-            "trace" => names.extend(super::lab::secrets::declared_trace_secret_env(command)),
-            "tunnel" => names.extend(super::lab::secrets::declared_tunnel_secret_env(command)),
-            _ => {}
-        }
-    }
-    names.sort();
-    names.dedup();
-    names
 }
 
 fn validate_runner_workload_required_capabilities(workload: &RunnerWorkload) -> Result<()> {
@@ -538,11 +511,15 @@ mod tests {
         })
     }
 
+    fn secret_plan(names: &[&str]) -> SecretEnvPlan {
+        SecretEnvPlan::from_secret_env_names(names.iter().map(|name| name.to_string()))
+    }
+
     #[test]
     fn runner_core_builds_complete_workload_payload() {
         let plan = plan();
         let command = command();
-        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+        let mut workload = build_runner_workload(RunnerWorkloadBuildInput {
             plan: &plan,
             command: &command,
             capture_patch: true,
@@ -557,6 +534,7 @@ mod tests {
             workspace_mapping_ref: Some("workspace_mapping"),
             proof_id: Some("proof-1"),
         });
+        workload.required_secrets.secret_env_plan = secret_plan(&["HOMEBODY_TRACE_SECRET"]);
 
         assert_eq!(workload.schema, RUNNER_WORKLOAD_SCHEMA);
         assert_eq!(workload.workload_id, "lab_offload.test.runner_workload");
@@ -628,7 +606,7 @@ mod tests {
             "lab-a",
             Some("/srv/homeboy/work"),
             &["homeboy".to_string(), "trace".to_string()],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect("matching dispatch is valid");
@@ -638,7 +616,7 @@ mod tests {
             "other-runner",
             Some("/srv/homeboy/work"),
             &["homeboy".to_string(), "trace".to_string()],
-            &[],
+            &SecretEnvPlan::default(),
             true,
         )
         .expect_err("drifted runner id must fail");
@@ -655,7 +633,7 @@ mod tests {
             "lab-a",
             Some("/srv/homeboy/work"),
             &["homeboy".to_string(), "trace".to_string()],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect_err("blank result refs plan id must fail");
@@ -672,7 +650,7 @@ mod tests {
             "lab-a",
             Some("/srv/homeboy/work"),
             &["homeboy".to_string(), "trace".to_string()],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect_err("mismatched result refs plan id must fail");
@@ -703,7 +681,7 @@ mod tests {
             "lab-a",
             Some("/srv/homeboy/work"),
             &["homeboy".to_string(), "trace".to_string()],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect_err("blank result refs artifact id must fail");
@@ -738,7 +716,7 @@ mod tests {
             "lab-a",
             Some("/srv/homeboy/work"),
             &["homeboy".to_string(), "test".to_string()],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect_err("drifted command label must fail");
@@ -770,7 +748,7 @@ mod tests {
             "lab-a",
             Some("/srv/homeboy/work"),
             &["homeboy".to_string(), "trace".to_string()],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect("matching full argv is valid");
@@ -780,7 +758,7 @@ mod tests {
             "lab-a",
             Some("/srv/homeboy/work"),
             &["trace".to_string()],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect("matching short argv is valid");
@@ -790,7 +768,7 @@ mod tests {
             "lab-a",
             Some("/srv/homeboy/work"),
             &["/srv/homeboy/bin/homeboy".to_string(), "trace".to_string()],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect("matching configured homeboy executable argv is valid");
@@ -804,7 +782,7 @@ mod tests {
                 "--force-hot".to_string(),
                 "trace".to_string(),
             ],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect("matching runner-injected homeboy argv is valid");
@@ -845,17 +823,17 @@ mod tests {
                 "homeboy".to_string(),
                 "--run-plan".to_string(),
             ],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect("matching fanout cook-batch argv is valid");
     }
 
     #[test]
-    fn runner_workload_validation_rejects_required_secret_categories_without_named_handoff() {
+    fn runner_workload_validation_rejects_required_secret_plan_without_named_handoff() {
         let plan = plan();
         let command = command();
-        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+        let mut workload = build_runner_workload(RunnerWorkloadBuildInput {
             plan: &plan,
             command: &command,
             capture_patch: true,
@@ -870,6 +848,7 @@ mod tests {
             workspace_mapping_ref: None,
             proof_id: None,
         });
+        workload.required_secrets.secret_env_plan = secret_plan(&["HOMEBODY_TRACE_SECRET"]);
 
         let err = validate_runner_workload_dispatch(
             Some(&workload),
@@ -880,17 +859,18 @@ mod tests {
                 "trace".to_string(),
                 "--secret-env=HOMEBODY_TRACE_SECRET".to_string(),
             ],
-            &[],
+            &SecretEnvPlan::default(),
             true,
         )
-        .expect_err("required secret category without named handoff must fail");
+        .expect_err("required secret plan without named handoff must fail");
         assert_eq!(err.details["field"], "runner_workload.required_secrets");
         assert!(err.message.contains("HOMEBODY_TRACE_SECRET"));
     }
 
     #[test]
     fn runner_workload_validation_rejects_wrong_trace_secret_handoff_name() {
-        let workload = workload();
+        let mut workload = workload();
+        workload.required_secrets.secret_env_plan = secret_plan(&["HOMEBODY_TRACE_SECRET"]);
 
         let err = validate_runner_workload_dispatch(
             Some(&workload),
@@ -901,7 +881,7 @@ mod tests {
                 "trace".to_string(),
                 "--secret-env=HOMEBODY_TRACE_SECRET".to_string(),
             ],
-            &["WRONG_SECRET".to_string()],
+            &secret_plan(&["WRONG_SECRET"]),
             true,
         )
         .expect_err("wrong trace secret handoff name must fail");
@@ -914,7 +894,7 @@ mod tests {
         let plan = plan();
         let mut command = command();
         command.hot_label = "agent-task dispatch";
-        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+        let mut workload = build_runner_workload(RunnerWorkloadBuildInput {
             plan: &plan,
             command: &command,
             capture_patch: true,
@@ -929,6 +909,7 @@ mod tests {
             workspace_mapping_ref: None,
             proof_id: None,
         });
+        workload.required_secrets.secret_env_plan = secret_plan(&["AGENT_TASK_SECRET"]);
 
         let err = validate_runner_workload_dispatch(
             Some(&workload),
@@ -940,7 +921,7 @@ mod tests {
                 "dispatch".to_string(),
                 "--secret-env=AGENT_TASK_SECRET".to_string(),
             ],
-            &["WRONG_SECRET".to_string()],
+            &secret_plan(&["WRONG_SECRET"]),
             true,
         )
         .expect_err("wrong agent-task secret handoff name must fail");
@@ -953,7 +934,7 @@ mod tests {
         let plan = plan();
         let mut command = command();
         command.hot_label = "tunnel preview-client start";
-        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+        let mut workload = build_runner_workload(RunnerWorkloadBuildInput {
             plan: &plan,
             command: &command,
             capture_patch: true,
@@ -968,6 +949,7 @@ mod tests {
             workspace_mapping_ref: None,
             proof_id: None,
         });
+        workload.required_secrets.secret_env_plan = secret_plan(&["HOMEBOY_PREVIEW_TUNNEL_TOKEN"]);
 
         let err = validate_runner_workload_dispatch(
             Some(&workload),
@@ -985,7 +967,7 @@ mod tests {
                 "--local-origin".to_string(),
                 "http://127.0.0.1:8888".to_string(),
             ],
-            &[],
+            &SecretEnvPlan::default(),
             true,
         )
         .expect_err("missing implicit tunnel secret handoff name must fail");
@@ -997,7 +979,7 @@ mod tests {
     fn runner_workload_validation_accepts_required_secret_categories_with_named_handoff() {
         let plan = plan();
         let command = command();
-        let workload = build_runner_workload(RunnerWorkloadBuildInput {
+        let mut workload = build_runner_workload(RunnerWorkloadBuildInput {
             plan: &plan,
             command: &command,
             capture_patch: true,
@@ -1012,13 +994,14 @@ mod tests {
             workspace_mapping_ref: None,
             proof_id: None,
         });
+        workload.required_secrets.secret_env_plan = secret_plan(&["HOMEBODY_TRACE_SECRET"]);
 
         validate_runner_workload_dispatch(
             Some(&workload),
             "lab-a",
             Some("/srv/homeboy/work"),
             &["homeboy".to_string(), "trace".to_string()],
-            &["HOMEBODY_TRACE_SECRET".to_string()],
+            &secret_plan(&["HOMEBODY_TRACE_SECRET"]),
             true,
         )
         .expect("required secret category with named handoff is valid");
@@ -1050,7 +1033,7 @@ mod tests {
             "lab-a",
             Some("/srv/homeboy/work"),
             &["homeboy".to_string(), "lint".to_string()],
-            &[],
+            &SecretEnvPlan::default(),
             true,
         )
         .expect("empty secret handoff is valid when no categories are required");

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -774,6 +774,7 @@ mod tests {
             required_capabilities: Vec::new(),
             required_secrets: RunnerWorkloadSecrets {
                 categories: Vec::new(),
+                secret_env_plan: SecretEnvPlan::default(),
             },
             required_extensions: Vec::new(),
             required_extension_revisions: Vec::new(),


### PR DESCRIPTION
## Summary
- Add `SecretEnvPlan` to the runner workload required secrets contract.
- Populate Lab runner workloads from the Lab secret handoff plan.
- Validate runner workload secret requirements by comparing `SecretEnvPlan` requirements instead of reparsing agent-task/trace/tunnel argv categories.
- Reuse workload secret plans when enqueueing runner exec jobs.

## Verification
- `cargo check`
- `cargo check --tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Implemented the small secret requirement contract change, updated call sites/tests, and ran targeted compile checks.