### PR TITLE
Keep fanout cook-batch dry-run local

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -654,6 +654,8 @@ const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
 const AGENT_TASK_COOK_FINALIZATION_CONTROLLER_REASON: &str =
     "agent-task cook finalization commits, pushes, and opens/updates GitHub PRs from the trusted controller; use --no-finalize for Lab patch evidence and finalize from the controller";
+const AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON: &str =
+    "agent-task fanout cook-batch --dry-run is controller-local planning; it does not execute cooks and should not offload or materialize the controller cwd";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabRunnerSupportSummary {
@@ -805,7 +807,22 @@ impl Commands {
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
-                        command: agent_task::AgentTaskFanoutCommand::CookBatch(_),
+                        command:
+                            agent_task::AgentTaskFanoutCommand::CookBatch(
+                                agent_task::AgentTaskFanoutCookBatchArgs { dry_run: true, .. },
+                            ),
+                    }),
+            }) => LabCommandContract::local_only(
+                AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
+                AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON,
+            ),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command:
+                    agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
+                        command:
+                            agent_task::AgentTaskFanoutCommand::CookBatch(
+                                agent_task::AgentTaskFanoutCookBatchArgs { dry_run: false, .. },
+                            ),
                     }),
             }) => LabCommandContract::portable(
                 AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,

--- a/tests/command_contract/lab_test.rs
+++ b/tests/command_contract/lab_test.rs
@@ -313,6 +313,18 @@ fn unsupported_lab_command_cases() -> Vec<Commands> {
     vec![
         parsed_command(&["homeboy", "agent-task", "retry", "agent-task-123"]),
         parsed_command(&["homeboy", "agent-task", "loop", "status", "site-loop"]),
+        parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "homeboy",
+            "--verify",
+            "true",
+            "--dry-run",
+            "https://github.com/Extra-Chill/homeboy/issues/6453",
+        ]),
         parsed_command(&["homeboy", "review", "--changed-only"]),
         parsed_command(&[
             "homeboy", "refactor", "rename", "--from", "old", "--to", "new",
@@ -326,6 +338,56 @@ fn unsupported_lab_command_cases() -> Vec<Commands> {
         parsed_command(&["homeboy", "worktree", "list"]),
         parsed_command(&["homeboy", "worktree", "remove", "homeboy@task"]),
     ]
+}
+
+#[test]
+fn agent_task_fanout_cook_batch_dry_run_stays_controller_local() {
+    let dry_run = parsed_command(&[
+        "homeboy",
+        "agent-task",
+        "fanout",
+        "cook-batch",
+        "--repo",
+        "homeboy",
+        "--verify",
+        "true",
+        "--dry-run",
+        "https://github.com/Extra-Chill/homeboy/issues/6453",
+    ]);
+    let contract = dry_run
+        .lab_contract()
+        .expect("dry-run planning exposes a local-only Lab contract");
+
+    assert!(!dry_run.supports_lab_runner());
+    assert_eq!(contract.hot_label, "agent-task fanout cook-batch");
+    assert_eq!(
+        contract.portability,
+        LabCommandPortability::LocalOnly(AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON)
+    );
+    assert!(!contract.routing_policy.default_lab_offload);
+    assert!(!contract.routing_policy.infer_source_path_tools);
+    assert!(!contract.capture_mutation_patch);
+
+    let actual_cook = parsed_command(&[
+        "homeboy",
+        "agent-task",
+        "fanout",
+        "cook-batch",
+        "--repo",
+        "homeboy",
+        "--verify",
+        "true",
+        "https://github.com/Extra-Chill/homeboy/issues/6453",
+    ]);
+
+    assert!(actual_cook.supports_lab_runner());
+    assert_eq!(
+        actual_cook
+            .lab_contract()
+            .expect("actual cook-batch remains Lab portable")
+            .portability,
+        LabCommandPortability::Portable
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Keep `agent-task fanout cook-batch --dry-run` controller-local in the Lab command contract.
- Preserve Lab-first offload behavior for actual non-dry-run fanout cooking.
- Add regression coverage for dry-run routing/materialization intent.

Fixes #7481

## Testing
- `cargo test command_contract::lab::tests`
- `cargo test command_contract::lab::tests::agent_task_fanout_cook_batch_dry_run_stays_controller_local`
- `cargo check --all-targets`

Note: `cargo fmt --check` still reports a pre-existing formatting diff in `src/core/agent_task/executor.rs`, which this PR does not touch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent (GPT-5.5)
- **Used for:** Implemented the Lab routing contract change, added regression coverage, and ran verification.