### PR TITLE
Fix multi-project deploy component resolution

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -287,17 +287,35 @@ fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::core::Result<(Str
 }
 
 fn resolve_multi_args(args: &DeployArgs) -> homeboy::core::Result<(Vec<String>, DeployConfig)> {
+    let component_ids = resolve_multi_component_ids(args)?;
+    let mut config = build_config(args, false);
+    config.component_ids = component_ids.clone();
+
+    Ok((component_ids, config))
+}
+
+fn resolve_multi_component_ids(args: &DeployArgs) -> homeboy::core::Result<Vec<String>> {
+    if let Some(ref spec) = args.json {
+        return Ok(deploy::parse_bulk_component_ids(spec)?
+            .into_iter()
+            .filter(|s| !s.is_empty())
+            .collect());
+    }
+
+    if let Some(ref comps) = args.component {
+        return Ok(comps.iter().filter(|s| !s.is_empty()).cloned().collect());
+    }
+
     let mut component_ids: Vec<String> = Vec::new();
     if let Some(ref target) = args.target_id {
         component_ids.push(target.clone());
     }
     component_ids.extend(args.component_ids.clone());
-    let component_ids: Vec<String> = component_ids
+
+    Ok(component_ids
         .into_iter()
         .filter(|s| !s.is_empty())
-        .collect();
-
-    Ok((component_ids, build_config(args, false)))
+        .collect())
 }
 
 fn build_config(args: &DeployArgs, skip_build: bool) -> DeployConfig {

--- a/tests/commands/deploy_test.rs
+++ b/tests/commands/deploy_test.rs
@@ -1,5 +1,7 @@
-use super::{run, DeployArgs};
+use super::{resolve_multi_args, run, DeployArgs};
+use crate::cli_surface::{Cli, Commands};
 use crate::commands::GlobalArgs;
+use clap::Parser;
 
 #[test]
 fn deploy_head_requires_apply_for_real_deploy() {
@@ -58,6 +60,89 @@ fn deploy_head_dry_run_does_not_require_apply() {
         Err(err) => err,
     };
     assert!(!err.message.contains("requires explicit --apply"));
+}
+
+#[test]
+fn multi_project_resolves_positional_components() {
+    let (components, config) = resolve_multi_args(&deploy_args(|args| {
+        args.projects = Some(vec!["project-a".to_string(), "project-b".to_string()]);
+        args.target_id = Some("component-a".to_string());
+        args.component_ids = vec!["component-b".to_string()];
+    }))
+    .expect("positional components should resolve");
+
+    assert_eq!(components, ["component-a", "component-b"]);
+    assert_eq!(config.component_ids, components);
+}
+
+#[test]
+fn multi_project_resolves_component_flag_components() {
+    let (components, config) = resolve_multi_args(&deploy_args(|args| {
+        args.projects = Some(vec!["project-a".to_string(), "project-b".to_string()]);
+        args.component = Some(vec!["component-a".to_string(), "component-b".to_string()]);
+    }))
+    .expect("component flag components should resolve");
+
+    assert_eq!(components, ["component-a", "component-b"]);
+    assert_eq!(config.component_ids, components);
+}
+
+#[test]
+fn multi_project_resolves_json_components() {
+    let (components, config) = resolve_multi_args(&deploy_args(|args| {
+        args.projects = Some(vec!["project-a".to_string(), "project-b".to_string()]);
+        args.json = Some(r#"{"component_ids":["component-a","component-b"]}"#.to_string());
+    }))
+    .expect("json components should resolve");
+
+    assert_eq!(components, ["component-a", "component-b"]);
+    assert_eq!(config.component_ids, components);
+}
+
+#[test]
+fn multi_project_zero_components_remains_validation_failure() {
+    let (components, config) = resolve_multi_args(&deploy_args(|args| {
+        args.projects = Some(vec!["project-a".to_string(), "project-b".to_string()]);
+    }))
+    .expect("empty component input is resolved for core validation");
+
+    assert!(components.is_empty());
+    assert!(config.component_ids.is_empty());
+
+    let err = homeboy::core::deploy::run_multi(
+        &["project-a".to_string(), "project-b".to_string()],
+        &components,
+        &config,
+    )
+    .expect_err("zero components should fail multi-project validation");
+
+    assert_eq!(err.details["field"], "component_ids");
+    assert!(err
+        .message
+        .contains("At least one component ID is required for multi-project deployment"));
+}
+
+#[test]
+fn deploy_parser_keeps_positionals_as_components_with_explicit_projects() {
+    let cli = Cli::parse_from([
+        "homeboy",
+        "deploy",
+        "--projects",
+        "project-a,project-b",
+        "component-a",
+        "component-b",
+    ]);
+
+    let Commands::Deploy(args) = cli.command else {
+        panic!("expected deploy command");
+    };
+
+    assert_eq!(
+        args.projects,
+        Some(vec!["project-a".to_string(), "project-b".to_string()])
+    );
+    assert_eq!(args.target_id, Some("component-a".to_string()));
+    assert_eq!(args.component_ids, ["component-b"]);
 }
 
 fn deploy_args(mut customize: impl FnMut(&mut DeployArgs)) -> DeployArgs {


### PR DESCRIPTION
## Summary

Fixes #7470. `resolve_multi_args()` (src/commands/deploy.rs:289) only read positional `component_ids` and ignored `-c/--component`; `--json` parsing lived only in the single-project branch — so multi-project deploys rejected components in every input form.

Now resolves --json first, then -c/--component, then treats all positionals as component IDs when --projects/--fleet picks the target set.

Regression tests cover all three input forms plus genuinely-empty validation and clap positional parsing with explicit --projects.

## Verification
`cargo test --lib deploy::` 192 passed; clippy/rustfmt clean on changed files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Opus 4.6) via opencode
- **Used for:** Root cause and implementation; reviewed and directed by Chris.