### PR TITLE
Add transport-neutral runner file transfer

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -18,8 +19,8 @@ use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnal
 use crate::core::paths;
 use crate::core::process::pid_is_running;
 use crate::core::runner::{
-    execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process, Runner,
-    RunnerProcessRequest,
+    execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
+    BrokerScope, Runner, RunnerProcessRequest,
 };
 use crate::core::secret_env_plan::SecretEnvPlan;
 use crate::core::source_snapshot::SourceSnapshot;
@@ -147,6 +148,19 @@ struct ExecRequest {
     runner_workload: Option<RunnerWorkload>,
     #[serde(default)]
     lifecycle: Option<RunnerJobLifecycleMetadata>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FilePathRequest {
+    runner_id: String,
+    path: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FileUploadRequest {
+    runner_id: String,
+    path: String,
+    content_base64: String,
 }
 
 pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
@@ -559,11 +573,26 @@ where
             Ok(body) => daemon_endpoint_response("jobs.exec", body),
             Err(err) => error_response(400, err),
         },
+        ("POST", "/files/mkdir") => match create_runner_file_directory(body, &broker_auth) {
+            Ok(body) => daemon_endpoint_response("files.mkdir", body),
+            Err(err) => remote_runner::auth_or_bad_request(err),
+        },
+        ("POST", "/files/upload") => match upload_runner_file(body, &broker_auth) {
+            Ok(body) => daemon_endpoint_response("files.upload", body),
+            Err(err) => remote_runner::auth_or_bad_request(err),
+        },
+        ("POST", "/files/download") => match download_runner_file(body, &broker_auth) {
+            Ok(body) => daemon_endpoint_response("files.download", body),
+            Err(err) => remote_runner::auth_or_bad_request(err),
+        },
         ("GET", "/exec") => HttpResponse {
             status_code: 405,
             body: json!({ "error": "method_not_allowed" }),
             artifact: None,
         },
+        ("GET", "/files/mkdir") | ("GET", "/files/upload") | ("GET", "/files/download") => {
+            method_not_allowed()
+        }
         ("POST", "/runner/sessions")
         | ("POST", "/runner/jobs")
         | ("POST", "/runner/jobs/reconcile")
@@ -581,6 +610,177 @@ where
             remote_runner::route(method, path, body, job_store, &broker_auth)
         }
         _ => route_read_only_api(method, path, body, job_store, analysis_runner),
