### PR TITLE
Support rig-backed fuzz profiles

### DIFF
--- a/src/commands/fuzz/execution.rs
+++ b/src/commands/fuzz/execution.rs
@@ -33,7 +33,8 @@ use super::types::{
 };
 use super::workloads::{
     build_target_inventory, fuzz_invocation_requirements, fuzz_workloads, load_rig,
-    resolve_component_id, resolve_fuzz_context, select_workload, FuzzRigContext,
+    resolve_component_id, resolve_fuzz_context, resolve_profile_workload_id, select_workload,
+    FuzzRigContext,
 };
 
 const FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND: &str = "fuzz_coverage_reconciliation";
@@ -81,7 +82,12 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         rig_context.as_ref(),
         extension_id.as_deref(),
     );
-    let selected_workload = select_workload(&workloads, args.workload_id.as_deref())?;
+    let selected_workload_id = resolve_profile_workload_id(
+        rig_context.as_ref().map(|context| &context.spec),
+        args.profile.as_deref(),
+        args.workload_id.as_deref(),
+    )?;
+    let selected_workload = select_workload(&workloads, selected_workload_id.as_deref())?;
     let target_inventory = build_target_inventory(
         &ctx.component_id,
         &workloads,
@@ -94,7 +100,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     let rig_id = rig_context.as_ref().map(|context| context.spec.id.clone());
     let workload_id = selected_workload
         .map(|workload| workload.id.clone())
-        .or_else(|| args.workload_id.clone());
+        .or(selected_workload_id);
     let execution_request = build_fuzz_execution_request(
         &args,
         &ctx.component_id,
@@ -1199,6 +1205,7 @@ pub(super) fn fuzz_runner_contract(config: Option<&FuzzConfig>) -> FuzzRunnerCon
         "HOMEBOY_FUZZ_RUN_ID",
         "HOMEBOY_FUZZ_SEED",
         "HOMEBOY_FUZZ_INVENTORY_FILE",
+        "HOMEBOY_FUZZ_SHARED_STATE",
         "HOMEBOY_FUZZ_MAX_DURATION",
         "HOMEBOY_FUZZ_GATE_PROFILE",
         "HOMEBOY_FUZZ_ALLOW_DESTRUCTIVE",
@@ -1394,6 +1401,12 @@ pub(super) fn fuzz_runner_env(
     if let Some(path) = args.inventory.as_ref() {
         env.push((
             "HOMEBOY_FUZZ_INVENTORY_FILE".to_string(),
+            path.to_string_lossy().to_string(),
+        ));
+    }
+    if let Some(path) = args.shared_state.as_ref() {
+        env.push((
+            "HOMEBOY_FUZZ_SHARED_STATE".to_string(),
             path.to_string_lossy().to_string(),
         ));
     }

--- a/src/commands/fuzz/planning.rs
+++ b/src/commands/fuzz/planning.rs
@@ -22,7 +22,7 @@ use super::types_extra::{
 };
 use super::workloads::{
     build_target_inventory, fuzz_workloads, load_rig, resolve_component_id, resolve_fuzz_context,
-    select_workload,
+    resolve_profile_workload_id, select_workload,
 };
 use homeboy::core::extension::ExtensionCapability;
 
@@ -50,10 +50,15 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
         rig_context.as_ref(),
         ctx.extension_id.as_deref(),
     );
-    let selected_workload = select_workload(&workloads, args.run.workload_id.as_deref())?;
+    let selected_workload_id = resolve_profile_workload_id(
+        rig_context.as_ref().map(|context| &context.spec),
+        args.run.profile.as_deref(),
+        args.run.workload_id.as_deref(),
+    )?;
+    let selected_workload = select_workload(&workloads, selected_workload_id.as_deref())?;
     let workload_id = selected_workload
         .map(|workload| workload.id.clone())
-        .or_else(|| args.run.workload_id.clone());
+        .or(selected_workload_id);
     let (required_artifacts, gates) = fuzz_gate_profile_contract(args.run.gate_profile.as_core());
     let request_id = args
         .request_id

--- a/src/commands/fuzz/tests/execution_tests.rs
+++ b/src/commands/fuzz/tests/execution_tests.rs
@@ -16,6 +16,8 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
                 setting_json: vec![],
             },
             workload_id: Some("parser".to_string()),
+            profile: None,
+            shared_state: None,
             run_id: Some("proof-1".to_string()),
             tracker_refs: vec![homeboy::core::evidence_manifest::TrackerRef {
                 kind: "github_issue".to_string(),
@@ -1230,6 +1232,8 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
                 setting_json: vec![],
             },
             workload_id: Some("parser".to_string()),
+            profile: None,
+            shared_state: None,
             run_id: Some("proof-bad-results".to_string()),
             tracker_refs: vec![],
             seed: None,

--- a/src/commands/fuzz/tests/mod.rs
+++ b/src/commands/fuzz/tests/mod.rs
@@ -27,8 +27,8 @@ use super::types::{
     FuzzValidateArgs, FuzzWorkloadOutput,
 };
 use super::workloads::{
-    fuzz_workloads, resolve_component_id, resolve_fuzz_context, rig_component_for_fuzz,
-    select_workload, FuzzRigContext,
+    fuzz_workloads, resolve_component_id, resolve_fuzz_context, resolve_profile_workload_id,
+    rig_component_for_fuzz, select_workload, FuzzRigContext,
 };
 use super::{run_contract, run_discover, FuzzArgs};
 use clap::Parser;
@@ -92,6 +92,8 @@ fn planner_args() -> FuzzPlanArgs {
             extension_override: ExtensionOverrideArgs::default(),
             setting_args: SettingArgs::default(),
             workload_id: Some("api-fuzz".to_string()),
+            profile: None,
+            shared_state: None,
             run_id: Some("proof-1".to_string()),
             tracker_refs: vec![],
             seed: None,
@@ -342,6 +344,8 @@ fn fuzz_run_args_with_run_id(run_id: &str) -> FuzzRunArgs {
             setting_json: vec![],
         },
         workload_id: Some("parser".to_string()),
+        profile: None,
+        shared_state: None,
         run_id: Some(run_id.to_string()),
         tracker_refs: vec![],
         seed: Some("1234".to_string()),

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -170,6 +170,96 @@ fn resolve_fuzz_context_preserves_rig_extensions_with_explicit_path_when_registr
 }
 
 #[test]
+fn resolve_fuzz_context_infers_single_rig_fuzz_workload_extension() {
+    with_isolated_home(|home| {
+        let extension_dir = home.path().join(".config/homeboy/extensions/generic");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("generic.json"),
+            serde_json::json!({
+                "name": "generic",
+                "version": "0.0.0",
+                "fuzz": { "workloads": [] }
+            })
+            .to_string(),
+        )
+        .expect("extension manifest");
+        let component_dir = tempfile::tempdir().expect("component dir");
+        let spec: RigSpec = serde_json::from_value(serde_json::json!({
+            "id": "package-fuzz",
+            "components": {
+                "package": {
+                    "path": component_dir.path().to_string_lossy(),
+                    "extensions": {
+                        "generic": { "settings": {} }
+                    }
+                }
+            },
+            "fuzz": { "default_component": "package" },
+            "fuzz_workloads": {
+                "generic": [{ "path": "${package.root}/fuzz/parser.json" }]
+            }
+        }))
+        .expect("parse rig spec");
+        let context = FuzzRigContext {
+            spec,
+            package_root: Some(home.path().join("rig-package")),
+        };
+        let comp = PositionalComponentArgs {
+            component: Some("package".to_string()),
+            path: None,
+        };
+
+        let resolved = resolve_fuzz_context(
+            "package",
+            &comp,
+            &SettingArgs::default(),
+            &ExtensionOverrideArgs::default(),
+            homeboy::core::extension::ExtensionCapability::Fuzz,
+            Some(&context),
+        )
+        .expect("resolve fuzz context");
+
+        assert_eq!(resolved.extension_id.as_deref(), Some("generic"));
+    });
+}
+
+#[test]
+fn resolve_profile_workload_id_uses_single_fuzz_profile_entry() {
+    let spec: RigSpec = serde_json::from_value(serde_json::json!({
+        "id": "package-fuzz",
+        "fuzz_profiles": {
+            "lab": ["mysql-poc-lifecycle-fuzz"]
+        }
+    }))
+    .expect("parse rig spec");
+
+    let workload_id = resolve_profile_workload_id(Some(&spec), Some("lab"), None)
+        .expect("resolve profile workload");
+
+    assert_eq!(workload_id.as_deref(), Some("mysql-poc-lifecycle-fuzz"));
+}
+
+#[test]
+fn resolve_profile_workload_id_rejects_unknown_profile_with_available_profiles() {
+    let spec: RigSpec = serde_json::from_value(serde_json::json!({
+        "id": "package-fuzz",
+        "fuzz_profiles": {
+            "lab": ["mysql-poc-lifecycle-fuzz"]
+        }
+    }))
+    .expect("parse rig spec");
+
+    let err = resolve_profile_workload_id(Some(&spec), Some("missing"), None)
+        .expect_err("missing profile should fail");
+
+    assert!(err
+        .message
+        .contains("does not declare fuzz profile 'missing'"));
+    assert_eq!(err.details["tried"], serde_json::json!(["lab"]));
+}
+
+#[test]
 fn fuzz_list_materializes_prepare_dependencies_before_workload_validation() {
     with_isolated_home(|home| {
         let component_dir = home.path().join("component");
@@ -482,6 +572,8 @@ fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_cont
             setting_json: vec![],
         },
         workload_id: Some("parser".to_string()),
+        profile: None,
+        shared_state: Some(PathBuf::from("/tmp/fuzz-shared-state")),
         run_id: Some("proof-1".to_string()),
         tracker_refs: vec![],
         seed: Some("1234".to_string()),
@@ -551,6 +643,10 @@ fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_cont
         "HOMEBOY_FUZZ_INVENTORY_FILE".to_string(),
         "/tmp/fuzz-inventory.json".to_string()
     )));
