### PR TITLE
Fix agent-runtime manifest diagnostics

### DIFF
--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -379,13 +379,20 @@ fn load_standalone_agent_runtime_manifest(
     let mut manifest: AgentRuntimeManifest = match config::from_str(&content) {
         Ok(manifest) => manifest,
         Err(error) => {
+            let class = match error.validation_json_category() {
+                Some("data") => "agent_runtime_manifest.schema_mismatch",
+                _ => "agent_runtime_manifest.parse_failed",
+            };
             return StandaloneAgentRuntimeManifestLoad::Invalid(AgentRuntimeDiscoveryDiagnostic {
-                class: "agent_runtime_manifest.parse_failed".to_string(),
-                message: error.to_string(),
+                class: class.to_string(),
+                message: error
+                    .validation_json_error()
+                    .unwrap_or_else(|| error.message.as_str())
+                    .to_string(),
                 runtime_id: Some(id),
                 extension_id: None,
                 path: Some(manifest_path.display().to_string()),
-            })
+            });
         }
     };
     manifest.id = id;
@@ -934,6 +941,48 @@ mod tests {
             assert_eq!(
                 catalog.diagnostics[0].runtime_id.as_deref(),
                 Some("broken-runtime")
+            );
+            assert!(
+                catalog.diagnostics[0].message.contains("line 1 column"),
+                "expected serde location detail, got {:?}",
+                catalog.diagnostics[0].message
+            );
+        });
+    }
+
+    #[test]
+    fn standalone_runtime_catalog_reports_schema_mismatch_for_valid_json_wrong_shape() {
+        crate::test_support::with_isolated_home(|home| {
+            let runtime_dir = home
+                .path()
+                .join(".config/homeboy/agent-runtimes")
+                .join("skewed-runtime");
+            std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+            std::fs::write(
+                runtime_dir.join("skewed-runtime.json"),
+                json!({
+                    "schema": AGENT_RUNTIME_MANIFEST_SCHEMA,
+                    "id": "skewed-runtime",
+                    "agent_task_executors": "not-an-array"
+                })
+                .to_string(),
+            )
+            .expect("runtime manifest");
+
+            let catalog = discover_standalone_agent_runtime_catalog();
+
+            assert!(catalog.manifests.is_empty());
+            assert_eq!(catalog.diagnostics.len(), 1);
+            assert_eq!(
+                catalog.diagnostics[0].class,
+                "agent_runtime_manifest.schema_mismatch"
+            );
+            assert!(
+                catalog.diagnostics[0]
+                    .message
+                    .contains("invalid type: string \"not-an-array\", expected a sequence"),
+                "expected serde schema detail, got {:?}",
+                catalog.diagnostics[0].message
             );
         });
     }

--- a/src/core/agent_task_provider/catalog.rs
+++ b/src/core/agent_task_provider/catalog.rs
@@ -1,5 +1,5 @@
 use super::resolution::{
-    discover_agent_task_executor_providers, lab_runtime_component_ids_for_plan_with_providers,
+    lab_runtime_component_ids_for_plan_with_providers,
     provider_requires_cwd_git_checkout_with_providers,
     required_extension_ids_for_plan_with_providers, select_provider,
 };
@@ -188,26 +188,62 @@ pub fn validate_provider_runner_readiness_for_backend(
     backend: &str,
     selector: Option<&str>,
 ) -> crate::core::Result<()> {
-    let providers = discover_agent_task_executor_providers();
-    validate_provider_runner_readiness_for_backend_with_providers(&providers, backend, selector)
+    let catalog = AgentTaskProviderCatalog::discover();
+    validate_provider_runner_readiness_for_backend_with_catalog(&catalog, backend, selector)
 }
 
