### PR TITLE
Materialize repo root for package preflight

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -964,6 +964,41 @@ mod tests {
     }
 
     #[test]
+    fn package_preflight_materializes_repo_root_for_subdirectory_component() {
+        crate::test_support::with_isolated_home(|_| {
+            let repo = tempfile::tempdir().expect("repo tempdir");
+            std::fs::create_dir(repo.path().join(".git")).expect("git marker");
+            std::fs::write(repo.path().join("build-input.txt"), "repo-root-input")
+                .expect("repo-root input");
+            let component = repo.path().join("packages").join("plugin");
+            std::fs::create_dir_all(&component).expect("component dir");
+            std::fs::write(component.join("fixture.php"), "<?php\n").expect("component file");
+
+            let package = release_package_extension(
+                "wordpress",
+                "test -f ../../build-input.txt; \
+                 test ! -e .git; \
+                 mkdir -p build; \
+                 cp ../../build-input.txt build/root-input.txt; \
+                 printf '[{\"path\":\"build/root-input.txt\",\"type\":\"archive\"}]'",
+            );
+            crate::core::extension::save_manifest(&package).expect("save package extension");
+
+            let result = package_preflight::run_package_preflight(
+                &[package],
+                "fixture",
+                &component.to_string_lossy(),
+                false,
+            )
+            .expect("package preflight");
+
+            assert_eq!(result.status, ReleaseStepStatus::Success);
+            let data = result.data.expect("preflight data");
+            assert_eq!(data["validated_action"].as_str(), Some("release.package"));
+        });
+    }
+
+    #[test]
     fn run_package_failure_names_the_failing_package_provider() {
         crate::test_support::with_isolated_home(|_| {
             let component = tempfile::tempdir().expect("component tempdir");

--- a/src/core/release/executor/package_preflight.rs
+++ b/src/core/release/executor/package_preflight.rs
@@ -21,9 +21,13 @@ pub(crate) fn run_package_preflight(
     super::lockfile_guard::guard_committed_lockfiles(Path::new(component_local_path))?;
     super::lockfile_guard::guard_local_file_dependencies(Path::new(component_local_path))?;
 
+    let source_component_path = Path::new(component_local_path);
+    let source_root = release_preflight_source_root(source_component_path)?;
     let temp = create_release_preflight_tempdir()?;
-    let temp_component_path = temp.join("component");
-    copy_release_preflight_tree(Path::new(component_local_path), &temp_component_path)?;
+    let temp_root_path = temp.join("repository");
+    copy_release_preflight_tree(&source_root, &temp_root_path)?;
+    let temp_component_path =
+        release_preflight_component_path(source_component_path, &source_root, &temp_root_path)?;
 
     let mut state = ReleaseState::default();
     let result = run_package(
@@ -50,6 +54,57 @@ pub(crate) fn run_package_preflight(
         Some(data),
         Vec::new(),
     ))
+}
+
+fn release_preflight_source_root(component_path: &Path) -> Result<PathBuf> {
+    let component_path = component_path.canonicalize().map_err(|e| {
+        Error::internal_io(
+            format!("Failed to resolve package preflight component path: {}", e),
+            Some(component_path.display().to_string()),
+        )
+    })?;
+
+    let mut current = component_path.as_path();
+    loop {
+        if current.join(".git").exists() {
+            return Ok(current.to_path_buf());
+        }
+        let Some(parent) = current.parent() else {
+            return Ok(component_path);
+        };
+        current = parent;
+    }
+}
+
+fn release_preflight_component_path(
+    source_component_path: &Path,
+    source_root: &Path,
+    temp_root_path: &Path,
+) -> Result<PathBuf> {
+    let source_component_path = source_component_path.canonicalize().map_err(|e| {
+        Error::internal_io(
+            format!("Failed to resolve package preflight component path: {}", e),
+            Some(source_component_path.display().to_string()),
+        )
+    })?;
+
+    let relative_component_path = source_component_path
+        .strip_prefix(source_root)
+        .map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to map package preflight component path into staged repo: {}",
+                    e
+                ),
+                Some(format!(
+                    "component: {}; source root: {}",
+                    source_component_path.display(),
+                    source_root.display()
+                )),
+            )
+        })?;
+
+    Ok(temp_root_path.join(relative_component_path))
 }
 
 fn create_release_preflight_tempdir() -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
- Fixes #7637.
- Materializes the git repository root for release package preflight when a component path is a repo subdirectory, then runs the package action from the staged component subdirectory.
- Keeps .git excluded from the preflight copy while preserving repo-root build inputs for monorepo packages.
- Adds regression coverage for a subdirectory component whose package command reads a repo-root file.

## Tests
- cargo fmt --check
- cargo check
- cargo test package_preflight_materializes_repo_root_for_subdirectory_component
- cargo test package_preflight_payload_distinguishes_staging_path_from_source_path

## Blockers
- cargo clippy --lib --tests -- -D warnings is blocked by existing unrelated repo-wide clippy violations outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected the release package preflight path, implemented the scoped repo-root materialization fix, added regression coverage, and ran focused verification.