### PR TITLE
Add rig lint and stable planning commands

### DIFF
--- a/src/commands/fuzz/dispatch.rs
+++ b/src/commands/fuzz/dispatch.rs
@@ -16,6 +16,7 @@ use super::inspect::run_inspect;
 use super::planning::{run_campaign, run_plan};
 use super::replay::{run_minimize, run_replay};
 use super::report::{run_report, run_validate};
+use super::stable::run_stable;
 use super::types::{
     FuzzArgs, FuzzCommand, FuzzContractOutput, FuzzDiscoverArgs, FuzzDiscoverOutput,
     FuzzDiscoverSummary, FuzzListArgs, FuzzListOutput, FuzzOutput,
@@ -37,6 +38,9 @@ pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
             Ok((FuzzOutput::RunCampaign(output), exit))
         }
         Some(FuzzCommand::Plan(plan_args)) => Ok((FuzzOutput::Plan(run_plan(plan_args)?), 0)),
+        Some(FuzzCommand::Stable(stable_args)) => {
+            Ok((FuzzOutput::StablePlan(run_stable(stable_args.command)?), 0))
+        }
         Some(FuzzCommand::RunCampaign(mut plan_args)) => {
             if !plan_args.dry_run {
                 plan_args.execute = true;

--- a/src/commands/fuzz/mod.rs
+++ b/src/commands/fuzz/mod.rs
@@ -6,6 +6,7 @@ mod inspect;
 mod planning;
 mod replay;
 mod report;
+mod stable;
 mod types;
 mod types_extra;
 mod workloads;

--- a/src/commands/fuzz/stable.rs
+++ b/src/commands/fuzz/stable.rs
@@ -1,0 +1,384 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::Deserialize;
+use serde_json::Value;
+
+use homeboy::core::error::{Error, Result};
+
+use super::types::{FuzzStableCommand, FuzzStablePlanArgs};
+use super::types_extra::{
+    FuzzStableCompareCommandOutput, FuzzStablePlanOutput, FuzzStableRunCommandOutput,
+};
+
+pub(super) fn run_stable(command: FuzzStableCommand) -> Result<FuzzStablePlanOutput> {
+    match command {
+        FuzzStableCommand::Plan(args) => run_stable_plan(args),
+    }
+}
+
+fn run_stable_plan(args: FuzzStablePlanArgs) -> Result<FuzzStablePlanOutput> {
+    if args.limit == 0 {
+        return Err(Error::validation_invalid_argument(
+            "limit",
+            "--limit must be a positive integer",
+            Some(args.limit.to_string()),
+            None,
+        ));
+    }
+    if args.hotspot_limit == 0 {
+        return Err(Error::validation_invalid_argument(
+            "hotspot-limit",
+            "--hotspot-limit must be a positive integer",
+            Some(args.hotspot_limit.to_string()),
+            None,
+        ));
+    }
+
+    let manifest = read_manifest(&args.manifest)?;
+    let rig_id = resolve_rig_id(&args.manifest, &manifest.rig)?;
+    let contracts = selected_contracts(&manifest.contracts, &args.stable_ids)?;
+    let run_id_prefix = args
+        .run_id_prefix
+        .clone()
+        .unwrap_or_else(|| format!("stable-{}", Utc::now().format("%Y%m%d")));
+
+    let mut run_commands = Vec::new();
+    for contract in contracts {
+        if contract.entry_workloads.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "manifest",
+                "stable workload contracts must declare at least one entry_workloads item",
+                Some(contract.id.clone()),
+                None,
+            ));
+        }
+        for (index, workload_id) in contract.entry_workloads.iter().enumerate() {
+            let run_id = format!(
+                "{}-{}-{:02}-{}",
+                run_id_prefix,
+                contract.id,
+                index + 1,
+                workload_id
+            );
+            let mut command = vec![
+                "homeboy".to_string(),
+                "fuzz".to_string(),
+                "run".to_string(),
+                "--lab-only".to_string(),
+                "--rig".to_string(),
+                rig_id.clone(),
+                "--workload".to_string(),
+                workload_id.clone(),
+                "--gate-profile".to_string(),
+                "measurement".to_string(),
+                "--run-id".to_string(),
+                run_id.clone(),
+                "--tracker-ref".to_string(),
+                format!("stable-workload:{}", contract.id),
+            ];
+            append_common_run_options(&mut command, &args);
+            if let Some(seconds) = contract
+                .budgets
+                .get("max_duration_seconds")
+                .and_then(Value::as_u64)
+            {
+                command.push("--max-duration".to_string());
+                command.push(format!("{seconds}s"));
+            }
+            for tracker_ref in &args.tracker_refs {
+                command.push("--tracker-ref".to_string());
+                command.push(tracker_ref.clone());
+            }
+            run_commands.push(FuzzStableRunCommandOutput {
+                stable_workload_id: contract.id.clone(),
+                workload_id: workload_id.clone(),
+                run_id,
+                command,
+            });
+        }
+    }
+
+    Ok(FuzzStablePlanOutput {
+        schema: "homeboy/fuzz-stable-lab-command-plan/v1".to_string(),
+        command: "fuzz.stable.plan".to_string(),
+        manifest: args.manifest.to_string_lossy().to_string(),
+        profile_id: manifest.profile_id,
+        rig_id: rig_id.clone(),
+        local_execution: false,
+        run_id_prefix,
+        run_commands,
+        compare_commands: compare_commands(&args, &rig_id),
+        next_steps: vec![
+            "Run the planned fuzz commands in Lab, then use the compare commands after two completed runs exist.".to_string(),
+            "Keep product-specific workload selection in the manifest; Homeboy only plans declared workload ids.".to_string(),
+        ],
+    })
+}
+
+fn append_common_run_options(command: &mut Vec<String>, args: &FuzzStablePlanArgs) {
+    if let Some(runner) = &args.runner {
+        command.push("--runner".to_string());
+        command.push(runner.clone());
+    }
+    if let Some(artifact_root) = &args.artifact_root {
+        command.push("--artifact-root".to_string());
+        command.push(artifact_root.to_string_lossy().to_string());
+    }
+    if args.detach_after_handoff {
+        command.push("--detach-after-handoff".to_string());
+    }
+}
+
+fn compare_commands(
+    args: &FuzzStablePlanArgs,
+    rig_id: &str,
+) -> Vec<FuzzStableCompareCommandOutput> {
+    vec![
+        FuzzStableCompareCommandOutput {
+            purpose: "list_recent_refs".to_string(),
+            command: with_lab_options(
+                vec![
+                    "homeboy",
+                    "runs",
+                    "refs",
+                    "--kind",
+                    "fuzz",
+                    "--rig",
+                    rig_id,
+                    "--status",
+                    "completed",
+                    "--since",
+                    &args.since,
+                    "--limit",
+                    &args.limit.to_string(),
+                    "--aggregate-artifact-kind",
+                    "fuzz.report",
+                ],
+                args,
+            ),
+        },
+        FuzzStableCompareCommandOutput {
+            purpose: "trend_elapsed_time".to_string(),
+            command: with_lab_options(
+                vec![
+                    "homeboy",
+                    "runs",
+                    "compare",
+                    "--kind",
+                    "fuzz",
+                    "--rig",
+                    rig_id,
+                    "--metric",
+                    "total_elapsed_ms",
+                    "--limit",
+                    &args.limit.to_string(),
+                ],
+                args,
+            ),
+        },
+        FuzzStableCompareCommandOutput {
+            purpose: "compare_hotspots_after_two_runs_complete".to_string(),
+            command: with_lab_options(
+                vec![
+                    "homeboy",
+                    "runs",
+                    "hotspots",
+                    "--baseline-run",
+                    "BASELINE_RUN_ID",
+                    "--candidate-run",
+                    "CANDIDATE_RUN_ID",
+                    "--limit",
+                    &args.hotspot_limit.to_string(),
+                ],
+                args,
+            ),
+        },
+    ]
+}
+
+fn with_lab_options(parts: Vec<&str>, args: &FuzzStablePlanArgs) -> Vec<String> {
+    let mut command: Vec<String> = parts.into_iter().map(str::to_string).collect();
+    if let Some(component) = &args.component {
+        command.push("--component".to_string());
+        command.push(component.clone());
+    }
+    command.push("--lab-only".to_string());
+    if let Some(runner) = &args.runner {
+        command.push("--runner".to_string());
+        command.push(runner.clone());
+    }
+    if let Some(artifact_root) = &args.artifact_root {
+        command.push("--artifact-root".to_string());
+        command.push(artifact_root.to_string_lossy().to_string());
+    }
+    command
+}
+
+fn selected_contracts<'a>(
+    contracts: &'a [StableWorkloadContract],
+    stable_ids: &[String],
+) -> Result<Vec<&'a StableWorkloadContract>> {
+    if stable_ids.is_empty() {
+        return Ok(contracts.iter().collect());
+    }
+    let selected: std::collections::BTreeSet<_> = stable_ids.iter().map(String::as_str).collect();
+    let filtered: Vec<_> = contracts
+        .iter()
+        .filter(|contract| selected.contains(contract.id.as_str()))
+        .collect();
+    let found: std::collections::BTreeSet<_> = filtered
+        .iter()
+        .map(|contract| contract.id.as_str())
+        .collect();
+    let missing: Vec<_> = selected.difference(&found).copied().collect();
+    if !missing.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "stable-id",
+            "unknown stable workload id(s)",
+            Some(missing.join(", ")),
+            None,
+        ));
+    }
+    Ok(filtered)
+}
+
+fn read_manifest(path: &Path) -> Result<StableWorkloadManifest> {
+    let content = fs::read_to_string(path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+    })?;
+    serde_json::from_str(&content).map_err(|error| {
+        Error::validation_invalid_argument(
+            "manifest",
+            "stable workload manifest must be valid JSON",
+            Some(error.to_string()),
+            None,
+        )
+    })
+}
+
+fn resolve_rig_id(manifest_path: &Path, rig_ref: &str) -> Result<String> {
+    if rig_ref.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "manifest.rig",
+            "stable workload manifest must declare rig",
+            None,
+            None,
+        ));
+    }
+    let package_root = manifest_path
+        .parent()
+        .and_then(|parent| {
+            (parent.file_name().and_then(|name| name.to_str()) == Some("manifests"))
+                .then(|| parent.parent())
+                .flatten()
+        })
+        .or_else(|| manifest_path.parent())
+        .unwrap_or_else(|| Path::new("."));
+    let rig_path = if Path::new(rig_ref).is_absolute() {
+        PathBuf::from(rig_ref)
+    } else {
+        package_root.join(rig_ref)
+    };
+    let content = fs::read_to_string(&rig_path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read manifest rig ref {}", rig_path.display())),
+        )
+    })?;
+    let value: Value = serde_json::from_str(&content).map_err(|error| {
+        Error::validation_invalid_argument(
+            "manifest.rig",
+            "manifest rig ref must point at valid rig JSON",
+            Some(error.to_string()),
+            None,
+        )
+    })?;
+    value
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "manifest.rig",
+                "manifest rig ref must point at a rig with a non-empty id",
+                Some(rig_path.to_string_lossy().to_string()),
+                None,
+            )
+        })
+}
+
+#[derive(Deserialize)]
+struct StableWorkloadManifest {
+    #[allow(dead_code)]
+    schema: Option<String>,
+    profile_id: Option<String>,
+    rig: String,
+    #[serde(default)]
+    contracts: Vec<StableWorkloadContract>,
+}
+
+#[derive(Deserialize)]
+struct StableWorkloadContract {
+    id: String,
+    #[serde(default)]
+    entry_workloads: Vec<String>,
+    #[serde(default)]
+    budgets: serde_json::Map<String, Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_plan_resolves_rig_and_builds_lab_commands() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("demo");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(rig_dir.join("rig.json"), r#"{"id":"demo-rig"}"#).expect("rig");
+        let manifests = temp.path().join("manifests");
+        fs::create_dir_all(&manifests).expect("manifests");
+        let manifest = manifests.join("stable-workloads.json");
+        fs::write(
+            &manifest,
+            r#"{
+                "schema":"example/stable-workloads/v1",
+                "profile_id":"stable-demo",
+                "rig":"rigs/demo/rig.json",
+                "contracts":[{"id":"api","entry_workloads":["read"],"budgets":{"max_duration_seconds":60}}]
+            }"#,
+        )
+        .expect("manifest");
+
+        let output = run_stable_plan(FuzzStablePlanArgs {
+            manifest,
+            stable_ids: vec!["api".to_string()],
+            runner: Some("lab".to_string()),
+            artifact_root: None,
+            run_id_prefix: Some("stable-demo".to_string()),
+            tracker_refs: vec!["issue:1".to_string()],
+            detach_after_handoff: true,
+            component: Some("component-a".to_string()),
+            since: "7d".to_string(),
+            limit: 5,
+            hotspot_limit: 3,
+        })
+        .expect("plan");
+
+        assert_eq!(output.rig_id, "demo-rig");
+        assert_eq!(output.run_commands.len(), 1);
+        assert!(output.run_commands[0]
+            .command
+            .contains(&"--lab-only".to_string()));
+        assert!(output.run_commands[0]
+            .command
+            .contains(&"--max-duration".to_string()));
+        assert!(output.compare_commands[0]
+            .command
+            .windows(2)
+            .any(|pair| pair == ["--component", "component-a"]));
+    }
+}

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -71,6 +71,8 @@ pub(crate) enum FuzzCommand {
     List(FuzzListArgs),
     /// Build a fuzz execution request without executing it
     Plan(FuzzPlanArgs),
+    /// Plan stable workload Lab commands from a manifest without executing them
+    Stable(FuzzStableArgs),
     /// Execute or dry-run a generated fuzz campaign plan
     RunCampaign(FuzzPlanArgs),
     /// Execute the selected fuzz workload, persist fuzz evidence, and surface its campaign contract
@@ -310,6 +312,65 @@ pub(crate) struct FuzzPlanArgs {
     /// Skip campaign entries whose run id already exists in the persisted run store.
     #[arg(long = "resume")]
     pub(crate) resume: bool,
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct FuzzStableArgs {
+    #[command(subcommand)]
+    pub(crate) command: FuzzStableCommand,
+}
+
+#[derive(Subcommand, Clone)]
+pub(crate) enum FuzzStableCommand {
+    /// Emit stable workload Lab command JSON from a stable workload manifest.
+    Plan(FuzzStablePlanArgs),
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct FuzzStablePlanArgs {
+    /// Stable workload manifest JSON path.
+    #[arg(long = "manifest", value_name = "PATH")]
+    pub(crate) manifest: PathBuf,
+
+    /// Limit to one or more stable workload ids. Repeatable and comma-separated.
+    #[arg(long = "stable-id", value_name = "ID[,ID]", value_delimiter = ',')]
+    pub(crate) stable_ids: Vec<String>,
+
+    /// Preferred Lab runner id to include in every command.
+    #[arg(long = "runner", value_name = "ID")]
+    pub(crate) runner: Option<String>,
+
+    /// Persisted artifact root to include in every command.
+    #[arg(long = "artifact-root", value_name = "DIR")]
+    pub(crate) artifact_root: Option<PathBuf>,
+
+    /// Stable run id prefix. Defaults to stable-YYYYMMDD.
+    #[arg(long = "run-id-prefix", value_name = "ID")]
+    pub(crate) run_id_prefix: Option<String>,
+
+    /// Extra tracker ref added to every run command. Repeatable. Format: KIND:ID.
+    #[arg(long = "tracker-ref", value_name = "KIND:ID")]
+    pub(crate) tracker_refs: Vec<String>,
+
+    /// Return after the Lab daemon accepts each run.
+    #[arg(long = "detach-after-handoff")]
+    pub(crate) detach_after_handoff: bool,
+
+    /// Optional component id for comparison commands.
+    #[arg(long = "component", value_name = "ID")]
+    pub(crate) component: Option<String>,
+
+    /// Lookback for refs compare command.
+    #[arg(long = "since", default_value = "30d")]
+    pub(crate) since: String,
+
+    /// Run-history limit for refs/compare commands.
+    #[arg(long = "limit", default_value_t = 50)]
+    pub(crate) limit: u64,
+
+    /// Hotspot compare row limit.
+    #[arg(long = "hotspot-limit", default_value_t = 20)]
+    pub(crate) hotspot_limit: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]

--- a/src/commands/fuzz/types_extra.rs
+++ b/src/commands/fuzz/types_extra.rs
@@ -25,6 +25,7 @@ pub enum FuzzOutput {
     Replay(FuzzReplayOutput),
     Minimize(FuzzReplayOutput),
     Inspect(FuzzInspectOutput),
+    StablePlan(FuzzStablePlanOutput),
 }
 
 #[derive(Serialize)]
@@ -253,6 +254,34 @@ pub struct FuzzCampaignRunOutput {
     pub run_ids: Vec<String>,
     pub result_refs: Vec<EvidenceRef>,
     pub next_steps: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct FuzzStablePlanOutput {
+    pub schema: String,
+    pub command: String,
+    pub manifest: String,
+    pub profile_id: Option<String>,
+    pub rig_id: String,
+    pub local_execution: bool,
+    pub run_id_prefix: String,
+    pub run_commands: Vec<FuzzStableRunCommandOutput>,
+    pub compare_commands: Vec<FuzzStableCompareCommandOutput>,
+    pub next_steps: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct FuzzStableRunCommandOutput {
+    pub stable_workload_id: String,
+    pub workload_id: String,
+    pub run_id: String,
+    pub command: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct FuzzStableCompareCommandOutput {
+    pub purpose: String,
+    pub command: Vec<String>,
 }
 
 #[derive(Serialize)]

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -147,6 +147,11 @@ enum RigCommand {
         #[arg(long)]
         all: bool,
     },
+    /// Validate rig package artifacts without touching the environment.
+    Package {
+        #[command(subcommand)]
+        command: RigPackageCommand,
+    },
     /// Tear down a rig: stop services and run its `down` pipeline
     Down {
         /// Rig ID
@@ -247,6 +252,15 @@ enum RigAppCommand {
     },
 }
 
+#[derive(Subcommand)]
+enum RigPackageCommand {
+    /// Lint every rig and package-level manifest under a local package path.
+    Lint {
+        /// Local package directory containing rig.json or rigs/<id>/rig.json
+        manifest_path: std::path::PathBuf,
+    },
+}
+
 #[derive(Args)]
 struct RigRunArgs {
     /// Rig ID
@@ -307,6 +321,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Up { rig_id, dry_run } => up(&rig_id, dry_run),
         RigCommand::Check { target, id, path } => check(&target, id.as_deref(), path.as_deref()),
         RigCommand::Lint { target, id, all } => lint(&target, id.as_deref(), all),
+        RigCommand::Package { command } => package(command),
         RigCommand::Down { rig_id } => down(&rig_id),
         RigCommand::Repair { rig_id } => repair(&rig_id),
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
@@ -323,6 +338,52 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Sources { command } => sources::run(command),
         RigCommand::App { command } => app(command),
     }
+}
+
+fn package(command: RigPackageCommand) -> CmdResult<RigCommandOutput> {
+    match command {
+        RigPackageCommand::Lint { manifest_path } => package_lint(&manifest_path),
+    }
+}
+
+fn package_lint(manifest_path: &std::path::Path) -> CmdResult<RigCommandOutput> {
+    let lint_root = rig_package_lint_root(manifest_path);
+    let report = rig::lint::run_package_lint_at(&lint_root)?;
+    let exit_code = if report.failed == 0 { 0 } else { 1 };
+    Ok((
+        RigCommandOutput::Check(RigCheckOutput {
+            command: "rig.package.lint",
+            report: homeboy::core::rig::CheckReport {
+                rig_id: lint_root.to_string_lossy().to_string(),
+                run_id: None,
+                pipeline: report,
+                success: exit_code == 0,
+                artifact_index: None,
+            },
+        }),
+        exit_code,
+    ))
+}
+
+fn rig_package_lint_root(path: &std::path::Path) -> std::path::PathBuf {
+    if path.is_file() && path.file_name().and_then(|name| name.to_str()) == Some("rig.json") {
+        if path
+            .parent()
+            .and_then(|parent| parent.parent())
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            == Some("rigs")
+        {
+            return path
+                .parent()
+                .and_then(|parent| parent.parent())
+                .and_then(|parent| parent.parent())
+                .unwrap_or(path)
+                .to_path_buf();
+        }
+        return path.parent().unwrap_or(path).to_path_buf();
+    }
+    path.to_path_buf()
 }
 
 fn release_lock(rig_id: &str, force: bool) -> CmdResult<RigCommandOutput> {

--- a/src/core/rig/lint.rs
+++ b/src/core/rig/lint.rs
@@ -1,5 +1,6 @@
 //! Generic rig package lint checks used by `homeboy rig check` and `homeboy rig lint`.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -51,6 +52,8 @@ pub fn run_package_lint_at(root: &Path) -> Result<PipelineOutcome> {
     let json_failures = json_parse_failures(root, &files)?;
     let template_failures = template_materialization_failures(root, &files)?;
     let contract_failures = contract_validation_failures(root)?;
+    let portability_failures = portability_failures(root, &files)?;
+    let reference_failures = workload_reference_failures(root, &files)?;
     let steps = vec![
         aggregate_step(
             "rig-package-lint",
@@ -71,6 +74,16 @@ pub fn run_package_lint_at(root: &Path) -> Result<PipelineOutcome> {
             "rig-package-lint",
             "rig package specs satisfy the Homeboy rig contract",
             contract_failures,
+        ),
+        aggregate_step(
+            "rig-package-lint",
+            "rig package paths are portable",
+            portability_failures,
+        ),
+        aggregate_step(
+            "rig-package-lint",
+            "rig package workload profiles reference declared workloads",
+            reference_failures,
         ),
     ];
 
@@ -223,6 +236,367 @@ fn template_materialization_failures(root: &Path, files: &[PathBuf]) -> Result<V
     Ok(failures)
 }
 
+fn portability_failures(root: &Path, files: &[PathBuf]) -> Result<Vec<String>> {
+    let mut failures = Vec::new();
+    for file in files.iter().filter(|path| portable_source_file(path)) {
+        let content = fs::read_to_string(file).unwrap_or_default();
+        let rel = display_relative(root, file);
+        if content.contains("/Users/") {
+            failures.push(format!(
+                "{rel}: use $HOME, homedir(), component paths, or settings instead of hard-coded /Users paths"
+            ));
+        }
+        if content.contains("~/Developer/") || content.contains("$HOME/Developer/") {
+            failures.push(format!(
+                "{rel}: use portable component path settings instead of committed ~/Developer or $HOME/Developer checkout paths"
+            ));
+        }
+    }
+
+    for file in files
+        .iter()
+        .filter(|path| path.file_name() == Some(OsStr::new("rig.json")))
+    {
+        let content = fs::read_to_string(file).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", file.display())))
+        })?;
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        failures.extend(shared_path_failures(root, file, &value));
+    }
+
+    Ok(failures)
+}
+
+fn portable_source_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(OsStr::to_str),
+        Some("json" | "mjs" | "js")
+    )
+}
+
+fn shared_path_failures(root: &Path, file: &Path, rig: &serde_json::Value) -> Vec<String> {
+    let rel = display_relative(root, file);
+    let Some(shared_paths) = rig.get("shared_paths") else {
+        return Vec::new();
+    };
+    let Some(shared_paths) = shared_paths.as_array() else {
+        return vec![format!("{rel}: shared_paths must be an array")];
+    };
+
+    let mut failures = Vec::new();
+    for (index, shared_path) in shared_paths.iter().enumerate() {
+        let Some(object) = shared_path.as_object() else {
+            failures.push(format!("{rel}: shared_paths[{index}] must be an object"));
+            continue;
+        };
+        let link = object
+            .get("link")
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .trim();
+        let target = object
+            .get("target")
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .trim();
+        let allow_self_target = object
+            .get("allow_self_target")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        if !link.is_empty() && link == target && !allow_self_target {
+            failures.push(format!(
+                "{rel}: shared_paths[{index}] link and target must differ unless allow_self_target is true"
+            ));
+        }
+    }
+    failures
+}
+
+fn workload_reference_failures(root: &Path, files: &[PathBuf]) -> Result<Vec<String>> {
+    let fuzz_workloads = collect_fuzz_workloads(root, files)?;
+    let mut failures = Vec::new();
+    for file in files
+        .iter()
+        .filter(|path| path.file_name() == Some(OsStr::new("rig.json")))
+    {
+        let content = fs::read_to_string(file).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", file.display())))
+        })?;
+        let Ok(rig) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        let package_root = package_root_for_rig(root, file);
+        let rel = display_relative(root, file);
+        failures.extend(fuzz_workload_failures(
+            root,
+            &package_root,
+            &rel,
+            &rig,
+            &fuzz_workloads,
+        ));
+        failures.extend(profile_reference_failures(
+            &rel,
+            &rig,
+            "fuzz_workloads",
+            "fuzz_profiles",
+        ));
+        failures.extend(bench_reference_failures(
+            &rel,
+            &rig,
+            &fuzz_workloads,
+            &package_root,
+        ));
+    }
+    Ok(failures)
+}
+
+fn collect_fuzz_workloads(
+    root: &Path,
+    files: &[PathBuf],
+) -> Result<BTreeMap<PathBuf, BTreeMap<String, PathBuf>>> {
+    let mut workloads: BTreeMap<PathBuf, BTreeMap<String, PathBuf>> = BTreeMap::new();
+    for file in files
+        .iter()
+        .filter(|path| path.extension() == Some(OsStr::new("json")))
+    {
+        let Some(package_root) = package_root_for_fuzz_workload(root, file) else {
+            continue;
+        };
+        let content = fs::read_to_string(file).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", file.display())))
+        })?;
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        if value.get("schema").and_then(|schema| schema.as_str())
+            != Some("homeboy/fuzz-workload/v1")
+        {
+            continue;
+        }
+        let ids = workload_ids(file, &value);
+        let package_workloads = workloads.entry(package_root).or_default();
+        for id in ids {
+            package_workloads.insert(id, file.clone());
+        }
+    }
+    Ok(workloads)
+}
+
+fn workload_ids(file: &Path, workload: &serde_json::Value) -> BTreeSet<String> {
+    let mut ids = BTreeSet::from([workload_id_from_path(file)]);
+    if let Some(id) = workload.get("id").and_then(|value| value.as_str()) {
+        if !id.trim().is_empty() {
+            ids.insert(id.to_string());
+        }
+    }
+    ids
+}
+
+fn fuzz_workload_failures(
+    root: &Path,
+    package_root: &Path,
+    rel: &str,
+    rig: &serde_json::Value,
+    fuzz_workloads: &BTreeMap<PathBuf, BTreeMap<String, PathBuf>>,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    let package_workloads = fuzz_workloads
+        .get(package_root)
+        .cloned()
+        .unwrap_or_default();
+    let mut rig_workload_ids = BTreeSet::new();
+    let Some(workloads) = rig.get("fuzz_workloads") else {
+        return failures;
+    };
+    let Some(workloads) = workloads.as_object() else {
+        failures.push(format!("{rel}: fuzz_workloads must be an object"));
+        return failures;
+    };
+    for (runner, declarations) in workloads {
+        let Some(declarations) = declarations.as_array() else {
+            failures.push(format!(
+                "{rel}: fuzz_workloads {runner} must be an array of workload declarations"
+            ));
+            continue;
+        };
+        for declaration in declarations {
+            let declaration_path = declaration
+                .as_str()
+                .or_else(|| declaration.get("path").and_then(|value| value.as_str()));
+            let Some(resolved) =
+                declaration_path.and_then(|path| resolve_package_path(path, package_root))
+            else {
+                failures.push(format!(
+                    "{rel}: fuzz_workloads {runner} declaration must use a resolvable path"
+                ));
+                continue;
+            };
+            if !resolved.exists() {
+                failures.push(format!(
+                    "{rel}: fuzz_workloads {runner} declares missing file {}",
+                    display_relative(root, &resolved)
+                ));
+                continue;
+            }
+            let workload_id = workload_id_from_path(&resolved);
+            if package_workloads.get(&workload_id) != Some(&resolved) {
+                failures.push(format!(
+                    "{rel}: fuzz_workloads {runner} declares {}, but fuzz workload id {workload_id} is not unique within this package",
+                    display_relative(root, &resolved)
+                ));
+            }
+            if !rig_workload_ids.insert(workload_id.clone()) {
+                failures.push(format!(
+                    "{rel}: fuzz workload id {workload_id} is declared more than once in this rig"
+                ));
+            }
+        }
+    }
+    failures
+}
+
+fn profile_reference_failures(
+    rel: &str,
+    rig: &serde_json::Value,
+    workloads_key: &str,
+    profiles_key: &str,
+) -> Vec<String> {
+    let declared = declared_workload_ids(rig, workloads_key);
+    let mut failures = Vec::new();
+    let Some(profiles) = rig.get(profiles_key) else {
+        return failures;
+    };
+    let Some(profiles) = profiles.as_object() else {
+        failures.push(format!("{rel}: {profiles_key} must be an object"));
+        return failures;
+    };
+    for (profile, refs) in profiles {
+        let Some(refs) = refs.as_array() else {
+            failures.push(format!(
+                "{rel}: {} profile {profile} must be an array of workload ids",
+                profiles_key.trim_end_matches('s')
+            ));
+            continue;
+        };
+        for workload_ref in refs.iter().filter_map(|value| value.as_str()) {
+            if !declared.contains(workload_ref) {
+                failures.push(format!(
+                    "{rel}: {} profile {profile} references {workload_ref}, but {workloads_key} does not declare a matching workload file",
+                    profiles_key.trim_end_matches('s')
+                ));
+            }
+        }
+    }
+    failures
+}
+
+fn bench_reference_failures(
+    rel: &str,
+    rig: &serde_json::Value,
+    fuzz_workloads: &BTreeMap<PathBuf, BTreeMap<String, PathBuf>>,
+    package_root: &Path,
+) -> Vec<String> {
+    let mut failures = profile_reference_failures(rel, rig, "bench_workloads", "bench_profiles");
+    let fuzz_ids: BTreeSet<String> = fuzz_workloads
+        .get(package_root)
+        .map(|workloads| workloads.keys().cloned().collect())
+        .unwrap_or_default();
+    for workload_id in declared_workload_ids(rig, "bench_workloads") {
+        if fuzz_ids.contains(&workload_id) {
+            failures.push(format!(
+                "{rel}: bench_workloads declares {workload_id}, but that id belongs to a fuzz workload in this package"
+            ));
+        }
+    }
+    failures
+}
+
+fn declared_workload_ids(rig: &serde_json::Value, key: &str) -> BTreeSet<String> {
+    let mut ids = BTreeSet::new();
+    let Some(workloads) = rig.get(key).and_then(|value| value.as_object()) else {
+        return ids;
+    };
+    for declarations in workloads.values().filter_map(|value| value.as_array()) {
+        for declaration in declarations {
+            let path = declaration
+                .as_str()
+                .or_else(|| declaration.get("path").and_then(|value| value.as_str()));
+            if let Some(path) = path {
+                ids.insert(workload_id_from_path(Path::new(path)));
+            }
+        }
+    }
+    ids
+}
+
+fn package_root_for_rig(root: &Path, file: &Path) -> PathBuf {
+    let rel = file.strip_prefix(root).unwrap_or(file);
+    let parts: Vec<_> = rel.components().collect();
+    for index in 0..parts.len() {
+        if parts[index].as_os_str() == OsStr::new("rigs") {
+            return parts[..index]
+                .iter()
+                .fold(root.to_path_buf(), |path, part| path.join(part));
+        }
+    }
+    file.parent().unwrap_or(root).to_path_buf()
+}
+
+fn package_root_for_fuzz_workload(root: &Path, file: &Path) -> Option<PathBuf> {
+    let rel = file.strip_prefix(root).unwrap_or(file);
+    let parts: Vec<_> = rel.components().collect();
+    for index in 0..parts.len() {
+        if parts[index].as_os_str() == OsStr::new("fuzz") {
+            return Some(
+                parts[..index]
+                    .iter()
+                    .fold(root.to_path_buf(), |path, part| path.join(part)),
+            );
+        }
+    }
+    None
+}
+
+fn resolve_package_path(path: &str, package_root: &Path) -> Option<PathBuf> {
+    if path.trim().is_empty() {
+        return None;
+    }
+    let expanded = path.replace("${package.root}", &package_root.to_string_lossy());
+    if expanded.contains("${") {
+        return None;
+    }
+    let path = PathBuf::from(expanded);
+    Some(if path.is_absolute() {
+        path
+    } else {
+        package_root.join(path)
+    })
+}
+
+fn workload_id_from_path(path: &Path) -> String {
+    let mut name = path
+        .file_name()
+        .and_then(OsStr::to_str)
+        .unwrap_or_default()
+        .to_string();
+    for suffix in [
+        ".workload.json",
+        ".bench.mjs",
+        ".php",
+        ".mjs",
+        ".js",
+        ".json",
+    ] {
+        if let Some(stripped) = name.strip_suffix(suffix) {
+            name = stripped.to_string();
+            break;
+        }
+    }
+    name
+}
+
 fn aggregate_step(kind: &str, label: &str, failures: Vec<String>) -> PipelineStepOutcome {
     if failures.is_empty() {
         return PipelineStepOutcome {
@@ -301,5 +675,70 @@ mod tests {
             .as_ref()
             .expect("contract error")
             .contains("dependency materialization"));
+    }
+
+    #[test]
+    fn package_lint_reports_portable_path_failures() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("portable");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "portable",
+                "shared_paths": [{"link":"shared","target":"shared"}],
+                "pipeline": {"check": [{"command": "ls ~/Developer/example"}]}
+            }"#,
+        )
+        .expect("write rig");
+
+        let outcome = run_package_lint_at(temp.path()).expect("lint package");
+        let portability_step = outcome
+            .steps
+            .iter()
+            .find(|step| step.label.contains("paths are portable"))
+            .expect("portability step");
+
+        assert_eq!(portability_step.status, "fail");
+        let error = portability_step.error.as_ref().expect("error");
+        assert!(error.contains("~/Developer"));
+        assert!(error.contains("shared_paths[0]"));
+    }
+
+    #[test]
+    fn package_lint_reports_profile_reference_failures() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("profiles");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "profiles",
+                "fuzz_workloads": {"node": ["fuzz/read.workload.json"]},
+                "fuzz_profiles": {"missing": ["write"]},
+                "bench_workloads": {"node": ["bench/read.bench.mjs"]},
+                "bench_profiles": {"missing": ["slow"]}
+            }"#,
+        )
+        .expect("write rig");
+        let fuzz_dir = temp.path().join("fuzz");
+        fs::create_dir_all(&fuzz_dir).expect("fuzz dir");
+        fs::write(
+            fuzz_dir.join("read.workload.json"),
+            r#"{"schema":"homeboy/fuzz-workload/v1","id":"read"}"#,
+        )
+        .expect("write workload");
+
+        let outcome = run_package_lint_at(temp.path()).expect("lint package");
+        let reference_step = outcome
+            .steps
+            .iter()
+            .find(|step| step.label.contains("profiles reference declared workloads"))
+            .expect("reference step");
+
+        assert_eq!(reference_step.status, "fail");
+        let error = reference_step.error.as_ref().expect("error");
+        assert!(error.contains("fuzz_profile profile missing references write"));
+        assert!(error.contains("bench_profile profile missing references slow"));
     }
 }

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -87,6 +87,35 @@ fn extension_dev_run_command_parses() {
 }
 
 #[test]
