### PR TITLE
fix: main is red — align generated-build-dir test with classifier contract

### DIFF
--- a/src/core/deploy/generated_artifacts.rs
+++ b/src/core/deploy/generated_artifacts.rs
@@ -268,8 +268,16 @@ mod tests {
             r#"{"artifact_cleanup_paths":["plugins/agentic-ui-block/app/tools/common/dist"]}"#,
         )
         .expect("homeboy config");
-        std::fs::create_dir_all(dir.join("build")).expect("build dir");
-        std::fs::write(dir.join("build/studio-native.zip"), "artifact").expect("build artifact");
+        let generated_build_dir = deploy_generated_build_dir();
+        std::fs::create_dir_all(dir.join(&generated_build_dir)).expect("build dir");
+        std::fs::write(
+            dir.join(&generated_build_dir).join("component.zip"),
+            "artifact",
+        )
+        .expect("build artifact");
+        std::fs::create_dir_all(dir.join("build")).expect("undeclared build dir");
+        std::fs::write(dir.join("build/component.zip"), "artifact")
+            .expect("undeclared build artifact");
         std::fs::create_dir_all(dir.join("plugins/agentic-ui-block/app/tools/common/dist"))
             .expect("dist dir");
         std::fs::write(
@@ -298,8 +306,10 @@ mod tests {
         };
         let report = uncommitted_file_report_excluding_known_generated(&component).expect("status");
 
-        assert_eq!(report.unexpected, vec!["homeboy.json", "src.rs"]);
-        assert!(report.known_generated.contains(&"build/".to_string()));
+        assert_eq!(report.unexpected, vec!["build/", "homeboy.json", "src.rs"]);
+        assert!(report
+            .known_generated
+            .contains(&format!("{generated_build_dir}/")));
         assert!(report
             .known_generated
             .contains(&"plugins/agentic-ui-block/app/tools/common/dist/".to_string()));


### PR DESCRIPTION
Fixes the failing `uncommitted_report_classifies_declared_cleanup_paths_and_archives` on main (#7461).

The test expected a bare untracked `build/` dir to be blessed as known-generated, but the classifier intentionally blesses only the homeboy-owned generated build dir (`deploy_generated_build_dir()` = `.homeboy-build`), declared cleanup paths, deploy target debris, and root package archives. Blessing arbitrary `build/` dirs would mask real deploy debris, and the fixture also carried a product-name literal (`studio-native.zip`) in core.

- Fixture now creates the real generated build dir dynamically and asserts it is blessed
- An undeclared `build/` dir is asserted as `unexpected` (the tightened contract)
- Product literal removed from the fixture

Verified: `cargo test core::deploy::generated_artifacts --lib` — all green.

Closes #7461

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (claude-fable-5, opencode)
- **Used for:** Root-caused the failure, wrote the test fix and PR; human reviews every line.