### PR TITLE
Remove shared asset fallback

### DIFF
--- a/src/core/extension/lifecycle/install_sources.rs
+++ b/src/core/extension/lifecycle/install_sources.rs
@@ -46,7 +46,7 @@ impl SharedAssetDeclaration {
 }
 
 pub(crate) fn shared_assets_for_root(source_root: &Path) -> Vec<String> {
-    let declared = std::fs::read_to_string(source_root.join("homeboy-extension-root.json"))
+    std::fs::read_to_string(source_root.join("homeboy-extension-root.json"))
         .ok()
         .and_then(|raw| serde_json::from_str::<ExtensionRootManifest>(&raw).ok())
         .map(|manifest| {
@@ -58,18 +58,7 @@ pub(crate) fn shared_assets_for_root(source_root: &Path) -> Vec<String> {
                 .filter(|path| !path.is_empty())
                 .collect::<Vec<_>>()
         })
-        .unwrap_or_default();
-    if !declared.is_empty() {
-        return declared;
-    }
-
-    vec![
-        "scripts/lib".to_string(),
-        "dependency-adapters".to_string(),
-        "agent-runtimes".to_string(),
-        "runtime-agent-ci".to_string(),
-        "agent-task-contracts".to_string(),
-    ]
+        .unwrap_or_default()
 }
 
 pub(super) fn install_configured_extension(
@@ -263,11 +252,9 @@ enum SharedAssetMode {
     /// back to.
     Copy,
     /// Symlink the install target to its live source tree. Used for linked/dev
-    /// installs (local-path source): edits to the shared monorepo assets
-    /// (`agent-runtimes`, `runtime-agent-ci`, `scripts/lib`,
-    /// `dependency-adapters`, `agent-task-contracts`) in the source worktree
-    /// are visible to the live install immediately, with no reinstall or
-    /// release. See #6396 / #1954.
+    /// installs (local-path source): edits to declared shared monorepo assets
+    /// in the source worktree are visible to the live install immediately, with
+    /// no reinstall or release. See #6396 / #1954.
     Symlink,
 }
 
@@ -375,11 +362,9 @@ fn symlink_shared_asset(source: &Path, target: &Path, shared_dir: &str) -> Resul
 
 /// Materialize shared monorepo assets for a linked (local-path) install.
 ///
-/// Linked installs symlink the shared trees to their live source so that edits
-/// to `agent-runtimes`, `runtime-agent-ci`, `scripts/lib`,
-/// `dependency-adapters`, and `agent-task-contracts` in the source worktree
-/// take effect immediately, enabling rapid local iteration without a reinstall
-/// or release.
+/// Linked installs symlink declared shared trees to their live source so edits
+/// in the source worktree take effect immediately, enabling rapid local
+/// iteration without a reinstall or release.
 pub(crate) fn install_linked_shared_assets(
     source: &Path,
     extension_dir: &Path,

--- a/src/core/extension/lifecycle/mod.rs
+++ b/src/core/extension/lifecycle/mod.rs
@@ -255,6 +255,20 @@ fn copy_shared_refresh_assets(source_root: Option<&Path>, durable_root: &Path) -
         return Ok(());
     };
 
+    let root_manifest = source_root.join("homeboy-extension-root.json");
+    if root_manifest.is_file() {
+        std::fs::copy(
+            &root_manifest,
+            durable_root.join("homeboy-extension-root.json"),
+        )
+        .map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some("copy extension root manifest for durable refresh".to_string()),
+            )
+        })?;
+    }
+
     for shared_dir in install_sources::shared_assets_for_root(source_root) {
         let source = source_root.join(&shared_dir);
         if source.is_dir() {
@@ -450,6 +464,39 @@ mod tests {
             ),
         )
         .expect("component config");
+    }
+
+    fn write_shared_asset_manifest(root: &Path, paths: &[&str]) {
+        let shared_assets = paths
+            .iter()
+            .map(|path| format!(r#"    {{ "path": "{}" }}"#, path))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        fs::write(
+            root.join("homeboy-extension-root.json"),
+            format!(
+                r#"{{
+  "shared_assets": [
+{}
+  ]
+}}"#,
+                shared_assets
+            ),
+        )
+        .expect("extension root manifest");
+    }
+
+    fn write_declared_runtime_shared_assets(root: &Path) {
+        write_shared_asset_manifest(
+            root,
+            &[
+                "agent-runtimes",
+                "runtime-agent-ci",
+                "agent-task-contracts",
+                "dependency-adapters",
+            ],
+        );
+        write_shared_runtime_fixture(root);
     }
 
     fn write_shared_runtime_fixture(root: &Path) {
@@ -749,7 +796,7 @@ exec '{}' "$@"
             let home = home.path();
             let lab_source = home.join("Developer/_lab_workspaces/run-123");
             write_extension_fixture(&lab_source, "alpha");
-            write_shared_runtime_fixture(&lab_source);
+            write_declared_runtime_shared_assets(&lab_source);
 
             let result = refresh(
                 &lab_source.join("alpha").to_string_lossy(),
@@ -940,12 +987,13 @@ exec '{}' "$@"
     }
 
     #[test]
-    fn cloned_monorepo_install_materializes_shared_scripts() {
+    fn cloned_monorepo_install_materializes_declared_shared_scripts() {
         with_isolated_home(|home| {
             let home = home.path();
             let source = home.join("source-repo");
             fs::create_dir_all(&source).expect("source repo");
             write_extension_fixture(&source, "rust");
+            write_shared_asset_manifest(&source, &["scripts/lib"]);
             let shared_helper = source.join("scripts/lib/test-result-adapters.sh");
             fs::create_dir_all(shared_helper.parent().expect("helper parent"))
                 .expect("shared scripts dir");
@@ -972,13 +1020,13 @@ exec '{}' "$@"
     }
 
     #[test]
-    fn cloned_monorepo_install_materializes_shared_agent_runtimes() {
+    fn cloned_monorepo_install_materializes_declared_shared_agent_runtimes() {
         with_isolated_home(|home| {
             let home = home.path();
             let source = home.join("source-repo");
             fs::create_dir_all(&source).expect("source repo");
             write_extension_fixture(&source, "wordpress");
-            write_shared_runtime_fixture(&source);
+            write_declared_runtime_shared_assets(&source);
             let remote = match prepare_git_repo(&source) {
                 Some(remote) => remote,
                 None => return,
@@ -1014,7 +1062,7 @@ exec '{}' "$@"
             let source = home.join("source-repo");
             fs::create_dir_all(&source).expect("source repo");
             write_extension_fixture(&source, "wordpress");
-            write_shared_runtime_fixture(&source);
+            write_declared_runtime_shared_assets(&source);
             let remote = match prepare_git_repo(&source) {
                 Some(remote) => remote,
                 None => return,
@@ -1036,7 +1084,7 @@ exec '{}' "$@"
     }
 
     #[test]
-    fn extracted_monorepo_update_materializes_shared_agent_runtimes() {
+    fn extracted_monorepo_update_materializes_declared_shared_agent_runtimes() {
         with_isolated_home(|home| {
             let home = home.path();
             let source = home.join("source-repo");
@@ -1049,11 +1097,8 @@ exec '{}' "$@"
 
             install(&remote_url.to_string_lossy(), Some("wordpress"))
                 .expect("install cloned extension");
-            assert!(!home
-                .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
-                .exists());
 
-            write_shared_runtime_fixture(&source);
+            write_declared_runtime_shared_assets(&source);
             assert!(commit_all(&source, "add runtime package"));
             assert!(run_git(&source, &["push", "origin", "HEAD"]));
 
@@ -1075,12 +1120,13 @@ exec '{}' "$@"
     }
 
     #[test]
-    fn linked_monorepo_install_materializes_shared_scripts() {
+    fn linked_monorepo_install_materializes_declared_shared_scripts() {
         with_isolated_home(|home| {
             let home = home.path();
             let source = home.join("source-repo");
             fs::create_dir_all(&source).expect("source repo");
             write_extension_fixture(&source, "wordpress");
+            write_shared_asset_manifest(&source, &["scripts/lib"]);
             let shared_helper = source.join("scripts/lib/test-result-adapters.sh");
             fs::create_dir_all(shared_helper.parent().expect("helper parent"))
                 .expect("shared scripts dir");
@@ -1106,13 +1152,13 @@ exec '{}' "$@"
     }
 
     #[test]
-    fn linked_monorepo_install_materializes_shared_agent_runtimes() {
+    fn linked_monorepo_install_materializes_declared_shared_agent_runtimes() {
         with_isolated_home(|home| {
             let home = home.path();
             let source = home.join("source-repo");
             fs::create_dir_all(&source).expect("source repo");
             write_extension_fixture(&source, "wordpress");
-            write_shared_runtime_fixture(&source);
+            write_declared_runtime_shared_assets(&source);
 
             install(
                 &source.join("wordpress").to_string_lossy(),
@@ -1142,6 +1188,16 @@ exec '{}' "$@"
             write_extension_fixture(&source, "wordpress");
             write_shared_runtime_fixture(&source);
             let shared_helper = source.join("scripts/lib/test-result-adapters.sh");
+            write_shared_asset_manifest(
+                &source,
+                &[
+                    "agent-runtimes",
+                    "runtime-agent-ci",
+                    "agent-task-contracts",
+                    "dependency-adapters",
+                    "scripts/lib",
+                ],
+            );
             fs::create_dir_all(shared_helper.parent().expect("helper parent"))
                 .expect("shared scripts dir");
             fs::write(&shared_helper, "noop() { :; }\n").expect("shared helper");
@@ -1201,7 +1257,7 @@ exec '{}' "$@"
             let source = home.join("source-repo");
             fs::create_dir_all(&source).expect("source repo");
             write_extension_fixture(&source, "wordpress");
-            write_shared_runtime_fixture(&source);
+            write_declared_runtime_shared_assets(&source);
 
             install(
                 &source.join("wordpress").to_string_lossy(),
@@ -1232,13 +1288,13 @@ exec '{}' "$@"
     }
 
     #[test]
-    fn linked_monorepo_root_install_with_id_materializes_shared_agent_runtimes() {
+    fn linked_monorepo_root_install_with_id_materializes_declared_shared_agent_runtimes() {
         with_isolated_home(|home| {
             let home = home.path();
             let source = home.join("source-repo");
             fs::create_dir_all(&source).expect("source repo");
             write_extension_fixture(&source, "wordpress");
-            write_shared_runtime_fixture(&source);
+            write_declared_runtime_shared_assets(&source);
 
             install(&source.to_string_lossy(), Some("wordpress"))
                 .expect("install linked extension from monorepo root");

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -525,6 +525,31 @@ mod tests {
         .expect("runtime agent ci helper");
     }
 
+    fn write_shared_asset_manifest(root: &Path, paths: &[&str]) {
+        let shared_assets = paths
+            .iter()
+            .map(|path| format!(r#"    {{ "path": "{}" }}"#, path))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        fs::write(
+            root.join("homeboy-extension-root.json"),
+            format!(
+                r#"{{
+  "shared_assets": [
+{}
+  ]
+}}"#,
+                shared_assets
+            ),
+        )
+        .expect("extension root manifest");
+    }
+
+    fn write_declared_runtime_shared_assets(root: &Path) {
+        write_shared_asset_manifest(root, &["agent-runtimes", "runtime-agent-ci"]);
+        write_shared_runtime_fixture(root);
+    }
+
     fn run_git(dir: &Path, args: &[&str]) -> bool {
         Command::new("git")
             .args(args)
@@ -725,14 +750,14 @@ mod tests {
     }
 
     #[test]
-    fn relink_materializes_shared_agent_runtimes() {
+    fn relink_materializes_declared_shared_agent_runtimes() {
         with_isolated_home(|home| {
             let home = home.path();
             let old_source = home.join("old-source");
             let new_source = home.join("new-source");
             write_extension_fixture(&old_source, "wordpress");
             write_extension_fixture_with_version(&new_source, "wordpress", "2.0.0");
-            write_shared_runtime_fixture(&new_source);
+            write_declared_runtime_shared_assets(&new_source);
 
             install(
                 &old_source.join("wordpress").to_string_lossy(),
@@ -753,14 +778,14 @@ mod tests {
     }
 
     #[test]
-    fn replace_from_monorepo_root_with_id_materializes_shared_agent_runtimes() {
+    fn replace_from_monorepo_root_with_id_materializes_declared_shared_agent_runtimes() {
         with_isolated_home(|home| {
             let home = home.path();
             let old_source = home.join("old-source");
             let new_source = home.join("new-source");
             write_extension_fixture(&old_source, "wordpress");
             write_extension_fixture_with_version(&new_source, "wordpress", "2.0.0");
-            write_shared_runtime_fixture(&new_source);
+            write_declared_runtime_shared_assets(&new_source);
 
             install(
                 &old_source.join("wordpress").to_string_lossy(),


### PR DESCRIPTION
## Summary
- Delete the transitional hardcoded shared-asset fallback list from extension install source resolution.
- Convert shared-asset lifecycle/repair tests to declare fixture root manifests.
- Preserve declared shared assets through durable refresh by copying `homeboy-extension-root.json` into the durable source root.

## Evidence
- Follow-up to #7563; depends on Extra-Chill/homeboy-extensions#2175 (merged).
- End-to-end install with this built binary: `cargo run -- extension install https://github.com/Extra-Chill/homeboy-extensions --id wordpress --replace` succeeded at source revision `0106c0c9`.
- Confirmed declared shared assets materialized: `extensions/scripts/lib/test-result-adapters.sh`, `extensions/dependency-adapters/examples/nodejs.json`, `agent-runtimes/wp-codebox/wp-codebox.json`, `runtime-agent-ci/lib/agent-task-provider-contract.js`, and `agent-task-contracts/agent-task-provider-contract.js`.
- Restored local extension registry from the same source with `homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id wordpress --replace`.

## Verification
- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(lifecycle) or test(install_sources) or test(extension)' --no-fail-fast` passed once: 1035 passed, 5912 skipped.
- Post-format rerun of the same nextest selection had one transient local HTTP egress reset in `core::extension::trace::probes::http_egress::tests::test_run_http_egress`; isolated rerun of that test passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Removed the transitional shared-assets fallback after the declared path went live; Chris reviews and owns the change.
