### PR TITLE
Route adapter JSON dispatch

### DIFF
--- a/src/commands/infra/adapter.rs
+++ b/src/commands/infra/adapter.rs
@@ -6,6 +6,7 @@ use crate::command_contract::{
 
 use crate::cli_surface::Commands;
 
+use crate::commands::output_runtime::CommandRun;
 use crate::commands::{contract, fleet, observe, GlobalArgs};
 
 pub(crate) type JsonHandlerResult = (homeboy::core::Result<Value>, i32);
@@ -132,6 +133,22 @@ pub(crate) fn command_adapter(
     }
 }
 
+pub(crate) fn run_command_output(
+    command: Commands,
+    global: &GlobalArgs,
+    output_file_mode: CommandOutputFileMode,
+) -> Result<CommandRun, Commands> {
+    let command_name = command.top_level_name();
+    let adapter = command_adapter(command, output_file_mode)?;
+    let (stdout_result, exit_code) = adapter.run(global);
+
+    Ok(CommandRun::from_command_stdout_result(
+        command_name,
+        stdout_result,
+        exit_code,
+    ))
+}
+
 pub(crate) fn output_descriptor(
     command: &Commands,
     output_file_mode: CommandOutputFileMode,
@@ -190,6 +207,12 @@ mod tests {
     #[test]
     fn command_adapter_recognizes_migrated_json_commands() {
         assert!(command_adapter(
+            parsed_command(&["homeboy", "fleet", "list"]),
+            CommandOutputFileMode::None,
+        )
+        .is_ok());
+
+        assert!(command_adapter(
             parsed_command(&["homeboy", "observe", "demo", "--watch-process", "sleep"]),
             CommandOutputFileMode::None,
         )
@@ -200,6 +223,22 @@ mod tests {
             CommandOutputFileMode::None,
         )
         .is_ok());
+    }
+
+    #[test]
+    fn run_command_output_routes_migrated_json_command() {
+        let run = run_command_output(
+            parsed_command(&["homeboy", "contract", "manifest"]),
+            &GlobalArgs {},
+            CommandOutputFileMode::None,
+        )
+        .unwrap_or_else(|_| panic!("contract should route through adapter JSON output"));
+
+        assert_eq!(run.command, "contract");
+        assert_eq!(run.exit_code, 0);
+        let value = run.stdout_result.expect("manifest should dispatch as JSON");
+        assert_eq!(value["command"], "contract.manifest");
+        assert!(value["commands"].is_array());
     }
 
     #[test]

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -28,114 +28,123 @@ pub fn run_command_output(
     crate::commands::utils::tty::status("homeboy is working...");
     let command_name = command.top_level_name();
 
-    let run = match command {
-        Commands::AgentTask(args) => {
-            let run_from_spec_output_ref =
-                agent_task_controller_run_from_spec_output_ref_eligible(&args, output_file);
-            let summary_kind = agent_task_summary_kind_for_output(&args);
-            let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), global);
-            let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
-                if let Some(output_file) = run_from_spec_output_ref {
-                    return render_controller_run_from_spec_output_ref(
-                        payload,
-                        exit_code,
-                        output_file,
-                    );
-                }
+    let run = match adapter::run_command_output(
+        command,
+        global,
+        crate::command_contract::CommandOutputFileMode::None,
+    ) {
+        Ok(run) => run,
+        Err(command) => match command {
+            Commands::AgentTask(args) => {
+                let run_from_spec_output_ref =
+                    agent_task_controller_run_from_spec_output_ref_eligible(&args, output_file);
+                let summary_kind = agent_task_summary_kind_for_output(&args);
+                let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), global);
+                let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
+                    if let Some(output_file) = run_from_spec_output_ref {
+                        return render_controller_run_from_spec_output_ref(
+                            payload,
+                            exit_code,
+                            output_file,
+                        );
+                    }
 
-                summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
-            });
+                    summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
+                });
 
