### PR TITLE
Use typed agent-task lifecycle handoff

### DIFF
--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -333,10 +333,6 @@ pub(super) fn run_provider_command_once(
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     if stdout.is_empty() {
-        if let Some(mut outcome) = parse_provider_outcome_from_mixed_output(&stderr) {
-            normalize_provider_outcome_roles(&mut outcome, provider);
-            return outcome;
-        }
         return failure_outcome(
             request,
             AgentTaskOutcomeStatus::ProviderError,
@@ -713,24 +709,6 @@ fn runtime_path_provenance(provider: &AgentTaskExecutorProvider) -> Value {
         "extension_id": provider.extension_id.as_deref(),
         "extension_path": provider.extension_path.as_deref(),
     })
-}
-
-fn parse_provider_outcome_from_mixed_output(output: &str) -> Option<AgentTaskOutcome> {
-    if output.trim().is_empty() {
-        return None;
-    }
-    if let Ok(outcome) = serde_json::from_str::<AgentTaskOutcome>(output) {
-        return Some(outcome);
-    }
-
-    for (index, _) in output.match_indices('{') {
-        let mut stream =
-            serde_json::Deserializer::from_str(&output[index..]).into_iter::<AgentTaskOutcome>();
-        if let Some(Ok(outcome)) = stream.next() {
-            return Some(outcome);
-        }
-    }
-    None
 }
 pub(super) fn render_provider_command_display(provider: &AgentTaskExecutorProvider) -> String {
     if let Some(display) = provider.invocation.display.as_deref() {

--- a/src/core/agent_task_provider/tests/scheduler_tests.rs
+++ b/src/core/agent_task_provider/tests/scheduler_tests.rs
@@ -127,28 +127,6 @@ fn scheduler_normalizes_malformed_provider_output() {
 }
 
 #[test]
-fn provider_preserves_structured_outcome_from_stderr_when_stdout_empty() {
-    let command = format!(
-        "node {}",
-        script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stderr.write('diagnostic prefix\\n' + JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'failed',summary:'captured provider evidence',failure_classification:'provider',diagnostics:[{class:'sample_runtime.empty_data_packet_returned',message:'empty data packet returned',data:{typed_artifacts:{}}}]}));")
-    );
-    let (request, provider) = request("task-stderr-outcome", command);
-
-    let outcome = run_provider_command(&request, &provider, None);
-
-    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Failed);
-    assert_eq!(
-        outcome.summary.as_deref(),
-        Some("captured provider evidence")
-    );
-    assert_eq!(
-        outcome.diagnostics[0].class,
-        "sample_runtime.empty_data_packet_returned"
-    );
-    assert_eq!(outcome.diagnostics[0].data["typed_artifacts"], json!({}));
-}
-
-#[test]
 fn provider_empty_stdout_captures_bounded_stderr_and_exit_context() {
     let command = format!(
         "node {}",
@@ -180,6 +158,53 @@ fn provider_empty_stdout_captures_bounded_stderr_and_exit_context() {
         .evidence_refs
         .iter()
         .any(|reference| reference.kind == "executor-result"));
+}
+
+#[test]
+fn provider_empty_stdout_records_failed_run_with_executor_evidence() {
+    crate::test_support::with_isolated_home(|_| {
+        let command = format!(
+            "node {}",
+            script("process.stderr.write('provider emitted diagnostics but no outcome'); process.exit(42);")
+        );
+        let (request, provider) = request("task-empty-stdout-recorded", command);
+        let plan = AgentTaskPlan::new("plan-empty-stdout-recorded", vec![request]);
+        let run_id = "run-empty-provider-output";
+        let scheduler =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]))
+            .with_run_id(run_id);
+
+        crate::core::agent_tasks::lifecycle::submit_plan(&plan, Some(run_id)).expect("submit plan");
+        crate::core::agent_tasks::lifecycle::mark_running(run_id).expect("mark running");
+        let aggregate = scheduler.run(plan.clone());
+        let record =
+            crate::core::agent_tasks::lifecycle::record_run_aggregate(run_id, &plan, &aggregate)
+                .expect("record aggregate");
+
+        assert_eq!(
+            record.state,
+            crate::core::agent_task_lifecycle::AgentTaskRunState::Failed
+        );
+        assert_eq!(
+            aggregate.outcomes[0].status,
+            AgentTaskOutcomeStatus::ProviderError
+        );
+        assert_eq!(
+            aggregate.outcomes[0].diagnostics[0].class,
+            "agent_task.provider_empty_stdout"
+        );
+        assert!(aggregate.outcomes[0]
+            .evidence_refs
+            .iter()
+            .any(|reference| reference.kind == "executor-result"));
+        assert!(record.latest_executor_evidence.is_some());
+        assert!(record
+            .artifact_refs
+            .iter()
+            .any(|reference| reference.kind == "executor-result"));
+    });
 }
 
 #[test]

