### PR TITLE
Derive Title_Snake_Case rename variants

### DIFF
--- a/src/core/refactor/rename/casing.rs
+++ b/src/core/refactor/rename/casing.rs
@@ -107,6 +107,15 @@ pub(super) fn join_upper_snake(words: &[String]) -> String {
         .join("_")
 }
 
+/// Join words as Title_Snake_Case: `["sample", "plugin", "agent"]` → `"Sample_Plugin_Agent"`
+pub(super) fn join_title_snake(words: &[String]) -> String {
+    words
+        .iter()
+        .map(|w| capitalize(w))
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
 /// Join words as PascalCase: `["sample", "plugin", "agent"]` → `"SamplePluginAgent"`
 pub(super) fn join_pascal(words: &[String]) -> String {
     words

--- a/src/core/refactor/rename/tests.rs
+++ b/src/core/refactor/rename/tests.rs
@@ -857,6 +857,10 @@ fn cross_separator_variants_from_kebab() {
         from_values.contains(&"WP_AGENT"),
         "Missing UPPER_SNAKE from"
     );
+    assert!(
+        from_values.contains(&"Wp_Agent"),
+        "Missing Title_Snake_Case from"
+    );
     assert!(from_values.contains(&"WpAgent"), "Missing PascalCase from");
     assert!(from_values.contains(&"wpAgent"), "Missing camelCase from");
     assert!(from_values.contains(&"Wp Agent"), "Missing display from");
@@ -872,6 +876,10 @@ fn cross_separator_variants_from_kebab() {
     assert!(
         to_values.contains(&"SAMPLE_PLUGIN_AGENT"),
         "Missing UPPER_SNAKE to"
+    );
+    assert!(
+        to_values.contains(&"Sample_Plugin_Agent"),
+        "Missing Title_Snake_Case to"
     );
     assert!(
         to_values.contains(&"SamplePluginAgent"),
@@ -898,6 +906,10 @@ fn cross_separator_variants_from_kebab() {
     assert!(
         from_values.contains(&"WP_AGENTS"),
         "Missing plural UPPER_SNAKE from"
+    );
+    assert!(
+        from_values.contains(&"Wp_Agents"),
+        "Missing plural Title_Snake_Case from"
     );
     assert!(
         from_values.contains(&"WpAgents"),
@@ -1045,6 +1057,62 @@ fn cross_separator_end_to_end_rename() {
     assert!(
         content.contains("sample-plugin-agents"),
         "Should rename plural kebab: {}",
+        content
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn title_snake_variant_renames_wordpress_class_names() {
+    let dir = std::env::temp_dir().join("homeboy_title_snake_variant_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    std::fs::write(
+        dir.join("plugin.php"),
+        "final class Studio_Native_Codebox_Client {}\n",
+    )
+    .unwrap();
+
+    let spec = RenameSpec::new("studio-native", "wp-build", RenameScope::All);
+    let result = generate_renames(&spec, &dir);
+    assert_eq!(result.edits.len(), 1);
+    let content = &result.edits[0].new_content;
+
+    assert!(content.contains("Wp_Build_Codebox_Client"), "{}", content);
+    assert!(
+        !content.contains("Studio_Native_Codebox_Client"),
+        "{}",
+        content
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn explicit_variant_overrides_title_snake_auto_variant() {
+    let dir = std::env::temp_dir().join("homeboy_title_snake_explicit_variant_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    std::fs::write(
+        dir.join("plugin.php"),
+        "final class Studio_Native_Codebox_Client {}\n",
+    )
+    .unwrap();
+
+    let spec = RenameSpec::new("studio-native", "wp-build", RenameScope::All)
+        .with_explicit_variants(vec![("Studio_Native".to_string(), "WPBuild".to_string())]);
+    let result = generate_renames(&spec, &dir);
+    assert_eq!(result.edits.len(), 1);
+    let content = &result.edits[0].new_content;
+
+    assert!(content.contains("WPBuild_Codebox_Client"), "{}", content);
+    assert!(!content.contains("Wp_Build_Codebox_Client"), "{}", content);
+    assert!(
+        !content.contains("Studio_Native_Codebox_Client"),
+        "{}",
         content
     );
 

--- a/src/core/refactor/rename/types.rs
+++ b/src/core/refactor/rename/types.rs
@@ -4,8 +4,8 @@ use crate::core::error::{Error, Result};
 use serde::Serialize;
 
 use super::casing::{
-    join_camel, join_display, join_kebab, join_pascal, join_snake, join_upper_snake, pluralize,
-    split_words,
+    join_camel, join_display, join_kebab, join_pascal, join_snake, join_title_snake,
+    join_upper_snake, pluralize, split_words,
 };
 
 // ============================================================================
@@ -242,6 +242,7 @@ impl RenameSpec {
     /// - `kebab-case` (e.g., `sample-plugin-agent`)
     /// - `snake_case` (e.g., `sample_plugin_agent`)
     /// - `UPPER_SNAKE` (e.g., `SAMPLE_PLUGIN_AGENT`)
+    /// - `Title_Snake_Case` (e.g., `Sample_Plugin_Agent`)
     /// - `PascalCase` (e.g., `SamplePluginAgent`)
     /// - `camelCase` (e.g., `samplePluginAgent`)
     /// - `Display Name` (e.g., `Sample Plugin Agent`)
@@ -267,10 +268,11 @@ impl RenameSpec {
         // to the same thing, and dedup handles it naturally.
         if !from_words.is_empty() && !to_words.is_empty() {
             // Singular forms — all naming conventions
-            let join_fns: [fn(&[String]) -> String; 6] = [
+            let join_fns: [fn(&[String]) -> String; 7] = [
                 join_kebab,
                 join_snake,
                 join_upper_snake,
+                join_title_snake,
                 join_pascal,
                 join_camel,
                 join_display,
@@ -279,6 +281,7 @@ impl RenameSpec {
                 "kebab",
                 "snake_case",
                 "UPPER_SNAKE",
+                "Title_Snake_Case",
                 "PascalCase",
                 "camelCase",
                 "Display Name",


### PR DESCRIPTION
Fixes #7556

## Summary
- Add auto-derived Title_Snake_Case rename variants using the same label/join-function machinery as existing variants.
- Include plural Title_Snake_Case generation through the existing plural variant loop.
- Cover WordPress-style class renames and explicit override precedence for the new auto variant.

## Verification
- cargo fmt
- cargo test refactor -- --test-threads=1
- cargo clippy

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Anthropic) via Claude Code / opencode agent
- **Used for:** Implementation and test authoring, reviewed and directed by Chris Huber