### PR TITLE
Fix review test formatting gate

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1224,10 +1224,14 @@ impl RunnerWorkloadCommandFamily {
     pub(crate) fn from_command_label(label: &str) -> Self {
         match label {
             label if label.starts_with("agent-task") => Self::AgentTask,
-            label if matches!(
-                label,
-                "review audit" | "review lint" | "review test" | "review build" | "review ci"
-            ) => Self::Quality,
+            label
+                if matches!(
+                    label,
+                    "review audit" | "review lint" | "review test" | "review build" | "review ci"
+                ) =>
+            {
+                Self::Quality
+            }
             LINT_LAB_LABEL | TEST_LAB_LABEL | AUDIT_LAB_LABEL | REVIEW_LAB_LABEL
             | BENCH_LAB_LABEL | FUZZ_LAB_LABEL | TRACE_LAB_LABEL | RIG_RUN_LAB_LABEL => {
                 Self::Quality

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1160,12 +1160,32 @@ mod tests {
     #[test]
     fn nested_review_quality_subcommands_use_specific_lab_labels() {
         for (args, expected_label) in [
-            (vec!["homeboy", "review", "audit", "data-machine"], "review audit"),
-            (vec!["homeboy", "review", "lint", "data-machine"], "review lint"),
-            (vec!["homeboy", "review", "test", "data-machine"], "review test"),
-            (vec!["homeboy", "review", "build", "data-machine"], "review build"),
             (
-                vec!["homeboy", "review", "ci", "run", "data-machine", "--job", "lint"],
+                vec!["homeboy", "review", "audit", "data-machine"],
+                "review audit",
+            ),
+            (
+                vec!["homeboy", "review", "lint", "data-machine"],
+                "review lint",
+            ),
+            (
+                vec!["homeboy", "review", "test", "data-machine"],
+                "review test",
+            ),
+            (
+                vec!["homeboy", "review", "build", "data-machine"],
+                "review build",
+            ),
+            (
+                vec![
+                    "homeboy",
+                    "review",
+                    "ci",
+                    "run",
+                    "data-machine",
+                    "--job",
+                    "lint",
+                ],
                 "review ci",
             ),
         ] {
@@ -1205,7 +1225,11 @@ mod tests {
     fn nested_review_quality_in_dir_offload_uses_current_dir_path() {
         let dir = tempdir().expect("tempdir");
         let _cwd = CwdGuard::set(dir.path());
-        let normalized = vec!["homeboy".to_string(), "review".to_string(), "lint".to_string()];
+        let normalized = vec![
+            "homeboy".to_string(),
+            "review".to_string(),
+            "lint".to_string(),
+        ];
         let cli = Cli::parse_from(&normalized);
 
         let rewritten = lab_route_source_path_args(&cli.command, &normalized, false)

--- a/src/core/agent_task_executor_evidence.rs
+++ b/src/core/agent_task_executor_evidence.rs
@@ -336,7 +336,9 @@ mod tests {
         with_artifact_root(|artifact_root| {
             let path = executor_evidence_dir(Some("run-1"), "task-1");
             assert!(path.starts_with(artifact_root));
-            assert!(!path.to_string_lossy().contains("homeboy-agent-task-evidence"));
+            assert!(!path
+                .to_string_lossy()
+                .contains("homeboy-agent-task-evidence"));
         });
     }
 

--- a/src/core/agent_task_provider/tests/scheduler_tests.rs
+++ b/src/core/agent_task_provider/tests/scheduler_tests.rs
@@ -206,7 +206,9 @@ fn provider_timeout_returns_structured_outcome() {
 
 #[test]
 fn provider_default_timeout_returns_structured_outcome_without_explicit_timeout() {
-    let _lock = DEFAULT_TIMEOUT_ENV_LOCK.lock().expect("default timeout env lock");
+    let _lock = DEFAULT_TIMEOUT_ENV_LOCK
+        .lock()
+        .expect("default timeout env lock");
     std::env::set_var("HOMEBOY_AGENT_TASK_TEST_DEFAULT_PROVIDER_TIMEOUT_MS", "50");
     let command = format!("node {}", script("setInterval(() => {}, 1000);"));
     let (request, provider) = request("task-default-timeout", command);
@@ -220,10 +222,7 @@ fn provider_default_timeout_returns_structured_outcome_without_explicit_timeout(
         Some(AgentTaskFailureClassification::Timeout)
     );
     assert_eq!(outcome.diagnostics[0].class, "agent_task.provider_timeout");
-    assert_eq!(
-        outcome.diagnostics[0].data["timeout_ms"],
-        json!(50)
-    );
+    assert_eq!(outcome.diagnostics[0].data["timeout_ms"], json!(50));
 }
 
 #[test]

--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -309,10 +309,11 @@ where
                 let executor_key = executor_key(&request);
                 let executor = Arc::clone(&self.executor);
                 let plan_id = plan.plan_id.clone();
-                let task_timeout_ms = crate::core::agent_task_timeout::effective_provider_timeout_ms(
-                    request.limits.timeout_ms.or(plan.options.timeout_ms),
-                    request.limits.max_runtime_ms,
-                );
+                let task_timeout_ms =
+                    crate::core::agent_task_timeout::effective_provider_timeout_ms(
+                        request.limits.timeout_ms.or(plan.options.timeout_ms),
+                        request.limits.max_runtime_ms,
+                    );
                 let tx = tx.clone();
                 let attempt = scheduled.attempt;
                 let context = AgentTaskExecutionContext {

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -352,11 +352,11 @@ pub mod service {
         evidence_ref_task_id, hydrate_evidence_ref, hydrate_evidence_summary, logs,
         normalize_plan_workspaces, offloaded_status_remediation,
         persist_provider_boundary_replay_evidence, promotion_source, read_plan, resume, retry,
-        run_cook, run_loaded_plan, run_next, run_status, run_submitted,
-        run_submitted_with_timeout, source_worktree_path, status, submit_plan_spec,
-        AgentTaskCookAttemptReport, AgentTaskCookReport,
-        AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts,
-        AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport, AgentTaskDiscoveryRun,
-        AgentTaskHydratedEvidence, AgentTaskRetryServiceResult, AgentTaskRunResult,
+        run_cook, run_loaded_plan, run_next, run_status, run_submitted, run_submitted_with_timeout,
+        source_worktree_path, status, submit_plan_spec, AgentTaskCookAttemptReport,
+        AgentTaskCookReport, AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands,
+        AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
+        AgentTaskDiscoveryRun, AgentTaskHydratedEvidence, AgentTaskRetryServiceResult,
+        AgentTaskRunResult,
     };
 }


### PR DESCRIPTION
## Summary
- Apply cargo fmt to files that made review test fail in its pre-test lint phase on main.
- Keep wrapper behavior unchanged; it already emits structured failure output once the local worktree is on current origin/main.

## Verification
- cargo fmt --check
- cargo run -- review test homeboy --path . progressed past cargo fmt --check and clippy, then emitted structured infrastructure-failure output after the remote runner terminated the cargo test phase with signal 15.
- Targeted local nextest reproduced separate environment-sensitive failures outside the release-blocking format gate; not baselined or disabled.

Refs #7609

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Diagnosed the release-gate failure, applied the formatting-only fix, and ran local/remote verification.