### PR TITLE
Consolidate command safety descriptors

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -79,8 +79,8 @@ pub use registry::{
 pub use spec::{
     non_core_command_doc_slugs, registered_command, registered_command_dispatch_family,
     registered_command_json_family, runtime_extension_command_doc_slugs, support_command_doc_slugs,
-    CommandDocKind, CommandDocSpec, CommandLabSupportSummary, CommandSafetySpec, CommandSpec,
-    COMMAND_DOC_REGISTRY, COMMAND_SPECS,
+    CommandDocKind, CommandDocSpec, CommandLabSupportSummary, CommandPathSafetySpec,
+    CommandSafetySpec, CommandSpec, COMMAND_DOC_REGISTRY, COMMAND_SPECS,
 };
 pub(crate) use spec::{
     AUDIT_LAB_LABEL, BENCH_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REVIEW_LAB_LABEL,

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -176,6 +176,22 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.risk_exemption = top_level.safety.risk_exemption;
             metadata.dangerous_flags = top_level.safety.dangerous_flags.to_vec();
         }
+
+        let subcommand_path = path.iter().skip(1).map(String::as_str).collect::<Vec<_>>();
+        if let Some(path_safety) = top_level.path_safety(&subcommand_path) {
+            metadata.mutates = path_safety.safety.mutates;
+            metadata.operator = path_safety.safety.operator;
+            metadata.dry_run_flag = path_safety.safety.dry_run_flag;
+            metadata.risk_exemption = path_safety.safety.risk_exemption;
+            metadata.dangerous_flags = path_safety.safety.dangerous_flags.to_vec();
+            if let Some(output_notes) = path_safety.output_notes {
+                metadata.output_notes = output_notes;
+            }
+            if let Some(lab_notes) = path_safety.lab_notes {
+                metadata.lab_notes = lab_notes;
+            }
+            return metadata;
+        }
     }
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
@@ -186,11 +202,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.output_notes =
                 "default JSON output is non-mutating; pass --write to write markdown docs to disk";
             metadata.dangerous_flags = vec!["--write"];
-        }
-        ["deps", "install"] | ["deps", "update"] | ["deps", "stack", "apply"] => {
-            metadata.mutates = true;
-            metadata.output_notes =
-                "mutates dependency manifests, lockfiles, or installed dependency trees";
         }
         ["review", "ci", "autofix"] => {
             metadata.mutates = true;
@@ -240,18 +251,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.output_notes =
                 "default output is non-mutating; pass --apply to repair or remove artifacts";
             metadata.dangerous_flags = vec!["--apply"];
-        }
-        ["server", "create"]
-        | ["server", "set"]
-        | ["server", "delete"]
-        | ["server", "connect"]
-        | ["server", "disconnect"]
-        | ["server", "key", "generate"]
-        | ["server", "key", "import"]
-        | ["server", "key", "use"]
-        | ["server", "key", "unset"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
         }
         ["extension", "setup"]
         | ["extension", "refresh"]
@@ -379,43 +378,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.output_notes = "default output is a non-mutating plan; pass --apply to mutate";
-        }
-        ["file", "write"] | ["file", "delete"] | ["file", "mkdir"] | ["file", "rename"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.output_notes = "default output is a non-mutating plan; pass --apply to mutate";
-            metadata.dangerous_flags = vec!["--apply"];
-        }
-        ["file", "edit"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.output_notes = "mutates file content unless --dry-run is passed";
-        }
-        ["file", "copy"] | ["file", "sync"] => {
-            metadata.mutates = true;
-        }
-        ["fleet", "exec"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.dry_run_flag = Some("--check");
-            metadata.output_notes = "default output is blocked for remote execution; pass --check to plan or --apply to execute";
-            metadata.dangerous_flags = vec!["--apply"];
-            metadata.lab_notes = "local-only: depends on local fleet/project/server configuration before SSH fan-out";
-        }
-        ["fleet", "create"]
-        | ["fleet", "set"]
-        | ["fleet", "delete"]
-        | ["fleet", "add"]
-        | ["fleet", "remove"] => {
-            metadata.mutates = true;
-            metadata.output_notes = "mutates local fleet configuration";
-        }
-        ["api", "post"] | ["api", "put"] | ["api", "patch"] | ["api", "delete"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.output_notes = "mutating API requests require --apply";
-            metadata.dangerous_flags = vec!["--apply"];
         }
         ["git", "issue", "create"]
         | ["git", "issue", "comment"]
@@ -557,13 +519,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.output_notes = "default output is a non-mutating orphan cleanup plan with candidate/remaining bytes; pass --apply to delete exact runner workspace paths and --passes to drain bounded pages";
             metadata.dangerous_flags = vec!["--apply"];
         }
