### PR TITLE
fix(ci): restore rust extension binding — unblock the release train

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -524,7 +524,9 @@
     }
   ],
   "docs_dir": "docs",
-  "extensions": {},
+  "extensions": {
+    "rust": {}
+  },
   "hooks": {},
   "id": "homeboy",
   "scripts": {


### PR DESCRIPTION
## Root cause

`8c3dcf5fc` ("test: bound slow rust suite") intended to drop the `rust_cargo_test_threads: 1` setting but removed the **entire** `extensions` block from `homeboy.json`, unbinding the rust extension from the component. Since then (first red run 2026-07-04T01:16Z, right after the last green v0.280.13 release run), every CI `homeboy lint`/`homeboy test` on main exits immediately with:

```json
{"summary": "No extension provider configured for component 'homeboy'", "diagnostics": {"code": "extension.unsupported"}, "exit_code": 2}
```

— no structured findings, so the Lint (exit 4) and Test (exit 2) gates fail, Release Quality Policy blocks, and **no release has shipped since v0.280.13 while main accumulated 120+ commits**. This is also the root of the extensions↔core manifest skew (#7533's live repro): the latest released binary predates current extensions-main contracts because the train is stalled.

The Build job succeeding while Lint/Test failed made this look like an artifact-handoff problem; it was capability resolution. Auto-reconciled failure trackers: #7507, #7394 — both should close once main goes green.

## Fix

Restore the rust extension binding without re-introducing the thread bound:

```json
"extensions": { "rust": {} }
```

## Verification

- `jq empty homeboy.json` — valid.
- `homeboy lint homeboy --path . --changed-since HEAD~1` from this branch resolves the rust extension, routes through the Lab runner, and returns `"status": "passed"` with structured lint-findings sidecars (previously: instant `extension.unsupported`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (claude-fable-5, opencode)
- **Used for:** Root-caused the release-train blockage from CI logs and git history, authored the one-line fix, verified via Lab-routed lint.