### PR TITLE
fix: preserve runner daemon parse recovery context

### DIFF
--- a/src/core/runner/daemon_http_get.rs
+++ b/src/core/runner/daemon_http_get.rs
@@ -1,8 +1,9 @@
 use reqwest::blocking::Client;
+use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 
-use crate::core::error::{Error, Result};
+use crate::core::error::{Error, ErrorCode, Result};
 
 /// Minimal CLI-style success envelope shared by the runner daemon HTTP GET
 /// helper. Both `connection.rs` and `execution.rs` previously carried their own
@@ -23,9 +24,12 @@ pub(super) fn daemon_get(client: &Client, local_url: &str, path: &str) -> Result
         .get(format!("{}{}", local_url.trim_end_matches('/'), path))
         .send()
         .map_err(|err| Error::internal_unexpected(format!("query runner daemon: {err}")))?;
-    let envelope: DaemonGetEnvelope = response.json().map_err(|err| {
-        Error::internal_json(err.to_string(), Some("parse daemon response".to_string()))
-    })?;
+    let status_code = response.status().as_u16();
+    let body = response
+        .text()
+        .map_err(|err| Error::internal_unexpected(format!("read runner daemon response: {err}")))?;
+    let envelope: DaemonGetEnvelope =
+        parse_daemon_response_json(&body, status_code, path, "parse daemon response")?;
     if !envelope.success {
         return Err(Error::internal_unexpected(format!(
             "daemon request failed: {}",
@@ -35,4 +39,44 @@ pub(super) fn daemon_get(client: &Client, local_url: &str, path: &str) -> Result
     envelope
         .data
         .ok_or_else(|| Error::internal_unexpected("daemon response missing data"))
+}
+
+pub(crate) fn parse_daemon_response_json<T: DeserializeOwned>(
+    body: &str,
+    status_code: u16,
+    path: &str,
+    context: &str,
+) -> Result<T> {
+    serde_json::from_str(body)
+        .map_err(|err| daemon_response_json_error(err, body, status_code, path, context))
+}
+
+fn daemon_response_json_error(
+    err: serde_json::Error,
+    body: &str,
+    status_code: u16,
+    path: &str,
+    context: &str,
+) -> Error {
+    let trimmed = body.trim();
+    let preview = trimmed.chars().take(500).collect::<String>();
+    let likely_truncated =
+        err.is_eof() || trimmed.ends_with('{') || trimmed.ends_with('[') || trimmed.ends_with(',');
+    let mut error = Error::new(
+        ErrorCode::InternalJsonError,
+        "Malformed runner daemon JSON response",
+        json!({
+            "error": err.to_string(),
+            "context": context,
+            "http_status": status_code,
+            "path": path,
+            "body_bytes": body.len(),
+            "body_preview": preview,
+            "likely_truncated": likely_truncated,
+        }),
+    );
+    error.retryable = Some(true);
+    error
+        .with_hint("The runner daemon response was malformed or truncated after a runner job may already exist; inspect the known job/run from the wrapping error instead of retrying blindly.".to_string())
+        .with_hint("Reconnect the runner daemon if repeated reads keep returning malformed JSON.".to_string())
 }

--- a/src/core/runner/execution/broker.rs
+++ b/src/core/runner/execution/broker.rs
@@ -130,8 +130,9 @@ pub(super) fn exec_via_reverse_broker(
         }
         std::thread::sleep(Duration::from_millis(200));
         let job_id = job.id.to_string();
-        job = fetch_daemon_job_resilient(&client, broker_url, &job_id)
-            .map_err(|err| daemon_job_context_error(&runner.id, &job_id, err))?;
+        job = fetch_daemon_job_resilient(&client, broker_url, &job_id).map_err(|err| {
+            daemon_job_context_error(&runner.id, &job_id, persisted_run_id.as_deref(), err)
+        })?;
     }
     let events = redact_runner_job_events(
         &fetch_daemon_events(&client, broker_url, &job.id.to_string())?,

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -137,8 +137,9 @@ pub(super) fn exec_via_daemon(
         }
         std::thread::sleep(Duration::from_millis(200));
         let job_id = job.id.to_string();
-        job = fetch_daemon_job_resilient(&client, local_url, &job_id)
-            .map_err(|err| daemon_job_context_error(&runner.id, &job_id, err))?;
+        job = fetch_daemon_job_resilient(&client, local_url, &job_id).map_err(|err| {
+            daemon_job_context_error(&runner.id, &job_id, persisted_run_id.as_deref(), err)
+        })?;
     }
     let job_id = job.id.to_string();
     let events = match fetch_daemon_events(&client, local_url, &job_id) {
@@ -542,7 +543,12 @@ pub(super) fn fetch_daemon_events(
     })
 }
 
-pub(super) fn daemon_job_context_error(runner_id: &str, job_id: &str, err: Error) -> Error {
+pub(super) fn daemon_job_context_error(
+    runner_id: &str,
+    job_id: &str,
+    persisted_run_id: Option<&str>,
+    err: Error,
+) -> Error {
     let runner_exec_prefix = format!("homeboy runner exec {runner_id} --");
     let runner_runs_list =
         format!("{runner_exec_prefix} homeboy runs list --status running --limit 20");
@@ -551,6 +557,11 @@ pub(super) fn daemon_job_context_error(runner_id: &str, job_id: &str, err: Error
     let runner_run_show = format!("{runner_exec_prefix} homeboy runs show <run-id>");
     let runner_run_evidence = format!("{runner_exec_prefix} homeboy runs evidence <run-id>");
     let runner_run_artifacts = format!("{runner_exec_prefix} homeboy runs artifacts <run-id>");
+    let persisted_run_show = persisted_run_id.map(|run_id| format!("homeboy runs show {run_id}"));
+    let persisted_run_evidence =
+        persisted_run_id.map(|run_id| format!("homeboy runs evidence {run_id}"));
+    let persisted_run_artifacts =
+        persisted_run_id.map(|run_id| format!("homeboy runs artifacts {run_id}"));
     let source_code = err.code.as_str();
     let source_message = err.message;
     let source_details = err.details;
@@ -564,6 +575,7 @@ pub(super) fn daemon_job_context_error(runner_id: &str, job_id: &str, err: Error
             "status": "recoverable_followup_required",
             "runner_id": runner_id,
             "job_id": job_id,
+            "persisted_run_id": persisted_run_id,
             "reason": "daemon_job_poll_failed",
             "recovery": {
                 "mode": "durable_runner_job",
@@ -573,6 +585,9 @@ pub(super) fn daemon_job_context_error(runner_id: &str, job_id: &str, err: Error
                 "runner_run_show": runner_run_show,
                 "runner_run_evidence": runner_run_evidence,
                 "runner_run_artifacts": runner_run_artifacts,
+                "persisted_run_show": persisted_run_show,
+                "persisted_run_evidence": persisted_run_evidence,
+                "persisted_run_artifacts": persisted_run_artifacts,
             },
             "source": {
                 "code": source_code,
@@ -586,7 +601,7 @@ pub(super) fn daemon_job_context_error(runner_id: &str, job_id: &str, err: Error
         runner_id,
         None,
         job_id,
-        None,
+        persisted_run_id,
         DaemonJobHandoffState::InFlight,
         true,
     ) {

--- a/src/core/runner/execution/daemon_api.rs
+++ b/src/core/runner/execution/daemon_api.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use crate::core::error::{Error, Result};
 
 use super::super::broker_http;
-use super::super::daemon_http_get::daemon_get;
+use super::super::daemon_http_get::{daemon_get, parse_daemon_response_json};
 use super::super::{load, status, RunnerTunnelMode};
 
 #[allow(unused_imports)]
@@ -100,9 +100,12 @@ pub(super) fn daemon_post(client: &Client, local_url: &str, path: &str) -> Resul
         .post(format!("{}{}", local_url.trim_end_matches('/'), path))
         .send()
         .map_err(|err| Error::internal_unexpected(format!("query runner daemon: {err}")))?;
-    let envelope: DaemonEnvelope = response.json().map_err(|err| {
-        Error::internal_json(err.to_string(), Some("parse daemon response".to_string()))
-    })?;
+    let status_code = response.status().as_u16();
+    let body = response
+        .text()
+        .map_err(|err| Error::internal_unexpected(format!("read runner daemon response: {err}")))?;
+    let envelope: DaemonEnvelope =
+        parse_daemon_response_json(&body, status_code, path, "parse daemon response")?;
     if !envelope.success {
         return Err(Error::internal_unexpected(format!(
             "daemon request failed: {}",

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -1028,7 +1028,7 @@ fn daemon_polling_error_for_known_job_is_recoverable_runner_disconnect() {
         "query runner daemon: error sending request for url (http://127.0.0.1:1234/jobs/{job_id})"
     ));
 
-    let err = daemon_job_context_error("lab", job_id, source);
+    let err = daemon_job_context_error("lab", job_id, None, source);
 
     assert_eq!(err.code, ErrorCode::RunnerControllerDisconnected);
     assert_eq!(err.retryable, Some(true));

--- a/src/core/runner/execution/tests/prepare.rs
+++ b/src/core/runner/execution/tests/prepare.rs
@@ -7,14 +7,69 @@ fn daemon_job_context_error_preserves_in_flight_job_details() {
     )
     .with_hint("original hint");
 
-    let err = daemon_job_context_error("homeboy-lab", "job-123", source);
+    let err = daemon_job_context_error("homeboy-lab", "job-123", None, source);
 
-    assert_eq!(err.code, ErrorCode::InternalUnexpected);
+    assert_eq!(err.code, ErrorCode::RunnerControllerDisconnected);
     assert_eq!(err.retryable, Some(true));
     assert_eq!(err.details["runner_id"], "homeboy-lab");
     assert_eq!(err.details["job_id"], "job-123");
     assert_eq!(err.hints[0].message, "original hint");
     assert!(err.message.contains("query runner daemon"));
+}
+
+#[test]
+fn daemon_job_context_error_preserves_persisted_run_retrieval() {
+    let source = Error::internal_json(
+        "EOF while parsing a value",
+        Some("parse daemon response".to_string()),
+    );
+
+    let err = daemon_job_context_error(
+        "homeboy-lab",
+        "job-123",
+        Some("runner-exec-lab-job-123"),
+        source,
+    );
+
+    assert_eq!(err.code, ErrorCode::RunnerControllerDisconnected);
+    assert_eq!(err.details["runner_id"], "homeboy-lab");
+    assert_eq!(err.details["job_id"], "job-123");
+    assert_eq!(err.details["persisted_run_id"], "runner-exec-lab-job-123");
+    assert_eq!(
+        err.details["recovery"]["persisted_run_show"],
+        "homeboy runs show runner-exec-lab-job-123"
+    );
+    assert_eq!(
+        err.details["recovery"]["persisted_run_evidence"],
+        "homeboy runs evidence runner-exec-lab-job-123"
+    );
+    assert!(err.hints.iter().any(|hint| hint
+        .message
+        .contains("Persisted run id: `runner-exec-lab-job-123`")));
+}
+
+#[test]
+fn malformed_daemon_response_json_is_structured_and_retryable() {
+    let err =
+        super::super::super::daemon_http_get::parse_daemon_response_json::<serde_json::Value>(
+            "{\"success\": true, \"data\":",
+            200,
+            "/jobs/job-123",
+            "parse daemon response",
+        )
+        .expect_err("malformed daemon JSON");
+
+    assert_eq!(err.code, ErrorCode::InternalJsonError);
+    assert_eq!(err.message, "Malformed runner daemon JSON response");
+    assert_eq!(err.retryable, Some(true));
+    assert_eq!(err.details["context"], "parse daemon response");
+    assert_eq!(err.details["http_status"], 200);
+    assert_eq!(err.details["path"], "/jobs/job-123");
+    assert_eq!(err.details["likely_truncated"], true);
+    assert!(err
+        .hints
+        .iter()
+        .any(|hint| hint.message.contains("known job/run")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve raw runner daemon response details when JSON parsing fails
- include runner job / persisted run recovery context in daemon polling errors
- add regression coverage for malformed daemon responses and terminal Lab transport failures

Fixes #7447.

## Verification
- `cargo test daemon_job_context_error_preserves_persisted_run_retrieval`
- `cargo test malformed_daemon_response_json_is_structured_and_retryable`
- `cargo test daemon_polling_error_for_known_job_is_recoverable_runner_disconnect`
- `cargo test terminal_lab_result_transport_error_preserves_recovery_ids`
- `cargo check`
- `git diff --check`

Note: `cargo check` reports existing unrelated warning `function is_missing_source_checkout_error is never used`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Lab daemon parse failure path, drafting the regression tests, and implementing the recovery-context fix.