-        ["api", "http", "request"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.output_notes = "mutating HTTP methods require --apply; GET, HEAD, and OPTIONS are allowed without it";
-            metadata.dangerous_flags =
-                vec!["--apply", "METHOD!=GET", "METHOD!=HEAD", "METHOD!=OPTIONS"];
-        }
         ["worktree", "queue-create"] => {
             metadata.mutates = true;
             metadata.dry_run_flag = Some("--dry-run");
@@ -656,17 +611,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         ["refactor", "undo", "delete"] => {
             metadata.mutates = true;
             metadata.output_notes = "deletes an undo snapshot without restoring it";
-        }
-        ["api", "auth", "login"]
-        | ["api", "auth", "set"]
-        | ["api", "auth", "remove"]
-        | ["api", "auth", "logout"]
-        | ["api", "auth", "profile", "set-basic"]
-        | ["api", "auth", "profile", "set-bearer"]
-        | ["api", "auth", "profile", "remove"] => {
-            metadata.mutates = true;
-            metadata.operator = true;
-            metadata.output_notes = "mutates keychain-backed authentication state";
         }
         _ => {}
     }

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -15,6 +15,7 @@ pub struct CommandSpec {
     pub docs_slug: Option<&'static str>,
     pub representative_argv: Option<&'static [&'static str]>,
     pub safety: CommandSafetySpec,
+    pub subcommand_safety: &'static [CommandPathSafetySpec],
     pub output_notes: &'static str,
     pub lab_supported: bool,
     pub lab_notes: &'static str,
