### PR TITLE
Project path materialization remaps

### DIFF
--- a/src/command_contract/constants.rs
+++ b/src/command_contract/constants.rs
@@ -162,6 +162,7 @@ pub struct RunnerExecutionRecordConstants {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct PathMaterializationPlanConstants {
     pub schema_id: String,
+    pub projection_fields: Vec<String>,
     pub roles: Vec<String>,
     pub owners: Vec<String>,
     pub materialization_modes: Vec<String>,
@@ -384,6 +385,11 @@ pub fn runner_execution_record_constants() -> RunnerExecutionRecordConstants {
 pub fn path_materialization_plan_constants() -> PathMaterializationPlanConstants {
     PathMaterializationPlanConstants {
         schema_id: PATH_MATERIALIZATION_PLAN_SCHEMA.to_string(),
+        projection_fields: vec![
+            "schema".to_string(),
+            "entries".to_string(),
+            "path_remaps".to_string(),
+        ],
         roles: vec![
             PATH_MATERIALIZATION_ROLE_PRIMARY_WORKSPACE.to_string(),
             PATH_MATERIALIZATION_ROLE_REQUIRED_PATH.to_string(),

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -41,9 +41,9 @@ use crate::core::run_outcome_envelope::{
     RunOutcomeEnvelope, RunOutcomeProjection, RUN_OUTCOME_ENVELOPE_SCHEMA,
 };
 use crate::core::runner_execution_envelope::{
-    PathMaterializationPlan, RunnerExecutionEnvelope, RunnerExecutionProjection,
-    RunnerExecutionRecord, PATH_MATERIALIZATION_PLAN_SCHEMA, RUNNER_EXECUTION_ENVELOPE_SCHEMA,
-    RUNNER_EXECUTION_RECORD_SCHEMA,
+    PathMaterializationPlan, PathMaterializationPlanProjection, RunnerExecutionEnvelope,
+    RunnerExecutionProjection, RunnerExecutionRecord, PATH_MATERIALIZATION_PLAN_SCHEMA,
+    RUNNER_EXECUTION_ENVELOPE_SCHEMA, RUNNER_EXECUTION_RECORD_SCHEMA,
 };
 use crate::core::secret_env_plan::{
     SecretEnvMaterializedHandoff, SecretEnvMaterializedHandoffRequest, SecretEnvPlan,
@@ -160,6 +160,7 @@ pub enum ContractMaterializeKind {
 #[clap(rename_all = "kebab-case")]
 pub enum ContractNormalizeKind {
     ArtifactRef,
+    PathMaterializationPlan,
     RunLifecycleStatus,
     RunnerExecutionRecord,
     RunOutcomeEnvelope,
@@ -205,6 +206,7 @@ pub struct ContractValidateOutput {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ContractNormalizeOutput {
     ArtifactRef(ArtifactRefNormalizeOutput),
+    PathMaterializationPlan(PathMaterializationPlanProjection),
     RunLifecycleStatus(RunLifecycleStatusNormalizeOutput),
     RunnerExecutionRecord(RunnerExecutionProjection),
     RunOutcomeEnvelope(RunOutcomeProjection),
@@ -481,6 +483,10 @@ fn normalize(args: ContractNormalizeArgs) -> Result<ContractNormalizeOutput> {
         ContractNormalizeKind::ArtifactRef => {
             normalize_artifact_ref(value).map(ContractNormalizeOutput::ArtifactRef)
         }
+        ContractNormalizeKind::PathMaterializationPlan => {
+            normalize_path_materialization_plan(value)
+                .map(ContractNormalizeOutput::PathMaterializationPlan)
+        }
         ContractNormalizeKind::RunLifecycleStatus => {
             normalize_run_lifecycle_status(value).map(ContractNormalizeOutput::RunLifecycleStatus)
         }
@@ -603,6 +609,18 @@ fn normalize_runner_execution_record(value: Value) -> Result<RunnerExecutionProj
     )?;
 
     Ok(record.projection())
+}
+
+fn normalize_path_materialization_plan(value: Value) -> Result<PathMaterializationPlanProjection> {
+    let plan: PathMaterializationPlan = deserialize_contract_value(
+        value,
+        "path-materialization-plan",
+        "expected a canonical path materialization plan JSON object with schema and entries",
+    )?;
+
+    validate_schema_field(PATH_MATERIALIZATION_PLAN_SCHEMA, &plan.schema)?;
+
+    Ok(plan.projection())
 }
 
 fn normalize_run_outcome_envelope(value: Value) -> Result<RunOutcomeProjection> {
@@ -892,6 +910,7 @@ fn contract_schema_catalog() -> ContractSchemaCatalog {
                     field("entries[].remote_path", "string", "Runner-side path to validate or materialize.", true),
                     field("entries[].materialization_mode", "string", "Materialization mode enum: existing_remote, git, or snapshot.", true),
                     field("entries[].validation_status", "string", "Validation/materialization status enum: validated or materialized.", true),
+                    field("projection.path_remaps", "array", "Normalize-only derived local-to-remote path remaps for runtime consumers. This is not accepted in the canonical input shape.", false),
                 ],
                 required: vec!["schema", "entries"],
                 example: path_materialization_plan_example(),
@@ -1862,6 +1881,7 @@ mod tests {
         assert!(path_materialization["example"]
             .get("runtime_mounts")
             .is_none());
+        assert!(fields.contains(&"projection.path_remaps"));
         assert!(catalog["contracts"]
             .as_array()
             .unwrap()
@@ -2043,6 +2063,96 @@ mod tests {
         assert_eq!(output.materialized_paths.len(), 1);
         assert_eq!(output.materialized_paths[0].remote_path, "/runner/project");
         assert_eq!(output.artifact_refs[0].id, "summary");
+    }
+
+    #[test]
+    fn path_materialization_plan_normalizer_projects_runtime_path_remaps() {
+        let output = normalize_path_materialization_plan(json!({
+            "schema": PATH_MATERIALIZATION_PLAN_SCHEMA,
+            "entries": [
+                {
+                    "role": "primary_workspace",
+                    "owner": "lab.execution_context",
+                    "local_path": "/local/project",
+                    "remote_path": "/runner/project",
+                    "materialization_mode": "snapshot",
+                    "validation_status": "materialized"
+                },
+                {
+                    "role": "required_path",
+                    "owner": "runner_exec.require_paths",
+                    "remote_path": "/runner/cache",
+                    "materialization_mode": "existing_remote",
+                    "validation_status": "validated"
+                }
+            ]
+        }))
+        .expect("path materialization plan should normalize");
+
+        assert_eq!(output.schema, PATH_MATERIALIZATION_PLAN_SCHEMA);
+        assert_eq!(output.entries.len(), 2);
+        assert_eq!(output.path_remaps.len(), 1);
+        assert_eq!(output.path_remaps[0].local_path, "/local/project");
+        assert_eq!(output.path_remaps[0].remote_path, "/runner/project");
+    }
+
+    #[test]
+    fn normalize_command_projects_path_materialization_plan_remaps() {
+        let input = json!({
+            "schema": PATH_MATERIALIZATION_PLAN_SCHEMA,
+            "entries": [
+                {
+                    "role": "primary_workspace",
+                    "owner": "runner_exec.source_snapshot",
+                    "local_path": "/local/project",
+                    "remote_path": "/runner/project",
+                    "materialization_mode": "snapshot",
+                    "validation_status": "materialized"
+                },
+                {
+                    "role": "required_path",
+                    "owner": "runner_exec.require_paths",
+                    "remote_path": "/runner/cache",
+                    "materialization_mode": "existing_remote",
+                    "validation_status": "validated"
+                }
+            ]
+        });
+
+        let (output, exit_code) = run(
+            ContractArgs {
+                command: ContractCommand::Normalize(ContractNormalizeArgs {
+                    kind: ContractNormalizeKind::PathMaterializationPlan,
+                    input: Some(input.to_string()),
+                    input_file: None,
+                }),
+            },
+            &GlobalArgs {},
+        )
+        .expect("normalize path materialization plan");
+
+        assert_eq!(exit_code, 0);
+        let ContractOutput::Normalize(ContractNormalizeOutput::PathMaterializationPlan(output)) =
+            output
+        else {
+            panic!("expected path materialization normalize output");
+        };
+        assert_eq!(output.schema, PATH_MATERIALIZATION_PLAN_SCHEMA);
+        assert_eq!(output.entries.len(), 2);
+        assert_eq!(output.path_remaps.len(), 1);
+        assert_eq!(output.path_remaps[0].local_path, "/local/project");
+        assert_eq!(output.path_remaps[0].remote_path, "/runner/project");
+    }
+
+    #[test]
+    fn path_materialization_plan_normalizer_rejects_alias_shape() {
+        let err = normalize_path_materialization_plan(json!({
+            "schema": PATH_MATERIALIZATION_PLAN_SCHEMA,
+            "paths": ["/runner/project"]
+        }))
+        .expect_err("alias-shaped plan should stay invalid");
+
+        assert!(err.message.contains("unknown field `paths`"));
     }
 
     #[test]

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -137,17 +137,11 @@ pub(in crate::core::runner) fn remap_provider_config_with_materialization_plan_i
 fn provider_config_path_remaps_from_materialization_plan(
     plan: &PathMaterializationPlan,
 ) -> Vec<LabPathRemap> {
-    plan.projection_entries()
+    plan.path_remaps()
         .into_iter()
-        .filter_map(|entry| {
-            let local = entry.local_path?;
-            if local.trim().is_empty() || entry.remote_path.trim().is_empty() {
-                return None;
-            }
-            Some(LabPathRemap {
-                local,
-                remote: entry.remote_path,
-            })
+        .map(|remap| LabPathRemap {
+            local: remap.local_path,
+            remote: remap.remote_path,
         })
         .collect()
 }

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -195,6 +195,20 @@ pub struct PathMaterializationProjection {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathMaterializationPlanProjection {
+    pub schema: String,
+    pub entries: Vec<PathMaterializationProjection>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub path_remaps: Vec<PathMaterializationPathRemap>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathMaterializationPathRemap {
+    pub local_path: String,
+    pub remote_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PathMaterializationPlan {
     #[serde(default = "path_materialization_plan_schema")]
@@ -308,6 +322,21 @@ impl PathMaterializationPlan {
             .iter()
             .map(PathMaterializationProjection::from)
             .collect()
+    }
+
+    pub fn path_remaps(&self) -> Vec<PathMaterializationPathRemap> {
+        self.entries
+            .iter()
+            .filter_map(PathMaterializationPathRemap::from_entry)
+            .collect()
+    }
+
+    pub fn projection(&self) -> PathMaterializationPlanProjection {
+        PathMaterializationPlanProjection {
+            schema: self.schema.clone(),
+            entries: self.projection_entries(),
+            path_remaps: self.path_remaps(),
+        }
     }
 }
 
@@ -572,6 +601,21 @@ impl From<&PathMaterializationEntry> for PathMaterializationProjection {
             materialization_mode: entry.materialization_mode.clone(),
             validation_status: entry.validation_status.clone(),
         }
+    }
+}
+
+impl PathMaterializationPathRemap {
+    fn from_entry(entry: &PathMaterializationEntry) -> Option<Self> {
+        let local_path = entry.local_path.as_deref()?.trim();
+        let remote_path = entry.remote_path.trim();
+        if local_path.is_empty() || remote_path.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            local_path: local_path.to_string(),
+            remote_path: remote_path.to_string(),
+        })
     }
 }
 
@@ -1026,6 +1070,33 @@ mod tests {
             PATH_MATERIALIZATION_STATUS_VALIDATED
         );
         assert!(PathMaterializationPlan::non_empty(Vec::new()).is_none());
+    }
+
+    #[test]
+    fn path_materialization_plan_projection_exports_runtime_path_remaps() {
+        let plan = PathMaterializationPlan::new(vec![
+            PathMaterializationEntry::primary_workspace_materialized(
+                PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
+                Some(" /local/project ".to_string()),
+                " /runner/project ",
+                PathMaterializationMode::Snapshot.to_string(),
+            ),
+            PathMaterializationEntry::required_existing_remote("/runner/cache"),
+            PathMaterializationEntry::primary_workspace_materialized(
+                PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG,
+                Some("".to_string()),
+                "/runner/empty-local",
+                PathMaterializationMode::Snapshot.to_string(),
+            ),
+        ]);
+
+        let projection = plan.projection();
+
+        assert_eq!(projection.schema, PATH_MATERIALIZATION_PLAN_SCHEMA);
+        assert_eq!(projection.entries.len(), 3);
+        assert_eq!(projection.path_remaps.len(), 1);
+        assert_eq!(projection.path_remaps[0].local_path, "/local/project");
+        assert_eq!(projection.path_remaps[0].remote_path, "/runner/project");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a strict canonical path materialization plan normalizer that projects runtime `path_remaps` from `{ schema, entries }` input.
- Document `projection.path_remaps` and constants as normalize output, not canonical input.
- Reuse the projection helper in lab provider config remap generation.

## Tests
- `cargo fmt --check`
- `cargo test path_materialization -- --nocapture`
- `cargo test contract_export_writes_stable_json_files -- --nocapture`

## Downstream note
- Extensions can consume `homeboy contract normalize path-materialization-plan` to obtain ergonomic `path_remaps` while keeping canonical input strict.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified the path-materialization projection contract.