### PR TITLE
Add typed actionable command envelopes

### DIFF
--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -21,14 +21,51 @@ summary artifact.
 
 ## Top-level envelope
 
-In JSON mode, Homeboy prints a `CliResponse<T>` where `T` is the
+In JSON mode, Homeboy prints a `homeboy/command-result/v3` envelope around the
 **command-specific output struct**.
 
 Success:
 
 ```json
 {
+  "schema": "homeboy/command-result/v3",
+  "command": "runs.show",
   "success": true,
+  "exit_code": 0,
+  "status": "succeeded",
+  "run": {
+    "id": "bench-run-42",
+    "kind": "bench",
+    "source": "homeboy-observation-store",
+    "status_command": "homeboy runs show bench-run-42",
+    "watch_command": "homeboy runs watch bench-run-42"
+  },
+  "refs": {
+    "runs": [
+      {
+        "id": "bench-run-42",
+        "kind": "bench",
+        "source": "homeboy-observation-store",
+        "status_command": "homeboy runs show bench-run-42",
+        "watch_command": "homeboy runs watch bench-run-42"
+      }
+    ]
+  },
+  "next_actions": [
+    {
+      "label": "show run",
+      "command": "homeboy runs show bench-run-42",
+      "kind": "show"
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "bench_artifact",
+      "kind": "bench_artifact",
+      "uri": "/tmp/bench-result.json",
+      "semantic_key": "file"
+    }
+  ],
   "data": { "...": "..." }
 }
 ```
@@ -52,6 +89,38 @@ Notes:
 - `error` is omitted on success.
 - `error.hints`/`error.retryable` are omitted when not set.
 - JSON serialization errors return `internal.json_error` (no silent fallback).
+- `next_actions`, `refs`, `artifacts`, and `evidence` are populated only from
+  typed command-output metadata. The envelope does not infer them from incidental
+  payload keys such as `run_id`, `hints`, or `artifact_path`.
+
+## Actionable result metadata
+
+Command handlers that have actionable follow-ups attach a reserved
+`_homeboy_actionable` field to their serializable output at the point they build
+the payload. The response layer consumes that reserved field, removes it from
+`data`, and copies the typed values into the envelope.
+
+The reserved metadata shape is:
+
+```json
+{
+  "run": { "id": "run-id", "kind": "bench", "source": "...", "status_command": "...", "watch_command": "..." },
+  "refs": {
+    "runs": [],
+    "jobs": [],
+    "agent_tasks": []
+  },
+  "next_actions": [
+    { "label": "review run", "command": "homeboy agent-task review run-id", "kind": "show" }
+  ],
+  "artifacts": [],
+  "evidence": []
+}
+```
+
+`next_actions[].kind` is optional and currently uses `watch`, `show`,
+`artifacts`, or `repair`. Commands not migrated to this metadata contract emit
+empty actionable envelope fields rather than guessed actions.
 
 ## Full status report output
 

--- a/src/commands/activity.rs
+++ b/src/commands/activity.rs
@@ -8,6 +8,10 @@ use homeboy::core::notify::{self, NotifyEvent, NotifyOutcome};
 use homeboy::core::observation::ObservationStore;
 use homeboy::core::{Error, Result};
 
+use super::utils::response::{
+    CommandActionableMetadata, CommandAgentTaskRef, CommandJobRef, CommandNextAction,
+    CommandNextActionKind, CommandResultRefs, CommandRunRef,
+};
 use super::{CmdResult, GlobalArgs};
 
 const TIMEOUT_EXIT_CODE: i32 = 124;
@@ -59,8 +63,19 @@ pub struct ActivityWatchArgs {
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum ActivityOutput {
-    Report(ActivityReport),
+    Report(ActivityReportOutput),
     Watch(ActivityWatchOutput),
+}
+
+#[derive(Serialize)]
+pub struct ActivityReportOutput {
+    #[serde(flatten)]
+    pub report: ActivityReport,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "CommandActionableMetadata::is_empty"
+    )]
+    pub actionable: CommandActionableMetadata,
 }
 
 #[derive(Serialize)]
@@ -76,6 +91,11 @@ pub struct ActivityWatchOutput {
     pub item: ActivityItem,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<String>,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "CommandActionableMetadata::is_empty"
+    )]
+    pub actionable: CommandActionableMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notify: Option<NotifyOutcome>,
 }
@@ -169,15 +189,22 @@ fn list(args: ActivityListArgs) -> CmdResult<ActivityOutput> {
     } else {
         ActivityScope::ActiveRecent
     };
