### PR TITLE
Route adapter lab metadata

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -9,8 +9,8 @@
 //! `lab_runner_unsupported_reason`, `lab_offload_mutation_flag`).
 
 use crate::cli_surface::Commands;
-use crate::command_contract::{CommandDescriptor, CommandOutputFileMode};
-use crate::commands::agent_task;
+use crate::command_contract::CommandDescriptor;
+use crate::commands::{adapter, agent_task};
 use crate::core::agent_tasks::provider::{default_backend, provider_requires_cwd_git_checkout};
 use crate::core::engine::execution_context::{self, ResolveOptions};
 use crate::core::extension::ExtensionCapability;
@@ -930,10 +930,8 @@ impl Commands {
             Commands::Worktree(args) => {
                 return CommandPortabilityContract::lab_optional(args.lab_contract());
             }
-            Commands::Fleet(args) => {
-                let contract = crate::commands::fleet::adapter(CommandOutputFileMode::None)
-                    .lab_contract(args);
-                return CommandPortabilityContract::lab_optional(contract);
+            Commands::Fleet(_) => {
+                return CommandPortabilityContract::lab_optional(adapter::lab_contract(self));
             }
             Commands::Review(args) => return CommandPortabilityContract::lab_optional(args.lab_contract()),
             Commands::Refactor(args) if args.is_hot_resource_command() => {

--- a/src/commands/infra/adapter.rs
+++ b/src/commands/infra/adapter.rs
@@ -144,6 +144,13 @@ pub(crate) fn output_descriptor(
     }
 }
 
+pub(crate) fn lab_contract(command: &Commands) -> Option<LabCommandContract> {
+    match command {
+        Commands::Fleet(args) => fleet::adapter(CommandOutputFileMode::None).lab_contract(args),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -268,5 +275,14 @@ mod tests {
         assert!(fleet::adapter(CommandOutputFileMode::None)
             .lab_contract(&args)
             .is_none());
+    }
+
+    #[test]
+    fn migrated_adapter_lab_contract_matches_command_contract() {
+        let command = parsed_command(&[
+            "homeboy", "fleet", "exec", "--apply", "growth", "wp", "plugin", "list",
+        ]);
+
+        assert_eq!(lab_contract(&command), command.lab_contract());
     }
 }


### PR DESCRIPTION
## Summary
- Add adapter-owned Lab contract routing for migrated adapter-backed commands.
- Route Fleet Lab metadata through the adapter helper from the command contract path.
- Add focused adapter test coverage that compares adapter Lab metadata with the public command contract path.

## Tests
- cargo fmt --check
- cargo test commands::infra::adapter::tests --lib
- cargo test command_contract --lib

## Stacking
- Stacked on #7647.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified the adapter Lab metadata consolidation.