### PR TITLE
Fix rig check stderr handling evidence

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -812,10 +812,33 @@ fn run_rig_workload_preflight(
         return Err(homeboy::core::Error::rig_pipeline_failed(
             &spec.id,
             "check",
-            "rig check failed; refusing to run bench against an unhealthy rig",
+            format!(
+                "rig check failed; refusing to run bench against an unhealthy rig. Failed check steps: {}",
+                failed_check_step_summary(&check.pipeline),
+            ),
         ));
     }
     Ok(())
+}
+
+fn failed_check_step_summary(pipeline: &rig::PipelineOutcome) -> String {
+    let failures = pipeline
+        .steps
+        .iter()
+        .filter(|step| step.status == "fail")
+        .map(|step| match step.error.as_deref() {
+            Some(error) if !error.trim().is_empty() => {
+                format!("{} [{}]: {}", step.label, step.kind, error)
+            }
+            _ => format!("{} [{}]", step.label, step.kind),
+        })
+        .collect::<Vec<_>>();
+
+    if failures.is_empty() {
+        "<no failed check step evidence recorded>".to_string()
+    } else {
+        failures.join("; ")
+    }
 }
 
 #[cfg(test)]
@@ -1024,6 +1047,49 @@ mod tests {
             .is_err());
 
             assert!(run_rig_workload_preflight(&rig_spec, None, &[]).is_err());
+        });
+    }
+
+    #[test]
+    fn rig_bench_preflight_failure_includes_check_command_evidence() {
+        with_isolated_home(|_| {
+            let rig_spec: RigSpec = serde_json::from_str(
+                r#"{
+                    "id": "static-site-importer-fixture-matrix",
+                    "pipeline": {
+                        "check": [
+                            {
+                                "kind": "check",
+                                "label": "fixture matrix tests",
+                                "command": "printf 'tests 100\\npass 99\\n' && printf '[fixture-matrix] real failure\\n' >&2; exit 7"
+                            }
+                        ]
+                    }
+                }"#,
+            )
+            .expect("parse rig spec");
+
+            let err = run_rig_workload_preflight(&rig_spec, None, &[])
+                .expect_err("failed check should abort bench preflight");
+            let message = err.to_string();
+
+            assert!(message.contains("fixture matrix tests"), "error: {message}");
+            assert!(message.contains("check"), "error: {message}");
+            assert!(
+                message.contains("Command `printf 'tests 100"),
+                "error: {message}"
+            );
+            assert!(
+                message.contains("exited 7 (expected 0)"),
+                "error: {message}"
+            );
+            assert!(message.contains("stdout:"), "error: {message}");
+            assert!(message.contains("tests 100"), "error: {message}");
+            assert!(message.contains("stderr:"), "error: {message}");
+            assert!(
+                message.contains("[fixture-matrix] real failure"),
+                "error: {message}"
+            );
         });
     }
 

--- a/src/core/rig/check.rs
+++ b/src/core/rig/check.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use super::expand::expand_vars;
 use super::service::discover_newest_for_spec;
 use super::spec::{CheckSpec, NewerThanSpec, RigSpec, TimeSource};
-use crate::core::error::{Error, Result};
+use crate::core::error::{CommandEvidence, Error, Result};
 use crate::core::http_probe;
 
 /// Run a check against the current rig state. Err on fail.
@@ -250,25 +250,41 @@ fn command_check(rig: &RigSpec, cmd: &str, expect_exit: i32) -> Result<()> {
 
     let actual = output.status.code().unwrap_or(-1);
     if actual != expect_exit {
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::validation_invalid_argument(
+        let problem = format!(
+            "Command `{}` exited {} (expected {})\nstdout:\n{}\nstderr:\n{}",
+            resolved,
+            actual,
+            expect_exit,
+            stream_evidence(&stdout),
+            stream_evidence(&stderr),
+        );
+        return Err(Error::validation_invalid_argument_with_evidence(
             "check.command",
-            format!(
-                "Command `{}` exited {} (expected {}){}",
-                resolved,
-                actual,
-                expect_exit,
-                if stderr.trim().is_empty() {
-                    String::new()
-                } else {
-                    format!(": {}", stderr.trim())
-                }
-            ),
+            problem,
             None,
             None,
+            Some(CommandEvidence {
+                command: resolved,
+                cwd: None,
+                location: None,
+                exit_code: actual,
+                stdout,
+                stderr: stderr.to_string(),
+                truncated: false,
+            }),
         ));
     }
     Ok(())
+}
+
+fn stream_evidence(stream: &str) -> &str {
+    if stream.trim().is_empty() {
+        "<empty>"
+    } else {
+        stream.trim()
+    }
 }
 
 /// Mtime comparison: pass when `left > right` (left is newer).

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -243,6 +243,35 @@ fn test_run_check() {
 }
 
 #[test]
+fn test_run_check_command_stderr_with_zero_exit_passes() {
+    with_isolated_home(|_dir| {
+        let rig: RigSpec = serde_json::from_str(
+            r#"{
+                "id": "check-stderr-success-fixture",
+                "pipeline": {
+                    "check": [
+                        {
+                            "kind": "check",
+                            "label": "warning-only command",
+                            "command": "printf 'fixture warning\\n' >&2; exit 0"
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .expect("parse rig");
+
+        let report = run_check(&rig).expect("run_check succeeds");
+
+        assert!(report.success, "stderr alone must not fail a check");
+        assert_eq!(report.pipeline.failed, 0);
+        assert!(report.pipeline.steps.iter().any(|step| {
+            step.label == "warning-only command" && step.status == "pass" && step.error.is_none()
+        }));
+    });
+}
+
+#[test]
 fn test_run_check_includes_declarative_requirements() {
     with_isolated_home(|dir| {
         let marker = dir.path().join("marker.txt");


### PR DESCRIPTION
## Summary
- Preserve exit-status-based rig check behavior when commands write stderr.
- Surface failed check labels, command, exit status, stdout, and stderr in bench preflight failures.
- Add regression coverage for stderr-on-success and failure evidence.

Fixes #7395

## Tests
- `cargo test test_run_check_command_stderr_with_zero_exit_passes`
- `cargo test rig_bench_preflight_failure_includes_check_command_evidence`
- `cargo test core::rig::check`
- `cargo test commands::bench::matrix::tests::rig_bench_preflight`
- `cargo test core::rig::runner::runner_test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigated the rig check/bench preflight path, implemented the fix, and added focused regression tests.