### PR TITLE
Preserve executor failure telemetry

### DIFF
--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -6,6 +6,8 @@ use super::secrets::{provider_secret_env_plan_with_status, provider_secret_sourc
 use super::*;
 use crate::core::agent_task_executor_evidence::link_latest_executor_evidence;
 
+const EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 16 * 1024;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ProviderCommandEnvError {
     Secret(AgentTaskSecretResolutionError),
@@ -339,7 +341,13 @@ pub(super) fn run_provider_command_once(
             AgentTaskFailureClassification::Provider,
             "agent_task.provider_empty_stdout",
             format!("provider '{}' produced no JSON outcome", provider.id),
-            json!({ "provider": provider.id, "command": command, "exit_code": output.status.code(), "stderr": stderr }),
+            executor_process_diagnostic_data(
+                &provider.id,
+                &command,
+                &output.status,
+                &stdout,
+                &stderr,
+            ),
         );
     }
 
@@ -361,9 +369,60 @@ pub(super) fn run_provider_command_once(
                 "provider '{}' returned malformed JSON: {error}",
                 provider.id
             ),
-            json!({ "provider": provider.id, "command": command, "exit_code": output.status.code(), "stderr": stderr, "stdout": stdout }),
+            executor_process_diagnostic_data(
+                &provider.id,
+                &command,
+                &output.status,
+                &stdout,
+                &stderr,
+            ),
         ),
     }
+}
+
+fn executor_process_diagnostic_data(
+    provider_id: &str,
+    command: &str,
+    status: &std::process::ExitStatus,
+    stdout: &str,
+    stderr: &str,
+) -> Value {
+    json!({
+        "provider": provider_id,
+        "command": command,
+        "exit_code": status.code(),
+        "signal": exit_signal(status),
+        "stdout": bounded_executor_output(stdout),
+        "stdout_bytes": stdout.len(),
+        "stdout_truncated": stdout.len() > EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES,
+        "stderr": bounded_executor_output(stderr),
+        "stderr_bytes": stderr.len(),
+        "stderr_truncated": stderr.len() > EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES,
+    })
+}
+
+fn bounded_executor_output(output: &str) -> String {
+    if output.len() <= EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES {
+        return output.to_string();
+    }
+
+    let mut start = output.len() - EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES;
+    while !output.is_char_boundary(start) {
+        start += 1;
+    }
+    output[start..].to_string()
+}
+
+#[cfg(unix)]
+fn exit_signal(status: &std::process::ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt;
+
+    status.signal()
+}
+
+#[cfg(not(unix))]
+fn exit_signal(_status: &std::process::ExitStatus) -> Option<i32> {
+    None
 }
 
 fn provider_preflight_failure(

--- a/src/core/agent_task_provider/tests/scheduler_tests.rs
+++ b/src/core/agent_task_provider/tests/scheduler_tests.rs
@@ -148,6 +148,40 @@ fn provider_preserves_structured_outcome_from_stderr_when_stdout_empty() {
 }
 
 #[test]
+fn provider_empty_stdout_captures_bounded_stderr_and_exit_context() {
+    let command = format!(
+        "node {}",
+        script("process.stderr.write('x'.repeat(20000) + 'runtime contract constants are incomplete'); process.exit(42);")
+    );
+    let (request, provider) = request("task-empty-stdout", command);
+
+    let outcome = run_provider_command(&request, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
+    assert_eq!(
+        outcome.diagnostics[0].class,
+        "agent_task.provider_empty_stdout"
+    );
+    assert_eq!(outcome.diagnostics[0].data["exit_code"], json!(42));
+    assert_eq!(outcome.diagnostics[0].data["stderr_truncated"], json!(true));
+    assert!(
+        outcome.diagnostics[0].data["stderr_bytes"]
+            .as_u64()
+            .expect("stderr byte count")
+            > 16_384
+    );
+    let stderr = outcome.diagnostics[0].data["stderr"]
+        .as_str()
+        .expect("stderr capture");
+    assert!(stderr.contains("runtime contract constants are incomplete"));
+    assert!(stderr.len() <= 16 * 1024);
+    assert!(outcome
+        .evidence_refs
+        .iter()
+        .any(|reference| reference.kind == "executor-result"));
+}
+
+#[test]
 fn provider_timeout_returns_structured_outcome() {
     let command = format!("node {}", script("setInterval(() => {}, 1000);"));
     let (mut request, provider) = request("task-timeout", command);

--- a/src/core/agent_task_scheduler/scheduling.rs
+++ b/src/core/agent_task_scheduler/scheduling.rs
@@ -598,12 +598,14 @@ impl AgentTaskScheduleSupport {
         if let Some(running) = running {
             Self::normalize_required_typed_artifacts(&mut outcome, &running.request);
             Self::recover_missing_typed_artifacts_wrapper_failure(&mut outcome, &running.request);
+            Self::classify_failed_nested_executor_status(&mut outcome);
+            Self::classify_incomplete_executor_result(&mut outcome);
             Self::classify_missing_required_typed_artifacts(&mut outcome, &running.request);
             Self::classify_invalid_required_typed_artifacts(&mut outcome, &running.request);
+        } else {
+            Self::classify_failed_nested_executor_status(&mut outcome);
+            Self::classify_incomplete_executor_result(&mut outcome);
         }
-
-        Self::classify_failed_nested_executor_status(&mut outcome);
-        Self::classify_incomplete_executor_result(&mut outcome);
 
         if let Some(running) = running {
             if let Some(timeout_ms) = running.timeout_ms {
@@ -817,6 +819,7 @@ impl AgentTaskScheduleSupport {
                 "path": failed_status.path,
                 "key": failed_status.key,
                 "value": failed_status.value,
+                "provider_run_result": outcome.outputs.get("provider_run_result").cloned(),
             }),
         });
     }

--- a/src/core/agent_task_scheduler/tests/fixtures.rs
+++ b/src/core/agent_task_scheduler/tests/fixtures.rs
@@ -29,6 +29,8 @@ pub(super) struct NestedTerminalStateFailedExecutor;
 
 pub(super) struct NestedAgentResultFailedExecutor;
 
+pub(super) struct NestedFailedStatusMissingArtifactsExecutor;
+
 pub(super) struct SuccessMissingRequiredArtifactsExecutor;
 
 pub(super) struct SuccessEmptyRequiredTypedArtifactExecutor {
@@ -227,6 +229,32 @@ impl AgentTaskExecutorAdapter for NestedAgentResultFailedExecutor {
             }),
             artifact: None,
             metadata: Value::Null,
+        });
+        outcome
+    }
+}
+
+impl AgentTaskExecutorAdapter for NestedFailedStatusMissingArtifactsExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        let mut outcome = outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded);
+        outcome.outputs = json!({
+            "provider_run_result": {
+                "status": "failed",
+                "metadata": {
+                    "provider_error": {
+                        "message": "OpenCode completed without producing declared artifact(s): patch, agent_result, transcript"
+                    },
+                    "run_id": "run-7367"
+                },
+                "refs": {
+                    "logs": ["file:///tmp/executor.stderr.log"],
+                    "artifact_bundles": ["file:///tmp/runtime-artifacts"]
+                }
+            }
         });
         outcome
     }

