### PR TITLE
Add all-package rig lint contract

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -21,9 +21,13 @@ Install with:
 homeboy rig install https://github.com/example-org/homeboy-rigs.git//packages/studio --id studio
 homeboy rig install ./packages/studio
 homeboy rig install ./packages --all
+homeboy rig lint ./packages --all
 ```
 
 For git sources, `repo.git//subpath` clones the repository root but discovers specs from the selected subpath. Installed source metadata records the package root, discovery path, linked/cloned ownership, and git revision so `rig update` and `rig sources` can refresh or remove the right files later.
+`rig lint --all` is a safe package validation command: it checks JSON, template
+materialization, and materialized rig-spec contracts without installing rigs or
+touching component checkouts.
 
 ## Top-Level Fields
 

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -109,13 +109,15 @@ Runs the `check` pipeline and reports every failing step instead of stopping at 
 ```sh
 homeboy rig lint studio
 homeboy rig lint ./packages/studio --id studio
+homeboy rig lint ./packages --all
 homeboy rig lint ./packages/studio/rigs/studio/rig.json
 ```
 
 Runs env-independent rig package lint only: conflict markers, JSON validity, and
-`extends` template materialization. It does not run requirements, component
-checkout probes, services, or live `check` steps, so CI can validate rig packages
-before a full environment exists.
+`extends` template materialization, plus materialized rig-spec contract checks.
+It does not run requirements, component checkout probes, services, or live
+`check` steps, so CI can validate rig packages before a full environment exists.
+Use `--all` for a local package directory that contains multiple rigs.
 
 ### `down`
 

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -143,6 +143,9 @@ enum RigCommand {
         /// Select a rig from a local package path containing multiple rigs
         #[arg(long)]
         id: Option<String>,
+        /// Lint every rig discovered in a local package path
+        #[arg(long)]
+        all: bool,
     },
     /// Tear down a rig: stop services and run its `down` pipeline
     Down {
@@ -303,7 +306,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Show { rig_id } => show(&rig_id),
         RigCommand::Up { rig_id, dry_run } => up(&rig_id, dry_run),
         RigCommand::Check { target, id, path } => check(&target, id.as_deref(), path.as_deref()),
-        RigCommand::Lint { target, id } => lint(&target, id.as_deref()),
+        RigCommand::Lint { target, id, all } => lint(&target, id.as_deref(), all),
         RigCommand::Down { rig_id } => down(&rig_id),
         RigCommand::Repair { rig_id } => repair(&rig_id),
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
@@ -617,7 +620,42 @@ fn check(
     ))
 }
 
-fn lint(target: &str, id: Option<&str>) -> CmdResult<RigCommandOutput> {
+fn lint(target: &str, id: Option<&str>, all: bool) -> CmdResult<RigCommandOutput> {
+    if all {
+        if id.is_some() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "id",
+                "Pass either --id or --all, not both",
+                id.map(str::to_string),
+                None,
+            ));
+        }
+        let path = std::path::Path::new(target);
+        if !path.is_dir() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "target",
+                "rig lint --all requires a local package directory",
+                Some(target.to_string()),
+                None,
+            ));
+        }
+        let report = rig::lint::run_package_lint_at(path)?;
+        let exit_code = if report.failed == 0 { 0 } else { 1 };
+        return Ok((
+            RigCommandOutput::Check(RigCheckOutput {
+                command: "rig.lint",
+                report: homeboy::core::rig::CheckReport {
+                    rig_id: target.to_string(),
+                    run_id: None,
+                    pipeline: report,
+                    success: exit_code == 0,
+                    artifact_index: None,
+                },
+            }),
+            exit_code,
+        ));
+    }
+
     let rig = if std::path::Path::new(target).exists() {
         rig::load_local_source(target, id)?
     } else {
@@ -1090,11 +1128,12 @@ mod tests {
         let cli = TestCli::try_parse_from(["homeboy", "lint", "./pkg", "--id", "alpha"])
             .expect("rig lint should parse");
 
-        let RigCommand::Lint { target, id } = cli.rig.command else {
+        let RigCommand::Lint { target, id, all } = cli.rig.command else {
             panic!("expected rig lint command");
         };
         assert_eq!(target, "./pkg");
         assert_eq!(id.as_deref(), Some("alpha"));
+        assert!(!all);
     }
 
     #[test]
@@ -1118,7 +1157,7 @@ mod tests {
             assert_eq!(check_exit, 1, "missing requirement should fail rig check");
 
             // The lint command skips requirements entirely and succeeds.
-            let (output, exit_code) = lint("lint-cmd", None).expect("rig lint runs");
+            let (output, exit_code) = lint("lint-cmd", None, false).expect("rig lint runs");
             assert_eq!(exit_code, 0);
             let json = serde_json::to_value(output).expect("serialize lint output");
             assert_eq!(json["payload"]["command"], "rig.lint");
@@ -1135,13 +1174,35 @@ mod tests {
                 serde_json::json!({ "id": "lint-id-guard" }),
             );
 
-            let err = match lint("lint-id-guard", Some("alpha")) {
+            let err = match lint("lint-id-guard", Some("alpha"), false) {
                 Ok(_) => panic!("--id against an installed rig id should fail"),
                 Err(err) => err,
             };
             assert_eq!(err.code.as_str(), "validation.invalid_argument");
             assert!(err.message.contains("local package path"));
         });
+    }
+
+    #[test]
+    fn lint_all_runs_package_lint_for_multi_rig_package() {
+        let temp = tempfile::TempDir::new().expect("package");
+        for id in ["alpha", "beta"] {
+            let rig_dir = temp.path().join("rigs").join(id);
+            std::fs::create_dir_all(&rig_dir).expect("rig dir");
+            std::fs::write(
+                rig_dir.join("rig.json"),
+                serde_json::json!({ "id": id }).to_string(),
+            )
+            .expect("write rig");
+        }
+
+        let (output, exit_code) =
+            lint(&temp.path().to_string_lossy(), None, true).expect("rig lint --all runs");
+
+        assert_eq!(exit_code, 0);
+        let json = serde_json::to_value(output).expect("serialize lint output");
+        assert_eq!(json["payload"]["command"], "rig.lint");
+        assert_eq!(json["payload"]["success"], true);
     }
 
     #[test]

--- a/src/core/rig/lint.rs
+++ b/src/core/rig/lint.rs
@@ -1,4 +1,4 @@
-//! Generic rig package lint checks used by `homeboy rig check`.
+//! Generic rig package lint checks used by `homeboy rig check` and `homeboy rig lint`.
 
 use std::ffi::OsStr;
 use std::fs;
@@ -31,12 +31,26 @@ pub fn run_package_lint(rig: &RigSpec) -> Result<PipelineOutcome> {
         return Ok(empty_outcome());
     };
 
-    let mut files = Vec::new();
-    collect_files(&root, &mut files)?;
+    run_package_lint_at(&root)
+}
 
