### PR TITLE
Load test settings from JSON profile files

### DIFF
--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -27,6 +27,8 @@ The `test` command resolves the component's linked extension with `test` capabil
 - `--drift`: Cross-reference production changes with test files
 - `--write`: Write fixes to disk for workflows that support it
 - `--since <REF>`: Git ref for drift detection (default `HEAD~10`)
+- `--settings-json-file <FILE>`: Load typed setting overrides from a JSON object file; repeatable
+- `--settings-profile <FILE>`: Alias for `--settings-json-file`
 - `--setting <key=value>`: Override component settings (can be used multiple times)
 - `--setting-json <key=json>`: Override component settings with typed JSON values
 - `--path <PATH>`: Override component `local_path` for this run
@@ -49,6 +51,9 @@ homeboy test my-component --skip-lint
 
 # Test with multiple setting overrides
 homeboy test my-component --setting database_type=mysql --setting mysql_database=test_db
+
+# Load a reusable settings profile, then override one setting explicitly
+homeboy test my-component --settings-json-file ./test-settings.json --setting database_type=mysql
 
 # Reproduce an extension-declared CI test job through the test workflow
 homeboy test my-component --ci-job unit
@@ -80,7 +85,9 @@ For a component to be testable, it must have:
 
 ## Settings
 
-Settings are extension-defined. Use `--setting key=value` for string values and `--setting-json key=<json>` when the runner expects typed values such as objects, arrays, booleans, numbers, or null.
+Settings are extension-defined. Use `--settings-json-file <FILE>` or `--settings-profile <FILE>` to load a JSON object whose top-level keys are setting names. Use `--setting key=value` for explicit string values and `--setting-json key=<json>` when the runner expects typed values such as objects, arrays, booleans, numbers, or null.
+
+Merge order is extension defaults, component settings, settings profile files, explicit `--setting`, then explicit `--setting-json`. Later values win for the same key, so command-line overrides take precedence over profile files.
 
 ## Output
 

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1267,8 +1267,11 @@ mod extension_ids {
                 component_id: args.comp.component.clone(),
                 path_override: args.comp.path.clone(),
                 capability,
-                settings_overrides: args.setting_args.setting.clone(),
-                settings_json_overrides: args.setting_args.setting_json.clone(),
+                settings_profile_json_overrides: args
+                    .setting_args
+                    .settings_profile_json_overrides()?,
+                settings_overrides: args.setting_args.settings_overrides()?,
+                settings_json_overrides: args.setting_args.settings_json_overrides()?,
                 extension_overrides: args.extension_override.extensions.clone(),
             })
         };
@@ -1298,6 +1301,7 @@ mod extension_ids {
                 path_override: args.comp.path.clone(),
                 capability,
                 settings_overrides: Vec::new(),
+                settings_profile_json_overrides: Vec::new(),
                 settings_json_overrides: Vec::new(),
                 extension_overrides: args.extension_override.extensions.clone(),
             })

