### PR TITLE
Keep GitHub release assets with skip-publish

### DIFF
--- a/src/core/release/plan_steps/release.rs
+++ b/src/core/release/plan_steps/release.rs
@@ -51,11 +51,18 @@ pub(in crate::core::release) fn build_release_steps(
         );
     }
 
-    let package_preflight_step_id = add_package_preflight_step(
-        &mut steps,
+    let github_release_will_run = !options.skip_github_release && github_release_applies(component);
+    let package_needed = release_package_needed(
         extensions,
         &publish_targets,
         options,
+        github_release_will_run,
+    );
+
+    let package_preflight_step_id = add_package_preflight_step(
+        &mut steps,
+        extensions,
+        package_needed,
         "preflight.changelog_bootstrap",
     );
 
@@ -115,7 +122,7 @@ pub(in crate::core::release) fn build_release_steps(
         StepConfig::new(),
     ));
 
-    let tag_needs = if !publish_targets.is_empty() && !options.pipeline.skip_publish {
+    let tag_needs = if package_needed {
         steps.push(ready_step(
             "package",
             "package",
@@ -147,7 +154,7 @@ pub(in crate::core::release) fn build_release_steps(
             .string("branch", push_branch),
     ));
 
-    if !options.skip_github_release && github_release_applies(component) {
+    if github_release_will_run {
         steps.push(ready_step(
             "github.release",
             "github.release",
@@ -243,6 +250,13 @@ fn build_head_release_steps(
 ) -> Vec<PlanStep> {
     let mut steps = Vec::new();
     let mut artifact_need = "preflight.remote_sync".to_string();
+    let github_release_will_run = !options.skip_github_release && github_release_applies(component);
+    let package_needed = release_package_needed(
+        extensions,
+        publish_targets,
+        options,
+        github_release_will_run,
+    );
 
     if !publish_targets.is_empty()
         && !options.pipeline.skip_publish
@@ -265,7 +279,7 @@ fn build_head_release_steps(
             string_config("dir", dir),
         ));
         artifact_need = "artifacts.inventory".to_string();
-    } else if !options.pipeline.skip_publish && has_package_capability(extensions) {
+    } else if package_needed {
         steps.push(ready_step(
             "package",
             "package",
@@ -283,7 +297,7 @@ fn build_head_release_steps(
         );
     }
 
-    if !options.skip_github_release && github_release_applies(component) {
+    if github_release_will_run {
         let tag_name = release_scope.tag_name(version);
         steps.push(ready_step(
             "github.release",
@@ -330,7 +344,7 @@ fn build_head_release_steps(
             } else {
                 vec!["cleanup".to_string()]
             }
-        } else if !options.skip_github_release && github_release_applies(component) {
+        } else if github_release_will_run {
             vec!["github.release".to_string()]
         } else {
             vec![artifact_need.clone()]
@@ -350,7 +364,7 @@ fn build_head_release_steps(
             vec!["post_release".to_string()]
         } else if !options.pipeline.skip_publish && !publish_step_ids.is_empty() {
             publish_step_ids
-        } else if !options.skip_github_release && github_release_applies(component) {
+        } else if github_release_will_run {
             vec!["github.release".to_string()]
         } else {
             vec![artifact_need]
@@ -371,14 +385,10 @@ fn build_head_release_steps(
 fn add_package_preflight_step(
     steps: &mut Vec<PlanStep>,
     extensions: &[ExtensionManifest],
-    publish_targets: &[String],
-    options: &ReleaseOptions,
+    package_needed: bool,
     needs: &str,
 ) -> Option<String> {
-    if publish_targets.is_empty()
-        || options.pipeline.skip_publish
-        || !has_package_capability(extensions)
-    {
+    if !package_needed || !has_package_capability(extensions) {
         return None;
     }
 
@@ -391,6 +401,17 @@ fn add_package_preflight_step(
         StepConfig::new(),
     ));
     Some(step_id)
+}
+
+fn release_package_needed(
+    extensions: &[ExtensionManifest],
+    publish_targets: &[String],
+    options: &ReleaseOptions,
+    github_release_will_run: bool,
+) -> bool {
+    has_package_capability(extensions)
+        && (github_release_will_run
+            || (!options.pipeline.skip_publish && !publish_targets.is_empty()))
 }
 
 fn add_release_extension_diagnostics(

--- a/src/core/release/plan_steps/tests/mod.rs
+++ b/src/core/release/plan_steps/tests/mod.rs
@@ -481,6 +481,136 @@ fn release_plan_runs_package_preflight_before_mutating_release_steps() {
 }
 
 #[test]
+fn skip_publish_still_packages_artifacts_for_github_release() {
+    let mut component = github_fixture_component();
+    component.extensions = Some(std::collections::HashMap::from([(
+        "fixture-packager".to_string(),
+        ScopedExtensionConfig::default(),
+    )]));
+    let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+        "name": "Fixture Packager",
+        "version": "1.0.0",
+        "actions": [
+            {
+                "id": "release.package",
+                "label": "Package release",
+                "type": "command",
+                "command": "true"
+            },
+            {
+                "id": "release.publish",
+                "label": "Publish release",
+                "type": "command",
+                "command": "true"
+            }
+        ]
+    }))
+    .expect("extension manifest");
+    extension.id = "fixture-packager".to_string();
+    let mut warnings = Vec::new();
+    let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
+    let options = ReleaseOptions {
+        bump_type: "patch".to_string(),
+        pipeline: ReleasePipelineOptions {
+            skip_publish: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let steps = build_release_steps(
+        &component,
+        &[extension],
+        "1.0.0",
+        "1.0.1",
+        &fixture_changelog_plan(),
+        &options,
+        &release_scope,
+        &mut warnings,
+        &mut hints,
+    )
+    .expect("steps");
+
+    let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+    let package_preflight_index = step_index(&ids, "preflight.package");
+    let tag_preflight_index = step_index(&ids, "preflight.tag_availability");
+    let package_index = step_index(&ids, "package");
+    let tag_index = step_index(&ids, "git.tag");
+    let push_index = step_index(&ids, "git.push");
+    let github_release_index = step_index(&ids, "github.release");
+
+    assert!(package_preflight_index < tag_preflight_index);
+    assert!(package_index < tag_index);
+    assert!(push_index < github_release_index);
+    assert_eq!(steps[tag_preflight_index].needs, vec!["preflight.package"]);
+    assert_eq!(steps[tag_index].needs, vec!["package"]);
+    assert_eq!(steps[github_release_index].needs, vec!["git.push"]);
+    assert!(!ids.iter().any(|id| id.starts_with("publish.")));
+    assert!(!ids.contains(&"cleanup"));
+}
+
+#[test]
+fn skip_publish_and_no_github_release_does_not_package_artifacts() {
+    let mut component = github_fixture_component();
+    component.extensions = Some(std::collections::HashMap::from([(
+        "fixture-packager".to_string(),
+        ScopedExtensionConfig::default(),
+    )]));
+    let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+        "name": "Fixture Packager",
+        "version": "1.0.0",
+        "actions": [
+            {
+                "id": "release.package",
+                "label": "Package release",
+                "type": "command",
+                "command": "true"
+            },
+            {
+                "id": "release.publish",
+                "label": "Publish release",
+                "type": "command",
+                "command": "true"
+            }
+        ]
+    }))
+    .expect("extension manifest");
+    extension.id = "fixture-packager".to_string();
+    let mut warnings = Vec::new();
+    let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
+    let options = ReleaseOptions {
+        bump_type: "patch".to_string(),
+        pipeline: ReleasePipelineOptions {
+            skip_publish: true,
+            ..Default::default()
+        },
+        skip_github_release: true,
+        ..Default::default()
+    };
+
+    let steps = build_release_steps(
+        &component,
+        &[extension],
+        "1.0.0",
+        "1.0.1",
+        &fixture_changelog_plan(),
+        &options,
+        &release_scope,
+        &mut warnings,
+        &mut hints,
+    )
+    .expect("steps");
+
+    let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+    assert!(!ids.contains(&"preflight.package"));
+    assert!(!ids.contains(&"package"));
+    assert!(!ids.contains(&"github.release"));
+    assert!(!ids.iter().any(|id| id.starts_with("publish.")));
+}
+
+#[test]
 fn release_plan_records_changelog_contract() {
     let component = fixture_component();
     let mut warnings = Vec::new();


### PR DESCRIPTION
## Summary
- Keep release package generation in the plan when a GitHub Release will run, even with --skip-publish.
- Continue skipping registry/external publish targets and cleanup under --skip-publish.
- Preserve --no-github-release plus --skip-publish as the explicit tag-only/no-assets path.

Fixes #7591.

## Verification
- cargo fmt --check
- cargo test --lib skip_publish
- cargo test --lib core::release::plan_steps::tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated release planning behavior, implemented the generic Homeboy fix, added focused tests, and prepared this PR.