+    assert!(env.contains(&(
+        "HOMEBOY_FUZZ_SHARED_STATE".to_string(),
+        "/tmp/fuzz-shared-state".to_string()
+    )));
     assert!(env.contains(&("HOMEBOY_FUZZ_MAX_DURATION".to_string(), "60s".to_string())));
     assert!(env.contains(&(
         "HOMEBOY_FUZZ_GATE_PROFILE".to_string(),
@@ -568,6 +664,9 @@ fn fuzz_runner_env_includes_results_file_selected_workload_path_and_generic_cont
     assert!(contract
         .env
         .contains(&"HOMEBOY_FUZZ_ARTIFACTS_DIR".to_string()));
+    assert!(contract
+        .env
+        .contains(&"HOMEBOY_FUZZ_SHARED_STATE".to_string()));
     assert!(contract
         .env
         .contains(&"HOMEBOY_FUZZ_EXECUTION_REQUEST_FILE".to_string()));
@@ -661,6 +760,8 @@ fn fuzz_runner_env_expands_rig_workload_and_injects_runtime_context() {
             setting_json: vec![],
         },
         workload_id: Some("parser".to_string()),
+        profile: None,
+        shared_state: None,
         run_id: Some("proof-1".to_string()),
         tracker_refs: vec![],
         seed: None,
@@ -790,6 +891,8 @@ fn fuzz_runner_env_stages_generic_workload_file_refs() {
             setting_json: vec![],
         },
         workload_id: Some("rest-product-batch-import".to_string()),
+        profile: None,
+        shared_state: None,
         run_id: Some("proof-1".to_string()),
         tracker_refs: vec![],
         seed: None,
@@ -930,6 +1033,8 @@ fn fuzz_runner_env_stages_nested_generic_workload_json_file_refs() {
             setting_json: vec![],
         },
         workload_id: Some("rest-product-batch-import".to_string()),
+        profile: None,
+        shared_state: None,
         run_id: Some("proof-1".to_string()),
         tracker_refs: vec![],
         seed: None,

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -190,6 +190,16 @@ pub struct FuzzRunArgs {
     #[arg(long = "workload", value_name = "ID")]
     pub(crate) workload_id: Option<String>,
 
+    /// Rig-defined fuzz profile to select. Profiles resolve to workload ids in
+    /// the selected rig's fuzz_profiles map.
+    #[arg(long = "profile", value_name = "ID")]
+    pub(crate) profile: Option<String>,
+
+    /// Shared state directory handed to the fuzz runner. Homeboy forwards the
+    /// path as HOMEBOY_FUZZ_SHARED_STATE; the runner owns any mutation policy.
+    #[arg(long = "shared-state", value_name = "DIR")]
+    pub(crate) shared_state: Option<PathBuf>,
+
     /// Stable caller-supplied proof label for downstream fuzz runners.
     #[arg(long = "run-id", value_name = "ID")]
     pub(crate) run_id: Option<String>,

--- a/src/commands/fuzz/workloads.rs
+++ b/src/commands/fuzz/workloads.rs
@@ -146,9 +146,82 @@ pub(super) fn resolve_fuzz_context(
         settings.setting.clone(),
         settings.setting_json.clone(),
     );
-    resolve_options.extension_overrides = extension_override.extensions.clone();
+    resolve_options.extension_overrides = if extension_override.extensions.is_empty() {
+        infer_single_rig_fuzz_extension(rig_spec)
+            .into_iter()
+            .collect()
+    } else {
+        extension_override.extensions.clone()
+    };
 
     execution_context::resolve_with_component(&resolve_options, component_override)
+}
+
+fn infer_single_rig_fuzz_extension(rig_spec: Option<&RigSpec>) -> Option<String> {
+    let mut ids = rig_spec
+        .map(|spec| rig::extension_ids_for_workloads(spec, rig::RigWorkloadKind::Fuzz))
+        .unwrap_or_default();
+    (ids.len() == 1).then(|| ids.remove(0))
+}
+
+pub(super) fn resolve_profile_workload_id(
+    rig_spec: Option<&RigSpec>,
+    profile: Option<&str>,
+    explicit_workload_id: Option<&str>,
+) -> homeboy::core::Result<Option<String>> {
+    if profile.is_some() && explicit_workload_id.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "profile",
+            "--profile and --workload cannot be combined; pass one workload selector",
+            profile.map(str::to_string),
+            None,
+        ));
+    }
+
+    let Some(profile) = profile else {
+        return Ok(explicit_workload_id.map(str::to_string));
+    };
+    let Some(spec) = rig_spec else {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "profile",
+            "fuzz profiles require --rig so Homeboy can read rig fuzz_profiles",
+            Some(profile.to_string()),
+            None,
+        ));
+    };
+    let Some(workload_ids) = spec.fuzz_profiles.get(profile) else {
+        let mut profiles = spec.fuzz_profiles.keys().cloned().collect::<Vec<_>>();
+        profiles.sort();
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "profile",
+            format!(
+                "rig '{}' does not declare fuzz profile '{}'",
+                spec.id, profile
+            ),
+            Some(profile.to_string()),
+            Some(profiles),
+        )
+        .with_hint(format!(
+            "Run `homeboy fuzz list --rig {}` to inspect resolved fuzz workloads",
+            spec.id
+        )));
+    };
+    if workload_ids.len() != 1 {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "profile",
+            format!(
+                "fuzz profile '{}' in rig '{}' resolves to {} workloads; `homeboy fuzz run` requires exactly one workload",
+                profile,
+                spec.id,
+                workload_ids.len()
+            ),
+            Some(profile.to_string()),
+            Some(workload_ids.clone()),
+        )
+        .with_hint("Select one workload with `--workload <id>` or use a campaign command for multi-workload profiles."));
+    }
+
+    Ok(workload_ids.first().cloned())
 }
 
 fn rig_component_path(spec: &RigSpec, component_id: &str) -> Option<String> {
@@ -381,6 +454,7 @@ pub(super) fn select_workload<'a>(
                     None,
                     None,
                 )
