### PR TITLE
Install dependency adapter shared assets

### DIFF
--- a/src/core/extension/lifecycle/install_sources.rs
+++ b/src/core/extension/lifecycle/install_sources.rs
@@ -17,7 +17,10 @@ use crate::core::paths;
 use super::super::execution::run_setup;
 use super::super::load_extension;
 use super::super::manifest::ExtensionManifest;
-use super::{derive_id_from_url, manifest_path_for_extension, slugify_id, write_source_metadata, InstallResult};
+use super::{
+    derive_id_from_url, manifest_path_for_extension, slugify_id, write_source_metadata,
+    InstallResult,
+};
 
 pub(super) fn install_configured_extension(
     source: &str,
@@ -212,8 +215,9 @@ enum SharedAssetMode {
     /// Symlink the install target to its live source tree. Used for linked/dev
     /// installs (local-path source): edits to the shared monorepo assets
     /// (`agent-runtimes`, `runtime-agent-ci`, `scripts/lib`,
-    /// `agent-task-contracts`) in the source worktree are visible to the live
-    /// install immediately, with no reinstall or release. See #6396 / #1954.
+    /// `dependency-adapters`, `agent-task-contracts`) in the source worktree
+    /// are visible to the live install immediately, with no reinstall or
+    /// release. See #6396 / #1954.
     Symlink,
 }
 
@@ -241,6 +245,7 @@ fn install_shared_assets_from_root(
 
     for shared_dir in [
         "scripts/lib",
+        "dependency-adapters",
         "agent-runtimes",
         "runtime-agent-ci",
         "agent-task-contracts",
@@ -253,6 +258,7 @@ fn install_shared_assets_from_root(
         let target = match shared_dir {
             "agent-runtimes" => paths::agent_runtimes()?,
             "runtime-agent-ci" | "agent-task-contracts" => paths::homeboy()?.join(shared_dir),
+            "dependency-adapters" => extensions_dir.join(shared_dir),
             // Shared extension libraries install under the extensions root so
             // installed wrappers can source `../../../scripts/lib/...`.
             _ => extensions_dir.join(shared_dir),
@@ -326,16 +332,21 @@ fn symlink_shared_asset(source: &Path, target: &Path, shared_dir: &str) -> Resul
 /// Materialize shared monorepo assets for a linked (local-path) install.
 ///
 /// Linked installs symlink the shared trees to their live source so that edits
-/// to `agent-runtimes`, `runtime-agent-ci`, `scripts/lib`, and
-/// `agent-task-contracts` in the source worktree take effect immediately,
-/// enabling rapid local iteration without a reinstall or release.
+/// to `agent-runtimes`, `runtime-agent-ci`, `scripts/lib`,
+/// `dependency-adapters`, and `agent-task-contracts` in the source worktree
+/// take effect immediately, enabling rapid local iteration without a reinstall
+/// or release.
 pub(crate) fn install_linked_shared_assets(
     source: &Path,
     extension_dir: &Path,
     source_root: Option<&Path>,
 ) -> Result<()> {
     if let Some(source_root) = source_root {
-        return install_shared_assets_from_root(source_root, extension_dir, SharedAssetMode::Symlink);
+        return install_shared_assets_from_root(
+            source_root,
+            extension_dir,
+            SharedAssetMode::Symlink,
+        );
     }
 
     if let Some(parent) = source.parent() {

--- a/src/core/extension/lifecycle/mod.rs
+++ b/src/core/extension/lifecycle/mod.rs
@@ -257,6 +257,7 @@ fn copy_shared_refresh_assets(source_root: Option<&Path>, durable_root: &Path) -
 
     for shared_dir in [
         "scripts/lib",
+        "dependency-adapters",
         "agent-runtimes",
         "runtime-agent-ci",
         "agent-task-contracts",
@@ -307,7 +308,9 @@ mod update;
 #[cfg(test)]
 use update::is_extension_update_workdir_clean;
 pub(crate) use update::write_source_metadata;
-pub use update::{check_update_available, read_source_revision, read_source_url, update, UpdateAvailable};
+pub use update::{
+    check_update_available, read_source_revision, read_source_url, update, UpdateAvailable,
+};
 
 /// Uninstall a extension. Automatically detects symlinks vs cloned directories.
 /// - Symlinked extensions: removes symlink only (source preserved)
@@ -489,6 +492,19 @@ mod tests {
             "module.exports = { contract: 'fixture' };\n",
         )
         .expect("agent task contract");
+
+        let dependency_adapter = root.join("dependency-adapters/examples/nodejs.json");
+        fs::create_dir_all(
+            dependency_adapter
+                .parent()
+                .expect("dependency adapter parent"),
+        )
+        .expect("dependency adapter dir");
+        fs::write(
+            &dependency_adapter,
+            r#"{"schema":"fixture","ecosystem":"nodejs"}"#,
+        )
+        .expect("dependency adapter manifest");
     }
 
     fn run_git(dir: &Path, args: &[&str]) -> bool {
@@ -739,6 +755,7 @@ exec '{}' "$@"
             let home = home.path();
             let lab_source = home.join("Developer/_lab_workspaces/run-123");
             write_extension_fixture(&lab_source, "alpha");
+            write_shared_runtime_fixture(&lab_source);
 
             let result = refresh(
                 &lab_source.join("alpha").to_string_lossy(),
@@ -759,6 +776,9 @@ exec '{}' "$@"
             let linked_target = fs::read_link(&result.path).expect("refresh install link target");
             assert!(linked_target.ends_with(".config/homeboy/extension-sources/alpha/alpha"));
             assert!(linked_target.exists());
+            assert!(home
+                .join(".config/homeboy/extensions/dependency-adapters/examples/nodejs.json")
+                .exists());
         });
     }
 
@@ -830,7 +850,10 @@ exec '{}' "$@"
                 !source.join("wordpress/.source-revision").exists(),
                 "linked install metadata should not dirty the source checkout"
             );
-            assert_eq!(read_source_revision("wordpress").as_deref(), Some("abc1234"));
+            assert_eq!(
+                read_source_revision("wordpress").as_deref(),
+                Some("abc1234")
+            );
             assert_eq!(
                 read_source_url(&result.path).as_deref(),
                 Some(source.join("wordpress").to_string_lossy().as_ref())
@@ -983,6 +1006,9 @@ exec '{}' "$@"
             assert!(home
                 .join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js")
                 .exists());
+            assert!(home
+                .join(".config/homeboy/extensions/dependency-adapters/examples/nodejs.json")
+                .exists());
         });
     }
 
@@ -1047,6 +1073,9 @@ exec '{}' "$@"
                 .exists());
             assert!(home
                 .join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js")
+                .exists());
+            assert!(home
+                .join(".config/homeboy/extensions/dependency-adapters/examples/nodejs.json")
                 .exists());
         });
     }
