### PR TITLE
Fix path materialization contract drift

### DIFF
--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -870,6 +870,28 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
                 example: runner_execution_envelope_example(),
             },
             ContractSchemaEntry {
+                id: PATH_MATERIALIZATION_PLAN_SCHEMA,
+                version: 1,
+                description: "Canonical runner-side path materialization plan. The top-level shape is exactly { schema, entries }; consumers must not substitute paths/runtime_mounts aliases.",
+                fields: vec![
+                    field(
+                        "schema",
+                        "string",
+                        "Schema ID for the path materialization plan.",
+                        true,
+                    ),
+                    field("entries", "array", "Path materialization entries.", true),
+                    field("entries[].role", "string", "Generic role for the path, such as primary_workspace or required_path.", true),
+                    field("entries[].owner", "string", "Generic producer/owner of the path declaration.", true),
+                    field("entries[].local_path", "string|null", "Controller/local source path when applicable.", false),
+                    field("entries[].remote_path", "string", "Runner-side path to validate or materialize.", true),
+                    field("entries[].materialization_mode", "string", "Materialization mode enum: existing_remote, git, or snapshot.", true),
+                    field("entries[].validation_status", "string", "Validation/materialization status enum: validated or materialized.", true),
+                ],
+                required: vec!["schema", "entries"],
+                example: path_materialization_plan_example(),
+            },
+            ContractSchemaEntry {
                 id: ARTIFACT_POSTPROCESS_SCHEMA,
                 version: 1,
                 description:
@@ -1139,6 +1161,29 @@ fn artifact_manifest_example() -> Value {
                 "label": "Final runtime output",
                 "content_type": "text/markdown",
                 "metadata": {}
+            }
+        ]
+    })
+}
+
+fn path_materialization_plan_example() -> Value {
+    json!({
+        "schema": PATH_MATERIALIZATION_PLAN_SCHEMA,
+        "entries": [
+            {
+                "role": "primary_workspace",
+                "owner": "runner_exec.source_snapshot",
+                "local_path": "/local/project",
+                "remote_path": "/runner/project",
+                "materialization_mode": "snapshot",
+                "validation_status": "materialized"
+            },
+            {
+                "role": "required_path",
+                "owner": "runner_exec.require_paths",
+                "remote_path": "/runner/cache",
+                "materialization_mode": "existing_remote",
+                "validation_status": "validated"
             }
         ]
     })
@@ -1754,6 +1799,34 @@ mod tests {
             .unwrap()
             .iter()
             .any(|contract| contract["id"] == RUNNER_EXECUTION_ENVELOPE_SCHEMA));
+        let path_materialization = catalog["contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|contract| contract["id"] == PATH_MATERIALIZATION_PLAN_SCHEMA)
+            .expect("path materialization contract export");
+        assert_eq!(
+            path_materialization["required"],
+            json!(["schema", "entries"])
+        );
+        let fields: Vec<_> = path_materialization["fields"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|field| field["name"].as_str().unwrap())
+            .collect();
+        assert!(fields.contains(&"schema"));
+        assert!(fields.contains(&"entries"));
+        assert!(fields.contains(&"entries[].remote_path"));
+        assert!(fields.contains(&"entries[].materialization_mode"));
+        assert_eq!(
+            path_materialization["example"]["schema"],
+            PATH_MATERIALIZATION_PLAN_SCHEMA
+        );
+        assert!(path_materialization["example"].get("paths").is_none());
+        assert!(path_materialization["example"]
+            .get("runtime_mounts")
+            .is_none());
         assert!(catalog["contracts"]
             .as_array()
             .unwrap()
@@ -2173,6 +2246,48 @@ mod tests {
 
         assert_eq!(output.schema, PATH_MATERIALIZATION_PLAN_SCHEMA);
         assert!(output.valid);
+    }
+
+    #[test]
+    fn rejects_drifted_path_materialization_plan_shape() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "path-materialization-plan-drifted.json",
+            json!({
+                "schema": PATH_MATERIALIZATION_PLAN_SCHEMA,
+                "paths": ["/runner/project"],
+                "runtime_mounts": []
+            }),
+        );
+
+        let err = validate_file(PATH_MATERIALIZATION_PLAN_SCHEMA, file)
+            .expect_err("drifted path materialization shape should fail validation");
+
+        assert!(err.details["error"]
+            .as_str()
+            .unwrap()
+            .contains("unknown field `paths`"));
+    }
+
+    #[test]
+    fn rejects_path_materialization_plan_without_entries() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "path-materialization-plan-missing-entries.json",
+            json!({
+                "schema": PATH_MATERIALIZATION_PLAN_SCHEMA
+            }),
+        );
+
+        let err = validate_file(PATH_MATERIALIZATION_PLAN_SCHEMA, file)
+            .expect_err("entries is the canonical required field");
+
+        assert!(err.details["error"]
+            .as_str()
+            .unwrap()
+            .contains("missing field `entries`"));
     }
 
     #[test]

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -194,10 +194,10 @@ pub struct PathMaterializationProjection {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct PathMaterializationPlan {
     #[serde(default = "path_materialization_plan_schema")]
     pub schema: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entries: Vec<PathMaterializationEntry>,
 }
 
@@ -311,6 +311,7 @@ impl PathMaterializationPlan {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct PathMaterializationEntry {
     pub role: String,
     pub owner: String,


### PR DESCRIPTION
## Summary
- Export `homeboy/path-materialization-plan/v1` in the core schema catalog with canonical `schema` + `entries` shape and sample payload.
- Tighten `PathMaterializationPlan`/entry deserialization so drifted `paths` and `runtime_mounts` aliases fail validation instead of silently parsing.
- Add contract tests that lock the exported schema ID, required fields, sample shape, and validation rejection paths.

Related: Extra-Chill/homeboy#6872, Extra-Chill/homeboy#6887. Downstream consumer: Extra-Chill/homeboy-extensions#1954.

## Tests
- `cargo test commands::contract::tests`
- `cargo test core::runner_execution_envelope::tests`
- `cargo fmt --check` was run and is blocked by pre-existing unrelated formatting drift in untouched files such as `src/commands/agent_task/fanout.rs`, `src/commands/runs/common.rs`, and `src/core/code_audit/engine.rs`.

## Downstream follow-up
- Homeboy Extensions should update its parser for `homeboy/path-materialization-plan/v1` to consume `entries` and drop the drifted `paths`/`runtime_mounts` shape.
- Homeboy Extensions should add a contract/export fixture check against Homeboy core's `schema-catalog.json` for this schema.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and tested the Homeboy core contract export/validation changes with Chris directing the target contract and PR requirements.
