### PR TITLE
Consolidate core boundary policy guard

### DIFF
--- a/tests/runtime_product_boundary_test.rs
+++ b/tests/runtime_product_boundary_test.rs
@@ -1,65 +1,70 @@
-use std::fs;
-use std::path::{Path, PathBuf};
-
 #[test]
-fn core_files_do_not_name_extension_owned_runtime_products() {
-    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let needles = [
-        format!("{}box", "code"),
-        format!("wp-{}box", "code"),
-        format!("{}machine", "data"),
-        format!("{}-machine", "data"),
-        format!("{} Machine", "Data"),
-        format!("{}Machine", "Data"),
-    ];
-    let mut violations = Vec::new();
+fn core_boundary_policy_has_explicit_owned_roots_and_product_terms() {
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("homeboy.json");
+    let config: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(manifest).expect("homeboy.json should be readable"),
+    )
+    .expect("homeboy.json should parse");
+    let policy = config["audit"]["source_policies"]
+        .as_array()
+        .expect("source_policies should be an array")
+        .iter()
+        .find(|policy| policy["convention"] == "core_boundary_leak:core-agnostic-source")
+        .expect("core boundary source policy should exist");
 
-    for root in ["src", "tests", "docs"] {
-        collect_violations(&repo.join(root), &repo, &needles, &mut violations);
-    }
-
-    assert!(
-        violations.is_empty(),
-        "Homeboy core must keep extension-owned runtime product knowledge in extensions/adapters:\n{}",
-        violations.join("\n")
+    assert_eq!(
+        values(policy, "include_path_contains"),
+        [
+            "src/core",
+            "src/commands/component.rs",
+            "src/commands/extension.rs",
+            "src/commands/lint.rs",
+            "src/commands/report.rs",
+            "src/commands/resources/mod.rs",
+            "src/commands/review/mod.rs",
+            "src/commands/test.rs",
+        ],
+        "core boundary scanning must stay limited to explicit core-owned implementation roots"
     );
-}
 
-fn collect_violations(path: &Path, repo: &Path, needles: &[String], violations: &mut Vec<String>) {
-    let entries = match fs::read_dir(path) {
-        Ok(entries) => entries,
-        Err(_) => return,
-    };
+    assert_eq!(
+        values(policy, "ignore_after_line_equals"),
+        ["#[cfg(test)]"],
+        "source-policy scanning should avoid test-only examples instead of raw-scanning prose"
+    );
 
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_violations(&path, repo, needles, violations);
-            continue;
-        }
-        if should_skip(&path, repo) {
-            continue;
-        }
-        let Ok(content) = fs::read_to_string(&path) else {
-            continue;
-        };
-        let lower = content.to_lowercase();
-        if needles
-            .iter()
-            .any(|needle| lower.contains(&needle.to_lowercase()))
-        {
-            violations.push(
-                path.strip_prefix(repo)
-                    .unwrap_or(&path)
-                    .display()
-                    .to_string(),
-            );
-        }
+    let terms = policy["terms"]
+        .as_array()
+        .expect("source policy terms should be an array")
+        .iter()
+        .filter_map(|term| term["value"].as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+
+    for term in [
+        "wordpress",
+        "WooCommerce",
+        "wp-content",
+        "WP_CLI",
+        "codebox",
+        "wp-codebox",
+        "wpcom-codebox",
+    ] {
+        assert!(
+            terms.contains(term),
+            "core boundary source policy must include product/runtime term `{term}`"
+        );
     }
 }
 
-fn should_skip(path: &Path, repo: &Path) -> bool {
-    let relative = path.strip_prefix(repo).unwrap_or(path);
-    relative == Path::new("docs/changelog.md")
-        || relative == Path::new("tests/runtime_product_boundary_test.rs")
+fn values<'a>(policy: &'a serde_json::Value, key: &str) -> Vec<&'a str> {
+    policy[key]
+        .as_array()
+        .unwrap_or_else(|| panic!("{key} should be an array"))
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .unwrap_or_else(|| panic!("{key} entry should be a string"))
+        })
+        .collect()
 }


### PR DESCRIPTION
## Summary
- Replace the overlapping raw runtime/product string scan with a focused source-policy config contract.
- Assert the core-boundary policy stays scoped to explicit core-owned implementation roots.
- Assert the policy keeps the current product/runtime boundary terms for WordPress, WooCommerce, and Codebox surfaces.

## Tests
- `cargo test --test runtime_product_boundary_test` passed.
- `cargo test --test architecture_core_agnostic_test` passed.
- `cargo test --test runtime_product_boundary_test --test core_agnostic_test --test architecture_core_agnostic_test` failed in existing `core_agnostic_test` cases with current non-baselined core boundary findings.
- `cargo fmt --check` failed with pre-existing formatting diffs across untouched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Drafted and verified the test consolidation, commit, push, and PR description.