### PR TITLE
Register artifact-postprocess in command docs

### DIFF
--- a/docs/commands/artifact-postprocess.md
+++ b/docs/commands/artifact-postprocess.md
@@ -1,0 +1,38 @@
+# `homeboy artifact-postprocess`
+
+Run a generic artifact postprocess plan over persisted artifact roots.
+
+## Synopsis
+
+```sh
+homeboy artifact-postprocess [OPTIONS] <PLAN>
+```
+
+## Arguments
+
+- `<PLAN>` - artifact postprocess plan JSON file, `@file` spec, or `-` for stdin.
+
+## Options
+
+- `--artifact-root-id <ID>` - artifact root id from the plan to use as `HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT`.
+- `--input-root-id <ID>` - optional artifact root id from the plan to expose as `${run.input}`.
+- `--result <PATH>` - write the bare artifact-postprocess result contract to this path.
+
+Global options such as `--output <PATH>` are also accepted.
+
+## Output
+
+The command returns the standard Homeboy JSON envelope. The payload includes the
+selected plan file, selected artifact root ids, optional result file, and the
+`homeboy/artifact-postprocess-result/v1` result contract.
+
+When `--result` is provided, Homeboy writes the bare result contract to that path
+in addition to the normal command envelope.
+
+## Contract
+
+`artifact-postprocess` consumes the generic
+`homeboy/artifact-postprocess/v1` plan contract. Plans declare persisted artifact
+roots and helper-driven actions without product-specific semantics.
+
+See [artifact postprocess runner contract](../architecture/artifact-postprocess-runner-contract.md).

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -2,6 +2,7 @@
 
 - [api](api.md)
 - [agent-task](agent-task.md)
+- [artifact-postprocess](artifact-postprocess.md) — generic helper-driven postprocessing for persisted artifact roots
 - [audit](audit.md) — code convention drift and structural analysis
 - [audit-baseline](audit-baseline.md) — deterministic audit baseline refresh workflow
 - [auth](auth.md)

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -160,13 +160,6 @@ const fn command_spec_with_output_notes(
     }
 }
 
-const fn command_spec_without_docs(spec: CommandSpec) -> CommandSpec {
-    CommandSpec {
-        docs_slug: None,
-        ..spec
-    }
-}
-
 const fn lab_command_spec_with_output_notes(
     name: &'static str,
     json_family: CommandJsonFamily,
@@ -529,12 +522,10 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         CommandJsonFamily::Workspace,
         "lists, shows, exports constants, exports schemas, validates, and normalizes Homeboy-owned contract metadata through the central contract surface",
     ),
-    command_spec_without_docs(
-        command_spec_with_output_notes(
-            "artifact-postprocess",
-            CommandJsonFamily::Workspace,
-            "runs a Homeboy artifact-postprocess plan over declared persisted artifact roots and emits the artifact-postprocess result contract",
-        ),
+    command_spec_with_output_notes(
+        "artifact-postprocess",
+        CommandJsonFamily::Workspace,
+        "runs a Homeboy artifact-postprocess plan over declared persisted artifact roots and emits the artifact-postprocess result contract",
     ),
     command_spec("daemon", CommandJsonFamily::Ops),
     command_spec_with_representative_argv(

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -11,6 +11,7 @@ fn command_surface_tracks_representative_live_paths() {
     let surface = current_command_surface();
 
     assert!(surface.contains_path(&["audit"]));
+    assert!(surface.contains_path(&["artifact-postprocess"]));
     assert!(surface.contains_path(&["manifest"]));
     assert!(surface.contains_path(&["report"]));
     assert!(surface.contains_path(&["git", "status"]));


### PR DESCRIPTION
## Summary
- Register artifact-postprocess with normal command docs metadata.
- Add command docs and index entry.
- Add command-surface regression coverage.

## Verification
- cargo test --test command_surface_test
- cargo test command_registry
- cargo test core_command_docs_do_not_drift_from_registry
- cargo run --quiet -- self doctor

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, and verification orchestration