### PR TITLE
test: bound slow Rust suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ clap = { version = "4.5", features = ["derive", "string"] }
 toml = "1.0.3"
 sha2 = "0.10.9"
 
+[features]
+default = []
+slow-tests = []
+
 [profile.dist]
 inherits = "release"
 lto = "thin"

--- a/docs/internals/test-tiers.md
+++ b/docs/internals/test-tiers.md
@@ -1,0 +1,16 @@
+# Test Tiers
+
+The default Rust gate is the bounded unit suite:
+
+```sh
+cargo nextest run --lib --no-fail-fast
+```
+
+Full-pipeline audit/refactor regressions that intentionally run broad audit machinery live in the explicit slow tier:
+
+```sh
+cargo test --lib --features slow-tests code_audit
+cargo test --lib --features slow-tests collect_refactor_sources_audit_write_uses_audit_refactor_engine
+```
+
+Use the slow tier when changing audit detector orchestration, audit fixability planning, or audit-driven refactor planning. These tests remain runnable, but they are not part of the default unit gate because they scan real fixture/checkouts and dominated local suite wall-clock time.

--- a/homeboy.json
+++ b/homeboy.json
@@ -1360,11 +1360,7 @@
     }
   ],
   "docs_dir": "docs",
-  "extensions": {
-    "rust": {
-      "rust_cargo_test_threads": 1
-    }
-  },
+  "extensions": {},
   "hooks": {},
   "id": "homeboy",
   "scripts": {

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -451,40 +451,72 @@ fn fuzz_run_campaign_cli_parses_as_campaign_command() {
 
 #[test]
 fn fuzz_run_campaign_dry_run_emits_structured_dispatch_records() {
-    let mut args = planner_args();
-    args.request_id = Some("campaign-1".to_string());
-    args.campaign_workloads = vec!["api-fuzz".to_string(), "db-fuzz".to_string()];
-    args.dry_run = true;
+    with_isolated_home(|home| {
+        let extension_dir = home.path().join(".config/homeboy/extensions/generic");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("generic.json"),
+            serde_json::json!({
+                "name": "generic",
+                "version": "0.0.0",
+                "fuzz": {
+                    "workloads": [
+                        { "id": "api-fuzz" },
+                        { "id": "db-fuzz" }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .expect("extension manifest");
+        let component = tempfile::tempdir().expect("component dir");
+        fs::write(
+            component.path().join("homeboy.json"),
+            serde_json::json!({
+                "id": "component-a",
+                "extensions": { "generic": { "settings": {} } }
+            })
+            .to_string(),
+        )
+        .expect("component config");
 
-    let (output, exit_code) = run_campaign(args).expect("dry-run campaign");
+        let mut args = planner_args();
+        args.run.comp.component = None;
+        args.run.comp.path = Some(component.path().to_string_lossy().to_string());
+        args.request_id = Some("campaign-1".to_string());
+        args.campaign_workloads = vec!["api-fuzz".to_string(), "db-fuzz".to_string()];
+        args.dry_run = true;
 
-    assert_eq!(exit_code, 0);
-    assert_eq!(output.status, "planned");
-    assert!(!output.execute);
-    assert!(output.dry_run);
-    assert_eq!(output.dispatch_records.len(), 2);
-    assert_eq!(output.dispatch_records[0].status, "planned");
-    assert_eq!(output.dispatch_records[0].run_id, "campaign-1-api-fuzz");
-    assert_eq!(output.dispatch_records[1].run_id, "campaign-1-db-fuzz");
-    assert_eq!(
-        output.dispatch_records[0]
-            .command
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>(),
-        vec![
-            "homeboy",
-            "fuzz",
-            "run",
-            "component-a",
-            "--workload",
-            "api-fuzz",
-            "--run-id",
-            "campaign-1-api-fuzz",
-            "--gate-profile",
-            "measurement",
-        ]
-    );
+        let (output, exit_code) = run_campaign(args).expect("dry-run campaign");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.status, "planned");
+        assert!(!output.execute);
+        assert!(output.dry_run);
+        assert_eq!(output.dispatch_records.len(), 2);
+        assert_eq!(output.dispatch_records[0].status, "planned");
+        assert_eq!(output.dispatch_records[0].run_id, "campaign-1-api-fuzz");
+        assert_eq!(output.dispatch_records[1].run_id, "campaign-1-db-fuzz");
+        assert_eq!(
+            output.dispatch_records[0]
+                .command
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            vec![
+                "homeboy",
+                "fuzz",
+                "run",
+                "component-a",
+                "--workload",
+                "api-fuzz",
+                "--run-id",
+                "campaign-1-api-fuzz",
+                "--gate-profile",
+                "measurement",
+            ]
+        );
+    });
 }
 
 #[test]

--- a/src/core/git/pr_policy.rs
+++ b/src/core/git/pr_policy.rs
@@ -586,22 +586,6 @@ mod tests {
     }
 
     #[test]
-    fn test_evaluate_merge_policy_requires_github_metadata() {
-        let dir = tempfile::TempDir::new().expect("temp dir");
-        let path = dir.path().join("policy.json");
-        fs::write(&path, r#"{"merge":{}}"#).expect("write policy");
-
-        let result = evaluate_merge_policy(PrPolicyMergeOptions {
-            component_id: "definitely-missing-component".into(),
-            policy_path: path.to_string_lossy().to_string(),
-            number: 1,
-            ..Default::default()
-        });
-
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn ci_gate_allows_terminal_green() {
         let mut decision = PrPolicyDecision {
             mode: "merge".into(),

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -1027,28 +1027,11 @@ mod tests {
     }
 
     #[test]
-    fn dependency_hygiene_fails_when_declared_dependency_is_missing() {
+    fn dependency_hygiene_fails_when_declared_dependency_path_is_missing() {
         let source = tempfile::tempdir().unwrap();
-        fs::write(
-            source.path().join(PORTABLE_CONFIG_FILE),
-            serde_json::json!({
-                "id": "source",
-                "extensions": {
-                    "example": {
-                        "settings": { "validation_dependencies": ["missing-dep"] }
-                    }
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
 
-        let err = require_dependency_hygiene_for_source(
-            source.path(),
-            None,
-            DependencyHygieneOptions { allow_stale: false },
-        )
-        .expect_err("missing dependency should fail");
+        let err = canonical_existing_dir(&source.path().join("missing-dep"), "missing-dep")
+            .expect_err("missing dependency path should fail");
 
         assert_eq!(err.details["field"], "validation_dependencies");
         assert!(err.message.contains("missing-dep"));

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -893,6 +893,7 @@ mod tests {
         assert!(!request.write);
     }
 
+    #[cfg(feature = "slow-tests")]
     #[test]
     fn collect_refactor_sources_audit_write_uses_audit_refactor_engine() {
         let root = tmp_dir("audit-write");

--- a/src/core/release/orchestrator.rs
+++ b/src/core/release/orchestrator.rs
@@ -118,31 +118,3 @@ fn restore_checkout_after_failed_run(
 
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use super::{run, run_with_plan};
-    use crate::core::release::types::ReleaseOptions;
-
-    #[test]
-    fn test_run() {
-        let err = run(
-            "missing-component-is-reported-by-orchestrator",
-            &ReleaseOptions::default(),
-        )
-        .expect_err("orchestrator should report missing components");
-
-        assert!(!err.to_string().is_empty());
-    }
-
-    #[test]
-    fn test_run_with_plan() {
-        let err = run_with_plan(
-            "missing-component-is-reported-by-orchestrator-plan-run",
-            &ReleaseOptions::default(),
-        )
-        .expect_err("orchestrator should report missing components before returning a plan/run");
-
-        assert!(!err.to_string().is_empty());
-    }
-}

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -217,22 +217,11 @@ fn apply_oversized_patch_release_policy(
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_oversized_patch_release_policy, plan};
+    use super::apply_oversized_patch_release_policy;
     use crate::core::release::types::{
-        ReleaseChangelogPlan, ReleaseOptions, ReleaseSemverCommit, ReleaseSemverRecommendation,
+        ReleaseChangelogPlan, ReleaseSemverCommit, ReleaseSemverRecommendation,
     };
     use std::collections::HashMap;
-
-    #[test]
-    fn test_plan() {
-        let err = plan(
-            "missing-component-is-reported-by-planner",
-            &ReleaseOptions::default(),
-        )
-        .expect_err("planner should report missing components");
-
-        assert!(!err.to_string().is_empty());
-    }
 
     /// Regression for the homeboy-action release blocker:
     /// `validate_working_tree_fail_fast` builds an Error with a hint vec

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -751,12 +751,6 @@ mod store_ops {
         ))
     }
 
-    fn is_missing_source_checkout_error(error: &Error) -> bool {
-        error.code == crate::core::error::ErrorCode::ValidationInvalidArgument
-            && error.details.get("field").and_then(|field| field.as_str())
-                == Some("source_checkout")
-    }
-
     pub(super) fn normalize_missing_path(path: &Path) -> PathBuf {
         let Some(parent) = path.parent() else {
             return path.to_path_buf();

--- a/tests/core/code_audit/audit_runtime_regression_test.rs
+++ b/tests/core/code_audit/audit_runtime_regression_test.rs
@@ -172,6 +172,7 @@ fn audit_runtime_regression_matches_snapshot() {
     );
 }
 
+#[cfg(feature = "slow-tests")]
 #[test]
 fn audit_runtime_regression_is_deterministic() {
     let first = finding_fingerprints(&run_fixture_audit().findings);

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -270,6 +270,7 @@ fn test_compute_fixability_skips_structural_only_results() {
     assert!(compute_fixability(&result).is_none());
 }
 
+#[cfg(feature = "slow-tests")]
 #[test]
 fn test_compute_fixability_counts_fixes_from_real_audit() {
     use std::fs;


### PR DESCRIPTION
## Summary
- Bounds the default Rust lib test suite by removing pure smoke offenders, isolating a fuzz campaign dry-run from ambient machine config, and moving full-pipeline audit/refactor regressions into an explicit slow tier.
- Removes the serialized Rust test-thread setting from `homeboy.json` so the default gate can run in parallel.
- Documents the slow tier in `docs/internals/test-tiers.md`.

Refs #7469

## Baseline Profile
Measured with `time cargo nextest run --lib --no-fail-fast` on this worktree before fixes:

1. `commands::fuzz::tests::planning_tests::fuzz_run_campaign_dry_run_emits_structured_dispatch_records` - 101.142s, failed after scanning ambient component state for `component-a`.
2. `core::code_audit::entry::audit_runtime_regression_test::audit_runtime_regression_is_deterministic` - 94.986s, real full audit workflow twice.
3. `core::code_audit::report::report_test::test_compute_fixability_counts_fixes_from_real_audit` - 93.717s, real audit plus fixability planning.
4. `core::refactor::plan::sources::tests::collect_refactor_sources_audit_write_uses_audit_refactor_engine` - 82.557s, real audit-driven refactor planning.
5. `core::git::pr_policy::tests::test_evaluate_merge_policy_requires_github_metadata` - 68.460s, missing-component smoke through broad GitHub/component resolution.
6. `core::hygiene::tests::dependency_hygiene_fails_when_declared_dependency_is_missing` - 68.090s, missing-dependency smoke through broad component resolution.
7. `core::release::orchestrator::tests::test_run` - 63.262s, missing-component smoke only asserting non-empty error.
8. `core::release::orchestrator::tests::test_run_with_plan` - 63.188s, missing-component smoke only asserting non-empty error.
9. `core::release::planner::tests::test_plan` - 62.869s, missing-component smoke only asserting non-empty error.

Baseline wall-clock: `4:34.73` for nextest, with existing local failures. `cargo test --lib` remained the original broken path and timed out after 1h in workspace/worker tests.

## Fixes And Root Causes
- Fuzz campaign dry-run: root cause was ambient component/provider resolution for `component-a`; fixed by using `with_isolated_home`, a temporary component path, and a tiny local fuzz extension fixture. The test now passes in 0.25s when run alone.
- Full audit determinism / fixability / audit-refactor tests: root cause was real full-pipeline audit/refactor execution dominating the default unit suite. Kept the behavior coverage, but moved the expensive cases behind the explicit `slow-tests` feature.
- Release planner/orchestrator and PR policy smoke tests: root cause was pure missing-component smoke coverage that paid broad component/GitHub resolution and asserted only that some error existed. Deleted as test theater.
- Dependency hygiene missing-dependency test: root cause was validating a missing dependency through global component resolution. Replaced it with the direct missing-path validator assertion that proves the error contract without scanning ambient state.
- Thread setting: removed `extensions.rust.rust_cargo_test_threads: 1` from `homeboy.json`; nextest default runs the suite in parallel.
- Dead private helper: deleted `is_missing_source_checkout_error` so `cargo check --all-targets` is warning-free.

## After Timing
- `time cargo nextest run --lib --no-fail-fast`: `1:34.05` wall-clock, 6,897 tests run.
- Slow-tier spot checks:
- `cargo test --lib --features slow-tests audit_runtime_regression_is_deterministic`: passed, test body 48.14s.
- `cargo test --lib --features slow-tests test_compute_fixability_counts_fixes_from_real_audit`: passed, test body 59.41s.
- `cargo test --lib --features slow-tests collect_refactor_sources_audit_write_uses_audit_refactor_engine`: passed, test body 71.44s.
- `cargo check --all-targets`: passed with no warnings.

## Slow Tier
Run the explicit tier with:

```sh
cargo test --lib --features slow-tests code_audit
cargo test --lib --features slow-tests collect_refactor_sources_audit_write_uses_audit_refactor_engine
```

Documented in `docs/internals/test-tiers.md`.

## Deleted Tests
- `core::release::orchestrator::tests::test_run`
- `core::release::orchestrator::tests::test_run_with_plan`
- `core::release::planner::tests::test_plan`
- `core::git::pr_policy::tests::test_evaluate_merge_policy_requires_github_metadata`

These only asserted non-empty / any-error behavior through expensive global resolution paths.

## Remaining Local Failures
The default nextest run is now under budget, but this machine still reports existing ambient-state failures outside this PR's slow-offender scope. The two sibling-owned agent_task failures remain present and intentionally untouched:

- `commands::agent_task::fanout::tests::batch_cook_plan_requires_independent_cooks_with_worktrees`
- `commands::agent_task::tests::lifecycle::replay_provider_boundary_projects_latest_executor_input`

Other remaining local ambient failures observed in nextest are runner/lab artifact and local state assumptions that were already present in the baseline failure inventory, plus reverse-broker local HTTP tests that fail after 10s. I did not change those unrelated semantics in this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated via Claude (opencode)
- **Used for:** Profiled and fixed the slow test suite; human reviews every line.
