### PR TITLE
Fix implicit agent-task git checkout materialization

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -929,14 +929,6 @@ mod agent_task_checkout {
                 dispatch: args,
                 ..
             }) => {
-                let has_workspace = args.cwd.as_ref().is_some_and(|cwd| !cwd.trim().is_empty())
-                    || args
-                        .workspace
-                        .as_ref()
-                        .is_some_and(|workspace| !workspace.trim().is_empty());
-                if !has_workspace {
-                    return false;
-                }
                 let backend = args.backend.clone().or_else(default_backend);
                 backend.as_ref().is_some_and(|backend| {
                     provider_requires_cwd_git_checkout(backend, args.selector.as_deref())

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -1068,7 +1068,7 @@ fn agent_task_git_checkout_policy_uses_default_backend_when_backend_is_omitted()
 }
 
 #[test]
-fn agent_task_git_checkout_policy_keeps_non_cwd_dispatch_snapshot_eligible() {
+fn agent_task_git_checkout_policy_covers_implicit_cwd_dispatch_workspace() {
     let command = parsed_command(&[
         "homeboy",
         "agent-task",
@@ -1084,11 +1084,33 @@ fn agent_task_git_checkout_policy_keeps_non_cwd_dispatch_snapshot_eligible() {
         panic!("expected agent-task command");
     };
 
-    assert!(!agent_task_provider_requires_cwd_git_checkout_with(
+    assert!(agent_task_provider_requires_cwd_git_checkout_with(
         &args.command,
         || Some("default-patch-provider".to_string()),
         |backend, _| backend == "default-patch-provider",
     ));
+
+    let command = parsed_command(&[
+        "homeboy",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "homeboy@smoke",
+        "--verify",
+        "true",
+        "--backend",
+        "generic-patch-provider",
+        "--prompt",
+        "cook",
+        "--no-finalize",
+    ]);
+    assert_eq!(
+        command
+            .lab_contract()
+            .expect("agent-task cook contract")
+            .workspace_mode_policy,
+        LabWorkspaceModePolicy::GitCheckoutRequired
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Require GitCheckoutRequired for agent-task cook providers that declare cwd git checkout, even when cwd is implicit.
- Keep implicit-cwd lab cooks on the git materialization path instead of snapshot-only workspaces.
- Add regression coverage for implicit cwd cook dispatch and the lab contract policy.

Fixes #7370.

## Testing
- cargo test agent_task_git_checkout_policy
- cargo test required_git_checkout

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Diagnosed the lab materialization contract gap, implemented the focused fix, and added regression coverage.