### PR TITLE
Unify daemon exec HTTP transport

### DIFF
--- a/src/core/runner/daemon_health.rs
+++ b/src/core/runner/daemon_health.rs
@@ -16,7 +16,12 @@ pub(super) fn runner_daemon_health_failure(err: &Error) -> Option<RunnerDaemonHe
     }
 
     let message = err.message.as_str();
-    let daemon_transport_failure = message.contains("query runner daemon")
+    let daemon_transport_failure = err
+        .details
+        .pointer("/daemon_transport_error/kind")
+        .and_then(|value| value.as_str())
+        .is_some_and(|kind| matches!(kind, "connect" | "timeout" | "status" | "body_decode"))
+        || message.contains("query runner daemon")
         || message.contains("submit runner daemon exec job")
         || message.contains("parse daemon exec response")
         || message.contains("daemon exec request failed");
@@ -45,14 +50,22 @@ mod tests {
 
     #[test]
     fn classifies_stale_daemon_transport_failures() {
-        let err = Error::internal_unexpected(
-            "query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)",
+        let err = Error::new(
+            ErrorCode::InternalUnexpected,
+            "runner daemon request failed",
+            serde_json::json!({
+                "daemon_transport_error": {
+                    "kind": "connect",
+                    "path": "/jobs/id",
+                    "http_status": null,
+                }
+            }),
         );
 
         assert_eq!(
             runner_daemon_health_failure(&err),
             Some(RunnerDaemonHealthFailure {
-                reason: "runner daemon health check failed: query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)"
+                reason: "runner daemon health check failed: runner daemon request failed"
                     .to_string(),
                 runner_id: None,
                 job_id: None,

--- a/src/core/runner/daemon_http_get.rs
+++ b/src/core/runner/daemon_http_get.rs
@@ -73,6 +73,11 @@ fn daemon_response_json_error(
             "body_bytes": body.len(),
             "body_preview": preview,
             "likely_truncated": likely_truncated,
+            "daemon_transport_error": {
+                "kind": "body_decode",
+                "path": path,
+                "http_status": status_code,
+            },
         }),
     );
     error.retryable = Some(true);

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::io::{Read, Write};
-use std::net::{Shutdown, TcpStream};
 use std::time::{Duration, Instant};
 
 use reqwest::blocking::Client;
@@ -74,8 +72,18 @@ pub(super) fn exec_via_daemon(
         "metadata": runner_exec_request_metadata(run_id.as_deref(), "daemon"),
         "lifecycle": lifecycle,
     });
-    let (status_code, response_body) = daemon_loopback_post_json(local_url, "/exec", &payload)
-        .map_err(|err| daemon_exec_loopback_transport_error(&runner.id, err))?;
+    let response = daemon_post_json_text(
+        &client,
+        local_url,
+        "/exec",
+        &payload,
+        DaemonPostOptions {
+            connection_close: true,
+        },
+    )
+    .map_err(|err| daemon_exec_loopback_transport_error(&runner.id, err))?;
+    let status_code = response.status_code;
+    let response_body = response.body;
     let envelope: DaemonEnvelope = serde_json::from_str(&response_body).map_err(|err| {
         // A stale/restarting daemon can answer the tunnel with a non-JSON or
         // empty body. Surface a clear, actionable error instead of a bare parse
@@ -254,104 +262,6 @@ pub(super) fn exec_via_daemon(
         },
         exit_code,
     ))
-}
-
-fn daemon_loopback_post_json(
-    local_url: &str,
-    path: &str,
-    payload: &Value,
-) -> std::io::Result<(u16, String)> {
-    let address = local_url
-        .trim_end_matches('/')
-        .strip_prefix("http://")
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "runner daemon URL must be http:// loopback",
-            )
-        })?;
-    if !(address.starts_with("127.0.0.1:") || address.starts_with("localhost:")) {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "runner daemon URL must target loopback",
-        ));
-    }
-    let body = serde_json::to_string(payload)
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    let mut stream = TcpStream::connect(address)?;
-    let timeout = Duration::from_secs(10);
-    stream.set_read_timeout(Some(timeout))?;
-    stream.set_write_timeout(Some(timeout))?;
-    write!(
-        stream,
-        "POST {path} HTTP/1.1\r\nHost: {address}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-        body.len(),
-        body
-    )?;
-    stream.flush()?;
-    stream.shutdown(Shutdown::Write)?;
-    let mut response = Vec::new();
-    let header_end = loop {
-        let mut chunk = [0_u8; 1024];
-        let read = stream.read(&mut chunk)?;
-        if read == 0 {
-            break None;
-        }
-        response.extend_from_slice(&chunk[..read]);
-        if let Some(index) = response.windows(4).position(|window| window == b"\r\n\r\n") {
-            break Some(index + 4);
-        }
-    }
-    .ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "daemon HTTP response missing header boundary",
-        )
-    })?;
-    let head = String::from_utf8_lossy(&response[..header_end - 4]);
-    let status_code = head
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .and_then(|code| code.parse::<u16>().ok())
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "daemon HTTP response missing status code",
-            )
-        })?;
-    let content_length = head
-        .lines()
-        .find_map(|line| {
-            let (name, value) = line.split_once(':')?;
-            name.eq_ignore_ascii_case("content-length")
-                .then(|| value.trim().parse::<usize>().ok())
-                .flatten()
-        })
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "daemon HTTP response missing content-length",
-            )
-        })?;
-    while response.len().saturating_sub(header_end) < content_length {
-        let mut chunk = [0_u8; 1024];
-        let read = stream.read(&mut chunk)?;
-        if read == 0 {
-            break;
-        }
-        response.extend_from_slice(&chunk[..read]);
-    }
-    let body_end = header_end + content_length;
-    if response.len() < body_end {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "daemon HTTP response ended before content-length bytes were read",
-        ));
-    }
-    let body = String::from_utf8(response[header_end..body_end].to_vec())
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    Ok((status_code, body))
 }
 
 pub(super) fn preflight_runner_capability_plan(

--- a/src/core/runner/execution/daemon_api.rs
+++ b/src/core/runner/execution/daemon_api.rs
@@ -1,9 +1,11 @@
 use std::time::Duration;
 
 use reqwest::blocking::Client;
+use reqwest::blocking::RequestBuilder;
+use reqwest::header::CONNECTION;
 use serde_json::{json, Value};
 
-use crate::core::error::{Error, Result};
+use crate::core::error::{Error, ErrorCode, Result};
 
 use super::super::broker_http;
 use super::super::daemon_http_get::{daemon_get, parse_daemon_response_json};
@@ -16,9 +18,78 @@ fn unsupported_daemon_api_method(method: &str) -> Error {
     Error::internal_unexpected(format!("unsupported daemon API method {method}"))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DaemonHttpErrorKind {
+    Connect,
+    Timeout,
+    Status,
+    BodyDecode,
+}
+
+impl DaemonHttpErrorKind {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            DaemonHttpErrorKind::Connect => "connect",
+            DaemonHttpErrorKind::Timeout => "timeout",
+            DaemonHttpErrorKind::Status => "status",
+            DaemonHttpErrorKind::BodyDecode => "body_decode",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct DaemonPostOptions {
+    pub(super) connection_close: bool,
+}
+
+pub(super) struct DaemonHttpTextResponse {
+    pub(super) status_code: u16,
+    pub(super) body: String,
+}
+
 pub(crate) fn canonical_daemon_body<'a>(data: &'a Value, context: &str) -> Result<&'a Value> {
     data.get("body")
         .ok_or_else(|| Error::internal_unexpected(format!("{context} missing canonical data.body")))
+}
+
+pub(super) fn daemon_transport_error(
+    kind: DaemonHttpErrorKind,
+    path: &str,
+    status_code: Option<u16>,
+    context: &str,
+    error: impl Into<String>,
+) -> Error {
+    let mut err = Error::new(
+        ErrorCode::InternalUnexpected,
+        format!("{context}: {}", error.into()),
+        json!({
+            "daemon_transport_error": {
+                "kind": kind.as_str(),
+                "path": path,
+                "http_status": status_code,
+            }
+        }),
+    );
+    err.retryable = Some(true);
+    err
+}
+
+fn classify_reqwest_error(err: &reqwest::Error) -> DaemonHttpErrorKind {
+    if err.is_timeout() {
+        DaemonHttpErrorKind::Timeout
+    } else if err.is_connect() {
+        DaemonHttpErrorKind::Connect
+    } else {
+        DaemonHttpErrorKind::Status
+    }
+}
+
+fn with_daemon_post_options(request: RequestBuilder, options: DaemonPostOptions) -> RequestBuilder {
+    if options.connection_close {
+        request.header(CONNECTION, "close")
+    } else {
+        request
+    }
 }
 
 pub(crate) fn daemon_api_get(runner_id: &str, path: &str) -> Result<Value> {
@@ -96,14 +167,15 @@ pub(super) fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> R
 }
 
 pub(super) fn daemon_post(client: &Client, local_url: &str, path: &str) -> Result<Value> {
-    let response = client
-        .post(format!("{}{}", local_url.trim_end_matches('/'), path))
-        .send()
-        .map_err(|err| Error::internal_unexpected(format!("query runner daemon: {err}")))?;
-    let status_code = response.status().as_u16();
-    let body = response
-        .text()
-        .map_err(|err| Error::internal_unexpected(format!("read runner daemon response: {err}")))?;
+    let response = daemon_post_json_text(
+        client,
+        local_url,
+        path,
+        &json!({}),
+        DaemonPostOptions::default(),
+    )?;
+    let status_code = response.status_code;
+    let body = response.body;
     let envelope: DaemonEnvelope =
         parse_daemon_response_json(&body, status_code, path, "parse daemon response")?;
     if !envelope.success {
@@ -115,4 +187,43 @@ pub(super) fn daemon_post(client: &Client, local_url: &str, path: &str) -> Resul
     envelope
         .data
         .ok_or_else(|| Error::internal_unexpected("daemon response missing data"))
+}
+
+pub(super) fn daemon_post_json_text(
+    client: &Client,
+    local_url: &str,
+    path: &str,
+    payload: &Value,
+    options: DaemonPostOptions,
+) -> Result<DaemonHttpTextResponse> {
+    let request = client
+        .post(format!("{}{}", local_url.trim_end_matches('/'), path))
+        .json(payload);
+    let response = with_daemon_post_options(request, options)
+        .send()
+        .map_err(|err| {
+            daemon_transport_error(
+                classify_reqwest_error(&err),
+                path,
+                err.status().map(|status| status.as_u16()),
+                "query runner daemon",
+                err.to_string(),
+            )
+        })?;
+    let status_code = response.status().as_u16();
+    let body = response.text().map_err(|err| {
+        daemon_transport_error(
+            if err.is_timeout() {
+                DaemonHttpErrorKind::Timeout
+            } else {
+                DaemonHttpErrorKind::BodyDecode
+            },
+            path,
+            Some(status_code),
+            "read runner daemon response",
+            err.to_string(),
+        )
+    })?;
+
+    Ok(DaemonHttpTextResponse { status_code, body })
 }

--- a/src/core/runner/execution/failure.rs
+++ b/src/core/runner/execution/failure.rs
@@ -419,13 +419,20 @@ pub(super) fn daemon_exec_request_failed_error(
     }
 }
 
-pub(super) fn daemon_exec_loopback_transport_error(runner_id: &str, err: std::io::Error) -> Error {
-    Error::internal_unexpected(format!(
-        "could not reach runner `{runner_id}` daemon to submit the exec request over loopback HTTP: {err}"
-    ))
+pub(super) fn daemon_exec_loopback_transport_error(runner_id: &str, err: Error) -> Error {
+    let mut wrapped = Error::new(
+        err.code,
+        format!(
+            "could not reach runner `{runner_id}` daemon to submit the exec request over loopback HTTP: {}",
+            err.message
+        ),
+        err.details,
+    )
     .with_hint(format!(
         "The daemon tunnel may be stale or the daemon may have restarted. Reconnect with `homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}` and retry."
-    ))
+    ));
+    wrapped.retryable = err.retryable;
+    wrapped
 }
 
 /// The exec response body could not be parsed as a daemon envelope — typically a

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -886,10 +886,14 @@ fn allow_unauthenticated_loopback_broker() {
 fn daemon_exec_failure_without_error_field_is_actionable() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
     let addr = listener.local_addr().expect("addr");
+    let (request_tx, request_rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("accept");
         let mut buffer = [0; 4096];
-        let _ = std::io::Read::read(&mut stream, &mut buffer).expect("read request");
+        let bytes = std::io::Read::read(&mut stream, &mut buffer).expect("read request");
+        request_tx
+            .send(String::from_utf8_lossy(&buffer[..bytes]).to_string())
+            .expect("send request");
         let body = serde_json::json!({
             "success": false,
             "data": {
@@ -929,6 +933,9 @@ fn daemon_exec_failure_without_error_field_is_actionable() {
     assert!(err.message.contains("validation.invalid_argument"));
     assert!(err.message.contains("runner exec requires an absolute cwd"));
     assert!(!err.message.contains(": null"));
+    let request = request_rx.recv().expect("request capture");
+    assert!(request.starts_with("POST /exec HTTP/1.1"));
+    assert!(request.to_ascii_lowercase().contains("connection: close"));
 }
 
 #[test]


### PR DESCRIPTION
## Root cause
`exec_via_daemon` used a private raw-TCP HTTP POST for `/exec` while the rest of daemon execution used the shared reqwest path. That duplicated request construction, response parsing, timeout behavior, and stale-daemon error classification.

## What changed
- Moved `/exec` submission to the shared reqwest daemon POST helper.
- Added `DaemonPostOptions { connection_close }` so the `/exec` handoff keeps the close-after-response behavior that the raw client introduced in `61e89eadbd` (`Fix runner daemon exec handoff (#6266)`).
- Added structured daemon transport details with `daemon_transport_error.kind` values for `connect`, `timeout`, `status`, and `body_decode`, and taught daemon health classification to match those variants before falling back to legacy message substrings.
- Marked malformed daemon JSON responses as `body_decode` in structured error details.
- Converted the localhost `/exec` fixture to assert the shared reqwest path sends `Connection: close`.

## Deleted
- Deleted `daemon_loopback_post_json` and the bespoke raw-TCP request/response parser from `src/core/runner/execution/daemon.rs`.
- `src/core/runner/execution/daemon.rs` is down 102 LOC; the commit deletes 121 LOC total.

## Connection-close / streaming requirement
Blame shows raw TCP replaced the original reqwest `/exec` POST in `61e89eadbd` for daemon exec handoff behavior, with later socket timeouts added in `cb5c49dcbc`. The concrete transport requirement preserved here is `Connection: close`; `/exec` still returns a daemon envelope rather than streaming a long-lived response, so reqwest can handle the body while explicitly sending the close header through the shared option.

## Verification
- `cargo fmt --check`
- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib core::runner::daemon_health::tests core::runner::execution::tests::handoff::daemon_exec_failure_without_error_field_is_actionable core::runner::execution::tests::handoff::daemon_exec_empty_envelope_over_http_is_actionable_not_null --no-fail-fast`
- Requested selection `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(daemon) or test(execution)' --no-fail-fast` completed with 460/464 passing. The remaining failures were outside the changed `/exec` path: the contract sample test fails standalone with `record.status` `failed` vs `succeeded`; the daemon HTTP/reverse-broker localhost timeout failures pass when isolated and appear fixture/concurrency-related.\n\nCloses #7532\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)\n- **Used for:** Unified the daemon exec transport and deleted the raw-TCP client; Chris reviews and owns the change.