### PR TITLE
fix(release): normalize project attachment local_path so release and deploy agree (#7410)

### DIFF
--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -61,7 +61,22 @@ pub fn resolve_project_component_with_standalone_snapshot(
     apply_standalone_component_fallbacks(&mut component, standalone_snapshot);
 
     let mut resolved = apply_component_overrides(&component, project);
-    resolved.local_path = attachment_local_path;
+    // Normalize the attachment `local_path` to an absolute path before it becomes
+    // the resolved component's machine-local checkout. Deploy resolves components
+    // directly through this function, while `release` reaches the same attachment
+    // via the composed inventory (project-attached components win on ID). Because
+    // `release` rejects a relative `local_path` outright (see
+    // `component::validate_local_path`) but deploy silently accepts one, a relative
+    // attachment value made the two commands resolve *different* checkouts for the
+    // same component id (#7410). Normalizing here — the single shared seam — makes
+    // `release`, `deploy`, and `component set` agree on one absolute path, matching
+    // the write-side normalization `component set` already applies (#6938). A tilde
+    // or absolute value is preserved as-is; a relative value is resolved against the
+    // current working directory, exactly as portable discovery already interprets it.
+    resolved.local_path = crate::core::component::normalize_component_local_path(
+        &attachment_local_path,
+    )
+    .unwrap_or(attachment_local_path);
 
     // Inherit project-level extensions when the component's homeboy.json doesn't
     // declare any. This handles clean tag clones from older releases where
@@ -351,5 +366,58 @@ mod tests {
                 "Component 'fixture' local_path '/tmp/homeboy-missing-component-path' does not exist",
             )
         }));
+    }
+
+    /// The resolved attachment `local_path` must be normalized to the *same*
+    /// absolute, lexically-clean checkout that `component set` persists — so
+    /// `homeboy release <id>` (which reaches this resolver through the composed
+    /// inventory) and `homeboy deploy` (which calls it directly) agree on one
+    /// source of truth instead of resolving different checkouts for the same id.
+    ///
+    /// Regression coverage for #7410 / #6938. This exercises the normalization
+    /// seam with a non-canonical attachment value (a `..` round-trip through the
+    /// parent), which `release`'s `validate_local_path` would otherwise leave
+    /// un-normalized while deploy silently accepted it. The value stays absolute
+    /// throughout, so the test needs no process-CWD mutation and is race-free.
+    #[test]
+    fn attachment_local_path_normalizes_matching_component_set() {
+        let repo = repo_with_portable_remote_path("wp-content/plugins/fixture");
+        let repo_path = repo.path().canonicalize().expect("canonical repo path");
+        let dir_name = repo_path.file_name().expect("repo dir name");
+
+        // A non-canonical but absolute attachment value: `<parent>/<dir>/../<dir>`.
+        // It points at the same checkout but is not lexically normalized, mirroring
+        // the drifted values that made `release` and `deploy` disagree.
+        let noncanonical = repo_path
+            .join("..")
+            .join(dir_name)
+            .to_string_lossy()
+            .to_string();
+
+        let project = project_with_attachment(None, noncanonical.clone());
+
+        let resolved =
+            resolve_project_component(&project, "fixture").expect("attachment resolves");
+
+        assert!(
+            std::path::Path::new(&resolved.local_path).is_absolute(),
+            "resolved local_path must be absolute, got {:?}",
+            resolved.local_path
+        );
+
+        // The resolver must agree with the write-side normalization that
+        // `component set` applies to the same value — one source of truth.
+        let component_set_value =
+            crate::core::component::normalize_component_local_path(&noncanonical)
+                .expect("normalize like component set");
+        assert_eq!(resolved.local_path, component_set_value);
+
+        // And it must point at the real checkout.
+        assert_eq!(
+            std::path::Path::new(&resolved.local_path)
+                .canonicalize()
+                .expect("canonical resolved path"),
+            repo_path
+        );
     }
 }


### PR DESCRIPTION
Fixes #7410.

## Problem

`homeboy release <id>` could fail with

```
Invalid argument 'local_path': Component 'studio-native' has relative local_path 'studio-native' which cannot be resolved. Use absolute path
```

even after `homeboy component set studio-native --local-path <absolute>` reported success and wrote the absolute path to `~/.config/homeboy/components/studio-native.json`, and even though `homeboy deploy` resolved the same component to an absolute checkout. So `release`, `deploy`, and `component set` were resolving **different sources of truth** for one component's `local_path`.

## Root cause

Traced to `resolve_effective_inner` in `src/core/component/resolution.rs`. When `release <id>` runs from a directory that contains a sibling directory whose name matches the positional component id -- e.g. running `homeboy release studio-native` from `/Users/chubes/Developer`, where `studio-native/` exists -- `Path::new("studio-native").is_dir()` is true, so the id is treated as a **bare-directory target**:

```rust
if accept_bare_directory && id_path.is_dir() {
    if let Some(mut discovered) = try_discover_from_portable(id_path)? {
        discovered.local_path = id.to_string(); // <- raw RELATIVE "studio-native"
        ...
```

This short-circuits **before** the registry/inventory lookup, storing the raw relative value as `local_path`. `release`'s `validate_local_path` then rejects the relative path -- while `component set` (standalone store) and `deploy` (project attachment) both resolve the same component to an absolute checkout. That is the three-way divergence in #7410.

Confirmed with a reproduction (isolated `HOME`, standalone store holding the absolute path):

- **Before**, run from a dir containing a `studio-native/` subdir: `release studio-native --dry-run` -> `success: false`, `error: has relative local_path 'studio-native'`.
- **After**: `release studio-native --dry-run` -> `success: true`, resolved `local_path` is absolute, no `--path` needed.

## Fix

- Normalize the bare-directory `local_path` to an absolute, lexically-clean path (the same `normalize_component_local_path` normalization `component set` applies on write, #6938). `release`, `deploy`, and `component set` now resolve the same absolute checkout.
- Also normalize the project-attachment `local_path` at the shared resolution seam (`resolve_project_component_with_standalone_snapshot`) so a relative attachment can't diverge `deploy` (which silently accepted it) from `release`-via-inventory (which rejected it).
- Already-absolute, clean paths are unchanged (`normalize_local_path` is purely lexical -- no filesystem/symlink resolution), so existing behavior for registered absolute paths is untouched.

## Tests

Two real resolver assertions (no mocks):

- `resolve_effective_normalizes_relative_bare_directory_to_absolute` -- a relative bare-directory id resolves to an absolute `local_path` that `validate_local_path` accepts (the exact path `release` failed on before).
- `attachment_local_path_normalizes_matching_component_set` -- a project attachment resolves to the same absolute path `component set`'s `normalize_component_local_path` persists.

All 33 `component::resolution` tests pass. End-to-end verified against a release build: `release studio-native --skip-checks --dry-run` now resolves the absolute path and no longer errors, without `--path`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (via Claude Code)
- **Used for:** Root-causing the resolver divergence in the Rust source (traced through inventory/bare-directory resolution with temporary instrumentation, since removed), implementing the normalization fix, and writing the regression tests. Chris reviewed and remains responsible for every line.
