### PR TITLE
Fix shared-repo component tag resolution across deploy, changes, and status

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -533,8 +533,7 @@ fn summarize_components(
         timer.begin("inspect_upstream_and_unreleased");
         for comp in &components {
             if include_upstream_drift {
-                if let Some(drift) = git_cache.fetch_upstream_drift_for(&comp.local_path, &comp.id)
-                {
+                if let Some(drift) = git_cache.fetch_upstream_drift_for(comp) {
                     if drift.is_behind() {
                         behind_upstream.push(comp.id.clone());
                     }
@@ -686,7 +685,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
         .iter()
         .filter_map(|c| {
             git_cache
-                .fetch_upstream_drift_for(&c.local_path, &c.id)
+                .fetch_upstream_drift_for(c)
                 .map(|d| (c.id.clone(), d))
         })
         .collect();
@@ -896,19 +895,23 @@ impl StatusGitCache {
         }
     }
 
-    fn fetch_upstream_drift_for(&mut self, path: &str, id: &str) -> Option<UpstreamDrift> {
-        let cache_key = upstream_drift_cache_key(path);
+    fn fetch_upstream_drift_for(
+        &mut self,
+        component: &component::Component,
+    ) -> Option<UpstreamDrift> {
+        let path = &component.local_path;
+        let cache_key = component_cache_key(component);
         if !self.upstream_drift.contains_key(&cache_key) {
             self.fetch_origin_tags_for(path);
             self.upstream_drift
-                .insert(cache_key.clone(), get_upstream_drift(path));
+                .insert(cache_key.clone(), get_upstream_drift(component));
         }
 
         let drift = self.upstream_drift.get(&cache_key)?;
 
         drift.as_ref().map(|cached| {
             let mut drift = cached.clone();
-            drift.component_id = id.to_string();
+            drift.component_id = component.id.clone();
             drift
         })
     }
@@ -932,9 +935,13 @@ impl StatusGitCache {
             let current_version = version::read_component_version(component)
                 .ok()
                 .map(|info| info.version);
-            let baseline = git::detect_baseline_with_version_from_fetched_tags(
+            let tag_prefix = homeboy::core::release::component_tag_prefix(component)
+                .ok()
+                .flatten();
+            let baseline = git::detect_baseline_with_version_and_tag_prefix_from_fetched_tags(
                 &component.local_path,
                 current_version.as_deref(),
+                tag_prefix.as_deref(),
             )
             .ok();
             self.baselines.insert(cache_key.clone(), baseline);
@@ -1002,13 +1009,19 @@ fn fetch_origin_tags(path: &str) {
     );
 }
 
-fn get_upstream_drift(path: &str) -> Option<UpstreamDrift> {
+fn get_upstream_drift(component: &component::Component) -> Option<UpstreamDrift> {
+    let path = &component.local_path;
     let snapshot = git::get_repo_snapshot(path).ok()?;
 
     // After fetching tags, find the latest tag across ALL refs (not just HEAD).
     // `git describe --tags --abbrev=0` only returns tags reachable from HEAD,
     // which misses newer tags when the local checkout is behind.
-    let latest_origin_tag = get_latest_tag_overall(path);
+    let tag_prefix = homeboy::core::release::component_tag_prefix(component)
+        .ok()
+        .flatten();
+    let latest_origin_tag = git::get_latest_tag_any_with_prefix(path, tag_prefix.as_deref())
+        .ok()
+        .flatten();
 
     Some(UpstreamDrift {
         component_id: String::new(), // caller sets component_id after
@@ -1016,24 +1029,6 @@ fn get_upstream_drift(path: &str) -> Option<UpstreamDrift> {
         behind: snapshot.behind,
         latest_origin_tag,
     })
-}
-
-/// Get the latest version tag in the repo regardless of what HEAD points to.
-///
-/// Unlike `get_latest_tag()` which uses `git describe` (reachable from HEAD),
-/// this lists all tags and picks the one with the highest semver version.
-fn get_latest_tag_overall(path: &str) -> Option<String> {
-    let output = homeboy::core::engine::command::run_in_optional(
-        path,
-        "git",
-        &["tag", "-l", "--sort=-v:refname"],
-    )?;
-
-    output
-        .lines()
-        .next()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
 }
 
 /// Log merged-but-unreleased components to stderr for human-readable output.
@@ -1520,18 +1515,26 @@ mod tests {
     }
 
     #[test]
-    fn upstream_drift_cache_reuses_git_root_and_preserves_component_id() {
+    fn upstream_drift_cache_is_component_scoped_in_shared_repos() {
         let (_dir, repo) = make_git_repo("monorepo");
         let component_dir = repo.join("components/demo");
         fs::create_dir_all(&component_dir).expect("component dir");
+        let component = component::Component {
+            id: "actual-component".to_string(),
+            local_path: component_dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
 
         let repo_key = upstream_drift_cache_key(&repo.to_string_lossy());
         let component_key = upstream_drift_cache_key(&component_dir.to_string_lossy());
         assert_eq!(component_key, repo_key);
 
+        let scoped_cache_key = component_cache_key(&component);
+        assert_ne!(scoped_cache_key, repo_key);
+
         let mut git_cache = StatusGitCache::default();
         git_cache.upstream_drift.insert(
-            repo_key,
+            scoped_cache_key,
             Some(UpstreamDrift {
                 component_id: "cached-component".to_string(),
                 ahead: Some(2),
@@ -1541,7 +1544,7 @@ mod tests {
         );
 
         let drift = git_cache
-            .fetch_upstream_drift_for(&component_dir.to_string_lossy(), "actual-component")
+            .fetch_upstream_drift_for(&component)
             .expect("cached drift");
 
         assert_eq!(drift.component_id, "actual-component");

--- a/src/core/deploy/execution/release_plan.rs
+++ b/src/core/deploy/execution/release_plan.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::core::component::Component;
-use crate::core::git;
+use crate::core::release;
 
 use super::super::orchestration_tag_checkout::deploy_tag_for_version;
 use super::super::release_download;
@@ -127,7 +127,7 @@ fn deploy_release_tag(component: &Component, config: &DeployConfig) -> Option<St
         return Some(deploy_tag_for_version(component, version));
     }
 
-    git::get_latest_tag(&component.local_path).ok().flatten()
+    release::latest_component_tag(component).ok().flatten()
 }
 
 #[cfg(test)]

--- a/src/core/deploy/orchestration/modes.rs
+++ b/src/core/deploy/orchestration/modes.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
-use crate::core::git;
 use crate::core::project::Project;
 
 use super::super::execution::{release_artifact_plan, ReleaseArtifactPlan};
@@ -212,7 +211,7 @@ fn latest_deploy_tag(component: &Component, expected_version: Option<&str>) -> R
         return Ok(deploy_tag_for_version(component, version));
     }
 
-    match git::get_latest_tag(&component.local_path) {
+    match crate::core::release::latest_component_tag(component) {
         Ok(Some(tag)) => Ok(tag),
         Ok(None) => Err(Error::validation_invalid_argument(
             "deploy",

--- a/src/core/deploy/orchestration_tag_checkout.rs
+++ b/src/core/deploy/orchestration_tag_checkout.rs
@@ -6,7 +6,7 @@
 
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
-use crate::core::git;
+use crate::core::release;
 
 /// Record of a tag checkout for later branch restoration.
 pub(super) struct TagCheckout {
@@ -69,7 +69,7 @@ pub(super) fn checkout_deploy_tags(
 
         let tag = match expected_version {
             Some(version) => deploy_tag_for_version(component, version),
-            None => match git::get_latest_tag(path) {
+            None => match release::latest_component_tag(component) {
                 Ok(Some(t)) => t,
                 Ok(None) => {
                     if !checkouts.is_empty() {
@@ -198,11 +198,10 @@ pub(super) fn checkout_deploy_tags(
 }
 
 pub(super) fn deploy_tag_for_version(component: &Component, version: &str) -> String {
-    let version = version.trim_start_matches('v');
-    match git::MonorepoContext::detect(&component.local_path, &component.id) {
-        Some(context) => context.format_tag(version),
-        None => format!("v{}", version),
-    }
+    release::component_tag_name(component, version).unwrap_or_else(|_| {
+        let version = version.trim_start_matches('v');
+        format!("v{}", version)
+    })
 }
 
 /// Restore original branches after deployment.

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -615,7 +615,15 @@ pub fn calculate_release_state(component: &Component) -> Option<ReleaseState> {
         .ok()
         .map(|info| info.version);
 
-    let baseline = git::detect_baseline_with_version(path, current_version.as_deref()).ok()?;
+    let tag_prefix = crate::core::release::component_tag_prefix(component)
+        .ok()
+        .flatten();
+    let baseline = git::detect_baseline_with_version_and_tag_prefix(
+        path,
+        current_version.as_deref(),
+        tag_prefix.as_deref(),
+    )
+    .ok()?;
 
     calculate_release_state_from_baseline(component, &baseline)
 }

--- a/src/core/deploy/provenance.rs
+++ b/src/core/deploy/provenance.rs
@@ -12,7 +12,7 @@ use sha2::{Digest, Sha256};
 
 use crate::core::component::Component;
 use crate::core::engine::command;
-use crate::core::git;
+use crate::core::release;
 
 use super::generated_artifacts::uncommitted_file_report_excluding_known_generated;
 use super::types::{ArtifactIdentity, BuildProvenance, BuildSource};
@@ -113,7 +113,7 @@ pub struct TagGap {
 /// Returns None if HEAD is at or behind the tag, or if no tags exist.
 pub fn detect_tag_gap(component: &Component) -> Option<TagGap> {
     let path = &component.local_path;
-    let tag = git::get_latest_tag(path).ok().flatten()?;
+    let tag = release::latest_component_tag(component).ok().flatten()?;
 
     let ahead_str = command::run_in_optional(
         path,

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -323,11 +323,23 @@ fn resolve_release_asset_api_url(
 
     Ok(assets.iter().find_map(|asset| {
         let name = asset.get("name")?.as_str()?;
-        if name != artifact_name {
+        if !release_asset_name_matches(name, artifact_name) {
             return None;
         }
         asset.get("url")?.as_str().map(ToString::to_string)
     }))
+}
+
+fn release_asset_name_matches(asset_name: &str, artifact_name: &str) -> bool {
+    if asset_name == artifact_name {
+        return true;
+    }
+
+    let Some((ordinal, rest)) = asset_name.split_once('-') else {
+        return false;
+    };
+
+    !ordinal.is_empty() && ordinal.chars().all(|c| c.is_ascii_digit()) && rest == artifact_name
 }
 
 fn github_auth_token(host: &str) -> Option<String> {
@@ -741,6 +753,26 @@ mod tests {
             repo.release_by_tag_api_url("v1.2.3"),
             "https://api.github.com/repos/Extra-Chill/homeboy/releases/tags/v1.2.3"
         );
+    }
+
+    #[test]
+    fn release_asset_name_matches_homeboy_ordinal_artifact_names() {
+        assert!(release_asset_name_matches(
+            "01-studio-native-theme.zip",
+            "studio-native-theme.zip"
+        ));
+        assert!(release_asset_name_matches(
+            "studio-native-theme.zip",
+            "studio-native-theme.zip"
+        ));
+        assert!(!release_asset_name_matches(
+            "studio-native.zip",
+            "studio-native-theme.zip"
+        ));
+        assert!(!release_asset_name_matches(
+            "theme-01-studio-native-theme.zip",
+            "studio-native-theme.zip"
+        ));
     }
 
     #[test]

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -58,6 +58,8 @@ pub use operations::{
 pub use operations_changes::{
     build_repo_baseline_snapshot, changes, changes_at, changes_bulk, changes_project,
     changes_project_filtered, detect_baseline_with_version,
+    detect_baseline_with_version_and_tag_prefix,
+    detect_baseline_with_version_and_tag_prefix_from_fetched_tags,
     detect_baseline_with_version_from_fetched_tags, BaselineInfo, BaselineSource, ChangelogInfo,
     ChangesOutput, RepoBaselineSnapshot,
 };

--- a/src/core/git/operations_changes.rs
+++ b/src/core/git/operations_changes.rs
@@ -109,6 +109,16 @@ pub fn detect_baseline_with_version(
     path: &str,
     current_version: Option<&str>,
 ) -> Result<BaselineInfo> {
+    detect_baseline_with_version_and_tag_prefix(path, current_version, None)
+}
+
+/// Detect baseline with version alignment checking and optional component tag
+/// namespace filtering.
+pub fn detect_baseline_with_version_and_tag_prefix(
+    path: &str,
+    current_version: Option<&str>,
+    tag_prefix: Option<&str>,
+) -> Result<BaselineInfo> {
     // Fetch tags from remote so locally-missing tags (pushed from another
     // machine) are available before we resolve the baseline. Best-effort:
     // if there is no remote or the network is unavailable we silently
@@ -116,7 +126,7 @@ pub fn detect_baseline_with_version(
     let _ =
         crate::core::engine::command::run_in_optional(path, "git", &["fetch", "--tags", "--quiet"]);
 
-    detect_baseline_with_version_from_fetched_tags(path, current_version)
+    detect_baseline_with_version_and_tag_prefix_from_fetched_tags(path, current_version, tag_prefix)
 }
 
 /// Detect baseline using tags already available locally.
@@ -127,8 +137,18 @@ pub fn detect_baseline_with_version_from_fetched_tags(
     path: &str,
     current_version: Option<&str>,
 ) -> Result<BaselineInfo> {
+    detect_baseline_with_version_and_tag_prefix_from_fetched_tags(path, current_version, None)
+}
+
+/// Detect baseline using tags already available locally, scoped to a component
+/// tag prefix when the component release namespace requires one.
+pub fn detect_baseline_with_version_and_tag_prefix_from_fetched_tags(
+    path: &str,
+    current_version: Option<&str>,
+    tag_prefix: Option<&str>,
+) -> Result<BaselineInfo> {
     // Priority 1: Check for latest tag
-    if let Some(tag) = get_latest_tag(path)? {
+    if let Some(tag) = get_latest_tag_with_prefix(path, tag_prefix)? {
         let tag_version = extract_version_from_tag(&tag);
 
         // If we have current version, check alignment
@@ -287,7 +307,15 @@ pub fn changes_at(
             let current_version = component
                 .as_ref()
                 .and_then(crate::core::release::version::get_component_version);
-            detect_baseline_with_version(&path, current_version.as_deref())?
+            let tag_prefix = component
+                .as_ref()
+                .and_then(|component| crate::core::release::component_tag_prefix(component).ok())
+                .flatten();
+            detect_baseline_with_version_and_tag_prefix(
+                &path,
+                current_version.as_deref(),
+                tag_prefix.as_deref(),
+            )?
         }
     };
 

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -42,6 +42,38 @@ pub use types::{
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{run_batch, run_command, SKIPPED_RELEASE_EXIT_CODE};
 
+/// Return the release tag name this component uses for a version.
+///
+/// This is the shared tag naming contract for release, deploy, status, and
+/// changes. Components scoped below a repository root use component-prefixed
+/// tags; root components use plain `vX.Y.Z` tags.
+pub fn component_tag_name(
+    component: &crate::core::component::Component,
+    version: &str,
+) -> crate::core::Result<String> {
+    let version = version.trim_start_matches('v');
+    let scope = scope::ReleaseScope::resolve(component, &component.id)?;
+    Ok(scope.tag_name(version))
+}
+
+/// Return the tag prefix this component uses, when it has a component-scoped
+/// release namespace.
+pub fn component_tag_prefix(
+    component: &crate::core::component::Component,
+) -> crate::core::Result<Option<String>> {
+    let scope = scope::ReleaseScope::resolve(component, &component.id)?;
+    Ok(scope.tag_prefix().map(str::to_string))
+}
+
+/// Resolve the latest release tag for this component using the same namespace
+/// that release uses when creating tags.
+pub fn latest_component_tag(
+    component: &crate::core::component::Component,
+) -> crate::core::Result<Option<String>> {
+    let scope = scope::ReleaseScope::resolve(component, &component.id)?;
+    scope.latest_tag()
+}
+
 /// Whether this component would normally get a reviewer-facing GitHub Release
 /// created as part of a release (i.e. it resolves to a GitHub remote).
 ///

--- a/src/core/release/scope.rs
+++ b/src/core/release/scope.rs
@@ -344,4 +344,82 @@ mod tests {
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].subject, "fix: update blocks engine package");
     }
+
+    #[test]
+    fn sibling_shared_repo_component_uses_its_prefixed_latest_tag() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "studio-native-theme-v0.1.0"]);
+        commit_file(
+            dir,
+            "packages/theme/style.css",
+            "Version: 0.1.1",
+            "release theme 0.1.1",
+        );
+        run_git(dir, &["tag", "studio-native-theme-v0.1.1"]);
+        commit_file(
+            dir,
+            "apps/studio-native/package.json",
+            "{\"version\":\"0.13.1\"}",
+            "release app 0.13.1",
+        );
+        run_git(dir, &["tag", "v0.13.1"]);
+
+        let primary = Component {
+            id: "studio-native".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let theme = Component {
+            id: "studio-native-theme".to_string(),
+            local_path: dir.join("packages/theme").to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            crate::core::release::component_tag_name(&primary, "0.13.2").unwrap(),
+            "v0.13.2"
+        );
+        assert_eq!(
+            crate::core::release::latest_component_tag(&primary)
+                .unwrap()
+                .as_deref(),
+            Some("v0.13.1")
+        );
+        assert_eq!(
+            crate::core::release::component_tag_name(&theme, "0.1.2").unwrap(),
+            "studio-native-theme-v0.1.2"
+        );
+        assert_eq!(
+            crate::core::release::latest_component_tag(&theme)
+                .unwrap()
+                .as_deref(),
+            Some("studio-native-theme-v0.1.1")
+        );
+    }
+
+    #[test]
+    fn secondary_shared_repo_component_does_not_fall_back_to_plain_tags() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        std::fs::create_dir_all(dir.join("packages/theme")).expect("theme dir");
+        run_git(dir, &["tag", "v0.13.1"]);
+
+        let theme = Component {
+            id: "studio-native-theme".to_string(),
+            local_path: dir.join("packages/theme").to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            crate::core::release::component_tag_name(&theme, "0.1.1").unwrap(),
+            "studio-native-theme-v0.1.1"
+        );
+        assert_eq!(
+            crate::core::release::latest_component_tag(&theme).unwrap(),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #7471. Release creates id-prefixed tags for secondary shared-repo components (`studio-native-theme-v0.1.1`), but deploy and every other latest-tag consumer used unscoped `git::get_latest_tag` — so `deploy --tagged` for the theme resolved the sibling plugin's `v0.13.1` and **silently deployed stale content** (reproduced in production use today).

## Fix

Shared resolvers in `core/release` (`component_tag_name` / `component_tag_prefix` / `latest_component_tag`) wrapping the existing `ReleaseScope` tag policy, so release and deploy can never diverge again. Routed through them:

- deploy `--tagged` checkout, `--version` tag formatting, release-asset planning, `--check`/provenance, tag-gap provenance, release-state baselines
- `changes` baseline resolution
- `status` upstream drift + baseline resolution (drift cache now component-scoped)

Secondary shared-repo components never fall back to plain `vX.Y.Z` tags — no silent wrong-tag resolution.

Bonus from the same issue: release-asset lookup now matches Homeboy's ordinal artifact names (`01-<component>.zip`) against the expected `<component>.zip`.

## Not in scope (follow-up)

GHE proxy env for deploy release-asset fetch (`release_download.rs` raw curl/gh calls) — needs config plumbing, tracked in #7471 discussion.

## Verification

- New tests: sibling shared-repo scenario (theme never matches plugin tags), no-plain-tag fallback for secondary components, component-scoped drift cache, ordinal asset-name matching.
- `cargo test --lib` for release (325), deploy (187), status (70), changes (48) modules: all pass. Full suite exceeds local timebox; CI carries it.
- `cargo clippy` clean apart from pre-existing repo-wide debt.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Opus 4.6) via opencode
- **Used for:** Root-cause analysis, implementation, and tests; reviewed and directed by Chris.