+                .with_hint("For rig-backed workloads, run `homeboy fuzz list --rig <id>` and pass `--workload <id>` or `--profile <profile>`.")
             });
     }
 

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -241,6 +241,7 @@ mod tests {
                 trace_experiments: Default::default(),
                 trace_guardrails: Default::default(),
                 bench_profiles: Default::default(),
+                fuzz_profiles: Default::default(),
                 app_launcher: None,
             },
             resources: RigResourcesSpec {

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -163,6 +163,13 @@ pub struct RigSpec {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub bench_profiles: HashMap<String, Vec<String>>,
 
+    /// Named fuzz workload suites keyed by profile name.
+    ///
+    /// `homeboy fuzz --rig <id> --profile <name>` resolves the profile to
+    /// workload ids, then uses the normal fuzz workload selection path.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub fuzz_profiles: HashMap<String, Vec<String>>,
+
     /// Optional desktop launcher wrapper for this rig.
     ///
     /// Generates a desktop launcher that runs `homeboy rig check` and

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -52,6 +52,7 @@ fn rig_with_launcher(install_dir: &str) -> RigSpec {
         trace_experiments: Default::default(),
         trace_guardrails: Default::default(),
         bench_profiles: Default::default(),
+        fuzz_profiles: Default::default(),
         app_launcher: Some(AppLauncherSpec {
             platform: AppLauncherPlatform::Macos,
             wrapper_display_name: "Studio (Dev)".to_string(),

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -30,6 +30,7 @@ fn minimal_rig() -> RigSpec {
         trace_experiments: Default::default(),
         trace_guardrails: Default::default(),
         bench_profiles: Default::default(),
+        fuzz_profiles: Default::default(),
         app_launcher: None,
     }
 }

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -37,6 +37,7 @@ fn rig_with(id: &str, components: HashMap<String, ComponentSpec>) -> RigSpec {
         trace_experiments: Default::default(),
         trace_guardrails: Default::default(),
         bench_profiles: Default::default(),
+        fuzz_profiles: Default::default(),
         app_launcher: None,
     }
 }

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -54,6 +54,7 @@ fn rig(id: &str, resources: RigResourcesSpec) -> RigSpec {
         trace_experiments: Default::default(),
         trace_guardrails: Default::default(),
         bench_profiles: Default::default(),
+        fuzz_profiles: Default::default(),
         app_launcher: None,
     }
 }

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -895,6 +895,7 @@ mod dag {
             trace_experiments: Default::default(),
             trace_guardrails: Default::default(),
             bench_profiles: Default::default(),
+            fuzz_profiles: Default::default(),
         }
     }
 
@@ -1205,6 +1206,7 @@ mod git_steps {
             trace_experiments: Default::default(),
             trace_guardrails: Default::default(),
             bench_profiles: Default::default(),
+            fuzz_profiles: Default::default(),
         }
     }
 
