### PR TITLE
Consolidate adapter output descriptors

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -9,8 +9,8 @@
 //! `lab_runner_unsupported_reason`, `lab_offload_mutation_flag`).
 
 use crate::cli_surface::Commands;
-use crate::command_contract::{CommandDescriptor, CommandOutputFileMode};
-use crate::commands::agent_task;
+use crate::command_contract::CommandDescriptor;
+use crate::commands::{adapter, agent_task};
 use crate::core::agent_tasks::provider::{default_backend, provider_requires_cwd_git_checkout};
 use crate::core::engine::execution_context::{self, ResolveOptions};
 use crate::core::extension::ExtensionCapability;
@@ -930,10 +930,8 @@ impl Commands {
             Commands::Worktree(args) => {
                 return CommandPortabilityContract::lab_optional(args.lab_contract());
             }
-            Commands::Fleet(args) => {
-                let contract = crate::commands::fleet::adapter(CommandOutputFileMode::None)
-                    .lab_contract(args);
-                return CommandPortabilityContract::lab_optional(contract);
+            Commands::Fleet(_) => {
+                return CommandPortabilityContract::lab_optional(adapter::lab_contract(self));
             }
             Commands::Review(args) => return CommandPortabilityContract::lab_optional(args.lab_contract()),
             Commands::Refactor(args) if args.is_hot_resource_command() => {

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -12,7 +12,7 @@
 //! returned from [`Commands::descriptor`].
 
 use crate::cli_surface::Commands;
-use crate::commands::{file, fleet, logs, observe, report, review, runner, runtime, trace};
+use crate::commands::{adapter, file, logs, report, review, runner, runtime, trace};
 
 use super::lab::apply_lab_contract_to_descriptor;
 use super::spec::registered_command;
@@ -154,6 +154,10 @@ impl Commands {
             }
         };
 
+        if let Some(descriptor) = adapter::output_descriptor(self, output_file_mode) {
+            return descriptor;
+        }
+
         match self {
             Commands::Ssh(args) if args.subcommand.is_none() && args.command.is_empty() => {
                 raw_ops_descriptor(
@@ -211,12 +215,8 @@ impl Commands {
             ),
             Commands::Bench(args) => args.output_descriptor(output_file_mode),
             Commands::Fuzz(args) => args.output_descriptor(output_file_mode),
-            Commands::Observe(_) => observe::adapter(output_file_mode).output_descriptor(),
             Commands::Refactor(_) => registered_json_envelope_descriptor(self, output_file_mode),
             Commands::Release(_) => registered_json_envelope_descriptor(self, output_file_mode),
-            Commands::Contract(_) => {
-                crate::commands::contract::adapter(output_file_mode).output_descriptor()
-            }
             Commands::Runner(args) if runner::is_compact_exec_stdout(args) => {
                 raw_ops_descriptor(CommandRawOutputMode::PlainText, output_file_mode)
             }
@@ -247,7 +247,9 @@ impl Commands {
             | Commands::Api(_)
             | Commands::Upgrade(_)
             | Commands::Ssh(_) => registered_json_envelope_descriptor(self, output_file_mode),
-            Commands::Fleet(_) => fleet::adapter(output_file_mode).output_descriptor(),
+            Commands::Fleet(_) | Commands::Observe(_) | Commands::Contract(_) => {
+                unreachable!("adapter-backed command descriptor returned before legacy routing")
+            }
             Commands::Triage(_) => registered_json_envelope_descriptor(self, output_file_mode),
         }
     }

--- a/src/commands/infra/adapter.rs
+++ b/src/commands/infra/adapter.rs
@@ -144,6 +144,13 @@ pub(crate) fn output_descriptor(
     }
 }
 
+pub(crate) fn lab_contract(command: &Commands) -> Option<LabCommandContract> {
+    match command {
+        Commands::Fleet(args) => fleet::adapter(CommandOutputFileMode::None).lab_contract(args),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -268,5 +275,14 @@ mod tests {
         assert!(fleet::adapter(CommandOutputFileMode::None)
             .lab_contract(&args)
             .is_none());
+    }
+
+    #[test]
+    fn migrated_adapter_lab_contract_matches_command_contract() {
+        let command = parsed_command(&[
+            "homeboy", "fleet", "exec", "--apply", "growth", "wp", "plugin", "list",
+        ]);
+
+        assert_eq!(lab_contract(&command), command.lab_contract());
     }
 }

--- a/src/commands/infra/adapter.rs
+++ b/src/commands/infra/adapter.rs
@@ -132,6 +132,18 @@ pub(crate) fn command_adapter(
     }
 }
 
+pub(crate) fn output_descriptor(
+    command: &Commands,
+    output_file_mode: CommandOutputFileMode,
+) -> Option<CommandOutputDescriptor> {
+    match command {
+        Commands::Fleet(_) => Some(fleet::adapter(output_file_mode).output_descriptor()),
+        Commands::Observe(_) => Some(observe::adapter(output_file_mode).output_descriptor()),
+        Commands::Contract(_) => Some(contract::adapter(output_file_mode).output_descriptor()),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,6 +193,50 @@ mod tests {
             CommandOutputFileMode::None,
         )
         .is_ok());
+    }
+
+    #[test]
+    fn migrated_adapter_output_descriptor_uses_adapter_contract() {
+        let descriptor = output_descriptor(
+            &parsed_command(&["homeboy", "contract", "manifest"]),
+            CommandOutputFileMode::GenericEnvelope,
+        )
+        .expect("contract is adapter-backed");
+
+        assert_eq!(descriptor.response_mode, CommandResponseMode::Json);
+        assert_eq!(descriptor.json_family, CommandJsonFamily::Workspace);
+        assert_eq!(
+            descriptor.output_file_mode,
+            CommandOutputFileMode::GenericEnvelope
+        );
+        assert_eq!(
+            descriptor.output_contract,
+            CommandOutputContractKind::JsonEnvelope
+        );
+    }
+
+    #[test]
+    fn migrated_adapter_output_descriptors_match_command_contracts() {
+        let commands = [
+            parsed_command(&["homeboy", "fleet", "list"]),
+            parsed_command(&["homeboy", "observe", "demo", "--watch-process", "sleep"]),
+            parsed_command(&["homeboy", "contract", "manifest"]),
+        ];
+        let output_file_modes = [
+            CommandOutputFileMode::None,
+            CommandOutputFileMode::GenericEnvelope,
+        ];
+
+        for command in commands {
+            for output_file_mode in output_file_modes {
+                let has_output_file = output_file_mode != CommandOutputFileMode::None;
+
+                assert_eq!(
+                    output_descriptor(&command, output_file_mode),
+                    Some(command.output_descriptor(has_output_file))
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Route `Commands::output_descriptor(...)` through adapter-owned output descriptor metadata for adapter-backed command families.
- Remove duplicated `Fleet`, `Observe`, and `Contract` descriptor logic from the legacy command-contract match arms.
- Keep legacy descriptor fallback behavior unchanged for non-migrated commands.
- Add focused drift coverage proving adapter descriptors match command-contract lookup for migrated families.

## Tests
- `cargo fmt --check`
- `cargo test commands::infra::adapter::tests --lib`
- `cargo test command_contract --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified the focused adapter contract cleanup.