### PR TITLE
Declare Lab secret env sources

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -47,19 +47,22 @@ pub use lab::{
     lab_runner_supports_contract_label, lab_runner_unsupported_hint,
     lab_runner_unsupported_message, AgentTaskDispatchIdentity, CommandPortabilityContract,
     LabCommandContract, LabCommandPortability, LabCommandRouteContract, LabLocalExecutionPolicy,
-    LabLocalHotPolicy, LabRoutingPolicy, LabRunnerSupportSummary, LabSelectedRunnerFallbackPolicy,
-    LabSourcePathMode, LabWorkspaceModePolicy, RunLocationIndex, RunnerHandoffArtifactManifestRef,
-    RunnerHandoffEnvelope, RunnerHandoffFollowCommands, RunnerWorkload, RunnerWorkloadArtifactRef,
-    RunnerWorkloadAssignment, RunnerWorkloadCapability, RunnerWorkloadCommandFamily,
-    RunnerWorkloadExtensionRevision, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
-    RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
-    RunnerWorkloadWorkspaceMappings, LAB_CAPABILITY_PLAYWRIGHT, LAB_TRACE_EXTRA_CAPABILITIES,
-    RUNNER_ARTIFACT_MANIFEST_FILE, RUNNER_ARTIFACT_MANIFEST_REF_NAME,
+    LabLocalHotPolicy, LabRoutingPolicy, LabRunnerSupportSummary, LabSecretEnvSource,
+    LabSelectedRunnerFallbackPolicy, LabSourcePathMode, LabWorkspaceModePolicy, RunLocationIndex,
+    RunnerHandoffArtifactManifestRef, RunnerHandoffEnvelope, RunnerHandoffFollowCommands,
+    RunnerWorkload, RunnerWorkloadArtifactRef, RunnerWorkloadAssignment, RunnerWorkloadCapability,
+    RunnerWorkloadCommandFamily, RunnerWorkloadExtensionRevision, RunnerWorkloadKind,
+    RunnerWorkloadMutationPolicy, RunnerWorkloadResultRefs, RunnerWorkloadSecrets,
+    RunnerWorkloadState, RunnerWorkloadWorkspaceMappings, LAB_CAPABILITY_PLAYWRIGHT,
+    LAB_TRACE_EXTRA_CAPABILITIES, RUNNER_ARTIFACT_MANIFEST_FILE, RUNNER_ARTIFACT_MANIFEST_REF_NAME,
     RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
     RUNNER_ARTIFACT_ROOT_DIR_SUFFIX, RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA,
     RUN_LOCATION_INDEX_SCHEMA,
 };
-pub(crate) use lab::{LAB_NO_EXTRA_CAPABILITIES, RIG_UP_LAB_UNSUPPORTED_REASON};
+pub(crate) use lab::{
+    LAB_NO_EXTRA_CAPABILITIES, LAB_TRACE_SECRET_ENV_SOURCES, LAB_TUNNEL_SECRET_ENV_SOURCES,
+    RIG_UP_LAB_UNSUPPORTED_REASON,
+};
 pub use output::{
     CommandDescriptor, CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind,
     CommandOutputDescriptor, CommandOutputFileMode, CommandRawOutputMode, CommandResponseMode,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -71,6 +71,20 @@ pub struct LabCommandRouteContract {
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
+pub enum LabSecretEnvSource {
+    AgentTask,
+    Trace,
+    Tunnel,
+}
+
+pub const LAB_NO_SECRET_ENV_SOURCES: &[LabSecretEnvSource] = &[];
+pub(crate) const LAB_AGENT_TASK_SECRET_ENV_SOURCES: &[LabSecretEnvSource] =
+    &[LabSecretEnvSource::AgentTask];
+pub(crate) const LAB_TRACE_SECRET_ENV_SOURCES: &[LabSecretEnvSource] = &[LabSecretEnvSource::Trace];
+pub(crate) const LAB_TUNNEL_SECRET_ENV_SOURCES: &[LabSecretEnvSource] =
+    &[LabSecretEnvSource::Tunnel];
+
+#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
 pub struct LabCommandContract {
     pub hot_label: &'static str,
     pub portability: LabCommandPortability,
@@ -79,6 +93,7 @@ pub struct LabCommandContract {
     pub capture_mutation_patch: bool,
     pub mutation_flag: Option<&'static str>,
     pub extra_required_capabilities: &'static [&'static str],
+    pub secret_env_sources: &'static [LabSecretEnvSource],
     /// Routing-policy flags shared across the Lab command layers.
     pub routing_policy: LabRoutingPolicy,
 }
@@ -683,7 +698,8 @@ impl Commands {
                 None,
                 true,
                 LAB_NO_EXTRA_CAPABILITIES,
-            ),
+            )
+            .with_secret_env_sources(LAB_AGENT_TASK_SECRET_ENV_SOURCES),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command: agent_task::AgentTaskCommand::Providers(_),
             }) => LabCommandContract::explicit_runner_simple(AGENT_TASK_PROVIDERS_LAB_LABEL),