+    let report = activity::activity_report(scope, args.limit)?;
+    let actionable = actionable_for_activity_report(&report);
     Ok((
-        ActivityOutput::Report(activity::activity_report(scope, args.limit)?),
+        ActivityOutput::Report(ActivityReportOutput { report, actionable }),
         0,
     ))
 }
 
 fn show(id: &str) -> CmdResult<ActivityOutput> {
     reconcile_runs_best_effort();
-    Ok((ActivityOutput::Report(activity::show_activity(id)?), 0))
+    let report = activity::show_activity(id)?;
+    let actionable = actionable_for_activity_report(&report);
+    Ok((
+        ActivityOutput::Report(ActivityReportOutput { report, actionable }),
+        0,
+    ))
 }
 
 fn watch(args: ActivityWatchArgs) -> CmdResult<ActivityOutput> {
@@ -244,6 +271,7 @@ fn watch_output(
         .iter()
         .map(|action| action.command.clone())
         .collect();
+    let actionable = actionable_for_activity_item(&item);
     (
         ActivityOutput::Watch(ActivityWatchOutput {
             schema: activity::ACTIVITY_REPORT_SCHEMA,
@@ -256,10 +284,133 @@ fn watch_output(
             poll_count,
             item,
             next_actions,
+            actionable,
             notify,
         }),
         exit_code,
     )
+}
+
+fn actionable_for_activity_item(item: &ActivityItem) -> CommandActionableMetadata {
+    let mut metadata = CommandActionableMetadata {
+        refs: CommandResultRefs {
+            runs: item
+                .refs
+                .run_id
+                .as_deref()
+                .map(activity_run_ref)
+                .into_iter()
+                .collect(),
+            jobs: item
+                .refs
+                .runner_job_id
+                .as_deref()
+                .map(activity_job_ref)
+                .into_iter()
+                .collect(),
+            agent_tasks: item
+                .refs
+                .agent_task_run_id
+                .as_deref()
+                .map(activity_agent_task_ref)
+                .into_iter()
+                .collect(),
+        },
+        next_actions: item
+            .next_actions
+            .iter()
+            .map(|action| {
+                CommandNextAction::new(action.label.clone(), action.command.clone())
+                    .with_kind(action_kind_from_label(&action.label))
+            })
+            .collect(),
+        artifacts: item
+            .artifacts
+            .iter()
+            .map(|artifact| super::utils::response::CommandArtifactRef {
+                id: artifact.id.clone(),
+                kind: artifact.kind.clone(),
+                uri: artifact.uri.clone(),
+                semantic_key: None,
+            })
+            .collect(),
+        evidence: item
+            .evidence
+            .iter()
+            .map(|evidence| super::utils::response::CommandEvidenceRef {
+                id: evidence.id.clone(),
+                kind: evidence.kind.clone(),
+                uri: evidence.uri.clone(),
+                semantic_key: None,
+            })
+            .collect(),
+        ..Default::default()
+    };
+    metadata.run = metadata.refs.runs.first().cloned();
+    metadata
+}
+
+fn actionable_for_activity_report(report: &ActivityReport) -> CommandActionableMetadata {
+    let mut metadata = CommandActionableMetadata::default();
+    for item in report.items.iter().take(20) {
+        let item_metadata = actionable_for_activity_item(item);
+        if metadata.run.is_none() {
+            metadata.run = item_metadata.run.clone();
+        }
+        metadata.refs.runs.extend(item_metadata.refs.runs);
+        metadata.refs.jobs.extend(item_metadata.refs.jobs);
+        metadata
+            .refs
+            .agent_tasks
+            .extend(item_metadata.refs.agent_tasks);
+        metadata.next_actions.extend(item_metadata.next_actions);
+        metadata.artifacts.extend(item_metadata.artifacts);
+        metadata.evidence.extend(item_metadata.evidence);
+    }
+    metadata
+}
+
+fn activity_run_ref(run_id: &str) -> CommandRunRef {
+    CommandRunRef {
+        id: run_id.to_string(),
+        kind: "activity".to_string(),
+        source: "homeboy-activity".to_string(),
+        location: None,
+        started_at: None,
+        updated_at: None,
+        finished_at: None,
+        status_command: format!("homeboy runs show {run_id}"),
+        watch_command: format!("homeboy runs watch {run_id}"),
+    }
+}
+
+fn activity_job_ref(job_id: &str) -> CommandJobRef {
+    CommandJobRef {
+        id: job_id.to_string(),
+        kind: "runner_job".to_string(),
+        source: "homeboy-activity".to_string(),
+        status_command: format!("homeboy activity show {job_id}"),
+        watch_command: Some(format!("homeboy activity watch {job_id}")),
+    }
+}
+
+fn activity_agent_task_ref(run_id: &str) -> CommandAgentTaskRef {
+    CommandAgentTaskRef {
+        id: run_id.to_string(),
+        source: "homeboy-activity".to_string(),
+        status_command: format!("homeboy agent-task status {run_id} --full"),
+        logs_command: format!("homeboy agent-task logs {run_id}"),
+        review_command: Some(format!("homeboy agent-task review {run_id}")),
+    }
+}
+
+fn action_kind_from_label(label: &str) -> CommandNextActionKind {
+    match label {
+        "watch" => CommandNextActionKind::Watch,
+        "artifacts" => CommandNextActionKind::Artifacts,
+        "repair" | "reconcile" => CommandNextActionKind::Repair,
+        _ => CommandNextActionKind::Show,
+    }
 }
 
 fn maybe_notify(

--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -17,6 +17,10 @@ use homeboy::core::agent_tasks::{AgentTaskEvidenceRef, AgentTaskOutcomeStatus};
 
 use super::super::CmdResult;
 use super::args::{CancelArgs, DiagnoseArgs, EvidenceArgs, ReplayProviderBoundaryArgs, StatusArgs};
+use crate::commands::utils::response::{
+    CommandActionableMetadata, CommandAgentTaskRef, CommandNextAction, CommandNextActionKind,
+    CommandResultRefs, ACTIONABLE_METADATA_KEY,
+};
 
 /// Cap the number of detail refs rendered in the compact summary so a noisy
 /// aggregate cannot flood recovery output. Overflow is reported as an
@@ -47,9 +51,12 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     let mut value = serde_json::to_value(&record).unwrap_or(Value::Null);
     enrich_with_diagnostic_summary(&mut value, &args.run_id)?;
     if args.full {
+        attach_agent_task_status_actionable(&mut value, &args.run_id);
         return Ok((value, 0));
     }
     let summary = compact_status_summary(&value, &args.run_id);
+    let mut summary = summary;
+    attach_agent_task_status_actionable(&mut summary, &args.run_id);
     Ok((summary, 0))
 }
 
@@ -63,7 +70,9 @@ pub(super) fn list_runs(
     options: agent_task_service_direct::AgentTaskDiscoveryOptions,
 ) -> CmdResult<Value> {
     let report = agent_task_service_direct::discover_runs_with_options(filter, options)?;
-    Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
+    let mut value = serde_json::to_value(report).unwrap_or(Value::Null);
+    attach_agent_task_discovery_actionable(&mut value);
+    Ok((value, 0))
 }
 
 /// `agent-task active`: list queued + running runs, but SEPARATE them into
@@ -91,6 +100,7 @@ pub(super) fn list_active(
             json!("run `homeboy agent-task active --reconcile` (or the per-run `commands.reconcile`) to safely cancel stale-running records without manual state edits"),
         );
     }
+    attach_agent_task_discovery_actionable(&mut value);
     Ok((value, 0))
 }
 