--- a/src/core/agent_task_scheduler/tests/outcome_tests.rs
+++ b/src/core/agent_task_scheduler/tests/outcome_tests.rs
@@ -113,6 +113,55 @@ fn missing_required_typed_artifacts_fails_succeeded_outcome() {
 }
 
 #[test]
+fn nested_executor_failure_context_wins_over_missing_required_artifacts() {
+    let scheduler = AgentTaskScheduler::new(NestedFailedStatusMissingArtifactsExecutor);
+
+    let aggregate = scheduler.run(plan_with_required_artifacts(&[
+        "patch",
+        "agent_result",
+        "transcript",
+    ]));
+
+    assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+    let outcome = &aggregate.outcomes[0];
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Failed);
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::ExecutionFailed)
+    );
+    assert!(outcome
+        .summary
+        .as_deref()
+        .unwrap_or_default()
+        .contains("outputs.provider_run_result.status=failed"));
+    assert!(outcome
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.class == "agent_task.nested_executor_failed_status"));
+    let nested_diagnostic = outcome
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.class == "agent_task.nested_executor_failed_status")
+        .expect("nested executor failure diagnostic");
+    assert_eq!(
+        nested_diagnostic.data["provider_run_result"]["metadata"]["provider_error"]["message"],
+        json!("OpenCode completed without producing declared artifact(s): patch, agent_result, transcript")
+    );
+    assert_eq!(
+        nested_diagnostic.data["provider_run_result"]["refs"]["logs"][0],
+        json!("file:///tmp/executor.stderr.log")
+    );
+    assert_eq!(
+        nested_diagnostic.data["provider_run_result"]["refs"]["artifact_bundles"][0],
+        json!("file:///tmp/runtime-artifacts")
+    );
+    assert!(!outcome
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.class == "agent_task.required_typed_artifacts_missing"));
+}
+
+#[test]
 fn empty_required_patch_artifact_is_valid_no_diff_evidence() {
     let temp = tempfile::tempdir().expect("tempdir");
     let patch_path = temp.path().join("patch.diff");


### PR DESCRIPTION
## Summary
- Add bounded stdout/stderr/exit diagnostics for empty or malformed provider output.
- Preserve provider run result context on nested executor failures.
- Classify nested executor failure before generic missing-artifact failure so operators see the real executor context.

Fixes #7367.
Related to #7397.

## Testing
- cargo check
- cargo test core::agent_task_provider::tests::scheduler_tests
- cargo test core::agent_task_scheduler::tests::outcome_tests
- rustfmt --check on changed files
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Local coding subagent implemented the fix and regression coverage; I reviewed, committed, pushed, and opened the PR.