### PR TITLE
Fix release recovery for orphaned tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,8 @@ jobs:
       should-release: ${{ steps.check.outputs.should-release }}
       bump-type: ${{ steps.check.outputs['release-bump-type'] }}
       recovery-release: ${{ steps.check.outputs.recovery-release }}
+      release-version: ${{ steps.check.outputs['release-version'] }}
+      release-tag: ${{ steps.check.outputs['release-tag'] }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -132,6 +134,7 @@ jobs:
           HEAD_SHA="$(git rev-parse HEAD)"
           RECOVERY_TAG="${{ steps.recovery.outputs['release-tag'] }}"
           RELEASE_VERSION="${{ steps.recovery.outputs['release-version'] || steps.release-check.outputs['release-version'] }}"
+          RELEASE_TAG="${{ steps.recovery.outputs['release-tag'] || steps.release-check.outputs['release-tag'] }}"
           BUMP_TYPE="${{ steps.recovery.outputs['release-bump-type'] || steps.release-check.outputs['release-bump-type'] }}"
 
           if [ "${{ steps.failed-release.outputs.blocked }}" = "true" ]; then
@@ -139,6 +142,8 @@ jobs:
           elif [ -n "${RECOVERY_TAG}" ]; then
             echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "release-bump-type=${BUMP_TYPE}" >> "$GITHUB_OUTPUT"
+            echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "release-tag=${RECOVERY_TAG}" >> "$GITHUB_OUTPUT"
             echo "recovery-release=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Release recovery will publish ${RECOVERY_TAG}"
           elif [ -z "${RELEASE_VERSION}" ]; then
@@ -147,9 +152,11 @@ jobs:
           else
             echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "release-bump-type=${BUMP_TYPE}" >> "$GITHUB_OUTPUT"
+            echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "release-tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
             if [ "${BUMP_TYPE}" = "recovery" ]; then
               echo "recovery-release=true" >> "$GITHUB_OUTPUT"
-              echo "::notice::Recovered prepared release tag; bypassing quality gates and publishing artifacts"
+              echo "::notice::Recovered prepared release tag ${RELEASE_TAG}; bypassing quality gates and publishing artifacts"
             else
               echo "recovery-release=false" >> "$GITHUB_OUTPUT"
             fi
@@ -509,7 +516,7 @@ jobs:
 
       - uses: Extra-Chill/homeboy-action@v2
         id: release
-        if: inputs.release_tag == ''
+        if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'
         with:
           source: '.'
           commands: release
@@ -522,17 +529,20 @@ jobs:
 
       - name: Mark prepared release for downstream publish
         id: prepared
-        if: inputs.release_tag == '' && steps.release.outputs['release-tag'] != ''
+        if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true' && steps.release.outputs['release-tag'] != ''
         run: |
           echo "prepared=true" >> "$GITHUB_OUTPUT"
           echo "::notice::Prepared ${{ steps.release.outputs['release-tag'] }}; downstream jobs will publish it in this run"
 
       - name: Use existing release tag
         id: recovery
-        if: inputs.release_tag != ''
+        if: inputs.release_tag != '' || needs.check.outputs.recovery-release == 'true'
         run: |
-          TAG="${{ inputs.release_tag }}"
-          VERSION="${TAG#v}"
+          TAG="${{ inputs.release_tag || needs.check.outputs['release-tag'] }}"
+          VERSION="${{ needs.check.outputs['release-version'] }}"
+          if [ -z "${VERSION}" ]; then
+            VERSION="${TAG#v}"
+          fi
 
           echo "release-version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "release-tag=${TAG}" >> "$GITHUB_OUTPUT"

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -8,12 +8,10 @@ use super::types::{
     ReleaseCommandInput, ReleaseCommandResult, ReleaseExecutionPlan, ReleaseOptions, ReleasePlan,
     ReleaseRun, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
 };
-use super::workflow_recover::run_recover;
+use super::workflow_recover::{recovery_release_plan, run_recover};
 
 #[cfg(test)]
-use super::workflow_recover::{
-    diagnose_orphan_tag, reconcile_release_branch, recovery_release_plan,
-};
+use super::workflow_recover::{diagnose_orphan_tag, reconcile_release_branch};
 
 /// Process exit code returned when a release is intentionally skipped (no tag,
 /// no package, no GitHub Release produced).
@@ -177,6 +175,16 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     };
 
     if options.dry_run {
+        if let Some(result) = prepared_tag_publish_recovery_result(
+            &input,
+            &component,
+            &release_scope,
+            &execution,
+            &bump_type,
+        )? {
+            return Ok((result, 0));
+        }
+
         let early_plan = super::plan(&input.component_id, &options).ok();
         let skipped_reason = early_plan.as_ref().and_then(skipped_reason_from_plan);
 
@@ -335,6 +343,81 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         },
         exit_code,
     ))
