### PR TITLE
Consolidate error cause handling

### DIFF
--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -311,7 +311,9 @@ fn delete_row(project_id: &str, args: &[String], apply: bool) -> CmdResult<DbOut
         let row_id: i64 = row_id
             .ok_or_else(|| homeboy::core::Error::config("Row ID required".to_string()))?
             .parse()
-            .map_err(|_| homeboy::core::Error::config("Row ID must be numeric".to_string()))?;
+            .map_err(|error| {
+                homeboy::core::Error::config(format!("Row ID must be numeric: {error}"))
+            })?;
         let sql = format!("DELETE FROM {} WHERE ID = {} LIMIT 1", table, row_id);
 
         return Ok((

--- a/src/core/agent_task_controller_service/spec_source.rs
+++ b/src/core/agent_task_controller_service/spec_source.rs
@@ -84,16 +84,42 @@ pub fn load_materialize_spec_source(source: &str) -> Result<MaterializeSpecSourc
         }),
         Err(spec_error) => {
             let manifest: ControllerSpecGeneratorManifest =
-                serde_json::from_str(&raw).map_err(|_| {
-                    Error::validation_invalid_argument(
+                serde_json::from_str(&raw).map_err(|manifest_error| {
+                    Error::validation_schema_mismatch(
                         "spec",
-                        spec_error.to_string(),
+                        "agent task repo loop spec or controller generator manifest",
                         Some(source.to_string()),
-                        None,
+                        spec_error.to_string(),
+                        Some(manifest_error.to_string()),
                     )
                 })?;
             load_generated_materialize_spec(source, manifest)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_manifest_shape_preserves_primary_and_fallback_serde_causes() {
+        let error = match load_materialize_spec_source("{}") {
+            Ok(_) => panic!("expected schema mismatch error"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("agent task repo loop spec"));
+        assert!(error.message.contains("fallback cause"));
+        assert!(error.details["cause"]
+            .as_str()
+            .expect("primary cause")
+            .contains("missing field"));
+        assert!(error.details["fallback_cause"]
+            .as_str()
+            .expect("fallback cause")
+            .contains("missing field"));
     }
 }
 

--- a/src/core/db/operations.rs
+++ b/src/core/db/operations.rs
@@ -332,7 +332,7 @@ pub fn delete_row(
     let row_id: i64 = row_id
         .ok_or_else(|| Error::config("Row ID required".to_string()))?
         .parse()
-        .map_err(|_| Error::config("Row ID must be numeric".to_string()))?;
+        .map_err(|error| Error::config(format!("Row ID must be numeric: {error}")))?;
     let ctx = build_context(project_id, subtarget)?;
 
     let delete_sql = format!("DELETE FROM {} WHERE ID = {} LIMIT 1", table, row_id);

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -221,6 +221,18 @@ pub struct InvalidArgumentDetails {
     pub command_evidence: Option<CommandEvidence>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct SchemaMismatchDetails {
+    pub field: String,
+    pub problem: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub expected: String,
+    pub cause: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_cause: Option<String>,
+}
+
 /// Captured evidence describing a single command-backed validation failure.
 ///
 /// Surfaced inside [`InvalidArgumentDetails::command_evidence`] so structured
@@ -438,6 +450,38 @@ impl Error {
         });
 
         Self::new(ErrorCode::ValidationInvalidArgument, message, details)
+    }
+
+    pub fn validation_schema_mismatch(
+        field: impl Into<String>,
+        expected: impl Into<String>,
+        id: Option<String>,
+        cause: impl Into<String>,
+        fallback_cause: Option<String>,
+    ) -> Self {
+        let field_str = field.into();
+        let expected_str = expected.into();
+        let cause_str = cause.into();
+        let problem = match &fallback_cause {
+            Some(fallback) => format!(
+                "does not match expected schema ({expected_str}); primary cause: {cause_str}; fallback cause: {fallback}"
+            ),
+            None => format!("does not match expected schema ({expected_str}): {cause_str}"),
+        };
+        let details = to_details(SchemaMismatchDetails {
+            field: field_str.clone(),
+            problem: problem.clone(),
+            id,
+            expected: expected_str,
+            cause: cause_str,
+            fallback_cause,
+        });
+
+        Self::new(
+            ErrorCode::ValidationInvalidArgument,
+            format!("Invalid argument '{}': {}", field_str, problem),
+            details,
+        )
     }
 
     pub fn validation_invalid_json(
@@ -929,13 +973,14 @@ impl Error {
     }
 
     pub fn remote_command_failed(details: RemoteCommandFailedDetails) -> Self {
-        let details = to_details(details);
+        Self::remote_command_failed_with_details("Remote command failed", details)
+    }
 
-        Self::new(
-            ErrorCode::RemoteCommandFailed,
-            "Remote command failed",
-            details,
-        )
+    pub fn remote_command_failed_with_details(
+        message: impl Into<String>,
+        details: impl Serialize,
+    ) -> Self {
+        Self::new(ErrorCode::RemoteCommandFailed, message, to_details(details))
     }
 
     pub fn git_command_failed(message: impl Into<String>) -> Self {
@@ -1061,6 +1106,11 @@ impl Error {
         self.hints.push(Hint {
             message: message.into(),
         });
+        self
+    }
+
+    pub fn with_retryable(mut self, retryable: bool) -> Self {
+        self.retryable = Some(retryable);
         self
     }
 

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -686,10 +686,10 @@ fn require_run(store: &ObservationStore, run_id: &str) -> Result<RunRecord> {
 }
 
 fn parse_job_id(job_id: &str) -> Result<Uuid> {
-    Uuid::parse_str(job_id).map_err(|_| {
+    Uuid::parse_str(job_id).map_err(|error| {
         Error::validation_invalid_argument(
             "job_id",
-            format!("invalid job id: {job_id}"),
+            format!("invalid job id: {job_id}: {error}"),
             Some(job_id.to_string()),
             None,
         )

--- a/src/core/release/planning_git.rs
+++ b/src/core/release/planning_git.rs
@@ -220,10 +220,10 @@ fn head_matches_remote_default(component: &Component, default_branch: &str) -> R
         "git rev-parse HEAD",
     )
     .map(|value| value.trim().to_string())
-    .map_err(|_| {
+    .map_err(|error| {
         Error::validation_invalid_argument(
             "release",
-            "Refusing to release because HEAD could not be resolved",
+            format!("Refusing to release because HEAD could not be resolved: {error}"),
             None,
             Some(vec![
                 "Ensure the checkout has at least one commit before releasing".to_string(),

--- a/src/core/runner/apply.rs
+++ b/src/core/runner/apply.rs
@@ -123,10 +123,13 @@ fn read_apply_input(path: &str) -> Result<LabPatchApplyInput> {
         Ok(input) => Ok(input),
         Err(contract_error) => {
             let legacy: LegacyLabPatchApplyInput =
-                serde_json::from_str(&contents).map_err(|_| {
-                    Error::internal_json(
+                serde_json::from_str(&contents).map_err(|legacy_error| {
+                    Error::validation_schema_mismatch(
+                        "lab_apply_input",
+                        "current Lab patch apply input or legacy Lab patch apply input",
+                        Some(path.to_string()),
                         contract_error.to_string(),
-                        Some("parse Lab apply input".to_string()),
+                        Some(legacy_error.to_string()),
                     )
                 })?;
             Ok(LabPatchApplyInput {
@@ -507,6 +510,26 @@ mod tests {
 
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
         assert!(err.message.contains("delta paths"));
+    }
+
+    #[test]
+    fn invalid_apply_input_preserves_current_and_legacy_schema_causes() {
+        let input_dir = tempfile::tempdir().expect("input tempdir");
+        let input = input_dir.path().join("bad-apply.json");
+        fs::write(&input, "{}").expect("write input");
+
+        let err = read_apply_input(input.to_str().expect("path str")).expect_err("schema error");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("current Lab patch apply input"));
+        assert!(err.details["cause"]
+            .as_str()
+            .expect("current schema cause")
+            .contains("missing field"));
+        assert!(err.details["fallback_cause"]
+            .as_str()
+            .expect("legacy schema cause")
+            .contains("missing field"));
     }
 
     fn git_repo() -> tempfile::TempDir {

--- a/src/core/runner/execution/failure.rs
+++ b/src/core/runner/execution/failure.rs
@@ -1,6 +1,6 @@
 use serde_json::{json, Value};
 
-use crate::core::error::{Error, ErrorCode};
+use crate::core::error::Error;
 use crate::core::redaction::{redact_argv, redact_argv_display};
 
 #[allow(unused_imports)]
@@ -30,6 +30,8 @@ pub fn runner_exec_failure_error(output: &RunnerExecOutput) -> Option<Error> {
         "remote_cwd": output.remote_cwd,
         "command": redacted_argv,
         "exit_code": output.exit_code,
+        "stdout": output.stdout,
+        "stderr": output.stderr,
         "execution": execution,
     });
     if let Some(runner_error) = runner_error {
@@ -40,8 +42,7 @@ pub fn runner_exec_failure_error(output: &RunnerExecOutput) -> Option<Error> {
         details["failure_context"] = serde_json::to_value(failure_context).unwrap_or(Value::Null);
     }
 
-    let mut error = Error::new(
-        ErrorCode::RemoteCommandFailed,
+    let mut error = Error::remote_command_failed_with_details(
         format!(
             "Runner command failed on `{}` with exit code {}: {}",
             output.runner_id, output.exit_code, cause

--- a/src/core/runner/transport.rs
+++ b/src/core/runner/transport.rs
@@ -439,7 +439,7 @@ fn unsupported_file_transfer_error(
     reason: &str,
     broker_url: Option<&str>,
 ) -> Error {
-    let mut error = Error::new(
+    Error::new(
         ErrorCode::RunnerLabTransportFailure,
         format!(
             "Lab offload runner `{runner_id}` does not currently support controller file transfer over `{transport}`: {reason}"
@@ -451,9 +451,8 @@ fn unsupported_file_transfer_error(
             "missing_capability": "runner_file_transfer",
             "supported_transports": ["direct_ssh"],
         }),
-    );
-    error.retryable = Some(false);
-    error
+    )
+    .with_retryable(false)
         .with_hint("Use a direct SSH runner for Lab @file arguments and structured-output download until the reverse broker exposes a file-transfer API.".to_string())
         .with_hint("Next transport implementation should provide mkdir/upload/download through the selected runner transport instead of calling SSH directly.".to_string())
 }
@@ -465,7 +464,7 @@ fn file_transfer_operation_error(
     stderr: String,
     transport: &str,
 ) -> Error {
-    let mut error = Error::new(
+    Error::new(
         ErrorCode::RunnerLabTransportFailure,
         format!(
             "Lab runner file transfer `{operation}` failed on runner `{runner_id}` for `{remote_path}`: {}",
@@ -478,9 +477,8 @@ fn file_transfer_operation_error(
             "stderr": stderr,
             "transport": transport,
         }),
-    );
-    error.retryable = Some(true);
-    error
+    )
+    .with_retryable(true)
 }
 
 fn http_file_transfer_error(
@@ -490,7 +488,7 @@ fn http_file_transfer_error(
     source: Error,
     transport: &str,
 ) -> Error {
-    let mut error = Error::new(
+    Error::new(
         ErrorCode::RunnerLabTransportFailure,
         format!(
             "Lab runner file transfer `{operation}` failed on runner `{runner_id}` for `{remote_path}`: {}",
@@ -503,9 +501,8 @@ fn http_file_transfer_error(
             "transport": transport,
             "source": source.details,
         }),
-    );
-    error.retryable = Some(true);
-    error
+    )
+    .with_retryable(true)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add shared schema-mismatch and retryable error builders
- preserve serde/git/parse causes at representative wrapper sites instead of swallowing them
- expose runner stdout/stderr on remote-command failures so existing failure digests include tails by default

## Swallowing-sites fixed
- src/core/agent_task_controller_service/spec_source.rs: preserves both repo-loop-spec and generator-manifest serde errors
- src/core/runner/apply.rs: preserves both current and legacy Lab apply input serde errors
- src/commands/db.rs and src/core/db/operations.rs: preserves numeric row-id parse errors
- src/core/http_api.rs: preserves UUID parse error text for job IDs
- src/core/release/planning_git.rs: preserves git HEAD resolution failure text

## Verification
- cargo check --all-targets
- ~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(error) or test(response) or test(failure_digest) or test(agent_runtime_manifest)' --no-fail-fast

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Consolidated error construction and eliminated cause-swallowing; Chris reviews and owns the change.