@@ -1323,6 +1325,7 @@ mod extension_lifecycle {
             trace_experiments: Default::default(),
             trace_guardrails: Default::default(),
             bench_profiles: Default::default(),
+            fuzz_profiles: Default::default(),
         }
     }
 
@@ -1458,6 +1461,7 @@ mod command_env {
             trace_experiments: Default::default(),
             trace_guardrails: Default::default(),
             bench_profiles: Default::default(),
+            fuzz_profiles: Default::default(),
             app_launcher: None,
         }
     }

--- a/tests/core/rig/pipeline_test/patch.rs
+++ b/tests/core/rig/pipeline_test/patch.rs
@@ -50,6 +50,7 @@ fn rig_with_patch(component_path: &str, step: PipelineStep) -> RigSpec {
         trace_experiments: Default::default(),
         trace_guardrails: Default::default(),
         bench_profiles: Default::default(),
+        fuzz_profiles: Default::default(),
         app_launcher: None,
     }
 }

--- a/tests/core/rig/pipeline_test/shared_path.rs
+++ b/tests/core/rig/pipeline_test/shared_path.rs
@@ -43,6 +43,7 @@ fn rig_with_shared_path(id: &str, shared: SharedPathSpec, op: SharedPathOp) -> R
         trace_experiments: Default::default(),
         trace_guardrails: Default::default(),
         bench_profiles: Default::default(),
