### PR TITLE
Fix rename path-move integrity

### DIFF
--- a/src/core/refactor/rename/engine.rs
+++ b/src/core/refactor/rename/engine.rs
@@ -13,6 +13,7 @@ use super::types::{
     CaseVariant, FileEdit, FileRename, Reference, RenameContext, RenameResult, RenameScope,
     RenameSpec, RenameTargeting,
 };
+use std::cmp::Reverse;
 
 // Boundary matching and literal matching are provided by crate::core::engine::codebase_scan.
 // See: find_boundary_matches(), find_literal_matches()
@@ -41,6 +42,17 @@ fn scan_config_for_scope(scope: &RenameScope) -> ScanConfig {
 
     ScanConfig {
         extensions,
+        ..ScanConfig::default()
+    }
+}
+
+/// Build a ScanConfig for path moves.
+///
+/// Path renames must include files that are intentionally skipped for content
+/// edits (images, sourcemaps, dotfiles) so renamed directory trees move intact.
+fn scan_config_for_path_renames() -> ScanConfig {
+    ScanConfig {
+        extensions: ExtensionFilter::All,
         ..ScanConfig::default()
     }
 }
@@ -123,7 +135,7 @@ pub fn find_references_with_targeting(
     let mut references = Vec::new();
 
     // Sort variants longest-first to prevent partial overlap
-    all_variants.sort_by(|a, b| b.from.len().cmp(&a.from.len()));
+    all_variants.sort_by_key(|variant| Reverse(variant.from.len()));
 
     let use_literal = spec.literal;
 
@@ -227,10 +239,15 @@ pub fn generate_renames_with_targeting(
     let references = find_references_with_targeting(spec, root, targeting);
     let config = scan_config_for_scope(&spec.scope);
     let files = target_files(codebase_scan::walk_files(root, &config), root, targeting);
+    let path_rename_files = target_files(
+        codebase_scan::walk_files(root, &scan_config_for_path_renames()),
+        root,
+        targeting,
+    );
 
     // Sort variants longest-first to prevent partial matches
     let mut sorted_variants = spec.variants.clone();
-    sorted_variants.sort_by(|a, b| b.from.len().cmp(&a.from.len()));
+    sorted_variants.sort_by_key(|variant| Reverse(variant.from.len()));
 
     // Generate file content edits using reverse-offset replacement
     let mut edits = Vec::new();
@@ -282,7 +299,7 @@ pub fn generate_renames_with_targeting(
 
             // Sort by position descending so we can replace from end to start
             // without invalidating earlier offsets
-            all_matches.sort_by(|a, b| b.0.cmp(&a.0));
+            all_matches.sort_by_key(|(start, _, _)| Reverse(*start));
 
             let mut new_content = content;
             for (start, end, replacement) in &all_matches {
@@ -301,18 +318,14 @@ pub fn generate_renames_with_targeting(
     // Generate file/directory renames
     let mut file_renames = Vec::new();
     if targeting.rename_files {
-        for file_path in &files {
+        for file_path in &path_rename_files {
             let relative = file_path
                 .strip_prefix(root)
                 .unwrap_or(file_path)
                 .to_string_lossy()
                 .to_string();
 
-            let mut new_relative = relative.clone();
-            for variant in &sorted_variants {
-                // Replace in path segments (word-boundary aware in file names)
-                new_relative = new_relative.replace(&variant.from, &variant.to);
-            }
+            let new_relative = rename_path_segments(&relative, &sorted_variants);
 
             if new_relative != relative {
                 file_renames.push(FileRename {
@@ -324,6 +337,7 @@ pub fn generate_renames_with_targeting(
     }
 
     // Deduplicate file renames
+    file_renames.sort_by(|a, b| a.from.cmp(&b.from));
     file_renames.dedup_by(|a, b| a.from == b.from);
 
     let total_references = references.len();
@@ -342,6 +356,19 @@ pub fn generate_renames_with_targeting(
         total_files,
         applied: false,
     }
+}
+
+fn rename_path_segments(path: &str, variants: &[CaseVariant]) -> String {
+    path.split('/')
+        .map(|segment| {
+            let mut renamed = segment.to_string();
+            for variant in variants {
+                renamed = renamed.replace(&variant.from, &variant.to);
+            }
+            renamed
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 fn target_files(files: Vec<PathBuf>, root: &Path, targeting: &RenameTargeting) -> Vec<PathBuf> {

--- a/src/core/refactor/rename/tests.rs
+++ b/src/core/refactor/rename/tests.rs
@@ -189,6 +189,107 @@ fn generate_renames_detects_file_renames() {
 }
 
 #[test]
+fn path_renames_include_skipped_content_files_in_renamed_directory() {
+    let dir = std::env::temp_dir().join("homeboy_refactor_skipped_path_move_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    let old_dir = dir.join("plugins/host/studio-native/build/assets/preview");
+    std::fs::create_dir_all(&old_dir).unwrap();
+
+    std::fs::write(old_dir.join("studio-native-preview.png"), b"png bytes").unwrap();
+    std::fs::write(old_dir.join("preview.js.map"), b"{\"version\":3}").unwrap();
+    std::fs::write(
+        dir.join("plugins/host/studio-native/.npmrc"),
+        b"legacy-peer-deps=true\n",
+    )
+    .unwrap();
+    std::fs::write(
+        old_dir.join("studio-native-preview.js"),
+        "studioNative();\n",
+    )
+    .unwrap();
+
+    let spec = RenameSpec::literal("studio-native", "wp-build", RenameScope::All);
+    let mut result = generate_renames(&spec, &dir);
+
+    assert!(result.file_renames.iter().any(|rename| {
+        rename.from == "plugins/host/studio-native/build/assets/preview/studio-native-preview.png"
+            && rename.to == "plugins/host/wp-build/build/assets/preview/wp-build-preview.png"
+    }));
+    assert!(result.file_renames.iter().any(|rename| {
+        rename.from == "plugins/host/studio-native/build/assets/preview/preview.js.map"
+            && rename.to == "plugins/host/wp-build/build/assets/preview/preview.js.map"
+    }));
+    assert!(result.file_renames.iter().any(|rename| {
+        rename.from == "plugins/host/studio-native/.npmrc"
+            && rename.to == "plugins/host/wp-build/.npmrc"
+    }));
+
+    apply_renames(&mut result, &dir).unwrap();
+
+    assert!(dir
+        .join("plugins/host/wp-build/build/assets/preview/wp-build-preview.png")
+        .exists());
+    assert!(dir
+        .join("plugins/host/wp-build/build/assets/preview/preview.js.map")
+        .exists());
+    assert!(dir.join("plugins/host/wp-build/.npmrc").exists());
+    assert!(!dir
+        .join("plugins/host/studio-native/build/assets/preview/studio-native-preview.png")
+        .exists());
+    assert!(!dir
+        .join("plugins/host/studio-native/build/assets/preview/preview.js.map")
+        .exists());
+    assert!(!dir.join("plugins/host/studio-native/.npmrc").exists());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn path_renames_preserve_intermediate_segments_under_renamed_ancestor() {
+    let dir = std::env::temp_dir().join("homeboy_refactor_nested_path_segment_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    let dist = dir.join("plugins/host/studio-native/modules/agentic-ui-block/dist");
+    std::fs::create_dir_all(&dist).unwrap();
+
+    std::fs::write(
+        dist.join("studio-native-agentic-ui-block.js"),
+        "studioNativeAgenticUiBlock();\n",
+    )
+    .unwrap();
+
+    let spec = RenameSpec::literal("studio-native", "wp-build", RenameScope::All);
+    let mut result = generate_renames(&spec, &dir);
+
+    let rename = result
+        .file_renames
+        .iter()
+        .find(|rename| rename.from.ends_with("studio-native-agentic-ui-block.js"))
+        .unwrap();
+    assert_eq!(
+        rename.from,
+        "plugins/host/studio-native/modules/agentic-ui-block/dist/studio-native-agentic-ui-block.js"
+    );
+    assert_eq!(
+        rename.to,
+        "plugins/host/wp-build/modules/agentic-ui-block/dist/wp-build-agentic-ui-block.js"
+    );
+
+    apply_renames(&mut result, &dir).unwrap();
+
+    assert!(dir
+        .join("plugins/host/wp-build/modules/agentic-ui-block/dist/wp-build-agentic-ui-block.js")
+        .exists());
+    assert!(!dir
+        .join("plugins/host/wp-build/modules/agentic-ui-block/wp-build-agentic-ui-block.js")
+        .exists());
+    assert!(!dir
+        .join("plugins/host/studio-native/modules/agentic-ui-block/dist/studio-native-agentic-ui-block.js")
+        .exists());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn word_boundary_no_false_positives() {
     let dir = std::env::temp_dir().join("homeboy_refactor_boundary_test");
     let _ = std::fs::create_dir_all(&dir);


### PR DESCRIPTION
Fixes #7555

## Root cause
- Rename path planning in src/core/refactor/rename/engine.rs reused the content-edit file scan for file_renames, so files filtered out of content editing, including images, sourcemaps, and dotfiles, were never scheduled for path moves.
- Path targets were produced with whole-string path replacement. The corrected implementation computes targets segment-by-segment so ancestor and basename renames compose without dropping untouched intermediate path segments.

## Fix
- Add a path-rename scan using ExtensionFilter::All while keeping content edits on the source-filtered scan.
- Compute file rename targets by transforming each path segment in place.
- Keep moves routed through the existing apply_edit_ops MoveFile path.
- Add regressions for skipped-content files under a renamed directory and the nested dist segment case.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Anthropic) via Claude Code / opencode agent
- **Used for:** Root-cause analysis, fix implementation, and test authoring, reviewed and directed by Chris Huber