+}
+
+fn prepared_tag_publish_recovery_result(
+    input: &ReleaseCommandInput,
+    component: &crate::core::component::Component,
+    release_scope: &ReleaseScope,
+    execution: &ReleaseExecutionPlan,
+    bump_type: &str,
+) -> Result<Option<ReleaseCommandResult>> {
+    if input.pipeline.head {
+        return Ok(None);
+    }
+
+    let Some(current_version) = current_component_version(component)? else {
+        return Ok(None);
+    };
+    let tag = release_scope.tag_name(&current_version);
+
+    if !crate::core::git::tag_exists_locally(&release_scope.git_root, &tag)? {
+        return Ok(None);
+    }
+    let tag_commit = crate::core::git::get_tag_commit(&release_scope.git_root, &tag)?;
+    let head_commit = crate::core::git::get_head_commit(&release_scope.git_root)?;
+    if tag_commit != head_commit {
+        return Ok(None);
+    }
+
+    Ok(prepared_tag_publish_recovery_decision(
+        input,
+        &current_version,
+        &tag,
+        execution,
+        bump_type,
+        super::executor::github_release_exists_for_tag(component, &tag),
+    ))
+}
+
+fn prepared_tag_publish_recovery_decision(
+    input: &ReleaseCommandInput,
+    current_version: &str,
+    tag: &str,
+    execution: &ReleaseExecutionPlan,
+    _bump_type: &str,
+    github_release_exists: Option<bool>,
+) -> Option<ReleaseCommandResult> {
+    match github_release_exists {
+        Some(false) => Some(ReleaseCommandResult {
+            phase: execution.phase,
+            component_id: input.component_id.clone(),
+            status: "planned".to_string(),
+            bump_type: "recovery".to_string(),
+            dry_run: true,
+            releasable_commits: 0,
+            new_version: Some(current_version.to_string()),
+            tag: Some(tag.to_string()),
+            skipped_reason: None,
+            plan: Some(recovery_release_plan(
+                &input.component_id,
+                current_version,
+                tag,
+                false,
+                false,
+                false,
+                &[format!(
+                    "Prepared tag {tag} exists at HEAD but has no GitHub Release; publish artifacts for the existing tag"
+                )],
+            )),
+            run: None,
+            deployment: None,
+            release_summary: vec![format!(
+                "Prepared tag {tag} exists at HEAD; GitHub Release is missing and should be published"
+            )],
+        }),
+        Some(true) | None => None,
+    }
 }
 
 fn run_dry_run_preflights(
@@ -1189,6 +1272,71 @@ mod tests {
 
         input.recover = true;
         assert_eq!(release_execution_plan(&input).phase, ReleasePhase::Recover);
+    }
+
+    #[test]
+    fn prepared_tag_without_github_release_plans_publish_recovery() {
+        let input = ReleaseCommandInput {
+            component_id: "fixture".to_string(),
+            dry_run: true,
+            ..Default::default()
+        };
+        let execution = release_execution_plan(&input);
+
+        let result = prepared_tag_publish_recovery_decision(
+            &input,
+            "1.2.3",
+            "v1.2.3",
+            &execution,
+            "none",
+            Some(false),
+        )
+        .expect("missing GitHub Release should publish existing tag");
+
+        assert_eq!(result.status, "planned");
+        assert_eq!(result.bump_type, "recovery");
+        assert_eq!(result.new_version.as_deref(), Some("1.2.3"));
+        assert_eq!(result.tag.as_deref(), Some("v1.2.3"));
+        assert!(result.skipped_reason.is_none());
+        assert!(result
+            .release_summary
+            .iter()
+            .any(|line| line.contains("GitHub Release is missing")));
+    }
+
+    #[test]
+    fn prepared_tag_with_github_release_is_noop() {
+        let input = ReleaseCommandInput {
+            component_id: "fixture".to_string(),
+            dry_run: true,
+            ..Default::default()
+        };
+        let execution = release_execution_plan(&input);
+
+        assert!(prepared_tag_publish_recovery_decision(
+            &input,
+            "1.2.3",
+            "v1.2.3",
+            &execution,
+            "none",
+            Some(true),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn prepared_tag_unknown_github_release_state_is_conservative_noop() {
+        let input = ReleaseCommandInput {
+            component_id: "fixture".to_string(),
+            dry_run: true,
+            ..Default::default()
+        };
+        let execution = release_execution_plan(&input);
+
+        assert!(prepared_tag_publish_recovery_decision(
+            &input, "1.2.3", "v1.2.3", &execution, "none", None,
+        )
+        .is_none());
     }
 
     #[test]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -158,14 +158,29 @@ fn release_recovery_bypasses_quality_gates_and_still_prepares() {
     let prepare = job_section(release_workflow(), "prepare");
 
     assert!(check.contains("recovery-release: ${{ steps.check.outputs.recovery-release }}"));
+    assert!(check.contains("release-version: ${{ steps.check.outputs['release-version'] }}"));
+    assert!(check.contains("release-tag: ${{ steps.check.outputs['release-tag'] }}"));
+    assert!(check.contains("RELEASE_TAG=\"${{ steps.recovery.outputs['release-tag'] || steps.release-check.outputs['release-tag'] }}\""));
     assert!(check.contains("echo \"recovery-release=true\" >> \"$GITHUB_OUTPUT\""));
-    assert!(check.contains("Recovered prepared release tag; bypassing quality gates"));
+    assert!(check.contains("echo \"release-tag=${RELEASE_TAG}\" >> \"$GITHUB_OUTPUT\""));
+    assert!(
+        check.contains("Recovered prepared release tag ${RELEASE_TAG}; bypassing quality gates")
+    );
 
     for section in [gate_audit, gate_lint, gate_test, policy] {
         assert!(section.contains("needs.check.outputs.recovery-release != 'true'"));
     }
 
     assert!(prepare.contains("needs.check.outputs.recovery-release == 'true'"));
+    assert!(prepare.contains(
+        "if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'"
+    ));
+    assert!(prepare.contains(
+        "if: inputs.release_tag != '' || needs.check.outputs.recovery-release == 'true'"
+    ));
+    assert!(
+        prepare.contains("TAG=\"${{ inputs.release_tag || needs.check.outputs['release-tag'] }}\"")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Detect prepared release tags at HEAD whose GitHub Release is missing during the release dry-run check.
- Emit a `recovery` release signal with the existing `release-version` and `release-tag` so the workflow treats the prepared tag as releasable.
- Route recovery publishes through artifact build + `Create GitHub Release` without re-running version/tag preparation.

## Skip root cause
The recurring wedge happens after a previous run creates the version-bump commit and tag, but skips or misses `Create GitHub Release`. A later push run checks out `main`, sees the current source version tag already points at `HEAD`, and `release_skip_plan` reports `release-already-at-head`. That skip only proved the tag exists, not that the GitHub Release exists. The workflow then gets no `release-version`/`release-tag` publish signal, sets `should-release=false`, and skips `Prepare Release`, `Plan Build Matrix`, and `Create GitHub Release`.

## Recovery fix
- `homeboy release --dry-run` now checks the current version tag at `HEAD` against GitHub Release state.
- If the tag exists at `HEAD` and `gh release view <tag>` is missing, the command returns a planned `recovery` result with `new_version` and `tag` populated instead of a skip.
- If the tag and GitHub Release both exist, the command remains a no-op.
- If GitHub Release state cannot be checked locally, the command stays conservative; CI has authenticated `gh` and can make the publish decision.
- The workflow now carries `release-version` and `release-tag` from `check` to `prepare`, and `prepare` uses the existing prepared tag when `recovery-release=true` instead of invoking a new version/tag mutation.

## Why #7596/#7597 missed this
Those changes fixed manual/prepared-tag recovery routing and output syntax, but the push-triggered check still depended on the release command surfacing a recovery state. The command’s `release-already-at-head` skip conflated “tag exists” with “Release is published”, so no workflow output ever reached the recovery path for an orphaned tag discovered on a normal push run.

## v0.281.11 recommendation
Leave `v0.281.11` in place unless we explicitly decide to prune historical orphan tags. It is already on `main` history and now has newer releases after it; deleting it is unnecessary for the train. The fixed workflow should recover future prepared-but-unpublished tags by publishing the missing Release instead of wedging.

## Verification
- `cargo check --all-targets`
- `cargo test --test release_workflow_test`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(release)' --no-fail-fast`
- `target/debug/homeboy release homeboy --dry-run --skip-checks=audit,lint,test` reached planning on the rebased branch and reported the expected feature-branch default-branch preflight refusal.

Closes #7609 (release half); hardens #7595.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Made release publish idempotently recover orphaned prepared tags; Chris reviews and owns the change.
