### PR TITLE
fix: isolate agent task machine state tests

### DIFF
--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -900,6 +900,7 @@ mod tests {
     use super::*;
     use crate::cli_surface::{Cli, Commands};
     use crate::commands::agent_task::{AgentTaskCommand, AgentTaskFanoutCommand};
+    use crate::test_support::with_isolated_home;
     use clap::Parser;
     use serde_json::json;
 
@@ -915,78 +916,83 @@ mod tests {
 
     #[test]
     fn batch_cook_plan_requires_independent_cooks_with_worktrees() {
-        let plan = BatchCookFanoutPlan::from_value(
-            json!({
-                "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
-                "fanout_id": "fanout/original",
-                "cooks": [
-                    {
-                        "cook_id": "5929-docs",
-                        "prompt": "fix docs",
-                        "repo": "homeboy",
-                        "cwd": "/runner/workspaces/homeboy@5929-docs",
-                        "workspace_materialization": [{
-                            "field": "cwd",
-                            "controller_path": "/Users/user/Developer/homeboy@5929-docs",
-                            "runner_path": "/runner/workspaces/homeboy@5929-docs",
-                            "branch": "fix/5929-docs",
-                            "ref": "fix/5929-docs",
-                            "sync_status": "materialized"
-                        }],
-                        "to_worktree": "homeboy@fix-5929-docs",
-                        "head": "fix/5929-docs",
-                        "verify": ["homeboy test homeboy"]
-                    },
-                    {
-                        "cook_id": "5929-cli",
-                        "prompt": "fix cli",
-                        "repo": "homeboy",
-                        "to_worktree": "homeboy@fix-5929-cli",
-                        "head": "fix/5929-cli",
-                        "verify": ["homeboy test homeboy"]
-                    }
-                ]
-            }),
-            &args(),
-        )
-        .expect("batch cook fanout plan");
+        with_isolated_home(|_| {
+            let plan = BatchCookFanoutPlan::from_value(
+                json!({
+                    "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
+                    "fanout_id": "fanout/original",
+                    "cooks": [
+                        {
+                            "cook_id": "5929-docs",
+                            "prompt": "fix docs",
+                            "repo": "homeboy",
+                            "cwd": "/runner/workspaces/homeboy@5929-docs",
+                            "workspace_materialization": [{
+                                "field": "cwd",
+                                "controller_path": "/Users/user/Developer/homeboy@5929-docs",
+                                "runner_path": "/runner/workspaces/homeboy@5929-docs",
+                                "branch": "fix/5929-docs",
+                                "ref": "fix/5929-docs",
+                                "sync_status": "materialized"
+                            }],
+                            "to_worktree": "homeboy@fix-5929-docs",
+                            "head": "fix/5929-docs",
+                            "verify": ["homeboy test homeboy"]
+                        },
+                        {
+                            "cook_id": "5929-cli",
+                            "prompt": "fix cli",
+                            "repo": "homeboy",
+                            "to_worktree": "homeboy@fix-5929-cli",
+                            "head": "fix/5929-cli",
+                            "verify": ["homeboy test homeboy"]
+                        }
+                    ]
+                }),
+                &args(),
+            )
+            .expect("batch cook fanout plan");
 
-        assert_eq!(plan.fanout_id, "fanout/refactor");
-        assert_eq!(plan.cooks.len(), 2);
-        assert_eq!(plan.cooks[0].backend.as_deref(), Some("test"));
-        assert_eq!(plan.cooks[0].selector.as_deref(), Some("fixture"));
-        let invocation = plan.cooks[0]
-            .to_cook_invocation(&plan)
-            .expect("cook invocation");
-        assert_eq!(invocation.options.to_worktree, "homeboy@fix-5929-docs");
-        assert_eq!(invocation.options.head.as_deref(), Some("fix/5929-docs"));
-        assert_eq!(
-            invocation.dispatch.cwd.as_deref(),
-            Some("/runner/workspaces/homeboy@5929-docs")
-        );
-        assert_eq!(invocation.dispatch.workspace, None);
-        assert_eq!(
-            invocation.dispatch.run_id.as_deref(),
-            Some("cook-5929-docs")
-        );
-        assert_eq!(
-            invocation.options.gates.verify,
-            vec!["homeboy test homeboy"]
-        );
-        assert!(invocation
-            .dispatch
-            .core
-            .client_context
-            .as_deref()
-            .expect("client context")
-            .contains("batch_cook"));
-        assert!(invocation
-            .dispatch
-            .core
-            .client_context
-            .as_deref()
-            .expect("client context")
-            .contains("/Users/user/Developer/homeboy@5929-docs"));
+            assert_eq!(plan.fanout_id, "fanout/refactor");
+            assert_eq!(plan.cooks.len(), 2);
+            assert_eq!(plan.cooks[0].backend.as_deref(), Some("test"));
+            assert_eq!(plan.cooks[0].selector.as_deref(), Some("fixture"));
+            let invocation = plan.cooks[0]
+                .to_cook_invocation(&plan)
+                .expect("cook invocation");
+            assert_eq!(invocation.options.to_worktree, "homeboy@fix-5929-docs");
+            assert_eq!(invocation.options.head.as_deref(), Some("fix/5929-docs"));
+            assert_eq!(
+                invocation.dispatch.cwd.as_deref(),
+                Some("/runner/workspaces/homeboy@5929-docs")
+            );
+            assert_eq!(invocation.dispatch.workspace, None);
+            let run_id = invocation
+                .dispatch
+                .run_id
+                .as_deref()
+                .expect("attempt run id");
+            assert!(run_id.starts_with("cook-5929-docs-attempt-1-"));
+            assert_eq!(run_id.len(), "cook-5929-docs-attempt-1-".len() + 8);
+            assert_eq!(
+                invocation.options.gates.verify,
+                vec!["homeboy test homeboy"]
+            );
+            assert!(invocation
+                .dispatch
+                .core
+                .client_context
+                .as_deref()
+                .expect("client context")
+                .contains("batch_cook"));
+            assert!(invocation
+                .dispatch
+                .core
+                .client_context
+                .as_deref()
+                .expect("client context")
+                .contains("/Users/user/Developer/homeboy@5929-docs"));
+        });
     }
 
     #[test]
@@ -1036,41 +1042,45 @@ mod tests {
 
     #[test]
     fn cook_batch_builds_batch_cook_plan_from_issue_urls() {
-        let args = cook_batch_args();
-        let plan = build_cook_batch_plan(&args).expect("cook batch plan");
+        with_isolated_home(|_| {
+            let args = cook_batch_args();
+            let plan = build_cook_batch_plan(&args).expect("cook batch plan");
 
-        assert_eq!(plan.fanout_id, "issue-wave");
-        assert_eq!(plan.cooks.len(), 2);
-        assert_eq!(plan.cooks[0].cook_id, "issue-6453");
-        assert_eq!(plan.cooks[0].to_worktree, "homeboy@fix-issue-6453-homeboy");
-        assert_eq!(
-            plan.cooks[0].head.as_deref(),
-            Some("fix/issue-6453-homeboy")
-        );
-        assert_eq!(
-            plan.cooks[0].title.as_deref(),
-            Some("Fix Extra-Chill/homeboy#6453")
-        );
-        assert!(plan.cooks[0]
-            .prompt
-            .as_deref()
-            .expect("prompt")
-            .contains("https://github.com/Extra-Chill/homeboy/issues/6453"));
-        let prompt = plan.cooks[0].prompt.as_deref().expect("prompt");
-        assert!(prompt.contains("Homeboy will commit, push fix/issue-6453-homeboy"));
-        assert!(prompt.contains("open/update the PR"));
-        assert!(prompt.contains("add AI disclosure"));
-        assert!(prompt.contains("Do not inspect credentials, configure git identity, commit, push"));
-        assert_eq!(plan.cooks[0].verify, vec!["cargo test --lib"]);
-        assert_eq!(plan.cooks[0].backend.as_deref(), Some("sandbox"));
+            assert_eq!(plan.fanout_id, "issue-wave");
+            assert_eq!(plan.cooks.len(), 2);
+            assert_eq!(plan.cooks[0].cook_id, "issue-6453");
+            assert_eq!(plan.cooks[0].to_worktree, "homeboy@fix-issue-6453-homeboy");
+            assert_eq!(
+                plan.cooks[0].head.as_deref(),
+                Some("fix/issue-6453-homeboy")
+            );
+            assert_eq!(
+                plan.cooks[0].title.as_deref(),
+                Some("Fix Extra-Chill/homeboy#6453")
+            );
+            assert!(plan.cooks[0]
+                .prompt
+                .as_deref()
+                .expect("prompt")
+                .contains("https://github.com/Extra-Chill/homeboy/issues/6453"));
+            let prompt = plan.cooks[0].prompt.as_deref().expect("prompt");
+            assert!(prompt.contains("Homeboy will commit, push fix/issue-6453-homeboy"));
+            assert!(prompt.contains("open/update the PR"));
+            assert!(prompt.contains("add AI disclosure"));
+            assert!(
+                prompt.contains("Do not inspect credentials, configure git identity, commit, push")
+            );
+            assert_eq!(plan.cooks[0].verify, vec!["cargo test --lib"]);
+            assert_eq!(plan.cooks[0].backend.as_deref(), Some("sandbox"));
 
-        let invocation = plan.cooks[0]
-            .to_cook_invocation(&plan)
-            .expect("cook invocation");
-        assert_eq!(
-            invocation.dispatch.workspace.as_deref(),
-            Some("homeboy@fix-issue-6453-homeboy")
-        );
+            let invocation = plan.cooks[0]
+                .to_cook_invocation(&plan)
+                .expect("cook invocation");
+            assert_eq!(
+                invocation.dispatch.workspace.as_deref(),
+                Some("homeboy@fix-issue-6453-homeboy")
+            );
+        });
     }
 
     #[test]

--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -378,11 +378,12 @@ fn hydrated_executor_input_value(
 }
 
 fn provider_boundary_projection(input: &Value) -> Value {
-    let executor_config = input
+    let mut executor_config = input
         .get("executor")
         .and_then(|executor| executor.get("config"))
         .cloned()
         .unwrap_or(Value::Null);
+    normalize_runtime_env_path_aliases_for_replay(&mut executor_config);
     let runtime_task = input
         .get("inputs")
         .and_then(|inputs| inputs.get("runtime_task"))
@@ -398,11 +399,88 @@ fn provider_boundary_projection(input: &Value) -> Value {
     json!({
         "runtime_task": runtime_task,
         "provider_config": executor_config,
-        "runtime_component_paths": input.pointer("/executor/config/runtime_component_paths").cloned().unwrap_or(Value::Null),
-        "runtime_env": input.pointer("/executor/config/runtime_env").cloned().unwrap_or(Value::Null),
+        "runtime_component_paths": executor_config.get("runtime_component_paths").cloned().unwrap_or(Value::Null),
+        "runtime_env": executor_config.get("runtime_env").cloned().unwrap_or(Value::Null),
         "artifact_declarations": input.get("artifact_declarations").cloned().unwrap_or(Value::Null),
         "package_descriptor": package_descriptor,
     })
+}
+
+fn normalize_runtime_env_path_aliases_for_replay(config: &mut Value) {
+    let aliases = runtime_env_path_aliases_for_replay(config);
+    if aliases.is_empty() {
+        return;
+    }
+
+    let Some(root) = config.as_object_mut() else {
+        return;
+    };
+    let component_paths = root
+        .get("runtime_component_paths")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if component_paths.is_empty() {
+        return;
+    }
+
+    if !root.get("runtime_env").is_some_and(Value::is_object) {
+        root.insert(
+            "runtime_env".to_string(),
+            Value::Object(serde_json::Map::new()),
+        );
+    }
+
+    let Some(runtime_env) = root.get_mut("runtime_env").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for (component_key, env_name) in aliases {
+        if let Some(selected_path) = component_paths
+            .get(&component_key)
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        {
+            runtime_env.insert(env_name, Value::String(selected_path));
+        }
+    }
+}
+
+fn runtime_env_path_aliases_for_replay(config: &Value) -> Vec<(String, String)> {
+    let mut aliases = Vec::new();
+    if let Some(map) = config
+        .get("runtime_env_path_aliases")
+        .and_then(Value::as_object)
+    {
+        for (component_key, env_names) in map {
+            collect_runtime_env_aliases_for_replay(component_key, env_names, &mut aliases);
+        }
+    }
+    if let Some(map) = config.get("runtime_env_aliases").and_then(Value::as_object) {
+        for (env_name, component_key) in map {
+            if let Some(component_key) = component_key.as_str() {
+                aliases.push((component_key.to_string(), env_name.to_string()));
+            }
+        }
+    }
+    aliases
+}
+
+fn collect_runtime_env_aliases_for_replay(
+    component_key: &str,
+    value: &Value,
+    aliases: &mut Vec<(String, String)>,
+) {
+    match value {
+        Value::String(env_name) => aliases.push((component_key.to_string(), env_name.to_string())),
+        Value::Array(items) => {
+            for item in items {
+                if let Some(env_name) = item.as_str() {
+                    aliases.push((component_key.to_string(), env_name.to_string()));
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 #[derive(Serialize)]

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -272,6 +272,9 @@ fn replay_provider_boundary_projects_latest_executor_input() {
                         },
                         "runtime_env": {
                             "SAMPLE_RUNTIME_DATA_MACHINE_PATH": "/runner/data-machine-patched"
+                        },
+                        "runtime_env_path_aliases": {
+                            "agent_runtime": "WP_CODEBOX_DATA_MACHINE_PATH"
                         }
                     }
                 },
@@ -837,61 +840,66 @@ fn resume_command_executes_existing_run() {
 
 #[test]
 fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
-    let observed_request = Arc::new(Mutex::new(None));
-    let executor = CapturingExecutor {
-        observed_request: Arc::clone(&observed_request),
-    };
-    let mut plan = test_plan();
-    plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
-    plan.tasks[0].workspace.component_id = Some("sample-agent-runtime".to_string());
-    plan.tasks[0].workspace.branch = Some("fix/runtime-guidance".to_string());
-    plan.tasks[0].workspace.base_ref = Some("origin/main".to_string());
-    plan.tasks[0].workspace.task_url =
-        Some("https://github.com/example/sample-agent-runtime/issues/179".to_string());
-    plan.tasks[0].workspace.cleanup = Some("preserve".to_string());
-    plan.tasks[0].workspace.materialization = json!({
-        "root": "/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance"
+    with_temp_home(|| {
+        let observed_request = Arc::new(Mutex::new(None));
+        let executor = CapturingExecutor {
+            observed_request: Arc::clone(&observed_request),
+        };
+        let mut plan = test_plan();
+        plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
+        plan.tasks[0].workspace.component_id = Some("sample-agent-runtime".to_string());
+        plan.tasks[0].workspace.branch = Some("fix/runtime-guidance".to_string());
+        plan.tasks[0].workspace.base_ref = Some("origin/main".to_string());
+        plan.tasks[0].workspace.task_url =
+            Some("https://github.com/example/sample-agent-runtime/issues/179".to_string());
+        plan.tasks[0].workspace.cleanup = Some("preserve".to_string());
+        plan.tasks[0].workspace.materialization = json!({
+            "root": "/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance"
+        });
+
+        let (_value, exit_code) =
+            run_loaded_plan(plan, None, executor).expect("run-plan completed");
+        let observed = observed_request
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .expect("provider saw request");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            observed.workspace.mode,
+            homeboy::core::agent_tasks::AgentTaskWorkspaceMode::Existing
+        );
+        assert_eq!(
+            observed.workspace.root.as_deref(),
+            Some("/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance")
+        );
+        assert_eq!(
+            observed.workspace.slug.as_deref(),
+            Some("sample-agent-runtime")
+        );
+        assert!(observed.workspace.kind.is_none());
+        assert!(observed.workspace.component_id.is_none());
+        assert!(observed.workspace.branch.is_none());
+        assert!(observed.workspace.base_ref.is_none());
+        assert!(observed.workspace.task_url.is_none());
+        assert!(observed.workspace.cleanup.is_none());
+        assert!(observed.workspace.materialization.is_null());
     });
-
-    let (_value, exit_code) = run_loaded_plan(plan, None, executor).expect("run-plan completed");
-    let observed = observed_request
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .clone()
-        .expect("provider saw request");
-
-    assert_eq!(exit_code, 0);
-    assert_eq!(
-        observed.workspace.mode,
-        homeboy::core::agent_tasks::AgentTaskWorkspaceMode::Existing
-    );
-    assert_eq!(
-        observed.workspace.root.as_deref(),
-        Some("/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance")
-    );
-    assert_eq!(
-        observed.workspace.slug.as_deref(),
-        Some("sample-agent-runtime")
-    );
-    assert!(observed.workspace.kind.is_none());
-    assert!(observed.workspace.component_id.is_none());
-    assert!(observed.workspace.branch.is_none());
-    assert!(observed.workspace.base_ref.is_none());
-    assert!(observed.workspace.task_url.is_none());
-    assert!(observed.workspace.cleanup.is_none());
-    assert!(observed.workspace.materialization.is_null());
 }
 
 #[test]
 fn run_plan_rejects_component_worktree_without_branch() {
-    let mut plan = test_plan();
-    plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
-    plan.tasks[0].workspace.component_id = Some("sample-agent-runtime".to_string());
+    with_temp_home(|| {
+        let mut plan = test_plan();
+        plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
+        plan.tasks[0].workspace.component_id = Some("sample-agent-runtime".to_string());
 
-    let error = run_loaded_plan(plan, None, CapturingExecutor::default())
-        .expect_err("component worktree without branch rejected");
-    let message = error.to_string();
+        let error = run_loaded_plan(plan, None, CapturingExecutor::default())
+            .expect_err("component worktree without branch rejected");
+        let message = error.to_string();
 
-    assert!(message.contains("workspace.branch"));
-    assert!(message.contains("requires branch"));
+        assert!(message.contains("workspace.branch"));
+        assert!(message.contains("requires branch"));
+    });
 }


### PR DESCRIPTION
## Summary
- isolate fanout cook invocation tests from host HOME/config state using the existing `with_isolated_home` helper
- make provider-boundary replay normalize persisted runtime env aliases from executor input evidence instead of relying on installed provider config
- wrap nearby `run_loaded_plan` lifecycle tests that were writing durable run state outside an isolated HOME

## Root cause
- Fanout cook invocation: the test called `to_cook_invocation()` outside `with_isolated_home`, so any path that persisted or resolved agent-task cook state could see this machine's real Homeboy HOME/config/artifact state. The production contract dispatches unique attempt run ids (`cook-...-attempt-1-<suffix>`) while the stable cook id remains the alias, so the test now isolates HOME and asserts the attempt-run-id shape rather than depending on host state.
- Provider-boundary replay: the replay fixture only carried `runtime_component_paths` plus a runtime-specific env entry. On machines with provider config declaring the `agent_runtime -> WP_CODEBOX_DATA_MACHINE_PATH` alias, that ambient config masked the incomplete evidence. In an isolated HOME, replay could only see the persisted executor input and returned `Null`. Replay now applies the same provider-agnostic alias shape from the persisted executor config (`runtime_env_path_aliases` / `runtime_env_aliases`) before projecting `runtime_env`.

## Isolation mechanism
- Tests use `with_isolated_home` / `with_temp_home`, which resets the config cache and points HOME, XDG data, artifact root, runtime tmpdir, and invocation runtime at temp locations.
- Provider-boundary replay is now deterministic from durable executor-input evidence; it does not need global provider/executor config to infer env aliases.

## Remaining leak inventory
- Fixed cheap nearby leaks: two lifecycle tests using `run_loaded_plan` without temp HOME, plus one additional fanout invocation-building unit.
- Left alone: pure status/contract projection tests that only operate on inline JSON and do not read or write Homeboy HOME/config/workspace paths.
- Larger inventory not addressed here: broader suite-wide HOME isolation and slow-suite/test-parallelism work from #7469 item 1/2/4 is out of scope for this PR.

## Test evidence
- `cargo test --lib commands::agent_task::fanout::tests::batch_cook_plan_requires_independent_cooks_with_worktrees -- --exact`
- `cargo test --lib commands::agent_task::tests::lifecycle::replay_provider_boundary_projects_latest_executor_input -- --exact`
- `cargo test --lib agent_task::` (112 passed)
- `cargo check --all-targets` (clean; existing dead-code warning in `src/core/worktree.rs`)

Refs #7469

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated via Claude (opencode)
- **Used for:** Root-caused and fixed test isolation leaks; human reviews every line.