### PR TITLE
Attach broker tokens to runner daemon requests

### DIFF
--- a/src/commands/runner/broker.rs
+++ b/src/commands/runner/broker.rs
@@ -109,7 +109,8 @@ fn install_store_on_ssh_runner(
     let mut client = server::SshClient::from_server(&configured_server, server_id)?;
     client.env = runner::RunnerSpec::from_runner(&configured_runner).effective_env();
 
-    let serialized = serde_json::to_string_pretty(store).map_err(|err| {
+    let enforcement_store = store.enforcement_copy();
+    let serialized = serde_json::to_string_pretty(&enforcement_store).map_err(|err| {
         Error::internal_json(
             err.to_string(),
             Some("serialize broker auth store for runner install".to_string()),

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -220,12 +220,16 @@ struct ExecRequest {
 struct FilePathRequest {
     runner_id: String,
     path: String,
+    #[serde(default)]
+    workspace_root: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 struct FileUploadRequest {
     runner_id: String,
     path: String,
+    #[serde(default)]
+    workspace_root: Option<String>,
     content_base64: String,
 }
 
@@ -798,7 +802,11 @@ fn create_runner_file_directory(
             )
         })?;
     broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
-    let path = resolve_runner_workspace_path(&request.runner_id, &request.path)?;
+    let path = resolve_runner_workspace_path(
+        &request.runner_id,
+        &request.path,
+        request.workspace_root.as_deref(),
+    )?;
     fs::create_dir_all(&path).map_err(|err| {
         Error::internal_io(err.to_string(), Some(format!("create {}", path.display())))
     })?;
@@ -820,7 +828,11 @@ fn upload_runner_file(
             )
         })?;
     broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
-    let path = resolve_runner_workspace_path(&request.runner_id, &request.path)?;
+    let path = resolve_runner_workspace_path(
+        &request.runner_id,
+        &request.path,
+        request.workspace_root.as_deref(),
+    )?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|err| {
             Error::internal_io(
@@ -861,7 +873,11 @@ fn download_runner_file(
             )
         })?;
     broker_auth.authorize(BrokerScope::Submit, Some(&request.runner_id))?;
-    let path = resolve_runner_workspace_path(&request.runner_id, &request.path)?;
+    let path = resolve_runner_workspace_path(
+        &request.runner_id,
+        &request.path,
+        request.workspace_root.as_deref(),
+    )?;
     let content = fs::read(&path).map_err(|err| {
         Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
     })?;
@@ -873,19 +889,29 @@ fn download_runner_file(
     }))
 }
 
-fn resolve_runner_workspace_path(runner_id: &str, requested_path: &str) -> Result<PathBuf> {
-    let runner = crate::core::runner::load(runner_id)?;
-    let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "workspace_root",
-            format!("runner `{runner_id}` file API requires workspace_root"),
-            Some(runner_id.to_string()),
-            Some(vec![
-                "Configure the runner workspace_root before using daemon file transfer."
-                    .to_string(),
-            ]),
-        )
-    })?;
+fn resolve_runner_workspace_path(
+    runner_id: &str,
+    requested_path: &str,
+    request_workspace_root: Option<&str>,
+) -> Result<PathBuf> {
+    let loaded_runner;
+    let workspace_root = match request_workspace_root.filter(|root| !root.trim().is_empty()) {
+        Some(root) => root,
+        None => {
+            loaded_runner = crate::core::runner::load(runner_id)?;
+            loaded_runner.workspace_root.as_deref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace_root",
+                    format!("runner `{runner_id}` file API requires workspace_root"),
+                    Some(runner_id.to_string()),
+                    Some(vec![
+                        "Configure the runner workspace_root before using daemon file transfer."
+                            .to_string(),
+                    ]),
+                )
+            })?
+        }
+    };
     let root = fs::canonicalize(workspace_root).map_err(|err| {
         Error::internal_io(
             err.to_string(),

--- a/src/core/runner/broker_auth.rs
+++ b/src/core/runner/broker_auth.rs
@@ -9,9 +9,11 @@
 //!
 //! * **Pairing.** An operator pairs a worker by minting a *runner credential*
 //!   on the broker host (`broker_auth_pair`). Pairing generates a random bearer
-//!   token, stores only its SHA-256 hash, and binds it to a single `runner_id`
-//!   with a set of [`BrokerScope`]s. The plaintext token is returned exactly
-//!   once so it can be handed to the worker; it is never persisted or logged.
+//!   token, stores its SHA-256 hash for enforcement, and binds it to a single
+//!   `runner_id` with a set of [`BrokerScope`]s. The controller copy may retain
+//!   the plaintext token so controller-side submit/file requests can attach it;
+//!   enforcement-host installs strip plaintext token material and keep hashes
+//!   only.
 //! * **Controller submit.** Job submission (`POST /runner/jobs`) is authorized
 //!   by a credential carrying the [`BrokerScope::Submit`] scope. Worker claims
 //!   are authorized by [`BrokerScope::Work`]. A credential may hold both.
@@ -26,8 +28,8 @@
 //!   broker into loopback-only smoke mode, which is gated to loopback binds.
 //!
 //! Tokens live in `~/.config/homeboy/broker_auth.json` with `0600` perms on
-//! Unix and are never emitted in normal command output — only the one-time mint
-//! response carries the plaintext.
+//! Unix. Plaintext token material is only kept in the controller-side copy and
+//! is never installed on runner enforcement hosts.
 
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -53,6 +55,19 @@ pub fn broker_token_from_env() -> Option<String> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+/// Resolve the controller-side broker submit token for `runner_id`.
+///
+/// `HOMEBOY_BROKER_TOKEN` remains an explicit override. Otherwise, use the
+/// newest active submit credential for the runner whose controller-local token
+/// still matches its persisted hash.
+pub fn broker_submit_token_for_runner(runner_id: &str) -> Result<Option<String>> {
+    if let Some(token) = broker_token_from_env() {
+        return Ok(Some(token));
+    }
+    let store = BrokerAuthStore::load()?;
+    Ok(store.submit_token_for_runner(runner_id))
 }
 
 /// Authorization scopes a broker credential may grant.
@@ -83,6 +98,11 @@ pub struct BrokerCredential {
     pub runner_id: String,
     /// Lowercase hex SHA-256 of the bearer token. Never the plaintext.
     pub token_sha256: String,
+    /// Controller-local plaintext token for attaching authenticated submit
+    /// requests. Stripped before installing the store on broker enforcement
+    /// hosts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
     /// Granted scopes.
     #[serde(default)]
     pub scopes: BTreeSet<BrokerScope>,
@@ -302,6 +322,7 @@ impl BrokerAuthStore {
             id: id.clone(),
             runner_id: runner_id.clone(),
             token_sha256: sha256_hex(&token),
+            token: Some(token.clone()),
             scopes,
             revoked_at: None,
             created_at: chrono::Utc::now().to_rfc3339(),
@@ -326,6 +347,32 @@ impl BrokerAuthStore {
             }
         }
         revoked
+    }
+
+    pub fn enforcement_copy(&self) -> Self {
+        let mut copy = self.clone();
+        for credential in &mut copy.credentials {
+            credential.token = None;
+        }
+        copy
+    }
+
+    pub fn submit_token_for_runner(&self, runner_id: &str) -> Option<String> {
+        self.credentials
+            .iter()
+            .rev()
+            .filter(|credential| {
+                credential.is_active()
+                    && credential.runner_id == runner_id
+                    && credential.scopes.contains(&BrokerScope::Submit)
+            })
+            .find_map(|credential| {
+                let token = credential.token.as_deref()?.trim();
+                if token.is_empty() || sha256_hex(token) != credential.token_sha256 {
+                    return None;
+                }
+                Some(token.to_string())
+            })
     }
 }
 
@@ -544,16 +591,68 @@ mod tests {
     }
 
     #[test]
-    fn minted_token_is_high_entropy_and_hashed_not_stored_plain() {
+    fn minted_token_is_high_entropy_and_controller_store_keeps_plaintext() {
         let (store, token) = store_with("runner-a", BrokerScope::Work);
         assert!(token.starts_with("hbk_"));
         assert!(token.len() > 32);
-        // Plaintext never appears in the persisted credential.
-        assert!(store
+        assert_eq!(store.credentials[0].token_sha256, sha256_hex(&token));
+        assert_eq!(store.credentials[0].token.as_deref(), Some(token.as_str()));
+    }
+
+    #[test]
+    fn enforcement_copy_strips_plaintext_tokens() {
+        let (store, token) = store_with("runner-a", BrokerScope::Work);
+        let enforcement_store = store.enforcement_copy();
+
+        assert_eq!(store.credentials[0].token.as_deref(), Some(token.as_str()));
+        assert!(enforcement_store
             .credentials
             .iter()
-            .all(|cred| cred.token_sha256 != token));
-        assert_eq!(store.credentials[0].token_sha256, sha256_hex(&token));
+            .all(|credential| credential.token.is_none()));
+        assert_eq!(
+            enforcement_store.credentials[0].token_sha256,
+            sha256_hex(&token)
+        );
+    }
+
+    #[test]
+    fn submit_token_for_runner_selects_newest_matching_submit_credential() {
+        let mut store = BrokerAuthStore::default();
+        store
+            .pair("cred-1", "runner-a", scopes(&[BrokerScope::Submit]))
+            .expect("pair first");
+        let newest = store
+            .pair(
+                "cred-2",
+                "runner-a",
+                scopes(&[BrokerScope::Submit, BrokerScope::Work]),
+            )
+            .expect("pair second");
+        store
+            .pair("cred-3", "runner-b", scopes(&[BrokerScope::Submit]))
+            .expect("pair other runner");
+
+        assert_eq!(
+            store.submit_token_for_runner("runner-a").as_deref(),
+            Some(newest.token.as_str())
+        );
+    }
+
+    #[test]
+    fn submit_token_for_runner_ignores_missing_or_mismatched_plaintext() {
+        let mut store = BrokerAuthStore::default();
+        let usable = store
+            .pair("cred-1", "runner-a", scopes(&[BrokerScope::Submit]))
+            .expect("pair first");
+        store
+            .pair("cred-2", "runner-a", scopes(&[BrokerScope::Submit]))
+            .expect("pair second");
+        store.credentials[1].token = Some("wrong-token".to_string());
+
+        assert_eq!(
+            store.submit_token_for_runner("runner-a").as_deref(),
+            Some(usable.token.as_str())
+        );
     }
 
     #[test]
@@ -582,10 +681,10 @@ mod tests {
                     Some("runner-a"),
                 )
                 .expect("work token survives store round trip");
-            assert!(loaded
-                .credentials
-                .iter()
-                .all(|credential| credential.token_sha256 != minted.token));
+            assert_eq!(
+                loaded.submit_token_for_runner("runner-a").as_deref(),
+                Some(minted.token.as_str())
+            );
         });
     }
 

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -538,7 +538,7 @@ pub fn reverse_broker_reconcile(runner_id: &str) -> Result<Value> {
         "/runner/jobs/reconcile",
         Value::Null,
         "reconcile reverse runner broker jobs",
-        broker_auth::broker_token_from_env().as_deref(),
+        broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
     )
 }
 
