### PR TITLE
Pass release package source path to extensions

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -670,7 +670,7 @@ pub(super) fn build_action_env(
     let component_path =
         crate::core::engine::text::json_path_str(payload, &["release", "local_path"]);
 
-    build_exec_env(
+    let mut env = build_exec_env(
         extension_id,
         project_id,
         component_id,
@@ -679,7 +679,16 @@ pub(super) fn build_action_env(
         project_base_path,
         None,
         component_path,
-    )
+    );
+    if let Some(source_path) =
+        crate::core::engine::text::json_path_str(payload, &["release", "source_path"])
+    {
+        env.push((
+            "HOMEBOY_RELEASE_SOURCE_PATH".to_string(),
+            source_path.to_string(),
+        ));
+    }
+    env
 }
 
 pub(super) fn execute_extension_command(

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -104,6 +104,7 @@ pub(super) fn execute_release_plan_step(
                 &mut context.state,
                 context.component_id,
                 &context.component.local_path,
+                None,
                 context.options.skip_build_validation,
             )
             .unwrap_or_else(|err| failed_result("package", "package", err)),

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -409,7 +409,7 @@ fn should_amend_release_commit(local_path: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::package::store_artifacts_from_output;
-    use super::{github_release, run_cleanup, run_package};
+    use super::{github_release, package_preflight, run_cleanup, run_package};
     use crate::core::component::Component;
     use crate::core::deploy::release_download::GitHubRepo;
     use crate::core::extension::ExtensionManifest;
@@ -768,6 +768,7 @@ mod tests {
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
+                None,
                 false,
             )
             .expect("package step");
@@ -858,6 +859,7 @@ mod tests {
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
+                None,
                 false,
             )
             .expect("package step");
@@ -891,6 +893,7 @@ mod tests {
                 &mut state,
                 "intelligence-horse-theme",
                 &component.path().to_string_lossy(),
+                None,
                 false,
             )
             .expect("package step");
@@ -900,6 +903,62 @@ mod tests {
             assert_eq!(
                 state.artifacts[0].path,
                 "build/intelligence-horse-theme.zip"
+            );
+        });
+    }
+
+    #[test]
+    fn package_preflight_payload_distinguishes_staging_path_from_source_path() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir().expect("component tempdir");
+            std::fs::write(component.path().join("fixture.php"), "<?php\n")
+                .expect("component file");
+            let payload_out = component.path().join("package-payload.json");
+            let source_env_out = component.path().join("release-source-env.txt");
+            let component_env_out = component.path().join("component-env.txt");
+            let package = release_package_extension(
+                "wordpress",
+                &format!(
+                    "printf '%s' \"$HOMEBOY_SETTINGS_JSON\" > '{}'; \
+                     printf '%s' \"${{HOMEBOY_RELEASE_SOURCE_PATH:-}}\" > '{}'; \
+                     printf '%s' \"$HOMEBOY_COMPONENT_PATH\" > '{}'; \
+                     mkdir -p build; printf artifact > build/fixture.zip; \
+                     printf '[{{\"path\":\"build/fixture.zip\",\"type\":\"archive\"}}]'",
+                    payload_out.display(),
+                    source_env_out.display(),
+                    component_env_out.display()
+                ),
+            );
+            crate::core::extension::save_manifest(&package).expect("save package extension");
+
+            let result = package_preflight::run_package_preflight(
+                &[package],
+                "fixture",
+                &component.path().to_string_lossy(),
+                false,
+            )
+            .expect("package preflight");
+
+            assert_eq!(result.status, ReleaseStepStatus::Success);
+            let payload: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(&payload_out).expect("payload output"),
+            )
+            .expect("payload json");
+            assert_eq!(
+                payload["release"]["source_path"].as_str(),
+                Some(component.path().to_string_lossy().as_ref())
+            );
+            assert_ne!(
+                payload["release"]["local_path"].as_str(),
+                payload["release"]["source_path"].as_str()
+            );
+            assert_eq!(
+                std::fs::read_to_string(&source_env_out).expect("source env"),
+                component.path().to_string_lossy()
+            );
+            assert_eq!(
+                std::fs::read_to_string(&component_env_out).expect("component env"),
+                payload["release"]["local_path"].as_str().unwrap()
             );
         });
     }
