### PR TITLE
Add configurable agent-task provider rotation

### DIFF
--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -213,6 +213,10 @@ pub fn build_dispatch_plan_with_provider_requirements(
         max_attempts: request.core.attempts.max(1),
         ..AgentTaskRetryPolicy::default()
     };
+    // Global provider rotation policy (`agent_task.rotation` in Homeboy config)
+    // flows into the plan options; per-task `metadata.provider_rotation`
+    // overrides it at dispatch time (#6978).
+    plan.options.rotation = defaults::load_config().agent_task.rotation;
     plan.metadata = serde_json::json!({
         "kind": "agent-task-dispatch",
         "repo": repo,
@@ -910,6 +914,54 @@ mod tests {
         assert!(!serialized.contains("kimaki"));
         assert!(!serialized.contains("channel"));
         assert!(!serialized.contains("thread"));
+    }
+
+    #[test]
+    fn dispatch_plan_applies_global_agent_task_rotation_policy() {
+        with_isolated_home(|_| {
+            let mut config = defaults::load_config();
+            config.agent_task.rotation = Some(
+                crate::core::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                    entries: vec![
+                        crate::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            backend: Some("fallback-backend-a".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    max_attempts: Some(2),
+                },
+            );
+            defaults::save_config(&config).expect("save config");
+
+            let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+                prompt: Some("Cook with rotation.".to_string()),
+                repo: Some("sample-plugin".to_string()),
+                ..DispatchRequestOverrides::default()
+            }))
+            .expect("dispatch plan");
+
+            let rotation = plan.options.rotation.expect("rotation policy on plan");
+            assert_eq!(rotation.entries.len(), 1);
+            assert_eq!(
+                rotation.entries[0].backend.as_deref(),
+                Some("fallback-backend-a")
+            );
+            assert_eq!(rotation.max_attempts, Some(2));
+        });
+    }
+
+    #[test]
+    fn dispatch_plan_leaves_rotation_unset_without_global_policy() {
+        with_isolated_home(|_| {
+            let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+                prompt: Some("Cook without rotation.".to_string()),
+                repo: Some("sample-plugin".to_string()),
+                ..DispatchRequestOverrides::default()
+            }))
+            .expect("dispatch plan");
+
+            assert!(plan.options.rotation.is_none());
+        });
     }
 
     #[test]

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
 use crate::core::agent_task::{
-    AgentTaskComponentContract, AgentTaskFailureClassification, AgentTaskOutcome, AgentTaskRequest,
+    AgentTaskComponentContract, AgentTaskFailureClassification, AgentTaskOutcome,
+    AgentTaskOutcomeStatus, AgentTaskRequest,
 };
 use crate::core::plan::{
     HomeboyPlan, PlanArtifact, PlanKind, PlanStep, PlanStepDependencyKind, PlanStepStatus,
@@ -392,6 +393,11 @@ mod config {
         pub timeout_ms: Option<u64>,
         #[serde(default)]
         pub retry: AgentTaskRetryPolicy,
+        /// Per-plan provider rotation policy. Takes precedence over the global
+        /// Homeboy config `agent_task.rotation`; a per-task
+        /// `metadata.provider_rotation` object overrides both (#6978).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub rotation: Option<AgentTaskProviderRotationPolicy>,
     }
 
     impl Default for AgentTaskScheduleOptions {
@@ -406,6 +412,7 @@ mod config {
                 adaptive_concurrency: None,
                 timeout_ms: None,
                 retry: AgentTaskRetryPolicy::default(),
+                rotation: None,
             }
         }
     }
