### PR TITLE
Fix review quality Lab workload labels

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1224,6 +1224,10 @@ impl RunnerWorkloadCommandFamily {
     pub(crate) fn from_command_label(label: &str) -> Self {
         match label {
             label if label.starts_with("agent-task") => Self::AgentTask,
+            label if matches!(
+                label,
+                "review audit" | "review lint" | "review test" | "review build" | "review ci"
+            ) => Self::Quality,
             LINT_LAB_LABEL | TEST_LAB_LABEL | AUDIT_LAB_LABEL | REVIEW_LAB_LABEL
             | BENCH_LAB_LABEL | FUZZ_LAB_LABEL | TRACE_LAB_LABEL | RIG_RUN_LAB_LABEL => {
                 Self::Quality
@@ -1283,6 +1287,18 @@ impl Commands {
             }
             Commands::Review(args) => {
                 extension_ids.extend(args.extension_override.extensions.clone());
+                match args.command.as_ref() {
+                    Some(crate::commands::review::ReviewCommand::Audit(audit_args)) => {
+                        extension_ids.extend(audit_args.audit.extension_override.extensions.clone())
+                    }
+                    Some(crate::commands::review::ReviewCommand::Lint(lint_args)) => {
+                        extension_ids.extend(lint_args.extension_override.extensions.clone())
+                    }
+                    Some(crate::commands::review::ReviewCommand::Test(test_args)) => {
+                        extension_ids.extend(test_args.extension_override.extensions.clone())
+                    }
+                    _ => {}
+                }
                 extension_ids.extend(review_lab_extension_ids(args)?);
             }
             Commands::AgentTask(args) => extension_ids.extend(agent_task_lab_extension_ids(args)?),
@@ -1348,15 +1364,28 @@ mod extension_ids {
     pub(crate) fn review_lab_extension_ids(
         args: &crate::commands::review::ReviewArgs,
     ) -> crate::core::Result<Vec<String>> {
+        let extension_overrides = match args.command.as_ref() {
+            Some(crate::commands::review::ReviewCommand::Audit(audit_args)) => {
+                audit_args.audit.extension_override.extensions.clone()
+            }
+            Some(crate::commands::review::ReviewCommand::Lint(lint_args)) => {
+                lint_args.extension_override.extensions.clone()
+            }
+            Some(crate::commands::review::ReviewCommand::Test(test_args)) => {
+                test_args.extension_override.extensions.clone()
+            }
+            _ => args.extension_override.extensions.clone(),
+        };
         let resolve_for = |capability: Option<ExtensionCapability>| {
+            let component_args = args.effective_component_args();
             execution_context::resolve(&ResolveOptions {
-                component_id: args.comp.component.clone(),
-                path_override: args.comp.path.clone(),
+                component_id: component_args.component.clone(),
+                path_override: component_args.path.clone(),
                 capability,
                 settings_overrides: Vec::new(),
                 settings_profile_json_overrides: Vec::new(),
                 settings_json_overrides: Vec::new(),
-                extension_overrides: args.extension_override.extensions.clone(),
+                extension_overrides: extension_overrides.clone(),
             })
         };
 

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -389,8 +389,15 @@ fn dispatch_config_layers(providers: &[AgentTaskExecutorProvider]) -> Value {
         .iter()
         .find(|provider| provider.default_backend)
         .or_else(|| providers.first())
+        .cloned();
+    let example_selector_id = example_selector
+        .as_ref()
         .map(|provider| provider.id.clone())
         .unwrap_or_else(|| "sample.executor-provider".to_string());
+    let example_ai_provider = example_selector
+        .as_ref()
+        .and_then(|provider| provider.provider_defaults.keys().next().cloned())
+        .unwrap_or_else(|| "example".to_string());
 
     serde_json::json!({
         "summary": "Dispatch configuration has two independent layers that are easy to confuse: the extension-provider selector picks which Homeboy executor runs the task, while the nested provider config picks which runtime/model that executor drives. Pass an executor provider id to --dispatch-selector, and pass runtime-specific provider configuration inside --dispatch-provider-config — never the other way around.",
@@ -409,11 +416,11 @@ fn dispatch_config_layers(providers: &[AgentTaskExecutorProvider]) -> Value {
                 "value_is": "Nested provider config JSON (and/or a model override), passed to the executor.",
             }
         ],
-        "common_mistake": "Passing runtime-specific provider configuration to --dispatch-selector. That selects the executor, not the model/provider, so it fails with 'no extension agent-task provider ... matched selector'. Put runtime-specific values in --dispatch-provider-config instead.",
+        "common_mistake": format!("Passing runtime-specific provider configuration such as `{example_ai_provider}` to --dispatch-selector. That selects the executor, not the model/provider, so it fails with 'no extension agent-task provider ... matched selector'. Put runtime-specific values in --dispatch-provider-config instead."),
         "example": {
             "description": "Run a task with a selected executor provider driving a nested AI runtime/provider config.",
             "command": format!(
-                "homeboy agent-task cook --dispatch-selector {example_selector} --dispatch-provider-config '{{\"provider\":\"example\"}}' --prompt @task.md"
+                "homeboy agent-task cook --dispatch-selector {example_selector_id} --dispatch-provider-config '{{\"provider\":\"{example_ai_provider}\"}}' --prompt @task.md"
             ),
         }
     })

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1157,6 +1157,66 @@ mod tests {
     }
 
     #[test]
+    fn nested_review_quality_subcommands_use_specific_lab_labels() {
+        for (args, expected_label) in [
+            (vec!["homeboy", "review", "audit", "data-machine"], "review audit"),
+            (vec!["homeboy", "review", "lint", "data-machine"], "review lint"),
+            (vec!["homeboy", "review", "test", "data-machine"], "review test"),
+            (vec!["homeboy", "review", "build", "data-machine"], "review build"),
+            (
+                vec!["homeboy", "review", "ci", "run", "data-machine", "--job", "lint"],
+                "review ci",
+            ),
+        ] {
+            let cli = Cli::parse_from(args);
+            let command = cli.command.lab_contract().unwrap();
+
+            assert_eq!(command.hot_label, expected_label);
+        }
+    }
+
+    #[test]
+    fn nested_review_lint_dispatch_uses_matching_lab_label() {
+        let cli = Cli::parse_from(["homeboy", "review", "lint", "data-machine"]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(command.hot_label, "review lint");
+        assert!(command.portable);
+        assert!(command.unsupported_reason.is_none());
+    }
+
+    #[test]
+    fn nested_review_quality_subcommand_resolves_effective_component() {
+        let cli = Cli::parse_from(["homeboy", "review", "lint", "data-machine"]);
+        let Commands::Review(args) = cli.command else {
+            panic!("expected review command");
+        };
+
+        assert_eq!(args.lab_label(), "review lint");
+        assert_eq!(
+            args.effective_component_args().component.as_deref(),
+            Some("data-machine")
+        );
+    }
+
+    #[test]
+    fn nested_review_quality_in_dir_offload_uses_current_dir_path() {
+        let dir = tempdir().expect("tempdir");
+        let _cwd = CwdGuard::set(dir.path());
+        let normalized = vec!["homeboy".to_string(), "review".to_string(), "lint".to_string()];
+        let cli = Cli::parse_from(&normalized);
+
+        let rewritten = lab_route_source_path_args(&cli.command, &normalized, false)
+            .expect("review lint without component gets cwd path rewrite");
+        let cwd = std::env::current_dir().expect("current dir");
+
+        assert_eq!(rewritten[0..3], normalized);
+        assert_eq!(rewritten[3], "--path");
+        assert_eq!(rewritten[4], cwd.to_string_lossy());
+    }
+
+    #[test]
     fn explicit_runner_for_changed_scope_test_is_lab_portable() {
         let cli = Cli::parse_from([
             "homeboy",

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -136,7 +136,7 @@ impl ReviewArgs {
                 ReviewCommand::AuditBaseline(_)
                 | ReviewCommand::Build(_)
                 | ReviewCommand::Ci(_) => Some(LabCommandContract::local_only(
-                    REVIEW_LAB_LABEL,
+                    self.lab_label(),
                     "this nested review subcommand has no portable Lab contract",
                 )),
             };
@@ -148,6 +148,27 @@ impl ReviewArgs {
             ))
         } else {
             Some(LabCommandContract::portable(REVIEW_LAB_LABEL, None, true, &[]).release_gate())
+        }
+    }
+
+    pub(crate) fn lab_label(&self) -> &'static str {
+        match self.command.as_ref() {
+            Some(ReviewCommand::Audit(_)) => "review audit",
+            Some(ReviewCommand::Lint(_)) => "review lint",
+            Some(ReviewCommand::Test(_)) => "review test",
+            Some(ReviewCommand::Build(_)) => "review build",
+            Some(ReviewCommand::Ci(_)) => "review ci",
+            Some(ReviewCommand::AuditBaseline(_)) => "review audit-baseline",
+            None => REVIEW_LAB_LABEL,
+        }
+    }
+
+    pub(crate) fn effective_component_args(&self) -> PositionalComponentArgs {
+        match self.command.as_ref() {
+            Some(ReviewCommand::Audit(args)) => args.audit.comp.clone(),
+            Some(ReviewCommand::Lint(args)) => args.comp.clone(),
+            Some(ReviewCommand::Test(args)) => args.comp.clone(),
+            _ => self.comp.clone(),
         }
     }
 }
@@ -297,7 +318,8 @@ fn to_value<T: Serialize>(result: CmdResult<T>) -> CmdResult<Value> {
 pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutput> {
     // Resolve component ID (auto-discovers from CWD when omitted) and source
     // path so we can probe git for the changed-file set ourselves.
-    let component = args.comp.load()?;
+    let component_args = args.effective_component_args();
+    let component = component_args.load()?;
     let component_label = component.id.clone();
     let source_path = component.local_path.clone();
 
@@ -595,7 +617,7 @@ fn build_audit_args(
     review_context: &ReviewExecutionContext,
 ) -> audit::AuditArgs {
     audit::AuditArgs {
-        comp: args.comp.clone(),
+        comp: args.effective_component_args(),
         extension_override: args.extension_override.clone(),
         conventions: false,
         only: Vec::new(),
@@ -623,7 +645,7 @@ fn selected_audit_profile(args: &ReviewArgs, review_context: &ReviewExecutionCon
 
 fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -> lint::LintArgs {
     lint::LintArgs {
-        comp: args.comp.clone(),
+        comp: args.effective_component_args(),
         summary: args.summary,
         file: None,
         glob: None,
@@ -647,7 +669,7 @@ fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -
 
 fn build_test_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -> test::TestArgs {
     test::TestArgs {
-        comp: args.comp.clone(),
+        comp: args.effective_component_args(),
         extension_override: args.extension_override.clone(),
         skip_lint: true,
         coverage: false,

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1551,6 +1551,30 @@ mod lab_args_rewrite_tests {
     use super::*;
 
     #[test]
+    fn lab_args_rewrite_preserves_nested_review_quality_command_label() {
+        let args = vec![
+            "homeboy".to_string(),
+            "review".to_string(),
+            "lint".to_string(),
+            "data-machine".to_string(),
+            "--lab-only".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+        ];
+
+        assert_eq!(
+            rewrite_lab_offload_args(&args, "/runner/data-machine", &[], None),
+            vec![
+                "homeboy".to_string(),
+                "--force-hot".to_string(),
+                "review".to_string(),
+                "lint".to_string(),
+                "data-machine".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn lab_args_rewrite_agent_task_dispatch_cwd() {
         let args = vec![
             "homeboy".to_string(),

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -371,38 +371,16 @@ fn dispatched_command_label(command_args: &[String], expected_label: &str) -> Op
         || expected_parts
             .iter()
             .any(|part| part.starts_with('-') || part.contains('/'))
-        || command_args.len() < expected_parts.len()
     {
         return None;
     }
 
-    let mut matched = Vec::with_capacity(expected_parts.len());
-    let mut command_index = 0;
-
-    for expected in expected_parts {
-        loop {
-            let Some(arg) = command_args.get(command_index).map(String::as_str) else {
-                return None;
-            };
-            command_index += 1;
-
-            if runner_workload_command_label_value_option(arg) {
-                command_index += 1;
-                continue;
-            }
-            if runner_workload_command_label_flag_option(arg) {
-                continue;
-            }
-
-            matched.push(arg);
-            if arg != expected {
-                return Some(matched.join(" "));
-            }
-            break;
-        }
+    let positional_parts = dispatched_positional_command_parts(command_args);
+    if positional_parts.len() < expected_parts.len() {
+        return None;
     }
 
-    Some(matched.join(" "))
+    Some(positional_parts[..expected_parts.len()].join(" "))
 }
 
 fn runner_workload_command_label_value_option(arg: &str) -> bool {
@@ -414,19 +392,41 @@ fn runner_workload_command_label_flag_option(arg: &str) -> bool {
 }
 
 fn dispatched_command_family(command_args: &[String]) -> RunnerWorkloadCommandFamily {
-    let max_parts = command_args.len().min(3);
+    let positional_parts = dispatched_positional_command_parts(command_args);
+    let max_parts = positional_parts.len().min(3);
     for part_count in (1..=max_parts).rev() {
-        let label = command_args[..part_count]
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .join(" ");
+        let label = positional_parts[..part_count].join(" ");
         let family = RunnerWorkloadCommandFamily::from_command_label(&label);
         if family != RunnerWorkloadCommandFamily::Unknown {
             return family;
         }
     }
     RunnerWorkloadCommandFamily::Unknown
+}
+
+fn dispatched_positional_command_parts(command_args: &[String]) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut iter = command_args.iter().peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if runner_workload_command_label_value_option(arg) {
+            let _ = iter.next();
+            continue;
+        }
+        if runner_workload_command_label_flag_option(arg) {
+            continue;
+        }
+        if arg.starts_with('-') {
+            if !arg.contains('=') && iter.peek().is_some_and(|next| !next.starts_with('-')) {
+                let _ = iter.next();
+            }
+            continue;
+        }
+        parts.push(arg.as_str());
+    }
+    parts
 }
 
 pub(crate) fn merge_runner_workload_capability_preflight(
@@ -852,6 +852,74 @@ mod tests {
             true,
         )
         .expect("matching runner-injected homeboy argv is valid");
+    }
+
+    #[test]
+    fn runner_workload_validation_accepts_nested_review_quality_labels() {
+        for label in [
+            "review audit",
+            "review lint",
+            "review test",
+            "review build",
+            "review ci",
+        ] {
+            let plan = plan();
+            let mut command = command();
+            command.hot_label = label;
+            command.required_extensions.clear();
+            command.required_capabilities.clear();
+            let workload = build_runner_workload(RunnerWorkloadBuildInput {
+                plan: &plan,
+                command: &command,
+                capture_patch: false,
+                mutation_flag: None,
+                allow_dirty_lab_workspace: false,
+                runner_id: "lab-a",
+                runner_mode: "direct_ssh",
+                assignment_source: "explicit",
+                status: "offloaded",
+                remote_workspace: Some("/srv/homeboy/work"),
+                fallback_reason: None,
+                workspace_mapping_ref: None,
+                proof_id: None,
+            });
+            let mut argv = label
+                .split_whitespace()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            argv.push("data-machine".to_string());
+
+            assert_eq!(
+                workload.kind.command_family,
+                RunnerWorkloadCommandFamily::Quality
+            );
+            validate_runner_workload_dispatch(
+                Some(&workload),
+                "lab-a",
+                Some("/srv/homeboy/work"),
+                &argv,
+                &SecretEnvPlan::default(),
+                false,
+            )
+            .expect("nested review quality command label is valid");
+
+            let mut argv_with_extension = vec![
+                "review".to_string(),
+                "--extension".to_string(),
+                "wordpress".to_string(),
+            ];
+            argv_with_extension.extend(label.split_whitespace().skip(1).map(str::to_string));
+            argv_with_extension.push("data-machine".to_string());
+            validate_runner_workload_dispatch(
+                Some(&workload),
+                "lab-a",
+                Some("/srv/homeboy/work"),
+                &argv_with_extension,
+                &SecretEnvPlan::default(),
+                false,
+            )
+            .expect("nested review quality command label tolerates interleaved options");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Canonicalizes nested review quality commands as `homeboy review <quality-subcommand> <component>`, matching the established quality-command convention where the subcommand comes before the target component.
- Derives Lab workload labels for `review audit|lint|test|build|ci` from the nested review command shape, and classifies those labels as `Quality`.
- Resolves the effective component from `review lint <component>` and from the current directory for `review lint`, including Lab source-path rewrite.
- Makes runner workload validation ignore interleaved command options like `review --extension wordpress lint <component>`, so the dispatched command and workload label compare on command tokens rather than injected flags.
- Updates the agent-task provider-layer example to use discovered provider defaults; this fixed a stale test included by the requested `test(review)` selector.

## Root Cause
After #7590 folded quality pillars under `review`, Lab workload identity was still derived inconsistently: the workload declared labels like `review lint`, while dispatched argv could parse as `review <component>`, `review --extension <id> lint`, or just `review lint` with family `Unknown`. Component resolution also treated `lint` as the component for `review lint <component>` because `review` was still a flat optional-component command.

## Canonical Order
Canonical order is `homeboy review <quality-subcommand> <component>`.

This matches the established top-level quality convention, e.g. `homeboy lint <component>`, `homeboy test <component>`, and keeps the subcommand adjacent to `review` so Lab workload labels remain `review lint`, `review audit`, etc.

## Before/After Lab Evidence
Before:
- `cargo run -- review lint data-machine --lab-only --runner homeboy-lab` failed on the current tree before this fix with Clap parsing: `unexpected argument 'data-machine' found`.
- After the parser/label fix but before option-aware workload validation, the same command reached Lab and failed with: `runner workload command label "review lint" does not match dispatched command "review --extension"`.

After:
- `cargo run -- review lint data-machine --lab-only --runner homeboy-lab` routed to `homeboy-lab` and executed remote lint as: `/home/chubes/Developer/_homeboy_binaries/homeboy-main/target/release/homeboy --force-hot review --extension wordpress lint data-machine`.
- The run no longer failed workload command-label/family validation; it proceeded into `data-machine` lint and reported existing PHPStan/PHPCS findings in that component.
- No `homeboy runner dev-sync` was required, so the runner stayed on its main binary.

## Verification
- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(route) or test(lab_args) or test(workload) or test(review)' --no-fail-fast` -> 437 passed
- Live Lab proof: `cargo run -- review lint data-machine --lab-only --runner homeboy-lab` routed and ran remote lint; lint findings are in `data-machine`, not Homeboy workload validation.

Closes #7601
Related: #7590, #7456

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.5 (`openai/gpt-5.5`)
- **Used for:** Fixed Lab workload label/family + component resolution for nested review commands; Chris reviews and owns the change.
