### PR TITLE
Reconcile ownerless running records

### DIFF
--- a/src/commands/runs/reconcile.rs
+++ b/src/commands/runs/reconcile.rs
@@ -12,6 +12,8 @@ use homeboy::core::process::pid_is_running;
 use crate::commands::runs::RunsOutput;
 use crate::commands::CmdResult;
 
+const OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 30;
+
 #[derive(Args, Clone, Default)]
 pub struct RunsReconcileArgs {
     /// Preview orphaned running records without mutating them
@@ -38,7 +40,7 @@ pub struct ReconciledRunSummary {
     pub status: String,
     pub started_at: String,
     pub finished_at: Option<String>,
-    pub owner_pid: u32,
+    pub owner_pid: Option<u32>,
     pub reason: String,
     pub artifact_count: usize,
 }
@@ -90,14 +92,11 @@ where
     let mut reconciled = Vec::new();
 
     for run in running {
-        let Some(owner_pid) = run_owner_pid(&run) else {
+        let Some(reason) = stale_running_reason(&run, &pid_is_alive) else {
             continue;
         };
-        if pid_is_alive(owner_pid) {
-            continue;
-        }
 
-        let reason = "owner_process_not_running".to_string();
+        let owner_pid = run_owner_pid(&run);
         let artifact_count = if dry_run {
             store.list_artifacts(&run.id)?.len()
         } else {
@@ -106,12 +105,8 @@ where
         let finished = if dry_run {
             None
         } else {
-            let metadata = with_reconcile_metadata(
-                &run,
-                owner_pid,
-                &reason,
-                &reconcile_run_dir_metadata(&run),
-            );
+            let metadata =
+                with_reconcile_metadata(&run, owner_pid, reason, &reconcile_run_dir_metadata(&run));
             Some(store.finish_run(&run.id, RunStatus::Stale, Some(metadata))?)
         };
 
@@ -123,12 +118,34 @@ where
             started_at: run.started_at,
             finished_at: finished.and_then(|run| run.finished_at),
             owner_pid,
-            reason,
+            reason: reason.to_string(),
             artifact_count,
         });
     }
 
     Ok(reconciled)
+}
+
+fn stale_running_reason<F>(run: &RunRecord, pid_is_alive: &F) -> Option<&'static str>
+where
+    F: Fn(u32) -> bool,
+{
+    if let Some(owner_pid) = run_owner_pid(run) {
+        return (!pid_is_alive(owner_pid)).then_some("owner_process_not_running");
+    }
+
+    ownerless_running_is_stale(run).then_some("owner_metadata_missing")
+}
+
+fn ownerless_running_is_stale(run: &RunRecord) -> bool {
+    chrono::DateTime::parse_from_rfc3339(&run.started_at)
+        .map(|started_at| {
+            chrono::Utc::now()
+                .signed_duration_since(started_at.with_timezone(&chrono::Utc))
+                .num_minutes()
+                >= OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES
+        })
+        .unwrap_or(false)
 }
 
 pub fn running_status_note(run: &RunRecord) -> Option<String> {
@@ -137,7 +154,7 @@ pub fn running_status_note(run: &RunRecord) -> Option<String> {
 
 fn with_reconcile_metadata(
     run: &RunRecord,
-    owner_pid: u32,
+    owner_pid: Option<u32>,
     reason: &str,
     run_dir_metadata: &Value,
 ) -> Value {
@@ -145,9 +162,16 @@ fn with_reconcile_metadata(
     let mut marker = serde_json::json!({
         "status": RunStatus::Stale.as_str(),
         "reason": reason,
-        "owner_pid": owner_pid,
         "reconciled_at": chrono::Utc::now().to_rfc3339(),
     });
+    if let Some(marker) = marker.as_object_mut() {
+        marker.insert(
+            "owner_pid".to_string(),
+            owner_pid
+                .map(|pid| Value::from(pid as u64))
+                .unwrap_or(Value::Null),
+        );
+    }
     if let (Some(marker), Some(run_dir_metadata)) =
         (marker.as_object_mut(), run_dir_metadata.as_object())
     {
@@ -243,7 +267,7 @@ fn read_extension_children(run_dir_path: &Path) -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy::core::observation::NewRunRecord;
+    use homeboy::core::observation::{NewRunRecord, RunRecord};
     use homeboy::test_support::with_isolated_home;
 
     struct XdgGuard(Option<String>);
@@ -275,6 +299,23 @@ mod tests {
             .rig_id(rig_id)
             .metadata(metadata)
             .build()
+    }
+
+    fn ownerless_running_run(id: &str, started_at: String) -> RunRecord {
+        RunRecord {
+            id: id.to_string(),
+            kind: "agent-task".to_string(),
+            component_id: Some("homeboy".to_string()),
+            started_at,
+            finished_at: None,
+            status: RunStatus::Running.as_str().to_string(),
+            command: Some("homeboy agent-task cook".to_string()),
+            cwd: Some("/tmp/homeboy-fixture".to_string()),
+            homeboy_version: Some("test-version".to_string()),
+            git_sha: Some("abc123".to_string()),
+            rig_id: Some("homeboy-lab".to_string()),
+            metadata_json: serde_json::json!({ "source": "legacy-runner" }),
+        }
     }
 
     #[test]
@@ -316,6 +357,66 @@ mod tests {
                 "stale"
             );
             assert_eq!(store.list_artifacts(&run.id).expect("artifacts").len(), 1);
+        });
+    }
+
+    #[test]
+    fn reconcile_marks_old_ownerless_running_records_stale() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            store
+                .import_run(&ownerless_running_run(
+                    "legacy-ownerless-run",
+                    "2026-05-02T16:46:46Z".to_string(),
+                ))
+                .expect("import ownerless run");
+
+            let reconciled =
+                reconcile_orphaned_running_runs(&store, 1000, false, |_| true).expect("reconcile");
+            let updated = store
+                .get_run("legacy-ownerless-run")
+                .expect("get run")
+                .expect("run exists");
+
+            assert_eq!(reconciled.len(), 1);
+            assert_eq!(reconciled[0].id, "legacy-ownerless-run");
+            assert_eq!(reconciled[0].owner_pid, None);
+            assert_eq!(reconciled[0].reason, "owner_metadata_missing");
+            assert_eq!(updated.status, "stale");
+            assert_eq!(
+                updated.metadata_json["homeboy_reconciled"]["reason"],
+                "owner_metadata_missing"
+            );
+            assert_eq!(
+                updated.metadata_json["homeboy_reconciled"]["owner_pid"],
+                Value::Null
+            );
+        });
+    }
+
+    #[test]
+    fn reconcile_keeps_fresh_ownerless_running_records_running() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            store
+                .import_run(&ownerless_running_run(
+                    "fresh-ownerless-run",
+                    chrono::Utc::now().to_rfc3339(),
+                ))
+                .expect("import ownerless run");
+
+            let reconciled =
+                reconcile_orphaned_running_runs(&store, 1000, false, |_| true).expect("reconcile");
+            let unchanged = store
+                .get_run("fresh-ownerless-run")
+                .expect("get run")
+                .expect("run exists");
+
+            assert!(reconciled.is_empty());
+            assert_eq!(unchanged.status, "running");
+            assert!(unchanged.finished_at.is_none());
         });
     }
 

