### PR TITLE
Deduplicate core helper implementations

### DIFF
--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -6,6 +6,7 @@ use homeboy::core::cleanup::{
 };
 use homeboy::core::defaults;
 use homeboy::core::engine;
+use homeboy::core::engine::shell::quote_arg;
 use homeboy::core::observation::runs_service::{
     self, PersistedArtifactCleanupOptions, RunnerDownloadCleanupOptions,
 };
@@ -458,7 +459,7 @@ fn remote_lab_workspace_categories(
                 category: "remote_lab_workspaces",
                 specialist_command: format!(
                     "homeboy runner workspace prune {}",
-                    shell_quote(&status.runner_id)
+                    quote_arg(&status.runner_id)
                 ),
                 included: true,
                 skipped: true,
@@ -487,7 +488,7 @@ fn remote_lab_workspace_categories(
                     category: "remote_lab_workspaces",
                     specialist_command: format!(
                         "homeboy runner workspace prune {}",
-                        shell_quote(&status.runner_id)
+                        quote_arg(&status.runner_id)
                     ),
                     included: true,
                     skipped: true,
@@ -514,12 +515,12 @@ fn remote_workspace_category(
     let command = if apply {
         format!(
             "homeboy runner workspace prune {} --apply --passes 10",
-            shell_quote(&output.runner_id)
+            quote_arg(&output.runner_id)
         )
     } else {
         format!(
             "homeboy runner workspace prune {}",
-            shell_quote(&output.runner_id)
+            quote_arg(&output.runner_id)
         )
     };
     category_from_output(
@@ -641,11 +642,11 @@ pub(crate) fn render_artifact_cleanup_summary(payload: &Value) -> Option<String>
     }
 
     let next = if mode == "apply" {
-        format!("homeboy cleanup artifacts --path {}", shell_quote(root))
+        format!("homeboy cleanup artifacts --path {}", quote_arg(root))
     } else {
         format!(
             "homeboy cleanup artifacts --path {} --apply",
-            shell_quote(root)
+            quote_arg(root)
         )
     };
     lines.push(format!("Next safe command: {next}"));
@@ -750,7 +751,7 @@ fn provider_command(provider: &Value) -> Option<String> {
     let parts: Vec<String> = argv
         .iter()
         .filter_map(Value::as_str)
-        .map(shell_quote)
+        .map(quote_arg)
         .collect();
     (!parts.is_empty()).then(|| parts.join(" "))
 }
@@ -792,17 +793,6 @@ fn format_bytes(bytes: u64) -> String {
         _ if (bytes as f64) < MIB => format!("{:.1} KiB", bytes as f64 / KIB),
         _ if (bytes as f64) < GIB => format!("{:.1} MiB", bytes as f64 / MIB),
         _ => format!("{:.1} GiB", bytes as f64 / GIB),
-    }
-}
-
-fn shell_quote(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | ':'))
-    {
-        value.to_string()
-    } else {
-        format!("'{}'", value.replace('\'', "'\\''"))
     }
 }
 

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -7,6 +7,7 @@ pub use output::RigCommandOutput;
 
 use clap::{Args, Subcommand};
 
