### PR TITLE
Install broker credentials during SSH runner pairing

### DIFF
--- a/src/commands/runner/broker.rs
+++ b/src/commands/runner/broker.rs
@@ -1,4 +1,6 @@
+use homeboy::core::engine::shell;
 use homeboy::core::runners::{self as runner};
+use homeboy::core::{server, Error};
 
 use super::cli::RunnerBrokerCommand;
 use super::types::{RunnerBrokerCredentialSummary, RunnerBrokerOutput};
@@ -15,6 +17,7 @@ pub(super) fn run_broker(
             runner_id,
             submit,
             work,
+            no_install,
         } => {
             let mut scopes: BTreeSet<runner::BrokerScope> = BTreeSet::new();
             if submit {
@@ -28,6 +31,9 @@ pub(super) fn run_broker(
                 scopes.insert(runner::BrokerScope::Work);
             }
             let minted = store.pair(id, runner_id, scopes)?;
+            if !no_install {
+                install_store_on_ssh_runner(&minted.runner_id, &store)?;
+            }
             let store_path = store.save()?;
             let scope_labels = scope_labels(&store, &minted.id);
             Ok(RunnerBrokerOutput {
@@ -81,6 +87,82 @@ pub(super) fn run_broker(
             })
         }
     }
+}
+
+fn install_store_on_ssh_runner(
+    runner_id: &str,
+    store: &runner::BrokerAuthStore,
+) -> Result<(), Error> {
+    let configured_runner = runner::load(runner_id)?;
+    if configured_runner.kind != runner::RunnerKind::Ssh {
+        return Ok(());
+    }
+    let server_id = configured_runner.server_id.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runner_id",
+            format!("SSH runner `{runner_id}` does not declare a server_id"),
+            Some(runner_id.to_string()),
+            None,
+        )
+    })?;
+    let configured_server = server::load(server_id)?;
+    let mut client = server::SshClient::from_server(&configured_server, server_id)?;
+    client.env = runner::RunnerSpec::from_runner(&configured_runner).effective_env();
+
+    let serialized = serde_json::to_string_pretty(store).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("serialize broker auth store for runner install".to_string()),
+        )
+    })?;
+    let mut temp = tempfile::NamedTempFile::new().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("create temporary broker auth store".to_string()),
+        )
+    })?;
+    use std::io::Write;
+    temp.write_all(serialized.as_bytes()).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("write temporary broker auth store".to_string()),
+        )
+    })?;
+    temp.flush().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("flush temporary broker auth store".to_string()),
+        )
+    })?;
+
+    let remote_dir = ".config/homeboy";
+    let remote_path = ".config/homeboy/broker_auth.json";
+    let mkdir = client.execute(&format!("mkdir -p {}", shell::quote_path(remote_dir)));
+    if !mkdir.success {
+        return Err(Error::internal_io(
+            mkdir.stderr.trim().to_string(),
+            Some(format!(
+                "create remote broker auth dir for runner `{runner_id}`"
+            )),
+        ));
+    }
+    let upload = client.upload_file(temp.path().to_string_lossy().as_ref(), remote_path);
+    if !upload.success {
+        return Err(Error::internal_io(
+            upload.stderr.trim().to_string(),
+            Some(format!("install broker auth store on runner `{runner_id}`")),
+        ));
+    }
+    let chmod = client.execute(&format!("chmod 600 {}", shell::quote_path(remote_path)));
+    if !chmod.success {
+        return Err(Error::internal_io(
+            chmod.stderr.trim().to_string(),
+            Some(format!(
+                "restrict broker auth store on runner `{runner_id}`"
+            )),
+        ));
+    }
+    Ok(())
 }
 
 fn scope_label(scope: &runner::BrokerScope) -> String {

--- a/src/commands/runner/cli.rs
+++ b/src/commands/runner/cli.rs
@@ -478,6 +478,10 @@ pub(super) enum RunnerBrokerCommand {
         /// Grant the worker scope (register/claim/event/finish/heartbeat)
         #[arg(long)]
         work: bool,
+
+        /// Store only on this controller; skip installing broker_auth.json on an SSH runner host
+        #[arg(long)]
+        no_install: bool,
     },
     /// Revoke a paired credential by id
     Revoke {

--- a/src/core/runner/broker_auth.rs
+++ b/src/core/runner/broker_auth.rs
@@ -185,7 +185,7 @@ impl BrokerAuthStore {
                 "broker has no paired runner credentials configured",
                 runner_id.map(str::to_string),
                 vec![
-                    "Pair a runner with `homeboy runner broker pair` to mint a scoped token."
+                    "Pair and install a runner credential with `homeboy runner broker pair <id> --runner-id <runner> --submit --work`, or use `--no-install` only when you will copy broker_auth.json to the broker enforcement host yourself."
                         .to_string(),
                     "For loopback-only smoke runs, set allow_unauthenticated_loopback in broker_auth.json."
                         .to_string(),
@@ -441,6 +441,9 @@ mod tests {
             .authorize(true, None, BrokerScope::Work, Some("runner-a"))
             .expect_err("secure by default");
         assert_eq!(err.code.as_str(), "broker.auth_denied");
+        assert!(err.hints.iter().any(|hint| {
+            hint.message.contains("--no-install") && hint.message.contains("broker_auth.json")
+        }));
     }
 
     #[test]
@@ -551,6 +554,39 @@ mod tests {
             .iter()
             .all(|cred| cred.token_sha256 != token));
         assert_eq!(store.credentials[0].token_sha256, sha256_hex(&token));
+    }
+
+    #[test]
+    fn saved_store_round_trips_hashed_credential_for_enforcement() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut store = BrokerAuthStore::default();
+            let minted = store
+                .pair(
+                    "cred-1",
+                    "runner-a",
+                    scopes(&[BrokerScope::Submit, BrokerScope::Work]),
+                )
+                .expect("pair");
+            let path = store.save().expect("save store");
+
+            assert!(path.ends_with("broker_auth.json"));
+            let loaded = BrokerAuthStore::load().expect("load store");
+            loaded
+                .authorize(false, Some(&minted.token), BrokerScope::Submit, None)
+                .expect("submit token survives store round trip");
+            loaded
+                .authorize(
+                    false,
+                    Some(&minted.token),
+                    BrokerScope::Work,
+                    Some("runner-a"),
+                )
+                .expect("work token survives store round trip");
+            assert!(loaded
+                .credentials
+                .iter()
+                .all(|credential| credential.token_sha256 != minted.token));
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes #7572
- Teach homeboy runner broker pair to install the updated broker_auth.json on the SSH runner host by default.
- Add --no-install for controller-local-only pairing when an operator will copy the store to the enforcement host manually.
- Update broker.auth_denied guidance to describe the complete pair/install workflow.
- Add credential-store round-trip coverage and hint text coverage.

## Root cause
runner broker pair only loaded and saved BrokerAuthStore on the controller in src/commands/runner/broker.rs. Broker enforcement loads BrokerAuthStore inside the daemon process via src/core/daemon/remote_runner.rs, so SSH runner enforcement never saw the minted credential and kept rejecting with broker.auth_denied.

## Verification
- rustfmt applied to touched files
- cargo test core::runner::broker_auth:: -- --test-threads=1
- cargo test core::runner::connection:: -- --test-threads=1 (combined-worktree affected verification)
- cargo test core::api_jobs:: -- --test-threads=1 (combined-worktree affected verification)
- cargo test core::daemon::remote_runner:: -- --test-threads=1 (combined-worktree affected verification)
- cargo clippy --all-targets --all-features completed with existing repo-wide warnings; no new warning from this change
- cargo test -- --test-threads=1 completed but failed 14 unrelated baseline/environment-sensitive tests outside this change; failures noted in local run output

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Anthropic) via Claude Code / opencode agent
- **Used for:** Root-cause analysis, fix implementation, and test authoring, reviewed and directed by Chris Huber