### PR TITLE
Improve package preflight diagnostics

### DIFF
--- a/src/core/extension/execution/action.rs
+++ b/src/core/extension/execution/action.rs
@@ -148,6 +148,8 @@ pub(crate) fn execute_action(
                 "stderr": execution.output.stderr,
                 "exitCode": execution.exit_code,
                 "success": execution.success,
+                "command": command_template,
+                "cwd": working_dir,
                 "payload": payload
             }))
         }

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -973,12 +973,21 @@ mod tests {
     fn package_preflight_materializes_repo_root_for_subdirectory_component() {
         crate::test_support::with_isolated_home(|_| {
             let repo = tempfile::tempdir().expect("repo tempdir");
-            std::fs::create_dir(repo.path().join(".git")).expect("git marker");
             std::fs::write(repo.path().join("build-input.txt"), "repo-root-input")
                 .expect("repo-root input");
             let component = repo.path().join("packages").join("plugin");
             std::fs::create_dir_all(&component).expect("component dir");
             std::fs::write(component.join("fixture.php"), "<?php\n").expect("component file");
+            run_in(repo.path(), &["git", "init", "-q"]);
+            run_in(
+                repo.path(),
+                &[
+                    "git",
+                    "add",
+                    "build-input.txt",
+                    "packages/plugin/fixture.php",
+                ],
+            );
 
             let package = release_package_extension(
                 "wordpress",
@@ -992,6 +1001,11 @@ mod tests {
 
             let result = package_preflight::run_package_preflight(
                 &[package],
+                &Component {
+                    id: "fixture".to_string(),
+                    local_path: component.to_string_lossy().to_string(),
+                    ..Component::default()
+                },
                 "fixture",
                 &component.to_string_lossy(),
                 false,
@@ -1001,6 +1015,72 @@ mod tests {
             assert_eq!(result.status, ReleaseStepStatus::Success);
             let data = result.data.expect("preflight data");
             assert_eq!(data["validated_action"].as_str(), Some("release.package"));
+        });
+    }
+
+    #[test]
+    fn package_preflight_failure_includes_actionable_diagnostics() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir().expect("component tempdir");
+            let package = release_package_extension(
+                "wordpress",
+                "printf 'building package\n'; printf 'error: missing tsconfig.base.json\n' >&2; exit 9",
+            );
+            crate::core::extension::save_manifest(&package).expect("save package extension");
+
+            let err = package_preflight::run_package_preflight(
+                &[package],
+                &Component {
+                    id: "fixture".to_string(),
+                    local_path: component.path().to_string_lossy().to_string(),
+                    ..Component::default()
+                },
+                "fixture",
+                &component.path().to_string_lossy(),
+                true,
+            )
+            .expect_err("failing package preflight should surface diagnostics");
+
+            let diagnostic = &err.details["diagnostic"];
+            assert_eq!(diagnostic["component_id"].as_str(), Some("fixture"));
+            assert_eq!(
+                diagnostic["package_root"].as_str(),
+                Some(component.path().to_string_lossy().as_ref())
+            );
+            assert!(diagnostic["build_cwd"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("homeboy-release-package-preflight"));
+            assert!(diagnostic["materialized_temp_root"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("homeboy-release-package-preflight"));
+            assert_eq!(diagnostic["exit_code"].as_i64(), Some(9));
+            let command = diagnostic["command"].as_str().expect("command");
+            assert!(command.contains("building package"));
+            assert!(command.contains("missing tsconfig.base.json"));
+            assert!(command.contains("exit 9"));
+            assert_eq!(
+                diagnostic["config_fields"]["component.local_path"].as_str(),
+                Some(component.path().to_string_lossy().as_ref())
+            );
+            assert_eq!(
+                diagnostic["config_fields"]["config.skip_build_validation"].as_bool(),
+                Some(true)
+            );
+            assert!(diagnostic["relevant_error_lines"]
+                .as_array()
+                .expect("relevant error lines")
+                .iter()
+                .any(|line| line.as_str() == Some("error: missing tsconfig.base.json")));
+
+            let artifact_path = err.details["artifact_path"]
+                .as_str()
+                .expect("artifact path");
+            assert!(std::path::Path::new(artifact_path).is_file());
+            let artifact = std::fs::read_to_string(artifact_path).expect("diagnostic artifact");
+            assert!(artifact.contains("missing tsconfig.base.json"));
+            assert!(err.message.contains("diagnostic artifact"));
         });
     }
 

--- a/src/core/release/executor/package.rs
+++ b/src/core/release/executor/package.rs
@@ -345,7 +345,9 @@ pub(super) fn store_artifacts_from_output(
     // dependency install inside the build script can fail intermittently, and
     // the real error must be visible in the structured error payload.
     if !success {
-        return Err(package_command_failure_error(exit_code, stdout, stderr));
+        return Err(package_command_failure_error(
+            exit_code, stdout, stderr, response,
+        ));
     }
 
     if stdout.trim().is_empty() {
@@ -456,7 +458,12 @@ fn safe_artifact_file_name(value: &str) -> String {
 /// Package/build tools commonly write progress to stdout and errors to stderr.
 /// Including both streams ensures the operator can diagnose the real failure
 /// instead of seeing truncated output.  Issue #3238.
-fn package_command_failure_error(exit_code: i64, stdout: &str, stderr: &str) -> Error {
+fn package_command_failure_error(
+    exit_code: i64,
+    stdout: &str,
+    stderr: &str,
+    response: &serde_json::Value,
+) -> Error {
     let stderr_trimmed = stderr.trim();
     let stdout_trimmed = stdout.trim();
     let has_stderr = !stderr_trimmed.is_empty();
@@ -483,7 +490,52 @@ fn package_command_failure_error(exit_code: i64, stdout: &str, stderr: &str) -> 
         detail.push_str(stdout_trimmed);
     }
 
-    Error::internal_unexpected(detail)
+    Error::new(
+        crate::core::error::ErrorCode::InternalUnexpected,
+        detail,
+        serde_json::json!({
+            "exit_code": exit_code,
+            "command": response.get("command").and_then(serde_json::Value::as_str),
+            "cwd": response.get("cwd").and_then(serde_json::Value::as_str),
+            "relevant_error_lines": relevant_package_error_lines(stdout, stderr),
+            "stdout": stdout_trimmed,
+            "stderr": stderr_trimmed,
+        }),
+    )
+}
+
+fn relevant_package_error_lines(stdout: &str, stderr: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    for line in stderr.lines().chain(stdout.lines()) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.contains("error")
+            || lower.contains("failed")
+            || lower.contains("missing")
+            || lower.contains("not found")
+            || lower.contains("enoent")
+        {
+            lines.push(trimmed.to_string());
+        }
+        if lines.len() >= 12 {
+            break;
+        }
+    }
+    if lines.is_empty() {
+        lines.extend(
+            stderr
+                .lines()
+                .chain(stdout.lines())
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .take(12)
+                .map(str::to_string),
+        );
+    }
+    lines
 }
 
 fn package_output_reports_missing_frontend_assets(stdout: &str, stderr: &str) -> bool {

--- a/src/core/release/executor/package_preflight.rs
+++ b/src/core/release/executor/package_preflight.rs
@@ -43,8 +43,27 @@ pub(crate) fn run_package_preflight(
         skip_build_validation,
     );
 
+    if let Err(err) = result {
+        let diagnostic = package_preflight_failure_diagnostic(
+            component_id,
+            component_local_path,
+            &temp,
+            &temp_component_path,
+            skip_build_validation,
+            &err,
+        );
+        let artifact_path = persist_package_preflight_failure_diagnostic(component_id, &diagnostic)
+            .unwrap_or_else(|persist_err| format!("unavailable: {}", persist_err.message));
+        let _ = std::fs::remove_dir_all(&temp);
+        return Err(package_preflight_failure_error(
+            err,
+            diagnostic,
+            artifact_path,
+        ));
+    }
+
     let _ = std::fs::remove_dir_all(&temp);
-    let result = result?;
+    let result = result.expect("checked package preflight error above");
     validate_package_completeness(component, Path::new(component_local_path), &state.artifacts)?;
 
     let data = serde_json::json!({
@@ -110,6 +129,115 @@ fn release_preflight_component_path(
         })?;
 
     Ok(temp_root_path.join(relative_component_path))
+}
+
+fn package_preflight_failure_diagnostic(
+    component_id: &str,
+    component_local_path: &str,
+    temp_root: &Path,
+    temp_component_path: &Path,
+    skip_build_validation: bool,
+    err: &Error,
+) -> serde_json::Value {
+    let source = err.details.get("source").unwrap_or(&err.details);
+    let command = source
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let build_cwd = source
+        .get("cwd")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| temp_component_path.display().to_string());
+    let exit_code = source
+        .get("exit_code")
+        .or_else(|| source.get("exitCode"))
+        .and_then(serde_json::Value::as_i64);
+    let relevant_error_lines = source
+        .get("relevant_error_lines")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!([]));
+
+    serde_json::json!({
+        "component_id": component_id,
+        "package_root": component_local_path,
+        "build_cwd": build_cwd,
+        "materialized_temp_root": temp_root.display().to_string(),
+        "command": command,
+        "exit_code": exit_code,
+        "relevant_error_lines": relevant_error_lines,
+        "config_fields": {
+            "component.local_path": component_local_path,
+            "release.local_path": temp_component_path.display().to_string(),
+            "release.source_path": component_local_path,
+            "config.skip_build_validation": skip_build_validation,
+        },
+        "error": {
+            "message": err.message,
+            "details": err.details,
+        }
+    })
+}
+
+fn persist_package_preflight_failure_diagnostic(
+    component_id: &str,
+    diagnostic: &serde_json::Value,
+) -> Result<String> {
+    let artifact_root = crate::core::paths::artifact_root()?;
+    let path = artifact_root
+        .join("release")
+        .join(crate::core::paths::sanitize_path_segment(component_id))
+        .join("package-preflight-failure.json");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to create package preflight diagnostic directory: {}",
+                    e
+                ),
+                Some(parent.display().to_string()),
+            )
+        })?;
+    }
+    let body = serde_json::to_string_pretty(diagnostic).map_err(|e| {
+        Error::internal_json(
+            e.to_string(),
+            Some("package preflight diagnostic".to_string()),
+        )
+    })?;
+    std::fs::write(&path, body).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to write package preflight diagnostic: {}", e),
+            Some(path.display().to_string()),
+        )
+    })?;
+    Ok(path.display().to_string())
+}
+
+fn package_preflight_failure_error(
+    err: Error,
+    diagnostic: serde_json::Value,
+    artifact_path: String,
+) -> Error {
+    let mut details = serde_json::json!({
+        "diagnostic": diagnostic,
+        "artifact_path": artifact_path,
+    });
+    details["diagnostic"]["artifact_path"] = serde_json::Value::String(artifact_path.clone());
+
+    let mut wrapped = Error::new(
+        err.code,
+        format!(
+            "Package preflight failed for component '{}'; diagnostic artifact: {}. {}",
+            details["diagnostic"]["component_id"].as_str().unwrap_or(""),
+            artifact_path,
+            err.message
+        ),
+        details,
+    );
+    wrapped.hints = err.hints;
+    wrapped.retryable = err.retryable;
+    wrapped
 }
 
 fn create_release_preflight_tempdir() -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
- Fixes #7636.
- Adds command/cwd evidence to captured command-backed extension action responses.
- Wraps package preflight failures with component id, package root, build cwd, materialized temp root, command, exit code, relevant error lines, config fields, and a persisted diagnostic artifact path.
- Adds regression coverage for a simulated package preflight failure.

## Tests
- cargo fmt --check
- git diff --check
- cargo test core::release::executor::tests::
- cargo clippy --lib --tests

## Notes
- cargo clippy --lib --tests -- -D warnings currently fails on pre-existing repository-wide warnings unrelated to this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the Homeboy package preflight diagnostics implementation and regression coverage.