+fn validate_provider_runner_readiness_for_backend_with_catalog(
+    catalog: &AgentTaskProviderCatalog,
+    backend: &str,
+    selector: Option<&str>,
+) -> crate::core::Result<()> {
+    validate_provider_runner_readiness_for_backend_with_diagnostics(
+        catalog.providers(),
+        catalog.diagnostics(),
+        backend,
+        selector,
+    )
+}
+
+#[cfg(test)]
 pub(super) fn validate_provider_runner_readiness_for_backend_with_providers(
     providers: &[AgentTaskExecutorProvider],
+    backend: &str,
+    selector: Option<&str>,
+) -> crate::core::Result<()> {
+    validate_provider_runner_readiness_for_backend_with_diagnostics(
+        providers,
+        &[],
+        backend,
+        selector,
+    )
+}
+
+fn validate_provider_runner_readiness_for_backend_with_diagnostics(
+    providers: &[AgentTaskExecutorProvider],
+    diagnostics: &[AgentRuntimeDiscoveryDiagnostic],
     backend: &str,
     selector: Option<&str>,
 ) -> crate::core::Result<()> {
     let provider = match resolve_provider_for_backend(providers, backend, selector) {
         ProviderResolution::Resolved(provider) => provider,
         ProviderResolution::NotFound => {
+            let matching_diagnostics =
+                runtime_discovery_diagnostics_for_backend(diagnostics, backend);
+            let mut suggestions = vec![
+                "Run `homeboy agent-task providers` on the same machine/runner to inspect registered providers.".to_string(),
+                "Install or sync the extension/runtime that declares the requested backend, or pass --backend with a registered backend.".to_string(),
+            ];
+            suggestions.extend(
+                matching_diagnostics
+                    .iter()
+                    .map(format_runtime_discovery_diagnostic),
+            );
             return Err(Error::validation_invalid_argument(
                 "backend",
-                format!("no extension agent-task provider found for backend '{backend}'"),
+                provider_not_found_message(backend, &matching_diagnostics),
                 Some(backend.to_string()),
-                Some(vec![
-                    "Run `homeboy agent-task providers` on the same machine/runner to inspect registered providers.".to_string(),
-                    "Install or sync the extension/runtime that declares the requested backend, or pass --backend with a registered backend.".to_string(),
-                ]),
+                Some(suggestions),
             ));
         }
         ProviderResolution::AmbiguousExtensionAlias { candidate_ids } => {
@@ -265,6 +301,42 @@ pub(super) fn validate_provider_runner_readiness_for_backend_with_providers(
     })?;
 
     Ok(())
+}
+
+pub(super) fn runtime_discovery_diagnostics_for_backend(
+    diagnostics: &[AgentRuntimeDiscoveryDiagnostic],
+    backend: &str,
+) -> Vec<AgentRuntimeDiscoveryDiagnostic> {
+    diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.runtime_id.as_deref() == Some(backend))
+        .cloned()
+        .collect()
+}
+
+pub(super) fn provider_not_found_message(
+    backend: &str,
+    diagnostics: &[AgentRuntimeDiscoveryDiagnostic],
+) -> String {
+    let base = format!("no extension agent-task provider found for backend '{backend}'");
+    if diagnostics.is_empty() {
+        return base;
+    }
+    let details = diagnostics
+        .iter()
+        .map(format_runtime_discovery_diagnostic)
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!("{base}; runtime discovery diagnostics: {details}")
+}
+
+pub(super) fn format_runtime_discovery_diagnostic(
+    diagnostic: &AgentRuntimeDiscoveryDiagnostic,
+) -> String {
+    match diagnostic.path.as_deref() {
+        Some(path) => format!("{} at {}: {}", diagnostic.class, path, diagnostic.message),
+        None => format!("{}: {}", diagnostic.class, diagnostic.message),
+    }
 }
 
 pub fn required_extension_ids_for_plan(plan: &AgentTaskPlan) -> Vec<String> {

--- a/src/core/agent_task_provider/executor.rs
+++ b/src/core/agent_task_provider/executor.rs
@@ -21,7 +21,13 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             request.executor.selector.as_deref(),
         ) {
             ProviderResolution::Resolved(provider) => provider,
-            resolution => return provider_resolution_failure_outcome(&request, resolution),
+            resolution => {
+                return provider_resolution_failure_outcome(
+                    &request,
+                    resolution,
+                    self.diagnostics(),
+                )
+            }
         };
 
         let missing_capabilities: Vec<String> = request
