### PR TITLE
Reject packaged Cargo source for self cleanup

### DIFF
--- a/src/core/cleanup.rs
+++ b/src/core/cleanup.rs
@@ -919,7 +919,7 @@ mod tests {
     }
 
     #[test]
-    fn self_artifact_manifest_resolves_homeboy_crate() {
+    fn self_artifact_manifest_rejects_packaged_cargo_registry_source() {
         let tmp = TempDir::new().expect("tempdir");
         fs::write(
             tmp.path().join("Cargo.toml"),
@@ -927,9 +927,47 @@ mod tests {
         )
         .expect("write manifest");
 
+        let err = validate_homeboy_manifest_dir(tmp.path()).expect_err("reject packaged source");
+
+        assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
+        assert!(err.message.contains("is not a Homeboy source git checkout"));
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("requires a source checkout, not a packaged Cargo registry source")));
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("homeboy cleanup artifacts --path <PATH>")));
+    }
+
+    #[test]
+    fn self_artifact_manifest_resolves_homeboy_git_checkout() {
+        let tmp = TempDir::new().expect("tempdir");
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"homeboy\"\n",
+        )
+        .expect("write manifest");
+        init_git_repository(tmp.path());
+
         let root = validate_homeboy_manifest_dir(tmp.path()).expect("homeboy manifest");
 
         assert_eq!(root, tmp.path());
+    }
+
+    #[test]
+    fn self_artifact_registry_rejection_suggests_active_checkout_when_discoverable() {
+        let tmp = TempDir::new().expect("tempdir");
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"homeboy\"\n",
+        )
+        .expect("write manifest");
+
+        let err = validate_homeboy_manifest_dir(tmp.path()).expect_err("reject packaged source");
+
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("Active Homeboy checkout appears to be:")));
     }
 
     #[test]
@@ -1653,6 +1691,10 @@ mod tests {
             ],
         );
         repo
+    }
+
+    fn init_git_repository(path: &Path) {
+        git(path, &["init", "-b", "main"]);
     }
 
     fn config_with_provider(provider: WorktreeProviderConfig) -> HomeboyConfig {

--- a/src/core/cleanup/self_artifacts.rs
+++ b/src/core/cleanup/self_artifacts.rs
@@ -40,13 +40,7 @@ pub(super) fn validate_homeboy_manifest_dir(manifest_dir: &Path) -> Result<PathB
         ));
     }
 
-    let raw = fs::read_to_string(&cargo_toml).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("read {}", cargo_toml.display())),
-        )
-    })?;
-    if !raw.lines().any(|line| line.trim() == "name = \"homeboy\"") {
+    if !cargo_manifest_package_is_homeboy(&cargo_toml)? {
         return Err(Error::validation_invalid_argument(
             "self_artifacts",
             format!("{} is not the Homeboy crate manifest", cargo_toml.display()),
@@ -55,7 +49,59 @@ pub(super) fn validate_homeboy_manifest_dir(manifest_dir: &Path) -> Result<PathB
         ));
     }
 
+    if !is_git_checkout(manifest_dir) {
+        let mut error = Error::validation_invalid_argument(
+            "self_artifacts",
+            format!(
+                "{} is not a Homeboy source git checkout",
+                manifest_dir.display()
+            ),
+            None,
+            None,
+        )
+        .with_hint("`homeboy cleanup artifacts --self` requires a source checkout, not a packaged Cargo registry source.")
+        .with_hint("Pass an explicit checkout with `homeboy cleanup artifacts --path <PATH>`, or configure and run from a source checkout.");
+
+        if let Some(checkout) = discover_active_homeboy_checkout()? {
+            error = error.with_hint(format!(
+                "Active Homeboy checkout appears to be: {}; retry with `homeboy cleanup artifacts --path {}`.",
+                checkout.display(),
+                checkout.display()
+            ));
+        }
+
+        return Err(error);
+    }
+
     Ok(manifest_dir.to_path_buf())
+}
+
+fn is_git_checkout(path: &Path) -> bool {
+    git::run_git(
+        path,
+        &["rev-parse", "--is-inside-work-tree"],
+        "git checkout",
+    )
+    .map(|output| output.trim() == "true")
+    .unwrap_or(false)
+}
+
+fn discover_active_homeboy_checkout() -> Result<Option<PathBuf>> {
+    let Ok(current_dir) = std::env::current_dir() else {
+        return Ok(None);
+    };
+
+    for candidate in current_dir.ancestors() {
+        let manifest = candidate.join("Cargo.toml");
+        if manifest.is_file()
+            && is_git_checkout(candidate)
+            && cargo_manifest_package_is_homeboy(&manifest)?
+        {
+            return Ok(Some(candidate.to_path_buf()));
+        }
+    }
+
+    Ok(None)
 }
 
 pub(super) fn self_temp_artifact_candidates(


### PR DESCRIPTION
## Summary
- Reject `homeboy cleanup artifacts --self` when `CARGO_MANIFEST_DIR` points at a packaged Cargo source instead of a git checkout.
- Keep `--self` rooted in a real Homeboy source checkout, with guidance to pass `--path` or use/configure a source checkout.
- Add focused cleanup tests for registry-source rejection, git checkout resolution, and active-checkout guidance.

Fixes #7380.

## Verification
- `rustfmt --check src/core/cleanup.rs src/core/cleanup/self_artifacts.rs`
- `cargo test core::cleanup::tests::self_artifact --lib`
- `cargo test core::cleanup::tests --lib`
- `cargo check --lib`

## Notes
- `cargo fmt --check` reports unrelated pre-existing formatting diffs outside this PR's touched files.
- `cargo clippy --lib -- -D warnings` reports unrelated pre-existing repo-wide Clippy findings outside this PR's touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Implemented the source-checkout validation change, added focused tests, and ran verification commands under Chris's direction.
