### PR TITLE
Guard GitHub Release artifacts when skipping publish

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -546,6 +546,23 @@ mod tests {
     }
 
     #[test]
+    fn package_output_with_zero_artifacts_fails_before_github_release_can_upload_nothing() {
+        let mut state = ReleaseState::default();
+        let response = serde_json::json!({
+            "success": true,
+            "exitCode": 0,
+            "stdout": "[]",
+            "stderr": ""
+        });
+
+        let err = store_artifacts_from_output(&mut state, &response)
+            .expect_err("empty package output should fail");
+
+        assert!(state.artifacts.is_empty());
+        assert!(err.message.contains("zero release artifacts"));
+    }
+
+    #[test]
     fn cleanup_removes_build_dir_when_release_artifact_is_inside_build() {
         let temp = tempfile::tempdir().expect("tempdir");
         let build_dir = temp.path().join("build");

--- a/src/core/release/executor/package.rs
+++ b/src/core/release/executor/package.rs
@@ -357,6 +357,11 @@ pub(super) fn store_artifacts_from_output(
         )
     })?;
     let artifacts: Vec<ReleaseArtifact> = parse_release_artifacts(&raw_artifacts)?;
+    if artifacts.is_empty() {
+        return Err(Error::internal_unexpected(
+            "Package command produced zero release artifacts. A package-backed release must emit at least one artifact.",
+        ));
+    }
     state.artifacts.extend(artifacts);
     Ok(())
 }

--- a/src/core/release/plan_steps/release.rs
+++ b/src/core/release/plan_steps/release.rs
@@ -51,11 +51,16 @@ pub(in crate::core::release) fn build_release_steps(
         );
     }
 
+    let github_release_needed = github_release_needed(component, options);
+    let package_step_needed =
+        package_step_needed(extensions, &publish_targets, options, github_release_needed);
+
     let package_preflight_step_id = add_package_preflight_step(
         &mut steps,
         extensions,
         &publish_targets,
         options,
+        github_release_needed,
         "preflight.changelog_bootstrap",
     );
 
@@ -115,7 +120,7 @@ pub(in crate::core::release) fn build_release_steps(
         StepConfig::new(),
     ));
 
