### PR TITLE
Resolve agent-task prompt store references

### DIFF
--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -131,7 +131,9 @@ mod tests {
     use super::*;
     use crate::test_support::with_isolated_home;
     use homeboy::core::agent_task::AgentTaskRequest;
+    use homeboy::core::agent_task_prompts;
     use homeboy::core::agent_tasks::dispatch_service;
+    use homeboy::core::agent_tasks::scheduler::AgentTaskPlan;
     use homeboy::core::agent_tasks::scheduler::{
         AgentTaskExecutionContext, AgentTaskExecutorAdapter,
     };
@@ -170,6 +172,44 @@ mod tests {
                 .as_str()
                 .expect("plan path")
                 .ends_with("plan.json"));
+        });
+    }
+
+    #[test]
+    fn dispatch_adapter_resolves_stored_prompt_reference_before_queueing_plan() {
+        with_isolated_home(|_| {
+            agent_task_prompts::save_prompt("homeboy-7388", "Cook from stored prompt.")
+                .expect("save prompt");
+
+            let (value, exit_code) = dispatch_service::run_dispatch_command(
+                dispatch_args(DispatchArgOverrides {
+                    prompt: Some("@prompt:homeboy-7388".to_string()),
+                    run_id: Some("dispatch-stored-prompt".to_string()),
+                    core: DispatchCoreInputs {
+                        queue_only: true,
+                        ..DispatchCoreInputs::default()
+                    },
+                    ..DispatchArgOverrides::default()
+                })
+                .into(),
+                NoopExecutor,
+            )
+            .expect("dispatch queued");
+
+            assert_eq!(exit_code, 0);
+            let plan_path = value["plan_path"].as_str().expect("plan path");
+            let raw = std::fs::read_to_string(plan_path).expect("read queued plan");
+            let plan: AgentTaskPlan = serde_json::from_str(&raw).expect("decode queued plan");
+
+            assert_eq!(plan.tasks[0].instructions, "Cook from stored prompt.");
+            assert_eq!(
+                plan.tasks[0].metadata["prompt_source"],
+                "@prompt:homeboy-7388"
+            );
+            assert_eq!(
+                plan.tasks[0].metadata["prompt_store"]["reference"],
+                "prompt:homeboy-7388"
+            );
         });
     }
 

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -7,6 +7,7 @@
 //! cook-handoff orchestration.
 
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::core::agent_task::{
     AgentTaskComponentContract, AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy,
@@ -99,10 +100,9 @@ pub fn build_dispatch_plan_with_provider_requirements(
         .then(|| runtime_dependency_graph.to_evidence_value());
     let mut tasks = Vec::new();
     for (index, prompt_spec) in prompt_specs.iter().enumerate() {
-        let instructions = dispatch_instructions(
-            read_text_spec(&prompt_spec.prompt, "prompt")?,
-            request.task_url.as_deref(),
-        );
+        let resolved_prompt = read_prompt_spec(&prompt_spec.prompt)?;
+        let instructions =
+            dispatch_instructions(resolved_prompt.content.clone(), request.task_url.as_deref());
         let task_id = prompt_spec.task_id.clone().unwrap_or_else(|| {
             request
                 .task_id
@@ -116,6 +116,13 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 kind: "task".to_string(),
                 uri: task_url.clone(),
                 revision: None,
+            });
+        }
+        if let Some(source) = &resolved_prompt.stored_prompt {
+            source_refs.push(AgentTaskSourceRef {
+                kind: "prompt".to_string(),
+                uri: source.reference.clone(),
+                revision: Some(source.sha256.clone()),
             });
         }
 
@@ -188,6 +195,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 "workspace": workspace_target.as_ref().map(|target| target.metadata.clone()),
                 "task_url": request.task_url,
                 "prompt_source": &prompt_spec.prompt,
+                "prompt_store": resolved_prompt.stored_prompt,
                 "dispatch": "agent-task cook",
                 "required_capabilities": request.required_capabilities,
                 "runtime_dependency_graph": runtime_dependency_graph_evidence,
@@ -626,6 +634,39 @@ fn read_text_spec(spec: &str, label: &str) -> Result<String> {
     })
 }
 