@@ -47,6 +48,14 @@ pub struct CommandSafetySpec {
     pub dry_run_flag: Option<&'static str>,
     pub risk_exemption: Option<&'static str>,
     pub dangerous_flags: &'static [&'static str],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandPathSafetySpec {
+    pub paths: &'static [&'static str],
+    pub safety: CommandSafetySpec,
+    pub output_notes: Option<&'static str>,
+    pub lab_notes: Option<&'static str>,
 }
 
 impl CommandSafetySpec {
@@ -110,6 +119,19 @@ impl CommandSpec {
     pub fn dispatch_family(&self) -> CommandDispatchFamily {
         self.json_family.into()
     }
+
+    pub fn path_safety(&self, path: &[&str]) -> Option<&'static CommandPathSafetySpec> {
+        self.subcommand_safety.iter().find(|entry| {
+            entry
+                .paths
+                .iter()
+                .any(|entry_path| path_matches(entry_path, path))
+        })
+    }
+}
+
+fn path_matches(spec: &str, path: &[&str]) -> bool {
+    spec.split_whitespace().eq(path.iter().copied())
 }
 
 const fn command_spec(name: &'static str, json_family: CommandJsonFamily) -> CommandSpec {
@@ -119,6 +141,7 @@ const fn command_spec(name: &'static str, json_family: CommandJsonFamily) -> Com
         docs_slug: Some(name),
         representative_argv: None,
         safety: CommandSafetySpec::read_only(),
+        subcommand_safety: &[],
         output_notes: "standard CLI output contract",
         lab_supported: false,
         lab_notes: DEFAULT_LAB_UNSUPPORTED_NOTES,
@@ -387,6 +410,11 @@ const FUZZ_DANGEROUS_FLAGS: &[&str] = &["--allow-destructive"];
 const CLEANUP_DANGEROUS_FLAGS: &[&str] = &["--apply"];
 const TRIAGE_DANGEROUS_FLAGS: &[&str] = &["--auto-merge"];
 const REFACTOR_DANGEROUS_FLAGS: &[&str] = &["--write", "--commit"];
+const FILE_APPLY_DANGEROUS_FLAGS: &[&str] = &["--apply"];
+const FLEET_EXEC_DANGEROUS_FLAGS: &[&str] = &["--apply"];
+const API_MUTATION_DANGEROUS_FLAGS: &[&str] = &["--apply"];
+const API_HTTP_REQUEST_DANGEROUS_FLAGS: &[&str] =
+    &["--apply", "METHOD!=GET", "METHOD!=HEAD", "METHOD!=OPTIONS"];
 
 const fn mutating_safety() -> CommandSafetySpec {
     CommandSafetySpec {
@@ -421,6 +449,114 @@ const fn guarded_safety(dangerous_flags: &'static [&'static str]) -> CommandSafe
     }
 }
 
+const fn paths_safety(
+    paths: &'static [&'static str],
+    safety: CommandSafetySpec,
+    output_notes: &'static str,
+) -> CommandPathSafetySpec {
+    CommandPathSafetySpec {
+        paths,
+        safety,
+        output_notes: Some(output_notes),
+        lab_notes: None,
+    }
+}
+
+const fn paths_safety_without_notes(
+    paths: &'static [&'static str],
+    safety: CommandSafetySpec,
+) -> CommandPathSafetySpec {
+    CommandPathSafetySpec {
+        paths,
+        safety,
+        output_notes: None,
+        lab_notes: None,
+    }
+}
+
+const DEPS_MUTATING_PATHS: &[&str] = &["install", "update", "stack apply"];
+const FILE_APPLY_PATHS: &[&str] = &["write", "delete", "mkdir", "rename"];
+const FILE_TRANSFER_PATHS: &[&str] = &["copy", "sync"];
+const FLEET_CONFIG_PATHS: &[&str] = &["create", "set", "delete", "add", "remove"];
+const API_MUTATION_PATHS: &[&str] = &["post", "put", "patch", "delete"];
+const API_AUTH_PATHS: &[&str] = &[
+    "auth login",
+    "auth set",
+    "auth remove",
+    "auth logout",
+    "auth profile set-basic",
+    "auth profile set-bearer",
+    "auth profile remove",
+];
+const SERVER_OPERATOR_PATHS: &[&str] = &[
+    "create",
+    "set",
+    "delete",
+    "connect",
+    "disconnect",
+    "key generate",
+    "key import",
+    "key use",
+    "key unset",
+];
+
+const DEPS_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
+    DEPS_MUTATING_PATHS,
+    mutating_safety(),
+    "mutates dependency manifests, lockfiles, or installed dependency trees",
+)];
+
+const FILE_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        FILE_APPLY_PATHS,
+        operator_safety(None, FILE_APPLY_DANGEROUS_FLAGS),
+        "default output is a non-mutating plan; pass --apply to mutate",
+    ),
+    paths_safety(
+        &["edit"],
+        operator_safety(Some("--dry-run"), &[]),
+        "mutates file content unless --dry-run is passed",
+    ),
+    paths_safety_without_notes(FILE_TRANSFER_PATHS, mutating_safety()),
+];
+
+const FLEET_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    CommandPathSafetySpec {
+        paths: &["exec"],
+        safety: operator_safety(Some("--check"), FLEET_EXEC_DANGEROUS_FLAGS),
+        output_notes: Some(
+            "default output is blocked for remote execution; pass --check to plan or --apply to execute",
+        ),
+        lab_notes: Some(
+            "local-only: depends on local fleet/project/server configuration before SSH fan-out",
+        ),
+    },
+    paths_safety(FLEET_CONFIG_PATHS, mutating_safety(), "mutates local fleet configuration"),
+];
+
+const API_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        API_MUTATION_PATHS,
+        operator_safety(None, API_MUTATION_DANGEROUS_FLAGS),
+        "mutating API requests require --apply",
+    ),
+    paths_safety(
+        &["http request"],
+        operator_safety(None, API_HTTP_REQUEST_DANGEROUS_FLAGS),
+        "mutating HTTP methods require --apply; GET, HEAD, and OPTIONS are allowed without it",
+    ),
+    paths_safety(
+        API_AUTH_PATHS,
+        operator_safety(None, &[]),
+        "mutates keychain-backed authentication state",
+    ),
+];
+
+const SERVER_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety_without_notes(
+    SERVER_OPERATOR_PATHS,
+    operator_safety(None, &[]),
+)];
+
 pub const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec {
         output_notes: "unified active/recent activity read model in the standard JSON envelope",
@@ -439,7 +575,10 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     ),
     command_spec("project", CommandJsonFamily::Workspace),
     command_spec("ssh", CommandJsonFamily::Ops),