--- a/src/commands/runs/remote.rs
+++ b/src/commands/runs/remote.rs
@@ -24,7 +24,12 @@ pub fn list_runner_runs(
     if let Some(component_id) = args.component_id {
         query.push(("component", component_id));
     }
-    if let Some(status) = args.status {
+    let status = if args.running {
+        Some("running".to_string())
+    } else {
+        args.status
+    };
+    if let Some(status) = status {
         query.push(("status", status));
     }
     if let Some(rig) = args.rig {

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -12,9 +12,12 @@ use uuid::Uuid;
 use crate::core::api_jobs::{self, ActiveRunnerJobSummary, JobStore};
 use crate::core::error::{Error, Result};
 use crate::core::observation::{
-    running_status_note, FindingListFilter, ObservationStore, RunListFilter, RunRecord,
+    run_owner_pid, running_status_note, FindingListFilter, ObservationStore, RunListFilter,
+    RunRecord, RunStatus,
 };
 use crate::core::{component, git, paths, rig, runner, stack};
+
+const OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 30;
 
 mod analysis_job_runner;
 mod sandbox_tools;
@@ -507,6 +510,7 @@ fn list_runs(
     job_store: &JobStore,
 ) -> Result<Vec<RunSummary>> {
     let store = ObservationStore::open_initialized()?;
+    reconcile_stale_running_runs_for_read(&store)?;
     let filter = RunListFilter {
         kind: kind_override
             .map(str::to_string)
@@ -574,12 +578,70 @@ fn active_runner_job_run_summary(job: ActiveRunnerJobSummary) -> RunSummary {
 
 fn show_run(run_id: &str) -> Result<RunDetail> {
     let store = ObservationStore::open_initialized()?;
+    reconcile_stale_running_runs_for_read(&store)?;
     let run = require_run(&store, run_id)?;
     Ok(RunDetail {
         summary: run_summary(run.clone()),
         homeboy_version: run.homeboy_version,
         metadata: run.metadata_json,
         artifacts: store.list_artifacts(run_id)?,
+    })
+}
+
+fn reconcile_stale_running_runs_for_read(store: &ObservationStore) -> Result<()> {
+    for run in store.list_runs(RunListFilter {
+        status: Some(RunStatus::Running.as_str().to_string()),
+        limit: Some(1000),
+        ..RunListFilter::default()
+    })? {
+        let Some(reason) = api_stale_running_reason(&run) else {
+            continue;
+        };
+        let metadata = api_reconcile_metadata(&run, reason);
+        store.finish_run(&run.id, RunStatus::Stale, Some(metadata))?;
+    }
+
+    Ok(())
+}
+
+fn api_stale_running_reason(run: &RunRecord) -> Option<&'static str> {
+    if let Some(owner_pid) = run_owner_pid(run) {
+        return (!crate::core::process::pid_is_running(owner_pid))
+            .then_some("owner_process_not_running");
+    }
+
+    api_ownerless_running_is_stale(run).then_some("owner_metadata_missing")
+}
+
+fn api_ownerless_running_is_stale(run: &RunRecord) -> bool {
+    chrono::DateTime::parse_from_rfc3339(&run.started_at)
+        .map(|started_at| {
+            chrono::Utc::now()
+                .signed_duration_since(started_at.with_timezone(&chrono::Utc))
+                .num_minutes()
+                >= OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES
+        })
+        .unwrap_or(false)
+}
+
+fn api_reconcile_metadata(run: &RunRecord, reason: &str) -> Value {
+    let mut metadata = run.metadata_json.clone();
+    let marker = json!({
+        "status": RunStatus::Stale.as_str(),
+        "reason": reason,
+        "owner_pid": run_owner_pid(run).map(|pid| Value::from(pid as u64)).unwrap_or(Value::Null),
+        "reconciled_at": chrono::Utc::now().to_rfc3339(),
+        "source": "http_api_read_reconcile",
+    });
+
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert("homeboy_reconciled".to_string(), marker);
+        return metadata;
+    }
+
+    json!({
+        "homeboy_reconciled": marker,
+        "homeboy_original_metadata": metadata,
     })
 }
 

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -454,6 +454,40 @@ fn test_handle() {
 }
 
 #[test]
+fn runs_list_reconciles_old_ownerless_running_records_before_responding() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let mut run = sample_imported_running_run("agent-task", "homeboy", "homeboy-lab");
+        run.id = "legacy-ownerless-run".to_string();
+        run.metadata_json = serde_json::json!({ "source": "legacy-runner" });
+        store.import_run(&run).expect("import ownerless run");
+
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: "/runs?status=running".to_string(),
+            body: None,
+        })
+        .expect("runs list");
+
+        assert!(response.body["runs"].as_array().expect("runs").is_empty());
+        let stored = store
+            .get_run("legacy-ownerless-run")
+            .expect("get run")
+            .expect("run exists");
+        assert_eq!(stored.status, "stale");
+        assert_eq!(
+            stored.metadata_json["homeboy_reconciled"]["reason"],
+            "owner_metadata_missing"
+        );
+        assert_eq!(
+            stored.metadata_json["homeboy_reconciled"]["source"],
+            "http_api_read_reconcile"
+        );
+    });
+}
+
+#[test]
 fn artifact_content_serves_encoded_artifact_store_locator() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
## Summary
- Mark old ownerless running observation records stale after a grace window.
- Preserve reconciliation metadata explaining ownerless stale transitions.
- Reconcile on HTTP read paths and forward runner-scoped --running status filters to runner daemons.

Fixes #7368.

## Testing
- cargo test --lib commands::runs::reconcile::tests::
- cargo test --lib runs_list_reconciles_old_ownerless_running_records_before_responding
- cargo test --lib commands::runs::tests::run_
- rustfmt --check on changed files
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Local coding subagent implemented the fix and regression coverage; I reviewed, committed, pushed, and opened the PR.