### PR TITLE
Clarify runner version alignment remediation

### DIFF
--- a/src/commands/runner/doctor/checks.rs
+++ b/src/commands/runner/doctor/checks.rs
@@ -144,13 +144,14 @@ pub fn homeboy_version_skew_check(
     let mut details = BTreeMap::new();
     details.insert("local_version".to_string(), local_version.to_string());
     details.insert("remote_version".to_string(), remote_version.to_string());
+    let quoted_runner_id = shell::quote_arg(runner_id);
     Some(warning_with_details(
         "homeboy.version_skew",
         format!(
             "Local Homeboy {local_version} differs from remote runner Homeboy {remote_version}"
         ),
         Some(format!(
-            "Upgrade Homeboy on runner `{runner_id}` to match the local client; for example: `homeboy ssh {server_id} -- homeboy upgrade --no-restart`, or rerun the runner setup/upgrade workflow"
+            "Align runner `{runner_id}` to this controller with `homeboy runner refresh-homeboy {quoted_runner_id} --ref v{local_version} --reconnect`; if that fails, inspect the remote runner with `homeboy ssh {server_id} -- homeboy --version`"
         )),
         details,
     ))

--- a/src/commands/runner/doctor/mod.rs
+++ b/src/commands/runner/doctor/mod.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use homeboy::core::agent_tasks::provider::{
     AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
 };
+use homeboy::core::engine::shell;
 use homeboy::core::runners::{
     self as runner, Runner, RunnerKind, RunnerToolRegistry, RunnerToolSpec, RunnerTunnelMode,
 };

--- a/src/commands/runner/doctor/tests/homeboy_path.rs
+++ b/src/commands/runner/doctor/tests/homeboy_path.rs
@@ -151,8 +151,7 @@ fn homeboy_version_skew_check_warns_for_different_versions() {
         check.details.get("remote_version").map(String::as_str),
         Some("0.197.7")
     );
-    assert!(check
-        .remediation
-        .as_deref()
-        .is_some_and(|value| value.contains("homeboy ssh lab -- homeboy upgrade")));
+    assert!(check.remediation.as_deref().is_some_and(
+        |value| value.contains("homeboy runner refresh-homeboy lab --ref v0.198.7 --reconnect")
+    ));
 }

