### PR TITLE
Add core compatibility constraints to extension manifests

### DIFF
--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -433,6 +433,7 @@ pub struct ExtensionDetail {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_url: Option<String>,
     pub runtime: String,
+    pub core_compatibility: homeboy::core::extension::CoreCompatibilityReport,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_requirements: Option<homeboy::core::extension::RuntimeRequirementsConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -501,6 +502,8 @@ pub struct ActionDetail {
 
 #[derive(Serialize)]
 pub struct RequiresDetail {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub homeboy: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extensions: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -888,11 +891,19 @@ fn show_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {
         .collect();
 
     let requires = extension.requires.as_ref().map(|r| RequiresDetail {
+        homeboy: r.homeboy.clone(),
         extensions: r.extensions.clone(),
         components: r.components.clone(),
     });
 
     let source_revision = homeboy::core::extension::read_source_revision(&extension.id);
+    let core_compatibility = homeboy::core::extension::evaluate_core_compatibility(
+        extension
+            .requires
+            .as_ref()
+            .and_then(|requires| requires.homeboy.as_deref()),
+        source_revision.clone(),
+    )?;
 
     let detail = ExtensionDetail {
         id: extension.id.clone(),
@@ -907,6 +918,7 @@ fn show_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {
         } else {
             "platform".to_string()
         },
+        core_compatibility,
         runtime_requirements: extension.runtime.clone(),
         has_setup,
         has_ready_check,
@@ -1563,6 +1575,7 @@ mod tests {
             description: String::new(),
             runtime: "platform".to_string(),
             compatible: true,
+            core_compatibility: homeboy::core::extension::CoreCompatibilityReport::undeclared(None),
             ready: true,
             ready_reason: None,
             ready_detail: None,
@@ -1617,6 +1630,9 @@ mod tests {
                 description: String::new(),
                 runtime: "platform".to_string(),
                 compatible: true,
+                core_compatibility: homeboy::core::extension::CoreCompatibilityReport::undeclared(
+                    None,
+                ),
                 ready: true,
                 ready_reason: None,
                 ready_detail: None,
@@ -1660,6 +1676,9 @@ mod tests {
                 description: String::new(),
                 runtime: "platform".to_string(),
                 compatible: true,
+                core_compatibility: homeboy::core::extension::CoreCompatibilityReport::undeclared(
+                    None,
+                ),
                 ready: true,
                 ready_reason: None,
                 ready_detail: None,

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -10,7 +10,9 @@ use crate::core::agent_task_provider::{
     AgentTaskProviderWorkspaceMaterialization,
 };
 use crate::core::command_invocation::COMMAND_INVOCATION_SCHEMA;
-use crate::core::extension::{load_all_extensions, load_extension, ExtensionManifest};
+use crate::core::extension::{
+    self, load_all_extensions, load_extension, ExtensionManifest, RequirementsConfig,
+};
 use crate::core::{config, paths, Error, Result};
 
 pub const AGENT_RUNTIME_MANIFEST_SCHEMA: &str = "homeboy/agent-runtime-manifest/v1";
@@ -49,6 +51,8 @@ pub struct AgentRuntimeManifest {
         skip_serializing_if = "AgentRuntimeMaterializationContract::is_empty"
     )]
     pub materialization: AgentRuntimeMaterializationContract,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires: Option<RequirementsConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -392,6 +396,18 @@ fn load_standalone_agent_runtime_manifest(
     manifest.extension_id = None;
     manifest.extension_path = None;
     manifest.runtime_path = Some(path.to_string_lossy().to_string());
+    if let Some(diagnostic) = agent_runtime_core_incompatible_diagnostic(
+        &manifest.id,
+        None,
+        manifest.runtime_path.as_deref(),
+        manifest
+            .requires
+            .as_ref()
+            .and_then(|requires| requires.homeboy.as_deref()),
+        None,
+    ) {
+        return StandaloneAgentRuntimeManifestLoad::Invalid(diagnostic);
+    }
     StandaloneAgentRuntimeManifestLoad::Loaded(manifest)
 }
 
@@ -402,6 +418,16 @@ pub(crate) fn discover_agent_runtime_catalog_from_extensions(
     let mut diagnostics = Vec::new();
     for extension in extensions {
         for runtime in &extension.agent_runtimes {
+            if let Some(diagnostic) = agent_runtime_core_incompatible_diagnostic(
+                &runtime.id,
+                Some(&extension.id),
+                extension.extension_path.as_deref(),
+                runtime_core_constraint(runtime, extension),
+                extension::read_source_revision(&extension.id),
+            ) {
+                diagnostics.push(diagnostic);
+                continue;
+            }
             let provider_catalog = parse_agent_task_executor_provider_catalog(
                 &runtime.agent_task_executors,
                 &runtime.id,
@@ -427,13 +453,14 @@ pub(crate) fn discover_agent_runtime_catalog_from_extensions(
                 )
                 .unwrap_or_default(),
                 extension_id: Some(extension.id.clone()),
+                requires: runtime_requires(runtime, extension),
                 extension_path: extension.extension_path.clone(),
                 runtime_path: extension.extension_path.clone(),
                 extra: runtime
                     .extra
                     .clone()
                     .into_iter()
-                    .filter(|(key, _)| key != "materialization")
+                    .filter(|(key, _)| key != "materialization" && key != "requires")
                     .collect(),
             });
         }
@@ -442,6 +469,61 @@ pub(crate) fn discover_agent_runtime_catalog_from_extensions(
         manifests: runtime_manifests,
         diagnostics,
     }
+}
+
+fn runtime_requires(
+    runtime: &crate::core::extension::AgentRuntimeManifestConfig,
+    extension: &ExtensionManifest,
+) -> Option<RequirementsConfig> {
+    runtime
+        .extra
+        .get("requires")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .or_else(|| extension.requires.clone())
+}
+
+fn runtime_core_constraint<'a>(
+    runtime: &'a crate::core::extension::AgentRuntimeManifestConfig,
+    extension: &'a ExtensionManifest,
+) -> Option<&'a str> {
+    runtime
+        .extra
+        .get("requires")
+        .and_then(|value| value.get("homeboy"))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| {
+            extension
+                .requires
+                .as_ref()
+                .and_then(|requires| requires.homeboy.as_deref())
+        })
+}
+
+fn agent_runtime_core_incompatible_diagnostic(
+    runtime_id: &str,
+    extension_id: Option<&str>,
+    path: Option<&str>,
+    requires_homeboy: Option<&str>,
+    source_revision: Option<String>,
+) -> Option<AgentRuntimeDiscoveryDiagnostic> {
+    let report = extension::evaluate_core_compatibility(requires_homeboy, source_revision).ok()?;
+    (report.status == "incompatible").then(|| AgentRuntimeDiscoveryDiagnostic {
+        class: "agent_runtime_manifest.core_incompatible".to_string(),
+        message: format!(
+            "Agent runtime manifest '{}' requires homeboy {}, but installed homeboy is {} (source_revision: {}). Run `{}` and retry.",
+            runtime_id,
+            report.requires_homeboy.as_deref().unwrap_or("<undeclared>"),
+            report.installed_homeboy,
+            report.source_revision.as_deref().unwrap_or("<missing>"),
+            report
+                .remediation_command
+                .as_deref()
+                .unwrap_or(extension::CORE_COMPAT_REMEDIATION_COMMAND)
+        ),
+        runtime_id: Some(runtime_id.to_string()),
+        extension_id: extension_id.map(str::to_string),
+        path: path.map(str::to_string),
+    })
 }
 
 pub(crate) fn discover_agent_task_executor_providers() -> Vec<AgentTaskExecutorProvider> {
@@ -913,6 +995,78 @@ mod tests {
     }
 
     #[test]
+    fn standalone_runtime_manifest_with_satisfied_core_constraint_loads() {
+        crate::test_support::with_isolated_home(|home| {
+            let runtime_dir = home
+                .path()
+                .join(".config/homeboy/agent-runtimes")
+                .join("compatible-runtime");
+            std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+            std::fs::write(
+                runtime_dir.join("compatible-runtime.json"),
+                json!({
+                    "schema": AGENT_RUNTIME_MANIFEST_SCHEMA,
+                    "id": "ignored-on-disk",
+                    "requires": { "homeboy": format!(">={}", extension::installed_homeboy_version()) },
+                    "agent_task_executors": [provider_json("compatible.default", "compatible")]
+                })
+                .to_string(),
+            )
+            .expect("runtime manifest");
+
+            let catalog = discover_standalone_agent_runtime_catalog();
+
+            assert!(catalog.diagnostics.is_empty());
+            assert_eq!(catalog.manifests.len(), 1);
+            let expected = format!(">={}", extension::installed_homeboy_version());
+            assert_eq!(
+                catalog.manifests[0]
+                    .requires
+                    .as_ref()
+                    .and_then(|requires| requires.homeboy.as_deref()),
+                Some(expected.as_str())
+            );
+        });
+    }
+
+    #[test]
+    fn standalone_runtime_manifest_with_unsatisfied_core_constraint_reports_diagnostic() {
+        crate::test_support::with_isolated_home(|home| {
+            let runtime_dir = home
+                .path()
+                .join(".config/homeboy/agent-runtimes")
+                .join("future-runtime");
+            std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+            std::fs::write(
+                runtime_dir.join("future-runtime.json"),
+                json!({
+                    "schema": AGENT_RUNTIME_MANIFEST_SCHEMA,
+                    "id": "ignored-on-disk",
+                    "requires": { "homeboy": ">=999.0.0" },
+                    "agent_task_executors": [provider_json("future.default", "future")]
+                })
+                .to_string(),
+            )
+            .expect("runtime manifest");
+
+            let catalog = discover_standalone_agent_runtime_catalog();
+
+            assert!(catalog.manifests.is_empty());
+            assert_eq!(catalog.diagnostics.len(), 1);
+            assert_eq!(
+                catalog.diagnostics[0].class,
+                "agent_runtime_manifest.core_incompatible"
+            );
+            assert_eq!(
+                catalog.diagnostics[0].runtime_id.as_deref(),
+                Some("future-runtime")
+            );
+            assert!(catalog.diagnostics[0].message.contains("homeboy upgrade"));
+            assert!(catalog.diagnostics[0].message.contains(">=999.0.0"));
+        });
+    }
+
+    #[test]
     fn standalone_runtime_catalog_reports_invalid_manifests() {
         crate::test_support::with_isolated_home(|home| {
             let runtime_dir = home
@@ -968,6 +1122,56 @@ mod tests {
             catalog.diagnostics[0].extension_id.as_deref(),
             Some("runtime-extension")
         );
+    }
+
+    #[test]
+    fn extension_runtime_manifest_with_unsatisfied_core_constraint_reports_diagnostic() {
+        let mut extension = extension("runtime-extension");
+        extension.requires = Some(
+            serde_json::from_value(json!({
+                "homeboy": ">=999.0.0"
+            }))
+            .expect("requires"),
+        );
+        extension.agent_runtimes.push(
+            serde_json::from_value(json!({
+                "id": "future-runtime",
+                "agent_task_executors": [provider_json("future.default", "future")]
+            }))
+            .expect("runtime manifest"),
+        );
+
+        let catalog = discover_agent_runtime_catalog_from_extensions(&[extension]);
+
+        assert!(catalog.manifests.is_empty());
+        assert_eq!(catalog.diagnostics.len(), 1);
+        assert_eq!(
+            catalog.diagnostics[0].class,
+            "agent_runtime_manifest.core_incompatible"
+        );
+        assert_eq!(
+            catalog.diagnostics[0].extension_id.as_deref(),
+            Some("runtime-extension")
+        );
+        assert!(catalog.diagnostics[0].message.contains("homeboy upgrade"));
+    }
+
+    #[test]
+    fn extension_runtime_manifest_without_core_constraint_behaves_as_before() {
+        let mut extension = extension("runtime-extension");
+        extension.agent_runtimes.push(
+            serde_json::from_value(json!({
+                "id": "example-runtime",
+                "agent_task_executors": [provider_json("example.default", "example")]
+            }))
+            .expect("runtime manifest"),
+        );
+
+        let catalog = discover_agent_runtime_catalog_from_extensions(&[extension]);
+
+        assert!(catalog.diagnostics.is_empty());
+        assert_eq!(catalog.manifests.len(), 1);
+        assert!(catalog.manifests[0].requires.is_none());
     }
 
     #[test]

--- a/src/core/extension/core_compat.rs
+++ b/src/core/extension/core_compat.rs
@@ -1,0 +1,176 @@
+use serde::Serialize;
+
+use crate::core::error::{Error, ErrorCode, Result};
+
+use super::version::VersionConstraint;
+
+pub const CORE_INCOMPATIBLE_DIAGNOSTIC: &str = "homeboy_core.incompatible";
+pub const CORE_COMPAT_REMEDIATION_COMMAND: &str = "homeboy upgrade";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CoreCompatibilityReport {
+    pub status: String,
+    pub installed_homeboy: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requires_homeboy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remediation_command: Option<String>,
+}
+
+impl CoreCompatibilityReport {
+    pub fn undeclared(source_revision: Option<String>) -> Self {
+        Self {
+            status: "undeclared".to_string(),
+            installed_homeboy: installed_homeboy_version(),
+            requires_homeboy: None,
+            source_revision,
+            remediation_command: None,
+        }
+    }
+}
+
+pub fn installed_homeboy_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+pub fn evaluate_core_compatibility(
+    requires_homeboy: Option<&str>,
+    source_revision: Option<String>,
+) -> Result<CoreCompatibilityReport> {
+    let installed = installed_homeboy_version();
+    let Some(constraint) = requires_homeboy.filter(|value| !value.trim().is_empty()) else {
+        return Ok(CoreCompatibilityReport::undeclared(source_revision));
+    };
+
+    let parsed_constraint = VersionConstraint::parse(constraint)?;
+    let installed_version = semver::Version::parse(&installed).map_err(|err| {
+        Error::validation_invalid_argument(
+            "homeboy_version",
+            format!(
+                "Installed homeboy version '{}' is not valid semver: {}",
+                installed, err
+            ),
+            Some(installed.clone()),
+            None,
+        )
+    })?;
+    let compatible = parsed_constraint.matches(&installed_version);
+
+    Ok(CoreCompatibilityReport {
+        status: if compatible {
+            "compatible".to_string()
+        } else {
+            "incompatible".to_string()
+        },
+        installed_homeboy: installed,
+        requires_homeboy: Some(constraint.to_string()),
+        source_revision,
+        remediation_command: (!compatible).then(|| CORE_COMPAT_REMEDIATION_COMMAND.to_string()),
+    })
+}
+
+pub fn validate_core_compatibility(
+    subject_kind: &str,
+    subject_id: &str,
+    requires_homeboy: Option<&str>,
+    source_revision: Option<String>,
+) -> Result<()> {
+    let report = evaluate_core_compatibility(requires_homeboy, source_revision)?;
+    if report.status == "incompatible" {
+        return Err(core_incompatible_error(subject_kind, subject_id, report));
+    }
+    Ok(())
+}
+
+pub fn core_incompatible_error(
+    subject_kind: &str,
+    subject_id: &str,
+    report: CoreCompatibilityReport,
+) -> Error {
+    let constraint = report.requires_homeboy.as_deref().unwrap_or("<undeclared>");
+    let source_revision = report.source_revision.as_deref().unwrap_or("<missing>");
+    let remediation = report
+        .remediation_command
+        .as_deref()
+        .unwrap_or(CORE_COMPAT_REMEDIATION_COMMAND);
+    Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!(
+            "Invalid argument 'homeboy_core': {subject_kind} '{subject_id}' requires homeboy {constraint}, but installed homeboy is {}. Run `{remediation}` and retry.",
+            report.installed_homeboy
+        ),
+        serde_json::json!({
+            "field": "homeboy_core",
+            "problem": CORE_INCOMPATIBLE_DIAGNOSTIC,
+            "diagnostic": {
+                "code": CORE_INCOMPATIBLE_DIAGNOSTIC,
+                "subject_kind": subject_kind,
+                "subject_id": subject_id,
+                "installed_homeboy": report.installed_homeboy,
+                "requires_homeboy": constraint,
+                "source_revision": source_revision,
+                "remediation_command": remediation,
+            },
+            "tried": [
+                format!("Installed homeboy version: {}", report.installed_homeboy),
+                format!("Declared homeboy constraint: {constraint}"),
+                format!("Source revision: {source_revision}"),
+                format!("Remediation: {remediation}"),
+            ]
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn undeclared_constraint_is_allowed() {
+        let report = evaluate_core_compatibility(None, None).expect("compat report");
+        assert_eq!(report.status, "undeclared");
+        assert!(report.requires_homeboy.is_none());
+    }
+
+    #[test]
+    fn satisfied_constraint_is_compatible() {
+        let current = installed_homeboy_version();
+        let report = evaluate_core_compatibility(Some(&format!(">={current}")), None)
+            .expect("compat report");
+        assert_eq!(report.status, "compatible");
+        assert_eq!(
+            report.requires_homeboy.as_deref(),
+            Some(format!(">={current}").as_str())
+        );
+    }
+
+    #[test]
+    fn unsatisfied_constraint_returns_typed_error_with_remediation() {
+        let err = validate_core_compatibility(
+            "extension",
+            "example",
+            Some(">=999.0.0"),
+            Some("abc123".to_string()),
+        )
+        .expect_err("incompatible core should fail");
+
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(
+            err.details["diagnostic"]["code"],
+            CORE_INCOMPATIBLE_DIAGNOSTIC
+        );
+        assert_eq!(
+            err.details["diagnostic"]["installed_homeboy"],
+            installed_homeboy_version()
+        );
+        assert_eq!(err.details["diagnostic"]["requires_homeboy"], ">=999.0.0");
+        assert_eq!(err.details["diagnostic"]["source_revision"], "abc123");
+        assert_eq!(
+            err.details["diagnostic"]["remediation_command"],
+            CORE_COMPAT_REMEDIATION_COMMAND
+        );
+        assert!(err.message.contains("homeboy upgrade"));
+    }
+}

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -23,6 +23,7 @@ use super::env_provider;
 use super::exec_context;
 use super::load_extension;
 use super::manifest::{ExtensionManifest, RuntimeConfig};
+use super::read_source_revision;
 use super::runner_contract::RunnerStepFilter;
 use super::runtime_helper;
 use super::scope::ExtensionScope;
@@ -572,6 +573,15 @@ pub(crate) fn prepare_capability_run(
     }
 
     let manifest = load_extension_manifest_from_dir(&execution.extension_path)?;
+    super::validate_core_compatibility(
+        "extension",
+        &execution.extension_id,
+        manifest
+            .get("requires")
+            .and_then(|requires| requires.get("homeboy"))
+            .and_then(serde_json::Value::as_str),
+        read_source_revision(&execution.extension_id),
+    )?;
     let settings_json = build_settings_json_from_manifest(
         &manifest,
         &execution.settings,
@@ -725,6 +735,15 @@ fn execute_extension_runtime(
     // - Direct execution cannot handle bash scripts or shell features
     // See executor.rs for detailed execution strategy decision tree
     let extension = load_extension(extension_id)?;
+    super::validate_core_compatibility(
+        "extension",
+        extension_id,
+        extension
+            .requires
+            .as_ref()
+            .and_then(|requires| requires.homeboy.as_deref()),
+        read_source_revision(extension_id),
+    )?;
     let runtime = extension_runtime(&extension)?;
     let run_command = runtime.run_command.as_ref().ok_or_else(|| {
         Error::config(format!(

--- a/src/core/extension/execution/action.rs
+++ b/src/core/extension/execution/action.rs
@@ -19,6 +19,15 @@ pub(crate) fn execute_action(
     payload: Option<&serde_json::Value>,
 ) -> Result<serde_json::Value> {
     let extension = load_extension(extension_id)?;
+    crate::core::extension::validate_core_compatibility(
+        "extension",
+        extension_id,
+        extension
+            .requires
+            .as_ref()
+            .and_then(|requires| requires.homeboy.as_deref()),
+        crate::core::extension::read_source_revision(extension_id),
+    )?;
 
     if extension.actions.is_empty() {
         return Err(Error::validation_invalid_argument(

--- a/src/core/extension/manifest_config.rs
+++ b/src/core/extension/manifest_config.rs
@@ -15,8 +15,10 @@ pub use trace_config::{
     TraceToolchainProvenanceConfig,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RequirementsConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub homeboy: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extensions: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -3,6 +3,7 @@ pub mod build;
 mod capability;
 mod compiler_warning_contract;
 pub mod component_script;
+mod core_compat;
 mod dev_run;
 mod env_provider;
 mod execution;
@@ -47,6 +48,11 @@ pub(crate) use capability::{extension_guidance_hints, stderr_tail};
 pub(crate) use compiler_warning_contract::{
     extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
     CompilerWarningContract,
+};
+pub use core_compat::{
+    core_incompatible_error, evaluate_core_compatibility, installed_homeboy_version,
+    validate_core_compatibility, CoreCompatibilityReport, CORE_COMPAT_REMEDIATION_COMMAND,
+    CORE_INCOMPATIBLE_DIAGNOSTIC,
 };
 pub use dev_run::{
     plan_extension_dev_run, run_extension_dev_run, ExtensionDevRunOutput, ExtensionDevRunPlan,

--- a/src/core/extension/summary.rs
+++ b/src/core/extension/summary.rs
@@ -4,6 +4,7 @@ use super::execution::{extension_ready_status, is_extension_compatible};
 use super::lifecycle::read_source_revision;
 use super::manifest::ActionType;
 use super::registry::{broken_extension_links, is_extension_linked, load_all_extensions};
+use super::{evaluate_core_compatibility, CoreCompatibilityReport};
 
 /// Summary of an extension for list views.
 #[derive(Debug, Clone, Serialize)]
@@ -14,6 +15,7 @@ pub struct ExtensionSummary {
     pub description: String,
     pub runtime: String,
     pub compatible: bool,
+    pub core_compatibility: CoreCompatibilityReport,
     pub ready: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
@@ -88,6 +90,13 @@ pub fn list_summaries(project: Option<&crate::core::project::Project>) -> Vec<Ex
                 .map(|_| true);
 
             let source_revision = read_source_revision(&ext.id);
+            let core_compatibility = evaluate_core_compatibility(
+                ext.requires
+                    .as_ref()
+                    .and_then(|requires| requires.homeboy.as_deref()),
+                source_revision.clone(),
+            )
+            .unwrap_or_else(|_| CoreCompatibilityReport::undeclared(source_revision.clone()));
 
             ExtensionSummary {
                 id: ext.id.clone(),
@@ -105,6 +114,7 @@ pub fn list_summaries(project: Option<&crate::core::project::Project>) -> Vec<Ex
                     "platform".to_string()
                 },
                 compatible,
+                core_compatibility,
                 ready: ready_status.ready,
                 ready_reason: ready_status.reason,
                 ready_detail: ready_status.detail,
@@ -131,6 +141,7 @@ pub fn list_summaries(project: Option<&crate::core::project::Project>) -> Vec<Ex
             description: String::new(),
             runtime: String::new(),
             compatible: false,
+            core_compatibility: CoreCompatibilityReport::undeclared(None),
             ready: false,
             ready_reason: Some("target_missing".to_string()),
             ready_detail: Some(format!("Linked target does not exist: {}", target)),

--- a/src/core/runner/execution/extension_parity.rs
+++ b/src/core/runner/execution/extension_parity.rs
@@ -112,6 +112,12 @@ fn validate_runner_extension(
             &output.stdout,
             requested_setting_keys,
         )?;
+        validate_runner_extension_core_compatibility(
+            runner_id,
+            homeboy_path,
+            extension_id,
+            &output.stdout,
+        )?;
         if let Err(err) = validate_runner_extension_revision(
             runner_id,
             runner,
@@ -144,6 +150,12 @@ fn validate_runner_extension(
                     extension_id,
                     &refreshed.stdout,
                     requested_setting_keys,
+                )?;
+                validate_runner_extension_core_compatibility(
+                    runner_id,
+                    homeboy_path,
+                    extension_id,
+                    &refreshed.stdout,
                 )?;
                 return Ok(());
             }
@@ -226,6 +238,63 @@ fn runner_extension_setting_declared(declared: &BTreeMap<String, String>, key: &
     };
 
     matches!(declared.get(parent).map(String::as_str), Some("object"))
+}
+
+fn validate_runner_extension_core_compatibility(
+    runner_id: &str,
+    homeboy_path: &str,
+    extension_id: &str,
+    remote_stdout: &str,
+) -> Result<()> {
+    let Some(report) = remote_extension_core_compatibility(remote_stdout) else {
+        return Ok(());
+    };
+    if report.status != "incompatible" {
+        return Ok(());
+    }
+
+    let constraint = report.requires_homeboy.as_deref().unwrap_or("<undeclared>");
+    let source_revision = report.source_revision.as_deref().unwrap_or("<missing>");
+    let command = format!("{homeboy_path} upgrade");
+    Err(Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!(
+            "Invalid argument 'runner_extension': Runner '{runner_id}' has homeboy-core incompatible extension parity for '{extension_id}' before command execution"
+        ),
+        serde_json::json!({
+            "field": "runner_extension",
+            "problem": "homeboy_core.incompatible",
+            "diagnostic": {
+                "code": "homeboy_core.incompatible",
+                "runner_id": runner_id,
+                "extension_id": extension_id,
+                "installed_homeboy": report.installed_homeboy,
+                "requires_homeboy": constraint,
+                "source_revision": source_revision,
+                "remediation_command": command,
+            },
+            "tried": [
+                format!("Runner homeboy version: {}", report.installed_homeboy),
+                format!("Declared homeboy constraint: {constraint}"),
+                format!("Runner extension source_revision: {source_revision}"),
+                format!("Remediation: {command}"),
+            ]
+        }),
+    ))
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct RemoteExtensionCoreCompatibility {
+    status: String,
+    installed_homeboy: String,
+    requires_homeboy: Option<String>,
+    source_revision: Option<String>,
+}
+
+fn remote_extension_core_compatibility(stdout: &str) -> Option<RemoteExtensionCoreCompatibility> {
+    let value: Value = serde_json::from_str(stdout.trim()).ok()?;
+    let extension = value.get("data").and_then(|data| data.get("extension"))?;
+    serde_json::from_value(extension.get("core_compatibility")?.clone()).ok()
 }
 
 #[derive(Default)]
@@ -846,9 +915,10 @@ fn extension_parity_diagnostic_tail(stderr: &str, stdout: &str) -> String {
 mod tests {
     use super::{
         controller_extension_metadata_required_error, controller_local_source_path,
-        local_source_runner_sync_error, remote_extension_ready_status,
-        remote_extension_setting_ids, remote_extension_source_revision,
-        requested_setting_keys_for_command, runner_extension_sync_command,
+        local_source_runner_sync_error, remote_extension_core_compatibility,
+        remote_extension_ready_status, remote_extension_setting_ids,
+        remote_extension_source_revision, requested_setting_keys_for_command,
+        runner_extension_sync_command, validate_runner_extension_core_compatibility,
         validate_runner_extension_ready, validate_runner_extension_revision,
         validate_runner_extension_settings,
     };
@@ -892,6 +962,41 @@ mod tests {
             remote_extension_source_revision(stdout).as_deref(),
             Some("abc1234")
         );
+    }
+
+    #[test]
+    fn remote_extension_core_compatibility_reads_extension_show_output() {
+        let stdout = r#"{"success":true,"data":{"extension":{"id":"wordpress","core_compatibility":{"status":"incompatible","installed_homeboy":"0.1.0","requires_homeboy":">=999.0.0","source_revision":"abc1234","remediation_command":"homeboy upgrade"}}}}"#;
+
+        let report = remote_extension_core_compatibility(stdout).expect("core compatibility");
+
+        assert_eq!(report.status, "incompatible");
+        assert_eq!(report.installed_homeboy, "0.1.0");
+        assert_eq!(report.requires_homeboy.as_deref(), Some(">=999.0.0"));
+        assert_eq!(report.source_revision.as_deref(), Some("abc1234"));
+    }
+
+    #[test]
+    fn runner_extension_core_compatibility_fails_fast_with_remediation() {
+        let stdout = r#"{"success":true,"data":{"extension":{"id":"wordpress","core_compatibility":{"status":"incompatible","installed_homeboy":"0.1.0","requires_homeboy":">=999.0.0","source_revision":"abc1234","remediation_command":"homeboy upgrade"}}}}"#;
+
+        let err = validate_runner_extension_core_compatibility(
+            "lab",
+            "/usr/local/bin/homeboy",
+            "wordpress",
+            stdout,
+        )
+        .expect_err("incompatible runner core should fail");
+
+        assert_eq!(
+            err.details["diagnostic"]["code"],
+            "homeboy_core.incompatible"
+        );
+        assert_eq!(
+            err.details["diagnostic"]["remediation_command"],
+            "/usr/local/bin/homeboy upgrade"
+        );
+        assert!(err.message.contains("homeboy-core incompatible"));
     }
 
     #[test]


### PR DESCRIPTION
## Contract description
Adds optional `requires.homeboy` semver constraints to extension manifests and agent-runtime manifests. Undeclared constraints remain allowed for incremental rollout. Declared constraints are evaluated with Homeboy's existing extension version-constraint parser, including `>=X.Y.Z` and caret ranges.

## Enforcement matrix
| Surface | Behavior |
| --- | --- |
| `extension list` | Reports `core_compatibility.status` as `compatible`, `incompatible`, or `undeclared`; listing does not fail. |
| `extension show` | Reports installed Homeboy version, declared constraint, source revision, and remediation command in `core_compatibility`; show does not fail. |
| `extension run` / extension actions / capability dispatch | Fails fast with typed `homeboy_core.incompatible` skew error before running extension code. |
| Runner extension-parity preflight | Validates runner `extension show` core compatibility alongside readiness/settings/revision parity and fails before dispatch with the runner upgrade command. |
| Agent-runtime discovery | Incompatible runtime manifests are skipped with `agent_runtime_manifest.core_incompatible` diagnostics instead of downstream provider disappearance. |

## Example error output
```text
Invalid argument 'homeboy_core': extension 'opencode' requires homeboy >=0.281.0, but installed homeboy is 0.280.13. Run `homeboy upgrade` and retry.
```

Structured diagnostic includes:
```json
{
  "code": "homeboy_core.incompatible",
  "subject_kind": "extension",
  "subject_id": "opencode",
  "installed_homeboy": "0.280.13",
  "requires_homeboy": ">=0.281.0",
  "source_revision": "05444b6f",
  "remediation_command": "homeboy upgrade"
}
```

Closes #7533

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Implemented the extension/runtime core-compat constraint and enforcement; Chris reviews and owns the change.
