### PR TITLE
Fix live Lab bench rig extension propagation

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -120,6 +120,7 @@ impl BenchArgs {
                 &spec,
                 rig::RigWorkloadKind::Bench,
             ));
+            extension_ids.extend(bench_component_extension_ids(&spec, run.comp.id()));
         }
         Ok(extension_ids.into_iter().collect())
     }
@@ -131,6 +132,38 @@ impl BenchArgs {
             Some(BenchCommand::List(_)) => None,
         }
     }
+}
+
+fn bench_component_extension_ids(spec: &RigSpec, explicit_component: Option<&str>) -> Vec<String> {
+    let component_ids = explicit_component
+        .map(|id| vec![id.to_string()])
+        .or_else(|| {
+            spec.bench
+                .as_ref()
+                .map(|bench| {
+                    if bench.components.is_empty() {
+                        bench.default_component.iter().cloned().collect()
+                    } else {
+                        bench.components.clone()
+                    }
+                })
+                .filter(|ids: &Vec<String>| !ids.is_empty())
+        });
+    let Some(component_ids) = component_ids else {
+        return Vec::new();
+    };
+
+    let mut extension_ids = BTreeSet::new();
+    for component_id in component_ids {
+        if let Some(extensions) = spec
+            .components
+            .get(&component_id)
+            .and_then(|component| component.extensions.as_ref())
+        {
+            extension_ids.extend(extensions.keys().cloned());
+        }
+    }
+    extension_ids.into_iter().collect()
 }
 
 #[derive(Subcommand)]

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -648,6 +648,8 @@ fn command_accepts_extension_override(arg: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli_surface::Cli;
+    use clap::Parser;
 
     #[test]
     fn final_remote_command_remaps_bench_env_path_settings() {
@@ -734,6 +736,73 @@ mod tests {
                 "wordpress-fixture".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn final_remote_command_forwards_rig_component_bench_extension() {
+        crate::test_support::with_isolated_home(|home| {
+            let rigs_dir = home.path().join(".config/homeboy/rigs");
+            std::fs::create_dir_all(&rigs_dir).expect("rigs dir");
+            std::fs::write(
+                rigs_dir.join("fixture-matrix.json"),
+                r#"{
+                    "components": {
+                        "node-project": {
+                            "path": "/controller/workspaces/node-project",
+                            "extensions": { "wordpress": {} }
+                        }
+                    },
+                    "bench": { "default_component": "node-project" }
+                }"#,
+            )
+            .expect("rig spec");
+
+            let args = vec![
+                "homeboy".to_string(),
+                "--runner".to_string(),
+                "homeboy-lab".to_string(),
+                "bench".to_string(),
+                "node-project".to_string(),
+                "--path".to_string(),
+                "/controller/workspaces/node-project".to_string(),
+                "--rig".to_string(),
+                "fixture-matrix".to_string(),
+            ];
+            let cli = Cli::parse_from(&args);
+            let route_contract = cli
+                .command
+                .lab_route_contract()
+                .expect("route contract result")
+                .expect("bench supports lab offload");
+            let contract =
+                crate::core::lab_routing::lab_offload_command_from_route_contract(route_contract);
+
+            let command = build_lab_offload_remote_command(
+                &["/runner/bin/homeboy".to_string()],
+                &args,
+                "/runner/workspaces/node-project",
+                &[],
+                None,
+                &contract.required_extensions,
+            );
+
+            assert_eq!(contract.required_extensions, vec!["wordpress".to_string()]);
+            assert_eq!(
+                command,
+                vec![
+                    "/runner/bin/homeboy".to_string(),
+                    "--force-hot".to_string(),
+                    "bench".to_string(),
+                    "--extension".to_string(),
+                    "wordpress".to_string(),
+                    "node-project".to_string(),
+                    "--path".to_string(),
+                    "/runner/workspaces/node-project".to_string(),
+                    "--rig".to_string(),
+                    "fixture-matrix".to_string(),
+                ]
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Propagate rig component-declared bench extensions into the Lab route contract for `homeboy bench --runner homeboy-lab --rig ...`.
- Preserve the existing bench workload extension propagation and explicit `--extension` override behavior.
- Add a regression that parses a real Lab bench CLI invocation, loads rig metadata, builds the route contract, and asserts the final runner-side command includes `--extension wordpress`.

## Root cause
Live Lab offload command construction already injected `contract.required_extensions` into the final runner command, but `BenchArgs::lab_required_extension_ids()` only populated that contract from `bench_workloads` keys or explicit `--extension` flags. Rigs that select their bench provider through the generic `components.<id>.extensions` declaration still ran locally because bench dispatch resolves that component extension config, but Lab planning saw no required extension and produced a runner command without `--extension wordpress`. The runner then fell back to package ecosystem detection and reported `Unsupported Homeboy project ecosystem: node`.

## Issue context
Fixes https://github.com/Extra-Chill/homeboy/issues/7296.

Failed run: `994304dd-0f74-4371-9f6c-be1e45d1acb9`.

This is not missing Node: Lab has `node v24.13.1` and `npm 11.8.0`, and SSI Node tests passed before the failure. The failing runner-side command omitted `--extension wordpress`, so Homeboy dispatched through generic ecosystem detection instead of the rig-declared WordPress/Codebox bench extension path.

## Tests
- `homeboy test homeboy --lab-only --skip-lint -- workspace_stage::tests::final_remote_command_forwards_rig_component_bench_extension` attempted twice on Lab; first was interrupted by the local tool timeout, second reached compile but runner RSS guard killed it before tests executed.
- Targeted Lab runner execution of `homeboy --force-hot test homeboy --skip-lint -- workspace_stage::tests::final_remote_command_forwards_rig_component_bench_extension` with `CARGO_BUILD_JOBS=1` passed; persisted run `runner-exec-generic-homeboy-lab-3eba7f5e-b10d-4620-808c-381b421a9dce`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated the Lab bench command planning path, implemented the propagation fix and regression, and ran targeted verification.