-            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                CommandPresentation {
-                    stdout: summary_stdout,
-                    stderr: None,
-                },
-            )
-        }
-        Commands::Runner(args) => runner::run_command_output(args, global),
-        Commands::Activity(args) => {
-            let (stdout_result, exit_code) = dispatch(Commands::Activity(args), global);
-            let summary_stdout = stdout_result
-                .as_ref()
-                .ok()
-                .and_then(super::activity::render_activity_summary);
+                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                    CommandPresentation {
+                        stdout: summary_stdout,
+                        stderr: None,
+                    },
+                )
+            }
+            Commands::Runner(args) => runner::run_command_output(args, global),
+            Commands::Activity(args) => {
+                let (stdout_result, exit_code) = dispatch(Commands::Activity(args), global);
+                let summary_stdout = stdout_result
+                    .as_ref()
+                    .ok()
+                    .and_then(super::activity::render_activity_summary);
 
-            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                CommandPresentation {
-                    stdout: summary_stdout,
-                    stderr: None,
-                },
-            )
-        }
-        Commands::Bench(args) => {
-            let summarize = bench_summary_eligible(&args);
-            let (stdout_result, exit_code) = dispatch(Commands::Bench(args), global);
-            let summary_stdout = summarize
-                .then(|| {
-                    stdout_result
-                        .as_ref()
-                        .ok()
-                        .and_then(super::bench_summary::render_bench_summary)
-                })
-                .flatten();
+                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                    CommandPresentation {
+                        stdout: summary_stdout,
+                        stderr: None,
+                    },
+                )
+            }
+            Commands::Bench(args) => {
+                let summarize = bench_summary_eligible(&args);
+                let (stdout_result, exit_code) = dispatch(Commands::Bench(args), global);
+                let summary_stdout = summarize
+                    .then(|| {
+                        stdout_result
+                            .as_ref()
+                            .ok()
+                            .and_then(super::bench_summary::render_bench_summary)
+                    })
+                    .flatten();
 
-            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                CommandPresentation {
-                    stdout: summary_stdout,
-                    stderr: None,
-                },
-            )
-        }
-        Commands::Cleanup(args) => {
-            let summarize = cleanup_summary_eligible(&args);
-            let (stdout_result, exit_code) = dispatch(Commands::Cleanup(args), global);
-            let summary_stdout = summarize
-                .then(|| {
-                    stdout_result
-                        .as_ref()
-                        .ok()
-                        .and_then(super::cleanup::render_cleanup_summary)
-                })
-                .flatten();
+                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                    CommandPresentation {
+                        stdout: summary_stdout,
+                        stderr: None,
+                    },
+                )
+            }
+            Commands::Cleanup(args) => {
+                let summarize = cleanup_summary_eligible(&args);
+                let (stdout_result, exit_code) = dispatch(Commands::Cleanup(args), global);
+                let summary_stdout = summarize
+                    .then(|| {
+                        stdout_result
+                            .as_ref()
+                            .ok()
+                            .and_then(super::cleanup::render_cleanup_summary)
+                    })
+                    .flatten();
 
-            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                CommandPresentation {
-                    stdout: summary_stdout,
-                    stderr: None,
-                },
-            )
-        }
-        Commands::Runs(args) => {
-            let summarize_show = runs_show_summary_eligible(&args);
-            let summarize_dossier = runs_dossier_summary_eligible(&args);
-            let summarize_proof = runs_proof_summary_eligible(&args);
-            let (stdout_result, exit_code) = dispatch(Commands::Runs(args), global);
-            let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
-                if let Some(rendered) = super::runs_summary::render_runs_field_selection(payload) {
-                    Some(rendered)
-                } else if summarize_show {
-                    super::runs_summary::render_runs_show_summary(payload)
-                } else if summarize_dossier {
-                    super::runs_dossier_summary::render_runs_dossier_summary(payload)
-                } else if summarize_proof {
-                    super::runs_proof_summary::render_runs_proof_summary(payload)
-                } else {
-                    None
-                }
-            });
+                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                    CommandPresentation {
+                        stdout: summary_stdout,
+                        stderr: None,
+                    },
+                )
+            }
+            Commands::Runs(args) => {
+                let summarize_show = runs_show_summary_eligible(&args);
+                let summarize_dossier = runs_dossier_summary_eligible(&args);
+                let summarize_proof = runs_proof_summary_eligible(&args);
+                let (stdout_result, exit_code) = dispatch(Commands::Runs(args), global);
+                let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
+                    if let Some(rendered) =
+                        super::runs_summary::render_runs_field_selection(payload)
+                    {
+                        Some(rendered)
+                    } else if summarize_show {
+                        super::runs_summary::render_runs_show_summary(payload)
+                    } else if summarize_dossier {
+                        super::runs_dossier_summary::render_runs_dossier_summary(payload)
+                    } else if summarize_proof {
+                        super::runs_proof_summary::render_runs_proof_summary(payload)
+                    } else {
+                        None
+                    }
+                });
 
-            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                CommandPresentation {
-                    stdout: summary_stdout,
-                    stderr: None,
-                },
-            )
-        }
-        command => {
-            let (stdout_result, exit_code) = dispatch(command, global);
-            CommandRun::from_stdout_result(stdout_result, exit_code)
-        }
+                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                    CommandPresentation {
+                        stdout: summary_stdout,
+                        stderr: None,
+                    },
+                )
+            }
+            command => {
+                let (stdout_result, exit_code) = dispatch(command, global);
+                CommandRun::from_stdout_result(stdout_result, exit_code)
+            }
+        },
     };
 
     run.with_command(command_name)

--- a/src/commands/json_output/quality.rs
+++ b/src/commands/json_output/quality.rs
@@ -1,14 +1,13 @@
 use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
-use crate::commands::{bench, fuzz, observe, review, trace, GlobalArgs};
+use crate::commands::{bench, fuzz, review, trace, GlobalArgs};
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
         Commands::Bench(args) => map(bench::run(args, global)),
         Commands::Fuzz(args) => map(fuzz::run(args, global)),
         Commands::Trace(args) => map(trace::run(args, global)),
-        Commands::Observe(args) => map(observe::run(args, global)),
         Commands::Review(args) => map(review::run(args, global)),
         _ => unreachable!("command routed to wrong JSON output family"),
     }

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -2,8 +2,8 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    activity, agent_task, cleanup, component, config, contract, extension, project, refactor,
-    release, report, rig, runner, runs, runtime, stack, tunnel, worktree, GlobalArgs,
+    activity, agent_task, cleanup, component, config, extension, project, refactor, release,
+    report, rig, runner, runs, runtime, stack, tunnel, worktree, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -13,7 +13,6 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Project(args) => map(project::run(args, global)),
         Commands::Component(args) => map(component::run(args, global)),
         Commands::Config(args) => map(config::run(args, global)),
-        Commands::Contract(args) => map(contract::run(args, global)),
         Commands::Extension(args) => map(extension::run(args, global)),
         Commands::Cleanup(args) => map(cleanup::run(args, global)),
         Commands::Release(args) => map(release::run(args, global)),


### PR DESCRIPTION
## Summary
- Add an adapter-owned JSON command-output helper for migrated adapter-backed commands.
- Route JSON command output through the adapter helper before legacy family dispatch.
- Remove duplicate legacy JSON dispatch arms for adapter-backed `observe` and `contract`.

## Tests
- `cargo fmt --check`
- `cargo test commands::infra::adapter::tests --lib`
- `cargo test json_output --lib`
- `cargo test command_contract --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified the adapter JSON dispatch consolidation.