### PR TITLE
Unify review lint scope routing

### DIFF
--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -834,13 +834,23 @@ fn lab_route_source_path_args(
     normalized_args: &[String],
     capture_mutation_patch: bool,
 ) -> Option<Vec<String>> {
-    if capture_mutation_patch {
+    if capture_mutation_patch || command_prefers_controller_source_path(command) {
         if let Some(rewritten) = rewrite_component_target_to_path(command, normalized_args) {
             return Some(rewritten);
         }
     }
 
     rewrite_ad_hoc_lab_workspace_to_path(command, normalized_args)
+}
+
+fn command_prefers_controller_source_path(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::Review(crate::commands::review::ReviewArgs {
+            command: Some(crate::commands::review::ReviewCommand::Lint(_)),
+            ..
+        })
+    )
 }
 
 /// When a `lint --fix` / `refactor --write` command targets a component by id
@@ -972,6 +982,10 @@ fn strip_component_target_args(
     let mut passthrough = false;
     let mut positional_stripped = false;
     while let Some(arg) = iter.next() {
+        if rewritten.is_empty() {
+            rewritten.push(arg.clone());
+            continue;
+        }
         if passthrough {
             rewritten.push(arg.clone());
             continue;
@@ -1159,12 +1173,32 @@ mod tests {
     #[test]
     fn nested_review_quality_subcommands_use_specific_lab_labels() {
         for (args, expected_label) in [
-            (vec!["homeboy", "review", "audit", "data-machine"], "review audit"),
-            (vec!["homeboy", "review", "lint", "data-machine"], "review lint"),
-            (vec!["homeboy", "review", "test", "data-machine"], "review test"),
-            (vec!["homeboy", "review", "build", "data-machine"], "review build"),
             (
-                vec!["homeboy", "review", "ci", "run", "data-machine", "--job", "lint"],
+                vec!["homeboy", "review", "audit", "data-machine"],
+                "review audit",
+            ),
+            (
+                vec!["homeboy", "review", "lint", "data-machine"],
+                "review lint",
+            ),
+            (
+                vec!["homeboy", "review", "test", "data-machine"],
+                "review test",
+            ),
+            (
+                vec!["homeboy", "review", "build", "data-machine"],
+                "review build",
+            ),
+            (
+                vec![
+                    "homeboy",
+                    "review",
+                    "ci",
+                    "run",
+                    "data-machine",
+                    "--job",
+                    "lint",
+                ],
                 "review ci",
             ),
         ] {
@@ -1204,7 +1238,11 @@ mod tests {
     fn nested_review_quality_in_dir_offload_uses_current_dir_path() {
         let dir = tempdir().expect("tempdir");
         let _cwd = CwdGuard::set(dir.path());
-        let normalized = vec!["homeboy".to_string(), "review".to_string(), "lint".to_string()];
+        let normalized = vec![
+            "homeboy".to_string(),
+            "review".to_string(),
+            "lint".to_string(),
+        ];
         let cli = Cli::parse_from(&normalized);
 
         let rewritten = lab_route_source_path_args(&cli.command, &normalized, false)
@@ -2554,16 +2592,27 @@ mod tests {
     }
 
     #[test]
-    fn lab_route_source_path_args_keeps_component_id_without_patch_capture() {
-        let cli = Cli::parse_from(["homeboy", "review", "lint", "sample-component"]);
+    fn lab_route_source_path_args_rewrites_review_lint_component_without_patch_capture() {
+        let cli = Cli::parse_from(["homeboy", "review", "lint", "homeboy"]);
         let normalized = vec![
             "homeboy".to_string(),
             "review".to_string(),
             "lint".to_string(),
-            "sample-component".to_string(),
+            "homeboy".to_string(),
         ];
 
-        assert!(lab_route_source_path_args(&cli.command, &normalized, false).is_none());
+        let rewritten = lab_route_source_path_args(&cli.command, &normalized, false)
+            .expect("review lint component id should become a source path");
+
+        assert_eq!(rewritten[0..3], normalized[0..3]);
+        assert_eq!(
+            rewritten
+                .iter()
+                .filter(|arg| arg.as_str() == "homeboy")
+                .count(),
+            1
+        );
+        assert!(rewritten.contains(&"--path".to_string()));
     }
 
     #[test]

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -59,6 +59,9 @@ pub struct LintArgs {
     #[arg(skip)]
     pub precomputed_changed_files: Option<Vec<String>>,
 
+    #[arg(skip)]
+    pub force_main_workflow: bool,
+
     #[arg(long, hide = true, value_name = "JSON")]
     pub lab_changed_files_json: Option<String>,
 
@@ -101,7 +104,12 @@ impl LintArgs {
     }
 
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
-        if self.is_full_workspace_run() || self.changed_since.is_some() || self.changed_only {
+        if self.is_full_workspace_run()
+            || self.changed_since.is_some()
+            || self.changed_only
+            || self.file.is_some()
+            || self.glob.is_some()
+        {
             return Some(
                 LabCommandContract::portable(
                     LINT_LAB_LABEL,
@@ -129,6 +137,7 @@ impl LintArgs {
 
     pub(crate) fn should_use_self_check_dispatch(&self) -> bool {
         !self.fix
+            && !self.force_main_workflow
             && self.ci_job.is_none()
             && !self.summary
             && self.is_full_workspace_run()
@@ -580,6 +589,21 @@ mod tests {
                 "scoped or behavior-changing args must use main lint workflow: {argv:?}"
             );
         }
+    }
+
+    #[test]
+    fn file_scoped_lint_has_lab_contract() {
+        let args = TestCli::try_parse_from(["lint", "homeboy", "--file", "src/lib.rs"])
+            .expect("file lint should parse")
+            .lint;
+
+        let contract = args.lab_contract().expect("file lint should offload");
+
+        assert_eq!(contract.hot_label, crate::command_contract::LINT_LAB_LABEL);
+        assert_eq!(
+            contract.portability,
+            crate::command_contract::LabCommandPortability::Portable
+        );
     }
 
     #[test]

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -297,7 +297,7 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         Some(ReviewCommand::Audit(args)) => to_value(audit::run(args.audit, global)),
         Some(ReviewCommand::AuditBaseline(args)) => to_value(audit_baseline::run(args, global)),
-        Some(ReviewCommand::Lint(args)) => to_value(lint::run(args, global)),
+        Some(ReviewCommand::Lint(args)) => to_value(lint::run(review_lint_args(args), global)),
         Some(ReviewCommand::Test(args)) => to_value(test::run(args, global)),
         Some(ReviewCommand::Build(args)) => to_value(build::run(args, global)),
         Some(ReviewCommand::Ci(args)) => to_value(ci::run(args, global)),
@@ -313,6 +313,11 @@ fn to_value<T: Serialize>(result: CmdResult<T>) -> CmdResult<Value> {
         ))
     })?;
     Ok((value, exit_code))
+}
+
+fn review_lint_args(mut args: lint::LintArgs) -> lint::LintArgs {
+    args.force_main_workflow = true;
+    args
 }
 
 pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutput> {
@@ -654,6 +659,7 @@ fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -
         precomputed_changed_files: review_context
             .precomputed_changed_files()
             .map(<[String]>::to_vec),
+        force_main_workflow: true,
         ci_job: None,
         sniff_filters: Default::default(),
         category: None,
@@ -1135,6 +1141,22 @@ mod tests {
         assert!(
             !lint_args.should_use_self_check_dispatch(),
             "review-scoped lint must run the main lint workflow, not full self-check scripts"
+        );
+    }
+
+    #[test]
+    fn direct_review_lint_args_do_not_use_self_check_dispatch() {
+        let cli =
+            TestCli::try_parse_from(["test", "lint", "homeboy"]).expect("review lint should parse");
+        let ReviewCommand::Lint(args) = cli.review.command.expect("lint subcommand") else {
+            panic!("expected lint subcommand");
+        };
+
+        let args = review_lint_args(args);
+
+        assert!(
+            !args.should_use_self_check_dispatch(),
+            "direct review lint must run the main lint workflow for every target form"
         );
     }
 

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -489,7 +489,7 @@ mod tests {
     }
 
     #[test]
-    fn changed_scope_commands_are_hot_but_file_scoped_lint_is_not() {
+    fn changed_and_file_scoped_lint_commands_are_hot() {
         let changed_lint = Cli::parse_from([
             "homeboy",
             "review",
@@ -503,7 +503,10 @@ mod tests {
         assert!(hot.lab_offload_unsupported_reason.is_none());
 
         let file_lint = Cli::parse_from(["homeboy", "review", "lint", "--file", "src/main.rs"]);
-        assert!(hot_command(&file_lint.command).is_none());
+        let hot = hot_command(&file_lint.command).expect("file-scope lint is hot");
+        assert_eq!(hot.label, "review lint");
+        assert!(hot.lab_offload_supported);
+        assert!(hot.lab_offload_unsupported_reason.is_none());
     }
 
     #[test]

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -44,6 +44,7 @@ fn lint_args(root: &Path) -> LintArgs {
         changed_only: false,
         changed_since: None,
         precomputed_changed_files: None,
+        force_main_workflow: false,
         lab_changed_files_json: None,
         ci_job: None,
         sniff_filters: LintSniffArgs::default(),


### PR DESCRIPTION
## Summary
- Route direct and umbrella `review lint` through the main extension lint workflow instead of component self-check dispatch so tool selection is consistent across component-id and path targets.
- Make file/glob-scoped lint Lab-portable so `review lint --file ... --runner ...` routes instead of failing as an unsupported invocation shape.
- Normalize Lab `review lint <component>` to the controller-resolved `--path` target so component-id and path forms materialize the same checkout on the runner.

## Root cause
`review lint <component>` could use the component self-check lint script for full unscoped runs, while path/ad-hoc Lab forms used the extension lint workflow. Those entry paths selected different producer sets for the same target. Separately, `LintArgs::lab_contract()` omitted `--file`/`--glob`, so global `--runner` rejected file-scoped review lint before routing.

## Before / after evidence
Before, the reported data-machine case diverged between component-id and path forms, and `--file` + `--runner` rejected as unsupported.

After, with this branch:
- `cargo run -- --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/review-lint-data-machine-component.json review lint data-machine --lab-only --runner homeboy-lab` => failed on lint findings, consistently: 79 findings; producers `phpcs=79`, `eslint=0`, `phpstan=0`.
- `cargo run -- --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/review-lint-data-machine-path.json review lint /Users/chubes/Developer/data-machine --lab-only --runner homeboy-lab` => same result: 79 findings; producers `phpcs=79`, `eslint=0`, `phpstan=0`.
- `cargo run -- --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/review-lint-data-machine-file.json review lint data-machine --file data-machine.php --lab-only --runner homeboy-lab` => routed through Lab instead of rejecting; the remote lint workflow ran and failed inside PHPStan PHAR loading on the lab runner, proving `--file` + `--runner` reaches the supported remote lint path.

## Verification
- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(review) or test(lint) or test(route) or test(scope)' --no-fail-fast` (477 passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Unified review-lint scope resolution across invocation shapes and fixed --file/--runner handling; Chris reviews and owns the change.
