### PR TITLE
Harden resource lifecycle cleanup index

### DIFF
--- a/src/commands/runner/lifecycle.rs
+++ b/src/commands/runner/lifecycle.rs
@@ -104,11 +104,16 @@ pub(super) fn lifecycle(
             .unwrap_or_else(|| "unknown".to_string()),
         runner_id: Some(runner_id.clone()),
         path: workspace.clone(),
+        root_bound: None,
         kind: "runner_workspace".to_string(),
         ttl: None,
         cleanup_policy: cleanup_policy_for_status(status),
         evidence_retention: ResourceEvidenceRetention::Manifest,
         cleanup_intent: ResourceCleanupIntent::DryRun,
+        cleanup_command: Some(format!(
+            "homeboy runs resources --run-id {} --cleanup-plan",
+            run_id.as_deref().or(job_id.as_deref()).unwrap_or("unknown")
+        )),
         status: resource_status_for_status(status),
     };
     let resource_lifecycle = ResourceLifecycle::inspect(&resource_record);

--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -125,11 +125,16 @@ fn metadata_with_resource_lifecycle(
         run_id: artifact.run_id.clone(),
         runner_id: Some(runner_id.to_string()),
         path: artifact.path.clone(),
+        root_bound: None,
         kind: format!("artifact_{}", artifact.artifact_type),
         ttl: Some("P30D".to_string()),
         cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
         evidence_retention: ResourceEvidenceRetention::Full,
         cleanup_intent: ResourceCleanupIntent::DryRun,
+        cleanup_command: Some(format!(
+            "homeboy runs resources --run-id {} --cleanup-plan",
+            artifact.run_id
+        )),
         status: ResourceLifecycleResourceStatus::Retained,
     };
     metadata["resource_lifecycle"] =

--- a/src/commands/runs/resources.rs
+++ b/src/commands/runs/resources.rs
@@ -124,8 +124,12 @@ pub struct RunsResourcesCleanupPlanItem {
     pub owner: String,
     pub run_id: String,
     pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_bound: Option<String>,
     pub kind: String,
     pub operation: ResourceCleanupOperation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_command: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -349,8 +353,10 @@ fn cleanup_plan_item(
         owner: record.owner.clone(),
         run_id: record.run_id.clone(),
         path: record.path.clone(),
+        root_bound: record.root_bound.clone(),
         kind: record.kind.clone(),
         operation,
+        cleanup_command: record.cleanup_command.clone(),
     }
 }
 
@@ -493,11 +499,15 @@ fn sample_resource_lifecycle_index() -> ResourceLifecycleIndex {
             run_id: "sample-run-1".to_string(),
             runner_id: Some("sample-runner".to_string()),
             path: "/tmp/homeboy/sample-run-1/workspace".to_string(),
+            root_bound: Some("/tmp/homeboy/sample-run-1".to_string()),
             kind: "workspace".to_string(),
             ttl: Some("P7D".to_string()),
             cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
             evidence_retention: ResourceEvidenceRetention::Manifest,
             cleanup_intent: Default::default(),
+            cleanup_command: Some(
+                "homeboy runs resources --run-id sample-run-1 --cleanup-plan".to_string(),
+            ),
             status: ResourceLifecycleResourceStatus::CleanupPending,
         }],
     }
@@ -521,11 +531,13 @@ mod tests {
             run_id: "run-1".to_string(),
             runner_id: None,
             path: "/tmp/resource".to_string(),
+            root_bound: None,
             kind: "workspace".to_string(),
             ttl: Some("P1D".to_string()),
             cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
             evidence_retention: ResourceEvidenceRetention::Metadata,
             cleanup_intent: ResourceCleanupIntent::DryRun,
+            cleanup_command: None,
             status,
         }
     }
