### PR TITLE
Fix artifact cleanup target discovery and review output

### DIFF
--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -6,14 +6,20 @@ This is the canonical artifact cleanup path. Worktree lifecycle cleanup is handl
 
 ## `homeboy cleanup artifacts`
 
-Scans the current repository and its managed Git worktrees for declared artifact paths. The command defaults to dry-run JSON output and only removes files when `--apply` is passed.
+Scans the current repository and its managed Git worktrees for built-in and declared artifact paths. The command defaults to dry-run output and only removes files when `--apply` is passed.
 
-Projects declare repo-relative cleanup paths with `artifact_cleanup_paths` in `homeboy.json`.
+Homeboy always treats Rust `target` directories as rebuildable artifacts. Projects can add repo-relative cleanup paths with `artifact_cleanup_paths` in `homeboy.json`.
 
 ```bash
 homeboy cleanup artifacts
 homeboy cleanup artifacts --path /path/to/checkout
+homeboy cleanup artifacts --sort size --limit 10
+homeboy cleanup artifacts --merged-only --sort size --limit 10
 homeboy cleanup artifacts --apply
 ```
 
-The JSON output includes worktree identity, candidate paths, estimated bytes, skipped reasons, applied rows, and a `summary` object. `summary.invocation_reclaimed_bytes` reports bytes reclaimed by the current command, `summary.remaining_candidate_bytes` reports cleanup candidates still present after the command, and `summary.cumulative_session_reclaimed_bytes` carries the local cumulative total for repeated `--apply` runs against the same repository. Cleanup refuses unsafe path declarations and skips artifact paths that contain tracked or staged source changes.
+Use `--sort size` to review the largest artifacts first, `--limit N` to bound the reported or removed candidates after sorting, and `--merged-only` to preserve artifacts from worktrees whose branch is not merged into its upstream.
+
+The JSON output includes worktree identity, candidate paths, estimated bytes, skipped reasons, applied rows, and a `summary` object. The terminal summary shows bounded candidate rows and points to the JSON output for full large reviews. `summary.invocation_reclaimed_bytes` reports bytes reclaimed by the current command, `summary.remaining_candidate_bytes` reports cleanup candidates still present after the command, and `summary.cumulative_session_reclaimed_bytes` carries the local cumulative total for repeated `--apply` runs against the same repository. Cleanup refuses unsafe path declarations and skips artifact paths that contain tracked or staged source changes.
+
+Regular status/cleanup disk-pressure integration is tracked separately from this command surface; use `homeboy cleanup artifacts --sort size --limit 10` as the explicit review path until that integration lands.

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -196,10 +196,19 @@ pub(crate) fn render_artifact_cleanup_summary(payload: &Value) -> Option<String>
         lines.push(format!("  - {reason}: {count}"));
     }
 