-    let conflict_failures = conflict_marker_failures(&root, &files)?;
-    let json_failures = json_parse_failures(&root, &files)?;
-    let template_failures = template_materialization_failures(&root, &files)?;
+pub fn run_package_lint_at(root: &Path) -> Result<PipelineOutcome> {
+    if !root.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            "Rig package lint target must be a directory",
+            Some(root.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+
+    let mut files = Vec::new();
+    collect_files(root, &mut files)?;
+
+    let conflict_failures = conflict_marker_failures(root, &files)?;
+    let json_failures = json_parse_failures(root, &files)?;
+    let template_failures = template_materialization_failures(root, &files)?;
+    let contract_failures = contract_validation_failures(root)?;
     let steps = vec![
         aggregate_step(
             "rig-package-lint",
@@ -53,6 +67,11 @@ pub fn run_package_lint(rig: &RigSpec) -> Result<PipelineOutcome> {
             "rig package template specs materialize",
             template_failures,
         ),
+        aggregate_step(
+            "rig-package-lint",
+            "rig package specs satisfy the Homeboy rig contract",
+            contract_failures,
+        ),
     ];
 
     Ok(PipelineOutcome {
@@ -61,6 +80,25 @@ pub fn run_package_lint(rig: &RigSpec) -> Result<PipelineOutcome> {
         failed: steps.iter().filter(|step| step.status == "fail").count(),
         steps,
     })
+}
+
+fn contract_validation_failures(root: &Path) -> Result<Vec<String>> {
+    let rigs = match super::discover_rigs(root) {
+        Ok(rigs) => rigs,
+        Err(error) => return Ok(vec![error.message]),
+    };
+
+    let mut failures = Vec::new();
+    for rig in rigs {
+        if let Err(error) = super::load_local_source(&root.to_string_lossy(), Some(&rig.id)) {
+            failures.push(format!(
+                "{}: {}",
+                display_relative(root, &rig.rig_path),
+                error.message
+            ));
+        }
+    }
+    Ok(failures)
 }
 
 fn empty_outcome() -> PipelineOutcome {
@@ -230,5 +268,38 @@ mod tests {
         let outcome = aggregate_step("rig-package-lint", "JSON parses", Vec::new());
         assert_eq!(outcome.status, "pass");
         assert_eq!(outcome.error, None);
+    }
+
+    #[test]
+    fn package_lint_reports_contract_failures_for_all_rigs() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("bad");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "bad",
+                "requirements": {
+                    "dependency_materialization": [
+                        { "id": "bad", "inputs": { "paths": ["artifact.txt"] } }
+                    ]
+                }
+            }"#,
+        )
+        .expect("write rig");
+
+        let outcome = run_package_lint_at(temp.path()).expect("lint package");
+
+        let contract_step = outcome
+            .steps
+            .iter()
+            .find(|step| step.label.contains("Homeboy rig contract"))
+            .expect("contract step");
+        assert_eq!(contract_step.status, "fail");
+        assert!(contract_step
+            .error
+            .as_ref()
+            .expect("contract error")
+            .contains("dependency materialization"));
     }
 }


### PR DESCRIPTION
## Summary
- add `homeboy rig lint <package> --all` for safe multi-rig package validation
- expose package-path linting from core and add a materialized rig contract validation step
- document the package validation command for rig package consumers

## Verification
- `cargo check` passed with existing warnings: unused `RunnerWorkspaceMaterializationPlan`, unused `is_missing_source_checkout_error`
- `cargo run --quiet -- rig lint tests/fixtures/rig-package-subpath/packages/studio --all` passed and emitted the new contract step
- `cargo fmt --check` is blocked by existing formatting drift outside this PR's files; it did not modify the worktree

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Implemented and verified the Homeboy rig package validation command surface with Chris's requested constraints.