@@ -615,7 +627,40 @@ mod tests {
 
         assert_eq!(cleanup.candidate_count, 1);
         assert_eq!(cleanup.planned_count, 1);
+        assert_eq!(cleanup.planned[0].root_bound, None);
         assert_eq!(cleanup.applied_count, 0);
+        assert!(resource_path.exists());
+    }
+
+    #[test]
+    fn cleanup_plan_surfaces_root_bound_and_follow_up_command() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let resource_path = tempdir.path().join("resource");
+        std::fs::create_dir(&resource_path).expect("resource dir");
+        let cleanup_command = "homeboy runs resources --run-id run-1 --cleanup-plan".to_string();
+        let resource = ResourceLifecycleRecord {
+            path: resource_path.display().to_string(),
+            root_bound: Some(tempdir.path().display().to_string()),
+            cleanup_command: Some(cleanup_command.clone()),
+            ..record(ResourceLifecycleResourceStatus::CleanupPending)
+        };
+
+        let cleanup = build_cleanup_output(
+            &[resource],
+            &RunsResourcesArgs {
+                cleanup_plan: true,
+                cleanup_root: Some(tempdir.path().to_path_buf()),
+                ..Default::default()
+            },
+        )
+        .expect("cleanup plan");
+
+        assert_eq!(cleanup.planned_count, 1);
+        assert_eq!(
+            cleanup.planned[0].root_bound,
+            Some(tempdir.path().display().to_string())
+        );
+        assert_eq!(cleanup.planned[0].cleanup_command, Some(cleanup_command));
         assert!(resource_path.exists());
     }
 

--- a/src/core/resource_lifecycle_index.rs
+++ b/src/core/resource_lifecycle_index.rs
@@ -31,6 +31,8 @@ pub struct ResourceLifecycleRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runner_id: Option<String>,
     pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_bound: Option<String>,
     pub kind: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ttl: Option<String>,
@@ -38,6 +40,8 @@ pub struct ResourceLifecycleRecord {
     pub evidence_retention: ResourceEvidenceRetention,
     #[serde(default)]
     pub cleanup_intent: ResourceCleanupIntent,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_command: Option<String>,
     pub status: ResourceLifecycleResourceStatus,
 }
 
@@ -65,10 +69,14 @@ pub struct ResourceLifecycleInspection {
     pub owner: String,
     pub run_id: String,
     pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_bound: Option<String>,
     pub kind: String,
     pub status: ResourceLifecycleResourceStatus,
     pub cleanup_policy: ResourceCleanupPolicy,
     pub cleanup_intent: ResourceCleanupIntent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_command: Option<String>,
     pub actionable: bool,
     pub cleanup_eligible: bool,
 }
@@ -79,10 +87,12 @@ impl ResourceLifecycleInspection {
             owner: record.owner.clone(),
             run_id: record.run_id.clone(),
             path: record.path.clone(),
+            root_bound: record.root_bound.clone(),
             kind: record.kind.clone(),
             status: record.status,
             cleanup_policy: record.cleanup_policy,
             cleanup_intent: record.cleanup_intent,
+            cleanup_command: record.cleanup_command.clone(),
             actionable: resource_lifecycle_record_is_actionable(record),
             cleanup_eligible: resource_lifecycle_record_is_cleanup_eligible(record),
         }
