### PR TITLE
Persist detached Lab agent-task records

### DIFF
--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -246,6 +246,111 @@ pub fn run_record_exists(run_id: &str) -> Result<bool> {
     store::record_exists(&sanitize_run_id(run_id))
 }
 
+#[derive(Debug, Clone)]
+pub struct DetachedLabRunRecord<'a> {
+    pub run_id: &'a str,
+    pub runner_id: &'a str,
+    pub runner_job_id: &'a str,
+    pub remote_workspace: &'a str,
+    pub remote_command: &'a [String],
+}
+
+pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(input.run_id);
+    let plan = detached_lab_plan(&run_id, &input);
+    let mut record = match store::read_record(&run_id) {
+        Ok(record) => record,
+        Err(error) if error.code == ErrorCode::ValidationInvalidArgument => {
+            submit_plan(&plan, Some(&run_id))?
+        }
+        Err(error) => return Err(error),
+    };
+    record.updated_at = Some(now_timestamp());
+    set_run_state(&mut record, AgentTaskRunState::Running);
+    for task in &mut record.tasks {
+        if task.state == AgentTaskState::Queued {
+            task.state = AgentTaskState::Running;
+        }
+    }
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("kind".to_string(), json!("lab_offload_detached_handoff"));
+    metadata.insert("runner_id".to_string(), json!(input.runner_id));
+    metadata.insert("runner_job_id".to_string(), json!(input.runner_job_id));
+    metadata.insert(
+        "remote_workspace".to_string(),
+        json!(input.remote_workspace),
+    );
+    metadata.insert("remote_command".to_string(), json!(input.remote_command));
+    metadata.insert("retryable".to_string(), json!(true));
+    metadata.remove("stale_running");
+    metadata.remove("stale_running_reason");
+    store::write_record(&record)?;
+    Ok(record)
+}
+
+fn detached_lab_plan(run_id: &str, input: &DetachedLabRunRecord<'_>) -> AgentTaskPlan {
+    let task = AgentTaskRequest {
+        schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+        task_id: format!("{run_id}-lab-handoff"),
+        group_key: Some("lab-offload".to_string()),
+        parent_plan_id: None,
+        executor: AgentTaskExecutor {
+            backend: "homeboy-lab".to_string(),
+            selector: Some(input.runner_id.to_string()),
+            runtime_selection: None,
+            required_capabilities: Vec::new(),
+            secret_env: Vec::new(),
+            model: None,
+            config: Value::Null,
+        },
+        instructions: "Detached Lab agent-task run handed off to a durable runner job.".to_string(),
+        inputs: json!({
+            "runner_id": input.runner_id,
+            "runner_job_id": input.runner_job_id,
+            "remote_workspace": input.remote_workspace,
+            "remote_command": input.remote_command,
+        }),
+        source_refs: vec![AgentTaskSourceRef {
+            kind: "lab-offload-runner-job".to_string(),
+            uri: format!(
+                "homeboy://runner/{}/job/{}",
+                input.runner_id, input.runner_job_id
+            ),
+            revision: None,
+        }],
+        workspace: AgentTaskWorkspace {
+            mode: AgentTaskWorkspaceMode::Existing,
+            root: Some(input.remote_workspace.to_string()),
+            kind: Some("lab-offload".to_string()),
+            cleanup: Some("preserve".to_string()),
+            materialization: json!({
+                "runner_id": input.runner_id,
+                "runner_job_id": input.runner_job_id,
+            }),
+            ..AgentTaskWorkspace::default()
+        },
+        component_contracts: Vec::new(),
+        policy: AgentTaskPolicy::default(),
+        limits: AgentTaskLimits::default(),
+        expected_artifacts: Vec::new(),
+        artifact_declarations: Vec::new(),
+        metadata: json!({
+            "kind": "lab_offload_detached_handoff",
+            "runner_id": input.runner_id,
+            "runner_job_id": input.runner_job_id,
+        }),
+    };
+    let mut plan = AgentTaskPlan::new(format!("{run_id}-lab-offload"), vec![task]);
+    plan.group_key = Some("lab-offload".to_string());
+    plan.metadata = json!({
+        "kind": "lab_offload_detached_handoff",
+        "runner_id": input.runner_id,
+        "runner_job_id": input.runner_job_id,
+        "remote_workspace": input.remote_workspace,
+    });
+    plan
+}
+
 pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
     if matches!(

--- a/src/core/agent_task_lifecycle/records.rs
+++ b/src/core/agent_task_lifecycle/records.rs
@@ -110,6 +110,10 @@ impl AgentTaskRunRecord {
             return;
         }
 
+        if self.runner_job_id().is_some() && self.has_fresh_update() {
+            return;
+        }
+
         let reason = if self.runner_job_id().is_some() {
             "runner_job_unverified_after_daemon_restart"
         } else if self.owner_pid().is_some() {
@@ -148,6 +152,18 @@ impl AgentTaskRunRecord {
             .get("runner_id")
             .and_then(Value::as_str)
             .filter(|value| !value.trim().is_empty())
+    }
+
+    fn has_fresh_update(&self) -> bool {
+        self.updated_at
+            .as_deref()
+            .and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok())
+            .is_some_and(|updated_at| {
+                chrono::Utc::now()
+                    .signed_duration_since(updated_at.with_timezone(&chrono::Utc))
+                    .num_minutes()
+                    < 30
+            })
     }
 
     /// A run is runner-backed when its durable record carries a runner id or

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -69,6 +69,37 @@ fn submit_plan_persists_queued_status() {
 }
 
 #[test]
+fn detached_lab_handoff_persists_inspectable_running_record() {
+    with_isolated_home(|_| {
+        let record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-detached",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &[
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ],
+        })
+        .expect("detached handoff recorded");
+
+        let loaded = status("agent-task-detached").expect("status resolves");
+        let log = logs("agent-task-detached").expect("logs resolve");
+        let artifacts = artifacts("agent-task-detached").expect("artifacts resolve");
+
+        assert_eq!(record.run_id, "agent-task-detached");
+        assert_eq!(loaded.state, AgentTaskRunState::Running);
+        assert_eq!(loaded.tasks[0].state, AgentTaskState::Running);
+        assert_eq!(loaded.metadata["runner_id"], "homeboy-lab");
+        assert_eq!(loaded.metadata["runner_job_id"], "job-123");
+        assert!(loaded.metadata.get("stale_running").is_none());
+        assert_eq!(log.events.len(), 1);
+        assert!(artifacts.evidence_refs.is_empty());
+    });
+}
+
+#[test]
 fn cook_index_keeps_repeated_attempts_unique_with_stable_latest_alias() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -919,6 +919,19 @@ pub(crate) fn run_lab_offload_inner(
         // ownership off so the RAII handle never reaps it out from under the
         // live job.
         materialized_workspace.preserve();
+        if let (Some(run_id), Some(job_id)) =
+            (agent_task_run_id.as_deref(), exec_output.job_id.as_deref())
+        {
+            agent_task_lifecycle::record_detached_lab_run(
+                agent_task_lifecycle::DetachedLabRunRecord {
+                    run_id,
+                    runner_id,
+                    runner_job_id: job_id,
+                    remote_workspace: &remote_cwd,
+                    remote_command: &remote_command,
+                },
+            )?;
+        }
         let mut stderr = String::new();
         for message in messages {
             stderr.push_str(&message);


### PR DESCRIPTION
## Summary
- Persist controller-side agent-task lifecycle records for detached Lab handoffs.
- Include runner id, job id, remote workspace, and command metadata so status/logs/artifacts can resolve.
- Keep fresh runner-backed running records from being marked stale immediately due to missing local owner PID.

Fixes #7362.

## Testing
- cargo check --lib
- cargo test --lib detached_lab_handoff_persists_inspectable_running_record
- cargo test --lib discovery_active_marks_runner_backed_running_run_as_stale_retryable
- cargo test --lib reverse_broker_exec_detached_surfaces_persisted_run_id
- cargo test --lib emit_durable_run_id_writes_json_to_output_before_execution
- rustfmt --check on changed files
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Local coding subagent implemented the fix and regression coverage; I reviewed, committed, pushed, and opened the PR.