### PR TITLE
Fix bench list rig workload discovery

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -9,8 +9,8 @@ use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::bench as extension_bench;
 use homeboy::core::extension::bench::{
     aggregate_comparison_with_axes, BenchCommandOutput, BenchComparisonOutput,
-    BenchComparisonSummaryOutput, BenchListWorkflowArgs, BenchListWorkflowResult, RigBenchEntry,
-    DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+    BenchComparisonSummaryOutput, BenchListProfile, BenchListWorkflowArgs, BenchListWorkflowResult,
+    RigBenchEntry, DEFAULT_REGRESSION_THRESHOLD_PERCENT,
 };
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::rig::{self, RigSpec};
@@ -904,13 +904,116 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
             rig_package: rig_context
                 .as_ref()
                 .and_then(|context| rig::package_evidence(&context.spec.id)),
+            profiles: rig_spec.map(bench_list_profiles).unwrap_or_default(),
         },
         &run_dir,
     );
     resource_run.write_to_run_dir(&run_dir)?;
-    let output = output?;
+    let mut output = output?;
+    if output.count == 0 {
+        output.hints = bench_list_empty_hints(args, rig_spec, &output.component_id);
+    }
 
     Ok((BenchOutput::List(output), 0))
+}
+
+fn bench_list_profiles(spec: &RigSpec) -> Vec<BenchListProfile> {
+    let mut profiles = spec
+        .bench_profiles
+        .iter()
+        .map(|(id, scenarios)| BenchListProfile {
+            id: id.clone(),
+            scenarios: scenarios.clone(),
+        })
+        .collect::<Vec<_>>();
+    profiles.sort_by(|a, b| a.id.cmp(&b.id));
+    profiles
+}
+
+fn bench_list_empty_hints(
+    args: &BenchListArgs,
+    rig_spec: Option<&RigSpec>,
+    component_id: &str,
+) -> Vec<String> {
+    if let Some(spec) = rig_spec {
+        let mut hints = Vec::new();
+        if !spec.bench_workloads.is_empty() {
+            hints.push(format!(
+                "rig '{}' declares bench workloads; verify its workload extension matches this component or pass the component id from the rig spec",
+                spec.id
+            ));
+        }
+        let profiles = bench_list_profiles(spec);
+        if !profiles.is_empty() {
+            hints.push(format!(
+                "rig '{}' declares bench profiles: {}; run `homeboy bench --rig {} --profile <profile>`",
+                spec.id,
+                profiles
+                    .iter()
+                    .map(|profile| profile.id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                spec.id
+            ));
+        }
+        return hints;
+    }
+
+    if args.comp.id().is_none() {
+        return Vec::new();
+    }
+
+    compatible_bench_rig_hints(component_id)
+}
+
+fn compatible_bench_rig_hints(component_id: &str) -> Vec<String> {
+    let Ok(rigs) = rig::list() else {
+        return Vec::new();
+    };
+
+    rigs.into_iter()
+        .filter(|spec| rig_matches_bench_component(spec, component_id))
+        .filter(|spec| !spec.bench_workloads.is_empty() || !spec.bench_profiles.is_empty())
+        .take(5)
+        .map(|spec| {
+            let profiles = bench_list_profiles(&spec);
+            let discovery = match (spec.bench_workloads.is_empty(), profiles.is_empty()) {
+                (false, false) => "bench workloads and profiles",
+                (false, true) => "bench workloads",
+                (true, false) => "bench profiles",
+                (true, true) => "bench discovery",
+            };
+            let profile_hint = if profiles.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "; profiles: {}",
+                    profiles
+                        .iter()
+                        .map(|profile| profile.id.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            format!(
+                "compatible rig '{}' declares {}{}; try `homeboy bench list {} --rig {}`",
+                spec.id, discovery, profile_hint, component_id, spec.id
+            )
+        })
+        .collect()
+}
+
+fn rig_matches_bench_component(spec: &RigSpec, component_id: &str) -> bool {
+    spec.components.contains_key(component_id)
+        || spec
+            .bench
+            .as_ref()
+            .map(|bench| {
+                matrix::bench_component_ids(bench)
+                    .iter()
+                    .any(|id| id == component_id)
+            })
+            .unwrap_or(false)
 }
 
 pub(crate) fn filter_component_conventional_bench_workloads(

--- a/src/commands/bench/tests/run_list_tests.rs
+++ b/src/commands/bench/tests/run_list_tests.rs
@@ -24,6 +24,61 @@ fn run_list_uses_rig_default_component_and_workloads() {
 }
 
 #[test]
+fn run_list_includes_rig_profiles() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_rig_with_profiles(
+            home,
+            "studio-bfb",
+            "studio",
+            component_dir.path(),
+            r#"{ "smoke": ["rig-extra"], "full": ["rig-extra", "rig-slow"] }"#,
+        );
+
+        let (output, exit_code) = run_list(&list_args(None, vec!["studio-bfb".to_string()]))
+            .expect("rig bench list should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::List(result) => {
+                assert_eq!(result.count, 2);
+                assert_eq!(result.profiles.len(), 2);
+                assert_eq!(result.profiles[0].id, "full");
+                assert_eq!(result.profiles[1].id, "smoke");
+                assert_eq!(result.profiles[1].scenarios, vec!["rig-extra"]);
+            }
+            _ => panic!("expected list output"),
+        }
+    });
+}
+
+#[test]
+fn run_list_hints_at_compatible_rig_when_component_scenarios_are_empty() {
+    with_isolated_home(|home| {
+        write_empty_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_registered_component(home, "studio", component_dir.path());
+        write_rig(home, "studio-bfb", "studio", component_dir.path());
+
+        let (output, exit_code) =
+            run_list(&list_args(Some("studio"), Vec::new())).expect("plain bench list should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::List(result) => {
+                assert_eq!(result.count, 0);
+                assert!(result.hints.iter().any(|hint| {
+                    hint.contains("studio-bfb")
+                        && hint.contains("homeboy bench list studio --rig studio-bfb")
+                }));
+            }
+            _ => panic!("expected list output"),
+        }
+    });
+}
+
+#[test]
 fn run_list_serializes_installed_rig_package_evidence() {
     with_isolated_home(|home| {
         write_bench_extension(home);
@@ -189,4 +244,47 @@ fn run_list_requires_rig_default_component_when_component_omitted() {
             message
         );
     });
+}
+
+fn write_empty_bench_extension(home: &TempDir) {
+    let extension_dir = home
+        .path()
+        .join(".config")
+        .join("homeboy")
+        .join("extensions")
+        .join("fixture-bench");
+    fs::create_dir_all(&extension_dir).expect("mkdir extension");
+    fs::write(
+        extension_dir.join("fixture-bench.json"),
+        r#"{
+                "name": "Fixture Bench",
+                "version": "0.0.0",
+                "bench": { "extension_script": "bench-runner.sh" }
+            }"#,
+    )
+    .expect("write extension manifest");
+
+    let script_path = extension_dir.join("bench-runner.sh");
+    fs::write(
+        &script_path,
+        r#"#!/bin/sh
+cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
+{
+  "component_id": "$HOMEBOY_COMPONENT_ID",
+  "iterations": 0,
+  "scenarios": []
+}
+JSON
+"#,
+    )
+    .expect("write bench script");
+
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&script_path)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod script");
+    }
 }