@@ -1148,6 +1177,10 @@ exec '{}' "$@"
                     home.join(".config/homeboy/extensions/scripts/lib"),
                     source.join("scripts/lib"),
                 ),
+                (
+                    home.join(".config/homeboy/extensions/dependency-adapters"),
+                    source.join("dependency-adapters"),
+                ),
             ] {
                 let meta = fs::symlink_metadata(&target)
                     .unwrap_or_else(|_| panic!("shared target exists: {}", target.display()));
@@ -1185,13 +1218,18 @@ exec '{}' "$@"
             // Edit the shared asset in the source worktree after install. Because
             // the install symlinks the tree, the edit must be visible at the live
             // install path with no reinstall — the iteration-blocker fix.
-            let source_contract = source.join("agent-task-contracts/agent-task-provider-contract.js");
-            fs::write(&source_contract, "module.exports = { contract: 'edited-live' };\n")
-                .expect("edit shared source file");
+            let source_contract =
+                source.join("agent-task-contracts/agent-task-provider-contract.js");
+            fs::write(
+                &source_contract,
+                "module.exports = { contract: 'edited-live' };\n",
+            )
+            .expect("edit shared source file");
 
             let installed_contract =
                 home.join(".config/homeboy/agent-task-contracts/agent-task-provider-contract.js");
-            let observed = fs::read_to_string(&installed_contract).expect("read installed contract");
+            let observed =
+                fs::read_to_string(&installed_contract).expect("read installed contract");
             assert!(
                 observed.contains("edited-live"),
                 "edit to the symlinked shared tree should be visible to the install, got: {observed}"

--- a/src/core/extension/lifecycle/update.rs
+++ b/src/core/extension/lifecycle/update.rs
@@ -137,9 +137,15 @@ pub(crate) fn write_source_metadata(
 ) {
     let metadata_dir = source_metadata_dir(extension_dir);
     if let Some(rev) = source_revision {
-        let _ = std::fs::write(metadata_dir.join(source_metadata_file(extension_dir, "revision")), rev);
+        let _ = std::fs::write(
+            metadata_dir.join(source_metadata_file(extension_dir, "revision")),
+            rev,
+        );
     }
-    let _ = std::fs::write(metadata_dir.join(source_metadata_file(extension_dir, "url")), source_url);
+    let _ = std::fs::write(
+        metadata_dir.join(source_metadata_file(extension_dir, "url")),
+        source_url,
+    );
 }
 
 pub fn read_source_url(extension_dir: &Path) -> Option<String> {


### PR DESCRIPTION
## Summary
- install `dependency-adapters` with extension shared assets for cloned, linked, and durable refresh installs
- keep dependency adapter manifests available beside shared project scripts in installed extension layouts
- extend lifecycle regression coverage for cloned, linked, and transient Lab refresh paths

## Testing
- `cargo test core::extension::lifecycle::tests -- --nocapture`
- `cargo build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated and fixed missing dependency adapter materialization for installed extension shared scripts, added regression coverage, and ran targeted verification.