### PR TITLE
Fix compact runner exec output

### DIFF
--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -13,7 +13,7 @@
 
 use crate::cli_surface::Commands;
 use crate::commands::{
-    changelog, file, fleet, logs, observe, report, review, runtime, trace, version,
+    changelog, file, fleet, logs, observe, report, review, runner, runtime, trace, version,
 };
 
 use super::lab::apply_lab_contract_to_descriptor;
@@ -228,6 +228,9 @@ impl Commands {
             Commands::Version(_) => version::adapter(output_file_mode).output_descriptor(),
             Commands::Contract(_) => {
                 crate::commands::contract::adapter(output_file_mode).output_descriptor()
+            }
+            Commands::Runner(args) if runner::is_compact_exec_stdout(args) => {
+                raw_ops_descriptor(CommandRawOutputMode::PlainText, output_file_mode)
             }
             Commands::AgentTask(_)
             | Commands::Project(_)
@@ -514,6 +517,35 @@ mod tests {
             CommandResponsePlan {
                 stdout: CommandStdoutMode::Raw(CommandRawOutputMode::Markdown),
                 output_file: CommandOutputFileMode::TraceJsonSummaryArtifact,
+            }
+        );
+
+        assert_eq!(
+            parsed_command(&["homeboy", "runner", "exec", "lab", "--", "homeboy", "runs", "list"])
+                .response_plan(false),
+            CommandResponsePlan {
+                stdout: CommandStdoutMode::Raw(CommandRawOutputMode::PlainText),
+                output_file: CommandOutputFileMode::None,
+            }
+        );
+
+        assert_eq!(
+            parsed_command(&[
+                "homeboy", "runner", "exec", "lab", "--json", "--", "homeboy", "runs", "list",
+            ])
+            .response_plan(false),
+            CommandResponsePlan {
+                stdout: CommandStdoutMode::JsonEnvelope,
+                output_file: CommandOutputFileMode::None,
+            }
+        );
+
+        assert_eq!(
+            parsed_command(&["homeboy", "runner", "exec", "lab", "--", "homeboy", "runs", "list"])
+                .response_plan(true),
+            CommandResponsePlan {
+                stdout: CommandStdoutMode::Raw(CommandRawOutputMode::PlainText),
+                output_file: CommandOutputFileMode::GenericEnvelope,
             }
         );
     }

--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -4,7 +4,7 @@ use crate::cli_surface::Commands;
 use crate::command_contract::{CommandRawOutputMode, CommandStdoutMode};
 
 use super::utils::{response as output, tty};
-use super::{changelog, docs, file, report, review, runs, runtime, trace, GlobalArgs};
+use super::{changelog, docs, file, report, review, runner, runs, runtime, trace, GlobalArgs};
 
 pub enum RawExecution {
     Handled(i32),
@@ -101,9 +101,19 @@ fn run_plain_text(command: Commands, global: &GlobalArgs) -> RawCommandRun {
             )),
             Err(err) => Err(err),
         }),
+        Commands::Runner(args) if runner::is_compact_exec_stdout(&args) => {
+            runner_compact_exec(args, global)
+        }
         Commands::Runtime(args) => raw_stdout_only(runtime::run_plain_text(args)),
         _ => raw_stdout_only(unsupported_output("plain text")),
     }
