### PR TITLE
Content-edit repo-config dotfiles and prune emptied dirs after rename moves

### DIFF
--- a/src/core/refactor/rename/engine.rs
+++ b/src/core/refactor/rename/engine.rs
@@ -5,7 +5,7 @@ use crate::core::engine::codebase_scan::{
     ExtensionFilter, ScanConfig,
 };
 use crate::core::error::{Error, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use super::safety::detect_collisions;
@@ -14,6 +14,23 @@ use super::types::{
     RenameSpec, RenameTargeting,
 };
 use std::cmp::Reverse;
+
+const REPO_CONFIG_DOTFILES: &[&str] = &[
+    ".dockerignore",
+    ".editorconfig",
+    ".eslintignore",
+    ".eslintrc",
+    ".gitattributes",
+    ".gitignore",
+    ".gitmodules",
+    ".markdownlintignore",
+    ".npmrc",
+    ".prettierignore",
+    ".prettierrc",
+    ".stylelintignore",
+    ".stylelintrc",
+    ".yarnrc",
+];
 
 // Boundary matching and literal matching are provided by crate::core::engine::codebase_scan.
 // See: find_boundary_matches(), find_literal_matches()
@@ -85,7 +102,7 @@ pub fn find_references_with_targeting(
     } else {
         scan_config_for_scope(&spec.scope)
     };
-    let files = target_files(codebase_scan::walk_files(root, &config), root, targeting);
+    let files = content_scan_files(root, &config, &spec.scope, targeting);
 
     // Build the working variant list — may be extended by discovery
     let mut all_variants = spec.variants.clone();
@@ -238,7 +255,7 @@ pub fn generate_renames_with_targeting(
 ) -> RenameResult {
     let references = find_references_with_targeting(spec, root, targeting);
     let config = scan_config_for_scope(&spec.scope);
-    let files = target_files(codebase_scan::walk_files(root, &config), root, targeting);
+    let files = content_scan_files(root, &config, &spec.scope, targeting);
     let path_rename_files = target_files(
         codebase_scan::walk_files(root, &scan_config_for_path_renames()),
         root,
@@ -358,6 +375,38 @@ pub fn generate_renames_with_targeting(
     }
 }
 
+fn content_scan_files(
+    root: &Path,
+    config: &ScanConfig,
+    scope: &RenameScope,
+    targeting: &RenameTargeting,
+) -> Vec<PathBuf> {
+    let mut files = target_files(codebase_scan::walk_files(root, config), root, targeting);
+
+    if !matches!(scope, RenameScope::Config | RenameScope::All) {
+        return files;
+    }
+
+    let mut seen: HashSet<PathBuf> = files.iter().cloned().collect();
+    let repo_config_files =
+        codebase_scan::walk_entries(root, &ScanConfig::default(), |name, is_dir| {
+            !is_dir && REPO_CONFIG_DOTFILES.contains(&name)
+        })
+        .into_iter()
+        .filter_map(|entry| match entry {
+            codebase_scan::WalkEntry::File(path) => Some(path),
+            codebase_scan::WalkEntry::Dir(_) => None,
+        });
+
+    for file in target_files(repo_config_files.collect(), root, targeting) {
+        if seen.insert(file.clone()) {
+            files.push(file);
+        }
+    }
+
+    files
+}
+
 fn rename_path_segments(path: &str, variants: &[CaseVariant]) -> String {
     path.split('/')
         .map(|segment| {
@@ -460,8 +509,51 @@ pub fn apply_renames(result: &mut RenameResult, root: &Path) -> Result<()> {
                 Some("rename.apply".to_string()),
             ));
         }
+
+        prune_empty_renamed_source_dirs(&result.file_renames, root);
     }
 
     result.applied = true;
     Ok(())
+}
+
+fn prune_empty_renamed_source_dirs(file_renames: &[FileRename], root: &Path) {
+    let mut source_dirs: Vec<PathBuf> = file_renames
+        .iter()
+        .filter_map(|rename| root.join(&rename.from).parent().map(Path::to_path_buf))
+        .collect();
+
+    source_dirs.sort_by_key(|path| Reverse(path.components().count()));
+    source_dirs.dedup();
+
+    for dir in source_dirs {
+        remove_empty_parents(&dir, root);
+    }
+}
+
+fn remove_empty_parents(dir: &Path, root: &Path) {
+    let mut current = dir;
+
+    while current != root && current.starts_with(root) {
+        if !current.is_dir() {
+            break;
+        }
+
+        match std::fs::read_dir(current) {
+            Ok(mut entries) => {
+                if entries.next().is_some() {
+                    break;
+                }
+                if std::fs::remove_dir(current).is_err() {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        current = parent;
+    }
 }

--- a/src/core/refactor/rename/tests.rs
+++ b/src/core/refactor/rename/tests.rs
@@ -245,6 +245,76 @@ fn path_renames_include_skipped_content_files_in_renamed_directory() {
 }
 
 #[test]
+fn repo_config_dotfiles_are_content_edited() {
+    let dir = std::env::temp_dir().join("homeboy_refactor_repo_config_dotfile_edit_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    std::fs::write(
+        dir.join(".gitignore"),
+        "plugins/host/studio-native/build/\nplugins/host/studio-native/assets/\n",
+    )
+    .unwrap();
+
+    let spec = RenameSpec::literal("studio-native", "wp-build", RenameScope::All);
+    let mut result = generate_renames(&spec, &dir);
+
+    let edit = result
+        .edits
+        .iter()
+        .find(|edit| edit.file == ".gitignore")
+        .expect(".gitignore should be content-edit eligible");
+    assert!(edit.new_content.contains("plugins/host/wp-build/build/"));
+    assert!(!edit.new_content.contains("studio-native"));
+
+    apply_renames(&mut result, &dir).unwrap();
+
+    let content = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
+    assert_eq!(
+        content,
+        "plugins/host/wp-build/build/\nplugins/host/wp-build/assets/\n"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn path_renames_prune_emptied_source_directories() {
+    let dir = std::env::temp_dir().join("homeboy_refactor_prune_empty_source_dirs_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("plugins/host/studio-native/assets")).unwrap();
+    std::fs::create_dir_all(dir.join("plugins/host/studio-native/build/js")).unwrap();
+
+    std::fs::write(
+        dir.join("plugins/host/studio-native/assets/studio-native-logo.svg"),
+        "<svg></svg>\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("plugins/host/studio-native/build/js/app.js"),
+        "console.log('ok');\n",
+    )
+    .unwrap();
+
+    let spec = RenameSpec::literal("studio-native", "wp-build", RenameScope::All);
+    let mut result = generate_renames(&spec, &dir);
+
+    apply_renames(&mut result, &dir).unwrap();
+
+    assert!(dir
+        .join("plugins/host/wp-build/assets/wp-build-logo.svg")
+        .exists());
+    assert!(dir.join("plugins/host/wp-build/build/js/app.js").exists());
+    assert!(!dir.join("plugins/host/studio-native/assets").exists());
+    assert!(!dir.join("plugins/host/studio-native/build/js").exists());
+    assert!(!dir.join("plugins/host/studio-native/build").exists());
+    assert!(!dir.join("plugins/host/studio-native").exists());
+    assert!(dir.join("plugins/host").exists());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn path_renames_preserve_intermediate_segments_under_renamed_ancestor() {
     let dir = std::env::temp_dir().join("homeboy_refactor_nested_path_segment_test");
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
Fixes #7566

## Root cause
- Rename content scanning used the normal source/config extension filter, so extensionless repo-config dotfiles like .gitignore and .gitattributes were excluded even under --scope all/config.
- Path moves used the shared move operation successfully, but no post-move cleanup removed empty source parent directories after every child moved away.

## Fix
- Supplement rename content scans for config/all scope with a small allowlist of known text repo-config dotfiles, without making arbitrary extensionless or binary files content-edit eligible.
- After successful path moves, prune empty source parent directories recursively up to, but not including, the rename root.

## Tests
- repo_config_dotfiles_are_content_edited
- path_renames_prune_emptied_source_directories

## Verification
- cargo fmt
- cargo test refactor -- --test-threads=1
- cargo clippy (passes; existing repo-wide warnings remain outside touched rename code)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Anthropic) via Claude Code / opencode agent
- **Used for:** Root-cause analysis, fix implementation, and test authoring, reviewed and directed by Chris Huber