### PR TITLE
Purge core genericity hardcodes

### DIFF
--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -55,8 +55,8 @@ pub struct AgentTaskControllerDispatchArgs {
 
     /// Extension-provider selector: the Homeboy executor provider id (e.g.
     /// `sample.executor-provider`) that runs controller-spawned
-    /// dispatch actions when the action omits one. This is NOT a model or AI
-    /// runtime name (codex, opencode, claude-code) — pass those in
+    /// dispatch actions when the action omits one. This is not model/runtime
+    /// provider configuration; pass runtime-specific values in
     /// --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "dispatch-selector",
@@ -71,8 +71,8 @@ pub struct AgentTaskControllerDispatchArgs {
 
     /// Agent/model provider config (JSON, @file, or -): the nested AI
     /// runtime/provider/model the selected executor uses for controller-spawned
-    /// dispatch actions when the action omits one. Put AI runtime names like
-    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
+    /// dispatch actions when the action omits one. Put runtime-specific provider
+    /// selection here, not in --dispatch-selector.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -96,9 +96,9 @@ pub struct AgentTaskFanoutCookBatchArgs {
     #[arg(long = "model", value_name = "MODEL")]
     pub model: Option<String>,
 
-    /// Named provider profile for common executor/model pairings. Explicit --backend/--model values win.
-    #[arg(long = "provider-profile", value_enum, value_name = "PROFILE")]
-    pub provider_profile: Option<AgentTaskProviderProfile>,
+    /// Named provider profile declared by an installed executor provider. Explicit --backend/--model values win.
+    #[arg(long = "provider-profile", value_name = "PROFILE")]
+    pub provider_profile: Option<String>,
 
     /// Secret environment variable name to hydrate for the provider. Repeatable.
     #[arg(long = "secret-env", value_name = "ENV")]
@@ -120,12 +120,6 @@ pub struct AgentTaskFanoutCookBatchArgs {
     pub run_plan: bool,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-pub enum AgentTaskProviderProfile {
-    /// Run through the opencode executor and request GPT-5.5/Codex model configuration.
-    OpencodeCodexGpt55,
-}
-
 #[derive(Args, Debug, Clone)]
 pub struct AgentTaskFanoutInputArgs {
     /// Batch-cook fanout spec JSON file, @file, inline JSON, or - for stdin.
@@ -140,10 +134,7 @@ pub struct AgentTaskFanoutInputArgs {
     #[arg(long = "backend", value_name = "BACKEND")]
     pub backend: Option<String>,
 
-    /// Default extension-provider selector for cooks without one: a Homeboy
-    /// executor provider id (e.g. `sample.executor-provider`), NOT
-    /// an AI runtime name (codex, opencode, claude-code). Set the AI runtime via
-    /// --provider-config. Run `homeboy agent-task providers` for valid ids.
+    /// Default extension-provider selector for cooks without one. Run `homeboy agent-task providers` for valid provider ids.
     #[arg(
         long = "selector",
         visible_alias = "provider-id",
@@ -513,7 +504,7 @@ pub struct AgentTaskCookArgs {
     pub protected_branches: Vec<String>,
 
     /// AI tool disclosure line for the PR body.
-    #[arg(long, default_value = "OpenCode (GPT-5.5)", value_name = "TEXT")]
+    #[arg(long, default_value = "AI-assisted", value_name = "TEXT")]
     pub ai_tool: String,
 
     /// AI assistance scope for the PR body.
@@ -571,8 +562,8 @@ pub struct AgentTaskLoopDefineArgs {
 
     /// Extension-provider selector: the Homeboy executor provider id (e.g.
     /// `sample.executor-provider`) that runs loop-spawned dispatch
-    /// actions when the action omits one. This is NOT a model or AI runtime name
-    /// (codex, opencode, claude-code) — pass those in --dispatch-provider-config.
+    /// actions when the action omits one. This is not model/runtime provider
+    /// configuration; pass runtime-specific values in --dispatch-provider-config.
     /// Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "dispatch-selector",
@@ -587,8 +578,8 @@ pub struct AgentTaskLoopDefineArgs {
 
     /// Agent/model provider config (JSON, @file, or -): the nested AI
     /// runtime/provider/model the selected executor uses for loop-spawned
-    /// dispatch actions when the action omits one. Put AI runtime names like
-    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
+    /// dispatch actions when the action omits one. Put runtime-specific provider
+    /// selection here, not in --dispatch-selector.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }
@@ -614,8 +605,8 @@ pub struct AgentTaskLoopResumeArgs {
 
     /// Extension-provider selector: the Homeboy executor provider id (e.g.
     /// `sample.executor-provider`) that runs loop-spawned dispatch
-    /// actions when the action omits one. This is NOT a model or AI runtime name
-    /// (codex, opencode, claude-code) — pass those in --dispatch-provider-config.
+    /// actions when the action omits one. This is not model/runtime provider
+    /// configuration; pass runtime-specific values in --dispatch-provider-config.
     /// Run `homeboy agent-task providers` for valid ids.
     #[arg(
         long = "dispatch-selector",
@@ -630,8 +621,8 @@ pub struct AgentTaskLoopResumeArgs {
 
     /// Agent/model provider config (JSON, @file, or -): the nested AI
     /// runtime/provider/model the selected executor uses for loop-spawned
-    /// dispatch actions when the action omits one. Put AI runtime names like
-    /// `codex`/`opencode`/`claude-code` here, not in --dispatch-selector.
+    /// dispatch actions when the action omits one. Put runtime-specific provider
+    /// selection here, not in --dispatch-selector.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -4,13 +4,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
 
+use homeboy::core::agent_task_provider::AgentTaskProviderProfileDeclaration;
 use homeboy::core::agent_tasks::batch;
 use homeboy::core::agent_tasks::dispatch_service::{
     self, AgentTaskDispatchCommand, DispatchCoreInputs,
 };
 use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
 use homeboy::core::agent_tasks::lifecycle as agent_task_lifecycle;
-use homeboy::core::agent_tasks::provider;
+use homeboy::core::agent_tasks::provider::{self, AgentTaskProviderCatalog};
 use homeboy::core::agent_tasks::service::{
     self as agent_task_service, AgentTaskCookServiceOptions,
 };
@@ -24,7 +25,7 @@ use super::super::CmdResult;
 use super::args::{
     AgentTaskFanoutArgs, AgentTaskFanoutBatchStatusArgs, AgentTaskFanoutCommand,
     AgentTaskFanoutCookBatchArgs, AgentTaskFanoutInputArgs, AgentTaskFanoutRunPlanArgs,
-    AgentTaskFanoutSubmitArgs, AgentTaskFanoutSubmitBatchArgs, AgentTaskProviderProfile,
+    AgentTaskFanoutSubmitArgs, AgentTaskFanoutSubmitBatchArgs,
 };
 use super::command_json_value;
 
@@ -695,23 +696,37 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
 }
 
 fn apply_provider_profile(args: &mut AgentTaskFanoutCookBatchArgs) {
-    match args.provider_profile {
-        Some(AgentTaskProviderProfile::OpencodeCodexGpt55) => {
-            if args.backend.is_none() {
-                args.backend = Some("opencode".to_string());
-            }
-            if args.model.is_none() {
-                args.model = Some("gpt-5.5".to_string());
-            }
-        }
-        None => {}
+    let Some(profile) = selected_provider_profile(args.provider_profile.as_deref()) else {
+        return;
+    };
+    if args.backend.is_none() {
+        args.backend = profile.backend;
     }
+    if args.selector.is_none() {
+        args.selector = profile.selector;
+    }
+    if args.model.is_none() {
+        args.model = profile.model;
+    }
+    if args.provider_config.is_none() {
+        args.provider_config = profile.provider_config.map(|value| value.to_string());
+    }
+}
+
+fn selected_provider_profile(name: Option<&str>) -> Option<AgentTaskProviderProfileDeclaration> {
+    let name = name?.trim();
+    AgentTaskProviderCatalog::discover()
+        .providers()
+        .iter()
+        .flat_map(|provider| provider.cli.profiles.iter())
+        .find(|profile| profile.name == name)
+        .cloned()
 }
 
 fn provider_selection_preflight(args: &AgentTaskFanoutCookBatchArgs) -> Value {
     let warnings = provider_selection_warnings(args);
     serde_json::json!({
-        "profile": args.provider_profile.map(provider_profile_name),
+        "profile": args.provider_profile,
         "executor": {
             "backend": args.backend,
             "selector": args.selector,
@@ -723,21 +738,11 @@ fn provider_selection_preflight(args: &AgentTaskFanoutCookBatchArgs) -> Value {
 }
 
 fn provider_selection_warnings(args: &AgentTaskFanoutCookBatchArgs) -> Vec<String> {
-    let Some(backend) = args.backend.as_deref() else {
-        return Vec::new();
-    };
-    if backend.eq_ignore_ascii_case("codex") {
-        return vec![
-            "--backend codex selects the Codex CLI executor backend. For opencode-native execution with Codex/GPT-5.5, use --provider-profile opencode-codex-gpt55 or --backend opencode --model gpt-5.5."
-                .to_string(),
-        ];
-    }
-    Vec::new()
-}
-
-fn provider_profile_name(profile: AgentTaskProviderProfile) -> &'static str {
-    match profile {
-        AgentTaskProviderProfile::OpencodeCodexGpt55 => "opencode-codex-gpt55",
+    match args.provider_profile.as_deref() {
+        Some(name) if selected_provider_profile(Some(name)).is_none() => vec![format!(
+            "provider profile '{name}' is not declared by installed executor providers; run `homeboy agent-task providers` to inspect available profiles"
+        )],
+        _ => Vec::new(),
     }
 }
 
@@ -929,7 +934,18 @@ fn default_private_gate_reveal() -> AgentTaskGateRevealPolicy {
 }
 
 fn default_ai_tool() -> String {
-    "OpenCode (GPT-5.5)".to_string()
+    AgentTaskProviderCatalog::discover()
+        .providers()
+        .iter()
+        .find_map(|provider| provider.cli.default_ai_disclosure.clone())
+        .or_else(|| {
+            AgentTaskProviderCatalog::discover()
+                .providers()
+                .iter()
+                .flat_map(|provider| provider.cli.profiles.iter())
+                .find_map(|profile| profile.ai_disclosure.clone())
+        })
+        .unwrap_or_else(|| "AI-assisted".to_string())
 }
 
 fn default_ai_used_for() -> String {
@@ -1176,42 +1192,38 @@ mod tests {
     }
 
     #[test]
-    fn cook_batch_provider_profile_sets_opencode_codex_defaults() {
+    fn cook_batch_unknown_provider_profile_warns_without_core_defaults() {
         let mut args = cook_batch_args();
         args.backend = None;
         args.model = None;
-        args.provider_profile = Some(AgentTaskProviderProfile::OpencodeCodexGpt55);
+        args.provider_profile = Some("example-profile".to_string());
 
         let (value, exit_code) = cook_batch(args).expect("cook batch dry run");
 
         assert_eq!(exit_code, 0);
         assert_eq!(
             value["preflight"]["provider_selection"]["profile"],
-            "opencode-codex-gpt55"
+            "example-profile"
         );
-        assert_eq!(
-            value["preflight"]["provider_selection"]["executor"]["backend"],
-            "opencode"
-        );
-        assert_eq!(value["preflight"]["provider_selection"]["model"], "gpt-5.5");
-        assert_eq!(value["plan"]["cooks"][0]["backend"], "opencode");
-        assert_eq!(value["plan"]["cooks"][0]["model"], "gpt-5.5");
+        assert!(value["preflight"]["provider_selection"]["warnings"][0]
+            .as_str()
+            .expect("warning")
+            .contains("not declared"));
     }
 
     #[test]
-    fn cook_batch_warns_when_codex_backend_selects_codex_cli_executor() {
+    fn cook_batch_does_not_warn_for_specific_backend_names_in_core() {
         let mut args = cook_batch_args();
-        args.backend = Some("codex".to_string());
+        args.backend = Some("example".to_string());
         args.provider_config = None;
 
         let (value, exit_code) = cook_batch(args).expect("cook batch dry run");
 
         assert_eq!(exit_code, 0);
-        let warning = value["preflight"]["provider_selection"]["warnings"][0]
-            .as_str()
-            .expect("warning");
-        assert!(warning.contains("Codex CLI executor backend"));
-        assert!(warning.contains("--provider-profile opencode-codex-gpt55"));
+        assert!(value["preflight"]["provider_selection"]["warnings"]
+            .as_array()
+            .expect("warnings")
+            .is_empty());
     }
 
     #[test]
@@ -1246,7 +1258,7 @@ mod tests {
         assert_eq!(args.from, "origin/main");
         assert_eq!(
             args.provider_profile,
-            Some(AgentTaskProviderProfile::OpencodeCodexGpt55)
+            Some("opencode-codex-gpt55".to_string())
         );
     }
 }

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -40,7 +40,7 @@ pub struct FinalizePrEvidenceArgs {
     pub artifact_refs: Vec<String>,
 
     /// AI tool disclosure line for the PR body.
-    #[arg(long, default_value = "OpenCode (GPT-5.5)", value_name = "TEXT")]
+    #[arg(long, default_value = "AI-assisted", value_name = "TEXT")]
     pub ai_tool: String,
 
     /// Actual model identifier for AI disclosure. Use "not recorded" only when provider metadata is missing.
@@ -393,7 +393,7 @@ fn dispatch_config_layers(providers: &[AgentTaskExecutorProvider]) -> Value {
         .unwrap_or_else(|| "sample.executor-provider".to_string());
 
     serde_json::json!({
-        "summary": "Dispatch configuration has two independent layers that are easy to confuse: the extension-provider selector picks which Homeboy executor runs the task, while the nested provider config picks which AI runtime/model that executor drives. Pass an executor provider id to --dispatch-selector, and pass the AI runtime (codex, opencode, claude-code, ...) inside --dispatch-provider-config — never the other way around.",
+        "summary": "Dispatch configuration has two independent layers that are easy to confuse: the extension-provider selector picks which Homeboy executor runs the task, while the nested provider config picks which runtime/model that executor drives. Pass an executor provider id to --dispatch-selector, and pass runtime-specific provider configuration inside --dispatch-provider-config — never the other way around.",
         "layers": [
             {
                 "layer": "extension_provider_selector",
@@ -405,15 +405,15 @@ fn dispatch_config_layers(providers: &[AgentTaskExecutorProvider]) -> Value {
             {
                 "layer": "agent_model_provider_config",
                 "flags": ["--dispatch-provider-config", "--provider-config", "--dispatch-model", "--model"],
-                "selects": "Which AI runtime/provider/model the selected executor uses (e.g. codex, opencode, claude-code).",
-                "value_is": "Nested provider config JSON (and/or a model override), passed to the executor — this is where an AI runtime name like `codex` belongs.",
+                "selects": "Which runtime/provider/model the selected executor uses.",
+                "value_is": "Nested provider config JSON (and/or a model override), passed to the executor.",
             }
         ],
-        "common_mistake": "Passing an AI runtime name (codex, opencode, claude-code) to --dispatch-selector. That selects the executor, not the model, so it fails with 'no extension agent-task provider ... matched selector'. Put the AI runtime in --dispatch-provider-config instead.",
+        "common_mistake": "Passing runtime-specific provider configuration to --dispatch-selector. That selects the executor, not the model/provider, so it fails with 'no extension agent-task provider ... matched selector'. Put runtime-specific values in --dispatch-provider-config instead.",
         "example": {
             "description": "Run a task with a selected executor provider driving a nested AI runtime/provider config.",
             "command": format!(
-                "homeboy agent-task cook --dispatch-selector {example_selector} --dispatch-provider-config '{{\"provider\":\"codex\"}}' --prompt @task.md"
+                "homeboy agent-task cook --dispatch-selector {example_selector} --dispatch-provider-config '{{\"provider\":\"example\"}}' --prompt @task.md"
             ),
         }
     })

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -1073,7 +1073,7 @@ mod tests {
     #[test]
     fn component_discovery_value_flags_temp_local_path() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let checkout = temp.path().join("opencode").join("homeboy-temp");
+        let checkout = temp.path().join("tmp").join("homeboy-temp");
         fs::create_dir_all(checkout.join(".git")).expect("git dir");
         fs::write(checkout.join("homeboy.json"), r#"{"id":"homeboy"}"#).expect("homeboy.json");
         let component = Component::new(
@@ -1100,7 +1100,7 @@ mod tests {
         assert!(value["local_path_diagnostic"]["warning"]
             .as_str()
             .unwrap_or_default()
-            .contains("temporary/opencode checkout"));
+            .contains("transient workspace checkout"));
         assert!(value["local_path_diagnostic"]["repair_command"]
             .as_str()
             .unwrap_or_default()

--- a/src/core/agent_task_provider/catalog.rs
+++ b/src/core/agent_task_provider/catalog.rs
@@ -259,12 +259,15 @@ fn validate_provider_runner_readiness_for_backend_with_diagnostics(
                 )]),
             ));
         }
-        ProviderResolution::SelectorMismatch { available_ids } => {
+        ProviderResolution::SelectorMismatch {
+            available_ids,
+            selector_hint,
+        } => {
             let mut suggestions = vec![format!(
                 "Available provider ids for backend '{backend}': {}.",
                 available_ids.join(", ")
             )];
-            if let Some(hint) = selector_runtime_provider_hint(backend, selector) {
+            if let Some(hint) = selector_hint {
                 suggestions.push(hint);
             }
             return Err(Error::validation_invalid_argument(

--- a/src/core/agent_task_provider/executor.rs
+++ b/src/core/agent_task_provider/executor.rs
@@ -94,7 +94,10 @@ fn provider_resolution_failure_outcome(
                 "available_provider_ids": candidate_ids,
             }),
         ),
-        ProviderResolution::SelectorMismatch { available_ids } => failure_outcome(
+        ProviderResolution::SelectorMismatch {
+            available_ids,
+            selector_hint,
+        } => failure_outcome(
             request,
             AgentTaskOutcomeStatus::Failed,
             AgentTaskFailureClassification::CapabilityMissing,
@@ -107,10 +110,7 @@ fn provider_resolution_failure_outcome(
                 "backend": request.executor.backend,
                 "selector": request.executor.selector,
                 "available_provider_ids": available_ids,
-                "hint": selector_runtime_provider_hint(
-                    &request.executor.backend,
-                    request.executor.selector.as_deref(),
-                ),
+                "hint": selector_hint,
             }),
         ),
     }

--- a/src/core/agent_task_provider/resolution.rs
+++ b/src/core/agent_task_provider/resolution.rs
@@ -85,7 +85,10 @@ pub(crate) enum ProviderResolution<'a> {
     /// One or more providers matched the backend/extension alias, but the
     /// supplied selector did not match any of them. The selectable provider
     /// ids are surfaced so the operator can correct the `--selector`.
-    SelectorMismatch { available_ids: Vec<String> },
+    SelectorMismatch {
+        available_ids: Vec<String>,
+        selector_hint: Option<String>,
+    },
 }
 
 pub(crate) fn selector_runtime_provider_hint(
@@ -93,13 +96,36 @@ pub(crate) fn selector_runtime_provider_hint(
     selector: Option<&str>,
 ) -> Option<String> {
     let selector = selector?.trim();
-    if !matches!(selector, "codex" | "opencode" | "claude-code") {
+    let catalog = AgentTaskProviderCatalog::discover();
+    let reserved = catalog
+        .providers()
+        .iter()
+        .flat_map(|provider| provider.cli.reserved_selector_hints.iter())
+        .any(|hint| hint == selector);
+    if !reserved {
         return None;
     }
 
     Some(format!(
-        "'{selector}' looks like a nested AI runtime provider, not a dispatch selector. --dispatch-selector selects the Homeboy executor provider id for backend '{backend}'; pass the AI provider in --dispatch-provider-config instead."
+        "'{selector}' is declared by an executor provider as runtime-specific provider configuration, not a dispatch selector. --dispatch-selector selects the Homeboy executor provider id for backend '{backend}'; pass runtime/provider configuration through --dispatch-provider-config instead."
     ))
+}
+
+fn selector_runtime_provider_hint_from_providers(
+    providers: &[&AgentTaskExecutorProvider],
+    backend: &str,
+    selector: Option<&str>,
+) -> Option<String> {
+    let selector = selector?.trim();
+    let reserved = providers
+        .iter()
+        .flat_map(|provider| provider.cli.reserved_selector_hints.iter())
+        .any(|hint| hint == selector);
+    reserved.then(|| {
+        format!(
+            "'{selector}' is declared by an executor provider as runtime-specific provider configuration, not a dispatch selector. --dispatch-selector selects the Homeboy executor provider id for backend '{backend}'; pass runtime/provider configuration through --dispatch-provider-config instead."
+        )
+    })
 }
 
 impl<'a> ProviderResolution<'a> {
@@ -133,6 +159,11 @@ pub(crate) fn resolve_provider_for_backend<'a>(
             return ProviderResolution::Resolved(provider);
         }
         return ProviderResolution::SelectorMismatch {
+            selector_hint: selector_runtime_provider_hint_from_providers(
+                &exact_matches,
+                backend,
+                selector,
+            ),
             available_ids: exact_matches
                 .iter()
                 .map(|provider| provider.id.clone())
@@ -183,6 +214,11 @@ fn resolve_provider_by_extension_alias<'a>(
         {
             Some(provider) => ProviderResolution::Resolved(provider),
             None => ProviderResolution::SelectorMismatch {
+                selector_hint: selector_runtime_provider_hint_from_providers(
+                    &alias_matches,
+                    backend,
+                    Some(selector),
+                ),
                 available_ids: alias_matches
                     .iter()
                     .map(|provider| provider.id.clone())

--- a/src/core/agent_task_provider/tests/common.rs
+++ b/src/core/agent_task_provider/tests/common.rs
@@ -37,6 +37,7 @@ pub(super) fn request(
         lab_runtime_components: Vec::new(),
         timeout_artifact_discovery: AgentTaskProviderTimeoutArtifactDiscovery::default(),
         role_aliases: AgentTaskProviderRoleAliases::default(),
+        cli: AgentTaskProviderCliMetadata::default(),
         result_contract: AgentTaskProviderResultContract::default(),
         runtime_contract: AgentTaskRuntimeContract::default(),
         extension_id: None,

--- a/src/core/agent_task_provider/tests/scheduler_tests.rs
+++ b/src/core/agent_task_provider/tests/scheduler_tests.rs
@@ -48,6 +48,7 @@ fn scheduler_reports_provider_selector_mismatch() {
     request.executor.selector = Some("codex".to_string());
     provider.id = "example.synthetic-agent-task-executor".to_string();
     provider.backend = "synthetic-runtime".to_string();
+    provider.cli.reserved_selector_hints = vec!["codex".to_string()];
     let scheduler =
         AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
             provider,
@@ -66,10 +67,10 @@ fn scheduler_reports_provider_selector_mismatch() {
     );
     assert!(aggregate.outcomes[0].diagnostics[0]
         .message
-        .contains("nested AI runtime provider"));
+        .contains("matched selector"));
     assert_eq!(
         aggregate.outcomes[0].diagnostics[0].data["hint"],
-        "'codex' looks like a nested AI runtime provider, not a dispatch selector. --dispatch-selector selects the Homeboy executor provider id for backend 'synthetic-runtime'; pass the AI provider in --dispatch-provider-config instead."
+        "'codex' is declared by an executor provider as runtime-specific provider configuration, not a dispatch selector. --dispatch-selector selects the Homeboy executor provider id for backend 'synthetic-runtime'; pass runtime/provider configuration through --dispatch-provider-config instead."
     );
 }
 

--- a/src/core/agent_task_provider/tests/selection_tests.rs
+++ b/src/core/agent_task_provider/tests/selection_tests.rs
@@ -232,6 +232,7 @@ fn provider_selection_reports_exact_backend_selector_mismatch() {
         resolution,
         ProviderResolution::SelectorMismatch {
             available_ids: vec!["example.synthetic-agent-task-executor".to_string()],
+            selector_hint: None,
         }
     );
 }
@@ -241,6 +242,7 @@ fn provider_readiness_selector_mismatch_explains_runtime_provider_confusion() {
     let (_, mut provider) = request("task-a", "node provider.js".to_string());
     provider.id = "example.sandbox-agent-task-executor".to_string();
     provider.backend = "sandbox".to_string();
+    provider.cli.reserved_selector_hints = vec!["codex".to_string()];
 
     let error = validate_provider_runner_readiness_for_backend_with_providers(
         &[provider],
@@ -255,7 +257,7 @@ fn provider_readiness_selector_mismatch_explains_runtime_provider_confusion() {
         .expect("tried suggestions");
     assert!(suggestions.iter().any(|value| value
         .as_str()
-        .is_some_and(|suggestion| suggestion.contains("nested AI runtime provider"))));
+        .is_some_and(|suggestion| suggestion.contains("runtime-specific provider configuration"))));
     assert!(suggestions.iter().any(|value| value
         .as_str()
         .is_some_and(|suggestion| suggestion.contains("example.sandbox-agent-task-executor"))));

--- a/src/core/agent_task_provider/types.rs
+++ b/src/core/agent_task_provider/types.rs
@@ -90,6 +90,11 @@ pub struct AgentTaskExecutorProvider {
     pub role_aliases: AgentTaskProviderRoleAliases,
     #[serde(
         default,
+        skip_serializing_if = "AgentTaskProviderCliMetadata::is_empty"
+    )]
+    pub cli: AgentTaskProviderCliMetadata,
+    #[serde(
+        default,
         skip_serializing_if = "AgentTaskProviderResultContract::is_empty"
     )]
     pub result_contract: AgentTaskProviderResultContract,
@@ -107,6 +112,39 @@ pub struct AgentTaskExecutorProvider {
     pub runtime_path: Option<String>,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentTaskProviderCliMetadata {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reserved_selector_hints: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub profiles: Vec<AgentTaskProviderProfileDeclaration>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_ai_disclosure: Option<String>,
+}
+
+impl AgentTaskProviderCliMetadata {
+    pub(super) fn is_empty(&self) -> bool {
+        self.reserved_selector_hints.is_empty()
+            && self.profiles.is_empty()
+            && self.default_ai_disclosure.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentTaskProviderProfileDeclaration {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ai_disclosure: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_config: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/cleanup/self_artifacts.rs
+++ b/src/core/cleanup/self_artifacts.rs
@@ -361,8 +361,16 @@ fn cargo_manifest_package_is_homeboy(cargo_toml: &Path) -> Result<bool> {
 }
 
 fn default_self_temp_roots() -> Vec<PathBuf> {
-    let temp_dir = std::env::temp_dir();
-    vec![temp_dir.clone(), temp_dir.join("opencode")]
+    let mut roots = vec![std::env::temp_dir()];
+    if let Ok(raw) = std::env::var("HOMEBOY_TRANSIENT_WORKSPACE_ROOTS") {
+        roots.extend(
+            raw.split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from),
+        );
+    }
+    roots
 }
 
 fn is_detached_homeboy_temp_artifact(path: &Path) -> bool {

--- a/src/core/component/inventory/path_diagnostics.rs
+++ b/src/core/component/inventory/path_diagnostics.rs
@@ -1,4 +1,5 @@
 use crate::core::component::Component;
+use crate::core::transient_workspace_policy::TransientWorkspacePolicy;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -33,7 +34,7 @@ pub(super) fn local_path_diagnostic_for(
     } else {
         Some(match status.as_str() {
             "temp_checkout" => format!(
-                "Component '{id}' local_path points at a temporary/opencode checkout: {local_path}"
+                "Component '{id}' local_path points at a transient workspace checkout: {local_path}"
             ),
             "missing" => format!("Component '{id}' local_path does not exist: {local_path}"),
             "non_git" => format!("Component '{id}' local_path is not a git checkout: {local_path}"),
@@ -104,27 +105,11 @@ pub(super) fn stable_workspace_roots(path: &Path) -> Vec<PathBuf> {
 }
 
 fn stable_root_before_temp_marker(path: &Path) -> Option<PathBuf> {
-    let segments = crate::core::paths::path_component_strings(path);
-    let mut root = PathBuf::new();
-    for segment in segments {
-        if segment == "opencode" || segment == "tmp" || segment == "Temp" || segment == "T" {
-            return if root.as_os_str().is_empty() {
-                None
-            } else {
-                Some(root)
-            };
-        }
-        root.push(&segment);
-    }
-    None
+    TransientWorkspacePolicy::current().stable_root_before_marker(path)
 }
 
 pub(super) fn is_temp_checkout_path(path: &Path) -> bool {
-    let rendered = path.to_string_lossy();
-    rendered.contains("/opencode/")
-        || rendered.contains("/tmp/opencode/")
-        || rendered.contains("/Temp/")
-        || rendered.contains("/T/opencode/")
+    TransientWorkspacePolicy::current().is_transient_path(path)
 }
 
 pub(super) fn detect_git_root(path: &Path) -> Option<PathBuf> {

--- a/src/core/component/inventory/tests.rs
+++ b/src/core/component/inventory/tests.rs
@@ -491,7 +491,7 @@ fn reconcile_flags_relative_local_path_and_repairs_to_absolute() {
 fn local_path_diagnostic_flags_temp_checkout_and_reports_stable_candidate() {
     let dir = TempDir::new().unwrap();
     let stable_checkout = dir.path().join("Developer").join("homeboy");
-    let temp_checkout = dir.path().join("opencode").join("homeboy-issue-4202-temp");
+    let temp_checkout = dir.path().join("tmp").join("homeboy-issue-4202-temp");
     init_git_repo(&stable_checkout);
     init_git_repo(&temp_checkout);
     write_portable_id(&stable_checkout, "homeboy");
@@ -523,7 +523,7 @@ fn local_path_diagnostic_flags_temp_checkout_and_reports_stable_candidate() {
         .warning
         .as_deref()
         .unwrap_or_default()
-        .contains("temporary/opencode checkout"));
+        .contains("transient workspace checkout"));
     assert!(diagnostic
         .repair_command
         .as_deref()
@@ -541,7 +541,7 @@ fn reconcile_repairs_temp_checkout_to_unique_stable_candidate() {
         .join("components");
     fs::create_dir_all(&config_components).unwrap();
     let stable_checkout = dir.path().join("Developer").join("homeboy");
-    let temp_checkout = dir.path().join("opencode").join("homeboy-temp");
+    let temp_checkout = dir.path().join("tmp").join("homeboy-temp");
     init_git_repo(&stable_checkout);
     init_git_repo(&temp_checkout);
     write_portable_id(&stable_checkout, "homeboy");

--- a/src/core/extension/lifecycle/install_sources.rs
+++ b/src/core/extension/lifecycle/install_sources.rs
@@ -5,6 +5,7 @@
 //! assets, and linking a local source directory. Kept in a sibling module so
 //! the lifecycle root stays under the structural line/item thresholds (#5241).
 
+use serde::Deserialize;
 use std::path::Path;
 
 use crate::core::agent_runtime_manifest::validate_installed_extension_agent_runtime_provider_discovery;
@@ -21,6 +22,55 @@ use super::{
     derive_id_from_url, manifest_path_for_extension, slugify_id, write_source_metadata,
     InstallResult,
 };
+
+#[derive(Debug, Deserialize)]
+struct ExtensionRootManifest {
+    #[serde(default)]
+    shared_assets: Vec<SharedAssetDeclaration>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum SharedAssetDeclaration {
+    Path(String),
+    Object { path: String },
+}
+
+impl SharedAssetDeclaration {
+    fn into_path(self) -> String {
+        match self {
+            SharedAssetDeclaration::Path(path) => path,
+            SharedAssetDeclaration::Object { path } => path,
+        }
+    }
+}
+
+pub(crate) fn shared_assets_for_root(source_root: &Path) -> Vec<String> {
+    let declared = std::fs::read_to_string(source_root.join("homeboy-extension-root.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<ExtensionRootManifest>(&raw).ok())
+        .map(|manifest| {
+            manifest
+                .shared_assets
+                .into_iter()
+                .map(SharedAssetDeclaration::into_path)
+                .map(|path| path.trim().to_string())
+                .filter(|path| !path.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !declared.is_empty() {
+        return declared;
+    }
+
+    vec![
+        "scripts/lib".to_string(),
+        "dependency-adapters".to_string(),
+        "agent-runtimes".to_string(),
+        "runtime-agent-ci".to_string(),
+        "agent-task-contracts".to_string(),
+    ]
+}
 
 pub(super) fn install_configured_extension(
     source: &str,
@@ -243,25 +293,19 @@ fn install_shared_assets_from_root(
         return Ok(());
     };
 
-    for shared_dir in [
-        "scripts/lib",
-        "dependency-adapters",
-        "agent-runtimes",
-        "runtime-agent-ci",
-        "agent-task-contracts",
-    ] {
-        let source = source_root.join(shared_dir);
+    for shared_dir in shared_assets_for_root(source_root) {
+        let source = source_root.join(&shared_dir);
         if !source.is_dir() {
             continue;
         }
 
-        let target = match shared_dir {
+        let target = match shared_dir.as_str() {
             "agent-runtimes" => paths::agent_runtimes()?,
-            "runtime-agent-ci" | "agent-task-contracts" => paths::homeboy()?.join(shared_dir),
-            "dependency-adapters" => extensions_dir.join(shared_dir),
+            "runtime-agent-ci" | "agent-task-contracts" => paths::homeboy()?.join(&shared_dir),
+            "dependency-adapters" => extensions_dir.join(&shared_dir),
             // Shared extension libraries install under the extensions root so
             // installed wrappers can source `../../../scripts/lib/...`.
-            _ => extensions_dir.join(shared_dir),
+            _ => extensions_dir.join(&shared_dir),
         };
         if let Some(parent) = target.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
@@ -271,11 +315,11 @@ fn install_shared_assets_from_root(
                 )
             })?;
         }
-        remove_existing_target(&target, shared_dir)?;
+        remove_existing_target(&target, &shared_dir)?;
 
         match mode {
             SharedAssetMode::Copy => copy_dir_recursive(&source, &target)?,
-            SharedAssetMode::Symlink => symlink_shared_asset(&source, &target, shared_dir)?,
+            SharedAssetMode::Symlink => symlink_shared_asset(&source, &target, &shared_dir)?,
         }
     }
 

--- a/src/core/extension/lifecycle/mod.rs
+++ b/src/core/extension/lifecycle/mod.rs
@@ -255,14 +255,8 @@ fn copy_shared_refresh_assets(source_root: Option<&Path>, durable_root: &Path) -
         return Ok(());
     };
 
-    for shared_dir in [
-        "scripts/lib",
-        "dependency-adapters",
-        "agent-runtimes",
-        "runtime-agent-ci",
-        "agent-task-contracts",
-    ] {
-        let source = source_root.join(shared_dir);
+    for shared_dir in install_sources::shared_assets_for_root(source_root) {
+        let source = source_root.join(&shared_dir);
         if source.is_dir() {
             copy_dir_recursive(&source, &durable_root.join(shared_dir))?;
         }

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -1,6 +1,7 @@
 use crate::core::engine::local_files;
 use crate::core::error::{Error, Result};
 use crate::core::paths;
+use serde::Deserialize;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -20,7 +21,6 @@ pub const RESOLVE_CONTEXT_ENV: &str = "HOMEBOY_RUNTIME_RESOLVE_CONTEXT";
 pub const DISPOSABLE_LOCAL_DB_ENV: &str = "HOMEBOY_RUNTIME_DISPOSABLE_LOCAL_DB";
 pub const BENCH_HELPER_SH_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_SH";
 pub const BENCH_HELPER_JS_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_JS";
-pub const BENCH_HELPER_PHP_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_PHP";
 
 struct RuntimeHelper {
     filename: &'static str,
@@ -108,13 +108,16 @@ const HELPERS: &[RuntimeHelper] = &[
         env_var: BENCH_HELPER_JS_ENV,
         legacy_fallback: true,
     },
-    RuntimeHelper {
-        filename: "bench-helper.php",
-        content: assets::BENCH_HELPER_PHP,
-        env_var: BENCH_HELPER_PHP_ENV,
-        legacy_fallback: true,
-    },
 ];
+
+#[derive(Debug, Deserialize)]
+struct DeclaredRuntimeHelper {
+    filename: String,
+    source: String,
+    env_var: String,
+    #[serde(default)]
+    legacy_fallback: bool,
+}
 
 /// Write a single runtime helper to disk if it's missing or stale.
 fn ensure_helper(runtime_dir: &std::path::Path, helper: &RuntimeHelper) -> Result<PathBuf> {
@@ -130,6 +133,43 @@ fn ensure_helper(runtime_dir: &std::path::Path, helper: &RuntimeHelper) -> Resul
     }
 
     Ok(helper_path)
+}
+
+fn ensure_declared_helper(
+    runtime_dir: &std::path::Path,
+    helper: &DeclaredRuntimeHelper,
+) -> Result<PathBuf> {
+    let source = PathBuf::from(&helper.source);
+    let content = fs::read_to_string(&source).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read declared runtime helper {}", source.display())),
+        )
+    })?;
+    let helper_path = runtime_dir.join(&helper.filename);
+    let current = fs::read_to_string(&helper_path).ok();
+    if current.as_deref() != Some(content.as_str()) {
+        local_files::write_file_atomic(
+            &helper_path,
+            &content,
+            &format!("write declared runtime helper {}", helper.filename),
+        )?;
+    }
+    Ok(helper_path)
+}
+
+fn declared_helpers() -> Result<Vec<DeclaredRuntimeHelper>> {
+    let Ok(raw) = env::var("HOMEBOY_RUNTIME_HELPERS_JSON") else {
+        return Ok(Vec::new());
+    };
+    serde_json::from_str(&raw).map_err(|e| {
+        Error::validation_invalid_argument(
+            "HOMEBOY_RUNTIME_HELPERS_JSON",
+            format!("declared runtime helpers JSON is invalid: {e}"),
+            None,
+            None,
+        )
+    })
 }
 
 #[cfg(not(windows))]
@@ -181,38 +221,40 @@ pub fn ensure_all_helpers() -> Result<Vec<(String, String)>> {
         ));
     }
 
+    for helper in declared_helpers()? {
+        let path = ensure_declared_helper(&runtime_dir, &helper)?;
+        if helper.legacy_fallback {
+            if let Some(ref legacy_dir) = legacy_runtime_dir {
+                ensure_declared_helper(legacy_dir, &helper)?;
+            }
+        }
+        env_pairs.push((helper.env_var, path.to_string_lossy().to_string()));
+    }
+
     Ok(env_pairs)
 }
 
 pub fn helper_path(name: &str) -> Result<PathBuf> {
     let normalized = name.trim();
-    let helper = HELPERS
-        .iter()
-        .find(|helper| helper.filename == normalized || helper.env_var == normalized)
+    let pairs = ensure_all_helpers()?;
+    let path = pairs
+        .into_iter()
+        .find_map(|(key, path)| {
+            let filename = PathBuf::from(&path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string);
+            (normalized == key || filename.as_deref() == Some(normalized)).then(|| PathBuf::from(path))
+        })
         .ok_or_else(|| {
             Error::validation_invalid_argument(
                 "helper",
                 format!("unknown runtime helper `{normalized}`"),
                 None,
-                Some(vec![format!(
-                    "Known helpers: {}",
-                    HELPERS
-                        .iter()
-                        .map(|helper| helper.filename)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )]),
+                Some(vec![
+                    "Known helpers are built-in helpers plus HOMEBOY_RUNTIME_HELPERS_JSON declarations".to_string(),
+                ]),
             )
-        })?;
-
-    let pairs = ensure_all_helpers()?;
-    let path = pairs
-        .into_iter()
-        .find_map(|(key, path)| (key == helper.env_var).then(|| PathBuf::from(path)))
-        .ok_or_else(|| {
-            Error::internal_unexpected(format!(
-                "runtime helper `{normalized}` was not materialized"
-            ))
         })?;
 
     if !path.is_file() {

--- a/src/core/extension/runtime_helper/assets.rs
+++ b/src/core/extension/runtime_helper/assets.rs
@@ -11,12 +11,6 @@ pub(super) const RESOLVE_CONTEXT_SH: &str = include_str!("../runtime/resolve-con
 pub(super) const DISPOSABLE_LOCAL_DB_SH: &str = include_str!("../runtime/disposable-local-db.sh");
 pub(super) const BENCH_HELPER_SH: &str = include_str!("../runtime/bench-helper.sh");
 pub(super) const BENCH_HELPER_JS: &str = include_str!("../runtime/bench-helper.mjs");
-pub(super) const BENCH_HELPER_PHP: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/assets/runtime/bench-helper.",
-    "p",
-    "hp"
-));
 
 #[cfg(test)]
 mod tests {
@@ -38,7 +32,6 @@ mod tests {
             DISPOSABLE_LOCAL_DB_SH,
             BENCH_HELPER_SH,
             BENCH_HELPER_JS,
-            BENCH_HELPER_PHP,
         ] {
             assert!(!content.trim().is_empty());
         }

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -57,10 +57,6 @@ fn ensure_all_helpers_writes_all_files() {
             pairs.iter().any(|(k, _)| k == BENCH_HELPER_JS_ENV),
             "bench JS helper should be in pairs"
         );
-        assert!(
-            pairs.iter().any(|(k, _)| k == BENCH_HELPER_PHP_ENV),
-            "bench PHP helper should be in pairs"
-        );
     });
 }
 
@@ -589,7 +585,6 @@ fn ensure_all_helpers_writes_legacy_bench_fallbacks() {
         for filename in [
             "bench-helper.sh".to_string(),
             "bench-helper.mjs".to_string(),
-            ["bench-helper.", "p", "hp"].concat(),
         ] {
             let path = home.path().join(".homeboy").join("runtime").join(filename);
             assert!(
@@ -979,13 +974,6 @@ if (result.code !== 0) throw new Error(`phase command failed: ${result.code}`);
 }
 
 #[test]
-fn bench_php_helper_documents_inventory_selection_and_artifact_helpers() {
-    assert!(assets::BENCH_HELPER_PHP.contains("function homeboy_bench_scenario_selected"));
-    assert!(assets::BENCH_HELPER_PHP.contains("function homeboy_bench_scenario_inventory_envelope"));
-    assert!(assets::BENCH_HELPER_PHP.contains("function homeboy_bench_artifact_ref"));
-}
-
-#[test]
 fn bench_js_helper_emits_compact_progress_to_stderr() {
     let dir = tempfile::tempdir().expect("tempdir");
     let helper_path = dir.path().join("bench-helper.mjs");
@@ -1047,7 +1035,6 @@ homeboyBenchProgress({ scenario: 'studio-agent-site-build', phase: 'setup' });
 fn bench_runtime_helpers_document_shared_contract() {
     for content in [
         assets::BENCH_HELPER_JS,
-        assets::BENCH_HELPER_PHP,
         assets::BENCH_HELPER_SH,
     ] {
         assert!(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -150,6 +150,7 @@ pub mod top_n;
 pub mod trace_compare;
 pub mod trace_experiment;
 pub mod trace_secrets;
+pub(crate) mod transient_workspace_policy;
 pub mod triage;
 pub mod tunnel;
 #[cfg(test)]

--- a/src/core/redaction.rs
+++ b/src/core/redaction.rs
@@ -12,7 +12,7 @@ pub struct RedactionPolicy {
 
 impl Default for RedactionPolicy {
     fn default() -> Self {
-        Self {
+        let mut policy = Self {
             sensitive_keys: [
                 "api_key",
                 "apikey",
@@ -43,13 +43,22 @@ impl Default for RedactionPolicy {
                 "x-api-key",
                 "x-auth-token",
                 "x-csrf-token",
-                "x-wp-nonce",
             ]
             .into_iter()
             .map(str::to_string)
             .collect(),
             replacement: DEFAULT_REPLACEMENT.to_string(),
+        };
+        if let Ok(raw) = std::env::var("HOMEBOY_REDACTION_SENSITIVE_HEADERS") {
+            for header in raw
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                policy = policy.with_sensitive_header(header);
+            }
         }
+        policy
     }
 }
 

--- a/src/core/rig/lint.rs
+++ b/src/core/rig/lint.rs
@@ -6,28 +6,15 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use serde::Deserialize;
+
 use super::install::read_source_metadata;
 use super::pipeline::{PipelineOutcome, PipelineStepOutcome};
 use super::spec::RigSpec;
 use crate::core::error::{Error, Result};
 
-/// Directories the rig package lint never descends into.
-///
-/// This MUST stay the union of the directories the downstream
-/// `homeboy-rigs` linter ignores (`scripts/lint-rig-packages.mjs`) so a rig
-/// package can never pass one linter and fail the other. `.sampleplugin` holds
-/// generated WP Codebox sample-plugin scaffolds; `.datamachine` is the
-/// top-level Data Machine working directory the homeboy-rigs package carries.
-const IGNORED_DIRECTORIES: &[&str] = &[
-    ".git",
-    ".homeboy",
-    ".claude",
-    ".sampleplugin",
-    ".datamachine",
-    ".opencode",
-    "node_modules",
-    "vendor",
-];
+/// Structural directories the generic rig package lint never descends into.
+const STRUCTURAL_IGNORED_DIRECTORIES: &[&str] = &[".git", ".homeboy"];
 
 pub fn run_package_lint(rig: &RigSpec) -> Result<PipelineOutcome> {
     let Some(root) = package_lint_root(rig) else {
@@ -38,6 +25,13 @@ pub fn run_package_lint(rig: &RigSpec) -> Result<PipelineOutcome> {
 }
 
 pub fn run_package_lint_at(root: &Path) -> Result<PipelineOutcome> {
+    run_package_lint_at_with_ignores(root, &[])
+}
+
+pub fn run_package_lint_at_with_ignores(
+    root: &Path,
+    package_ignores: &[String],
+) -> Result<PipelineOutcome> {
     if !root.is_dir() {
         return Err(Error::validation_invalid_argument(
             "source",
@@ -48,7 +42,10 @@ pub fn run_package_lint_at(root: &Path) -> Result<PipelineOutcome> {
     }
 
     let mut files = Vec::new();
-    collect_files(root, &mut files)?;
+    let mut declared_ignores = package_ignores.to_vec();
+    declared_ignores.extend(package_manifest_ignores(root)?);
+    let ignore_policy = IgnorePolicy::new(&declared_ignores);
+    collect_files(root, &mut files, &ignore_policy)?;
 
     let conflict_failures = conflict_marker_failures(root, &files)?;
     let json_failures = json_parse_failures(root, &files)?;
@@ -138,16 +135,23 @@ fn package_lint_root(rig: &RigSpec) -> Option<PathBuf> {
         .filter(|path| path.is_dir())
 }
 
-fn collect_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    if let Some(authored_files) = collect_git_authored_files(root)? {
+fn collect_files(
+    root: &Path,
+    files: &mut Vec<PathBuf>,
+    ignore_policy: &IgnorePolicy,
+) -> Result<()> {
+    if let Some(authored_files) = collect_git_authored_files(root, ignore_policy)? {
         files.extend(authored_files);
         return Ok(());
     }
 
-    collect_files_inner(root, files, "read rig package directory")
+    collect_files_inner(root, files, "read rig package directory", ignore_policy)
 }
 
-fn collect_git_authored_files(root: &Path) -> Result<Option<Vec<PathBuf>>> {
+fn collect_git_authored_files(
+    root: &Path,
+    ignore_policy: &IgnorePolicy,
+) -> Result<Option<Vec<PathBuf>>> {
     let Some(git_root) = crate::core::git::repo_root(root) else {
         return Ok(None);
     };
@@ -184,7 +188,7 @@ fn collect_git_authored_files(root: &Path) -> Result<Option<Vec<PathBuf>>> {
         .filter_map(|entry| std::str::from_utf8(entry).ok())
         .map(|entry| git_root.join(entry))
         .filter(|path| path.is_file())
-        .filter(|path| !has_ignored_directory(root.as_path(), path))
+        .filter(|path| !has_ignored_directory(root.as_path(), path, ignore_policy))
         .collect();
     Ok(Some(files))
 }
@@ -193,6 +197,7 @@ fn collect_files_inner(
     directory: &Path,
     files: &mut Vec<PathBuf>,
     context: &'static str,
+    ignore_policy: &IgnorePolicy,
 ) -> Result<()> {
     let entries = fs::read_dir(directory)
         .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
@@ -204,8 +209,8 @@ fn collect_files_inner(
             .file_type()
             .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
         if file_type.is_dir() {
-            if !ignored_directory(entry.file_name().as_os_str()) {
-                collect_files_inner(&path, files, context)?;
+            if !ignore_policy.ignored_directory(entry.file_name().as_os_str()) {
+                collect_files_inner(&path, files, context, ignore_policy)?;
             }
         } else if file_type.is_file() {
             files.push(path);
@@ -214,20 +219,68 @@ fn collect_files_inner(
     Ok(())
 }
 
-fn ignored_directory(name: &OsStr) -> bool {
-    IGNORED_DIRECTORIES
-        .iter()
-        .any(|ignored| name == OsStr::new(ignored))
+struct IgnorePolicy {
+    directories: BTreeSet<String>,
 }
 
-fn has_ignored_directory(root: &Path, path: &Path) -> bool {
+#[derive(Debug, Deserialize)]
+struct RigPackageLintManifest {
+    #[serde(default)]
+    lint_ignore_directories: Vec<String>,
+}
+
+fn package_manifest_ignores(root: &Path) -> Result<Vec<String>> {
+    let manifest = root.join("homeboy-rig-package.json");
+    if !manifest.is_file() {
+        return Ok(Vec::new());
+    }
+    let raw = fs::read_to_string(&manifest).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read {}", manifest.display())),
+        )
+    })?;
+    let parsed: RigPackageLintManifest = serde_json::from_str(&raw).map_err(|error| {
+        Error::validation_invalid_argument(
+            "homeboy-rig-package.json",
+            format!("rig package lint manifest is invalid: {error}"),
+            Some(manifest.to_string_lossy().to_string()),
+            None,
+        )
+    })?;
+    Ok(parsed.lint_ignore_directories)
+}
+
+impl IgnorePolicy {
+    fn new(package_ignores: &[String]) -> Self {
+        let mut directories = STRUCTURAL_IGNORED_DIRECTORIES
+            .iter()
+            .map(|value| value.to_string())
+            .collect::<BTreeSet<_>>();
+        directories.extend(
+            package_ignores
+                .iter()
+                .filter(|value| !value.trim().is_empty())
+                .cloned(),
+        );
+        Self { directories }
+    }
+
+    fn ignored_directory(&self, name: &OsStr) -> bool {
+        self.directories
+            .iter()
+            .any(|ignored| name == OsStr::new(ignored))
+    }
+}
+
+fn has_ignored_directory(root: &Path, path: &Path, ignore_policy: &IgnorePolicy) -> bool {
     path.strip_prefix(root)
         .unwrap_or(path)
         .parent()
         .map(|parent| {
             parent
                 .components()
-                .any(|component| ignored_directory(component.as_os_str()))
+                .any(|component| ignore_policy.ignored_directory(component.as_os_str()))
         })
         .unwrap_or(false)
 }
@@ -745,7 +798,7 @@ mod tests {
 
     #[test]
     fn lint_ignores_homeboy_metadata_directory() {
-        assert!(ignored_directory(OsStr::new(".homeboy")));
+        assert!(IgnorePolicy::new(&[]).ignored_directory(OsStr::new(".homeboy")));
     }
 
     #[test]

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -220,7 +220,7 @@ fn runner_provider_unavailable_reason(
             candidate_ids.len(),
             candidate_ids.join(", ")
         )),
-        ProviderResolution::SelectorMismatch { available_ids } => Some(format!(
+        ProviderResolution::SelectorMismatch { available_ids, .. } => Some(format!(
             "backend `{}` matches runner providers ({}), but selector/id `{}` does not match any of them",
             selection.backend,
             available_ids.join(", "),

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -2343,6 +2343,7 @@ HOMEBOY_SHARED_MISSING_SECRET_TEST, HOMEBOY_OTHER_MISSING_SECRET_TEST"
             lab_runtime_components: Vec::new(),
             timeout_artifact_discovery: Default::default(),
             role_aliases: Default::default(),
+            cli: Default::default(),
             result_contract: Default::default(),
             runtime_contract: Default::default(),
             extension_id: None,

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -725,7 +725,7 @@ mod provider_config_remap_tests {
         let err =
             remap_provider_config_in_args(&args, &[]).expect_err("malformed @file should fail");
 
-        assert_eq!(err.to_string(), "Invalid JSON");
+        assert!(err.to_string().starts_with("Invalid JSON"));
         assert!(
             err.hints.iter().any(|hint| hint
                 .message

--- a/src/core/transient_workspace_policy.rs
+++ b/src/core/transient_workspace_policy.rs
@@ -1,0 +1,53 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TransientWorkspacePolicy {
+    markers: Vec<String>,
+}
+
+impl Default for TransientWorkspacePolicy {
+    fn default() -> Self {
+        Self {
+            markers: vec!["tmp".to_string(), "Temp".to_string(), "T".to_string()],
+        }
+    }
+}
+
+impl TransientWorkspacePolicy {
+    pub(crate) fn current() -> Self {
+        let mut policy = Self::default();
+        if let Ok(raw) = std::env::var("HOMEBOY_TRANSIENT_WORKSPACE_MARKERS") {
+            for marker in raw
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                if !policy.markers.iter().any(|existing| existing == marker) {
+                    policy.markers.push(marker.to_string());
+                }
+            }
+        }
+        policy
+    }
+
+    pub(crate) fn is_transient_path(&self, path: &Path) -> bool {
+        crate::core::paths::path_component_strings(path)
+            .iter()
+            .any(|segment| self.markers.iter().any(|marker| marker == segment))
+    }
+
+    pub(crate) fn stable_root_before_marker(&self, path: &Path) -> Option<PathBuf> {
+        let mut root = PathBuf::new();
+        for segment in crate::core::paths::path_component_strings(path) {
+            if self.markers.iter().any(|marker| marker == &segment) {
+                return if root.as_os_str().is_empty() {
+                    None
+                } else {
+                    Some(root)
+                };
+            }
+            root.push(segment);
+        }
+        None
+    }
+}

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -772,6 +772,11 @@ mod install_flows {
         let _home = HomeGuard::new();
         let package = tempfile::tempdir().expect("package");
         write_rig(package.path(), "lint-dm", &minimal_rig("lint-dm"));
+        fs::write(
+            package.path().join("homeboy-rig-package.json"),
+            r#"{"lint_ignore_directories":[".datamachine"]}"#,
+        )
+        .expect("write rig package manifest");
         let datamachine = package.path().join(".datamachine");
         fs::create_dir_all(&datamachine).expect("datamachine dir");
         fs::write(datamachine.join("notes.txt"), "<<<<<<< ours\n")


### PR DESCRIPTION
## Summary

Part of #6855. Related #2240.

This PR removes the audited product/runtime/framework hardcodes from Homeboy core by moving them behind provider metadata, declared helper registries, package/root manifests, and generic config seams.

## Violation to fix

| Violation | Fix |
| --- | --- |
| Runtime/provider selector hints hardcoded in core (`codex`, `opencode`, `claude-code`) | Added provider-declared `cli.reserved_selector_hints`; resolution carries provider-declared selector hints into diagnostics without core naming runtimes. |
| Hardcoded `AgentTaskProviderProfile::OpencodeCodexGpt55` and OpenCode/GPT-5.5 disclosure defaults | Replaced the enum with string profile names resolved from provider-declared `cli.profiles`; default disclosure is provider-declared with generic fallback `AI-assisted`. |
| CLI/help text names specific runtimes as examples | Reworded touched agent-task dispatch/profile help and explainer output to point operators at `agent-task providers` and provider config without naming runtimes. |
| Transient workspace checks know `/opencode/` | Added one `TransientWorkspacePolicy` with generic defaults and env-declared marker/root append seams; path diagnostics and self-artifact cleanup share it. |
| Core embeds `bench-helper.php` and exports a PHP-specific helper asset | Removed the embedded PHP helper from core; added `HOMEBOY_RUNTIME_HELPERS_JSON` declared-helper materialization so extension-owned helpers can be exported under declared env vars. |
| Rig lint ignores extension/package/runtime directories in core | Core now only structurally ignores `.git` and `.homeboy`; package-specific ignores are declared in `homeboy-rig-package.json` via `lint_ignore_directories`. |
| Redaction defaults include WordPress-specific `x-wp-nonce` | Removed `x-wp-nonce` from core defaults and added generic `HOMEBOY_REDACTION_SENSITIVE_HEADERS` append seam. |
| Extension lifecycle hardcodes shared asset directory names | Added root manifest support via `homeboy-extension-root.json` `shared_assets`; install and durable refresh copy/symlink only declared shared assets, with current list retained as a transitional fallback when no root manifest exists. |

## Follow-ups

- homeboy-extensions should declare `cli.reserved_selector_hints`, `cli.profiles`, and `cli.default_ai_disclosure` on its agent runtime provider manifests so existing operator profiles/disclosure labels remain available through declared data.
- homeboy-extensions should provide the former PHP bench helper as an extension-owned declared runtime helper through `HOMEBOY_RUNTIME_HELPERS_JSON` or a follow-up manifest-to-env bridge.
- homeboy-rigs packages should add `homeboy-rig-package.json` with package-specific `lint_ignore_directories` such as `.datamachine`, `.sampleplugin`, `.claude`, `.opencode`, `node_modules`, and `vendor` where applicable.
- WordPress-aware extensions/config should append `x-wp-nonce` through `HOMEBOY_REDACTION_SENSITIVE_HEADERS` until a richer extension redaction-policy manifest field is wired.
- homeboy-extensions should add `homeboy-extension-root.json` with the current shared asset dirs (`scripts/lib`, `dependency-adapters`, `agent-runtimes`, `runtime-agent-ci`, `agent-task-contracts`) so core’s transitional fallback can be removed.

## Verification

- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(agent_task_provider) or test(path_diagnostics) or test(runtime_helper) or test(rig) or test(redaction) or test(lifecycle) or test(install_sources) or test(args)' --no-fail-fast` (1014 passed, 5909 skipped)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Purged runtime/product/framework hardcodes from Homeboy core behind declared-data seams; Chris reviews and owns the change.