+#[derive(Clone, serde::Serialize)]
+struct StoredPromptSource {
+    id: String,
+    reference: String,
+    sha256: String,
+}
+
+struct ResolvedPromptSpec {
+    content: String,
+    stored_prompt: Option<StoredPromptSource>,
+}
+
+fn read_prompt_spec(spec: &str) -> Result<ResolvedPromptSpec> {
+    if let Some(id) = agent_task_prompts::stored_prompt_ref_id(spec) {
+        let content = agent_task_prompts::read_prompt(id)?;
+        let sha256 = format!("sha256:{:x}", Sha256::digest(content.as_bytes()));
+        let id = agent_task_prompts::prompt_id(id)?;
+        return Ok(ResolvedPromptSpec {
+            content,
+            stored_prompt: Some(StoredPromptSource {
+                reference: format!("{}{}", agent_task_prompts::PROMPT_REF_PREFIX, id),
+                id,
+                sha256,
+            }),
+        });
+    }
+
+    Ok(ResolvedPromptSpec {
+        content: read_text_spec(spec, "prompt")?,
+        stored_prompt: None,
+    })
+}
+
 struct DispatchPromptSpec {
     prompt: String,
     task_id: Option<String>,
@@ -818,6 +859,7 @@ mod tests {
         dispatch, DispatchCoreInputs, DISPATCH_RESULT_SCHEMA,
     };
     use crate::core::agent_task_lifecycle::{self as lifecycle, AgentTaskRunState};
+    use crate::core::agent_task_prompts;
     use crate::core::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskExecutorAdapter};
     use crate::test_support::with_isolated_home;
     use std::collections::HashMap;
@@ -868,6 +910,49 @@ mod tests {
         assert!(!serialized.contains("kimaki"));
         assert!(!serialized.contains("channel"));
         assert!(!serialized.contains("thread"));
+    }
+
+    #[test]
+    fn builds_dispatch_plan_from_stored_prompt_reference() {
+        with_isolated_home(|_| {
+            agent_task_prompts::save_prompt("homeboy-7388", "Use the prompt store.")
+                .expect("save prompt");
+
+            let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+                prompt: Some("@prompt:homeboy-7388".to_string()),
+                repo: Some("homeboy".to_string()),
+                ..DispatchRequestOverrides::default()
+            }))
+            .expect("dispatch plan");
+
+            assert_eq!(plan.tasks[0].instructions, "Use the prompt store.");
+            assert_eq!(plan.tasks[0].source_refs.len(), 1);
+            assert_eq!(plan.tasks[0].source_refs[0].kind, "prompt");
+            assert_eq!(plan.tasks[0].source_refs[0].uri, "prompt:homeboy-7388");
+            assert!(plan.tasks[0].source_refs[0]
+                .revision
+                .as_deref()
+                .expect("prompt revision")
+                .starts_with("sha256:"));
+            assert_eq!(plan.tasks[0].metadata["prompt_store"]["id"], "homeboy-7388");
+        });
+    }
+
+    #[test]
+    fn builds_dispatch_plan_from_stored_task_reference_without_at_prefix() {
+        with_isolated_home(|_| {
+            agent_task_prompts::save_prompt("task-ref", "Cook this task.").expect("save prompt");
+
+            let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+                tasks: vec!["prompt:task-ref".to_string()],
+                repo: Some("homeboy".to_string()),
+                ..DispatchRequestOverrides::default()
+            }))
+            .expect("dispatch plan");
+
+            assert_eq!(plan.tasks[0].instructions, "Cook this task.");
+            assert_eq!(plan.tasks[0].source_refs[0].uri, "prompt:task-ref");
+        });
     }
 
     #[test]

