### PR TITLE
Record rig resources in lifecycle index

### DIFF
--- a/src/core/resource_lifecycle_index.rs
+++ b/src/core/resource_lifecycle_index.rs
@@ -264,6 +264,22 @@ pub fn resource_lifecycle_index_from_artifacts(
 ) -> Result<Option<ResourceLifecycleIndex>> {
     let mut resources = Vec::new();
     for artifact in artifacts {
+        if let Some(value) = artifact.metadata_json.get("resource_lifecycle_index") {
+            let index: ResourceLifecycleIndex =
+                serde_json::from_value(value.clone()).map_err(|err| {
+                    Error::internal_json(
+                        err.to_string(),
+                        Some(format!(
+                            "parse resource lifecycle index metadata for artifact {}",
+                            artifact.id
+                        )),
+                    )
+                })?;
+            index.validate()?;
+            resources.extend(index.resources);
+            continue;
+        }
+
         let Some(value) = artifact.metadata_json.get("resource_lifecycle") else {
             continue;
         };
@@ -366,6 +382,39 @@ mod tests {
     #[test]
     fn validates_resource_lifecycle_index() {
         index().validate().unwrap();
+    }
+
+    #[test]
+    fn extracts_resource_lifecycle_index_artifact_metadata() {
+        let source = ResourceLifecycleIndex {
+            schema: RESOURCE_LIFECYCLE_INDEX_SCHEMA.to_string(),
+            resources: vec![record()],
+        };
+        let artifact = ArtifactRecord {
+            id: "artifact-1".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "resource_lifecycle_index".to_string(),
+            artifact_type: "file".to_string(),
+            path: "/tmp/index.json".to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: None,
+            metadata_json: serde_json::json!({
+                "resource_lifecycle_index": source,
+            }),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+
+        let index = resource_lifecycle_index_from_artifacts(&[artifact])
+            .expect("parse index metadata")
+            .expect("index present");
+
+        assert_eq!(index.resources.len(), 1);
+        assert_eq!(index.resources[0].kind, "workspace");
     }
 
     #[test]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -29,6 +29,7 @@ mod json_config;
 pub mod lease;
 pub mod lint;
 pub mod pipeline;
+pub mod resource_lifecycle;
 pub mod runner;
 pub mod service;
 pub mod source;
@@ -59,6 +60,9 @@ pub use lease::{
     ReleaseLeaseOutcome, RigRunLease, RIG_LEASE_TTL_ENV,
 };
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
+pub use resource_lifecycle::{
+    rig_resource_lifecycle_index, rig_resource_lifecycle_records, RigResourceLifecycleOptions,
+};
 pub use runner::{
     head_sha_and_branch, run_bench_prepare, run_check, run_check_groups, run_down,
     run_fuzz_prepare, run_lint, run_repair, run_status, run_up, snapshot_state, BenchPrepareReport,

--- a/src/core/rig/resource_lifecycle.rs
+++ b/src/core/rig/resource_lifecycle.rs
@@ -1,0 +1,130 @@
+use crate::core::resource_cleanup_intent::ResourceCleanupIntent;
+use crate::core::resource_lifecycle_index::{
+    ResourceCleanupPolicy, ResourceEvidenceRetention, ResourceLifecycleIndex,
+    ResourceLifecycleRecord, ResourceLifecycleResourceStatus, RESOURCE_LIFECYCLE_INDEX_SCHEMA,
+};
+
+use super::spec::RigResourcesSpec;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RigResourceLifecycleOptions {
+    pub owner: String,
+    pub run_id: String,
+    pub runner_id: Option<String>,
+    pub cleanup_intent: ResourceCleanupIntent,
+    pub status: ResourceLifecycleResourceStatus,
+}
+
+impl RigResourceLifecycleOptions {
+    pub fn new(run_id: impl Into<String>, status: ResourceLifecycleResourceStatus) -> Self {
+        Self {
+            owner: "homeboy.rig".to_string(),
+            run_id: run_id.into(),
+            runner_id: None,
+            cleanup_intent: ResourceCleanupIntent::DryRun,
+            status,
+        }
+    }
+}
+
+pub fn rig_resource_lifecycle_index(
+    rig_id: &str,
+    resources: &RigResourcesSpec,
+    options: RigResourceLifecycleOptions,
+) -> ResourceLifecycleIndex {
+    ResourceLifecycleIndex {
+        schema: RESOURCE_LIFECYCLE_INDEX_SCHEMA.to_string(),
+        resources: rig_resource_lifecycle_records(rig_id, resources, options),
+    }
+}
+
+pub fn rig_resource_lifecycle_records(
+    rig_id: &str,
+    resources: &RigResourcesSpec,
+    options: RigResourceLifecycleOptions,
+) -> Vec<ResourceLifecycleRecord> {
+    let mut records = Vec::new();
+
+    for token in &resources.exclusive {
+        records.push(record(
+            &options,
+            "rig_exclusive",
+            format!("rig://{rig_id}/exclusive/{token}"),
+        ));
+    }
+    for path in &resources.paths {
+        records.push(record(&options, "rig_path", path.clone()));
+    }
+    for port in &resources.ports {
+        records.push(record(
+            &options,
+            "rig_port",
+            format!("tcp://localhost:{port}"),
+        ));
+    }
+    for pattern in &resources.process_patterns {
+        records.push(record(
+            &options,
+            "rig_process_pattern",
+            format!("process-pattern:{pattern}"),
+        ));
+    }
+
+    records
+}
+
+fn record(
+    options: &RigResourceLifecycleOptions,
+    kind: &str,
+    path: String,
+) -> ResourceLifecycleRecord {
+    ResourceLifecycleRecord {
+        owner: options.owner.clone(),
+        run_id: options.run_id.clone(),
+        runner_id: options.runner_id.clone(),
+        path,
+        kind: kind.to_string(),
+        ttl: None,
+        cleanup_policy: ResourceCleanupPolicy::Manual,
+        evidence_retention: ResourceEvidenceRetention::Metadata,
+        cleanup_intent: options.cleanup_intent,
+        status: options.status,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_rig_resource_declarations_to_lifecycle_records() {
+        let resources = RigResourcesSpec {
+            exclusive: vec!["runtime".to_string()],
+            paths: vec!["/tmp/homeboy-rig".to_string()],
+            ports: vec![9981],
+            process_patterns: vec!["homeboy fixture".to_string()],
+        };
+
+        let index = rig_resource_lifecycle_index(
+            "fixture-rig",
+            &resources,
+            RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active),
+        );
+
+        index.validate().expect("contract-valid lifecycle index");
+        assert_eq!(index.resources.len(), 4);
+        assert_eq!(index.resources[0].owner, "homeboy.rig");
+        assert_eq!(
+            index.resources[0].path,
+            "rig://fixture-rig/exclusive/runtime"
+        );
+        assert_eq!(index.resources[1].kind, "rig_path");
+        assert_eq!(index.resources[1].path, "/tmp/homeboy-rig");
+        assert_eq!(index.resources[2].path, "tcp://localhost:9981");
+        assert_eq!(index.resources[3].path, "process-pattern:homeboy fixture");
+        assert_eq!(
+            index.resources[0].cleanup_policy,
+            ResourceCleanupPolicy::Manual
+        );
+    }
+}

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -5,6 +5,7 @@
 //! homeboy versions.
 
 use std::collections::{BTreeMap, HashMap};
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
@@ -20,6 +21,7 @@ use super::pipeline::{
     run_pipeline_with_settings, run_prepare_requirement_steps, PipelineOutcome,
     PipelineStepOutcome,
 };
+use super::resource_lifecycle::{rig_resource_lifecycle_index, RigResourceLifecycleOptions};
 use super::service::{self, ServiceStatus};
 use super::spec::{DependencyMaterializationOutputKind, RigSpec, ServiceKind, SymlinkSpec};
 use super::state::{
@@ -28,6 +30,9 @@ use super::state::{
 use crate::core::engine::command::run_in_optional;
 use crate::core::error::{Error, Result};
 use crate::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+use crate::core::resource_lifecycle_index::{
+    ResourceLifecycleIndex, ResourceLifecycleResourceStatus,
+};
 
 /// Report from `rig up`.
 #[derive(Debug, Clone, Serialize)]
@@ -921,6 +926,7 @@ impl RigRunObserver {
         let _ = observer
             .store
             .finish_run(&observer.run_id, status, Some(metadata));
+        observer.record_resource_lifecycle_index(rig, status, pipeline);
         artifact_index::for_completed_rig_run(
             &observer.store,
             rig,
@@ -928,6 +934,82 @@ impl RigRunObserver {
             status.as_str(),
             pipeline,
         )
+    }
+
+    fn record_resource_lifecycle_index(
+        &self,
+        rig: &RigSpec,
+        status: RunStatus,
+        pipeline: Option<&PipelineOutcome>,
+    ) {
+        let resources = match self.command.as_str() {
+            "up" if status == RunStatus::Pass => super::expand::expand_resources(rig),
+            "up" => super::expand::expand_resources(rig),
+            "check" => super::expand::expand_resources(rig),
+            "down" => RigState::load(&rig.id)
+                .ok()
+                .and_then(|state| {
+                    state
+                        .materialized
+                        .map(|materialized| materialized.resources)
+                })
+                .unwrap_or_else(|| super::expand::expand_resources(rig)),
+            _ => return,
+        };
+        if resources.is_empty() {
+            return;
+        }
+
+        let lifecycle_status = match self.command.as_str() {
+            "up" if status == RunStatus::Pass => ResourceLifecycleResourceStatus::Active,
+            "up" => ResourceLifecycleResourceStatus::Failed,
+            "check" => ResourceLifecycleResourceStatus::Declared,
+            "down" if status == RunStatus::Pass => ResourceLifecycleResourceStatus::Cleaned,
+            "down" => ResourceLifecycleResourceStatus::CleanupPending,
+            _ => return,
+        };
+        let index = rig_resource_lifecycle_index(
+            &rig.id,
+            &resources,
+            RigResourceLifecycleOptions::new(&self.run_id, lifecycle_status),
+        );
+        if index.resources.is_empty() || index.validate().is_err() {
+            return;
+        }
+
+        let _ = self.write_resource_lifecycle_index_artifact(&index, pipeline);
+    }
+
+    fn write_resource_lifecycle_index_artifact(
+        &self,
+        index: &ResourceLifecycleIndex,
+        pipeline: Option<&PipelineOutcome>,
+    ) -> Result<()> {
+        let path = std::env::temp_dir().join(format!(
+            "homeboy-rig-resource-lifecycle-{}-{}.json",
+            self.run_id,
+            std::process::id()
+        ));
+        let json = serde_json::to_vec_pretty(index).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize rig resource lifecycle index".to_string()),
+            )
+        })?;
+        fs::write(&path, json).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("write {}", path.display())))
+        })?;
+        let record = self.store.record_artifact_with_metadata(
+            &self.run_id,
+            "rig_resource_lifecycle_index",
+            &path,
+            serde_json::json!({
+                "resource_lifecycle_index": index,
+                "pipeline": pipeline,
+            }),
+        );
+        let _ = fs::remove_file(path);
+        record.map(|_| ())
     }
 }
 

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -5,8 +5,11 @@ use std::process::Command;
 
 use crate::core::observation::{ObservationStore, RunListFilter};
 use crate::core::paths;
