### PR TITLE
Allow executable readiness without env

### DIFF
--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -1037,6 +1037,58 @@ mod tests {
     }
 
     #[test]
+    fn standalone_runtime_manifest_accepts_path_discovered_executable_readiness_without_env() {
+        crate::test_support::with_isolated_home(|home| {
+            let runtime_dir = home
+                .path()
+                .join(".config/homeboy/agent-runtimes")
+                .join("opencode");
+            std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+            std::fs::write(
+                runtime_dir.join("opencode.json"),
+                json!({
+                    "schema": AGENT_RUNTIME_MANIFEST_SCHEMA,
+                    "id": "ignored-on-disk",
+                    "label": "OpenCode",
+                    "agent_task_executors": [{
+                        "schema": AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+                        "id": "opencode.agent-task-executor",
+                        "backend": "opencode",
+                        "command": "node {{runtime_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs",
+                        "runner_readiness": [{
+                            "id": "opencode.executable",
+                            "label": "OpenCode executable",
+                            "executable": {
+                                "candidates": ["opencode"],
+                                "version_command": ["--version"],
+                                "install_hint": "Install opencode so it is available on PATH."
+                            }
+                        }]
+                    }]
+                })
+                .to_string(),
+            )
+            .expect("runtime manifest");
+
+            let catalog = discover_standalone_agent_runtime_catalog();
+
+            assert!(catalog.diagnostics.is_empty(), "{:?}", catalog.diagnostics);
+            assert_eq!(catalog.manifests.len(), 1);
+            let executable = catalog.manifests[0].agent_task_executors[0].runner_readiness[0]
+                .executable
+                .as_ref()
+                .expect("executable readiness");
+            assert!(executable.env.is_empty());
+            assert_eq!(executable.candidates, vec!["opencode".to_string()]);
+            assert_eq!(executable.version_command, vec!["--version".to_string()]);
+            assert_eq!(
+                executable.install_hint.as_deref(),
+                Some("Install opencode so it is available on PATH.")
+            );
+        });
+    }
+
+    #[test]
     fn standalone_runtime_manifest_with_unsatisfied_core_constraint_reports_diagnostic() {
         crate::test_support::with_isolated_home(|home| {
             let runtime_dir = home

--- a/src/core/agent_task_provider/tests/manifest_tests.rs
+++ b/src/core/agent_task_provider/tests/manifest_tests.rs
@@ -83,6 +83,45 @@ fn provider_manifest_accepts_command_invocation_contract() {
 }
 
 #[test]
+fn provider_manifest_defaults_executable_readiness_env_when_omitted() {
+    let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+        "id": "path-runtime.agent-task-executor",
+        "backend": "path-runtime",
+        "command": "node {{runtime_path}}/scripts/agent/homeboy-path-runtime-agent-task-executor.cjs",
+        "runner_readiness": [{
+            "id": "path-runtime.executable",
+            "label": "PATH runtime executable",
+            "executable": {
+                "candidates": ["path-runtime"],
+                "version_command": ["--version"],
+                "install_hint": "Install path-runtime so it is available on PATH."
+            }
+        }]
+    }))
+    .expect("provider manifest");
+
+    let executable = provider.runner_readiness[0]
+        .executable
+        .as_ref()
+        .expect("executable readiness");
+    assert!(executable.env.is_empty());
+    assert_eq!(executable.candidates, vec!["path-runtime".to_string()]);
+    assert_eq!(executable.version_command, vec!["--version".to_string()]);
+    assert_eq!(
+        executable.install_hint.as_deref(),
+        Some("Install path-runtime so it is available on PATH.")
+    );
+
+    let exported = serde_json::to_value(&provider).expect("provider export");
+    assert!(
+        exported["runner_readiness"][0]["executable"]
+            .get("env")
+            .is_none(),
+        "empty env should remain omitted on export: {exported:?}"
+    );
+}
+
+#[test]
 fn default_provider_catalog_normalizes_codex_command_to_invocation_argv() {
     crate::test_support::with_isolated_home(|home| {
         let runtime_dir = home.path().join(".config/homeboy/agent-runtimes/codex");

--- a/src/core/agent_task_provider/types.rs
+++ b/src/core/agent_task_provider/types.rs
@@ -293,6 +293,7 @@ pub struct AgentTaskProviderEnvPathReadiness {
 pub struct AgentTaskProviderExecutableReadiness {
     /// Environment variable names that should receive the resolved executable path.
     /// Existing non-empty env values win before binary candidate discovery.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub env: Vec<String>,
     /// Ordered executable names or paths to try when env does not already point
     /// at an executable. Bare names are resolved on PATH; paths are checked as-is.


### PR DESCRIPTION
## Summary
- Makes `AgentTaskProviderExecutableReadiness.env` optional with serde default + empty-vector export omission.
- Adds regression coverage for provider manifests and standalone runtime manifests whose executable readiness is discovered from PATH candidates without `env`.
- Focused audit found no other same-class fixes to make: adjacent collection fields in `agent_task_provider/types.rs` and `agent_runtime_manifest.rs` already default where sparse manifests are valid; `env_path.env` remains required because that readiness block needs env names to inspect.

## Root cause
`AgentTaskProviderExecutableReadiness.env` was the only field in that executable readiness block without a serde default. Runtime manifests such as opencode legitimately omit it because the executable is discovered from PATH candidates and no env var receives the resolved path. That caused standalone runtime discovery to reject the manifest before the opencode executor could register.

Closes #7600

## Before / After Evidence
Before, installed `homeboy agent-task providers --refresh` on this machine reported:

```json
{
  "class": "agent_runtime_manifest.schema_mismatch",
  "message": "missing field `env` at line 122 column 11",
  "path": "/Users/chubes/.config/homeboy/agent-runtimes/opencode/opencode.json",
  "runtime_id": "opencode"
}
```

After, the fixed binary reading the same unmodified manifest reports no diagnostics and registers opencode:

```sh
cargo run --quiet -- agent-task providers --refresh | jq '{diagnostics: .data.diagnostics, opencode_provider_ids: [.data.providers[]? | select(.runtime_id == "opencode") | .id], opencode_identity: [.data.provider_identity_catalog[]? | select(.runtime_id == "opencode")]}'
```

```json
{
  "diagnostics": [],
  "opencode_provider_ids": [
    "opencode.agent-task-executor"
  ],
  "opencode_identity": [
    {
      "ai_provider_ids": [
        "codex"
      ],
      "executor_backend": "opencode",
      "executor_provider_id": "opencode.agent-task-executor",
      "model": null,
      "runtime_id": "opencode",
      "runtime_package_source": null,
      "runtime_path": "/Users/chubes/.config/homeboy/agent-runtimes/opencode"
    }
  ]
}
```

## Verification
- `cargo fmt --check`
- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(agent_task_provider) or test(agent_runtime_manifest)' --no-fail-fast` (116 passed)
- `cargo run --quiet -- agent-task providers --refresh` against the real installed opencode manifest

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Made executable-readiness env optional so PATH-discovered runtimes parse; Chris reviews and owns the change.