@@ -494,6 +501,80 @@ mod config {
         pub max_retries_total: Option<u32>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         pub retryable_failure_classifications: Vec<AgentTaskFailureClassification>,
+    }
+
+    /// Operator-configured provider rotation policy for agent-task execution.
+    ///
+    /// On a rotation-eligible failure (provider capacity classifications only:
+    /// `provider`, `transient`, `timeout`), the scheduler re-dispatches the same
+    /// task contract with the next entry in the chain until entries are
+    /// exhausted or the attempt bound is reached. Task-level failures
+    /// (`execution_failed`, `policy_denied`, `invalid_input`,
+    /// `capability_missing`) never rotate so a provider swap cannot mask a real
+    /// task failure or policy denial. The policy is pure operator data — core
+    /// hardcodes no provider or model names (#6978).
+    #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct AgentTaskProviderRotationPolicy {
+        /// Ordered rotation chain. The first attempt always uses the task's own
+        /// executor; entry N handles the (N+1)-th attempt after a
+        /// rotation-eligible failure.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub entries: Vec<AgentTaskProviderRotationEntry>,
+        /// Bound on total dispatch attempts per task (including the first).
+        /// Defaults to `entries.len() + 1` when unset.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub max_attempts: Option<u32>,
+    }
+
+    impl AgentTaskProviderRotationPolicy {
+        /// Total dispatch attempts allowed per task, including the first
+        /// attempt on the task's own executor.
+        pub fn max_total_attempts(&self) -> u32 {
+            self.max_attempts
+                .unwrap_or_else(|| self.entries.len() as u32 + 1)
+                .max(1)
+        }
+    }
+
+    /// One rotation target: executor selector overrides and/or nested provider
+    /// config/model, mirroring the dispatch config layer shapes
+    /// (`--dispatch-selector` / `--dispatch-provider-config`). Unset fields
+    /// inherit the values from the failing attempt.
+    #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct AgentTaskProviderRotationEntry {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub backend: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub selector: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub model: Option<String>,
+        /// JSON object merged over the executor's provider config (same shape
+        /// as `--dispatch-provider-config` / `--provider-config`).
+        #[serde(default, skip_serializing_if = "Value::is_null")]
+        pub provider_config: Value,
+    }
+
+    /// Durable evidence for one dispatch attempt of a task under a provider
+    /// rotation policy. Recorded in order on the final outcome under
+    /// `metadata.provider_rotation.attempts` so run records and
+    /// `agent-task status|logs` show which provider/model handled each attempt
+    /// and why failed attempts rotated.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct AgentTaskProviderRotationAttempt {
+        pub attempt: u32,
+        /// Number of rotation entries consumed before this attempt
+        /// (0 = the task's original executor).
+        pub rotation_index: usize,
+        pub backend: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub selector: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub model: Option<String>,
+        pub status: AgentTaskOutcomeStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub failure_classification: Option<AgentTaskFailureClassification>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub summary: Option<String>,
     }
 }
 