--- a/src/core/agent_task_prompts.rs
+++ b/src/core/agent_task_prompts.rs
@@ -108,10 +108,16 @@ pub fn list_prompts() -> Result<Vec<AgentTaskPromptRecord>> {
 }
 
 pub fn resolve_stored_prompt_ref(spec: &str) -> Result<Option<String>> {
-    let Some(name) = spec.strip_prefix(PROMPT_REF_PREFIX) else {
+    let Some(name) = stored_prompt_ref_id(spec) else {
         return Ok(None);
     };
     Ok(Some(read_prompt(name)?))
+}
+
+pub fn stored_prompt_ref_id(spec: &str) -> Option<&str> {
+    spec.strip_prefix('@')
+        .unwrap_or(spec)
+        .strip_prefix(PROMPT_REF_PREFIX)
 }
 
 pub fn read_prompt_input(spec: &str) -> Result<String> {
@@ -121,6 +127,10 @@ pub fn read_prompt_input(spec: &str) -> Result<String> {
             Error::internal_io(error.to_string(), Some("read stdin".to_string()))
         })?;
         return Ok(buf);
+    }
+
+    if let Some(prompt) = resolve_stored_prompt_ref(spec)? {
+        return Ok(prompt);
     }
 
     if let Some(path) = spec.strip_prefix('@') {
@@ -162,13 +172,22 @@ fn prompt_io_error(
     error: std::io::Error,
 ) -> Error {
     if error.kind() == std::io::ErrorKind::NotFound {
+        let mut hints =
+            vec!["Run `homeboy agent-task prompts list` to see stored prompts".to_string()];
+        if let Ok(records) = list_prompts() {
+            let ids = records
+                .into_iter()
+                .map(|record| record.id)
+                .collect::<Vec<_>>();
+            if !ids.is_empty() {
+                hints.push(format!("Available stored prompt ids: {}", ids.join(", ")));
+            }
+        }
         return Error::validation_invalid_argument(
             field,
             format!("stored agent-task prompt '{}' was not found", name),
             Some(name.to_string()),
-            Some(vec![
-                "Run `homeboy agent-task prompts list` to see stored prompts".to_string(),
-            ]),
+            Some(hints),
         );
     }
     Error::internal_io(error.to_string(), Some(path.display().to_string()))
@@ -209,6 +228,10 @@ mod tests {
             assert_eq!(ids, vec!["alpha".to_string(), "beta".to_string()]);
             assert_eq!(
                 resolve_stored_prompt_ref("prompt:alpha").expect("resolve ref"),
+                Some("first".to_string())
+            );
+            assert_eq!(
+                resolve_stored_prompt_ref("@prompt:alpha").expect("resolve at ref"),
                 Some("first".to_string())
             );
             assert_eq!(

--- a/src/core/runner/lab_args/agent_task_specs.rs
+++ b/src/core/runner/lab_args/agent_task_specs.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
+use crate::core::agent_task_prompts;
 use crate::core::config::read_json_spec_to_string;
 use crate::core::{Error, Result};
 
@@ -334,7 +335,14 @@ fn read_agent_task_text_spec_to_inline(
     field: &str,
 ) -> Result<String> {
     if spec == "-" || !spec.starts_with('@') {
+        if let Some(prompt) = agent_task_prompts::resolve_stored_prompt_ref(spec)? {
+            return Ok(prompt);
+        }
         return Ok(spec.to_string());
+    }
+
+    if let Some(prompt) = agent_task_prompts::resolve_stored_prompt_ref(spec)? {
+        return Ok(prompt);
     }
 
     let raw_path = spec.trim_start_matches('@');

--- a/src/core/runner/lab_args/at_files.rs
+++ b/src/core/runner/lab_args/at_files.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
+use crate::core::agent_task_prompts;
 use crate::core::{Error, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,12 +82,12 @@ fn at_file_tokens(args: &[String]) -> Vec<String> {
             passthrough = true;
             continue;
         }
-        if arg.starts_with('@') {
+        if arg.starts_with('@') && agent_task_prompts::stored_prompt_ref_id(arg).is_none() {
             tokens.push(arg.clone());
             continue;
         }
         if let Some((_, value)) = arg.split_once('=') {
-            if value.starts_with('@') {
+            if value.starts_with('@') && agent_task_prompts::stored_prompt_ref_id(value).is_none() {
                 tokens.push(value.to_string());
             }
         }

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1195,6 +1195,8 @@ mod run_plan_remap_tests {
 
 mod prompt_files_tests {
     use super::*;
+    use crate::core::agent_task_prompts;
+    use crate::test_support::with_isolated_home;
 
     #[test]
     fn inline_agent_task_prompt_files_reads_absolute_prompt_file() {
@@ -1236,6 +1238,29 @@ mod prompt_files_tests {
 
         assert_eq!(out[3], "--task=Fix issue 1");
         assert_eq!(out[5], "[\"Fix issue 2\"]");
+    }
+
+    #[test]
+    fn inline_agent_task_prompt_files_resolves_stored_prompt_references() {
+        with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            agent_task_prompts::save_prompt("homeboy-7388", "Cook from the store")
+                .expect("save prompt");
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--prompt".to_string(),
+                "@prompt:homeboy-7388".to_string(),
+                "--task=prompt:homeboy-7388".to_string(),
+            ];
+
+            let out =
+                inline_agent_task_prompt_files_in_args(&args, temp.path()).expect("inline prompt");
+
+            assert_eq!(out[4], "Cook from the store");
+            assert_eq!(out[5], "--task=Cook from the store");
+        });
     }
 
     #[test]
@@ -1726,6 +1751,23 @@ mod lab_args_rewrite_tests {
                 format!("--config={}", specs[0].remote_spec),
             ]
         );
+    }
+
+    #[test]
+    fn lab_args_at_file_preflight_ignores_stored_prompt_references() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "@prompt:homeboy-7388".to_string(),
+            "--task=@prompt:homeboy-7388".to_string(),
+        ];
+
+        let specs = lab_at_file_specs(&args, dir.path(), "/runner/workspace").expect("specs");
+
+        assert!(specs.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Support first-class prompt store references using prompt:<id> and @prompt:<id>.
- Resolve stored prompt refs before generic @file handling.
- Carry prompt source metadata and inline stored prompt content before Lab runner execution.

Fixes #7388.

## Testing
- cargo test agent_task_prompts
- cargo test builds_dispatch_plan_from_stored_prompt_reference
- cargo test builds_dispatch_plan_from_stored_task_reference_without_at_prefix
- cargo test dispatch_adapter_resolves_stored_prompt_reference_before_queueing_plan
- cargo test inline_agent_task_prompt_files_resolves_stored_prompt_references
- cargo test lab_args_at_file_preflight_ignores_stored_prompt_references
- rustfmt --check on changed files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Local coding subagent implemented the fix and regression coverage; I reviewed, committed, pushed, and opened the PR.