@@ -551,7 +551,7 @@ pub fn reverse_broker_artifact(runner_id: &str, job_id: &str, artifact_id: &str)
         &broker_url,
         &format!("/runner/jobs/{job_id}/artifacts/{artifact_id}"),
         "lookup reverse runner broker artifact",
-        broker_auth::broker_token_from_env().as_deref(),
+        broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
     )
 }
 

--- a/src/core/runner/execution/broker.rs
+++ b/src/core/runner/execution/broker.rs
@@ -70,7 +70,7 @@ pub(super) fn exec_via_reverse_broker(
         }),
         require_paths: require_paths.clone(),
     };
-    let broker_token = super::super::broker_auth::broker_token_from_env();
+    let broker_token = super::super::broker_auth::broker_submit_token_for_runner(&runner.id)?;
     let data = broker_http::post_json(
         &client,
         broker_url,

--- a/src/core/runner/execution/daemon_api.rs
+++ b/src/core/runner/execution/daemon_api.rs
@@ -136,7 +136,7 @@ pub(super) fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> R
                 ]),
             ));
         };
-        let broker_token = super::super::broker_auth::broker_token_from_env();
+        let broker_token = super::super::broker_auth::broker_submit_token_for_runner(runner_id)?;
         return match method {
             "GET" => broker_http::get_json(
                 &client,

--- a/src/core/runner/execution/handoff.rs
+++ b/src/core/runner/execution/handoff.rs
@@ -215,13 +215,14 @@ pub fn runner_job_cancel(runner_id: &str, job_id: &str) -> Result<(Job, Vec<JobE
                 "reverse runner session has no broker URL",
             ));
         };