-    command_spec("server", CommandJsonFamily::Ops),
+    CommandSpec {
+        subcommand_safety: SERVER_SUBCOMMAND_SAFETY,
+        ..command_spec("server", CommandJsonFamily::Ops)
+    },
     command_spec_with_representative_argv(
         &["homeboy", "bench"],
         lab_command_spec_with_summary(
@@ -476,9 +615,18 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     },
     command_spec("observe", CommandJsonFamily::Quality),
     command_spec("db", CommandJsonFamily::Ops),
-    command_spec("deps", CommandJsonFamily::Ops),
-    command_spec("file", CommandJsonFamily::Ops),
-    command_spec("fleet", CommandJsonFamily::Ops),
+    CommandSpec {
+        subcommand_safety: DEPS_SUBCOMMAND_SAFETY,
+        ..command_spec("deps", CommandJsonFamily::Ops)
+    },
+    CommandSpec {
+        subcommand_safety: FILE_SUBCOMMAND_SAFETY,
+        ..command_spec("file", CommandJsonFamily::Ops)
+    },
+    CommandSpec {
+        subcommand_safety: FLEET_SUBCOMMAND_SAFETY,
+        ..command_spec("fleet", CommandJsonFamily::Ops)
+    },
     command_spec("logs", CommandJsonFamily::Ops),
     command_spec_with_safety(
         "triage",
@@ -619,7 +767,10 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         "inspects the active Homeboy runtime and renders built-in CLI documentation",
     ),
     command_spec("stack", CommandJsonFamily::Workspace),
-    command_spec("api", CommandJsonFamily::Ops),
+    CommandSpec {
+        subcommand_safety: API_SUBCOMMAND_SAFETY,
+        ..command_spec("api", CommandJsonFamily::Ops)
+    },
     command_spec_with_output_notes_and_safety(
         "upgrade",
         CommandJsonFamily::Ops,


### PR DESCRIPTION
## Summary

Part of #7516 and #7456.

This consolidates one slice of per-command declaration boilerplate by extending the existing `command_contract::CommandSpec` as the single descriptor source for path-scoped command safety metadata.

## Duplication map

Before this change, command metadata was split across parallel registries:

- `src/cli_surface.rs`: clap enum/argument surface and `Commands::top_level_name()`.
- `src/command_contract/spec.rs`: top-level command name, JSON family, docs slug, lab summary, top-level safety, output notes.
- `src/command_contract/safety_manifest.rs`: separate hand-written path match for subcommand safety, dry-run flags, dangerous flags, output notes, lab notes.
- `src/command_contract/output.rs`: output descriptor routing by `Commands::*` plus registered top-level specs for the simple JSON-envelope path.
- `src/commands/json_output/*`: JSON dispatch family match arms.
- `src/help_topics`: docs topics outside the command spec table for non-core/support pages.

The migrated duplication was specifically: subcommand safety/output/lab notes for `api`, `deps`, `file`, `fleet`, and `server` were declared by hand in the safety manifest even though those commands already had top-level `CommandSpec` entries.

## Descriptor design

- Added `CommandPathSafetySpec` under `command_contract::spec`.
- Extended `CommandSpec` with `subcommand_safety`.
- `CommandSpec::path_safety()` now resolves grouped path strings like `"auth profile set-basic"` against the clap-derived manifest path.
- `safety_manifest` now derives migrated path-scoped safety metadata from the registered command spec before falling back to the remaining legacy match arms.

This keeps the existing command-contract registry as the source of truth. It does not introduce a v2 registry.

## Migrated commands

Full migrated safety subtrees:

- `api`: mutating REST verbs, `api http request`, auth/keychain mutation paths.
- `deps`: install/update/stack apply mutation paths.
- `file`: write/delete/mkdir/rename/apply, edit dry-run, copy/sync mutation paths.
- `fleet`: exec operator/apply/check/lab notes, config mutation paths.
- `server`: server and key operator mutation paths.

Follow-up candidates for the same descriptor pattern:

- `project`, `component`, `config`, `extension`, `runner`, `worktree`, `stack`, `runs`, `agent-task`, `rig`, `tunnel`, `git`, `review`, `refactor`.
- Output routing and lab portability still have remaining parallel `Commands::*` match arms; #7516 can move those into the same descriptor once command-specific raw/markdown special cases are modeled.

## LOC / drift reduction

- Deleted 72 lines of duplicated hand-maintained safety match arms from `safety_manifest`.
- Added the reusable path descriptor primitive plus the migrated declarations in `spec`.
- Total PR diff is +95 LOC because this is the first slice adding the descriptor primitive; future migrations should be net-negative without adding another primitive.

## Identical-output proof

Generated `cargo run --quiet -- contract manifest` from current `origin/main` and this branch, parsed both JSON outputs, and compared the migrated top-level entries structurally.

Result: identical entries for `api`, `deps`, `file`, `fleet`, and `server`.

## Verification

- `cargo check --all-targets`
- `~/.cargo/bin/cargo-nextest nextest run --lib -E 'test(command_contract) or test(cli) or test(registry) or test(manifest) or test(contract)' --no-fail-fast`\n- `cargo run --quiet -- contract manifest`\n- Manifest diff proof against `origin/main`: `api`, `deps`, `file`, `fleet`, `server` identical after JSON parse.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)\n- **Used for:** Consolidated per-command registration into a single declarative descriptor; Chris reviews and owns the change.\n