### PR TITLE
Refresh runner mirrors before run listing

### DIFF
--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -35,6 +35,7 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
 
     let store = ObservationStore::open_initialized()?;
     reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
+    runs_service::refresh_running_mirrored_daemon_evidence_best_effort(&store);
     // `--running` is shorthand for `--status running`; the two are mutually
     // exclusive at the CLI layer so this never overrides an explicit status.
     let status = if args.running {

--- a/src/commands/runs/reconcile.rs
+++ b/src/commands/runs/reconcile.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use homeboy::core::engine::run_dir;
 use homeboy::core::observation::{
-    run_owner_pid, ObservationStore, RunListFilter, RunRecord, RunStatus,
+    run_owner_pid, runs_service, ObservationStore, RunListFilter, RunRecord, RunStatus,
 };
 use homeboy::core::process::pid_is_running;
 
@@ -47,6 +47,7 @@ pub struct ReconciledRunSummary {
 
 pub fn reconcile_runs(args: RunsReconcileArgs) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
+    runs_service::refresh_running_mirrored_daemon_evidence_best_effort(&store);
     let inspected = store
         .list_runs(RunListFilter {
             status: Some(RunStatus::Running.as_str().to_string()),

--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 
 use super::{
     ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, ObservationStore,
-    RunListFilter, RunRecord,
+    RunListFilter, RunRecord, RunStatus,
 };
 use crate::core::artifact_links::{cached_validated_viewer_links, public_artifact_url};
 use crate::core::engine::temp::CleanupSizeTotals;
@@ -216,6 +216,28 @@ mod run_lookup {
                 "Warning: could not refresh mirrored Lab runner evidence for `{run_id}`: {}",
                 err.message
             );
+        }
+    }
+
+    /// Best-effort refresh of all locally-running Lab runner mirror records.
+    ///
+    /// A controller can exit, disconnect, or time out while the runner daemon keeps
+    /// executing the job. Refreshing before list/reconcile reads lets the local
+    /// observation store converge on the daemon's terminal state without requiring
+    /// operators to know and run `runs show <mirror-run-id>` first.
+    pub fn refresh_running_mirrored_daemon_evidence_best_effort(store: &ObservationStore) {
+        let runs = store
+            .list_runs(RunListFilter {
+                status: Some(RunStatus::Running.as_str().to_string()),
+                limit: Some(1000),
+                ..Default::default()
+            })
+            .unwrap_or_default();
+
+        for run in runs {
+            if crate::core::runners::mirrored_runner_job_identity(&run).is_some() {
+                refresh_mirrored_daemon_evidence_best_effort(&run.id);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refresh locally-running Lab runner mirror records from connected daemon jobs before local `runs list` output.
- Run the same refresh before `runs reconcile` so daemon-backed terminal state wins before owner-PID stale reconciliation.
- Keeps controller-side observation state converged when the original controller exits/disconnects while the runner daemon finishes the job.

## Validation
- `rustfmt --check src/core/observation/runs_service.rs src/commands/runs/handlers.rs src/commands/runs/reconcile.rs`
- `cargo test runs::tests::run_list_reconciles_owned_dead_running_runs_before_listing`
- `target/debug/homeboy runs list --running --limit 50 --include-active-runner-jobs` returned no ghost running rows after refreshing live `homeboy-lab` daemon mirrors.
- `target/debug/homeboy runs reconcile --dry-run --limit 100` returned `inspected: 0`, `reconciled: []` after the refresh.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed the runner mirror durability failure, implemented the small Homeboy fix, ran validation, and drafted this PR.