### PR TITLE
Consolidate command registry metadata

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -938,7 +938,7 @@ mod tests {
         let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let index = commands_index();
 
-        for entry in crate::command_contract::COMMAND_REGISTRY {
+        for entry in crate::command_contract::COMMAND_SPECS {
             let Some(path) = entry.docs_path() else {
                 continue;
             };
@@ -966,14 +966,14 @@ mod tests {
             .filter(|subcommand| !subcommand.is_hide_set())
             .map(|subcommand| subcommand.get_name().to_string())
             .collect::<BTreeSet<_>>();
-        let registry_names = crate::command_contract::COMMAND_REGISTRY
+        let registry_names = crate::command_contract::COMMAND_SPECS
             .iter()
             .map(|entry| entry.name.to_string())
             .collect::<BTreeSet<_>>();
         assert_eq!(registry_names, parser_names);
 
         let manifest = current_command_safety_manifest();
-        for entry in crate::command_contract::COMMAND_REGISTRY {
+        for entry in crate::command_contract::COMMAND_SPECS {
             let manifest_entry = manifest
                 .find_path(&[entry.name])
                 .unwrap_or_else(|| panic!("manifest missing registered command `{}`", entry.name));
@@ -1016,7 +1016,7 @@ mod tests {
     #[test]
     fn core_command_docs_do_not_drift_from_registry() {
         let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let registered_docs = crate::command_contract::COMMAND_REGISTRY
+        let registered_docs = crate::command_contract::COMMAND_SPECS
             .iter()
             .filter_map(|entry| entry.docs_slug)
             .collect::<BTreeSet<_>>();

--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -72,8 +72,8 @@ pub use registry::{
 pub use spec::{
     non_core_command_doc_slugs, registered_command, registered_command_dispatch_family,
     registered_command_json_family, runtime_extension_command_doc_slugs, support_command_doc_slugs,
-    CommandDocKind, CommandDocSpec, CommandLabSupportSummary, CommandRegistryEntry,
-    CommandSafetySpec, CommandSpec, COMMAND_DOC_REGISTRY, COMMAND_REGISTRY, COMMAND_SPECS,
+    CommandDocKind, CommandDocSpec, CommandLabSupportSummary, CommandSafetySpec, CommandSpec,
+    COMMAND_DOC_REGISTRY, COMMAND_SPECS,
 };
 pub(crate) use spec::{
     AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REVIEW_LAB_LABEL,

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -340,51 +340,15 @@ fn registered_json_envelope_descriptor(
 
 #[cfg(test)]
 mod tests {
-    use super::super::spec::{COMMAND_REGISTRY, DEFAULT_LAB_UNSUPPORTED_NOTES};
+    use super::super::spec::{COMMAND_SPECS, DEFAULT_LAB_UNSUPPORTED_NOTES};
     use super::*;
     use crate::cli_surface::{Cli, Commands};
-    use clap::CommandFactory;
     use clap::Parser;
-    use std::collections::BTreeSet;
 
     fn parsed_command(args: &[&str]) -> Commands {
         Cli::try_parse_from(args)
             .expect("CLI args should parse")
             .command
-    }
-
-    fn lab_supported_registry_sample_argv(command_name: &str) -> Option<&'static [&'static str]> {
-        match command_name {
-            "agent-task" => Some(&["homeboy", "agent-task", "providers"]),
-            "test" => Some(&["homeboy", "test"]),
-            "bench" => Some(&["homeboy", "bench"]),
-            "fuzz" => Some(&["homeboy", "fuzz"]),
-            "trace" => Some(&["homeboy", "trace"]),
-            "lint" => Some(&["homeboy", "lint"]),
-            "review" => Some(&["homeboy", "review"]),
-            "audit" => Some(&["homeboy", "audit"]),
-            "refactor" => Some(&["homeboy", "refactor", "--all"]),
-            "runtime" => Some(&[
-                "homeboy",
-                "runtime",
-                "refresh",
-                "example-runtime",
-                "--source",
-                ".",
-            ]),
-            "rig" => Some(&["homeboy", "rig", "check", "example-rig"]),
-            "worktree" => Some(&["homeboy", "worktree", "cleanup"]),
-            "tunnel" => Some(&[
-                "homeboy",
-                "tunnel",
-                "service",
-                "start",
-                "example-service",
-                "--command",
-                "npm start",
-            ]),
-            _ => None,
-        }
     }
 
     #[test]
@@ -463,22 +427,8 @@ mod tests {
     }
 
     #[test]
-    fn command_registry_covers_top_level_parser_surface() {
-        let parser_names = Cli::command()
-            .get_subcommands()
-            .map(|subcommand| subcommand.get_name().to_string())
-            .collect::<BTreeSet<_>>();
-        let registry_names = COMMAND_REGISTRY
-            .iter()
-            .map(|entry| entry.name.to_string())
-            .collect::<BTreeSet<_>>();
-
-        assert_eq!(registry_names, parser_names);
-    }
-
-    #[test]
     fn command_registry_lab_metadata_is_explicit() {
-        for entry in COMMAND_REGISTRY {
+        for entry in COMMAND_SPECS {
             if entry.lab_supported {
                 assert_ne!(
                     entry.lab_notes, DEFAULT_LAB_UNSUPPORTED_NOTES,
@@ -502,8 +452,8 @@ mod tests {
 
     #[test]
     fn command_registry_lab_metadata_matches_command_support_for_parseable_samples() {
-        for entry in COMMAND_REGISTRY.iter().filter(|entry| entry.lab_supported) {
-            let argv = lab_supported_registry_sample_argv(entry.name).unwrap_or_else(|| {
+        for entry in COMMAND_SPECS.iter().filter(|entry| entry.lab_supported) {
+            let argv = entry.representative_argv.unwrap_or_else(|| {
                 panic!(
                     "Lab-supported registry command `{}` needs a representative parseable argv sample",
                     entry.name
@@ -534,7 +484,7 @@ mod tests {
 
     #[test]
     fn command_registry_docs_path_is_present_for_commands_with_docs() {
-        for entry in COMMAND_REGISTRY {
+        for entry in COMMAND_SPECS {
             if let Some(slug) = entry.docs_slug {
                 assert_eq!(
                     entry.docs_path().as_deref(),

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -13,14 +13,13 @@ pub struct CommandSpec {
     pub name: &'static str,
     pub json_family: CommandJsonFamily,
     pub docs_slug: Option<&'static str>,
+    pub representative_argv: Option<&'static [&'static str]>,
     pub safety: CommandSafetySpec,
     pub output_notes: &'static str,
     pub lab_supported: bool,
     pub lab_notes: &'static str,
     pub lab_support_summary: &'static [CommandLabSupportSummary],
 }
-
-pub type CommandRegistryEntry = CommandSpec;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CommandLabSupportSummary {
@@ -118,6 +117,7 @@ const fn command_spec(name: &'static str, json_family: CommandJsonFamily) -> Com
         name,
         json_family,
         docs_slug: Some(name),
+        representative_argv: None,
         safety: CommandSafetySpec::read_only(),
         output_notes: "standard CLI output contract",
         lab_supported: false,
@@ -157,6 +157,13 @@ const fn command_spec_with_output_notes(
     CommandSpec {
         output_notes,
         ..command_spec(name, json_family)
+    }
+}
+
+const fn command_spec_without_docs(spec: CommandSpec) -> CommandSpec {
+    CommandSpec {
+        docs_slug: None,
+        ..spec
     }
 }
 
@@ -206,6 +213,16 @@ const fn lab_command_spec_with_output_notes_and_summary(
     CommandSpec {
         lab_support_summary,
         ..lab_command_spec_with_output_notes(name, json_family, lab_notes, output_notes)
+    }
+}
+
+const fn command_spec_with_representative_argv(
+    representative_argv: &'static [&'static str],
+    spec: CommandSpec,
+) -> CommandSpec {
+    CommandSpec {
+        representative_argv: Some(representative_argv),
+        ..spec
     }
 }
 
@@ -420,55 +437,73 @@ const fn guarded_safety(dangerous_flags: &'static [&'static str]) -> CommandSafe
 }
 
 pub const COMMAND_SPECS: &[CommandSpec] = &[
-    lab_command_spec_with_summary(
-        "agent-task",
-        CommandJsonFamily::Workspace,
-        "Lab runner routing covers portable, explicit-runner, and runner-resident agent-task workflows",
-        AGENT_TASK_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &["homeboy", "agent-task", "providers"],
+        lab_command_spec_with_summary(
+            "agent-task",
+            CommandJsonFamily::Workspace,
+            "Lab runner routing covers portable, explicit-runner, and runner-resident agent-task workflows",
+            AGENT_TASK_LAB_SUPPORT,
+        ),
     ),
     command_spec("project", CommandJsonFamily::Workspace),
     command_spec("ssh", CommandJsonFamily::Ops),
     command_spec("server", CommandJsonFamily::Ops),
-    lab_command_spec_with_summary(
-        "test",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for test runs",
-        TEST_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &["homeboy", "test"],
+        lab_command_spec_with_summary(
+            "test",
+            CommandJsonFamily::Quality,
+            "portable Lab offload is available for test runs",
+            TEST_LAB_SUPPORT,
+        ),
     ),
-    lab_command_spec_with_summary(
-        "bench",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for benchmark runs",
-        BENCH_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &["homeboy", "bench"],
+        lab_command_spec_with_summary(
+            "bench",
+            CommandJsonFamily::Quality,
+            "portable Lab offload is available for benchmark runs",
+            BENCH_LAB_SUPPORT,
+        ),
     ),
     CommandSpec {
         safety: guarded_safety(FUZZ_DANGEROUS_FLAGS),
-        ..lab_command_spec_with_summary(
-            "fuzz",
-            CommandJsonFamily::Quality,
-            "fuzz is measurement-only by default; --allow-destructive requires explicit disposable homeboy/isolation-proof/v1 input",
-            FUZZ_LAB_SUPPORT,
+        ..command_spec_with_representative_argv(
+            &["homeboy", "fuzz"],
+            lab_command_spec_with_summary(
+                "fuzz",
+                CommandJsonFamily::Quality,
+                "fuzz is measurement-only by default; --allow-destructive requires explicit disposable homeboy/isolation-proof/v1 input",
+                FUZZ_LAB_SUPPORT,
+            ),
         )
     },
     CommandSpec {
         safety: mutating_safety(),
-        ..lab_command_spec_with_output_notes_and_summary(
-            "trace",
-            CommandJsonFamily::Quality,
-            "portable Lab offload is available for trace runs",
-            "runs trace workflows and records observation artifacts unless using read-only subcommands",
-            TRACE_LAB_SUPPORT,
+        ..command_spec_with_representative_argv(
+            &["homeboy", "trace"],
+            lab_command_spec_with_output_notes_and_summary(
+                "trace",
+                CommandJsonFamily::Quality,
+                "portable Lab offload is available for trace runs",
+                "runs trace workflows and records observation artifacts unless using read-only subcommands",
+                TRACE_LAB_SUPPORT,
+            ),
         )
     },
     command_spec("observe", CommandJsonFamily::Quality),
     CommandSpec {
         safety: guarded_safety(LINT_DANGEROUS_FLAGS),
-        ..lab_command_spec_with_output_notes_and_summary(
-            "lint",
-            CommandJsonFamily::Quality,
-            "portable Lab offload is available for changed-scope lint runs",
-            "runs lint workflows; pass --fix to apply auto-fixable findings in place",
-            LINT_LAB_SUPPORT,
+        ..command_spec_with_representative_argv(
+            &["homeboy", "lint"],
+            lab_command_spec_with_output_notes_and_summary(
+                "lint",
+                CommandJsonFamily::Quality,
+                "portable Lab offload is available for changed-scope lint runs",
+                "runs lint workflows; pass --fix to apply auto-fixable findings in place",
+                LINT_LAB_SUPPORT,
+            ),
         )
     },
     command_spec("db", CommandJsonFamily::Ops),
@@ -494,17 +529,22 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         CommandJsonFamily::Workspace,
         "lists, shows, exports constants, exports schemas, validates, and normalizes Homeboy-owned contract metadata through the central contract surface",
     ),
-    command_spec_with_output_notes(
-        "artifact-postprocess",
-        CommandJsonFamily::Workspace,
-        "runs a Homeboy artifact-postprocess plan over declared persisted artifact roots and emits the artifact-postprocess result contract",
+    command_spec_without_docs(
+        command_spec_with_output_notes(
+            "artifact-postprocess",
+            CommandJsonFamily::Workspace,
+            "runs a Homeboy artifact-postprocess plan over declared persisted artifact roots and emits the artifact-postprocess result contract",
+        ),
     ),
     command_spec("daemon", CommandJsonFamily::Ops),
-    lab_command_spec_with_summary(
-        "extension",
-        CommandJsonFamily::Workspace,
-        "Lab runner routing covers runner extension refresh/update/dev-run workflows",
-        EXTENSION_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &["homeboy", "extension", "refresh", "."],
+        lab_command_spec_with_summary(
+            "extension",
+            CommandJsonFamily::Workspace,
+            "Lab runner routing covers runner extension refresh/update/dev-run workflows",
+            EXTENSION_LAB_SUPPORT,
+        ),
     ),
     command_spec("status", CommandJsonFamily::Ops),
     command_spec("docs", CommandJsonFamily::Workspace),
@@ -534,17 +574,23 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         operator_safety(Some("--dry-run"), RELEASE_DANGEROUS_FLAGS),
     ),
     command_spec("report", CommandJsonFamily::Workspace),
-    lab_command_spec_with_summary(
-        "review",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for release-gate review runs",
-        REVIEW_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &["homeboy", "review"],
+        lab_command_spec_with_summary(
+            "review",
+            CommandJsonFamily::Quality,
+            "portable Lab offload is available for release-gate review runs",
+            REVIEW_LAB_SUPPORT,
+        ),
     ),
-    lab_command_spec_with_summary(
-        "audit",
-        CommandJsonFamily::Quality,
-        "portable Lab offload is available for audit source runs",
-        AUDIT_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &["homeboy", "audit"],
+        lab_command_spec_with_summary(
+            "audit",
+            CommandJsonFamily::Quality,
+            "portable Lab offload is available for audit source runs",
+            AUDIT_LAB_SUPPORT,
+        ),
     ),
     command_spec("audit-baseline", CommandJsonFamily::Quality),
     CommandSpec {
@@ -555,39 +601,69 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             risk_exemption: None,
             dangerous_flags: REFACTOR_DANGEROUS_FLAGS,
         },
-        ..lab_command_spec_with_output_notes_and_summary(
-            "refactor",
-            CommandJsonFamily::Workspace,
-            "portable Lab offload is available for refactor source runs",
-            "refactor subcommands can rewrite source files; use planning/dry-run modes where available",
-            REFACTOR_LAB_SUPPORT,
+        ..command_spec_with_representative_argv(
+            &["homeboy", "refactor", "--all"],
+            lab_command_spec_with_output_notes_and_summary(
+                "refactor",
+                CommandJsonFamily::Workspace,
+                "portable Lab offload is available for refactor source runs",
+                "refactor subcommands can rewrite source files; use planning/dry-run modes where available",
+                REFACTOR_LAB_SUPPORT,
+            ),
         )
     },
     command_spec("refs", CommandJsonFamily::Workspace),
-    lab_command_spec_with_summary(
-        "rig",
-        CommandJsonFamily::Workspace,
-        "portable Lab offload is available for rig check workflows",
-        RIG_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &["homeboy", "rig", "check", "example-rig"],
+        lab_command_spec_with_summary(
+            "rig",
+            CommandJsonFamily::Workspace,
+            "portable Lab offload is available for rig check workflows",
+            RIG_LAB_SUPPORT,
+        ),
     ),
     command_spec("runner", CommandJsonFamily::Workspace),
-    lab_command_spec_with_summary(
-        "runtime",
-        CommandJsonFamily::Workspace,
-        "Lab runner routing covers runtime package refresh workflows",
-        RUNTIME_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &[
+            "homeboy",
+            "runtime",
+            "refresh",
+            "example-runtime",
+            "--source",
+            ".",
+        ],
+        lab_command_spec_with_summary(
+            "runtime",
+            CommandJsonFamily::Workspace,
+            "Lab runner routing covers runtime package refresh workflows",
+            RUNTIME_LAB_SUPPORT,
+        ),
     ),
-    lab_command_spec_with_summary(
-        "worktree",
-        CommandJsonFamily::Workspace,
-        "Lab runner routing covers runner-resident task worktree cleanup",
-        WORKTREE_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &["homeboy", "worktree", "cleanup"],
+        lab_command_spec_with_summary(
+            "worktree",
+            CommandJsonFamily::Workspace,
+            "Lab runner routing covers runner-resident task worktree cleanup",
+            WORKTREE_LAB_SUPPORT,
+        ),
     ),
-    lab_command_spec_with_summary(
-        "tunnel",
-        CommandJsonFamily::Workspace,
-        "Lab runner routing covers tunnel preview and service workflows",
-        TUNNEL_LAB_SUPPORT,
+    command_spec_with_representative_argv(
+        &[
+            "homeboy",
+            "tunnel",
+            "service",
+            "start",
+            "example-service",
+            "--command",
+            "npm start",
+        ],
+        lab_command_spec_with_summary(
+            "tunnel",
+            CommandJsonFamily::Workspace,
+            "Lab runner routing covers tunnel preview and service workflows",
+            TUNNEL_LAB_SUPPORT,
+        ),
     ),
     command_spec("runs", CommandJsonFamily::Workspace),
     command_spec("self", CommandJsonFamily::Ops),
@@ -608,8 +684,6 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         operator_safety(None, UPGRADE_DANGEROUS_FLAGS),
     ),
 ];
-
-pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = COMMAND_SPECS;
 
 pub const COMMAND_DOC_REGISTRY: &[CommandDocSpec] = &[
     CommandDocSpec {

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -11,7 +11,7 @@ use crate::command_contract::{
     contract_constants, registered_contract, registered_contracts, ArtifactPostprocessPlan,
     CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
     CommandRawOutputMode, CommandResponseMode, CommandStdoutMode, ContractConstantsOutput,
-    ContractRegistryEntry, ARTIFACT_POSTPROCESS_SCHEMA, COMMAND_REGISTRY,
+    ContractRegistryEntry, ARTIFACT_POSTPROCESS_SCHEMA, COMMAND_SPECS,
     PUBLIC_OUTPUT_VARIANT_CONTRACTS, RUNNER_ARTIFACT_MANIFEST_FILE,
     RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
     RUNNER_ARTIFACT_ROOT_DIR_SUFFIX, RUNNER_HANDOFF_ENVELOPE_SCHEMA, RUNNER_WORKLOAD_SCHEMA,
@@ -741,7 +741,7 @@ fn command_registry_export() -> CommandRegistryExport {
             field("lab", "object", "Lab runner support metadata.", true),
         ],
         required: vec!["name", "json_family", "dispatch_family", "safety", "output", "lab"],
-        commands: COMMAND_REGISTRY
+        commands: COMMAND_SPECS
             .iter()
             .map(|entry| CommandContractExport {
                 name: entry.name,


### PR DESCRIPTION
## Summary
- make `COMMAND_SPECS` the single core command metadata registry
- move representative argv coverage into command specs
- remove duplicate registry/test-only shape preservation

## Verification
- `cargo test -q command_registry`
- `cargo test -q command_spec_output_descriptor_uses_shared_contract_shape`
- Clean PR branch diff check passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the refactor seam, drafted implementation and tests, and prepared the PR branch.