### PR TITLE
Use scoped changelog notes for component releases

### DIFF
--- a/src/core/release/executor/github_release/mod.rs
+++ b/src/core/release/executor/github_release/mod.rs
@@ -33,8 +33,9 @@ pub(crate) use crate::core::release::types::ReleaseStepResult;
 pub(crate) use gh_cli::{github_cli_env, github_release_artifact_paths};
 #[cfg(test)]
 pub(crate) use notes::{
-    fallback_release_notes, github_changelog_url, github_generated_notes_start_tag,
-    github_release_notes_start_tag, replace_full_changelog_footer, GitHubReleaseBody,
+    build_github_release_body, fallback_release_notes, github_changelog_url,
+    github_generated_notes_start_tag, github_release_notes_start_tag,
+    replace_full_changelog_footer, GitHubReleaseBody,
 };
 #[cfg(test)]
 pub(crate) use repair::{

--- a/src/core/release/executor/github_release/notes.rs
+++ b/src/core/release/executor/github_release/notes.rs
@@ -5,6 +5,7 @@ use crate::core::component::GithubConfig;
 use crate::core::deploy::release_download::GitHubRepo;
 use crate::core::error::{Error, Result};
 use crate::core::release::changelog;
+use crate::core::release::scope::ReleaseScope;
 use crate::core::release::types::ReleaseState;
 
 use super::gh_cli::{gh_command, safe_filename};
@@ -60,6 +61,19 @@ pub(crate) fn build_github_release_body(
     changelog_url: Option<&str>,
     notes_start_tag: Option<&str>,
 ) -> GitHubReleaseBody {
+    if component_release_notes_require_changelog_fallback(component) {
+        log_status!(
+            "release",
+            "Using Homeboy changelog notes for component-scoped release {} because GitHub generated release notes cannot path-filter monorepo commits",
+            tag
+        );
+        return GitHubReleaseBody {
+            body: fallback_release_notes(state, changelog_url, tag),
+            generated_notes_ok: false,
+            changelog_url: changelog_url.map(str::to_string),
+        };
+    }
+
     match github_generated_notes(github, &component.github, tag, notes_start_tag) {
         Ok(generated_notes) => {
             let body = changelog_url
@@ -84,6 +98,12 @@ pub(crate) fn build_github_release_body(
             }
         }
     }
+}
+
+fn component_release_notes_require_changelog_fallback(component: &Component) -> bool {
+    ReleaseScope::resolve(component, &component.id)
+        .map(|scope| !scope.path_prefix.is_empty() || !scope.path_prefixes.is_empty())
+        .unwrap_or(false)
 }
 
 /// Persist the exact release body to `build/<tag>-release-notes.md` so it is

--- a/src/core/release/executor/github_release/tests/notes_tests.rs
+++ b/src/core/release/executor/github_release/tests/notes_tests.rs
@@ -2,8 +2,10 @@
 
 use crate::core::release::types::ReleaseState;
 
-use super::super::{create_failed_result, fallback_release_notes, GitHubReleaseBody};
-use super::{data_str, test_body, test_repair, test_repo};
+use super::super::{
+    build_github_release_body, create_failed_result, fallback_release_notes, GitHubReleaseBody,
+};
+use super::{data_str, git_repo, test_body, test_repair, test_repo};
 
 #[test]
 fn fallback_release_notes_uses_changelog_notes_when_present() {
@@ -34,6 +36,36 @@ fn fallback_release_notes_falls_back_to_minimal_body_when_empty() {
     let notes = fallback_release_notes(&state, None, "v0.10.6");
 
     assert_eq!(notes, "Release v0.10.6");
+}
+
+#[test]
+fn component_scoped_release_body_uses_changelog_fallback() {
+    let temp = git_repo();
+    let component_dir = temp.path().join("packages/wordpress");
+    std::fs::create_dir_all(&component_dir).expect("create component dir");
+    let component = crate::core::component::Component {
+        id: "wordpress".to_string(),
+        local_path: component_dir.to_string_lossy().to_string(),
+        ..Default::default()
+    };
+    let state = ReleaseState {
+        notes: Some("## wordpress-v1.2.3\n\n- Fix scoped release notes".to_string()),
+        ..Default::default()
+    };
+
+    let body = build_github_release_body(
+        &component,
+        &test_repo(),
+        "wordpress-v1.2.3",
+        &state,
+        Some("https://github.com/example-org/studio-web/blob/wordpress-v1.2.3/packages/wordpress/CHANGELOG.md"),
+        Some("wordpress-v1.2.2"),
+    );
+
+    assert!(!body.generated_notes_ok);
+    assert_eq!(body.source_label(), "changelog-fallback");
+    assert!(body.body.contains("- Fix scoped release notes"));
+    assert!(body.body.contains("packages/wordpress/CHANGELOG.md"));
 }
 
 // ---- Issue #3508: the exact GitHub Release body must be discoverable ----


### PR DESCRIPTION
## Summary
- Use Homeboy's finalized changelog notes for component-scoped GitHub releases.
- Avoid GitHub generated release notes for scoped monorepo components because the API cannot path-filter sibling commits.
- Add regression coverage for a subdirectory component release body using the changelog fallback.

## Testing
- cargo fmt --check
- cargo test core::release::executor::github_release::tests::notes_tests -- --nocapture

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Investigated the Homeboy release-notes path, implemented the scoped fallback, added regression coverage, and ran focused verification.