-    let candidate_lines = artifact_candidate_lines(payload, 10);
+    let candidate_display_limit = 10;
+    let candidate_lines = artifact_candidate_lines(payload, candidate_display_limit);
     if !candidate_lines.is_empty() {
-        lines.push("Rebuildable artifacts:".to_string());
+        lines.push(format!(
+            "Rebuildable artifacts (showing {} of {candidate_count}):",
+            candidate_lines.len()
+        ));
         lines.extend(candidate_lines);
+        if candidate_count > candidate_display_limit as u64 {
+            lines.push(format!(
+                "Full candidate list is available in JSON output; use --sort size --limit {candidate_display_limit} for a bounded largest-first review."
+            ));
+        }
     }
 
     let next = if mode == "apply" {
@@ -370,9 +379,36 @@ fn shell_quote(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use clap::Parser;
     use serde_json::json;
 
+    use crate::cli_surface::{Cli, Commands};
+
     use super::*;
+
+    #[test]
+    fn cleanup_artifacts_cli_accepts_bounded_review_flags() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "cleanup",
+            "artifacts",
+            "--sort",
+            "size",
+            "--limit",
+            "7",
+            "--merged-only",
+        ]);
+
+        let Commands::Cleanup(args) = cli.command else {
+            panic!("expected cleanup command");
+        };
+        let CleanupCommand::Artifacts(args) = args.command else {
+            panic!("expected cleanup artifacts command");
+        };
+        assert!(matches!(args.sort, CleanupArtifactsSortArg::Size));
+        assert_eq!(args.limit, Some(7));
+        assert!(args.merged_only);
+    }
 
     #[test]
     fn cleanup_artifacts_summary_emphasizes_operator_counts() {
@@ -456,9 +492,41 @@ mod tests {
 
         let summary = render_artifact_cleanup_summary(&payload).expect("summary");
 
+        assert!(summary.contains("Rebuildable artifacts (showing 2 of 2):"));
         let first = summary.find("  - 2.0 KiB /tmp/repo/node_modules").unwrap();
         let second = summary.find("  - 1.0 KiB /tmp/repo/dist").unwrap();
         assert!(first < second);
+    }
+
+    #[test]
+    fn cleanup_artifacts_summary_marks_truncated_candidate_list() {
+        let candidates: Vec<_> = (0..12)
+            .map(|index| {
+                json!({
+                    "path": format!("/tmp/repo/target-{index}"),
+                    "size_bytes": 1024
+                })
+            })
+            .collect();
+        let payload = json!({
+            "command": "cleanup.artifacts",
+            "mode": "dry_run",
+            "root": "/tmp/repo",
+            "candidate_count": 12,
+            "skipped_count": 0,
+            "applied_count": 0,
+            "estimated_bytes": 12288,
+            "reclaimed_bytes": 0,
+            "candidates": candidates,
+            "skipped": []
+        });
+
+        let summary = render_artifact_cleanup_summary(&payload).expect("summary");
+
+        assert!(summary.contains("Rebuildable artifacts (showing 10 of 12):"));
+        assert!(summary.contains("Full candidate list is available in JSON output"));
+        assert!(summary.contains("--sort size --limit 10"));
+        assert!(!summary.contains("/tmp/repo/target-10"));
     }
 
     #[test]

--- a/src/core/cleanup.rs
+++ b/src/core/cleanup.rs
@@ -22,6 +22,7 @@ use self_artifacts::{homeboy_source_checkout, self_temp_artifact_candidates};
 
 const ARTIFACT_DIR_REMOVE_ATTEMPTS: usize = 3;
 const ARTIFACT_DIR_REMOVE_RETRY_DELAY: Duration = Duration::from_millis(50);
+const BUILTIN_ARTIFACT_PATHS: &[(&str, &str)] = &[("target", "rust_target")];
 
 #[derive(Debug, Clone, Default)]
 pub struct ArtifactCleanupOptions {
@@ -475,7 +476,14 @@ fn discover_worktrees(root: &Path) -> Result<Vec<WorktreeInfo>> {
 }
 
 pub(crate) fn artifact_declarations(worktree: &Path) -> Result<Vec<ArtifactDeclaration>> {
-    let mut declarations = Vec::new();
+    let mut declarations: Vec<ArtifactDeclaration> = BUILTIN_ARTIFACT_PATHS
+        .iter()
+        .map(|(relative_path, kind)| ArtifactDeclaration {
+            relative_path: (*relative_path).to_string(),
+            kind: (*kind).to_string(),
+            declared_by: "homeboy:builtin_artifact_paths".to_string(),
+        })
+        .collect();
 
     let config_path = worktree.join("homeboy.json");
     if config_path.exists() {
@@ -771,7 +779,7 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         fs::write(
             tmp.path().join("homeboy.json"),
-            r#"{"artifact_cleanup_paths":["runtime/generated-fixture","dist"]}"#,
+            r#"{"artifact_cleanup_paths":["runtime/generated-fixture","target"]}"#,
         )
         .expect("write config");
 
@@ -783,20 +791,77 @@ mod tests {
         assert_eq!(
             declarations
                 .iter()
-                .filter(|row| row.relative_path == "dist")
+                .filter(|row| row.relative_path == "target")
                 .count(),
             1,
             "declared paths should not duplicate builtins"
         );
+        let target = declarations
+            .iter()
+            .find(|row| row.relative_path == "target")
+            .expect("target declaration");
+        assert_eq!(target.kind, "rust_target");
+        assert_eq!(target.declared_by, "homeboy:builtin_artifact_paths");
     }
 
     #[test]
-    fn artifact_declarations_do_not_include_ecosystem_defaults() {
+    fn artifact_declarations_include_builtin_rust_target() {
         let tmp = TempDir::new().expect("tempdir");
 
         let declarations = artifact_declarations(tmp.path()).expect("declarations");
 
-        assert!(declarations.is_empty());
+        assert_eq!(declarations.len(), 1);
+        assert_eq!(declarations[0].relative_path, "target");
+        assert_eq!(declarations[0].kind, "rust_target");
+        assert_eq!(
+            declarations[0].declared_by,
+            "homeboy:builtin_artifact_paths"
+        );
+    }
+
+    #[test]
+    fn dry_run_detects_builtin_target_without_homeboy_json() {
+        let repo = TempDir::new().expect("repo tempdir");
+        git(repo.path(), &["init", "-b", "main"]);
+        write_file(
+            &repo.path().join("Cargo.toml"),
+            "[package]\nname = \"fixture\"\n",
+        );
+        write_file(&repo.path().join("src/lib.rs"), "source");
+        git(repo.path(), &["add", "Cargo.toml", "src/lib.rs"]);
+        git(
+            repo.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+        write_file(&repo.path().join("target/debug/app"), "artifact");
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: false,
+            self_artifacts: false,
+            temp_roots: Vec::new(),
+            sort: ArtifactCleanupSort::Discovery,
+            limit: None,
+            merged_only: false,
+        })
+        .expect("dry-run cleanup");
+
+        let target = output
+            .candidates
+            .iter()
+            .find(|row| row.relative_path == "target")
+            .expect("target candidate");
+        assert_eq!(target.kind, "rust_target");
+        assert_eq!(target.declared_by, "homeboy:builtin_artifact_paths");
+        assert!(repo.path().join("target/debug/app").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add built-in artifact cleanup declaration for Rust `target` directories so worktrees are detected without per-repo `homeboy.json` declarations.
- Keep bounded review ergonomics covered with `--sort size`, `--limit`, and `--merged-only` CLI tests.
- Compact cleanup summaries now state how many candidates are shown and point operators to JSON output for full large reviews.
- Document explicit artifact cleanup usage and note regular status/disk-pressure integration as follow-up scope.

Fixes #7440
Fixes #7441
Fixes #7442
Refs #7443

## Tests
- `cargo test cleanup::`
- `cargo run -- cleanup artifacts --help`
- `cargo check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the cleanup discovery/output fix, added regression tests, ran verification, and prepared this PR.