--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -16,9 +16,10 @@ pub use crate::core::agent_task_schedule::{
     AgentTaskArtifactOutputDeclaration, AgentTaskArtifactRunBinding, AgentTaskBackpressureStatus,
     AgentTaskCancellationToken, AgentTaskChildRun, AgentTaskExecutionContext,
     AgentTaskOutputBinding, AgentTaskOutputDependencies, AgentTaskPlan, AgentTaskProgressEvent,
-    AgentTaskQueueStatus, AgentTaskResourceBudget, AgentTaskResourceBudgetStatus,
-    AgentTaskRetryPolicy, AgentTaskScheduleOptions, AgentTaskState, AGENT_TASK_AGGREGATE_SCHEMA,
-    AGENT_TASK_PLAN_SCHEMA,
+    AgentTaskProviderRotationAttempt, AgentTaskProviderRotationEntry,
+    AgentTaskProviderRotationPolicy, AgentTaskQueueStatus, AgentTaskResourceBudget,
+    AgentTaskResourceBudgetStatus, AgentTaskRetryPolicy, AgentTaskScheduleOptions, AgentTaskState,
+    AGENT_TASK_AGGREGATE_SCHEMA, AGENT_TASK_PLAN_SCHEMA,
 };
 use crate::core::agent_task_timeout::timeout_with_grace;
 use crate::core::agent_task_timeout_artifacts::{
@@ -88,6 +89,8 @@ where
             .map(|request| ScheduledTask {
                 request,
                 attempt: 1,
+                rotation_index: 0,
+                rotation_attempts: Vec::new(),
             })
             .collect();
         let mut running: Vec<RunningTask> = Vec::new();
@@ -318,6 +321,8 @@ where
                     attempt,
                     started_at: Instant::now(),
                     timeout_ms: task_timeout_ms,
+                    rotation_index: scheduled.rotation_index,
+                    rotation_attempts: scheduled.rotation_attempts,
                 });
 
                 thread::spawn(move || {
@@ -400,8 +405,68 @@ where
                         queued.push_back(ScheduledTask {
                             request,
                             attempt: next_attempt,
+                            rotation_index: running_task.rotation_index,
+                            rotation_attempts: running_task.rotation_attempts,
                         });
                         continue;
+                    }
+                    let rotation_policy = AgentTaskScheduleSupport::rotation_policy_for_request(
+                        &running_task.request,
+                        plan.options.rotation.as_ref(),
+                    );
+                    if let Some(policy) = &rotation_policy {
+                        if AgentTaskScheduleSupport::should_rotate_provider(
+                            &outcome,
+                            policy,
+                            running_task.rotation_index,
+                            result.attempt,
+                        ) {
+                            let mut rotation_attempts = running_task.rotation_attempts;
+                            rotation_attempts.push(
+                                AgentTaskScheduleSupport::rotation_attempt_record(
+                                    &running_task.request,
+                                    &outcome,
+                                    result.attempt,
+                                    running_task.rotation_index,
+                                ),
+                            );
+                            let entry = &policy.entries[running_task.rotation_index];
+                            let mut request = running_task.request;
+                            AgentTaskScheduleSupport::apply_rotation_entry(&mut request, entry);
+                            request.parent_plan_id = Some(plan.plan_id.clone());
+                            let next_attempt = result.attempt + 1;
+                            events.push(event(
+                                &request.task_id,
+                                AgentTaskState::Queued,
+                                next_attempt,
+                                Some(format!(
+                                    "provider rotation queued: entry {} of {}",
+                                    running_task.rotation_index + 1,
+                                    policy.entries.len()
+                                )),
+                            ));
+                            queued.push_back(ScheduledTask {
+                                request,
+                                attempt: next_attempt,
+                                rotation_index: running_task.rotation_index + 1,
+                                rotation_attempts,
+                            });
+                            continue;
+                        }
+                    }
+                    let mut outcome = outcome;
+                    if !running_task.rotation_attempts.is_empty() {
+                        let mut rotation_attempts = running_task.rotation_attempts.clone();
+                        rotation_attempts.push(AgentTaskScheduleSupport::rotation_attempt_record(
+                            &running_task.request,
+                            &outcome,
+                            result.attempt,
+                            running_task.rotation_index,
+                        ));
+                        AgentTaskScheduleSupport::attach_rotation_evidence(
+                            &mut outcome,
+                            &rotation_attempts,
+                        );
                     }
                     record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
                 }
@@ -447,6 +512,10 @@ where
 struct ScheduledTask {
     request: AgentTaskRequest,
     attempt: u32,
+    /// Rotation entries already consumed for this task (0 = original executor).
+    rotation_index: usize,
+    /// Ordered evidence for prior dispatch attempts under a rotation policy.
+    rotation_attempts: Vec<AgentTaskProviderRotationAttempt>,
 }
 
 #[derive(Debug, Clone)]
@@ -459,6 +528,10 @@ struct RunningTask {
     attempt: u32,
     started_at: Instant,
     timeout_ms: Option<u64>,
+    /// Rotation entries already consumed for this task (0 = original executor).
+    rotation_index: usize,
+    /// Ordered evidence for prior dispatch attempts under a rotation policy.
+    rotation_attempts: Vec<AgentTaskProviderRotationAttempt>,
 }
 
 struct TaskResult {

--- a/src/core/agent_task_scheduler/scheduling.rs
+++ b/src/core/agent_task_scheduler/scheduling.rs
@@ -1004,6 +1004,145 @@ impl AgentTaskScheduleSupport {
         }
     }
 
