### PR TITLE
Add artifact postprocess runner command

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -4,11 +4,11 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use crate::commands::{
-    agent_task, api, audit, audit_baseline, auth, bench, build, changelog, changes, ci, cleanup,
-    component, config, contract, daemon, db, deploy, extension, file, fleet, fuzz, git, http,
-    issues, lint, logs, manifest, observe, project, refactor, refs, release, report, review, rig,
-    runner, runs, runtime, self_cmd, server, ssh, stack, status, test, trace, triage, tunnel, undo,
-    upgrade, version, worktree,
+    agent_task, api, artifact_postprocess, audit, audit_baseline, auth, bench, build, changelog,
+    changes, ci, cleanup, component, config, contract, daemon, db, deploy, extension, file, fleet,
+    fuzz, git, http, issues, lint, logs, manifest, observe, project, refactor, refs, release,
+    report, review, rig, runner, runs, runtime, self_cmd, server, ssh, stack, status, test, trace,
+    triage, tunnel, undo, upgrade, version, worktree,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -122,6 +122,9 @@ pub enum Commands {
     Config(config::ConfigArgs),
     /// Inspect, export, validate, and normalize Homeboy contract metadata
     Contract(contract::ContractArgs),
+    /// Run a generic artifact postprocess plan over persisted artifact roots
+    #[command(name = "artifact-postprocess")]
+    ArtifactPostprocess(artifact_postprocess::ArtifactPostprocessArgs),
     /// Run the local-only HTTP API daemon
     Daemon(daemon::DaemonArgs),
     /// Execute CLI-compatible extensions
@@ -570,6 +573,7 @@ mod entry_command_impls {
                 Commands::Component(_) => "component",
                 Commands::Config(_) => "config",
                 Commands::Contract(_) => "contract",
+                Commands::ArtifactPostprocess(_) => "artifact-postprocess",
                 Commands::Daemon(_) => "daemon",
                 Commands::Extension(_) => "extension",
                 Commands::Status(_) => "status",

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -233,6 +233,7 @@ impl Commands {
             | Commands::Project(_)
             | Commands::Component(_)
             | Commands::Config(_)
+            | Commands::ArtifactPostprocess(_)
             | Commands::Extension(_)
             | Commands::Manifest(_)
             | Commands::Changelog(_)

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -494,6 +494,11 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         CommandJsonFamily::Workspace,
         "lists, shows, exports constants, exports schemas, validates, and normalizes Homeboy-owned contract metadata through the central contract surface",
     ),
+    command_spec_with_output_notes(
+        "artifact-postprocess",
+        CommandJsonFamily::Workspace,
+        "runs a Homeboy artifact-postprocess plan over declared persisted artifact roots and emits the artifact-postprocess result contract",
+    ),
     command_spec("daemon", CommandJsonFamily::Ops),
     lab_command_spec_with_summary(
         "extension",

--- a/src/commands/artifact_postprocess.rs
+++ b/src/commands/artifact_postprocess.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use homeboy::core::artifacts::{
+    run_artifact_postprocess_plan_for_persisted_root, ArtifactPostprocessPlan,
+};
+use serde::Serialize;
+
+use super::{CmdResult, GlobalArgs};
+
+#[derive(Args)]
+pub struct ArtifactPostprocessArgs {
+    /// Artifact postprocess plan JSON file, @file spec, or - for stdin.
+    #[arg(value_name = "PLAN")]
+    pub plan: String,
+
+    /// Artifact root id from the plan to use as HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT.
+    #[arg(long, value_name = "ID")]
+    pub artifact_root_id: Option<String>,
+
+    /// Optional artifact root id from the plan to expose as ${run.input}.
+    #[arg(long, value_name = "ID")]
+    pub input_root_id: Option<String>,
+
+    /// Write the bare artifact-postprocess result contract to this path.
+    #[arg(long, value_name = "PATH")]
+    pub result: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ArtifactPostprocessCommandOutput {
+    pub command: &'static str,
+    pub plan_file: String,
+    pub artifact_root_id: Option<String>,
+    pub input_root_id: Option<String>,
+    pub result_file: Option<String>,
+    pub result: homeboy::core::artifacts::ArtifactPostprocessResult,
+}
+
+pub fn run(
+    args: ArtifactPostprocessArgs,
+    _global: &GlobalArgs,
+) -> CmdResult<ArtifactPostprocessCommandOutput> {
+    let raw = homeboy::core::config::read_json_spec_to_string(&args.plan)?;
+    let plan: ArtifactPostprocessPlan = serde_json::from_str(&raw).map_err(|error| {
+        homeboy::core::Error::validation_invalid_json(
+            error,
+            Some("parse artifact postprocess plan".to_string()),
+            Some(args.plan.clone()),
+        )
+    })?;
+    let result = run_artifact_postprocess_plan_for_persisted_root(
+        &plan,
+        args.artifact_root_id.as_deref(),
+        args.input_root_id.as_deref(),
+    )?;
+    if let Some(path) = args.result.as_ref() {
+        write_result(path, &result)?;
+    }
+    let exit_code = if result.success { 0 } else { 1 };
+
+    Ok((
+        ArtifactPostprocessCommandOutput {
+            command: "artifact-postprocess",
+            plan_file: args.plan,
+            artifact_root_id: args.artifact_root_id,
+            input_root_id: args.input_root_id,
+            result_file: args.result.map(|path| path.to_string_lossy().to_string()),
+            result,
+        },
+        exit_code,
+    ))
+}
+
+fn write_result(
+    path: &std::path::Path,
+    result: &homeboy::core::artifacts::ArtifactPostprocessResult,
+) -> homeboy::core::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            homeboy::core::Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+        })?;
+    }
+    let json = homeboy::core::config::to_json_string(result)?;
+    std::fs::write(path, format!("{json}\n")).map_err(|error| {
+        homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+    })
+}

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -2,9 +2,9 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    agent_task, build, changelog, changes, cleanup, component, config, contract, docs, extension,
-    manifest, project, refactor, refs, release, report, rig, runner, runs, runtime, stack, tunnel,
-    undo, worktree, GlobalArgs,
+    agent_task, artifact_postprocess, build, changelog, changes, cleanup, component, config,
+    contract, docs, extension, manifest, project, refactor, refs, release, report, rig, runner,
+    runs, runtime, stack, tunnel, undo, worktree, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -14,6 +14,7 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Component(args) => map(component::run(args, global)),
         Commands::Config(args) => map(config::run(args, global)),
         Commands::Contract(args) => map(contract::run(args, global)),
+        Commands::ArtifactPostprocess(args) => map(artifact_postprocess::run(args, global)),
         Commands::Extension(args) => map(extension::run(args, global)),
         Commands::Docs(args) => map(docs::run(args, global)),
         Commands::Manifest(args) => map(manifest::run(args, global)),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -185,6 +185,7 @@ pub mod agent_task;
 pub(crate) mod agent_task_dispatch;
 pub(crate) mod agent_task_summary;
 pub mod api;
+pub mod artifact_postprocess;
 pub mod audit;
 pub mod audit_baseline;
 pub mod auth;

--- a/src/core/artifact_postprocess.rs
+++ b/src/core/artifact_postprocess.rs
@@ -206,6 +206,29 @@ pub fn run_artifact_postprocess_plan(
     })
 }
 