--- a/src/commands/report/bench_coverage.rs
+++ b/src/commands/report/bench_coverage.rs
@@ -145,6 +145,7 @@ fn component_report(
             extra_workloads: Vec::new(),
             env_provider_extensions: Vec::new(),
             rig_package: None,
+            profiles: Vec::new(),
         },
         &run_dir,
     );

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -69,7 +69,7 @@ pub use report::{
     MetricDelta as ReportMetricDelta, RigBenchEntry,
 };
 pub use run::{
-    run_bench_list_workflow, run_main_bench_workflow, BenchListWorkflowArgs,
+    run_bench_list_workflow, run_main_bench_workflow, BenchListProfile, BenchListWorkflowArgs,
     BenchListWorkflowResult, BenchRunWorkflowArgs, BenchRunWorkflowResult,
 };
 

--- a/src/core/extension/bench/run/list.rs
+++ b/src/core/extension/bench/run/list.rs
@@ -46,6 +46,7 @@ pub fn run_bench_list_workflow(
             results_file,
             &args.scenario_ids,
             args.rig_package,
+            args.profiles,
         );
     }
 
@@ -100,6 +101,7 @@ pub fn run_bench_list_workflow(
         results_file,
         &args.scenario_ids,
         args.rig_package,
+        args.profiles,
     )
 }
 
