### PR TITLE
Fix release recovery quality gate bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
       bump-type: ${{ steps.check.outputs.release-bump-type }}
+      recovery-release: ${{ steps.check.outputs.recovery-release }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -138,6 +139,7 @@ jobs:
           elif [ -n "${RECOVERY_TAG}" ]; then
             echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "release-bump-type=${BUMP_TYPE}" >> "$GITHUB_OUTPUT"
+            echo "recovery-release=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Release recovery will publish ${RECOVERY_TAG}"
           elif [ -z "${RELEASE_VERSION}" ]; then
             echo "should-release=false" >> "$GITHUB_OUTPUT"
@@ -145,6 +147,12 @@ jobs:
           else
             echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "release-bump-type=${BUMP_TYPE}" >> "$GITHUB_OUTPUT"
+            if [ "${BUMP_TYPE}" = "recovery" ]; then
+              echo "recovery-release=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::Recovered prepared release tag; bypassing quality gates and publishing artifacts"
+            else
+              echo "recovery-release=false" >> "$GITHUB_OUTPUT"
+            fi
             echo "::notice::Release dry-run predicts v${RELEASE_VERSION} (${BUMP_TYPE})"
           fi
 
@@ -194,7 +202,7 @@ jobs:
     needs:
       - check
       - gate-build
-    if: needs.check.outputs.should-release == 'true'
+    if: needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true'
     runs-on: ubuntu-latest
     outputs:
       audit-result: ${{ steps.audit.outcome }}
@@ -243,7 +251,7 @@ jobs:
     needs:
       - check
       - gate-build
-    if: needs.check.outputs.should-release == 'true'
+    if: needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -287,7 +295,7 @@ jobs:
     needs:
       - check
       - gate-build
-    if: needs.check.outputs.should-release == 'true'
+    if: needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -336,7 +344,7 @@ jobs:
       - gate-build
       - gate-lint
       - gate-test
-    if: ${{ always() && inputs.release_tag == '' && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' }}
+    if: ${{ always() && inputs.release_tag == '' && needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true' && needs.gate-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -394,7 +402,7 @@ jobs:
       - gate-audit
       - gate-lint
       - gate-test
-    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' }}
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true' && needs.gate-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Enforce release-blocking commands
@@ -441,7 +449,7 @@ jobs:
       - check
       - gate-build
       - release-quality-policy
-    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' && (inputs.release_tag != '' || needs.release-quality-policy.result == 'success') }}
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' && (needs.check.outputs.recovery-release == 'true' || inputs.release_tag != '' || needs.release-quality-policy.result == 'success') }}
     runs-on: ubuntu-latest
     outputs:
       release-version: ${{ steps.outputs.outputs.release-version }}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -43,7 +43,7 @@ fn release_refactor_gate_enables_non_pr_repair_path() {
 #[test]
 fn release_quality_policy_defaults_to_lint_and_test_blocking() {
     assert!(release_workflow().contains(
-        "RELEASE_BLOCKING_COMMANDS: ${{ inputs.release_blocking_commands || 'lint,test' }}"
+        "RELEASE_BLOCKING_COMMANDS: ${{ inputs.release_blocking_commands || 'review lint,review test' }}"
     ));
 
     let policy = job_section(release_workflow(), "release-quality-policy");
@@ -77,7 +77,7 @@ fn release_ci_disables_homeboy_update_checks() {
 fn release_test_gate_does_not_repeat_separate_lint_gate() {
     let gate_test = job_section(release_workflow(), "gate-test");
 
-    assert!(gate_test.contains("commands: test"));
+    assert!(gate_test.contains("commands: review test"));
     assert!(gate_test.contains("--skip-lint"));
     assert!(gate_test.contains("--changed-since {0}"));
 }
@@ -128,12 +128,14 @@ fn release_prepare_uses_prepared_output_to_unlock_publish_jobs() {
     let prepare = job_section(release_workflow(), "prepare");
     let plan = job_section(release_workflow(), "plan");
 
-    assert!(prepare.contains(
-        "prepared: ${{ steps.recovery.outputs.prepared || steps.prepared.outputs.prepared }}"
-    ));
+    assert!(prepare.contains("prepared: ${{ steps.outputs.outputs.prepared }}"));
     assert!(prepare.contains("id: prepared"));
+    assert!(prepare.contains("id: outputs"));
     assert!(prepare.contains("steps.release.outputs.release-tag != ''"));
     assert!(prepare.contains("echo \"prepared=true\" >> \"$GITHUB_OUTPUT\""));
+    assert!(prepare.contains(
+        "PREPARED=\"${{ steps.recovery.outputs.prepared || steps.prepared.outputs.prepared }}\""
+    ));
     assert!(prepare.contains("downstream jobs will publish it in this run"));
     assert!(
         prepare.contains("Skipping release preparation; downstream jobs will publish existing tag")
@@ -142,6 +144,26 @@ fn release_prepare_uses_prepared_output_to_unlock_publish_jobs() {
     assert!(plan.contains("needs.prepare.outputs.prepared == 'true'"));
     assert!(plan.contains("needs.prepare.outputs.release-tag != ''"));
     assert!(!plan.contains("needs.prepare.outputs.released == 'true'"));
+}
+
+#[test]
+fn release_recovery_bypasses_quality_gates_and_still_prepares() {
+    let check = job_section(release_workflow(), "check");
+    let gate_audit = job_section(release_workflow(), "gate-audit");
+    let gate_lint = job_section(release_workflow(), "gate-lint");
+    let gate_test = job_section(release_workflow(), "gate-test");
+    let policy = job_section(release_workflow(), "release-quality-policy");
+    let prepare = job_section(release_workflow(), "prepare");
+
+    assert!(check.contains("recovery-release: ${{ steps.check.outputs.recovery-release }}"));
+    assert!(check.contains("echo \"recovery-release=true\" >> \"$GITHUB_OUTPUT\""));
+    assert!(check.contains("Recovered prepared release tag; bypassing quality gates"));
+
+    for section in [gate_audit, gate_lint, gate_test, policy] {
+        assert!(section.contains("needs.check.outputs.recovery-release != 'true'"));
+    }
+
+    assert!(prepare.contains("needs.check.outputs.recovery-release == 'true'"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- mark release runs that are publishing an existing/prepared tag as recovery runs
- skip audit/lint/test/refactor/policy gates during recovery while still allowing prepare and artifact publishing to continue
- update release workflow tests for the review-nested command shape and recovery bypass path

Fixes #7595.

## Testing
- `cargo test --test release_workflow_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Diagnosed the release recovery workflow failure and drafted the workflow/test changes.