-    let tag_needs = if !publish_targets.is_empty() && !options.pipeline.skip_publish {
+    let tag_needs = if package_step_needed {
         steps.push(ready_step(
             "package",
             "package",
@@ -147,7 +152,7 @@ pub(in crate::core::release) fn build_release_steps(
             .string("branch", push_branch),
     ));
 
-    if !options.skip_github_release && github_release_applies(component) {
+    if github_release_needed {
         steps.push(ready_step(
             "github.release",
             "github.release",
@@ -265,7 +270,7 @@ fn build_head_release_steps(
             string_config("dir", dir),
         ));
         artifact_need = "artifacts.inventory".to_string();
-    } else if !options.pipeline.skip_publish && has_package_capability(extensions) {
+    } else if head_package_step_needed(component, extensions, publish_targets, options) {
         steps.push(ready_step(
             "package",
             "package",
@@ -283,7 +288,7 @@ fn build_head_release_steps(
         );
     }
 
-    if !options.skip_github_release && github_release_applies(component) {
+    if github_release_needed(component, options) {
         let tag_name = release_scope.tag_name(version);
         steps.push(ready_step(
             "github.release",
@@ -330,7 +335,7 @@ fn build_head_release_steps(
             } else {
                 vec!["cleanup".to_string()]
             }
-        } else if !options.skip_github_release && github_release_applies(component) {
+        } else if github_release_needed(component, options) {
             vec!["github.release".to_string()]
         } else {
             vec![artifact_need.clone()]
@@ -350,7 +355,7 @@ fn build_head_release_steps(
             vec!["post_release".to_string()]
         } else if !options.pipeline.skip_publish && !publish_step_ids.is_empty() {
             publish_step_ids
-        } else if !options.skip_github_release && github_release_applies(component) {
+        } else if github_release_needed(component, options) {
             vec!["github.release".to_string()]
         } else {
             vec![artifact_need]
@@ -373,12 +378,10 @@ fn add_package_preflight_step(
     extensions: &[ExtensionManifest],
     publish_targets: &[String],
     options: &ReleaseOptions,
+    github_release_needed: bool,
     needs: &str,
 ) -> Option<String> {
-    if publish_targets.is_empty()
-        || options.pipeline.skip_publish
-        || !has_package_capability(extensions)
-    {
+    if !package_step_needed(extensions, publish_targets, options, github_release_needed) {
         return None;
     }
 
@@ -391,6 +394,32 @@ fn add_package_preflight_step(
         StepConfig::new(),
     ));
     Some(step_id)
+}
+
+fn github_release_needed(component: &Component, options: &ReleaseOptions) -> bool {
+    !options.skip_github_release && github_release_applies(component)
+}
+
+fn package_step_needed(
+    extensions: &[ExtensionManifest],
+    publish_targets: &[String],
+    options: &ReleaseOptions,
+    github_release_needed: bool,
+) -> bool {
+    has_package_capability(extensions)
+        && ((!publish_targets.is_empty() && !options.pipeline.skip_publish)
+            || github_release_needed)
+}
+
+fn head_package_step_needed(
+    component: &Component,
+    extensions: &[ExtensionManifest],
+    publish_targets: &[String],
+    options: &ReleaseOptions,
+) -> bool {
+    has_package_capability(extensions)
+        && ((!publish_targets.is_empty() && !options.pipeline.skip_publish)
+            || github_release_needed(component, options))
 }
 
 fn add_release_extension_diagnostics(

--- a/src/core/release/plan_steps/tests/mod.rs
+++ b/src/core/release/plan_steps/tests/mod.rs
@@ -481,6 +481,122 @@ fn release_plan_runs_package_preflight_before_mutating_release_steps() {
 }
 
 #[test]
+fn skip_publish_with_package_provider_still_packages_before_github_release() {
+    let component = github_fixture_component();
+    let extension = release_extension("artifact-packager", &["release.package", "release.publish"]);
+    let mut warnings = Vec::new();
+    let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
+    let options = ReleaseOptions {
+        bump_type: "patch".to_string(),
+        pipeline: ReleasePipelineOptions {
+            skip_publish: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let steps = build_release_steps(
+        &component,
+        &[extension],
+        "1.0.0",
+        "1.0.1",
+        &fixture_changelog_plan(),
+        &options,
+        &release_scope,
+        &mut warnings,
+        &mut hints,
+    )
+    .expect("steps");
+
+    let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+    let package_preflight_index = step_index(&ids, "preflight.package");
+    let package_index = step_index(&ids, "package");
+    let github_release_index = step_index(&ids, "github.release");
+
+    assert!(package_preflight_index < package_index);
+    assert!(package_index < github_release_index);
+    assert_eq!(steps[package_index].needs, vec!["git.commit"]);
+    assert_eq!(steps[step_index(&ids, "git.tag")].needs, vec!["package"]);
+    assert_eq!(steps[github_release_index].needs, vec!["git.push"]);
+    assert!(!ids.contains(&"publish.artifact-packager"));
+    assert!(!ids.contains(&"cleanup"));
+}
+
+#[test]
+fn skip_publish_tag_only_release_can_skip_package_when_no_upload_needs_assets() {
+    let component = github_fixture_component();
+    let extension = release_extension("artifact-packager", &["release.package", "release.publish"]);
+    let mut warnings = Vec::new();
+    let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
+    let options = ReleaseOptions {
+        bump_type: "patch".to_string(),
+        skip_github_release: true,
+        pipeline: ReleasePipelineOptions {
+            skip_publish: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let steps = build_release_steps(
+        &component,
+        &[extension],
+        "1.0.0",
+        "1.0.1",
+        &fixture_changelog_plan(),
+        &options,
+        &release_scope,
+        &mut warnings,
+        &mut hints,
+    )
+    .expect("steps");
+
+    let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+    assert!(!ids.contains(&"preflight.package"));
+    assert!(!ids.contains(&"package"));
+    assert!(!ids.contains(&"github.release"));
+    assert!(!ids.contains(&"publish.artifact-packager"));
+    assert_eq!(steps[step_index(&ids, "git.tag")].needs, vec!["git.commit"]);
+}
+
+#[test]
+fn head_skip_publish_with_package_provider_still_packages_before_github_release() {
+    let component = github_fixture_component();
+    let extension = release_extension("artifact-packager", &["release.package"]);
+    let mut warnings = Vec::new();
+    let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
+    let options = ReleaseOptions {
+        bump_type: "head".to_string(),
+        pipeline: ReleasePipelineOptions {
+            head: true,
+            skip_publish: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let steps = build_release_steps(
+        &component,
+        &[extension],
+        "1.0.1",
+        "1.0.1",
+        &fixture_changelog_plan(),
+        &options,
+        &release_scope,
+        &mut warnings,
+        &mut hints,
+    )
+    .expect("steps");
+
+    let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+    assert_eq!(ids, vec!["package", "github.release"]);
+    assert_eq!(steps[1].needs, vec!["package"]);
+}
+
+#[test]
 fn release_plan_records_changelog_contract() {
     let component = fixture_component();
     let mut warnings = Vec::new();
@@ -885,6 +1001,22 @@ fn fixture_changelog_plan() -> ReleaseChangelogPlan {
         )]),
         entry_count: 1,
     }
+}
+
+fn release_extension(id: &str, actions: &[&str]) -> ExtensionManifest {
+    let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+        "name": id,
+        "version": "1.0.0",
+        "actions": actions.iter().map(|action| serde_json::json!({
+            "id": action,
+            "label": action,
+            "type": "command",
+            "command": "true"
+        })).collect::<Vec<_>>()
+    }))
+    .expect("extension manifest");
+    extension.id = id.to_string();
+    extension
 }
 
 fn semver_recommendation(


### PR DESCRIPTION
## Summary
- keep release packaging in the plan when a GitHub Release will upload package artifacts, even with --skip-publish
- preserve tag-only/no-GitHub-Release behavior where --skip-publish can omit packaging
- fail package execution when a package provider emits zero artifacts so github.release cannot create a package-backed zero-asset release

Fixes #7591

## Verification
- cargo test core::release::plan_steps::tests::
- cargo test core::release::executor::tests::package_output_with_zero_artifacts_fails_before_github_release_can_upload_nothing

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Drafted the release planning/execution regression tests and minimal implementation changes with Chris directing the issue scope.