@@ -135,6 +145,121 @@ fn active_liveness_buckets(report: &agent_task_service::AgentTaskDiscoveryReport
         "suspect": suspect,
         "unreconciled": unreconciled,
     })
+}
+
+fn attach_agent_task_status_actionable(value: &mut Value, run_id: &str) {
+    let mut metadata = CommandActionableMetadata {
+        refs: CommandResultRefs {
+            agent_tasks: vec![agent_task_ref(run_id)],
+            ..Default::default()
+        },
+        next_actions: vec![
+            CommandNextAction::new(
+                "show status",
+                format!("homeboy agent-task status {run_id} --full"),
+            )
+            .with_kind(CommandNextActionKind::Show),
+            CommandNextAction::new("show logs", format!("homeboy agent-task logs {run_id}"))
+                .with_kind(CommandNextActionKind::Show),
+            CommandNextAction::new(
+                "list artifacts",
+                format!("homeboy agent-task artifacts {run_id}"),
+            )
+            .with_kind(CommandNextActionKind::Artifacts),
+        ],
+        ..Default::default()
+    };
+
+    let review_command = format!("homeboy agent-task review {run_id}");
+    metadata.next_actions.push(
+        CommandNextAction::new("review run", review_command).with_kind(CommandNextActionKind::Show),
+    );
+
+    attach_actionable_metadata(value, metadata);
+}
+
+fn attach_agent_task_discovery_actionable(value: &mut Value) {
+    let runs = value
+        .get("runs")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut metadata = CommandActionableMetadata::default();
+
+    for run in runs.iter().take(20) {
+        let Some(run_id) = run.get("run_id").and_then(Value::as_str) else {
+            continue;
+        };
+        metadata.refs.agent_tasks.push(agent_task_ref(run_id));
+        if let Some(commands) = run.get("commands") {
+            push_command_action(
+                &mut metadata.next_actions,
+                "show status",
+                commands.get("status"),
+                CommandNextActionKind::Show,
+            );
+            push_command_action(
+                &mut metadata.next_actions,
+                "show logs",
+                commands.get("logs"),
+                CommandNextActionKind::Show,
+            );
+            push_command_action(
+                &mut metadata.next_actions,
+                "list artifacts",
+                commands.get("artifacts"),
+                CommandNextActionKind::Artifacts,
+            );
+            if run
+                .get("liveness")
+                .and_then(Value::as_str)
+                .is_some_and(|liveness| liveness != "active")
+            {
+                push_command_action(
+                    &mut metadata.next_actions,
+                    "reconcile stale run",
+                    commands.get("reconcile"),
+                    CommandNextActionKind::Repair,
+                );
+            }
+        }
+    }
+
+    attach_actionable_metadata(value, metadata);
+}
+
+fn agent_task_ref(run_id: &str) -> CommandAgentTaskRef {
+    CommandAgentTaskRef {
+        id: run_id.to_string(),
+        source: "homeboy-agent-task-lifecycle".to_string(),
+        status_command: format!("homeboy agent-task status {run_id} --full"),
+        logs_command: format!("homeboy agent-task logs {run_id}"),
+        review_command: Some(format!("homeboy agent-task review {run_id}")),
+    }
+}
+
+fn push_command_action(
+    actions: &mut Vec<CommandNextAction>,
+    label: &str,
+    command: Option<&Value>,
+    kind: CommandNextActionKind,
+) {
+    let Some(command) = command.and_then(Value::as_str) else {
+        return;
+    };
+    actions.push(CommandNextAction::new(label, command).with_kind(kind));
+}
+
+fn attach_actionable_metadata(value: &mut Value, metadata: CommandActionableMetadata) {
+    if metadata.is_empty() {
+        return;
+    }
+    let Value::Object(map) = value else {
+        return;
+    };
+    if let Ok(metadata) = serde_json::to_value(metadata) {
+        map.insert(ACTIONABLE_METADATA_KEY.to_string(), metadata);
+    }
 }
 
 pub(super) fn logs(args: StatusArgs) -> CmdResult<Value> {

--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -20,9 +20,10 @@ use homeboy::core::{api_jobs, runners as runner};
 use super::bench::run_contains_scenario;
 use super::common::{run_summaries_with_artifact_indexes, RunSummary};
 use super::types::{
-    RunDetail, RunsArtifactArgs, RunsArtifactCommand, RunsArtifactGetArgs, RunsArtifactGetOutput,
-    RunsArtifactPathGuide, RunsArtifactPullEntry, RunsArtifactPullSummary, RunsArtifactsArgs,
-    RunsArtifactsOutput, RunsDirectoryArtifactPublicationGuidance, RunsEnvKeyOutput, RunsEnvOutput,
+    actionable_for_run_detail, actionable_for_run_list, RunDetail, RunsArtifactArgs,
+    RunsArtifactCommand, RunsArtifactGetArgs, RunsArtifactGetOutput, RunsArtifactPathGuide,
+    RunsArtifactPullEntry, RunsArtifactPullSummary, RunsArtifactsArgs, RunsArtifactsOutput,
+    RunsDirectoryArtifactPublicationGuidance, RunsEnvKeyOutput, RunsEnvOutput,
     RunsEnvSourceLayerOutput, RunsEnvSummary, RunsFieldSelectionOutput, RunsListArgs,
     RunsListOutput, RunsOutput, RunsResumePlanOutput, RunsSelectedField, RunsShowOutput,
 };
@@ -65,7 +66,15 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
         runs.extend(active_runner_job_summaries(status_filter.as_deref()));
     }
 