+    }
+}
+
+fn create_runner_file_directory(
+    body: Option<serde_json::Value>,
+    broker_auth: &remote_runner::BrokerAuthContext,
+) -> Result<serde_json::Value> {
+    let request: FilePathRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
+        .map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("parse file mkdir request".to_string()),
+            )
+        })?;
+    broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
+    let path = resolve_runner_workspace_path(&request.runner_id, &request.path)?;
+    fs::create_dir_all(&path).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("create {}", path.display())))
+    })?;
+    Ok(json!({
+        "runner_id": request.runner_id,
+        "path": path.display().to_string(),
+    }))
+}
+
+fn upload_runner_file(
+    body: Option<serde_json::Value>,
+    broker_auth: &remote_runner::BrokerAuthContext,
+) -> Result<serde_json::Value> {
+    let request: FileUploadRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
+        .map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("parse file upload request".to_string()),
+            )
+        })?;
+    broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
+    let path = resolve_runner_workspace_path(&request.runner_id, &request.path)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    let content = base64::engine::general_purpose::STANDARD
+        .decode(&request.content_base64)
+        .map_err(|err| {
+            Error::validation_invalid_argument(
+                "content_base64",
+                format!("runner file upload content is not valid base64: {err}"),
+                None,
+                None,
+            )
+        })?;
+    fs::write(&path, &content).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("write {}", path.display())))
+    })?;
+    Ok(json!({
+        "runner_id": request.runner_id,
+        "path": path.display().to_string(),
+        "size_bytes": content.len(),
+    }))
+}
+
+fn download_runner_file(
+    body: Option<serde_json::Value>,
+    broker_auth: &remote_runner::BrokerAuthContext,
+) -> Result<serde_json::Value> {
+    let request: FilePathRequest = serde_json::from_value(body.unwrap_or_else(|| json!({})))
+        .map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("parse file download request".to_string()),
+            )
+        })?;
+    broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
+    let path = resolve_runner_workspace_path(&request.runner_id, &request.path)?;
+    let content = fs::read(&path).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
+    })?;
+    Ok(json!({
+        "runner_id": request.runner_id,
+        "path": path.display().to_string(),
+        "size_bytes": content.len(),
+        "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
+    }))
+}
+
+fn resolve_runner_workspace_path(runner_id: &str, requested_path: &str) -> Result<PathBuf> {
+    let runner = crate::core::runner::load(runner_id)?;
+    let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace_root",
+            format!("runner `{runner_id}` file API requires workspace_root"),
+            Some(runner_id.to_string()),
+            Some(vec![
+                "Configure the runner workspace_root before using daemon file transfer."
+                    .to_string(),
+            ]),
+        )
+    })?;
+    let root = fs::canonicalize(workspace_root).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!(
+                "canonicalize runner workspace_root {workspace_root}"
+            )),
+        )
+    })?;
+    let requested = Path::new(requested_path);
+    let candidate = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        root.join(requested)
+    };
+    let normalized = canonicalize_existing_prefix(&normalize_path(&candidate));
+    if !normalized.starts_with(&root) {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "runner file path must stay inside the runner workspace_root",
+            Some(requested_path.to_string()),
+            Some(vec![format!(
+                "Runner `{runner_id}` workspace_root is {}.",
+                root.display()
+            )]),
+        ));
+    }
+    Ok(normalized)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn canonicalize_existing_prefix(path: &Path) -> PathBuf {
+    if let Ok(canonical) = fs::canonicalize(path) {
+        return canonical;
+    }
+
+    let mut missing = Vec::new();
+    let mut current = path;
+    loop {
+        if let Ok(canonical) = fs::canonicalize(current) {
+            let mut resolved = canonical;
+            for component in missing.iter().rev() {
+                resolved.push(component);
+            }
+            return resolved;
+        }
+        let Some(file_name) = current.file_name() else {
+            return path.to_path_buf();
+        };
+        missing.push(file_name.to_os_string());
+        let Some(parent) = current.parent() else {
+            return path.to_path_buf();
+        };
+        current = parent;
     }
 }
 

