### PR TITLE
Normalize agent task provider invocations

### DIFF
--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -9,6 +9,7 @@ use crate::core::agent_task_provider::{
     AgentTaskExecutorProvider, AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
     AgentTaskProviderWorkspaceMaterialization,
 };
+use crate::core::command_invocation::COMMAND_INVOCATION_SCHEMA;
 use crate::core::extension::{load_all_extensions, load_extension, ExtensionManifest};
 use crate::core::{config, paths, Error, Result};
 
@@ -470,6 +471,7 @@ fn agent_task_executor_providers_from_runtime_manifests(
     for runtime_manifest in runtime_manifests {
         let materialization_plan = runtime_materialization_plan(&runtime_manifest);
         for mut provider in runtime_manifest.agent_task_executors {
+            normalize_agent_task_executor_provider_invocation(&mut provider);
             provider.extension_id = runtime_manifest.extension_id.clone();
             provider.extension_path = runtime_manifest.extension_path.clone();
             if provider.runtime_package_source.is_none() {
@@ -486,6 +488,22 @@ fn agent_task_executor_providers_from_runtime_manifests(
         }
     }
     providers
+}
+
+fn normalize_agent_task_executor_provider_invocation(provider: &mut AgentTaskExecutorProvider) {
+    if !provider.invocation.argv.is_empty()
+        || !provider.command_argv.is_empty()
+        || provider.command.trim().is_empty()
+    {
+        return;
+    }
+
+    provider.invocation.schema = Some(COMMAND_INVOCATION_SCHEMA.to_string());
+    provider.invocation.argv = provider
+        .command
+        .split_whitespace()
+        .map(str::to_string)
+        .collect();
 }
 
 pub(crate) fn validate_installed_extension_agent_runtime_provider_discovery(

--- a/src/core/agent_task_provider/tests/manifest_tests.rs
+++ b/src/core/agent_task_provider/tests/manifest_tests.rs
@@ -83,6 +83,55 @@ fn provider_manifest_accepts_command_invocation_contract() {
 }
 
 #[test]
+fn default_provider_catalog_normalizes_codex_command_to_invocation_argv() {
+    crate::test_support::with_isolated_home(|home| {
+        let runtime_dir = home.path().join(".config/homeboy/agent-runtimes/codex");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        std::fs::write(
+            runtime_dir.join("codex.json"),
+            json!({
+                "schema": crate::core::agent_runtime_manifest::AGENT_RUNTIME_MANIFEST_SCHEMA,
+                "id": "codex",
+                "agent_task_executors": [{
+                    "schema": AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+                    "id": "codex.agent-task-executor",
+                    "backend": "codex",
+                    "command": "codex-agent-task-executor --json"
+                }]
+            })
+            .to_string(),
+        )
+        .expect("runtime manifest");
+
+        let catalog = AgentTaskProviderCatalog::discover();
+        let provider = catalog
+            .providers()
+            .iter()
+            .find(|provider| provider.id == "codex.agent-task-executor")
+            .expect("codex provider discovered");
+
+        assert!(provider.command_argv.is_empty());
+        assert_eq!(provider.command, "codex-agent-task-executor --json");
+        assert_eq!(
+            provider.invocation.schema.as_deref(),
+            Some(crate::core::command_invocation::COMMAND_INVOCATION_SCHEMA)
+        );
+        assert_eq!(
+            provider.invocation.argv,
+            vec![
+                "codex-agent-task-executor".to_string(),
+                "--json".to_string()
+            ]
+        );
+
+        let (program, args, cwd) = provider_command_parts(provider).expect("command parts");
+        assert_eq!(program, "codex-agent-task-executor");
+        assert_eq!(args, vec!["--json"]);
+        assert_eq!(cwd, None);
+    });
+}
+
+#[test]
 fn provider_command_parts_warns_for_legacy_string_command() {
     let (_request, provider) = request("task-legacy-command", "legacy-provider --flag".to_string());
 


### PR DESCRIPTION
## Summary
- Normalize legacy agent-task provider string commands into the current command invocation argv contract during provider catalog construction.
- Preserve parsed legacy command data while ensuring execution prefers invocation.argv and avoids repeated deprecated string-command warnings.
- Add a Codex provider catalog regression test covering codex.agent-task-executor invocation argv normalization.

Fixes #7482

## Testing
- cargo test --lib agent_task_provider::tests::manifest_tests
- cargo check --all-targets

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent (GPT-5.5)
- **Used for:** Implemented the provider catalog normalization, added regression coverage, and ran verification.