### PR TITLE
Validate release package runtime completeness

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -42,6 +42,7 @@ pub(super) fn execute_release_plan_step(
         "preflight.package" => Ok(Some(
             executor::package_preflight::run_package_preflight(
                 context.extensions,
+                context.component,
                 context.component_id,
                 &context.component.local_path,
                 context.options.skip_build_validation,

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -911,6 +911,7 @@ mod tests {
     fn package_preflight_payload_distinguishes_staging_path_from_source_path() {
         crate::test_support::with_isolated_home(|_| {
             let component = tempfile::tempdir().expect("component tempdir");
+            run_in(component.path(), &["git", "init"]);
             std::fs::write(component.path().join("fixture.php"), "<?php\n")
                 .expect("component file");
             let payload_out = component.path().join("package-payload.json");
@@ -933,6 +934,11 @@ mod tests {
 
             let result = package_preflight::run_package_preflight(
                 &[package],
+                &Component {
+                    id: "fixture".to_string(),
+                    local_path: component.path().to_string_lossy().to_string(),
+                    ..Component::default()
+                },
                 "fixture",
                 &component.path().to_string_lossy(),
                 false,

--- a/src/core/release/executor/package_preflight.rs
+++ b/src/core/release/executor/package_preflight.rs
@@ -1,8 +1,11 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
+use crate::core::component::{CommandScopeConfig, Component};
 use crate::core::error::{Error, Result};
 use crate::core::extension::ExtensionManifest;
-use crate::core::release::types::{ReleaseState, ReleaseStepResult};
+use crate::core::release::types::{ReleaseArtifact, ReleaseState, ReleaseStepResult};
 
 use super::{run_package, step_success};
 
@@ -10,6 +13,7 @@ use super::{run_package, step_success};
 /// pipeline mutates changelog, version files, or git state.
 pub(crate) fn run_package_preflight(
     extensions: &[ExtensionManifest],
+    component: &Component,
     component_id: &str,
     component_local_path: &str,
     skip_build_validation: bool,
@@ -37,6 +41,7 @@ pub(crate) fn run_package_preflight(
 
     let _ = std::fs::remove_dir_all(&temp);
     let result = result?;
+    validate_package_completeness(component, Path::new(component_local_path), &state.artifacts)?;
 
     let data = serde_json::json!({
         "component_path": component_local_path,
@@ -159,5 +164,324 @@ fn copy_release_preflight_symlink(source: &Path, destination: &Path) -> Result<(
                 .unwrap_or(target)
         };
         copy_release_preflight_entry(&target_path, destination)
+    }
+}
+
+fn validate_package_completeness(
+    component: &Component,
+    component_path: &Path,
+    artifacts: &[ReleaseArtifact],
+) -> Result<()> {
+    let expected = tracked_runtime_files(component, component_path)?;
+    if expected.is_empty() {
+        return Ok(());
+    }
+
+    let mut archive_entries = BTreeSet::new();
+    for artifact in artifacts {
+        let artifact_path = resolve_artifact_path(component_path, artifact);
+        if !artifact_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+        {
+            continue;
+        }
+        archive_entries.extend(read_zip_entries(&artifact_path)?);
+    }
+
+    if archive_entries.is_empty() {
+        return Ok(());
+    }
+
+    let missing: Vec<String> = expected
+        .into_iter()
+        .filter(|path| !archive_contains_path(&archive_entries, path))
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "preflight.package",
+        format!(
+            "Release package is missing {} tracked runtime file(s): {}",
+            missing.len(),
+            missing.iter().take(20).cloned().collect::<Vec<_>>().join(", ")
+        ),
+        Some(format!(
+            "{}",
+            serde_json::json!({
+                "missing": missing,
+                "source": component_path,
+                "checked_artifact_type": "zip"
+            })
+        )),
+        Some(vec![
+            "Update the release.package action so the artifact includes every tracked runtime file, or add an explicit release scope exclude for intentional omissions.".to_string(),
+        ]),
+    ))
+}
+
+fn tracked_runtime_files(component: &Component, component_path: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["ls-files", "-z"])
+        .current_dir(component_path)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to inspect tracked files for package preflight: {}",
+                    e
+                ),
+                Some(component_path.display().to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(Error::internal_unexpected(format!(
+            "Failed to inspect tracked files for package preflight: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    let scope = release_scope(component);
+    let files = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|raw| !raw.is_empty())
+        .filter_map(|raw| String::from_utf8(raw.to_vec()).ok())
+        .map(|path| normalize_archive_path(&path))
+        .filter(|path| runtime_candidate(path))
+        .filter(|path| scope_allows(path, &scope))
+        .collect::<Vec<_>>();
+    Ok(files)
+}
+
+fn release_scope(component: &Component) -> CommandScopeConfig {
+    let mut scope = CommandScopeConfig::default();
+    if let Some(scopes) = component.scopes.as_ref() {
+        if let Some(defaults) = scopes.defaults.as_ref() {
+            scope.include.extend(defaults.include.clone());
+            scope.exclude.extend(defaults.exclude.clone());
+        }
+        if let Some(release) = scopes.release.as_ref() {
+            scope.include.extend(release.include.clone());
+            scope.exclude.extend(release.exclude.clone());
+        }
+    }
+    scope
+}
+
+fn runtime_candidate(path: &str) -> bool {
+    let file_name = path.rsplit('/').next().unwrap_or(path);
+    if matches!(
+        file_name,
+        "package.json"
+            | "package-lock.json"
+            | "composer.json"
+            | "composer.lock"
+            | "tsconfig.json"
+            | "phpunit.xml"
+            | "phpunit.xml.dist"
+    ) {
+        return false;
+    }
+    if path.starts_with(".github/")
+        || path.starts_with("docs/")
+        || path.starts_with("test/")
+        || path.starts_with("tests/")
+        || path.starts_with("__tests__/")
+        || path.starts_with("node_modules/")
+        || path.starts_with("target/")
+    {
+        return false;
+    }
+
+    matches!(
+        Path::new(path)
+            .extension()
+            .and_then(|extension| extension.to_str()),
+        Some("php" | "inc" | "phtml" | "js" | "mjs" | "cjs" | "css" | "json")
+    )
+}
+
+fn scope_allows(path: &str, scope: &CommandScopeConfig) -> bool {
+    if !scope.include.is_empty()
+        && !scope
+            .include
+            .iter()
+            .any(|pattern| path_matches(pattern, path))
+    {
+        return false;
+    }
+    !scope
+        .exclude
+        .iter()
+        .any(|pattern| path_matches(pattern, path))
+}
+
+fn path_matches(pattern: &str, path: &str) -> bool {
+    glob_match::glob_match(pattern, path)
+        || glob_match::glob_match(pattern, &format!("/{}", path))
+        || path.starts_with(pattern.trim_end_matches('/'))
+}
+
+fn resolve_artifact_path(component_path: &Path, artifact: &ReleaseArtifact) -> PathBuf {
+    let path = artifact
+        .durable_path
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+        .unwrap_or(&artifact.path);
+    let path = Path::new(path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        component_path.join(path)
+    }
+}
+
+fn read_zip_entries(path: &Path) -> Result<BTreeSet<String>> {
+    let file = std::fs::File::open(path).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to open release package artifact for completeness check: {}",
+                e
+            ),
+            Some(path.display().to_string()),
+        )
+    })?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to inspect release package artifact '{}': {}",
+            path.display(),
+            e
+        ))
+    })?;
+
+    let mut entries = BTreeSet::new();
+    for index in 0..archive.len() {
+        let entry = archive.by_index(index).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to inspect release package artifact '{}': {}",
+                path.display(),
+                e
+            ))
+        })?;
+        if entry.is_dir() {
+            continue;
+        }
+        entries.insert(normalize_archive_path(entry.name()));
+    }
+    Ok(entries)
+}
+
+fn archive_contains_path(entries: &BTreeSet<String>, path: &str) -> bool {
+    entries
+        .iter()
+        .any(|entry| entry == path || entry.ends_with(&format!("/{}", path)))
+}
+
+fn normalize_archive_path(path: &str) -> String {
+    path.replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn package_completeness_flags_tracked_runtime_dir_missing_from_zip() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join("agents")).expect("agents dir");
+        std::fs::write(repo.path().join("plugin.php"), "<?php\n").expect("plugin");
+        std::fs::write(repo.path().join("agents/runtime.php"), "<?php\n").expect("agent");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "plugin.php", "agents/runtime.php"]);
+
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("plugin/plugin.php", "<?php\n")]);
+
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: repo.path().to_string_lossy().to_string(),
+            ..Component::default()
+        };
+        let artifacts = vec![ReleaseArtifact {
+            path: "build/package.zip".to_string(),
+            durable_path: None,
+            artifact_type: Some("archive".to_string()),
+            platform: None,
+        }];
+
+        let error = validate_package_completeness(&component, repo.path(), &artifacts)
+            .expect_err("missing tracked runtime file should fail");
+
+        assert!(error.message.contains("agents/runtime.php"));
+    }
+
+    #[test]
+    fn package_completeness_honors_release_scope_excludes() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join("agents")).expect("agents dir");
+        std::fs::write(repo.path().join("plugin.php"), "<?php\n").expect("plugin");
+        std::fs::write(repo.path().join("agents/runtime.php"), "<?php\n").expect("agent");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "plugin.php", "agents/runtime.php"]);
+
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("plugin/plugin.php", "<?php\n")]);
+
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: repo.path().to_string_lossy().to_string(),
+            scopes: Some(crate::core::component::ScopeConfig {
+                release: Some(CommandScopeConfig {
+                    include: Vec::new(),
+                    exclude: vec!["agents/**".to_string()],
+                }),
+                ..Default::default()
+            }),
+            ..Component::default()
+        };
+        let artifacts = vec![ReleaseArtifact {
+            path: "build/package.zip".to_string(),
+            durable_path: None,
+            artifact_type: Some("archive".to_string()),
+            platform: None,
+        }];
+
+        validate_package_completeness(&component, repo.path(), &artifacts)
+            .expect("excluded runtime file should not fail");
+    }
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn write_zip(path: &Path, entries: &[(&str, &str)]) {
+        let file = std::fs::File::create(path).expect("zip file");
+        let mut zip = zip::ZipWriter::new(file);
+        for (name, body) in entries {
+            zip.start_file(*name, zip::write::FileOptions::default())
+                .expect("zip entry");
+            zip.write_all(body.as_bytes()).expect("zip body");
+        }
+        zip.finish().expect("finish zip");
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #7635.
- Adds release package preflight validation that compares tracked runtime files from the component checkout against produced zip artifact contents.
- Honors existing component release/default scope include/exclude rules for intentional omissions.
- Adds regression coverage for a tracked runtime directory missing from the zip and scope-based exclusion behavior.

## Tests
- cargo fmt --check
- cargo test package_completeness --lib
- cargo test package_preflight --lib
- cargo clippy --lib -- -D warnings (fails on existing repo-wide clippy warnings outside this change)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected release packaging flow, implemented package completeness preflight and regression tests, and ran focused verification.