### PR TITLE
Fix bench gating for unrun fixtures

### DIFF
--- a/src/commands/bench/fanout.rs
+++ b/src/commands/bench/fanout.rs
@@ -10,7 +10,7 @@ use homeboy::core::agent_tasks::{
     AgentTaskOutcomeStatus, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA,
     AGENT_TASK_REQUEST_SCHEMA,
 };
-use homeboy::core::extension::bench::{BenchGate, BenchGateResult};
+use homeboy::core::extension::bench::{BenchGate, BenchGateOp, BenchGateResult};
 use homeboy::core::rig::RigSpec;
 
 use super::{matrix, BenchReportFormat, BenchRunArgs};
@@ -166,15 +166,23 @@ fn apply_result_gates(
     mut matrix: AgentTaskMatrixAggregate,
     gates: &[BenchGate],
 ) -> (AgentTaskMatrixAggregate, Vec<BenchGateResult>, Vec<String>) {
-    if gates.is_empty() {
-        return (matrix, Vec::new(), Vec::new());
-    }
-
     let mut results = Vec::new();
     let mut failures = Vec::new();
     for cell in &mut matrix.cells {
         let metrics = numeric_metrics_for_cell(&cell.metadata);
-        for gate in gates {
+        let mut cell_gates = gates.to_vec();
+        if should_default_gate_not_run_fixtures(&metrics, &cell.metadata)
+            && !cell_gates
+                .iter()
+                .any(|gate| gate.metric == "not_run_fixture_count")
+        {
+            cell_gates.push(BenchGate {
+                metric: "not_run_fixture_count".to_string(),
+                op: BenchGateOp::Lte,
+                value: 0.0,
+            });
+        }
+        for gate in &cell_gates {
             let result = gate.evaluate_actual(
                 &format!("matrix cell `{}` result", cell.cell_id),
                 metrics.get(&gate.metric).copied(),
@@ -205,6 +213,25 @@ fn apply_result_gates(
     }
 
     (matrix, results, failures)
+}
+
+fn should_default_gate_not_run_fixtures(metrics: &BTreeMap<String, f64>, metadata: &Value) -> bool {
+    metrics.get("fixture_count").copied().unwrap_or(0.0) > 0.0
+        && metrics.contains_key("not_run_fixture_count")
+        && !explicit_planning_or_dry_run_metadata(metadata)
+}
+
+fn explicit_planning_or_dry_run_metadata(metadata: &Value) -> bool {
+    ["execution_status", "mode", "intent"].iter().any(|key| {
+        metadata
+            .get(*key)
+            .and_then(Value::as_str)
+            .is_some_and(is_planning_or_dry_run_value)
+    })
+}
+
+fn is_planning_or_dry_run_value(value: &str) -> bool {
+    matches!(value, "dry_run" | "dry-run" | "planning")
 }
 
 fn numeric_metrics_for_cell(metadata: &Value) -> BTreeMap<String, f64> {
@@ -526,7 +553,52 @@ mod tests {
         assert!(failures.is_empty());
     }
 
+    #[test]
+    fn default_result_gate_fails_matrix_cell_with_discovered_but_not_run_fixtures() {
+        let aggregate = matrix_aggregate_with_metrics(serde_json::json!({
+            "fixture_count": 13,
+            "not_run_fixture_count": 13,
+            "failed_fixture_count": 0
+        }));
+
+        let (aggregate, results, failures) = apply_result_gates(aggregate, &[]);
+
+        assert!(!aggregate.passed);
+        assert_eq!(
+            aggregate.execution_state,
+            AgentTaskMatrixExecutionState::ExecutedWithFindings
+        );
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].passed);
+        assert_eq!(results[0].metric, "not_run_fixture_count");
+        assert!(failures[0].contains("not_run_fixture_count lte 0"));
+    }
+
+    #[test]
+    fn default_result_gate_skips_matrix_cell_explicit_planning_workload() {
+        let mut aggregate = matrix_aggregate_with_metrics(serde_json::json!({
+            "fixture_count": 13,
+            "not_run_fixture_count": 13,
+            "failed_fixture_count": 0
+        }));
+        aggregate.cells[0].metadata["execution_status"] = serde_json::json!("planning");
+
+        let (aggregate, results, failures) = apply_result_gates(aggregate, &[]);
+
+        assert!(aggregate.passed);
+        assert_eq!(
+            aggregate.execution_state,
+            AgentTaskMatrixExecutionState::ExecutedClean
+        );
+        assert!(results.is_empty());
+        assert!(failures.is_empty());
+    }
+
     fn matrix_aggregate_with_metric(metric: &str, value: f64) -> AgentTaskMatrixAggregate {
+        matrix_aggregate_with_metrics(serde_json::json!({ metric: value }))
+    }
+
+    fn matrix_aggregate_with_metrics(metrics: serde_json::Value) -> AgentTaskMatrixAggregate {
         AgentTaskMatrixAggregate {
             schema: homeboy::core::agent_tasks::AGENT_TASK_MATRIX_AGGREGATE_SCHEMA.to_string(),
             plan_id: "bench/example".to_string(),
@@ -541,7 +613,7 @@ mod tests {
                 artifacts: Vec::new(),
                 evidence_refs: Vec::new(),
                 diagnostics: Vec::new(),
-                metadata: serde_json::json!({ "metrics": { metric: value } }),
+                metadata: serde_json::json!({ "metrics": metrics }),
             }],
         }
     }

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -9,8 +9,8 @@ use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::bench as extension_bench;
 use homeboy::core::extension::bench::report::collect_artifacts;
 use homeboy::core::extension::bench::{
-    BenchCommandOutput, BenchGate, BenchResults, BenchRunExecution, BenchRunWorkflowArgs,
-    BenchRunWorkflowResult,
+    BenchCommandOutput, BenchGate, BenchGateOp, BenchResults, BenchRunExecution,
+    BenchRunWorkflowArgs, BenchRunWorkflowResult,
 };
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::rig::lease::ActiveRigRunLease;
@@ -334,13 +334,17 @@ struct DeclaredBenchGates {
 }
 
 fn apply_declared_bench_gates(workflow: &mut BenchRunWorkflowResult, gates: DeclaredBenchGates) {
-    if gates.scenario_gates.is_empty() && gates.result_gates.is_empty() {
-        return;
-    }
-
     let Some(results) = workflow.results.as_mut() else {
         return;
     };
+
+    let synthesized_not_run_gates = append_default_not_run_fixture_gates(results);
+    if gates.scenario_gates.is_empty()
+        && gates.result_gates.is_empty()
+        && !synthesized_not_run_gates
+    {
+        return;
+    }
 
     for scenario in &mut results.scenarios {
         if let Some(gates) = gates.scenario_gates.get(&scenario.id) {
@@ -362,6 +366,49 @@ fn apply_declared_bench_gates(workflow: &mut BenchRunWorkflowResult, gates: Decl
     if workflow.exit_code == 0 {
         workflow.exit_code = 1;
     }
+}
+
+fn append_default_not_run_fixture_gates(results: &mut BenchResults) -> bool {
+    let result_dry_run = explicit_planning_or_dry_run_metadata(&results.metadata);
+    let mut appended = false;
+    for scenario in &mut results.scenarios {
+        if result_dry_run || explicit_planning_or_dry_run_metadata(&scenario.metadata) {
+            continue;
+        }
+        let fixture_count = scenario.metrics.get("fixture_count").unwrap_or(0.0);
+        if fixture_count <= 0.0 || scenario.metrics.get("not_run_fixture_count").is_none() {
+            continue;
+        }
+        if scenario
+            .gates
+            .iter()
+            .any(|gate| gate.metric == "not_run_fixture_count")
+        {
+            continue;
+        }
+        scenario.gates.push(BenchGate {
+            metric: "not_run_fixture_count".to_string(),
+            op: BenchGateOp::Lte,
+            value: 0.0,
+        });
+        appended = true;
+    }
+    appended
+}
+
+fn explicit_planning_or_dry_run_metadata(
+    metadata: &std::collections::BTreeMap<String, serde_json::Value>,
+) -> bool {
+    ["execution_status", "mode", "intent"].iter().any(|key| {
+        metadata
+            .get(*key)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(is_planning_or_dry_run_value)
+    })
+}
+
+fn is_planning_or_dry_run_value(value: &str) -> bool {
+    matches!(value, "dry_run" | "dry-run" | "planning")
 }
 
 fn suffix_component_results(mut results: BenchResults, component_id: &str) -> BenchResults {
@@ -1233,6 +1280,95 @@ mod tests {
             homeboy::core::gate::HomeboyGateStatus::Failed
         );
         assert!(workflow.gate_failures[0].contains("failed_fixture_count lte 0"));
+    }
+
+    #[test]
+    fn default_result_gate_fails_discovered_but_not_run_fixtures() {
+        let results = homeboy::core::extension::bench::parse_bench_results_str(
+            r#"{
+                "component_id": "static-site-importer",
+                "iterations": 1,
+                "scenarios": [
+                    {
+                        "id": "static-site-fixture-matrix",
+                        "iterations": 1,
+                        "metrics": {
+                            "fixture_count": 13,
+                            "not_run_fixture_count": 13,
+                            "failed_fixture_count": 0
+                        },
+                        "metadata": { "execution_status": "not_requested" }
+                    }
+                ]
+            }"#,
+        )
+        .expect("parse bench results");
+        let mut workflow = BenchRunWorkflowResult {
+            status: "passed".to_string(),
+            component: "static-site-importer".to_string(),
+            exit_code: 0,
+            iterations: 1,
+            results: Some(results),
+            gate_results: Vec::new(),
+            gate_failures: Vec::new(),
+            baseline_comparison: None,
+            hints: None,
+            failure: None,
+            diagnostics: Vec::new(),
+        };
+
+        apply_declared_bench_gates(&mut workflow, DeclaredBenchGates::default());
+
+        assert_eq!(workflow.status, "failed");
+        assert_eq!(workflow.exit_code, 1);
+        assert_eq!(workflow.gate_results.len(), 1);
+        assert!(workflow.gate_results[0]
+            .id
+            .contains("not_run_fixture_count"));
+        assert!(workflow.gate_failures[0].contains("not_run_fixture_count lte 0"));
+    }
+
+    #[test]
+    fn default_not_run_fixture_gate_skips_explicit_planning_workload() {
+        let results = homeboy::core::extension::bench::parse_bench_results_str(
+            r#"{
+                "component_id": "static-site-importer",
+                "iterations": 1,
+                "scenarios": [
+                    {
+                        "id": "static-site-fixture-matrix",
+                        "iterations": 1,
+                        "metrics": {
+                            "fixture_count": 13,
+                            "not_run_fixture_count": 13,
+                            "failed_fixture_count": 0
+                        },
+                        "metadata": { "execution_status": "planning" }
+                    }
+                ]
+            }"#,
+        )
+        .expect("parse bench results");
+        let mut workflow = BenchRunWorkflowResult {
+            status: "passed".to_string(),
+            component: "static-site-importer".to_string(),
+            exit_code: 0,
+            iterations: 1,
+            results: Some(results),
+            gate_results: Vec::new(),
+            gate_failures: Vec::new(),
+            baseline_comparison: None,
+            hints: None,
+            failure: None,
+            diagnostics: Vec::new(),
+        };
+
+        apply_declared_bench_gates(&mut workflow, DeclaredBenchGates::default());
+
+        assert_eq!(workflow.status, "passed");
+        assert_eq!(workflow.exit_code, 0);
+        assert!(workflow.gate_results.is_empty());
+        assert!(workflow.gate_failures.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #7472

## Summary
- Add a default bench result gate for discovered fixtures that were not executed (`not_run_fixture_count <= 0`).
- Preserve explicit dry-run/planning workloads via structured metadata (`execution_status`, `mode`, or `intent` set to `dry_run`, `dry-run`, or `planning`).
- Cover both direct bench result gating and matrix fan-out aggregation paths.

## Testing
- `cargo test default_result_gate --lib`
- `cargo test default_not_run_fixture_gate_skips_explicit_planning_workload --lib`
- `cargo test result_gate_ --lib`
- `cargo check --all-targets`
- `cargo test --lib` attempted; did not complete within 10 minutes while unrelated runner/workspace tests were still running.

## Notes
- `cargo fmt --check` is currently blocked by an unrelated pre-existing formatting diff in `src/core/agent_task/executor.rs`; changed files were formatted directly with `rustfmt`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent (GPT-5.5)
- **Used for:** Implemented the bench gating fix, added regression coverage, and ran verification.