### PR TITLE
Recover releases from dangling latest tags

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -231,8 +231,12 @@ fn release_step_is_plan_only(step: &PlanStep) -> bool {
 
 fn planned_release_tag_name(context: &ReleaseExecutionContext) -> Result<String> {
     let version_info = super::version::read_component_version(context.component)?;
+    let release_scope =
+        super::scope::ReleaseScope::resolve(context.component, context.component_id)?;
+    let (version_floor_base, _) =
+        super::planning_semver::release_version_floor_base(&release_scope, &version_info.version)?;
     let new_version =
-        super::version::increment_version(&version_info.version, &context.options.bump_type)
+        super::version::increment_version(&version_floor_base, &context.options.bump_type)
             .ok_or_else(|| {
                 Error::validation_invalid_argument(
                     "bump_type",
@@ -247,8 +251,6 @@ fn planned_release_tag_name(context: &ReleaseExecutionContext) -> Result<String>
                     ]),
                 )
             })?;
-    let release_scope =
-        super::scope::ReleaseScope::resolve(context.component, context.component_id)?;
 
     Ok(release_scope.tag_name(&new_version))
 }
@@ -664,8 +666,8 @@ fn dirty_side_effect_failure(step: &PlanStep, files: Vec<String>) -> ReleaseStep
 #[cfg(test)]
 mod tests {
     use super::{
-        execute_release_plan_step, release_step_is_plan_only, release_step_is_show_stopper,
-        release_step_unexpected_dirty_files, ReleaseExecutionContext,
+        execute_release_plan_step, planned_release_tag_name, release_step_is_plan_only,
+        release_step_is_show_stopper, release_step_unexpected_dirty_files, ReleaseExecutionContext,
     };
     use crate::core::component::{Component, ComponentScriptsConfig, VersionTarget};
     use crate::core::plan::PlanStep;
@@ -1249,6 +1251,62 @@ mod tests {
         );
         let plugin = std::fs::read_to_string(temp.path().join("plugin.php")).expect("read plugin");
         assert!(plugin.contains("Version: 0.7.0"));
+    }
+
+    #[test]
+    fn planned_release_tag_name_floors_against_unreachable_higher_tag() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        run_in(root, &["git", "init", "-q"]);
+        configure_git_user(root);
+        let component_dir = root.join("packages/fixture");
+        std::fs::create_dir_all(&component_dir).expect("create component dir");
+        std::fs::write(
+            component_dir.join("fixture.json"),
+            "{\"version\":\"0.1.0\"}\n",
+        )
+        .expect("write version file");
+        run_in(root, &["git", "add", "packages/fixture/fixture.json"]);
+        run_in(root, &["git", "commit", "-q", "-m", "chore: initial"]);
+        run_in(root, &["git", "branch", "-M", "main"]);
+        run_in(root, &["git", "tag", "fixture-v0.1.0"]);
+        run_in(root, &["git", "checkout", "-q", "-b", "release-v0.2.0"]);
+        std::fs::write(
+            component_dir.join("fixture.json"),
+            "{\"version\":\"0.2.0\"}\n",
+        )
+        .expect("write release version");
+        run_in(root, &["git", "add", "packages/fixture/fixture.json"]);
+        run_in(root, &["git", "commit", "-q", "-m", "release: v0.2.0"]);
+        run_in(root, &["git", "tag", "fixture-v0.2.0"]);
+        run_in(root, &["git", "checkout", "-q", "main"]);
+
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: component_dir.to_string_lossy().to_string(),
+            version_targets: Some(vec![VersionTarget {
+                file: "fixture.json".to_string(),
+                pattern: Some(r#""version":\s*"([0-9.]+)""#.to_string()),
+                artifact_path: None,
+            }]),
+            ..Default::default()
+        };
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+        let context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState::default(),
+            publish_failed: false,
+        };
+
+        let tag = planned_release_tag_name(&context).expect("planned tag");
+
+        assert_eq!(tag, "fixture-v0.2.1");
     }
 
     #[test]

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -10,7 +10,8 @@ use super::planning_changelog::{build_changelog_plan, generate_changelog_entries
 use super::planning_policy::release_skip_plan;
 use super::planning_semver::{
     build_semver_recommendation, current_version_tag_at_head, current_version_tag_name,
-    validate_current_version_tag_reachable, validate_release_version_floor,
+    release_version_floor_base, validate_current_version_tag_reachable,
+    validate_release_version_floor,
 };
 use super::planning_worktree::validate_release_worktree;
 use super::scope::ReleaseScope;
@@ -30,6 +31,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let extensions = resolve_extensions(&component)?;
 
     let mut v = ValidationCollector::new();
+    let mut warnings = Vec::new();
 
     let release_scope = ReleaseScope::resolve(&component, component_id)?;
     let version_info = v.capture(version::read_component_version(&component), "version");
@@ -99,7 +101,19 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         if options.pipeline.head {
             Some(info.version.clone())
         } else {
-            match version::increment_version(&info.version, &options.bump_type) {
+            let (version_floor_base, floor_tag) = v
+                .capture(
+                    release_version_floor_base(&release_scope, &info.version),
+                    "tag",
+                )
+                .unwrap_or_else(|| (info.version.clone(), None));
+            if let Some(tag) = floor_tag {
+                warnings.push(format!(
+                    "Latest release tag {} is ahead of source version {}; planning the next release from {} to avoid reusing an existing tag.",
+                    tag, info.version, version_floor_base
+                ));
+            }
+            match version::increment_version(&version_floor_base, &options.bump_type) {
                 Some(ver) => Some(ver),
                 None => {
                     v.push(
@@ -146,7 +160,6 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         Error::internal_unexpected("new_version missing after validation".to_string())
     })?;
 
-    let mut warnings = Vec::new();
     let mut hints = Vec::new();
     let changelog_plan = build_changelog_plan(&component, options, pending_entries)?;
     if let Some(warning) =

--- a/src/core/release/planning_semver.rs
+++ b/src/core/release/planning_semver.rs
@@ -93,6 +93,30 @@ pub(super) fn validate_release_version_floor(
     None
 }
 
+pub(super) fn release_version_floor_base(
+    scope: &ReleaseScope,
+    current_version: &str,
+) -> Result<(String, Option<String>)> {
+    let Some(latest_tag) = scope.latest_tag_any()? else {
+        return Ok((current_version.to_string(), None));
+    };
+    let Some(tag_version) = git::extract_version_from_tag(&latest_tag) else {
+        return Ok((current_version.to_string(), None));
+    };
+    let Ok(tag_version_semver) = semver::Version::parse(&tag_version) else {
+        return Ok((current_version.to_string(), None));
+    };
+    let Ok(current_version_semver) = semver::Version::parse(current_version) else {
+        return Ok((current_version.to_string(), None));
+    };
+
+    if tag_version_semver > current_version_semver {
+        Ok((tag_version, Some(latest_tag)))
+    } else {
+        Ok((current_version.to_string(), None))
+    }
+}
+
 pub(super) fn validate_current_version_tag_reachable(
     scope: &ReleaseScope,
     current_version: &str,
@@ -157,52 +181,12 @@ pub(super) fn current_version_tag_at_head(
 pub(super) fn resolve_tag_and_commits(
     scope: &ReleaseScope,
 ) -> Result<(Option<String>, Vec<git::CommitInfo>)> {
-    // Make release tags (and connecting history) available before the
-    // reachability/changelog-range guard inspects them. A tagless or shallow
-    // release checkout would otherwise report a genuinely-reachable tag as "not
-    // reachable from HEAD" and refuse (issue #6916). Best-effort: offline
-    // checkouts still fall through to the guard against local history, so a tag
-    // that is truly not an ancestor of HEAD is still refused.
-    let (latest_tag, commits) = scope.commits_since_latest_tag()?;
-    validate_latest_release_tag_reachable(scope, latest_tag.as_deref())?;
-    Ok((latest_tag, commits))
-}
-
-fn validate_latest_release_tag_reachable(
-    scope: &ReleaseScope,
-    latest_reachable_tag: Option<&str>,
-) -> Result<()> {
-    let Some(latest_any_tag) = scope.latest_tag_any()? else {
-        return Ok(());
-    };
-
-    if latest_reachable_tag == Some(latest_any_tag.as_str()) {
-        return Ok(());
-    }
-
-    if git::is_ancestor(&scope.git_root, &latest_any_tag, "HEAD")? {
-        return Ok(());
-    }
-
-    Err(Error::validation_invalid_argument(
-        "release-range",
-        format!(
-            "Latest release tag {} is not reachable from HEAD. Refusing to plan changelog entries from {} because that would duplicate a prior release range.",
-            latest_any_tag,
-            latest_reachable_tag.unwrap_or("the initial commit")
-        ),
-        Some(format!("Repository: {}", scope.git_root)),
-        Some(vec![
-            format!(
-                "Merge or recover the {} release commit onto the selected release base/default branch, then rerun the release.",
-                latest_any_tag
-            ),
-            format!(
-                "Inspect the boundary: git merge-base --is-ancestor {} HEAD",
-                latest_any_tag
-            ),
-        ]),
-    ))
+    // Make release tags (and connecting history) available before resolving the
+    // reachable changelog base. A tagless or shallow release checkout would
+    // otherwise miss a genuinely reachable tag and over-expand the range (issue
+    // #6916). Truly off-branch tags are handled by version flooring instead of
+    // becoming the changelog base.
+    scope.commits_since_latest_tag()
 }
 
 fn commit_rows(commits: &[git::CommitInfo]) -> Vec<ReleaseSemverCommit> {
@@ -272,7 +256,7 @@ fn commit_range(latest_tag: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_semver_recommendation, resolve_tag_and_commits,
+        build_semver_recommendation, release_version_floor_base, resolve_tag_and_commits,
         validate_current_version_tag_reachable, validate_release_version_floor,
     };
     use crate::core::component::{CommandScopeConfig, Component, ScopeConfig, VersionTarget};
@@ -490,7 +474,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_tag_and_commits_fails_closed_when_latest_release_tag_is_off_branch() {
+    fn resolve_tag_and_commits_uses_reachable_tag_when_latest_release_tag_is_off_branch() {
         let temp = git_repo();
         let dir = temp.path();
         commit_file(dir, "README.md", "initial", "chore: initial");
@@ -519,12 +503,38 @@ mod tests {
             ..Default::default()
         };
         let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
-        let err = resolve_tag_and_commits(&release_scope)
-            .expect_err("off-branch latest release tag should fail closed");
+        let (latest_tag, commits) =
+            resolve_tag_and_commits(&release_scope).expect("off-branch latest tag should recover");
 
-        assert!(err.message.contains("Latest release tag v0.2.0"));
-        assert!(err.message.contains("not reachable from HEAD"));
-        assert!(err.message.contains("duplicate a prior release range"));
+        assert_eq!(latest_tag.as_deref(), Some("v0.1.0"));
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].subject, "fix: second release work");
+    }
+
+    #[test]
+    fn release_version_floor_base_uses_unreachable_higher_tag() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["branch", "-M", "main"]);
+        run_git(dir, &["tag", "v0.1.0"]);
+        commit_file(dir, "fix.txt", "work", "fix: release work");
+        run_git(dir, &["branch", "release-v0.2.0"]);
+        run_git(dir, &["checkout", "-q", "release-v0.2.0"]);
+        commit_file(dir, "VERSION", "0.2.0", "release: v0.2.0");
+        run_git(dir, &["tag", "v0.2.0"]);
+        run_git(dir, &["checkout", "-q", "main"]);
+
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+        let (floor, floor_tag) = release_version_floor_base(&release_scope, "0.1.0")
+            .expect("version floor should resolve");
+
+        assert_eq!(floor, "0.2.0");
+        assert_eq!(floor_tag.as_deref(), Some("v0.2.0"));
     }
 
     #[test]
@@ -656,11 +666,11 @@ mod tests {
         assert_eq!(commits[0].subject, "fix: patch bug");
     }
 
-    /// Guard correctness preserved: a tag that is genuinely NOT an ancestor of
-    /// HEAD must still refuse, even after the fetch-before-guard step pulls all
-    /// tags from origin.
+    /// A tag that is genuinely NOT an ancestor of HEAD must not become the
+    /// changelog base, even after the fetch-before-range step pulls all tags
+    /// from origin. Recovery uses the latest reachable tag for release notes.
     #[test]
-    fn resolve_tag_and_commits_still_refuses_genuinely_unreachable_tag_after_fetch() {
+    fn resolve_tag_and_commits_ignores_genuinely_unreachable_tag_after_fetch() {
         // Upstream has a tag on an off-branch commit that never merges into the
         // main line that the working checkout tracks.
         let origin = git_repo();
@@ -678,7 +688,7 @@ mod tests {
 
         // Working checkout tracks main and, like the real failure, is missing
         // tags locally. The fetch step will pull v0.2.0, but it remains
-        // off-branch — so the guard must still fail closed.
+        // off-branch, so the reachable v0.1.0 tag remains the changelog base.
         let work = tempfile::tempdir().expect("tempdir");
         let work_dir = work.path();
         run_git(
@@ -701,10 +711,11 @@ mod tests {
             ..Default::default()
         };
         let release_scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
-        let err = resolve_tag_and_commits(&release_scope)
-            .expect_err("off-branch tag must still fail closed after fetching tags");
+        let (latest_tag, commits) = resolve_tag_and_commits(&release_scope)
+            .expect("off-branch tag should not block changelog planning");
 
-        assert!(err.message.contains("Latest release tag v0.2.0"));
-        assert!(err.message.contains("not reachable from HEAD"));
+        assert_eq!(latest_tag.as_deref(), Some("v0.1.0"));
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].subject, "fix: second work");
     }
 }


### PR DESCRIPTION
## Summary
- let release planning recover when the highest component release tag is off-branch/dangling
- keep changelog generation based on the latest reachable tag while flooring the next version above the highest known tag
- make early tag-availability preflight use the same version-floor calculation as the main release plan

## Root cause
`homeboy-extensions` main is red because `homeboy release` treated dangling highest component tags like `go-v1.5.3` and `swift-v2.6.2` as fatal changelog-range errors. Those tags are not ancestors of `origin/main`, so the old hard guard blocked before Homeboy could create a safe next release from HEAD.

## Verification
- `cargo test core::release::planning_semver`
- `cargo test core::release::execution_dispatch::tests::planned_release_tag_name_floors_against_unreachable_higher_tag`
- patched dry-run in `Extra-Chill/homeboy-extensions` from `origin/main`: `homeboy release go --dry-run` plans `go-v1.6.1`
- patched dry-run in `Extra-Chill/homeboy-extensions` from `origin/main`: `homeboy release swift --dry-run` plans `swift-v2.6.3` and checks tag availability for `swift-v2.6.3`

## Propagation
`Extra-Chill/homeboy-extensions` uses `Extra-Chill/homeboy-action@v2` with `version: latest`, so extensions release jobs need this Homeboy fix released and picked up by the action cache/latest binary before rerun.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Investigated the failed release workflow, implemented the Homeboy release recovery fix, added regression coverage, and verified against `homeboy-extensions` dry-runs.