+    /// Effective provider rotation policy for one task: a per-task
+    /// `metadata.provider_rotation` object overrides the plan-level
+    /// `options.rotation` policy. Returns `None` when no policy with entries is
+    /// configured so unconfigured behavior stays byte-for-byte unchanged.
+    pub(super) fn rotation_policy_for_request(
+        request: &AgentTaskRequest,
+        plan_rotation: Option<&AgentTaskProviderRotationPolicy>,
+    ) -> Option<AgentTaskProviderRotationPolicy> {
+        request
+            .metadata
+            .get("provider_rotation")
+            .and_then(|value| {
+                serde_json::from_value::<AgentTaskProviderRotationPolicy>(value.clone()).ok()
+            })
+            .or_else(|| plan_rotation.cloned())
+            .filter(|policy| !policy.entries.is_empty())
+    }
+
+    /// Rotation triggers only on provider capacity failures (`provider`,
+    /// `transient`, `timeout` classifications). Task-level failures
+    /// (`execution_failed`, `policy_denied`, `invalid_input`,
+    /// `capability_missing`, `unknown`) never rotate so a provider swap cannot
+    /// mask a real task failure or policy denial (#6978).
+    pub(super) fn should_rotate_provider(
+        outcome: &AgentTaskOutcome,
+        policy: &AgentTaskProviderRotationPolicy,
+        rotation_index: usize,
+        attempt: u32,
+    ) -> bool {
+        rotation_index < policy.entries.len()
+            && attempt < policy.max_total_attempts()
+            && !matches!(
+                outcome.status,
+                AgentTaskOutcomeStatus::Succeeded
+                    | AgentTaskOutcomeStatus::NoOp
+                    | AgentTaskOutcomeStatus::Cancelled
+            )
+            && matches!(
+                outcome.failure_classification,
+                Some(
+                    AgentTaskFailureClassification::Provider
+                        | AgentTaskFailureClassification::Transient
+                        | AgentTaskFailureClassification::Timeout
+                )
+            )
+    }
+
+    /// Apply one rotation entry onto the re-dispatched request's executor.
+    /// Unset entry fields inherit the failing attempt's values; the entry's
+    /// `provider_config` object is merged over the executor config, mirroring
+    /// the dispatch provider-config layering.
+    pub(super) fn apply_rotation_entry(
+        request: &mut AgentTaskRequest,
+        entry: &AgentTaskProviderRotationEntry,
+    ) {
+        let executor = &mut request.executor;
+        if let Some(backend) = &entry.backend {
+            executor.backend = backend.clone();
+        }
+        if let Some(selector) = &entry.selector {
+            executor.selector = Some(selector.clone());
+        }
+        if let Some(model) = &entry.model {
+            executor.model = Some(model.clone());
+        }
+        if let Some(overrides) = entry.provider_config.as_object() {
+            if !overrides.is_empty() {
+                if !executor.config.is_object() {
+                    executor.config = Value::Object(serde_json::Map::new());
+                }
+                executor
+                    .config
+                    .as_object_mut()
+                    .expect("executor config object")
+                    .extend(overrides.clone());
+            }
+        }
+        if let Some(selection) = executor.runtime_selection.as_mut() {
+            if entry.backend.is_some() {
+                selection.executor_backend = entry.backend.clone();
+            }
+            if entry.selector.is_some() {
+                selection.executor_provider_id = entry.selector.clone();
+            }
+            if entry.model.is_some() {
+                selection.model = entry.model.clone();
+            }
+            if let Some(provider) = entry
+                .provider_config
+                .get("provider")
+                .and_then(Value::as_str)
+            {
+                selection.ai_provider_id = Some(provider.to_string());
+            }
+        }
+    }
+
+    /// Evidence record for one dispatch attempt under a rotation policy.
+    pub(super) fn rotation_attempt_record(
+        request: &AgentTaskRequest,
+        outcome: &AgentTaskOutcome,
+        attempt: u32,
+        rotation_index: usize,
+    ) -> AgentTaskProviderRotationAttempt {
+        AgentTaskProviderRotationAttempt {
+            attempt,
+            rotation_index,
+            backend: request.executor.backend.clone(),
+            selector: request.executor.selector.clone(),
+            model: request.executor.model().map(str::to_string),
+            status: outcome.status,
+            failure_classification: outcome.failure_classification,
+            summary: outcome.summary.clone(),
+        }
+    }
+
+    /// Attach the ordered attempt sequence to the final outcome under
+    /// `metadata.provider_rotation.attempts` so durable run records and
+    /// `agent-task status|logs|latest` show what happened per attempt.
+    pub(super) fn attach_rotation_evidence(
+        outcome: &mut AgentTaskOutcome,
+        attempts: &[AgentTaskProviderRotationAttempt],
+    ) {
+        if attempts.is_empty() {
+            return;
+        }
+        if !outcome.metadata.is_object() {
+            outcome.metadata = serde_json::json!({});
+        }
+        outcome
+            .metadata
+            .as_object_mut()
+            .expect("outcome metadata object")
+            .insert(
+                "provider_rotation".to_string(),
+                serde_json::json!({ "attempts": attempts }),
+            );
+    }
+
     pub(super) fn should_retry(
         outcome: &AgentTaskOutcome,
         attempt: u32,

--- a/src/core/agent_task_scheduler/tests/fixtures.rs
+++ b/src/core/agent_task_scheduler/tests/fixtures.rs
@@ -309,6 +309,52 @@ impl AgentTaskExecutorAdapter for SuccessEmptyRequiredTypedArtifactExecutor {
     }
 }
 