-    Ok((RunsOutput::List(RunsListOutput { command, runs }), 0))
+    let actionable = actionable_for_run_list(&runs);
+    Ok((
+        RunsOutput::List(RunsListOutput {
+            command,
+            runs,
+            actionable,
+        }),
+        0,
+    ))
 }
 
 fn active_runner_job_summaries(status: Option<&str>) -> Vec<RunSummary> {
@@ -106,10 +115,13 @@ pub fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
     let run = runs_service::require_run(&store, run_id)?;
     runs_service::refresh_mirrored_daemon_evidence_best_effort(&run.id);
     let run = runs_service::require_run(&store, &run.id)?;
+    let run = run_detail(&store, run)?;
+    let actionable = actionable_for_run_detail(&run);
     Ok((
         RunsOutput::Show(RunsShowOutput {
             command: "runs.show",
-            run: run_detail(&store, run)?,
+            run,
+            actionable,
         }),
         0,
     ))

--- a/src/commands/runs/remote.rs
+++ b/src/commands/runs/remote.rs
@@ -7,10 +7,10 @@ use homeboy::core::runners as runner;
 use homeboy::core::Error;
 
 use super::types::{
-    RunsArtifactGetArgs, RunsArtifactPathGuide, RunsArtifactsOutput,
+    actionable_for_run_list, RunsArtifactGetArgs, RunsArtifactPathGuide, RunsArtifactsOutput,
     RunsDirectoryArtifactPublicationGuidance,
 };
-use super::{remote_artifact, CmdResult, RunsListArgs, RunsListOutput, RunsOutput};
+use super::{remote_artifact, CmdResult, RunSummary, RunsListArgs, RunsListOutput, RunsOutput};
 
 pub fn list_runner_runs(
     runner_id: &str,
@@ -42,14 +42,23 @@ pub fn list_runner_runs(
         .collect::<Vec<_>>()
         .join("&");
     let data = runner::daemon_api_get(runner_id, &format!("/runs?{query}"))?;
-    let runs = serde_json::from_value(data["body"]["runs"].clone()).map_err(|err| {
-        Error::internal_json(
-            err.to_string(),
-            Some("parse runner daemon runs list".to_string()),
-        )
-    })?;
+    let runs: Vec<RunSummary> =
+        serde_json::from_value(data["body"]["runs"].clone()).map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("parse runner daemon runs list".to_string()),
+            )
+        })?;
 
-    Ok((RunsOutput::List(RunsListOutput { command, runs }), 0))
+    let actionable = actionable_for_run_list(&runs);
+    Ok((
+        RunsOutput::List(RunsListOutput {
+            command,
+            runs,
+            actionable,
+        }),
+        0,
+    ))
 }
 
 pub fn runner_artifacts(runner_id: &str, run_id: &str) -> CmdResult<RunsOutput> {

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -41,6 +41,10 @@ use super::refs::{RunsRefsArgs, RunsRefsOutput};
 use super::resources::{RunsResourcesArgs, RunsResourcesOutput};
 use super::watch::{RunsWatchArgs, RunsWatchOutput};
 use crate::commands::fuzz::FuzzCompareOutput;
+use crate::commands::utils::response::{
+    CommandActionableMetadata, CommandArtifactRef, CommandNextAction, CommandNextActionKind,
+    CommandResultRefs, CommandRunRef,
+};
 
 pub(super) const DEFAULT_LIMIT: i64 = 20;
 
@@ -224,12 +228,22 @@ pub enum RunsOutput {
 pub struct RunsListOutput {
     pub command: &'static str,
     pub runs: Vec<RunSummary>,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "CommandActionableMetadata::is_empty"
+    )]
+    pub actionable: CommandActionableMetadata,
 }
 
 #[derive(Serialize)]
 pub struct RunsShowOutput {
     pub command: &'static str,
     pub run: RunDetail,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "CommandActionableMetadata::is_empty"
+    )]
+    pub actionable: CommandActionableMetadata,
 }
 
 /// Field-projection result for `runs show -q` / `runs artifact get -q`.
@@ -687,4 +701,97 @@ pub struct RunDetail {
     pub homeboy_version: Option<String>,
     pub metadata: Value,
     pub artifacts: Vec<ArtifactRecord>,
+}
+
+pub(super) fn actionable_for_run_summary(run: &RunSummary) -> CommandActionableMetadata {
+    CommandActionableMetadata::for_run(run_ref_from_summary(run))
+        .with_next_action(
+            CommandNextAction::new("show run", format!("homeboy runs show {}", run.id))
+                .with_kind(CommandNextActionKind::Show),
+        )
+        .with_next_action(
+            CommandNextAction::new("watch run", format!("homeboy runs watch {}", run.id))
+                .with_kind(CommandNextActionKind::Watch),
+        )
+        .with_next_action(
+            CommandNextAction::new(
+                "list artifacts",
+                format!("homeboy runs artifacts {}", run.id),
+            )
+            .with_kind(CommandNextActionKind::Artifacts),
+        )
+}
+
+pub(super) fn actionable_for_run_list(runs: &[RunSummary]) -> CommandActionableMetadata {
+    let run_refs = runs.iter().map(run_ref_from_summary).collect::<Vec<_>>();
+    let next_actions = runs
+        .iter()
+        .take(10)
+        .flat_map(|run| {
+            [
+                CommandNextAction::new("show run", format!("homeboy runs show {}", run.id))
+                    .with_kind(CommandNextActionKind::Show),
+                CommandNextAction::new("watch run", format!("homeboy runs watch {}", run.id))
+                    .with_kind(CommandNextActionKind::Watch),
+            ]
+        })
+        .collect();
+
+    CommandActionableMetadata {
+        run: run_refs.first().cloned(),
+        refs: CommandResultRefs {
+            runs: run_refs,
+            ..Default::default()
+        },
+        next_actions,
+        ..Default::default()
+    }
+}
+
+pub(super) fn actionable_for_run_detail(run: &RunDetail) -> CommandActionableMetadata {
+    let mut metadata = actionable_for_run_summary(&run.summary);
+    metadata.artifacts = run
+        .artifacts
+        .iter()
+        .map(|artifact| CommandArtifactRef {
+            id: artifact.id.clone(),
+            kind: artifact.kind.clone(),
+            uri: artifact
+                .public_url
+                .clone()
+                .or_else(|| artifact.viewer_url.clone())
+                .or_else(|| artifact.url.clone())
+                .unwrap_or_else(|| artifact.path.clone()),
+            semantic_key: Some(artifact.artifact_type.clone()),
+        })
+        .collect();
+    metadata
+        .next_actions
+        .extend(run.artifacts.iter().filter_map(|artifact| {
+            (artifact.artifact_type == "file").then(|| {
+                CommandNextAction::new(
+                    format!("get artifact {}", artifact.id),
+                    format!(
+                        "homeboy runs artifact get {} {} -o <path>",
+                        run.summary.id, artifact.id
+                    ),
+                )
+                .with_kind(CommandNextActionKind::Artifacts)
+            })
+        }));
+    metadata
+}
+
+fn run_ref_from_summary(run: &RunSummary) -> CommandRunRef {
+    CommandRunRef {
+        id: run.id.clone(),
+        kind: run.kind.clone(),
+        source: "homeboy-observation-store".to_string(),
+        location: run.cwd.clone(),
+        started_at: Some(run.started_at.clone()),
+        updated_at: None,
+        finished_at: run.finished_at.clone(),
+        status_command: format!("homeboy runs show {}", run.id),
+        watch_command: format!("homeboy runs watch {}", run.id),
+    }
 }