@@ -53,20 +59,27 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
 fn provider_resolution_failure_outcome(
     request: &AgentTaskRequest,
     resolution: ProviderResolution<'_>,
+    diagnostics: &[AgentRuntimeDiscoveryDiagnostic],
 ) -> AgentTaskOutcome {
     match resolution {
         ProviderResolution::Resolved(_) => unreachable!("resolved provider handled before failure"),
-        ProviderResolution::NotFound => failure_outcome(
-            request,
-            AgentTaskOutcomeStatus::Failed,
-            AgentTaskFailureClassification::CapabilityMissing,
-            "agent_task.provider_missing",
-            format!(
-                "no extension agent-task provider found for backend '{}'",
-                request.executor.backend
-            ),
-            json!({ "backend": request.executor.backend }),
-        ),
+        ProviderResolution::NotFound => {
+            let matching_diagnostics = runtime_discovery_diagnostics_for_backend(
+                diagnostics,
+                &request.executor.backend,
+            );
+            failure_outcome(
+                request,
+                AgentTaskOutcomeStatus::Failed,
+                AgentTaskFailureClassification::CapabilityMissing,
+                "agent_task.provider_missing",
+                provider_not_found_message(&request.executor.backend, &matching_diagnostics),
+                json!({
+                    "backend": request.executor.backend,
+                    "runtime_discovery_diagnostics": matching_diagnostics,
+                }),
+            )
+        }
         ProviderResolution::AmbiguousExtensionAlias { candidate_ids } => failure_outcome(
             request,
             AgentTaskOutcomeStatus::Failed,

--- a/src/core/agent_task_provider/resolution.rs
+++ b/src/core/agent_task_provider/resolution.rs
@@ -48,6 +48,7 @@ pub(super) fn provider_requires_cwd_git_checkout_with_providers(
         })
         .unwrap_or(false)
 }
+#[cfg(test)]
 pub(super) fn discover_agent_task_executor_providers() -> Vec<AgentTaskExecutorProvider> {
     agent_runtime_manifest::discover_agent_task_executor_providers()
 }

--- a/src/core/agent_task_provider/tests/manifest_tests.rs
+++ b/src/core/agent_task_provider/tests/manifest_tests.rs
@@ -132,6 +132,43 @@ fn default_provider_catalog_normalizes_codex_command_to_invocation_argv() {
 }
 
 #[test]
+fn provider_missing_chains_matching_runtime_discovery_diagnostics() {
+    let (mut request, _provider) = request("missing-opencode", "unused".to_string());
+    request.executor.backend = "opencode".to_string();
+    let executor = ExtensionProviderAgentTaskExecutor::from_catalog(AgentTaskProviderCatalog {
+        providers: Vec::new(),
+        diagnostics: vec![AgentRuntimeDiscoveryDiagnostic {
+            class: "agent_runtime_manifest.schema_mismatch".to_string(),
+            message: "invalid type: map, expected string at line 12 column 18".to_string(),
+            runtime_id: Some("opencode".to_string()),
+            extension_id: None,
+            path: Some("/tmp/opencode/opencode.json".to_string()),
+        }],
+        version: None,
+    });
+
+    let outcome = executor.execute(
+        request,
+        AgentTaskExecutionContext {
+            plan_id: "test-plan".to_string(),
+            run_id: None,
+            attempt: 1,
+            cancellation: AgentTaskCancellationToken::default(),
+        },
+    );
+
+    let summary = outcome.summary.as_deref().expect("summary");
+    assert!(summary.contains("no extension agent-task provider found for backend 'opencode'"));
+    assert!(summary.contains("agent_runtime_manifest.schema_mismatch"));
+    assert!(summary.contains("invalid type: map, expected string at line 12 column 18"));
+    assert_eq!(outcome.diagnostics[0].class, "agent_task.provider_missing");
+    assert_eq!(
+        outcome.diagnostics[0].data["runtime_discovery_diagnostics"][0]["class"],
+        "agent_runtime_manifest.schema_mismatch"
+    );
+}
+
+#[test]
 fn provider_command_parts_warns_for_legacy_string_command() {
     let (_request, provider) = request("task-legacy-command", "legacy-provider --flag".to_string());
 

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -445,8 +445,16 @@ impl Error {
         context: Option<String>,
         received: Option<String>,
     ) -> Self {
+        let error = err.to_string();
+        let category = match err.classify() {
+            serde_json::error::Category::Io => "io",
+            serde_json::error::Category::Syntax => "syntax",
+            serde_json::error::Category::Data => "data",
+            serde_json::error::Category::Eof => "eof",
+        };
         let mut details = serde_json::json!({
-            "error": err.to_string(),
+            "error": error,
+            "category": category,
             "context": context,
         });
         if let Some(received_json) = received {
@@ -454,7 +462,25 @@ impl Error {
                 serde_json::json!(received_json.chars().take(200).collect::<String>());
         }
 
-        Self::new(ErrorCode::ValidationInvalidJson, "Invalid JSON", details)
+        Self::new(
+            ErrorCode::ValidationInvalidJson,
+            format!("Invalid JSON: {error}"),
+            details,
+        )
+    }
+
+    pub fn validation_json_error(&self) -> Option<&str> {
+        if self.code != ErrorCode::ValidationInvalidJson {
+            return None;
+        }
+        self.details.get("error").and_then(Value::as_str)
+    }
+
+    pub fn validation_json_category(&self) -> Option<&str> {
+        if self.code != ErrorCode::ValidationInvalidJson {
+            return None;
+        }
+        self.details.get("category").and_then(Value::as_str)
     }
 
     pub fn dependency_step_failed(


### PR DESCRIPTION
## Root cause

Standalone agent-runtime manifest discovery parsed manifests through `config::from_str`, but the shared invalid-JSON error displayed only `Invalid JSON`. The underlying serde error stayed in structured details, so valid JSON with a deserialization/schema mismatch was reported as a syntax-style `agent_runtime_manifest.parse_failed` diagnostic.

Provider resolution then returned the bare `no extension agent-task provider found for backend 'opencode'` error without attaching the runtime discovery diagnostics that explained why the requested runtime was missing from the provider catalog.

## Fix

- Preserve the serde error text and category in the shared invalid-JSON error surface.
- Classify standalone runtime manifest serde data errors as `agent_runtime_manifest.schema_mismatch`; syntax/eof/io parse failures remain `agent_runtime_manifest.parse_failed`.
- Chain runtime discovery diagnostics with a matching `runtime_id` into provider-not-found messages, hints, and the agent-task outcome diagnostic payload.
- Add focused tests for schema mismatch diagnostics, syntax diagnostics, and provider-not-found diagnostic chaining.

## Before / after diagnostic example

Before:

```json
{"class":"agent_runtime_manifest.parse_failed","message":"Invalid JSON","path":"~/.config/homeboy/agent-runtimes/opencode/opencode.json","runtime_id":"opencode"}
```

After, manifest discovery:

```json
{
  "class": "agent_runtime_manifest.schema_mismatch",
  "message": "invalid type: string \"not-an-array\", expected a sequence at line 1 column 99",
  "path": "/tmp/homeboy-7537-demo/.config/homeboy/agent-runtimes/opencode/opencode.json",
  "runtime_id": "opencode"
}
```

After, provider-not-found:

```text
no extension agent-task provider found for backend 'opencode'; runtime discovery diagnostics: agent_runtime_manifest.schema_mismatch at /tmp/homeboy-7537-demo/.config/homeboy/agent-runtimes/opencode/opencode.json: invalid type: string "not-an-array", expected a sequence at line 1 column 99
```

Closes #7537.

Related: #7533.

## Verification

- `cargo check --all-targets`
- `cargo nextest run --lib -E 'test(agent_runtime_manifest) or test(agent_task_provider)' --no-fail-fast`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Fixed diagnostic error swallowing and provider-not-found diagnostic chaining; Chris reviews and owns the change.
