### PR TITLE
Add dependency adapter manifest boundary

### DIFF
--- a/src/core/deps_provider.rs
+++ b/src/core/deps_provider.rs
@@ -121,6 +121,7 @@ impl DependencyProviderCommand {
 }
 
 pub(crate) enum DependencyProvider {
+    Manifest(ManifestDependencyProvider),
     Composer(ComposerDependencyProvider),
     Npm(NpmDependencyProvider),
     // Boxed: `ExtensionDependencyProvider` carries a full execution context and
@@ -142,6 +143,7 @@ impl DependencyProvider {
             package_filter,
         };
         match self {
+            DependencyProvider::Manifest(provider) => provider.status(request),
             DependencyProvider::Composer(provider) => provider.status(request),
             DependencyProvider::Npm(provider) => provider.status(request),
             DependencyProvider::Extension(provider) => provider.status(request),
@@ -160,6 +162,7 @@ impl DependencyProvider {
             package,
         };
         match self {
+            DependencyProvider::Manifest(provider) => provider.handles_package(request),
             DependencyProvider::Composer(provider) => provider.handles_package(request),
             DependencyProvider::Npm(provider) => provider.handles_package(request),
             DependencyProvider::Extension(provider) => provider.handles_package(request),
@@ -180,6 +183,7 @@ impl DependencyProvider {
             constraint,
         };
         match self {
+            DependencyProvider::Manifest(provider) => provider.update(request),
             DependencyProvider::Composer(provider) => provider.update(request),
             DependencyProvider::Npm(provider) => provider.update(request),
             DependencyProvider::Extension(provider) => provider.update(request),
@@ -194,6 +198,7 @@ impl DependencyProvider {
     ) -> Result<Option<DependencyCommandResult>> {
         let context = DependencyProviderContext { component, path };
         match self {
+            DependencyProvider::Manifest(provider) => provider.install(context),
             DependencyProvider::Composer(provider) => provider.install(context),
             DependencyProvider::Npm(provider) => provider.install(context),
             DependencyProvider::ComponentScript(provider) => provider.install(context),
@@ -208,6 +213,7 @@ impl DependencyProvider {
     ) -> Result<Option<DependencyProviderCommand>> {
         let context = DependencyProviderContext { component, path };
         match self {
+            DependencyProvider::Manifest(provider) => provider.install_command(context),
             DependencyProvider::Composer(provider) => provider.install_command(context),
             DependencyProvider::Npm(provider) => provider.install_command(context),
             DependencyProvider::ComponentScript(provider) => provider.install_command(context),
@@ -249,6 +255,11 @@ pub(crate) fn resolve_dependency_providers_optional(
     path: &Path,
 ) -> Result<Vec<DependencyProvider>> {
     let mut providers = Vec::new();
+
+    if let Some(provider) = ManifestDependencyProvider::load(path)? {
+        providers.push(DependencyProvider::Manifest(provider));
+        return Ok(providers);
+    }
 
     if ComposerDependencyProvider::supports(path) {
         providers.push(DependencyProvider::Composer(ComposerDependencyProvider));
@@ -304,6 +315,220 @@ pub(crate) fn dependency_provider_snapshot(
     }
 
     Ok(snapshot)
+}
+
+const DEPENDENCY_ADAPTER_MANIFEST: &str = "homeboy-deps.json";
+
+#[derive(Debug, Clone)]
+pub(crate) struct ManifestDependencyProvider {
+    manifest: DependencyAdapterManifest,
+}
+
+impl ManifestDependencyProvider {
+    fn load(path: &Path) -> Result<Option<Self>> {
+        let manifest_path = path.join(DEPENDENCY_ADAPTER_MANIFEST);
+        if !manifest_path.is_file() {
+            return Ok(None);
+        }
+
+        let manifest = read_dependency_adapter_manifest(&manifest_path)?;
+        Ok(Some(Self { manifest }))
+    }
+
+    fn command(
+        &self,
+        command: &DependencyAdapterCommand,
+        context: DependencyProviderContext<'_>,
+        package: Option<&str>,
+        constraint: Option<&str>,
+    ) -> DependencyProviderCommand {
+        let mut argv = command.argv.clone();
+        for arg in &mut argv {
+            *arg = expand_manifest_command_arg(arg, package, constraint);
+        }
+        argv.retain(|arg| !arg.is_empty());
+        let program = argv.first().cloned().unwrap_or_default();
+        let args = argv.into_iter().skip(1).collect();
+        let cwd = command
+            .cwd
+            .as_ref()
+            .map(|cwd| context.path.join(cwd))
+            .unwrap_or_else(|| context.path.to_path_buf());
+        DependencyProviderCommand::new(program, args, cwd)
+    }
+
+    fn status_with_filter(&self, package_filter: Option<&str>) -> ProviderDependencyStatus {
+        ProviderDependencyStatus {
+            package_manager: self.manifest.provider.clone(),
+            dependency_identities: self.manifest.dependency_identities.clone(),
+            packages: self
+                .manifest
+                .packages
+                .iter()
+                .filter(|package| {
+                    package_filter
+                        .map(|filter| filter == package.name)
+                        .unwrap_or(true)
+                })
+                .cloned()
+                .collect(),
+        }
+    }
+}
+
+impl DependencyProviderAdapter for ManifestDependencyProvider {
+    fn status(
+        &self,
+        request: DependencyProviderStatusRequest<'_>,
+    ) -> Result<ProviderDependencyStatus> {
+        Ok(self.status_with_filter(request.package_filter))
+    }
+
+    fn handles_package(&self, request: DependencyProviderPackageRequest<'_>) -> Result<bool> {
+        Ok(self
+            .manifest
+            .packages
+            .iter()
+            .any(|package| package.name == request.package)
+            || self.manifest.commands.update.is_some())
+    }
+
+    fn update(
+        &self,
+        request: DependencyProviderUpdateRequest<'_>,
+    ) -> Result<DependencyUpdateResult> {
+        let Some(command) = &self.manifest.commands.update else {
+            return Err(Error::validation_invalid_argument(
+                "dependency_provider",
+                format!(
+                    "Dependency adapter '{}' does not define an update command",
+                    self.manifest.provider
+                ),
+                Some(self.manifest.provider.clone()),
+                None,
+            ));
+        };
+        let before = self
+            .status_with_filter(Some(request.package))
+            .packages
+            .into_iter()
+            .next();
+        let command = self.command(
+            command,
+            request.context,
+            Some(request.package),
+            request.constraint,
+        );
+        let result = run_dependency_provider_command(&command, "command")?;
+        let after = self
+            .status_with_filter(Some(request.package))
+            .packages
+            .into_iter()
+            .next();
+
+        Ok(DependencyUpdateResult {
+            component_id: request.context.component.id.clone(),
+            component_path: request.context.path.display().to_string(),
+            package_manager: self.manifest.provider.clone(),
+            package: request.package.to_string(),
+            requested_constraint: request.constraint.map(str::to_string),
+            command: result.command,
+            before,
+            after,
+            stdout: result.stdout,
+            stderr: result.stderr,
+            install: None,
+            rebuild: None,
+        })
+    }
+
+    fn install(
+        &self,
+        context: DependencyProviderContext<'_>,
+    ) -> Result<Option<DependencyCommandResult>> {
+        let Some(command) = &self.manifest.commands.install else {
+            return Ok(None);
+        };
+        let command = self.command(command, context, None, None);
+        Ok(Some(run_dependency_provider_command(&command, "install")?))
+    }
+
+    fn install_command(
+        &self,
+        context: DependencyProviderContext<'_>,
+    ) -> Result<Option<DependencyProviderCommand>> {
+        Ok(self
+            .manifest
+            .commands
+            .install
+            .as_ref()
+            .map(|command| self.command(command, context, None, None)))
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DependencyAdapterManifest {
+    provider: String,
+    #[serde(default)]
+    dependency_identities: Vec<String>,
+    #[serde(default)]
+    packages: Vec<DependencyPackage>,
+    #[serde(default)]
+    commands: DependencyAdapterCommands,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct DependencyAdapterCommands {
+    install: Option<DependencyAdapterCommand>,
+    update: Option<DependencyAdapterCommand>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DependencyAdapterCommand {
+    argv: Vec<String>,
+    cwd: Option<PathBuf>,
+}
+
+fn read_dependency_adapter_manifest(path: &Path) -> Result<DependencyAdapterManifest> {
+    let raw = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    let manifest: DependencyAdapterManifest = serde_json::from_str(&raw).map_err(|e| {
+        Error::validation_invalid_json(e, Some(path.display().to_string()), Some(raw))
+    })?;
+    if manifest.provider.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "provider",
+            "Dependency adapter manifest provider must not be empty".to_string(),
+            None,
+            None,
+        ));
+    }
+    for command in [
+        manifest.commands.install.as_ref(),
+        manifest.commands.update.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if command.argv.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "commands.argv",
+                "Dependency adapter command argv must not be empty".to_string(),
+                None,
+                None,
+            ));
+        }
+    }
+    Ok(manifest)
+}
+
+fn expand_manifest_command_arg(
+    arg: &str,
+    package: Option<&str>,
+    constraint: Option<&str>,
+) -> String {
+    arg.replace("{package}", package.unwrap_or_default())
+        .replace("{constraint}", constraint.unwrap_or_default())
 }
 
 pub fn composer_command_args(package: &str, action: &ComposerAction) -> Vec<String> {

--- a/tests/deps_test.rs
+++ b/tests/deps_test.rs
@@ -7,6 +7,16 @@ fn write_file(path: &std::path::Path, contents: &str) {
     fs::write(path, contents).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
 }
 
+fn make_executable(path: &std::path::Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut mode = fs::metadata(path).unwrap().permissions();
+        mode.set_mode(0o755);
+        fs::set_permissions(path, mode).unwrap();
+    }
+}
+
 fn fixture_component(path: &std::path::Path) -> (&'static str, String) {
     ("fixture", path.display().to_string())
 }
@@ -181,6 +191,124 @@ fn composer_install_command_args_are_runtime_prep_safe() {
     assert_eq!(
         deps::composer_install_command_args(),
         vec!["install", "--no-interaction", "--no-progress"]
+    );
+}
+
+#[test]
+fn status_prefers_neutral_adapter_manifest_over_builtin_manifests() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let root_path = root.display().to_string();
+
+    write_file(
+        &root.join("homeboy-deps.json"),
+        r#"{
+            "provider": "fixture-adapter",
+            "dependency_identities": ["fixture/root"],
+            "packages": [
+                {
+                    "name": "fixture/package",
+                    "manifest_section": "adapter-dependencies",
+                    "constraint": "^1.0",
+                    "locked_version": "1.2.3",
+                    "locked_reference": "adapter-ref"
+                }
+            ],
+            "commands": {
+                "install": { "argv": ["fixture-adapter", "install"] }
+            }
+        }"#,
+    );
+    write_file(
+        &root.join("composer.json"),
+        r#"{ "require": { "fixture/composer": "^9.0" } }"#,
+    );
+    write_file(
+        &root.join("package.json"),
+        r#"{ "dependencies": { "fixture-npm": "^9.0.0" } }"#,
+    );
+
+    let status = deps::status(Some("fixture"), Some(&root_path), None).unwrap();
+
+    assert_eq!(status.package_manager, "fixture-adapter");
+    assert_eq!(status.packages.len(), 1);
+    assert_eq!(status.packages[0].name, "fixture/package");
+    assert_eq!(status.packages[0].constraint.as_deref(), Some("^1.0"));
+}
+
+#[test]
+fn neutral_adapter_manifest_discovers_install_command_and_runs_update_install() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let root_path = root.display().to_string();
+    let adapter = root.join("fixture-adapter.sh");
+    write_file(
+        &adapter,
+        r#"#!/bin/sh
+printf '%s\n' "$@" >> adapter-args.txt
+"#,
+    );
+    make_executable(&adapter);
+    write_file(
+        &root.join("homeboy-deps.json"),
+        &format!(
+            r#"{{
+                "provider": "fixture-adapter",
+                "packages": [{{
+                    "name": "fixture/package",
+                    "manifest_section": "adapter-dependencies",
+                    "constraint": "^1.0",
+                    "locked_version": "1.2.3"
+                }}],
+                "commands": {{
+                    "install": {{ "argv": ["{}", "install"] }},
+                    "update": {{ "argv": ["{}", "update", "{{package}}", "{{constraint}}"] }}
+                }}
+            }}"#,
+            adapter.display(),
+            adapter.display()
+        ),
+    );
+
+    let plan = deps::dependency_install_plan(root).unwrap();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].provider_id, "fixture-adapter");
+    assert_eq!(
+        plan[0].command,
+        vec![adapter.display().to_string(), "install".to_string()]
+    );
+
+    let install = deps::install(Some("fixture"), Some(&root_path)).unwrap();
+    assert_eq!(install.package_manager, "fixture-adapter");
+    assert_eq!(install.installs.len(), 1);
+    assert_eq!(install.installs[0].command, plan[0].command);
+
+    let update = deps::update(
+        Some("fixture"),
+        Some(&root_path),
+        "fixture/package",
+        Some("^2.0"),
+        DependencyUpdateOptions {
+            install: false,
+            rebuild: false,
+        },
+    )
+    .unwrap();
+    assert_eq!(update.package_manager, "fixture-adapter");
+    assert_eq!(update.package, "fixture/package");
+    assert_eq!(update.requested_constraint.as_deref(), Some("^2.0"));
+    assert_eq!(
+        update.command,
+        vec![
+            adapter.display().to_string(),
+            "update".to_string(),
+            "fixture/package".to_string(),
+            "^2.0".to_string(),
+        ]
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("adapter-args.txt")).unwrap(),
+        "install\nupdate\nfixture/package\n^2.0\n"
     );
 }
 


### PR DESCRIPTION
## Summary
- Add neutral `homeboy-deps.json` adapter manifest discovery.
- Add `ManifestDependencyProvider` implementing the existing dependency provider contract.
- Prefer adapter manifests when present while keeping Composer/NPM/component/extension providers as current fallback.
- Add neutral fake adapter tests for status, install planning, install execution, and update execution.

## Verification
- `cargo test --test deps_test`
- `cargo test --test deps_npm_provider_test`
- `cargo test dependency_install_plan --lib`
- `git diff --check`

## Follow-up
- Move Composer/NPM behavior into provider-owned adapter manifest producers, then remove the built-in Composer/NPM providers from core.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Boundary implementation, test coverage, and verification orchestration.