### PR TITLE
Fail closed for controller secret resolution

### DIFF
--- a/src/core/runner/execution/secrets.rs
+++ b/src/core/runner/execution/secrets.rs
@@ -286,37 +286,60 @@ pub(super) fn resolve_controller_secret_env_for_command(
     required_names: &[String],
     env: &HashMap<String, String>,
 ) -> Result<HashMap<String, String>> {
-    let mut resolved = HashMap::new();
-    let fallback_sources = provider_secret_sources_for_discovered_providers();
+    resolve_controller_secret_env_for_command_with_fallbacks(
+        secret_env,
+        required_names,
+        env,
+        &provider_secret_sources_for_discovered_providers(),
+    )
+}
+
+pub(super) fn resolve_controller_secret_env_for_command_with_fallbacks(
+    secret_env: &HashMap<String, server::RunnerSecretEnvRef>,
+    required_names: &[String],
+    env: &HashMap<String, String>,
+    fallback_sources: &HashMap<String, crate::core::defaults::AgentTaskSecretSource>,
+) -> Result<HashMap<String, String>> {
+    let mut controller_secret_env = HashMap::new();
+    let mut controller_required_names = Vec::new();
     for name in required_names {
         if env.contains_key(name.as_str()) {
             continue;
         }
         let Some(source) = secret_env.get(name.as_str()) else {
+            controller_required_names.push(name.clone());
             continue;
         };
-        if source
-            .secret
-            .as_deref()
-            .is_some_and(|value| !value.trim().is_empty())
-        {
-            resolved.extend(resolve_runner_secret_env(&HashMap::from([(
-                name.clone(),
-                source.clone(),
-            )]))?);
+        if is_runner_deferred_secret_env_ref(source) {
             continue;
         }
-
-        if fallback_sources.contains_key(name) {
-            if let Ok(values) = agent_task_secrets::resolve_secret_env_with_fallbacks(
-                std::slice::from_ref(name),
-                &fallback_sources,
-            ) {
-                resolved.extend(values);
-            }
-        }
+        controller_required_names.push(name.clone());
+        controller_secret_env.insert(name.clone(), source.clone());
     }
-    Ok(resolved)
+
+    resolve_runner_secret_env_for_command_with_fallbacks(
+        &controller_secret_env,
+        &controller_required_names,
+        env,
+        fallback_sources,
+    )
+}
+
+fn is_runner_deferred_secret_env_ref(source: &server::RunnerSecretEnvRef) -> bool {
+    let has_env = source
+        .env
+        .as_ref()
+        .is_some_and(|value| !value.trim().is_empty());
+    let has_file = source
+        .file
+        .as_ref()
+        .is_some_and(|value| !value.trim().is_empty());
+    let has_secret = source
+        .secret
+        .as_ref()
+        .is_some_and(|value| !value.trim().is_empty());
+
+    (has_env || has_file) && !has_secret && has_env != has_file
 }
 
 #[cfg(test)]

--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -114,6 +114,43 @@ fn remote_daemon_secret_env_refs_forward_controller_secrets_and_keep_runner_refs
 }
 
 #[test]
+fn remote_daemon_secret_env_refs_require_missing_controller_refs() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+
+        let mut runner = ssh_runner();
+        runner.workspace_root = Some(workspace.display().to_string());
+
+        let err = prepare_runner_process(RunnerProcessRequest {
+            runner_id: "lab".to_string(),
+            runner: Some(runner),
+            cwd: Some(workspace.display().to_string()),
+            project_id: None,
+            command: vec!["true".to_string()],
+            env: Default::default(),
+            secret_env_names: vec!["MISSING_CONTROLLER_SECRET".to_string()],
+            secret_env_plan: None,
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: Some(SourceSnapshot::existing_remote(
+                "lab",
+                &workspace.display().to_string(),
+                Some(&workspace.display().to_string()),
+            )),
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: false,
+        })
+        .expect_err("missing controller secret ref should fail during controller prep");
+
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.details["field"], "secret_env");
+        assert!(err.message.contains("MISSING_CONTROLLER_SECRET"));
+    });
+}
+
+#[test]
 fn daemon_read_only_runner_exec_ignores_unrelated_missing_secret_env_refs() {
     crate::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/src/core/runner/execution/tests/secret_source.rs
+++ b/src/core/runner/execution/tests/secret_source.rs
@@ -161,6 +161,59 @@ fn runner_secret_env_resolution_uses_provider_json_file_source_values() {
 }
 
 #[test]
+fn controller_secret_env_resolution_errors_when_required_name_has_no_ref() {
+    let err = resolve_controller_secret_env_for_command_with_fallbacks(
+        &HashMap::new(),
+        &["MISSING_CONTROLLER_SECRET".to_string()],
+        &HashMap::new(),
+        &HashMap::new(),
+    )
+    .expect_err("missing controller secret ref should fail closed");
+
+    assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+    assert_eq!(err.details["field"], "secret_env");
+    assert!(err.message.contains("MISSING_CONTROLLER_SECRET"));
+    assert!(err
+        .message
+        .contains("missing runner secret env ref for MISSING_CONTROLLER_SECRET"));
+}
+
+#[test]
+fn controller_secret_env_resolution_uses_fallback_sources() {
+    crate::test_support::with_isolated_home(|home| {
+        let provider_dir = home.path().join(".provider");
+        std::fs::create_dir_all(&provider_dir).expect("provider dir");
+        std::fs::write(
+            provider_dir.join("auth.json"),
+            serde_json::json!({
+                "tokens": {
+                    "access_token": "controller-access-secret"
+                }
+            })
+            .to_string(),
+        )
+        .expect("auth json");
+        let sources = HashMap::from([(
+            "PROVIDER_ACCESS_TOKEN".to_string(),
+            json_file_source("~/.provider/auth.json", "tokens.access_token"),
+        )]);
+
+        let resolved = resolve_controller_secret_env_for_command_with_fallbacks(
+            &HashMap::new(),
+            &["PROVIDER_ACCESS_TOKEN".to_string()],
+            &HashMap::new(),
+            &sources,
+        )
+        .expect("controller fallback source resolves");
+
+        assert_eq!(
+            resolved.get("PROVIDER_ACCESS_TOKEN"),
+            Some(&"controller-access-secret".to_string())
+        );
+    });
+}
+
+#[test]
 fn runner_secret_env_resolution_accepts_secret_env_plan_names() {
     std::env::set_var("HOMEBOY_PLAN_SECRET_ENV_TEST", "plan-secret-value");
     let plan = crate::core::secret_env_plan::SecretEnvPlan::from_secret_env_names([


### PR DESCRIPTION
## Summary
- Route controller secret resolution through the canonical resolver.
- Preserve explicit runner-deferred refs while erroring on missing/unresolved required controller secrets.
- Add tests for missing refs and fallback sources.

## Verification
- rustfmt --check src/core/runner/execution/secrets.rs src/core/runner/execution/tests/secret_source.rs src/core/runner/execution/tests/exec.rs
- cargo test core::runner::execution::tests::secret_source
- cargo test core::runner::execution::tests::exec

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, and verification orchestration