### PR TITLE
Add unified activity surface

### DIFF
--- a/docs/commands/activity.md
+++ b/docs/commands/activity.md
@@ -1,0 +1,31 @@
+# `homeboy activity`
+
+Unified read-only activity surface for orchestrators and operators asking what Homeboy is doing now and what just finished.
+
+## Usage
+
+```bash
+homeboy activity
+homeboy activity list --limit 50
+homeboy activity show <id>
+homeboy activity watch <id> --timeout 30m
+```
+
+`<id>` resolves across observation run ids, agent-task run ids, and runner daemon job ids.
+
+## Output
+
+JSON output uses the standard command-result envelope with `data.schema = homeboy/activity-report/v1`. The activity payload normalizes observation runs, agent-task lifecycle records, daemon jobs, and connected runner sessions into `ActivityItem` records with:
+
+- `id`, `kind`, `source_store`, `state`
+- timestamps: `created_at`, `updated_at`, `finished_at`
+- runner refs: `runner_id`, `job_id`, `transport`
+- cross refs: `run_id`, `agent_task_run_id`, `runner_job_id`
+- artifact/evidence refs
+- structured `next_actions` with `label` and exact `command`
+
+Human output is a compact table followed by next-action command lines per item.
+
+## Scope
+
+This is a local read model only. It does not create a daemon, event bus, or offloaded job, and the Lab contract marks it local-only.

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -1,6 +1,7 @@
 # Commands index
 
 - [api](api.md)
