### PR TITLE
Fix release workflow hyphenated output references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
-      bump-type: ${{ steps.check.outputs.release-bump-type }}
+      bump-type: ${{ steps.check.outputs['release-bump-type'] }}
       recovery-release: ${{ steps.check.outputs.recovery-release }}
     steps:
       - uses: actions/checkout@v4
@@ -130,9 +130,9 @@ jobs:
         id: check
         run: |
           HEAD_SHA="$(git rev-parse HEAD)"
-          RECOVERY_TAG="${{ steps.recovery.outputs.release-tag }}"
-          RELEASE_VERSION="${{ steps.recovery.outputs.release-version || steps.release-check.outputs.release-version }}"
-          BUMP_TYPE="${{ steps.recovery.outputs.release-bump-type || steps.release-check.outputs.release-bump-type }}"
+          RECOVERY_TAG="${{ steps.recovery.outputs['release-tag'] }}"
+          RELEASE_VERSION="${{ steps.recovery.outputs['release-version'] || steps.release-check.outputs['release-version'] }}"
+          BUMP_TYPE="${{ steps.recovery.outputs['release-bump-type'] || steps.release-check.outputs['release-bump-type'] }}"
 
           if [ "${{ steps.failed-release.outputs.blocked }}" = "true" ]; then
             echo "should-release=false" >> "$GITHUB_OUTPUT"
@@ -452,8 +452,8 @@ jobs:
     if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' && (needs.check.outputs.recovery-release == 'true' || inputs.release_tag != '' || needs.release-quality-policy.result == 'success') }}
     runs-on: ubuntu-latest
     outputs:
-      release-version: ${{ steps.outputs.outputs.release-version }}
-      release-tag: ${{ steps.outputs.outputs.release-tag }}
+      release-version: ${{ steps.outputs.outputs['release-version'] }}
+      release-tag: ${{ steps.outputs.outputs['release-tag'] }}
       prepared: ${{ steps.outputs.outputs.prepared }}
       released: ${{ steps.outputs.outputs.released }}
     steps:
@@ -522,10 +522,10 @@ jobs:
 
       - name: Mark prepared release for downstream publish
         id: prepared
-        if: inputs.release_tag == '' && steps.release.outputs.release-tag != ''
+        if: inputs.release_tag == '' && steps.release.outputs['release-tag'] != ''
         run: |
           echo "prepared=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::Prepared ${{ steps.release.outputs.release-tag }}; downstream jobs will publish it in this run"
+          echo "::notice::Prepared ${{ steps.release.outputs['release-tag'] }}; downstream jobs will publish it in this run"
 
       - name: Use existing release tag
         id: recovery
@@ -543,8 +543,8 @@ jobs:
       - name: Resolve release outputs
         id: outputs
         run: |
-          RELEASE_VERSION="${{ steps.recovery.outputs.release-version || steps.release.outputs.release-version }}"
-          RELEASE_TAG="${{ steps.recovery.outputs.release-tag || steps.release.outputs.release-tag }}"
+          RELEASE_VERSION="${{ steps.recovery.outputs['release-version'] || steps.release.outputs['release-version'] }}"
+          RELEASE_TAG="${{ steps.recovery.outputs['release-tag'] || steps.release.outputs['release-tag'] }}"
           PREPARED="${{ steps.recovery.outputs.prepared || steps.prepared.outputs.prepared }}"
           RELEASED="${{ steps.recovery.outputs.released || steps.release.outputs.released }}"
 
@@ -557,17 +557,17 @@ jobs:
   plan:
     name: Plan Build Matrix
     needs: prepare
-    if: needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs.release-tag != ''
+    if: needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != ''
     runs-on: ubuntu-22.04
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag-flag: ${{ format('--tag={0}', needs.prepare.outputs.release-tag) }}
+      tag-flag: ${{ format('--tag={0}', needs.prepare.outputs['release-tag']) }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release-tag }}
+          ref: ${{ needs.prepare.outputs['release-tag'] }}
           persist-credentials: false
           submodules: recursive
 
@@ -583,7 +583,7 @@ jobs:
 
       - id: plan
         run: |
-          dist host --steps=create --tag=${{ needs.prepare.outputs.release-tag }} --output-format=json > plan-dist-manifest.json
+          dist host --steps=create --tag=${{ needs.prepare.outputs['release-tag'] }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -615,7 +615,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release-tag }}
+          ref: ${{ needs.prepare.outputs['release-tag'] }}
           persist-credentials: false
           submodules: recursive
 
@@ -675,7 +675,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release-tag }}
+          ref: ${{ needs.prepare.outputs['release-tag'] }}
           persist-credentials: false
           submodules: recursive
 
@@ -760,7 +760,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release-tag }}
+          ref: ${{ needs.prepare.outputs['release-tag'] }}
           persist-credentials: false
           submodules: recursive
 
@@ -782,7 +782,7 @@ jobs:
       - id: host
         shell: bash
         run: |
-          dist host --tag=${{ needs.prepare.outputs.release-tag }} --steps=upload --output-format=json > dist-manifest.json
+          dist host --tag=${{ needs.prepare.outputs['release-tag'] }} --steps=upload --output-format=json > dist-manifest.json
           echo "artifacts uploaded successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -131,18 +131,20 @@ fn release_prepare_uses_prepared_output_to_unlock_publish_jobs() {
     assert!(prepare.contains("prepared: ${{ steps.outputs.outputs.prepared }}"));
     assert!(prepare.contains("id: prepared"));
     assert!(prepare.contains("id: outputs"));
-    assert!(prepare.contains("steps.release.outputs.release-tag != ''"));
+    assert!(prepare.contains("steps.release.outputs['release-tag'] != ''"));
     assert!(prepare.contains("echo \"prepared=true\" >> \"$GITHUB_OUTPUT\""));
     assert!(prepare.contains(
         "PREPARED=\"${{ steps.recovery.outputs.prepared || steps.prepared.outputs.prepared }}\""
     ));
+    assert!(prepare.contains("release-tag: ${{ steps.outputs.outputs['release-tag'] }}"));
     assert!(prepare.contains("downstream jobs will publish it in this run"));
     assert!(
         prepare.contains("Skipping release preparation; downstream jobs will publish existing tag")
     );
 
     assert!(plan.contains("needs.prepare.outputs.prepared == 'true'"));
-    assert!(plan.contains("needs.prepare.outputs.release-tag != ''"));
+    assert!(plan.contains("needs.prepare.outputs['release-tag'] != ''"));
+    assert!(plan.contains("needs.prepare.outputs['release-tag']"));
     assert!(!plan.contains("needs.prepare.outputs.released == 'true'"));
 }
 


### PR DESCRIPTION
## Summary
- use bracket notation for hyphenated release workflow outputs such as `release-tag` and `release-version`
- keep prepared-tag recovery outputs visible to downstream plan/build/publish jobs
- update release workflow regression tests to catch dot-notation regressions

Follow-up for #7595 after run `28742522777` skipped publish jobs despite `Prepare Release` emitting `prepared=true` and `release-tag=v0.281.7`.

## Testing
- `cargo test --test release_workflow_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Diagnosed the release workflow output propagation failure and drafted the workflow/test fix.
