### PR TITLE
Clarify review format gate failures

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1224,10 +1224,14 @@ impl RunnerWorkloadCommandFamily {
     pub(crate) fn from_command_label(label: &str) -> Self {
         match label {
             label if label.starts_with("agent-task") => Self::AgentTask,
-            label if matches!(
-                label,
-                "review audit" | "review lint" | "review test" | "review build" | "review ci"
-            ) => Self::Quality,
+            label
+                if matches!(
+                    label,
+                    "review audit" | "review lint" | "review test" | "review build" | "review ci"
+                ) =>
+            {
+                Self::Quality
+            }
             LINT_LAB_LABEL | TEST_LAB_LABEL | AUDIT_LAB_LABEL | REVIEW_LAB_LABEL
             | BENCH_LAB_LABEL | FUZZ_LAB_LABEL | TRACE_LAB_LABEL | RIG_RUN_LAB_LABEL => {
                 Self::Quality

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1159,12 +1159,32 @@ mod tests {
     #[test]
     fn nested_review_quality_subcommands_use_specific_lab_labels() {
         for (args, expected_label) in [
-            (vec!["homeboy", "review", "audit", "data-machine"], "review audit"),
-            (vec!["homeboy", "review", "lint", "data-machine"], "review lint"),
-            (vec!["homeboy", "review", "test", "data-machine"], "review test"),
-            (vec!["homeboy", "review", "build", "data-machine"], "review build"),
             (
-                vec!["homeboy", "review", "ci", "run", "data-machine", "--job", "lint"],
+                vec!["homeboy", "review", "audit", "data-machine"],
+                "review audit",
+            ),
+            (
+                vec!["homeboy", "review", "lint", "data-machine"],
+                "review lint",
+            ),
+            (
+                vec!["homeboy", "review", "test", "data-machine"],
+                "review test",
+            ),
+            (
+                vec!["homeboy", "review", "build", "data-machine"],
+                "review build",
+            ),
+            (
+                vec![
+                    "homeboy",
+                    "review",
+                    "ci",
+                    "run",
+                    "data-machine",
+                    "--job",
+                    "lint",
+                ],
                 "review ci",
             ),
         ] {
@@ -1204,7 +1224,11 @@ mod tests {
     fn nested_review_quality_in_dir_offload_uses_current_dir_path() {
         let dir = tempdir().expect("tempdir");
         let _cwd = CwdGuard::set(dir.path());
-        let normalized = vec!["homeboy".to_string(), "review".to_string(), "lint".to_string()];
+        let normalized = vec![
+            "homeboy".to_string(),
+            "review".to_string(),
+            "lint".to_string(),
+        ];
         let cli = Cli::parse_from(&normalized);
 
         let rewritten = lab_route_source_path_args(&cli.command, &normalized, false)

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -714,6 +714,11 @@ fn audit_finding_count(output: &AuditCommandOutput) -> usize {
 
 fn lint_finding_count(output: &LintCommandOutput) -> usize {
     output.findings.as_ref().map(|f| f.len()).unwrap_or(0)
+        + output
+            .formatting_findings
+            .as_ref()
+            .map(|formatting| formatting.files.len().max(1))
+            .unwrap_or(0)
 }
 
 fn test_finding_count(output: &TestCommandOutput) -> usize {

--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -5,7 +5,7 @@
 use homeboy::core::error::Hint;
 use homeboy::core::{Error, ErrorCode, Result};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use super::output::{write_output_file_atomically, OutputWriteOptions};
 
@@ -513,7 +513,7 @@ fn envelope_for_data(
         }
     }
 
-    let diagnostics = failure_diagnostics_for_data(exit_code, &run, &artifacts);
+    let diagnostics = failure_diagnostics_for_data(exit_code, &run, &artifacts, &data);
 
     CommandResultEnvelope {
         schema: COMMAND_RESULT_SCHEMA,
@@ -537,13 +537,15 @@ fn failure_diagnostics_for_data(
     exit_code: i32,
     run: &Option<CommandRunRef>,
     artifacts: &[CommandArtifactRef],
+    data: &Value,
 ) -> Option<CommandDiagnostics> {
     if exit_code == 0 {
         return None;
     }
-    let failure_digest = run
-        .as_ref()
-        .and_then(|run| failure_digest_for_run(&run.id, artifacts));
+    let failure_digest = failure_digest_for_data(data).or_else(|| {
+        run.as_ref()
+            .and_then(|run| failure_digest_for_run(&run.id, artifacts))
+    });
     failure_digest.map(|failure_digest| CommandDiagnostics {
         code: "command.failed".to_string(),
         message: failure_digest.summary.clone(),
@@ -564,8 +566,103 @@ fn failure_digest_for_error(err: &Error) -> Option<CommandFailureDigest> {
             next_actions: Vec::new(),
             retryable: err.retryable,
         }),
+        _ => Some(CommandFailureDigest {
+            summary: err.message.clone(),
+            stdout_tail: None,
+            stderr_tail: None,
+            artifact_refs: Vec::new(),
+            next_actions: Vec::new(),
+            retryable: err.retryable,
+        }),
+    }
+}
+
+fn failure_digest_for_data(data: &Value) -> Option<CommandFailureDigest> {
+    if let Some(digest) = formatting_failure_digest(data) {
+        return Some(digest);
+    }
+    let failure = data.get("failure").and_then(Value::as_object);
+    let summary = failure
+        .and_then(|failure| string_at_object(failure, "summary"))
+        .or_else(|| {
+            data.get("phase")
+                .and_then(Value::as_object)
+                .and_then(|phase| string_at_object(phase, "summary"))
+        })
+        .or_else(|| {
+            data.get("summary")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })?;
+
+    Some(CommandFailureDigest {
+        summary,
+        stdout_tail: raw_output_tail(data, "stdout_tail"),
+        stderr_tail: raw_output_tail(data, "stderr_tail"),
+        artifact_refs: Vec::new(),
+        next_actions: Vec::new(),
+        retryable: None,
+    })
+}
+
+fn formatting_failure_digest(data: &Value) -> Option<CommandFailureDigest> {
+    let formatting = find_object_key(data, "formatting_findings")?;
+    let files = formatting_files(formatting);
+    let command = string_at_object(formatting, "suggested_command")?;
+    let summary = if files.is_empty() {
+        format!("FORMAT: format check failed; run `{command}`")
+    } else {
+        format!(
+            "FORMAT: format check found {} unformatted file(s): {}; run `{}`",
+            files.len(),
+            files.join(", "),
+            command
+        )
+    };
+    Some(CommandFailureDigest {
+        summary,
+        stdout_tail: raw_output_tail(data, "stdout_tail"),
+        stderr_tail: raw_output_tail(data, "stderr_tail"),
+        artifact_refs: Vec::new(),
+        next_actions: vec![CommandNextAction::new("fix formatting", command)
+            .with_kind(CommandNextActionKind::Repair)],
+        retryable: Some(false),
+    })
+}
+
+fn find_object_key<'a>(value: &'a Value, key: &str) -> Option<&'a Map<String, Value>> {
+    match value {
+        Value::Object(map) => map
+            .get(key)
+            .and_then(Value::as_object)
+            .or_else(|| map.values().find_map(|value| find_object_key(value, key))),
+        Value::Array(values) => values.iter().find_map(|value| find_object_key(value, key)),
         _ => None,
     }
+}
+
+fn formatting_files(formatting: &Map<String, Value>) -> Vec<String> {
+    formatting
+        .get("files")
+        .and_then(Value::as_array)
+        .map(|files| {
+            files
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn string_at_object(object: &Map<String, Value>, key: &str) -> Option<String> {
+    object.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+fn raw_output_tail(data: &Value, key: &str) -> Option<String> {
+    data.get("raw_output")
+        .and_then(Value::as_object)
+        .and_then(|raw| string_at_object(raw, key))
 }
 
 fn failure_digest_for_run(
@@ -916,6 +1013,40 @@ mod tests {
         assert_eq!(
             value["diagnostics"]["failure_digest"]["stderr_tail"],
             "before\nstderr tail"
+        );
+    }
+
+    #[test]
+    fn failed_quality_payload_includes_format_failure_digest_without_run_evidence() {
+        let response = cli_response_for_json_result_for_command(
+            &Ok(json!({
+                "command": "review",
+                "summary": { "status": "failed" },
+                "lint": {
+                    "stage": "lint",
+                    "passed": false,
+                    "output": {
+                        "formatting_findings": {
+                            "files": ["src/lib.rs", "src/main.rs"],
+                            "suggested_command": "cargo fmt"
+                        }
+                    }
+                }
+            })),
+            1,
+            "review",
+            None,
+        );
+        let value = serde_json::to_value(response).expect("response json");
+
+        assert_eq!(value["success"], false);
+        assert_eq!(
+            value["diagnostics"]["failure_digest"]["summary"],
+            "FORMAT: format check found 2 unformatted file(s): src/lib.rs, src/main.rs; run `cargo fmt`"
+        );
+        assert_eq!(
+            value["diagnostics"]["failure_digest"]["next_actions"][0]["command"],
+            "cargo fmt"
         );
     }
 

--- a/src/core/extension/lint/report.rs
+++ b/src/core/extension/lint/report.rs
@@ -16,7 +16,7 @@ use crate::core::refactor::AppliedRefactor;
 use serde::Serialize;
 use serde_json::Value;
 
-use super::run::{LintRunWorkflowResult, LintSummaryOutput};
+use super::run::{FormattingFindings, LintRunWorkflowResult, LintSummaryOutput};
 
 /// Unified output envelope for the lint command.
 ///
@@ -90,7 +90,11 @@ pub fn from_main_workflow_with_ci_context(
     let failure = if exit_code == 0 {
         None
     } else {
-        Some(lint_phase_failure(exit_code, finding_count))
+        Some(lint_phase_failure(
+            exit_code,
+            finding_count,
+            result.formatting_findings.as_ref(),
+        ))
     };
 
     (
@@ -229,7 +233,31 @@ pub fn from_lint_fix(component_label: String, run: RefactorSourceRun) -> (LintCo
     )
 }
 
-fn lint_phase_failure(exit_code: i32, finding_count: usize) -> PhaseFailure {
+fn lint_phase_failure(
+    exit_code: i32,
+    finding_count: usize,
+    formatting_findings: Option<&FormattingFindings>,
+) -> PhaseFailure {
+    if let Some(formatting) = formatting_findings {
+        let count = formatting.files.len();
+        return PhaseFailure {
+            phase: VerificationPhase::Format,
+            category: PhaseFailureCategory::Findings,
+            summary: if count == 0 {
+                format!(
+                    "format check failed; run `{}`",
+                    formatting.suggested_command
+                )
+            } else {
+                format!(
+                    "format check found {} unformatted file(s): {}; run `{}`",
+                    count,
+                    formatting.files.join(", "),
+                    formatting.suggested_command
+                )
+            },
+        };
+    }
     let category = phase_failure_category_from_exit_code(exit_code);
     PhaseFailure {
         phase: VerificationPhase::Lint,
@@ -284,6 +312,40 @@ mod tests {
         assert_eq!(
             output.phase.summary,
             "lint phase failed with 2 finding(s) across phpcs passed: 0, eslint failed: 1, phpstan failed: 1"
+        );
+    }
+
+    #[test]
+    fn formatting_findings_surface_as_format_failure() {
+        let result = LintRunWorkflowResult {
+            status: "failed".to_string(),
+            component: "fixture".to_string(),
+            exit_code: 1,
+            harness_error: false,
+            autofix: None,
+            hints: None,
+            baseline_comparison: None,
+            formatting_findings: Some(FormattingFindings {
+                files: vec!["src/lib.rs".to_string(), "src/main.rs".to_string()],
+                summary: Some("FMT SUMMARY: 2 files need formatting".to_string()),
+                suggested_command: "cargo fmt".to_string(),
+            }),
+            findings: Some(Vec::new()),
+            producer_summaries: Vec::new(),
+            summary: None,
+            self_check_capture: None,
+            extension_phase_timings: Vec::new(),
+        };
+
+        let (output, exit_code) = from_main_workflow(result);
+
+        assert_eq!(exit_code, 1);
+        let failure = output.failure.expect("format failure");
+        assert_eq!(failure.phase, VerificationPhase::Format);
+        assert_eq!(failure.category, PhaseFailureCategory::Findings);
+        assert_eq!(
+            failure.summary,
+            "format check found 2 unformatted file(s): src/lib.rs, src/main.rs; run `cargo fmt`"
         );
     }
 }

--- a/src/core/extension/runner_contract.rs
+++ b/src/core/extension/runner_contract.rs
@@ -25,6 +25,7 @@ pub const GENERIC_INFRASTRUCTURE_FAILURE_MARKERS: &[&str] = &[
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
 pub enum VerificationPhase {
+    Format,
     Syntax,
     Lint,
     Typecheck,

--- a/src/core/review/artifact_findings.rs
+++ b/src/core/review/artifact_findings.rs
@@ -31,7 +31,26 @@ impl ReviewArtifactFindings for AuditCommandOutput {
 
 impl ReviewArtifactFindings for LintCommandOutput {
     fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
-        self.findings.clone().unwrap_or_default()
+        let mut findings = self.findings.clone().unwrap_or_default();
+        if let Some(formatting) = &self.formatting_findings {
+            findings.extend(formatting.files.iter().map(|file| {
+                HomeboyFinding::builder(
+                    "format",
+                    format!(
+                        "Formatting required; run `{}`",
+                        formatting.suggested_command
+                    ),
+                )
+                .rule("format-check")
+                .category("format")
+                .severity("error")
+                .file(file.clone())
+                .fixable(true)
+                .metadata("suggested_command", formatting.suggested_command.clone())
+                .build()
+            }));
+        }
+        findings
     }
 }
 

--- a/src/core/review/render.rs
+++ b/src/core/review/render.rs
@@ -197,6 +197,20 @@ fn render_ci_stage(out: &mut String, stage: &ReviewStage<CiRunOutput>) {
 
 /// Render the lint stage body — top sniff codes (by `category`) with counts.
 fn render_lint_body(out: &mut String, output: &LintCommandOutput) {
+    if let Some(formatting) = &output.formatting_findings {
+        let _ = writeln!(out, "- **FORMAT** — run `{}`", formatting.suggested_command);
+        for file in formatting.files.iter().take(TOP_N) {
+            let _ = writeln!(out, "- `{}` needs formatting", file);
+        }
+        if formatting.files.len() > TOP_N {
+            let _ = writeln!(
+                out,
+                "- _… {} more file(s) need formatting_",
+                formatting.files.len() - TOP_N
+            );
+        }
+    }
+
     let findings = match output.findings.as_ref() {
         Some(f) if !f.is_empty() => f,
         _ => return,


### PR DESCRIPTION
## Summary
- prefer structured payload failure details when building command-result failure digests
- classify formatter failures as format findings with a repair action instead of generic lint/test failures
- include format findings in review artifact counts, PR rendering, and review artifact findings
- apply rustfmt output so the branch itself is clean under the format gate

## Verification
- cargo fmt --check
- cargo check --all-targets
- ~/.cargo/bin/cargo-nextest nextest run --lib failed_quality_payload_includes_format_failure_digest_without_run_evidence formatting_findings_surface_as_format_failure formatting_findings_parse_diff_paths_and_summary --no-fail-fast
- Requested broad nextest expression was also run: ~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(review) or test(test) or test(response) or test(failure_digest)' --no-fail-fast. It selected 6,951 lib tests and ended with 6,941 passed / 10 unrelated environment-sensitive failures.
- Temporary local rustfmt violation proof: HOMEBOY_RELEASE_GATE_LOCAL_HOT=allowed cargo run --quiet -- --force-hot --allow-local-hot review lint homeboy --path . emitted diagnostics.failure_digest summary: FORMAT: format check found 1 unformatted file(s) ...; run `cargo fmt`, with next action `cargo fmt`. The temporary violation was reverted.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Made the review quality gate always emit structured, categorized failures (incl. format violations); Chris reviews and owns the change.