### PR TITLE
Unify command output run rendering

### DIFF
--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -455,7 +455,7 @@ pub(crate) fn adapter(
     )
 }
 
-fn run_json(args: ContractArgs, global: &GlobalArgs) -> adapter::JsonCommandRun {
+fn run_json(args: ContractArgs, global: &GlobalArgs) -> adapter::JsonHandlerResult {
     crate::commands::utils::response::map_cmd_result_to_json(run(args, global))
 }
 

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -203,7 +203,7 @@ pub(crate) fn adapter(
         .with_lab_contract(lab_contract)
 }
 
-fn run_json(args: FleetArgs, global: &super::GlobalArgs) -> adapter::JsonCommandRun {
+fn run_json(args: FleetArgs, global: &super::GlobalArgs) -> adapter::JsonHandlerResult {
     crate::commands::utils::response::map_cmd_result_to_json(run(args, global))
 }
 

--- a/src/commands/infra/adapter.rs
+++ b/src/commands/infra/adapter.rs
@@ -8,8 +8,8 @@ use crate::cli_surface::Commands;
 
 use crate::commands::{contract, fleet, observe, GlobalArgs};
 
-pub(crate) type JsonCommandRun = (homeboy::core::Result<Value>, i32);
-pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonCommandRun;
+pub(crate) type JsonHandlerResult = (homeboy::core::Result<Value>, i32);
+pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonHandlerResult;
 pub(crate) type LabContractResolver<Args> = fn(&Args) -> Option<LabCommandContract>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,7 +56,7 @@ pub(crate) struct TypedCommandAdapter<Args> {
 }
 
 pub(crate) struct BoundCommandAdapter {
-    run: Box<dyn FnOnce(&GlobalArgs) -> JsonCommandRun>,
+    run: Box<dyn FnOnce(&GlobalArgs) -> JsonHandlerResult>,
 }
 
 impl BoundCommandAdapter {
@@ -70,7 +70,7 @@ impl BoundCommandAdapter {
         }
     }
 
-    pub fn run(self, global: &GlobalArgs) -> JsonCommandRun {
+    pub fn run(self, global: &GlobalArgs) -> JsonHandlerResult {
         (self.run)(global)
     }
 }

--- a/src/commands/infra/output_runtime.rs
+++ b/src/commands/infra/output_runtime.rs
@@ -6,12 +6,13 @@ use crate::command_contract::CommandOutputFileMode;
 use crate::commands::utils::response as output;
 use crate::commands::{review, trace, GlobalArgs};
 
-pub struct JsonCommandRun {
+pub struct CommandRun {
     pub command: String,
     pub stdout_result: homeboy::core::Result<Value>,
     pub exit_code: i32,
     pub output_file_result: Option<homeboy::core::Result<Value>>,
     pub presentation: CommandPresentation,
+    pub raw_stdout: Option<homeboy::core::Result<String>>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -20,7 +21,7 @@ pub struct CommandPresentation {
     pub stderr: Option<String>,
 }
 
-impl JsonCommandRun {
+impl CommandRun {
     pub fn from_stdout_result(stdout_result: homeboy::core::Result<Value>, exit_code: i32) -> Self {
         Self::from_command_stdout_result("unknown", stdout_result, exit_code)
     }
@@ -36,6 +37,7 @@ impl JsonCommandRun {
             exit_code,
             output_file_result: None,
             presentation: CommandPresentation::default(),
+            raw_stdout: None,
         }
     }
 
@@ -49,12 +51,13 @@ impl JsonCommandRun {
         self
     }
 
-    pub fn from_raw(
-        raw_run: crate::commands::raw_output::RawCommandRun,
-    ) -> (Self, homeboy::core::Result<String>) {
-        let exit_code = raw_run.exit_code;
-        let raw_stdout = raw_run.stdout_result;
-        let output_file_result = match raw_run.output_file_result {
+    pub fn from_raw_stdout(
+        command: impl Into<String>,
+        raw_stdout: homeboy::core::Result<String>,
+        exit_code: i32,
+        output_file_result: Option<homeboy::core::Result<Value>>,
+    ) -> Self {
+        let stdout_result = match output_file_result.clone() {
             Some(result) => result,
             None => match raw_stdout.as_ref() {
                 Ok(content) => Ok(Value::String(content.clone())),
@@ -62,16 +65,14 @@ impl JsonCommandRun {
             },
         };
 
-        (
-            Self {
-                command: "unknown".to_string(),
-                stdout_result: output_file_result,
-                exit_code,
-                output_file_result: None,
-                presentation: CommandPresentation::default(),
-            },
-            raw_stdout,
-        )
+        Self {
+            command: command.into(),
+            stdout_result,
+            exit_code,
+            output_file_result,
+            presentation: CommandPresentation::default(),
+            raw_stdout: Some(raw_stdout),
+        }
     }
 }
 
@@ -85,7 +86,7 @@ impl<'a> OutputService<'a> {
     }
 
     pub fn emit_json_result(&self, result: homeboy::core::Result<Value>, exit_code: i32) {
-        let run = JsonCommandRun::from_stdout_result(result, exit_code);
+        let run = CommandRun::from_stdout_result(result, exit_code);
         self.write_output_file(&run, CommandOutputFileMode::GenericEnvelope);
         output::print_json_result_for_command(
             run.stdout_result,
@@ -96,8 +97,25 @@ impl<'a> OutputService<'a> {
         .ok();
     }
 
-    pub fn emit_run(&self, run: JsonCommandRun, mode: CommandOutputFileMode) -> i32 {
+    pub fn emit_run(&self, run: CommandRun, mode: CommandOutputFileMode) -> i32 {
         self.write_output_file(&run, mode);
+        if let Some(raw_stdout) = run.raw_stdout {
+            match raw_stdout {
+                Ok(content) => print!("{}", content),
+                Err(err) => {
+                    output::print_json_result_for_command(
+                        Err(err),
+                        run.exit_code,
+                        &run.command,
+                        None,
+                    )
+                    .ok();
+                }
+            }
+
+            return run.exit_code;
+        }
+
         if let Some(stderr) = &run.presentation.stderr {
             eprint!("{}", stderr);
         }
@@ -112,26 +130,7 @@ impl<'a> OutputService<'a> {
         run.exit_code
     }
 
-    pub fn emit_raw_run(
-        &self,
-        raw_run: crate::commands::raw_output::RawCommandRun,
-        mode: CommandOutputFileMode,
-    ) -> i32 {
-        let (json_run, raw_stdout) = JsonCommandRun::from_raw(raw_run);
-        let exit_code = json_run.exit_code;
-        self.write_output_file(&json_run, mode);
-
-        match raw_stdout {
-            Ok(content) => print!("{}", content),
-            Err(err) => {
-                output::print_result::<Value>(Err(err)).ok();
-            }
-        }
-
-        exit_code
-    }
-
-    pub fn write_output_file(&self, run: &JsonCommandRun, mode: CommandOutputFileMode) {
+    pub fn write_output_file(&self, run: &CommandRun, mode: CommandOutputFileMode) {
         write_output_file(run, mode, self.output_file);
     }
 }
@@ -151,8 +150,8 @@ pub fn run_command(
             let run = run_json(*command, global, plan.output_file, output_file);
             output_service.emit_run(run, plan.output_file)
         }
-        crate::commands::raw_output::CommandRunPreparation::Raw(raw_run) => {
-            output_service.emit_raw_run(raw_run, plan.output_file)
+        crate::commands::raw_output::CommandRunPreparation::Raw(run) => {
+            output_service.emit_run(run, plan.output_file)
         }
     }
 }
@@ -206,18 +205,19 @@ pub fn run_json(
     global: &GlobalArgs,
     mode: CommandOutputFileMode,
     output_file: Option<&str>,
-) -> JsonCommandRun {
+) -> CommandRun {
     match (mode, command) {
         (CommandOutputFileMode::TraceJsonSummaryArtifact, Commands::Trace(args)) => {
             let (stdout_result, exit_code, output_file_result) =
                 trace::run_json_with_output_artifact(args, global);
 
-            JsonCommandRun {
+            CommandRun {
                 command: "trace".to_string(),
                 stdout_result,
                 exit_code,
                 output_file_result,
                 presentation: CommandPresentation::default(),
+                raw_stdout: None,
             }
         }
         (_, command) => {
@@ -226,7 +226,7 @@ pub fn run_json(
     }
 }
 
-pub fn write_output_file(run: &JsonCommandRun, mode: CommandOutputFileMode, path: Option<&str>) {
+pub fn write_output_file(run: &CommandRun, mode: CommandOutputFileMode, path: Option<&str>) {
     let Some(path) = path else {
         return;
     };
@@ -273,7 +273,7 @@ fn presentation_envelope(
 }
 
 pub fn select_output_file_result(
-    run: &JsonCommandRun,
+    run: &CommandRun,
     mode: CommandOutputFileMode,
 ) -> &homeboy::core::Result<Value> {
     match mode {
@@ -294,42 +294,36 @@ mod tests {
 
     fn run_with_output_file_result(
         output_file_result: Option<homeboy::core::Result<Value>>,
-    ) -> JsonCommandRun {
-        JsonCommandRun {
+    ) -> CommandRun {
+        CommandRun {
             command: "test".to_string(),
             stdout_result: Ok(json!({ "kind": "stdout" })),
             exit_code: 0,
             output_file_result,
             presentation: CommandPresentation::default(),
+            raw_stdout: None,
         }
     }
 
     #[test]
     fn raw_command_run_without_artifact_uses_raw_stdout_for_file_payload() {
-        let raw_run = crate::commands::raw_output::RawCommandRun {
-            stdout_result: Ok("plain output".to_string()),
-            exit_code: 0,
-            output_file_result: None,
-        };
+        let run = CommandRun::from_raw_stdout("test", Ok("plain output".to_string()), 0, None);
 
-        let (json_run, raw_stdout) = JsonCommandRun::from_raw(raw_run);
-
-        assert_eq!(raw_stdout.unwrap(), "plain output");
-        assert_eq!(json_run.stdout_result.unwrap(), json!("plain output"));
+        assert_eq!(run.raw_stdout.unwrap().unwrap(), "plain output");
+        assert_eq!(run.stdout_result.unwrap(), json!("plain output"));
     }
 
     #[test]
     fn raw_command_run_with_artifact_uses_artifact_for_file_payload() {
-        let raw_run = crate::commands::raw_output::RawCommandRun {
-            stdout_result: Ok("markdown output".to_string()),
-            exit_code: 0,
-            output_file_result: Some(Ok(json!({ "artifact": true }))),
-        };
+        let run = CommandRun::from_raw_stdout(
+            "test",
+            Ok("markdown output".to_string()),
+            0,
+            Some(Ok(json!({ "artifact": true }))),
+        );
 
-        let (json_run, raw_stdout) = JsonCommandRun::from_raw(raw_run);
-
-        assert_eq!(raw_stdout.unwrap(), "markdown output");
-        assert_eq!(json_run.stdout_result.unwrap(), json!({ "artifact": true }));
+        assert_eq!(run.raw_stdout.unwrap().unwrap(), "markdown output");
+        assert_eq!(run.stdout_result.unwrap(), json!({ "artifact": true }));
     }
 
     #[test]
@@ -370,7 +364,7 @@ mod tests {
 
     #[test]
     fn presentation_does_not_replace_structured_stdout_or_file_payload() {
-        let run = JsonCommandRun::from_stdout_result(Ok(json!({ "kind": "stdout" })), 0)
+        let run = CommandRun::from_stdout_result(Ok(json!({ "kind": "stdout" })), 0)
             .with_presentation(CommandPresentation {
                 stdout: Some("short summary\n".to_string()),
                 stderr: Some("progress\n".to_string()),
@@ -390,7 +384,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("controller-result.json");
         let large = "x".repeat(2 * 1024 * 1024);
-        let run = JsonCommandRun::from_stdout_result(
+        let run = CommandRun::from_stdout_result(
             Ok(json!({
                 "schema": "homeboy/agent-task-loop-controller-run-from-spec-result/v1",
                 "loop_id": "large-loop",
@@ -446,7 +440,7 @@ mod tests {
     fn review_output_file_writes_stable_artifact_without_envelope() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("review.json");
-        let run = JsonCommandRun::from_stdout_result(
+        let run = CommandRun::from_stdout_result(
             Ok(json!({
                 "command": "review",
                 "artifact": {

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -4,7 +4,7 @@ use crate::cli_surface::Commands;
 use crate::command_contract::{registered_command, CommandDispatchFamily};
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
-use super::output_runtime::{CommandPresentation, JsonCommandRun};
+use super::output_runtime::{CommandPresentation, CommandRun};
 use super::{adapter, runner, GlobalArgs};
 
 mod ops;
@@ -24,7 +24,7 @@ pub fn run_command_output(
     command: Commands,
     global: &GlobalArgs,
     output_file: Option<&str>,
-) -> JsonCommandRun {
+) -> CommandRun {
     crate::commands::utils::tty::status("homeboy is working...");
     let command_name = command.top_level_name();
 
@@ -46,7 +46,7 @@ pub fn run_command_output(
                 summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
             });
 
-            JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
                 CommandPresentation {
                     stdout: summary_stdout,
                     stderr: None,
@@ -61,7 +61,7 @@ pub fn run_command_output(
                 .ok()
                 .and_then(super::activity::render_activity_summary);
 
-            JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
                 CommandPresentation {
                     stdout: summary_stdout,
                     stderr: None,
@@ -80,7 +80,7 @@ pub fn run_command_output(
                 })
                 .flatten();
 
-            JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
                 CommandPresentation {
                     stdout: summary_stdout,
                     stderr: None,
@@ -99,7 +99,7 @@ pub fn run_command_output(
                 })
                 .flatten();
 
-            JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
                 CommandPresentation {
                     stdout: summary_stdout,
                     stderr: None,
@@ -125,7 +125,7 @@ pub fn run_command_output(
                 }
             });
 
-            JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
                 CommandPresentation {
                     stdout: summary_stdout,
                     stderr: None,
@@ -134,7 +134,7 @@ pub fn run_command_output(
         }
         command => {
             let (stdout_result, exit_code) = dispatch(command, global);
-            JsonCommandRun::from_stdout_result(stdout_result, exit_code)
+            CommandRun::from_stdout_result(stdout_result, exit_code)
         }
     };
 

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -88,7 +88,7 @@ pub(crate) fn adapter(
     adapter::TypedCommandAdapter::json_only(CommandJsonFamily::Quality, output_file_mode, run_json)
 }
 
-fn run_json(args: ObserveArgs, global: &GlobalArgs) -> adapter::JsonCommandRun {
+fn run_json(args: ObserveArgs, global: &GlobalArgs) -> adapter::JsonHandlerResult {
     crate::commands::utils::response::map_cmd_result_to_json(run(args, global))
 }
 

--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -1,8 +1,7 @@
-use serde_json::Value;
-
 use crate::cli_surface::Commands;
 use crate::command_contract::{CommandRawOutputMode, CommandStdoutMode};
 
+use super::output_runtime::CommandRun;
 use super::utils::{response as output, tty};
 use super::{file, release, report, review, runner, runs, runtime, self_cmd, trace, GlobalArgs};
 
@@ -14,13 +13,7 @@ pub enum RawExecution {
 pub enum CommandRunPreparation {
     Handled(i32),
     Json(Box<Commands>),
-    Raw(RawCommandRun),
-}
-
-pub struct RawCommandRun {
-    pub stdout_result: homeboy::core::Result<String>,
-    pub exit_code: i32,
-    pub output_file_result: Option<homeboy::core::Result<Value>>,
+    Raw(CommandRun),
 }
 
 pub fn prepare_command_run(
@@ -56,7 +49,7 @@ pub fn run_and_print(
     let raw_run =
         run(command, global, mode).expect("markdown and plain-text modes should return raw output");
 
-    RawExecution::Handled(match raw_run.stdout_result {
+    RawExecution::Handled(match raw_run.raw_stdout.expect("raw mode has raw stdout") {
         Ok(content) => {
             print!("{}", content);
             raw_run.exit_code
@@ -72,7 +65,7 @@ pub fn run(
     command: Commands,
     global: &GlobalArgs,
     mode: CommandRawOutputMode,
-) -> Option<RawCommandRun> {
+) -> Option<CommandRun> {
     match mode {
         CommandRawOutputMode::InteractivePassthrough => None,
         CommandRawOutputMode::Markdown => Some(run_markdown(command, global)),
@@ -80,7 +73,7 @@ pub fn run(
     }
 }
 
-fn run_markdown(command: Commands, global: &GlobalArgs) -> RawCommandRun {
+fn run_markdown(command: Commands, global: &GlobalArgs) -> CommandRun {
     match command {
         Commands::SelfCmd(args) => raw_stdout_only(self_cmd::run_docs_markdown(args)),
         Commands::Release(args) => match args.markdown_changelog_args() {
@@ -97,7 +90,7 @@ fn run_markdown(command: Commands, global: &GlobalArgs) -> RawCommandRun {
     }
 }
 
-fn run_plain_text(command: Commands, global: &GlobalArgs) -> RawCommandRun {
+fn run_plain_text(command: Commands, global: &GlobalArgs) -> CommandRun {
     match command {
         Commands::File(args) => raw_stdout_only(match file::run(args, global) {
             Ok((file::FileCommandOutput::Raw(content), exit_code)) => Ok((content, exit_code)),
@@ -117,22 +110,16 @@ fn run_plain_text(command: Commands, global: &GlobalArgs) -> RawCommandRun {
 fn runner_compact_exec(
     args: crate::commands::runner::RunnerArgs,
     global: &GlobalArgs,
-) -> RawCommandRun {
+) -> CommandRun {
     runner::run_plain_text_raw(args, global)
 }
 
-pub fn raw_stdout_only(result: homeboy::core::Result<(String, i32)>) -> RawCommandRun {
+pub fn raw_stdout_only(result: homeboy::core::Result<(String, i32)>) -> CommandRun {
     match result {
-        Ok((content, exit_code)) => RawCommandRun {
-            stdout_result: Ok(content),
-            exit_code,
-            output_file_result: None,
-        },
-        Err(err) => RawCommandRun {
-            stdout_result: Err(err),
-            exit_code: 1,
-            output_file_result: None,
-        },
+        Ok((content, exit_code)) => {
+            CommandRun::from_raw_stdout("unknown", Ok(content), exit_code, None)
+        }
+        Err(err) => CommandRun::from_raw_stdout("unknown", Err(err), 1, None),
     }
 }
 
@@ -191,7 +178,8 @@ mod tests {
             CommandRawOutputMode::PlainText,
         )
         .expect("plain text mode should return a result")
-        .stdout_result
+        .raw_stdout
+        .expect("raw mode has raw stdout")
         .expect_err("manifest does not support plain text output");
 
         assert!(result.to_string().contains("plain text output"));

--- a/src/commands/review/raw_output.rs
+++ b/src/commands/review/raw_output.rs
@@ -1,10 +1,10 @@
-use crate::commands::raw_output::RawCommandRun;
+use crate::commands::output_runtime::CommandRun;
 use crate::commands::GlobalArgs;
 use homeboy::core::review::render;
 
 use super::{run_umbrella, ReviewArgs};
 
-pub fn run_markdown_with_json(args: ReviewArgs, global: &GlobalArgs) -> RawCommandRun {
+pub fn run_markdown_with_json(args: ReviewArgs, global: &GlobalArgs) -> CommandRun {
     let banners = args.banner.clone();
     match run_umbrella(args, global) {
         Ok((output, exit_code)) => {
@@ -14,21 +14,18 @@ pub fn run_markdown_with_json(args: ReviewArgs, global: &GlobalArgs) -> RawComma
                 render::render_pr_comment_with_banners(&output, &banners)
             };
 
-            RawCommandRun {
-                stdout_result: Ok(md),
+            CommandRun::from_raw_stdout(
+                "review",
+                Ok(md),
                 exit_code,
-                output_file_result: Some(serde_json::to_value(output).map_err(|err| {
+                Some(serde_json::to_value(output).map_err(|err| {
                     homeboy::core::Error::internal_json(
                         err.to_string(),
                         Some("serialize response".to_string()),
                     )
                 })),
-            }
+            )
         }
-        Err(err) => RawCommandRun {
-            stdout_result: Err(err),
-            exit_code: 1,
-            output_file_result: None,
-        },
+        Err(err) => CommandRun::from_raw_stdout("review", Err(err), 1, None),
     }
 }

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -4,8 +4,7 @@ use homeboy::core::runners::{
 use homeboy::core::server::RunnerSettings;
 use serde_json::Value;
 
-use super::super::output_runtime::{CommandPresentation, JsonCommandRun};
-use super::super::raw_output::RawCommandRun;
+use super::super::output_runtime::{CommandPresentation, CommandRun};
 use super::super::CmdResult;
 use super::broker::run_broker;
 use super::cli::{RunnerArgs, RunnerCommand};
@@ -265,7 +264,7 @@ pub fn run(
     }
 }
 
-pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) -> JsonCommandRun {
+pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) -> CommandRun {
     crate::commands::utils::tty::status("homeboy is working...");
 
     match args.command {
@@ -398,7 +397,7 @@ pub fn run_command_output(args: RunnerArgs, _global: &super::super::GlobalArgs) 
                     RunnerArgs { command },
                     _global,
                 ));
-            JsonCommandRun::from_stdout_result(stdout_result, exit_code)
+            CommandRun::from_stdout_result(stdout_result, exit_code)
         }
     }
 }
@@ -423,7 +422,7 @@ fn run_json_exec(
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
     command: Vec<String>,
-) -> JsonCommandRun {
+) -> CommandRun {
     let (stdout_result, exit_code) = crate::commands::utils::response::map_cmd_result_to_json(
         exec(
             &id,
@@ -452,7 +451,7 @@ fn run_json_exec(
             )
         }),
     );
-    JsonCommandRun::from_stdout_result(stdout_result, exit_code)
+    CommandRun::from_stdout_result(stdout_result, exit_code)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -475,7 +474,7 @@ fn run_raw_exec(
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
     command: Vec<String>,
-) -> JsonCommandRun {
+) -> CommandRun {
     match exec(
         &id,
         cwd,
@@ -502,7 +501,7 @@ fn run_raw_exec(
                 crate::commands::utils::response::map_cmd_result_to_json::<RunnerCommandOutput>(
                     Err(err),
                 );
-            JsonCommandRun::from_stdout_result(stdout_result, exit_code)
+            CommandRun::from_stdout_result(stdout_result, exit_code)
         }
     }
 }
@@ -527,7 +526,7 @@ fn run_compact_exec_json(
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
     command: Vec<String>,
-) -> JsonCommandRun {
+) -> CommandRun {
     let raw_run = run_compact_exec(
         id,
         cwd,
@@ -548,12 +547,16 @@ fn run_compact_exec_json(
         summary_outputs,
         command,
     );
-    let (run, raw_stdout) = JsonCommandRun::from_raw(raw_run);
-    run.with_presentation(CommandPresentation {
-        stdout: raw_stdout.ok(),
-        stderr: None,
-    })
-    .with_command("runner")
+    let presentation_stdout = raw_run
+        .raw_stdout
+        .as_ref()
+        .and_then(|result| result.as_ref().ok().cloned());
+    raw_run
+        .with_presentation(CommandPresentation {
+            stdout: presentation_stdout,
+            stderr: None,
+        })
+        .with_command("runner")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -576,7 +579,7 @@ pub(super) fn run_compact_exec(
     artifact_dir_outputs: Vec<String>,
     summary_outputs: Vec<String>,
     command: Vec<String>,
-) -> RawCommandRun {
+) -> CommandRun {
     match exec(
         &id,
         cwd,
@@ -598,26 +601,29 @@ pub(super) fn run_compact_exec(
         command,
     ) {
         Ok((output, exit_code)) => compact_exec_command_run(output, exit_code),
-        Err(err) => RawCommandRun {
-            stdout_result: Err(err),
-            exit_code: 1,
-            output_file_result: None,
-        },
+        Err(err) => {
+            let (output_file_result, exit_code) =
+                crate::commands::utils::response::map_cmd_result_to_json::<RunnerCommandOutput>(
+                    Err(err.clone()),
+                );
+            CommandRun::from_raw_stdout("runner", Err(err), exit_code, Some(output_file_result))
+        }
     }
 }
 
-pub(super) fn compact_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> RawCommandRun {
+pub(super) fn compact_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> CommandRun {
     let compact_stdout = render_compact_exec_output(&output);
     let (output_file_result, _) = crate::commands::utils::response::map_cmd_result_to_json(Ok((
         RunnerCommandOutput::Execution(runner_exec_command_output(output)),
         exit_code,
     )));
 
-    RawCommandRun {
-        stdout_result: Ok(compact_stdout),
+    CommandRun::from_raw_stdout(
+        "runner",
+        Ok(compact_stdout),
         exit_code,
-        output_file_result: Some(output_file_result),
-    }
+        Some(output_file_result),
+    )
 }
 
 pub(super) fn render_compact_exec_output(output: &RunnerExecOutput) -> String {
@@ -671,7 +677,7 @@ fn render_stream(stream: &str) -> String {
         .unwrap_or_else(|| stream.to_string())
 }
 
-pub(super) fn raw_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> JsonCommandRun {
+pub(super) fn raw_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> CommandRun {
     let presentation_stdout = output.stdout.clone();
     let presentation_stderr = output.stderr.clone();
     let (stdout_result, _) = crate::commands::utils::response::map_cmd_result_to_json(Ok((
@@ -679,7 +685,7 @@ pub(super) fn raw_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> 
         exit_code,
     )));
 
-    JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+    CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
         CommandPresentation {
             stdout: Some(presentation_stdout),
             stderr: Some(presentation_stderr),

--- a/src/commands/runner/mod.rs
+++ b/src/commands/runner/mod.rs
@@ -36,7 +36,7 @@ pub fn is_compact_exec_stdout(args: &RunnerArgs) -> bool {
 pub fn run_plain_text_raw(
     args: RunnerArgs,
     _global: &super::GlobalArgs,
-) -> super::raw_output::RawCommandRun {
+) -> super::output_runtime::CommandRun {
     match args.command {
         cli::RunnerCommand::Exec {
             id,
@@ -79,15 +79,16 @@ pub fn run_plain_text_raw(
             summary_outputs,
             command,
         ),
-        _ => super::raw_output::RawCommandRun {
-            stdout_result: Err(homeboy::core::Error::validation_invalid_argument(
+        _ => super::output_runtime::CommandRun::from_raw_stdout(
+            "runner",
+            Err(homeboy::core::Error::validation_invalid_argument(
                 "output_mode",
                 "runner command does not support plain text output",
                 None,
                 None,
             )),
-            exit_code: 2,
-            output_file_result: None,
-        },
+            2,
+            None,
+        ),
     }
 }

--- a/src/commands/runner/tests/exec.rs
+++ b/src/commands/runner/tests/exec.rs
@@ -143,9 +143,11 @@ fn compact_exec_command_run_preserves_full_output_file_payload() {
     let run = compact_exec_command_run(output, 0);
 
     assert!(run
-        .stdout_result
+        .raw_stdout
         .as_ref()
         .expect("compact stdout")
+        .as_ref()
+        .expect("compact stdout result")
         .contains("Stdout:\nhello\n"));
     let output_file = run
         .output_file_result

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -294,7 +294,7 @@ pub fn run_markdown(args: TraceArgs, global: &GlobalArgs) -> CmdResult<String> {
 pub fn run_markdown_with_json_artifact(
     args: TraceArgs,
     _global: &GlobalArgs,
-) -> super::raw_output::RawCommandRun {
+) -> super::output_runtime::CommandRun {
     let output_to_json = |output: &TraceCommandOutput| {
         serde_json::to_value(output).map_err(|err| {
             homeboy::core::Error::internal_json(
@@ -307,20 +307,17 @@ pub fn run_markdown_with_json_artifact(
     match run_outputs(args) {
         Ok(((stdout_output, artifact_output), exit_code)) => {
             let markdown = render_markdown_output(&stdout_output);
-            super::raw_output::RawCommandRun {
-                stdout_result: Ok(markdown),
+            super::output_runtime::CommandRun::from_raw_stdout(
+                "trace",
+                Ok(markdown),
                 exit_code,
-                output_file_result: Some(match artifact_output {
+                Some(match artifact_output {
                     Some(ref output) => output_to_json(output),
                     None => output_to_json(&stdout_output),
                 }),
-            }
+            )
         }
-        Err(err) => super::raw_output::RawCommandRun {
-            stdout_result: Err(err),
-            exit_code: 1,
-            output_file_result: None,
-        },
+        Err(err) => super::output_runtime::CommandRun::from_raw_stdout("trace", Err(err), 1, None),
     }
 }
 

--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -62,7 +62,7 @@ fn validation_error_writes_json_output_file() {
             .expect("output file json");
 
     assert_eq!(file_json, stdout_json);
-    assert_eq!(file_json["schema"], "homeboy/command-result/v2");
+    assert_eq!(file_json["schema"], "homeboy/command-result/v3");
     assert_eq!(file_json["success"], false);
     assert_eq!(
         file_json["diagnostics"]["code"],
@@ -93,7 +93,7 @@ fn bare_json_output_format_is_rejected_as_footgun() {
         );
 
         let stdout_json: Value = serde_json::from_slice(&output.stdout).expect("stdout json");
-        assert_eq!(stdout_json["schema"], "homeboy/command-result/v2");
+        assert_eq!(stdout_json["schema"], "homeboy/command-result/v3");
         assert_eq!(stdout_json["success"], false);
         assert_eq!(
             stdout_json["diagnostics"]["code"],


### PR DESCRIPTION
## Summary
- Collapses the parallel JSON/raw runtime structs into one command runtime object: `CommandRun`.
- Keeps `homeboy/command-result/v3` as the canonical envelope; `response.rs` remains the single envelope constructor for structured stdout and output files.
- Treats JSON, markdown/plain raw stdout, compact runner output, and interactive fallback as presentation choices over the same command run instead of separate runtime shapes.

## Parallel-runtime map collapsed
- Before: `response.rs` built/printed v3 envelopes, `output_runtime.rs` rewrapped `JsonCommandRun`, `raw_output` returned a separate `RawCommandRun`, and runner/review/trace bridged between those shapes manually.
- After: command dispatch returns one `CommandRun` carrying the structured payload, optional output-file payload, presentation streams, and optional raw stdout.
- Raw/markdown/plain paths now call `CommandRun::from_raw_stdout(...)`; output-file writing and stdout emission both go through `OutputService::emit_run`.

## Renderer design
- Structured renderer: `CommandRun.stdout_result` -> `response::print_json_result_for_command` -> v3 envelope.
- Presentation renderer: `CommandPresentation { stdout, stderr }` remains embedded in the v3 envelope for compact summaries/raw exec streams.
- Raw renderer: `CommandRun.raw_stdout` prints passthrough stdout, while the same run still owns the structured payload for `--output`.
- Output-file renderer: `write_output_file` selects the run payload by `CommandOutputFileMode` without needing a raw-to-json runtime conversion.

## Output-identical proof
- Kept the v3 envelope construction in `response.rs` unchanged.
- Existing response/output/contract tests pass unchanged except stale v2 assertions in `tests/output_errors.rs`, updated to the current v3 contract.
- Output-contract fixture consumers pass; fixture files under `tests/fixtures/output_contracts` were not changed.
- Fixed raw validation error parity so stdout and `--output` write the same command-aware v3 envelope.

## Net LOC
- 153 insertions, 168 deletions; net -15 LOC.

## Verification
- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(response) or test(output) or test(raw_output) or test(json_output) or test(command_contract)' --no-fail-fast` (211/211 passed)
- `~/.cargo/bin/cargo-nextest nextest run --test output_errors --test report_performance_digest_test --no-fail-fast` (12/12 passed)
- `cargo run -- status`
- `cargo run -- contract manifest`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Unified the output pipeline into one envelope with pluggable renderers; Chris reviews and owns the change.
