### PR TITLE
Project provider config materialization plans

### DIFF
--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -65,7 +65,7 @@ use super::super::lab_args::{
     inject_agent_task_default_provider_config_in_args, lab_at_file_specs, lab_offload_source_path,
     materialize_agent_task_specs_in_args, preflight_provider_config_paths_materialized_in_args,
     provider_config_runtime_manifest, remap_lab_at_file_args, remap_path_settings_in_args,
-    remap_provider_config_in_args, rewrite_lab_offload_args,
+    remap_provider_config_with_materialization_plan_in_args, rewrite_lab_offload_args,
     rewrite_runner_resident_lab_offload_args, LabAtFileSpec, LabPathRemap,
 };
 use super::super::lab_capabilities::lab_runner_capability_contract;

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -2,6 +2,10 @@
 
 use super::*;
 use crate::core::rig;
+use crate::core::runner_execution_envelope::{
+    PathMaterializationEntry, PathMaterializationPlan,
+    PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG, PATH_MATERIALIZATION_STATUS_MATERIALIZED,
+};
 
 pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) plan: HomeboyPlan,
@@ -387,7 +391,12 @@ fn prepare_lab_offload_workspace_stage_inner(
         &offload_args,
         &remote_cwd,
     );
-    let remapped_args = remap_provider_config_in_args(&remapped_args, &path_remaps)?;
+    let provider_config_materialization_plan =
+        provider_config_path_materialization_plan(contract, sync_mode, &workspace_mapping);
+    let remapped_args = remap_provider_config_with_materialization_plan_in_args(
+        &remapped_args,
+        &provider_config_materialization_plan,
+    )?;
     let agent_task_specs = materialize_agent_task_specs_in_args(
         &remapped_args,
         &path_remaps,
@@ -571,6 +580,37 @@ pub(crate) fn path_remaps_from_workspace_mapping(
     }
 
     remaps
+}
+
+fn provider_config_path_materialization_plan(
+    contract: &LabOffloadCommand,
+    sync_mode: RunnerWorkspaceSyncMode,
+    workspace_mapping: &[LabWorkspaceMappingEntry],
+) -> PathMaterializationPlan {
+    let materialization_mode = lab_path_materialization_mode(contract, sync_mode);
+    PathMaterializationPlan::new(workspace_mapping.iter().map(|entry| {
+        PathMaterializationEntry::new(
+            entry.role(),
+            PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG,
+            Some(entry.local_path().to_string()),
+            entry.remote_path(),
+            materialization_mode.clone(),
+            PATH_MATERIALIZATION_STATUS_MATERIALIZED,
+        )
+    }))
+}
+
+fn lab_path_materialization_mode(
+    contract: &LabOffloadCommand,
+    sync_mode: RunnerWorkspaceSyncMode,
+) -> String {
+    if matches!(
+        contract.workspace_mode_policy,
+        LabOffloadWorkspaceModePolicy::RunnerResident
+    ) {
+        return "existing_remote".to_string();
+    }
+    sync_mode.label().to_string()
 }
 
 fn rewrite_lab_offload_remote_command_args(
@@ -1362,6 +1402,45 @@ mod tests {
         assert!(!command
             .iter()
             .any(|arg| arg == &requested_source.display().to_string()));
+    }
+
+    #[test]
+    fn provider_config_materialization_plan_projects_lab_policy_and_mappings() {
+        let synced = test_synced_workspace(
+            "/controller/workspaces/provider-runtime",
+            "/runner/workspaces/provider-runtime",
+        );
+        let workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
+        let contract = LabOffloadCommand {
+            hot_label: "agent-task.run",
+            portable: true,
+            unsupported_reason: None,
+            source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
+            workspace_mode_policy: LabOffloadWorkspaceModePolicy::GitCheckoutRequired,
+            secret_env_sources: Vec::new(),
+            required_extensions: Vec::new(),
+            required_capabilities: Vec::new(),
+            routing_policy: crate::command_contract::LabRoutingPolicy::default(),
+        };
+
+        let plan = provider_config_path_materialization_plan(
+            &contract,
+            RunnerWorkspaceSyncMode::Git,
+            &workspace_mapping,
+        );
+
+        assert_eq!(plan.entries.len(), 1);
+        assert_eq!(plan.entries[0].role, "primary");
+        assert_eq!(plan.entries[0].owner, "lab.provider_config");
+        assert_eq!(
+            plan.entries[0].local_path.as_deref(),
+            Some("/controller/workspaces/provider-runtime")
+        );
+        assert_eq!(
+            plan.entries[0].remote_path,
+            "/runner/workspaces/provider-runtime"
+        );
+        assert_eq!(plan.entries[0].materialization_mode, "git");
     }
 
     fn test_synced_workspace(local_path: &str, remote_path: &str) -> RunnerWorkspaceSyncOutput {

--- a/src/core/runner/lab_args/mod.rs
+++ b/src/core/runner/lab_args/mod.rs
@@ -37,8 +37,10 @@ pub(super) use offload::{
     lab_offload_source_path, rewrite_lab_offload_args, rewrite_runner_resident_lab_offload_args,
 };
 pub(super) use path_remap::{remap_path_settings_in_args, LabPathRemap};
+#[cfg(test)]
+pub(super) use provider_config::remap_provider_config_in_args;
 pub(super) use provider_config::{
     inject_agent_task_default_provider_config_in_args,
     preflight_provider_config_paths_materialized_in_args, provider_config_runtime_manifest,
-    remap_provider_config_in_args,
+    remap_provider_config_with_materialization_plan_in_args,
 };

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
 use crate::core::config::read_json_spec_to_string;
 use crate::core::defaults;
+use crate::core::runner_execution_envelope::PathMaterializationPlan;
 use crate::core::{Error, Result};
 
 use super::envelope::{ArgValue, ExecutionEnvelope};
@@ -123,6 +124,32 @@ pub(in crate::core::runner) fn remap_provider_config_in_args(
     });
 
     envelope.try_rewrite_provider_config_values(|spec| remap_provider_config_spec(spec, &ordered))
+}
+
+pub(in crate::core::runner) fn remap_provider_config_with_materialization_plan_in_args(
+    args: &[String],
+    plan: &PathMaterializationPlan,
+) -> Result<Vec<String>> {
+    let mappings = provider_config_path_remaps_from_materialization_plan(plan);
+    remap_provider_config_in_args(args, &mappings)
+}
+
+fn provider_config_path_remaps_from_materialization_plan(
+    plan: &PathMaterializationPlan,
+) -> Vec<LabPathRemap> {
+    plan.projection_entries()
+        .into_iter()
+        .filter_map(|entry| {
+            let local = entry.local_path?;
+            if local.trim().is_empty() || entry.remote_path.trim().is_empty() {
+                return None;
+            }
+            Some(LabPathRemap {
+                local,
+                remote: entry.remote_path,
+            })
+        })
+        .collect()
 }
 
 pub(in crate::core::runner) fn inject_agent_task_default_provider_config_in_args(

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -353,6 +353,44 @@ mod provider_config_remap_tests {
     }
 
     #[test]
+    fn remap_provider_config_uses_typed_materialization_plan_projection() {
+        let plan = crate::core::runner_execution_envelope::PathMaterializationPlan::new(vec![
+            crate::core::runner_execution_envelope::PathMaterializationEntry::primary_workspace_materialized(
+                crate::core::runner_execution_envelope::PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG,
+                Some("/Users/user/Developer/provider-runtime".to_string()),
+                "/home/user/_lab_workspaces/provider-runtime",
+                "snapshot",
+            ),
+        ]);
+        let config = serde_json::json!({
+            "workspace_root": "/Users/user/Developer/provider-runtime",
+            "provider_plugin_paths": ["/Users/user/Developer/provider-runtime/provider"]
+        })
+        .to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--provider-config".to_string(),
+            config,
+        ];
+
+        let out = remap_provider_config_with_materialization_plan_in_args(&args, &plan)
+            .expect("remap provider config");
+        let cfg_idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
+        let remapped: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("inline json");
+
+        assert_eq!(
+            remapped["workspace_root"],
+            "/home/user/_lab_workspaces/provider-runtime"
+        );
+        assert_eq!(
+            remapped["provider_plugin_paths"][0],
+            "/home/user/_lab_workspaces/provider-runtime/provider"
+        );
+    }
+
+    #[test]
     fn remap_inlines_and_rewrites_dispatch_provider_config_local_paths() {
         let mappings = vec![
             LabPathRemap {

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -20,6 +20,7 @@ pub const PATH_MATERIALIZATION_ROLE_REQUIRED_PATH: &str = "required_path";
 pub const PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT: &str =
     "runner_exec.source_snapshot";
 pub const PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS: &str = "runner_exec.require_paths";
+pub const PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG: &str = "lab.provider_config";
 pub const PATH_MATERIALIZATION_STATUS_MATERIALIZED: &str = "materialized";
 pub const PATH_MATERIALIZATION_STATUS_VALIDATED: &str = "validated";
 


### PR DESCRIPTION
## Summary
- Add a typed path-materialization owner for Lab provider config.
- Project provider-config remaps from `PathMaterializationPlan`.
- Preserve existing compatibility paths while moving offload away from argv surgery.

## Tests
- cargo test remap_provider_config_uses_typed_materialization_plan_projection
- cargo test provider_config_materialization_plan_projects_lab_policy_and_mappings
- cargo test path_materialization_plan_helpers_emit_canonical_shape
- cargo test runner_execution_projection_flattens_materialized_paths

## Dependencies
- Downstream HBEX can begin consuming typed materialization plans.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the minimal typed materialization projection and tests.