### PR TITLE
Add runner dev-sync extension overlays

### DIFF
--- a/src/core/runner/execution/extension_parity.rs
+++ b/src/core/runner/execution/extension_parity.rs
@@ -114,6 +114,7 @@ fn validate_runner_extension(
         )?;
         if let Err(err) = validate_runner_extension_revision(
             runner_id,
+            runner,
             homeboy_path,
             extension_id,
             &output.stdout,
@@ -177,7 +178,14 @@ fn validate_runner_extension_parity_status(
     remote_stdout: &str,
 ) -> Result<()> {
     validate_runner_extension_ready(runner_id, homeboy_path, extension_id, remote_stdout)?;
-    validate_runner_extension_revision(runner_id, homeboy_path, extension_id, remote_stdout)
+    let runner = super::super::load(runner_id)?;
+    validate_runner_extension_revision(
+        runner_id,
+        &runner,
+        homeboy_path,
+        extension_id,
+        remote_stdout,
+    )
 }
 
 fn validate_runner_extension_settings(
@@ -224,6 +232,28 @@ fn runner_extension_setting_declared(declared: &BTreeMap<String, String>, key: &
 struct RemoteExtensionMetadata {
     path: Option<String>,
     source_revision: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct DevSyncExtensionOverlay {
+    id: String,
+    source_path: String,
+    content_hash: String,
+}
+
+fn dev_sync_extension_overlay(
+    runner: &Runner,
+    extension_id: &str,
+) -> Option<DevSyncExtensionOverlay> {
+    let extensions = runner
+        .resources
+        .get("dev_sync")?
+        .get("extensions")?
+        .as_array()?;
+    extensions.iter().find_map(|value| {
+        let overlay: DevSyncExtensionOverlay = serde_json::from_value(value.clone()).ok()?;
+        (overlay.id == extension_id).then_some(overlay)
+    })
 }
 
 fn unsupported_runner_extension_setting_error(
@@ -568,10 +598,20 @@ fn remote_extension_ready_status(stdout: &str) -> Option<RemoteExtensionReadySta
 
 fn validate_runner_extension_revision(
     runner_id: &str,
+    runner: &Runner,
     homeboy_path: &str,
     extension_id: &str,
     remote_stdout: &str,
 ) -> Result<()> {
+    if let Some(overlay) = dev_sync_extension_overlay(runner, extension_id) {
+        return validate_dev_overlay_extension_revision(
+            runner_id,
+            homeboy_path,
+            extension_id,
+            remote_stdout,
+            &overlay,
+        );
+    }
     let local_revision = extension::read_source_revision(extension_id);
     let remote_revision = remote_extension_source_revision(remote_stdout);
     let Some(local_revision) = local_revision.filter(|revision| !revision.trim().is_empty()) else {
@@ -613,6 +653,84 @@ fn validate_runner_extension_revision(
             ),
         ]),
     ))
+}
+
+fn validate_dev_overlay_extension_revision(
+    runner_id: &str,
+    homeboy_path: &str,
+    extension_id: &str,
+    remote_stdout: &str,
+    overlay: &DevSyncExtensionOverlay,
+) -> Result<()> {
+    let current_hash =
+        super::super::extension_source_content_hash(Path::new(&overlay.source_path))?;
+    if current_hash != overlay.content_hash {
+        return Err(dev_overlay_mismatch_error(
+            runner_id,
+            homeboy_path,
+            extension_id,
+            overlay,
+            &current_hash,
+            remote_extension_source_revision(remote_stdout).as_deref(),
+        ));
+    }
+
+    let remote_revision = remote_extension_source_revision(remote_stdout);
+    if remote_revision.as_deref() == Some(overlay.content_hash.as_str()) {
+        return Ok(());
+    }
+
+    Err(dev_overlay_mismatch_error(
+        runner_id,
+        homeboy_path,
+        extension_id,
+        overlay,
+        &current_hash,
+        remote_revision.as_deref(),
+    ))
+}
+
+fn dev_overlay_mismatch_error(
+    runner_id: &str,
+    _homeboy_path: &str,
+    extension_id: &str,
+    overlay: &DevSyncExtensionOverlay,
+    current_hash: &str,
+    remote_revision: Option<&str>,
+) -> Error {
+    let command = format!(
+        "homeboy runner dev-sync {} --extensions {}={}",
+        shell::quote_arg(runner_id),
+        shell::quote_arg(extension_id),
+        shell::quote_arg(&overlay.source_path)
+    );
+    Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!(
+            "Invalid argument 'runner_extension': Runner '{runner_id}' has stale dev-overlay extension parity for '{extension_id}' before command execution"
+        ),
+        serde_json::json!({
+            "field": "runner_extension",
+            "problem": "dev_overlay_content_hash_mismatch",
+            "id": extension_id,
+            "diagnostic": {
+                "code": "runner_extension.dev_overlay_content_hash_mismatch",
+                "runner_id": runner_id,
+                "extension_id": extension_id,
+                "recorded_content_hash": overlay.content_hash,
+                "current_content_hash": current_hash,
+                "runner_extension_source_revision": remote_revision.unwrap_or("<missing>"),
+                "source_path": overlay.source_path,
+                "remediation_command": command,
+            },
+            "tried": [
+                format!("Recorded dev overlay content_hash: {}", overlay.content_hash),
+                format!("Current local extension content_hash: {current_hash}"),
+                format!("Runner extension source_revision: {}", remote_revision.unwrap_or("<missing>")),
+                format!("Re-sync the dev overlay before dispatch: {command}"),
+            ]
+        }),
+    )
 }
 
 fn remote_extension_source_revision(stdout: &str) -> Option<String> {
@@ -736,7 +854,35 @@ mod tests {
     };
     use crate::test_support::with_isolated_home;
 
+    use crate::core::runner::{Runner, RunnerKind};
+    use std::collections::HashMap;
     use std::fs;
+
+    fn runner_with_overlay(extension_id: &str, source_path: &str, content_hash: &str) -> Runner {
+        let mut resources = HashMap::new();
+        resources.insert(
+            "dev_sync".to_string(),
+            serde_json::json!({
+                "schema": "homeboy/runner-dev-sync/v1",
+                "extensions": [{
+                    "id": extension_id,
+                    "source_path": source_path,
+                    "content_hash": content_hash,
+                }]
+            }),
+        );
+        Runner {
+            id: "homeboy-lab".to_string(),
+            kind: RunnerKind::Local,
+            server_id: None,
+            workspace_root: Some("/runner/ws".to_string()),
+            settings: Default::default(),
+            env: HashMap::new(),
+            secret_env: HashMap::new(),
+            resources,
+            policy: Default::default(),
+        }
+    }
 
     #[test]
     fn remote_extension_source_revision_reads_extension_show_output() {
@@ -968,9 +1114,11 @@ mod tests {
             fs::create_dir_all(&extension_dir).expect("extension dir");
             fs::write(extension_dir.join(".source-revision"), "local123\n").expect("revision");
             let remote_stdout = r#"{"success":true,"data":{"extension":{"id":"wordpress","source_revision":"remote456"}}}"#;
+            let runner = runner_with_overlay("other", "/tmp/other", "unused");
 
             let err = validate_runner_extension_revision(
                 "homeboy-lab",
+                &runner,
                 "homeboy",
                 "wordpress",
                 remote_stdout,
@@ -990,9 +1138,11 @@ mod tests {
             fs::create_dir_all(&extension_dir).expect("extension dir");
             fs::write(extension_dir.join(".source-revision"), "local123\n").expect("revision");
             let remote_stdout = r#"{"success":true,"data":{"extension":{"id":"wordpress"}}}"#;
+            let runner = runner_with_overlay("other", "/tmp/other", "unused");
 
             let err = validate_runner_extension_revision(
                 "homeboy-lab",
+                &runner,
                 "homeboy",
                 "wordpress",
                 remote_stdout,
@@ -1003,6 +1153,60 @@ mod tests {
             assert!(err.details["tried"].to_string().contains("local123"));
             assert!(err.details["tried"].to_string().contains("<missing>"));
         });
+    }
+
+    #[test]
+    fn revision_parity_accepts_matching_dev_overlay_content_hash() {
+        let tempdir = tempfile::tempdir().expect("source dir");
+        fs::write(tempdir.path().join("rust.json"), r#"{"id":"rust"}"#).expect("manifest");
+        fs::write(tempdir.path().join("run.sh"), "echo hi\n").expect("source file");
+        let hash = crate::core::runner::extension_source_content_hash(tempdir.path())
+            .expect("content hash");
+        let runner = runner_with_overlay("rust", &tempdir.path().display().to_string(), &hash);
+        let remote_stdout = format!(
+            r#"{{"success":true,"data":{{"extension":{{"id":"rust","source_revision":"{hash}"}}}}}}"#
+        );
+
+        validate_runner_extension_revision(
+            "homeboy-lab",
+            &runner,
+            "homeboy",
+            "rust",
+            &remote_stdout,
+        )
+        .expect("matching dev overlay hash should pass parity");
+    }
+
+    #[test]
+    fn revision_parity_rejects_changed_dev_overlay_with_resync_command() {
+        let tempdir = tempfile::tempdir().expect("source dir");
+        fs::write(tempdir.path().join("rust.json"), r#"{"id":"rust"}"#).expect("manifest");
+        fs::write(tempdir.path().join("run.sh"), "echo hi\n").expect("source file");
+        let hash = crate::core::runner::extension_source_content_hash(tempdir.path())
+            .expect("content hash");
+        fs::write(tempdir.path().join("run.sh"), "echo changed\n").expect("mutate source");
+        let runner = runner_with_overlay("rust", &tempdir.path().display().to_string(), &hash);
+        let remote_stdout = format!(
+            r#"{{"success":true,"data":{{"extension":{{"id":"rust","source_revision":"{hash}"}}}}}}"#
+        );
+
+        let err = validate_runner_extension_revision(
+            "homeboy-lab",
+            &runner,
+            "homeboy",
+            "rust",
+            &remote_stdout,
+        )
+        .expect_err("changed dev overlay source should fail parity");
+
+        assert_eq!(
+            err.details["diagnostic"]["code"].as_str(),
+            Some("runner_extension.dev_overlay_content_hash_mismatch")
+        );
+        assert!(err.details["diagnostic"]["remediation_command"]
+            .as_str()
+            .expect("command")
+            .contains("homeboy runner dev-sync homeboy-lab --extensions rust="));
     }
 
     #[test]

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -9,6 +9,10 @@ use sha2::{Digest, Sha256};
 
 use crate::core::error::{Error, Result};
 use crate::core::output::MergeOutput;
+use crate::core::resource_lifecycle_index::{
+    ResourceCleanupPolicy, ResourceEvidenceRetention, ResourceLifecycleRecord,
+    ResourceLifecycleResourceStatus,
+};
 
 use super::{
     connect, disconnect, exec, load, merge, normalize_runner_command_env_for_homeboy_path,
@@ -88,6 +92,30 @@ pub struct RunnerDevSyncBinaryProvenance {
     pub dirty: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerDevSyncExtensionProvenance {
+    pub id: String,
+    pub source_path: String,
+    pub synced_source_path: String,
+    pub content_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+    pub dirty: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dirty_fingerprint: Option<String>,
+    pub synced_at: String,
+    pub dev_overlay: bool,
+    pub lifecycle: ResourceLifecycleRecord,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunnerDevSyncExtensionPlan {
+    pub id: String,
+    pub source_path: String,
+    pub synced_source_path: String,
+    pub content_hash: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunnerDevSyncPlan {
     pub runner_id: String,
@@ -96,6 +124,7 @@ pub struct RunnerDevSyncPlan {
     pub local_binary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote_binary: Option<String>,
+    pub extensions: Vec<RunnerDevSyncExtensionPlan>,
     pub reconnect: bool,
     pub followup_commands: Vec<String>,
 }
@@ -109,6 +138,7 @@ pub struct RunnerDevSyncOutput {
     pub plan: RunnerDevSyncPlan,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub binary: Option<RunnerDevSyncBinaryProvenance>,
+    pub extensions: Vec<RunnerDevSyncExtensionProvenance>,
     pub extensions_deferred: Vec<String>,
     pub updated_fields: Vec<String>,
     pub daemon_refreshed: bool,
@@ -315,6 +345,7 @@ pub fn plan_runner_dev_sync(options: &RunnerDevSyncOptions) -> Result<RunnerDevS
             .as_ref()
             .and_then(|path| sha256_file(Path::new(path)).ok())
             .map(|sha| dev_binary_path(workspace_root, &sha)),
+        extensions: plan_extension_overlays(workspace_root, &options.extensions)?,
         reconnect: options.reconnect,
         followup_commands: dev_sync_followups(&runner.id, options.reconnect),
     })
@@ -343,7 +374,8 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
                 dry_run: true,
                 plan,
                 binary: None,
-                extensions_deferred: options.extensions,
+                extensions: Vec::new(),
+                extensions_deferred: Vec::new(),
                 updated_fields: Vec::new(),
                 daemon_refreshed: false,
                 reconnect_required: !options.reconnect,
@@ -399,7 +431,10 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
         },
     )?;
     if chmod_exit != 0 {
-        return Ok((dev_sync_failure_output(options, plan, None), chmod_exit));
+        return Ok((
+            dev_sync_failure_output(options, plan, None, Vec::new()),
+            chmod_exit,
+        ));
     }
 
     let (refresh_output, exit_code) = refresh_homeboy_binary(HomeboyBinaryRefreshOptions {
@@ -414,7 +449,10 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
         dry_run: false,
     })?;
     if exit_code != 0 {
-        return Ok((dev_sync_failure_output(options, plan, None), exit_code));
+        return Ok((
+            dev_sync_failure_output(options, plan, None, Vec::new()),
+            exit_code,
+        ));
     }
 
     let source_revision = source_path.as_deref().and_then(git_revision);
@@ -428,6 +466,7 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
         source_revision,
         dirty,
     };
+    let extensions = sync_extension_overlays(&options.runner_id, &plan, &transfer)?;
 
     let mut runner = load(&options.runner_id)?;
     runner.resources.insert(
@@ -435,8 +474,8 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
         serde_json::json!({
             "schema": "homeboy/runner-dev-sync/v1",
             "homeboy": binary,
-            "extensions": [],
-            "extensions_deferred": options.extensions,
+            "extensions": extensions,
+            "extensions_deferred": [],
         }),
     );
     let patch = serde_json::json!({ "resources": runner.resources });
@@ -453,7 +492,8 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
             dry_run: false,
             plan,
             binary: Some(binary),
-            extensions_deferred: options.extensions,
+            extensions,
+            extensions_deferred: Vec::new(),
             updated_fields,
             daemon_refreshed: refresh_output.daemon_refreshed,
             reconnect_required: refresh_output.reconnect_required,
@@ -467,6 +507,7 @@ fn dev_sync_failure_output(
     options: RunnerDevSyncOptions,
     plan: RunnerDevSyncPlan,
     binary: Option<RunnerDevSyncBinaryProvenance>,
+    extensions: Vec<RunnerDevSyncExtensionProvenance>,
 ) -> RunnerDevSyncOutput {
     RunnerDevSyncOutput {
         variant: "dev_sync",
@@ -475,12 +516,149 @@ fn dev_sync_failure_output(
         dry_run: false,
         plan,
         binary,
+        extensions,
         extensions_deferred: options.extensions,
         updated_fields: Vec::new(),
         daemon_refreshed: false,
         reconnect_required: !options.reconnect,
         next_actions: dev_sync_next_actions(&options.runner_id, options.reconnect),
     }
+}
+
+fn plan_extension_overlays(
+    workspace_root: &str,
+    specs: &[String],
+) -> Result<Vec<RunnerDevSyncExtensionPlan>> {
+    specs
+        .iter()
+        .map(|spec| {
+            let (id, source) = parse_extension_spec(spec)?;
+            let source_path = expand_path(source);
+            let content_hash = extension_source_content_hash(&source_path)?;
+            Ok(RunnerDevSyncExtensionPlan {
+                id: id.to_string(),
+                source_path: source_path.display().to_string(),
+                synced_source_path: dev_extension_path(workspace_root, id, &content_hash),
+                content_hash,
+            })
+        })
+        .collect()
+}
+
+fn sync_extension_overlays(
+    runner_id: &str,
+    plan: &RunnerDevSyncPlan,
+    transfer: &RunnerFileTransfer,
+) -> Result<Vec<RunnerDevSyncExtensionProvenance>> {
+    let mut overlays = Vec::new();
+    for extension in &plan.extensions {
+        sync_extension_overlay_source(runner_id, extension, transfer)?;
+        let source = Path::new(&extension.source_path);
+        let dirty = git_dirty(source);
+        overlays.push(RunnerDevSyncExtensionProvenance {
+            id: extension.id.clone(),
+            source_path: extension.source_path.clone(),
+            synced_source_path: extension.synced_source_path.clone(),
+            content_hash: extension.content_hash.clone(),
+            source_revision: git_revision(source),
+            dirty,
+            dirty_fingerprint: dirty.then(|| git_dirty_fingerprint(source)).flatten(),
+            synced_at: chrono::Utc::now().to_rfc3339(),
+            dev_overlay: true,
+            lifecycle: dev_extension_lifecycle(
+                runner_id,
+                &extension.synced_source_path,
+                &extension.id,
+            ),
+        });
+    }
+    Ok(overlays)
+}
+
+fn sync_extension_overlay_source(
+    runner_id: &str,
+    extension: &RunnerDevSyncExtensionPlan,
+    transfer: &RunnerFileTransfer,
+) -> Result<()> {
+    let tempdir = tempfile::tempdir().map_err(|err| {
+        Error::internal_io(err.to_string(), Some("stage extension overlay".to_string()))
+    })?;
+    let staged = tempdir.path().join("source");
+    super::copy_snapshot_to_directory(Path::new(&extension.source_path), &staged, &[])?;
+    let archive = tempdir.path().join("source.tar");
+    let status = Command::new("tar")
+        .args([
+            "-C",
+            &staged.display().to_string(),
+            "-cf",
+            &archive.display().to_string(),
+            ".",
+        ])
+        .status()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("archive extension overlay".to_string()),
+            )
+        })?;
+    if !status.success() {
+        return Err(Error::internal_unexpected(
+            "archive extension overlay failed".to_string(),
+        ));
+    }
+
+    let remote_archive = format!("{}.tar", extension.synced_source_path.trim_end_matches('/'));
+    let remote_parent = Path::new(&extension.synced_source_path)
+        .parent()
+        .and_then(Path::to_str)
+        .ok_or_else(|| {
+            Error::internal_json("invalid remote extension overlay path".to_string(), None)
+        })?;
+    transfer.ensure_directory(remote_parent)?;
+    transfer.upload_file(&archive.display().to_string(), &remote_archive)?;
+    let script = format!(
+        "set -e\nrm -rf {dest}\nmkdir -p {dest}\ntar -xf {archive} -C {dest}\nrm -f {archive}\nhomeboy extension refresh {dest} --id {id} --ref {hash}\n",
+        dest = sq(&extension.synced_source_path),
+        archive = sq(&remote_archive),
+        id = sq(&extension.id),
+        hash = sq(&extension.content_hash),
+    );
+    let (_output, exit_code) = exec(
+        runner_id,
+        RunnerExecOptions {
+            cwd: None,
+            project_id: None,
+            allow_diagnostic_ssh: true,
+            command: vec!["bash".to_string(), "-lc".to_string(), script],
+            env: Default::default(),
+            secret_env_names: Vec::new(),
+            secret_env_plan: None,
+            env_materialization: None,
+            capture_patch: false,
+            raw_exec: true,
+            source_snapshot: None,
+            capability_preflight: None,
+            required_extensions: Vec::new(),
+            require_paths: Vec::new(),
+            runner_workload: None,
+            run_id: None,
+            detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
+        },
+    )?;
+    if exit_code != 0 {
+        return Err(Error::validation_invalid_argument(
+            "extensions",
+            format!(
+                "failed to relink dev overlay extension '{}' on runner",
+                extension.id
+            ),
+            Some(extension.synced_source_path.clone()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn materialize_script(source: &str, git_ref: &str, target_dir: &str, binary_path: &str) -> String {
@@ -581,6 +759,95 @@ fn dev_binary_path(workspace_root: &str, sha256: &str) -> String {
     )
 }
 
+fn dev_extension_path(workspace_root: &str, id: &str, content_hash: &str) -> String {
+    format!(
+        "{}/_lab_workspaces/dev-extensions/{}/{}/",
+        workspace_root.trim_end_matches('/'),
+        sanitize_ref(id),
+        &content_hash[..16]
+    )
+}
+
+pub(crate) fn extension_source_content_hash(path: &Path) -> Result<String> {
+    let mut entries = Vec::new();
+    collect_hash_entries(path, path, &mut entries)?;
+    entries.sort();
+    let mut hasher = Sha256::new();
+    for (relative, path) in entries {
+        hasher.update(relative.as_bytes());
+        hasher.update([0]);
+        let mut file = fs::File::open(&path)
+            .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+        let mut buffer = [0_u8; 8192];
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .map_err(|err| Error::internal_json(err.to_string(), None))?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn collect_hash_entries(
+    root: &Path,
+    path: &Path,
+    entries: &mut Vec<(String, PathBuf)>,
+) -> Result<()> {
+    let mut children = fs::read_dir(path)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+    children.sort_by_key(|entry| entry.path());
+    for entry in children {
+        let path = entry.path();
+        if entry.file_name().to_string_lossy() == ".git" {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+        if metadata.is_dir() {
+            collect_hash_entries(root, &path, entries)?;
+        } else if metadata.is_file() {
+            let relative = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            entries.push((relative, path));
+        }
+    }
+    Ok(())
+}
+
+fn dev_extension_lifecycle(
+    runner_id: &str,
+    remote_path: &str,
+    extension_id: &str,
+) -> ResourceLifecycleRecord {
+    ResourceLifecycleRecord {
+        owner: "runner.dev_sync.extension_overlay".to_string(),
+        run_id: format!("runner-dev-sync-{runner_id}-{extension_id}"),
+        runner_id: Some(runner_id.to_string()),
+        path: remote_path.to_string(),
+        root_bound: None,
+        kind: "runner_dev_extension_overlay".to_string(),
+        ttl: Some("P7D".to_string()),
+        cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
+        evidence_retention: ResourceEvidenceRetention::Metadata,
+        cleanup_intent: Default::default(),
+        cleanup_command: Some(format!(
+            "homeboy runner dev-sync {} --extensions {}=<path>",
+            shell_arg(runner_id),
+            shell_arg(extension_id)
+        )),
+        status: ResourceLifecycleResourceStatus::Active,
+    }
+}
+
 fn sha256_file(path: &Path) -> Result<String> {
     let mut file = fs::File::open(path).map_err(|err| {
         Error::validation_invalid_argument(
@@ -627,26 +894,50 @@ fn git_dirty(path: &Path) -> bool {
         .is_some_and(|output| !output.stdout.is_empty())
 }
 
+fn git_dirty_fingerprint(path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            &path.display().to_string(),
+            "status",
+            "--porcelain=v1",
+        ])
+        .output()
+        .ok()?;
+    output.status.success().then(|| {
+        let mut hasher = Sha256::new();
+        hasher.update(&output.stdout);
+        format!("{:x}", hasher.finalize())
+    })
+}
+
 fn validate_extension_specs(specs: &[String]) -> Result<()> {
     for spec in specs {
-        let Some((id, path)) = spec.split_once('=') else {
-            return Err(Error::validation_invalid_argument(
-                "extensions",
-                "extension dev-sync specs must use id=path",
-                Some(spec.clone()),
-                None,
-            ));
-        };
-        if id.trim().is_empty() || path.trim().is_empty() {
-            return Err(Error::validation_invalid_argument(
-                "extensions",
-                "extension dev-sync specs must include a non-empty id and path",
-                Some(spec.clone()),
-                None,
-            ));
-        }
+        parse_extension_spec(spec)?;
     }
     Ok(())
+}
+
+fn parse_extension_spec(spec: &str) -> Result<(&str, &str)> {
+    let Some((id, path)) = spec.split_once('=') else {
+        return Err(Error::validation_invalid_argument(
+            "extensions",
+            "extension dev-sync specs must use id=path",
+            Some(spec.to_string()),
+            None,
+        ));
+    };
+    let id = id.trim();
+    let path = path.trim();
+    if id.is_empty() || path.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "extensions",
+            "extension dev-sync specs must include a non-empty id and path",
+            Some(spec.to_string()),
+            None,
+        ));
+    }
+    Ok((id, path))
 }
 
 fn dev_sync_followups(runner_id: &str, reconnect: bool) -> Vec<String> {
@@ -843,6 +1134,37 @@ mod tests {
             dev_binary_path("/runner/ws/", "0123456789abcdef9999"),
             "/runner/ws/_homeboy_binaries/dev/0123456789abcdef/homeboy"
         );
+    }
+
+    #[test]
+    fn extension_overlay_plan_uses_content_hash_slot() {
+        let dir = tempfile::tempdir().expect("extension source");
+        std::fs::write(dir.path().join("rust.json"), r#"{"id":"rust"}"#).expect("manifest");
+        std::fs::write(dir.path().join("run.sh"), "echo hi\n").expect("source");
+
+        let plan =
+            plan_extension_overlays("/runner/ws/", &[format!("rust={}", dir.path().display())])
+                .expect("overlay plan");
+
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0].id, "rust");
+        assert!(plan[0]
+            .synced_source_path
+            .starts_with("/runner/ws/_lab_workspaces/dev-extensions/rust/"));
+        assert!(plan[0].synced_source_path.ends_with('/'));
+    }
+
+    #[test]
+    fn extension_overlay_lifecycle_uses_ttl_cleanup_policy() {
+        let lifecycle = dev_extension_lifecycle("lab", "/runner/ws/dev/rust/hash", "rust");
+
+        assert_eq!(lifecycle.owner, "runner.dev_sync.extension_overlay");
+        assert_eq!(lifecycle.ttl.as_deref(), Some("P7D"));
+        assert_eq!(
+            lifecycle.cleanup_policy,
+            ResourceCleanupPolicy::DeleteAfterTtl
+        );
+        assert_eq!(lifecycle.status, ResourceLifecycleResourceStatus::Active);
     }
 
     #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -106,10 +106,11 @@ pub(crate) use git_dependency_materialization::{
     RunnerDependencyCacheSaveOutput, RunnerDependencyCacheSaveRequest,
     RunnerGitDependencyMaterializationOptions, RunnerGitDependencyMaterializationOutput,
 };
+pub(crate) use homeboy_refresh::extension_source_content_hash;
 pub use homeboy_refresh::{
     plan_homeboy_binary_refresh, refresh_homeboy_binary, runner_dev_sync, HomeboyBinaryRefreshMode,
     HomeboyBinaryRefreshOptions, HomeboyBinaryRefreshOutput, HomeboyBinaryRefreshPlan,
-    RunnerDevSyncOptions, RunnerDevSyncOutput, RunnerDevSyncPlan,
+    RunnerDevSyncExtensionProvenance, RunnerDevSyncOptions, RunnerDevSyncOutput, RunnerDevSyncPlan,
 };
 pub use lab::{
     execute_lab_offload, LabJobOverrides, LabLocalExecutionPolicy, LabOffloadCommand,


### PR DESCRIPTION
## UX walkthrough
- Build/select a dev Homeboy binary with `homeboy runner dev-sync <runner> --homeboy-source <checkout> --reconnect` or reuse the merged binary slot flow.
- Sync local extension work with `homeboy runner dev-sync <runner> --extensions rust=/path/to/homeboy-extensions/rust`; the source is snapshotted to `<workspace_root>/_lab_workspaces/dev-extensions/<id>/<hash>/`, relinked through extension refresh, and recorded in `runner.resources.dev_sync.extensions`.
- Offloaded runner jobs accept the overlay only while the local source content hash still matches the recorded overlay hash and the runner extension reports that same hash as `source_revision`.
- If the checkout changes, parity fails with `runner_extension.dev_overlay_content_hash_mismatch` and a concrete `homeboy runner dev-sync <runner> --extensions id=path` command to re-run.
- Return to release-installed extensions with the existing clean refresh path; full automatic extension release restore is deferred because existing runner provenance does not record prior release install origins.

## Design
- Extends the existing `runner dev-sync` provenance record instead of adding a second store.
- Uses a deterministic content hash over source files, excluding `.git`, for runner slot selection and parity.
- Reuses existing snapshot materialization and extension lifecycle refresh/relink behavior rather than adding a parallel installer.
- Adds TTL-backed resource lifecycle metadata for dev overlay slots using `delete_after_ttl` / `P7D`.
- Keeps extension parity changes metadata-driven and localized to `extension_parity.rs`.

## LOC delta
- `src/core/runner/homeboy_refresh.rs`: extension overlay planning, sync, provenance, content hashing, TTL lifecycle tests.
- `src/core/runner/execution/extension_parity.rs`: dev-overlay parity acceptance and mismatch diagnostics.
- `src/core/runner/mod.rs`: crate-visible hash helper export.

## Verification
- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test homeboy_refresh --lib`
- `cargo test extension_parity --lib`
- `cargo test lifecycle --lib`

Closes #7503. Advances Extra-Chill/homeboy-extensions#2155. Related: #1954, #6396.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (claude-fable-5) orchestrator with GPT 5.5 coding subagent
- **Used for:** Investigation identified the parity refusal blocking local extension iteration; the subagent implemented the dev overlay path.