### PR TITLE
Unify cleanup front door

### DIFF
--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -5,16 +5,50 @@ use homeboy::core::cleanup::{
     self, ArtifactCleanupOptions, ArtifactCleanupSort, ResourceCleanupOptions,
 };
 use homeboy::core::defaults;
+use homeboy::core::engine;
+use homeboy::core::observation::runs_service::{
+    self, PersistedArtifactCleanupOptions, RunnerDownloadCleanupOptions,
+};
 use homeboy::core::resource_cleanup_intent::ResourceCleanupIntent;
+use homeboy::core::runners::{
+    self as runner, RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput,
+};
+use homeboy::core::worktree::{self, WorktreeCleanupOptions, WorktreeCleanupOutput};
 use homeboy::core::worktree_providers::WorktreeProviderCleanupOptions;
+use serde::Serialize;
 use serde_json::Value;
 
+use super::runs::{runs_resources, RunsOutput, RunsResourcesArgs, RunsResourcesOutput};
+use super::utils::response::{CommandActionableMetadata, CommandNextAction};
 use super::CmdResult;
 
 #[derive(Args)]
 pub struct CleanupArgs {
+    /// Apply cleanup across the selected categories. Omit for inventory dry-run output.
+    #[arg(long)]
+    pub apply: bool,
+
+    /// Include only these cleanup categories. Comma-separated or repeatable.
+    #[arg(long, value_enum, value_delimiter = ',')]
+    pub include: Vec<CleanupCategoryArg>,
+
+    /// Exclude these cleanup categories. Comma-separated or repeatable.
+    #[arg(long, value_enum, value_delimiter = ',')]
+    pub exclude: Vec<CleanupCategoryArg>,
+
     #[command(subcommand)]
-    pub command: CleanupCommand,
+    pub command: Option<CleanupCommand>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum CleanupCategoryArg {
+    RepoArtifacts,
+    TaskWorktrees,
+    PersistedRunArtifacts,
+    RunnerDownloads,
+    RemoteLabWorkspaces,
+    RuntimeTmp,
 }
 
 #[derive(Subcommand)]
@@ -82,7 +116,7 @@ pub struct CleanupWorktreesArgs {
 
 pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<Value> {
     match args.command {
-        CleanupCommand::Artifacts(args) => cleanup::cleanup_resources_from_config(
+        Some(CleanupCommand::Artifacts(args)) => cleanup::cleanup_resources_from_config(
             ResourceCleanupOptions {
                 intent: cleanup_intent(args.apply),
                 artifacts: Some(ArtifactCleanupOptions {
@@ -110,7 +144,7 @@ pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<Value> {
             })
         })
         .map(|output| (output, 0)),
-        CleanupCommand::Worktrees(args) => cleanup::cleanup_resources_from_config(
+        Some(CleanupCommand::Worktrees(args)) => cleanup::cleanup_resources_from_config(
             ResourceCleanupOptions {
                 intent: cleanup_intent(args.apply),
                 artifacts: None,
@@ -131,6 +165,401 @@ pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<Value> {
             })
         })
         .map(|output| (output, 0)),
+        None => cleanup_inventory(args).map(|output| (output, 0)),
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct CleanupInventoryOutput {
+    pub command: &'static str,
+    pub mode: &'static str,
+    pub category_count: usize,
+    pub candidate_count: usize,
+    pub applied_count: usize,
+    pub skipped_count: usize,
+    pub estimated_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub categories: Vec<CleanupInventoryCategory>,
+    #[serde(rename = "_homeboy_actionable")]
+    pub actionable: CommandActionableMetadata,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CleanupInventoryCategory {
+    pub category: &'static str,
+    pub specialist_command: String,
+    pub included: bool,
+    pub skipped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<String>,
+    pub candidate_count: usize,
+    pub applied_count: usize,
+    pub skipped_count: usize,
+    pub estimated_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub output: Value,
+}
+
+fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
+    let selected = CleanupCategorySelection::new(args.include, args.exclude);
+    let apply = args.apply;
+    let mut categories = Vec::new();
+
+    if selected.includes(CleanupCategoryArg::RepoArtifacts) {
+        let output = cleanup::cleanup_artifacts(ArtifactCleanupOptions {
+            path: None,
+            apply,
+            self_artifacts: false,
+            temp_roots: Vec::new(),
+            sort: ArtifactCleanupSort::Discovery,
+            limit: None,
+            merged_only: false,
+        })?;
+        categories.push(category_from_output(
+            "repo_artifacts",
+            if apply {
+                "homeboy cleanup artifacts --apply"
+            } else {
+                "homeboy cleanup artifacts"
+            },
+            output.candidate_count,
+            output.applied_count,
+            output.skipped_count,
+            output.estimated_bytes,
+            output.reclaimed_bytes,
+            output,
+        )?);
+    }
+
+    if selected.includes(CleanupCategoryArg::TaskWorktrees) {
+        let output = worktree::cleanup(WorktreeCleanupOptions {
+            force: false,
+            dry_run: !apply,
+            cleanup_branches: apply,
+            allow_unmerged_branches: false,
+        })?;
+        categories.push(task_worktrees_category(output, apply)?);
+    }
+
+    if selected.includes(CleanupCategoryArg::PersistedRunArtifacts) {
+        let persisted =
+            runs_service::cleanup_persisted_artifacts(PersistedArtifactCleanupOptions {
+                apply,
+                older_than_days: 30,
+                run_id: None,
+                kind: None,
+                artifact_type: None,
+                run_kind: None,
+                component_id: None,
+                limit: 1000,
+            })?;
+        let resources = runs_resources(RunsResourcesArgs {
+            cleanup_plan: true,
+            apply: false,
+            cleanup_root: None,
+            limit: 1000,
+            ..RunsResourcesArgs::default()
+        })?
+        .0;
+        let RunsOutput::Resources(resources) = resources else {
+            return Err(homeboy::core::Error::internal_unexpected(
+                "runs resources returned unexpected output",
+            ));
+        };
+        categories.push(persisted_artifacts_category(persisted, resources, apply)?);
+    }
+
+    if selected.includes(CleanupCategoryArg::RunnerDownloads) {
+        let output = runs_service::cleanup_runner_downloads(RunnerDownloadCleanupOptions {
+            apply,
+            runner: None,
+            run_id: None,
+        })?;
+        categories.push(category_from_output(
+            "runner_downloads",
+            if apply {
+                "homeboy runs artifact cleanup-downloads --apply"
+            } else {
+                "homeboy runs artifact cleanup-downloads"
+            },
+            output.file_count + output.directory_count,
+            usize::from(output.removed),
+            0,
+            output.size_bytes,
+            if output.removed { output.size_bytes } else { 0 },
+            output,
+        )?);
+    }
+
+    if selected.includes(CleanupCategoryArg::RemoteLabWorkspaces) {
+        categories.extend(remote_lab_workspace_categories(apply)?);
+    }
+
+    if selected.includes(CleanupCategoryArg::RuntimeTmp) {
+        let output = engine::temp::cleanup_runtime_tmp(apply, 7, None, 1000)?;
+        categories.push(category_from_output(
+            "runtime_tmp",
+            if apply {
+                "homeboy self cleanup-runtime-tmp --apply"
+            } else {
+                "homeboy self cleanup-runtime-tmp"
+            },
+            output.planned_count,
+            output.removed_count,
+            output.skipped_count,
+            output.totals.planned_size_bytes,
+            output.totals.removed_size_bytes,
+            output,
+        )?);
+    }
+
+    let candidate_count = categories
+        .iter()
+        .map(|category| category.candidate_count)
+        .sum();
+    let applied_count = categories
+        .iter()
+        .map(|category| category.applied_count)
+        .sum();
+    let skipped_count = categories
+        .iter()
+        .map(|category| category.skipped_count)
+        .sum();
+    let estimated_bytes = categories
+        .iter()
+        .map(|category| category.estimated_bytes)
+        .sum();
+    let reclaimed_bytes = categories
+        .iter()
+        .map(|category| category.reclaimed_bytes)
+        .sum();
+    let actionable = cleanup_actionable(&categories, apply);
+    serde_json::to_value(CleanupInventoryOutput {
+        command: "cleanup.inventory",
+        mode: if apply { "apply" } else { "dry_run" },
+        category_count: categories.len(),
+        candidate_count,
+        applied_count,
+        skipped_count,
+        estimated_bytes,
+        reclaimed_bytes,
+        categories,
+        actionable,
+    })
+    .map_err(|err| {
+        homeboy::core::Error::internal_json(err.to_string(), Some("cleanup inventory".to_string()))
+    })
+}
+
+struct CleanupCategorySelection {
+    include: Vec<CleanupCategoryArg>,
+    exclude: Vec<CleanupCategoryArg>,
+}
+
+impl CleanupCategorySelection {
+    fn new(include: Vec<CleanupCategoryArg>, exclude: Vec<CleanupCategoryArg>) -> Self {
+        Self { include, exclude }
+    }
+
+    fn includes(&self, category: CleanupCategoryArg) -> bool {
+        (self.include.is_empty() || self.include.contains(&category))
+            && !self.exclude.contains(&category)
+    }
+}
+
+fn category_from_output<T: Serialize>(
+    category: &'static str,
+    specialist_command: &str,
+    candidate_count: usize,
+    applied_count: usize,
+    skipped_count: usize,
+    estimated_bytes: u64,
+    reclaimed_bytes: u64,
+    output: T,
+) -> homeboy::core::Result<CleanupInventoryCategory> {
+    Ok(CleanupInventoryCategory {
+        category,
+        specialist_command: specialist_command.to_string(),
+        included: true,
+        skipped: false,
+        skip_reason: None,
+        candidate_count,
+        applied_count,
+        skipped_count,
+        estimated_bytes,
+        reclaimed_bytes,
+        output: serde_json::to_value(output).map_err(|err| {
+            homeboy::core::Error::internal_json(err.to_string(), Some(category.to_string()))
+        })?,
+    })
+}
+
+fn task_worktrees_category(
+    output: WorktreeCleanupOutput,
+    apply: bool,
+) -> homeboy::core::Result<CleanupInventoryCategory> {
+    category_from_output(
+        "task_worktrees",
+        if apply {
+            "homeboy worktree cleanup --cleanup-branches"
+        } else {
+            "homeboy worktree cleanup --dry-run --cleanup-branches"
+        },
+        output.counts.candidates,
+        output.counts.removed + output.counts.branches_deleted,
+        output.counts.skipped,
+        0,
+        0,
+        output,
+    )
+}
+
+fn persisted_artifacts_category(
+    persisted: runs_service::PersistedArtifactCleanupOutcome,
+    resources: RunsResourcesOutput,
+    apply: bool,
+) -> homeboy::core::Result<CleanupInventoryCategory> {
+    let resource_cleanup_candidates = resources
+        .cleanup
+        .as_ref()
+        .map(|cleanup| cleanup.candidate_count)
+        .unwrap_or(0);
+    let output = serde_json::json!({
+        "persisted_artifacts": persisted,
+        "resource_lifecycle": resources,
+    });
+    Ok(CleanupInventoryCategory {
+        category: "persisted_run_artifacts",
+        specialist_command: if apply {
+            "homeboy runs artifact cleanup-persisted --apply"
+        } else {
+            "homeboy runs artifact cleanup-persisted"
+        }
+        .to_string(),
+        included: true,
+        skipped: false,
+        skip_reason: None,
+        candidate_count: persisted.planned_record_count + resource_cleanup_candidates,
+        applied_count: persisted.removed_record_count,
+        skipped_count: persisted.skipped_count,
+        estimated_bytes: persisted.totals.planned_size_bytes,
+        reclaimed_bytes: persisted.totals.removed_size_bytes,
+        output,
+    })
+}
+
+fn remote_lab_workspace_categories(
+    apply: bool,
+) -> homeboy::core::Result<Vec<CleanupInventoryCategory>> {
+    let mut categories = Vec::new();
+    for status in runner::statuses()? {
+        if status.runner_id == "local" || !status.connected {
+            categories.push(CleanupInventoryCategory {
+                category: "remote_lab_workspaces",
+                specialist_command: format!(
+                    "homeboy runner workspace prune {}",
+                    shell_quote(&status.runner_id)
+                ),
+                included: true,
+                skipped: true,
+                skip_reason: Some("runner is not connected".to_string()),
+                candidate_count: 0,
+                applied_count: 0,
+                skipped_count: 1,
+                estimated_bytes: 0,
+                reclaimed_bytes: 0,
+                output: serde_json::json!({ "runner_id": status.runner_id, "connected": status.connected }),
+            });
+            continue;
+        }
+        let output = match runner::prune_workspaces(
+            &status.runner_id,
+            RunnerWorkspacePruneOptions {
+                apply,
+                min_age_hours: 24,
+                limit: 25,
+                passes: if apply { 10 } else { 1 },
+            },
+        ) {
+            Ok((output, _)) => output,
+            Err(error) => {
+                categories.push(CleanupInventoryCategory {
+                    category: "remote_lab_workspaces",
+                    specialist_command: format!(
+                        "homeboy runner workspace prune {}",
+                        shell_quote(&status.runner_id)
+                    ),
+                    included: true,
+                    skipped: true,
+                    skip_reason: Some(error.message),
+                    candidate_count: 0,
+                    applied_count: 0,
+                    skipped_count: 1,
+                    estimated_bytes: 0,
+                    reclaimed_bytes: 0,
+                    output: serde_json::json!({ "runner_id": status.runner_id }),
+                });
+                continue;
+            }
+        };
+        categories.push(remote_workspace_category(output, apply)?);
+    }
+    Ok(categories)
+}
+
+fn remote_workspace_category(
+    output: RunnerWorkspacePruneOutput,
+    apply: bool,
+) -> homeboy::core::Result<CleanupInventoryCategory> {
+    let command = if apply {
+        format!(
+            "homeboy runner workspace prune {} --apply --passes 10",
+            shell_quote(&output.runner_id)
+        )
+    } else {
+        format!(
+            "homeboy runner workspace prune {}",
+            shell_quote(&output.runner_id)
+        )
+    };
+    category_from_output(
+        "remote_lab_workspaces",
+        &command,
+        output.total_candidate_count,
+        output.removed.len(),
+        output.skipped.len(),
+        output.total_candidate_bytes,
+        output.total_removed_bytes,
+        output,
+    )
+}
+
+fn cleanup_actionable(
+    categories: &[CleanupInventoryCategory],
+    apply: bool,
+) -> CommandActionableMetadata {
+    let mut actionable = CommandActionableMetadata::default();
+    for category in categories {
+        if category.skipped || category.candidate_count == 0 {
+            continue;
+        }
+        actionable.next_actions.push(CommandNextAction::new(
+            format!("{} cleanup", category.category.replace('_', " ")),
+            if apply {
+                category.specialist_command.clone()
+            } else {
+                apply_command(&category.specialist_command)
+            },
+        ));
+    }
+    actionable
+}
+
+fn apply_command(command: &str) -> String {
+    if command.contains(" --apply") {
+        command.to_string()
+    } else {
+        format!("{command} --apply")
     }
 }
 
@@ -402,12 +831,67 @@ mod tests {
         let Commands::Cleanup(args) = cli.command else {
             panic!("expected cleanup command");
         };
-        let CleanupCommand::Artifacts(args) = args.command else {
+        let Some(CleanupCommand::Artifacts(args)) = args.command else {
             panic!("expected cleanup artifacts command");
         };
         assert!(matches!(args.sort, CleanupArtifactsSortArg::Size));
         assert_eq!(args.limit, Some(7));
         assert!(args.merged_only);
+    }
+
+    #[test]
+    fn cleanup_front_door_accepts_include_exclude_without_subcommand() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "cleanup",
+            "--include",
+            "repo-artifacts,task-worktrees",
+            "--exclude",
+            "runtime-tmp",
+            "--apply",
+        ]);
+
+        let Commands::Cleanup(args) = cli.command else {
+            panic!("expected cleanup command");
+        };
+        assert!(args.apply);
+        assert!(args.command.is_none());
+        assert_eq!(args.include.len(), 2);
+        assert!(args.include.contains(&CleanupCategoryArg::RepoArtifacts));
+        assert!(args.include.contains(&CleanupCategoryArg::TaskWorktrees));
+        assert_eq!(args.exclude, vec![CleanupCategoryArg::RuntimeTmp]);
+    }
+
+    #[test]
+    fn cleanup_category_selection_is_table_driven() {
+        let cases = [
+            (vec![], vec![], CleanupCategoryArg::RepoArtifacts, true),
+            (
+                vec![CleanupCategoryArg::TaskWorktrees],
+                vec![],
+                CleanupCategoryArg::RepoArtifacts,
+                false,
+            ),
+            (
+                vec![CleanupCategoryArg::TaskWorktrees],
+                vec![],
+                CleanupCategoryArg::TaskWorktrees,
+                true,
+            ),
+            (
+                vec![],
+                vec![CleanupCategoryArg::RuntimeTmp],
+                CleanupCategoryArg::RuntimeTmp,
+                false,
+            ),
+        ];
+
+        for (include, exclude, category, expected) in cases {
+            assert_eq!(
+                CleanupCategorySelection::new(include, exclude).includes(category),
+                expected
+            );
+        }
     }
 
     #[test]

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -307,8 +307,8 @@ fn bench_summary_eligible(args: &crate::commands::bench::BenchArgs) -> bool {
 fn cleanup_summary_eligible(args: &crate::commands::cleanup::CleanupArgs) -> bool {
     matches!(
         args.command,
-        crate::commands::cleanup::CleanupCommand::Artifacts(_)
-            | crate::commands::cleanup::CleanupCommand::Worktrees(_)
+        Some(crate::commands::cleanup::CleanupCommand::Artifacts(_))
+            | Some(crate::commands::cleanup::CleanupCommand::Worktrees(_))
     ) && !homeboy::core::lab_routing::is_lab_offload_subprocess()
 }
 
@@ -406,7 +406,10 @@ mod tests {
     #[test]
     fn cleanup_artifacts_summary_is_eligible_for_operator_stdout() {
         let args = crate::commands::cleanup::CleanupArgs {
-            command: crate::commands::cleanup::CleanupCommand::Artifacts(
+            apply: false,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            command: Some(crate::commands::cleanup::CleanupCommand::Artifacts(
                 crate::commands::cleanup::CleanupArtifactsArgs {
                     apply: false,
                     self_artifacts: false,
@@ -416,7 +419,7 @@ mod tests {
                     limit: None,
                     merged_only: false,
                 },
-            ),
+            )),
         };
 
         assert!(cleanup_summary_eligible(&args));

--- a/src/commands/runs/mod.rs
+++ b/src/commands/runs/mod.rs
@@ -66,7 +66,7 @@ pub use bench::{bench_compare, BenchCompareOutput, RunsBenchCompareArgs};
 pub(super) use bench::{bench_numeric_metrics, run_contains_scenario};
 pub use distribution::{runs_distribution, RunsDistributionArgs, RunsDistributionOutput};
 pub use dossier::{runs_dossier, RunsDossierOutput};
-pub use resources::{RunsResourcesArgs, RunsResourcesOutput};
+pub use resources::{runs_resources, RunsResourcesArgs, RunsResourcesOutput};
 
 // Test-only helpers consumed by sibling test modules via `super::runs::*` / `super::*`.
 #[cfg(test)]

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -104,6 +104,12 @@ enum WorktreeCommand {
         /// Allow dirty/unpushed worktree removal; hard gates still apply
         #[arg(long)]
         force: bool,
+        /// Delete the local task branch after removing the worktree when branch safety allows it.
+        #[arg(long)]
+        cleanup_branch: bool,
+        /// Permit deleting an unmerged task branch. Requires --cleanup-branch.
+        #[arg(long, requires = "cleanup_branch")]
+        allow_unmerged_branch: bool,
     },
     /// Remove cleanup-eligible task worktrees after safety checks
     Cleanup {
@@ -116,6 +122,12 @@ enum WorktreeCommand {
         /// Also remove declared rebuildable artifacts from the Homeboy checkout that built this binary.
         #[arg(long)]
         cleanup_artifacts: bool,
+        /// Delete merged task branches for removed cleanup candidates.
+        #[arg(long)]
+        cleanup_branches: bool,
+        /// Permit deleting unmerged task branches. Requires --cleanup-branches.
+        #[arg(long, requires = "cleanup_branches")]
+        allow_unmerged_branches: bool,
     },
 }
 
@@ -212,15 +224,30 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
         })?),
         WorktreeCommand::List => WorktreeOutput::List(worktree::list()?),
         WorktreeCommand::Status { id } => WorktreeOutput::Status(worktree::status(&id)?),
-        WorktreeCommand::Remove { id, force } => {
-            WorktreeOutput::Remove(worktree::remove(WorktreeRemoveOptions { id, force })?)
-        }
+        WorktreeCommand::Remove {
+            id,
+            force,
+            cleanup_branch,
+            allow_unmerged_branch,
+        } => WorktreeOutput::Remove(worktree::remove(WorktreeRemoveOptions {
+            id,
+            force,
+            cleanup_branch,
+            allow_unmerged_branch,
+        })?),
         WorktreeCommand::Cleanup {
             force,
             dry_run,
             cleanup_artifacts,
+            cleanup_branches,
+            allow_unmerged_branches,
         } => {
-            let worktrees = worktree::cleanup(WorktreeCleanupOptions { force, dry_run })?;
+            let worktrees = worktree::cleanup(WorktreeCleanupOptions {
+                force,
+                dry_run,
+                cleanup_branches,
+                allow_unmerged_branches,
+            })?;
             let artifact_cleanup = if cleanup_artifacts {
                 Some(artifact_cleanup::cleanup_artifacts(
                     ArtifactCleanupOptions {

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -23,6 +23,30 @@ mod types {
         PreserveOnFailure,
     }
 
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum BranchCleanupIntent {
+        DeleteWhenMerged,
+        Preserve,
+    }
+
+    impl Default for BranchCleanupIntent {
+        fn default() -> Self {
+            Self::DeleteWhenMerged
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum BranchCleanupStatus {
+        Merged,
+        Unmerged,
+        Missing,
+        Preserved,
+        Unknown,
+        Deleted,
+    }
+
     impl CleanupPolicy {
         pub(super) fn default_for_run(run_id: Option<&str>) -> Self {
             if run_id.is_some() {
@@ -46,6 +70,8 @@ mod types {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub run_id: Option<String>,
         pub cleanup_policy: CleanupPolicy,
+        #[serde(default)]
+        pub branch_cleanup_intent: BranchCleanupIntent,
         pub created_at: String,
         pub state: TaskWorktreeState,
     }
@@ -141,6 +167,7 @@ mod types {
     pub struct WorktreeRemoveOutput {
         pub record: TaskWorktreeRecord,
         pub safety: WorktreeSafetyReport,
+        pub branch_cleanup: WorktreeBranchCleanupReport,
         pub removed: bool,
     }
 
@@ -158,12 +185,29 @@ mod types {
         pub candidates: usize,
         pub removed: usize,
         pub skipped: usize,
+        pub branch_delete_candidates: usize,
+        pub branches_deleted: usize,
+        pub unmerged_branches: usize,
     }
 
     #[derive(Debug, Clone, Serialize)]
     pub struct WorktreeCleanupCandidate {
         pub record: TaskWorktreeRecord,
         pub safety: WorktreeSafetyReport,
+        pub branch_cleanup: WorktreeBranchCleanupReport,
+    }
+
+    #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+    pub struct WorktreeBranchCleanupReport {
+        pub branch: String,
+        pub base_ref: String,
+        pub intent: BranchCleanupIntent,
+        pub status: BranchCleanupStatus,
+        pub safe_delete: bool,
+        pub deleted: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub reason: Option<String>,
+        pub cleanup_command: String,
     }
 
     #[derive(Debug, Clone, Serialize)]
@@ -196,12 +240,16 @@ mod types {
     pub struct WorktreeRemoveOptions {
         pub id: String,
         pub force: bool,
+        pub cleanup_branch: bool,
+        pub allow_unmerged_branch: bool,
     }
 
     #[derive(Debug, Clone)]
     pub struct WorktreeCleanupOptions {
         pub force: bool,
         pub dry_run: bool,
+        pub cleanup_branches: bool,
+        pub allow_unmerged_branches: bool,
     }
 
     #[derive(Debug, Clone)]
@@ -261,8 +309,9 @@ mod types {
 }
 
 pub use types::{
-    AdoptedWorkspaceRecord, CleanupPolicy, TaskWorktreeRecord, TaskWorktreeState,
-    WorkspaceRefRecord, WorktreeAdoptOptions, WorktreeAdoptOutput, WorktreeCleanupCandidate,
+    AdoptedWorkspaceRecord, BranchCleanupIntent, BranchCleanupStatus, CleanupPolicy,
+    TaskWorktreeRecord, TaskWorktreeState, WorkspaceRefRecord, WorktreeAdoptOptions,
+    WorktreeAdoptOutput, WorktreeBranchCleanupReport, WorktreeCleanupCandidate,
     WorktreeCleanupCounts, WorktreeCleanupOptions, WorktreeCleanupOutput, WorktreeCleanupSkipped,
     WorktreeCreateOptions, WorktreeCreateOutput, WorktreeListOutput, WorktreeQueueCreateOptions,
     WorktreeQueueCreateOutput, WorktreeQueueCreateRow, WorktreeQueueCreateStatus,
@@ -376,6 +425,8 @@ mod store_ops {
                     continue;
                 }
             };
+            let branch_cleanup = branch_cleanup_report(&record)
+                .unwrap_or_else(|error| branch_cleanup_unknown(&record, error.message));
             let skip_reasons = cleanup_skip_reasons(&safety, options.force);
             if !skip_reasons.is_empty() {
                 skipped.push(WorktreeCleanupSkipped {
@@ -389,6 +440,7 @@ mod store_ops {
             candidates.push(WorktreeCleanupCandidate {
                 record: record.clone(),
                 safety: safety.clone(),
+                branch_cleanup: branch_cleanup.clone(),
             });
 
             if !options.dry_run {
@@ -396,15 +448,32 @@ mod store_ops {
                     WorktreeRemoveOptions {
                         id: record.id,
                         force: options.force,
+                        cleanup_branch: options.cleanup_branches,
+                        allow_unmerged_branch: options.allow_unmerged_branches,
                     },
                     store,
                 )?);
             }
         }
+        let branch_delete_candidates = candidates
+            .iter()
+            .filter(|candidate| candidate.branch_cleanup.safe_delete)
+            .count();
+        let unmerged_branches = candidates
+            .iter()
+            .filter(|candidate| candidate.branch_cleanup.status == BranchCleanupStatus::Unmerged)
+            .count();
+        let branches_deleted = removed
+            .iter()
+            .filter(|output| output.branch_cleanup.deleted)
+            .count();
         let counts = WorktreeCleanupCounts {
             candidates: candidates.len() + skipped.len(),
             removed: removed.len(),
             skipped: skipped.len(),
+            branch_delete_candidates,
+            branches_deleted,
+            unmerged_branches,
         };
         Ok(WorktreeCleanupOutput {
             dry_run: options.dry_run,
@@ -501,6 +570,7 @@ mod store_ops {
             cleanup_policy: options
                 .cleanup_policy
                 .unwrap_or_else(|| CleanupPolicy::default_for_run(options.run_id.as_deref())),
+            branch_cleanup_intent: BranchCleanupIntent::DeleteWhenMerged,
             created_at: chrono::Utc::now().to_rfc3339(),
             state: TaskWorktreeState::Active,
         };
@@ -569,13 +639,160 @@ mod store_ops {
                 "git worktree remove",
             )?;
         }
+        let mut branch_cleanup = branch_cleanup_report(&record)
+            .unwrap_or_else(|error| branch_cleanup_unknown(&record, error.message));
+        if options.cleanup_branch {
+            branch_cleanup =
+                apply_branch_cleanup(&record, branch_cleanup, options.allow_unmerged_branch)?;
+        }
         record.state = TaskWorktreeState::Removed;
         write_record(store_dir, &record)?;
         Ok(WorktreeRemoveOutput {
             record,
             safety,
+            branch_cleanup,
             removed: true,
         })
+    }
+
+    pub(super) fn branch_cleanup_report(
+        record: &TaskWorktreeRecord,
+    ) -> Result<WorktreeBranchCleanupReport> {
+        let cleanup_command = format!(
+            "homeboy worktree remove {} --cleanup-branch",
+            shell_arg(&record.id)
+        );
+        if record.branch_cleanup_intent == BranchCleanupIntent::Preserve {
+            return Ok(WorktreeBranchCleanupReport {
+                branch: record.branch.clone(),
+                base_ref: record.base_ref.clone(),
+                intent: record.branch_cleanup_intent.clone(),
+                status: BranchCleanupStatus::Preserved,
+                safe_delete: false,
+                deleted: false,
+                reason: Some("branch cleanup intent preserves this branch".to_string()),
+                cleanup_command,
+            });
+        }
+        let source = resolved_source_checkout(record)?;
+        let branch = record.branch.as_str();
+        let exists = git::run_git(
+            &source,
+            &[
+                "show-ref",
+                "--verify",
+                "--quiet",
+                &format!("refs/heads/{branch}"),
+            ],
+            "git show-ref branch",
+        )
+        .is_ok();
+        if !exists {
+            return Ok(WorktreeBranchCleanupReport {
+                branch: record.branch.clone(),
+                base_ref: record.base_ref.clone(),
+                intent: record.branch_cleanup_intent.clone(),
+                status: BranchCleanupStatus::Missing,
+                safe_delete: false,
+                deleted: false,
+                reason: Some("local branch is already missing".to_string()),
+                cleanup_command,
+            });
+        }
+        let base_ref = branch_cleanup_base_ref(record);
+        let merged = git::run_git(
+            &source,
+            &["merge-base", "--is-ancestor", branch, &base_ref],
+            "git merge-base branch cleanup",
+        )
+        .is_ok();
+        Ok(WorktreeBranchCleanupReport {
+            branch: record.branch.clone(),
+            base_ref,
+            intent: record.branch_cleanup_intent.clone(),
+            status: if merged {
+                BranchCleanupStatus::Merged
+            } else {
+                BranchCleanupStatus::Unmerged
+            },
+            safe_delete: merged,
+            deleted: false,
+            reason: if merged {
+                Some("branch is merged into the cleanup base ref".to_string())
+            } else {
+                Some("branch is not merged into the cleanup base ref".to_string())
+            },
+            cleanup_command,
+        })
+    }
+
+    fn apply_branch_cleanup(
+        record: &TaskWorktreeRecord,
+        mut report: WorktreeBranchCleanupReport,
+        allow_unmerged_branch: bool,
+    ) -> Result<WorktreeBranchCleanupReport> {
+        if report.status == BranchCleanupStatus::Missing || report.deleted {
+            return Ok(report);
+        }
+        if !report.safe_delete && !allow_unmerged_branch {
+            return Ok(report);
+        }
+        let source = resolved_source_checkout(record)?;
+        let delete_flag = if report.safe_delete { "-d" } else { "-D" };
+        git::run_git(
+            &source,
+            &["branch", delete_flag, &record.branch],
+            "git branch delete task worktree branch",
+        )?;
+        report.deleted = true;
+        report.status = BranchCleanupStatus::Deleted;
+        report.reason = Some(if report.safe_delete {
+            "merged branch deleted".to_string()
+        } else {
+            "unmerged branch deleted by explicit allow flag".to_string()
+        });
+        Ok(report)
+    }
+
+    fn branch_cleanup_unknown(
+        record: &TaskWorktreeRecord,
+        reason: String,
+    ) -> WorktreeBranchCleanupReport {
+        WorktreeBranchCleanupReport {
+            branch: record.branch.clone(),
+            base_ref: record.base_ref.clone(),
+            intent: record.branch_cleanup_intent.clone(),
+            status: BranchCleanupStatus::Unknown,
+            safe_delete: false,
+            deleted: false,
+            reason: Some(reason),
+            cleanup_command: format!(
+                "homeboy worktree remove {} --cleanup-branch",
+                shell_arg(&record.id)
+            ),
+        }
+    }
+
+    fn branch_cleanup_base_ref(record: &TaskWorktreeRecord) -> String {
+        let trimmed = record.base_ref.trim();
+        if trimmed.is_empty() || trimmed == "HEAD" {
+            return "HEAD".to_string();
+        }
+        trimmed
+            .strip_prefix("origin/")
+            .unwrap_or(trimmed)
+            .to_string()
+    }
+
+    fn shell_arg(value: &str) -> String {
+        if value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | '@' | ':'))
+        {
+            value.to_string()
+        } else {
+            format!("'{}'", value.replace('\'', "'\\''"))
+        }
     }
 
     pub(super) fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafetyReport> {
@@ -1073,6 +1290,7 @@ mod tests {
             task_url: Some("https://example.com/task".to_string()),
             run_id: None,
             cleanup_policy: CleanupPolicy::RemoveWhenSafe,
+            branch_cleanup_intent: BranchCleanupIntent::DeleteWhenMerged,
             created_at: "2026-01-01T00:00:00Z".to_string(),
             state: TaskWorktreeState::Active,
         }
@@ -1188,6 +1406,8 @@ mod tests {
             WorktreeCleanupOptions {
                 force: false,
                 dry_run: false,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
             },
             &store,
         )
@@ -1201,6 +1421,80 @@ mod tests {
         assert!(output.removed[0].removed);
         assert!(output.removed[0].safety.worktree_missing);
         assert_eq!(updated.state, TaskWorktreeState::Removed);
+    }
+
+    #[test]
+    fn cleanup_deletes_merged_task_branch_when_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = git_repo();
+        run_git(source.path(), &["branch", "task"]);
+        let worktree = sibling_worktree_path(source.path(), "merged-branch-cleanup");
+        let store = dir.path().join("store");
+        let record = fixture_record(source.path(), &worktree);
+        write_record(&store, &record).unwrap();
+
+        let output = cleanup_with_store(
+            WorktreeCleanupOptions {
+                force: false,
+                dry_run: false,
+                cleanup_branches: true,
+                allow_unmerged_branches: false,
+            },
+            &store,
+        )
+        .unwrap();
+
+        assert_eq!(output.counts.branch_delete_candidates, 1);
+        assert_eq!(output.counts.branches_deleted, 1);
+        assert_eq!(
+            output.removed[0].branch_cleanup.status,
+            BranchCleanupStatus::Deleted
+        );
+        assert!(std::process::Command::new("git")
+            .args(["show-ref", "--verify", "--quiet", "refs/heads/task"])
+            .current_dir(source.path())
+            .status()
+            .unwrap()
+            .code()
+            .is_some_and(|code| code != 0));
+    }
+
+    #[test]
+    fn cleanup_reports_unmerged_task_branch_without_deleting_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = git_repo();
+        run_git(source.path(), &["checkout", "-q", "-b", "task"]);
+        fs::write(source.path().join("task.txt"), "task\n").unwrap();
+        run_git(source.path(), &["add", "."]);
+        run_git(source.path(), &["commit", "-q", "-m", "task"]);
+        run_git(source.path(), &["checkout", "-q", "-"]);
+        let worktree = sibling_worktree_path(source.path(), "unmerged-branch-cleanup");
+        let store = dir.path().join("store");
+        let record = fixture_record(source.path(), &worktree);
+        write_record(&store, &record).unwrap();
+
+        let output = cleanup_with_store(
+            WorktreeCleanupOptions {
+                force: false,
+                dry_run: false,
+                cleanup_branches: true,
+                allow_unmerged_branches: false,
+            },
+            &store,
+        )
+        .unwrap();
+
+        assert_eq!(output.counts.branch_delete_candidates, 0);
+        assert_eq!(output.counts.branches_deleted, 0);
+        assert_eq!(output.counts.unmerged_branches, 1);
+        assert_eq!(
+            output.removed[0].branch_cleanup.status,
+            BranchCleanupStatus::Unmerged
+        );
+        run_git(
+            source.path(),
+            &["show-ref", "--verify", "--quiet", "refs/heads/task"],
+        );
     }
 
     #[test]
@@ -1282,6 +1576,8 @@ mod tests {
                 WorktreeCleanupOptions {
                     force: false,
                     dry_run: false,
+                    cleanup_branches: false,
+                    allow_unmerged_branches: false,
                 },
                 &store,
             )
@@ -1330,6 +1626,8 @@ mod tests {
             WorktreeCleanupOptions {
                 force: false,
                 dry_run: false,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
             },
             &store,
         )
@@ -1361,6 +1659,8 @@ mod tests {
             WorktreeCleanupOptions {
                 force: true,
                 dry_run: false,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
             },
             &store,
         )
@@ -1401,6 +1701,8 @@ mod tests {
             WorktreeCleanupOptions {
                 force: false,
                 dry_run: true,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
             },
             &store,
         )
@@ -1441,6 +1743,8 @@ mod tests {
             WorktreeCleanupOptions {
                 force: true,
                 dry_run: false,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
             },
             &store,
         )


### PR DESCRIPTION
## Summary
- Makes `homeboy cleanup` with no subcommand produce a dry-run inventory across Homeboy-owned cleanup categories.
- Adds `homeboy cleanup --apply` with `--include` / `--exclude` category scoping while preserving specialist command surfaces.
- Extends task-worktree cleanup records/output with branch cleanup intent and merged/unmerged branch classification.

## Inventory categories
| Category | Specialist command | Apply behavior | Safety semantics |
|---|---|---|---|
| Repo artifacts | `homeboy cleanup artifacts` | Calls existing artifact cleanup implementation | Existing path containment, dirty/tracked-change guards, merged-only support remain in specialist command |
| Local task worktrees + branches | `homeboy worktree cleanup --cleanup-branches` | Removes cleanup-eligible worktrees and deletes merged task branches | Existing worktree hard gates remain; unmerged branches are reported and preserved unless an explicit unmerged-branch flag is used on the specialist command |
| Persisted run artifacts + resource lifecycle TTLs | `homeboy runs artifact cleanup-persisted` and `homeboy runs resources --cleanup-plan` | Removes persisted artifact bytes/rows via existing persisted cleanup; reports resource lifecycle TTL cleanup status | Existing artifact-root checks, metadata-only skips, resource lifecycle retention/TTL classification, and apply intent checks remain owned by specialist implementations |
| Runner download caches | `homeboy runs artifact cleanup-downloads` | Removes runner download cache root via existing implementation | Existing runner/run path component validation remains in place |
| Remote lab workspaces | `homeboy runner workspace prune <runner>` | Prunes connected runner workspaces through existing prune implementation | Disconnected runners are skipped cleanly; prune internals and resource lifecycle TTL handling remain untouched |
| Runtime tmp | `homeboy self cleanup-runtime-tmp` | Removes eligible runtime tmp entries via existing implementation | Existing runtime tmp root containment, symlink, age, prefix, and limit checks remain in place |

## Safety semantics
- The front door composes existing specialist implementations instead of reimplementing discovery or deletion.
- `--apply` maps to the same underlying apply/dry-run switches used by specialist commands.
- `--include <categories>` and `--exclude <categories>` bound both inventory and apply.
- Remote lab workspace cleanup only runs for connected runners; disconnected/local rows are inventory skips.
- Structured output includes per-category counts, bytes, specialist command strings, and actionable next actions via the command-result envelope metadata path.

## Branch lifecycle design
- Task-worktree records now carry `branch_cleanup_intent` with a default `delete_when_merged` intent for backward-compatible existing records.
- Cleanup reports each task branch as merged, unmerged, missing, preserved, unknown, or deleted.
- Merged branches are safe-delete candidates and are deleted during `homeboy cleanup --apply` / `homeboy worktree cleanup --cleanup-branches`.
- Unmerged branches are never deleted by the front door. The targeted specialist command exposes an explicit unmerged-branch flag for exceptional manual cleanup.

## Verification
- `cargo fmt --check`
- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(cleanup) or test(worktree) or test(resources)' --no-fail-fast`\n- `cargo run -- cleanup --include runtime-tmp`\n\nPart of #7502. Closes #6678.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)\n- **Used for:** Implemented the unified cleanup inventory/front door and worktree branch lifecycle; Chris reviews and owns the change.