### PR TITLE
Fix explicit variant precedence in rename

### DIFF
--- a/src/core/refactor/rename/tests.rs
+++ b/src/core/refactor/rename/tests.rs
@@ -984,6 +984,28 @@ fn explicit_variants_handle_project_specific_acronyms() {
 }
 
 #[test]
+fn explicit_variants_override_auto_variants_with_same_from() {
+    let dir = std::env::temp_dir().join("homeboy_explicit_variant_precedence_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    std::fs::write(dir.join("plugin.php"), "fn studio_native_gate() {}\n").unwrap();
+
+    let spec = RenameSpec::new("studio-native", "wp-build", RenameScope::All)
+        .with_explicit_variants(vec![("studio_native".to_string(), "wpbuild".to_string())]);
+
+    let result = generate_renames(&spec, &dir);
+    assert_eq!(result.edits.len(), 1);
+    let content = &result.edits[0].new_content;
+
+    assert!(content.contains("wpbuild_gate"), "{}", content);
+    assert!(!content.contains("wp_build_gate"), "{}", content);
+    assert!(!content.contains("studio_native_gate"), "{}", content);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn root_artifacts_directory_is_skipped_by_default() {
     let dir = std::env::temp_dir().join("homeboy_refactor_artifacts_skip_test");
     let _ = std::fs::remove_dir_all(&dir);

--- a/src/core/refactor/rename/types.rs
+++ b/src/core/refactor/rename/types.rs
@@ -356,6 +356,11 @@ impl RenameSpec {
     /// or language-specific class prefixes, without teaching the rename engine
     /// what those conventions mean.
     pub fn with_explicit_variants(mut self, variants: Vec<(String, String)>) -> Self {
+        let explicit_froms: std::collections::HashSet<&str> =
+            variants.iter().map(|(from, _)| from.as_str()).collect();
+        self.variants
+            .retain(|variant| !explicit_froms.contains(variant.from.as_str()));
+
         for (from, to) in variants {
             self.variants.push(CaseVariant {
                 from,
@@ -370,7 +375,7 @@ impl RenameSpec {
 
 pub(super) fn deduplicate_variants(variants: &mut Vec<CaseVariant>) {
     // Sort by from length descending first so longer matches take priority.
-    variants.sort_by(|a, b| b.from.len().cmp(&a.from.len()));
+    variants.sort_by_key(|variant| std::cmp::Reverse(variant.from.len()));
     let mut seen = std::collections::HashSet::new();
     variants.retain(|variant| seen.insert(variant.from.clone()));
 }


### PR DESCRIPTION
Fixes #7553

## Summary
- Preserve caller intent for explicit rename variants when they share the same source spelling as an auto-derived case variant.
- Remove existing same-from variants before appending explicit mappings, then keep the existing dedupe/longer-match priority behavior.
- Add a regression test for the real-world studio-native to wp-build mapping where studio_native must become wpbuild.

## Verification
- cargo test core::refactor::rename::tests::explicit_variants_override_auto_variants_with_same_from
- cargo test refactor -- --test-threads=1
- cargo test -- --test-threads=1 timed out after 10 minutes while still running
- cargo clippy completed with existing repository warnings

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Anthropic) via Claude Code / opencode agent
- **Used for:** Root-cause analysis, fix implementation, and test authoring, reviewed and directed by Chris Huber