+}
+
+fn runner_compact_exec(
+    args: crate::commands::runner::RunnerArgs,
+    global: &GlobalArgs,
+) -> RawCommandRun {
+    runner::run_plain_text_raw(args, global)
 }
 
 pub fn raw_stdout_only(result: homeboy::core::Result<(String, i32)>) -> RawCommandRun {

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -14,6 +14,19 @@ pub struct RunnerArgs {
     pub(super) command: RunnerCommand,
 }
 
+impl RunnerArgs {
+    pub fn compact_exec_stdout(&self) -> bool {
+        matches!(
+            &self.command,
+            RunnerCommand::Exec {
+                json: false,
+                raw: false,
+                ..
+            }
+        )
+    }
+}
+
 #[derive(Subcommand)]
 pub(super) enum RunnerCommand {
     /// Register a local or SSH execution runner
@@ -315,6 +328,10 @@ pub(super) enum RunnerCommand {
         /// Relative paths are resolved from the runner exec cwd. Repeat for multiple summaries.
         #[arg(long = "summary", value_name = "PATH")]
         summary_outputs: Vec<String>,
+
+        /// Print the full structured runner execution envelope to stdout.
+        #[arg(long)]
+        json: bool,
 
         /// Print remote stdout/stderr directly instead of the structured JSON envelope.
         /// Use global --output to still write the full structured envelope to a file.

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -2,8 +2,10 @@ use homeboy::core::runners::{
     self as runner, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, RunnerExecOutput,
 };
 use homeboy::core::server::RunnerSettings;
+use serde_json::Value;
 
 use super::super::output_runtime::{CommandPresentation, JsonCommandRun};
+use super::super::raw_output::RawCommandRun;
 use super::super::CmdResult;
 use super::broker::run_broker;
 use super::cli::{RunnerArgs, RunnerCommand};
@@ -174,6 +176,7 @@ pub fn run(
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            json: _,
             raw: _,
             command,
         } => map_execution(exec(
@@ -269,9 +272,92 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             artifact_outputs,
             artifact_dir_outputs,
             summary_outputs,
+            json: true,
+            raw: false,
+            command,
+        } => run_json_exec(
+            id,
+            cwd,
+            sync_workspace,
+            project,
+            ssh,
+            capture_patch,
+            require_paths,
+            script_file,
+            env,
+            secret_env,
+            secret_env_plan,
+            secret_env_plan_file,
+            dry_run,
+            run_id,
+            artifact_outputs,
+            artifact_dir_outputs,
+            summary_outputs,
+            command,
+        ),
+        RunnerCommand::Exec {
+            id,
+            cwd,
+            sync_workspace,
+            project,
+            ssh,
+            capture_patch,
+            require_paths,
+            script_file,
+            env,
+            secret_env,
+            secret_env_plan,
+            secret_env_plan_file,
+            dry_run,
+            run_id,
+            artifact_outputs,
+            artifact_dir_outputs,
+            summary_outputs,
             raw: true,
+            json: false,
             command,
         } => run_raw_exec(
+            id,
+            cwd,
+            sync_workspace,
+            project,
+            ssh,
+            capture_patch,
+            require_paths,
+            script_file,
+            env,
+            secret_env,
+            secret_env_plan,
+            secret_env_plan_file,
+            dry_run,
+            run_id,
+            artifact_outputs,
+            artifact_dir_outputs,
+            summary_outputs,
+            command,
+        ),
+        RunnerCommand::Exec {
+            id,
+            cwd,
+            sync_workspace,
+            project,
+            ssh,
+            capture_patch,
+            require_paths,
+            script_file,
+            env,
+            secret_env,
+            secret_env_plan,
+            secret_env_plan_file,
+            dry_run,
+            run_id,
+            artifact_outputs,
+            artifact_dir_outputs,
+            summary_outputs,
+            raw: false,
+            json: false,
+            command,
+        } => run_compact_exec_json(
             id,
             cwd,
             sync_workspace,
@@ -300,6 +386,53 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
             JsonCommandRun::from_stdout_result(stdout_result, exit_code)
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_json_exec(
+    id: String,
+    cwd: Option<String>,
+    sync_workspace: Option<String>,
+    project: Option<String>,
+    ssh: bool,
+    capture_patch: bool,
+    require_paths: Vec<String>,
+    script_file: Option<String>,
+    env: Vec<String>,
+    secret_env: Vec<String>,
+    secret_env_plan: Option<String>,
+    secret_env_plan_file: Option<String>,
+    dry_run: bool,
+    run_id: Option<String>,
+    artifact_outputs: Vec<String>,
+    artifact_dir_outputs: Vec<String>,
+    summary_outputs: Vec<String>,
+    command: Vec<String>,
+) -> JsonCommandRun {
+    let (stdout_result, exit_code) = crate::commands::utils::response::map_cmd_result_to_json(
+        exec(
+            &id,
+            cwd,
+            sync_workspace,
+            project,
+            ssh,
+            capture_patch,
+            require_paths,
+            script_file,
+            env,
+            secret_env,
+            secret_env_plan,
+            secret_env_plan_file,
+            dry_run,
+            run_id,
+            artifact_outputs,
+            artifact_dir_outputs,
+            summary_outputs,
+            command,
+        )
+        .map(|(output, exit_code)| (RunnerCommandOutput::Execution(output), exit_code)),
+    );
+    JsonCommandRun::from_stdout_result(stdout_result, exit_code)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -352,6 +485,170 @@ fn run_raw_exec(
             JsonCommandRun::from_stdout_result(stdout_result, exit_code)
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_compact_exec_json(
+    id: String,
+    cwd: Option<String>,
+    sync_workspace: Option<String>,
+    project: Option<String>,
+    ssh: bool,
+    capture_patch: bool,
+    require_paths: Vec<String>,
+    script_file: Option<String>,
+    env: Vec<String>,
+    secret_env: Vec<String>,
+    secret_env_plan: Option<String>,
+    secret_env_plan_file: Option<String>,
+    dry_run: bool,
+    run_id: Option<String>,
+    artifact_outputs: Vec<String>,
+    artifact_dir_outputs: Vec<String>,
+    summary_outputs: Vec<String>,
+    command: Vec<String>,
+) -> JsonCommandRun {
+    let raw_run = run_compact_exec(
+        id,
+        cwd,
+        sync_workspace,
+        project,
+        ssh,
+        capture_patch,
+        require_paths,
+        script_file,
+        env,
+        secret_env,
+        secret_env_plan,
+        secret_env_plan_file,
+        dry_run,
+        run_id,
+        artifact_outputs,
+        artifact_dir_outputs,
+        summary_outputs,
+        command,
+    );
+    let (run, raw_stdout) = JsonCommandRun::from_raw(raw_run);
+    run.with_presentation(CommandPresentation {
+        stdout: raw_stdout.ok(),
+        stderr: None,
+    })
+    .with_command("runner")
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_compact_exec(
+    id: String,
+    cwd: Option<String>,
+    sync_workspace: Option<String>,
+    project: Option<String>,
+    ssh: bool,
+    capture_patch: bool,
+    require_paths: Vec<String>,
+    script_file: Option<String>,
+    env: Vec<String>,
+    secret_env: Vec<String>,
+    secret_env_plan: Option<String>,
+    secret_env_plan_file: Option<String>,
+    dry_run: bool,
+    run_id: Option<String>,
+    artifact_outputs: Vec<String>,
+    artifact_dir_outputs: Vec<String>,
+    summary_outputs: Vec<String>,
+    command: Vec<String>,
+) -> RawCommandRun {
+    match exec(
+        &id,
+        cwd,
+        sync_workspace,
+        project,
+        ssh,
+        capture_patch,
+        require_paths,
+        script_file,
+        env,
+        secret_env,
+        secret_env_plan,
+        secret_env_plan_file,
+        dry_run,
+        run_id,
+        artifact_outputs,
+        artifact_dir_outputs,
+        summary_outputs,
+        command,
+    ) {
+        Ok((output, exit_code)) => compact_exec_command_run(output, exit_code),
+        Err(err) => RawCommandRun {
+            stdout_result: Err(err),
+            exit_code: 1,
+            output_file_result: None,
+        },
+    }
+}
+
+pub(super) fn compact_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> RawCommandRun {
+    let compact_stdout = render_compact_exec_output(&output);
+    let (output_file_result, _) = crate::commands::utils::response::map_cmd_result_to_json(Ok((
+        RunnerCommandOutput::Execution(output),
+        exit_code,
+    )));
+
+    RawCommandRun {
+        stdout_result: Ok(compact_stdout),
+        exit_code,
+        output_file_result: Some(output_file_result),
+    }
+}
+
+pub(super) fn render_compact_exec_output(output: &RunnerExecOutput) -> String {
+    let mut rendered = String::new();
+    rendered.push_str(&format!("Runner: {}\n", output.runner_id));
+    rendered.push_str(&format!("Remote cwd: {}\n", output.remote_cwd));
+    rendered.push_str(&format!("Exit status: {}\n", output.exit_code));
+    if let Some(job_id) = output.job_id.as_deref() {
+        rendered.push_str(&format!("Job: {job_id}\n"));
+    }
+    if let Some(run_id) = output.mirror_run_id.as_deref() {
+        rendered.push_str(&format!("Run: {run_id}\n"));
+    }
+    for artifact in &output.artifacts {
+        let label = artifact.name.as_deref().unwrap_or(&artifact.id);
+        let uri = artifact
+            .url
+            .as_deref()
+            .or(artifact.path.as_deref())
+            .unwrap_or("unresolved");
+        rendered.push_str(&format!("Artifact: {label} ({uri})\n"));
+    }
+    for artifact in &output.promoted_outputs {
+        rendered.push_str(&format!(
+            "Artifact: {} ({})\n",
+            artifact.artifact_id, artifact.artifact_path
+        ));
+    }
+    rendered.push('\n');
+    if !output.stdout.is_empty() {
+        rendered.push_str("Stdout:\n");
+        rendered.push_str(&render_stream(&output.stdout));
+        if !rendered.ends_with('\n') {
+            rendered.push('\n');
+        }
+    }
+    if !output.stderr.is_empty() {
+        rendered.push_str("Stderr:\n");
+        rendered.push_str(&output.stderr);
+        if !rendered.ends_with('\n') {
+            rendered.push('\n');
+        }
+    }
+    rendered
+}
+
+fn render_stream(stream: &str) -> String {
+    serde_json::from_str::<Value>(stream)
+        .ok()
+        .and_then(|value| serde_json::to_string_pretty(&value).ok())
+        .unwrap_or_else(|| stream.to_string())
 }
 
 pub(super) fn raw_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> JsonCommandRun {

--- a/src/commands/runner/mod.rs
+++ b/src/commands/runner/mod.rs
@@ -28,3 +28,66 @@ pub use cli::RunnerArgs;
 pub use dispatch::{run, run_command_output};
 pub(crate) use status::declared_tool_diagnostics;
 pub use types::RunnerToolDiagnostics;
+
+pub fn is_compact_exec_stdout(args: &RunnerArgs) -> bool {
+    args.compact_exec_stdout()
+}
+
+pub fn run_plain_text_raw(
+    args: RunnerArgs,
+    _global: &super::GlobalArgs,
+) -> super::raw_output::RawCommandRun {
+    match args.command {
+        cli::RunnerCommand::Exec {
+            id,
+            cwd,
+            sync_workspace,
+            project,
+            ssh,
+            capture_patch,
+            require_paths,
+            script_file,
+            env,
+            secret_env,
+            secret_env_plan,
+            secret_env_plan_file,
+            dry_run,
+            run_id,
+            artifact_outputs,
+            artifact_dir_outputs,
+            summary_outputs,
+            json: false,
+            raw: false,
+            command,
+        } => dispatch::run_compact_exec(
+            id,
+            cwd,
+            sync_workspace,
+            project,
+            ssh,
+            capture_patch,
+            require_paths,
+            script_file,
+            env,
+            secret_env,
+            secret_env_plan,
+            secret_env_plan_file,
+            dry_run,
+            run_id,
+            artifact_outputs,
+            artifact_dir_outputs,
+            summary_outputs,
+            command,
+        ),
+        _ => super::raw_output::RawCommandRun {
+            stdout_result: Err(homeboy::core::Error::validation_invalid_argument(
+                "output_mode",
+                "runner command does not support plain text output",
+                None,
+                None,
+            )),
+            exit_code: 2,
+            output_file_result: None,
+        },
+    }
+}

--- a/src/commands/runner/tests/exec.rs
+++ b/src/commands/runner/tests/exec.rs
@@ -1,4 +1,6 @@
-use super::super::dispatch::raw_exec_command_run;
+use super::super::dispatch::{
+    compact_exec_command_run, raw_exec_command_run, render_compact_exec_output,
+};
 use super::super::exec::{
     exec, exec_workspace_context, prepare_runner_exec_command, prepare_runner_exec_env,
     prepare_runner_exec_secret_env_plan, promote_runner_exec_artifact_dirs,
@@ -55,6 +57,103 @@ fn raw_exec_command_run_keeps_structured_output_and_presentation_streams() {
     assert_eq!(value["stdout"], "hello\n");
     assert_eq!(value["stderr"], "warn\n");
     assert_eq!(value["job_id"], "job-123");
+}
+
+#[test]
+fn compact_exec_output_shows_metadata_and_streams_once() {
+    let output = RunnerExecOutput {
+        variant: "exec",
+        command: "runner.exec",
+        runner_id: "lab".to_string(),
+        dry_run: false,
+        mode: runner::RunnerExecMode::Daemon,
+        argv: vec![
+            "homeboy".to_string(),
+            "runs".to_string(),
+            "list".to_string(),
+        ],
+        remote_cwd: "/workspace".to_string(),
+        exit_code: 0,
+        stdout: r#"{"runs":[{"id":"run-1"}]}"#.to_string(),
+        stderr: "warn\n".to_string(),
+        source_snapshot: None,
+        job: None,
+        runner_job: None,
+        job_id: Some("job-123".to_string()),
+        job_events: None,
+        mirror_run_id: Some("mirror-1".to_string()),
+        patch: None,
+        mutation_artifacts: None,
+        artifacts: Vec::new(),
+        promoted_outputs: Vec::new(),
+        structured_summaries: Vec::new(),
+        metrics: None,
+        capture: None,
+        execution_record: None,
+        runner_result: None,
+        handoff: None,
+        diagnostics: None,
+    };
+
+    let rendered = render_compact_exec_output(&output);
+
+    assert!(rendered.contains("Runner: lab\n"));
+    assert!(rendered.contains("Remote cwd: /workspace\n"));
+    assert!(rendered.contains("Exit status: 0\n"));
+    assert!(rendered.contains("Job: job-123\n"));
+    assert!(rendered.contains("Run: mirror-1\n"));
+    assert!(rendered.contains("Stdout:\n{\n  \"runs\": ["));
+    assert!(rendered.contains("Stderr:\nwarn\n"));
+    assert_eq!(rendered.matches("Stdout:").count(), 1);
+    assert_eq!(rendered.matches("Stderr:").count(), 1);
+}
+
+#[test]
+fn compact_exec_command_run_preserves_full_output_file_payload() {
+    let output = RunnerExecOutput {
+        variant: "exec",
+        command: "runner.exec",
+        runner_id: "lab".to_string(),
+        dry_run: false,
+        mode: runner::RunnerExecMode::Daemon,
+        argv: vec!["printf".to_string(), "hello".to_string()],
+        remote_cwd: "/workspace".to_string(),
+        exit_code: 0,
+        stdout: "hello\n".to_string(),
+        stderr: String::new(),
+        source_snapshot: None,
+        job: None,
+        runner_job: None,
+        job_id: Some("job-123".to_string()),
+        job_events: None,
+        mirror_run_id: None,
+        patch: None,
+        mutation_artifacts: None,
+        artifacts: Vec::new(),
+        promoted_outputs: Vec::new(),
+        structured_summaries: Vec::new(),
+        metrics: None,
+        capture: None,
+        execution_record: None,
+        runner_result: None,
+        handoff: None,
+        diagnostics: None,
+    };
+
+    let run = compact_exec_command_run(output, 0);
+
+    assert!(run
+        .stdout_result
+        .as_ref()
+        .expect("compact stdout")
+        .contains("Stdout:\nhello\n"));
+    let output_file = run
+        .output_file_result
+        .expect("full output file payload")
+        .expect("serialized payload");
+    assert_eq!(output_file["command"], "runner.exec");
+    assert_eq!(output_file["stdout"], "hello\n");
+    assert_eq!(output_file["job_id"], "job-123");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Make default `homeboy runner exec` terminal output compact plaintext for operator introspection.
- Add `runner exec --json` to preserve the prior full structured stdout envelope.
- Keep full structured runner exec output available through `--output` while compact stdout shows metadata and streams once.

Fixes #7476

## Testing
- `cargo test commands::runner::tests::exec --lib`
- `cargo test command_contract::output::tests::test_response_plan --lib`
- `cargo check --all-targets`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent (GPT-5.5)
- **Used for:** Implemented the compact runner exec terminal output path, tests, verification, and PR preparation.