### PR TITLE
Remove dead Lab contract scaffolding

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1332,39 +1332,6 @@ mod extension_ids {
         ))
     }
 
-    pub(crate) fn test_lab_extension_ids(
-        args: &crate::commands::test::TestArgs,
-    ) -> crate::core::Result<Vec<String>> {
-        let resolve_for = |capability: Option<ExtensionCapability>| {
-            execution_context::resolve(&ResolveOptions {
-                component_id: args.comp.component.clone(),
-                path_override: args.comp.path.clone(),
-                capability,
-                settings_profile_json_overrides: args
-                    .setting_args
-                    .settings_profile_json_overrides()?,
-                settings_overrides: args.setting_args.settings_overrides()?,
-                settings_json_overrides: args.setting_args.settings_json_overrides()?,
-                extension_overrides: args.extension_override.extensions.clone(),
-            })
-        };
-
-        let source_context = resolve_for(None)?;
-
-        if !args.drift
-            && args.ci_job.is_none()
-            && source_context
-                .component
-                .has_script(ExtensionCapability::Test)
-        {
-            return Ok(Vec::new());
-        }
-
-        let context = resolve_for(Some(ExtensionCapability::Test))?;
-
-        Ok(context.extension_id.into_iter().collect())
-    }
-
     pub(crate) fn review_lab_extension_ids(
         args: &crate::commands::review::ReviewArgs,
     ) -> crate::core::Result<Vec<String>> {

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -285,24 +285,6 @@ const AGENT_TASK_LAB_SUPPORT: &[CommandLabSupportSummary] = &[
     },
 ];
 
-const LINT_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
-    contract_labels: &[LINT_LAB_LABEL],
-    message_label: LINT_LAB_LABEL,
-    hint_label: LINT_LAB_LABEL,
-}];
-
-const TEST_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
-    contract_labels: &[TEST_LAB_LABEL],
-    message_label: TEST_LAB_LABEL,
-    hint_label: TEST_LAB_LABEL,
-}];
-
-const AUDIT_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
-    contract_labels: &[AUDIT_LAB_LABEL],
-    message_label: AUDIT_LAB_LABEL,
-    hint_label: AUDIT_LAB_LABEL,
-}];
-
 const REVIEW_LAB_SUPPORT: &[CommandLabSupportSummary] = &[CommandLabSupportSummary {
     contract_labels: &[REVIEW_LAB_LABEL],
     message_label: REVIEW_LAB_LABEL,
@@ -405,7 +387,6 @@ const RELEASE_DANGEROUS_FLAGS: &[&str] = &[
     "--force-lower-bump",
 ];
 const UPGRADE_DANGEROUS_FLAGS: &[&str] = &["--force", "--upgrade-runner"];
-const LINT_DANGEROUS_FLAGS: &[&str] = &["--fix", "--force"];
 const FUZZ_DANGEROUS_FLAGS: &[&str] = &["--allow-destructive"];
 const CLEANUP_DANGEROUS_FLAGS: &[&str] = &["--apply"];
 const TRIAGE_DANGEROUS_FLAGS: &[&str] = &["--auto-merge"];


### PR DESCRIPTION
## Summary
- Removed unused Lab support summary constants for lint/test/audit.
- Removed unused lint dangerous flags constant.
- Removed unused test Lab extension resolver helper.
- Left live Lab labels and review/runner extension resolution paths unchanged.

## Tests
- cargo fmt --check
- cargo test command_contract --lib
- cargo test -- --list timed out after 120s while compiling, per requested cap

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Identified, removed, and verified dead Lab contract scaffolding.