### PR TITLE
Unify Lab workload metadata derivation

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -1060,26 +1060,29 @@ pub(crate) fn run_lab_offload_inner(
         env_delta,
     )?;
     lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
-    let mut runner_workload = build_runner_workload(RunnerWorkloadBuildInput {
-        plan: &plan,
-        command: &contract,
-        capture_patch: request.capture_patch,
-        mutation_flag: request.mutation_flag,
-        allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
-        runner_id,
-        runner_mode: status_tunnel_mode(&runner_status).metadata_value(),
-        assignment_source: selection.source.metadata_value(),
-        status: "offloaded",
-        remote_workspace: Some(&remote_cwd),
-        fallback_reason: None,
-        workspace_mapping_ref: execution_context.workspace_mapping_ref(),
-        proof_id: lab_metadata
-            .get("proof")
-            .and_then(|proof| proof.get("id"))
-            .and_then(|id| id.as_str()),
-    });
+    let mut runner_workload = build_runner_workload_for_dispatched_command(
+        RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &contract,
+            capture_patch: request.capture_patch,
+            mutation_flag: request.mutation_flag,
+            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+            runner_id,
+            runner_mode: status_tunnel_mode(&runner_status).metadata_value(),
+            assignment_source: selection.source.metadata_value(),
+            status: "offloaded",
+            remote_workspace: Some(&remote_cwd),
+            fallback_reason: None,
+            workspace_mapping_ref: execution_context.workspace_mapping_ref(),
+            proof_id: lab_metadata
+                .get("proof")
+                .and_then(|proof| proof.get("id"))
+                .and_then(|id| id.as_str()),
+        },
+        &command,
+    );
     runner_workload.agent_task =
-        runner_workload_agent_task_from_command(&remapped_args, agent_task_run_id.as_deref());
+        runner_workload_agent_task_from_command(&command, agent_task_run_id.as_deref());
     runner_workload.required_secrets.secret_env_plan = secret_env_handoff.secret_env_plan.clone();
     lab_metadata["runner_workload"] =
         serde_json::to_value(&runner_workload).unwrap_or(serde_json::json!(null));

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -112,7 +112,8 @@ use super::super::{
 };
 
 use super::super::workload::{
-    build_runner_workload, runner_workload_agent_task_from_command, RunnerWorkloadBuildInput,
+    build_runner_workload_for_dispatched_command, runner_workload_agent_task_from_command,
+    RunnerWorkloadBuildInput,
 };
 use super::agent_task_bridge::{
     agent_task_dispatch_run_isolation_token, ensure_agent_task_dispatch_run_id_with,

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -125,23 +125,26 @@ pub(crate) fn run_runner_resident_lab_offload(
         &remapped_args,
         Default::default(),
     )?;
-    let mut runner_workload = build_runner_workload(RunnerWorkloadBuildInput {
-        plan: &plan,
-        command: &contract,
-        capture_patch: request.capture_patch,
-        mutation_flag: request.mutation_flag,
-        allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
-        runner_id,
-        runner_mode: status_tunnel_mode(runner_status).metadata_value(),
-        assignment_source: selection.source.metadata_value(),
-        status: "offloaded",
-        remote_workspace: Some(&execution_context.remote_cwd),
-        fallback_reason: None,
-        workspace_mapping_ref: execution_context.workspace_mapping_ref(),
-        proof_id: None,
-    });
+    let mut runner_workload = build_runner_workload_for_dispatched_command(
+        RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &contract,
+            capture_patch: request.capture_patch,
+            mutation_flag: request.mutation_flag,
+            allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+            runner_id,
+            runner_mode: status_tunnel_mode(runner_status).metadata_value(),
+            assignment_source: selection.source.metadata_value(),
+            status: "offloaded",
+            remote_workspace: Some(&execution_context.remote_cwd),
+            fallback_reason: None,
+            workspace_mapping_ref: execution_context.workspace_mapping_ref(),
+            proof_id: None,
+        },
+        &command,
+    );
     runner_workload.agent_task =