@@ -183,6 +193,15 @@ pub fn resource_lifecycle_cleanup_path(
     let root = root
         .canonicalize()
         .map_err(|_| "cleanup root does not exist".to_string())?;
+    let root_bound = record
+        .root_bound
+        .as_deref()
+        .map(|path| {
+            PathBuf::from(path)
+                .canonicalize()
+                .map_err(|_| "declared root bound does not exist".to_string())
+        })
+        .transpose()?;
     let path = PathBuf::from(&record.path);
     let metadata =
         fs::symlink_metadata(&path).map_err(|_| "resource path does not exist".to_string())?;
@@ -212,6 +231,15 @@ pub fn resource_lifecycle_cleanup_path(
 
     if !containment_path.starts_with(&root) {
         return Err("resource path is outside cleanup root".to_string());
+    }
+
+    if let Some(root_bound) = &root_bound {
+        if containment_path == *root_bound {
+            return Err("resource path is declared root bound".to_string());
+        }
+        if !containment_path.starts_with(root_bound) {
+            return Err("resource path is outside declared root bound".to_string());
+        }
     }
 
     Ok(cleanup_path)
@@ -321,6 +349,14 @@ pub fn validate_resource_lifecycle_record(
         validate_required_field(&format!("{prefix}.runner_id"), runner_id)?;
     }
 
+    if let Some(root_bound) = &record.root_bound {
+        validate_required_field(&format!("{prefix}.root_bound"), root_bound)?;
+    }
+
+    if let Some(cleanup_command) = &record.cleanup_command {
+        validate_required_field(&format!("{prefix}.cleanup_command"), cleanup_command)?;
+    }
+
     if let Some(ttl) = &record.ttl {
         validate_required_field(&format!("{prefix}.ttl"), ttl)?;
     } else if matches!(record.cleanup_policy, ResourceCleanupPolicy::DeleteAfterTtl) {
@@ -363,11 +399,15 @@ mod tests {
             run_id: "run-1".to_string(),
             runner_id: Some("runner-1".to_string()),
             path: "/tmp/homeboy/run-1/workspace".to_string(),
+            root_bound: None,
             kind: "workspace".to_string(),
             ttl: Some("P7D".to_string()),
             cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
             evidence_retention: ResourceEvidenceRetention::Manifest,
             cleanup_intent: ResourceCleanupIntent::DryRun,
+            cleanup_command: Some(
+                "homeboy runs resources --run-id run-1 --cleanup-plan".to_string(),
+            ),
             status: ResourceLifecycleResourceStatus::Active,
         }
     }
@@ -382,6 +422,16 @@ mod tests {
     #[test]
     fn validates_resource_lifecycle_index() {
         index().validate().unwrap();
+    }
+
+    #[test]
+    fn validates_root_bound_and_follow_up_cleanup_command() {
+        let mut index = index();
+        index.resources[0].root_bound = Some("/tmp/homeboy/run-1".to_string());
+        index.resources[0].cleanup_command =
+            Some("homeboy runs resources --run-id run-1 --cleanup-plan".to_string());
+
+        index.validate().unwrap();
     }
 
     #[test]
@@ -437,6 +487,23 @@ mod tests {
 
         assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
         assert_eq!(error.details["field"], "resources[0].path");
+    }
+
+    #[test]
+    fn rejects_blank_root_bound_and_cleanup_command() {
+        let mut contract = index();
+        contract.resources[0].root_bound = Some("  ".to_string());
+
+        let error = contract.validate().unwrap_err();
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "resources[0].root_bound");
+
+        let mut contract = index();
+        contract.resources[0].cleanup_command = Some("  ".to_string());
+
+        let error = contract.validate().unwrap_err();
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(error.details["field"], "resources[0].cleanup_command");
     }
 
     #[test]
@@ -502,6 +569,29 @@ mod tests {
             .expect_err("outside path must be rejected");
 
         assert_eq!(error, "resource path is outside cleanup root");
+    }
+
+    #[test]
+    fn cleanup_path_enforces_declared_root_bound() {
+        let cleanup_root = tempfile::tempdir().expect("cleanup root");
+        let bound = cleanup_root.path().join("owned");
+        let sibling = cleanup_root.path().join("other");
+        std::fs::create_dir(&bound).expect("bound dir");
+        std::fs::create_dir(&sibling).expect("sibling dir");
+        let resource_path = sibling.join("resource");
+        std::fs::write(&resource_path, "generated").expect("resource file");
+        let resource = ResourceLifecycleRecord {
+            path: resource_path.display().to_string(),
+            root_bound: Some(bound.display().to_string()),
+            cleanup_intent: ResourceCleanupIntent::Apply,
+            ..record()
+        };
+
+        let error = ResourceLifecycle::cleanup_path(cleanup_root.path(), &resource)
+            .expect_err("outside root bound must be rejected");
+
+        assert_eq!(error, "resource path is outside declared root bound");
+        assert!(resource_path.exists());
     }
 
     #[cfg(unix)]

--- a/src/core/rig/resource_lifecycle.rs
+++ b/src/core/rig/resource_lifecycle.rs
@@ -83,11 +83,16 @@ fn record(
         run_id: options.run_id.clone(),
         runner_id: options.runner_id.clone(),
         path,
+        root_bound: None,
         kind: kind.to_string(),
         ttl: None,
         cleanup_policy: ResourceCleanupPolicy::Manual,
         evidence_retention: ResourceEvidenceRetention::Metadata,
         cleanup_intent: options.cleanup_intent,
+        cleanup_command: Some(format!(
+            "homeboy runs resources --run-id {} --cleanup-plan",
+            options.run_id
+        )),
         status: options.status,
     }
 }

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -823,11 +823,14 @@ pub(crate) fn workspace_resource_lifecycle(
         run_id: run_id.unwrap_or("materialized-workspace").to_string(),
         runner_id: Some(runner_id.to_string()),
         path: remote_path.to_string(),
+        root_bound: None,
         kind: "runner_workspace".to_string(),
         ttl: None,
         cleanup_policy,
         evidence_retention: ResourceEvidenceRetention::Metadata,
         cleanup_intent: Default::default(),
+        cleanup_command: run_id
+            .map(|run_id| format!("homeboy runs resources --run-id {run_id} --cleanup-plan")),
         status: ResourceLifecycleResourceStatus::Active,
     }
 }
