### PR TITLE
Scope run artifact listings to requested run

### DIFF
--- a/src/commands/runs/artifact_index_tests.rs
+++ b/src/commands/runs/artifact_index_tests.rs
@@ -546,3 +546,64 @@ fn runs_artifacts_surfaces_static_html_preview_entrypoints() {
         assert_eq!(output.preview_entrypoints[0].public_url, None);
     });
 }
+
+#[test]
+fn runs_artifacts_returns_empty_for_run_when_only_mismatched_related_artifacts_exist() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let job_id = "job-123";
+        let requested_run = store
+            .start_run(sample_run(
+                "runner-exec",
+                "wpcom",
+                "wpcom-phpunit",
+                serde_json::json!({
+                    "lab": {
+                        "runner": { "id": "lab" },
+                        "remote_job": { "id": job_id }
+                    }
+                }),
+            ))
+            .expect("requested run");
+        store
+            .finish_run(&requested_run.id, RunStatus::Fail, None)
+            .expect("finish requested run");
+        let unrelated_run = store
+            .start_run(sample_run(
+                "bench",
+                "static-site-importer",
+                "static-site-fixture-matrix",
+                serde_json::json!({
+                    "scenario_id": "static-site-fixture-matrix",
+                    "lab": { "remote_job_id": job_id }
+                }),
+            ))
+            .expect("unrelated run");
+        store
+            .finish_run(&unrelated_run.id, RunStatus::Pass, None)
+            .expect("finish unrelated run");
+        let summary = home.path().join("unrelated-summary.json");
+        std::fs::write(&summary, br#"{"passed":true}"#).expect("summary");
+        store
+            .record_artifact_with_metadata(
+                &unrelated_run.id,
+                "summary",
+                &summary,
+                serde_json::json!({
+                    "local_run_id": "different-local-run",
+                    "remote_run_id": "different-remote-run",
+                    "scenario_id": "static-site-fixture-matrix"
+                }),
+            )
+            .expect("unrelated artifact");
+
+        let (output, _) = handlers::artifacts(&requested_run.id).expect("artifacts");
+        let RunsOutput::Artifacts(output) = output else {
+            panic!("expected artifacts output");
+        };
+
+        assert_eq!(output.run_id, requested_run.id);
+        assert!(output.artifacts.is_empty());
+    });
+}

--- a/src/commands/runs/tests/mod.rs
+++ b/src/commands/runs/tests/mod.rs
@@ -542,7 +542,7 @@ fn runner_job_artifact_listing_includes_related_lab_run_artifacts() {
 }
 
 #[test]
-fn runner_job_matrix_summary_result_refs_exclude_related_lab_run_artifacts() {
+fn runner_job_artifact_listing_excludes_related_lab_run_artifacts() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();
         let store = ObservationStore::open_initialized().expect("store");
@@ -608,7 +608,7 @@ fn runner_job_matrix_summary_result_refs_exclude_related_lab_run_artifacts() {
             panic!("expected artifacts output");
         };
 
-        assert!(output
+        assert!(!output
             .artifacts
             .iter()
             .any(|artifact| artifact.id == remote_artifact.id));

--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -290,8 +290,7 @@ mod artifact_links {
         Ok(artifacts)
     }
 
-    /// List the enriched artifact records for a run, including downstream
-    /// Lab job artifacts.
+    /// List the enriched artifact records attached to a run.
     ///
     /// Side-effect ordering matches the CLI: refresh mirrored daemon evidence,
     /// then index nested publication artifact refs, then list and enrich.
@@ -299,11 +298,10 @@ mod artifact_links {
         store: &ObservationStore,
         run_id: &str,
     ) -> Result<Vec<ArtifactRecord>> {
-        let run = require_run(store, run_id)?;
+        require_run(store, run_id)?;
         refresh_mirrored_daemon_evidence_best_effort(run_id);
         crate::core::artifacts::index_remote_published_artifact_refs_for_run(store, run_id)?;
-        let mut artifacts = store.list_artifacts(run_id)?;
-        artifacts.extend(related_lab_artifacts_for_runner_job(store, &run)?);
+        let artifacts = store.list_artifacts(run_id)?;
         Ok(enrich_artifact_links(artifacts))
     }
 }
@@ -1357,16 +1355,14 @@ mod tests {
 
         // The hydrated record now parses into a non-zero matrix summary, where
         // the un-hydrated `remote_file` record would have summarized 0.
-        let summary =
-            crate::core::artifacts::summarize_matrix_artifacts("run-1", &hydrated, &[])
-                .expect("summary");
+        let summary = crate::core::artifacts::summarize_matrix_artifacts("run-1", &hydrated, &[])
+            .expect("summary");
         assert_eq!(summary.finding_count, 1);
         assert_eq!(summary.top_diagnostic_kinds[0].key, "missing_title");
         assert_eq!(summary.top_fixtures[0].key, "home");
 
-        let zero =
-            crate::core::artifacts::summarize_matrix_artifacts("run-1", &[remote], &[])
-                .expect("summary");
+        let zero = crate::core::artifacts::summarize_matrix_artifacts("run-1", &[remote], &[])
+            .expect("summary");
         assert_eq!(zero.finding_count, 0);
     }
 
@@ -1437,7 +1433,11 @@ mod tests {
             "homeboy bench run homeboy",
             serde_json::json!({ "lab": { "run_label": "meta-label" } }),
         );
-        let runs = vec![by_command.clone(), by_command_eq.clone(), by_metadata.clone()];
+        let runs = vec![
+            by_command.clone(),
+            by_command_eq.clone(),
+            by_metadata.clone(),
+        ];
 
         // Human label carried in the command resolves to its observation UUID.
         assert_eq!(


### PR DESCRIPTION
## Summary
- make `runs artifacts <run-id>` list only artifacts attached to the requested run
- stop silently appending related Lab job artifacts from sibling/unrelated runs
- add regression coverage for unrelated persisted artifacts with mismatched run metadata

Fixes #7392

## Testing
- `cargo test -q commands::runs::artifact_index_tests`
- `cargo test -q commands::runs::tests`
- `rustfmt --check src/commands/runs/artifact_index_tests.rs src/commands/runs/tests/mod.rs src/core/observation/runs_service.rs`
- `git diff --check`

Note: targeted tests report existing warning `is_missing_source_checkout_error` is never used.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Filing the issue, implementing the artifact scoping fix, adding regression coverage, and running targeted verification.