### PR TITLE
Fix rig settings env interpolation

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -46,8 +46,9 @@ fn prepare_rig_bench_context(
     let declared_spec = spec.clone();
     apply_bench_path_override(&mut spec, args);
     source.spec = spec.clone();
-    let lease = rig::lease::acquire_active_run_lease(&spec, "bench")?;
     let prepare_settings = bench_prepare_settings(args);
+    let lease =
+        rig::lease::acquire_active_run_lease_with_settings(&spec, "bench", &prepare_settings)?;
     if let Some(prepare) = rig::run_bench_prepare(&spec, &prepare_settings)? {
         if !prepare.success {
             return Err(homeboy::core::Error::rig_pipeline_failed(
@@ -697,7 +698,12 @@ fn run_component_with_rig_context(
     let selected_scenarios = selected_scenario_ids(args, rig_spec)?;
 
     if let Some(spec) = rig_spec {
-        run_rig_workload_preflight(spec, ctx.extension_id.as_deref(), &selected_scenarios)?;
+        run_rig_workload_preflight(
+            spec,
+            ctx.extension_id.as_deref(),
+            &selected_scenarios,
+            &ctx.resolved_settings().string_overrides(),
+        )?;
     }
 
     let observation = observation::start(BenchObservationStart {
@@ -845,6 +851,7 @@ fn run_rig_workload_preflight(
     spec: &RigSpec,
     extension_id: Option<&str>,
     scenario_ids: &[String],
+    settings: &[(String, String)],
 ) -> homeboy::core::Result<()> {
     let groups = rig::check_groups_for_bench_scenarios(spec, scenario_ids).or_else(|| {
         extension_id.and_then(|id| {
@@ -852,8 +859,8 @@ fn run_rig_workload_preflight(
         })
     });
     let check = match groups {
-        Some(groups) => rig::run_check_groups(spec, &groups)?,
-        None => rig::run_check(spec)?,
+        Some(groups) => rig::run_check_groups_with_settings(spec, &groups, settings)?,
+        None => rig::run_check_with_settings(spec, settings)?,
     };
     if !check.success {
         return Err(homeboy::core::Error::rig_pipeline_failed(
@@ -1083,17 +1090,23 @@ mod tests {
             )
             .expect("parse rig spec");
 
-            run_rig_workload_preflight(&rig_spec, None, &["rest-product-batch-import".to_string()])
-                .expect("REST scenario should skip unrelated admin checks");
+            run_rig_workload_preflight(
+                &rig_spec,
+                None,
+                &["rest-product-batch-import".to_string()],
+                &[],
+            )
+            .expect("REST scenario should skip unrelated admin checks");
 
             assert!(run_rig_workload_preflight(
                 &rig_spec,
                 None,
                 &["admin-page-assets".to_string()],
+                &[],
             )
             .is_err());
 
-            assert!(run_rig_workload_preflight(&rig_spec, None, &[]).is_err());
+            assert!(run_rig_workload_preflight(&rig_spec, None, &[], &[]).is_err());
         });
     }
 
@@ -1116,7 +1129,7 @@ mod tests {
             )
             .expect("parse rig spec");
 
-            let err = run_rig_workload_preflight(&rig_spec, None, &[])
+            let err = run_rig_workload_preflight(&rig_spec, None, &[], &[])
                 .expect_err("failed check should abort bench preflight");
             let message = err.to_string();
 
@@ -1172,10 +1185,13 @@ mod tests {
             )
             .expect("parse rig spec");
 
-            assert!(
-                run_rig_workload_preflight(&rig_spec, None, &["unknown-scenario".to_string()],)
-                    .is_err()
-            );
+            assert!(run_rig_workload_preflight(
+                &rig_spec,
+                None,
+                &["unknown-scenario".to_string()],
+                &[],
+            )
+            .is_err());
         });
     }
 

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -156,6 +156,8 @@ enum RigCommand {
     Down {
         /// Rig ID
         rig_id: String,
+        #[command(flatten)]
+        setting_args: SettingArgs,
     },
     /// Repair safe declared drift without running the full `up` pipeline
     Repair {
@@ -322,7 +324,10 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Check { target, id, path } => check(&target, id.as_deref(), path.as_deref()),
         RigCommand::Lint { target, id, all } => lint(&target, id.as_deref(), all),
         RigCommand::Package { command } => package(command),
-        RigCommand::Down { rig_id } => down(&rig_id),
+        RigCommand::Down {
+            rig_id,
+            setting_args,
+        } => down(&rig_id, &setting_args),
         RigCommand::Repair { rig_id } => repair(&rig_id),
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
         RigCommand::Run(args) => run_profile(args),
@@ -791,9 +796,10 @@ fn apply_check_path_override(rig: &mut rig::RigSpec, path: &str) -> homeboy::cor
     Ok(())
 }
 
-fn down(rig_id: &str) -> CmdResult<RigCommandOutput> {
+fn down(rig_id: &str, setting_args: &SettingArgs) -> CmdResult<RigCommandOutput> {
     let rig = rig::load(rig_id)?;
-    let report = rig::run_down(&rig)?;
+    let settings = materialized_setting_env_args(setting_args)?;
+    let report = rig::run_down_with_settings(&rig, &settings)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
         RigCommandOutput::Down(RigDownOutput {
@@ -802,6 +808,26 @@ fn down(rig_id: &str) -> CmdResult<RigCommandOutput> {
         }),
         exit_code,
     ))
+}
+
+fn materialized_setting_env_args(
+    setting_args: &SettingArgs,
+) -> homeboy::core::Result<Vec<(String, String)>> {
+    let mut settings = Vec::new();
+    settings.extend(
+        setting_args
+            .settings_profile_json_overrides()?
+            .into_iter()
+            .map(|(key, value)| (key, value.to_string())),
+    );
+    settings.extend(setting_args.settings_overrides()?);
+    settings.extend(
+        setting_args
+            .settings_json_overrides()?
+            .into_iter()
+            .map(|(key, value)| (key, value.to_string())),
+    );
+    Ok(settings)
 }
 
 fn repair(rig_id: &str) -> CmdResult<RigCommandOutput> {

--- a/src/core/rig/expand.rs
+++ b/src/core/rig/expand.rs
@@ -13,18 +13,38 @@
 
 use super::spec::{RigResourcesSpec, RigSpec};
 use crate::core::expand;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Expand variables + tilde in a string.
 pub fn expand_vars(rig: &RigSpec, input: &str) -> String {
-    expand::expand_with_tilde(input, |token| resolve_token(rig, token))
+    expand_vars_with_settings(rig, input, &[])
+}
+
+/// Expand variables + tilde in a string, with rig settings materialized as
+/// `HOMEBOY_SETTINGS_<KEY>` values for `${env.*}` lookups.
+pub fn expand_vars_with_settings(
+    rig: &RigSpec,
+    input: &str,
+    settings: &[(String, String)],
+) -> String {
+    let env = settings_env(settings);
+    expand::expand_with_tilde(input, |token| resolve_token(rig, token, &env))
 }
 
 /// Return a copy of the rig resource declarations with expandable string entries expanded.
 pub fn expand_resources(rig: &RigSpec) -> RigResourcesSpec {
+    expand_resources_with_settings(rig, &[])
+}
+
+/// Return a copy of the rig resource declarations with expandable string entries expanded.
+pub fn expand_resources_with_settings(
+    rig: &RigSpec,
+    settings: &[(String, String)],
+) -> RigResourcesSpec {
     let mut resources = rig.resources.clone();
     resources.exclusive = merge_expanded_strings(
         rig,
+        settings,
         resources.exclusive.iter().map(String::as_str),
         std::iter::empty(),
     )
@@ -35,6 +55,7 @@ pub fn expand_resources(rig: &RigSpec) -> RigResourcesSpec {
     let derived_paths = rig.symlinks.iter().map(|symlink| symlink.link.as_str());
     resources.paths = merge_expanded_strings(
         rig,
+        settings,
         resources.paths.iter().map(String::as_str),
         derived_paths,
     );
@@ -56,12 +77,13 @@ pub fn expand_resources(rig: &RigSpec) -> RigResourcesSpec {
 
 fn merge_expanded_strings<'a>(
     rig: &RigSpec,
+    settings: &[(String, String)],
     explicit: impl Iterator<Item = &'a str>,
     derived: impl Iterator<Item = &'a str>,
 ) -> Vec<String> {
     merge_strings(
-        explicit.map(|value| expand_vars(rig, value)),
-        derived.map(|value| expand_vars(rig, value)),
+        explicit.map(|value| expand_vars_with_settings(rig, value, settings)),
+        derived.map(|value| expand_vars_with_settings(rig, value, settings)),
     )
 }
 
@@ -96,7 +118,7 @@ fn normalize_exclusive_resource(resource: String) -> String {
     resource
 }
 
-fn resolve_token(rig: &RigSpec, token: &str) -> Option<String> {
+fn resolve_token(rig: &RigSpec, token: &str, env: &BTreeMap<String, String>) -> Option<String> {
     if token == "package.root" {
         if let Some(package_root) = super::local_package_root(&rig.id) {
             return Some(package_root.to_string_lossy().to_string());
@@ -123,16 +145,54 @@ fn resolve_token(rig: &RigSpec, token: &str) -> Option<String> {
             return Some(override_path);
         }
         let expanded = expand::expand_with_tilde(&component.path, |token| match token {
-            "package.root" => resolve_token(rig, token),
-            token if token.starts_with("env.") => resolve_token(rig, token),
+            "package.root" => resolve_token(rig, token, env),
+            token if token.starts_with("env.") => resolve_token(rig, token, env),
             _ => None,
         });
         return Some(expanded);
     }
     if let Some(name) = token.strip_prefix("env.") {
+        if let Some(value) = env.get(name) {
+            return Some(value.clone());
+        }
         return Some(std::env::var(name).unwrap_or_default());
     }
     None
+}
+
+/// Materialize rig settings as environment variables.
+///
+/// Settings override inherited process env for their own `HOMEBOY_SETTINGS_*`
+/// names. That matches bench setting semantics: an explicit CLI setting is the
+/// effective value for this invocation.
+pub fn settings_env(settings: &[(String, String)]) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    for (key, value) in settings {
+        env.insert(
+            format!("HOMEBOY_SETTINGS_{}", key.to_uppercase()),
+            value.clone(),
+        );
+        let sanitized = shell_safe_setting_env_key(key);
+        let raw = format!("HOMEBOY_SETTINGS_{}", key.to_uppercase());
+        if sanitized != raw {
+            env.insert(sanitized, value.clone());
+        }
+    }
+    env
+}
+
+fn shell_safe_setting_env_key(key: &str) -> String {
+    let normalized = key
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!("HOMEBOY_SETTINGS_{normalized}")
 }
 
 /// Read a per-component effective-path override from the environment.

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -20,7 +20,7 @@ mod lock;
 /// holder is never reclaimed automatically.
 pub const RIG_LEASE_TTL_ENV: &str = "HOMEBOY_RIG_LEASE_TTL_SECS";
 
-use super::expand::expand_resources;
+use super::expand::expand_resources_with_settings;
 use super::spec::{RigResourcesSpec, RigSpec};
 use super::state::now_rfc3339;
 use crate::core::error::{Error, Result, RigResourceConflictInfo};
@@ -68,7 +68,17 @@ impl Drop for ActiveRigRunLease {
 
 /// Acquire an active-run lease for a mutating rig command.
 pub fn acquire_active_run_lease(rig: &RigSpec, command: &str) -> Result<Option<ActiveRigRunLease>> {
-    let resources = expand_resources(rig);
+    acquire_active_run_lease_with_settings(rig, command, &[])
+}
+
+/// Acquire an active-run lease after materializing rig settings as env values
+/// for resource interpolation.
+pub fn acquire_active_run_lease_with_settings(
+    rig: &RigSpec,
+    command: &str,
+    settings: &[(String, String)],
+) -> Result<Option<ActiveRigRunLease>> {
+    let resources = expand_resources_with_settings(rig, settings);
     if resources.is_empty() {
         return Ok(None);
     }

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -56,15 +56,17 @@ pub use install::{
     StackSourceMetadata,
 };
 pub use lease::{
-    acquire_active_run_lease, active_run_leases, release_active_run_lease, ActiveRigRunLease,
-    ReleaseLeaseOutcome, RigRunLease, RIG_LEASE_TTL_ENV,
+    acquire_active_run_lease, acquire_active_run_lease_with_settings, active_run_leases,
+    release_active_run_lease, ActiveRigRunLease, ReleaseLeaseOutcome, RigRunLease,
+    RIG_LEASE_TTL_ENV,
 };
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use resource_lifecycle::{
     rig_resource_lifecycle_index, rig_resource_lifecycle_records, RigResourceLifecycleOptions,
 };
 pub use runner::{
-    head_sha_and_branch, run_bench_prepare, run_check, run_check_groups, run_down,
+    head_sha_and_branch, run_bench_prepare, run_check, run_check_groups,
+    run_check_groups_with_settings, run_check_with_settings, run_down, run_down_with_settings,
     run_fuzz_prepare, run_lint, run_repair, run_status, run_up, snapshot_state, BenchPrepareReport,
     CheckReport, DownReport, FuzzPrepareReport, RepairReport, RepairResourceReport,
     RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,

--- a/src/core/rig/pipeline/command_step.rs
+++ b/src/core/rig/pipeline/command_step.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command;
 
-use super::super::expand::expand_vars;
+use super::super::expand::{expand_vars_with_settings, settings_env};
 use super::super::spec::{PipelineStep, RigSpec};
 use super::super::toolchain;
 use crate::core::error::{Error, Result};
@@ -16,12 +16,12 @@ pub(in crate::core::rig) fn run_command_step(
     env: &HashMap<String, String>,
     settings: &[(String, String)],
 ) -> Result<()> {
-    let expanded = expand_vars(rig, cmd);
+    let expanded = expand_vars_with_settings(rig, cmd, settings);
     let mut command = Command::new(command_step_shell());
     command.arg("-c").arg(&expanded);
 
     if let Some(cwd) = cwd {
-        let resolved = expand_vars(rig, cwd);
+        let resolved = expand_vars_with_settings(rig, cwd, settings);
         command.current_dir(PathBuf::from(resolved));
     }
 
@@ -32,7 +32,7 @@ pub(in crate::core::rig) fn run_command_step(
     }
 
     for (k, v) in env {
-        command.env(k, expand_vars(rig, v));
+        command.env(k, expand_vars_with_settings(rig, v, settings));
     }
 
     for (k, v) in settings_env(settings) {
@@ -63,36 +63,6 @@ pub(in crate::core::rig) fn run_command_step(
     Ok(())
 }
 
-fn settings_env(settings: &[(String, String)]) -> Vec<(String, String)> {
-    let mut env = Vec::new();
-    for (key, value) in settings {
-        env.push((
-            format!("HOMEBOY_SETTINGS_{}", key.to_uppercase()),
-            value.clone(),
-        ));
-        let sanitized = shell_safe_setting_env_key(key);
-        let raw = format!("HOMEBOY_SETTINGS_{}", key.to_uppercase());
-        if sanitized != raw {
-            env.push((sanitized, value.clone()));
-        }
-    }
-    env
-}
-
-fn shell_safe_setting_env_key(key: &str) -> String {
-    let normalized = key
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() {
-                character.to_ascii_uppercase()
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    format!("HOMEBOY_SETTINGS_{normalized}")
-}
-
 pub(super) fn run_command_pipeline_step(
     rig: &RigSpec,
     step: &PipelineStep,
@@ -121,12 +91,12 @@ fn run_command_if_missing_step(
     env: &HashMap<String, String>,
     settings: &[(String, String)],
 ) -> Result<()> {
-    let expanded_missing = expand_vars(rig, missing);
+    let expanded_missing = expand_vars_with_settings(rig, missing, settings);
     let missing_path = PathBuf::from(&expanded_missing);
     let resolved_missing = if missing_path.is_absolute() {
         missing_path
     } else if let Some(cwd) = cwd {
-        PathBuf::from(expand_vars(rig, cwd)).join(missing_path)
+        PathBuf::from(expand_vars_with_settings(rig, cwd, settings)).join(missing_path)
     } else {
         missing_path
     };

--- a/src/core/rig/pipeline/mod.rs
+++ b/src/core/rig/pipeline/mod.rs
@@ -47,6 +47,7 @@ pub fn run_pipeline_check_groups(
     rig: &RigSpec,
     groups: &[String],
     fail_fast: bool,
+    settings: &[(String, String)],
 ) -> Result<PipelineOutcome> {
     let wanted: BTreeSet<&str> = groups.iter().map(String::as_str).collect();
     let steps = rig
@@ -58,7 +59,7 @@ pub fn run_pipeline_check_groups(
         .filter(|step| ordering::step_matches_groups(step, &wanted))
         .collect::<Vec<_>>();
     let ordered_indices = ordering::order_pipeline_steps(rig, "check", &steps)?;
-    run_ordered_steps(rig, "check", &steps, ordered_indices, fail_fast, &[])
+    run_ordered_steps(rig, "check", &steps, ordered_indices, fail_fast, settings)
 }
 
 pub fn run_prepare_requirement_steps(

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -199,12 +199,21 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
 /// Run the `check` pipeline. Unlike `up`, does NOT fail-fast — reports every
 /// failing check so the user can fix them all in one pass.
 pub fn run_check(rig: &RigSpec) -> Result<CheckReport> {
+    run_check_with_settings(rig, &[])
+}
+
+/// Run the `check` pipeline with invocation settings materialized as
+/// `HOMEBOY_SETTINGS_<KEY>` env vars for command expansion/execution.
+pub fn run_check_with_settings(
+    rig: &RigSpec,
+    settings: &[(String, String)],
+) -> Result<CheckReport> {
     let observer = RigRunObserver::start(rig, "check");
 
     let mut result = (|| {
         let requirements = evaluate_requirements(rig);
         let package_lint = run_package_lint(rig)?;
-        let check_outcome = run_pipeline(rig, "check", false)?;
+        let check_outcome = run_pipeline_with_settings(rig, "check", false, settings)?;
         let outcome = merge_check_outcomes(vec![requirements, package_lint, check_outcome]);
 
         let mut state = RigState::load(&rig.id)?;
@@ -285,7 +294,17 @@ fn merge_check_outcomes(outcomes: Vec<PipelineOutcome>) -> PipelineOutcome {
 /// This intentionally does not update `last_check`: the report is a scoped
 /// command preflight, not proof that the whole rig passed `homeboy rig check`.
 pub fn run_check_groups(rig: &RigSpec, groups: &[String]) -> Result<CheckReport> {
-    let outcome = run_pipeline_check_groups(rig, groups, false)?;
+    run_check_groups_with_settings(rig, groups, &[])
+}
+
+/// Run grouped check-pipeline steps with invocation settings materialized as
+/// `HOMEBOY_SETTINGS_<KEY>` env vars for command expansion/execution.
+pub fn run_check_groups_with_settings(
+    rig: &RigSpec,
+    groups: &[String],
+    settings: &[(String, String)],
+) -> Result<CheckReport> {
+    let outcome = run_pipeline_check_groups(rig, groups, false, settings)?;
 
     Ok(CheckReport {
         rig_id: rig.id.clone(),
@@ -566,9 +585,15 @@ fn merge_prepare_outcomes(
 /// service the rig knows about (belt + suspenders — spec authors sometimes
 /// forget to add `service stop` steps to `down`).
 pub fn run_down(rig: &RigSpec) -> Result<DownReport> {
-    let _lease = acquire_active_run_lease(rig, "down")?;
+    run_down_with_settings(rig, &[])
+}
+
+/// Tear down a rig with invocation settings available to resource expansion and
+/// the `down` pipeline as `HOMEBOY_SETTINGS_<KEY>` env vars.
+pub fn run_down_with_settings(rig: &RigSpec, settings: &[(String, String)]) -> Result<DownReport> {
+    let _lease = super::lease::acquire_active_run_lease_with_settings(rig, "down", settings)?;
     let pipeline = if rig.pipeline.contains_key("down") {
-        Some(run_pipeline(rig, "down", false)?)
+        Some(run_pipeline_with_settings(rig, "down", false, settings)?)
     } else {
         None
     };

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -4,7 +4,9 @@
 //! public function of the module; additional cases cover edge conditions.
 
 use crate::core::paths;
-use crate::core::rig::expand::{expand_resources, expand_vars};
+use crate::core::rig::expand::{
+    expand_resources, expand_resources_with_settings, expand_vars, expand_vars_with_settings,
+};
 use crate::core::rig::spec::{
     ComponentSpec, DiscoverSpec, RigSpec, ServiceKind, ServiceSpec, SymlinkSpec,
 };
@@ -134,6 +136,26 @@ fn test_expand_vars_env_variable() {
 }
 
 #[test]
+fn test_expand_vars_settings_override_inherited_env() {
+    let previous = std::env::var("HOMEBOY_SETTINGS_RIG_NAMESPACE").ok();
+    std::env::set_var("HOMEBOY_SETTINGS_RIG_NAMESPACE", "inherited");
+    let rig = rig_with("t", HashMap::new());
+
+    let expanded = expand_vars_with_settings(
+        &rig,
+        "ns=${env.HOMEBOY_SETTINGS_RIG_NAMESPACE}",
+        &[("rig_namespace".to_string(), "cli".to_string())],
+    );
+
+    match previous {
+        Some(value) => std::env::set_var("HOMEBOY_SETTINGS_RIG_NAMESPACE", value),
+        None => std::env::remove_var("HOMEBOY_SETTINGS_RIG_NAMESPACE"),
+    }
+
+    assert_eq!(expanded, "ns=cli");
+}
+
+#[test]
 fn test_expand_vars_unknown_token_is_literal() {
     let rig = rig_with("t", HashMap::new());
     assert_eq!(expand_vars(&rig, "${unknown.thing}"), "${unknown.thing}");
@@ -212,6 +234,22 @@ fn test_expand_resources_expands_string_entries() {
         assert_eq!(resources.process_patterns, vec!["app-server-child.mjs"]);
         assert_eq!(resources.paths, expected_paths);
     });
+}
+
+#[test]
+fn test_expand_resources_with_settings_expands_exclusive_and_paths() {
+    let mut rig = rig_with("settings-resources", HashMap::new());
+    rig.resources.exclusive = vec!["fixture:${env.HOMEBOY_SETTINGS_FIXTURE_NAMESPACE}".to_string()];
+    rig.resources.paths =
+        vec!["/tmp/fixture-${env.HOMEBOY_SETTINGS_FIXTURE_NAMESPACE}".to_string()];
+
+    let resources = expand_resources_with_settings(
+        &rig,
+        &[("fixture_namespace".to_string(), "bench-a".to_string())],
+    );
+
+    assert_eq!(resources.exclusive, vec!["fixture:bench-a"]);
+    assert_eq!(resources.paths, vec!["/tmp/fixture-bench-a"]);
 }
 
 #[test]

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -2,8 +2,8 @@
 
 use crate::core::error::ErrorCode;
 use crate::core::rig::lease::{
-    acquire_active_run_lease, active_run_leases, release_active_run_lease, ReleaseLeaseOutcome,
-    RIG_LEASE_TTL_ENV,
+    acquire_active_run_lease, acquire_active_run_lease_with_settings, active_run_leases,
+    release_active_run_lease, ReleaseLeaseOutcome, RIG_LEASE_TTL_ENV,
 };
 use crate::core::rig::spec::{RigResourcesSpec, RigSpec};
 use crate::core::rig::{run_up, RigRunLease};
@@ -152,6 +152,32 @@ fn test_acquire_active_run_lease_blocks_env_expanded_exclusive_resources() {
 
         assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
         assert!(conflict.message.contains("studio-runtime:bench-a"));
+
+        drop(lease);
+    });
+}
+
+#[test]
+fn test_acquire_active_run_lease_expands_settings_in_resources() {
+    with_isolated_home(|_| {
+        let resources = RigResourcesSpec {
+            exclusive: vec!["fixture:${env.HOMEBOY_SETTINGS_FIXTURE_NAMESPACE}".to_string()],
+            paths: vec!["/tmp/fixture-${env.HOMEBOY_SETTINGS_FIXTURE_NAMESPACE}".to_string()],
+            ports: Vec::new(),
+            process_patterns: Vec::new(),
+        };
+        let studio = rig("studio", resources.clone());
+        let studio_bfb = rig("studio-bfb", resources);
+        let settings = vec![("fixture_namespace".to_string(), "bench-a".to_string())];
+
+        let lease = acquire_active_run_lease_with_settings(&studio, "bench", &settings)
+            .expect("first lease")
+            .expect("resourceful rig leases");
+        let conflict = acquire_active_run_lease_with_settings(&studio_bfb, "bench", &settings)
+            .expect_err("settings-expanded token conflicts");
+
+        assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
+        assert!(conflict.message.contains("fixture:bench-a"));
 
         drop(lease);
     });

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -85,7 +85,7 @@ fn test_run_pipeline_check_groups() {
     )
     .expect("parse rig");
 
-    let outcome = run_pipeline_check_groups(&rig, &["desktop-app".to_string()], false)
+    let outcome = run_pipeline_check_groups(&rig, &["desktop-app".to_string()], false, &[])
         .expect("scoped pipeline runs");
 
     assert!(outcome.is_success());

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -17,9 +17,9 @@ use std::collections::HashMap;
 
 use crate::core::rig::pipeline::PipelineOutcome;
 use crate::core::rig::runner::{
-    head_sha_and_branch, run_check, run_check_groups, run_down, run_repair, run_status, run_up,
-    snapshot_state, CheckReport, RigStatusReport, ServiceStatusReport, SymlinkStatusState,
-    UpReport,
+    head_sha_and_branch, run_check, run_check_groups, run_down, run_down_with_settings, run_repair,
+    run_status, run_up, snapshot_state, CheckReport, RigStatusReport, ServiceStatusReport,
+    SymlinkStatusState, UpReport,
 };
 use crate::core::rig::spec::{
     ComponentSpec, ExecutableRequirementSpec, FilesystemAssertionKind, FilesystemAssertionSpec,
@@ -381,6 +381,45 @@ fn test_run_down() {
                 .is_none(),
             "down clears materialized ownership"
         );
+    });
+}
+
+#[test]
+fn test_run_down_with_settings_exposes_env_to_pipeline() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let marker = tmp.path().join("down-setting.txt");
+        let marker_arg = marker.to_string_lossy();
+        let mut rig = minimal_spec("run-down-settings-fixture");
+        let mut pipeline = HashMap::new();
+        pipeline.insert(
+            "down".to_string(),
+            vec![PipelineStep::Command {
+                step_id: None,
+                depends_on: Vec::new(),
+                cmd: format!(
+                    "printf '%s' '${{env.HOMEBOY_SETTINGS_FIXTURE_NAMESPACE}}' > {}",
+                    marker_arg
+                ),
+                cwd: None,
+                env: HashMap::new(),
+                requires_capabilities: Vec::new(),
+                requires_providers: Vec::new(),
+                provides_capabilities: Vec::new(),
+                provides_providers: Vec::new(),
+                label: Some("write down namespace".to_string()),
+            }],
+        );
+        rig.pipeline = pipeline;
+
+        let report = run_down_with_settings(
+            &rig,
+            &[("fixture_namespace".to_string(), "bench-a".to_string())],
+        )
+        .expect("run_down succeeds");
+
+        assert!(report.success, "outcome: {:?}", report.pipeline);
+        assert_eq!(std::fs::read_to_string(marker).expect("marker"), "bench-a");
     });
 }
 


### PR DESCRIPTION
## Problem
Rig specs can interpolate settings-derived env names such as `${env.HOMEBOY_SETTINGS_<KEY>}` in `resources.exclusive`, `resources.paths`, and pipeline commands. `homeboy bench --rig <rig> --setting <key>=<value>` resolved those settings for the bench workflow, but resource interpolation read only inherited process env and `down` received no settings context. That collapsed namespaced exclusive locks, produced empty resource paths, and made guarded cleanup commands no-op when the setting was not already exported by the parent process.

## Fix approach
- Added shared settings env materialization in `src/core/rig/expand.rs` and settings-aware expansion helpers for `${env.*}` resolution.
- Reused the same settings env map for resource expansion, active-run lease acquisition, command-step expansion/execution, check preflight pipelines, and `down` pipelines.
- Added settings-aware wrappers for rig leases/check/down while keeping existing no-settings entrypoints as compatibility wrappers.
- Added `--setting` / `--setting-json` / settings-file support to standalone `homeboy rig down <rig>` so operators can explicitly tear down namespaced resources. When a setting is absent, interpolation still resolves empty, preserving the rig author's guard behavior.

## Precedence
Explicit Homeboy settings win over inherited process env for the `HOMEBOY_SETTINGS_*` names they own. That matches bench workflow semantics: the CLI-provided setting is the effective invocation value, so resource locks and cleanup pipelines should use that same value rather than a stale exported parent env var.

## Test evidence
- `cargo fmt`
- `cargo test core::rig::expand`
- `cargo test core::rig::lease`
- `cargo test core::rig::pipeline`
- `cargo test core::rig::runner`
- `cargo test commands::bench::matrix`
- `cargo build`

Closes #7490

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via opencode subagent, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation, tests, and PR drafting; reviewed by Chris Huber
