### PR TITLE
Fix agent task executor evidence path collisions

### DIFF
--- a/src/core/agent_task/executor.rs
+++ b/src/core/agent_task/executor.rs
@@ -79,7 +79,6 @@ impl AgentTaskExecutor {
             .and_then(|selection| selection.model.as_deref())
             .or(self.model.as_deref())
     }
-
 }
 
 fn config_str<'a>(config: &'a Value, key: &str) -> Option<&'a str> {

--- a/src/core/agent_task_executor_evidence.rs
+++ b/src/core/agent_task_executor_evidence.rs
@@ -52,9 +52,10 @@ pub const EXECUTOR_RESULT_FILE: &str = "executor-result.json";
 pub(crate) fn link_latest_executor_evidence(
     request: &AgentTaskRequest,
     outcome: &mut AgentTaskOutcome,
+    run_id: Option<&str>,
 ) {
     let policy = RedactionPolicy::default();
-    let dir = executor_evidence_dir(&request.task_id);
+    let dir = executor_evidence_dir(run_id, &request.task_id);
     if fs::create_dir_all(&dir).is_err() {
         return;
     }
@@ -88,14 +89,14 @@ pub(crate) fn link_latest_executor_evidence(
     }
 }
 
-/// Stable, per-task evidence directory under the system temp dir.
+/// Stable, per-run/per-task evidence directory under the system temp dir.
 ///