+pub fn run_artifact_postprocess_plan_for_persisted_root(
+    plan: &ArtifactPostprocessPlan,
+    artifact_root_id: Option<&str>,
+    input_root_id: Option<&str>,
+) -> Result<ArtifactPostprocessResult> {
+    validate_artifact_postprocess_plan(plan)?;
+    let artifact_root = selected_artifact_postprocess_root(plan, artifact_root_id)?;
+    let input_root = input_root_id
+        .map(|id| {
+            selected_artifact_postprocess_root(plan, Some(id)).map(|root| PathBuf::from(&root.path))
+        })
+        .transpose()?;
+
+    run_artifact_postprocess_plan(
+        plan,
+        &ArtifactPostprocessContext {
+            artifact_root: Path::new(&artifact_root.path),
+            input_root: input_root.as_deref(),
+            path_expander: None,
+        },
+    )
+}
+
 pub fn run_artifact_postprocess_steps(
     steps: &[ArtifactPostprocessAction],
     context: &ArtifactPostprocessContext<'_>,
@@ -488,6 +511,39 @@ fn validate_reviewer_ref(reviewer_ref: &ArtifactPostprocessReviewerRef) -> Resul
         ));
     }
     Ok(())
+}
+
+fn selected_artifact_postprocess_root<'a>(
+    plan: &'a ArtifactPostprocessPlan,
+    artifact_root_id: Option<&str>,
+) -> Result<&'a ArtifactPostprocessRoot> {
+    match artifact_root_id {
+        Some(id) => plan
+            .artifact_roots
+            .iter()
+            .find(|root| root.id == id)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "artifact_postprocess.artifact_root_id",
+                    format!("artifact postprocess plan does not declare artifact root `{id}`"),
+                    Some(id.to_string()),
+                    Some(
+                        plan.artifact_roots
+                            .iter()
+                            .map(|root| root.id.clone())
+                            .collect(),
+                    ),
+                )
+            }),
+        None => plan.artifact_roots.first().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_postprocess.artifact_roots",
+                "artifact postprocess plan must declare at least one persisted artifact root",
+                None,
+                None,
+            )
+        }),
+    }
 }
 
 fn validate_non_empty(field: &str, value: &str) -> Result<()> {

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -37,11 +37,12 @@ pub use super::artifact_origin::{
 };
 pub use super::artifact_postprocess::{
     describe_artifact_postprocess_plan, record_artifact_postprocess_outputs,
-    run_artifact_postprocess_plan, run_artifact_postprocess_steps,
-    validate_artifact_postprocess_plan, ArtifactPostprocessAction, ArtifactPostprocessContext,
-    ArtifactPostprocessOutput, ArtifactPostprocessPlan, ArtifactPostprocessPlanDescription,
-    ArtifactPostprocessProducedArtifact, ArtifactPostprocessResult, ArtifactPostprocessReviewerRef,
-    ArtifactPostprocessRoot, ARTIFACT_POSTPROCESS_PLAN_SCHEMA, ARTIFACT_POSTPROCESS_RESULT_SCHEMA,
+    run_artifact_postprocess_plan, run_artifact_postprocess_plan_for_persisted_root,
+    run_artifact_postprocess_steps, validate_artifact_postprocess_plan, ArtifactPostprocessAction,
+    ArtifactPostprocessContext, ArtifactPostprocessOutput, ArtifactPostprocessPlan,
+    ArtifactPostprocessPlanDescription, ArtifactPostprocessProducedArtifact,
+    ArtifactPostprocessResult, ArtifactPostprocessReviewerRef, ArtifactPostprocessRoot,
+    ARTIFACT_POSTPROCESS_PLAN_SCHEMA, ARTIFACT_POSTPROCESS_RESULT_SCHEMA,
     ARTIFACT_POSTPROCESS_SCHEMA,
 };
 pub use super::artifact_preview::{html_preview_entrypoints, ArtifactPreviewEntrypoint};


### PR DESCRIPTION
## Summary
- Add a generic `homeboy artifact-postprocess` command that reads an artifact-postprocess plan and runs it over a selected persisted artifact root.
- Add a reusable core helper for executing plans against declared artifact roots by id.
- Register the command with the CLI surface, JSON workspace dispatch, and command contract metadata.

## Context
- Advances `homeboy.artifact-postprocess` beyond contract-only/fuzz-local use toward a runner-executable primitive over persisted artifact roots.
- Intended to unblock downstream runner wiring such as homeboy-rigs PR 643.

## Verification
- `cargo check` passes.
- `cargo run --quiet -- artifact-postprocess --help` parses and prints the new command help.
- `rustfmt --check src/commands/artifact_postprocess.rs src/core/artifact_postprocess.rs src/command_contract/output.rs src/command_contract/spec.rs` passes.

## Notes
- Full repo/module-root `rustfmt --check` still reports unrelated pre-existing formatting drift in other modules, so this PR intentionally avoids broad formatting churn.
- No hot commands or local test suites were run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Drafted and implemented the small command/core helper change, ran safe verification, and prepared this PR description.