### PR TITLE
Fix hanging worker cancellation test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+slow-timeout = { period = "30s", terminate-after = 4 }

--- a/src/core/runner/worker/tests/support.rs
+++ b/src/core/runner/worker/tests/support.rs
@@ -97,16 +97,27 @@ pub(super) fn spawn_cancelling_after_claim_broker(
 
 pub(super) fn spawn_cancelling_on_second_snapshot_broker(
     store: JobStore,
-    expected_requests: usize,
+    max_requests: usize,
     seen_paths: Option<Arc<std::sync::Mutex<Vec<String>>>>,
-) -> (String, std::thread::JoinHandle<()>) {
+) -> (String, MockBrokerHandle) {
     let snapshots = Arc::new(std::sync::Mutex::new(0_u8));
-    spawn_custom_broker(
-        store,
-        expected_requests,
-        seen_paths,
-        move |store, request| {
-            if let Some(job_id) = request.path.strip_prefix("/jobs/") {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+    let addr = listener.local_addr().expect("addr");
+    let broker_url = format!("http://{addr}");
+    let handle = std::thread::spawn(move || {
+        for _ in 0..max_requests {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let request = read_request(&mut stream);
+            if request.path == "/__shutdown" {
+                break;
+            }
+            if let Some(seen_paths) = &seen_paths {
+                seen_paths
+                    .lock()
+                    .expect("record request path")
+                    .push(request.path.clone());
+            }
+            let response = if let Some(job_id) = request.path.strip_prefix("/jobs/") {
                 let job_id = uuid::Uuid::parse_str(job_id).expect("job id");
                 let mut snapshots = snapshots.lock().expect("snapshot count");
                 *snapshots += 1;
@@ -114,14 +125,35 @@ pub(super) fn spawn_cancelling_on_second_snapshot_broker(
                     store.cancel(job_id, "user requested").expect("cancel job");
                 }
                 let job = store.get(job_id).expect("job");
-                return serde_json::json!({
+                serde_json::json!({
                     "success": true,
                     "data": { "body": { "job": job } }
-                });
-            }
-            handle_request(store, request)
-        },
-    )
+                })
+            } else {
+                handle_request(&store, &request)
+            };
+            write_response(&mut stream, response);
+        }
+    });
+    (broker_url.clone(), MockBrokerHandle { broker_url, handle })
+}
+
+pub(super) struct MockBrokerHandle {
+    broker_url: String,
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl MockBrokerHandle {
+    pub(super) fn join(self) -> std::thread::Result<()> {
+        let _ = send_shutdown_request(&self.broker_url);
+        self.handle.join()
+    }
+}
+
+fn send_shutdown_request(broker_url: &str) -> std::io::Result<()> {
+    let addr = broker_url.trim_start_matches("http://");
+    let mut stream = std::net::TcpStream::connect(addr)?;
+    stream.write_all(b"GET /__shutdown HTTP/1.1\r\nHost: mock\r\nContent-Length: 0\r\n\r\n")
 }
 
 fn spawn_custom_broker<F>(


### PR DESCRIPTION
## Summary
- Root-caused the hanging reverse worker cancel-after-execution test to the mock broker waiting in accept() for a guessed fixed request count after the worker correctly exited without /finish.
- Added an explicit shutdown-capable mock broker handle for the cancel-on-second-snapshot helper so tests can join the broker deterministically without weakening the no-/finish coverage.
- Added .config/nextest.toml default slow-timeout enforcement so future per-test hangs are terminated by nextest.

Part of #7469

## Verification
- cargo nextest run --lib -E 'test(worker_tests)' --no-fail-fast: 12 passed, 6896 skipped; completed in 0.967s after compilation.
- cargo check --all-targets: passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Root-caused and fixed the hanging test, added nextest timeout enforcement; Chris reviews and owns the change.