### PR TITLE
Fix extension dev-run workload secrets initializer

### DIFF
--- a/src/core/extension/dev_run.rs
+++ b/src/core/extension/dev_run.rs
@@ -336,6 +336,7 @@ fn extension_dev_run_workload(
         required_capabilities: Vec::new(),
         required_secrets: RunnerWorkloadSecrets {
             categories: Vec::new(),
+            secret_env_plan: Default::default(),
         },
         required_extensions,
         required_extension_revisions: Vec::new(),


### PR DESCRIPTION
## Summary
- Add the missing `secret_env_plan` field when constructing extension dev-run workloads.
- Unblocks `homeboy upgrade --method source` from current main on macOS.

## Testing
- Attempted `homeboy upgrade --method source --source-path /Users/chubes/Developer/homeboy@fix-bench-offload-rig-extension-live-path --force --skip-extensions --skip-runners`; before this fix it failed with `missing field secret_env_plan in initializer of RunnerWorkloadSecrets`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Diagnosed the source-upgrade compile failure while preparing SSI production-scale verification and drafted the minimal initializer fix.