-/// Keyed by a sanitized task id (not a random suffix) so the latest raw input
-/// and result always live at a predictable path operators can read directly
-/// instead of guessing temp directory names.
-fn executor_evidence_dir(task_id: &str) -> PathBuf {
+/// Recorded runs use their durable run id as the first path segment so repeated
+/// fanout child cooks with the same task id keep distinct evidence files.
+fn executor_evidence_dir(run_id: Option<&str>, task_id: &str) -> PathBuf {
     std::env::temp_dir()
         .join("homeboy-agent-task-evidence")
+        .join(sanitize_task_id(run_id.unwrap_or("unrecorded-run")))
         .join(sanitize_task_id(task_id))
 }
 
@@ -179,6 +180,9 @@ mod tests {
         AgentTaskPolicy, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
     };
     use serde_json::Map;
+    use std::sync::Mutex;
+
+    static TEMP_DIR_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn test_request() -> AgentTaskRequest {
         AgentTaskRequest {
@@ -236,8 +240,9 @@ mod tests {
     }
 
     fn with_temp_dir<R>(test: impl FnOnce() -> R) -> R {
-        // Isolate writes to a unique temp dir so the stable per-task path does
-        // not collide across parallel test runs.
+        // Isolate writes to a unique temp dir without racing parallel tests that
+        // also read `std::env::temp_dir()`.
+        let _lock = TEMP_DIR_ENV_LOCK.lock().expect("temp dir env lock");
         let guard = tempfile::tempdir().expect("temp dir");
         let previous = std::env::var_os("TMPDIR");
         std::env::set_var("TMPDIR", guard.path());
@@ -254,7 +259,7 @@ mod tests {
         with_temp_dir(|| {
             let request = test_request();
             let mut outcome = test_outcome();
-            link_latest_executor_evidence(&request, &mut outcome);
+            link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
 
             let kinds: Vec<&str> = outcome
                 .evidence_refs
@@ -279,7 +284,7 @@ mod tests {
         with_temp_dir(|| {
             let request = test_request();
             let mut outcome = test_outcome();
-            link_latest_executor_evidence(&request, &mut outcome);
+            link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
 
             let input_ref = outcome
                 .evidence_refs
@@ -309,20 +314,57 @@ mod tests {
         with_temp_dir(|| {
             let request = test_request();
             let mut outcome = test_outcome();
-            link_latest_executor_evidence(&request, &mut outcome);
+            link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
             let first = outcome.evidence_refs.len();
-            link_latest_executor_evidence(&request, &mut outcome);
+            link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
             assert_eq!(outcome.evidence_refs.len(), first);
         });
     }
 
     #[test]
-    fn evidence_dir_is_stable_for_a_task_id() {
-        let first = executor_evidence_dir("task/with weird:chars");
-        let second = executor_evidence_dir("task/with weird:chars");
+    fn evidence_dir_is_stable_for_a_run_and_task_id() {
+        let first = executor_evidence_dir(Some("run/attempt:1"), "task/with weird:chars");
+        let second = executor_evidence_dir(Some("run/attempt:1"), "task/with weird:chars");
         assert_eq!(first, second);
         assert!(first
             .to_string_lossy()
             .contains("homeboy-agent-task-evidence"));
+    }
+
+    #[test]
+    fn repeated_child_runs_with_same_task_id_keep_distinct_evidence_paths() {
+        with_temp_dir(|| {
+            let request = test_request();
+            let mut first_outcome = test_outcome();
+            let mut second_outcome = test_outcome();
+
+            link_latest_executor_evidence(
+                &request,
+                &mut first_outcome,
+                Some("cook-homeboy-attempt-1-aaaa1111"),
+            );
+            link_latest_executor_evidence(
+                &request,
+                &mut second_outcome,
+                Some("cook-homeboy-attempt-1-bbbb2222"),
+            );
+
+            let first_input = first_outcome
+                .evidence_refs
+                .iter()
+                .find(|evidence| evidence.kind == EXECUTOR_INPUT_EVIDENCE_KIND)
+                .expect("first executor input evidence");
+            let second_input = second_outcome
+                .evidence_refs
+                .iter()
+                .find(|evidence| evidence.kind == EXECUTOR_INPUT_EVIDENCE_KIND)
+                .expect("second executor input evidence");
+
+            assert_ne!(first_input.uri, second_input.uri);
+            assert!(first_input.uri.contains("cook-homeboy-attempt-1-aaaa1111"));
+            assert!(second_input.uri.contains("cook-homeboy-attempt-1-bbbb2222"));
+            assert!(Path::new(first_input.uri.strip_prefix("file://").unwrap()).is_file());
+            assert!(Path::new(second_input.uri.strip_prefix("file://").unwrap()).is_file());
+        });
     }
 }

--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -35,6 +35,7 @@ const PROVIDER_TRANSIENT_BASE_BACKOFF_MS: u64 = 250;
 pub(super) fn run_provider_command(
     request: &AgentTaskRequest,
     provider: &AgentTaskExecutorProvider,
+    run_id: Option<&str>,
 ) -> AgentTaskOutcome {
     let mut attempt = 1;
     loop {
@@ -48,7 +49,7 @@ pub(super) fn run_provider_command(
             }
             // Preserve and link the latest raw executor input/result as
             // first-class run evidence before returning the final outcome.
-            link_latest_executor_evidence(request, &mut outcome);
+            link_latest_executor_evidence(request, &mut outcome, run_id);
             return outcome;
         }
 

--- a/src/core/agent_task_provider/executor.rs
+++ b/src/core/agent_task_provider/executor.rs
@@ -6,7 +6,7 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
     fn execute(
         &self,
         request: AgentTaskRequest,
-        _context: AgentTaskExecutionContext,
+        context: AgentTaskExecutionContext,
     ) -> AgentTaskOutcome {
         if request.executor.backend == "fixture" {
             return run_fixture_provider(&request);
@@ -46,7 +46,7 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             );
         }
 
-        run_provider_command(&request, provider)
+        run_provider_command(&request, provider, context.run_id.as_deref())
     }
 }
 

--- a/src/core/agent_task_provider/tests/manifest_tests.rs
+++ b/src/core/agent_task_provider/tests/manifest_tests.rs
@@ -353,7 +353,7 @@ fn runtime_contract_normalizes_provider_outputs_to_canonical_artifacts() {
         staging: AgentTaskRuntimeStagingContract::default(),
     };
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
     assert_eq!(outcome.summary.as_deref(), Some("runtime finished"));
@@ -402,7 +402,7 @@ fn runtime_contract_maps_failed_runtime_status() {
     provider.runtime_contract.normalization.status_path =
         Some("outputs.sample_runtime.state".to_string());
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Failed);
     assert_eq!(

--- a/src/core/agent_task_provider/tests/scheduler_tests.rs
+++ b/src/core/agent_task_provider/tests/scheduler_tests.rs
@@ -133,7 +133,7 @@ fn provider_preserves_structured_outcome_from_stderr_when_stdout_empty() {
     );
     let (request, provider) = request("task-stderr-outcome", command);
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Failed);
     assert_eq!(
@@ -155,7 +155,7 @@ fn provider_empty_stdout_captures_bounded_stderr_and_exit_context() {
     );
     let (request, provider) = request("task-empty-stdout", command);
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
     assert_eq!(
@@ -209,7 +209,7 @@ fn provider_can_return_timeout_payload_during_wrapper_grace() {
     let (mut request, provider) = request("task-timeout-payload", command);
     request.limits.timeout_ms = Some(3000);
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Timeout);
     assert_eq!(
@@ -469,7 +469,7 @@ fn provider_retries_transient_error_then_succeeds() {
     let command = format!("node {}", transient_then_success_script(&state_path, 2));
     let (request, provider) = request("task-transient-recover", command);
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(
         outcome.status,
@@ -498,7 +498,7 @@ fn provider_does_not_retry_permanent_error() {
     let command = format!("node {}", permanent_error_script(&state_path));
     let (request, provider) = request("task-permanent", command);
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
     assert_eq!(
@@ -529,7 +529,7 @@ fn provider_exhausts_bounded_transient_retries() {
     let command = format!("node {}", transient_then_success_script(&state_path, 999));
     let (request, provider) = request("task-transient-exhaust", command);
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(
         outcome.status,

--- a/src/core/agent_task_provider/tests/selection_tests.rs
+++ b/src/core/agent_task_provider/tests/selection_tests.rs
@@ -133,6 +133,7 @@ fn repo_local_gate_execution_kind_runs_without_extension_provider() {
         request,
         AgentTaskExecutionContext {
             plan_id: "gate-plan".to_string(),
+            run_id: Some("gate-run".to_string()),
             attempt: 1,
             cancellation: AgentTaskCancellationToken::default(),
         },
@@ -317,7 +318,7 @@ process.stdout.write(JSON.stringify({
     let (mut request, provider) = request("task-artifact-normalization", command);
     request.expected_artifacts = vec!["patch".to_string()];
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
     assert_eq!(outcome.outputs["artifact_declarations"][0]["name"], "patch");
@@ -358,7 +359,7 @@ process.stdout.write(JSON.stringify({
         "{{extension_path}}".to_string(),
     ];
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
     assert!(outcome
@@ -392,7 +393,7 @@ process.stdout.write(JSON.stringify({
     provider.invocation.argv = vec!["node".to_string(), "provider.js".to_string()];
     provider.invocation.cwd = Some("{{runtime_path}}".to_string());
 
-    let outcome = run_provider_command(&request, &provider);
+    let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
     assert!(outcome

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -863,6 +863,7 @@ mod cancellation {
     #[derive(Debug, Clone)]
     pub struct AgentTaskExecutionContext {
         pub plan_id: String,
+        pub run_id: Option<String>,
         pub attempt: u32,
         pub cancellation: AgentTaskCancellationToken,
     }

--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -45,6 +45,7 @@ pub trait AgentTaskExecutorAdapter: Send + Sync + 'static {
 
 pub struct AgentTaskScheduler<E> {
     executor: Arc<E>,
+    run_id: Option<String>,
 }
 
 impl<E> AgentTaskScheduler<E>
@@ -54,7 +55,13 @@ where
     pub fn new(executor: E) -> Self {
         Self {
             executor: Arc::new(executor),
+            run_id: None,
         }
+    }
+
+    pub fn with_run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
     }
 
     pub fn run(&self, plan: AgentTaskPlan) -> AgentTaskAggregate {
@@ -307,6 +314,7 @@ where
                 let attempt = scheduled.attempt;
                 let context = AgentTaskExecutionContext {
                     plan_id,
+                    run_id: self.run_id.clone(),
                     attempt,
                     cancellation: cancellation.clone(),
                 };

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -55,7 +55,7 @@ where
         agent_task_lifecycle::mark_running(run_id)?;
     }
 
-    let aggregate = run_plan_with_scheduler(plan.clone(), executor);
+    let aggregate = run_plan_with_scheduler(plan.clone(), record_run_id, executor);
     if let Some(run_id) = record_run_id {
         agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
     }
@@ -177,7 +177,7 @@ fn run_prepared_claimed<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
-    let aggregate = run_plan_with_scheduler(plan.clone(), executor);
+    let aggregate = run_plan_with_scheduler(plan.clone(), Some(&run_id), executor);
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(AgentTaskRunResult {
         exit_code: aggregate_exit_code(&aggregate),
@@ -224,11 +224,19 @@ fn preflight_plan_secret_env(plan: &AgentTaskPlan) -> Result<()> {
     })
 }
 
-fn run_plan_with_scheduler<E>(plan: AgentTaskPlan, executor: E) -> AgentTaskAggregate
+fn run_plan_with_scheduler<E>(
+    plan: AgentTaskPlan,
+    run_id: Option<&str>,
+    executor: E,
+) -> AgentTaskAggregate
 where
     E: AgentTaskExecutorAdapter,
 {
-    AgentTaskScheduler::new(executor).run(plan)
+    let scheduler = AgentTaskScheduler::new(executor);
+    match run_id {
+        Some(run_id) => scheduler.with_run_id(run_id.to_string()).run(plan),
+        None => scheduler.run(plan),
+    }
 }
 
 pub fn aggregate_exit_code(aggregate: &AgentTaskAggregate) -> i32 {


### PR DESCRIPTION
## Summary
- Thread durable agent-task run ids into scheduler execution context.
- Persist raw executor input/result evidence under per-run/per-task directories.
- Add regression coverage for repeated child runs with the same task id producing distinct evidence refs.

Fixes #7479

## Verification
- cargo test core::agent_task_executor_evidence::tests
- cargo test core::agent_task_fanout::tests
- cargo check --all-targets

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent (GPT-5.5)
- **Used for:** Implemented the run-scoped evidence path fix, regression coverage, verification, and PR preparation.