+        fuzz_profiles: Default::default(),
         app_launcher: None,
     }
 }

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -36,6 +36,7 @@ fn observation_spec(id: &str) -> RigSpec {
         trace_experiments: HashMap::new(),
         trace_guardrails: Vec::new(),
         bench_profiles: HashMap::new(),
+        fuzz_profiles: HashMap::new(),
         app_launcher: None,
     }
 }

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -61,6 +61,7 @@ fn minimal_spec(id: &str) -> RigSpec {
         trace_experiments: HashMap::new(),
         trace_guardrails: Vec::new(),
         bench_profiles: HashMap::new(),
+        fuzz_profiles: HashMap::new(),
         app_launcher: None,
     }
 }
@@ -633,6 +634,7 @@ fn test_run_down_cleans_state_owned_shared_paths() {
             trace_experiments: HashMap::new(),
             trace_guardrails: Vec::new(),
             bench_profiles: HashMap::new(),
+            fuzz_profiles: HashMap::new(),
             app_launcher: None,
         };
 
@@ -704,6 +706,7 @@ fn test_run_status() {
             trace_experiments: HashMap::new(),
             trace_guardrails: Vec::new(),
             bench_profiles: HashMap::new(),
+            fuzz_profiles: HashMap::new(),
         };
 
         let status = run_status(&rig).expect("run_status with service");
