### PR TITLE
Add rig extends array merge directives

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -66,7 +66,10 @@ Merge rules are intentionally generic:
 
 - Parent files are applied in order; the declaring rig is applied last.
 - Objects merge recursively.
-- Arrays and scalar values replace the inherited value.
+- Plain arrays and scalar values replace the inherited value.
+- A child field whose inherited value is an array can opt into array merge semantics by using an object directive instead of a plain array:
+  - `{ "$append": [...] }` appends entries after the inherited array.
+  - `{ "$merge_by": "<key>", "entries": [...] }` merges array objects by a key field such as `id` or `label`; matching entries deep-merge with the same object rules, and new keyed entries append.
 - `extends` paths must be non-empty relative paths that stay inside the rig package source root.
 
 Example:
@@ -97,6 +100,47 @@ Example:
 ```
 
 The installed rig keeps the base `pipeline.check` and `components.app.branch`, while replacing `components.app.path`.
+
+Array merge example:
+
+```jsonc
+// templates/base.json
+{
+  "pipeline": {
+    "up": [
+      { "kind": "check", "label": "base setup complete", "command": "./scripts/base-setup.sh" }
+    ],
+    "check": [
+      { "kind": "check", "label": "npm available", "command": "npm --version" },
+      { "kind": "check", "label": "build", "command": "npm run build", "metadata": { "retries": 1 } }
+    ]
+  }
+}
+```
+
+```jsonc
+// rigs/app/rig.json
+{
+  "extends": "../../templates/base.json",
+  "id": "app",
+  "pipeline": {
+    "check": {
+      "$merge_by": "label",
+      "entries": [
+        { "kind": "check", "label": "build", "command": "npm run build -- --fast", "metadata": { "timeout": 60 } },
+        { "kind": "check", "label": "app checkout exists", "file": "${components.app.path}" }
+      ]
+    },
+    "up": {
+      "$append": [
+        { "kind": "check", "label": "local setup complete", "command": "./scripts/setup.sh" }
+      ]
+    }
+  }
+}
+```
+
+The materialized `pipeline.check` keeps `npm available`, deep-merges the `build` step so `metadata.retries` and `metadata.timeout` both survive, and appends `app checkout exists`. Plain array fields still replace inherited arrays unless one of these directives is used.
 
 ## Package Dependencies
 

--- a/src/core/rig/discovery.rs
+++ b/src/core/rig/discovery.rs
@@ -197,12 +197,13 @@ fn discovered_from_path(
 ///
 /// `extends` children are partial specs by design — they may legitimately omit
 /// required fields that a base template supplies, and they may carry
-/// post-materialization-only constructs such as the array-merge directive
-/// (`{ "$merge": "append" }`). Validating the raw child against the full schema
-/// would reject those, so when a spec declares `extends` we materialize it
-/// first (merging templates and stripping directives) and validate the
-/// resolved spec. Specs without `extends` keep the identical raw-parse schema
-/// gate so malformed specs still fail discovery with the same error shape.
+/// post-materialization-only constructs such as the array-merge directives
+/// (`{ "$append": [...] }` / `{ "$merge_by": "label", "entries": [...] }`).
+/// Validating the raw child against the full schema would reject those, so when
+/// a spec declares `extends` we materialize it first (merging templates and
+/// stripping directives) and validate the resolved spec. Specs without
+/// `extends` keep the identical raw-parse schema gate so malformed specs still
+/// fail discovery with the same error shape.
 fn parse_discovered_rig_spec(path: &Path, source_root: &Path) -> Result<super::RigSpec> {
     let value = match super::install::materialize_rig_spec(path, source_root)? {
         Some(materialized) => materialized,

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -313,9 +313,9 @@ fn materialize_rig_spec_value(
         let parent_value = read_json_value(&parent)?;
         let parent_materialized =
             materialize_rig_spec_value(&parent, source_root, parent_value, stack)?;
-        merge_json(&mut merged, parent_materialized);
+        merge_json(&mut merged, parent_materialized, &parent, "")?;
     }
-    merge_json(&mut merged, value);
+    merge_json(&mut merged, value, path, "")?;
 
     stack.pop();
     Ok(merged)
@@ -549,105 +549,43 @@ fn materialized_runner_source_root(path: &Path) -> Option<PathBuf> {
         .map(|window| window[1].to_path_buf())
 }
 
-/// Opt-in array merge mode for `extends` template inheritance.
-///
-/// A child array selects a mode by placing a single directive object —
-/// `{ "$merge": "<mode>" }` — as its first element. Without a directive an
-/// overlay array fully replaces the base array, preserving the historical
-/// `extends` behavior for every existing consumer.
-#[derive(Clone, Copy)]
-enum ArrayMergeMode {
-    /// Base elements first, then the child's elements.
-    Append,
-    /// Child elements first, then the base's elements.
-    Prepend,
-    /// Merge by `label`: child elements deep-merge into the base element with
-    /// the same `label` (or append when no match / no label).
-    ByLabel,
-}
+const ARRAY_APPEND_DIRECTIVE_KEY: &str = "$append";
+const ARRAY_MERGE_BY_DIRECTIVE_KEY: &str = "$merge_by";
+const ARRAY_MERGE_ENTRIES_KEY: &str = "entries";
 
-const ARRAY_MERGE_DIRECTIVE_KEY: &str = "$merge";
-
-/// Detect a leading `{ "$merge": "<mode>" }` directive on an overlay array.
-///
-/// The directive object must be the array's first element and carry exactly the
-/// single `$merge` key so a real step that happens to set other fields is never
-/// misread as a directive.
-fn array_merge_mode(overlay: &[serde_json::Value]) -> Option<ArrayMergeMode> {
-    let directive = overlay.first()?.as_object()?;
-    if directive.len() != 1 {
-        return None;
-    }
-    match directive.get(ARRAY_MERGE_DIRECTIVE_KEY)?.as_str()? {
-        "append" => Some(ArrayMergeMode::Append),
-        "prepend" => Some(ArrayMergeMode::Prepend),
-        "by_label" => Some(ArrayMergeMode::ByLabel),
-        _ => None,
-    }
-}
-
-fn merge_array(target: &mut serde_json::Value, overlay: Vec<serde_json::Value>) {
-    let Some(mode) = array_merge_mode(&overlay) else {
-        *target = serde_json::Value::Array(overlay);
-        return;
+fn extends_merge_error(source_path: &Path, field_path: &str, problem: impl Into<String>) -> Error {
+    let field = if field_path.is_empty() {
+        "<root>".to_string()
+    } else {
+        field_path.to_string()
     };
-
-    // Strip the leading directive element; the remainder is the child payload.
-    let child: Vec<serde_json::Value> = overlay.into_iter().skip(1).collect();
-    let base = match target.take() {
-        serde_json::Value::Array(base) => base,
-        // No base array (key absent or a different type): the child payload
-        // stands alone, with append/prepend/by_label all collapsing to it.
-        _ => Vec::new(),
-    };
-
-    let merged = match mode {
-        ArrayMergeMode::Append => {
-            let mut merged = base;
-            merged.extend(child);
-            merged
-        }
-        ArrayMergeMode::Prepend => {
-            let mut merged = child;
-            merged.extend(base);
-            merged
-        }
-        ArrayMergeMode::ByLabel => merge_array_by_label(base, child),
-    };
-
-    *target = serde_json::Value::Array(merged);
+    Error::validation_invalid_argument(
+        field,
+        problem,
+        Some(source_path.to_string_lossy().to_string()),
+        None,
+    )
 }
 
-fn merge_array_by_label(
-    base: Vec<serde_json::Value>,
-    child: Vec<serde_json::Value>,
-) -> Vec<serde_json::Value> {
-    let mut merged = base;
-    for item in child {
-        let label = item
-            .get("label")
-            .and_then(|label| label.as_str())
-            .map(str::to_string);
-        if let Some(label) = label {
-            if let Some(existing) = merged.iter_mut().find(|entry| {
-                entry.get("label").and_then(|label| label.as_str()) == Some(label.as_str())
-            }) {
-                merge_json(existing, item);
-                continue;
-            }
-        }
-        merged.push(item);
-    }
-    merged
-}
-
-fn merge_json(target: &mut serde_json::Value, overlay: serde_json::Value) {
+fn merge_json(
+    target: &mut serde_json::Value,
+    overlay: serde_json::Value,
+    source_path: &Path,
+    field_path: &str,
+) -> Result<()> {
     match overlay {
         serde_json::Value::Object(overlay) => {
-            if let serde_json::Value::Object(target) = target {
+            if target.is_array() && overlay.keys().any(|key| key.starts_with('$')) {
+                merge_array_directive(target, overlay, source_path, field_path)?;
+            } else if let serde_json::Value::Object(target) = target {
                 for (key, value) in overlay {
+                    let child_path = if field_path.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{field_path}.{key}")
+                    };
                     match target.get_mut(&key) {
-                        Some(existing) => merge_json(existing, value),
+                        Some(existing) => merge_json(existing, value, source_path, &child_path)?,
                         None => {
                             target.insert(key, value);
                         }
@@ -657,9 +595,151 @@ fn merge_json(target: &mut serde_json::Value, overlay: serde_json::Value) {
                 *target = serde_json::Value::Object(overlay);
             }
         }
-        serde_json::Value::Array(overlay) => merge_array(target, overlay),
+        serde_json::Value::Array(overlay) => *target = serde_json::Value::Array(overlay),
         overlay => *target = overlay,
     }
+    Ok(())
+}
+
+fn merge_array_directive(
+    target: &mut serde_json::Value,
+    mut overlay: serde_json::Map<String, serde_json::Value>,
+    source_path: &Path,
+    field_path: &str,
+) -> Result<()> {
+    for key in overlay.keys().filter(|key| key.starts_with('$')) {
+        if key != ARRAY_APPEND_DIRECTIVE_KEY && key != ARRAY_MERGE_BY_DIRECTIVE_KEY {
+            return Err(extends_merge_error(
+                source_path,
+                field_path,
+                format!(
+                    "Unknown rig extends array merge directive '{}' in {}",
+                    key,
+                    source_path.display()
+                ),
+            ));
+        }
+    }
+
+    if overlay.contains_key(ARRAY_APPEND_DIRECTIVE_KEY)
+        && overlay.contains_key(ARRAY_MERGE_BY_DIRECTIVE_KEY)
+    {
+        return Err(extends_merge_error(
+            source_path,
+            field_path,
+            format!(
+                "Rig extends array merge directive in {} must use either '$append' or '$merge_by', not both",
+                source_path.display()
+            ),
+        ));
+    }
+
+    if let Some(append) = overlay.remove(ARRAY_APPEND_DIRECTIVE_KEY) {
+        if !overlay.is_empty() {
+            return Err(extends_merge_error(
+                source_path,
+                field_path,
+                format!(
+                    "Rig extends '$append' directive in {} must only contain '$append'",
+                    source_path.display()
+                ),
+            ));
+        }
+        let mut base = target.take().as_array().cloned().unwrap_or_default();
+        let serde_json::Value::Array(entries) = append else {
+            return Err(extends_merge_error(
+                source_path,
+                field_path,
+                format!(
+                    "Rig extends '$append' directive in {} must be an array",
+                    source_path.display()
+                ),
+            ));
+        };
+        base.extend(entries);
+        *target = serde_json::Value::Array(base);
+        return Ok(());
+    }
+
+    let Some(merge_by) = overlay.remove(ARRAY_MERGE_BY_DIRECTIVE_KEY) else {
+        *target = serde_json::Value::Object(overlay);
+        return Ok(());
+    };
+    let serde_json::Value::String(key_field) = merge_by else {
+        return Err(extends_merge_error(
+            source_path,
+            field_path,
+            format!(
+                "Rig extends '$merge_by' directive in {} must be a string key field",
+                source_path.display()
+            ),
+        ));
+    };
+    if key_field.trim().is_empty() {
+        return Err(extends_merge_error(
+            source_path,
+            field_path,
+            format!(
+                "Rig extends '$merge_by' directive in {} must name a non-empty key field",
+                source_path.display()
+            ),
+        ));
+    }
+    let Some(entries) = overlay.remove(ARRAY_MERGE_ENTRIES_KEY) else {
+        return Err(extends_merge_error(
+            source_path,
+            field_path,
+            format!(
+                "Rig extends '$merge_by' directive in {} must include an 'entries' array",
+                source_path.display()
+            ),
+        ));
+    };
+    if !overlay.is_empty() {
+        return Err(extends_merge_error(
+            source_path,
+            field_path,
+            format!(
+                "Rig extends '$merge_by' directive in {} must only contain '$merge_by' and 'entries'",
+                source_path.display()
+            ),
+        ));
+    }
+    let serde_json::Value::Array(entries) = entries else {
+        return Err(extends_merge_error(
+            source_path,
+            field_path,
+            format!(
+                "Rig extends '$merge_by' directive entries in {} must be an array",
+                source_path.display()
+            ),
+        ));
+    };
+
+    let mut base = target.take().as_array().cloned().unwrap_or_default();
+    for entry in entries {
+        let Some(key_value) = entry.get(&key_field).cloned() else {
+            return Err(extends_merge_error(
+                source_path,
+                field_path,
+                format!(
+                    "Rig extends '$merge_by' entry in {} is missing key field '{}'",
+                    source_path.display(),
+                    key_field
+                ),
+            ));
+        };
+        if let Some(existing) = base
+            .iter_mut()
+            .find(|candidate| candidate.get(&key_field) == Some(&key_value))
+        {
+            merge_json(existing, entry, source_path, field_path)?;
+        } else {
+            base.push(entry);
+        }
+    }
+    *target = serde_json::Value::Array(base);
+    Ok(())
 }
 
 fn ensure_rig_refreshable(rig: &DiscoveredRig, target: &Path) -> Result<()> {

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -788,151 +788,90 @@ mod install_flows {
     }
 
     #[test]
-    fn install_appends_pipeline_steps_for_extends_with_merge_directive() {
-        let _home = HomeGuard::new();
-        let package = tempfile::tempdir().expect("package");
-        fs::create_dir_all(package.path().join("templates")).expect("templates dir");
-        fs::write(
-            package.path().join("templates/base.json"),
-            r#"{
-            "description": "base rig",
-            "pipeline": {
-                "check": [
-                    { "kind": "check", "label": "npm available", "command": "npm --version" }
-                ]
+    fn install_supports_extends_array_merge_directives() {
+        let cases = [
+            (
+                "appender",
+                r#"{
+                    "$append": [
+                        { "kind": "check", "label": "sample runtime cli exists", "command": "sample-runtime --version" }
+                    ]
+                }"#,
+                vec!["npm available", "build", "sample runtime cli exists"],
+                None,
+            ),
+            (
+                "keyed",
+                r#"{
+                    "$merge_by": "label",
+                    "entries": [
+                        { "kind": "check", "label": "build", "command": "make build --fast", "metadata": { "timeout": 60 } },
+                        { "kind": "check", "label": "lint", "command": "make lint" }
+                    ]
+                }"#,
+                vec!["npm available", "build", "lint"],
+                Some(("make build --fast", 60)),
+            ),
+        ];
+
+        for (id, check_overlay, expected_labels, expected_build) in cases {
+            let _home = HomeGuard::new();
+            let package = tempfile::tempdir().expect("package");
+            fs::create_dir_all(package.path().join("templates")).expect("templates dir");
+            fs::write(
+                package.path().join("templates/base.json"),
+                r#"{
+                "description": "base rig",
+                "pipeline": {
+                    "check": [
+                        { "kind": "check", "label": "npm available", "command": "npm --version" },
+                        { "kind": "check", "label": "build", "command": "make build", "metadata": { "retries": 1 } }
+                    ]
+                }
+            }"#,
+            )
+            .expect("base template");
+            write_rig(
+                package.path(),
+                id,
+                &format!(
+                    r#"{{
+                    "extends": "../../templates/base.json",
+                    "id": "{id}",
+                    "pipeline": {{
+                        "check": {check_overlay}
+                    }}
+                }}"#
+                ),
+            );
+
+            install(package.path().to_str().unwrap(), None, false).expect("install");
+
+            let installed_path = crate::core::paths::rig_config(id).expect("rig config");
+            let installed = fs::read_to_string(&installed_path).expect("installed rig");
+            assert!(!installed.contains("$append"));
+            assert!(!installed.contains("$merge_by"));
+            let value: serde_json::Value =
+                serde_json::from_str(&installed).expect("materialized json");
+            let checks = value["pipeline"]["check"].as_array().expect("check array");
+            let labels: Vec<&str> = checks
+                .iter()
+                .map(|step| step["label"].as_str().expect("label"))
+                .collect();
+            assert_eq!(labels, expected_labels);
+
+            if let Some((expected_command, expected_timeout)) = expected_build {
+                let build = checks
+                    .iter()
+                    .find(|step| step["label"] == "build")
+                    .expect("build step");
+                assert_eq!(build["command"], expected_command);
+                assert_eq!(build["metadata"]["retries"], 1);
+                assert_eq!(build["metadata"]["timeout"], expected_timeout);
             }
-        }"#,
-        )
-        .expect("base template");
-        write_rig(
-            package.path(),
-            "appender",
-            r#"{
-            "extends": "../../templates/base.json",
-            "id": "appender",
-            "pipeline": {
-                "check": [
-                    { "$merge": "append" },
-                    { "kind": "check", "label": "sample runtime cli exists", "command": "sample-runtime --version" }
-                ]
-            }
-        }"#,
-        );
 
-        install(package.path().to_str().unwrap(), None, false).expect("install");
-
-        let installed_path = crate::core::paths::rig_config("appender").expect("rig config");
-        let installed = fs::read_to_string(&installed_path).expect("installed rig");
-        assert!(
-            !installed.contains("$merge"),
-            "merge directive must be stripped from the materialized spec"
-        );
-        let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
-        let labels: Vec<&str> = value["pipeline"]["check"]
-            .as_array()
-            .expect("check array")
-            .iter()
-            .map(|step| step["label"].as_str().expect("label"))
-            .collect();
-        assert_eq!(labels, vec!["npm available", "sample runtime cli exists"]);
-
-        // The materialized spec still parses as a rig (directive fully removed).
-        load("appender").expect("load appended rig");
-    }
-
-    #[test]
-    fn install_prepends_pipeline_steps_for_extends_with_merge_directive() {
-        let _home = HomeGuard::new();
-        let package = tempfile::tempdir().expect("package");
-        fs::create_dir_all(package.path().join("templates")).expect("templates dir");
-        fs::write(
-            package.path().join("templates/base.json"),
-            r#"{
-            "pipeline": {
-                "check": [
-                    { "kind": "check", "label": "base last", "command": "echo base" }
-                ]
-            }
-        }"#,
-        )
-        .expect("base template");
-        write_rig(
-            package.path(),
-            "prepender",
-            r#"{
-            "extends": "../../templates/base.json",
-            "id": "prepender",
-            "pipeline": {
-                "check": [
-                    { "$merge": "prepend" },
-                    { "kind": "check", "label": "child first", "command": "echo child" }
-                ]
-            }
-        }"#,
-        );
-
-        install(package.path().to_str().unwrap(), None, false).expect("install");
-        let installed_path = crate::core::paths::rig_config("prepender").expect("rig config");
-        let installed = fs::read_to_string(&installed_path).expect("installed rig");
-        let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
-        let labels: Vec<&str> = value["pipeline"]["check"]
-            .as_array()
-            .expect("check array")
-            .iter()
-            .map(|step| step["label"].as_str().expect("label"))
-            .collect();
-        assert_eq!(labels, vec!["child first", "base last"]);
-    }
-
-    #[test]
-    fn install_merges_pipeline_steps_by_label_for_extends() {
-        let _home = HomeGuard::new();
-        let package = tempfile::tempdir().expect("package");
-        fs::create_dir_all(package.path().join("templates")).expect("templates dir");
-        fs::write(
-            package.path().join("templates/base.json"),
-            r#"{
-            "pipeline": {
-                "check": [
-                    { "kind": "check", "label": "npm available", "command": "npm --version" },
-                    { "kind": "check", "label": "build", "command": "make build" }
-                ]
-            }
-        }"#,
-        )
-        .expect("base template");
-        write_rig(
-            package.path(),
-            "keyed",
-            r#"{
-            "extends": "../../templates/base.json",
-            "id": "keyed",
-            "pipeline": {
-                "check": [
-                    { "$merge": "by_label" },
-                    { "kind": "check", "label": "build", "command": "make build --fast" },
-                    { "kind": "check", "label": "lint", "command": "make lint" }
-                ]
-            }
-        }"#,
-        );
-
-        install(package.path().to_str().unwrap(), None, false).expect("install");
-        let installed_path = crate::core::paths::rig_config("keyed").expect("rig config");
-        let installed = fs::read_to_string(&installed_path).expect("installed rig");
-        let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
-        let checks = value["pipeline"]["check"].as_array().expect("check array");
-        let labels: Vec<&str> = checks
-            .iter()
-            .map(|step| step["label"].as_str().expect("label"))
-            .collect();
-        // Base order preserved, the overridden "build" stays in place, "lint" appended.
-        assert_eq!(labels, vec!["npm available", "build", "lint"]);
-        let build = checks
-            .iter()
-            .find(|step| step["label"] == "build")
-            .expect("build step");
-        assert_eq!(build["command"], "make build --fast");
+            load(id).expect("load materialized rig");
+        }
     }
 
     #[test]
@@ -977,6 +916,70 @@ mod install_flows {
             .collect();
         // Default behavior unchanged: no directive means the child array wins wholesale.
         assert_eq!(labels, vec!["child only"]);
+    }
+
+    #[test]
+    fn install_rejects_invalid_extends_array_merge_directives() {
+        let cases = [
+            (
+                "bad-directive",
+                r#"{ "$prepend": [{ "kind": "check", "label": "child", "command": "echo child" }] }"#,
+                "$prepend",
+                "pipeline.check",
+            ),
+            (
+                "missing-key",
+                r#"{ "$merge_by": "label", "entries": [{ "kind": "check", "command": "echo child" }] }"#,
+                "missing key field 'label'",
+                "pipeline.check",
+            ),
+        ];
+
+        for (id, check_overlay, expected_message, expected_field) in cases {
+            let _home = HomeGuard::new();
+            let package = tempfile::tempdir().expect("package");
+            fs::create_dir_all(package.path().join("templates")).expect("templates dir");
+            fs::write(
+                package.path().join("templates/base.json"),
+                r#"{
+                "pipeline": {
+                    "check": [
+                        { "kind": "check", "label": "base", "command": "echo base" }
+                    ]
+                }
+            }"#,
+            )
+            .expect("base template");
+            let rig_path = write_rig(
+                package.path(),
+                id,
+                &format!(
+                    r#"{{
+                    "extends": "../../templates/base.json",
+                    "id": "{id}",
+                    "pipeline": {{
+                        "check": {check_overlay}
+                    }}
+                }}"#
+                ),
+            );
+
+            let err = install(package.path().to_str().unwrap(), None, false)
+                .expect_err("invalid directive should fail");
+
+            assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+            assert_eq!(err.details["field"], expected_field);
+            assert_eq!(
+                err.details["id"].as_str(),
+                Some(rig_path.to_string_lossy().as_ref())
+            );
+            assert!(
+                err.message.contains(expected_message),
+                "{} did not contain {}",
+                err.message,
+                expected_message
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds opt-in array merge directives to rig `extends` materialization so child rigs can append to inherited arrays or merge array object entries by a named key without replacing the entire parent array.

Closes #6828.
Related: #6681.

## Semantics

| Child overlay shape | Before | After |
| --- | --- | --- |
| Plain object over object | Deep-merged recursively | Unchanged: deep-merged recursively |
| Plain array over array | Replaced parent array wholesale | Unchanged: replaces parent array wholesale |
| Scalar over any value | Replaced parent value | Unchanged: replaces parent value |
| `{ "$append": [...] }` over inherited array | Invalid/raw object would fail schema or replace | Appends entries after inherited array |
| `{ "$merge_by": "<key>", "entries": [...] }` over inherited array | Invalid/raw object would fail schema or replace | Merges object entries by the named key; matching entries deep-merge, new entries append |
| Unknown `$` directive over inherited array | Not typed | Fails with a typed validation error naming the rig file and field path |

## Example

```jsonc
{
  "extends": "../../templates/base.json",
  "id": "app",
  "pipeline": {
    "check": {
      "$merge_by": "label",
      "entries": [
        { "kind": "check", "label": "build", "command": "npm run build -- --fast" },
        { "kind": "check", "label": "app checkout exists", "file": "${components.app.path}" }
      ]
    },
    "up": {
      "$append": [
        { "kind": "check", "label": "local setup complete", "command": "./scripts/setup.sh" }
      ]
    }
  }
}
```

## Verification

- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest list -E 'test(rig)'`\n- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(rig)' --no-fail-fast`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)\n- **Used for:** Implemented rig extends array append/keyed-merge semantics; Chris reviews and owns the change.