### PR TITLE
Remove changelog self flag

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -105,7 +105,7 @@ fn collect_md_files(docs_root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
 
         if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
             // Exclude docs/changelog.md from embedded docs.
-            // Homeboy's changelog is accessed via `homeboy changelog --self` instead.
+            // Homeboy's changelog is accessed via `homeboy changelog` instead.
             // Only exclude changelog.md at the docs root, not docs/commands/changelog.md.
             if path.file_name().and_then(|n| n.to_str()) == Some("changelog.md")
                 && path.parent() == Some(docs_root)

--- a/docs/commands/changelog.md
+++ b/docs/commands/changelog.md
@@ -22,16 +22,11 @@ In JSON output mode, the default `show` output is returned as JSON (with a `cont
 
 ```sh
 homeboy changelog
-homeboy changelog --self
 homeboy changelog show
 homeboy changelog show <component_id>
 ```
 
 Shows the embedded Homeboy CLI changelog documentation (from `docs/changelog.md`), or a specific component's changelog when a component ID is provided.
-
-Options:
-
-- `--self`: explicit alias for the default Homeboy changelog output
 
 This prints raw markdown to stdout.
 

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -6,10 +6,6 @@ use homeboy::core::release::changelog::{self, ShowOutput};
 
 #[derive(Args)]
 pub struct ChangelogArgs {
-    /// Show Homeboy's own changelog (release notes)
-    #[arg(long = "self")]
-    pub show_self: bool,
-
     #[command(subcommand)]
     pub command: Option<ChangelogCommand>,
 }
@@ -39,15 +35,12 @@ pub enum ChangelogOutput {
 }
 
 pub fn run_markdown(args: ChangelogArgs) -> CmdResult<String> {
-    match (&args.command, args.show_self) {
-        (None, _) => show_homeboy_markdown(),
-        (Some(ChangelogCommand::Show { component_id: None }), _) => show_homeboy_markdown(),
-        (
-            Some(ChangelogCommand::Show {
-                component_id: Some(id),
-            }),
-            _,
-        ) => {
+    match &args.command {
+        None => show_homeboy_markdown(),
+        Some(ChangelogCommand::Show { component_id: None }) => show_homeboy_markdown(),
+        Some(ChangelogCommand::Show {
+            component_id: Some(id),
+        }) => {
             let output = changelog::show(id)?;
             Ok((output.content, 0))
         }
@@ -62,21 +55,18 @@ pub fn run(
     args: ChangelogArgs,
     _global: &crate::commands::GlobalArgs,
 ) -> CmdResult<ChangelogOutput> {
-    match (&args.command, args.show_self) {
-        (None, _) => {
+    match &args.command {
+        None => {
             let (out, code) = show_homeboy_json()?;
             Ok((ChangelogOutput::Show(out), code))
         }
-        (Some(ChangelogCommand::Show { component_id: None }), _) => {
+        Some(ChangelogCommand::Show { component_id: None }) => {
             let (out, code) = show_homeboy_json()?;
             Ok((ChangelogOutput::Show(out), code))
         }
-        (
-            Some(ChangelogCommand::Show {
-                component_id: Some(id),
-            }),
-            _,
-        ) => {
+        Some(ChangelogCommand::Show {
+            component_id: Some(id),
+        }) => {
             let output = changelog::show(id)?;
             Ok((ChangelogOutput::ShowComponent(output), 0))
         }


### PR DESCRIPTION
## Summary
- Remove the parsed-but-ignored `homeboy changelog --self` flag.
- Keep `homeboy changelog` / `homeboy changelog show` as the self-changelog paths.
- Update command docs and embedded-doc comment to stop advertising the removed alias.

## Testing
- `cargo check`
- `cargo test changelog`
- `target/debug/homeboy changelog --self` rejects the removed flag

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the cleanup, updated docs, ran targeted verification, and prepared this PR.