### PR TITLE
Carry source materialization in lab route plans

### DIFF
--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1,4 +1,5 @@
 use homeboy::cli_surface::{Cli, Commands};
+use homeboy::core::command_execution_plan::CommandSourceMaterialization;
 use homeboy::core::component::{self, TargetSpec};
 use homeboy::core::git;
 use homeboy::core::lab_routing::{
@@ -883,6 +884,12 @@ fn rewrite_ad_hoc_lab_workspace_to_path(
     command: &Commands,
     normalized_args: &[String],
 ) -> Option<Vec<String>> {
+    let contract = command.lab_contract()?;
+    let plan = lab_routing::lab_route_plan_from_contract(contract);
+    if plan.source_materialization != CommandSourceMaterialization::ControllerCwdAsPathArg {
+        return None;
+    }
+
     let needs_path = match command {
         Commands::Audit(args) => args.comp.component.is_none() && args.comp.path.is_none(),
         Commands::Lint(args) => args.comp.component.is_none() && args.comp.path.is_none(),

--- a/src/core/command_execution_plan.rs
+++ b/src/core/command_execution_plan.rs
@@ -120,6 +120,7 @@ pub struct LabRoutePlan {
     pub label: String,
     pub portability: CommandPortability,
     pub source_policy: CommandSourcePolicy,
+    pub source_materialization: CommandSourceMaterialization,
     pub workspace_policy: CommandWorkspacePolicy,
     pub output_contract: CommandOutputContract,
     pub required_extensions: Vec<String>,
@@ -137,6 +138,7 @@ impl LabRoutePlan {
             label: label.into(),
             portability: CommandPortability::Portable,
             source_policy: CommandSourcePolicy::ControllerCwdOrExplicitPath,
+            source_materialization: CommandSourceMaterialization::ControllerCwdAsPathArg,
             workspace_policy: CommandWorkspacePolicy::ChangedSinceGitElseSnapshot,
             output_contract: CommandOutputContract::inherit(),
             required_extensions: Vec::new(),
@@ -159,4 +161,11 @@ impl LabRoutePlan {
             CommandPortability::LocalOnly { reason } => Some(reason),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandSourceMaterialization {
+    None,
+    ControllerCwdAsPathArg,
 }

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -9,7 +9,8 @@ use crate::command_contract::{
     LabWorkspaceModePolicy,
 };
 use crate::core::command_execution_plan::{
-    CommandPortability, CommandSourcePolicy, CommandWorkspacePolicy, LabRoutePlan,
+    CommandPortability, CommandSourceMaterialization, CommandSourcePolicy, CommandWorkspacePolicy,
+    LabRoutePlan,
 };
 use crate::core::observation::records::RunEvidenceCommands;
 use crate::core::observation::RunStatus;
@@ -353,6 +354,10 @@ pub fn lab_offload_command_from_contract(
     lab_offload_command_from_route_contract(contract.into_route_contract(required_extensions))
 }
 
+pub fn lab_route_plan_from_contract(contract: LabCommandContract) -> LabRoutePlan {
+    lab_route_plan_from_route_contract(contract.into_route_contract(Vec::new()))
+}
+
 pub fn lab_offload_command_from_route_contract(
     route_contract: LabCommandRouteContract,
 ) -> runners::LabOffloadCommand {
@@ -398,9 +403,7 @@ pub fn lab_offload_command_from_route_contract(
     }
 }
 
-pub(crate) fn lab_route_plan_from_route_contract(
-    route_contract: LabCommandRouteContract,
-) -> LabRoutePlan {
+pub fn lab_route_plan_from_route_contract(route_contract: LabCommandRouteContract) -> LabRoutePlan {
     let contract = route_contract.command;
     let mut plan = match contract.portability {
         LabCommandPortability::Portable => LabRoutePlan::portable(contract.hot_label),
@@ -412,6 +415,10 @@ pub(crate) fn lab_route_plan_from_route_contract(
     plan.source_policy = match contract.source_path_mode {
         LabSourcePathMode::CwdOrPathFlag => CommandSourcePolicy::ControllerCwdOrExplicitPath,
         LabSourcePathMode::RunnerResident => CommandSourcePolicy::RunnerResident,
+    };
+    plan.source_materialization = match contract.source_path_mode {
+        LabSourcePathMode::CwdOrPathFlag => CommandSourceMaterialization::ControllerCwdAsPathArg,
+        LabSourcePathMode::RunnerResident => CommandSourceMaterialization::None,
     };
     plan.workspace_policy = match contract.workspace_mode_policy {
         LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot => {
@@ -512,7 +519,8 @@ mod tests {
         LAB_CAPABILITY_PLAYWRIGHT, LAB_TRACE_EXTRA_CAPABILITIES,
     };
     use crate::core::command_execution_plan::{
-        CommandPortability, CommandSourcePolicy, CommandWorkspacePolicy,
+        CommandPortability, CommandSourceMaterialization, CommandSourcePolicy,
+        CommandWorkspacePolicy,
     };
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
@@ -607,6 +615,10 @@ mod tests {
             CommandSourcePolicy::ControllerCwdOrExplicitPath
         );
         assert_eq!(
+            plan.source_materialization,
+            CommandSourceMaterialization::ControllerCwdAsPathArg
+        );
+        assert_eq!(
             plan.workspace_policy,
             CommandWorkspacePolicy::GitCheckoutRequired
         );
@@ -631,6 +643,10 @@ mod tests {
 
         assert_eq!(plan.local_only_reason(), Some("needs controller services"));
         assert_eq!(plan.source_policy, CommandSourcePolicy::RunnerResident);
+        assert_eq!(
+            plan.source_materialization,
+            CommandSourceMaterialization::None
+        );
         assert_eq!(
             plan.workspace_policy,
             CommandWorkspacePolicy::RunnerResident


### PR DESCRIPTION
## Summary
- add source materialization to the lab route plan
- route ad-hoc lab workspace rewrites through the plan instead of command-shape-only logic
- add focused coverage for the contract slice

Refs Extra-Chill/homeboy#6652
Refs Extra-Chill/homeboy#6684

## Testing
- cargo fmt
- cargo test lab_route_plan_from_contract
- cargo test rewrite_ad_hoc_lab_workspace

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode plus local implementation subagent
- **Used for:** Investigation, patch drafting, and targeted verification.