+- [activity](activity.md) — unified active and recently finished Homeboy work
 - [agent-task](agent-task.md)
 - [artifact-postprocess](artifact-postprocess.md) — generic helper-driven postprocessing for persisted artifact roots
 - [audit](audit.md) — code convention drift and structural analysis

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -4,11 +4,11 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use crate::commands::{
-    agent_task, api, artifact_postprocess, audit, audit_baseline, auth, bench, build, changelog,
-    changes, ci, cleanup, component, config, contract, daemon, db, deploy, extension, file, fleet,
-    fuzz, git, http, issues, lint, logs, manifest, observe, project, refactor, refs, release,
-    report, review, rig, runner, runs, runtime, self_cmd, server, ssh, stack, status, test, trace,
-    triage, tunnel, undo, upgrade, version, worktree,
+    activity, agent_task, api, artifact_postprocess, audit, audit_baseline, auth, bench, build,
+    changelog, changes, ci, cleanup, component, config, contract, daemon, db, deploy, extension,
+    file, fleet, fuzz, git, http, issues, lint, logs, manifest, observe, project, refactor, refs,
+    release, report, review, rig, runner, runs, runtime, self_cmd, server, ssh, stack, status,
+    test, trace, triage, tunnel, undo, upgrade, version, worktree,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -83,6 +83,8 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Unified view of active and recently finished Homeboy work
+    Activity(activity::ActivityArgs),
     /// Run generic agent task plans
     #[command(name = "agent-task")]
     AgentTask(agent_task::AgentTaskArgs),
@@ -559,6 +561,7 @@ mod entry_command_impls {
     impl Commands {
         pub fn top_level_name(&self) -> &'static str {
             match self {
+                Commands::Activity(_) => "activity",
                 Commands::AgentTask(_) => "agent-task",
                 Commands::Project(_) => "project",
                 Commands::Ssh(_) => "ssh",

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -232,7 +232,8 @@ impl Commands {
             Commands::Runner(args) if runner::is_compact_exec_stdout(args) => {
                 raw_ops_descriptor(CommandRawOutputMode::PlainText, output_file_mode)
             }
-            Commands::AgentTask(_)
+            Commands::Activity(_)
+            | Commands::AgentTask(_)
             | Commands::Project(_)
             | Commands::Component(_)
             | Commands::Config(_)

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -430,6 +430,12 @@ const fn guarded_safety(dangerous_flags: &'static [&'static str]) -> CommandSafe
 }
 
 pub const COMMAND_SPECS: &[CommandSpec] = &[
+    CommandSpec {
+        output_notes: "unified active/recent activity read model in the standard JSON envelope",
+        lab_supported: false,
+        lab_notes: "read-only local activity query; never offloaded because it inspects operator-local stores",
+        ..command_spec("activity", CommandJsonFamily::Workspace)
+    },
     command_spec_with_representative_argv(
         &["homeboy", "agent-task", "providers"],
         lab_command_spec_with_summary(

--- a/src/commands/activity.rs
+++ b/src/commands/activity.rs
@@ -1,0 +1,363 @@
+use std::time::{Duration, Instant};
+
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use homeboy::core::activity::{self, ActivityItem, ActivityReport, ActivityScope, ActivityState};
+use homeboy::core::notify::{self, NotifyEvent, NotifyOutcome};
+use homeboy::core::observation::ObservationStore;
+use homeboy::core::{Error, Result};
+
+use super::{CmdResult, GlobalArgs};
+
+const TIMEOUT_EXIT_CODE: i32 = 124;
+
+#[derive(Args, Clone)]
+pub struct ActivityArgs {
+    #[command(subcommand)]
+    command: Option<ActivityCommand>,
+}
+
+#[derive(Subcommand, Clone)]
+enum ActivityCommand {
+    /// List active and recent Homeboy work
+    List(ActivityListArgs),
+    /// Resolve and show one activity item by run/task/job id
+    Show { id: String },
+    /// Poll any activity item until it reaches a terminal state
+    Watch(ActivityWatchArgs),
+}
+
+#[derive(Args, Clone)]
+pub struct ActivityListArgs {
+    /// Maximum activity items to return.
+    #[arg(long, default_value_t = 20)]
+    limit: usize,
+    /// Include older completed records instead of active + recent.
+    #[arg(long)]
+    all: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct ActivityWatchArgs {
+    /// Activity id, observation run id, agent-task run id, or runner job id.
+    pub id: String,
+    /// Maximum time to wait before giving up (e.g. `30m`, `2h`, `7d`).
+    #[arg(long)]
+    pub timeout: Option<String>,
+    /// Delay between status polls (e.g. `2s`, `1m`).
+    #[arg(long, default_value = "2s")]
+    pub interval: String,
+    /// Emit a local completion notification when the item reaches a terminal state.
+    #[arg(long)]
+    pub notify: bool,
+    /// Override HOMEBOY_NOTIFY_COMMAND. Implies `--notify`.
+    #[arg(long, requires = "notify")]
+    pub notify_command: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum ActivityOutput {
+    Report(ActivityReport),
+    Watch(ActivityWatchOutput),
+}
+
+#[derive(Serialize)]
+pub struct ActivityWatchOutput {
+    pub schema: &'static str,
+    pub command: &'static str,
+    pub id: String,
+    pub state: ActivityState,
+    pub terminal: bool,
+    pub timed_out: bool,
+    pub waited_secs: u64,
+    pub poll_count: u64,
+    pub item: ActivityItem,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_actions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notify: Option<NotifyOutcome>,
+}
+
+pub fn run(args: ActivityArgs, _global: &GlobalArgs) -> CmdResult<ActivityOutput> {
+    match args
+        .command
+        .unwrap_or(ActivityCommand::List(ActivityListArgs {
+            limit: 20,
+            all: false,
+        })) {
+        ActivityCommand::List(args) => list(args),
+        ActivityCommand::Show { id } => show(&id),
+        ActivityCommand::Watch(args) => watch(args),
+    }
+}
+
+pub fn render_activity_summary(payload: &serde_json::Value) -> Option<String> {
+    let report = payload.get("payload").or(Some(payload))?;
+    let counts = report.get("counts")?;
+    let items = report.get("items")?.as_array()?;
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "activity: total={} active={} running={} queued={} failed={} stale={}",
+        counts.get("total")?.as_u64()?,
+        counts.get("active")?.as_u64()?,
+        counts.get("running")?.as_u64()?,
+        counts.get("queued")?.as_u64()?,
+        counts.get("failed")?.as_u64()?,
+        counts.get("stale")?.as_u64()?,
+    ));
+    if items.is_empty() {
+        lines.push("No active or recent Homeboy activity.".to_string());
+        return Some(format!("{}\n", lines.join("\n")));
+    }
+    lines.push(format!(
+        "{:<28} {:<14} {:<18} {}",
+        "id", "state", "kind", "updated"
+    ));
+    for item in items {
+        let id = item
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("-");
+        let state = item
+            .get("state")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown");
+        let kind = item
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("-");
+        let updated = item
+            .get("updated_at")
+            .or_else(|| item.get("created_at"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("-");
+        lines.push(format!(
+            "{:<28} {:<14} {:<18} {}",
+            truncate(id, 28),
+            state,
+            truncate(kind, 18),
+            updated
+        ));
+        if let Some(actions) = item
+            .get("next_actions")
+            .and_then(serde_json::Value::as_array)
+        {
+            for action in actions.iter().take(2) {
+                let label = action
+                    .get("label")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("next");
+                let command = action
+                    .get("command")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                if !command.is_empty() {
+                    lines.push(format!("  next: {label}: {command}"));
+                }
+            }
+        }
+    }
+    Some(format!("{}\n", lines.join("\n")))
+}
+
+fn list(args: ActivityListArgs) -> CmdResult<ActivityOutput> {
+    reconcile_runs_best_effort();
+    let scope = if args.all {
+        ActivityScope::All
+    } else {
+        ActivityScope::ActiveRecent
+    };
+    Ok((
+        ActivityOutput::Report(activity::activity_report(scope, args.limit)?),
+        0,
+    ))
+}
+
+fn show(id: &str) -> CmdResult<ActivityOutput> {
+    reconcile_runs_best_effort();
+    Ok((ActivityOutput::Report(activity::show_activity(id)?), 0))
+}
+
+fn watch(args: ActivityWatchArgs) -> CmdResult<ActivityOutput> {
+    let interval = parse_duration(&args.interval)?;
+    let timeout = args.timeout.as_deref().map(parse_duration).transpose()?;
+    let started = Instant::now();
+    let mut poll_count = 0;
+
+    loop {
+        reconcile_runs_best_effort();
+        let item = activity::resolve_activity(&args.id)?;
+        poll_count += 1;
+        eprintln!(
+            "activity {}: {:?} (poll {})",
+            args.id, item.state, poll_count
+        );
+        if !item.state.is_active() {
+            return Ok(watch_output(
+                args,
+                item,
+                false,
+                started.elapsed(),
+                poll_count,
+            ));
+        }
+        if let Some(timeout) = timeout {
+            if started.elapsed() >= timeout {
+                return Ok(watch_output(
+                    args,
+                    item,
+                    true,
+                    started.elapsed(),
+                    poll_count,
+                ));
+            }
+        }
+        std::thread::sleep(interval);
+    }
+}
+
+fn reconcile_runs_best_effort() {
+    if let Ok(store) = ObservationStore::open_initialized() {
+        let _ = crate::commands::runs::reconcile::reconcile_owned_stale_running_runs(&store, 1000);
+    }
+}
+
+fn watch_output(
+    args: ActivityWatchArgs,
+    item: ActivityItem,
+    timed_out: bool,
+    waited: Duration,
+    poll_count: u64,
+) -> (ActivityOutput, i32) {
+    let notify = maybe_notify(&args, &item, timed_out);
+    let exit_code = if timed_out {
+        TIMEOUT_EXIT_CODE
+    } else if item.state.is_failure() {
+        1
+    } else {
+        0
+    };
+    let next_actions = item
+        .next_actions
+        .iter()
+        .map(|action| action.command.clone())
+        .collect();
+    (
+        ActivityOutput::Watch(ActivityWatchOutput {
+            schema: activity::ACTIVITY_REPORT_SCHEMA,
+            command: "activity.watch",
+            id: args.id,
+            state: item.state.clone(),
+            terminal: !timed_out,
+            timed_out,
+            waited_secs: waited.as_secs(),
+            poll_count,
+            item,
+            next_actions,
+            notify,
+        }),
+        exit_code,
+    )
+}
+
+fn maybe_notify(
+    args: &ActivityWatchArgs,
+    item: &ActivityItem,
+    timed_out: bool,
+) -> Option<NotifyOutcome> {
+    if !args.notify && args.notify_command.is_none() {
+        return None;
+    }
+    let status = if timed_out {
+        "timed_out".to_string()
+    } else {
+        format!("{:?}", item.state).to_lowercase()
+    };
+    Some(notify::dispatch(
+        &NotifyEvent {
+            title: format!("homeboy activity {status}"),
+            body: format!("{} {}", item.kind, item.id),
+            status,
+            run_id: item.id.clone(),
+        },
+        args.notify_command.as_deref(),
+    ))
+}
+
+fn parse_duration(raw: &str) -> Result<Duration> {
+    let trimmed = raw.trim();
+    let split = trimmed
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (amount, unit) = trimmed.split_at(split);
+    if amount.is_empty() || unit.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "duration",
+            "expected duration like 2s, 30m, or 1h",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+    let amount = amount.parse::<u64>().map_err(|_| {
+        Error::validation_invalid_argument(
+            "duration",
+            "duration amount must be a positive integer",
+            Some(raw.to_string()),
+            None,
+        )
+    })?;
+    let seconds = match unit {
+        "s" | "sec" | "secs" | "second" | "seconds" => amount,
+        "m" | "min" | "mins" | "minute" | "minutes" => amount * 60,
+        "h" | "hr" | "hrs" | "hour" | "hours" => amount * 60 * 60,
+        "d" | "day" | "days" => amount * 60 * 60 * 24,
+        _ => {
+            return Err(Error::validation_invalid_argument(
+                "duration",
+                "duration unit must be s, m, h, or d",
+                Some(raw.to_string()),
+                None,
+            ))
+        }
+    };
+    Ok(Duration::from_secs(seconds))
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    if value.chars().count() <= width {
+        value.to_string()
+    } else {
+        let mut truncated = value
+            .chars()
+            .take(width.saturating_sub(1))
+            .collect::<String>();
+        truncated.push('~');
+        truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn empty_state_summary_is_explicit() {
+        let rendered = render_activity_summary(&json!({
+            "counts": {"total": 0, "active": 0, "running": 0, "queued": 0, "failed": 0, "stale": 0},
+            "items": []
+        }))
+        .expect("summary");
+        assert!(rendered.contains("No active or recent Homeboy activity."));
+    }
+
+    #[test]
+    fn duration_parser_accepts_seconds() {
+        assert_eq!(
+            parse_duration("2s").expect("duration"),
+            Duration::from_secs(2)
+        );
+    }
+}

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -73,6 +73,20 @@ pub fn run_command_output(
             )
         }
         Commands::Runner(args) => runner::run_command_output(args, global),
+        Commands::Activity(args) => {
+            let (stdout_result, exit_code) = dispatch(Commands::Activity(args), global);
+            let summary_stdout = stdout_result
+                .as_ref()
+                .ok()
+                .and_then(super::activity::render_activity_summary);
+
+            JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                CommandPresentation {
+                    stdout: summary_stdout,
+                    stderr: None,
+                },
+            )
+        }
         Commands::Bench(args) => {
             let summarize = bench_summary_eligible(&args);
             let (stdout_result, exit_code) = dispatch(Commands::Bench(args), global);

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -2,13 +2,14 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    agent_task, artifact_postprocess, build, changelog, changes, cleanup, component, config,
-    contract, docs, extension, manifest, project, refactor, refs, release, report, rig, runner,
-    runs, runtime, stack, tunnel, undo, worktree, GlobalArgs,
+    activity, agent_task, artifact_postprocess, build, changelog, changes, cleanup, component,
+    config, contract, docs, extension, manifest, project, refactor, refs, release, report, rig,
+    runner, runs, runtime, stack, tunnel, undo, worktree, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
+        Commands::Activity(args) => map(activity::run(args, global)),
         Commands::AgentTask(args) => map(agent_task::run(args, global)),
         Commands::Project(args) => map(project::run(args, global)),
         Commands::Component(args) => map(component::run(args, global)),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -181,6 +181,7 @@ pub fn finalize_set_spec(
     Ok((json_string, replace_fields))
 }
 
+pub mod activity;
 pub mod agent_task;
 pub(crate) mod agent_task_dispatch;
 pub(crate) mod agent_task_summary;

--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -31,7 +31,7 @@ mod latest;
 mod loop_sync;
 mod proof;
 mod query;
-mod reconcile;
+pub(crate) mod reconcile;
 mod refs;
 mod remote;
 mod remote_artifact;

--- a/src/commands/runs/reconcile.rs
+++ b/src/commands/runs/reconcile.rs
@@ -69,7 +69,7 @@ pub fn reconcile_runs(args: RunsReconcileArgs) -> CmdResult<RunsOutput> {
     ))
 }
 
-pub(super) fn reconcile_owned_stale_running_runs(
+pub(crate) fn reconcile_owned_stale_running_runs(
     store: &ObservationStore,
     limit: i64,
 ) -> homeboy::core::Result<Vec<ReconciledRunSummary>> {
@@ -139,6 +139,10 @@ where
 }
 
 fn ownerless_running_is_stale(run: &RunRecord) -> bool {
+    if runner_backed_run(run) {
+        return false;
+    }
+
     chrono::DateTime::parse_from_rfc3339(&run.started_at)
         .map(|started_at| {
             chrono::Utc::now()
@@ -147,6 +151,28 @@ fn ownerless_running_is_stale(run: &RunRecord) -> bool {
                 >= OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES
         })
         .unwrap_or(false)
+}
+
+fn runner_backed_run(run: &RunRecord) -> bool {
+    metadata_string(&run.metadata_json, &["runner_job_id", "job_id"]).is_some()
+        || run
+            .metadata_json
+            .get("identity")
+            .and_then(|identity| metadata_string(identity, &["runner_job_id", "job_id"]))
+            .is_some()
+        || run
+            .metadata_json
+            .get("lab")
+            .and_then(|lab| lab.get("remote_job"))
+            .and_then(|remote_job| metadata_string(remote_job, &["id", "job_id"]))
+            .is_some()
+}
+
+fn metadata_string(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
 }
 
 pub fn running_status_note(run: &RunRecord) -> Option<String> {

--- a/src/core/activity.rs
+++ b/src/core/activity.rs
@@ -1,0 +1,812 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::core::agent_task_lifecycle::{self, AgentTaskRunRecord, AgentTaskRunState};
+use crate::core::api_jobs::{self, ActiveRunnerJobSummary, Job, JobStatus};
+use crate::core::observation::{ObservationStore, RunListFilter, RunRecord, RunStatus};
+use crate::core::{paths, runners, Error, Result};
+
+pub const ACTIVITY_REPORT_SCHEMA: &str = "homeboy/activity-report/v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivityScope {
+    ActiveRecent,
+    All,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityState {
+    Queued,
+    Running,
+    Succeeded,
+    PartialFailure,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Stale,
+    Unknown,
+}
+
+impl ActivityState {
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Queued | Self::Running)
+    }
+
+    pub fn is_failure(&self) -> bool {
+        matches!(
+            self,
+            Self::PartialFailure | Self::Failed | Self::TimedOut | Self::Stale | Self::Unknown
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivityNextAction {
+    pub label: String,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivityRunnerRefs {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivityCrossRefs {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_task_run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_job_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivityEvidenceRef {
+    pub id: String,
+    pub kind: String,
+    pub uri: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivityItem {
+    pub id: String,
+    pub kind: String,
+    pub source_store: String,
+    pub state: ActivityState,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub runner: ActivityRunnerRefs,
+    #[serde(default)]
+    pub refs: ActivityCrossRefs,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<ActivityEvidenceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<ActivityEvidenceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_actions: Vec<ActivityNextAction>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivityCounts {
+    pub total: usize,
+    pub active: usize,
+    pub queued: usize,
+    pub running: usize,
+    pub succeeded: usize,
+    pub partial_failure: usize,
+    pub failed: usize,
+    pub cancelled: usize,
+    pub timed_out: usize,
+    pub stale: usize,
+    pub unknown: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivityReport {
+    pub schema: &'static str,
+    pub command: &'static str,
+    pub counts: ActivityCounts,
+    pub items: Vec<ActivityItem>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_actions: Vec<String>,
+}
+
+pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityReport> {
+    let mut collector = ActivityCollector::default();
+    observation::collect(&mut collector, limit)?;
+    agent_tasks::collect(&mut collector, limit)?;
+    daemon_jobs::collect(&mut collector)?;
+    runner_sessions::collect(&mut collector);
+    Ok(report_from_items(collector.items(scope, limit), "activity"))
+}
+
+pub fn show_activity(id: &str) -> Result<ActivityReport> {
+    let report = activity_report(ActivityScope::All, 1000)?;
+    let Some(item) = resolve_item(&report.items, id) else {
+        return Err(Error::validation_invalid_argument(
+            "id",
+            format!("activity item not found: {id}"),
+            Some(id.to_string()),
+            Some(vec![
+                "Run `homeboy activity` to list active and recent work.".to_string(),
+            ]),
+        ));
+    };
+    Ok(report_from_items(vec![item.clone()], "activity.show"))
+}
+
+pub fn resolve_activity(id: &str) -> Result<ActivityItem> {
+    let report = activity_report(ActivityScope::All, 1000)?;
+    resolve_item(&report.items, id).cloned().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "id",
+            format!("activity item not found: {id}"),
+            Some(id.to_string()),
+            Some(vec![
+                "Run `homeboy activity` to list active and recent work.".to_string(),
+            ]),
+        )
+    })
+}
+
+fn resolve_item<'a>(items: &'a [ActivityItem], id: &str) -> Option<&'a ActivityItem> {
+    items.iter().find(|item| {
+        item.id == id
+            || item.refs.run_id.as_deref() == Some(id)
+            || item.refs.agent_task_run_id.as_deref() == Some(id)
+            || item.refs.runner_job_id.as_deref() == Some(id)
+    })
+}
+
+fn report_from_items(items: Vec<ActivityItem>, command: &'static str) -> ActivityReport {
+    let counts = counts_for_items(&items);
+    let next_actions = items
+        .iter()
+        .flat_map(|item| {
+            item.next_actions
+                .iter()
+                .map(|action| action.command.clone())
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    ActivityReport {
+        schema: ACTIVITY_REPORT_SCHEMA,
+        command,
+        counts,
+        items,
+        next_actions,
+    }
+}
+
+fn counts_for_items(items: &[ActivityItem]) -> ActivityCounts {
+    let mut counts = ActivityCounts {
+        total: items.len(),
+        ..Default::default()
+    };
+    for item in items {
+        if item.state.is_active() {
+            counts.active += 1;
+        }
+        match item.state {
+            ActivityState::Queued => counts.queued += 1,
+            ActivityState::Running => counts.running += 1,
+            ActivityState::Succeeded => counts.succeeded += 1,
+            ActivityState::PartialFailure => counts.partial_failure += 1,
+            ActivityState::Failed => counts.failed += 1,
+            ActivityState::Cancelled => counts.cancelled += 1,
+            ActivityState::TimedOut => counts.timed_out += 1,
+            ActivityState::Stale => counts.stale += 1,
+            ActivityState::Unknown => counts.unknown += 1,
+        }
+    }
+    counts
+}
+
+#[derive(Default)]
+struct ActivityCollector {
+    items: BTreeMap<String, ActivityItem>,
+}
+
+impl ActivityCollector {
+    fn insert(&mut self, item: ActivityItem) {
+        let key = dedupe_key(&item);
+        self.items
+            .entry(key)
+            .and_modify(|existing| merge_item(existing, &item))
+            .or_insert(item);
+    }
+
+    fn items(self, scope: ActivityScope, limit: usize) -> Vec<ActivityItem> {
+        let mut items = self.items.into_values().collect::<Vec<_>>();
+        items.sort_by(|left, right| item_sort_key(right).cmp(&item_sort_key(left)));
+        if scope == ActivityScope::ActiveRecent {
+            items.retain(|item| item.state.is_active() || item.finished_at.is_some());
+        }
+        items.truncate(limit.max(1));
+        items
+    }
+}
+
+fn dedupe_key(item: &ActivityItem) -> String {
+    if let Some(run_id) = &item.refs.run_id {
+        return format!("run:{run_id}");
+    }
+    if let Some(agent_task_run_id) = &item.refs.agent_task_run_id {
+        return format!("agent-task:{agent_task_run_id}");
+    }
+    if let Some(job_id) = &item.refs.runner_job_id {
+        return format!("runner-job:{job_id}");
+    }
+    item.id.clone()
+}
+
+fn merge_item(existing: &mut ActivityItem, incoming: &ActivityItem) {
+    if existing.refs.run_id.is_none() {
+        existing.refs.run_id = incoming.refs.run_id.clone();
+    }
+    if existing.refs.agent_task_run_id.is_none() {
+        existing.refs.agent_task_run_id = incoming.refs.agent_task_run_id.clone();
+    }
+    if existing.refs.runner_job_id.is_none() {
+        existing.refs.runner_job_id = incoming.refs.runner_job_id.clone();
+    }
+    if existing.runner.runner_id.is_none() {
+        existing.runner.runner_id = incoming.runner.runner_id.clone();
+    }
+    if existing.runner.job_id.is_none() {
+        existing.runner.job_id = incoming.runner.job_id.clone();
+    }
+    if existing.runner.transport.is_none() {
+        existing.runner.transport = incoming.runner.transport.clone();
+    }
+    if incoming.state.is_active()
+        || (!existing.state.is_active() && incoming.updated_at > existing.updated_at)
+    {
+        existing.state = incoming.state.clone();
+    }
+    append_unique(&mut existing.artifacts, &incoming.artifacts);
+    append_unique(&mut existing.evidence, &incoming.evidence);
+    append_actions(&mut existing.next_actions, &incoming.next_actions);
+}
+
+fn append_unique(target: &mut Vec<ActivityEvidenceRef>, incoming: &[ActivityEvidenceRef]) {
+    for item in incoming {
+        if !target.iter().any(|existing| existing.uri == item.uri) {
+            target.push(item.clone());
+        }
+    }
+}
+
+fn append_actions(target: &mut Vec<ActivityNextAction>, incoming: &[ActivityNextAction]) {
+    for action in incoming {
+        if !target
+            .iter()
+            .any(|existing| existing.command == action.command)
+        {
+            target.push(action.clone());
+        }
+    }
+}
+
+fn item_sort_key(item: &ActivityItem) -> (bool, Option<DateTime<Utc>>, String) {
+    (
+        item.state.is_active(),
+        item.updated_at
+            .as_deref()
+            .or(Some(item.created_at.as_str()))
+            .and_then(parse_ts),
+        item.id.clone(),
+    )
+}
+
+fn parse_ts(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn metadata_string(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn action(label: impl Into<String>, command: impl Into<String>) -> ActivityNextAction {
+    ActivityNextAction {
+        label: label.into(),
+        command: command.into(),
+    }
+}
+
+mod observation {
+    use super::*;
+
+    pub(super) fn collect(collector: &mut ActivityCollector, limit: usize) -> Result<()> {
+        let store = ObservationStore::open_initialized()?;
+        let records = store.list_runs(RunListFilter {
+            limit: Some(limit as i64),
+            ..Default::default()
+        })?;
+        for run in records {
+            collector.insert(item_from_run(&store, run)?);
+        }
+        Ok(())
+    }
+
+    fn item_from_run(store: &ObservationStore, run: RunRecord) -> Result<ActivityItem> {
+        let artifacts = store
+            .list_artifacts(&run.id)?
+            .into_iter()
+            .map(|artifact| ActivityEvidenceRef {
+                id: artifact.id,
+                kind: artifact.kind,
+                uri: artifact
+                    .public_url
+                    .or(artifact.url)
+                    .unwrap_or(artifact.path),
+            })
+            .collect::<Vec<_>>();
+        let runner_id = metadata_string(&run.metadata_json, &["runner_id"]);
+        let job_id = metadata_string(&run.metadata_json, &["runner_job_id", "job_id"]);
+        Ok(ActivityItem {
+            id: run.id.clone(),
+            kind: run.kind.clone(),
+            source_store: "observation.sqlite".to_string(),
+            state: state_from_run_status(&run.status),
+            created_at: run.started_at.clone(),
+            updated_at: run
+                .finished_at
+                .clone()
+                .or_else(|| Some(run.started_at.clone())),
+            finished_at: run.finished_at,
+            command: run.command,
+            cwd: run.cwd,
+            runner: ActivityRunnerRefs {
+                runner_id,
+                job_id: job_id.clone(),
+                transport: None,
+            },
+            refs: ActivityCrossRefs {
+                run_id: Some(run.id.clone()),
+                agent_task_run_id: None,
+                runner_job_id: job_id,
+            },
+            artifacts,
+            evidence: Vec::new(),
+            next_actions: actions_for_observation_run(&run.id, state_from_run_status(&run.status)),
+        })
+    }
+
+    fn state_from_run_status(status: &str) -> ActivityState {
+        match RunStatus::from_label(status) {
+            Some(RunStatus::Running) => ActivityState::Running,
+            Some(RunStatus::Pass | RunStatus::Skipped) => ActivityState::Succeeded,
+            Some(RunStatus::Fail | RunStatus::Error) => ActivityState::Failed,
+            Some(RunStatus::Stale) => ActivityState::Stale,
+            None => ActivityState::Unknown,
+        }
+    }
+
+    fn actions_for_observation_run(run_id: &str, state: ActivityState) -> Vec<ActivityNextAction> {
+        let mut actions = vec![action("show run", format!("homeboy runs show {run_id}"))];
+        if state.is_active() {
+            actions.push(action(
+                "watch run",
+                format!("homeboy activity watch {run_id}"),
+            ));
+        }
+        actions.push(action(
+            "artifacts",
+            format!("homeboy runs artifacts {run_id}"),
+        ));
+        if matches!(state, ActivityState::Stale) {
+            actions.push(action("reconcile stale runs", "homeboy runs reconcile"));
+        }
+        actions
+    }
+}
+
+mod agent_tasks {
+    use super::*;
+
+    pub(super) fn collect(collector: &mut ActivityCollector, limit: usize) -> Result<()> {
+        for record in agent_task_lifecycle::list_records()?
+            .into_iter()
+            .take(limit)
+        {
+            collector.insert(item_from_agent_task(record));
+        }
+        Ok(())
+    }
+
+    fn item_from_agent_task(record: AgentTaskRunRecord) -> ActivityItem {
+        let runner_id = metadata_string(&record.metadata, &["runner_id"]);
+        let job_id = metadata_string(&record.metadata, &["runner_job_id", "job_id"]);
+        let remote_run_id = metadata_string(&record.metadata, &["remote_run_id"]);
+        let state = state_from_agent_task(record.state);
+        ActivityItem {
+            id: record.run_id.clone(),
+            kind: "agent-task".to_string(),
+            source_store: "agent-task.lifecycle".to_string(),
+            state: state.clone(),
+            created_at: record.submitted_at.clone(),
+            updated_at: record.updated_at.clone(),
+            finished_at: if state.is_active() {
+                None
+            } else {
+                record.updated_at.clone()
+            },
+            command: None,
+            cwd: None,
+            runner: ActivityRunnerRefs {
+                runner_id,
+                job_id: job_id.clone(),
+                transport: remote_run_id,
+            },
+            refs: ActivityCrossRefs {
+                run_id: None,
+                agent_task_run_id: Some(record.run_id.clone()),
+                runner_job_id: job_id,
+            },
+            artifacts: record
+                .artifact_refs
+                .into_iter()
+                .map(|artifact| ActivityEvidenceRef {
+                    id: artifact.task_id,
+                    kind: artifact.kind,
+                    uri: artifact.uri,
+                })
+                .collect(),
+            evidence: record
+                .latest_executor_evidence
+                .into_iter()
+                .flat_map(|evidence| evidence.refs())
+                .enumerate()
+                .map(|(index, evidence)| ActivityEvidenceRef {
+                    id: evidence
+                        .label
+                        .unwrap_or_else(|| format!("evidence-{}", index + 1)),
+                    kind: evidence.kind,
+                    uri: evidence.uri,
+                })
+                .collect(),
+            next_actions: actions_for_agent_task(&record.run_id, state),
+        }
+    }
+
+    fn state_from_agent_task(state: AgentTaskRunState) -> ActivityState {
+        match state {
+            AgentTaskRunState::Queued => ActivityState::Queued,
+            AgentTaskRunState::Running => ActivityState::Running,
+            AgentTaskRunState::Succeeded => ActivityState::Succeeded,
+            AgentTaskRunState::PartialFailure => ActivityState::PartialFailure,
+            AgentTaskRunState::Failed => ActivityState::Failed,
+            AgentTaskRunState::Cancelled => ActivityState::Cancelled,
+        }
+    }
+
+    fn actions_for_agent_task(run_id: &str, state: ActivityState) -> Vec<ActivityNextAction> {
+        let mut actions = vec![
+            action("status", format!("homeboy agent-task status {run_id}")),
+            action("logs", format!("homeboy agent-task logs {run_id}")),
+            action(
+                "artifacts",
+                format!("homeboy agent-task artifacts {run_id}"),
+            ),
+        ];
+        if state.is_active() {
+            actions.push(action("watch", format!("homeboy activity watch {run_id}")));
+        } else if state.is_failure() {
+            actions.push(action(
+                "retry",
+                format!("homeboy agent-task retry --run {run_id}"),
+            ));
+        }
+        if matches!(state, ActivityState::Stale) {
+            actions.push(action("reconcile", "homeboy agent-task active --reconcile"));
+        }
+        actions
+    }
+}
+
+mod daemon_jobs {
+    use super::*;
+
+    pub(super) fn collect(collector: &mut ActivityCollector) -> Result<()> {
+        let path = paths::daemon_jobs_file()?;
+        if !path.exists() {
+            return Ok(());
+        }
+        let store = api_jobs::JobStore::open(path)?;
+        for job in store.list() {
+            collector.insert(item_from_job(job));
+        }
+        Ok(())
+    }
+
+    fn item_from_job(job: Job) -> ActivityItem {
+        let state = state_from_job(job.status);
+        let job_id = job.id.to_string();
+        let durable_run_id = durable_run_id(&job);
+        ActivityItem {
+            id: job_id.clone(),
+            kind: job.operation.clone(),
+            source_store: "daemon.jobs-json".to_string(),
+            state: state.clone(),
+            created_at: ms_to_rfc3339(job.created_at_ms),
+            updated_at: Some(ms_to_rfc3339(job.updated_at_ms)),
+            finished_at: job.finished_at_ms.map(ms_to_rfc3339),
+            command: Some(job.operation),
+            cwd: None,
+            runner: ActivityRunnerRefs {
+                runner_id: job
+                    .claimed_by_runner_id
+                    .clone()
+                    .or(job.target_runner_id.clone()),
+                job_id: Some(job_id.clone()),
+                transport: Some("daemon".to_string()),
+            },
+            refs: ActivityCrossRefs {
+                run_id: durable_run_id,
+                agent_task_run_id: None,
+                runner_job_id: Some(job_id.clone()),
+            },
+            artifacts: job
+                .artifacts
+                .into_iter()
+                .map(|artifact| ActivityEvidenceRef {
+                    id: artifact.id,
+                    kind: artifact.mime.unwrap_or_else(|| "artifact".to_string()),
+                    uri: artifact
+                        .url
+                        .or(artifact.path)
+                        .unwrap_or_else(|| "homeboy://artifact/unavailable".to_string()),
+                })
+                .collect(),
+            evidence: Vec::new(),
+            next_actions: actions_for_job(None, &job_id, state),
+        }
+    }
+
+    fn durable_run_id(job: &Job) -> Option<String> {
+        job.source_snapshot.as_ref().and_then(|_| None)
+    }
+
+    fn state_from_job(status: JobStatus) -> ActivityState {
+        match status {
+            JobStatus::Queued => ActivityState::Queued,
+            JobStatus::Running => ActivityState::Running,
+            JobStatus::Succeeded => ActivityState::Succeeded,
+            JobStatus::Failed => ActivityState::Failed,
+            JobStatus::Cancelled => ActivityState::Cancelled,
+        }
+    }
+
+    fn actions_for_job(
+        runner_id: Option<&str>,
+        job_id: &str,
+        state: ActivityState,
+    ) -> Vec<ActivityNextAction> {
+        let mut actions = Vec::new();
+        if let Some(runner_id) = runner_id {
+            actions.push(action(
+                "logs",
+                format!("homeboy runner job logs {runner_id} {job_id}"),
+            ));
+            if state.is_active() {
+                actions.push(action(
+                    "follow logs",
+                    format!("homeboy runner job logs {runner_id} {job_id} --follow"),
+                ));
+            }
+        } else {
+            actions.push(action("daemon status", "homeboy daemon status"));
+        }
+        actions
+    }
+
+    fn ms_to_rfc3339(ms: u64) -> String {
+        DateTime::<Utc>::from_timestamp_millis(ms as i64)
+            .unwrap_or_else(Utc::now)
+            .to_rfc3339()
+    }
+}
+
+mod runner_sessions {
+    use super::*;
+
+    pub(super) fn collect(collector: &mut ActivityCollector) {
+        for report in runners::statuses()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|report| report.connected)
+        {
+            for job in report.active_jobs {
+                collector.insert(item_from_active_runner_job(job));
+            }
+        }
+    }
+
+    fn item_from_active_runner_job(job: ActiveRunnerJobSummary) -> ActivityItem {
+        let state = if job.stale_reason.is_some() {
+            ActivityState::Stale
+        } else {
+            state_from_job(job.status)
+        };
+        ActivityItem {
+            id: job
+                .durable_run_id
+                .clone()
+                .unwrap_or_else(|| job.job_id.clone()),
+            kind: job.kind.clone(),
+            source_store: "runner.session".to_string(),
+            state: state.clone(),
+            created_at: ms_to_rfc3339(job.started_at_ms),
+            updated_at: Some(ms_to_rfc3339(job.updated_at_ms)),
+            finished_at: None,
+            command: Some(job.command.clone()),
+            cwd: job.cwd,
+            runner: ActivityRunnerRefs {
+                runner_id: Some(job.runner_id.clone()),
+                job_id: Some(job.job_id.clone()),
+                transport: Some(job.source.clone()),
+            },
+            refs: ActivityCrossRefs {
+                run_id: job.durable_run_id,
+                agent_task_run_id: None,
+                runner_job_id: Some(job.job_id.clone()),
+            },
+            artifacts: Vec::new(),
+            evidence: Vec::new(),
+            next_actions: actions_for_runner_job(&job.runner_id, &job.job_id, state),
+        }
+    }
+
+    fn state_from_job(status: JobStatus) -> ActivityState {
+        match status {
+            JobStatus::Queued => ActivityState::Queued,
+            JobStatus::Running => ActivityState::Running,
+            JobStatus::Succeeded => ActivityState::Succeeded,
+            JobStatus::Failed => ActivityState::Failed,
+            JobStatus::Cancelled => ActivityState::Cancelled,
+        }
+    }
+
+    fn actions_for_runner_job(
+        runner_id: &str,
+        job_id: &str,
+        state: ActivityState,
+    ) -> Vec<ActivityNextAction> {
+        let mut actions = vec![action(
+            "logs",
+            format!("homeboy runner job logs {runner_id} {job_id}"),
+        )];
+        if state.is_active() {
+            actions.push(action(
+                "follow logs",
+                format!("homeboy runner job logs {runner_id} {job_id} --follow"),
+            ));
+            actions.push(action("watch", format!("homeboy activity watch {job_id}")));
+        }
+        if state.is_failure() {
+            actions.push(action(
+                "reconcile",
+                format!("homeboy runner job logs {runner_id} {job_id}"),
+            ));
+        }
+        actions
+    }
+
+    fn ms_to_rfc3339(ms: u64) -> String {
+        DateTime::<Utc>::from_timestamp_millis(ms as i64)
+            .unwrap_or_else(Utc::now)
+            .to_rfc3339()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: &str, state: ActivityState) -> ActivityItem {
+        ActivityItem {
+            id: id.to_string(),
+            kind: "bench".to_string(),
+            source_store: "test".to_string(),
+            state,
+            created_at: "2026-07-04T00:00:00Z".to_string(),
+            updated_at: None,
+            finished_at: None,
+            command: None,
+            cwd: None,
+            runner: ActivityRunnerRefs::default(),
+            refs: ActivityCrossRefs {
+                run_id: Some(id.to_string()),
+                agent_task_run_id: None,
+                runner_job_id: None,
+            },
+            artifacts: Vec::new(),
+            evidence: Vec::new(),
+            next_actions: vec![action("show", format!("homeboy runs show {id}"))],
+        }
+    }
+
+    #[test]
+    fn source_merging_dedupes_by_run_id() {
+        let mut collector = ActivityCollector::default();
+        collector.insert(item("run-1", ActivityState::Running));
+        let mut duplicate = item("job-1", ActivityState::Queued);
+        duplicate.refs.run_id = Some("run-1".to_string());
+        duplicate.refs.runner_job_id = Some("job-1".to_string());
+        duplicate.runner.job_id = Some("job-1".to_string());
+        collector.insert(duplicate);
+
+        let items = collector.items(ActivityScope::All, 10);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].refs.run_id.as_deref(), Some("run-1"));
+        assert_eq!(items[0].refs.runner_job_id.as_deref(), Some("job-1"));
+    }
+
+    #[test]
+    fn id_resolution_checks_all_id_spaces() {
+        let mut item = item("run-1", ActivityState::Succeeded);
+        item.refs.agent_task_run_id = Some("agent-1".to_string());
+        item.refs.runner_job_id = Some("job-1".to_string());
+        let items = vec![item];
+
+        assert!(resolve_item(&items, "run-1").is_some());
+        assert!(resolve_item(&items, "agent-1").is_some());
+        assert!(resolve_item(&items, "job-1").is_some());
+        assert!(resolve_item(&items, "missing").is_none());
+    }
+
+    #[test]
+    fn counts_normalize_states() {
+        let items = vec![
+            item("queued", ActivityState::Queued),
+            item("running", ActivityState::Running),
+            item("stale", ActivityState::Stale),
+        ];
+        let counts = counts_for_items(&items);
+        assert_eq!(counts.total, 3);
+        assert_eq!(counts.active, 2);
+        assert_eq!(counts.queued, 1);
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.stale, 1);
+    }
+
+    #[test]
+    fn next_actions_are_lifted_as_exact_commands() {
+        let report = report_from_items(vec![item("run-1", ActivityState::Running)], "activity");
+        assert_eq!(report.next_actions, vec!["homeboy runs show run-1"]);
+        assert_eq!(report.items[0].next_actions[0].label, "show");
+    }
+
+    #[test]
+    fn empty_state_output_has_zero_counts() {
+        let report = report_from_items(Vec::new(), "activity");
+        assert_eq!(report.counts.total, 0);
+        assert!(report.items.is_empty());
+        assert!(report.next_actions.is_empty());
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ pub mod config;
 // Compatibility exports for existing `homeboy::core::<module>` consumers. Prefer the
 // facade modules above for new code so implementation files can move without
 // becoming accidental public API.
+pub mod activity;
 pub mod agent_runtime_manifest;
 pub mod agent_task;
 pub mod agent_task_aggregate;


### PR DESCRIPTION
## Problem
Homeboy activity is fragmented across observation runs, agent-task lifecycle records, daemon jobs, and runner sessions. Orchestrators need one read-only answer to what is running now and what just finished, with concrete follow-up commands instead of command-specific spelunking.

Part of #7451 (activity surface; envelope hardening is the remaining half). Related: #6768, #6761.

## ActivityItem contract
`homeboy activity` now emits `homeboy/activity-report/v1` through the standard command-result envelope. Each item normalizes:
- `id`, `kind`, `source_store`, `state`
- timestamps: `created_at`, `updated_at`, `finished_at`
- runner refs: `runner_id`, `job_id`, `transport`
- cross refs: `run_id`, `agent_task_run_id`, `runner_job_id`
- `artifacts` and `evidence`
- structured `next_actions` as `{ label, command }`

The command also lifts exact action commands into the envelope-level `next_actions` array.

## Sample human output
```text
activity: total=1 active=0 running=0 queued=0 failed=1 stale=0
id                           state          kind               updated
agent-task-8e50acbc-72c1-4c~ failed         agent-task         2026-07-04T03:24:32Z
  next: status: homeboy agent-task status agent-task-8e50acbc-72c1-4c82-a882-730771723e70
  next: logs: homeboy agent-task logs agent-task-8e50acbc-72c1-4c82-a882-730771723e70
```

## Sample JSON output
```json
{
  "schema": "homeboy/command-result/v2",
  "command": "activity",
  "success": true,
  "next_actions": [
    "homeboy agent-task artifacts agent-task-8e50acbc-72c1-4c82-a882-730771723e70",
    "homeboy agent-task logs agent-task-8e50acbc-72c1-4c82-a882-730771723e70",
    "homeboy agent-task retry --run agent-task-8e50acbc-72c1-4c82-a882-730771723e70",
    "homeboy agent-task status agent-task-8e50acbc-72c1-4c82-a882-730771723e70"
  ],
  "data": {
    "schema": "homeboy/activity-report/v1",
    "counts": { "total": 1, "active": 0, "failed": 1, "running": 0, "queued": 0, "stale": 0 },
    "items": [
      {
        "id": "agent-task-8e50acbc-72c1-4c82-a882-730771723e70",
        "kind": "agent-task",
        "source_store": "agent-task.lifecycle",
        "state": "failed",
        "refs": { "agent_task_run_id": "agent-task-8e50acbc-72c1-4c82-a882-730771723e70" },
        "next_actions": [
          { "label": "status", "command": "homeboy agent-task status agent-task-8e50acbc-72c1-4c82-a882-730771723e70" },
          { "label": "retry", "command": "homeboy agent-task retry --run agent-task-8e50acbc-72c1-4c82-a882-730771723e70" }
        ]
      }
    ]
  }
}
```

## Shipped
- New `src/core/activity.rs` read model across observation SQLite runs, agent-task lifecycle, daemon jobs, and runner session active jobs.
- New `homeboy activity`, `homeboy activity show <id>`, and `homeboy activity watch <id>` commands.
- Cross-store dedupe by run/task/job refs.
- State normalization and concrete next actions per state.
- Existing runs reconcile path reused before activity reads/watches.
- Registry/docs wiring for parser, top-level name, command specs, Lab local-only policy, and command docs.
- Reconcile guard for runner-backed ownerless records so unavailable runner refresh does not incorrectly stale local evidence.

## Deferred
None for this half. Envelope hardening remains the other half of #7451.

## LOC delta
`13 files changed, 1271 insertions(+), 11 deletions(-)`

## Verification
- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test activity`
- `cargo test --test command_surface_test`
- `cargo test agent_task_service::tests`
- `cargo test commands::runs::tests`
- `cargo run -- activity list --limit 1 --output <json-file>`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (claude-fable-5) orchestrator with GPT 5.5 coding subagent
- **Used for:** Investigation mapped the fragmented activity stores; the subagent implemented the normalized activity surface.
