### PR TITLE
Fix remote daemon handshake parsing with noisy stdout

### DIFF
--- a/src/core/api_jobs/persistence.rs
+++ b/src/core/api_jobs/persistence.rs
@@ -71,8 +71,37 @@ pub(super) fn write_durable_store(path: &Path, durable: &DurableJobStore) -> Res
             Some("serialize daemon job store".to_string()),
         )
     })?;
-    fs::write(path, body)
-        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("write {}", path.display()))))
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let temp_path = parent.join(format!(
+        ".{}.tmp-{}-{}",
+        path.file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("jobs.json"),
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    fs::write(&temp_path, body).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("write {}", temp_path.display())),
+        )
+    })?;
+    if let Ok(file) = fs::File::open(&temp_path) {
+        file.sync_all().map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("sync {}", temp_path.display())))
+        })?;
+    }
+    fs::rename(&temp_path, path).map_err(|e| {
+        let _ = fs::remove_file(&temp_path);
+        Error::internal_io(
+            e.to_string(),
+            Some(format!(
+                "rename {} to {}",
+                temp_path.display(),
+                path.display()
+            )),
+        )
+    })
 }
 
 pub(super) fn reconcile_stale_jobs(

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1110,7 +1110,29 @@ mod remote_daemon {
     }
 
     pub(super) fn parse_envelope(stdout: &str) -> serde_json::Result<CliEnvelope> {
-        serde_json::from_str(stdout.trim())
+        parse_json_from_mixed_stdout(stdout)
+    }
+
+    pub(crate) fn parse_json_from_mixed_stdout<T>(stdout: &str) -> serde_json::Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        match serde_json::from_str(stdout.trim()) {
+            Ok(value) => Ok(value),
+            Err(original) => {
+                for (index, ch) in stdout.char_indices() {
+                    if ch != '{' {
+                        continue;
+                    }
+                    let mut stream =
+                        serde_json::Deserializer::from_str(&stdout[index..]).into_iter();
+                    if let Some(Ok(value)) = stream.next() {
+                        return Ok(value);
+                    }
+                }
+                Err(original)
+            }
+        }
     }
 
     pub(super) fn parse_loopback_daemon_addr(address: &str) -> std::result::Result<SocketAddr, ()> {
@@ -1341,6 +1363,24 @@ mod tests {
                 .get("address")
                 .unwrap(),
             "127.0.0.1:49152"
+        );
+    }
+
+    #[test]
+    fn parses_daemon_envelope_after_noisy_stdout_preamble() {
+        let envelope = parse_envelope(
+            "Setting up Swift test infrastructure...\nSwift unavailable; Swift extension installed but not ready...\n{\"success\":true,\"data\":{\"action\":\"start\",\"address\":\"127.0.0.1:49152\",\"pid\":123,\"lease_id\":\"lease-1\"}}\n",
+        )
+        .expect("parse envelope after preamble");
+
+        assert!(envelope.success);
+        assert_eq!(
+            envelope
+                .data
+                .unwrap()
+                .get("address")
+                .and_then(Value::as_str),
+            Some("127.0.0.1:49152")
         );
     }
 

--- a/src/core/runner/connection_daemon.rs
+++ b/src/core/runner/connection_daemon.rs
@@ -13,6 +13,7 @@ use super::{
     failed_connect, open_loopback_tunnel, parse_loopback_daemon_addr, remote_daemon_start,
     remote_daemon_stop, reserve_loopback_port, terminate_pid, wait_for_tcp, RemoteDaemon,
 };
+use crate::core::runner::connection::remote_daemon::parse_json_from_mixed_stdout;
 use crate::core::runner::daemon_freshness::repair_or_fail;
 use crate::core::runner::{RunnerConnectReport, RunnerFailureKind};
 use std::collections::BTreeMap;
@@ -216,8 +217,10 @@ fn daemon_http_body(local_url: &str) -> std::result::Result<Value, String> {
         .send()
         .map_err(|err| format!("query remote daemon version: {err}"))?;
     let status_code = response.status().as_u16();
-    let body: Value = response
-        .json()
+    let body_text = response
+        .text()
+        .map_err(|err| format!("read remote daemon version response: {err}"))?;
+    let body: Value = parse_json_from_mixed_stdout(&body_text)
         .map_err(|err| format!("parse remote daemon version response: {err}"))?;
     if status_code >= 400 {
         return Err(format!(


### PR DESCRIPTION
## Summary
- Fixes #7571
- Parse daemon CLI JSON envelopes from mixed stdout so extension/setup preamble does not break remote daemon status/start handshakes.
- Parse daemon HTTP /version bodies through the same tolerant JSON extractor.
- Harden daemon jobs.json persistence with temp-file + sync + rename writes to avoid truncated durable state after interruption.

## Root cause
Remote runner daemon status/start parsing used strict serde_json::from_str(stdout.trim()) in src/core/runner/connection.rs, and /version parsing used reqwest JSON parsing in src/core/runner/connection_daemon.rs. Any non-protocol stdout preamble before the JSON envelope made the controller fail the handshake.

## Verification
- rustfmt applied to touched files
- cargo test core::runner::connection:: -- --test-threads=1
- cargo test core::api_jobs:: -- --test-threads=1
- cargo test core::runner::broker_auth:: -- --test-threads=1 (combined-worktree affected verification)
- cargo test core::daemon::remote_runner:: -- --test-threads=1 (combined-worktree affected verification)
- cargo clippy --all-targets --all-features completed with existing repo-wide warnings; no new warning from this change after fixing the parser warning
- cargo test -- --test-threads=1 completed but failed 14 unrelated baseline/environment-sensitive tests outside this change; failures noted in local run output

## jobs.json corruption note
write_durable_store previously used fs::write directly for daemon/jobs.json. This PR switches to writing a unique temp file, syncing it, and renaming it into place so a crash/interruption does not leave a partial jobs.json that later gets quarantined as corrupt.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Anthropic) via Claude Code / opencode agent
- **Used for:** Root-cause analysis, fix implementation, and test authoring, reviewed and directed by Chris Huber