@@ -881,6 +884,7 @@ fn test_snapshot_state() {
         trace_experiments: HashMap::new(),
         trace_guardrails: Vec::new(),
         bench_profiles: HashMap::new(),
+        fuzz_profiles: HashMap::new(),
         app_launcher: None,
     };
 

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -53,6 +53,7 @@ mod lifecycle {
             trace_experiments: HashMap::new(),
             trace_guardrails: Vec::new(),
             bench_profiles: HashMap::new(),
+            fuzz_profiles: HashMap::new(),
         }
     }
 
@@ -82,6 +83,7 @@ mod lifecycle {
             trace_experiments: HashMap::new(),
             trace_guardrails: Vec::new(),
             bench_profiles: HashMap::new(),
+            fuzz_profiles: HashMap::new(),
         }
     }
 

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -49,6 +49,7 @@ fn rig_with_components(components: HashMap<String, ComponentSpec>) -> RigSpec {
         trace_experiments: Default::default(),
         trace_guardrails: Default::default(),
         bench_profiles: Default::default(),
+        fuzz_profiles: Default::default(),
         app_launcher: None,
     }
 }


### PR DESCRIPTION
## Summary
- add generic rig `fuzz_profiles` support and `homeboy fuzz --profile <id>` workload selection
- infer a single rig-declared fuzz workload extension when no explicit `--extension` is supplied
- accept `--shared-state <DIR>` for fuzz and forward it to runners as `HOMEBOY_FUZZ_SHARED_STATE`
- improve unknown workload/profile guidance for rig-backed fuzz runs

## Tests
- `cargo test fuzz::tests::workload_tests --no-default-features`
- `cargo test fuzz::tests --no-default-features`
- `cargo test core::rig::workloads_test --no-default-features`
- `cargo run --no-default-features -- fuzz --help`

## Caveats
- Did not run the Studio MySQL fuzz workload locally; this PR only verifies parsing, resolution, planning helpers, and non-destructive unit paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with model openai/gpt-5.5
- **Used for:** Inspecting the Homeboy fuzz/rig resolution path, drafting the generic implementation, adding tests, and running focused verification.