### PR TITLE
Log Lab offload command provenance

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -2,6 +2,7 @@
 //! output-file download, and stream-truncation guard.
 
 use super::*;
+use crate::core::build_identity;
 use crate::core::secret_env_plan::SECRET_ENV_PLAN_ENV_DELTA_SOURCE;
 
 /// Homeboy-owned Lab artifact directory for a given runner checkout root.
@@ -463,6 +464,7 @@ pub(crate) fn run_lab_offload_inner(
         source_snapshot,
         remapped_args,
         agent_task_run_id,
+        runner_required_extensions,
         command,
         remote_command,
         remote_output_file,
@@ -523,6 +525,17 @@ pub(crate) fn run_lab_offload_inner(
         redact_argv_display(&command),
         runner_id,
         remote_cwd
+    );
+    eprintln!(
+        "Lab offload provenance: controller_exe=`{}` controller_build=`{}` source_args=`{}` remapped_args=`{}` required_extensions={} final_argv=`{}`.",
+        std::env::current_exe()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|error| format!("<unavailable: {error}>")),
+        build_identity::current().display,
+        redact_argv_display(request.normalized_args),
+        redact_argv_display(&remapped_args),
+        serde_json::to_string(&runner_required_extensions).unwrap_or_else(|_| "[]".to_string()),
+        redact_argv_display(&remote_command),
     );
     if let Some(run_id) = &agent_task_run_id {
         emit_durable_run_id_before_execution(

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -13,6 +13,7 @@ pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) source_snapshot: SourceSnapshot,
     pub(crate) remapped_args: Vec<String>,
     pub(crate) agent_task_run_id: Option<String>,
+    pub(crate) runner_required_extensions: Vec<String>,
     pub(crate) command: Vec<String>,
     pub(crate) remote_command: Vec<String>,
     pub(crate) remote_output_file: Option<String>,
@@ -441,6 +442,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         &contract.required_extensions,
         Path::new(&synced.local_path),
     )?;
+    let runner_required_extensions = runner_command_plan.required_extensions.clone();
     let command = build_lab_offload_remote_command(
         command_prefix_argv,
         &remapped_args,
@@ -467,6 +469,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         source_snapshot,
         remapped_args,
         agent_task_run_id,
+        runner_required_extensions,
         command,
         remote_command,
         remote_output_file,


### PR DESCRIPTION
## Summary
- Log the active controller executable/build and final Lab offload argv provenance at the exact `Lab offload: running ...` boundary.
- Carry `RunnerCommandPlan` required extensions through workspace staging so the live log shows whether the typed plan resolved `wordpress` before final argv rendering.

## Why
The SSI fixture matrix path still emits a runner command without `--extension wordpress` after #7334. Latest failed run: `0b1f634c-a455-45cc-abdd-6867f97dbcb9`. We need proof of which controller binary and plan data produced the command before another behavioral patch.

## Testing
- `rustfmt --check src/core/runner/lab/offload/inner.rs src/core/runner/lab/offload/workspace_stage.rs`
- `cargo test core::runner::lab::offload::workspace_stage::tests -- --nocapture`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Added targeted provenance around the live Lab offload command boundary to debug the stale command emission.