### PR TITLE
Fix bench Lab env-provider extension forwarding

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -116,10 +116,16 @@ impl BenchArgs {
         let mut extension_ids = BTreeSet::new();
         for rig_id in &run.rig {
             let spec = rig::load(rig_id)?;
-            extension_ids.extend(rig::extension_ids_for_workloads(
-                &spec,
-                rig::RigWorkloadKind::Bench,
-            ));
+            let workload_extension_ids =
+                rig::extension_ids_for_workloads(&spec, rig::RigWorkloadKind::Bench);
+            for extension_id in &workload_extension_ids {
+                extension_ids.extend(rig::env_provider_extensions_for_extension_workloads(
+                    &spec,
+                    rig::RigWorkloadKind::Bench,
+                    extension_id,
+                ));
+            }
+            extension_ids.extend(workload_extension_ids);
             extension_ids.extend(bench_component_extension_ids(&spec, run.comp.id()));
         }
         Ok(extension_ids.into_iter().collect())

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -806,6 +806,95 @@ mod tests {
     }
 
     #[test]
+    fn final_remote_command_forwards_rig_bench_env_provider_extension() {
+        crate::test_support::with_isolated_home(|home| {
+            let rigs_dir = home.path().join(".config/homeboy/rigs");
+            std::fs::create_dir_all(&rigs_dir).expect("rigs dir");
+            std::fs::write(
+                rigs_dir.join("static-site-importer-fixture-matrix.json"),
+                r#"{
+                    "components": {
+                        "static-site-importer": {
+                            "component_id": "static-site-importer",
+                            "path": "/controller/workspaces/static-site-importer"
+                        }
+                    },
+                    "bench": { "default_component": "static-site-importer" },
+                    "bench_workloads": {
+                        "nodejs": [
+                            {
+                                "path": "${package.root}/bench/static-site-fixture-matrix.bench.mjs",
+                                "env_provider_extensions": ["wordpress"]
+                            }
+                        ]
+                    }
+                }"#,
+            )
+            .expect("rig spec");
+
+            let args = vec![
+                "homeboy".to_string(),
+                "--runner".to_string(),
+                "homeboy-lab".to_string(),
+                "bench".to_string(),
+                "static-site-importer".to_string(),
+                "--path".to_string(),
+                "/controller/workspaces/static-site-importer".to_string(),
+                "--rig".to_string(),
+                "static-site-importer-fixture-matrix".to_string(),
+            ];
+            let cli = Cli::parse_from(&args);
+            let route_contract = cli
+                .command
+                .lab_route_contract()
+                .expect("route contract result")
+                .expect("bench supports lab offload");
+            let contract =
+                crate::core::lab_routing::lab_offload_command_from_route_contract(route_contract);
+
+            let command = build_lab_offload_remote_command(
+                &["/runner/bin/homeboy".to_string()],
+                &args,
+                "/runner/workspaces/static-site-importer",
+                &[],
+                None,
+                &contract.required_extensions,
+            );
+
+            let wordpress_flag = command
+                .windows(2)
+                .position(|window| window == ["--extension", "wordpress"])
+                .expect("final remote command includes --extension wordpress");
+            let rig_flag = command
+                .iter()
+                .position(|arg| arg == "--rig")
+                .expect("final remote command includes --rig");
+            assert!(
+                wordpress_flag < rig_flag,
+                "--extension wordpress must be injected before --rig in final runner command: {}",
+                command.join(" ")
+            );
+            assert_eq!(
+                command,
+                vec![
+                    "/runner/bin/homeboy".to_string(),
+                    "--force-hot".to_string(),
+                    "bench".to_string(),
+                    "--extension".to_string(),
+                    "nodejs".to_string(),
+                    "--extension".to_string(),
+                    "wordpress".to_string(),
+                    "static-site-importer".to_string(),
+                    "--path".to_string(),
+                    "/runner/workspaces/static-site-importer".to_string(),
+                    "--rig".to_string(),
+                    "static-site-importer-fixture-matrix".to_string(),
+                ]
+            );
+        });
+    }
+
+    #[test]
     fn final_remote_command_keeps_explicit_extension_override() {
         let args = vec![
             "homeboy".to_string(),


### PR DESCRIPTION
## Summary
- Forward rig bench workload env-provider extensions into Lab required extensions.
- Add a final remote-command regression using the SSI fixture-matrix shape so the command sent to the runner includes `--extension wordpress` before `--rig`.

## Root cause
The failed run `ee423d08-7360-4072-8c30-cccdde4a93a9` was not missing Node: Node was present and SSI tests passed before the runner-side bench dispatch failed. The live rig declares WordPress as a bench workload env provider via `bench_workloads.nodejs[].env_provider_extensions = ["wordpress"]`, but Lab routing only collected bench workload keys and component extension maps as required extensions. That left the final remote command without `--extension wordpress`, so the runner entered generic Node bench execution and reported `Unsupported Homeboy project ecosystem: node`.

## Verification
- `cargo test final_remote_command_forwards_rig_bench_env_provider_extension --quiet`
- `cargo test final_remote_command_forwards_rig --quiet`

## Notes
- `cargo fmt --check` is currently blocked by unrelated pre-existing formatting drift across many files; this PR does not format unrelated files.

Fixes #7296

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Traced the Lab offload command path, implemented the generic required-extension data-flow fix, and added targeted regression coverage.