--- a/src/core/daemon/remote_runner.rs
+++ b/src/core/daemon/remote_runner.rs
@@ -37,7 +37,11 @@ impl BrokerAuthContext {
 
     /// Authorize this request against the on-disk broker auth store for the
     /// given scope and (optionally) the runner id carried in the request body.
-    fn authorize(&self, required: BrokerScope, runner_id: Option<&str>) -> Result<()> {
+    pub(in crate::core::daemon) fn authorize(
+        &self,
+        required: BrokerScope,
+        runner_id: Option<&str>,
+    ) -> Result<()> {
         if self.trusted_local {
             return Ok(());
         }
@@ -548,7 +552,7 @@ fn cancel(job_id: Uuid, job_store: &JobStore, auth: &BrokerAuthContext) -> Resul
 /// Map a handler error to an HTTP response. Broker auth rejections become
 /// `401 Unauthorized` (so unauthenticated callers see a distinct status), all
 /// other errors keep the existing `400 Bad Request` contract.
-fn auth_or_bad_request(err: Error) -> HttpResponse {
+pub(in crate::core::daemon) fn auth_or_bad_request(err: Error) -> HttpResponse {
     if err.code == crate::core::error::ErrorCode::BrokerAuthDenied {
         error_response(401, err)
     } else {

--- a/src/core/runner/transport.rs
+++ b/src/core/runner/transport.rs
@@ -1,11 +1,18 @@
+use std::fs;
+use std::time::Duration;
+
+use base64::Engine;
+use reqwest::blocking::Client;
+use serde::Deserialize;
 use serde_json::json;
+use serde_json::Value;
 
 use crate::core::engine::shell;
 use crate::core::error::{Error, ErrorCode, Result};
 use crate::core::server::{self, SshClient};
 
 use super::session::{RunnerSession, RunnerStatusReport, RunnerTunnelMode};
-use super::{Runner, RunnerKind};
+use super::{broker_auth, broker_http, Runner, RunnerKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RunnerSessionHandle {
@@ -37,6 +44,10 @@ pub(crate) enum RunnerTransport {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RunnerFileTransferCapability {
+    DaemonHttp {
+        endpoint_url: String,
+        broker: bool,
+    },
     DirectSsh {
         server_id: String,
     },
@@ -49,7 +60,28 @@ pub(crate) enum RunnerFileTransferCapability {
 
 pub(crate) struct RunnerFileTransfer {
     runner_id: String,
-    client: SshClient,
+    channel: RunnerFileChannel,
+}
+
+enum RunnerFileChannel {
+    DirectSsh(SshClient),
+    DaemonHttp {
+        client: Client,
+        endpoint_url: String,
+        broker_token: Option<String>,
+    },
+    BrokerHttp {
+        client: Client,
+        endpoint_url: String,
+        broker_token: Option<String>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct HttpFileEnvelope {
+    success: bool,
+    data: Option<Value>,
+    error: Option<Value>,
 }
 
 impl RunnerFileTransferCapability {
@@ -58,19 +90,21 @@ impl RunnerFileTransferCapability {
         status: Option<&RunnerStatusReport>,
     ) -> RunnerFileTransferCapability {
         match select_runner_transport(runner, status, false) {
-            RunnerTransport::ReverseBroker(handle) => RunnerFileTransferCapability::Unsupported {
-                transport: "reverse_broker",
-                reason: "Lab runner file transfer over the reverse broker is not implemented yet",
-                broker_url: Some(handle.endpoint_url().to_string()),
+            RunnerTransport::ReverseBroker(handle) => RunnerFileTransferCapability::DaemonHttp {
+                endpoint_url: handle.endpoint_url().to_string(),
+                broker: true,
             },
             RunnerTransport::Local => RunnerFileTransferCapability::Unsupported {
                 transport: "local",
                 reason: "Lab runner file transfer requires a remote runner transport",
                 broker_url: None,
             },
-            RunnerTransport::DirectDaemon(_)
-            | RunnerTransport::DiagnosticSsh
-            | RunnerTransport::Unavailable => match (runner.kind.clone(), runner.server_id.clone()) {
+            RunnerTransport::DirectDaemon(handle) => RunnerFileTransferCapability::DaemonHttp {
+                endpoint_url: handle.endpoint_url().to_string(),
+                broker: false,
+            },
+            RunnerTransport::DiagnosticSsh | RunnerTransport::Unavailable => {
+                match (runner.kind.clone(), runner.server_id.clone()) {
                 (RunnerKind::Ssh, Some(server_id)) => {
                     RunnerFileTransferCapability::DirectSsh { server_id }
                 }
@@ -84,13 +118,15 @@ impl RunnerFileTransferCapability {
                     reason: "Lab runner file transfer requires a remote runner transport",
                     broker_url: None,
                 },
-            },
+                }
+            }
         }
     }
 
-    pub(crate) fn ensure_supported(&self, runner_id: &str) -> Result<&str> {
+    pub(crate) fn ensure_supported(&self, runner_id: &str) -> Result<()> {
         match self {
-            RunnerFileTransferCapability::DirectSsh { server_id } => Ok(server_id.as_str()),
+            RunnerFileTransferCapability::DaemonHttp { .. }
+            | RunnerFileTransferCapability::DirectSsh { .. } => Ok(()),
             RunnerFileTransferCapability::Unsupported {
                 transport,
                 reason,
@@ -111,56 +147,235 @@ impl RunnerFileTransfer {
         status: Option<&RunnerStatusReport>,
     ) -> Result<RunnerFileTransfer> {
         let capability = RunnerFileTransferCapability::for_runner(runner, status);
-        let server_id = capability.ensure_supported(&runner.id)?;
-        let server = server::load(server_id)?;
-        let mut client = SshClient::from_server(&server, server_id)?;
-        client.env.extend(runner.env.clone());
+        capability.ensure_supported(&runner.id)?;
+        let channel = match capability {
+            RunnerFileTransferCapability::DaemonHttp {
+                endpoint_url,
+                broker,
+            } => {
+                let mut client_builder = Client::builder().timeout(Duration::from_secs(30));
+                if !broker {
+                    client_builder = client_builder.no_proxy();
+                }
+                let client = client_builder.build().map_err(|err| {
+                    Error::internal_unexpected(format!("build runner file HTTP client: {err}"))
+                })?;
+                let broker_token = broker_auth::broker_token_from_env();
+                if broker {
+                    RunnerFileChannel::BrokerHttp {
+                        client,
+                        endpoint_url,
+                        broker_token,
+                    }
+                } else {
+                    RunnerFileChannel::DaemonHttp {
+                        client,
+                        endpoint_url,
+                        broker_token,
+                    }
+                }
+            }
+            RunnerFileTransferCapability::DirectSsh { server_id } => {
+                let server = server::load(&server_id)?;
+                let mut client = SshClient::from_server(&server, &server_id)?;
+                client.env.extend(runner.env.clone());
+                RunnerFileChannel::DirectSsh(client)
+            }
+            RunnerFileTransferCapability::Unsupported { .. } => unreachable!("checked above"),
+        };
         Ok(RunnerFileTransfer {
             runner_id: runner.id.clone(),
-            client,
+            channel,
         })
     }
 
     pub(crate) fn ensure_directory(&self, remote_dir: &str) -> Result<()> {
-        let mkdir = self
-            .client
-            .execute(&format!("mkdir -p {}", shell::quote_arg(remote_dir)));
-        if !mkdir.success {
-            return Err(file_transfer_operation_error(
-                &self.runner_id,
-                "mkdir",
-                remote_dir,
-                mkdir.stderr,
-            ));
+        match &self.channel {
+            RunnerFileChannel::DirectSsh(client) => {
+                let mkdir = client.execute(&format!("mkdir -p {}", shell::quote_arg(remote_dir)));
+                if !mkdir.success {
+                    return Err(file_transfer_operation_error(
+                        &self.runner_id,
+                        "mkdir",
+                        remote_dir,
+                        mkdir.stderr,
+                        "direct_ssh",
+                    ));
+                }
+            }
+            RunnerFileChannel::DaemonHttp { .. } | RunnerFileChannel::BrokerHttp { .. } => {
+                self.http_post_json(
+                    "/files/mkdir",
+                    json!({ "runner_id": &self.runner_id, "path": remote_dir }),
+                    "mkdir",
+                    remote_dir,
+                )?;
+            }
         }
         Ok(())
     }
 
     pub(crate) fn upload_file(&self, local_path: &str, remote_path: &str) -> Result<()> {
-        let upload = self.client.upload_file(local_path, remote_path);
-        if !upload.success {
-            return Err(file_transfer_operation_error(
-                &self.runner_id,
-                "upload",
-                remote_path,
-                upload.stderr,
-            ));
+        match &self.channel {
+            RunnerFileChannel::DirectSsh(client) => {
+                let upload = client.upload_file(local_path, remote_path);
+                if !upload.success {
+                    return Err(file_transfer_operation_error(
+                        &self.runner_id,
+                        "upload",
+                        remote_path,
+                        upload.stderr,
+                        "direct_ssh",
+                    ));
+                }
+            }
+            RunnerFileChannel::DaemonHttp { .. } | RunnerFileChannel::BrokerHttp { .. } => {
+                let content = fs::read(local_path).map_err(|err| {
+                    Error::internal_io(err.to_string(), Some(format!("read {local_path}")))
+                })?;
+                self.http_post_json(
+                    "/files/upload",
+                    json!({
+                        "runner_id": &self.runner_id,
+                        "path": remote_path,
+                        "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
+                    }),
+                    "upload",
+                    remote_path,
+                )?;
+            }
         }
         Ok(())
     }
 
     pub(crate) fn download_file(&self, remote_path: &str, local_path: &str) -> Result<()> {
-        let download = self.client.download_file(remote_path, local_path);
-        if !download.success {
-            return Err(file_transfer_operation_error(
-                &self.runner_id,
-                "download",
-                remote_path,
-                download.stderr,
-            ));
+        match &self.channel {
+            RunnerFileChannel::DirectSsh(client) => {
+                let download = client.download_file(remote_path, local_path);
+                if !download.success {
+                    return Err(file_transfer_operation_error(
+                        &self.runner_id,
+                        "download",
+                        remote_path,
+                        download.stderr,
+                        "direct_ssh",
+                    ));
+                }
+            }
+            RunnerFileChannel::DaemonHttp { .. } | RunnerFileChannel::BrokerHttp { .. } => {
+                let body = self.http_post_json(
+                    "/files/download",
+                    json!({ "runner_id": &self.runner_id, "path": remote_path }),
+                    "download",
+                    remote_path,
+                )?;
+                let encoded = body
+                    .get("content_base64")
+                    .and_then(|value| value.as_str())
+                    .ok_or_else(|| {
+                        Error::internal_unexpected("runner file download missing content_base64")
+                    })?;
+                let content = base64::engine::general_purpose::STANDARD
+                    .decode(encoded)
+                    .map_err(|err| {
+                        Error::internal_json(
+                            err.to_string(),
+                            Some("decode runner file download".to_string()),
+                        )
+                    })?;
+                fs::write(local_path, content).map_err(|err| {
+                    Error::internal_io(err.to_string(), Some(format!("write {local_path}")))
+                })?;
+            }
         }
         Ok(())
     }
+
+    fn http_post_json(
+        &self,
+        path: &str,
+        body: Value,
+        operation: &str,
+        remote_path: &str,
+    ) -> Result<Value> {
+        match &self.channel {
+            RunnerFileChannel::DirectSsh(_) => unreachable!("direct SSH does not use HTTP"),
+            RunnerFileChannel::BrokerHttp {
+                client,
+                endpoint_url,
+                broker_token,
+            } => broker_http::post_json(
+                client,
+                endpoint_url,
+                path,
+                body,
+                "runner file broker request",
+                broker_token.as_deref(),
+            )
+            .map_err(|err| {
+                http_file_transfer_error(
+                    &self.runner_id,
+                    operation,
+                    remote_path,
+                    err,
+                    "reverse_broker",
+                )
+            }),
+            RunnerFileChannel::DaemonHttp {
+                client,
+                endpoint_url,
+                broker_token,
+            } => daemon_file_post_json(client, endpoint_url, path, body, broker_token.as_deref())
+                .map_err(|err| {
+                    http_file_transfer_error(
+                        &self.runner_id,
+                        operation,
+                        remote_path,
+                        err,
+                        "daemon_http",
+                    )
+                }),
+        }
+    }
+}
+
+fn daemon_file_post_json(
+    client: &Client,
+    base_url: &str,
+    path: &str,
+    body: Value,
+    token: Option<&str>,
+) -> Result<Value> {
+    let mut request = client
+        .post(format!("{}{}", base_url.trim_end_matches('/'), path))
+        .json(&body);
+    if let Some(token) = token.filter(|token| !token.trim().is_empty()) {
+        request = request
+            .header(broker_auth::BROKER_TOKEN_HEADER, token)
+            .bearer_auth(token);
+    }
+    let response = request
+        .send()
+        .map_err(|err| Error::internal_unexpected(format!("runner file daemon request: {err}")))?;
+    let status_code = response.status().as_u16();
+    let envelope: HttpFileEnvelope = response.json().map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse runner file daemon response".to_string()),
+        )
+    })?;
+    if status_code >= 400 || !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "runner file daemon request failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+    let data = envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("runner file daemon response missing data"))?;
+    data.get("body")
+        .cloned()
+        .ok_or_else(|| Error::internal_unexpected("runner file daemon response missing data.body"))
 }
 
 pub(crate) fn select_runner_transport(
@@ -230,6 +445,7 @@ fn file_transfer_operation_error(
     operation: &str,
     remote_path: &str,
     stderr: String,
+    transport: &str,
 ) -> Error {
     let mut error = Error::new(
         ErrorCode::RunnerLabTransportFailure,
@@ -242,7 +458,32 @@ fn file_transfer_operation_error(
             "operation": operation,
             "remote_path": remote_path,
             "stderr": stderr,
-            "transport": "direct_ssh",
+            "transport": transport,
+        }),
+    );
+    error.retryable = Some(true);
+    error
+}
+
+fn http_file_transfer_error(
+    runner_id: &str,
+    operation: &str,
+    remote_path: &str,
+    source: Error,
+    transport: &str,
+) -> Error {
+    let mut error = Error::new(
+        ErrorCode::RunnerLabTransportFailure,
+        format!(
+            "Lab runner file transfer `{operation}` failed on runner `{runner_id}` for `{remote_path}`: {}",
+            source.message
+        ),
+        json!({
+            "runner_id": runner_id,
+            "operation": operation,
+            "remote_path": remote_path,
+            "transport": transport,
+            "source": source.details,
         }),
     );
     error.retryable = Some(true);
@@ -360,21 +601,34 @@ mod tests {
     }
 
     #[test]
-    fn file_transfer_errors_for_reverse_broker_with_actionable_metadata() {
+    fn file_transfer_selects_reverse_broker_http_when_connected() {
         let runner = runner(RunnerKind::Ssh);
         let mut session = session(RunnerTunnelMode::Reverse);
         session.broker_url = Some("https://broker.example".to_string());
         let capability = RunnerFileTransferCapability::for_runner(&runner, Some(&status(session)));
-        let err = capability
-            .ensure_supported("test-runner")
-            .expect_err("reverse broker file transfer should be unsupported");
 
-        assert_eq!(err.code, ErrorCode::RunnerLabTransportFailure);
-        assert_eq!(err.details["transport"], "reverse_broker");
-        assert_eq!(err.details["broker_url"], "https://broker.example");
-        assert_eq!(err.details["missing_capability"], "runner_file_transfer");
-        assert!(err
-            .message
-            .contains("does not currently support controller file transfer"));
+        assert_eq!(
+            capability,
+            RunnerFileTransferCapability::DaemonHttp {
+                endpoint_url: "https://broker.example".to_string(),
+                broker: true,
+            }
+        );
+    }
+
+    #[test]
+    fn file_transfer_selects_direct_daemon_http_when_connected() {
+        let runner = runner(RunnerKind::Ssh);
+        let mut session = session(RunnerTunnelMode::DirectSsh);
+        session.local_url = Some("http://127.0.0.1:1234".to_string());
+        let capability = RunnerFileTransferCapability::for_runner(&runner, Some(&status(session)));
+
+        assert_eq!(
+            capability,
+            RunnerFileTransferCapability::DaemonHttp {
+                endpoint_url: "http://127.0.0.1:1234".to_string(),
+                broker: false,
+            }
+        );
     }
 }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore};
 use crate::core::observation::{ArtifactRecord, NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
+use base64::Engine;
 
 const DAEMON_TEST_RESPONSE_LIMIT_BYTES: u64 = 64 * 1024;
 
@@ -32,6 +33,19 @@ fn write_daemon_state_for_test(state: &DaemonState) {
     let path = state_path().expect("state path");
     std::fs::create_dir_all(path.parent().expect("state parent")).expect("state dir");
     std::fs::write(&path, serde_json::to_string(state).expect("state json")).expect("write state");
+}
+
+fn create_local_runner_for_file_api(id: &str, workspace_root: &std::path::Path) {
+    crate::core::runner::create(
+        &serde_json::json!({
+            "id": id,
+            "kind": "local",
+            "workspace_root": workspace_root.display().to_string(),
+        })
+        .to_string(),
+        false,
+    )
+    .expect("create local runner");
 }
 
 #[test]
@@ -93,6 +107,107 @@ fn health_route_refreshes_daemon_lease_heartbeat() {
     assert_eq!(response.status_code, 200);
     assert_eq!(response.body["lease"]["lease_id"], state.lease_id);
     assert_ne!(refreshed.last_seen_at, state.last_seen_at);
+}
+
+#[test]
+fn file_route_rejects_paths_outside_runner_workspace_root() {
+    let _home = HomeGuard::new();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    create_local_runner_for_file_api("file-lab", &workspace);
+
+    let response = route_with_job_store_and_body(
+        "POST",
+        "/files/download",
+        Some(serde_json::json!({
+            "runner_id": "file-lab",
+            "path": workspace.join("..").join("secret.txt").display().to_string(),
+        })),
+        &JobStore::default(),
+    );
+
+    assert_eq!(response.status_code, 400);
+    assert_eq!(response.body["details"]["field"], "path");
+    assert!(response.body["message"]
+        .as_str()
+        .expect("message")
+        .contains("workspace_root"));
+}
+
+#[test]
+fn file_route_requires_broker_submit_auth_for_untrusted_requests() {
+    let _home = HomeGuard::new();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    create_local_runner_for_file_api("file-lab", &workspace);
+
+    let response = route_with_job_store_and_body_and_runner_and_auth(
+        "POST",
+        "/files/download",
+        Some(serde_json::json!({
+            "runner_id": "file-lab",
+            "path": "report.json",
+        })),
+        &JobStore::default(),
+        UnsupportedAnalysisJobRunner,
+        remote_runner::BrokerAuthContext {
+            token: None,
+            loopback_bind: false,
+            trusted_local: false,
+        },
+    );
+
+    assert_eq!(response.status_code, 401);
+    assert_eq!(response.body["error"], "broker.auth_denied");
+}
+
+#[test]
+fn file_routes_upload_and_download_inside_runner_workspace_root() {
+    let _home = HomeGuard::new();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    create_local_runner_for_file_api("file-lab", &workspace);
+
+    let upload = route_with_job_store_and_body(
+        "POST",
+        "/files/upload",
+        Some(serde_json::json!({
+            "runner_id": "file-lab",
+            "path": "nested/report.json",
+            "content_base64": base64::engine::general_purpose::STANDARD.encode(br#"{"ok":true}"#),
+        })),
+        &JobStore::default(),
+    );
+    assert_eq!(upload.status_code, 200, "upload body: {}", upload.body);
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("nested/report.json")).expect("uploaded file"),
+        r#"{"ok":true}"#
+    );
+
+    let download = route_with_job_store_and_body(
+        "POST",
+        "/files/download",
+        Some(serde_json::json!({
+            "runner_id": "file-lab",
+            "path": workspace.join("nested/report.json").display().to_string(),
+        })),
+        &JobStore::default(),
+    );
+    assert_eq!(
+        download.status_code, 200,
+        "download body: {}",
+        download.body
+    );
+    let encoded = download.body["body"]["content_base64"]
+        .as_str()
+        .expect("content_base64");
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .expect("decode content");
+    assert_eq!(decoded, br#"{"ok":true}"#);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds daemon HTTP file endpoints for mkdir/upload/download using inline base64 payloads.
- Enforces runner workspace-root path confinement, including traversal rejection and canonical existing-prefix handling.
- Mirrors the same file endpoints through reverse-broker HTTP with broker submit auth.
- Routes Lab @file upload and structured-output download through a shared runner file channel that selects direct daemon HTTP, reverse broker HTTP, or direct SSH fallback from the active runner transport.

## Design
- File API: POST /files/mkdir, /files/upload, and /files/download accept runner_id + path, with upload/download content encoded as content_base64. The daemon resolves paths against the runner workspace_root and rejects paths outside that root.
- Shared transfer abstraction: RunnerFileTransfer now owns a transport-specific channel. Connected direct-daemon sessions use loopback daemon HTTP; reverse sessions use broker HTTP; disconnected SSH runners keep the existing direct SSH behavior.
- Shared job flow: deferred. This PR ships the #7501 file API increment and leaves daemon/broker execution-flow dedupe as follow-up to avoid widening the review surface beyond the file-transfer fix.

## LOC delta
- 4 files changed: 633 insertions, 60 deletions.

## Verification
- cargo fmt --check: passed
- cargo check --all-targets: passed
- cargo test file_route: passed, 4 passed
- cargo test runner::transport::tests: passed, 6 passed
- cargo test core::daemon::daemon_test: passed, 37 passed
- cargo test core::runner::execution::tests: passed, 82 passed

Closes #7501. Part of #6684-adjacent transport consolidation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (claude-fable-5) orchestrator with GPT 5.5 coding subagent
- **Used for:** Investigation identified the dual transport paths; the subagent designed and implemented the shared file API and job flow.