@@ -126,6 +128,7 @@ pub(crate) fn bench_list_result(
     results_file: PathBuf,
     scenario_ids: &[String],
     rig_package: Option<crate::core::extension::bench::parsing::RigPackageEvidence>,
+    profiles: Vec<super::types::BenchListProfile>,
 ) -> Result<BenchListWorkflowResult> {
     let mut parsed = parsing::parse_bench_results_file_with_artifact_context(&results_file, None)?;
     normalize_workload_json_scenario_ids(&mut parsed);
@@ -137,6 +140,8 @@ pub(crate) fn bench_list_result(
         component_id: parsed.component_id,
         scenarios: parsed.scenarios,
         count,
+        profiles,
+        hints: Vec::new(),
         rig_package,
     })
 }

--- a/src/core/extension/bench/run/mod.rs
+++ b/src/core/extension/bench/run/mod.rs
@@ -10,8 +10,8 @@ mod types;
 mod workflow;
 
 pub use types::{
-    BenchListWorkflowArgs, BenchListWorkflowResult, BenchRunFailure, BenchRunWorkflowArgs,
-    BenchRunWorkflowResult,
+    BenchListProfile, BenchListWorkflowArgs, BenchListWorkflowResult, BenchRunFailure,
+    BenchRunWorkflowArgs, BenchRunWorkflowResult,
 };
 
 pub use list::run_bench_list_workflow;
@@ -311,6 +311,7 @@ mod tests {
             extra_workloads: Vec::new(),
             env_provider_extensions: Vec::new(),
             rig_package: None,
+            profiles: Vec::new(),
         })
         .expect("component-script list env");
 
@@ -341,6 +342,7 @@ mod tests {
             extra_workloads: Vec::new(),
             env_provider_extensions: Vec::new(),
             rig_package: None,
+            profiles: Vec::new(),
         })
         .expect("component-script list env");
 
@@ -851,6 +853,8 @@ printf '{}' > "$(dirname "$HOMEBOY_BENCH_RESULTS_FILE")/bench-report.json"
             component: "homeboy".to_string(),
             component_id: "homeboy".to_string(),
             count: 1,
+            profiles: Vec::new(),
+            hints: Vec::new(),
             rig_package: None,
             scenarios: vec![BenchScenario {
                 id: "audit-self".to_string(),

--- a/src/core/extension/bench/run/types.rs
+++ b/src/core/extension/bench/run/types.rs
@@ -131,6 +131,13 @@ pub struct BenchListWorkflowArgs {
     pub extra_workloads: Vec<PathBuf>,
     pub env_provider_extensions: Vec<String>,
     pub rig_package: Option<RigPackageEvidence>,
+    pub profiles: Vec<BenchListProfile>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BenchListProfile {
+    pub id: String,
+    pub scenarios: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -139,6 +146,10 @@ pub struct BenchListWorkflowResult {
     pub component_id: String,
     pub scenarios: Vec<BenchScenario>,
     pub count: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub profiles: Vec<BenchListProfile>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rig_package: Option<RigPackageEvidence>,
 }


### PR DESCRIPTION
## Summary
- include rig-declared bench profiles in `homeboy bench list --rig <rig>` output
- add hints when component-local bench discovery is empty but compatible rigs declare bench workloads/profiles
- cover rig profile listing and empty component discovery hinting with regression tests

Fixes #7474

## Verification
- `cargo test commands::bench::tests::run_list_tests --lib`
- `cargo check --all-targets`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent (GPT-5.5)
- **Used for:** Implemented the bench list rig discovery fix, regression tests, and verification.