### PR TITLE
Simplify runner exec option construction

### DIFF
--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -123,6 +123,103 @@ pub struct RunnerExecOptions {
     pub print_handoff: bool,
 }
 
+impl Default for RunnerExecOptions {
+    fn default() -> Self {
+        Self {
+            cwd: None,
+            project_id: None,
+            allow_diagnostic_ssh: false,
+            command: Vec::new(),
+            env: HashMap::new(),
+            secret_env_names: Vec::new(),
+            secret_env_plan: None,
+            env_materialization: None,
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            capability_preflight: None,
+            required_extensions: Vec::new(),
+            accepted_extension_settings: Vec::new(),
+            require_paths: Vec::new(),
+            runner_workload: None,
+            run_id: None,
+            detach_after_handoff: false,
+            mirror_evidence: true,
+            print_handoff: true,
+        }
+    }
+}
+
+impl RunnerExecOptions {
+    pub(crate) fn command(command: Vec<String>) -> Self {
+        Self {
+            command,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn raw_command(command: Vec<String>) -> Self {
+        Self {
+            raw_exec: true,
+            ..Self::command(command)
+        }
+    }
+
+    pub(crate) fn diagnostic_raw_command(command: Vec<String>) -> Self {
+        Self {
+            allow_diagnostic_ssh: true,
+            ..Self::raw_command(command)
+        }
+    }
+
+    pub(crate) fn diagnostic_raw_shell(script: String) -> Self {
+        Self::diagnostic_raw_command(vec!["bash".to_string(), "-lc".to_string(), script])
+    }
+
+    pub(crate) fn with_cwd(mut self, cwd: impl Into<String>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    pub(crate) fn with_env(mut self, env: HashMap<String, String>) -> Self {
+        self.env = env;
+        self
+    }
+
+    pub(crate) fn with_capability_preflight(
+        mut self,
+        capability_preflight: RunnerCapabilityPreflight,
+    ) -> Self {
+        self.capability_preflight = Some(capability_preflight);
+        self
+    }
+
+    pub(crate) fn with_optional_capability_preflight(
+        mut self,
+        capability_preflight: Option<RunnerCapabilityPreflight>,
+    ) -> Self {
+        self.capability_preflight = capability_preflight;
+        self
+    }
+
+    pub(crate) fn with_source_snapshot(mut self, source_snapshot: SourceSnapshot) -> Self {
+        self.source_snapshot = Some(source_snapshot);
+        self
+    }
+
+    pub(crate) fn with_required_extensions(mut self, required_extensions: Vec<String>) -> Self {
+        self.required_extensions = required_extensions;
+        self
+    }
+
+    pub(crate) fn without_evidence_mirror(mut self) -> Self {
+        self.mirror_evidence = false;
+        self.print_handoff = false;
+        self
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RunnerExecMode {

--- a/src/core/runner/extension_materialization.rs
+++ b/src/core/runner/extension_materialization.rs
@@ -224,32 +224,7 @@ fn upload_snapshot(
         dest = shell::quote_path(&plan.synced_source_path),
         archive = shell::quote_path(&remote_archive),
     );
-    let (_output, exit_code) = exec(
-        &runner.id,
-        RunnerExecOptions {
-            cwd: None,
-            project_id: None,
-            allow_diagnostic_ssh: true,
-            command: vec!["bash".to_string(), "-lc".to_string(), extract],
-            env: Default::default(),
-            secret_env_names: Vec::new(),
-            secret_env_plan: None,
-            env_materialization: None,
-            capture_patch: false,
-            raw_exec: true,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            capability_preflight: None,
-            required_extensions: Vec::new(),
-            accepted_extension_settings: Vec::new(),
-            require_paths: Vec::new(),
-            runner_workload: None,
-            run_id: None,
-            detach_after_handoff: false,
-            mirror_evidence: true,
-            print_handoff: true,
-        },
-    )?;
+    let (_output, exit_code) = exec(&runner.id, RunnerExecOptions::diagnostic_raw_shell(extract))?;
     if exit_code != 0 {
         return Err(Error::validation_invalid_argument(
             "extensions",
@@ -326,29 +301,7 @@ pub(crate) fn runner_extension_exists(
 }
 
 fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecOptions {
-    RunnerExecOptions {
-        cwd: None,
-        project_id: None,
-        allow_diagnostic_ssh: true,
-        command,
-        env: runner.env.clone(),
-        secret_env_names: Vec::new(),
-        secret_env_plan: None,
-        env_materialization: None,
-        capture_patch: false,
-        raw_exec: true,
-        source_snapshot: None,
-        path_materialization_plan: None,
-        capability_preflight: None,
-        required_extensions: Vec::new(),
-        accepted_extension_settings: Vec::new(),
-        require_paths: Vec::new(),
-        runner_workload: None,
-        run_id: None,
-        detach_after_handoff: false,
-        mirror_evidence: true,
-        print_handoff: true,
-    }
+    RunnerExecOptions::diagnostic_raw_command(command).with_env(runner.env.clone())
 }
 
 fn runner_exec_detail(output: &super::RunnerExecOutput) -> String {

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -229,33 +229,13 @@ pub fn refresh_homeboy_binary(
 
     let (exec_output, exit_code) = exec(
         &plan.runner_id,
-        RunnerExecOptions {
-            cwd: None,
-            project_id: None,
-            allow_diagnostic_ssh: true,
-            command: vec!["bash".to_string(), "-lc".to_string(), plan.script.clone()],
-            env: Default::default(),
-            secret_env_names: Vec::new(),
-            secret_env_plan: None,
-            env_materialization: None,
-            capture_patch: false,
-            raw_exec: true,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            capability_preflight: Some(RunnerCapabilityPreflight {
+        RunnerExecOptions::diagnostic_raw_shell(plan.script.clone()).with_capability_preflight(
+            RunnerCapabilityPreflight {
                 command: "runner.refresh-homeboy".to_string(),
                 required_commands,
                 ..Default::default()
-            }),
-            required_extensions: Vec::new(),
-            accepted_extension_settings: Vec::new(),
-            require_paths: Vec::new(),
-            runner_workload: None,
-            run_id: None,
-            detach_after_handoff: false,
-            mirror_evidence: true,
-            print_handoff: true,
-        },
+            },
+        ),
     )?;
     if exit_code != 0 {
         return Ok((
@@ -392,29 +372,7 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
     let chmod_script = format!("chmod 0755 {}", quote_path(&remote_binary));
     let (_chmod, chmod_exit) = exec(
         &options.runner_id,
-        RunnerExecOptions {
-            cwd: None,
-            project_id: None,
-            allow_diagnostic_ssh: true,
-            command: vec!["bash".to_string(), "-lc".to_string(), chmod_script],
-            env: Default::default(),
-            secret_env_names: Vec::new(),
-            secret_env_plan: None,
-            env_materialization: None,
-            capture_patch: false,
-            raw_exec: true,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            capability_preflight: None,
-            required_extensions: Vec::new(),
-            accepted_extension_settings: Vec::new(),
-            require_paths: Vec::new(),
-            runner_workload: None,
-            run_id: None,
-            detach_after_handoff: false,
-            mirror_evidence: true,
-            print_handoff: true,
-        },
+        RunnerExecOptions::diagnostic_raw_shell(chmod_script),
     )?;
     if chmod_exit != 0 {
         return Ok((

--- a/src/core/runner/lab/offload/hydration.rs
+++ b/src/core/runner/lab/offload/hydration.rs
@@ -15,8 +15,6 @@
 //! runner workspace root, before the executor starts. No new provider knowledge
 //! or framework-specific logic is introduced here; detection stays in `deps.rs`.
 
-use std::collections::HashMap;
-
 use serde::Serialize;
 
 use crate::core::deps;
@@ -99,37 +97,13 @@ pub(crate) fn hydrate_lab_workspace_dependencies(
         let started = std::time::Instant::now();
         let (output, exit_code) = exec(
             runner_id,
-            RunnerExecOptions {
-                cwd: Some(remote_path.to_string()),
-                project_id: None,
-                allow_diagnostic_ssh: false,
-                command: plan_step.command.clone(),
-                env: HashMap::new(),
-                secret_env_names: Vec::new(),
-                secret_env_plan: None,
-                env_materialization: None,
-                capture_patch: false,
-                // The install command is a provider-built shell argv (e.g.
-                // a provider-owned install command, not a Homeboy-routed command, so dispatch
-                // it raw to the runner exactly as the provider produced it.
-                raw_exec: true,
-                source_snapshot: None,
-                path_materialization_plan: None,
-                capability_preflight: None,
-                required_extensions: Vec::new(),
-                accepted_extension_settings: Vec::new(),
-                require_paths: Vec::new(),
-                runner_workload: None,
-                run_id: None,
-                detach_after_handoff: false,
-                // Hydration is a workspace-setup sub-step of the agent-task
-                // offload, not a standalone run. The provider install runs as a
-                // runner daemon job (queryable via `runner job logs <job_id>`),
-                // but it is not mirrored as its own controller-side run record so
-                // `runs list` stays focused on the agent-task run itself.
-                mirror_evidence: false,
-                print_handoff: false,
-            },
+            // The install command is provider-built shell argv, not a
+            // Homeboy-routed command, so dispatch it raw exactly as produced.
+            // Hydration is a workspace-setup sub-step of the agent-task offload,
+            // so do not mirror it as a standalone controller-side run record.
+            RunnerExecOptions::raw_command(plan_step.command.clone())
+                .with_cwd(remote_path)
+                .without_evidence_mirror(),
         )?;
         let step = LabWorkspaceHydrationStep {
             provider_id: plan_step.provider_id.clone(),

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -211,6 +211,36 @@ pub(crate) struct LabDispatchExecutionContext<'a> {
     pub(crate) detach_after_handoff: bool,
 }
 
+fn lab_runner_exec_options(
+    context: &LabDispatchExecutionContext<'_>,
+    env: std::collections::HashMap<String, String>,
+    secret_env_names: Vec<String>,
+) -> RunnerExecOptions {
+    RunnerExecOptions {
+        cwd: Some(context.remote_cwd.clone()),
+        project_id: None,
+        allow_diagnostic_ssh: false,
+        command: context.command.clone(),
+        env,
+        secret_env_names,
+        secret_env_plan: Some(context.secret_env_handoff.secret_env_plan.clone()),
+        env_materialization: None,
+        capture_patch: context.request.capture_patch,
+        raw_exec: false,
+        source_snapshot: context.source_snapshot.clone(),
+        path_materialization_plan: context.path_materialization_plan.clone(),
+        capability_preflight: context.capability_preflight.clone(),
+        required_extensions: context.contract.required_extensions.clone(),
+        accepted_extension_settings: context.accepted_extension_settings.clone(),
+        require_paths: Vec::new(),
+        runner_workload: context.runner_workload.clone(),
+        run_id: context.agent_task_run_id.clone(),
+        detach_after_handoff: context.detach_after_handoff,
+        mirror_evidence: context.mirror_evidence,
+        print_handoff: context.print_handoff,
+    }
+}
+
 pub(crate) fn exec_lab_context(
     mut context: LabDispatchExecutionContext<'_>,
 ) -> Result<LabOffloadOutcome> {
@@ -232,7 +262,7 @@ pub(crate) fn exec_lab_context(
             env: base_env,
             secret_names: Vec::new(),
         })
-        .chain(context.env_resolution_layers)
+        .chain(context.env_resolution_layers.clone())
         .chain(std::iter::once(LabEnvResolutionLayer {
             source: "job_override",
             env: request.job_overrides.env.clone(),
@@ -299,29 +329,7 @@ pub(crate) fn exec_lab_context(
     let remote_exec_started = std::time::Instant::now();
     let exec_result = exec(
         runner_id,
-        RunnerExecOptions {
-            cwd: Some(context.remote_cwd.clone()),
-            project_id: None,
-            allow_diagnostic_ssh: false,
-            command: context.command.clone(),
-            env,
-            secret_env_names,
-            secret_env_plan: Some(context.secret_env_handoff.secret_env_plan.clone()),
-            env_materialization: None,
-            capture_patch: request.capture_patch,
-            raw_exec: false,
-            source_snapshot: context.source_snapshot.clone(),
-            path_materialization_plan: context.path_materialization_plan.clone(),
-            capability_preflight: context.capability_preflight.clone(),
-            required_extensions: contract.required_extensions.clone(),
-            accepted_extension_settings: context.accepted_extension_settings.clone(),
-            require_paths: Vec::new(),
-            runner_workload: context.runner_workload.clone(),
-            run_id: context.agent_task_run_id.clone(),
-            detach_after_handoff: context.detach_after_handoff,
-            mirror_evidence: context.mirror_evidence,
-            print_handoff: context.print_handoff,
-        },
+        lab_runner_exec_options(&context, env, secret_env_names),
     );
     context
         .overhead

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -322,29 +322,12 @@ pub(crate) fn refresh_managed_runner_sources(
     for source in plans {
         let (output, exit_code) = exec(
             runner_id,
-            RunnerExecOptions {
-                cwd: Some(cwd.to_string()),
-                project_id: None,
-                allow_diagnostic_ssh: false,
-                command: vec!["sh".to_string(), "-lc".to_string(), source.script.clone()],
-                env: Default::default(),
-                secret_env_names: Vec::new(),
-                secret_env_plan: None,
-                env_materialization: None,
-                capture_patch: false,
-                raw_exec: false,
-                source_snapshot: None,
-                path_materialization_plan: None,
-                capability_preflight: None,
-                required_extensions: Vec::new(),
-                accepted_extension_settings: Vec::new(),
-                require_paths: Vec::new(),
-                runner_workload: None,
-                run_id: None,
-                detach_after_handoff: false,
-                mirror_evidence: true,
-                print_handoff: true,
-            },
+            RunnerExecOptions::command(vec![
+                "sh".to_string(),
+                "-lc".to_string(),
+                source.script.clone(),
+            ])
+            .with_cwd(cwd),
         )?;
         if exit_code != 0 {
             return Err(Error::validation_invalid_argument(

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -258,29 +258,12 @@ fn probe_agent_task_providers_on_runner(
 ) -> Result<AgentTaskProviderProbeOutput> {
     let (output, exit_code) = exec(
         runner_id,
-        RunnerExecOptions {
-            cwd: Some(remote_cwd.to_string()),
-            project_id: None,
-            allow_diagnostic_ssh: false,
-            command: command.to_vec(),
-            env,
-            secret_env_names: Vec::new(),
-            secret_env_plan: None,
-            env_materialization: None,
-            capture_patch: false,
-            raw_exec: false,
-            source_snapshot: Some(source_snapshot),
-            path_materialization_plan: None,
-            capability_preflight,
-            required_extensions,
-            accepted_extension_settings: Vec::new(),
-            require_paths: Vec::new(),
-            runner_workload: None,
-            run_id: None,
-            detach_after_handoff: false,
-            mirror_evidence: true,
-            print_handoff: true,
-        },
+        RunnerExecOptions::command(command.to_vec())
+            .with_cwd(remote_cwd)
+            .with_env(env)
+            .with_source_snapshot(source_snapshot)
+            .with_required_extensions(required_extensions)
+            .with_optional_capability_preflight(capability_preflight),
     )?;
 
     Ok(AgentTaskProviderProbeOutput {

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -535,29 +535,7 @@ fn run_runtime_overlay_install_step(
 
     let (output, exit_code) = super::exec(
         runner_id,
-        super::RunnerExecOptions {
-            cwd: Some(remote_workdir.to_string()),
-            project_id: None,
-            allow_diagnostic_ssh: false,
-            command,
-            env: std::collections::HashMap::new(),
-            secret_env_names: Vec::new(),
-            secret_env_plan: None,
-            env_materialization: None,
-            capture_patch: false,
-            raw_exec: true,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            capability_preflight: None,
-            required_extensions: Vec::new(),
-            accepted_extension_settings: Vec::new(),
-            require_paths: Vec::new(),
-            runner_workload: None,
-            run_id: None,
-            detach_after_handoff: false,
-            mirror_evidence: true,
-            print_handoff: true,
-        },
+        super::RunnerExecOptions::raw_command(command).with_cwd(remote_workdir),
     )?;
     if exit_code == 0 {
         return Ok(());

--- a/src/core/runner/lab_workspaces_deps.rs
+++ b/src/core/runner/lab_workspaces_deps.rs
@@ -7,7 +7,7 @@
 //! Split out of `lab_workspaces.rs` to keep the workspace-mapping entry points
 //! separate from the dependency-discovery internals.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use crate::core::component::{self, TargetSpec};
@@ -469,31 +469,11 @@ pub(super) fn bootstrap_source_cli_dependencies(
 
     let (output, exit_code) = exec(
         runner_id,
-        RunnerExecOptions {
-            cwd: Some(remote_path.to_string()),
-            project_id: None,
-            allow_diagnostic_ssh: false,
-            command: command.to_vec(),
-            env: HashMap::new(),
-            secret_env_names: Vec::new(),
-            secret_env_plan: None,
-            env_materialization: None,
-            capture_patch: false,
-            raw_exec: true,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            // Validate remote capability parity before dispatch. Concrete command
-            // requirements are supplied declaratively by the workspace provider.
-            capability_preflight: Some(source_cli_bootstrap_capability_preflight()),
-            required_extensions: Vec::new(),
-            accepted_extension_settings: Vec::new(),
-            require_paths: Vec::new(),
-            runner_workload: None,
-            run_id: None,
-            detach_after_handoff: false,
-            mirror_evidence: true,
-            print_handoff: true,
-        },
+        // Validate remote capability parity before dispatch. Concrete command
+        // requirements are supplied declaratively by the workspace provider.
+        RunnerExecOptions::raw_command(command.to_vec())
+            .with_cwd(remote_path)
+            .with_capability_preflight(source_cli_bootstrap_capability_preflight()),
     )?;
     if exit_code == 0 {
         return Ok(());

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::core::rig;
@@ -257,34 +257,14 @@ pub(super) fn sync_lab_offload_rigs(
 
         let (output, exit_code) = exec(
             runner_id,
-            RunnerExecOptions {
-                cwd: Some(remote_cwd.to_string()),
-                project_id: None,
-                allow_diagnostic_ssh: false,
-                command: install_command,
-                env: HashMap::new(),
-                secret_env_names: Vec::new(),
-                secret_env_plan: None,
-                env_materialization: None,
-                capture_patch: false,
-                raw_exec: false,
-                source_snapshot: None,
-                path_materialization_plan: None,
-                // Validate remote capability parity before dispatch: the install
-                // is executed by the runner-side `homeboy` binary, so require
-                // that tool on the runner. `exec` no-ops this gate for local and
-                // already-capable SSH runners, so behavior is unchanged on a
-                // correctly provisioned runner and fails early otherwise (#5285).
-                capability_preflight: Some(rig_install_capability_preflight()),
-                required_extensions: Vec::new(),
-                accepted_extension_settings: Vec::new(),
-                require_paths: Vec::new(),
-                runner_workload: None,
-                run_id: None,
-                detach_after_handoff: false,
-                mirror_evidence: true,
-                print_handoff: true,
-            },
+            // Validate remote capability parity before dispatch: the install is
+            // executed by the runner-side `homeboy` binary, so require that tool
+            // on the runner. `exec` no-ops this gate for local and already-capable
+            // SSH runners, so behavior is unchanged on a correctly provisioned
+            // runner and fails early otherwise (#5285).
+            RunnerExecOptions::command(install_command)
+                .with_cwd(remote_cwd)
+                .with_capability_preflight(rig_install_capability_preflight()),
         )?;
 
         if exit_code != 0 {

--- a/src/core/runner/rig_materialization/rig_source_install.rs
+++ b/src/core/runner/rig_materialization/rig_source_install.rs
@@ -5,7 +5,6 @@
 //! metadata, and validating installed source paths. Kept in a sibling module so
 //! the root stays under the structural item-count threshold (#5241).
 
-use std::collections::HashMap;
 use std::path::Path;
 
 use crate::core::{Error, Result};
@@ -66,29 +65,7 @@ fn exec_runner_rig_sources_command(
     command.extend(args.iter().map(|arg| arg.to_string()));
     exec(
         runner_id,
-        RunnerExecOptions {
-            cwd: Some(remote_cwd.to_string()),
-            project_id: None,
-            allow_diagnostic_ssh: false,
-            command,
-            env: HashMap::new(),
-            secret_env_names: Vec::new(),
-            secret_env_plan: None,
-            env_materialization: None,
-            capture_patch: false,
-            raw_exec: false,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            capability_preflight: None,
-            required_extensions: Vec::new(),
-            accepted_extension_settings: Vec::new(),
-            require_paths: Vec::new(),
-            runner_workload: None,
-            run_id: None,
-            detach_after_handoff: false,
-            mirror_evidence: true,
-            print_handoff: true,
-        },
+        RunnerExecOptions::command(command).with_cwd(remote_cwd),
     )
 }
 


### PR DESCRIPTION
## Summary
- Added focused  constructors/builders for common runner dispatch shapes.
- Replaced repeated hand-assembled exec option structs in refresh/dev-sync, extension materialization, lab workspace hydration/install, provider preflight, resident source refresh, and rig materialization paths.
- Extracted Lab offload dispatch option assembly into  so  reads more like preflight -> dispatch -> record handling.

## Before/after module map
Before:
- : owned exec transport orchestration and the raw  data shape, but callers hand-built the same default-heavy option struct repeatedly.
- : self-refresh/dev-sync mixed refresh planning with bespoke raw shell exec option construction.
- : extension provenance/materialization plus repeated diagnostic raw shell exec setup.
- : Lab dispatch pipeline plus inline exec option assembly.
- , , , , , : materialization/preflight helpers each rebuilt the same runner exec defaults locally.

After:
- : remains the execution owner and now exposes internal constructors/builders (, , , and focused  helpers) as the clean seam for caller setup.
- Callers express only their deltas: cwd, env, source snapshot, capability preflight, required extensions, or mirror suppression.
- : dispatch options are isolated in , keeping the main handoff path easier to read while preserving upstream  behavior.
- Daemon lifecycle/lease logic, Lab dual-dispatch behavior, and agent-task lifecycle mirroring were not reworked.

## Coupling reduced
- Removed repeated knowledge of default runner exec flags from materialization and preflight modules.
- Kept transport selection and execution internals inside ; caller modules now use a small internal options seam instead of mirroring the full struct.
- Left specialized envelope and high-touch lifecycle-adjacent constructors intact rather than churning recent fixes.

## LOC
- Net: 172 insertions, 301 deletions across runner files (-129 LOC).

## Verification
- 
-  (1548 passed, 5434 skipped after rebase)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Simplified the runner module structure and reduced repeated context construction; Chris reviews and owns the change.