--- a/src/commands/bench/tests/settings_tests.rs
+++ b/src/commands/bench/tests/settings_tests.rs
@@ -4,6 +4,7 @@ use super::*;
 fn unknown_setting_key_warns_before_run() {
     let ctx = ctx_with_accepted_setting_keys(&["workflow_bench_env", "iterations"]);
     let setting_args = SettingArgs {
+        settings_json_file: Vec::new(),
         // `bench_env` is a typo for the declared `workflow_bench_env`.
         setting: vec![("bench_env.CORPUS".to_string(), "1000".to_string())],
         setting_json: Vec::new(),
@@ -29,6 +30,7 @@ fn unknown_setting_key_warns_before_run() {
 fn declared_setting_key_does_not_warn() {
     let ctx = ctx_with_accepted_setting_keys(&["workflow_bench_env"]);
     let setting_args = SettingArgs {
+        settings_json_file: Vec::new(),
         setting: vec![("workflow_bench_env.CORPUS".to_string(), "1000".to_string())],
         setting_json: Vec::new(),
     };
@@ -40,6 +42,7 @@ fn declared_setting_key_does_not_warn() {
 fn declared_rig_setting_key_does_not_warn_as_extension_unknown() {
     let ctx = ctx_with_accepted_setting_keys(&["workflow_bench_env"]);
     let setting_args = SettingArgs {
+        settings_json_file: Vec::new(),
         setting: vec![(
             "fixture_matrix_namespace".to_string(),
             "nightly".to_string(),
@@ -55,6 +58,7 @@ fn declared_rig_setting_key_does_not_warn_as_extension_unknown() {
 fn unknown_setting_still_warns_when_not_declared_by_extension_or_rig() {
     let ctx = ctx_with_accepted_setting_keys(&["workflow_bench_env"]);
     let setting_args = SettingArgs {
+        settings_json_file: Vec::new(),
         setting: vec![(
             "unexpected_fixture_input".to_string(),
             "nightly".to_string(),

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -403,6 +403,7 @@ fn run_list(args: CiListArgs, _global: &GlobalArgs) -> CmdResult<CiOutput> {
         path_override: args.comp.path.clone(),
         capability: None,
         settings_overrides: Vec::new(),
+        settings_profile_json_overrides: Vec::new(),
         settings_json_overrides: Vec::new(),
         extension_overrides: args.extension_override.extensions.clone(),
     })?;
@@ -436,6 +437,7 @@ fn run_ci(args: CiRunArgs, _global: &GlobalArgs) -> CmdResult<CiOutput> {
         path_override: args.comp.path.clone(),
         capability: None,
         settings_overrides: Vec::new(),
+        settings_profile_json_overrides: Vec::new(),
         settings_json_overrides: Vec::new(),
         extension_overrides: args.extension_override.extensions.clone(),
     })?;
@@ -471,6 +473,7 @@ fn run_autofix(args: CiAutofixArgs, _global: &GlobalArgs) -> CmdResult<CiOutput>
         path_override: args.comp.path.clone(),
         capability: None,
         settings_overrides: Vec::new(),
+        settings_profile_json_overrides: Vec::new(),
         settings_json_overrides: Vec::new(),
         extension_overrides: args.extension_override.extensions.clone(),
     })?;

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -11,6 +11,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             rig: Some("package-fuzz".to_string()),
             extension_override: ExtensionOverrideArgs { extensions: vec![] },
             setting_args: SettingArgs {
+                settings_json_file: vec![],
                 setting: vec![],
                 setting_json: vec![],
             },
@@ -1187,6 +1188,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             rig: Some("package-fuzz".to_string()),
             extension_override: ExtensionOverrideArgs { extensions: vec![] },
             setting_args: SettingArgs {
+                settings_json_file: vec![],
                 setting: vec![],
                 setting_json: vec![],
             },

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -303,6 +303,7 @@ fn fuzz_run_args_with_run_id(run_id: &str) -> FuzzRunArgs {
         rig: Some("package-fuzz".to_string()),
         extension_override: ExtensionOverrideArgs { extensions: vec![] },
         setting_args: SettingArgs {
+            settings_json_file: vec![],
             setting: vec![],
             setting_json: vec![],
         },

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -477,6 +477,7 @@ fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_cont
         rig: None,
         extension_override: ExtensionOverrideArgs { extensions: vec![] },
         setting_args: SettingArgs {
+            settings_json_file: vec![],
             setting: vec![],
             setting_json: vec![],
         },
@@ -654,6 +655,7 @@ fn fuzz_runner_env_expands_rig_workload_and_injects_runtime_context() {
         rig: Some("package-fuzz".to_string()),
         extension_override: ExtensionOverrideArgs { extensions: vec![] },
         setting_args: SettingArgs {
+            settings_json_file: vec![],
             setting: vec![],
             setting_json: vec![],
         },
@@ -781,6 +783,7 @@ fn fuzz_runner_env_stages_generic_workload_file_refs() {
         rig: Some("package-fuzz".to_string()),
         extension_override: ExtensionOverrideArgs { extensions: vec![] },
         setting_args: SettingArgs {
+            settings_json_file: vec![],
             setting: vec![],
             setting_json: vec![],
         },
@@ -919,6 +922,7 @@ fn fuzz_runner_env_stages_nested_generic_workload_json_file_refs() {
         rig: Some("package-fuzz".to_string()),
         extension_override: ExtensionOverrideArgs { extensions: vec![] },
         setting_args: SettingArgs {
+            settings_json_file: vec![],
             setting: vec![],
             setting_json: vec![],
         },

--- a/src/commands/fuzz/workloads.rs
+++ b/src/commands/fuzz/workloads.rs
@@ -244,6 +244,7 @@ mod tests {
         }))
         .expect("parse rig spec");
         let settings = SettingArgs {
+            settings_json_file: vec![],
             setting: vec![
                 (
                     "components.package.path".to_string(),

--- a/src/commands/infra/source_command.rs
+++ b/src/commands/infra/source_command.rs
@@ -15,8 +15,9 @@ pub(crate) fn resolve_source_context(
         component_id: comp.component.clone(),
         path_override: comp.path.clone(),
         capability,
-        settings_overrides: settings.setting.clone(),
-        settings_json_overrides: settings.setting_json.clone(),
+        settings_profile_json_overrides: settings.settings_profile_json_overrides()?,
+        settings_overrides: settings.settings_overrides()?,
+        settings_json_overrides: settings.settings_json_overrides()?,
         extension_overrides: extension_override.extensions.clone(),
     })
 }

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -174,7 +174,8 @@ impl<Args, Output: Serialize + ReviewArtifactFindings> ReviewStageDescriptor<Arg
     }
 }
 
-fn dispatch_review_plan_step( // homeboy-audit: allow-thin-command-adapter
+fn dispatch_review_plan_step(
+    // homeboy-audit: allow-thin-command-adapter
     step: &PlanStep,
     args: &ReviewArgs,
     global: &GlobalArgs,
@@ -304,8 +305,10 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
     let mut lint_stage = None;
     let mut test_stage = None;
 
-    let stage_run = match review::execute_review_plan_steps(&quality_plan.steps, |step| { // homeboy-audit: allow-thin-command-adapter
-        dispatch_review_plan_step(step, &args, global, &component_label, &review_context) // homeboy-audit: allow-thin-command-adapter
+    let stage_run = match review::execute_review_plan_steps(&quality_plan.steps, |step| {
+        // homeboy-audit: allow-thin-command-adapter
+        dispatch_review_plan_step(step, &args, global, &component_label, &review_context)
+        // homeboy-audit: allow-thin-command-adapter
     }) {
         Ok(run) => run,
         Err(error) => {
@@ -338,6 +341,7 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
                 path_override: args.comp.path.clone(),
                 capability: None,
                 settings_overrides: Vec::new(),
+                settings_profile_json_overrides: Vec::new(),
                 settings_json_overrides: Vec::new(),
                 extension_overrides: args.extension_override.extensions.clone(),
             })?;

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -1067,6 +1067,7 @@ mod tests {
             shared_state: Some(std::path::PathBuf::from("/tmp/homeboy-shared")),
             concurrency: 4,
             setting_args: SettingArgs {
+                settings_json_file: vec![],
                 setting: vec![("bench_env.CORPUS_SIZE".to_string(), "44".to_string())],
                 setting_json: vec![(
                     "artifact_env".to_string(),

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -118,8 +118,7 @@ impl TestArgs {
             && self.lab_changed_files_json.is_none()
             && self.ci_job.is_none()
             && cli_passthrough_args.is_empty()
-            && self.setting_args.setting.is_empty()
-            && self.setting_args.setting_json.is_empty()
+            && !self.setting_args.has_overrides()
             && !self.baseline_args.baseline
             && !self.baseline_args.ignore_baseline
             && !self.baseline_args.ratchet
@@ -563,6 +562,24 @@ mod tests {
     }
 
     #[test]
+    fn parses_settings_json_file_and_profile_alias() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "homeboy",
+            "--settings-json-file",
+            "base.json",
+            "--settings-profile",
+            "profile.json",
+        ])
+        .expect("test should parse settings file flags");
+
+        assert_eq!(
+            cli.test.setting_args.settings_json_file,
+            vec![PathBuf::from("base.json"), PathBuf::from("profile.json")]
+        );
+    }
+
+    #[test]
     fn self_check_dispatch_only_allows_unscoped_default_test() {
         let default = TestCli::try_parse_from(["test", "homeboy"])
             .expect("default test should parse")
@@ -576,6 +593,7 @@ mod tests {
             vec!["test", "homeboy", "--analyze"],
             vec!["test", "homeboy", "--changed-since", "origin/main"],
             vec!["test", "homeboy", "--setting", "runner=ci"],
+            vec!["test", "homeboy", "--settings-json-file", "profile.json"],
             vec!["test", "homeboy", "--baseline"],
             vec!["test", "homeboy", "--", "--filter=SmokeTest"],
         ] {
@@ -832,6 +850,18 @@ mod tests {
         let args = vec![
             "--setting".to_string(),
             "database_type=mysql".to_string(),
+            "--filter=SomeTest".to_string(),
+        ];
+        let result = filter_homeboy_flags(&args);
+        assert_eq!(result, vec!["--filter=SomeTest"]);
+    }
+
+    #[test]
+    fn filter_strips_settings_json_file_aliases() {
+        let args = vec![
+            "--settings-json-file".to_string(),
+            "base.json".to_string(),
+            "--settings-profile=profile.json".to_string(),
             "--filter=SomeTest".to_string(),
         ];
         let result = filter_homeboy_flags(&args);

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -139,6 +139,14 @@ fn command_flag_specs(command: &Command) -> Vec<CliFlagSpec> {
                     takes_value,
                 });
             }
+            if let Some(aliases) = arg.get_all_aliases() {
+                for alias in aliases {
+                    flags.push(CliFlagSpec {
+                        flag: format!("--{}", alias),
+                        takes_value,
+                    });
+                }
+            }
             if let Some(short) = arg.get_short() {
                 flags.push(CliFlagSpec {
                     flag: format!("-{}", short),
@@ -529,13 +537,19 @@ pub struct DryRunArgs {
 }
 
 // ============================================================================
-// SettingArgs: --setting key=value + --setting-json key=<json>
+// SettingArgs: --settings-json-file + --setting key=value + --setting-json key=<json>
 // ============================================================================
+
+use std::path::{Path, PathBuf};
 
 /// Settings overrides flattened into every command that runs an extension
 /// capability (test, bench, lint, build, validate).
 ///
-/// Two flags by design:
+/// Three inputs by design:
+///
+/// - `--settings-json-file <file>` / `--settings-profile <file>` (typed):
+///   read a JSON object and apply each top-level key as a typed setting value.
+///   These values sit below explicit CLI overrides.
 ///
 /// - `--setting key=value` (string-coerced): the original "set this string
 ///   override" path. Values are always strings, mirroring how operators
@@ -556,6 +570,18 @@ pub struct DryRunArgs {
 /// strictly more expressive and was specified later in the merge order).
 #[derive(Args, Debug, Clone, Default)]
 pub struct SettingArgs {
+    /// Load typed setting overrides from a JSON object file. Repeatable.
+    ///
+    /// Each top-level object key becomes a setting key. Values retain their
+    /// JSON type. Explicit --setting and --setting-json flags override file
+    /// values for the same key.
+    #[arg(
+        long = "settings-json-file",
+        alias = "settings-profile",
+        value_name = "FILE"
+    )]
+    pub settings_json_file: Vec<PathBuf>,
+
     /// String setting override. Repeatable.
     ///
     /// Format: `--setting key=value`. Use dotted keys such as
@@ -580,4 +606,129 @@ pub struct SettingArgs {
     ///   --setting-json my_flag=true
     #[arg(long = "setting-json", value_parser = crate::commands::parse_key_json)]
     pub setting_json: Vec<(String, serde_json::Value)>,
+}
+
+impl SettingArgs {
+    pub fn settings_overrides(&self) -> homeboy::core::Result<Vec<(String, String)>> {
+        Ok(self.setting.clone())
+    }
+
+    pub fn settings_profile_json_overrides(
+        &self,
+    ) -> homeboy::core::Result<Vec<(String, serde_json::Value)>> {
+        let mut settings = Vec::new();
+
+        for path in &self.settings_json_file {
+            settings.extend(read_settings_json_file(path)?);
+        }
+
+        Ok(settings)
+    }
+
+    pub fn settings_json_overrides(
+        &self,
+    ) -> homeboy::core::Result<Vec<(String, serde_json::Value)>> {
+        Ok(self.setting_json.clone())
+    }
+
+    pub fn has_overrides(&self) -> bool {
+        !self.settings_json_file.is_empty()
+            || !self.setting.is_empty()
+            || !self.setting_json.is_empty()
+    }
+}
+
+fn read_settings_json_file(path: &Path) -> homeboy::core::Result<Vec<(String, serde_json::Value)>> {
+    let raw = std::fs::read_to_string(path).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "settings-json-file",
+            format!("failed to read {}: {error}", path.display()),
+            Some(path.display().to_string()),
+            None,
+        )
+    })?;
+
+    let value: serde_json::Value = serde_json::from_str(&raw).map_err(|error| {
+        homeboy::core::Error::validation_invalid_json(
+            error,
+            Some(format!("settings JSON file {}", path.display())),
+            Some(raw.clone()),
+        )
+    })?;
+
+    let serde_json::Value::Object(map) = value else {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "settings-json-file",
+            format!("{} must contain a JSON object", path.display()),
+            Some(path.display().to_string()),
+            None,
+        ));
+    };
+
+    Ok(map.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SettingArgs;
+
+    #[test]
+    fn settings_json_file_loads_typed_profile_values() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"mode":"file","retries":2,"env":{"A":"1"},"flag":true}"#,
+        )
+        .expect("write profile");
+
+        let args = SettingArgs {
+            settings_json_file: vec![path],
+            setting: vec![("mode".to_string(), "cli-string".to_string())],
+            setting_json: vec![("mode".to_string(), serde_json::json!("cli-json"))],
+        };
+
+        assert_eq!(
+            args.settings_overrides().expect("settings"),
+            vec![("mode".to_string(), "cli-string".to_string())]
+        );
+
+        let json = args
+            .settings_profile_json_overrides()
+            .expect("json settings");
+        assert_eq!(json.len(), 4);
+        assert_eq!(
+            json[0],
+            ("env".to_string(), serde_json::json!({ "A": "1" }))
+        );
+        assert_eq!(json[1], ("flag".to_string(), serde_json::json!(true)));
+        assert_eq!(json[2], ("mode".to_string(), serde_json::json!("file")));
+        assert_eq!(json[3], ("retries".to_string(), serde_json::json!(2)));
+
+        assert_eq!(
+            args.settings_json_overrides()
+                .expect("explicit json settings"),
+            vec![("mode".to_string(), serde_json::json!("cli-json"))]
+        );
+    }
+
+    #[test]
+    fn settings_json_file_rejects_non_object_json() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"["not", "an", "object"]"#).expect("write profile");
+
+        let args = SettingArgs {
+            settings_json_file: vec![path],
+            ..Default::default()
+        };
+
+        let error = args
+            .settings_profile_json_overrides()
+            .expect_err("non-object profile should fail");
+        assert_eq!(
+            error.code,
+            homeboy::core::ErrorCode::ValidationInvalidArgument
+        );
+    }
 }

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -77,6 +77,10 @@ pub struct ResolveOptions {
     /// Additional settings from `--setting key=value` flags (string values).
     pub settings_overrides: Vec<(String, String)>,
 
+    /// Additional typed settings from settings profile files. Applied before
+    /// explicit CLI overrides so `--setting` and `--setting-json` win.
+    pub settings_profile_json_overrides: Vec<(String, serde_json::Value)>,
+
     /// Additional settings from `--setting-json key=<json>` flags (typed
     /// values). Applied after `settings_overrides` so JSON wins on
     /// conflict. Required for object-shaped settings whose dispatcher
@@ -104,6 +108,7 @@ impl ResolveOptions {
             path_override,
             capability: Some(capability),
             settings_overrides: settings,
+            settings_profile_json_overrides: Vec::new(),
             settings_json_overrides: Vec::new(),
             extension_overrides: Vec::new(),
         }
@@ -124,6 +129,7 @@ impl ResolveOptions {
             path_override,
             capability: Some(capability),
             settings_overrides: settings,
+            settings_profile_json_overrides: Vec::new(),
             settings_json_overrides: settings_json,
             extension_overrides: Vec::new(),
         }
@@ -136,6 +142,7 @@ impl ResolveOptions {
             path_override,
             capability: None,
             settings_overrides: Vec::new(),
+            settings_profile_json_overrides: Vec::new(),
             settings_json_overrides: Vec::new(),
             extension_overrides: Vec::new(),
         }
@@ -259,6 +266,11 @@ pub fn resolve_with_component(
                 })?;
             let accepted_setting_keys = ext_context.accepted_setting_keys.clone();
             let mut settings = ext_context.settings.clone();
+            // Merge settings profile files below explicit CLI overrides.
+            for (key, value) in &options.settings_profile_json_overrides {
+                settings.retain(|(k, _)| k != key);
+                settings.push((key.clone(), value.clone()));
+            }
             // Merge CLI string overrides on top (CLI string values stay strings).
             for (key, value) in &options.settings_overrides {
                 // Remove existing key if present (override semantics)
@@ -283,8 +295,16 @@ pub fn resolve_with_component(
         } else {
             // No extension context — only CLI overrides, wrapped as JSON strings.
             let mut settings = Vec::new();
+            for (key, value) in &options.settings_profile_json_overrides {
+                settings.retain(|(k, _)| k != key);
+                settings.push((key.clone(), value.clone()));
+            }
             for (key, value) in &options.settings_overrides {
                 merge_string_setting_override(&mut settings, key, value);
+            }
+            for (key, value) in &options.settings_json_overrides {
+                settings.retain(|(k, _)| k != key);
+                settings.push((key.clone(), value.clone()));
             }
             (None, None, settings, Vec::new())
         };
@@ -725,6 +745,7 @@ mod tests {
             path_override: None,
             capability: Some(ExtensionCapability::Lint),
             settings_overrides: Vec::new(),
+            settings_profile_json_overrides: Vec::new(),
             settings_json_overrides: Vec::new(),
             extension_overrides: Vec::new(),
         };
@@ -1103,6 +1124,7 @@ mod tests {
                 ("mode".to_string(), "strict".to_string()),
                 ("lang".to_string(), "rust".to_string()),
             ],
+            settings_profile_json_overrides: Vec::new(),
             settings_json_overrides: Vec::new(),
             extension_overrides: Vec::new(),
         };
@@ -1113,6 +1135,33 @@ mod tests {
             .settings
             .iter()
             .any(|(k, v)| k == "mode" && v == "strict"));
+    }
+
+    #[test]
+    fn explicit_cli_settings_override_profile_values() {
+        let options = ResolveOptions {
+            component_id: Some("test".to_string()),
+            path_override: Some("/tmp".to_string()),
+            capability: None,
+            settings_profile_json_overrides: vec![
+                ("mode".to_string(), serde_json::json!("profile")),
+                ("typed".to_string(), serde_json::json!("profile")),
+            ],
+            settings_overrides: vec![("mode".to_string(), "cli-string".to_string())],
+            settings_json_overrides: vec![("typed".to_string(), serde_json::json!("cli-json"))],
+            extension_overrides: Vec::new(),
+        };
+
+        let ctx = resolve(&options).expect("resolve should succeed");
+
+        assert!(ctx
+            .settings
+            .iter()
+            .any(|(k, v)| k == "mode" && v == "cli-string"));
+        assert!(ctx
+            .settings
+            .iter()
+            .any(|(k, v)| k == "typed" && v == &serde_json::json!("cli-json")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `--settings-json-file` / `--settings-profile` support for typed test settings
- merge profile values below explicit CLI `--setting` and `--setting-json` overrides
- document the new test command flags and update command/lab setting surfaces

Fixes #7390

## Testing
- `cargo test -q commands::utils::args`
- `cargo test -q commands::test`
- `cargo test -q core::engine::execution_context`
- `rustfmt --check src/command_contract/lab.rs src/commands/bench/tests/settings_tests.rs src/commands/ci.rs src/commands/fuzz/tests/execution_tests.rs src/commands/fuzz/tests/mod.rs src/commands/fuzz/tests/workload_tests.rs src/commands/fuzz/workloads.rs src/commands/infra/source_command.rs src/commands/review/mod.rs src/commands/rig/mod.rs src/commands/test.rs src/commands/utils/args.rs src/core/engine/execution_context.rs`
- `git diff --check`

Note: targeted tests report existing warning `is_missing_source_checkout_error` is never used. Broader `cargo test command_surface` was checked during development and currently fails on unrelated docs coverage for `docs/commands/runner.md`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Filing the issue, designing the generic settings profile contract, implementing the merge path, updating docs, and running targeted verification.