### PR TITLE
refactor: consolidate local exec and ssh transfer plumbing

### DIFF
--- a/src/core/deploy/transfer.rs
+++ b/src/core/deploy/transfer.rs
@@ -62,21 +62,16 @@ fn rsync_directory(
     // Remote deploy: rsync over SSH
     let mut rsync_args = vec!["-a".to_string(), "--delete".to_string()];
 
-    // Build SSH command with the same options as scp
     let mut ssh_cmd_parts = vec!["ssh".to_string()];
-    if let Some(identity_file) = &ssh_client.identity_file {
-        ssh_cmd_parts.extend(["-i".to_string(), identity_file.clone()]);
-    }
-    if ssh_client.port != 22 {
-        ssh_cmd_parts.extend(["-p".to_string(), ssh_client.port.to_string()]);
-    }
-    // Use same safety options as SSH client
-    ssh_cmd_parts.extend([
-        "-o".to_string(),
-        "BatchMode=yes".to_string(),
-        "-o".to_string(),
-        "ConnectTimeout=10".to_string(),
-    ]);
+    ssh_cmd_parts.extend(crate::core::server::ssh_args::client_option_args(
+        &ssh_client,
+        crate::core::server::ssh_args::SshArgOptions {
+            batch_mode: true,
+            connect_timeout: true,
+            port_flag: Some(crate::core::server::ssh_args::SshPortFlag::Lowercase),
+            ..crate::core::server::ssh_args::SshArgOptions::default()
+        },
+    ));
 
     rsync_args.extend(["-e".to_string(), ssh_cmd_parts.join(" ")]);
     rsync_args.push(local_str.clone());

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -14,7 +14,7 @@ use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 use crate::core::http_api::RunSummary;
 use crate::core::paths;
-use crate::core::server::{self, Server, ServerAuthMode, SshClient};
+use crate::core::server::{self, Server, SshClient};
 
 use super::session::{
     ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState,
@@ -881,44 +881,17 @@ mod remote_daemon {
             };
         }
 
-        let mut args = Vec::new();
-        if let Some(identity_file) = server
-            .identity_file
-            .as_deref()
-            .filter(|path| !path.is_empty())
-        {
-            args.push("-i".to_string());
-            args.push(shellexpand::tilde(identity_file).to_string());
-        }
-        if server.port != 22 {
-            args.push("-p".to_string());
-            args.push(server.port.to_string());
-        }
-        if let Some(auth) = &server.auth {
-            if auth.mode == ServerAuthMode::KeyPlusPasswordControlmaster {
-                let control_path = auth
-                    .session
-                    .control_path
-                    .as_deref()
-                    .unwrap_or("~/.ssh/controlmasters/%h-%p-%r");
-                let persist = auth.session.persist.as_deref().unwrap_or("4h");
-                args.extend([
-                    "-o".to_string(),
-                    "ControlMaster=auto".to_string(),
-                    "-o".to_string(),
-                    format!("ControlPath={}", shellexpand::tilde(control_path)),
-                    "-o".to_string(),
-                    format!("ControlPersist={}", persist),
-                ]);
-            }
-        }
+        let mut args = crate::core::server::ssh_args::server_option_args(
+            server,
+            crate::core::server::ssh_args::SshArgOptions {
+                batch_mode: true,
+                connect_timeout: true,
+                exit_on_forward_failure: true,
+                port_flag: Some(crate::core::server::ssh_args::SshPortFlag::Lowercase),
+                ..crate::core::server::ssh_args::SshArgOptions::default()
+            },
+        );
         args.extend([
-            "-o".to_string(),
-            "BatchMode=yes".to_string(),
-            "-o".to_string(),
-            "ExitOnForwardFailure=yes".to_string(),
-            "-o".to_string(),
-            "ConnectTimeout=10".to_string(),
             "-N".to_string(),
             "-L".to_string(),
             format!("127.0.0.1:{}:{}:{}", local_port, remote_host, remote_port),

--- a/src/core/runner/workspace/util.rs
+++ b/src/core/runner/workspace/util.rs
@@ -153,30 +153,18 @@ pub(super) fn tar_exclude_args(excludes: &[String]) -> String {
 }
 
 pub(super) fn ssh_args(client: &SshClient) -> String {
-    let mut args = vec![
-        "-o BatchMode=yes".to_string(),
-        "-o ConnectTimeout=10".to_string(),
-        "-o ServerAliveInterval=15".to_string(),
-        "-o ServerAliveCountMax=3".to_string(),
-    ];
-    if let Some(identity_file) = &client.identity_file {
-        args.push(format!("-i {}", shell::quote_arg(identity_file)));
-    }
-    if let Some(session) = &client.auth {
-        args.push("-o ControlMaster=auto".to_string());
-        args.push(format!(
-            "-o ControlPath={}",
-            shell::quote_arg(&session.control_path)
-        ));
-        args.push(format!(
-            "-o ControlPersist={}",
-            shell::quote_arg(&session.persist)
-        ));
-    }
-    if client.port != 22 {
-        args.push(format!("-p {}", client.port));
-    }
-    args.join(" ")
+    crate::core::server::ssh_args::shell_join_args(
+        &crate::core::server::ssh_args::client_option_args(
+            client,
+            crate::core::server::ssh_args::SshArgOptions {
+                batch_mode: true,
+                connect_timeout: true,
+                keepalive: true,
+                port_flag: Some(crate::core::server::ssh_args::SshPortFlag::Lowercase),
+                ..crate::core::server::ssh_args::SshArgOptions::default()
+            },
+        ),
+    )
 }
 
 pub(crate) fn parent_remote_path(path: &str) -> String {

--- a/src/core/server/client/local_exec.rs
+++ b/src/core/server/client/local_exec.rs
@@ -1,4 +1,6 @@
+use std::io::{Read, Write};
 use std::process::{Command, Stdio};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::core::engine::invocation;
@@ -49,6 +51,13 @@ pub(crate) fn execute_local_command_in_dir_with_timeout(
     execute_local_command_in_dir_impl(command, current_dir, env, Some(timeout), None)
 }
 
+#[derive(Clone, Copy)]
+enum StreamMode {
+    Capture,
+    Passthrough,
+    StderrPassthrough,
+}
+
 fn execute_local_command_in_dir_impl(
     command: &str,
     current_dir: Option<&str>,
@@ -56,9 +65,24 @@ fn execute_local_command_in_dir_impl(
     timeout: Option<Duration>,
     stdin: Option<Vec<u8>>,
 ) -> CommandOutput {
-    use std::io::{Read, Write};
-    use std::thread;
+    run_local_command(
+        command,
+        current_dir,
+        env,
+        timeout,
+        stdin,
+        StreamMode::Capture,
+    )
+}
 
+fn run_local_command(
+    command: &str,
+    current_dir: Option<&str>,
+    env: Option<&[(&str, &str)]>,
+    timeout: Option<Duration>,
+    stdin: Option<Vec<u8>>,
+    stream_mode: StreamMode,
+) -> CommandOutput {
     #[cfg(windows)]
     let mut cmd = {
         let mut cmd = Command::new("cmd");
@@ -110,19 +134,6 @@ fn execute_local_command_in_dir_impl(
     );
     let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
 
-    fn read_all<R: Read>(mut src: R) -> String {
-        let mut captured = Vec::new();
-        let mut buf = [0u8; 4096];
-        loop {
-            match src.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => captured.extend_from_slice(&buf[..n]),
-                Err(_) => break,
-            }
-        }
-        String::from_utf8_lossy(&captured).to_string()
-    }
-
     // Stream the provided stdin bytes on a dedicated thread, then close the pipe
     // (EOF). The command's own stdin is empty for this path, so the buffer is
     // small and never deadlocks against the captured stdout/stderr pipes.
@@ -134,14 +145,20 @@ fn execute_local_command_in_dir_impl(
         })
     });
 
-    let stdout_handle = child
-        .stdout
-        .take()
-        .map(|pipe| thread::spawn(move || read_all(pipe)));
-    let stderr_handle = child
-        .stderr
-        .take()
-        .map(|pipe| thread::spawn(move || read_all(pipe)));
+    let stdout_handle = child.stdout.take().map(|pipe| {
+        thread::spawn(move || match stream_mode {
+            StreamMode::Passthrough => tee_to(pipe, std::io::stdout()),
+            StreamMode::Capture | StreamMode::StderrPassthrough => read_all(pipe),
+        })
+    });
+    let stderr_handle = child.stderr.take().map(|pipe| {
+        thread::spawn(move || match stream_mode {
+            StreamMode::Capture => read_all(pipe),
+            StreamMode::Passthrough | StreamMode::StderrPassthrough => {
+                tee_to(pipe, std::io::stderr())
+            }
+        })
+    });
 
     let (status, delegated_failure, timed_out) =
         wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard, timeout);
@@ -205,6 +222,40 @@ fn execute_local_command_in_dir_impl(
         cleanup_guard.cleanup();
     }
     output
+}
+
+fn read_all<R: Read>(mut src: R) -> String {
+    let mut captured = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        match src.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => captured.extend_from_slice(&buf[..n]),
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&captured).to_string()
+}
+
+fn tee_to<R, W>(mut src: R, mut sink: W) -> String
+where
+    R: Read,
+    W: Write,
+{
+    let mut captured = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        match src.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                let _ = sink.write_all(&buf[..n]);
+                let _ = sink.flush();
+                captured.extend_from_slice(&buf[..n]);
+            }
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&captured).to_string()
 }
 
 pub fn execute_local_command_interactive(
@@ -277,149 +328,14 @@ fn execute_local_command_passthrough_impl(
     env: Option<&[(&str, &str)]>,
     timeout: Option<Duration>,
 ) -> CommandOutput {
-    use std::io::{Read, Write};
-    use std::thread;
-
-    #[cfg(windows)]
-    let mut cmd = {
-        let mut cmd = Command::new("cmd");
-        cmd.args(["/C", command]);
-        cmd
-    };
-
-    #[cfg(not(windows))]
-    let mut cmd = {
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", command]);
-        cmd
-    };
-
-    if let Some(dir) = current_dir {
-        cmd.current_dir(dir);
-    }
-
-    if let Some(env_pairs) = env {
-        cmd.envs(env_pairs.iter().copied());
-    }
-
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
-    configure_process_group_cleanup(&mut cmd);
-
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) => {
-            return CommandOutput {
-                stdout: String::new(),
-                stderr: format!("Command error: {}", e),
-                success: false,
-                exit_code: -1,
-                timed_out: false,
-                child_resource: None,
-            };
-        }
-    };
-    let mut cleanup_guard = Some(ProcessGroupCleanupGuard::new(child.id()));
-    let _invocation_child_guard = invocation_child_guard(
-        env,
-        child.id(),
-        cleanup_guard.as_ref().and_then(|guard| guard.pgid()),
+    run_local_command(
         command,
-    );
-    let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
-
-    // Tee each stream: copy every chunk to the parent's stdout/stderr as it
-    // arrives (preserving the live-progress UX) while buffering it for the
-    // caller. Using 4 KiB reads keeps latency low without excess syscalls.
-    fn tee_to<R, W>(mut src: R, mut sink: W) -> String
-    where
-        R: Read,
-        W: Write,
-    {
-        let mut captured = Vec::new();
-        let mut buf = [0u8; 4096];
-        loop {
-            match src.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    let _ = sink.write_all(&buf[..n]);
-                    let _ = sink.flush();
-                    captured.extend_from_slice(&buf[..n]);
-                }
-                Err(_) => break,
-            }
-        }
-        String::from_utf8_lossy(&captured).to_string()
-    }
-
-    let stdout_handle = child
-        .stdout
-        .take()
-        .map(|pipe| thread::spawn(move || tee_to(pipe, std::io::stdout())));
-    let stderr_handle = child
-        .stderr
-        .take()
-        .map(|pipe| thread::spawn(move || tee_to(pipe, std::io::stderr())));
-
-    let (status, delegated_failure, timed_out) =
-        wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard, timeout);
-    let interrupted_signal = active_cleanup_signal();
-
-    let stdout = stdout_handle
-        .and_then(|h| h.join().ok())
-        .unwrap_or_default();
-    let stderr = stderr_handle
-        .and_then(|h| h.join().ok())
-        .unwrap_or_default();
-
-    let output = match status {
-        Ok(status) => CommandOutput {
-            stdout,
-            stderr: stderr_with_delegated_failure(
-                stderr_with_timeout(
-                    stderr_with_interruption(stderr, interrupted_signal),
-                    timed_out,
-                    timeout,
-                ),
-                delegated_failure.as_ref(),
-            ),
-            success: status.success()
-                && interrupted_signal.is_none()
-                && delegated_failure.is_none()
-                && !timed_out,
-            exit_code: timed_out_exit_code(
-                timed_out,
-                interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
-            ),
-            timed_out,
-            child_resource: Some(monitor.finish()),
-        },
-        Err(e) => CommandOutput {
-            stdout,
-            stderr: stderr_with_delegated_failure(
-                stderr_with_interruption(
-                    stderr_with_timeout(
-                        format!("{stderr}\nCommand error: {}", e),
-                        timed_out,
-                        timeout,
-                    ),
-                    interrupted_signal,
-                ),
-                delegated_failure.as_ref(),
-            ),
-            success: false,
-            exit_code: timed_out_exit_code(
-                timed_out,
-                interrupted_exit_code(interrupted_signal, -1),
-            ),
-            timed_out,
-            child_resource: Some(monitor.finish()),
-        },
-    };
-    if let Some(cleanup_guard) = cleanup_guard.take() {
-        cleanup_guard.cleanup();
-    }
-    output
+        current_dir,
+        env,
+        timeout,
+        None,
+        StreamMode::Passthrough,
+    )
 }
 
 pub(crate) fn execute_local_command_stderr_passthrough(
@@ -445,156 +361,14 @@ fn execute_local_command_stderr_passthrough_impl(
     env: Option<&[(&str, &str)]>,
     timeout: Option<Duration>,
 ) -> CommandOutput {
-    use std::io::{Read, Write};
-    use std::thread;
-
-    #[cfg(windows)]
-    let mut cmd = {
-        let mut cmd = Command::new("cmd");
-        cmd.args(["/C", command]);
-        cmd
-    };
-
-    #[cfg(not(windows))]
-    let mut cmd = {
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", command]);
-        cmd
-    };
-
-    if let Some(dir) = current_dir {
-        cmd.current_dir(dir);
-    }
-
-    if let Some(env_pairs) = env {
-        cmd.envs(env_pairs.iter().copied());
-    }
-
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
-    configure_process_group_cleanup(&mut cmd);
-
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) => {
-            return CommandOutput {
-                stdout: String::new(),
-                stderr: format!("Command error: {}", e),
-                success: false,
-                exit_code: -1,
-                timed_out: false,
-                child_resource: None,
-            };
-        }
-    };
-    let mut cleanup_guard = Some(ProcessGroupCleanupGuard::new(child.id()));
-    let _invocation_child_guard = invocation_child_guard(
-        env,
-        child.id(),
-        cleanup_guard.as_ref().and_then(|guard| guard.pgid()),
+    run_local_command(
         command,
-    );
-    let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
-
-    fn read_all<R: Read>(mut src: R) -> String {
-        let mut captured = Vec::new();
-        let mut buf = [0u8; 4096];
-        loop {
-            match src.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => captured.extend_from_slice(&buf[..n]),
-                Err(_) => break,
-            }
-        }
-        String::from_utf8_lossy(&captured).to_string()
-    }
-
-    fn tee_to_stderr<R: Read>(mut src: R) -> String {
-        let mut captured = Vec::new();
-        let mut buf = [0u8; 4096];
-        let mut sink = std::io::stderr();
-        loop {
-            match src.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    let _ = sink.write_all(&buf[..n]);
-                    let _ = sink.flush();
-                    captured.extend_from_slice(&buf[..n]);
-                }
-                Err(_) => break,
-            }
-        }
-        String::from_utf8_lossy(&captured).to_string()
-    }
-
-    let stdout_handle = child
-        .stdout
-        .take()
-        .map(|pipe| thread::spawn(move || read_all(pipe)));
-    let stderr_handle = child
-        .stderr
-        .take()
-        .map(|pipe| thread::spawn(move || tee_to_stderr(pipe)));
-
-    let (status, delegated_failure, timed_out) =
-        wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard, timeout);
-    let interrupted_signal = active_cleanup_signal();
-
-    let stdout = stdout_handle
-        .and_then(|h| h.join().ok())
-        .unwrap_or_default();
-    let stderr = stderr_handle
-        .and_then(|h| h.join().ok())
-        .unwrap_or_default();
-
-    let output = match status {
-        Ok(status) => CommandOutput {
-            stdout,
-            stderr: stderr_with_delegated_failure(
-                stderr_with_timeout(
-                    stderr_with_interruption(stderr, interrupted_signal),
-                    timed_out,
-                    timeout,
-                ),
-                delegated_failure.as_ref(),
-            ),
-            success: status.success()
-                && interrupted_signal.is_none()
-                && delegated_failure.is_none()
-                && !timed_out,
-            exit_code: timed_out_exit_code(
-                timed_out,
-                interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
-            ),
-            timed_out,
-            child_resource: Some(monitor.finish()),
-        },
-        Err(e) => CommandOutput {
-            stdout,
-            stderr: stderr_with_delegated_failure(
-                stderr_with_interruption(
-                    stderr_with_timeout(
-                        format!("{stderr}\nCommand error: {}", e),
-                        timed_out,
-                        timeout,
-                    ),
-                    interrupted_signal,
-                ),
-                delegated_failure.as_ref(),
-            ),
-            success: false,
-            exit_code: timed_out_exit_code(
-                timed_out,
-                interrupted_exit_code(interrupted_signal, -1),
-            ),
-            timed_out,
-            child_resource: Some(monitor.finish()),
-        },
-    };
-    if let Some(cleanup_guard) = cleanup_guard.take() {
-        cleanup_guard.cleanup();
-    }
-    output
+        current_dir,
+        env,
+        timeout,
+        None,
+        StreamMode::StderrPassthrough,
+    )
 }
 
 fn timed_out_exit_code(timed_out: bool, fallback: i32) -> i32 {

--- a/src/core/server/client/ssh_client.rs
+++ b/src/core/server/client/ssh_client.rs
@@ -7,6 +7,7 @@ use crate::core::error::{Error, Result};
 use crate::core::runner::{quote_runner_env_value, remote_shell_path_preamble};
 
 use super::super::session::ensure_control_path_parent;
+use super::super::ssh_args::{client_ssh_args, SshArgOptions, SshPortFlag};
 use super::super::{
     ManagedSshSession, ManagedSshSessionOutput, Server, ServerAuthMode, ServerSessionConfig,
 };
@@ -140,51 +141,18 @@ impl SshClient {
     }
 
     pub(crate) fn build_ssh_args(&self, command: Option<&str>, interactive: bool) -> Vec<String> {
-        let mut args = Vec::new();
-
-        if let Some(identity_file) = &self.identity_file {
-            args.push("-i".to_string());
-            args.push(identity_file.clone());
-        }
-
-        if self.port != 22 {
-            args.push("-p".to_string());
-            args.push(self.port.to_string());
-        }
-
-        if let Some(session) = &self.auth {
-            args.extend([
-                "-o".to_string(),
-                "ControlMaster=auto".to_string(),
-                "-o".to_string(),
-                format!("ControlPath={}", session.control_path),
-                "-o".to_string(),
-                format!("ControlPersist={}", session.persist),
-            ]);
-        }
-
-        // For non-interactive commands, add timeout and keepalive options
-        // to prevent hangs on stalled connections or unexpected prompts.
-        if !interactive {
-            args.extend([
-                "-o".to_string(),
-                "BatchMode=yes".to_string(),
-                "-o".to_string(),
-                "ConnectTimeout=10".to_string(),
-                "-o".to_string(),
-                "ServerAliveInterval=15".to_string(),
-                "-o".to_string(),
-                "ServerAliveCountMax=3".to_string(),
-            ]);
-        }
-
-        args.push(format!("{}@{}", self.user, self.host));
-
-        if let Some(cmd) = command {
-            args.push(cmd.to_string());
-        }
-
-        args
+        client_ssh_args(
+            self,
+            SshArgOptions {
+                interactive,
+                batch_mode: true,
+                connect_timeout: true,
+                keepalive: true,
+                port_flag: Some(SshPortFlag::Lowercase),
+                command,
+                ..SshArgOptions::default()
+            },
+        )
     }
 
     fn build_session_control_args(&self, operation: &str) -> Result<Vec<String>> {

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod http;
 mod keys;
 mod process_cleanup;
 mod session;
+pub(crate) mod ssh_args;
 pub mod transfer;
 
 pub(crate) use client::DELEGATED_RUN_STATUS_FILE_ENV;

--- a/src/core/server/ssh_args.rs
+++ b/src/core/server/ssh_args.rs
@@ -1,0 +1,172 @@
+use crate::core::engine::shell;
+
+use super::{ManagedSshSession, Server, ServerAuthMode, SshClient};
+
+#[derive(Clone, Copy)]
+pub(crate) enum SshPortFlag {
+    Lowercase,
+    Uppercase,
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct SshArgOptions<'a> {
+    pub(crate) interactive: bool,
+    pub(crate) strict_host_key_checking_no: bool,
+    pub(crate) batch_mode: bool,
+    pub(crate) connect_timeout: bool,
+    pub(crate) keepalive: bool,
+    pub(crate) exit_on_forward_failure: bool,
+    pub(crate) legacy_scp: bool,
+    pub(crate) port_flag: Option<SshPortFlag>,
+    pub(crate) command: Option<&'a str>,
+}
+
+pub(crate) fn client_ssh_args(client: &SshClient, options: SshArgOptions<'_>) -> Vec<String> {
+    let mut args = client_connection_args(
+        &client.user,
+        &client.host,
+        client.port,
+        client.identity_file.as_deref(),
+        client.auth.as_ref(),
+        options,
+    );
+    args.push(format!("{}@{}", client.user, client.host));
+    if let Some(command) = options.command {
+        args.push(command.to_string());
+    }
+    args
+}
+
+pub(crate) fn client_option_args(client: &SshClient, options: SshArgOptions<'_>) -> Vec<String> {
+    client_connection_args(
+        &client.user,
+        &client.host,
+        client.port,
+        client.identity_file.as_deref(),
+        client.auth.as_ref(),
+        options,
+    )
+}
+
+pub(crate) fn server_option_args(server: &Server, options: SshArgOptions<'_>) -> Vec<String> {
+    let auth = server
+        .auth
+        .as_ref()
+        .filter(|auth| auth.mode == ServerAuthMode::KeyPlusPasswordControlmaster)
+        .map(ManagedSshSession::from_auth);
+    client_connection_args(
+        &server.user,
+        &server.host,
+        server.port,
+        server
+            .identity_file
+            .as_deref()
+            .filter(|path| !path.is_empty()),
+        auth.as_ref(),
+        options,
+    )
+}
+
+pub(crate) fn shell_join_args(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| shell::quote_arg(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn client_connection_args(
+    _user: &str,
+    _host: &str,
+    port: u16,
+    identity_file: Option<&str>,
+    auth: Option<&ManagedSshSession>,
+    options: SshArgOptions<'_>,
+) -> Vec<String> {
+    let mut args = Vec::new();
+
+    if options.legacy_scp {
+        args.push("-O".to_string());
+    }
+
+    if let Some(identity_file) = identity_file {
+        args.push("-i".to_string());
+        args.push(shellexpand::tilde(identity_file).to_string());
+    }
+
+    if let Some(flag) = options.port_flag {
+        if port != 22 {
+            args.push(match flag {
+                SshPortFlag::Lowercase => "-p".to_string(),
+                SshPortFlag::Uppercase => "-P".to_string(),
+            });
+            args.push(port.to_string());
+        }
+    }
+
+    if options.strict_host_key_checking_no {
+        push_option(&mut args, "StrictHostKeyChecking=no");
+    }
+
+    if let Some(session) = auth {
+        push_option(&mut args, "ControlMaster=auto");
+        push_option(&mut args, format!("ControlPath={}", session.control_path));
+        push_option(&mut args, format!("ControlPersist={}", session.persist));
+    }
+
+    if options.batch_mode && !options.interactive {
+        push_option(&mut args, "BatchMode=yes");
+    }
+    if options.exit_on_forward_failure {
+        push_option(&mut args, "ExitOnForwardFailure=yes");
+    }
+    if options.connect_timeout && !options.interactive {
+        push_option(&mut args, "ConnectTimeout=10");
+    }
+    if options.keepalive && !options.interactive {
+        push_option(&mut args, "ServerAliveInterval=15");
+        push_option(&mut args, "ServerAliveCountMax=3");
+    }
+
+    args
+}
+
+fn push_option(args: &mut Vec<String>, option: impl Into<String>) {
+    args.push("-o".to_string());
+    args.push(option.into());
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn shell_join_quotes_ssh_option_values_with_spaces() {
+        let client = SshClient {
+            host: "example.test".to_string(),
+            user: "deploy".to_string(),
+            port: 2222,
+            identity_file: Some("/tmp/key with spaces".to_string()),
+            auth: Some(ManagedSshSession {
+                control_path: "/tmp/control path".to_string(),
+                persist: "4h".to_string(),
+            }),
+            is_local: false,
+            env: HashMap::new(),
+        };
+
+        let rendered = shell_join_args(&client_option_args(
+            &client,
+            SshArgOptions {
+                batch_mode: true,
+                port_flag: Some(SshPortFlag::Lowercase),
+                ..SshArgOptions::default()
+            },
+        ));
+
+        assert!(rendered.contains("-i '/tmp/key with spaces'"));
+        assert!(rendered.contains("-o 'ControlPath=/tmp/control path'"));
+        assert!(rendered.contains("-p 2222"));
+    }
+}

--- a/src/core/server/transfer.rs
+++ b/src/core/server/transfer.rs
@@ -1,4 +1,7 @@
 use super::SshClient;
+use crate::core::server::ssh_args::{
+    client_option_args, shell_join_args, SshArgOptions, SshPortFlag,
+};
 use serde::Serialize;
 use std::process::{Command, Stdio};
 
@@ -95,61 +98,24 @@ pub fn parse_target(target: &str) -> TransferTarget {
     TransferTarget::Local(target.to_string())
 }
 
-/// Build scp-compatible SSH args for a server connection.
-fn build_scp_args(client: &SshClient) -> Vec<String> {
-    let mut args = vec![
-        "-O".to_string(), // Use legacy SCP protocol (not SFTP)
-        "-o".to_string(),
-        "StrictHostKeyChecking=no".to_string(),
-        "-o".to_string(),
-        "BatchMode=yes".to_string(),
-    ];
-
-    if let Some(identity_file) = &client.identity_file {
-        args.push("-i".to_string());
-        args.push(identity_file.clone());
-    }
-
-    if let Some(session) = &client.auth {
-        args.extend([
-            "-o".to_string(),
-            "ControlMaster=auto".to_string(),
-            "-o".to_string(),
-            format!("ControlPath={}", session.control_path),
-            "-o".to_string(),
-            format!("ControlPersist={}", session.persist),
-        ]);
-    }
-
-    if client.port != 22 {
-        args.push("-P".to_string()); // scp uses -P (uppercase) for port
-        args.push(client.port.to_string());
-    }
-
-    args
+enum TransferBackend {
+    Scp { args: Vec<String> },
+    Shell { command: String },
 }
 
-/// Build SSH connection args for server-to-server tar pipe.
-fn build_ssh_args(client: &SshClient) -> String {
-    let mut args = Vec::new();
-    args.push("-o StrictHostKeyChecking=no".to_string());
-    args.push("-o BatchMode=yes".to_string());
+struct TransferPlan {
+    method: String,
+    direction: String,
+    backend: TransferBackend,
+}
 
-    if let Some(identity_file) = &client.identity_file {
-        args.push(format!("-i {}", identity_file));
+impl TransferPlan {
+    fn dry_run_output(&self, config: &TransferConfig) -> (TransferOutput, i32) {
+        (
+            transfer_output(config, &self.method, &self.direction, true, None, true),
+            0,
+        )
     }
-
-    if let Some(session) = &client.auth {
-        args.push("-o ControlMaster=auto".to_string());
-        args.push(format!("-o ControlPath={}", session.control_path));
-        args.push(format!("-o ControlPersist={}", session.persist));
-    }
-
-    if client.port != 22 {
-        args.push(format!("-p {}", client.port));
-    }
-
-    args.join(" ")
 }
 
 /// Execute a file transfer between local and remote paths, or between two servers.
@@ -173,10 +139,10 @@ pub fn transfer(config: &TransferConfig) -> crate::core::Result<(TransferOutput,
             ))
         }
         (TransferTarget::Local(local_path), TransferTarget::Remote { server_id, path }) => {
-            run_push(config, local_path, server_id, path)
+            execute_plan(config, plan_push(config, local_path, server_id, path)?)
         }
         (TransferTarget::Remote { server_id, path }, TransferTarget::Local(local_path)) => {
-            run_pull(config, server_id, path, local_path)
+            execute_plan(config, plan_pull(config, server_id, path, local_path)?)
         }
         (
             TransferTarget::Remote {
@@ -187,17 +153,20 @@ pub fn transfer(config: &TransferConfig) -> crate::core::Result<(TransferOutput,
                 server_id: dst_id,
                 path: dst_path,
             },
-        ) => run_server_to_server(config, src_id, src_path, dst_id, dst_path),
+        ) => execute_plan(
+            config,
+            plan_server_to_server(config, src_id, src_path, dst_id, dst_path)?,
+        ),
     }
 }
 
 /// Push a local file/directory to a remote server via scp.
-fn run_push(
+fn plan_push(
     config: &TransferConfig,
     local_path: &str,
     server_id: &str,
     remote_path: &str,
-) -> crate::core::Result<(TransferOutput, i32)> {
+) -> crate::core::Result<TransferPlan> {
     let srv = super::load(server_id)?;
     let client = SshClient::from_server(&srv, server_id)?;
 
@@ -211,7 +180,11 @@ fn run_push(
             server_id,
             remote_path
         );
-        return Ok((transfer_output(config, "scp", "push", true, None, true), 0));
+        return Ok(TransferPlan {
+            method: "scp".to_string(),
+            direction: "push".to_string(),
+            backend: TransferBackend::Scp { args: Vec::new() },
+        });
     }
 
     // Validate local path exists
@@ -225,7 +198,7 @@ fn run_push(
         ));
     }
 
-    let mut scp_args = build_scp_args(&client);
+    let mut scp_args = scp_args(&client);
 
     if config.recursive || local.is_dir() {
         scp_args.push("-r".to_string());
@@ -245,16 +218,20 @@ fn run_push(
         remote_path
     );
 
-    execute_scp(&scp_args, config)
+    Ok(TransferPlan {
+        method: "scp".to_string(),
+        direction: "push".to_string(),
+        backend: TransferBackend::Scp { args: scp_args },
+    })
 }
 
 /// Pull a remote file/directory to a local path via scp.
-fn run_pull(
+fn plan_pull(
     config: &TransferConfig,
     server_id: &str,
     remote_path: &str,
     local_path: &str,
-) -> crate::core::Result<(TransferOutput, i32)> {
+) -> crate::core::Result<TransferPlan> {
     let srv = super::load(server_id)?;
     let client = SshClient::from_server(&srv, server_id)?;
 
@@ -268,7 +245,11 @@ fn run_pull(
             remote_path,
             local_path
         );
-        return Ok((transfer_output(config, "scp", "pull", true, None, true), 0));
+        return Ok(TransferPlan {
+            method: "scp".to_string(),
+            direction: "pull".to_string(),
+            backend: TransferBackend::Scp { args: Vec::new() },
+        });
     }
 
     // Ensure parent directory exists for local destination
@@ -284,7 +265,7 @@ fn run_pull(
         }
     }
 
-    let mut scp_args = build_scp_args(&client);
+    let mut scp_args = scp_args(&client);
 
     if config.recursive {
         scp_args.push("-r".to_string());
@@ -304,17 +285,21 @@ fn run_pull(
         local_path
     );
 
-    execute_scp(&scp_args, config)
+    Ok(TransferPlan {
+        method: "scp".to_string(),
+        direction: "pull".to_string(),
+        backend: TransferBackend::Scp { args: scp_args },
+    })
 }
 
 /// Transfer between two remote servers via SSH tar pipe.
-fn run_server_to_server(
+fn plan_server_to_server(
     config: &TransferConfig,
     src_id: &str,
     src_path: &str,
     dst_id: &str,
     dst_path: &str,
-) -> crate::core::Result<(TransferOutput, i32)> {
+) -> crate::core::Result<TransferPlan> {
     let src_server = super::load(src_id)?;
     let dst_server = super::load(dst_id)?;
 
@@ -336,14 +321,17 @@ fn run_server_to_server(
             dst_path
         );
         log_status!("dry-run", "Method: {}", method);
-        return Ok((
-            transfer_output(config, method, "server-to-server", true, None, true),
-            0,
-        ));
+        return Ok(TransferPlan {
+            method: method.to_string(),
+            direction: "server-to-server".to_string(),
+            backend: TransferBackend::Shell {
+                command: String::new(),
+            },
+        });
     }
 
-    let source_ssh_args = build_ssh_args(&src_client);
-    let dest_ssh_args = build_ssh_args(&dst_client);
+    let source_ssh_args = ssh_shell_args(&src_client);
+    let dest_ssh_args = ssh_shell_args(&dst_client);
 
     let source_remote = format!("{}@{}", src_client.user, src_client.host);
     let dest_remote = format!("{}@{}", dst_client.user, dst_client.host);
@@ -381,13 +369,40 @@ fn run_server_to_server(
         ("cat-pipe".to_string(), cmd)
     };
 
-    log_status!("transfer", "{} -> {}", config.source, config.destination);
-    log_status!("transfer", "Method: {}", method);
+    Ok(TransferPlan {
+        method,
+        direction: "server-to-server".to_string(),
+        backend: TransferBackend::Shell { command },
+    })
+}
 
-    let output = Command::new("sh")
-        .args(["-c", &command])
-        .stdin(Stdio::null())
-        .output();
+fn execute_plan(
+    config: &TransferConfig,
+    plan: TransferPlan,
+) -> crate::core::Result<(TransferOutput, i32)> {
+    if config.dry_run {
+        return Ok(plan.dry_run_output(config));
+    }
+
+    if matches!(&plan.backend, TransferBackend::Shell { .. }) {
+        log_status!("transfer", "{} -> {}", config.source, config.destination);
+        log_status!("transfer", "Method: {}", plan.method);
+    }
+
+    let output = match &plan.backend {
+        TransferBackend::Scp { args } => {
+            Command::new("scp").args(args).stdin(Stdio::null()).output()
+        }
+        TransferBackend::Shell { command } => Command::new("sh")
+            .args(["-c", command])
+            .stdin(Stdio::null())
+            .output(),
+    };
+
+    let backend_label = match plan.backend {
+        TransferBackend::Scp { .. } => "scp",
+        TransferBackend::Shell { .. } => "transfer",
+    };
 
     match output {
         Ok(out) => {
@@ -403,8 +418,8 @@ fn run_server_to_server(
             Ok((
                 transfer_output(
                     config,
-                    method,
-                    "server-to-server",
+                    plan.method,
+                    plan.direction,
                     success,
                     if success { None } else { Some(stderr) },
                     false,
@@ -415,10 +430,10 @@ fn run_server_to_server(
         Err(e) => Ok((
             transfer_output(
                 config,
-                method,
-                "server-to-server",
+                plan.method,
+                plan.direction,
                 false,
-                Some(format!("Failed to execute transfer: {}", e)),
+                Some(format!("Failed to execute {}: {}", backend_label, e)),
                 false,
             ),
             1,
@@ -426,55 +441,29 @@ fn run_server_to_server(
     }
 }
 
-/// Execute an scp command and return structured output.
-fn execute_scp(
-    scp_args: &[String],
-    config: &TransferConfig,
-) -> crate::core::Result<(TransferOutput, i32)> {
-    let output = Command::new("scp")
-        .args(scp_args)
-        .stdin(Stdio::null())
-        .output();
+fn scp_args(client: &SshClient) -> Vec<String> {
+    client_option_args(
+        client,
+        SshArgOptions {
+            strict_host_key_checking_no: true,
+            batch_mode: true,
+            legacy_scp: true,
+            port_flag: Some(SshPortFlag::Uppercase),
+            ..SshArgOptions::default()
+        },
+    )
+}
 
-    match output {
-        Ok(out) => {
-            let success = out.status.success();
-            let stderr = String::from_utf8_lossy(&out.stderr).to_string();
-
-            if !success {
-                eprintln!("[transfer] Failed: {}", stderr);
-            } else {
-                log_status!("transfer", "Complete");
-            }
-
-            Ok((
-                transfer_output(
-                    config,
-                    "scp",
-                    if config.source.contains(':') {
-                        "pull"
-                    } else {
-                        "push"
-                    },
-                    success,
-                    if success { None } else { Some(stderr) },
-                    false,
-                ),
-                if success { 0 } else { 1 },
-            ))
-        }
-        Err(e) => Ok((
-            transfer_output(
-                config,
-                "scp",
-                "unknown",
-                false,
-                Some(format!("Failed to execute scp: {}", e)),
-                false,
-            ),
-            1,
-        )),
-    }
+fn ssh_shell_args(client: &SshClient) -> String {
+    shell_join_args(&client_option_args(
+        client,
+        SshArgOptions {
+            strict_host_key_checking_no: true,
+            batch_mode: true,
+            port_flag: Some(SshPortFlag::Lowercase),
+            ..SshArgOptions::default()
+        },
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary\n- Consolidates local command execution into one runner selected by a stream-mode enum.\n- Adds a shared SSH option renderer for argv and shell-string call sites.\n- Replaces file-transfer-specific SCP/shell/dry-run execution paths with one typed transfer plan and executor.\n\n## Cluster LOC delta\n- Cluster 1, local exec: +88 / -314, net -226.\n- Cluster 3, SSH arg construction: approximately +228 / -159, net +69.\n- Cluster 4, file transfer planner/executor: approximately +109 / -92, net +17.\n- Overall PR: +425 / -565, net -140.\n\nCluster 3 and 4 both touch `src/core/server/transfer.rs`, so their per-cluster deltas are grouped from the relevant hunks; overall git diff stat is exact.\n\n## Test evidence\n- `cargo check --all-targets` passed. Existing warning remains: `is_missing_source_checkout_error` is unused.\n- `cargo test --lib` was attempted twice and timed out during long-running workspace/worker tests: first at 900s, then at 1800s. Hundreds of tests had passed before timeout; no test failure was reported before termination.\n- Focused changed-module tests passed:\n  - `cargo test --lib core::server::ssh_args`: 1 passed.\n  - `cargo test --lib core::server::transfer`: 3 passed.\n  - `cargo test --lib core::server::client`: 21 passed.\n\n## Issue\nRefs #7455.\n\nThis does not close #7455. Remaining clusters are git plumbing, command-target resolution, and typed runs metadata; I commented the remaining scope on the issue.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated via Claude (opencode)\n- **Used for:** Implemented the consolidation and tests from a scoped investigation brief; human reviews every line.