--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -704,7 +704,10 @@ pub(super) fn runner_artifact_feature_diagnostics(
 fn lab_runner_homeboy_refresh_commands(runner_id: &str) -> Vec<String> {
     let runner_arg = shell_arg(runner_id);
     vec![
-        format!("homeboy runner refresh-homeboy {runner_arg} --ref main --reconnect"),
+        format!(
+            "homeboy runner refresh-homeboy {runner_arg} --ref v{} --reconnect",
+            env!("CARGO_PKG_VERSION")
+        ),
         format!("homeboy runner disconnect {runner_arg}"),
         format!("homeboy runner connect {runner_arg}"),
     ]
@@ -724,7 +727,10 @@ pub(super) fn runner_followups(runner_id: Option<&str>) -> Vec<LabFollowup> {
         },
         LabFollowup {
             label: "refresh_homeboy".to_string(),
-            command: format!("homeboy runner refresh-homeboy {runner_arg} --ref main --reconnect"),
+            command: format!(
+                "homeboy runner refresh-homeboy {runner_arg} --ref v{} --reconnect",
+                env!("CARGO_PKG_VERSION")
+            ),
             purpose: "Materialize a clean runner-side Homeboy binary, select it for Lab jobs, and refresh the daemon session.".to_string(),
         },
         LabFollowup {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1482,7 +1482,10 @@ mod tests {
         assert_eq!(
             warning.recovery_commands,
             vec![
-                "homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect".to_string(),
+                format!(
+                    "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
+                    env!("CARGO_PKG_VERSION")
+                ),
                 "homeboy runner disconnect homeboy-lab".to_string(),
                 "homeboy runner connect homeboy-lab".to_string(),
             ]

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -719,8 +719,9 @@ fn dev_sync_followups(runner_id: &str, reconnect: bool) -> Vec<String> {
 fn dev_sync_next_actions(runner_id: &str, reconnect: bool) -> Vec<String> {
     let mut actions = refresh_followups(runner_id, reconnect);
     actions.push(format!(
-        "homeboy runner refresh-homeboy {} --ref main --reconnect",
-        shell_arg(runner_id)
+        "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
+        shell_arg(runner_id),
+        env!("CARGO_PKG_VERSION")
     ));
     actions
 }

--- a/src/core/runner/lab/offload/metadata.rs
+++ b/src/core/runner/lab/offload/metadata.rs
@@ -201,10 +201,7 @@ pub(crate) fn lab_runner_homeboy_metadata(
     let controller_version = env!("CARGO_PKG_VERSION");
     let controller_build_identity = crate::core::build_identity::current().display;
     let refresh_commands = vec![
-        format!(
-            "homeboy runner refresh-homeboy {} --ref main --reconnect",
-            shell::quote_arg(runner_id)
-        ),
+        runner_homeboy_align_to_controller_command(runner_id),
         format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
         format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
     ];
@@ -385,8 +382,15 @@ pub(crate) fn lab_runner_homeboy_compatible_drift_warning(
         .as_ref()
         .map(|session| session.homeboy_version.as_str())
         .unwrap_or("<unknown>");
+    let remediation = runner_homeboy_align_to_controller_command(
+        status
+            .session
+            .as_ref()
+            .map(|session| session.runner_id.as_str())
+            .unwrap_or("<runner-id>"),
+    );
     Some(format!(
-        "Lab offload: runner reports Homeboy `{runner_version}` while the controller is `{controller_version}`; same MAJOR.MINOR (patch drift only) is wire-compatible, proceeding. Set runner setting `require_exact_homeboy_version` or export `{REQUIRE_EXACT_RUNNER_VERSION_ENV}=1` to enforce exact-match."
+        "Lab offload: runner reports Homeboy `{runner_version}` while the controller is `{controller_version}`; same MAJOR.MINOR (patch drift only) is wire-compatible, proceeding. Align the runner with `{remediation}`. Set runner setting `require_exact_homeboy_version` or export `{REQUIRE_EXACT_RUNNER_VERSION_ENV}=1` to enforce exact-match."
     ))
 }
 
@@ -430,12 +434,7 @@ fn runner_homeboy_primary_remediation_command(
     runner_homeboy_refresh_commands(runner_id, status)
         .into_iter()
         .next()
-        .unwrap_or_else(|| {
-            format!(
-                "homeboy runner refresh-homeboy {} --ref main --reconnect",
-                shell::quote_arg(runner_id)
-            )
-        })
+        .unwrap_or_else(|| runner_homeboy_align_to_controller_command(runner_id))
 }
 
 fn runner_homeboy_topology_recovery_command(
@@ -662,7 +661,7 @@ pub(crate) fn stale_runner_homeboy_error(
     ));
     tried.extend([
         format!("Reconnect runner `{runner_id}` before retrying Lab offload: {refresh}"),
-        format!("If the runner binary itself is stale, refresh or select a clean runner binary with `homeboy runner refresh-homeboy {} --ref main --reconnect`.", shell::quote_arg(runner_id)),
+        format!("If the runner binary itself is stale, refresh or select a clean runner binary with `{}`.", runner_homeboy_align_to_controller_command(runner_id)),
         "Use --force-hot --allow-local-hot only if you intentionally want to bypass Lab offload and run locally.".to_string(),
     ]);
     Error::validation_invalid_argument(
@@ -688,13 +687,18 @@ pub(crate) fn runner_homeboy_refresh_commands(
         return commands;
     }
     vec![
-        format!(
-            "homeboy runner refresh-homeboy {} --ref main --reconnect",
-            shell::quote_arg(runner_id)
-        ),
+        runner_homeboy_align_to_controller_command(runner_id),
         format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
         format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
     ]
+}
+
+pub(crate) fn runner_homeboy_align_to_controller_command(runner_id: &str) -> String {
+    format!(
+        "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
+        shell::quote_arg(runner_id),
+        env!("CARGO_PKG_VERSION")
+    )
 }
 
 pub(crate) fn runner_session_homeboy_display(

--- a/src/core/runner/lab/offload/tests/capability_metadata.rs
+++ b/src/core/runner/lab/offload/tests/capability_metadata.rs
@@ -285,7 +285,10 @@ fn lab_runner_homeboy_metadata_names_binary_and_refresh_path() {
     assert_eq!(
         metadata["refresh_commands"],
         serde_json::json!([
-            "homeboy runner refresh-homeboy 'homeboy lab' --ref main --reconnect",
+            format!(
+                "homeboy runner refresh-homeboy 'homeboy lab' --ref v{} --reconnect",
+                env!("CARGO_PKG_VERSION")
+            ),
             "homeboy runner disconnect 'homeboy lab'",
             "homeboy runner connect 'homeboy lab'"
         ])
@@ -320,10 +323,12 @@ fn runner_homeboy_version_drift_blocks_offload_with_upgrade_guidance() {
         .contains("connected runner daemon reports Homeboy version `homeboy 0.0.0`"));
     assert!(err.message.contains(env!("CARGO_PKG_VERSION")));
     let tried = err.details["tried"].as_array().expect("tried hints");
-    assert!(tried
-        .iter()
-        .any(|hint| hint.as_str().is_some_and(|hint| hint
-            .contains("homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect"))));
+    assert!(tried.iter().any(
+        |hint| hint.as_str().is_some_and(|hint| hint.contains(&format!(
+            "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
+            env!("CARGO_PKG_VERSION")
+        )))
+    ));
     assert!(tried.iter().any(|hint| hint
         .as_str()
         .is_some_and(|hint| hint.contains("refresh or select a clean runner binary"))));
@@ -372,7 +377,22 @@ fn same_minor_patch_drift_is_compatible_and_proceeds_with_warning() {
     let warning = lab_runner_homeboy_compatible_drift_warning(&status, false)
         .expect("compatible patch drift should warn");
     assert!(warning.contains("wire-compatible"));
+    assert!(warning.contains(&format!(
+        "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
+        env!("CARGO_PKG_VERSION")
+    )));
     assert!(warning.contains("require_exact_homeboy_version"));
+}
+
+#[test]
+fn matching_runner_version_has_no_compatible_drift_warning() {
+    let status = status_with_runner_version("homeboy-lab", env!("CARGO_PKG_VERSION"));
+
+    assert_eq!(
+        classify_runner_homeboy_version_drift(&status),
+        RunnerHomeboyVersionDrift::None
+    );
+    assert!(lab_runner_homeboy_compatible_drift_warning(&status, false).is_none());
 }
 
 #[test]
@@ -461,7 +481,10 @@ fn older_runner_than_controller_points_to_runner_refresh_first() {
     let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
     assert_eq!(
         metadata["primary_remediation_command"],
-        "homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect"
+        format!(
+            "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
+            env!("CARGO_PKG_VERSION")
+        )
     );
 
     let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
@@ -469,8 +492,10 @@ fn older_runner_than_controller_points_to_runner_refresh_first() {
     assert!(tried
         .first()
         .and_then(|hint| hint.as_str())
-        .is_some_and(|hint| hint
-            .contains("homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect")));
+        .is_some_and(|hint| hint.contains(&format!(
+            "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect",
+            env!("CARGO_PKG_VERSION")
+        ))));
 }
 
 #[test]
@@ -655,10 +680,12 @@ fn stale_runner_homeboy_error_blocks_offload_with_reconnect_guidance() {
         .is_some_and(|hint| hint.contains(
             "homeboy runner refresh-homeboy 'homeboy lab' --select /home/user/Developer/_lab_workspaces/homeboy-post-4583-proof/target/debug/homeboy --reconnect"
         )));
-    assert!(tried
-        .iter()
-        .any(|hint| hint.as_str().is_some_and(|hint| hint
-            .contains("homeboy runner refresh-homeboy 'homeboy lab' --ref main --reconnect"))));
+    assert!(tried.iter().any(
+        |hint| hint.as_str().is_some_and(|hint| hint.contains(&format!(
+            "homeboy runner refresh-homeboy 'homeboy lab' --ref v{} --reconnect",
+            env!("CARGO_PKG_VERSION")
+        )))
+    ));
     assert!(tried.iter().any(|hint| hint
         .as_str()
         .is_some_and(|hint| hint.contains("refresh or select a clean runner binary"))));
@@ -728,7 +755,10 @@ fn runner_homeboy_metadata_carries_stale_daemon_details() {
     assert_eq!(
         metadata["refresh_commands"],
         serde_json::json!([
-            "homeboy runner refresh-homeboy lab --ref main --reconnect",
+            format!(
+                "homeboy runner refresh-homeboy lab --ref v{} --reconnect",
+                env!("CARGO_PKG_VERSION")
+            ),
             "homeboy runner disconnect lab",
             "homeboy runner connect lab"
         ])

--- a/src/core/runner/lab/provider_preflight.rs
+++ b/src/core/runner/lab/provider_preflight.rs
@@ -531,8 +531,9 @@ fn refresh_command(runner_id: &str, runner_homeboy: &serde_json::Value) -> Strin
         })
         .unwrap_or_else(|| {
             format!(
-                "homeboy runner refresh-homeboy {} --ref main --reconnect",
-                shell::quote_arg(runner_id)
+                "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
+                shell::quote_arg(runner_id),
+                env!("CARGO_PKG_VERSION")
             )
         })
 }

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::daemon::DaemonFreshnessReport;
 
+use crate::core::engine::shell;
 use crate::core::redaction::redact_argv_display;
 
 use crate::core::api_jobs::{ActiveRunnerJobSummary, Job, JobArtifactMetadata, JobStatus};
@@ -569,7 +570,7 @@ impl RunnerStaleDaemonWarning {
         session_homeboy_build_identity: Option<String>,
         current_homeboy_build_identity: Option<String>,
     ) -> Self {
-        let recovery_commands = vec![
+        let recovery_commands = [
             format!("homeboy runner disconnect {}", runner_id),
             format!("homeboy runner connect {}", runner_id),
         ];
@@ -588,9 +589,13 @@ impl RunnerStaleDaemonWarning {
             stale_runtime_paths: Vec::new(),
             changed_runtime_paths: Vec::new(),
             recovery_commands: vec![
-                format!("homeboy runner refresh-homeboy {} --ref main --reconnect", runner_id),
-                format!("homeboy runner disconnect {}", runner_id),
-                format!("homeboy runner connect {}", runner_id),
+                format!(
+                    "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
+                    shell::quote_arg(runner_id),
+                    env!("CARGO_PKG_VERSION")
+                ),
+                format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
+                format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
             ],
         }
     }


### PR DESCRIPTION
## Summary
- replace partial runner-version drift remediation with a single controller-version alignment command
- surface the same `homeboy runner refresh-homeboy <runner> --ref v<controller-version> --reconnect` command from runner doctor, Lab offload metadata/errors, runner status follow-ups, and compatible patch-drift warnings
- keep managed toolchain/cache alignment out of Homeboy core; extension-specific caches remain extension-owned

## Reliability papercut
Offloaded jobs can run on a runner Homeboy binary that differs from the local controller. Detection already existed, but fixing drift was a manual multi-step footgun and some guidance pointed at latest/main or runner-local upgrade instead of deliberately aligning the runner to the controller version.

## Why generic
This only compares and remediates Homeboy controller/runner binary drift. It does not mention wp-codebox or any managed toolchain cache; extension/toolchain cache refresh remains in the extension layer.

## Tests
- `cargo test homeboy_version_skew_check`
- `cargo test runner_homeboy` (relevant unit group passed before command timeout while Cargo continued enumerating integration harnesses)
- `cargo test same_minor_patch_drift`
- `cargo test matching_runner_version`
- `cargo test older_runner_than_controller`
- `cargo build`
- `cargo clippy --all-targets` (passes with existing warnings)

Note: `cargo clippy --all-targets -- -D warnings` is not green on current main because of unrelated repo-wide lint warnings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode with GPT-5.5 (`openai/gpt-5.5`); requested disclosure context: Claude Fable 5 orchestrator + GPT-5.5 subagents
- **Used for:** Diagnosing the fleet version-alignment papercut, implementing the remediation text/warning updates, and running scoped verification