@@ -697,7 +713,8 @@ impl Commands {
                 None,
                 true,
                 LAB_NO_EXTRA_CAPABILITIES,
-            ),
+            )
+            .with_secret_env_sources(LAB_AGENT_TASK_SECRET_ENV_SOURCES),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
@@ -708,7 +725,8 @@ impl Commands {
                 None,
                 true,
                 LAB_NO_EXTRA_CAPABILITIES,
-            ),
+            )
+            .with_secret_env_sources(LAB_AGENT_TASK_SECRET_ENV_SOURCES),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
@@ -716,7 +734,8 @@ impl Commands {
                     }),
             }) => LabCommandContract::explicit_runner_simple(
                 AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
-            ),
+            )
+            .with_secret_env_sources(LAB_AGENT_TASK_SECRET_ENV_SOURCES),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
@@ -744,7 +763,8 @@ impl Commands {
                 None,
                 false,
                 LAB_NO_EXTRA_CAPABILITIES,
-            ),
+            )
+            .with_secret_env_sources(LAB_AGENT_TASK_SECRET_ENV_SOURCES),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Controller(agent_task::AgentTaskControllerArgs {
@@ -962,6 +982,7 @@ impl LabCommandContract {
             capture_mutation_patch: mutation_flag.is_some(),
             mutation_flag,
             extra_required_capabilities,
+            secret_env_sources: LAB_NO_SECRET_ENV_SOURCES,
             routing_policy: LabRoutingPolicy {
                 default_lab_offload: true,
                 infer_source_path_tools: true,
@@ -1056,6 +1077,7 @@ impl LabCommandContract {
             capture_mutation_patch: false,
             mutation_flag: None,
             extra_required_capabilities: LAB_NO_EXTRA_CAPABILITIES,
+            secret_env_sources: LAB_NO_SECRET_ENV_SOURCES,
             routing_policy: LabRoutingPolicy {
                 default_lab_offload: false,
                 infer_source_path_tools: false,
@@ -1071,6 +1093,14 @@ impl LabCommandContract {
     /// stale-runner local fallback when a default Lab runner is configured.
     pub(crate) const fn release_gate(mut self) -> Self {
         self.routing_policy.release_gate = true;
+        self
+    }
+
+    pub(crate) const fn with_secret_env_sources(
+        mut self,
+        sources: &'static [LabSecretEnvSource],
+    ) -> Self {
+        self.secret_env_sources = sources;
         self
     }
 }

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -21,7 +21,7 @@ use super::utils::args::{BaselineArgs, PositionalComponentArgs, SettingArgs};
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
     CommandPortabilityContract, LabCommandContract, LabWorkspaceModePolicy,
-    LAB_TRACE_EXTRA_CAPABILITIES, TRACE_LAB_LABEL,
+    LAB_TRACE_EXTRA_CAPABILITIES, LAB_TRACE_SECRET_ENV_SOURCES, TRACE_LAB_LABEL,
 };
 
 mod aggregate;
@@ -273,7 +273,8 @@ impl TraceArgs {
             self.keep_overlay.then_some("--keep-overlay"),
             false,
             LAB_TRACE_EXTRA_CAPABILITIES,
-        );
+        )
+        .with_secret_env_sources(LAB_TRACE_SECRET_ENV_SOURCES);
         if self.is_compare_target_run() {
             contract.workspace_mode_policy = LabWorkspaceModePolicy::Git;
         }

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -25,8 +25,9 @@ use std::path::PathBuf;
 
 use super::{CmdResult, DynamicSetArgs};
 use crate::command_contract::{
-    CommandPortabilityContract, LabCommandContract, TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
-    TUNNEL_SERVICE_EXPOSE_LAB_LABEL, TUNNEL_SERVICE_START_LAB_LABEL,
+    CommandPortabilityContract, LabCommandContract, LAB_TUNNEL_SECRET_ENV_SOURCES,
+    TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL, TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
+    TUNNEL_SERVICE_START_LAB_LABEL,
 };
 
 mod service;
@@ -129,9 +130,10 @@ impl TunnelArgs {
             ));
         }
         if self.is_service_start() {
-            return CommandPortabilityContract::lab(LabCommandContract::runner_resident(
-                TUNNEL_SERVICE_START_LAB_LABEL,
-            ));
+            return CommandPortabilityContract::lab(
+                LabCommandContract::runner_resident(TUNNEL_SERVICE_START_LAB_LABEL)
+                    .with_secret_env_sources(LAB_TUNNEL_SECRET_ENV_SOURCES),
+            );
         }
         if self.is_service_expose() {
             return CommandPortabilityContract::lab(LabCommandContract::runner_resident(

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -819,6 +819,7 @@ mod tests {
             source_path_mode: crate::core::runner::LabOffloadSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy:
                 crate::core::runner::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+            secret_env_sources: Vec::new(),
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             routing_policy: crate::command_contract::LabRoutingPolicy::default(),

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -356,6 +356,7 @@ pub fn lab_offload_command_from_route_contract(
 ) -> runners::LabOffloadCommand {
     let hot_label = route_contract.command.hot_label;
     let portability = route_contract.command.portability;
+    let secret_env_sources = route_contract.command.secret_env_sources.to_vec();
     let plan = lab_route_plan_from_route_contract(route_contract);
     runners::LabOffloadCommand {
         hot_label,
@@ -388,6 +389,7 @@ pub fn lab_offload_command_from_route_contract(
                 runners::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot
             }
         },
+        secret_env_sources,
         required_extensions: plan.required_extensions,
         required_capabilities: plan.required_capabilities,
         routing_policy: plan.routing_policy,
@@ -550,6 +552,7 @@ mod tests {
             capture_mutation_patch: true,
             mutation_flag: Some("--keep-overlay"),
             extra_required_capabilities: LAB_TRACE_EXTRA_CAPABILITIES,
+            secret_env_sources: crate::command_contract::LAB_TRACE_SECRET_ENV_SOURCES,
             routing_policy: LabRoutingPolicy {
                 default_lab_offload: true,
                 infer_source_path_tools: false,

--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -394,6 +394,7 @@ fn worker_local_workload_validation_uses_implicit_command_secret_names() {
             source_path_mode: crate::core::runner::LabOffloadSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy:
                 crate::core::runner::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+            secret_env_sources: Vec::new(),
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             routing_policy: crate::command_contract::LabRoutingPolicy::default(),

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -594,8 +594,11 @@ pub(crate) fn run_lab_offload_inner(
     }
     let env_delta_before_secret_handoff = env_delta.clone();
     lab_metadata["runtime_overlays"] = runtime_overlay_metadata;
-    let secret_env_handoff =
-        build_lab_secret_env_handoff_plan(&changed_since_preflight.args, env_delta)?;
+    let secret_env_handoff = build_lab_secret_env_handoff_plan(
+        &contract.secret_env_sources,
+        &changed_since_preflight.args,
+        env_delta,
+    )?;
     lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
     let mut runner_workload = build_runner_workload(RunnerWorkloadBuildInput {
         plan: &plan,

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -124,7 +124,11 @@ pub(crate) fn run_runner_resident_lab_offload(
         "command_paths": "runner_side",
     });
     lab_metadata["job_scoped_overrides"] = job_scoped_overrides_metadata(&request.job_overrides);
-    let secret_env_handoff = build_lab_secret_env_handoff_plan(&remapped_args, Default::default())?;
+    let secret_env_handoff = build_lab_secret_env_handoff_plan(
+        &contract.secret_env_sources,
+        &remapped_args,
+        Default::default(),
+    )?;
     lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
     let base_env = build_lab_offload_env_with_passthroughs(&lab_metadata);
     lab_metadata["env_resolution"] = lab_env_resolution_report(vec![

--- a/src/core/runner/lab/offload/tests/mod.rs
+++ b/src/core/runner/lab/offload/tests/mod.rs
@@ -33,6 +33,7 @@ pub(super) fn portable_lab_command(label: &'static str) -> LabOffloadCommand {
         unsupported_reason: None,
         source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
         workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+        secret_env_sources: Vec::new(),
         required_extensions: Vec::new(),
         required_capabilities: Vec::new(),
         routing_policy: crate::command_contract::LabRoutingPolicy {
@@ -52,6 +53,7 @@ pub(super) fn local_only_lab_command(reason: &'static str) -> LabOffloadCommand 
         unsupported_reason: Some(reason),
         source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
         workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+        secret_env_sources: Vec::new(),
         required_extensions: Vec::new(),
         required_capabilities: Vec::new(),
         routing_policy: crate::command_contract::LabRoutingPolicy::default(),

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -43,6 +43,7 @@ pub struct LabOffloadCommand {
     pub unsupported_reason: Option<&'static str>,
     pub source_path_mode: LabOffloadSourcePathMode,
     pub workspace_mode_policy: LabOffloadWorkspaceModePolicy,
+    pub secret_env_sources: Vec<crate::command_contract::LabSecretEnvSource>,
     pub required_extensions: Vec<String>,
     pub required_capabilities: Vec<crate::command_contract::RunnerWorkloadCapability>,
     /// Routing-policy flags shared across the Lab command layers

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashMap;
 
+use crate::command_contract::LabSecretEnvSource;
 use crate::core::agent_tasks::provider::{
     provider_runner_secret_env_for_plan_with_providers,
     provider_secret_sources_for_plan_with_providers, provider_secret_sources_for_providers,
@@ -40,15 +41,35 @@ pub(super) struct LabSecretEnvHandoffPlan {
 }
 
 pub(super) fn build_lab_secret_env_handoff_plan(
+    secret_env_sources: &[LabSecretEnvSource],
     args: &[String],
     mut env_delta: HashMap<String, String>,
 ) -> Result<LabSecretEnvHandoffPlan> {
-    let agent_task_secret_env = hydrate_agent_task_secret_env(args, &mut env_delta)?;
-    let trace_secret_env = hydrate_trace_secret_env(args, &mut env_delta)?;
-    let tunnel_secret_env = hydrate_tunnel_secret_env(args, &mut env_delta)?;
-    let mut secret_env_names = declared_agent_task_secret_env_for_handoff(args)?;
-    secret_env_names.extend(declared_trace_secret_env(args));
-    secret_env_names.extend(declared_tunnel_secret_env(args));
+    let agent_task_secret_env = if secret_env_sources.contains(&LabSecretEnvSource::AgentTask) {
+        hydrate_agent_task_secret_env(args, &mut env_delta)?
+    } else {
+        empty_agent_task_secret_env_metadata()
+    };
+    let trace_secret_env = if secret_env_sources.contains(&LabSecretEnvSource::Trace) {
+        hydrate_trace_secret_env(args, &mut env_delta)?
+    } else {
+        crate::core::trace_secrets::empty_status()
+    };
+    let tunnel_secret_env = if secret_env_sources.contains(&LabSecretEnvSource::Tunnel) {
+        hydrate_tunnel_secret_env(args, &mut env_delta)?
+    } else {
+        empty_tunnel_secret_env_metadata()
+    };
+    let mut secret_env_names = Vec::new();
+    if secret_env_sources.contains(&LabSecretEnvSource::AgentTask) {
+        secret_env_names.extend(declared_agent_task_secret_env_for_handoff(args)?);
+    }
+    if secret_env_sources.contains(&LabSecretEnvSource::Trace) {
+        secret_env_names.extend(declared_trace_secret_env(args));
+    }
+    if secret_env_sources.contains(&LabSecretEnvSource::Tunnel) {
+        secret_env_names.extend(declared_tunnel_secret_env(args));
+    }
     secret_env_names.sort();
     secret_env_names.dedup();
     let secret_env_plan = SecretEnvPlan::from_secret_env_names(secret_env_names.clone());
@@ -92,6 +113,21 @@ pub(super) fn build_lab_secret_env_handoff_plan(
         secret_env_plan,
         secret_env_names,
         runner_deferred_secret_env,
+    })
+}
+
+fn empty_agent_task_secret_env_metadata() -> serde_json::Value {
+    serde_json::json!({
+        "schema": "homeboy/lab-agent-task-secret-env/v1",
+        "secret_env": [],
+        "runner_deferred_secret_env": [],
+    })
+}
+
+fn empty_tunnel_secret_env_metadata() -> serde_json::Value {
+    serde_json::json!({
+        "schema": "homeboy/lab-tunnel-secret-env/v1",
+        "runner_deferred_secret_env": [],
     })
 }
 
@@ -210,11 +246,7 @@ fn hydrate_agent_task_secret_env_with_providers(
     runner_deferred_names.sort();
     runner_deferred_names.dedup();
     if names.is_empty() && runner_deferred_names.is_empty() {
-        return Ok(serde_json::json!({
-            "schema": "homeboy/lab-agent-task-secret-env/v1",
-            "secret_env": [],
-            "runner_deferred_secret_env": [],
-        }));
+        return Ok(empty_agent_task_secret_env_metadata());
     }
 
     let fallback_sources = subcommand_index(args, "agent-task")
@@ -291,6 +323,10 @@ pub(super) fn hydrate_tunnel_secret_env(
     _env: &mut HashMap<String, String>,
 ) -> Result<serde_json::Value> {
     let names = declared_tunnel_secret_env(args);
+    if names.is_empty() {
+        return Ok(empty_tunnel_secret_env_metadata());
+    }
+
     Ok(serde_json::json!({
         "schema": "homeboy/lab-tunnel-secret-env/v1",
         "runner_deferred_secret_env": names
@@ -1054,7 +1090,9 @@ mod tests {
         );
         std::env::set_var("HOMEBOY_TRACE_HANDOFF_SECRET_TEST", "trace-secret-value");
 
-        let plan = build_lab_secret_env_handoff_plan(&args, env_delta).expect("handoff plan");
+        let plan =
+            build_lab_secret_env_handoff_plan(&[LabSecretEnvSource::Trace], &args, env_delta)
+                .expect("handoff plan");
 
         assert_eq!(
             plan.env_delta
@@ -1101,6 +1139,27 @@ mod tests {
     }
 
     #[test]
+    fn lab_secret_env_handoff_plan_consumes_declared_sources_only() {
+        let args = vec![
+            "homeboy".to_string(),
+            "trace".to_string(),
+            "compare".to_string(),
+            "woocommerce-gateway-stripe".to_string(),
+            "real-wallet".to_string(),
+            "--secret-env=HOMEBOY_UNDECLARED_TRACE_SECRET_TEST".to_string(),
+        ];
+        let _secret = RemovedEnvVar::new("HOMEBOY_UNDECLARED_TRACE_SECRET_TEST");
+        std::env::set_var("HOMEBOY_UNDECLARED_TRACE_SECRET_TEST", "trace-secret-value");
+
+        let plan =
+            build_lab_secret_env_handoff_plan(&[], &args, HashMap::new()).expect("handoff plan");
+
+        assert!(plan.secret_env_names.is_empty());
+        assert!(plan.env_delta.is_empty());
+        assert!(plan.runner_deferred_secret_env.is_empty());
+    }
+
+    #[test]
     fn lab_secret_env_handoff_plan_reports_runner_deferred_requirements() {
         let args = vec![
             "homeboy".to_string(),
@@ -1112,7 +1171,9 @@ mod tests {
             "--token-env=HOMEBOY_RUNNER_PREVIEW_TOKEN".to_string(),
         ];
 
-        let plan = build_lab_secret_env_handoff_plan(&args, HashMap::new()).expect("handoff plan");
+        let plan =
+            build_lab_secret_env_handoff_plan(&[LabSecretEnvSource::Tunnel], &args, HashMap::new())
+                .expect("handoff plan");
 
         assert!(plan.env_delta.is_empty());
         assert_eq!(
@@ -1157,7 +1218,9 @@ mod tests {
             "https://preview-broker.example.test".to_string(),
             "--token-env=HOMEBOY_RUNNER_PREFLIGHT_TOKEN".to_string(),
         ];
-        let handoff = build_lab_secret_env_handoff_plan(&args, HashMap::new()).expect("handoff");
+        let handoff =
+            build_lab_secret_env_handoff_plan(&[LabSecretEnvSource::Tunnel], &args, HashMap::new())
+                .expect("handoff");
         let runner = fixture_runner(HashMap::new());
 
         let err =
@@ -1182,7 +1245,9 @@ mod tests {
             "https://preview-broker.example.test".to_string(),
             "--token-env=HOMEBOY_UNKNOWN_RUNNER_TOKEN".to_string(),
         ];
-        let handoff = build_lab_secret_env_handoff_plan(&args, HashMap::new()).expect("handoff");
+        let handoff =
+            build_lab_secret_env_handoff_plan(&[LabSecretEnvSource::Tunnel], &args, HashMap::new())
+                .expect("handoff");
 
         preflight_lab_secret_env_handoff("lab-a", None, &HashMap::new(), &handoff)
             .expect("unknown runner-side secret status should remain runner-deferred");
@@ -1202,7 +1267,9 @@ mod tests {
             "HOMEBOY_CONTROLLER_PREFLIGHT_SECRET",
             "controller-secret-value-must-not-leak",
         );
-        let handoff = build_lab_secret_env_handoff_plan(&args, HashMap::new()).expect("handoff");
+        let handoff =
+            build_lab_secret_env_handoff_plan(&[LabSecretEnvSource::Trace], &args, HashMap::new())
+                .expect("handoff");
         let runner = fixture_runner(HashMap::new());
 
         let err =
@@ -1243,8 +1310,12 @@ mod tests {
         )
         .expect("write plan");
 
-        let handoff = build_lab_secret_env_handoff_plan(&run_plan_args(&plan_path), HashMap::new())
-            .expect("handoff plan");
+        let handoff = build_lab_secret_env_handoff_plan(
+            &[LabSecretEnvSource::AgentTask],
+            &run_plan_args(&plan_path),
+            HashMap::new(),
+        )
+        .expect("handoff plan");
 
         assert_eq!(
             handoff.secret_env_plan.secret_env_names(),
@@ -1408,6 +1479,7 @@ mod tests {
         );
 
         let plan = build_lab_secret_env_handoff_plan(
+            &[LabSecretEnvSource::AgentTask],
             &[
                 "homeboy".to_string(),
                 "agent-task".to_string(),

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -479,6 +479,7 @@ mod tests {
             unsupported_reason: None,
             source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+            secret_env_sources: Vec::new(),
             required_extensions: vec!["browser".to_string()],
             required_capabilities: vec![RunnerWorkloadCapability {
                 name: "playwright".to_string(),

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -388,6 +388,51 @@ fn lab_route_contract_carries_command_specific_requirements() {
             .routing_policy
             .infer_source_path_tools
     );
+    assert_eq!(
+        route_contract.command.secret_env_sources,
+        &[LabSecretEnvSource::Trace]
+    );
+
+    let command = parsed_command(&[
+        "homeboy",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "homeboy@cook",
+        "--verify",
+        "true",
+        "--no-finalize",
+        "--prompt",
+        "cook",
+    ]);
+    let route_contract = command
+        .lab_route_contract()
+        .expect("route contract resolves")
+        .expect("agent-task has a Lab route contract");
+    assert_eq!(
+        route_contract.command.secret_env_sources,
+        &[LabSecretEnvSource::AgentTask]
+    );
+
+    let command = parsed_command(&[
+        "homeboy",
+        "tunnel",
+        "service",
+        "start",
+        "preview",
+        "--cwd",
+        "/runner/workspaces/site",
+        "--command",
+        "npm run dev",
+    ]);
+    let route_contract = command
+        .lab_route_contract()
+        .expect("route contract resolves")
+        .expect("tunnel service start has a Lab route contract");
+    assert_eq!(
+        route_contract.command.secret_env_sources,
+        &[LabSecretEnvSource::Tunnel]
+    );
 }
 
 #[test]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -912,6 +912,7 @@ fn daemon_exec_derives_implicit_command_secret_names_before_workload_validation(
         source_path_mode: crate::core::runner::LabOffloadSourcePathMode::CwdOrPathFlag,
         workspace_mode_policy:
             crate::core::runner::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+        secret_env_sources: Vec::new(),
         required_extensions: Vec::new(),
         required_capabilities: Vec::new(),
         routing_policy: crate::command_contract::LabRoutingPolicy::default(),


### PR DESCRIPTION
## Summary
- add explicit Lab secret env source declarations to command contracts
- route Lab offload secret handoff through declared sources instead of command-family probing
- add regression coverage for declared-source behavior

## Verification
- Targeted tests passed in the source cook worktree: `cargo test lab_secret_env_handoff_plan`, `cargo test lab_route_contract_carries_command_specific_requirements`.
- Clean PR branch diff check passed.
- Clean branch rerun hit cargo package-cache lock timeout under parallel verification before producing a test result.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the refactor seam, drafted implementation and tests, and prepared the PR branch.