### PR TITLE
Speed up git-backed status tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,10 @@
 [profile.default]
 slow-timeout = { period = "30s", terminate-after = 4 }
+
+[profile.ci]
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[profile.quick]
+fail-fast = true
+slow-timeout = { period = "30s", terminate-after = 4 }

--- a/docs/internals/test-tiers.md
+++ b/docs/internals/test-tiers.md
@@ -3,8 +3,24 @@
 The default Rust gate is the bounded unit suite:
 
 ```sh
-cargo nextest run --lib --no-fail-fast
+cargo nextest run --profile default --lib
 ```
+
+CI uses the non-fail-fast profile so one run reports the full failure set:
+
+```sh
+cargo nextest run --profile ci --lib
+```
+
+For local edit loops, use the quick profile with the module or test filter you are changing:
+
+```sh
+cargo nextest run --profile quick --lib <filter>
+```
+
+The profile timeouts are guardrails for hangs, not performance targets. When doing
+test-suite speed work, capture before/after wall time and the slowest tests from
+the nextest summary so lock contention and fixture setup costs stay visible.
 
 Full-pipeline audit/refactor regressions that intentionally run broad audit machinery live in the explicit slow tier:
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1161,15 +1161,11 @@ mod tests {
     }
 
     fn make_git_repo(name: &str) -> (TempDir, std::path::PathBuf) {
-        let dir = TempDir::new().expect("tempdir");
-        let repo = dir.path().join(name);
-        fs::create_dir_all(&repo).expect("repo dir");
-        Command::new("git")
-            .args(["init", "-q"])
-            .current_dir(&repo)
-            .status()
-            .expect("git init");
-        (dir, repo)
+        crate::test_support::shared_git_repo_fixture(name)
+    }
+
+    fn make_committed_git_repo(name: &str) -> (TempDir, std::path::PathBuf) {
+        crate::test_support::shared_committed_git_repo_fixture(name)
     }
 
     fn empty_status_output() -> StatusOutput {
@@ -1391,10 +1387,6 @@ mod tests {
         assert!(status.success(), "git {:?} failed", args);
     }
 
-    fn commit_empty(repo: &std::path::Path, message: &str) {
-        run_git(repo, &["commit", "--allow-empty", "-q", "-m", message]);
-    }
-
     #[test]
     fn parser_accepts_unreleased_filter() {
         let cli = Cli::try_parse_from(["homeboy", "status", "--unreleased"])
@@ -1453,9 +1445,8 @@ mod tests {
 
     #[test]
     fn default_origin_branch_resolves_origin_head_symbolic_ref() {
-        let (_dir, repo) = make_git_repo("with-origin");
+        let (_dir, repo) = make_committed_git_repo("with-origin");
         // Build a fake "origin" remote by cloning into a bare repo and wiring it up.
-        commit_empty(&repo, "feat: initial");
         // Create the origin/main remote-tracking ref directly so the resolver
         // has something to find without network access.
         run_git(&repo, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
@@ -1474,8 +1465,7 @@ mod tests {
 
     #[test]
     fn default_origin_branch_falls_back_to_conventional_branches() {
-        let (_dir, repo) = make_git_repo("fallback-origin");
-        commit_empty(&repo, "feat: initial");
+        let (_dir, repo) = make_committed_git_repo("fallback-origin");
         // No origin/HEAD symbolic ref; only a conventional remote-tracking ref.
         run_git(&repo, &["update-ref", "refs/remotes/origin/trunk", "HEAD"]);
 
@@ -1485,8 +1475,7 @@ mod tests {
 
     #[test]
     fn default_origin_branch_none_without_remote_refs() {
-        let (_dir, repo) = make_git_repo("no-origin");
-        commit_empty(&repo, "feat: initial");
+        let (_dir, repo) = make_committed_git_repo("no-origin");
 
         assert!(default_origin_branch(&repo.to_string_lossy()).is_none());
     }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,6 +1,12 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use tempfile::TempDir;
+
+static SHARED_EMPTY_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
+static SHARED_COMMITTED_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
 
 pub(crate) struct HomeGuard {
     prior: Option<String>,
@@ -190,6 +196,73 @@ pub(crate) fn write_source_extension(home: &std::path::Path, id: &str, file_exte
         std::fs::write(extension_dir.join("grammar.toml"), minimal_source_grammar())
             .expect("source grammar");
     }
+}
+
+pub(crate) fn shared_git_repo_fixture(name: &str) -> (TempDir, PathBuf) {
+    shared_git_repo_fixture_from_template(name, shared_empty_git_repo_template())
+}
+
+pub(crate) fn shared_committed_git_repo_fixture(name: &str) -> (TempDir, PathBuf) {
+    shared_git_repo_fixture_from_template(name, shared_committed_git_repo_template())
+}
+
+fn shared_git_repo_fixture_from_template(name: &str, template: &Path) -> (TempDir, PathBuf) {
+    let temp = TempDir::new().expect("git fixture tempdir");
+    let repo = temp.path().join(name);
+    copy_dir_all(template, &repo).expect("copy git fixture template");
+    (temp, repo)
+}
+
+fn shared_empty_git_repo_template() -> &'static Path {
+    SHARED_EMPTY_GIT_REPO_TEMPLATE
+        .get_or_init(|| {
+            let temp = TempDir::new().expect("git template tempdir");
+            run_git_fixture_command(temp.path(), &["init", "-q"]);
+            temp
+        })
+        .path()
+}
+
+fn shared_committed_git_repo_template() -> &'static Path {
+    SHARED_COMMITTED_GIT_REPO_TEMPLATE
+        .get_or_init(|| {
+            let temp = TempDir::new().expect("committed git template tempdir");
+            run_git_fixture_command(temp.path(), &["init", "-q"]);
+            std::fs::write(temp.path().join("README.md"), "# homeboy test fixture\n")
+                .expect("git template readme");
+            run_git_fixture_command(temp.path(), &["add", "README.md"]);
+            run_git_fixture_command(temp.path(), &["commit", "-q", "-m", "test fixture"]);
+            temp
+        })
+        .path()
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let target = to.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_all(&entry.path(), &target)?;
+        } else {
+            fs::copy(entry.path(), target)?;
+        }
+    }
+    Ok(())
+}
+
+fn run_git_fixture_command(repo: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "homeboy-test")
+        .env("GIT_AUTHOR_EMAIL", "homeboy-test@example.invalid")
+        .env("GIT_COMMITTER_NAME", "homeboy-test")
+        .env("GIT_COMMITTER_EMAIL", "homeboy-test@example.invalid")
+        .status()
+        .expect("git fixture command");
+    assert!(status.success(), "git fixture command {:?} failed", args);
 }
 
 fn minimal_source_grammar() -> &'static str {


### PR DESCRIPTION
## Summary
- Adds shared per-process git fixture templates for empty and committed repos in `test_support`.
- Converts `commands::status` git-backed tests to copy template repos instead of running `git init` and redundant commits per test.
- Adds explicit `ci` and `quick` nextest profiles and documents canonical test-tier commands.

Part of #7469, part of #7505.

## Measurements

Command used for full-lib measurements:

```sh
/usr/bin/time -p ~/.cargo/bin/cargo-nextest nextest run --lib --no-fail-fast
```

| Run | Nextest test runtime | Wall time | Result |
| --- | ---: | ---: | --- |
| Before | 77.789s | 196.24s | 6911 passed, 15 failed, 18 skipped |
| After | 71.399s | 95.38s | 6912 passed, 14 failed, 18 skipped |

Notes:
- The wall-time delta includes cold-build vs warm-build effects, so the defensible suite-runtime improvement is the nextest runtime movement: 77.789s to 71.399s.
- The full run still fails on pre-existing unrelated tests, including docs/contract drift, component inventory diagnostics, `http_api_test::test_handle`, and intermittent reverse-broker handoff timeout. This PR does not claim a green full suite.
- Touched-module verification: `cargo check --all-targets` passed; `cargo-nextest nextest run --profile quick --lib commands::status::tests` passed 18/18.

## Slowest-test movement

| Rank | Before | After |
| ---: | --- | --- |
| 1 | 43.333s `core::daemon::daemon_test::test_serve_writes_state_and_routes_health_requests` | 35.684s `core::daemon::daemon_test::health_route_refreshes_daemon_lease_heartbeat` |
| 2 | 43.284s `core::daemon::daemon_test::health_route_refreshes_daemon_lease_heartbeat` | 35.658s `core::daemon::daemon_test::test_serve_writes_state_and_routes_health_requests` |
| 3 | 37.367s `commands::status::tests::status_id_with_path_full_uses_explicit_component_id` | 33.967s `commands::status::tests::status_id_with_path_full_uses_explicit_component_id` |
| 4 | 37.128s `commands::infra::route::tests::explicit_runner_for_changed_scope_test_is_lab_portable` | 33.765s `commands::infra::route::tests::explicit_runner_for_changed_scope_test_is_lab_portable` |
| 5 | 36.695s `commands::release::tests::no_github_release_guard_ignores_unresolvable_components` | 33.156s `commands::release::tests::no_github_release_guard_ignores_unresolvable_components` |

## Fixture-pool design

`src/test_support.rs` now owns two lazy templates:
- `shared_git_repo_fixture`: empty initialized repo, preserving tests that expect no commits or remotes.
- `shared_committed_git_repo_fixture`: initialized repo with a single committed README for tests that need a valid `HEAD`.

Each test gets an isolated tempdir copy of the template, so tests can mutate refs/files without sharing state. This avoids repeated setup while preserving per-test isolation.

## Env-lock findings

The slowest tests are still dominated by HOME/XDG-derived daemon/status/audit paths. Nextest elapsed times show lock-wait clusters: small daemon/status tests report 30-40s when run inside the full suite, while the status module alone completes in about 13s after compilation. That confirms #7505 remains the larger structural bottleneck.

I did not do a sweeping HOME/XDG refactor in this PR because daemon/status production APIs derive paths through global defaults. Replacing that safely needs explicit path-injected APIs through those internals rather than more test-only mutation.

## Follow-up list

- Add path-injected daemon state/status helpers so daemon tests can stop using `HomeGuard` for state-file isolation.
- Split audit-runtime regression tests out of the default lib binary or give them explicit slow-tier coverage only.
- Convert repeated git setup in `core/component/inventory`, `commands/agent_task/tests/dispatch`, and `core/git/operation_tests` to shared fixtures once their current failures/drift are resolved.
- Investigate the reverse-broker handoff timeout that still appears intermittently in full-lib nextest.
- Decide whether `status_id_with_path_full_uses_explicit_component_id` should stay in the default tier; it remains lock-sensitive and was still top-3 slow after this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Structural test-suite speed work with measured results; Chris reviews and owns the change.