@@ -925,6 +984,7 @@ mod tests {
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
+                None,
                 false,
             )
             .expect_err("failing package provider should fail the step");
@@ -961,6 +1021,7 @@ mod tests {
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
+                None,
                 false,
             )
             .expect_err("persistently failing package should fail after retry");
@@ -1011,6 +1072,7 @@ mod tests {
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
+                None,
                 false,
             )
             .expect("retry after transient failure should succeed");

--- a/src/core/release/executor/package.rs
+++ b/src/core/release/executor/package.rs
@@ -27,6 +27,7 @@ pub(crate) fn run_package(
     state: &mut ReleaseState,
     component_id: &str,
     component_local_path: &str,
+    component_source_path: Option<&str>,
     skip_build_validation: bool,
 ) -> Result<ReleaseStepResult> {
     let package_extensions: Vec<&ExtensionManifest> = extensions
@@ -52,6 +53,7 @@ pub(crate) fn run_package(
             state,
             component_id,
             component_local_path,
+            component_source_path,
             extra_config.as_ref(),
         );
         let response = run_package_action_with_retry(&extension.id, &payload)
@@ -209,7 +211,7 @@ pub(crate) fn run_extension_release_preflight(
         );
     }
 
-    let payload = build_release_payload(state, component_id, component_local_path, None);
+    let payload = build_release_payload(state, component_id, component_local_path, None, None);
     let response =
         match extension::execute_action(extension_id, action_id, None, None, Some(&payload)) {
             Ok(response) => response,
@@ -279,6 +281,7 @@ pub(crate) fn build_release_payload(
     state: &ReleaseState,
     component_id: &str,
     component_local_path: &str,
+    component_source_path: Option<&str>,
     extra_config: Option<&std::collections::HashMap<String, serde_json::Value>>,
 ) -> serde_json::Value {
     let version = state.version.clone().unwrap_or_default();
@@ -295,6 +298,12 @@ pub(crate) fn build_release_payload(
             "artifacts": state.artifacts,
         }
     });
+
+    if let Some(source_path) = component_source_path {
+        if source_path != component_local_path {
+            payload["release"]["source_path"] = serde_json::Value::String(source_path.to_string());
+        }
+    }
 
     if let Some(config) = extra_config {
         if !config.is_empty() {

--- a/src/core/release/executor/package_preflight.rs
+++ b/src/core/release/executor/package_preflight.rs
@@ -31,6 +31,7 @@ pub(crate) fn run_package_preflight(
         &mut state,
         component_id,
         &temp_component_path.to_string_lossy(),
+        Some(component_local_path),
         skip_build_validation,
     );
 

--- a/src/core/release/executor/prepare.rs
+++ b/src/core/release/executor/prepare.rs
@@ -27,7 +27,7 @@ pub(crate) fn run_prepare(
         ));
     }
 
-    let payload = build_release_payload(state, component_id, component_local_path, None);
+    let payload = build_release_payload(state, component_id, component_local_path, None, None);
     let mut responses = Vec::new();
 
     for extension in providers {

--- a/src/core/release/executor/publish.rs
+++ b/src/core/release/executor/publish.rs
@@ -47,6 +47,7 @@ pub(crate) fn run_publish(
         state,
         component_id,
         component_local_path,
+        None,
         extra_config.as_ref(),
     );
     let response = extension::execute_action(&extension.id, action_id, None, None, Some(&payload))?;

--- a/src/core/release/package_recovery.rs
+++ b/src/core/release/package_recovery.rs
@@ -51,6 +51,7 @@ pub fn package_existing_tag(
         &mut state,
         component_id,
         &component.local_path,
+        None,
         skip_build_validation,
     )?;
     if state.artifacts.is_empty() {


### PR DESCRIPTION
## Summary
- Add a generic release.source_path payload field when package preflight validates a temporary component copy.
- Export HOMEBOY_RELEASE_SOURCE_PATH for release action handlers.
- Keep release.local_path as the package/staging path and normal releases unchanged.
- Add regression coverage proving preflight distinguishes staging path, source path, and HOMEBOY_COMPONENT_PATH.

## Verification
- cargo fmt --check
- cargo test package_preflight_payload_distinguishes_staging_path_from_source_path --lib
- cargo test run_package_passes_component_id_from_release_payload_to_action_env --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the release package env/payload contract, implemented the core source-path propagation, and added regression coverage.