### PR TITLE
Hydrate release dependencies before quality gates

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -33,6 +33,7 @@ pub(super) fn execute_release_plan_step(
         "preflight.working_tree" => Ok(Some(run_working_tree_preflight(step, context))),
         "preflight.remote_sync" => Ok(Some(run_remote_sync_preflight(step, context))),
         "preflight.bump_policy" => Ok(Some(run_bump_policy_preflight(step))),
+        "preflight.dependencies" => Ok(Some(run_dependencies_preflight(step, context))),
         "preflight.lint" => Ok(Some(run_lint_preflight(step, context))),
         "preflight.test" => Ok(Some(run_test_preflight(step, context))),
         "preflight.changelog_bootstrap" => {
@@ -220,6 +221,7 @@ fn release_step_is_plan_only(step: &PlanStep) -> bool {
         && step.kind != "preflight.working_tree"
         && step.kind != "preflight.remote_sync"
         && step.kind != "preflight.bump_policy"
+        && step.kind != "preflight.dependencies"
         && step.kind != "preflight.lint"
         && step.kind != "preflight.test"
         && step.kind != "preflight.changelog_bootstrap"
@@ -376,6 +378,39 @@ fn run_bump_policy_preflight(step: &PlanStep) -> ReleaseStepResult {
     }
 }
 
+fn run_dependencies_preflight(
+    step: &PlanStep,
+    context: &ReleaseExecutionContext,
+) -> ReleaseStepResult {
+    let component_path = std::path::Path::new(&context.component.local_path);
+    match crate::core::deps::install_for_resolved(context.component, component_path) {
+        Ok(Some(result)) => ReleaseStepResult {
+            id: step.id.clone(),
+            step_type: step.kind.clone(),
+            status: ReleaseStepStatus::Success,
+            missing: Vec::new(),
+            warnings: Vec::new(),
+            hints: Vec::new(),
+            data: Some(serde_json::json!({
+                "ran": !result.installs.is_empty(),
+                "dependencies": result,
+            })),
+            error: None,
+        },
+        Ok(None) => ReleaseStepResult {
+            id: step.id.clone(),
+            step_type: step.kind.clone(),
+            status: ReleaseStepStatus::Success,
+            missing: Vec::new(),
+            warnings: Vec::new(),
+            hints: Vec::new(),
+            data: Some(serde_json::json!({ "ran": false })),
+            error: None,
+        },
+        Err(err) => failed_result(&step.id, &step.kind, err),
+    }
+}
+
 fn run_lint_preflight(step: &PlanStep, context: &ReleaseExecutionContext) -> ReleaseStepResult {
     use super::planning_quality::LintQualityOutcome;
 
@@ -482,6 +517,7 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
             | "preflight.working_tree"
             | "preflight.remote_sync"
             | "preflight.bump_policy"
+            | "preflight.dependencies"
             | "preflight.lint"
             | "preflight.test"
             | "preflight.changelog_bootstrap"
@@ -568,7 +604,12 @@ fn guard_step_dirty_side_effects(
 fn release_step_dirty_side_effects_are_guarded(step: &PlanStep) -> bool {
     matches!(
         step.kind.as_str(),
-        "preflight.lint" | "preflight.test" | "preflight.package" | "release.prepare" | "package"
+        "preflight.dependencies"
+            | "preflight.lint"
+            | "preflight.test"
+            | "preflight.package"
+            | "release.prepare"
+            | "package"
     )
 }
 
@@ -701,6 +742,9 @@ mod tests {
             "preflight.bump_policy"
         )));
         assert!(!release_step_is_plan_only(&plan_step(
+            "preflight.dependencies"
+        )));
+        assert!(!release_step_is_plan_only(&plan_step(
             "preflight.extension.registry.publish_token"
         )));
         assert!(!release_step_is_plan_only(&plan_step("preflight.lint")));
@@ -711,6 +755,56 @@ mod tests {
         assert!(!release_step_is_plan_only(&plan_step("preflight.package")));
         assert!(!release_step_is_plan_only(&plan_step("changelog.finalize")));
         assert!(!release_step_is_plan_only(&plan_step("deploy")));
+    }
+
+    #[test]
+    fn dependency_preflight_hydrates_before_lint_self_check() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("homeboy-deps.json"),
+            r#"{
+                "provider": "fixture",
+                "commands": {
+                    "install": {
+                        "argv": [
+                            "sh",
+                            "-c",
+                            "mkdir -p node_modules/typescript/bin && touch node_modules/typescript/bin/tsc"
+                        ]
+                    }
+                }
+            }"#,
+        )
+        .expect("write deps manifest");
+
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            scripts: Some(ComponentScriptsConfig {
+                lint: vec!["test -f node_modules/typescript/bin/tsc".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let options = ReleaseOptions::default();
+        let mut context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState::default(),
+            publish_failed: false,
+        };
+
+        let deps = execute_release_plan_step(&plan_step("preflight.dependencies"), &mut context)
+            .expect("dependency dispatch")
+            .expect("dependency result");
+        assert_eq!(deps.status, ReleaseStepStatus::Success);
+
+        let lint = execute_release_plan_step(&plan_step("preflight.lint"), &mut context)
+            .expect("lint dispatch")
+            .expect("lint result");
+        assert_eq!(lint.status, ReleaseStepStatus::Success);
     }
 
     #[test]

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -25,7 +25,7 @@ pub(super) fn build_initial_preflight_plan(
     if let Some(tag_step) = early_tag_availability_step(options, false) {
         let insert_at = steps
             .iter()
-            .position(|step| step.id == "preflight.lint")
+            .position(|step| step.id == "preflight.dependencies")
             .unwrap_or(steps.len());
         steps.insert(insert_at, tag_step);
     }
@@ -56,6 +56,7 @@ pub(super) fn initial_executable_preflight_ids() -> &'static [&'static str] {
         "preflight.working_tree",
         "preflight.remote_sync",
         "preflight.tag_availability",
+        "preflight.dependencies",
         "preflight.lint",
         "preflight.test",
         "preflight.changelog_bootstrap",
@@ -328,6 +329,7 @@ mod tests {
                 "preflight.working_tree",
                 "preflight.remote_sync",
                 "preflight.tag_availability",
+                "preflight.dependencies",
                 "preflight.lint",
                 "preflight.test",
                 "preflight.changelog_bootstrap",
@@ -362,6 +364,27 @@ mod tests {
     }
 
     #[test]
+    fn initial_preflight_plan_hydrates_dependencies_before_lint() {
+        let options = ReleaseOptions {
+            bump_type: "none".to_string(),
+            ..Default::default()
+        };
+        let plan = super::build_initial_preflight_plan("fixture", &options);
+        let steps = plan.plan.steps;
+        let deps = steps
+            .iter()
+            .position(|step| step.id == "preflight.dependencies")
+            .expect("dependency preflight");
+        let lint = steps
+            .iter()
+            .position(|step| step.id == "preflight.lint")
+            .expect("lint preflight");
+
+        assert!(deps < lint, "dependencies must hydrate before lint runs");
+        assert_eq!(steps[lint].needs, vec!["preflight.dependencies"]);
+    }
+
+    #[test]
     fn test_build_initial_preflight_plan() {
         let options = ReleaseOptions {
             bump_type: "none".to_string(),
@@ -386,6 +409,7 @@ mod tests {
                 "preflight.git_identity",
                 "preflight.working_tree",
                 "preflight.remote_sync",
+                "preflight.dependencies",
                 "preflight.lint",
                 "preflight.test",
                 "preflight.changelog_bootstrap",

--- a/src/core/release/plan_steps/preflight.rs
+++ b/src/core/release/plan_steps/preflight.rs
@@ -57,6 +57,14 @@ pub(in crate::core::release) fn build_preflight_steps(
 
     steps.extend(build_extension_release_preflight_steps(extensions));
 
+    steps.push(ready_step(
+        "preflight.dependencies",
+        "preflight.dependencies",
+        "Hydrate release dependencies",
+        vec!["preflight.bump_policy".to_string()],
+        StepConfig::new(),
+    ));
+
     if let Some(identity) = options.git_identity.as_ref() {
         steps.insert(
             1,
@@ -117,10 +125,10 @@ fn build_extension_release_preflight_steps(extensions: &[ExtensionManifest]) -> 
 }
 
 fn build_quality_steps(options: &ReleaseOptions) -> Vec<PlanStep> {
-    build_shared_quality_steps(
-        &QualityPlanOptions::release_preflight("release", options.skip_checks)
-            .with_granular_skips(&options.skip_checks_granular),
-    )
+    let mut quality_options = QualityPlanOptions::release_preflight("release", options.skip_checks)
+        .with_granular_skips(&options.skip_checks_granular);
+    quality_options.lint_needs = vec!["preflight.dependencies".to_string()];
+    build_shared_quality_steps(&quality_options)
 }
 
 fn build_bump_policy_step(

--- a/src/core/release/plan_steps/tests/mod.rs
+++ b/src/core/release/plan_steps/tests/mod.rs
@@ -28,6 +28,7 @@ fn test_build_preflight_steps() {
             "preflight.working_tree",
             "preflight.remote_sync",
             "preflight.bump_policy",
+            "preflight.dependencies",
             "preflight.audit",
             "preflight.lint",
             "preflight.test",
@@ -198,6 +199,10 @@ fn release_plan_records_explicit_quality_preflights() {
         .iter()
         .find(|step| step.id == "preflight.audit")
         .expect("audit step");
+    let dependencies = steps
+        .iter()
+        .find(|step| step.id == "preflight.dependencies")
+        .expect("dependencies step");
     let lint = steps
         .iter()
         .find(|step| step.id == "preflight.lint")
@@ -216,8 +221,10 @@ fn release_plan_records_explicit_quality_preflights() {
         audit.inputs.get("reason").and_then(|value| value.as_str()),
         Some("no-release-audit-policy")
     );
+    assert_eq!(dependencies.status, PlanStepStatus::Ready);
+    assert_eq!(dependencies.needs, vec!["preflight.bump_policy"]);
     assert_eq!(lint.status, PlanStepStatus::Ready);
-    assert_eq!(lint.needs, vec!["preflight.bump_policy"]);
+    assert_eq!(lint.needs, vec!["preflight.dependencies"]);
     assert_eq!(test.status, PlanStepStatus::Ready);
     assert_eq!(test.needs, vec!["preflight.lint"]);
     assert_eq!(changelog_bootstrap.needs, vec!["preflight.test"]);


### PR DESCRIPTION
## Summary
- add a release preflight step that runs the existing dependency provider install before lint/test quality gates
- make release lint depend on dependency hydration
- cover the release-critical path where lint requires a dependency artifact created by the dependency provider

## Verification
- cargo test dependency_preflight_hydrates_before_lint_self_check
- cargo test initial_preflight_plan_hydrates_dependencies_before_lint
- cargo test release_plan_records_explicit_quality_preflights
- cargo test test_build_preflight_steps
- cargo build --release

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Investigated the wp-codebox release blocker, implemented the Homeboy release preflight fix, and ran targeted verification.