+use crate::core::resource_lifecycle_index::{
+    resource_lifecycle_index_from_artifacts, ResourceLifecycleResourceStatus,
+};
 use crate::core::rig::runner::{run_check, run_up};
-use crate::core::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
+use crate::core::rig::spec::{ComponentSpec, PipelineStep, RigResourcesSpec, RigSpec};
 use crate::core::rig::{RigSourceMetadata, RigState};
 use crate::test_support::with_isolated_home;
 
@@ -197,6 +200,12 @@ fn test_run_up_persists_step_order_source_and_component_snapshot() {
         let sha = git_output(&repo, &["rev-parse", "HEAD"]);
 
         let mut rig = observation_spec("observed-up");
+        rig.resources = RigResourcesSpec {
+            exclusive: vec!["observed-runtime".to_string()],
+            paths: vec![repo.to_string_lossy().to_string()],
+            ports: vec![9981],
+            process_patterns: Vec::new(),
+        };
         rig.components.insert(
             "component".to_string(),
             ComponentSpec {
@@ -265,6 +274,24 @@ fn test_run_up_persists_step_order_source_and_component_snapshot() {
             metadata["state"]["materialized"]["components"]["component"]["sha"],
             sha
         );
+
+        let artifacts = ObservationStore::open_initialized()
+            .expect("store")
+            .list_artifacts(&runs[0].id)
+            .expect("list artifacts");
+        let resource_index = resource_lifecycle_index_from_artifacts(&artifacts)
+            .expect("resource lifecycle index parses")
+            .expect("rig lifecycle index artifact exists");
+        assert_eq!(resource_index.resources.len(), 3);
+        assert!(resource_index.resources.iter().any(|record| {
+            record.kind == "rig_exclusive"
+                && record.path == "rig://observed-up/exclusive/observed-runtime"
+                && record.status == ResourceLifecycleResourceStatus::Active
+        }));
+        assert!(resource_index
+            .resources
+            .iter()
+            .any(|record| record.kind == "rig_path" && record.path == repo.to_string_lossy()));
     });
 }
 


### PR DESCRIPTION
## Summary
- Add rig resource lifecycle helpers for converting rig resource declarations into `ResourceLifecycleRecord`s.
- Persist `rig_resource_lifecycle_index` artifacts from rig `up`, `check`, and `down` observations.
- Teach lifecycle index loading to consume full resource lifecycle index artifacts.

## Verification
- `cargo test resource_lifecycle_index`
- `cargo test converts_rig_resource_declarations_to_lifecycle_records`
- `cargo test runner_observation_test`
- `cargo test runner_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigation, refactor implementation, test updates, and verification orchestration.