### PR TITLE
Derive Title-Kebab-Case rename variants

### DIFF
--- a/src/core/refactor/rename/casing.rs
+++ b/src/core/refactor/rename/casing.rs
@@ -93,6 +93,15 @@ pub(super) fn join_kebab(words: &[String]) -> String {
     words.join("-")
 }
 
+/// Join words as Title-Kebab-Case: `["sample", "plugin", "agent"]` → `"Sample-Plugin-Agent"`
+pub(super) fn join_title_kebab(words: &[String]) -> String {
+    words
+        .iter()
+        .map(|w| capitalize(w))
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
 /// Join words as snake_case: `["sample", "plugin", "agent"]` → `"sample_plugin_agent"`
 pub(super) fn join_snake(words: &[String]) -> String {
     words.join("_")

--- a/src/core/refactor/rename/tests.rs
+++ b/src/core/refactor/rename/tests.rs
@@ -852,6 +852,10 @@ fn cross_separator_variants_from_kebab() {
 
     // Singular forms — all naming conventions
     assert!(from_values.contains(&"wp-agent"), "Missing kebab from");
+    assert!(
+        from_values.contains(&"Wp-Agent"),
+        "Missing Title-Kebab-Case from"
+    );
     assert!(from_values.contains(&"wp_agent"), "Missing snake from");
     assert!(
         from_values.contains(&"WP_AGENT"),
@@ -868,6 +872,10 @@ fn cross_separator_variants_from_kebab() {
     assert!(
         to_values.contains(&"sample-plugin-agent"),
         "Missing kebab to"
+    );
+    assert!(
+        to_values.contains(&"Sample-Plugin-Agent"),
+        "Missing Title-Kebab-Case to"
     );
     assert!(
         to_values.contains(&"sample_plugin_agent"),
@@ -900,6 +908,10 @@ fn cross_separator_variants_from_kebab() {
         "Missing plural kebab from"
     );
     assert!(
+        from_values.contains(&"Wp-Agents"),
+        "Missing plural Title-Kebab-Case from"
+    );
+    assert!(
         from_values.contains(&"wp_agents"),
         "Missing plural snake from"
     );
@@ -924,6 +936,10 @@ fn cross_separator_variants_from_pascal() {
     let from_values: Vec<&str> = spec.variants.iter().map(|v| v.from.as_str()).collect();
 
     assert!(from_values.contains(&"wp-agent"), "Missing kebab from");
+    assert!(
+        from_values.contains(&"Wp-Agent"),
+        "Missing Title-Kebab-Case from"
+    );
     assert!(from_values.contains(&"wp_agent"), "Missing snake from");
     assert!(
         from_values.contains(&"WP_AGENT"),
@@ -940,6 +956,10 @@ fn cross_separator_variants_from_snake() {
     let from_values: Vec<&str> = spec.variants.iter().map(|v| v.from.as_str()).collect();
 
     assert!(from_values.contains(&"wp-agent"), "Missing kebab from");
+    assert!(
+        from_values.contains(&"Wp-Agent"),
+        "Missing Title-Kebab-Case from"
+    );
     assert!(from_values.contains(&"wp_agent"), "Missing snake from");
     assert!(
         from_values.contains(&"WP_AGENT"),
@@ -1086,6 +1106,56 @@ fn title_snake_variant_renames_wordpress_class_names() {
         "{}",
         content
     );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn title_kebab_variant_renames_hyphenated_doc_comments() {
+    let dir = std::env::temp_dir().join("homeboy_title_kebab_variant_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    std::fs::write(
+        dir.join("plugin.php"),
+        "// Studio-Native-shaped site_spec\n",
+    )
+    .unwrap();
+
+    let spec = RenameSpec::new("studio-native", "wp-build", RenameScope::All);
+    let result = generate_renames(&spec, &dir);
+    assert_eq!(result.edits.len(), 1);
+    let content = &result.edits[0].new_content;
+
+    assert!(content.contains("Wp-Build-shaped"), "{}", content);
+    assert!(!content.contains("Studio-Native-shaped"), "{}", content);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn explicit_variant_overrides_title_kebab_auto_variant() {
+    let dir = std::env::temp_dir().join("homeboy_title_kebab_explicit_variant_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    std::fs::write(
+        dir.join("plugin.php"),
+        "// Studio-Native-shaped site_spec\n",
+    )
+    .unwrap();
+
+    let spec =
+        RenameSpec::new("studio-native", "wp-build", RenameScope::All).with_explicit_variants(
+            vec![("Studio-Native".to_string(), "WordPress-Build".to_string())],
+        );
+    let result = generate_renames(&spec, &dir);
+    assert_eq!(result.edits.len(), 1);
+    let content = &result.edits[0].new_content;
+
+    assert!(content.contains("WordPress-Build-shaped"), "{}", content);
+    assert!(!content.contains("Wp-Build-shaped"), "{}", content);
+    assert!(!content.contains("Studio-Native-shaped"), "{}", content);
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/src/core/refactor/rename/types.rs
+++ b/src/core/refactor/rename/types.rs
@@ -4,8 +4,8 @@ use crate::core::error::{Error, Result};
 use serde::Serialize;
 
 use super::casing::{
-    join_camel, join_display, join_kebab, join_pascal, join_snake, join_title_snake,
-    join_upper_snake, pluralize, split_words,
+    join_camel, join_display, join_kebab, join_pascal, join_snake, join_title_kebab,
+    join_title_snake, join_upper_snake, pluralize, split_words,
 };
 
 // ============================================================================
@@ -240,6 +240,7 @@ impl RenameSpec {
     /// all standard naming convention variants:
     ///
     /// - `kebab-case` (e.g., `sample-plugin-agent`)
+    /// - `Title-Kebab-Case` (e.g., `Sample-Plugin-Agent`)
     /// - `snake_case` (e.g., `sample_plugin_agent`)
     /// - `UPPER_SNAKE` (e.g., `SAMPLE_PLUGIN_AGENT`)
     /// - `Title_Snake_Case` (e.g., `Sample_Plugin_Agent`)
@@ -268,8 +269,9 @@ impl RenameSpec {
         // to the same thing, and dedup handles it naturally.
         if !from_words.is_empty() && !to_words.is_empty() {
             // Singular forms — all naming conventions
-            let join_fns: [fn(&[String]) -> String; 7] = [
+            let join_fns: [fn(&[String]) -> String; 8] = [
                 join_kebab,
+                join_title_kebab,
                 join_snake,
                 join_upper_snake,
                 join_title_snake,
@@ -279,6 +281,7 @@ impl RenameSpec {
             ];
             let labels = [
                 "kebab",
+                "Title-Kebab-Case",
                 "snake_case",
                 "UPPER_SNAKE",
                 "Title_Snake_Case",


### PR DESCRIPTION
Fixes #7567

## Summary
- Adds a generated Title-Kebab-Case rename variant (`Studio-Native` -> `Wp-Build`) and plural form.
- Keeps the new variant in the shared derivation/dedupe path so longer-from-first ordering and explicit `--variant` precedence continue to apply.
- Adds coverage for automatic Title-Kebab replacement and explicit override behavior.

## Verification
- `cargo fmt`
- `cargo test refactor -- --test-threads=1`
- `cargo clippy` (completed successfully; existing warnings are outside touched files)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Anthropic) via Claude Code / opencode agent
- **Used for:** Implementation and test authoring, reviewed and directed by Chris Huber