+use homeboy::core::engine::shell::quote_arg;
 use homeboy::core::rig;
 
 use self::output::{
@@ -639,19 +640,9 @@ fn non_portable_up_error(rig_id: &str) -> homeboy::core::Error {
 
 fn shell_join(args: &[String]) -> String {
     args.iter()
-        .map(|arg| shell_quote(arg))
+        .map(|arg| quote_arg(arg))
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-fn shell_quote(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | ':' | '='))
-    {
-        return value.to_string();
-    }
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn check(

--- a/src/commands/runner/refresh_plan.rs
+++ b/src/commands/runner/refresh_plan.rs
@@ -4,6 +4,7 @@ use clap::Args;
 use serde::Serialize;
 
 use homeboy::core::build_identity::BuildIdentity;
+use homeboy::core::engine::shell::quote_arg;
 use homeboy::core::runner_execution_envelope::{
     RunnerExecutionArtifactDeclaration, RunnerExecutionArtifactRef, RunnerExecutionEnvelope,
     RunnerExecutionLifecyclePolicy, RunnerExecutionRecord, RunnerExecutionResultRefs,
@@ -806,27 +807,16 @@ fn next_commands(
 
 fn shell_join(args: &[&str]) -> String {
     args.iter()
-        .map(|arg| shell_quote(arg))
+        .map(|arg| quote_arg(arg))
         .collect::<Vec<_>>()
         .join(" ")
 }
 
 fn shell_join_owned(args: &[String]) -> String {
     args.iter()
-        .map(|arg| shell_quote(arg))
+        .map(|arg| quote_arg(arg))
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-fn shell_quote(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | ':' | '='))
-    {
-        return value.to_string();
-    }
-
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 #[cfg(test)]
@@ -1202,8 +1192,8 @@ mod tests {
 
     #[test]
     fn shell_quote_handles_spaces_and_single_quotes() {
-        assert_eq!(shell_quote("simple/path"), "simple/path");
-        assert_eq!(shell_quote("two words"), "'two words'");
-        assert_eq!(shell_quote("it's ok"), "'it'\\''s ok'");
+        assert_eq!(quote_arg("simple/path"), "simple/path");
+        assert_eq!(quote_arg("two words"), "'two words'");
+        assert_eq!(quote_arg("it's ok"), "'it'\\''s ok'");
     }
 }

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -202,7 +202,6 @@ pub struct ExtensionOverrideArgs {
     pub extensions: Vec<String>,
 }
 
-#[allow(dead_code)]
 impl PositionalComponentArgs {
     pub fn load(&self) -> homeboy::core::Result<Component> {
         component::resolve_effective(self.component.as_deref(), self.path.as_deref(), None)
@@ -517,13 +516,6 @@ impl LintSniffArgs {
 pub struct WriteModeArgs {
     #[arg(long)]
     pub write: bool,
-}
-
-#[allow(dead_code)]
-impl WriteModeArgs {
-    pub(crate) fn is_dry_run(&self) -> bool {
-        !self.write
-    }
 }
 
 // ============================================================================

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -31,18 +31,12 @@ pub struct SymbolDiff {
     pub file: String,
     /// Exports that existed in the base but are gone in current.
     pub removed_exports: Vec<String>,
-    /// Exports that exist in current but not in base (new API).
-    #[allow(dead_code)] // Symmetric with removed_exports; used for impact reporting.
-    pub added_exports: Vec<String>,
     /// Exports that exist in both but with a likely rename (fuzzy matched).
     pub renamed_exports: Vec<(String, String)>, // (old_name, new_name)
     /// The type/class name changed.
     pub type_renamed: Option<(String, String)>, // (old_name, new_name)
     /// Hooks that were removed or renamed.
     pub removed_hooks: Vec<String>,
-    /// Hooks that were added.
-    #[allow(dead_code)] // Symmetric with removed_hooks; used for impact reporting.
-    pub added_hooks: Vec<String>,
 }
 
 /// A file affected by changes in another file.
@@ -164,11 +158,9 @@ pub(crate) fn diff_changed_files(
             (Some(base), None) => SymbolDiff {
                 file: file.clone(),
                 removed_exports: base.public_api.clone(),
-                added_exports: vec![],
                 renamed_exports: vec![],
                 type_renamed: None,
                 removed_hooks: base.hooks.iter().map(|h| h.name.clone()).collect(),
-                added_hooks: vec![],
             },
             // New file — nothing to trace (no old callers)
             (None, Some(_)) => continue,
@@ -204,7 +196,7 @@ fn diff_fingerprints(file: &str, base: &FileFingerprint, current: &FileFingerpri
         .collect();
 
     // Try to match removed → added as renames (simple: same position or similar name)
-    let (renamed, truly_removed, truly_added) = match_renames(&removed, &added);
+    let (renamed, truly_removed) = match_renames(&removed, &added);
 
     // Check type/class rename
     let type_renamed = match (&base.type_name, &current.type_name) {
@@ -220,19 +212,12 @@ fn diff_fingerprints(file: &str, base: &FileFingerprint, current: &FileFingerpri
         .difference(&current_hooks)
         .map(|s| s.to_string())
         .collect();
-    let added_hooks: Vec<String> = current_hooks
-        .difference(&base_hooks)
-        .map(|s| s.to_string())
-        .collect();
-
     SymbolDiff {
         file: file.to_string(),
         removed_exports: truly_removed,
-        added_exports: truly_added,
         renamed_exports: renamed,
         type_renamed,
         removed_hooks,
-        added_hooks,
     }
 }
 
@@ -242,11 +227,7 @@ fn diff_fingerprints(file: &str, base: &FileFingerprint, current: &FileFingerpri
 /// substring with an added name, treat it as a rename. Returns:
 /// - matched renames (old, new)
 /// - truly removed (no match found)
-/// - truly added (no match found)
-fn match_renames(
-    removed: &[String],
-    added: &[String],
-) -> (Vec<(String, String)>, Vec<String>, Vec<String>) {
+fn match_renames(removed: &[String], added: &[String]) -> (Vec<(String, String)>, Vec<String>) {
     let mut renames = Vec::new();
     let mut used_added: HashSet<usize> = HashSet::new();
     let mut truly_removed = Vec::new();
@@ -272,14 +253,7 @@ fn match_renames(
         }
     }
 
-    let truly_added: Vec<String> = added
-        .iter()
-        .enumerate()
-        .filter(|(i, _)| !used_added.contains(i))
-        .map(|(_, s)| s.clone())
-        .collect();
-
-    (renames, truly_removed, truly_added)
+    (renames, truly_removed)
 }
 
 /// Simple similarity score between two strings (0.0 = nothing in common, 1.0 = identical).
@@ -532,19 +506,18 @@ mod tests {
     fn test_match_renames_exact_pair() {
         let removed = vec!["doThing".to_string()];
         let added = vec!["doStuff".to_string(), "completelyNew".to_string()];
-        let (renames, truly_removed, truly_added) = match_renames(&removed, &added);
+        let (renames, truly_removed) = match_renames(&removed, &added);
 
         // doThing and doStuff share "do" + similar length — may or may not match
         // depending on threshold. The key test is that the function runs.
         assert!(renames.len() + truly_removed.len() == 1);
-        assert!(!truly_added.is_empty());
     }
 
     #[test]
     fn test_match_renames_clear_rename() {
         let removed = vec!["processRequest".to_string()];
         let added = vec!["processApiRequest".to_string()];
-        let (renames, truly_removed, _) = match_renames(&removed, &added);
+        let (renames, truly_removed) = match_renames(&removed, &added);
 
         // High similarity — should match
         assert_eq!(renames.len(), 1, "should detect rename");
@@ -630,7 +603,6 @@ mod tests {
 
         let diff = diff_fingerprints("Foo.php", &base, &current);
         assert!(diff.removed_hooks.contains(&"my_custom_action".to_string()));
-        assert!(diff.added_hooks.contains(&"my_renamed_action".to_string()));
     }
 
     #[test]
@@ -639,11 +611,9 @@ mod tests {
         let diff = SymbolDiff {
             file: "Foo.php".to_string(),
             removed_exports: vec!["doThing".to_string()],
-            added_exports: vec![],
             renamed_exports: vec![],
             type_renamed: None,
             removed_hooks: vec![],
-            added_hooks: vec![],
         };
 
         let bar = make_fingerprint(
@@ -683,11 +653,9 @@ mod tests {
         let diff = SymbolDiff {
             file: "Foo.php".to_string(),
             removed_exports: vec![],
-            added_exports: vec![],
             renamed_exports: vec![],
             type_renamed: Some(("FooHandler".to_string(), "BarHandler".to_string())),
             removed_hooks: vec![],
-            added_hooks: vec![],
         };
 
         let consumer = make_fingerprint(
@@ -717,11 +685,9 @@ mod tests {
         let diff = SymbolDiff {
             file: "Base.php".to_string(),
             removed_exports: vec![],
-            added_exports: vec![],
             renamed_exports: vec![],
             type_renamed: Some(("BaseTask".to_string(), "AbstractTask".to_string())),
             removed_hooks: vec![],
-            added_hooks: vec![],
         };
 
         let child = make_fingerprint(
@@ -751,11 +717,9 @@ mod tests {
         let diff = SymbolDiff {
             file: "Provider.php".to_string(),
             removed_exports: vec![],
-            added_exports: vec![],
             renamed_exports: vec![],
             type_renamed: None,
             removed_hooks: vec!["my_custom_hook".to_string()],
-            added_hooks: vec![],
         };
 
         let listener = make_fingerprint(
@@ -786,11 +750,9 @@ mod tests {
         let diff = SymbolDiff {
             file: "Foo.php".to_string(),
             removed_exports: vec!["doThing".to_string()],
-            added_exports: vec![],
             renamed_exports: vec![],
             type_renamed: None,
             removed_hooks: vec![],
-            added_hooks: vec![],
         };
 
         let foo = make_fingerprint(
@@ -819,11 +781,9 @@ mod tests {
         let diff = SymbolDiff {
             file: "Foo.php".to_string(),
             removed_exports: vec![],
-            added_exports: vec![],
             renamed_exports: vec![("doThing".to_string(), "doStuff".to_string())],
             type_renamed: None,
             removed_hooks: vec![],
-            added_hooks: vec![],
         };
 
         let bar = make_fingerprint(

--- a/src/core/component/inventory/path_diagnostics.rs
+++ b/src/core/component/inventory/path_diagnostics.rs
@@ -1,7 +1,8 @@
 use crate::core::component::Component;
+use crate::core::engine::shell::quote_path;
+use crate::core::git::{run_git, run_git_output};
 use crate::core::transient_workspace_policy::TransientWorkspacePolicy;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use super::reconcile::{
     discover_reconcile_candidates, reconcile_status, standalone_registration_exists,
@@ -117,11 +118,7 @@ pub(super) fn detect_git_root(path: &Path) -> Option<PathBuf> {
         return Some(path.to_path_buf());
     }
 
-    let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .current_dir(path)
-        .output()
-        .ok()?;
+    let output = run_git_output(path, &["rev-parse", "--show-toplevel"], "git rev-parse").ok()?;
     if !output.status.success() {
         return None;
     }
@@ -134,15 +131,7 @@ pub(super) fn detect_git_root(path: &Path) -> Option<PathBuf> {
 }
 
 fn git_output(path: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let value = run_git(path, args, "git metadata").ok()?.trim().to_string();
     if value.is_empty() {
         None
     } else {
@@ -151,5 +140,5 @@ fn git_output(path: &Path, args: &[&str]) -> Option<String> {
 }
 
 fn shell_quote_for_hint(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
+    quote_path(value)
 }

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -3,6 +3,7 @@ use crate::core::component::{
 };
 use crate::core::error::{Error, Result};
 use crate::core::extension::{self, ExtensionCapability};
+use crate::core::git::{run_git, run_git_output};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -335,17 +336,10 @@ fn same_git_common_dir(a: &Path, b: &Path) -> bool {
 }
 
 fn git_common_dir(dir: &Path) -> Option<PathBuf> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--git-common-dir"])
-        .current_dir(dir)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let raw = run_git(dir, &["rev-parse", "--git-common-dir"], "git common dir")
+        .ok()?
+        .trim()
+        .to_string();
     if raw.is_empty() {
         return None;
     }
@@ -508,17 +502,14 @@ fn path_strictly_contains(parent: &Path, child: &Path) -> bool {
 
 /// Find the git root directory for a given path.
 pub(crate) fn detect_git_root(dir: &Path) -> Option<PathBuf> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .current_dir(dir)
-        .output()
-        .ok()?;
+    let output = run_git_output(dir, &["rev-parse", "--show-toplevel"], "git root").ok()?;
+    if !output.status.success() {
+        return None;
+    }
 
-    if output.status.success() {
-        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !path.is_empty() {
-            return Some(PathBuf::from(path));
-        }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !path.is_empty() {
+        return Some(PathBuf::from(path));
     }
     None
 }
@@ -805,6 +796,7 @@ fn duplicate_portable_id_error(component_id: &str, paths: Vec<PathBuf>) -> Error
             "Use --path <component-dir> to disambiguate the intended component when the command supports path overrides".to_string(),
         ]),
     )
+    .with_hint("Use --path <component-dir> to disambiguate the intended component when the command supports path overrides")
 }
 
 #[cfg(test)]

--- a/src/core/refactor/plan/generate/signatures.rs
+++ b/src/core/refactor/plan/generate/signatures.rs
@@ -9,7 +9,6 @@ pub(crate) struct MethodSignature {
     /// Full signature line (e.g., "public function execute(array $config): array").
     pub(crate) signature: String,
     /// The language this was extracted from.
-    #[allow(dead_code)]
     pub(crate) language: Language,
     /// Full method body (between braces), extracted from the conforming file.
     /// None if the body couldn't be extracted.

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -9,7 +9,6 @@ use serde::Serialize;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 mod audit_source;
 mod cache;
@@ -380,11 +379,7 @@ fn is_homeboy_owned_ci_artifact(path: &str) -> bool {
 }
 
 fn log_git_status_short(root: &Path) {
-    match Command::new("git")
-        .args(["status", "--short"])
-        .current_dir(root)
-        .output()
-    {
+    match git::run_git_output(root, &["status", "--short"], "git status --short") {
         Ok(output) if output.status.success() => {
             let status = String::from_utf8_lossy(&output.stdout);
             if status.trim().is_empty() {
@@ -427,11 +422,9 @@ fn clean_homeboy_owned_ci_artifacts(root: &Path) -> crate::core::Result<bool> {
         }
     }
 
-    let _ = Command::new("git")
-        .args(["restore", "--staged", "--worktree", "--"])
-        .args(HOMEBOY_OWNED_CI_ARTIFACT_DIRS)
-        .current_dir(root)
-        .output();
+    let mut restore_args = vec!["restore", "--staged", "--worktree", "--"];
+    restore_args.extend_from_slice(HOMEBOY_OWNED_CI_ARTIFACT_DIRS);
+    let _ = git::run_git_output(root, &restore_args, "git restore Homeboy CI artifacts");
 
     let root_str = root.to_string_lossy().to_string();
     Ok(!git::get_uncommitted_changes(&root_str)

--- a/src/core/refactor/plan/sources/lint_scope.rs
+++ b/src/core/refactor/plan/sources/lint_scope.rs
@@ -4,7 +4,6 @@ use crate::core::Error;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 pub(super) struct ReleaseOwnedFileSnapshot {
     relative: String,
@@ -205,14 +204,9 @@ pub(super) fn reject_unsafe_lint_autofix_changes(
 }
 
 fn lint_autofix_diff(root: &Path, changed_files: &[String]) -> crate::core::Result<String> {
-    let output = Command::new("git")
-        .arg("diff")
-        .arg("--unified=0")
-        .arg("--")
-        .args(changed_files)
-        .current_dir(root)
-        .output()
-        .map_err(|error| Error::internal_io(error.to_string(), Some("run git diff".to_string())))?;
+    let mut args = vec!["diff", "--unified=0", "--"];
+    args.extend(changed_files.iter().map(String::as_str));
+    let output = git::run_git_output(root, &args, "git diff")?;
 
     if !output.status.success() {
         return Err(Error::git_command_failed(format!(

--- a/src/core/release/executor/github_release/gh_cli.rs
+++ b/src/core/release/executor/github_release/gh_cli.rs
@@ -2,6 +2,7 @@
 
 use crate::core::component::GithubConfig;
 use crate::core::deploy::release_download::GitHubRepo;
+use crate::core::engine::shell::quote_arg;
 use crate::core::release::types::ReleaseState;
 
 pub(crate) fn gh_is_available() -> bool {
@@ -51,7 +52,7 @@ pub(super) fn gh_env_prefix(env: &[(String, String)]) -> String {
     let parts = env
         .iter()
         .filter(|(key, value)| !key.is_empty() && !value.is_empty())
-        .map(|(key, value)| format!("{}={}", key, shell_quote(value)))
+        .map(|(key, value)| format!("{}={}", key, quote_arg(value)))
         .collect::<Vec<_>>();
     if parts.is_empty() {
         String::new()
@@ -109,17 +110,6 @@ pub(super) fn safe_filename(value: &str) -> String {
             }
         })
         .collect()
-}
-
-pub(super) fn shell_quote(value: &str) -> String {
-    if value
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-' | ':' | '=' | '@'))
-    {
-        return value.to_string();
-    }
-
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn gh_probe_succeeds(github: &GitHubRepo, config: &GithubConfig, args: &[&str]) -> bool {

--- a/src/core/release/executor/github_release/repair.rs
+++ b/src/core/release/executor/github_release/repair.rs
@@ -2,8 +2,9 @@
 
 use crate::core::component::GithubConfig;
 use crate::core::deploy::release_download::GitHubRepo;
+use crate::core::engine::shell::quote_arg;
 
-use super::gh_cli::{gh_env_hint, gh_env_prefix, github_cli_env, safe_filename, shell_quote};
+use super::gh_cli::{gh_env_hint, gh_env_prefix, github_cli_env, safe_filename};
 
 #[derive(Debug, Clone)]
 pub(crate) struct GitHubReleaseRepairCommands {
@@ -90,21 +91,17 @@ fn github_release_repair_commands_with_env(
     let mut generate_notes = vec![
         format!("{}gh", env_prefix),
         "api".to_string(),
-        shell_quote(&endpoint),
+        quote_arg(&endpoint),
         "-f".to_string(),
-        shell_quote(&format!("tag_name={}", tag)),
+        quote_arg(&format!("tag_name={}", tag)),
     ];
     if let Some(previous) = previous_tag {
         generate_notes.push("-f".to_string());
-        generate_notes.push(shell_quote(&format!("previous_tag_name={}", previous)));
+        generate_notes.push(quote_arg(&format!("previous_tag_name={}", previous)));
     }
     generate_notes.push("--jq".to_string());
-    generate_notes.push(shell_quote(".body"));
-    let regenerate_command = format!(
-        "{} > {}",
-        generate_notes.join(" "),
-        shell_quote(&notes_file)
-    );
+    generate_notes.push(quote_arg(".body"));
+    let regenerate_command = format!("{} > {}", generate_notes.join(" "), quote_arg(&notes_file));
     // The notes-generation step is only meaningful when there is no persisted
     // exact body. With a persisted body, regenerating would risk a divergent
     // result, so the "generate" step becomes a no-op note that reuses the file.
@@ -121,23 +118,23 @@ fn github_release_repair_commands_with_env(
         format!("{}gh", env_prefix),
         "release".to_string(),
         "create".to_string(),
-        shell_quote(tag),
+        quote_arg(tag),
         "--title".to_string(),
-        shell_quote(tag),
+        quote_arg(tag),
         "--notes-file".to_string(),
-        shell_quote(&notes_file),
+        quote_arg(&notes_file),
     ];
     for path in artifact_paths {
-        create.push(shell_quote(path));
+        create.push(quote_arg(path));
     }
     create.push("-R".to_string());
-    create.push(shell_quote(&repo_flag));
+    create.push(quote_arg(&repo_flag));
 
     let view_command = format!(
         "{}gh release view {} -R {}",
         env_prefix,
-        shell_quote(tag),
-        shell_quote(&repo_flag)
+        quote_arg(tag),
+        quote_arg(&repo_flag)
     );
     let env_hint = gh_env_hint(github, &env);
 

--- a/src/core/release/scope.rs
+++ b/src/core/release/scope.rs
@@ -69,11 +69,6 @@ impl ReleaseScope {
         git::get_latest_tag_any_with_prefix(&self.git_root, self.tag_prefix())
     }
 
-    #[allow(dead_code)]
-    pub fn previous_tag_before(&self, tag: &str) -> Result<Option<String>> {
-        git::get_previous_tag_before_with_prefix(&self.git_root, tag, self.tag_prefix())
-    }
-
     pub fn previous_tag_before_any(&self, tag: &str) -> Result<Option<String>> {
         git::get_previous_tag_before_any_with_prefix(&self.git_root, tag, self.tag_prefix())
     }
@@ -287,13 +282,6 @@ mod tests {
             ReleaseScope::resolve(&wordpress, "wordpress").expect("package scope");
 
         assert_eq!(root_scope.latest_tag().unwrap().as_deref(), Some("v2.10.0"));
-        assert_eq!(
-            root_scope
-                .previous_tag_before("v2.10.0")
-                .unwrap()
-                .as_deref(),
-            Some("v2.9.3")
-        );
         assert_eq!(root_scope.tag_name("2.10.1"), "v2.10.1");
         assert_eq!(
             wordpress_scope.latest_tag().unwrap().as_deref(),

--- a/src/core/runner/extension_materialization.rs
+++ b/src/core/runner/extension_materialization.rs
@@ -221,8 +221,8 @@ fn upload_snapshot(
     transfer.upload_file(&archive.display().to_string(), &remote_archive)?;
     let extract = format!(
         "set -e\nrm -rf {dest}\nmkdir -p {dest}\ntar -xf {archive} -C {dest}\nrm -f {archive}\n",
-        dest = sq(&plan.synced_source_path),
-        archive = sq(&remote_archive),
+        dest = shell::quote_path(&plan.synced_source_path),
+        archive = shell::quote_path(&remote_archive),
     );
     let (_output, exit_code) = exec(
         &runner.id,
@@ -593,22 +593,8 @@ fn shell_command(command: &[String]) -> String {
         .join(" ")
 }
 
-fn sq(value: &str) -> String {
-    let mut out = String::with_capacity(value.len() + 2);
-    out.push('\'');
-    for ch in value.chars() {
-        if ch == '\'' {
-            out.push_str("'\\''");
-        } else {
-            out.push(ch);
-        }
-    }
-    out.push('\'');
-    out
-}
-
 fn shell_arg(value: &str) -> String {
-    sq(value)
+    shell::quote_path(value)
 }
 
 #[cfg(test)]

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use crate::core::engine::shell::{quote_arg, quote_path};
 use crate::core::error::{Error, Result};
+use crate::core::git::{run_git, run_git_output};
 use crate::core::output::MergeOutput;
 
 use super::{
@@ -386,7 +388,7 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
     transfer.ensure_directory(remote_parent)?;
     transfer.upload_file(&local_binary.display().to_string(), &remote_binary)?;
 
-    let chmod_script = format!("chmod 0755 {}", sq(&remote_binary));
+    let chmod_script = format!("chmod 0755 {}", quote_path(&remote_binary));
     let (_chmod, chmod_exit) = exec(
         &options.runner_id,
         RunnerExecOptions {
@@ -545,17 +547,17 @@ fn sync_extension_overlays(
 fn materialize_script(source: &str, git_ref: &str, target_dir: &str, binary_path: &str) -> String {
     format!(
         "set -e\nsource={}\nref={}\ndir={}\nbinary={}\nmkdir -p \"$(dirname \"$dir\")\"\nif [ ! -d \"$dir/.git\" ]; then\n  git clone \"$source\" \"$dir\"\nfi\ncurrent_remote=$(git -C \"$dir\" config --get remote.origin.url 2>/dev/null || true)\nif [ \"$current_remote\" != \"$source\" ]; then\n  git -C \"$dir\" remote set-url origin \"$source\" 2>/dev/null || git -C \"$dir\" remote add origin \"$source\"\nfi\ngit -C \"$dir\" fetch --prune origin\ntarget=$(git -C \"$dir\" rev-parse --verify --quiet \"origin/$ref\" || git -C \"$dir\" rev-parse --verify --quiet \"$ref\")\nif [ -z \"$target\" ]; then\n  echo \"Homeboy ref not found: $ref\" >&2\n  exit 1\nfi\ngit -C \"$dir\" checkout --quiet --force --detach \"$target\"\ngit -C \"$dir\" reset --hard \"$target\"\ncargo build --release --bin homeboy --manifest-path \"$dir/Cargo.toml\"\n\"$binary\" self identity\n",
-        sq(source),
-        sq(git_ref),
-        sq(target_dir),
-        sq(binary_path),
+        quote_path(source),
+        quote_path(git_ref),
+        quote_path(target_dir),
+        quote_path(binary_path),
     )
 }
 
 fn identity_probe_script(binary_path: &str) -> String {
     format!(
         "set -e\nbinary={}\n\"$binary\" self identity\n",
-        sq(binary_path)
+        quote_path(binary_path)
     )
 }
 
@@ -668,20 +670,13 @@ fn expand_path(path: &str) -> PathBuf {
 }
 
 fn git_revision(path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["-C", &path.display().to_string(), "rev-parse", "HEAD"])
-        .output()
-        .ok()?;
-    output
-        .status
-        .success()
-        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    run_git(path, &["rev-parse", "HEAD"], "git rev-parse")
+        .ok()
+        .map(|stdout| stdout.trim().to_string())
 }
 
 fn git_dirty(path: &Path) -> bool {
-    Command::new("git")
-        .args(["-C", &path.display().to_string(), "status", "--porcelain"])
-        .output()
+    run_git_output(path, &["status", "--porcelain"], "git status --porcelain")
         .ok()
         .is_some_and(|output| !output.stdout.is_empty())
 }
@@ -783,22 +778,8 @@ impl IfEmpty for String {
     }
 }
 
-fn sq(value: &str) -> String {
-    let mut out = String::with_capacity(value.len() + 2);
-    out.push('\'');
-    for ch in value.chars() {
-        if ch == '\'' {
-            out.push_str("'\\''");
-        } else {
-            out.push(ch);
-        }
-    }
-    out.push('\'');
-    out
-}
-
 fn shell_arg(value: &str) -> String {
-    sq(value)
+    quote_arg(value)
 }
 
 #[cfg(test)]

--- a/src/core/runner/managed_source.rs
+++ b/src/core/runner/managed_source.rs
@@ -29,6 +29,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::core::agent_task_provider::AgentTaskProviderRunnerSource;
+use crate::core::engine::shell;
 
 /// A resolved, validated plan for syncing a single managed runner source. The
 /// `script` is a POSIX shell program intended to run on the runner.
@@ -108,7 +109,7 @@ fn render_sync_script(path: &str, remote_url: Option<&str>, git_ref: Option<&str
 
     match remote_url {
         Some(remote_url) => {
-            let quoted_remote = sq(remote_url);
+            let quoted_remote = shell::quote_path(remote_url);
             script.push_str(&format!("remote={quoted_remote}\n"));
             // Clone when the checkout (or its .git) is missing.
             script.push_str("if [ ! -d \"$dir/.git\" ]; then\n");
@@ -140,7 +141,7 @@ fn render_sync_script(path: &str, remote_url: Option<&str>, git_ref: Option<&str
 
     match git_ref {
         Some(git_ref) => {
-            let quoted_ref = sq(git_ref);
+            let quoted_ref = shell::quote_path(git_ref);
             script.push_str(&format!("ref={quoted_ref}\n"));
             // Resolve the ref preferring the remote-tracking form so a declared
             // branch syncs to origin's tip rather than a stale local branch.
@@ -179,22 +180,6 @@ fn render_sync_script(path: &str, remote_url: Option<&str>, git_ref: Option<&str
     script
 }
 
-/// POSIX single-quote escaping: wrap in single quotes and replace embedded
-/// single quotes with the `'\''` sequence.
-fn sq(value: &str) -> String {
-    let mut out = String::with_capacity(value.len() + 2);
-    out.push('\'');
-    for ch in value.chars() {
-        if ch == '\'' {
-            out.push_str("'\\''");
-        } else {
-            out.push(ch);
-        }
-    }
-    out.push('\'');
-    out
-}
-
 /// Render a shell expression for manifest-declared runner paths. Manifests are
 /// runner-side contracts, so leading `~` must resolve against the runner user,
 /// not the machine that planned the sync.
@@ -204,10 +189,10 @@ fn shell_path_expr(path: &str) -> String {
     }
 
     if let Some(rest) = path.strip_prefix("~/") {
-        return format!("\"${{HOME}}\"/{}", sq(rest));
+        return format!("\"${{HOME}}\"/{}", shell::quote_path(rest));
     }
 
-    sq(path)
+    shell::quote_path(path)
 }
 
 #[cfg(test)]
@@ -338,9 +323,9 @@ mod tests {
     }
 
     #[test]
-    fn sq_escapes_embedded_single_quotes() {
-        assert_eq!(sq("a'b"), "'a'\\''b'");
-        assert_eq!(sq("/plain/path"), "'/plain/path'");
+    fn shell_path_escapes_embedded_single_quotes() {
+        assert_eq!(shell::quote_path("a'b"), "'a'\\''b'");
+        assert_eq!(shell::quote_path("/plain/path"), "'/plain/path'");
     }
 
     #[test]

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -1,5 +1,7 @@
 use crate::core::defaults;
+use crate::core::engine::shell::quote_path;
 use crate::core::error::{Error, Result};
+use crate::core::git::{run_git, run_git_output};
 use crate::core::stream_capture::StreamCaptureMetadata;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -368,15 +370,7 @@ fn display_path(path: &Path) -> String {
 }
 
 fn shell_quote_path(path: &Path) -> String {
-    shell_quote(&path.display().to_string())
-}
-
-fn shell_quote(value: &str) -> String {
-    if value.is_empty() {
-        return "''".to_string();
-    }
-
-    format!("'{}'", value.replace('\'', "'\\''"))
+    quote_path(&path.display().to_string())
 }
 
 /// Read back the active binary version after a successful swap, retrying while
@@ -605,20 +599,19 @@ fn origin_default_branch(workspace_root: &Path) -> Result<Option<String>> {
 }
 
 fn git_command_success(workspace_root: &Path, args: &[&str]) -> Result<bool> {
-    Ok(git_command_output(workspace_root, args)?.status.success())
+    Ok(
+        run_git_output(workspace_root, args, "prepare source checkout")?
+            .status
+            .success(),
+    )
 }
 
 fn git_command_stdout(workspace_root: &Path, args: &[&str]) -> Result<String> {
-    let output = git_command_output(workspace_root, args)?;
-    if !output.status.success() {
-        return Err(git_command_error(args, &output));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    run_git(workspace_root, args, "prepare source checkout").map(|stdout| stdout.trim().to_string())
 }
 
 fn git_command_stdout_optional(workspace_root: &Path, args: &[&str]) -> Result<Option<String>> {
-    let output = git_command_output(workspace_root, args)?;
+    let output = run_git_output(workspace_root, args, "prepare source checkout")?;
     if !output.status.success() {
         return Ok(None);
     }
@@ -629,38 +622,7 @@ fn git_command_stdout_optional(workspace_root: &Path, args: &[&str]) -> Result<O
 }
 
 fn run_git_command(workspace_root: &Path, args: &[&str]) -> Result<()> {
-    let output = git_command_output(workspace_root, args)?;
-    if output.status.success() {
-        return Ok(());
-    }
-
-    Err(git_command_error(args, &output))
-}
-
-fn git_command_output(workspace_root: &Path, args: &[&str]) -> Result<std::process::Output> {
-    Command::new("git")
-        .arg("-C")
-        .arg(workspace_root)
-        .args(args)
-        .output()
-        .map_err(|e| Error::internal_io(e.to_string(), Some("prepare source checkout".to_string())))
-}
-
-fn git_command_error(args: &[&str], output: &std::process::Output) -> Error {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let detail = if !stderr.is_empty() {
-        stderr
-    } else if !stdout.is_empty() {
-        stdout
-    } else {
-        format!("exit code {}", output.status.code().unwrap_or(1))
-    };
-
-    Error::internal_io(
-        format!("git {} failed: {detail}", args.join(" ")),
-        Some("prepare source checkout".to_string()),
-    )
+    run_git(workspace_root, args, "prepare source checkout").map(|_| ())
 }
 
 const DETACHED_SOURCE_GIT_PULL_GUARD: &str = r#"git() {
@@ -1462,10 +1424,7 @@ mod tests {
 
     #[test]
     fn shell_quote_handles_paths_with_single_quotes() {
-        assert_eq!(
-            shell_quote("/tmp/homeboy's/bin"),
-            "'/tmp/homeboy'\\''s/bin'"
-        );
+        assert_eq!(quote_path("/tmp/homeboy's/bin"), "'/tmp/homeboy'\\''s/bin'");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Collapse duplicated shell quoting helpers onto src/core/engine/shell.rs quote_arg/quote_path.
- Route targeted raw git command call sites through the canonical core git run_git/run_git_output helpers.
- Remove or correct audited dead-code suppressions and delete truly unused reporting fields/methods.

## Dedup table
| Helper | Sites collapsed | LOC deleted |
| --- | --- | ---: |
| Shell quoting | upgrade execution, runner homeboy refresh, path diagnostics, cleanup, rig, runner refresh plan, GitHub release repair/CLI, extension materialization, managed source | 143 |
| Git executor | refactor source status/restore, lint autofix diff, component resolution/root/common-dir, path diagnostics metadata/root, upgrade source preparation, runner homeboy refresh provenance | 63 |
| Dead code | WriteModeArgs::is_dry_run, ReleaseScope::previous_tag_before, SymbolDiff added-only fields, MethodSignature stale suppression, PositionalComponentArgs stale suppression | 117 |

## Dead-code verdict table
| Site | Verdict | Action |
| --- | --- | --- |
| src/commands/utils/args.rs PositionalComponentArgs impl | Live production API | Removed stale #[allow(dead_code)] |
| src/commands/utils/args.rs WriteModeArgs::is_dry_run | Truly dead | Deleted method and suppression |
| src/core/release/scope.rs previous_tag_before | Test-only dead API with _any sibling used | Deleted method and narrow test assertion |
| src/core/code_audit/impact.rs added_exports/added_hooks | Populated/tested but not consumed by reporting | Deleted fields, computations, and fixture fields |
| src/core/refactor/plan/generate/signatures.rs MethodSignature::language | Live in generate_method_stub/fallback | Removed stale #[allow(dead_code)] |
| src/core/config.rs RAII guard field | Legit retained guard | Unchanged |

## Net LOC
- 17 files changed, 99 insertions(+), 323 deletions(-), net -224 LOC.

## Verification
- cargo check --all-targets
- ~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(shell) or test(git) or test(upgrade) or test(refactor) or test(resolution) or test(path_diagnostics) or test(release)' --no-fail-fast

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Collapsed duplicated shell-quote/git-executor helpers and purged dead code; Chris reviews and owns the change.