+fn rig_package_lint_and_fuzz_stable_plan_parse() {
+    Cli::try_parse_from(["homeboy", "rig", "package", "lint", "./fixtures"])
+        .expect("rig package lint should parse");
+
+    Cli::try_parse_from([
+        "homeboy",
+        "fuzz",
+        "stable",
+        "plan",
+        "--manifest",
+        "manifests/stable-workloads.json",
+        "--stable-id",
+        "api,checkout",
+        "--runner",
+        "lab",
+        "--artifact-root",
+        "artifacts",
+        "--run-id-prefix",
+        "stable-demo",
+        "--tracker-ref",
+        "issue:123",
+        "--detach-after-handoff",
+        "--component",
+        "component-a",
+    ])
+    .expect("fuzz stable plan should parse");
+}
+
+#[test]
 fn agent_task_dispatch_is_not_public_cli_surface() {
     let surface = current_command_surface();
 


### PR DESCRIPTION
## Summary
- Add generic `homeboy rig package lint`.
- Add generic `homeboy fuzz stable plan`.
- Move portable path, shared path, cleanup/profile, and stable Lab planning primitives upstream.

## Tests
- cargo test stable_plan_resolves_rig_and_builds_lab_commands
- cargo test package_lint_reports_portable_path_failures
- cargo test package_lint_reports_profile_reference_failures
- cargo test --test command_surface_test rig_package_lint_and_fuzz_stable_plan_parse

## Dependencies
- Enables Homeboy Rigs to delete generic lint/planning code after adoption.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Promoted generic Rigs validation/planning primitives into Homeboy.