### PR TITLE
Clarify linked extension update repair path

### DIFF
--- a/src/core/extension/lifecycle/mod.rs
+++ b/src/core/extension/lifecycle/mod.rs
@@ -1413,6 +1413,38 @@ exec '{}' "$@"
         });
     }
 
+    #[test]
+    fn linked_update_reports_reinstall_repair_when_source_is_not_git_backed() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("copied-source");
+            fs::create_dir_all(&source).expect("source repo");
+            write_extension_fixture(&source, "wordpress");
+
+            install(
+                &source.join("wordpress").to_string_lossy(),
+                Some("wordpress"),
+            )
+            .expect("install linked extension");
+
+            let error = update("wordpress", false)
+                .expect_err("non-git linked source should fail with repair guidance");
+
+            assert!(
+                error.message.contains("not inside a git checkout"),
+                "unexpected error: {}",
+                error.message
+            );
+            assert!(
+                error.hints.iter().any(|hint| hint.message.contains(
+                    "homeboy extension install <source-path-or-url> --id wordpress --reinstall"
+                )),
+                "expected reinstall repair hint, got: {:?}",
+                error.hints
+            );
+        });
+    }
+
     #[cfg(unix)]
     #[test]
     fn test_run_setup_if_configured() {

--- a/src/core/extension/lifecycle/update.rs
+++ b/src/core/extension/lifecycle/update.rs
@@ -268,10 +268,7 @@ fn update_linked_extension(
             .join(source_dir)
     };
     let source_dir = source_dir.canonicalize().unwrap_or(source_dir);
-    let git_root_str = git::get_git_root(&source_dir.to_string_lossy())?;
-    let git_root = PathBuf::from(&git_root_str)
-        .canonicalize()
-        .unwrap_or_else(|_| PathBuf::from(git_root_str));
+    let git_root = linked_extension_git_root(extension_id, &source_dir)?;
     let old_branch = git::current_branch(&git_root);
     let old_source_revision = git::short_head_revision(&git_root);
 
@@ -341,6 +338,33 @@ fn update_linked_extension(
         },
         repaired_source_metadata: None,
     })
+}
+
+fn linked_extension_git_root(extension_id: &str, source_dir: &Path) -> Result<PathBuf> {
+    let mut candidate = Some(source_dir);
+    while let Some(path) = candidate {
+        if let Ok(git_root_str) = git::get_git_root(&path.to_string_lossy()) {
+            return Ok(PathBuf::from(&git_root_str)
+                .canonicalize()
+                .unwrap_or_else(|_| PathBuf::from(git_root_str)));
+        }
+        candidate = path.parent();
+    }
+
+    Err(Error::validation_invalid_argument(
+        "extension_id",
+        format!(
+            "Linked extension '{}' points at {}, but that path is not inside a git checkout Homeboy can update.",
+            extension_id,
+            source_dir.display()
+        ),
+        Some(extension_id.to_string()),
+        None,
+    )
+    .with_hint(format!(
+        "Repair by reinstalling from the original source: homeboy extension install <source-path-or-url> --id {} --reinstall",
+        extension_id
+    )))
 }
 
 /// Check if a git-cloned extension has updates available.


### PR DESCRIPTION
## Summary
- Resolves linked extension git roots by walking up from the symlink target.
- Replaces raw git failures for copied/non-git linked extension sources with actionable reinstall repair guidance.
- Adds a regression test for non-git linked extension update failure output.

## Verification
- `rustfmt --check src/core/extension/lifecycle/update.rs src/core/extension/lifecycle/mod.rs`
- `cargo test linked_update_reports_reinstall_repair_when_source_is_not_git_backed --quiet`
- `cargo test update_all_updates_linked_extensions_through_single_update_path --quiet`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed the extension update blocker found during Jetpack fuzz setup and implemented the focused upstream repair-path fix.