+        let broker_token = super::super::broker_auth::broker_submit_token_for_runner(&runner.id)?;
         broker_http::post_json(
             &client,
             broker_url,
             &path,
             json!({}),
             "cancel reverse runner broker job",
-            super::super::broker_auth::broker_token_from_env().as_deref(),
+            broker_token.as_deref(),
         )?
     } else {
         return Err(runner_job_cancel_unsupported(

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -15,9 +15,9 @@ mod apply;
 mod broker_auth;
 mod broker_http;
 pub use broker_auth::{
-    broker_token_from_env, extract_bearer_token, store_path as broker_auth_store_path,
-    BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential,
-    BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    broker_submit_token_for_runner, broker_token_from_env, extract_bearer_token,
+    store_path as broker_auth_store_path, BrokerAuthGrant, BrokerAuthStore, BrokerCredential,
+    BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 mod capabilities;
 mod command_path;

--- a/src/core/runner/transport.rs
+++ b/src/core/runner/transport.rs
@@ -60,6 +60,7 @@ pub(crate) enum RunnerFileTransferCapability {
 
 pub(crate) struct RunnerFileTransfer {
     runner_id: String,
+    workspace_root: Option<String>,
     channel: RunnerFileChannel,
 }
 
@@ -160,7 +161,7 @@ impl RunnerFileTransfer {
                 let client = client_builder.build().map_err(|err| {
                     Error::internal_unexpected(format!("build runner file HTTP client: {err}"))
                 })?;
-                let broker_token = broker_auth::broker_token_from_env();
+                let broker_token = broker_auth::broker_submit_token_for_runner(&runner.id)?;
                 if broker {
                     RunnerFileChannel::BrokerHttp {
                         client,
@@ -185,6 +186,7 @@ impl RunnerFileTransfer {
         };
         Ok(RunnerFileTransfer {
             runner_id: runner.id.clone(),
+            workspace_root: runner.workspace_root.clone(),
             channel,
         })
     }
@@ -206,7 +208,7 @@ impl RunnerFileTransfer {
             RunnerFileChannel::DaemonHttp { .. } | RunnerFileChannel::BrokerHttp { .. } => {
                 self.http_post_json(
                     "/files/mkdir",
-                    json!({ "runner_id": &self.runner_id, "path": remote_dir }),
+                    self.file_path_body(remote_dir),
                     "mkdir",
                     remote_dir,
                 )?;
@@ -235,11 +237,10 @@ impl RunnerFileTransfer {
                 })?;
                 self.http_post_json(
                     "/files/upload",
-                    json!({
-                        "runner_id": &self.runner_id,
-                        "path": remote_path,
-                        "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
-                    }),
+                    self.file_upload_body(
+                        remote_path,
+                        base64::engine::general_purpose::STANDARD.encode(content),
+                    ),
                     "upload",
                     remote_path,
                 )?;
@@ -265,7 +266,7 @@ impl RunnerFileTransfer {
             RunnerFileChannel::DaemonHttp { .. } | RunnerFileChannel::BrokerHttp { .. } => {
                 let body = self.http_post_json(
                     "/files/download",
-                    json!({ "runner_id": &self.runner_id, "path": remote_path }),
+                    self.file_path_body(remote_path),
                     "download",
                     remote_path,
                 )?;
@@ -336,6 +337,23 @@ impl RunnerFileTransfer {
                     )
                 }),
         }
+    }
+
+    fn file_path_body(&self, path: &str) -> Value {
+        json!({
+            "runner_id": &self.runner_id,
+            "path": path,
+            "workspace_root": &self.workspace_root,
+        })
+    }
+
+    fn file_upload_body(&self, path: &str, content_base64: String) -> Value {
+        json!({
+            "runner_id": &self.runner_id,
+            "path": path,
+            "workspace_root": &self.workspace_root,
+            "content_base64": content_base64,
+        })
     }
 }
 
@@ -496,6 +514,7 @@ mod tests {
     use crate::core::runner::session::{
         RunnerActiveJobState, RunnerSessionRole, RunnerSessionState,
     };
+    use std::io::{Read, Write};
 
     fn runner(kind: RunnerKind) -> Runner {
         Runner {
@@ -631,5 +650,54 @@ mod tests {
                 broker: false,
             }
         );
+    }
+
+    #[test]
+    fn daemon_file_post_json_attaches_broker_token_headers() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("addr");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = String::new();
+            let mut buffer = [0_u8; 4096];
+            loop {
+                let read = stream.read(&mut buffer).expect("read");
+                if read == 0 {
+                    break;
+                }
+                request.push_str(&String::from_utf8_lossy(&buffer[..read]));
+                if request.contains("\r\n\r\n") {
+                    break;
+                }
+            }
+            let response = concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "Content-Type: application/json\r\n",
+                "Connection: close\r\n",
+                "\r\n",
+                "{\"success\":true,\"data\":{\"body\":{\"ok\":true}}}"
+            );
+            stream.write_all(response.as_bytes()).expect("write");
+            request
+        });
+        let client = Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("client");
+
+        let body = daemon_file_post_json(
+            &client,
+            &format!("http://{address}"),
+            "/files/mkdir",
+            json!({ "runner_id": "test-runner", "path": "/tmp/x" }),
+            Some("secret-token"),
+        )
+        .expect("daemon response");
+
+        assert_eq!(body["ok"], true);
+        let request = server.join().expect("server");
+        assert!(request.contains("x-homeboy-broker-token: secret-token"));
+        assert!(request.contains("authorization: Bearer secret-token"));
     }
 }

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -25,10 +25,10 @@
 // ----------------------------------------------------------------------------
 
 pub use super::runner::{
-    apply_change_artifact, apply_workspace_patch, broker_auth_store_path, broker_token_from_env,
-    capture_lab_offload_subprocess_metadata, connect, reverse_broker_artifact,
-    reverse_broker_reconcile, BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope,
-    MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
+    broker_submit_token_for_runner, broker_token_from_env, capture_lab_offload_subprocess_metadata,
+    connect, reverse_broker_artifact, reverse_broker_reconcile, BrokerAuthGrant, BrokerAuthStore,
+    BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use super::runner::{
     connect_reverse, disconnect, download_remote_artifact,

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -166,6 +166,28 @@ fn file_route_requires_broker_submit_auth_for_untrusted_requests() {
 }
 
 #[test]
+fn file_route_accepts_request_workspace_root_without_runner_config() {
+    let _home = HomeGuard::new();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let response = route_with_job_store_and_body(
+        "POST",
+        "/files/mkdir",
+        Some(serde_json::json!({
+            "runner_id": "file-lab-without-local-config",
+            "workspace_root": workspace.display().to_string(),
+            "path": workspace.join("artifacts").display().to_string(),
+        })),
+        &JobStore::default(),
+    );
+
+    assert_eq!(response.status_code, 200, "mkdir body: {}", response.body);
+    assert!(workspace.join("artifacts").is_dir());
+}
+
+#[test]
 fn file_routes_upload_and_download_inside_runner_workspace_root() {
     let _home = HomeGuard::new();
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary
- Fixes #7572
- Attach controller broker credentials to runner daemon and reverse broker requests by resolving the newest active submit credential for the target runner.
- Preserve daemon/broker enforcement semantics: configured brokers require bearer tokens; `allow_unauthenticated_loopback` remains only for explicitly unconfigured loopback smoke mode.
- Send the controller's runner `workspace_root` with authenticated file API requests so runner daemons do not need controller-side server config to validate file paths.

## Root cause
The runner file daemon enforces auth in `src/core/runner/broker_auth.rs` via `BrokerAuthStore::authorize()`, surfaced from `src/core/daemon.rs` file routes (`/files/mkdir`, `/files/upload`, `/files/download`). The intended design is token attachment, not loopback bypass: once credentials exist, the daemon rejects missing tokens even for direct SSH loopback tunnels unless the broker is unconfigured and explicitly opted into `allow_unauthenticated_loopback`.

Controller-side file transfer in `src/core/runner/transport.rs` already had header attachment logic, but it only read `HOMEBOY_BROKER_TOKEN`. Pairing stored the credential hash in `broker_auth.json`, so normal controller requests had no persisted plaintext token to attach. With multiple credentials for one runner, there was also no runner-aware token selection path.

After the token attach fix, the live proof exposed the next link in the same chain: the daemon-side file API tried to load the runner/server config locally on the runner host to discover `workspace_root`, which failed with `server.not_found` because that controller-side config is not mirrored onto the runner.

## Fix
- `runner broker pair` now keeps the plaintext token in the controller-local store for submit/file request signing and installs a stripped enforcement copy on the runner host.
- Added `broker_submit_token_for_runner()` and store selection logic that prefers the newest active submit credential for the requested runner and verifies the plaintext token still matches its stored hash.
- Updated direct daemon file transfer, reverse broker job submission, reconcile/artifact lookup, daemon API requests, and job cancellation to resolve tokens by runner id.
- Added `workspace_root` to authenticated file API payloads and taught the daemon to validate requested paths against that supplied root before falling back to local runner config.

## End-to-end proof
Built and invoked the worktree binary directly, without cargo-installing over the user's active binary.

Runner refresh for proof: `./target/release/homeboy runner refresh-homeboy homeboy-lab --ref fix/controller-broker-token-attach --reconnect --output ./runner-refresh-proof.json`
- Runner binary after refresh: `homeboy 0.281.3+54baa2edfe4a`

Required proof command: `./target/release/homeboy test wp-build-repo --path /Users/chubes/Developer/studio-native@rename-wordpress-build --output ./gate-proof.json`
- Lab offload selected `homeboy-lab` via direct SSH mode.
- The artifact-dir mkdir got past bearer-token auth and path validation.
- The wp-build test phase executed on the runner and passed.
- Proof run id: `62608475-2804-4b84-80ac-6506e0668746`
- Final phase result: `phase=test`, `status=passed`, `exit_code=0`, summary `test phase passed`.

## Verification
- `cargo fmt`
- `cargo test core::runner::broker_auth:: -- --test-threads=1`
- `cargo test core::runner::transport:: -- --test-threads=1`
- `cargo test file_route_accepts_request_workspace_root_without_runner_config -- --test-threads=1`
- `cargo build --release`
- `cargo clippy --all-targets --all-features` completed with the existing repo-wide warning baseline; no new warnings in touched auth/file-transfer/daemon code.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Anthropic) via Claude Code / opencode agent
- **Used for:** Root-cause analysis, fix implementation, live-runner verification, and test authoring, reviewed and directed by Chris Huber
