### PR TITLE
fix(release): normalize bare-directory local_path to absolute (#7410)

### DIFF
--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -610,8 +610,18 @@ fn resolve_effective_inner(
         } else {
             let id_path = Path::new(id);
             if accept_bare_directory && id_path.is_dir() {
+                // The positional identifier resolves to a directory, so treat it as
+                // a bare-directory target. Normalize it to an absolute `local_path`:
+                // a relative value like `studio-native` (a sibling dir of the CWD)
+                // would otherwise be stored verbatim and later rejected by
+                // `validate_local_path` ("has relative local_path ... cannot be
+                // resolved"), even though `component set` and `deploy` resolve the
+                // same component to an absolute checkout. Normalizing here keeps all
+                // three in agreement (#7410).
+                let local_path = normalize_component_local_path(id).unwrap_or_else(|_| id.to_string());
+
                 if let Some(mut discovered) = try_discover_from_portable(id_path)? {
-                    discovered.local_path = id.to_string();
+                    discovered.local_path = local_path;
                     discovered.resolve_remote_path();
                     return Ok(discovered);
                 }
@@ -623,7 +633,7 @@ fn resolve_effective_inner(
 
                 return Ok(Component {
                     id: name,
-                    local_path: id.to_string(),
+                    local_path,
                     ..Component::default()
                 });
             }
@@ -798,6 +808,40 @@ mod tests {
 
         assert_eq!(component.id, "raw-repo");
         assert_eq!(component.local_path, repo.to_string_lossy());
+    }
+
+    #[test]
+    fn resolve_effective_normalizes_relative_bare_directory_to_absolute() {
+        // Regression for #7410: `homeboy release studio-native` run from a
+        // directory that contains a `studio-native` sibling resolves the
+        // positional id as a bare directory. The resulting `local_path` must be
+        // absolute so it agrees with what `component set` persists and `deploy`
+        // resolves — a relative value here is later rejected by
+        // `validate_local_path` ("has relative local_path ... cannot be resolved").
+        let dir = tempfile::tempdir().expect("temp dir");
+        let repo = dir.path().join("studio-native");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+
+        let component = with_cwd(dir.path(), || {
+            resolve_effective(Some("studio-native"), None, None)
+                .expect("relative bare directory should resolve")
+        });
+
+        assert!(
+            Path::new(&component.local_path).is_absolute(),
+            "bare-directory local_path must be absolute, got {:?}",
+            component.local_path
+        );
+        // And it must resolve to the real checkout, matching `component set`'s
+        // write-side normalization of the same relative value.
+        assert_eq!(
+            Path::new(&component.local_path)
+                .canonicalize()
+                .expect("canonical resolved path"),
+            repo.canonicalize().expect("canonical repo path"),
+        );
+        // release's own validation must now accept it.
+        assert!(validate_local_path(&component).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #7417, completing the fix for #7410.

## Why a second PR

#7417 merged the project-attachment half of the #7410 fix, but the **primary root cause was not included in the merged commit** (the branch was merged at an earlier commit than the final force-pushed one). This PR ships that missing half. Without it, `homeboy release <id>` still fails with the relative-`local_path` error in the exact reported scenario.

## Root cause

In `resolve_effective_inner` (`src/core/component/resolution.rs`), when `release <id>` runs from a directory that contains a sibling directory matching the positional component id — e.g. `homeboy release studio-native` from `/Users/chubes/Developer`, where `studio-native/` exists — `Path::new("studio-native").is_dir()` is true, so the id is treated as a **bare-directory target** and the raw **relative** value is stored as `local_path`, short-circuiting before the registry/inventory lookup:

```rust
if accept_bare_directory && id_path.is_dir() {
    if let Some(mut discovered) = try_discover_from_portable(id_path)? {
        discovered.local_path = id.to_string(); // raw RELATIVE "studio-native"
```

`release`'s `validate_local_path` then rejects the relative path, while `component set` (standalone store, absolute) and `deploy` (project attachment, absolute) resolve the same component to an absolute checkout — the three-way divergence in #7410.

## Fix

Normalize the bare-directory `local_path` to an absolute, lexically-clean path (the same `normalize_component_local_path` that `component set` applies on write, #6938). Already-absolute paths are unchanged.

## Test + verification

- `resolve_effective_normalizes_relative_bare_directory_to_absolute` — a relative bare-directory id resolves to an absolute `local_path` that `validate_local_path` accepts.
- End-to-end against a release build, from a CWD containing a `studio-native/` subdir:
  - **Before:** `release studio-native --skip-checks --dry-run` -> `success: false`, `has relative local_path 'studio-native'`.
  - **After:** `success: true`, resolved `local_path` absolute, no `--path` needed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (via Claude Code)
- **Used for:** Root-causing the bare-directory resolution divergence in the Rust source and writing the regression test. Chris reviewed and remains responsible for every line.