+/// Executor that records every dispatched request and returns a scripted
+/// `(status, failure_classification)` sequence, one entry per call (the last
+/// entry repeats if calls outrun the script). Used to prove provider rotation
+/// behavior against exact executor selections per attempt.
+pub(super) struct RotationScriptedExecutor {
+    pub(super) script: Vec<(
+        AgentTaskOutcomeStatus,
+        Option<AgentTaskFailureClassification>,
+    )>,
+    pub(super) observed: Arc<Mutex<Vec<AgentTaskRequest>>>,
+    pub(super) calls: Arc<AtomicUsize>,
+}
+
+impl RotationScriptedExecutor {
+    pub(super) fn new(
+        script: Vec<(
+            AgentTaskOutcomeStatus,
+            Option<AgentTaskFailureClassification>,
+        )>,
+    ) -> Self {
+        Self {
+            script,
+            observed: Arc::new(Mutex::new(Vec::new())),
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl AgentTaskExecutorAdapter for RotationScriptedExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        self.observed
+            .lock()
+            .expect("observed requests")
+            .push(request.clone());
+        let (status, classification) = self.script[call.min(self.script.len() - 1)];
+        let mut result = outcome(request.task_id, status);
+        result.failure_classification = classification;
+        result
+    }
+}
+
 pub(super) struct RecordingExecutor {
     pub(super) statuses: HashMap<String, AgentTaskOutcomeStatus>,
     pub(super) delay: Duration,

--- a/src/core/agent_task_scheduler/tests/scheduling_tests.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests.rs
@@ -332,6 +332,280 @@ mod resource_budget_tests {
     }
 }
 
+mod provider_rotation_tests {
+    use super::*;
+
+    fn rotation_policy(
+        entries: Vec<AgentTaskProviderRotationEntry>,
+    ) -> AgentTaskProviderRotationPolicy {
+        AgentTaskProviderRotationPolicy {
+            entries,
+            max_attempts: None,
+        }
+    }
+
+    fn entry(backend: &str) -> AgentTaskProviderRotationEntry {
+        AgentTaskProviderRotationEntry {
+            backend: Some(backend.to_string()),
+            ..AgentTaskProviderRotationEntry::default()
+        }
+    }
+
+    fn provider_failure() -> (
+        AgentTaskOutcomeStatus,
+        Option<AgentTaskFailureClassification>,
+    ) {
+        (
+            AgentTaskOutcomeStatus::ProviderError,
+            Some(AgentTaskFailureClassification::Provider),
+        )
+    }
+
+    fn success() -> (
+        AgentTaskOutcomeStatus,
+        Option<AgentTaskFailureClassification>,
+    ) {
+        (AgentTaskOutcomeStatus::Succeeded, None)
+    }
+
+    #[test]
+    fn rotates_to_next_entry_on_provider_failure_and_stops_at_first_success() {
+        let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
+        let observed = Arc::clone(&executor.observed);
+        let calls = Arc::clone(&executor.calls);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        plan.options.rotation = Some(rotation_policy(vec![
+            AgentTaskProviderRotationEntry {
+                backend: Some("fallback-backend-a".to_string()),
+                selector: Some("fallback-a.agent-task-executor".to_string()),
+                model: Some("fallback-model-a".to_string()),
+                provider_config: json!({ "provider": "fallback-provider-a" }),
+            },
+            entry("fallback-backend-b"),
+        ]));
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.totals.succeeded, 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        let observed = observed.lock().expect("observed requests");
+        assert_eq!(observed[0].executor.backend, "test");
+        assert_eq!(observed[1].executor.backend, "fallback-backend-a");
+        assert_eq!(
+            observed[1].executor.selector.as_deref(),
+            Some("fallback-a.agent-task-executor")
+        );
+        assert_eq!(
+            observed[1].executor.model.as_deref(),
+            Some("fallback-model-a")
+        );
+        assert_eq!(
+            observed[1]
+                .executor
+                .config
+                .get("provider")
+                .and_then(Value::as_str),
+            Some("fallback-provider-a")
+        );
+
+        let attempts = aggregate.outcomes[0]
+            .metadata
+            .pointer("/provider_rotation/attempts")
+            .and_then(Value::as_array)
+            .expect("rotation attempts evidence");
+        assert_eq!(attempts.len(), 2);
+        assert_eq!(attempts[0]["attempt"], 1);
+        assert_eq!(attempts[0]["backend"], "test");
+        assert_eq!(attempts[0]["failure_classification"], "provider");
+        assert_eq!(attempts[0]["status"], "provider_error");
+        assert_eq!(attempts[1]["attempt"], 2);
+        assert_eq!(attempts[1]["backend"], "fallback-backend-a");
+        assert_eq!(attempts[1]["status"], "succeeded");
+        assert!(aggregate.events.iter().any(|event| {
+            event.message.as_deref() == Some("provider rotation queued: entry 1 of 2")
+        }));
+    }
+
+    #[test]
+    fn rotates_on_transient_and_timeout_classifications() {
+        for classification in [
+            AgentTaskFailureClassification::Transient,
+            AgentTaskFailureClassification::Timeout,
+        ] {
+            let status = if classification == AgentTaskFailureClassification::Timeout {
+                AgentTaskOutcomeStatus::Timeout
+            } else {
+                AgentTaskOutcomeStatus::ProviderError
+            };
+            let executor =
+                RotationScriptedExecutor::new(vec![(status, Some(classification)), success()]);
+            let calls = Arc::clone(&executor.calls);
+            let scheduler = AgentTaskScheduler::new(executor);
+            let mut plan = plan_with_tasks(1);
+            plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
+
+            let aggregate = scheduler.run(plan);
+
+            assert_eq!(
+                aggregate.status,
+                AgentTaskAggregateStatus::Succeeded,
+                "classification {classification:?} should rotate"
+            );
+            assert_eq!(calls.load(Ordering::SeqCst), 2);
+        }
+    }
+
+    #[test]
+    fn does_not_rotate_on_task_level_failure_classifications() {
+        for classification in [
+            AgentTaskFailureClassification::ExecutionFailed,
+            AgentTaskFailureClassification::PolicyDenied,
+            AgentTaskFailureClassification::InvalidInput,
+            AgentTaskFailureClassification::CapabilityMissing,
+        ] {
+            let executor = RotationScriptedExecutor::new(vec![
+                (AgentTaskOutcomeStatus::Failed, Some(classification)),
+                success(),
+            ]);
+            let calls = Arc::clone(&executor.calls);
+            let scheduler = AgentTaskScheduler::new(executor);
+            let mut plan = plan_with_tasks(1);
+            plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
+
+            let aggregate = scheduler.run(plan);
+
+            assert_eq!(
+                aggregate.status,
+                AgentTaskAggregateStatus::Failed,
+                "classification {classification:?} must not rotate"
+            );
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "classification {classification:?} must not re-dispatch"
+            );
+            assert_eq!(
+                aggregate.outcomes[0].failure_classification,
+                Some(classification)
+            );
+            assert!(aggregate.outcomes[0]
+                .metadata
+                .pointer("/provider_rotation")
+                .is_none());
+        }
+    }
+
+    #[test]
+    fn rotation_exhausts_entries_and_records_attempt_sequence_in_order() {
+        let executor = RotationScriptedExecutor::new(vec![provider_failure()]);
+        let observed = Arc::clone(&executor.observed);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        plan.options.rotation = Some(rotation_policy(vec![
+            entry("fallback-backend-a"),
+            entry("fallback-backend-b"),
+        ]));
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        let observed = observed.lock().expect("observed requests");
+        assert_eq!(observed.len(), 3);
+        assert_eq!(observed[1].executor.backend, "fallback-backend-a");
+        assert_eq!(observed[2].executor.backend, "fallback-backend-b");
+        let attempts = aggregate.outcomes[0]
+            .metadata
+            .pointer("/provider_rotation/attempts")
+            .and_then(Value::as_array)
+            .expect("rotation attempts evidence");
+        assert_eq!(attempts.len(), 3);
+        assert_eq!(
+            attempts
+                .iter()
+                .map(|attempt| attempt["rotation_index"].as_u64().expect("rotation index"))
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        assert!(attempts
+            .iter()
+            .all(|attempt| attempt["failure_classification"] == "provider"));
+    }
+
+    #[test]
+    fn rotation_respects_configured_max_attempts_bound() {
+        let executor = RotationScriptedExecutor::new(vec![provider_failure()]);
+        let calls = Arc::clone(&executor.calls);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        plan.options.rotation = Some(AgentTaskProviderRotationPolicy {
+            entries: vec![
+                entry("fallback-backend-a"),
+                entry("fallback-backend-b"),
+                entry("fallback-backend-c"),
+            ],
+            max_attempts: Some(2),
+        });
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        let attempts = aggregate.outcomes[0]
+            .metadata
+            .pointer("/provider_rotation/attempts")
+            .and_then(Value::as_array)
+            .expect("rotation attempts evidence");
+        assert_eq!(attempts.len(), 2);
+    }
+
+    #[test]
+    fn request_metadata_rotation_overrides_plan_policy() {
+        let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
+        let observed = Arc::clone(&executor.observed);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        plan.options.rotation = Some(rotation_policy(vec![entry("plan-fallback")]));
+        plan.tasks[0].metadata = json!({
+            "provider_rotation": {
+                "entries": [{ "backend": "request-fallback" }]
+            }
+        });
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        let observed = observed.lock().expect("observed requests");
+        assert_eq!(observed[1].executor.backend, "request-fallback");
+    }
+
+    #[test]
+    fn no_rotation_policy_keeps_single_attempt_behavior_unchanged() {
+        let executor = RotationScriptedExecutor::new(vec![provider_failure()]);
+        let calls = Arc::clone(&executor.calls);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let plan = plan_with_tasks(1);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            aggregate.outcomes[0].failure_classification,
+            Some(AgentTaskFailureClassification::Provider)
+        );
+        assert!(aggregate.outcomes[0]
+            .metadata
+            .pointer("/provider_rotation")
+            .is_none());
+        assert!(!aggregate.events.iter().any(|event| event
+            .message
+            .as_deref()
+            .is_some_and(|message| { message.contains("provider rotation") })));
+    }
+}
+
 mod timeout_tests {
     use super::*;
 

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+use crate::core::agent_task_schedule::AgentTaskProviderRotationPolicy;
+
 #[path = "defaults/builtins.rs"]
 mod builtins;
 mod io;
@@ -190,6 +192,12 @@ pub struct AgentTaskConfig {
     pub default_backend: Option<String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub secrets: HashMap<String, AgentTaskSecretSource>,
+    /// Global provider rotation policy for agent-task dispatch, settable via
+    /// `homeboy config set /agent_task/rotation <json> --json`. A per-plan
+    /// `options.rotation` or per-task `metadata.provider_rotation` override
+    /// takes precedence (#6978).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotation: Option<AgentTaskProviderRotationPolicy>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -414,6 +422,45 @@ mod tests {
         let secret = config.agent_task.secrets.get("TOKEN").unwrap();
         assert_eq!(secret.source, "config");
         assert_eq!(secret.value.as_deref(), Some("redacted-test-token"));
+    }
+
+    #[test]
+    fn homeboy_config_parses_agent_task_rotation_policy() {
+        let config: HomeboyConfig = serde_json::from_str(
+            r#"{
+                "agent_task": {
+                    "rotation": {
+                        "entries": [
+                            { "backend": "fallback-backend-a", "model": "fallback-model-a" },
+                            { "selector": "fallback-b.agent-task-executor", "provider_config": { "provider": "fallback-provider-b" } }
+                        ],
+                        "max_attempts": 3
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let rotation = config.agent_task.rotation.expect("rotation policy");
+        assert_eq!(rotation.entries.len(), 2);
+        assert_eq!(rotation.max_attempts, Some(3));
+        assert_eq!(
+            rotation.entries[0].backend.as_deref(),
+            Some("fallback-backend-a")
+        );
+        assert_eq!(
+            rotation.entries[0].model.as_deref(),
+            Some("fallback-model-a")
+        );
+        assert_eq!(
+            rotation.entries[1].selector.as_deref(),
+            Some("fallback-b.agent-task-executor")
+        );
+        assert_eq!(
+            rotation.entries[1].provider_config["provider"],
+            "fallback-provider-b"
+        );
+        assert!(HomeboyConfig::default().agent_task.rotation.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #6978

## What

Adds a generic, operator-configurable provider rotation policy to agent-task dispatch. On a rotation-eligible failure, the scheduler re-dispatches the **same task contract** (workspace, tool policy, prompt, verification gates) with the next entry in the rotation chain until an attempt succeeds, entries are exhausted, or the attempt bound is hit.

## Rotation semantics

- **Rotates on:** `provider`, `transient`, `timeout` failure classifications (provider capacity problems).
- **Never rotates on:** `execution_failed`, `policy_denied`, `invalid_input`, `capability_missing` — a provider swap must not mask a real task failure or policy denial.
- Retry policy runs first; rotation only engages after retries on the current provider are exhausted.
- With no policy configured, behavior is unchanged (single provider, classified failure).

## Configuration (three layers, most specific wins)

1. Global config: `homeboy config set /agent_task/rotation '<json>' --json`
2. Per-plan: `options.rotation`
3. Per-task: `metadata.provider_rotation`

```json
{
  "entries": [
    { "backend": "backend-a", "model": "model-a" },
    { "selector": "b.agent-task-executor", "provider_config": { "provider": "provider-b" } }
  ],
  "max_attempts": 3
}
```

Entry fields (`backend`, `selector`, `model`, `provider_config`) mirror the existing dispatch config layers; unset fields inherit from the failing attempt. Core hardcodes no provider or model names — the policy is pure operator data.

## Evidence

Every attempt (provider, model, status, failure classification) is recorded in order on the final outcome under `metadata.provider_rotation.attempts`, visible via `agent-task status|logs|latest` and durable run records.

## Tests

Scheduler tests with a scripted fake executor cover: rotation on each eligible classification stopping at first success; no rotation on any task-level classification; ordered attempt evidence; `max_attempts` bound; per-task override precedence; and byte-for-byte unchanged no-policy behavior. Plus dispatch-plan and config-parse tests.

**Note:** local `cargo test` was not run to completion (long local build); relying on CI for the verification gate. Pre-existing rustfmt drift on main in unrelated files was left untouched.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** anthropic/claude-fable-5 via opencode (orchestrator + general subagent)
- **Used for:** Implementation, tests, and PR drafting against the #6978 acceptance criteria; diff reviewed by the orchestrating agent before push.