-        runner_workload_agent_task_from_command(&remapped_args, agent_task_run_id.as_deref());
+        runner_workload_agent_task_from_command(&command, agent_task_run_id.as_deref());
     runner_workload.required_secrets.secret_env_plan = secret_env_handoff.secret_env_plan.clone();
     lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
     let path_remaps =

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -1,3 +1,4 @@
+use crate::cli_surface::Cli;
 use crate::command_contract::{
     RunnerWorkload, RunnerWorkloadAgentTask, RunnerWorkloadAgentTaskDispatchKind,
     RunnerWorkloadAgentTaskLifecycleMirrorPolicy, RunnerWorkloadAssignment,
@@ -9,6 +10,7 @@ use crate::command_contract::{
 use crate::core::error::{Error, Result};
 use crate::core::plan::HomeboyPlan;
 use crate::core::secret_env_plan::SecretEnvPlan;
+use clap::Parser;
 
 use super::{
     LabOffloadCommand, LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy,
@@ -31,16 +33,34 @@ pub(crate) struct RunnerWorkloadBuildInput<'a> {
     pub proof_id: Option<&'a str>,
 }
 
+#[cfg(test)]
 pub(crate) fn build_runner_workload(input: RunnerWorkloadBuildInput<'_>) -> RunnerWorkload {
+    let command_label = input.command.hot_label.to_string();
+    build_runner_workload_with_command_label(input, command_label)
+}
+
+pub(crate) fn build_runner_workload_for_dispatched_command(
+    input: RunnerWorkloadBuildInput<'_>,
+    dispatched_command: &[String],
+) -> RunnerWorkload {
+    let command_label = runner_workload_command_label_from_dispatched_command(dispatched_command)
+        .unwrap_or_else(|| input.command.hot_label.to_string());
+    build_runner_workload_with_command_label(input, command_label)
+}
+
+fn build_runner_workload_with_command_label(
+    input: RunnerWorkloadBuildInput<'_>,
+    command_label: String,
+) -> RunnerWorkload {
     let workspace_mapping_ref = input.workspace_mapping_ref.map(str::to_string);
+    let command_family = RunnerWorkloadCommandFamily::from_command_label(&command_label);
+    let required_secret_categories = required_secret_categories(&command_label);
     RunnerWorkload {
         schema: RUNNER_WORKLOAD_SCHEMA.to_string(),
         workload_id: format!("{}.runner_workload", input.plan.id),
         kind: RunnerWorkloadKind {
-            command_label: input.command.hot_label.to_string(),
-            command_family: RunnerWorkloadCommandFamily::from_command_label(
-                input.command.hot_label,
-            ),
+            command_label,
+            command_family,
         },
         agent_task: None,
         workspace_mappings: RunnerWorkloadWorkspaceMappings {
@@ -51,7 +71,7 @@ pub(crate) fn build_runner_workload(input: RunnerWorkloadBuildInput<'_>) -> Runn
         },
         required_capabilities: required_capabilities(input.command),
         required_secrets: RunnerWorkloadSecrets {
-            categories: required_secret_categories(input.command.hot_label),
+            categories: required_secret_categories,
             secret_env_plan: SecretEnvPlan::default(),
         },
         required_extensions: input.command.required_extensions.clone(),
@@ -82,6 +102,33 @@ pub(crate) fn build_runner_workload(input: RunnerWorkloadBuildInput<'_>) -> Runn
             artifacts: Vec::new(),
         },
     }
+}
+
+fn runner_workload_command_label_from_dispatched_command(command: &[String]) -> Option<String> {
+    let argv = cli_argv_from_dispatched_command(command)?;
+    let cli = Cli::try_parse_from(argv).ok()?;
+    let route_contract = cli.command.lab_route_contract().ok()??;
+    Some(route_contract.command.hot_label.to_string())
+}
+
+fn cli_argv_from_dispatched_command(command: &[String]) -> Option<Vec<String>> {
+    if command.is_empty() {
+        return None;
+    }
+    if is_homeboy_executable(&command[0]) {
+        return Some(command.to_vec());
+    }
+    let mut argv = Vec::with_capacity(command.len() + 1);
+    argv.push("homeboy".to_string());
+    argv.extend(command.iter().cloned());
+    Some(argv)
+}
+
+fn is_homeboy_executable(value: &str) -> bool {
+    std::path::Path::new(value)
+        .file_name()
+        .and_then(|name| name.to_str())
+        == Some("homeboy")
 }
 
 pub(crate) fn runner_workload_agent_task_from_command(
@@ -575,6 +622,121 @@ mod tests {
             workspace_mapping_ref: None,
             proof_id: None,
         })
+    }
+
+    #[test]
+    fn runner_workload_kind_comes_from_dispatched_command_for_lab_shapes() {
+        struct Case {
+            name: &'static str,
+            argv: Vec<&'static str>,
+            expected_label: &'static str,
+            expected_family: RunnerWorkloadCommandFamily,
+        }
+
+        let cases = [
+            Case {
+                name: "review lint component",
+                argv: vec![
+                    "/srv/homeboy/bin/homeboy",
+                    "--force-hot",
+                    "review",
+                    "lint",
+                    "homeboy",
+                ],
+                expected_label: "review lint",
+                expected_family: RunnerWorkloadCommandFamily::Quality,
+            },
+            Case {
+                name: "agent-task cook",
+                argv: vec![
+                    "/srv/homeboy/bin/homeboy",
+                    "--force-hot",
+                    "agent-task",
+                    "cook",
+                    "--to-worktree",
+                    "homeboy@cook",
+                    "--goal",
+                    "tighten lab dispatch metadata",
+                    "--verify",
+                    "cargo check --all-targets",
+                    "--no-finalize",
+                ],
+                expected_label: "agent-task cook/run-plan/retry --run",
+                expected_family: RunnerWorkloadCommandFamily::AgentTask,
+            },
+            Case {
+                name: "plain offloaded command",
+                argv: vec![
+                    "/srv/homeboy/bin/homeboy",
+                    "--force-hot",
+                    "extension",
+                    "update",
+                    "wordpress",
+                ],
+                expected_label: "extension update",
+                expected_family: RunnerWorkloadCommandFamily::Unknown,
+            },
+            Case {
+                name: "resident-path command",
+                argv: vec![
+                    "/srv/homeboy/bin/homeboy",
+                    "--force-hot",
+                    "agent-task",
+                    "status",
+                    "run-1",
+                ],
+                expected_label:
+                    "agent-task run/run-next/status/logs/artifacts/review/list/active/latest",
+                expected_family: RunnerWorkloadCommandFamily::AgentTask,
+            },
+        ];
+
+        for case in cases {
+            let plan = plan();
+            let mut command = command();
+            command.hot_label = "trace";
+            let dispatched_command = case
+                .argv
+                .iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>();
+
+            let workload = build_runner_workload_for_dispatched_command(
+                RunnerWorkloadBuildInput {
+                    plan: &plan,
+                    command: &command,
+                    capture_patch: true,
+                    mutation_flag: None,
+                    allow_dirty_lab_workspace: false,
+                    runner_id: "lab-a",
+                    runner_mode: "direct_ssh",
+                    assignment_source: "explicit",
+                    status: "offloaded",
+                    remote_workspace: Some("/srv/homeboy/work"),
+                    fallback_reason: None,
+                    workspace_mapping_ref: Some("path_materialization_plan"),
+                    proof_id: None,
+                },
+                &dispatched_command,
+            );
+
+            assert_eq!(
+                workload.kind.command_label, case.expected_label,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                workload.kind.command_family, case.expected_family,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                workload.workspace_mappings.mapping_ref.as_deref(),
+                Some("path_materialization_plan"),
+                "{}",
+                case.name
+            );
+        }
     }
 
     fn secret_plan(names: &[&str]) -> SecretEnvPlan {


### PR DESCRIPTION
## Summary
- Derive Lab runner workload command label and command family from the actual dispatched Homeboy argv via the same CLI Lab route contract surface.
- Route both standard materialized Lab offload and runner-resident Lab offload through the same dispatched-argv workload builder.
- Keep runner-resident fast execution intact: it still dispatches against the existing remote checkout and carries an `existing_remote` path materialization plan.

## Before / after fork map
- Before: standard Lab offload built `RunnerWorkload.kind` from `LabOffloadCommand.hot_label`, then separately attached `agent_task` from `remapped_args`.
- Before: runner-resident Lab offload repeated the same workload construction separately, with its own resident `LabExecutionContext`, resident argv rewrite, and agent-task extraction.
- After: both paths pass the exact remote command argv to `build_runner_workload_for_dispatched_command`; label, family, and secret categories are derived from one resolved workload label.
- After: both paths extract the `agent_task` workload section from the same command argv that is executed.
- After: resident capability remains a data shape: `runner_resident_path_materialization_plan` still emits `existing_remote` entries and the shared dispatch tail receives that populated plan.

## Net LOC
- `git diff --stat`: 4 files changed, 210 insertions(+), 41 deletions(-).
- Net: +169 LOC. The regression table accounts for most of the increase; production construction now uses one dispatched-argv builder for both standard and resident paths.

## Regression guard
- Added table-driven coverage for review lint, agent-task cook, a plain offloaded command, and a resident-path command.
- Each case asserts the workload label and family come from the dispatched command, even when the supplied contract label is intentionally wrong, and that the workload references a populated `path_materialization_plan`.

## Verification
- `cargo check --all-targets`
- `/Users/chubes/.cargo/bin/cargo-nextest nextest run --lib -E 'test(offload) or test(resident) or test(route) or test(lab_args) or test(workload)' --no-fail-fast`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)\n- **Used for:** Collapsed remaining Lab dual-path workload/label/family construction into one derivation; Chris reviews and owns the change.