### PR TITLE
Add stable workload planning command

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -9,6 +9,7 @@ homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--see
 homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
 homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--campaign-manifest <path>] [--campaign-workload <id>] [--lab-runner <id>] [--required-artifact <id>] [--execute|--dry-run] [--resume] [--allow-destructive --isolation isolated --isolation-proof <path>]
+homeboy fuzz stable plan --manifest <path> [--stable-id <id[,id]>] [--runner <id>] [--artifact-root <dir>] [--run-id-prefix <id>] [--tracker-ref <kind:id>] [--detach-after-handoff] [--component <id>] [--since <duration>] [--limit <n>] [--hotspot-limit <n>]
 homeboy fuzz run-campaign [<component>] [--rig <id>] [--campaign-manifest <path>] [--campaign-workload <id>] [--dry-run] [--resume] [fuzz run options]
 homeboy fuzz validate <results-file>
 homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--inventory <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--output-envelope <path>]
@@ -209,6 +210,50 @@ The resulting `campaign_plan.entries[]` are sorted by workload id, deduplicated,
 and include `run_id`, `tracker_refs`, `artifact_requirements`, `lab_runner`, a
 request copy scoped to the workload, and a command vector suitable for a caller
 or Lab orchestration layer to schedule explicitly.
+
+`homeboy fuzz stable plan --manifest <path>` reads a product-owned stable workload
+manifest and emits deterministic Lab command vectors without executing them. The
+manifest keeps product identity in data: Homeboy only reads `profile_id`, `rig`,
+`contracts[].id`, `contracts[].entry_workloads[]`, and an optional
+`contracts[].budgets.max_duration_seconds`. The `rig` value points at a rig JSON
+file, relative to the manifest package root when the manifest lives under
+`manifests/`, and Homeboy resolves the concrete rig id from that file.
+
+Example stable workload manifest:
+
+```json
+{
+  "schema": "example/stable-workloads/v1",
+  "profile_id": "stable-demo",
+  "rig": "rigs/demo/rig.json",
+  "contracts": [
+    {
+      "id": "read-paths",
+      "entry_workloads": ["generated-read-cases", "read-profile"],
+      "budgets": { "max_duration_seconds": 600 }
+    }
+  ]
+}
+```
+
+Example planner command:
+
+```bash
+homeboy fuzz stable plan \
+  --manifest manifests/stable-workloads.json \
+  --stable-id read-paths \
+  --run-id-prefix stable-demo-20260703 \
+  --runner lab-a \
+  --component demo-component \
+  --tracker-ref github_issue:owner/repo#123
+```
+
+The output variant is `stable_plan`. It includes `run_commands[]` entries for
+`homeboy fuzz run --lab-only --rig <resolved-rig-id> --workload <id>` with stable
+run ids shaped as `<prefix>-<stable-id>-<index>-<workload-id>`, plus comparison
+commands for `homeboy runs refs`, `homeboy runs compare`, and `homeboy runs
+hotspots`. Use those comparison commands only after Lab has completed at least two
+persisted fuzz runs.
 
 Campaign execution returns `variant: "run_campaign"` with `dispatch_records[]`.
 Each record includes the planned entry id, workload id, run id, command vector,

--- a/src/commands/fuzz/stable.rs
+++ b/src/commands/fuzz/stable.rs
@@ -370,15 +370,70 @@ mod tests {
 
         assert_eq!(output.rig_id, "demo-rig");
         assert_eq!(output.run_commands.len(), 1);
-        assert!(output.run_commands[0]
-            .command
-            .contains(&"--lab-only".to_string()));
-        assert!(output.run_commands[0]
-            .command
-            .contains(&"--max-duration".to_string()));
+        assert_eq!(
+            output.run_commands[0].command,
+            vec![
+                "homeboy",
+                "fuzz",
+                "run",
+                "--lab-only",
+                "--rig",
+                "demo-rig",
+                "--workload",
+                "read",
+                "--gate-profile",
+                "measurement",
+                "--run-id",
+                "stable-demo-api-01-read",
+                "--tracker-ref",
+                "stable-workload:api",
+                "--runner",
+                "lab",
+                "--detach-after-handoff",
+                "--max-duration",
+                "60s",
+                "--tracker-ref",
+                "issue:1",
+            ]
+        );
         assert!(output.compare_commands[0]
             .command
             .windows(2)
             .any(|pair| pair == ["--component", "component-a"]));
+        assert_eq!(
+            output.compare_commands[2].command,
+            vec![
+                "homeboy",
+                "runs",
+                "hotspots",
+                "--baseline-run",
+                "BASELINE_RUN_ID",
+                "--candidate-run",
+                "CANDIDATE_RUN_ID",
+                "--limit",
+                "3",
+                "--component",
+                "component-a",
+                "--lab-only",
+                "--runner",
+                "lab",
+            ]
+        );
+    }
+
+    #[test]
+    fn stable_plan_rejects_unknown_stable_id() {
+        let contracts = vec![StableWorkloadContract {
+            id: "known".to_string(),
+            entry_workloads: vec!["workload".to_string()],
+            budgets: serde_json::Map::new(),
+        }];
+        let result = selected_contracts(&contracts, &["missing".to_string()]);
+
+        let err = match result {
+            Ok(_) => panic!("unknown stable id should fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("unknown stable workload id"));
     }
 }

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -57,6 +57,15 @@ impl FuzzArgs {
             _ => self.run.extension_override.extensions.as_slice(),
         }
     }
+
+    pub(crate) fn consumes_runner_as_plan_input(&self) -> bool {
+        matches!(
+            self.command,
+            Some(FuzzCommand::Stable(FuzzStableArgs {
+                command: FuzzStableCommand::Plan(_),
+            }))
+        )
+    }
 }
 
 #[derive(Subcommand)]

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -783,12 +783,13 @@ fn is_runs_list_runner_option(args: &[String]) -> bool {
 }
 
 fn is_command_local_runner_option(command: &Commands) -> bool {
-    matches!(
-        command,
+    match command {
         Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
             command: crate::commands::agent_task::AgentTaskCommand::Doctor(_),
-        })
-    )
+        }) => true,
+        Commands::Fuzz(args) => args.consumes_runner_as_plan_input(),
+        _ => false,
+    }
 }
 
 fn write_offloaded_stdout(path: &str, stdout: &str) -> homeboy::core::Result<()> {


### PR DESCRIPTION
## Summary
- Add/test `homeboy fuzz stable plan` for deterministic stable workload Lab planning.
- Consume `--runner` as planner data instead of offloading the planner itself.
- Document the stable workload manifest shape and migration usage.

## Verification
- `cargo test fuzz::stable`
- `cargo test cli_surface::tests::command_registry_docs_paths_exist_and_are_indexed`
- `cargo test cli_surface::tests::core_command_docs_do_not_drift_from_registry`
- `cargo test cli_surface::tests::documented_command_forms_parse`
- Direct Woo manifest check with `cargo run -- fuzz stable plan ...`

## Known unrelated issue
- Full `cargo test cli_surface::tests` still has existing docs drift for `docs/commands/runner.md` not documenting `runner lifecycle`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Command implementation, docs, tests, and verification orchestration.