### PR TITLE
Accept --json on structured output commands

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -204,6 +204,10 @@ struct BenchListArgs {
     /// Additional arguments to pass to the bench runner (must follow --)
     #[arg(last = true)]
     args: Vec<String>,
+
+    /// Accepted for consistency with other structured-output commands.
+    #[arg(long, hide = true)]
+    json: bool,
 }
 
 #[derive(Args, Clone)]

--- a/src/commands/bench/parse_tests.rs
+++ b/src/commands/bench/parse_tests.rs
@@ -27,6 +27,17 @@ fn parses_bench_list_rig_flag() {
 }
 
 #[test]
+fn parses_bench_list_json_flag() {
+    let cli = TestCli::try_parse_from(["bench", "list", "--json"])
+        .expect("bench list --json should parse");
+
+    match cli.bench.command.expect("list command") {
+        BenchCommand::List(args) => assert!(args.json),
+        _ => panic!("expected bench list command"),
+    }
+}
+
+#[test]
 fn parses_repeated_scenario_flags() {
     let cli = TestCli::try_parse_from([
         "bench",

--- a/src/commands/bench/tests/mod.rs
+++ b/src/commands/bench/tests/mod.rs
@@ -450,6 +450,7 @@ fn list_args(component: Option<&str>, rig: Vec<String>) -> BenchListArgs {
         scenario_ids: Vec::new(),
         setting_args: SettingArgs::default(),
         args: Vec::new(),
+        json: false,
     }
 }
 

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -60,6 +60,9 @@ enum ComponentCommand {
         /// Discover component from a directory's homeboy.json instead of the registry
         #[arg(long)]
         path: Option<String>,
+        /// Accepted for consistency with other structured-output commands.
+        #[arg(long, hide = true)]
+        json: bool,
     },
     /// Update component configuration fields
     ///
@@ -304,7 +307,7 @@ pub fn run(
                 0,
             ))
         }
-        ComponentCommand::Show { id, path } => show(id.as_deref(), path.as_deref()),
+        ComponentCommand::Show { id, path, .. } => show(id.as_deref(), path.as_deref()),
         ComponentCommand::Set {
             args,
             local_path,
@@ -902,8 +905,28 @@ fn shared(id: Option<&str>) -> CmdResult<ComponentOutput> {
 mod tests {
     use super::*;
     use crate::cli_surface::Cli;
-    use clap::CommandFactory;
+    use clap::{CommandFactory, Parser};
     use std::fs;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        component: ComponentArgs,
+    }
+
+    #[test]
+    fn parses_component_show_json_flag() {
+        let cli = TestCli::try_parse_from(["component", "show", "homeboy", "--json"])
+            .expect("component show --json should parse");
+
+        match cli.component.command {
+            ComponentCommand::Show { id, json, .. } => {
+                assert_eq!(id.as_deref(), Some("homeboy"));
+                assert!(json);
+            }
+            _ => panic!("expected component show command"),
+        }
+    }
 
     #[test]
     fn test_component_set_flags_has_any_all_none() {


### PR DESCRIPTION
## Summary
- Accept trailing `--json` on `component show` and `bench list` without changing their existing structured output behavior.
- Add targeted clap parse coverage for both commands.

Fixes #7477

## Testing
- `cargo test commands::bench::parse_tests --all-targets`
- `cargo test commands::component::tests::parses_component_show_json_flag --all-targets`
- `cargo check --all-targets`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent (GPT-5.5)
- **Used for:** Implemented the CLI flag normalization change, added targeted parse tests, and ran verification.