### PR TITLE
fix: report detached lab handoff as running

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -446,7 +446,7 @@ impl RunnerHandoffEnvelope {
         };
         let evidence = RunnerHandoffEvidence {
             schema: "homeboy/runner-handoff-evidence/v1".to_string(),
-            status: "handoff_complete".to_string(),
+            status: "running".to_string(),
             runner_id: runner_id.to_string(),
             runner_job_id: job_id.to_string(),
             run_id: mirror_run_id.clone(),
@@ -472,7 +472,7 @@ impl RunnerHandoffEnvelope {
         };
         Self {
             schema: RUNNER_HANDOFF_ENVELOPE_SCHEMA.to_string(),
-            status: "handoff_complete".to_string(),
+            status: "running".to_string(),
             execution_location: format!("runner:{runner_id}"),
             identity: AgentTaskDispatchIdentity {
                 runner_id: runner_id.to_string(),
@@ -495,45 +495,46 @@ impl RunnerHandoffEnvelope {
     }
 
     pub fn runner_execution_record(&self) -> RunnerExecutionRecord {
-        RunnerExecutionRecord::terminal(
-            self.job_id.clone(),
-            self.runner_id.clone(),
-            "daemon",
-            if self.status == "handoff_complete" {
-                0
-            } else {
-                1
-            },
-        )
-        .with_job_id(self.job_id.clone())
-        .with_mirror_run_id(
-            self.mirror_run_id
-                .clone()
-                .or_else(|| self.persisted_run_id.clone())
-                .or_else(|| self.durable_run_id.clone()),
-        )
-        .with_path_materialization_plan(PathMaterializationPlan::non_empty(vec![
-            PathMaterializationEntry::primary_workspace_materialized(
-                PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
-                None,
-                self.remote_cwd.clone(),
-                PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
-            ),
-        ]))
-        .with_artifact_refs(self.evidence.artifact_refs.iter().map(|artifact| {
-            RunnerExecutionArtifactRef {
-                id: artifact.id.clone(),
-                name: artifact.name.clone(),
-                path: artifact.path.clone(),
-                url: artifact.url.clone(),
-            }
-        }))
-        .with_next_actions(self.evidence.next_commands.iter().map(|command| {
-            RunnerExecutionNextAction {
-                label: command.label.clone(),
-                command: command.command.clone(),
-            }
-        }))
+        let record = if self.status == "running" {
+            RunnerExecutionRecord::in_flight(self.job_id.clone(), self.runner_id.clone(), "daemon")
+        } else {
+            RunnerExecutionRecord::terminal(
+                self.job_id.clone(),
+                self.runner_id.clone(),
+                "daemon",
+                if self.status == "succeeded" { 0 } else { 1 },
+            )
+        };
+        record
+            .with_job_id(self.job_id.clone())
+            .with_mirror_run_id(
+                self.mirror_run_id
+                    .clone()
+                    .or_else(|| self.persisted_run_id.clone())
+                    .or_else(|| self.durable_run_id.clone()),
+            )
+            .with_path_materialization_plan(PathMaterializationPlan::non_empty(vec![
+                PathMaterializationEntry::primary_workspace_materialized(
+                    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
+                    None,
+                    self.remote_cwd.clone(),
+                    PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
+                ),
+            ]))
+            .with_artifact_refs(self.evidence.artifact_refs.iter().map(|artifact| {
+                RunnerExecutionArtifactRef {
+                    id: artifact.id.clone(),
+                    name: artifact.name.clone(),
+                    path: artifact.path.clone(),
+                    url: artifact.url.clone(),
+                }
+            }))
+            .with_next_actions(self.evidence.next_commands.iter().map(|command| {
+                RunnerExecutionNextAction {
+                    label: command.label.clone(),
+                    command: command.command.clone(),
+                }
+            }))
     }
 
     pub fn run_outcome_envelope(&self) -> RunOutcomeEnvelope {

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -137,6 +137,22 @@ pub fn route_after_parse(
             }
             Ok(None)
         }
+        LabRouteOutcome::InFlight(output) => {
+            if !output.stderr.is_empty() {
+                eprint!("{}", output.stderr);
+            }
+            if let Some(path) = output_file {
+                write_offloaded_stdout(
+                    path,
+                    output
+                        .output_file_content
+                        .as_deref()
+                        .unwrap_or(&output.stdout),
+                )?;
+            }
+            print!("{}", output.stdout);
+            Ok(Some(output.exit_code))
+        }
         LabRouteOutcome::Offloaded(output) => {
             if !output.stderr.is_empty() {
                 eprint!("{}", output.stderr);

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -161,6 +161,8 @@ pub struct LabRouteOutput {
 pub enum LabRouteOutcome {
     /// The command should continue executing locally on the controller.
     RunLocal,
+    /// The command was handed to a runner and is still in flight.
+    InFlight(LabRouteOutput),
     /// The command was offloaded to a runner; render the captured output.
     Offloaded(LabRouteOutput),
 }
@@ -177,7 +179,15 @@ pub fn dispatch_lab_offload(
     runner_id: Option<&str>,
     observer: Box<dyn LabDispatchObserver>,
 ) -> Result<LabRouteOutcome> {
-    match route_lab_offload(request) {
+    lab_offload_outcome_to_route_outcome(route_lab_offload(request), runner_id, observer)
+}
+
+fn lab_offload_outcome_to_route_outcome(
+    outcome: Result<runners::LabOffloadOutcome>,
+    runner_id: Option<&str>,
+    observer: Box<dyn LabDispatchObserver>,
+) -> Result<LabRouteOutcome> {
+    match outcome {
         Err(err) => {
             let _ = observer.finish(
                 RunStatus::Error,
@@ -243,7 +253,84 @@ pub fn dispatch_lab_offload(
                 output_file_content,
             }))
         }
+        Ok(runners::LabOffloadOutcome::InFlight {
+            stdout,
+            stderr,
+            exit_code,
+            output_file_content,
+            ..
+        }) => {
+            let retrieval = observer.run_id().map(PersistedRunRetrieval::for_run);
+            let stdout = stdout_with_in_flight_status(&stdout, retrieval.as_ref());
+            let output_file_content = output_file_content
+                .as_deref()
+                .map(|content| stdout_with_in_flight_status(content, retrieval.as_ref()))
+                .or_else(|| Some(stdout.clone()));
+            Ok(LabRouteOutcome::InFlight(LabRouteOutput {
+                stdout,
+                stderr,
+                exit_code,
+                output_file_content,
+            }))
+        }
     }
+}
+
+fn stdout_with_in_flight_status(stdout: &str, retrieval: Option<&PersistedRunRetrieval>) -> String {
+    let mut value = serde_json::from_str::<serde_json::Value>(stdout).unwrap_or_else(|_| {
+        json!({
+            "status": "running",
+            "output": stdout,
+        })
+    });
+    let run_id = retrieval
+        .map(|retrieval| retrieval.run_id.clone())
+        .or_else(|| metadata_path_string(&value, &["identity", "run_id"]))
+        .or_else(|| metadata_path_string(&value, &["persisted_run_id"]))
+        .or_else(|| metadata_path_string(&value, &["durable_run_id"]));
+    let runner_id = metadata_path_string(&value, &["identity", "runner_id"])
+        .or_else(|| metadata_path_string(&value, &["runner_id"]));
+    let runner_job_id = metadata_path_string(&value, &["identity", "runner_job_id"])
+        .or_else(|| metadata_path_string(&value, &["job_id"]));
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "status".to_string(),
+            serde_json::Value::String("running".to_string()),
+        );
+        let mut in_flight = json!({
+            "status": "running",
+            "run_id": run_id,
+            "runner_id": runner_id,
+            "runner_job_id": runner_job_id,
+        });
+        if let Some(in_flight_object) = in_flight.as_object_mut() {
+            if let Some(retrieval) = retrieval {
+                in_flight_object.insert("homeboy_persisted_run".to_string(), retrieval.to_json());
+                in_flight_object.insert(
+                    "watch_command".to_string(),
+                    serde_json::Value::String(format!("homeboy runs watch {}", retrieval.run_id)),
+                );
+            }
+            if let (Some(runner_id), Some(runner_job_id)) = (runner_id, runner_job_id) {
+                in_flight_object.insert(
+                    "runner_job_watch_command".to_string(),
+                    serde_json::Value::String(format!(
+                        "homeboy runner job logs {runner_id} {runner_job_id} --follow"
+                    )),
+                );
+            }
+        }
+        object.insert("homeboy_in_flight".to_string(), in_flight);
+        if let Some(retrieval) = retrieval {
+            object.insert("homeboy_persisted_run".to_string(), retrieval.to_json());
+        }
+    }
+    serde_json::to_string_pretty(&value)
+        .map(|mut rendered| {
+            rendered.push('\n');
+            rendered
+        })
+        .unwrap_or_else(|_| stdout.to_string())
 }
 
 fn attach_handoff_metadata(metadata: &mut serde_json::Value, stdout: &str) {
@@ -522,6 +609,7 @@ mod tests {
         CommandPortability, CommandSourceMaterialization, CommandSourcePolicy,
         CommandWorkspacePolicy,
     };
+    use crate::core::plan::{HomeboyPlan, PlanKind};
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
     struct EnvGuard {
@@ -756,6 +844,102 @@ mod tests {
             json["homeboy_persisted_run"]["id_scope"],
             "persisted_homeboy_run"
         );
+    }
+
+    #[test]
+    fn detached_handoff_maps_to_in_flight_output_and_leaves_run_running() {
+        let finished = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let observer = Box::new(RecordingObserver {
+            run_id: Some("dispatch-run-7448".to_string()),
+            finished: finished.clone(),
+        });
+        let stdout = r#"{
+            "schema":"homeboy/runner-exec-handoff/v1",
+            "status":"running",
+            "identity":{
+                "runner_id":"homeboy-lab",
+                "runner_job_id":"job-7448",
+                "run_id":"agent-task-7448"
+            },
+            "job_id":"job-7448",
+            "follow_commands":{
+                "job_logs":"homeboy runner job logs homeboy-lab job-7448 --follow"
+            }
+        }"#;
+
+        let outcome = lab_offload_outcome_to_route_outcome(
+            Ok(runners::LabOffloadOutcome::InFlight {
+                plan: test_plan(),
+                stdout: stdout.to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+                output_file_content: Some(stdout.to_string()),
+            }),
+            Some("homeboy-lab"),
+            observer,
+        )
+        .expect("route outcome");
+
+        let LabRouteOutcome::InFlight(output) = outcome else {
+            panic!("expected in-flight outcome");
+        };
+        assert_eq!(output.exit_code, 0);
+        let json: serde_json::Value = serde_json::from_str(&output.stdout).expect("json stdout");
+        assert_eq!(json["status"], "running");
+        assert_eq!(json["homeboy_in_flight"]["status"], "running");
+        assert_eq!(
+            json["homeboy_in_flight"]["homeboy_persisted_run"]["persisted_run_id"],
+            "dispatch-run-7448"
+        );
+        assert_eq!(
+            json["homeboy_in_flight"]["watch_command"],
+            "homeboy runs watch dispatch-run-7448"
+        );
+        assert_eq!(
+            json["homeboy_in_flight"]["runner_job_watch_command"],
+            "homeboy runner job logs homeboy-lab job-7448 --follow"
+        );
+        assert!(finished.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn terminal_offload_maps_to_terminal_output_and_finishes_run() {
+        let finished = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let observer = Box::new(RecordingObserver {
+            run_id: Some("dispatch-run-terminal".to_string()),
+            finished: finished.clone(),
+        });
+
+        let outcome = lab_offload_outcome_to_route_outcome(
+            Ok(runners::LabOffloadOutcome::Offloaded {
+                plan: test_plan(),
+                stdout: r#"{"success":true}"#.to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+                output_file_content: None,
+            }),
+            Some("homeboy-lab"),
+            observer,
+        )
+        .expect("route outcome");
+
+        let LabRouteOutcome::Offloaded(output) = outcome else {
+            panic!("expected terminal offload outcome");
+        };
+        assert_eq!(output.exit_code, 0);
+        let json: serde_json::Value = serde_json::from_str(&output.stdout).expect("json stdout");
+        assert_eq!(
+            json["homeboy_persisted_run"]["persisted_run_id"],
+            "dispatch-run-terminal"
+        );
+        let recorded = finished.lock().unwrap().clone();
+        let (status, metadata) = recorded.expect("observer finished");
+        assert_eq!(status, RunStatus::Pass);
+        assert_eq!(metadata["lab_dispatch"]["status"], "offloaded_complete");
+    }
+
+    fn test_plan() -> HomeboyPlan {
+        HomeboyPlan::for_description(PlanKind::LabOffload, "test lab offload")
     }
 
     #[test]

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -498,7 +498,7 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             envelope.schema,
             crate::command_contract::RUNNER_HANDOFF_ENVELOPE_SCHEMA
         );
-        assert_eq!(envelope.status, "handoff_complete");
+        assert_eq!(envelope.status, "running");
         assert_eq!(envelope.execution_location, "runner:lab");
         assert_eq!(envelope.identity.runner_id, "lab");
         assert_eq!(envelope.identity.runner_job_id, job_id);
@@ -548,7 +548,7 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             envelope.run_location_index.follow_commands.job_logs,
             format!("homeboy runner job logs lab {job_id} --follow")
         );
-        assert_eq!(envelope.evidence.status, "handoff_complete");
+        assert_eq!(envelope.evidence.status, "running");
         assert_eq!(envelope.evidence.runner_id, "lab");
         assert_eq!(envelope.evidence.runner_job_id, job_id);
         assert_eq!(
@@ -586,7 +586,7 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             envelope.mirror_run_id.as_deref(),
             Some("agent-task-run-6454")
         );
-        assert_eq!(json["status"], "handoff_complete");
+        assert_eq!(json["status"], "running");
         assert_eq!(json["identity"]["runner_id"], "lab");
         assert_eq!(json["identity"]["runner_job_id"], job_id);
         assert_eq!(json["identity"]["persisted_run_id"], "agent-task-run-6454");
@@ -656,7 +656,7 @@ fn runner_handoff_envelope_omits_agent_task_followups_without_run_id() {
         json["schema"],
         crate::command_contract::RUNNER_HANDOFF_ENVELOPE_SCHEMA
     );
-    assert_eq!(json["status"], "handoff_complete");
+    assert_eq!(json["status"], "running");
     assert_eq!(json["execution_location"], "runner:lab");
     assert_eq!(json["identity"]["runner_id"], "lab");
     assert_eq!(json["identity"]["runner_job_id"], "job-123");

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -939,7 +939,7 @@ pub(crate) fn run_lab_offload_inner(
             stderr.push('\n');
         }
         stderr.push_str(&exec_output.stderr);
-        return Ok(LabOffloadOutcome::Offloaded {
+        return Ok(LabOffloadOutcome::InFlight {
             plan,
             stdout: exec_output.stdout.clone(),
             stderr,

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -83,4 +83,11 @@ pub enum LabOffloadOutcome {
         exit_code: i32,
         output_file_content: Option<String>,
     },
+    InFlight {
+        plan: HomeboyPlan,
+        stdout: String,
+        stderr: String,
+        exit_code: i32,
+        output_file_content: Option<String>,
+    },
 }


### PR DESCRIPTION
## Summary
- Split detached Lab handoff from terminal offload completion with explicit in-flight outcomes.
- Keep dispatch run records running after detached handoff instead of finishing them as pass/fail.
- Render detached handoff structured output with status=running plus persisted run and watch guidance.

## Fix design
- Added LabOffloadOutcome::InFlight and LabRouteOutcome::InFlight so detached handoff no longer flows through terminal Offloaded handling.
- run_lab_offload_inner returns InFlight for detach_after_handoff, preserving the remote workspace and detached run record behavior while changing the route contract.
- dispatch_lab_offload now maps in-flight outcomes without calling observer.finish, so local run records stay running until daemon evidence later confirms terminal status.
- Detached handoff envelopes now carry status=running; terminal offloads still finish through Offloaded and mark dispatch runs pass/fail.

## Test evidence
- cargo check --all-targets passed.
- cargo test core::lab_routing::tests passed: 16 passed.
- cargo test core::runner::execution::tests::handoff passed: 21 passed.

Closes #7448

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated via Claude (opencode)
- **Used for:** Implemented the fix, tests, and PR from a scoped investigation brief; human reviews every line.