### PR TITLE
Gate fuzz mutations on isolated runs

### DIFF
--- a/src/commands/fuzz/planning.rs
+++ b/src/commands/fuzz/planning.rs
@@ -713,6 +713,7 @@ pub(super) fn plan_inventory_selection(
                 safety_class,
                 args.strategy,
                 destructive_allowed,
+                args.run.isolation.requests_isolation(),
                 &filters,
                 &workload_operations,
             );
@@ -1016,6 +1017,9 @@ fn skip_reason_detail(
     args: &FuzzPlanArgs,
     isolation_proof: Option<&IsolationProof>,
 ) -> &'static str {
+    if reason == "unsafe" {
+        return "mutation-capable fuzz operations require --isolation isolated";
+    }
     if reason != "destructive" {
         return "operation is outside the selected strategy, filters, or supported operation families";
     }
@@ -1057,6 +1061,7 @@ fn operation_skip_reason(
     safety_class: FuzzSafetyClass,
     strategy: FuzzPlanStrategy,
     destructive_allowed: bool,
+    isolation_requested: bool,
     filters: &BTreeSet<String>,
     workload_operations: &BTreeSet<String>,
 ) -> Option<&'static str> {
@@ -1081,7 +1086,28 @@ fn operation_skip_reason(
     if !strategy_matches_operation(strategy, family.expect("family checked above")) {
         return Some("unsupported");
     }
+    if requires_isolated_mutation(family, safety_class) && !isolation_requested {
+        return Some("unsafe");
+    }
     None
+}
+
+fn requires_isolated_mutation(
+    family: Option<FuzzOperationFamily>,
+    safety_class: FuzzSafetyClass,
+) -> bool {
+    matches!(
+        family,
+        Some(
+            FuzzOperationFamily::Create
+                | FuzzOperationFamily::Update
+                | FuzzOperationFamily::Delete
+                | FuzzOperationFamily::Submit
+        )
+    ) || matches!(
+        safety_class,
+        FuzzSafetyClass::Idempotent | FuzzSafetyClass::IsolatedMutation
+    )
 }
 
 fn strategy_matches_operation(strategy: FuzzPlanStrategy, family: FuzzOperationFamily) -> bool {

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -222,6 +222,36 @@ fn destructive_inventory() -> FuzzTargetInventory {
     .expect("inventory parses")
 }
 
+fn mutation_family_inventory() -> FuzzTargetInventory {
+    FuzzTargetInventory::from_value(serde_json::json!({
+        "schema": "homeboy/fuzz-target-inventory/v1",
+        "version": 1,
+        "id": "component-a-inventory",
+        "targets": [
+            {
+                "schema": "homeboy/fuzz-target/v1",
+                "id": "api.users",
+                "kind": "api",
+                "operations": [
+                    { "id": "api.users.read", "kind": "GET", "family": "read" },
+                    { "id": "api.users.create", "kind": "POST", "family": "create" },
+                    { "id": "api.users.update", "kind": "PATCH", "family": "update" },
+                    { "id": "api.users.delete", "kind": "DELETE", "family": "delete" },
+                    { "id": "api.users.submit", "kind": "submit", "family": "submit" }
+                ]
+            }
+        ],
+        "workloads": [
+            {
+                "schema": "homeboy/fuzz-workload/v1",
+                "id": "api-fuzz",
+                "safety_class": "read_only"
+            }
+        ]
+    }))
+    .expect("inventory parses")
+}
+
 fn write_inventory(path: &Path, inventory: &FuzzTargetInventory) {
     fs::write(
         path,

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -55,7 +55,8 @@ fn fuzz_discover_requires_inventory_artifacts() {
 
 #[test]
 fn fuzz_plan_selects_inventory_targets_operations_seeds_and_budgets() {
-    let args = planner_args();
+    let mut args = planner_args();
+    args.run.isolation = FuzzIsolationArg::Isolated;
     let metadata = super::plan_inventory_selection(&args, &planner_inventory(), None).unwrap();
 
     assert_eq!(
@@ -489,6 +490,7 @@ fn fuzz_run_campaign_dry_run_emits_structured_dispatch_records() {
 #[test]
 fn fuzz_plan_operation_filter_limits_inventory_selection() {
     let mut args = planner_args();
+    args.run.isolation = FuzzIsolationArg::Isolated;
     args.operations = vec!["read".to_string()];
 
     let metadata = super::plan_inventory_selection(&args, &planner_inventory(), None).unwrap();
@@ -510,6 +512,64 @@ fn fuzz_plan_operation_filter_limits_inventory_selection() {
         metadata["skipped"]["operations"].as_array().unwrap().len(),
         1
     );
+}
+
+#[test]
+fn fuzz_plan_skips_mutating_operation_families_in_shared_mode() {
+    let metadata =
+        super::plan_inventory_selection(&planner_args(), &mutation_family_inventory(), None)
+            .unwrap();
+
+    assert_eq!(
+        metadata["selection"]["operation_families"],
+        serde_json::json!(["read"])
+    );
+    assert_eq!(
+        metadata["selection"]["operations"][0]["operation_id"],
+        serde_json::json!("api.users.read")
+    );
+    let skipped = metadata["skipped"]["operations"].as_array().unwrap();
+    assert_eq!(skipped.len(), 4);
+    assert!(skipped
+        .iter()
+        .all(|operation| operation["reason"] == serde_json::json!("unsafe")));
+    assert_eq!(metadata["isolation"]["mode"], serde_json::json!("shared"));
+}
+
+#[test]
+fn fuzz_plan_includes_mutating_operation_families_in_isolated_mode() {
+    let mut args = planner_args();
+    args.run.isolation = FuzzIsolationArg::Isolated;
+
+    let metadata = super::plan_inventory_selection(&args, &mutation_family_inventory(), None)
+        .expect("isolated mutation planning");
+
+    assert_eq!(
+        metadata["selection"]["operation_families"],
+        serde_json::json!(["create", "delete", "read", "submit", "update"])
+    );
+    assert!(metadata["skipped"]["operations"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+    assert_eq!(metadata["isolation"]["required"], serde_json::json!(true));
+    assert_eq!(metadata["isolation"]["mode"], serde_json::json!("isolated"));
+}
+
+#[test]
+fn fuzz_plan_skips_isolated_mutation_safety_class_in_shared_mode() {
+    let metadata =
+        super::plan_inventory_selection(&planner_args(), &planner_inventory(), None).unwrap();
+
+    assert!(metadata["selection"]["operations"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+    assert!(metadata["skipped"]["operations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|operation| operation["reason"] == serde_json::json!("unsafe")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Treats mutation-capable fuzz operation families as requiring isolated execution.
- Skips create/update/delete/submit operations in shared mode using existing unsafe skip semantics.
- Keeps Homeboy core product-neutral and preserves stricter destructive proof handling.

## Verification
- `rustfmt --check src/commands/fuzz/planning.rs src/commands/fuzz/tests/planning_tests.rs src/commands/fuzz/tests/mod.rs`
- `cargo test fuzz_plan --quiet`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the generic fuzz mutation isolation gate and test coverage with Chris directing the contract requirements.