### PR TITLE
fix: clean terminal runner workspaces

### DIFF
--- a/src/commands/runs/resources.rs
+++ b/src/commands/runs/resources.rs
@@ -1,10 +1,11 @@
 use std::path::{Path, PathBuf};
 
 use clap::Args;
-use homeboy::core::observation::{ObservationStore, RunListFilter};
+use homeboy::core::observation::{ObservationStore, RunListFilter, RunStatus};
 use homeboy::core::resource_lifecycle_index::{
     resource_lifecycle_index_from_artifacts, resource_lifecycle_record_is_actionable,
-    resource_lifecycle_record_is_cleanup_eligible, ResourceCleanupPolicy,
+    resource_lifecycle_record_is_cleanup_eligible,
+    transition_preserved_runner_workspaces_to_cleanup_pending, ResourceCleanupPolicy,
     ResourceEvidenceRetention, ResourceLifecycle, ResourceLifecycleCleanupOperation,
     ResourceLifecycleIndex, ResourceLifecycleRecord, ResourceLifecycleResourceStatus,
     RESOURCE_LIFECYCLE_INDEX_SCHEMA,
@@ -297,16 +298,14 @@ fn build_cleanup_output(
             continue;
         };
 
-        match ResourceLifecycle::cleanup_path(root, record) {
-            Ok(path) => {
-                if args.apply {
-                    ResourceLifecycle::delete_path(&path)?;
-                    applied.push(cleanup_applied_item(record, args.cleanup_operation));
-                } else {
-                    planned.push(cleanup_plan_item(record, args.cleanup_operation));
-                }
+        match cleanup_dispatch(record, root, args)? {
+            CleanupDispatch::Plan => {
+                planned.push(cleanup_plan_item(record, args.cleanup_operation))
             }
-            Err(reason) => skipped.push(cleanup_skip(record, reason)),
+            CleanupDispatch::Applied => {
+                applied.push(cleanup_applied_item(record, args.cleanup_operation))
+            }
+            CleanupDispatch::Skipped(reason) => skipped.push(cleanup_skip(record, reason)),
         }
     }
 
@@ -323,6 +322,45 @@ fn build_cleanup_output(
         applied,
         skipped,
     })
+}
+
+enum CleanupDispatch {
+    Plan,
+    Applied,
+    Skipped(String),
+}
+
+fn cleanup_dispatch(
+    record: &ResourceLifecycleRecord,
+    root: &Path,
+    args: &RunsResourcesArgs,
+) -> Result<CleanupDispatch> {
+    if record.is_runner_workspace() && record.runner_id.is_some() {
+        if !args.apply {
+            return Ok(CleanupDispatch::Plan);
+        }
+        let runner_id = record.runner_id.as_deref().expect("checked runner_id");
+        homeboy::core::runner::reap_run_workspace(runner_id, &record.path, None)?;
+        return Ok(CleanupDispatch::Applied);
+    }
+
+    if record.runner_id.is_some() {
+        return Ok(CleanupDispatch::Skipped(
+            "remote-owned resource has no cleanup executor; leaving plan-only".to_string(),
+        ));
+    }
+
+    match ResourceLifecycle::cleanup_path(root, record) {
+        Ok(path) => {
+            if args.apply {
+                ResourceLifecycle::delete_path(&path)?;
+                Ok(CleanupDispatch::Applied)
+            } else {
+                Ok(CleanupDispatch::Plan)
+            }
+        }
+        Err(reason) => Ok(CleanupDispatch::Skipped(reason)),
+    }
 }
 
 fn canonical_cleanup_root(root: &Path) -> Result<PathBuf> {
@@ -427,9 +465,11 @@ fn load_observation_store_index(
             .collect()
     };
 
-    let Some(index) = resource_lifecycle_index_from_artifacts(&artifacts)? else {
+    let Some(mut index) = resource_lifecycle_index_from_artifacts(&artifacts)? else {
         return Ok(Vec::new());
     };
+
+    apply_terminal_workspace_transitions(store, &mut index)?;
 
     Ok(vec![LoadedResourceIndex {
         source: match run_id {
@@ -438,6 +478,35 @@ fn load_observation_store_index(
         },
         index,
     }])
+}
+
+fn apply_terminal_workspace_transitions(
+    store: &ObservationStore,
+    index: &mut ResourceLifecycleIndex,
+) -> Result<()> {
+    let mut run_ids = index
+        .resources
+        .iter()
+        .filter(|record| record.is_runner_workspace())
+        .map(|record| record.run_id.clone())
+        .collect::<Vec<_>>();
+    run_ids.sort();
+    run_ids.dedup();
+
+    for run_id in run_ids {
+        let Some(run) = store.get_run(&run_id)? else {
+            continue;
+        };
+        if is_terminal_run_status(&run.status) {
+            transition_preserved_runner_workspaces_to_cleanup_pending(index, &run_id);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_terminal_run_status(status: &str) -> bool {
+    RunStatus::from_label(status).is_some_and(RunStatus::is_terminal)
 }
 
 fn load_index_file(path: &Path) -> Result<LoadedResourceIndex> {
@@ -807,6 +876,123 @@ mod tests {
 
         assert_eq!(cleanup.applied_count, 1);
         assert!(!resource_path.exists());
+    }
+
+    #[test]
+    fn apply_reaps_runner_workspace_through_runner_transport() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace_root = tempfile::tempdir().expect("workspace root");
+            let lab_root = workspace_root.path().join("_lab_workspaces");
+            let resource_path = lab_root.join("repo");
+            std::fs::create_dir_all(&resource_path).expect("runner workspace");
+            std::fs::write(resource_path.join("generated.txt"), "generated")
+                .expect("workspace file");
+            homeboy::core::runner::create(
+                &format!(
+                    r#"{{"id":"lab-local","kind":"local","workspace_root":"{}"}}"#,
+                    workspace_root.path().display()
+                ),
+                false,
+            )
+            .expect("create local runner");
+            let resource = ResourceLifecycleRecord {
+                owner: "runner.workspace".to_string(),
+                runner_id: Some("lab-local".to_string()),
+                path: resource_path.display().to_string(),
+                kind: "runner_workspace".to_string(),
+                cleanup_intent: ResourceCleanupIntent::Apply,
+                ..record(ResourceLifecycleResourceStatus::CleanupPending)
+            };
+
+            let cleanup = build_cleanup_output(
+                &[resource],
+                &RunsResourcesArgs {
+                    apply: true,
+                    cleanup_root: Some(workspace_root.path().to_path_buf()),
+                    ..Default::default()
+                },
+            )
+            .expect("cleanup apply");
+
+            assert_eq!(cleanup.applied_count, 1);
+            assert!(!resource_path.exists());
+        });
+    }
+
+    #[test]
+    fn apply_keeps_unsupported_remote_records_plan_only() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let resource = ResourceLifecycleRecord {
+            owner: "homeboy-runs".to_string(),
+            runner_id: Some("lab".to_string()),
+            path: "/srv/homeboy/artifacts/run-1".to_string(),
+            cleanup_intent: ResourceCleanupIntent::Apply,
+            ..record(ResourceLifecycleResourceStatus::CleanupPending)
+        };
+
+        let cleanup = build_cleanup_output(
+            &[resource],
+            &RunsResourcesArgs {
+                apply: true,
+                cleanup_root: Some(tempdir.path().to_path_buf()),
+                ..Default::default()
+            },
+        )
+        .expect("cleanup apply");
+
+        assert_eq!(cleanup.applied_count, 0);
+        assert_eq!(cleanup.skipped_count, 1);
+        assert_eq!(
+            cleanup.skipped[0].reason,
+            "remote-owned resource has no cleanup executor; leaving plan-only"
+        );
+    }
+
+    #[test]
+    fn terminal_store_run_flips_preserved_runner_workspace_eligibility() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let store = temp_store(&tempdir);
+        let run = store
+            .start_run(NewRunRecord::builder("agent-task").build())
+            .expect("run");
+        store
+            .finish_run(&run.id, RunStatus::Pass, None)
+            .expect("finish run");
+        let artifact_path = tempdir.path().join("artifact.json");
+        std::fs::write(&artifact_path, "{}").expect("artifact file");
+        let resource = ResourceLifecycleRecord {
+            owner: "runner.workspace".to_string(),
+            run_id: run.id.clone(),
+            runner_id: Some("lab".to_string()),
+            path: "/srv/homeboy/_lab_workspaces/repo".to_string(),
+            kind: "runner_workspace".to_string(),
+            ttl: None,
+            cleanup_policy: ResourceCleanupPolicy::Preserve,
+            status: ResourceLifecycleResourceStatus::Active,
+            ..record(ResourceLifecycleResourceStatus::Active)
+        };
+        store
+            .record_artifact_with_metadata(
+                &run.id,
+                "lab-metadata",
+                &artifact_path,
+                serde_json::json!({ "workspace_resource_lifecycle": resource }),
+            )
+            .expect("artifact with resource lifecycle metadata");
+
+        let indexes = load_observation_store_index(&store, Some(&run.id)).expect("store index");
+
+        let transitioned = &indexes[0].index.resources[0];
+        assert_eq!(
+            transitioned.cleanup_policy,
+            ResourceCleanupPolicy::DeleteAfterTtl
+        );
+        assert_eq!(transitioned.ttl.as_deref(), Some("P7D"));
+        assert_eq!(
+            transitioned.status,
+            ResourceLifecycleResourceStatus::CleanupPending
+        );
+        assert!(resource_lifecycle_record_is_cleanup_eligible(transitioned));
     }
 
     #[test]

--- a/src/core/resource_lifecycle_index.rs
+++ b/src/core/resource_lifecycle_index.rs
@@ -103,6 +103,10 @@ impl ResourceLifecycleRecord {
     pub fn validate(&self, index: usize) -> Result<()> {
         validate_resource_lifecycle_record(index, self)
     }
+
+    pub fn is_runner_workspace(&self) -> bool {
+        self.owner == "runner.workspace" && self.kind == "runner_workspace"
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -308,20 +312,19 @@ pub fn resource_lifecycle_index_from_artifacts(
             continue;
         }
 
-        let Some(value) = artifact.metadata_json.get("resource_lifecycle") else {
-            continue;
-        };
-        let record: ResourceLifecycleRecord =
-            serde_json::from_value(value.clone()).map_err(|err| {
-                Error::internal_json(
-                    err.to_string(),
-                    Some(format!(
-                        "parse resource lifecycle metadata for artifact {}",
-                        artifact.id
-                    )),
-                )
-            })?;
-        resources.push(record);
+        for key in ["resource_lifecycle", "workspace_resource_lifecycle"] {
+            let Some(value) = artifact.metadata_json.get(key) else {
+                continue;
+            };
+            let record: ResourceLifecycleRecord =
+                serde_json::from_value(value.clone()).map_err(|err| {
+                    Error::internal_json(
+                        err.to_string(),
+                        Some(format!("parse {key} metadata for artifact {}", artifact.id)),
+                    )
+                })?;
+            resources.push(record);
+        }
     }
     if resources.is_empty() {
         return Ok(None);
@@ -333,6 +336,24 @@ pub fn resource_lifecycle_index_from_artifacts(
     };
     index.validate()?;
     Ok(Some(index))
+}
+
+pub fn transition_preserved_runner_workspaces_to_cleanup_pending(
+    index: &mut ResourceLifecycleIndex,
+    run_id: &str,
+) {
+    for record in &mut index.resources {
+        if record.run_id == run_id
+            && record.is_runner_workspace()
+            && record.runner_id.is_some()
+            && matches!(record.cleanup_policy, ResourceCleanupPolicy::Preserve)
+            && matches!(record.status, ResourceLifecycleResourceStatus::Active)
+        {
+            record.cleanup_policy = ResourceCleanupPolicy::DeleteAfterTtl;
+            record.ttl.get_or_insert_with(|| "P7D".to_string());
+            record.status = ResourceLifecycleResourceStatus::CleanupPending;
+        }
+    }
 }
 
 pub fn validate_resource_lifecycle_record(
@@ -465,6 +486,78 @@ mod tests {
 
         assert_eq!(index.resources.len(), 1);
         assert_eq!(index.resources[0].kind, "workspace");
+    }
+
+    #[test]
+    fn extracts_workspace_resource_lifecycle_artifact_metadata() {
+        let mut source = record();
+        source.owner = "runner.workspace".to_string();
+        source.kind = "runner_workspace".to_string();
+        let artifact = ArtifactRecord {
+            id: "artifact-1".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "lab-metadata".to_string(),
+            artifact_type: "metadata".to_string(),
+            path: "/tmp/index.json".to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: None,
+            metadata_json: serde_json::json!({
+                "workspace_resource_lifecycle": source,
+            }),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+
+        let index = resource_lifecycle_index_from_artifacts(&[artifact])
+            .expect("parse index metadata")
+            .expect("index present");
+
+        assert_eq!(index.resources.len(), 1);
+        assert_eq!(index.resources[0].owner, "runner.workspace");
+    }
+
+    #[test]
+    fn terminal_transition_flips_preserved_runner_workspace_eligibility() {
+        let mut index = ResourceLifecycleIndex {
+            schema: RESOURCE_LIFECYCLE_INDEX_SCHEMA.to_string(),
+            resources: vec![ResourceLifecycleRecord {
+                owner: "runner.workspace".to_string(),
+                run_id: "run-1".to_string(),
+                runner_id: Some("lab".to_string()),
+                path: "/srv/homeboy/_lab_workspaces/repo".to_string(),
+                root_bound: None,
+                kind: "runner_workspace".to_string(),
+                ttl: None,
+                cleanup_policy: ResourceCleanupPolicy::Preserve,
+                evidence_retention: ResourceEvidenceRetention::Metadata,
+                cleanup_intent: ResourceCleanupIntent::DryRun,
+                cleanup_command: None,
+                status: ResourceLifecycleResourceStatus::Active,
+            }],
+        };
+
+        assert!(!resource_lifecycle_record_is_cleanup_eligible(
+            &index.resources[0]
+        ));
+
+        transition_preserved_runner_workspaces_to_cleanup_pending(&mut index, "run-1");
+
+        assert_eq!(
+            index.resources[0].cleanup_policy,
+            ResourceCleanupPolicy::DeleteAfterTtl
+        );
+        assert_eq!(index.resources[0].ttl.as_deref(), Some("P7D"));
+        assert_eq!(
+            index.resources[0].status,
+            ResourceLifecycleResourceStatus::CleanupPending
+        );
+        assert!(resource_lifecycle_record_is_cleanup_eligible(
+            &index.resources[0]
+        ));
     }
 
     #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -138,6 +138,7 @@ pub use session::{
 pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub(crate) use transport::{select_runner_transport, RunnerFileTransfer, RunnerTransport};
 pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
+pub use workspace::reap_run_workspace;
 pub use workspace::{
     list_workspaces, plan_workspace_pull, prune_workspaces, pull_workspace, sync_workspace,
     workspace_snapshots, ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry,

--- a/src/core/runner/workspace/mod.rs
+++ b/src/core/runner/workspace/mod.rs
@@ -19,7 +19,7 @@ pub use pull::{plan_workspace_pull, pull_workspace};
 pub use sync::sync_workspace;
 #[cfg(test)]
 pub(crate) use sync::workspace_resource_lifecycle;
-pub use sync::{list_workspaces, prune_workspaces, workspace_snapshots};
+pub use sync::{list_workspaces, prune_workspaces, reap_run_workspace, workspace_snapshots};
 pub use types::{
     ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceListEntry,
     RunnerWorkspaceListOutput, RunnerWorkspaceMaterializationContract,

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -465,7 +465,7 @@ fn prune_candidates_for_runner(
 /// (`RunnerLifecycleOwner::Controller`, surfaced via the workspace lease built
 /// by [`workspace_lease`]), so reaping the exact path this run materialized is
 /// safe without the source-path-missing heuristic the bulk orphan prune applies.
-pub(crate) fn reap_run_workspace(
+pub fn reap_run_workspace(
     runner_id: &str,
     remote_path: &str,
     artifact_dir: Option<&str>,


### PR DESCRIPTION
## Summary
- Extract runner workspace lifecycle metadata emitted as workspace_resource_lifecycle so it participates in runs resources indexing.
- Transition preserved runner.workspace records to cleanup-pending DeleteAfterTtl when their mirrored observation-store run reaches a terminal status.
- Route runner.workspace cleanup through runner workspace reap transport and keep unsupported remote-owned records plan-only instead of local-delete pretending.

## Design
- Resource lifecycle records now expose an is_runner_workspace predicate and a transition helper for preserved active runner workspaces.
- runs resources applies terminal transitions while loading observation-store resource indexes, using RunStatus::from_label(...).is_terminal() as the source of terminality.
- Cleanup dispatch is owner-aware: runner.workspace + runner_id calls homeboy::core::runner::reap_run_workspace, runner_id records without an executor are skipped with an honest plan-only reason, and only local records use ResourceLifecycle::cleanup_path/delete_path.

## Test evidence
- cargo test runs::resources::tests --all-targets
- cargo test resource_lifecycle_index::tests --all-targets
- cargo check --all-targets

Closes #7449

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated via Claude (opencode)
- **Used for:** Implemented the fix, tests, and PR from a scoped investigation brief; human reviews every line.