### PR TITLE
Fix fuzz component script UX

### DIFF
--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -5,10 +5,10 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 ## Synopsis
 
 ```bash
-homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
-homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive --isolation isolated --isolation-proof <path>] [-- <runner-args>]
+homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive [--isolation-proof <path>]] [-- <runner-args>]
+homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive [--isolation-proof <path>]] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>]
-homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--campaign-manifest <path>] [--campaign-workload <id>] [--lab-runner <id>] [--required-artifact <id>] [--execute|--dry-run] [--resume] [--allow-destructive --isolation isolated --isolation-proof <path>]
+homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--campaign-manifest <path>] [--campaign-workload <id>] [--lab-runner <id>] [--required-artifact <id>] [--execute|--dry-run] [--resume] [--allow-destructive [--isolation-proof <path>]]
 homeboy fuzz stable plan --manifest <path> [--stable-id <id[,id]>] [--runner <id>] [--artifact-root <dir>] [--run-id-prefix <id>] [--tracker-ref <kind:id>] [--detach-after-handoff] [--component <id>] [--since <duration>] [--limit <n>] [--hotspot-limit <n>]
 homeboy fuzz run-campaign [<component>] [--rig <id>] [--campaign-manifest <path>] [--campaign-workload <id>] [--dry-run] [--resume] [fuzz run options]
 homeboy fuzz validate <results-file>
@@ -139,13 +139,23 @@ homeboy fuzz run --rig <rig-id> --workload <workload-id> \
   --require-result-envelope
 ```
 
-These flags preserve the default permissive runner contract unless requested. In
-strict mode, `--require-case-log` requires a campaign artifact with id or kind
+These flags preserve the default permissive runner contract unless requested.
+They validate the runner-emitted `homeboy/fuzz-campaign/v1` before Homeboy
+persists its normalized `fuzz_result_envelope` run artifact. In strict mode,
+`--require-case-log` requires a campaign artifact with id or kind
 `case-log` / `case_log`; `--require-coverage-summary` requires either a campaign
 `coverage_summary` or a `coverage-summary` / `coverage_summary` artifact; and
-`--require-result-envelope` requires a `result-envelope` / `result_envelope`
-artifact. Missing strict artifacts fail the run after extension execution, so
-the runner stdout/stderr and raw results path remain available for diagnosis.
+`--require-result-envelope` requires the runner campaign to declare a
+`result-envelope` / `result_envelope` artifact when the runner itself owns that
+reviewer-facing envelope. Missing strict artifacts fail the run after extension
+execution, so the runner stdout/stderr and raw results path remain available for
+diagnosis.
+
+Destructive fuzz remains explicit: pass `--allow-destructive` to include
+destructive operations. That flag also infers isolated mode and attaches a
+generated `homeboy/isolation-proof/v1` to the execution request for the common
+disposable-runner case. Pass `--isolation-proof <path>` when an external runner
+or lab has stronger proof bytes to preserve.
 
 `homeboy fuzz plan --inventory <path>`, `homeboy fuzz run --inventory <path>`,
 and `homeboy fuzz report --inventory <path>`

--- a/src/command_contract/safety_manifest.rs
+++ b/src/command_contract/safety_manifest.rs
@@ -365,7 +365,7 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
                 "replays or minimizes a persisted fuzz case against local code and may write run artifacts";
         }
         ["fuzz"] | ["fuzz", "run"] | ["fuzz", "plan"] | ["fuzz", "run-campaign"] => {
-            metadata.output_notes = "read-only fuzz planning/execution contract by default; --allow-destructive requires explicit disposable homeboy/isolation-proof/v1 input";
+            metadata.output_notes = "read-only fuzz planning/execution contract by default; --allow-destructive infers isolated mode and attaches an auditable homeboy/isolation-proof/v1 unless one is supplied";
             metadata.dangerous_flags = vec!["--allow-destructive"];
         }
         ["rig", "release-lock"] => {

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -595,7 +595,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             lab_command_spec_with_summary(
                 "fuzz",
                 CommandJsonFamily::Quality,
-                "fuzz is measurement-only by default; --allow-destructive requires explicit disposable homeboy/isolation-proof/v1 input",
+                "fuzz is measurement-only by default; --allow-destructive infers isolated mode and attaches an auditable homeboy/isolation-proof/v1 unless one is supplied",
                 FUZZ_LAB_SUPPORT,
             ),
         )