--- a/src/core/runner/agent_task_lifecycle_event.rs
+++ b/src/core/runner/agent_task_lifecycle_event.rs
@@ -21,31 +21,6 @@ fn agent_task_run_plan_lifecycle_event_schema() -> String {
     AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA.to_string()
 }
 
-pub(crate) fn agent_task_run_plan_lifecycle_event_from_output(
-    identity: AgentTaskDispatchIdentity,
-    output: &str,
-) -> Result<Option<AgentTaskRunPlanLifecycleEvent>> {
-    let envelope = parse_offloaded_run_plan_envelope(output)?;
-    if !is_agent_task_run_plan_envelope(&envelope) {
-        return Ok(None);
-    }
-    let Some(aggregate_value) = envelope.get("data").cloned() else {
-        return Ok(None);
-    };
-    let aggregate: AgentTaskAggregate =
-        serde_json::from_value(aggregate_value).map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("parse offloaded agent-task aggregate".to_string()),
-            )
-        })?;
-    Ok(Some(AgentTaskRunPlanLifecycleEvent {
-        schema: AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA.to_string(),
-        identity,
-        aggregate,
-    }))
-}
-
 pub(crate) fn parse_offloaded_run_plan_envelope(stdout: &str) -> Result<serde_json::Value> {
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout) {
         return Ok(value);
@@ -135,25 +110,9 @@ pub(crate) fn agent_task_run_plan_lifecycle_event_from_workload_result(
         return Ok(Some(event));
     }
 
-    let aggregate =
-        if let Some(aggregate) = result.get("data").and_then(agent_task_aggregate_from_value) {
-            aggregate
-        } else if let Some(stdout) = result.get("stdout").and_then(serde_json::Value::as_str) {
-            match agent_task_run_plan_lifecycle_event_from_output(
-                AgentTaskDispatchIdentity {
-                    runner_id: runner_id.to_string(),
-                    runner_job_id: runner_job_id.to_string(),
-                    run_id: Some(agent_task.run_id.clone()),
-                    ..AgentTaskDispatchIdentity::default()
-                },
-                stdout,
-            )? {
-                Some(event) => return Ok(Some(event)),
-                None => return Ok(None),
-            }
-        } else {
-            return Ok(None);
-        };
+    let Some(aggregate) = result.get("data").and_then(agent_task_aggregate_from_value) else {
+        return Ok(None);
+    };
 
     Ok(Some(AgentTaskRunPlanLifecycleEvent {
         schema: AGENT_TASK_RUN_PLAN_LIFECYCLE_EVENT_SCHEMA.to_string(),

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -5,8 +5,8 @@
 //! - Once the runner streams output back, `mirror_agent_task_run_plan_lifecycle`
 //!   replays the run-plan aggregate into the controller's lifecycle store so
 //!   `homeboy agent-task status/logs` keeps working transparently.
-//! - The dispatch-envelope parsers below let the offload orchestrator recover
-//!   structured failure metadata from mixed stdout/stderr streams.
+//! - The legacy dispatch-envelope parser is retained only for pre-typed runners
+//!   that cannot surface the handoff through workload events/results.
 
 use std::fs;
 
@@ -155,27 +155,39 @@ fn mirror_legacy_agent_task_run_plan_lifecycle(
     if plan_spec == "-" {
         return Ok(());
     }
+    // Legacy runner compatibility: only pre-typed runner workloads reach this
+    // branch, so argv/stdout recovery is intentionally centralized here.
     let aggregate = match agent_task_run_plan_lifecycle_event_from_job_events(job_events) {
         Some(event) => event.aggregate,
-        None => {
-            let envelope = parse_offloaded_run_plan_envelope(
-                agent_task_run_plan_lifecycle_output(stdout, output_file_content),
-            )?;
-            if !is_agent_task_run_plan_envelope(&envelope) {
-                return Ok(());
-            }
-            let Some(aggregate_value) = envelope.get("data").cloned() else {
-                return Ok(());
-            };
-            serde_json::from_value(aggregate_value).map_err(|error| {
-                Error::internal_json(
-                    error.to_string(),
-                    Some("parse offloaded agent-task aggregate".to_string()),
-                )
-            })?
-        }
+        None => legacy_agent_task_run_plan_aggregate(stdout, output_file_content)?,
     };
     mirror_agent_task_run_plan_aggregate(&plan_spec, &run_id, aggregate)
+}
+
+fn legacy_agent_task_run_plan_aggregate(
+    stdout: &str,
+    output_file_content: Option<&str>,
+) -> Result<AgentTaskAggregate> {
+    let envelope = parse_offloaded_run_plan_envelope(agent_task_run_plan_lifecycle_output(
+        stdout,
+        output_file_content,
+    ))?;
+    if !is_agent_task_run_plan_envelope(&envelope) {
+        return Err(Error::internal_unexpected(
+            "legacy agent-task run-plan output did not contain an aggregate envelope",
+        ));
+    }
+    let Some(aggregate_value) = envelope.get("data").cloned() else {
+        return Err(Error::internal_unexpected(
+            "legacy agent-task run-plan output aggregate envelope was missing data",
+        ));
+    };
+    serde_json::from_value(aggregate_value).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse legacy offloaded agent-task aggregate".to_string()),
+        )
+    })
 }
 
 fn mirror_agent_task_run_plan_aggregate(
@@ -694,7 +706,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn offloaded_run_plan_envelope_parser_tolerates_extension_stdout_chatter() {
+    fn legacy_offloaded_run_plan_envelope_parser_tolerates_extension_stdout_chatter() {
         let stdout = concat!(
             "Preparing extension runtime...\n",
             "Installing declared dependencies...\n",
@@ -709,7 +721,7 @@ mod tests {
     }
 
     #[test]
-    fn offloaded_run_plan_envelope_parser_selects_aggregate_from_mixed_json() {
+    fn legacy_offloaded_run_plan_envelope_parser_selects_aggregate_from_mixed_json() {
         let stdout = concat!(
             "{\"success\":true,\"data\":{\"command\":\"extension.setup\"}}\n",
             "setup complete\n",
@@ -919,7 +931,7 @@ mod tests {
     }
 
     #[test]
-    fn non_aggregate_offloaded_run_plan_stdout_is_not_mirrored() {
+    fn typed_run_plan_lifecycle_ignores_stdout_without_job_event() {
         let args = vec![
             "homeboy".to_string(),
             "agent-task".to_string(),
@@ -931,8 +943,15 @@ mod tests {
         ];
         let stdout = "{\"success\":true,\"data\":{\"command\":\"extension.setup\"}}";
 
-        mirror_agent_task_run_plan_lifecycle(&args, None, stdout, None, None)
-            .expect("ignore non-aggregate output");
+        let agent_task = RunnerWorkloadAgentTask {
+            run_id: "run-typed-no-event".to_string(),
+            plan_ref: Some("@/tmp/plan.json".to_string()),
+            dispatch_kind: crate::command_contract::RunnerWorkloadAgentTaskDispatchKind::RunPlan,
+            lifecycle_mirror_policy: RunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
+        };
+
+        mirror_agent_task_run_plan_lifecycle(&args, Some(&agent_task), stdout, None, None)
+            .expect("typed path does not parse stdout fallback");
     }
 
     #[test]
@@ -991,7 +1010,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_run_plan_lifecycle_fallback_still_uses_argv_and_stdout() {
+    fn legacy_run_plan_lifecycle_branch_uses_argv_and_stdout_only_without_typed_workload() {
         crate::test_support::with_isolated_home(|_| {
             let temp = tempfile::tempdir().expect("tempdir");
             let plan_path = temp.path().join("plan.json");

--- a/src/core/runner/worker/result.rs
+++ b/src/core/runner/worker/result.rs
@@ -1,12 +1,11 @@
 use base64::Engine;
 use serde_json::json;
 
-use crate::command_contract::AgentTaskDispatchIdentity;
 use crate::core::api_jobs::{
     Job, JobArtifactMetadata, RemoteRunnerJobRequest, RemoteRunnerJobResult,
 };
 use crate::core::run_outcome_envelope::RunOutcomeEnvelope;
-use crate::core::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_output;
+use crate::core::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events;
 
 use super::super::capabilities::RunnerCapabilityPreflight;
 use super::types::{ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
@@ -49,21 +48,8 @@ pub(super) fn remote_runner_result_from_exec_output(
                 serde_json::to_value(provenance).unwrap_or(serde_json::Value::Null);
         }
     }
-    if let Some(lifecycle_event) = agent_task_run_plan_lifecycle_event_from_output(
-        AgentTaskDispatchIdentity {
-            runner_id: exec_output.runner_id.clone(),
-            runner_job_id: exec_output.job_id.clone().unwrap_or_default(),
-            persisted_run_id: exec_output.mirror_run_id.clone(),
-            run_id: exec_output.mirror_run_id.clone(),
-            handoff_id: exec_output
-                .job_id
-                .as_ref()
-                .map(|job_id| format!("runner:{}:job:{job_id}", exec_output.runner_id)),
-        },
-        &exec_output.stdout,
-    )
-    .ok()
-    .flatten()
+    if let Some(lifecycle_event) =
+        agent_task_run_plan_lifecycle_event_from_job_events(exec_output.job_events.as_deref())
     {
         data["agent_task_lifecycle_event"] =
             serde_json::to_value(lifecycle_event).unwrap_or(serde_json::Value::Null);

--- a/src/core/runner/worker/tests/result_tests.rs
+++ b/src/core/runner/worker/tests/result_tests.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use crate::core::api_jobs::JobArtifactMetadata;
+use crate::core::api_jobs::{JobArtifactMetadata, JobEvent, JobEventKind};
 use crate::core::runner::{
     RunnerExecMode, RunnerExecOutput, RunnerResourceGuardViolation, RunnerResourceMetrics,
 };
@@ -312,22 +312,37 @@ fn reverse_worker_result_attaches_typed_agent_task_lifecycle_event() {
             argv: vec!["homeboy".to_string(), "agent-task".to_string()],
             remote_cwd: "/srv/workspace".to_string(),
             exit_code: 0,
-            stdout: concat!(
-                "runner chatter\n",
-                "{\"success\":true,\"data\":{",
-                "\"schema\":\"homeboy/agent-task-aggregate/v1\",",
-                "\"plan_id\":\"plan-typed\",",
-                "\"status\":\"succeeded\",",
-                "\"totals\":{\"skipped\":0,\"succeeded\":1,\"failed\":0},",
-                "\"outcomes\":[]}}"
-            )
-            .to_string(),
+            stdout: "runner chatter without parseable lifecycle".to_string(),
             stderr: String::new(),
             source_snapshot: None,
             job: None,
             runner_job: None,
             job_id: Some("job-typed".to_string()),
-            job_events: None,
+            job_events: Some(vec![JobEvent {
+                sequence: 1,
+                job_id: uuid::Uuid::nil(),
+                kind: JobEventKind::Progress,
+                timestamp_ms: 1,
+                message: Some("agent-task lifecycle event".to_string()),
+                data: Some(json!({
+                    "schema": "homeboy/runner-workload-agent-task-lifecycle-event/v1",
+                    "agent_task_lifecycle_event": {
+                        "schema": "homeboy/agent-task-run-plan-lifecycle-event/v1",
+                        "identity": {
+                            "runner_id": "lab-default",
+                            "runner_job_id": "job-typed",
+                            "run_id": "run-typed"
+                        },
+                        "aggregate": {
+                            "schema":"homeboy/agent-task-aggregate/v1",
+                            "plan_id":"plan-typed",
+                            "status":"succeeded",
+                            "totals":{"skipped":0,"succeeded":1,"failed":0},
+                            "outcomes":[]
+                        }
+                    }
+                })),
+            }]),
             mirror_run_id: Some("run-typed".to_string()),
             patch: None,
             mutation_artifacts: None,


### PR DESCRIPTION
## Summary
- Move agent-task run-plan lifecycle mirroring to the typed workload/job-event contract for typed workloads.
- Keep argv/stdout recovery only in the centralized legacy no-typed-workload branch.
- Treat empty provider stdout as a typed provider failure with durable executor evidence instead of parsing stderr as a fallback outcome.

## Parse-sites-removed map
- `agent_task_run_plan_lifecycle_event_from_output`: deleted; reverse worker result and workload-result paths now consume typed job events/result data.
- `agent_task_run_plan_lifecycle_event_from_workload_result` stdout branch: deleted; typed workload results no longer parse stdout.
- `run_provider_command_once` empty stdout stderr outcome recovery: deleted; empty stdout records `agent_task.provider_empty_stdout` with bounded stdout/stderr diagnostics and executor evidence refs.
- `parse_provider_outcome_from_mixed_output`: deleted with the stderr fallback test.
- Run-plan argv/stdout fallback remains only in `mirror_legacy_agent_task_run_plan_lifecycle` for legacy no-typed-workload runners.

## Empty-output robustness
- Empty provider output now persists a failed run with `agent_task.provider_empty_stdout`, bounded process diagnostics, and `executor-input` / `executor-result` evidence refs.

## Net LOC
- 6 files changed, 124 insertions(+), 142 deletions(-), net -18 LOC.

## Verification
- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(agent_task_bridge) or test(agent_task_controller) or test(command_runner) or test(agent_task_provider) or test(workload)' --no-fail-fast` (318 tests)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Moved agent-task lifecycle facts off stdout/argv parsing onto the typed contract and hardened empty-output handling; Chris reviews and owns the change.