--- a/src/commands/runs/watch.rs
+++ b/src/commands/runs/watch.rs
@@ -24,8 +24,9 @@ use homeboy::core::observation::runs_service;
 use homeboy::core::observation::{ObservationStore, RunRecord, RunStatus};
 
 use super::common::{parse_duration, RunSummary};
-use super::types::RunsOutput;
+use super::types::{actionable_for_run_summary, RunsOutput};
 use super::{reconcile, CmdResult};
+use crate::commands::utils::response::CommandActionableMetadata;
 
 /// Exit code returned when the run did not settle before `--timeout`. Matches
 /// the GNU `timeout(1)` convention so wrappers can recognize the case.
@@ -65,6 +66,11 @@ pub struct RunsWatchOutput {
     pub waited_secs: u64,
     pub poll_count: u64,
     pub run: RunSummary,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "CommandActionableMetadata::is_empty"
+    )]
+    pub actionable: CommandActionableMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notify: Option<NotifyOutcome>,
 }
@@ -210,6 +216,9 @@ fn build_output(
         exit_code_for_status(&status)
     };
 
+    let run = super::run_summary(result.run);
+    let actionable = actionable_for_run_summary(&run);
+
     (
         RunsWatchOutput {
             command: "runs.watch",
@@ -219,7 +228,8 @@ fn build_output(
             timed_out,
             waited_secs: result.waited.as_secs(),
             poll_count: result.poll_count,
-            run: super::run_summary(result.run),
+            run,
+            actionable,
             notify,
         },
         exit_code,

--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -4,14 +4,13 @@
 
 use homeboy::core::error::Hint;
 use homeboy::core::{Error, ErrorCode, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 
 use super::output::{write_output_file_atomically, OutputWriteOptions};
 
-const COMMAND_RESULT_SCHEMA: &str = "homeboy/command-result/v2";
+const COMMAND_RESULT_SCHEMA: &str = "homeboy/command-result/v3";
+pub const ACTIONABLE_METADATA_KEY: &str = "_homeboy_actionable";
 
 #[derive(Debug, Serialize)]
 pub struct CommandResultEnvelope<T: Serialize> {
@@ -22,10 +21,12 @@ pub struct CommandResultEnvelope<T: Serialize> {
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run: Option<CommandRunRef>,
+    #[serde(default, skip_serializing_if = "CommandResultRefs::is_empty")]
+    pub refs: CommandResultRefs,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub next_actions: Vec<String>,
+    pub next_actions: Vec<CommandNextAction>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<CommandArtifactRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -38,7 +39,100 @@ pub struct CommandResultEnvelope<T: Serialize> {
     pub presentation: Option<CommandPresentationEnvelope>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CommandActionableMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run: Option<CommandRunRef>,
+    #[serde(default, skip_serializing_if = "CommandResultRefs::is_empty")]
+    pub refs: CommandResultRefs,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_actions: Vec<CommandNextAction>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<CommandArtifactRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<CommandEvidenceRef>,
+}
+
+impl CommandActionableMetadata {
+    pub fn is_empty(&self) -> bool {
+        self.run.is_none()
+            && self.refs.is_empty()
+            && self.next_actions.is_empty()
+            && self.artifacts.is_empty()
+            && self.evidence.is_empty()
+    }
+
+    pub fn for_run(run: CommandRunRef) -> Self {
+        Self {
+            run: Some(run.clone()),
+            refs: CommandResultRefs {
+                runs: vec![run],
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    pub fn with_next_action(mut self, action: CommandNextAction) -> Self {
+        self.next_actions.push(action);
+        self
+    }
+
+    pub fn with_artifact(mut self, artifact: CommandArtifactRef) -> Self {
+        self.artifacts.push(artifact);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CommandResultRefs {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runs: Vec<CommandRunRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub jobs: Vec<CommandJobRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agent_tasks: Vec<CommandAgentTaskRef>,
+}
+
+impl CommandResultRefs {
+    pub fn is_empty(&self) -> bool {
+        self.runs.is_empty() && self.jobs.is_empty() && self.agent_tasks.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandNextAction {
+    pub label: String,
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<CommandNextActionKind>,
+}
+
+impl CommandNextAction {
+    pub fn new(label: impl Into<String>, command: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            command: command.into(),
+            kind: None,
+        }
+    }
+
+    pub fn with_kind(mut self, kind: CommandNextActionKind) -> Self {
+        self.kind = Some(kind);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandNextActionKind {
+    Watch,
+    Show,
+    Artifacts,
+    Repair,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandRunRef {
     pub id: String,
     pub kind: String,
@@ -55,7 +149,27 @@ pub struct CommandRunRef {
     pub watch_command: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandJobRef {
+    pub id: String,
+    pub kind: String,
+    pub source: String,
+    pub status_command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watch_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandAgentTaskRef {
+    pub id: String,
+    pub source: String,
+    pub status_command: String,
+    pub logs_command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandArtifactRef {
     pub id: String,
     pub kind: String,
@@ -64,7 +178,7 @@ pub struct CommandArtifactRef {
     pub semantic_key: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandEvidenceRef {
     pub id: String,
     pub kind: String,
@@ -101,6 +215,7 @@ impl<T: Serialize> CommandResultEnvelope<T> {
             exit_code: 0,
             status: "succeeded".to_string(),
             run: None,
+            refs: CommandResultRefs::default(),
             summary: None,
             next_actions: Vec::new(),
             artifacts: Vec::new(),
@@ -127,8 +242,9 @@ impl CommandResultEnvelope<()> {
             exit_code,
             status: status_for_result(None, exit_code),
             run: None,
+            refs: CommandResultRefs::default(),
             summary: Some(err.message.clone()),
-            next_actions: err.hints.iter().map(|hint| hint.message.clone()).collect(),
+            next_actions: Vec::new(),
             artifacts: Vec::new(),
             evidence: Vec::new(),
             diagnostics: Some(CommandDiagnostics {
@@ -304,6 +420,7 @@ impl CommandResultEnvelope<()> {
             exit_code: self.exit_code,
             status: self.status,
             run: self.run,
+            refs: self.refs,
             summary: self.summary,
             next_actions: self.next_actions,
             artifacts: self.artifacts,
@@ -317,14 +434,19 @@ impl CommandResultEnvelope<()> {
 
 fn envelope_for_data(
     command: &str,
-    data: Value,
+    mut data: Value,
     exit_code: i32,
     presentation: Option<CommandPresentationEnvelope>,
 ) -> CommandResultEnvelope<Value> {
     let success = exit_code == 0;
-    let run = run_ref_for_payload(command, &data);
-    let artifacts = artifact_refs_for_payload(&data);
-    let mut evidence = evidence_refs_for_payload(&data);
+    let mut actionable = actionable_metadata_for_payload(&mut data).unwrap_or_default();
+    if actionable.run.is_none() {
+        actionable.run = actionable.refs.runs.first().cloned();
+    }
+    let run = actionable.run;
+    let refs = actionable.refs;
+    let artifacts = actionable.artifacts;
+    let mut evidence = actionable.evidence;
 
     if evidence.is_empty() {
         if let Some(run) = &run {
@@ -344,8 +466,9 @@ fn envelope_for_data(
         exit_code,
         status: status_for_result(Some(&data), exit_code),
         run,
+        refs,
         summary: summary_for_payload(&data, presentation.as_ref()),
-        next_actions: next_actions_for_payload(&data),
+        next_actions: actionable.next_actions,
         artifacts,
         evidence,
         diagnostics: None,
@@ -379,128 +502,27 @@ fn normalize_status(status: &str) -> Option<&'static str> {
     }
 }
 
-fn run_ref_for_payload(command: &str, data: &Value) -> Option<CommandRunRef> {
-    let id = string_at(data, &["run_id"])
-        .or_else(|| string_at(data, &["run", "id"]))
-        .or_else(|| string_at(data, &["status", "run_id"]))
-        .or_else(|| synthetic_run_id(command, data));
-    let id = id?;
-    let kind = string_at(data, &["run", "kind"])
-        .or_else(|| string_at(data, &["kind"]))
-        .unwrap_or_else(|| command.to_string());
-    let location =
-        string_at(data, &["run", "location"]).or_else(|| string_at(data, &["artifact_path"]));
-
-    Some(CommandRunRef {
-        id: id.clone(),
-        kind,
-        source: "homeboy-cli".to_string(),
-        location,
-        started_at: string_at(data, &["run", "started_at"])
-            .or_else(|| string_at(data, &["started_at"])),
-        updated_at: string_at(data, &["run", "updated_at"])
-            .or_else(|| string_at(data, &["updated_at"])),
-        finished_at: string_at(data, &["run", "finished_at"])
-            .or_else(|| string_at(data, &["finished_at"])),
-        status_command: format!("homeboy runs show {id}"),
-        watch_command: format!("homeboy runs watch {id}"),
-    })
-}
-
-fn synthetic_run_id(command: &str, data: &Value) -> Option<String> {
-    if !matches!(command, "build" | "deploy" | "release") {
-        return None;
-    }
-
-    let mut hasher = DefaultHasher::new();
-    command.hash(&mut hasher);
-    serde_json::to_string(data).ok()?.hash(&mut hasher);
-    Some(format!("{command}-{:016x}", hasher.finish()))
-}
-
-fn artifact_refs_for_payload(data: &Value) -> Vec<CommandArtifactRef> {
-    let mut refs = Vec::new();
-    collect_artifact_paths(data, &mut refs);
-    refs
-}
-
-fn collect_artifact_paths(value: &Value, refs: &mut Vec<CommandArtifactRef>) {
-    match value {
+fn actionable_metadata_for_payload(data: &mut Value) -> Option<CommandActionableMetadata> {
+    match data {
         Value::Object(map) => {
-            if let Some(path) = map.get("artifact_path").and_then(Value::as_str) {
-                let id = format!("artifact-{}", refs.len() + 1);
-                refs.push(CommandArtifactRef {
-                    id,
-                    kind: "file".to_string(),
-                    uri: path.to_string(),
-                    semantic_key: Some("artifact_path".to_string()),
-                });
+            if let Some(metadata) = map.remove(ACTIONABLE_METADATA_KEY) {
+                return serde_json::from_value(metadata).ok();
             }
-            if let Some(path) = map.get("durable_path").and_then(Value::as_str) {
-                let id = format!("artifact-{}", refs.len() + 1);
-                refs.push(CommandArtifactRef {
-                    id,
-                    kind: "file".to_string(),
-                    uri: path.to_string(),
-                    semantic_key: Some("durable_path".to_string()),
-                });
+            for child in map.values_mut() {
+                if let Some(metadata) = actionable_metadata_for_payload(child) {
+                    return Some(metadata);
+                }
             }
-            for child in map.values() {
-                collect_artifact_paths(child, refs);
-            }
+            None
         }
         Value::Array(items) => {
-            for item in items {
-                collect_artifact_paths(item, refs);
+            for child in items {
+                if let Some(metadata) = actionable_metadata_for_payload(child) {
+                    return Some(metadata);
+                }
             }
+            None
         }
-        _ => {}
-    }
-}
-
-fn evidence_refs_for_payload(data: &Value) -> Vec<CommandEvidenceRef> {
-    data.get("evidence_refs")
-        .or_else(|| data.get("evidence"))
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .enumerate()
-                .filter_map(|(index, item)| evidence_ref_from_value(index, item))
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn evidence_ref_from_value(index: usize, value: &Value) -> Option<CommandEvidenceRef> {
-    match value {
-        Value::String(uri) => Some(CommandEvidenceRef {
-            id: format!("evidence-{}", index + 1),
-            kind: "reference".to_string(),
-            uri: uri.clone(),
-            semantic_key: None,
-        }),
-        Value::Object(map) => Some(CommandEvidenceRef {
-            id: map
-                .get("id")
-                .and_then(Value::as_str)
-                .unwrap_or("evidence")
-                .to_string(),
-            kind: map
-                .get("kind")
-                .and_then(Value::as_str)
-                .unwrap_or("reference")
-                .to_string(),
-            uri: map
-                .get("uri")
-                .or_else(|| map.get("path"))
-                .and_then(Value::as_str)?
-                .to_string(),
-            semantic_key: map
-                .get("semantic_key")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-        }),
         _ => None,
     }
 }
@@ -514,20 +536,6 @@ fn summary_for_payload(
         .or_else(|| string_at(data, &["summary"]))
         .or_else(|| string_at(data, &["message"]))
         .map(|summary| summary.chars().take(4000).collect())
-}
-
-fn next_actions_for_payload(data: &Value) -> Vec<String> {
-    data.get("next_actions")
-        .or_else(|| data.get("hints"))
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::to_string)
-                .collect()
-        })
-        .unwrap_or_default()
 }
 
 fn string_at(value: &Value, path: &[&str]) -> Option<String> {
@@ -610,7 +618,7 @@ mod tests {
         assert_eq!(parsed["schema"], COMMAND_RESULT_SCHEMA);
         assert_eq!(parsed["success"], true);
         assert_eq!(parsed["data"]["run_id"], "run-plan-atomic");
-        assert_eq!(parsed["run"]["id"], "run-plan-atomic");
+        assert!(parsed.get("run").is_none());
         assert_eq!(parsed["data"]["complete"], true);
         assert!(
             std::fs::read_dir(dir.path())
@@ -625,9 +633,55 @@ mod tests {
     }
 
     #[test]
-    fn json_envelope_uses_v2_contract_and_embeds_presentation() {
+    fn json_envelope_uses_v3_contract_and_embeds_typed_actionable_metadata() {
         let response = cli_response_for_json_result_for_command(
-            &Ok(json!({ "run_id": "run-123", "hints": ["homeboy runs show run-123"] })),
+            &Ok(json!({
+                "run_id": "run-123",
+                "hints": ["not lifted"],
+                ACTIONABLE_METADATA_KEY: {
+                    "run": {
+                        "id": "run-123",
+                        "kind": "bench",
+                        "source": "test",
+                        "location": null,
+                        "started_at": null,
+                        "updated_at": null,
+                        "finished_at": null,
+                        "status_command": "homeboy runs show run-123",
+                        "watch_command": "homeboy runs watch run-123"
+                    },
+                    "refs": {
+                        "runs": [{
+                            "id": "run-123",
+                            "kind": "bench",
+                            "source": "test",
+                            "location": null,
+                            "started_at": null,
+                            "updated_at": null,
+                            "finished_at": null,
+                            "status_command": "homeboy runs show run-123",
+                            "watch_command": "homeboy runs watch run-123"
+                        }]
+                    },
+                    "next_actions": [{
+                        "label": "show run",
+                        "command": "homeboy runs show run-123",
+                        "kind": "show"
+                    }],
+                    "artifacts": [{
+                        "id": "artifact-1",
+                        "kind": "file",
+                        "uri": "/tmp/artifact.json",
+                        "semantic_key": "report"
+                    }],
+                    "evidence": [{
+                        "id": "evidence-1",
+                        "kind": "command-result",
+                        "uri": "homeboy://runs/run-123/result",
+                        "semantic_key": "command_result"
+                    }]
+                }
+            })),
             0,
             "observe",
             Some(CommandPresentationEnvelope {
@@ -641,27 +695,38 @@ mod tests {
         assert_eq!(value["command"], "observe");
         assert_eq!(value["status"], "succeeded");
         assert_eq!(value["run"]["id"], "run-123");
+        assert_eq!(value["refs"]["runs"][0]["id"], "run-123");
         assert_eq!(value["run"]["status_command"], "homeboy runs show run-123");
         assert_eq!(value["presentation"]["stdout"], "Observed 3 events\n");
         assert_eq!(value["summary"], "Observed 3 events\n");
-        assert_eq!(value["next_actions"][0], "homeboy runs show run-123");
+        assert_eq!(value["next_actions"][0]["label"], "show run");
+        assert_eq!(
+            value["next_actions"][0]["command"],
+            "homeboy runs show run-123"
+        );
+        assert_eq!(value["artifacts"][0]["uri"], "/tmp/artifact.json");
+        assert!(value["data"].get(ACTIONABLE_METADATA_KEY).is_none());
     }
 
     #[test]
-    fn build_deploy_and_release_payloads_get_stable_run_and_evidence_refs() {
-        for command in ["build", "deploy", "release"] {
-            let payload = Ok(json!({ "command": command, "component_id": "component-a" }));
-            let first = cli_response_for_json_result_for_command(&payload, 0, command, None);
-            let second = cli_response_for_json_result_for_command(&payload, 0, command, None);
-            let first = serde_json::to_value(first).expect("first json");
-            let second = serde_json::to_value(second).expect("second json");
+    fn unmigrated_payloads_do_not_get_heuristic_actionable_fields() {
+        let response = cli_response_for_json_result_for_command(
+            &Ok(json!({
+                "run_id": "run-123",
+                "hints": ["homeboy runs show run-123"],
+                "artifact_path": "/tmp/artifact.json",
+                "evidence": ["homeboy://runs/run-123/result"]
+            })),
+            0,
+            "observe",
+            None,
+        );
+        let value = serde_json::to_value(response).expect("response json");
 
-            assert!(first["run"]["id"]
-                .as_str()
-                .expect("run id")
-                .starts_with(command));
-            assert_eq!(first["run"]["id"], second["run"]["id"]);
-            assert_eq!(first["evidence"][0]["semantic_key"], "command_result");
-        }
+        assert!(value.get("run").is_none());
+        assert!(value.get("refs").is_none());
+        assert!(value.get("next_actions").is_none());
+        assert!(value.get("artifacts").is_none());
+        assert!(value.get("evidence").is_none());
     }
 }


### PR DESCRIPTION
## Contract design
- Bumps the command-result envelope to `homeboy/command-result/v3`.
- Adds typed envelope actions: `next_actions[] = { label, command, kind? }`, with `kind` values `watch`, `show`, `artifacts`, and `repair`.
- Adds typed refs via `refs.runs[]`, `refs.jobs[]`, and `refs.agent_tasks[]`, while keeping the existing singular `run` convenience field for the primary run.
- Adds typed `artifacts[]` and `evidence[]` envelope fields sourced from command output metadata.
- Command handlers attach reserved `_homeboy_actionable` metadata when they build their output payloads. The response layer consumes that reserved field, removes it from `data`, and copies the typed values into the envelope.
- Deletes heuristic lifting from arbitrary `data.next_actions` / `data.hints`, magic `run_id` / `run.id` / `status.run_id` inference, synthetic build/deploy/release run ids, recursive artifact-path guessing, and loose evidence scraping. Unmigrated commands now emit empty actionable envelope fields honestly.

## Sample before/after JSON
Before, machine consumers saw heuristic strings or guessed refs only when payload keys happened to match:

```json
{
  "schema": "homeboy/command-result/v2",
  "command": "runs",
  "next_actions": [],
  "data": { "variant": "list", "payload": { "runs": [] } }
}
```

After, migrated commands expose first-class actions and refs at the envelope level:

```json
{
  "schema": "homeboy/command-result/v3",
  "command": "runs",
  "run": {
    "id": "22b4848d-229f-43f0-b20a-74a1be2ebedf",
    "kind": "test",
    "source": "homeboy-observation-store",
    "status_command": "homeboy runs show 22b4848d-229f-43f0-b20a-74a1be2ebedf",
    "watch_command": "homeboy runs watch 22b4848d-229f-43f0-b20a-74a1be2ebedf"
  },
  "refs": { "runs": [{ "id": "22b4848d-229f-43f0-b20a-74a1be2ebedf" }] },
  "next_actions": [
    { "label": "show run", "command": "homeboy runs show 22b4848d-229f-43f0-b20a-74a1be2ebedf", "kind": "show" },
    { "label": "watch run", "command": "homeboy runs watch 22b4848d-229f-43f0-b20a-74a1be2ebedf", "kind": "watch" }
  ]
}
```

## Migration list
- `runs list` including remote runner-backed lists.
- `runs show` including artifact refs and `runs artifact get ...` actions.
- `runs watch`.
- `agent-task status` / `agent-task status --full`.
- `agent-task list`, `agent-task active`, and `agent-task latest`.
- `activity list`, `activity show`, and `activity watch` as the reference consumer for activity item actions, refs, artifacts, and evidence.

## LOC delta
- `8 files changed, 731 insertions(+), 183 deletions(-)`.

## Verification
- `cargo fmt --check` passed.
- `cargo check --all-targets` passed.
- `cargo test commands::utils::response` passed: 5 passed.
- `cargo test commands::agent_task` passed: 124 passed.
- `cargo test commands::activity` passed: 2 passed.
- `cargo test commands::runs` ran; 173 passed, 1 failed in `commands::runs::evidence::tests::evidence_includes_related_lab_fuzz_results_for_runner_failure`. Rerunning that exact test reproduced the same `Server not found` Lab refresh warning before `raw fuzz results artifact is discoverable`, so this appears environment/config-dependent and not introduced by envelope changes.
- Smoke: `cargo run -- runs list --limit 1 --output /tmp/homeboy-runs-list-envelope.json` produced v3 top-level `run`, `refs.runs`, `next_actions`, and no leaked `_homeboy_actionable` in `data`.
- Smoke: `cargo run -- agent-task latest --output /tmp/homeboy-agent-task-latest-envelope.json` produced v3 top-level `refs.agent_tasks` and typed `next_actions`.
- Smoke: `cargo run -- activity list --limit 1 --output /tmp/homeboy-activity-envelope.json` produced v3 top-level `refs.agent_tasks`, `next_actions`, `artifacts`, and `evidence`.

Completes the envelope half of #7451 (activity surface landed in #7513).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (claude-fable-5) orchestrator with GPT 5.5 coding subagent
- **Used for:** Investigation identified the heuristic envelope lifting; the subagent implemented the typed actionable-result contract.