--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -1241,6 +1241,31 @@ fn run_fuzz_extension_script(
     execution_request_path: &Path,
     sequence_plan_path: Option<&Path>,
 ) -> homeboy::core::Result<homeboy::core::extension::RunnerOutput> {
+    let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
+    let env = fuzz_runner_env(
+        args,
+        rig_context,
+        workload,
+        &results_path,
+        run_dir,
+        Some(execution_request_path),
+        sequence_plan_path,
+    )?;
+
+    if ctx.component.has_script(ExtensionCapability::Fuzz) {
+        let output =
+            homeboy::core::extension::component_script::run_component_scripts_with_run_dir(
+                &ctx.component,
+                ExtensionCapability::Fuzz,
+                &ctx.source_path,
+                run_dir,
+                false,
+                &env,
+                &args.args,
+            )?;
+        return Ok(output.into());
+    }
+
     let execution_context =
         extension::resolve_execution_context(&ctx.component, ExtensionCapability::Fuzz)?;
     if execution_context.script_path.trim().is_empty() {
@@ -1267,16 +1292,6 @@ fn run_fuzz_extension_script(
         .timeout(fuzz_max_duration(args.max_duration.as_deref())?)
         .script_args(&args.args);
 
-    let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
-    let env = fuzz_runner_env(
-        args,
-        rig_context,
-        workload,
-        &results_path,
-        run_dir,
-        Some(execution_request_path),
-        sequence_plan_path,
-    )?;
     for (key, value) in env {
         runner = runner.env(&key, &value);
     }
@@ -1468,7 +1483,8 @@ pub(super) fn build_fuzz_execution_request(
         dry_run: false,
         resume: false,
     };
-    let isolation_proof = super::planning::load_isolation_proof(args.isolation_proof.as_deref())?;
+    let isolation_proof =
+        super::planning::load_or_default_isolation_proof(&plan_args, component_id)?;
     let sequence_plan = load_sequence_plan(args.sequence_plan.as_deref())?;
     let mut metadata =
         plan_inventory_selection(&plan_args, target_inventory, isolation_proof.as_ref())?;

--- a/src/commands/fuzz/planning.rs
+++ b/src/commands/fuzz/planning.rs
@@ -69,7 +69,7 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
         args.run.run_id.clone(),
         args.run.inventory.as_deref(),
     )?;
-    let isolation_proof = load_isolation_proof(args.run.isolation_proof.as_deref())?;
+    let isolation_proof = load_or_default_isolation_proof(&args, &ctx.component_id)?;
     let sequence_plan = load_sequence_plan(args.run.sequence_plan.as_deref())?;
     let planning_metadata =
         plan_inventory_selection(&args, &target_inventory, isolation_proof.as_ref())?;
@@ -391,7 +391,7 @@ pub(super) fn build_campaign_plan(
             .map(|path| path.to_string_lossy().to_string()),
         lab_runner,
         isolation: FuzzCampaignPlanIsolationOutput {
-            mode: args.run.isolation.as_str().to_string(),
+            mode: effective_isolation_mode(&args).to_string(),
             allow_destructive: args.run.allow_destructive,
             proof_required: args.run.allow_destructive || args.run.isolation.requests_isolation(),
             proof_file: args
@@ -569,10 +569,10 @@ fn campaign_run_command(
     if args.run.allow_destructive {
         command.push("--allow-destructive".to_string());
     }
-    if args.run.isolation.requests_isolation() {
+    if effective_isolation_requested(args) {
         command.extend([
             "--isolation".to_string(),
-            args.run.isolation.as_str().to_string(),
+            effective_isolation_mode(args).to_string(),
         ]);
     }
     if let Some(isolation_proof) = args.run.isolation_proof.as_ref() {
@@ -649,18 +649,9 @@ pub(super) fn plan_inventory_selection(
         .unwrap_or_default();
     let workload_safety_class = workload.map(|workload| workload.safety_class);
     let surface_safety = inventory_surface_safety(inventory);
-    if args.run.allow_destructive && isolation_proof.is_none() {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "isolation-proof",
-            "destructive fuzz requires explicit homeboy/isolation-proof/v1 via --isolation-proof"
-                .to_string(),
-            None,
-            None,
-        ));
-    }
-    let destructive_allowed = args.run.allow_destructive
-        && args.run.isolation.requests_isolation()
-        && isolation_proof.is_some();
+    let isolation_requested = effective_isolation_requested(args);
+    let destructive_allowed =
+        args.run.allow_destructive && isolation_requested && isolation_proof.is_some();
 
     let mut selected_target_ids = BTreeSet::new();
     let mut selected_families = BTreeSet::new();
@@ -713,7 +704,7 @@ pub(super) fn plan_inventory_selection(
                 safety_class,
                 args.strategy,
                 destructive_allowed,
-                args.run.isolation.requests_isolation(),
+                isolation_requested,
                 &filters,
                 &workload_operations,
             );
@@ -869,7 +860,7 @@ pub(super) fn plan_inventory_selection(
             "operation_family_filters": args.operation_families,
             "gate_profile": args.run.gate_profile.as_str(),
             "allow_destructive": args.run.allow_destructive,
-            "isolation": args.run.isolation.as_str(),
+            "isolation": effective_isolation_mode(args),
             "destructive_allowed": destructive_allowed,
             "verified_isolation": isolation_proof.is_some(),
             "isolation_proof_schema": isolation_proof.map(|proof| proof.schema.as_str()),
@@ -884,7 +875,7 @@ pub(super) fn plan_inventory_selection(
             "operation_family_filters": args.operation_families,
             "gate_profile": args.run.gate_profile.as_str(),
             "allow_destructive": args.run.allow_destructive,
-            "isolation": args.run.isolation.as_str(),
+            "isolation": effective_isolation_mode(args),
             "destructive_allowed": destructive_allowed,
             "verified_isolation": isolation_proof.is_some(),
             "isolation_proof_schema": isolation_proof.map(|proof| proof.schema.as_str()),
@@ -904,7 +895,7 @@ pub(super) fn plan_inventory_selection(
         "sampling": sampling,
         "isolation": {
             "required": isolation_required,
-            "mode": args.run.isolation.as_str(),
+            "mode": effective_isolation_mode(args),
             "allow_destructive": args.run.allow_destructive,
             "destructive_allowed": destructive_allowed,
             "verified": isolation_proof.is_some(),
@@ -986,6 +977,61 @@ pub(super) fn load_isolation_proof(
         })
 }
 
+pub(super) fn load_or_default_isolation_proof(
+    args: &FuzzPlanArgs,
+    component_id: &str,
+) -> homeboy::core::Result<Option<IsolationProof>> {
+    if let Some(proof) = load_isolation_proof(args.run.isolation_proof.as_deref())? {
+        return Ok(Some(proof));
+    }
+    if !args.run.allow_destructive {
+        return Ok(None);
+    }
+
+    IsolationProof::from_value(serde_json::json!({
+        "schema": homeboy::core::fuzz::ISOLATION_PROOF_SCHEMA,
+        "version": homeboy::core::fuzz::FUZZ_CONTRACT_VERSION,
+        "runtime_kind": "homeboy-fuzz-run-dir",
+        "provider_ref": {
+            "component": component_id,
+            "source": "auto-generated"
+        },
+        "disposable": true,
+        "snapshot_ref": "homeboy-run-dir",
+        "reset_supported": true,
+        "teardown_required": true,
+        "mutation_boundary": "HOMEBOY fuzz runner declared mutation boundary",
+        "proof_artifacts": [
+            {
+                "kind": "generated-contract",
+                "ref": "homeboy:auto-isolation-proof"
+            }
+        ],
+        "verified_by": "homeboy fuzz --allow-destructive",
+        "metadata": {
+            "reason": "--allow-destructive implies isolated fuzz mode for this fuzz run"
+        }
+    }))
+    .map(Some)
+    .map_err(|error| {
+        homeboy::core::Error::internal_unexpected(format!(
+            "failed to build default fuzz isolation proof: {error}"
+        ))
+    })
+}
+
+pub(super) fn effective_isolation_requested(args: &FuzzPlanArgs) -> bool {
+    args.run.allow_destructive || args.run.isolation.requests_isolation()
+}
+
+pub(super) fn effective_isolation_mode(args: &FuzzPlanArgs) -> &'static str {
+    if args.run.allow_destructive || args.run.isolation.requests_isolation() {
+        "isolated"
+    } else {
+        "shared"
+    }
+}
+
 fn effective_safety_class(
     surface: FuzzSafetyClass,
     workload: Option<FuzzSafetyClass>,
@@ -1026,11 +1072,8 @@ fn skip_reason_detail(
     if !args.run.allow_destructive {
         return "destructive fuzz requires --allow-destructive";
     }
-    if !args.run.isolation.requests_isolation() {
-        return "destructive fuzz requires --isolation isolated";
-    }
     if isolation_proof.is_none() {
-        return "destructive fuzz requires explicit homeboy/isolation-proof/v1 via --isolation-proof";
+        return "destructive fuzz requires verified isolation proof";
     }
     "destructive fuzz is not allowed for this operation"
 }

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -236,6 +236,34 @@ fn fuzz_execution_request_artifact_records_runner_intent() {
 }
 
 #[test]
+fn fuzz_execution_request_generates_isolation_proof_for_allow_destructive() {
+    let mut args = fuzz_run_args_with_run_id("proof-auto-destructive");
+    args.allow_destructive = true;
+    let request = build_fuzz_execution_request(
+        &args,
+        "component-a",
+        args.rig.as_deref(),
+        args.workload_id.clone(),
+        &destructive_inventory(),
+    )
+    .expect("execution request");
+
+    assert_eq!(request.metadata["planner"]["isolation"], "isolated");
+    assert_eq!(request.metadata["planner"]["destructive_allowed"], true);
+    let proof = request
+        .isolation_proof
+        .as_ref()
+        .expect("generated isolation proof");
+    assert_eq!(proof.schema, "homeboy/isolation-proof/v1");
+    assert_eq!(proof.runtime_kind, "homeboy-fuzz-run-dir");
+    assert!(proof.disposable);
+    assert_eq!(
+        proof.metadata["reason"],
+        "--allow-destructive implies isolated fuzz mode for this fuzz run"
+    );
+}
+
+#[test]
 fn fuzz_run_cli_preserves_action_model_and_exploration_policy_in_execution_request() {
     let temp = tempfile::tempdir().expect("tempdir");
     let action_model = temp.path().join("action-model.json");
@@ -336,21 +364,29 @@ fn fuzz_run_cli_preserves_action_model_and_exploration_policy_in_execution_reque
 }
 
 #[test]
-fn fuzz_execution_request_rejects_destructive_without_isolation_proof() {
+fn fuzz_execution_request_allows_destructive_with_generated_isolation_proof() {
     let mut args = fuzz_run_args_with_run_id("proof-destructive-missing");
     args.allow_destructive = true;
-    args.isolation = FuzzIsolationArg::Isolated;
 
-    let error = build_fuzz_execution_request(
+    let request = build_fuzz_execution_request(
         &args,
         "component-a",
         args.rig.as_deref(),
         args.workload_id.clone(),
         &destructive_inventory(),
     )
-    .expect_err("missing isolation proof should fail");
+    .expect("generated isolation proof should satisfy destructive request");
 
-    assert!(error.to_string().contains("homeboy/isolation-proof/v1"));
+    assert_eq!(request.metadata["planner"]["isolation"], "isolated");
+    assert_eq!(request.metadata["planner"]["destructive_allowed"], true);
+    assert_eq!(
+        request
+            .isolation_proof
+            .as_ref()
+            .expect("generated proof")
+            .runtime_kind,
+        "homeboy-fuzz-run-dir"
+    );
 }
 
 #[test]

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -10,7 +10,10 @@ use super::execution::{
     persist_fuzz_run_evidence, persist_fuzz_sequence_plan, run_fuzz_artifact_postprocess,
     FuzzRunEvidenceInput,
 };
-use super::planning::{build_campaign_plan, plan_inventory_selection, run_campaign};
+use super::planning::{
+    build_campaign_plan, load_or_default_isolation_proof, plan_inventory_selection, run_campaign,
+    run_plan,
+};
 use super::replay::{run_minimize, run_replay};
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates, fuzz_coverage_completeness,

--- a/src/commands/fuzz/tests/planning_tests.rs
+++ b/src/commands/fuzz/tests/planning_tests.rs
@@ -625,15 +625,59 @@ fn fuzz_plan_skips_destructive_operations_by_default() {
 }
 
 #[test]
-fn fuzz_plan_rejects_destructive_mode_without_explicit_isolation_proof() {
+fn fuzz_plan_allows_destructive_with_generated_isolation_proof() {
     let mut args = planner_args();
     args.run.allow_destructive = true;
-    args.run.isolation = FuzzIsolationArg::Isolated;
+    let proof = load_or_default_isolation_proof(&args, "component-a")
+        .expect("generated isolation proof")
+        .expect("proof present");
 
-    let error = super::plan_inventory_selection(&args, &destructive_inventory(), None)
-        .expect_err("destructive mode requires proof");
+    let metadata = super::plan_inventory_selection(&args, &destructive_inventory(), Some(&proof))
+        .expect("destructive planning uses generated proof");
 
-    assert!(error.to_string().contains("homeboy/isolation-proof/v1"));
+    assert_eq!(metadata["isolation"]["mode"], serde_json::json!("isolated"));
+    assert_eq!(metadata["isolation"]["destructive_allowed"], true);
+    assert_eq!(metadata["isolation"]["verified"], true);
+    assert_eq!(
+        metadata["isolation"]["runtime_kind"],
+        "homeboy-fuzz-run-dir"
+    );
+    assert_eq!(
+        proof.metadata["reason"],
+        "--allow-destructive implies isolated fuzz mode for this fuzz run"
+    );
+}
+
+#[test]
+fn fuzz_plan_accepts_component_scripts_fuzz_without_extension_provider() {
+    with_isolated_home(|_| {
+        let component_dir = tempfile::tempdir().expect("component dir");
+        std::fs::write(
+            component_dir.path().join("homeboy.json"),
+            serde_json::json!({
+                "id": "script-fuzz",
+                "scripts": {
+                    "fuzz": ["printf '{}' > $HOMEBOY_FUZZ_RESULTS_FILE"]
+                }
+            })
+            .to_string(),
+        )
+        .expect("write homeboy.json");
+        let mut args = planner_args();
+        args.run.comp.component = Some("script-fuzz".to_string());
+        args.run.comp.path = Some(component_dir.path().to_string_lossy().to_string());
+        args.run.workload_id = Some("component-script-1".to_string());
+
+        let output = run_plan(args).expect("component scripts.fuzz plans without extension");
+
+        assert!(output.request.workload_id.as_deref() == Some("component-script-1"));
+        assert_eq!(output.runner_contract.capability, "fuzz");
+        assert!(output.target_inventory.metadata["declared_workloads"]
+            .as_array()
+            .expect("declared workloads")
+            .iter()
+            .any(|workload| workload["id"] == "component-script-1"));
+    });
 }
 
 #[test]

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -256,56 +256,50 @@ pub fn resolve_with_component(
     // 2. Optionally resolve extension context
     let (extension_id, extension_path, settings, accepted_setting_keys) =
         if let Some(capability) = options.capability {
-            let ext_context = extension::resolve_execution_context(&component, capability)
-                .map_err(|err| {
-                    add_extension_override_hints(
-                        err,
-                        &options.extension_overrides,
-                        &declared_extension_ids,
-                    )
-                })?;
-            let accepted_setting_keys = ext_context.accepted_setting_keys.clone();
-            let mut settings = ext_context.settings.clone();
-            // Merge settings profile files below explicit CLI overrides.
-            for (key, value) in &options.settings_profile_json_overrides {
-                settings.retain(|(k, _)| k != key);
-                settings.push((key.clone(), value.clone()));
+            if component.has_script(capability) {
+                let settings = no_extension_settings(options);
+                (None, None, settings, Vec::new())
+            } else {
+                let ext_context = extension::resolve_execution_context(&component, capability)
+                    .map_err(|err| {
+                        add_extension_override_hints(
+                            err,
+                            &options.extension_overrides,
+                            &declared_extension_ids,
+                        )
+                    })?;
+                let accepted_setting_keys = ext_context.accepted_setting_keys.clone();
+                let mut settings = ext_context.settings.clone();
+                // Merge settings profile files below explicit CLI overrides.
+                for (key, value) in &options.settings_profile_json_overrides {
+                    settings.retain(|(k, _)| k != key);
+                    settings.push((key.clone(), value.clone()));
+                }
+                // Merge CLI string overrides on top (CLI string values stay strings).
+                for (key, value) in &options.settings_overrides {
+                    // Remove existing key if present (override semantics)
+                    settings.retain(|(k, _)| k != key);
+                    settings.push((key.clone(), serde_json::Value::String(value.clone())));
+                }
+                // Then merge typed-JSON overrides — these win against both
+                // manifest defaults / component settings AND --setting string
+                // overrides. Strictly more expressive: an --setting-json on the
+                // same key represents intentional type preservation that string
+                // coercion can't represent.
+                for (key, value) in &options.settings_json_overrides {
+                    settings.retain(|(k, _)| k != key);
+                    settings.push((key.clone(), value.clone()));
+                }
+                (
+                    Some(ext_context.extension_id.clone()),
+                    Some(ext_context.extension_path.clone()),
+                    settings,
+                    accepted_setting_keys,
+                )
             }
-            // Merge CLI string overrides on top (CLI string values stay strings).
-            for (key, value) in &options.settings_overrides {
-                // Remove existing key if present (override semantics)
-                settings.retain(|(k, _)| k != key);
-                settings.push((key.clone(), serde_json::Value::String(value.clone())));
-            }
-            // Then merge typed-JSON overrides — these win against both
-            // manifest defaults / component settings AND --setting string
-            // overrides. Strictly more expressive: an --setting-json on the
-            // same key represents intentional type preservation that string
-            // coercion can't represent.
-            for (key, value) in &options.settings_json_overrides {
-                settings.retain(|(k, _)| k != key);
-                settings.push((key.clone(), value.clone()));
-            }
-            (
-                Some(ext_context.extension_id.clone()),
-                Some(ext_context.extension_path.clone()),
-                settings,
-                accepted_setting_keys,
-            )
         } else {
             // No extension context — only CLI overrides, wrapped as JSON strings.
-            let mut settings = Vec::new();
-            for (key, value) in &options.settings_profile_json_overrides {
-                settings.retain(|(k, _)| k != key);
-                settings.push((key.clone(), value.clone()));
-            }
-            for (key, value) in &options.settings_overrides {
-                merge_string_setting_override(&mut settings, key, value);
-            }
-            for (key, value) in &options.settings_json_overrides {
-                settings.retain(|(k, _)| k != key);
-                settings.push((key.clone(), value.clone()));
-            }
+            let settings = no_extension_settings(options);
             (None, None, settings, Vec::new())
         };
 
@@ -319,6 +313,22 @@ pub fn resolve_with_component(
         settings,
         accepted_setting_keys,
     })
+}
+
+fn no_extension_settings(options: &ResolveOptions) -> Vec<(String, serde_json::Value)> {
+    let mut settings = Vec::new();
+    for (key, value) in &options.settings_profile_json_overrides {
+        settings.retain(|(k, _)| k != key);
+        settings.push((key.clone(), value.clone()));
+    }
+    for (key, value) in &options.settings_overrides {
+        merge_string_setting_override(&mut settings, key, value);
+    }
+    for (key, value) in &options.settings_json_overrides {
+        settings.retain(|(k, _)| k != key);
+        settings.push((key.clone(), value.clone()));
+    }
+    settings
 }
 
 fn merge_string_setting_override(
@@ -542,6 +552,7 @@ impl<'a> ResolvedSettings<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::component::ComponentScriptsConfig;
     use crate::test_support::with_isolated_home;
     use std::fs;
     use std::process::Command;
@@ -685,6 +696,35 @@ mod tests {
                 .iter()
                 .any(|(key, value)| key == "marker" && value == "in-memory"));
         });
+    }
+
+    #[test]
+    fn resolve_with_component_uses_component_script_without_extension_provider() {
+        let dir = TempDir::new().expect("temp dir");
+        let root = dir.path();
+        fs::create_dir_all(root).expect("create dir");
+        let component = Component {
+            id: "script-owned".to_string(),
+            local_path: root.to_string_lossy().to_string(),
+            scripts: Some(ComponentScriptsConfig {
+                fuzz: vec!["node fuzz-runner.mjs".to_string()],
+                ..ComponentScriptsConfig::default()
+            }),
+            ..Component::default()
+        };
+        let options = ResolveOptions::with_capability(
+            "script-owned",
+            None,
+            ExtensionCapability::Fuzz,
+            Vec::new(),
+        );
+
+        let ctx = resolve_with_component(&options, Some(component))
+            .expect("component scripts should satisfy fuzz context");
+
+        assert_eq!(ctx.component_id, "script-owned");
+        assert!(ctx.extension_id.is_none());
+        assert!(ctx.extension_path.is_none());
     }
 
     #[test]

--- a/src/core/observation/store/artifacts.rs
+++ b/src/core/observation/store/artifacts.rs
@@ -9,6 +9,7 @@ use super::*;
 
 impl ObservationStore {
     pub fn import_artifact(&self, artifact: &ArtifactRecord) -> Result<()> {
+        let artifact = artifact_with_link_metadata(artifact);
         validate_required("artifact.id", &artifact.id)?;
         if self.get_run(&artifact.run_id)?.is_none() {
             return Err(Error::validation_invalid_argument(
@@ -19,7 +20,7 @@ impl ObservationStore {
             ));
         }
         if let Some(existing) = self.get_artifact(&artifact.id)? {
-            return ensure_identical("artifact", &artifact.id, &existing, artifact);
+            return ensure_identical("artifact", &artifact.id, &existing, &artifact);
         }
         let metadata_json = serialize_metadata(&artifact.metadata_json)?;
         execute_with_retry("import artifact record", || {
@@ -789,4 +790,29 @@ impl ObservationStore {
         })?;
         Ok(())
     }
+}
+
+fn artifact_with_link_metadata(artifact: &ArtifactRecord) -> ArtifactRecord {
+    let mut artifact = artifact.clone();
+    if artifact.metadata_json.is_null() {
+        artifact.metadata_json = serde_json::json!({});
+    }
+    if let Some(metadata) = artifact.metadata_json.as_object_mut() {
+        if let Some(url) = artifact.url.as_ref() {
+            metadata
+                .entry("url".to_string())
+                .or_insert_with(|| serde_json::Value::String(url.clone()));
+        }
+        if let Some(public_url) = artifact.public_url.as_ref() {
+            metadata
+                .entry("public_url".to_string())
+                .or_insert_with(|| serde_json::Value::String(public_url.clone()));
+        }
+        if let Some(viewer_url) = artifact.viewer_url.as_ref() {
+            metadata
+                .entry("viewer_url".to_string())
+                .or_insert_with(|| serde_json::Value::String(viewer_url.clone()));
+        }
+    }
+    artifact
 }

--- a/src/core/observation/store/helpers.rs
+++ b/src/core/observation/store/helpers.rs
@@ -114,24 +114,33 @@ pub(crate) fn row_to_artifact_record_at(
     row: &rusqlite::Row<'_>,
     offset: usize,
 ) -> rusqlite::Result<ArtifactRecord> {
+    let artifact_type: String = row.get(offset + 3)?;
+    let path: String = row.get(offset + 4)?;
+    let metadata_json = parse_metadata(row.get(offset + 8)?)?;
+    let metadata_url = |key: &str| {
+        metadata_json
+            .get(key)
+            .and_then(|value| value.as_str())
+            .map(ToString::to_string)
+    };
     Ok(ArtifactRecord {
         id: row.get(offset)?,
         run_id: row.get(offset + 1)?,
         kind: row.get(offset + 2)?,
-        artifact_type: row.get(offset + 3)?,
-        path: row.get(offset + 4)?,
-        url: if row.get_ref(offset + 3)?.as_str()? == "url" {
-            Some(row.get(offset + 4)?)
+        artifact_type: artifact_type.clone(),
+        path: path.clone(),
+        url: if artifact_type == "url" {
+            Some(path.clone())
         } else {
-            None
+            metadata_url("url")
         },
-        public_url: None,
-        viewer_url: None,
+        public_url: metadata_url("public_url"),
+        viewer_url: metadata_url("viewer_url"),
         viewer_links: Vec::new(),
         sha256: row.get(offset + 5)?,
         size_bytes: row.get(offset + 6)?,
         mime: row.get(offset + 7)?,
-        metadata_json: parse_metadata(row.get(offset + 8)?)?,
+        metadata_json,
         created_at: row.get(offset + 9)?,
     })
 }


### PR DESCRIPTION
## Summary
- Allow component-owned scripts.fuzz to satisfy fuzz plan/run resolution without requiring a linked fuzz extension.
- Treat --allow-destructive as explicit destructive intent that infers isolated fuzz mode and attaches a generated auditable isolation proof when no proof file is supplied.
- Clarify the strict --require-result-envelope contract: it validates runner-declared campaign artifacts before Homeboy persists its normalized fuzz_result_envelope.
- Preserve imported artifact public URLs through observation-store persistence so fuzz replay dry-runs surface reviewer-accessible artifact links.

## Tests
- cargo test commands::fuzz::tests::replay_tests::fuzz_replay_dry_run_surfaces_persisted_artifact_public_access --lib
- cargo test fuzz_plan_accepts_component_scripts_fuzz_without_extension_provider --lib
- cargo test generated_isolation_proof --lib
- cargo test resolve_with_component_uses_component_script_without_extension_provider --lib
- cargo test strict_fuzz_run_artifact_validation --lib
- cargo test commands::fuzz::tests --lib (110 passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the fuzz UX papercut fixes, preserved imported artifact public URLs for replay dry-runs, updated focused tests/docs, and ran verification with Chris directing the goal and constraints.