### PR TITLE
Fix remaining release blockers from #7529

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -42,6 +42,9 @@ homeboy config set /defaults/permissions/local/file_mode '"g+r"'
 # Store copied run artifacts in a repo- or agent-readable directory
 homeboy config set /artifact_root '"~/Developer/.homeboy-artifacts"'
 
+# Apply environment to every gh subprocess for a GitHub Enterprise host
+homeboy config set /github_hosts/github.example.com/env/HTTPS_PROXY '"socks5://127.0.0.1:8080"'
+
 # Set an extension string setting without JSON quoting
 homeboy config set /settings/wp_sample-runtime_provider codex --string
 ```
@@ -82,6 +85,13 @@ homeboy config path
 ```json
 {
   "artifact_root": null,
+  "github_hosts": {
+    "github.example.com": {
+      "env": {
+        "HTTPS_PROXY": "socks5://127.0.0.1:8080"
+      }
+    }
+  },
   "defaults": {
     "install_methods": {
       "homebrew": {
@@ -135,6 +145,15 @@ Controls where Homeboy copies persisted run artifacts from commands such as `ben
 - Config override: `homeboy config set /artifact_root '"~/Developer/.homeboy-artifacts"'`
 
 Precedence is CLI flag, then environment variable, then global config, then the built-in default.
+
+### GitHub Hosts
+
+Controls environment variables Homeboy adds to `gh` subprocesses for repositories on a specific GitHub host.
+
+- `github_hosts.<hostname>.env`: Environment variables applied to `gh` when the component remote host matches `<hostname>`.
+- `github_hosts.<hostname>.proxy`: Convenience value for `HTTPS_PROXY`.
+- Component-owned `github.hosts.<hostname>` config overrides global `github_hosts.<hostname>` values.
+- `GH_HOST` is derived from the repository host and is not accepted from config.
 
 ### Install Methods
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,6 +29,7 @@ the higher-level system model and core/extension boundary, see
 
 - `defaults`
 - `artifact_root` — Optional directory where persisted run artifacts are copied. Override per command with `homeboy --artifact-root <dir>` or per process with `HOMEBOY_ARTIFACT_ROOT`.
+- `github_hosts` — Host-scoped environment for `gh` subprocesses, keyed by GitHub hostname. Example: `/github_hosts/github.example.com/env/HTTPS_PROXY`.
 - `update_check` — Enable automatic update check on startup (default: true). Disable with `homeboy config set /update_check false` or set HOMEBOY_NO_UPDATE_CHECK=1.
 
 ### `InstallMethodsConfig`

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -826,6 +826,15 @@ fn resolve_component_ids(
 
     // Positional component IDs
     if components.is_empty() {
+        if let Some(path) = args.path.as_deref() {
+            return match component::resolve_effective(None, Some(path), None) {
+                Ok(comp) => Ok(vec![comp.id]),
+                Err(_) => Err(homeboy::core::Error::validation_missing_argument(vec![
+                    "component ID(s), or --project <project-id>".to_string(),
+                ])),
+            };
+        }
+
         // Try CWD-based component detection
         match component::resolve_effective(None, None, None) {
             Ok(comp) => Ok(vec![comp.id]),

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -3,6 +3,7 @@ use crate::core::component::{
 };
 use crate::core::error::{Error, Result};
 use crate::core::extension::{self, ExtensionCapability};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 /// Shared target-resolution input for component/path-oriented commands.
@@ -379,6 +380,11 @@ fn synthetic_component_for_path(path: &str) -> Component {
 
 fn resolve_path_override(path: &str) -> Result<Component> {
     if let Some(mut discovered) = try_discover_from_portable(Path::new(path))? {
+        validate_duplicate_portable_component_ids(
+            &discovered.id,
+            Path::new(path),
+            Some(Path::new(path)),
+        )?;
         discovered.local_path = path.to_string();
         discovered.resolve_remote_path();
         return Ok(discovered);
@@ -388,6 +394,7 @@ fn resolve_path_override(path: &str) -> Result<Component> {
     if let Some(git_root) = detect_git_root(dir) {
         if git_root != dir {
             if let Some(mut discovered) = try_discover_from_portable(&git_root)? {
+                validate_duplicate_portable_component_ids(&discovered.id, &git_root, None)?;
                 discovered.local_path = path.to_string();
                 discovered.resolve_remote_path();
                 return Ok(discovered);
@@ -529,12 +536,14 @@ pub fn resolve(id: Option<&str>) -> Result<Component> {
     let cwd = std::env::current_dir().map_err(|e| Error::internal_io(e.to_string(), None))?;
 
     if let Some(component) = try_discover_from_portable(&cwd)? {
+        validate_duplicate_portable_component_ids(&component.id, &cwd, None)?;
         return Ok(component);
     }
 
     if let Some(git_root) = detect_git_root(&cwd) {
         if git_root != cwd {
             if let Some(component) = try_discover_from_portable(&git_root)? {
+                validate_duplicate_portable_component_ids(&component.id, &git_root, None)?;
                 return Ok(component);
             }
         }
@@ -593,7 +602,27 @@ fn resolve_effective_inner(
     if let Some(id) = id {
         if let Some(path) = path_override {
             if let Some(mut discovered) = try_discover_from_portable(Path::new(path))? {
-                discovered.id = id.to_string();
+                if discovered.id != id {
+                    return Err(Error::validation_invalid_argument(
+                        "component_id",
+                        format!(
+                            "Component ID '{}' does not match homeboy.json id '{}' at {}",
+                            id,
+                            discovered.id,
+                            Path::new(path).join("homeboy.json").display()
+                        ),
+                        Some(id.to_string()),
+                        Some(vec![
+                            format!("Use the path-owned component id: homeboy release {} --path {}", discovered.id, path),
+                            "Or rename one homeboy.json id so component IDs are unique within the checkout".to_string(),
+                        ]),
+                    ));
+                }
+                validate_duplicate_portable_component_ids(
+                    id,
+                    Path::new(path),
+                    Some(Path::new(path)),
+                )?;
                 discovered.local_path = path.to_string();
                 discovered.resolve_remote_path();
                 Ok(discovered)
@@ -622,6 +651,11 @@ fn resolve_effective_inner(
                     normalize_component_local_path(id).unwrap_or_else(|_| id.to_string());
 
                 if let Some(mut discovered) = try_discover_from_portable(id_path)? {
+                    validate_duplicate_portable_component_ids(
+                        &discovered.id,
+                        id_path,
+                        Some(id_path),
+                    )?;
                     discovered.local_path = local_path;
                     discovered.resolve_remote_path();
                     return Ok(discovered);
@@ -644,6 +678,11 @@ fn resolve_effective_inner(
             // This ensures `homeboy test foo` from a different clone of `foo`
             // operates on the current checkout, not the registered local_path (#694).
             if let Some(cwd_component) = prefer_cwd_for_component(id) {
+                validate_duplicate_portable_component_ids(
+                    id,
+                    Path::new(&cwd_component.local_path),
+                    None,
+                )?;
                 return Ok(cwd_component);
             }
 
@@ -670,6 +709,102 @@ fn resolve_effective_inner(
 
         resolve(None)
     }
+}
+
+pub(crate) fn validate_duplicate_portable_component_ids(
+    component_id: &str,
+    selected_dir: &Path,
+    explicit_dir: Option<&Path>,
+) -> Result<()> {
+    let scope = detect_git_root(selected_dir).unwrap_or_else(|| selected_dir.to_path_buf());
+    let matches = portable_config_paths_for_id(&scope, component_id)?;
+    if matches.len() <= 1 {
+        return Ok(());
+    }
+
+    if let Some(explicit_dir) = explicit_dir {
+        let explicit_config = canonical_config_path(explicit_dir.join("homeboy.json"));
+        if matches.iter().any(|path| path == &explicit_config) {
+            return Ok(());
+        }
+    }
+
+    Err(duplicate_portable_id_error(component_id, matches))
+}
+
+fn portable_config_paths_for_id(scope: &Path, component_id: &str) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    collect_portable_config_paths_for_id(scope, component_id, &mut seen, &mut paths)?;
+    paths.sort();
+    Ok(paths)
+}
+
+fn collect_portable_config_paths_for_id(
+    dir: &Path,
+    component_id: &str,
+    seen: &mut HashSet<PathBuf>,
+    paths: &mut Vec<PathBuf>,
+) -> Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(()),
+    };
+
+    let config_path = dir.join("homeboy.json");
+    if config_path.exists()
+        && crate::core::component::infer_portable_component_id(dir)
+            .ok()
+            .as_deref()
+            == Some(component_id)
+    {
+        let canonical = canonical_config_path(config_path);
+        if seen.insert(canonical.clone()) {
+            paths.push(canonical);
+        }
+    }
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() || should_skip_portable_duplicate_scan_dir(&path) {
+            continue;
+        }
+        collect_portable_config_paths_for_id(&path, component_id, seen, paths)?;
+    }
+
+    Ok(())
+}
+
+fn should_skip_portable_duplicate_scan_dir(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(".git" | ".homeboy" | "target" | "node_modules" | "vendor")
+    )
+}
+
+fn canonical_config_path(path: PathBuf) -> PathBuf {
+    path.canonicalize().unwrap_or(path)
+}
+
+fn duplicate_portable_id_error(component_id: &str, paths: Vec<PathBuf>) -> Error {
+    let path_list = paths
+        .iter()
+        .map(|path| format!("- {}", path.display()))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Error::validation_invalid_argument(
+        "component_id",
+        format!(
+            "Component id '{}' is declared by multiple homeboy.json files:\n{}",
+            component_id, path_list
+        ),
+        Some(component_id.to_string()),
+        Some(vec![
+            "Rename one homeboy.json id so each local component id is unique within the checkout".to_string(),
+            "Use --path <component-dir> to disambiguate the intended component when the command supports path overrides".to_string(),
+        ]),
+    )
 }
 
 #[cfg(test)]
@@ -721,6 +856,57 @@ mod tests {
             args,
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn write_portable(dir: &Path, id: &str) {
+        fs::create_dir_all(dir).expect("component dir");
+        fs::write(
+            dir.join("homeboy.json"),
+            serde_json::json!({
+                "id": id,
+                "build_artifact": format!("build/{id}.zip")
+            })
+            .to_string(),
+        )
+        .expect("portable config");
+    }
+
+    #[test]
+    fn duplicate_portable_ids_error_for_id_only_resolution_scope() {
+        let repo = tempfile::tempdir().expect("repo");
+        git(repo.path(), &["init"]);
+        write_portable(repo.path(), "fixture");
+        write_portable(&repo.path().join("plugins/fixture"), "fixture");
+
+        let err = validate_duplicate_portable_component_ids("fixture", repo.path(), None)
+            .expect_err("duplicate id should fail");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("multiple homeboy.json files"));
+        assert!(err.message.contains("plugins/fixture/homeboy.json"));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("Use --path")));
+    }
+
+    #[test]
+    fn explicit_path_disambiguates_duplicate_portable_ids() {
+        let repo = tempfile::tempdir().expect("repo");
+        git(repo.path(), &["init"]);
+        write_portable(repo.path(), "fixture");
+        let nested = repo.path().join("plugins/fixture");
+        write_portable(&nested, "fixture");
+
+        let resolved = resolve_effective(
+            Some("fixture"),
+            Some(nested.to_string_lossy().as_ref()),
+            None,
+        )
+        .expect("explicit path should select the nested config");
+
+        assert_eq!(resolved.id, "fixture");
+        assert_eq!(resolved.local_path, nested.to_string_lossy());
     }
 
     #[test]

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -887,7 +887,7 @@ mod tests {
         assert!(err
             .hints
             .iter()
-            .any(|hint| hint.message.contains("Use --path")));
+            .any(|hint| hint.message.contains("--path <component-dir>")));
     }
 
     #[test]

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -51,6 +51,14 @@ pub struct HomeboyConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub worktree_providers: HashMap<String, WorktreeProviderConfig>,
 
+    /// Host-scoped environment for GitHub CLI subprocesses keyed by hostname.
+    ///
+    /// Values are applied whenever Homeboy runs `gh` for a repository whose
+    /// remote URL resolves to that host. Component-level `github.hosts` entries
+    /// override these global defaults.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub github_hosts: HashMap<String, crate::core::component::GithubHostConfig>,
+
     /// Extension and executor settings addressed through `/settings/...`.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub settings: HashMap<String, Value>,
@@ -123,6 +131,7 @@ impl Default for HomeboyConfig {
             triage: TriageConfig::default(),
             agent_task: AgentTaskConfig::default(),
             worktree_providers: HashMap::new(),
+            github_hosts: HashMap::new(),
             settings: HashMap::new(),
             release_gate: ReleaseGateConfig::default(),
             artifact_root: None,

--- a/src/core/git/gh_client.rs
+++ b/src/core/git/gh_client.rs
@@ -4,9 +4,10 @@ use std::process::{Command, Output, Stdio};
 
 use serde::de::DeserializeOwned;
 
-use crate::core::component::GithubConfig;
+use crate::core::component::{GithubConfig, GithubHostConfig};
 use crate::core::deploy::release_download::GitHubRepo;
 use crate::core::error::{Error, Result};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct GhClient {
@@ -198,12 +199,16 @@ pub fn command_probe_succeeds(mut command: Command) -> bool {
 }
 
 pub fn github_cli_env(host: &str, config: &GithubConfig) -> Vec<(String, String)> {
-    github_cli_env_with_inherited(host, config, |key| std::env::var(key).ok())
+    let global_config = crate::core::defaults::load_config();
+    github_cli_env_with_global_and_inherited(host, config, &global_config.github_hosts, |key| {
+        std::env::var(key).ok()
+    })
 }
 
-fn github_cli_env_with_inherited(
+fn github_cli_env_with_global_and_inherited(
     host: &str,
     config: &GithubConfig,
+    global_hosts: &HashMap<String, GithubHostConfig>,
     inherited_env: impl Fn(&str) -> Option<String>,
 ) -> Vec<(String, String)> {
     let mut env = Vec::new();
@@ -211,9 +216,11 @@ fn github_cli_env_with_inherited(
         env.push(("GH_HOST".to_string(), host.to_string()));
     }
 
-    let host_config = config.hosts.get(host);
-    if let Some(proxy) = host_config
+    let global_host_config = global_hosts.get(host);
+    let component_host_config = config.hosts.get(host);
+    if let Some(proxy) = component_host_config
         .and_then(|host_config| host_config.proxy.clone())
+        .or_else(|| global_host_config.and_then(|host_config| host_config.proxy.clone()))
         .or_else(|| inherited_enterprise_https_proxy(host, &inherited_env))
         .filter(|proxy| !proxy.is_empty())
     {
@@ -241,18 +248,22 @@ fn github_cli_env_with_inherited(
         }
     }
 
-    let Some(host_config) = host_config else {
-        return env;
-    };
+    apply_host_env(&mut env, global_host_config);
+    apply_host_env(&mut env, component_host_config);
 
+    env
+}
+
+fn apply_host_env(env: &mut Vec<(String, String)>, host_config: Option<&GithubHostConfig>) {
+    let Some(host_config) = host_config else {
+        return;
+    };
     for (key, value) in &host_config.env {
         if !key.is_empty() && key != "GH_HOST" {
             env.retain(|(existing, _)| existing != key);
             env.push((key.clone(), value.clone()));
         }
     }
-
-    env
 }
 
 fn inherited_enterprise_https_proxy(
@@ -276,7 +287,7 @@ mod tests {
     use crate::core::component::{GithubConfig, GithubHostConfig};
 
     use super::{
-        delete_branch_ref_api_args, github_cli_env, github_cli_env_with_inherited,
+        delete_branch_ref_api_args, github_cli_env, github_cli_env_with_global_and_inherited,
         pr_merge_api_args, GhClient,
     };
 
@@ -331,9 +342,10 @@ mod tests {
 
     #[test]
     fn github_cli_env_sets_enterprise_host_without_implicit_proxy() {
-        let env = github_cli_env_with_inherited(
+        let env = github_cli_env_with_global_and_inherited(
             "github.enterprise.test",
             &GithubConfig::default(),
+            &HashMap::new(),
             |_| None,
         );
 
@@ -356,9 +368,10 @@ mod tests {
             ),
         ]);
 
-        let env = github_cli_env_with_inherited(
+        let env = github_cli_env_with_global_and_inherited(
             "github.enterprise.test",
             &GithubConfig::default(),
+            &HashMap::new(),
             |key| inherited.get(key).cloned(),
         );
 
@@ -400,9 +413,12 @@ mod tests {
             ),
         ]);
 
-        let env = github_cli_env_with_inherited("github.enterprise.test", &config, |key| {
-            inherited.get(key).cloned()
-        });
+        let env = github_cli_env_with_global_and_inherited(
+            "github.enterprise.test",
+            &config,
+            &HashMap::new(),
+            |key| inherited.get(key).cloned(),
+        );
 
         assert!(env.contains(&(
             "HTTPS_PROXY".to_string(),
@@ -436,6 +452,69 @@ mod tests {
             "HTTPS_PROXY".to_string(),
             "https://proxy.example.test:9443".to_string()
         )));
+    }
+
+    #[test]
+    fn github_cli_env_applies_global_host_env() {
+        let mut global_hosts = HashMap::new();
+        global_hosts.insert(
+            "github.enterprise.test".to_string(),
+            GithubHostConfig {
+                proxy: Some("socks5://127.0.0.1:8080".to_string()),
+                env: HashMap::from([("NO_PROXY".to_string(), "metadata.internal".to_string())]),
+            },
+        );
+
+        let env = github_cli_env_with_global_and_inherited(
+            "github.enterprise.test",
+            &GithubConfig::default(),
+            &global_hosts,
+            |_| None,
+        );
+
+        assert!(env.contains(&("GH_HOST".to_string(), "github.enterprise.test".to_string())));
+        assert!(env.contains(&(
+            "HTTPS_PROXY".to_string(),
+            "socks5://127.0.0.1:8080".to_string()
+        )));
+        assert!(env.contains(&("NO_PROXY".to_string(), "metadata.internal".to_string())));
+    }
+
+    #[test]
+    fn github_cli_env_component_host_env_overrides_global_host_env() {
+        let mut global_hosts = HashMap::new();
+        global_hosts.insert(
+            "github.enterprise.test".to_string(),
+            GithubHostConfig {
+                proxy: Some("socks5://127.0.0.1:8080".to_string()),
+                env: HashMap::from([("NO_PROXY".to_string(), "global".to_string())]),
+            },
+        );
+        let mut component_hosts = HashMap::new();
+        component_hosts.insert(
+            "github.enterprise.test".to_string(),
+            GithubHostConfig {
+                proxy: Some("https://component-proxy.example.test".to_string()),
+                env: HashMap::from([("NO_PROXY".to_string(), "component".to_string())]),
+            },
+        );
+        let config = GithubConfig {
+            hosts: component_hosts,
+        };
+
+        let env = github_cli_env_with_global_and_inherited(
+            "github.enterprise.test",
+            &config,
+            &global_hosts,
+            |_| None,
+        );
+
+        assert!(env.contains(&(
+            "HTTPS_PROXY".to_string(),
+            "https://component-proxy.example.test".to_string()
+        )));
+        assert!(env.contains(&("NO_PROXY".to_string(), "component".to_string())));
+        assert!(!env.contains(&("NO_PROXY".to_string(), "global".to_string())));
     }
 
     #[test]

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -25,6 +25,11 @@ pub fn resolve_project_component_with_standalone_snapshot(
             .find(|component| component.id == component_id)
     {
         super::super::validate_component_local_path(project, component_id)?;
+        crate::core::component::resolution::validate_duplicate_portable_component_ids(
+            component_id,
+            Path::new(&attachment.local_path),
+            None,
+        )?;
         (
             discover_attached_component(Path::new(&attachment.local_path)).ok_or_else(|| {
                 Error::validation_invalid_argument(

--- a/src/core/release/planning_worktree.rs
+++ b/src/core/release/planning_worktree.rs
@@ -3,6 +3,7 @@ use crate::core::error::{Error, Result};
 use crate::core::git::UncommittedChanges;
 use crate::core::release::changelog;
 use crate::core::release::version::ComponentVersionInfo;
+use std::path::{Path, PathBuf};
 
 use super::types::ReleaseOptions;
 
@@ -32,9 +33,10 @@ pub(super) fn validate_release_worktree(
     let allowed = get_release_allowed_files(
         &changelog_path,
         &version_targets,
-        std::path::Path::new(&component.local_path),
+        Path::new(&component.local_path),
     );
-    let unexpected = get_unexpected_uncommitted_files(&uncommitted, &allowed);
+    let build_artifacts = declared_build_artifact_paths(component);
+    let unexpected = get_unexpected_uncommitted_files(&uncommitted, &allowed, &build_artifacts);
 
     if !unexpected.is_empty() {
         return Ok(Some(serde_json::json!({
@@ -83,7 +85,8 @@ pub(super) fn validate_working_tree_fail_fast(component: &Component) -> Result<(
         .cloned()
         .collect();
 
-    let unexpected = filter_homeboy_managed(all_files);
+    let build_artifacts = declared_build_artifact_paths(component);
+    let unexpected = filter_homeboy_managed_and_declared_artifacts(all_files, &build_artifacts);
     if unexpected.is_empty() {
         return Ok(());
     }
@@ -128,6 +131,21 @@ pub(super) fn filter_homeboy_managed(files: Vec<String>) -> Vec<String> {
     files
         .into_iter()
         .filter(|f| !is_homeboy_managed_path(f))
+        .collect()
+}
+
+fn filter_homeboy_managed_and_declared_artifacts(
+    files: Vec<String>,
+    declared_artifacts: &[String],
+) -> Vec<String> {
+    files
+        .into_iter()
+        .filter(|f| !is_homeboy_managed_path(f))
+        .filter(|f| {
+            !declared_artifacts
+                .iter()
+                .any(|artifact| paths_match(f, artifact))
+        })
         .collect()
 }
 
@@ -182,6 +200,7 @@ fn derived_release_lockfiles(version_target: &str) -> Vec<String> {
 fn get_unexpected_uncommitted_files(
     uncommitted: &UncommittedChanges,
     allowed: &[String],
+    declared_artifacts: &[String],
 ) -> Vec<String> {
     let all_uncommitted: Vec<&String> = uncommitted
         .staged
@@ -194,15 +213,98 @@ fn get_unexpected_uncommitted_files(
         .into_iter()
         .filter(|f| !is_homeboy_managed_path(f))
         .filter(|f| !allowed.iter().any(|a| f.ends_with(a) || a.ends_with(*f)))
+        .filter(|f| {
+            !declared_artifacts
+                .iter()
+                .any(|artifact| paths_match(f, artifact))
+        })
         .cloned()
         .collect()
+}
+
+fn paths_match(file: &str, allowed: &str) -> bool {
+    file == allowed || file.ends_with(allowed) || allowed.ends_with(file)
+}
+
+fn declared_build_artifact_paths(component: &Component) -> Vec<String> {
+    let status_root = Path::new(&component.local_path);
+    let scan_root = crate::core::component::resolution::detect_git_root(status_root)
+        .unwrap_or_else(|| status_root.to_path_buf());
+    let mut artifacts = Vec::new();
+    collect_declared_build_artifact_paths(&scan_root, status_root, &mut artifacts);
+    artifacts.sort();
+    artifacts.dedup();
+    artifacts
+}
+
+fn collect_declared_build_artifact_paths(
+    dir: &Path,
+    status_root: &Path,
+    artifacts: &mut Vec<String>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    let config_path = dir.join("homeboy.json");
+    if let Some(artifact) = read_declared_build_artifact(&config_path) {
+        let artifact_path = Path::new(&artifact);
+        let absolute = if artifact_path.is_absolute() {
+            artifact_path.to_path_buf()
+        } else {
+            dir.join(artifact_path)
+        };
+        if let Some(relative) = relative_path_string(&absolute, status_root) {
+            artifacts.push(relative);
+        }
+    }
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() || should_skip_artifact_scan_dir(&path) {
+            continue;
+        }
+        collect_declared_build_artifact_paths(&path, status_root, artifacts);
+    }
+}
+
+fn read_declared_build_artifact(config_path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(config_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    json.get("build_artifact")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn relative_path_string(path: &Path, root: &Path) -> Option<String> {
+    let path = normalize_path(path);
+    let root = normalize_path(root);
+    path.strip_prefix(&root)
+        .ok()
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .filter(|relative| !relative.is_empty())
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.canonicalize()
+        .unwrap_or_else(|_| crate::core::paths::normalize_local_path(path))
+}
+
+fn should_skip_artifact_scan_dir(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(".git" | ".homeboy" | "target" | "node_modules" | "vendor")
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        filter_homeboy_managed, get_release_allowed_files, get_unexpected_uncommitted_files,
-        is_homeboy_managed_path, validate_release_worktree, validate_working_tree_fail_fast,
+        declared_build_artifact_paths, filter_homeboy_managed, get_release_allowed_files,
+        get_unexpected_uncommitted_files, is_homeboy_managed_path, validate_release_worktree,
+        validate_working_tree_fail_fast,
     };
     use crate::core::component::Component;
     use crate::core::git::UncommittedChanges;
@@ -377,7 +479,7 @@ mod tests {
     #[test]
     fn unexpected_files_skip_homeboy_build_dir() {
         let changes = uncommitted(&[], &[], &[".homeboy-build/sample-plugin-0.70.1.zip"]);
-        let unexpected = get_unexpected_uncommitted_files(&changes, &[]);
+        let unexpected = get_unexpected_uncommitted_files(&changes, &[], &[]);
         assert!(
             unexpected.is_empty(),
             "homeboy-managed scratch should never trigger working_tree error, got: {:?}",
@@ -388,8 +490,34 @@ mod tests {
     #[test]
     fn unexpected_files_still_catch_user_changes() {
         let changes = uncommitted(&["src/lib.rs"], &[], &[".homeboy-build/foo"]);
-        let unexpected = get_unexpected_uncommitted_files(&changes, &[]);
+        let unexpected = get_unexpected_uncommitted_files(&changes, &[], &[]);
         assert_eq!(unexpected, vec!["src/lib.rs"]);
+    }
+
+    #[test]
+    fn unexpected_files_skip_declared_build_artifacts() {
+        let changes = uncommitted(&[], &[], &["plugins/a/build/a.zip", "src/lib.rs"]);
+        let declared = vec!["plugins/a/build/a.zip".to_string()];
+        let unexpected = get_unexpected_uncommitted_files(&changes, &[], &declared);
+
+        assert_eq!(unexpected, vec!["src/lib.rs"]);
+    }
+
+    #[test]
+    fn declared_build_artifacts_include_sibling_component_configs() {
+        let temp = git_repo();
+        let dir = temp.path();
+        std::fs::write(dir.join("homeboy.json"), r#"{"id":"root"}"#).unwrap();
+        std::fs::create_dir_all(dir.join("plugins/a")).unwrap();
+        std::fs::write(
+            dir.join("plugins/a/homeboy.json"),
+            r#"{"id":"a","build_artifact":"build/a.zip"}"#,
+        )
+        .unwrap();
+
+        let artifacts = declared_build_artifact_paths(&git_component(dir));
+
+        assert_eq!(artifacts, vec!["plugins/a/build/a.zip"]);
     }
 
     #[test]
@@ -400,7 +528,7 @@ mod tests {
             &[".homeboy-build/foo"],
         );
         let allowed = vec!["docs/changelog.md".to_string(), "manifest.toml".to_string()];
-        let unexpected = get_unexpected_uncommitted_files(&changes, &allowed);
+        let unexpected = get_unexpected_uncommitted_files(&changes, &allowed, &[]);
         assert!(
             unexpected.is_empty(),
             "allowed files + homeboy scratch should yield clean result, got: {:?}",


### PR DESCRIPTION
## Summary

Fixes the remaining Homeboy CLI release blockers from #7529:

- Duplicate component IDs now hard-error when multiple distinct local `homeboy.json` files claim the same ID in the resolution scope.
- Release preflight now ignores declared build artifacts left by prior component packages in the same checkout.
- `gh` subprocesses now receive global per-host environment from `/github_hosts/<hostname>/env`, merged by the repo remote host.

## Root Cause / Fix

### Duplicate component-id hard error

Root cause: target resolution accepted the first matching component ID or overwrote a path-discovered portable ID with the positional ID, so root and nested `homeboy.json` files could silently mix contexts.

Fix:
- Added canonical-path duplicate portable ID detection at `src/core/component/resolution.rs:714` and wired it into path/CWD/project resolution at `src/core/component/resolution.rs:383`, `src/core/component/resolution.rs:539`, and `src/core/project/component/resolution.rs:28`.
- Preserved explicit `--path` as disambiguation and rejected mismatched positional ID vs path-owned `homeboy.json` ID at `src/core/component/resolution.rs:603`.
- Fixed `homeboy release --path <dir>` with no positional component so the component ID comes from the path, not CWD, at `src/commands/release.rs:829`.

### Release residue self-blocks next release

Root cause: release working-tree preflight treated package zips produced at declared `build_artifact` paths as untracked user changes, so component A's packaged artifact could block component B in the same monorepo.

Fix:
- Release preflight now builds a declared artifact allowlist before fail-fast and release worktree checks at `src/core/release/planning_worktree.rs:38` and `src/core/release/planning_worktree.rs:88`.
- The allowlist scans local `homeboy.json` files under the git checkout and resolves each `build_artifact` relative to its declaring config at `src/core/release/planning_worktree.rs:229`.

### Per-host GitHub env for gh subprocesses

Root cause: release GitHub publishing used only ambient env plus component-local GitHub config; there was no global host-scoped config surface for hosts that always require proxy/env.

Fix:
- Added top-level global config key `/github_hosts/<hostname>` at `src/core/defaults.rs:60`.
- `GhClient`/release `gh` env construction now merges global host env by parsed remote host, then component host overrides, at `src/core/git/gh_client.rs:203` and `src/core/git/gh_client.rs:208`.
- Documented the config key and examples at `docs/commands/config.md:46`, `docs/commands/config.md:149`, and `docs/reference/configuration.md:32`.

## Verification

- `perl -e 'alarm shift; exec @ARGV' 300 cargo build` after commit 1: passed.
- `perl -e 'alarm shift; exec @ARGV' 300 cargo build` after commit 2: passed.
- `perl -e 'alarm shift; exec @ARGV' 300 cargo build` after commit 3: passed.
- Local tests were not executed. The local test suite hangs indefinitely on this machine; CI owns test execution.
- `cargo test` and `cargo clippy` were not run by instruction.

Fixes #7529

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — orchestrated by Claude (claude-fable-5), implementation by GPT-5.5 subagent
- **Used for:** Implemented the remaining #7529 items (duplicate-id hard error, release residue, per-host gh env); reviewed by Chris.
