### PR TITLE
Add disposable local DB runtime helper

### DIFF
--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -89,6 +89,10 @@ Settings are extension-defined. Use `--settings-json-file <FILE>` or `--settings
 
 Merge order is extension defaults, component settings, settings profile files, explicit `--setting`, then explicit `--setting-json`. Later values win for the same key, so command-line overrides take precedence over profile files.
 
+## Disposable Local Databases
+
+Homeboy materializes `HOMEBOY_RUNTIME_DISPOSABLE_LOCAL_DB` for extension runners that need an isolated local MySQL/MariaDB service. Source that helper and call `homeboy_disposable_local_db_start` with caller-owned environment variable names, for example `--env-database TEST_DB_NAME --env-user TEST_DB_USER --env-password TEST_DB_PASSWORD --env-socket TEST_DB_SOCKET`. The helper initializes a temporary datadir, starts a socket-only server with networking disabled, creates one database/user, exports only the requested env vars, and registers cleanup on process exit. Framework-specific mapping belongs in the extension or caller profile.
+
 ## Output
 
 Returns JSON with test results:

--- a/src/core/extension/runtime/disposable-local-db.sh
+++ b/src/core/extension/runtime/disposable-local-db.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+
+# Generic disposable local MySQL/MariaDB helper for extension runners.
+#
+# The caller owns framework-specific semantics by choosing which environment
+# variable names receive the connection values. Homeboy only owns a local,
+# socket-only database lifecycle and cleanup.
+
+HOMEBOY_DISPOSABLE_LOCAL_DB_DIR="${HOMEBOY_DISPOSABLE_LOCAL_DB_DIR:-}"
+HOMEBOY_DISPOSABLE_LOCAL_DB_PID="${HOMEBOY_DISPOSABLE_LOCAL_DB_PID:-}"
+HOMEBOY_DISPOSABLE_LOCAL_DB_SOCKET="${HOMEBOY_DISPOSABLE_LOCAL_DB_SOCKET:-}"
+HOMEBOY_DISPOSABLE_LOCAL_DB_CLIENT="${HOMEBOY_DISPOSABLE_LOCAL_DB_CLIENT:-}"
+HOMEBOY_DISPOSABLE_LOCAL_DB_STOP_REGISTERED="${HOMEBOY_DISPOSABLE_LOCAL_DB_STOP_REGISTERED:-0}"
+
+homeboy_disposable_local_db_usage() {
+    cat <<'EOF'
+Usage: homeboy_disposable_local_db_start [options]
+
+Starts an isolated local MySQL/MariaDB instance on a Unix socket, creates one
+database/user, exports requested env vars, and registers EXIT cleanup.
+
+Options:
+  --database NAME          Database name to create (default: homeboy_test)
+  --user NAME              Database user to create (default: homeboy)
+  --password VALUE         Database password (default: generated)
+  --tmp-dir PATH           Parent temp directory (default: mktemp under TMPDIR)
+  --env-host NAME          Export NAME=localhost
+  --env-port NAME          Export NAME=0
+  --env-socket NAME        Export NAME=<socket path>
+  --env-database NAME      Export NAME=<database>
+  --env-user NAME          Export NAME=<user>
+  --env-password NAME      Export NAME=<password>
+EOF
+}
+
+homeboy_disposable_local_db_find_command() {
+    local candidate
+    for candidate in "$@"; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            command -v "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+homeboy_disposable_local_db_random_password() {
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex 16
+        return 0
+    fi
+    od -An -tx1 -N16 /dev/urandom | tr -d ' \n'
+}
+
+homeboy_disposable_local_db_export() {
+    local env_name="$1"
+    local env_value="$2"
+
+    [ -n "$env_name" ] || return 0
+    if [[ ! "$env_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        echo "ERROR: invalid environment variable name for disposable local DB: $env_name" >&2
+        return 2
+    fi
+    export "${env_name}=${env_value}"
+}
+
+homeboy_disposable_local_db_validate_identifier() {
+    local label="$1"
+    local value="$2"
+
+    if [[ ! "$value" =~ ^[A-Za-z0-9_]+$ ]]; then
+        echo "ERROR: disposable local DB ${label} must contain only letters, numbers, and underscores: $value" >&2
+        return 2
+    fi
+}
+
+homeboy_disposable_local_db_sql_string() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\'/\'\'}"
+    printf "%s" "$value"
+}
+
+homeboy_disposable_local_db_stop() {
+    local pid="${HOMEBOY_DISPOSABLE_LOCAL_DB_PID:-}"
+    local dir="${HOMEBOY_DISPOSABLE_LOCAL_DB_DIR:-}"
+
+    if [ -n "$pid" ] && kill -0 "$pid" >/dev/null 2>&1; then
+        kill "$pid" >/dev/null 2>&1 || true
+        local waited=0
+        while kill -0 "$pid" >/dev/null 2>&1 && [ "$waited" -lt 50 ]; do
+            sleep 0.1
+            waited=$((waited + 1))
+        done
+        if kill -0 "$pid" >/dev/null 2>&1; then
+            kill -9 "$pid" >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if [ -n "$dir" ] && [ -d "$dir" ]; then
+        rm -rf "$dir"
+    fi
+
+    HOMEBOY_DISPOSABLE_LOCAL_DB_PID=""
+    HOMEBOY_DISPOSABLE_LOCAL_DB_DIR=""
+    HOMEBOY_DISPOSABLE_LOCAL_DB_SOCKET=""
+}
+
+homeboy_disposable_local_db_init_datadir() {
+    local datadir="$1"
+    local init_log="$2"
+    local init_cmd server_cmd
+
+    if init_cmd=$(homeboy_disposable_local_db_find_command mariadb-install-db mysql_install_db); then
+        "$init_cmd" --datadir="$datadir" --auth-root-authentication-method=normal --skip-test-db >"$init_log" 2>&1
+        return $?
+    fi
+
+    if server_cmd=$(homeboy_disposable_local_db_find_command mariadbd mysqld); then
+        "$server_cmd" --no-defaults --initialize-insecure --datadir="$datadir" >"$init_log" 2>&1
+        return $?
+    fi
+
+    echo "ERROR: no MySQL/MariaDB initializer found. Install mariadb-install-db, mysql_install_db, mariadbd, or mysqld." >&2
+    return 2
+}
+
+homeboy_disposable_local_db_start() {
+    local database="homeboy_test"
+    local user="homeboy"
+    local password=""
+    local tmp_parent="${TMPDIR:-/tmp}"
+    local env_host=""
+    local env_port=""
+    local env_socket=""
+    local env_database=""
+    local env_user=""
+    local env_password=""
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --database) database="${2:-}"; shift 2 ;;
+            --user) user="${2:-}"; shift 2 ;;
+            --password) password="${2:-}"; shift 2 ;;
+            --tmp-dir) tmp_parent="${2:-}"; shift 2 ;;
+            --env-host) env_host="${2:-}"; shift 2 ;;
+            --env-port) env_port="${2:-}"; shift 2 ;;
+            --env-socket) env_socket="${2:-}"; shift 2 ;;
+            --env-database) env_database="${2:-}"; shift 2 ;;
+            --env-user) env_user="${2:-}"; shift 2 ;;
+            --env-password) env_password="${2:-}"; shift 2 ;;
+            --help|-h) homeboy_disposable_local_db_usage; return 0 ;;
+            *) echo "ERROR: unknown disposable local DB option: $1" >&2; homeboy_disposable_local_db_usage >&2; return 2 ;;
+        esac
+    done
+
+    if [ -n "${HOMEBOY_DISPOSABLE_LOCAL_DB_PID:-}" ] && kill -0 "$HOMEBOY_DISPOSABLE_LOCAL_DB_PID" >/dev/null 2>&1; then
+        echo "ERROR: disposable local DB is already running in this shell (pid ${HOMEBOY_DISPOSABLE_LOCAL_DB_PID})." >&2
+        return 2
+    fi
+
+    if [ -z "$database" ] || [ -z "$user" ]; then
+        echo "ERROR: disposable local DB database and user must be non-empty." >&2
+        return 2
+    fi
+    homeboy_disposable_local_db_validate_identifier "database" "$database" || return $?
+    homeboy_disposable_local_db_validate_identifier "user" "$user" || return $?
+
+    local server_cmd client_cmd admin_cmd
+    server_cmd=$(homeboy_disposable_local_db_find_command mariadbd mysqld) || { echo "ERROR: no MySQL/MariaDB server binary found. Install mariadbd or mysqld." >&2; return 2; }
+    client_cmd=$(homeboy_disposable_local_db_find_command mariadb mysql) || { echo "ERROR: no MySQL/MariaDB client found. Install mariadb or mysql." >&2; return 2; }
+    admin_cmd=$(homeboy_disposable_local_db_find_command mariadb-admin mysqladmin) || { echo "ERROR: no MySQL/MariaDB admin client found. Install mariadb-admin or mysqladmin." >&2; return 2; }
+
+    password="${password:-$(homeboy_disposable_local_db_random_password)}"
+
+    local run_dir datadir socket pid_file log_file init_log
+    run_dir=$(mktemp -d "${tmp_parent%/}/homeboy-local-db.XXXXXX") || return 1
+    datadir="${run_dir}/data"
+    socket="${run_dir}/mysql.sock"
+    pid_file="${run_dir}/mysql.pid"
+    log_file="${run_dir}/mysql.log"
+    init_log="${run_dir}/mysql-init.log"
+    mkdir -p "$datadir"
+
+    if ! homeboy_disposable_local_db_init_datadir "$datadir" "$init_log"; then
+        echo "ERROR: failed to initialize disposable local DB datadir. See $init_log" >&2
+        rm -rf "$run_dir"
+        return 1
+    fi
+
+    "$server_cmd" --no-defaults --datadir="$datadir" --socket="$socket" --pid-file="$pid_file" --skip-networking --log-error="$log_file" --innodb-flush-method=normal >/dev/null 2>&1 &
+    local pid=$!
+
+    HOMEBOY_DISPOSABLE_LOCAL_DB_DIR="$run_dir"
+    HOMEBOY_DISPOSABLE_LOCAL_DB_PID="$pid"
+    HOMEBOY_DISPOSABLE_LOCAL_DB_SOCKET="$socket"
+    HOMEBOY_DISPOSABLE_LOCAL_DB_CLIENT="$client_cmd"
+
+    local waited=0
+    until "$admin_cmd" --protocol=socket --socket="$socket" -uroot ping >/dev/null 2>&1; do
+        if ! kill -0 "$pid" >/dev/null 2>&1; then
+            echo "ERROR: disposable local DB exited during startup. See $log_file" >&2
+            homeboy_disposable_local_db_stop
+            return 1
+        fi
+        waited=$((waited + 1))
+        if [ "$waited" -gt 200 ]; then
+            echo "ERROR: timed out waiting for disposable local DB startup. See $log_file" >&2
+            homeboy_disposable_local_db_stop
+            return 1
+        fi
+        sleep 0.1
+    done
+
+    local sql_password
+    sql_password=$(homeboy_disposable_local_db_sql_string "$password")
+    if ! "$client_cmd" --protocol=socket --socket="$socket" -uroot <<SQL
+CREATE DATABASE \`${database}\`;
+CREATE USER '${user}'@'localhost' IDENTIFIED BY '${sql_password}';
+GRANT ALL PRIVILEGES ON \`${database}\`.* TO '${user}'@'localhost';
+FLUSH PRIVILEGES;
+SQL
+    then
+        echo "ERROR: failed to create disposable local DB credentials. See $log_file" >&2
+        homeboy_disposable_local_db_stop
+        return 1
+    fi
+
+    homeboy_disposable_local_db_export "$env_host" "localhost"
+    homeboy_disposable_local_db_export "$env_port" "0"
+    homeboy_disposable_local_db_export "$env_socket" "$socket"
+    homeboy_disposable_local_db_export "$env_database" "$database"
+    homeboy_disposable_local_db_export "$env_user" "$user"
+    homeboy_disposable_local_db_export "$env_password" "$password"
+
+    if [ "${HOMEBOY_DISPOSABLE_LOCAL_DB_STOP_REGISTERED:-0}" != "1" ]; then
+        trap homeboy_disposable_local_db_stop EXIT
+        HOMEBOY_DISPOSABLE_LOCAL_DB_STOP_REGISTERED=1
+    fi
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -17,6 +17,7 @@ pub const EMIT_LINT_FINDING_ENV: &str = "HOMEBOY_RUNTIME_EMIT_LINT_FINDING";
 pub const EMIT_TEST_FAILURE_ENV: &str = "HOMEBOY_RUNTIME_EMIT_TEST_FAILURE";
 pub const SIDECAR_WRITER_ENV: &str = "HOMEBOY_RUNTIME_SIDECAR_WRITER";
 pub const RESOLVE_CONTEXT_ENV: &str = "HOMEBOY_RUNTIME_RESOLVE_CONTEXT";
+pub const DISPOSABLE_LOCAL_DB_ENV: &str = "HOMEBOY_RUNTIME_DISPOSABLE_LOCAL_DB";
 pub const BENCH_HELPER_SH_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_SH";
 pub const BENCH_HELPER_JS_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_JS";
 pub const BENCH_HELPER_PHP_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_PHP";
@@ -87,6 +88,12 @@ const HELPERS: &[RuntimeHelper] = &[
         filename: "resolve-context.sh",
         content: assets::RESOLVE_CONTEXT_SH,
         env_var: RESOLVE_CONTEXT_ENV,
+        legacy_fallback: false,
+    },
+    RuntimeHelper {
+        filename: "disposable-local-db.sh",
+        content: assets::DISPOSABLE_LOCAL_DB_SH,
+        env_var: DISPOSABLE_LOCAL_DB_ENV,
         legacy_fallback: false,
     },
     RuntimeHelper {

--- a/src/core/extension/runtime_helper/assets.rs
+++ b/src/core/extension/runtime_helper/assets.rs
@@ -8,6 +8,7 @@ pub(super) const EMIT_LINT_FINDING_SH: &str = include_str!("../runtime/emit-lint
 pub(super) const EMIT_TEST_FAILURE_SH: &str = include_str!("../runtime/emit-test-failure.sh");
 pub(super) const SIDECAR_WRITER_SH: &str = include_str!("../runtime/sidecar-writer.sh");
 pub(super) const RESOLVE_CONTEXT_SH: &str = include_str!("../runtime/resolve-context.sh");
+pub(super) const DISPOSABLE_LOCAL_DB_SH: &str = include_str!("../runtime/disposable-local-db.sh");
 pub(super) const BENCH_HELPER_SH: &str = include_str!("../runtime/bench-helper.sh");
 pub(super) const BENCH_HELPER_JS: &str = include_str!("../runtime/bench-helper.mjs");
 pub(super) const BENCH_HELPER_PHP: &str = include_str!(concat!(
@@ -34,6 +35,7 @@ mod tests {
             EMIT_TEST_FAILURE_SH,
             SIDECAR_WRITER_SH,
             RESOLVE_CONTEXT_SH,
+            DISPOSABLE_LOCAL_DB_SH,
             BENCH_HELPER_SH,
             BENCH_HELPER_JS,
             BENCH_HELPER_PHP,

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -50,6 +50,10 @@ fn ensure_all_helpers_writes_all_files() {
             "resolve context helper should be in pairs"
         );
         assert!(
+            pairs.iter().any(|(k, _)| k == DISPOSABLE_LOCAL_DB_ENV),
+            "disposable local DB helper should be in pairs"
+        );
+        assert!(
             pairs.iter().any(|(k, _)| k == BENCH_HELPER_JS_ENV),
             "bench JS helper should be in pairs"
         );
@@ -178,6 +182,30 @@ fn sidecar_writer_appends_and_merges_json_arrays() {
         r#"[{"tool":"lint","message":"one","fingerprint":"first"},{"tool":"lint","message":"two","fingerprint":"second"},{"tool":"lint","message":"three","fingerprint":"third"}]
 "#
     );
+}
+
+#[test]
+fn disposable_local_db_helper_exports_requested_env_names_without_framework_terms() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("disposable-local-db.sh");
+    std::fs::write(&helper_path, assets::DISPOSABLE_LOCAL_DB_SH).expect("write helper");
+
+    let output = std::process::Command::new("bash")
+        .arg("-n")
+        .arg(&helper_path)
+        .output()
+        .expect("syntax check helper");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = std::fs::read_to_string(&helper_path).expect("helper content");
+    assert!(content.contains("--env-database"));
+    assert!(content.contains("homeboy_disposable_local_db_start"));
+    assert!(!content.to_lowercase().contains("wpcom"));
+    assert!(!content.to_lowercase().contains("wordpress"));
 }
 
 fn shasum_hex(algo: &str, identity: &str) -> String {


### PR DESCRIPTION
## Summary
- Add a generic Homeboy runtime helper for disposable local MySQL/MariaDB services.
- Materialize the helper as HOMEBOY_RUNTIME_DISPOSABLE_LOCAL_DB for extension runners.
- Document caller-owned env mapping for test runners while keeping framework and product semantics out of Homeboy core.

## Verification
- bash -n src/core/extension/runtime/disposable-local-db.sh
- cargo test runtime_helper
- cargo test core_agnostic

Note: live database startup was not run because this machine does not have mariadbd or mysqld installed; the helper fails closed with an install diagnostic when the server binary is unavailable.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigated the Homeboy/WP Codebox runner boundary, implemented the generic runtime helper, added docs/tests, and ran local verification.