### PR TITLE
Enforce resource lifecycle TTLs

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -917,6 +917,7 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
     if output.count == 0 {
         output.hints = bench_list_empty_hints(args, rig_spec, &output.component_id);
     }
+    run_dir.cleanup();
 
     Ok((BenchOutput::List(output), 0))
 }

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -183,6 +183,9 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         &results_path,
     );
     let campaign_contract = fuzz_campaign_contract(fuzz_config.as_ref(), args.seed.as_deref());
+    if success {
+        run_dir.cleanup();
+    }
 
     Ok((
         FuzzRunOutput {

--- a/src/commands/runs/resources.rs
+++ b/src/commands/runs/resources.rs
@@ -498,11 +498,23 @@ fn apply_terminal_workspace_transitions(
             continue;
         };
         if is_terminal_run_status(&run.status) {
-            transition_preserved_runner_workspaces_to_cleanup_pending(index, &run_id);
+            transition_preserved_runner_workspaces_to_cleanup_pending(
+                index,
+                &run_id,
+                default_runner_workspace_ttl().as_str(),
+            );
         }
     }
 
     Ok(())
+}
+
+fn default_runner_workspace_ttl() -> String {
+    homeboy::core::defaults::load_config()
+        .lab
+        .runner_workspace_ttl
+        .filter(|ttl| !ttl.trim().is_empty())
+        .unwrap_or_else(|| "P7D".to_string())
 }
 
 fn is_terminal_run_status(status: &str) -> bool {
@@ -570,7 +582,7 @@ fn sample_resource_lifecycle_index() -> ResourceLifecycleIndex {
             path: "/tmp/homeboy/sample-run-1/workspace".to_string(),
             root_bound: Some("/tmp/homeboy/sample-run-1".to_string()),
             kind: "workspace".to_string(),
-            ttl: Some("P7D".to_string()),
+            ttl: Some("2020-01-01T00:00:00Z".to_string()),
             cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
             evidence_retention: ResourceEvidenceRetention::Manifest,
             cleanup_intent: Default::default(),
@@ -602,7 +614,7 @@ mod tests {
             path: "/tmp/resource".to_string(),
             root_bound: None,
             kind: "workspace".to_string(),
-            ttl: Some("P1D".to_string()),
+            ttl: Some("2020-01-01T00:00:00Z".to_string()),
             cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
             evidence_retention: ResourceEvidenceRetention::Metadata,
             cleanup_intent: ResourceCleanupIntent::DryRun,
@@ -988,6 +1000,7 @@ mod tests {
             ResourceCleanupPolicy::DeleteAfterTtl
         );
         assert_eq!(transitioned.ttl.as_deref(), Some("P7D"));
+        assert_eq!(transitioned.cleanup_intent, ResourceCleanupIntent::Apply);
         assert_eq!(
             transitioned.status,
             ResourceLifecycleResourceStatus::CleanupPending

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -178,6 +178,8 @@ pub fn default_true() -> bool {
 pub struct LabConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preferred_runner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_workspace_ttl: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/core/resource_lifecycle_index.rs
+++ b/src/core/resource_lifecycle_index.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
@@ -171,6 +172,13 @@ pub fn resource_lifecycle_record_is_actionable(record: &ResourceLifecycleRecord)
 }
 
 pub fn resource_lifecycle_record_is_cleanup_eligible(record: &ResourceLifecycleRecord) -> bool {
+    resource_lifecycle_record_is_cleanup_eligible_at(record, chrono::Utc::now())
+}
+
+pub fn resource_lifecycle_record_is_cleanup_eligible_at(
+    record: &ResourceLifecycleRecord,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
     if matches!(record.status, ResourceLifecycleResourceStatus::Cleaned) {
         return false;
     }
@@ -179,15 +187,71 @@ pub fn resource_lifecycle_record_is_cleanup_eligible(record: &ResourceLifecycleR
         return true;
     }
 
+    if matches!(record.cleanup_policy, ResourceCleanupPolicy::DeleteAfterTtl) {
+        return resource_lifecycle_ttl_expired_at(record, now).unwrap_or(false);
+    }
+
     matches!(
         record.status,
         ResourceLifecycleResourceStatus::CleanupPending
     ) || matches!(
         record.cleanup_policy,
-        ResourceCleanupPolicy::DeleteAfterTtl
-            | ResourceCleanupPolicy::DeleteOnSuccess
-            | ResourceCleanupPolicy::DeleteOnTerminal
+        ResourceCleanupPolicy::DeleteOnSuccess | ResourceCleanupPolicy::DeleteOnTerminal
     )
+}
+
+pub fn resource_lifecycle_ttl_expired_at(
+    record: &ResourceLifecycleRecord,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<bool> {
+    let ttl = record.ttl.as_deref()?;
+    if let Ok(deadline) = chrono::DateTime::parse_from_rfc3339(ttl) {
+        return Some(now >= deadline.with_timezone(&chrono::Utc));
+    }
+
+    let ttl_seconds = parse_resource_lifecycle_ttl_seconds(ttl)?;
+    let modified = fs::metadata(&record.path)
+        .and_then(|metadata| metadata.modified())
+        .ok()?;
+    let modified = chrono::DateTime::<chrono::Utc>::from(modified);
+    Some(now.signed_duration_since(modified).num_seconds() >= ttl_seconds as i64)
+}
+
+pub fn resource_lifecycle_path_ttl_expired_at(
+    ttl: &str,
+    modified: SystemTime,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    if let Ok(deadline) = chrono::DateTime::parse_from_rfc3339(ttl) {
+        return now >= deadline.with_timezone(&chrono::Utc);
+    }
+    let Some(ttl_seconds) = parse_resource_lifecycle_ttl_seconds(ttl) else {
+        return false;
+    };
+    let modified = chrono::DateTime::<chrono::Utc>::from(modified);
+    now.signed_duration_since(modified).num_seconds() >= ttl_seconds as i64
+}
+
+fn parse_resource_lifecycle_ttl_seconds(ttl: &str) -> Option<u64> {
+    let ttl = ttl.trim();
+    if ttl.is_empty() {
+        return None;
+    }
+    if let Some(seconds) = ttl.strip_suffix('s').or_else(|| ttl.strip_suffix('S')) {
+        return seconds.parse::<u64>().ok();
+    }
+    let value = ttl.strip_prefix('P')?;
+    if let Some(days) = value.strip_suffix('D') {
+        return days.parse::<u64>().ok().map(|days| days * 24 * 60 * 60);
+    }
+    let time = value.strip_prefix('T')?;
+    if let Some(hours) = time.strip_suffix('H') {
+        return hours.parse::<u64>().ok().map(|hours| hours * 60 * 60);
+    }
+    if let Some(minutes) = time.strip_suffix('M') {
+        return minutes.parse::<u64>().ok().map(|minutes| minutes * 60);
+    }
+    time.strip_suffix('S')?.parse::<u64>().ok()
 }
 
 pub fn resource_lifecycle_cleanup_path(
@@ -341,6 +405,7 @@ pub fn resource_lifecycle_index_from_artifacts(
 pub fn transition_preserved_runner_workspaces_to_cleanup_pending(
     index: &mut ResourceLifecycleIndex,
     run_id: &str,
+    default_ttl: &str,
 ) {
     for record in &mut index.resources {
         if record.run_id == run_id
@@ -350,7 +415,8 @@ pub fn transition_preserved_runner_workspaces_to_cleanup_pending(
             && matches!(record.status, ResourceLifecycleResourceStatus::Active)
         {
             record.cleanup_policy = ResourceCleanupPolicy::DeleteAfterTtl;
-            record.ttl.get_or_insert_with(|| "P7D".to_string());
+            record.ttl.get_or_insert_with(|| default_ttl.to_string());
+            record.cleanup_intent = ResourceCleanupIntent::Apply;
             record.status = ResourceLifecycleResourceStatus::CleanupPending;
         }
     }
@@ -422,7 +488,7 @@ mod tests {
             path: "/tmp/homeboy/run-1/workspace".to_string(),
             root_bound: None,
             kind: "workspace".to_string(),
-            ttl: Some("P7D".to_string()),
+            ttl: Some("2020-01-01T00:00:00Z".to_string()),
             cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
             evidence_retention: ResourceEvidenceRetention::Manifest,
             cleanup_intent: ResourceCleanupIntent::DryRun,
@@ -544,7 +610,7 @@ mod tests {
             &index.resources[0]
         ));
 
-        transition_preserved_runner_workspaces_to_cleanup_pending(&mut index, "run-1");
+        transition_preserved_runner_workspaces_to_cleanup_pending(&mut index, "run-1", "P7D");
 
         assert_eq!(
             index.resources[0].cleanup_policy,
@@ -552,11 +618,39 @@ mod tests {
         );
         assert_eq!(index.resources[0].ttl.as_deref(), Some("P7D"));
         assert_eq!(
+            index.resources[0].cleanup_intent,
+            ResourceCleanupIntent::Apply
+        );
+        assert_eq!(
             index.resources[0].status,
             ResourceLifecycleResourceStatus::CleanupPending
         );
         assert!(resource_lifecycle_record_is_cleanup_eligible(
             &index.resources[0]
+        ));
+    }
+
+    #[test]
+    fn delete_after_ttl_is_cleanup_eligible_only_after_path_age_expires() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let resource_path = tempdir.path().join("resource");
+        std::fs::write(&resource_path, "generated").expect("resource");
+        let resource = ResourceLifecycleRecord {
+            path: resource_path.display().to_string(),
+            ttl: Some("P1D".to_string()),
+            cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
+            status: ResourceLifecycleResourceStatus::CleanupPending,
+            ..record()
+        };
+        let now = chrono::Utc::now();
+
+        assert!(!resource_lifecycle_record_is_cleanup_eligible_at(
+            &resource, now
+        ));
+        assert!(resource_lifecycle_path_ttl_expired_at(
+            "P1D",
+            SystemTime::now() - std::time::Duration::from_secs(2 * 24 * 60 * 60),
+            now
         ));
     }
 

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -7,8 +7,8 @@ use base64::Engine;
 use crate::core::engine::temp;
 use crate::core::error::{Error, Result};
 use crate::core::resource_lifecycle_index::{
-    ResourceCleanupPolicy, ResourceEvidenceRetention, ResourceLifecycle, ResourceLifecycleRecord,
-    ResourceLifecycleResourceStatus,
+    resource_lifecycle_path_ttl_expired_at, ResourceCleanupPolicy, ResourceEvidenceRetention,
+    ResourceLifecycle, ResourceLifecycleRecord, ResourceLifecycleResourceStatus,
 };
 
 use super::super::validation_dependencies::{
@@ -1173,9 +1173,10 @@ fn classify_local_candidate(
     let Some(source_path) = metadata.get("local_path").and_then(|value| value.as_str()) else {
         return Ok(None);
     };
-    if Path::new(source_path).exists() {
+    let reason = prune_candidate_reason(&metadata, path, source_path)?;
+    let Some(reason) = reason else {
         return Ok(None);
-    }
+    };
     Ok(Some(RunnerWorkspacePruneEntry {
         remote_path: path.display().to_string(),
         source_path: source_path.to_string(),
@@ -1197,8 +1198,44 @@ fn classify_local_candidate(
             .map(str::to_string),
         age_seconds,
         bytes: directory_size(path)?,
-        reason: "source_path_missing".to_string(),
+        reason,
     }))
+}
+
+fn prune_candidate_reason(
+    metadata: &serde_json::Value,
+    path: &Path,
+    source_path: &str,
+) -> Result<Option<String>> {
+    if let Some(resource) = metadata.get("resource_lifecycle") {
+        let resource: ResourceLifecycleRecord =
+            serde_json::from_value(resource.clone()).map_err(|err| {
+                Error::internal_json(err.to_string(), Some(path.display().to_string()))
+            })?;
+        if matches!(
+            resource.cleanup_policy,
+            ResourceCleanupPolicy::DeleteAfterTtl
+        ) {
+            if let Some(ttl) = resource.ttl.as_deref() {
+                let modified = fs::metadata(path)
+                    .and_then(|metadata| metadata.modified())
+                    .map_err(|err| {
+                        Error::internal_io(
+                            err.to_string(),
+                            Some("read workspace mtime".to_string()),
+                        )
+                    })?;
+                if resource_lifecycle_path_ttl_expired_at(ttl, modified, chrono::Utc::now()) {
+                    return Ok(Some("resource_ttl_expired".to_string()));
+                }
+            }
+        }
+    }
+
+    if !Path::new(source_path).exists() {
+        return Ok(Some("source_path_missing".to_string()));
+    }
+    Ok(None)
 }
 
 fn prune_candidates_ssh(
@@ -1234,9 +1271,10 @@ fn prune_candidates_ssh(
         let Some(source_path) = metadata.get("local_path").and_then(|value| value.as_str()) else {
             continue;
         };
-        if Path::new(source_path).exists() {
+        let reason = prune_candidate_reason_from_decoded_metadata(&metadata, age_seconds);
+        let Some(reason) = reason else {
             continue;
-        }
+        };
         candidates.push(RunnerWorkspacePruneEntry {
             remote_path,
             source_path: source_path.to_string(),
@@ -1258,7 +1296,7 @@ fn prune_candidates_ssh(
                 .map(str::to_string),
             age_seconds,
             bytes,
-            reason: "source_path_missing".to_string(),
+            reason,
         });
     }
     candidates.sort_by(|a, b| {
@@ -1267,6 +1305,32 @@ fn prune_candidates_ssh(
             .then_with(|| b.age_seconds.cmp(&a.age_seconds))
     });
     Ok(candidates)
+}
+
+fn prune_candidate_reason_from_decoded_metadata(
+    metadata: &serde_json::Value,
+    age_seconds: u64,
+) -> Option<String> {
+    if let Some(resource) = metadata.get("resource_lifecycle") {
+        if resource
+            .get("cleanup_policy")
+            .and_then(|value| value.as_str())
+            == Some("delete_after_ttl")
+        {
+            if let Some(ttl) = resource.get("ttl").and_then(|value| value.as_str()) {
+                let modified = std::time::SystemTime::now()
+                    .checked_sub(std::time::Duration::from_secs(age_seconds))?;
+                if resource_lifecycle_path_ttl_expired_at(ttl, modified, chrono::Utc::now()) {
+                    return Some("resource_ttl_expired".to_string());
+                }
+            }
+        }
+    }
+
+    let source_path = metadata
+        .get("local_path")
+        .and_then(|value| value.as_str())?;
+    (!Path::new(source_path).exists()).then(|| "source_path_missing".to_string())
 }
 
 pub(crate) fn prune_scan_command(root: &str, min_age: u64) -> String {

--- a/src/core/runner/workspace/tests/prune.rs
+++ b/src/core/runner/workspace/tests/prune.rs
@@ -120,6 +120,55 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
 }
 
 #[test]
+fn prune_workspaces_reaps_ttl_expired_lifecycle_workspace_with_live_source() {
+    crate::test_support::with_isolated_home(|_| {
+        let source_parent = tempfile::tempdir().expect("source parent");
+        let source = source_parent.path().join("live-source");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        fs::create_dir_all(&source).expect("source dir");
+        fs::write(source.join("file.txt"), "live\n").expect("source file");
+        crate::core::runner::create(
+            &format!(
+                r#"{{"id":"lab-local-prune-ttl","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let (synced, _) = sync_workspace(
+            "lab-local-prune-ttl",
+            sync_options(source.display().to_string()),
+        )
+        .expect("sync workspace");
+        let metadata_path = Path::new(&synced.remote_path).join(".homeboy/runner-workspace.json");
+        let mut metadata: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&metadata_path).expect("metadata"))
+                .expect("metadata json");
+        metadata["resource_lifecycle"]["cleanup_policy"] = serde_json::json!("delete_after_ttl");
+        metadata["resource_lifecycle"]["ttl"] = serde_json::json!("2020-01-01T00:00:00Z");
+        fs::write(&metadata_path, metadata.to_string()).expect("write metadata");
+
+        let (output, exit_code) = prune_workspaces(
+            "lab-local-prune-ttl",
+            RunnerWorkspacePruneOptions {
+                apply: false,
+                min_age_hours: 0,
+                limit: 10,
+                passes: 1,
+            },
+        )
+        .expect("prune preview");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.candidates.len(), 1);
+        assert_eq!(output.candidates[0].remote_path, synced.remote_path);
+        assert_eq!(output.candidates[0].reason, "resource_ttl_expired");
+        assert!(Path::new(&synced.remote_path).exists());
+        assert!(source.exists());
+    });
+}
+
+#[test]
 fn prune_workspaces_preview_reports_synthetic_odd_path_without_deleting() {
     crate::test_support::with_isolated_home(|_| {
         let runner_root = tempfile::tempdir().expect("runner root tempdir");


### PR DESCRIPTION
## Problem
ResourceLifecycleRecord carried ttl metadata but DeleteAfterTtl records were treated as cleanup-eligible without checking time, and runner workspace prune only considered missing source paths. Lab-side durable workspaces could also remain Preserve forever after terminal runs.

## Design
- Make DeleteAfterTtl eligibility time-aware for RFC3339 deadlines and simple ISO-style durations such as P7D/PT1H/PT30M/PT30S, using resource path mtime for duration TTLs.
- Transition preserved runner workspaces to DeleteAfterTtl + apply intent when their owning run is terminal, with default lab.runner_workspace_ttl config and P7D fallback.
- Extend runner workspace prune to consume resource_lifecycle metadata and surface TTL-expired workspaces as resource_ttl_expired candidates while preserving the existing source_path_missing path.
- Clean bench list and successful fuzz run RunDir directories through the existing RunDir cleanup mechanism.

## LOC delta
- 243 insertions, 17 deletions.

## Verification
- cargo fmt --check
- cargo check --all-targets
- cargo test resource_lifecycle --lib
- cargo test runs::resources --lib
- cargo test prune_workspaces --lib
- cargo test cleanup_runtime_tmp --lib

## Issue Links
Part of #7502. Advances #6687. Related: #6678, #6752, #7443.

## Shipped vs deferred
- Shipped: TTL-aware cleanup eligibility, terminal preserved-workspace TTL transition, runner workspace prune TTL candidates, bounded existing cleanup plans via --limit, bench/fuzz RunDir success cleanup.
- Deferred: daemon/global periodic automatic reaper pass and byte-budget limit per invocation. This PR keeps deletion behind the existing runs resources / runner workspace prune surfaces instead of adding hidden mutation at every command boundary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (claude-fable-5) orchestrator with GPT 5.5 coding subagent
- **Used for:** Investigation identified unenforced TTLs and preserved-workspace scrap; the subagent implemented the reaper and cleanup wiring.