@@ -1316,11 +1319,13 @@ fn remove_local_workspace_with_lifecycle(root: &Path, path: &Path) -> Result<()>
         run_id: "materialized-workspace".to_string(),
         runner_id: None,
         path: path.display().to_string(),
+        root_bound: Some(root.display().to_string()),
         kind: "runner_workspace".to_string(),
         ttl: None,
         cleanup_policy: ResourceCleanupPolicy::DeleteOnSuccess,
         evidence_retention: ResourceEvidenceRetention::Metadata,
         cleanup_intent: Default::default(),
+        cleanup_command: None,
         status: ResourceLifecycleResourceStatus::CleanupPending,
     };
     let cleanup_path = ResourceLifecycle::cleanup_path(root, &resource).map_err(|reason| {


### PR DESCRIPTION
## Summary
- Extend the central resource lifecycle record with optional root bounds and a follow-up cleanup command.
- Surface root bounds and cleanup commands in runs resources cleanup plans.
- Enforce declared filesystem root bounds in the central cleanup path guard, including tests for refusal outside the declared bound.
- Populate follow-up cleanup commands from existing runner, rig, artifact, and workspace resource lifecycle producers.

## Tests
- `rustfmt --check src/core/resource_lifecycle_index.rs src/commands/runs/resources.rs src/commands/runs/remote_artifact.rs src/commands/runner/lifecycle.rs src/core/runner/workspace/sync.rs src/core/rig/resource_lifecycle.rs`
- `cargo check`
- `cargo test resource_lifecycle_index`
- `cargo test cleanup_plan`
- `cargo test output_contracts`
- `git diff --check`

Known pre-existing failure observed while checking broader surface tests:
- `cargo test command_surface` fails because `docs/commands/runner.md` does not document `lifecycle` from live help. This PR does not add that command or broaden into runner docs.

## Follow-up cleanup paths
- `cleanup artifacts` / artifact cleanup output remains on its current cleanup model.
- runs artifact cleanup remains separate except for resource lifecycle metadata attached to run artifacts.
- runner workspace prune/reap still has its own cleanup command path, now with lifecycle root-bound protection for local deletion.
- worktree cleanup and self cleanup-runtime-tmp remain separate cleanup surfaces.
- lease resources are represented by rig lifecycle records, but lease release/prune orchestration is not moved into the central planner in this slice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and tested the resource lifecycle cleanup contract hardening with Chris directing the PR scope.