### PR TITLE
Route extension show to Lab runners

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -924,6 +924,9 @@ impl Commands {
             Commands::Extension(args) if args.is_update_command() => {
                 LabCommandContract::explicit_runner_simple(args.update_command_label())
             }
+            Commands::Extension(args) if args.is_runner_resident_read_command() => {
+                LabCommandContract::runner_resident(args.runner_resident_read_command_label())
+            }
             Commands::Runtime(args) if args.is_refresh_command() => {
                 LabCommandContract::explicit_runner_simple(RUNTIME_REFRESH_LAB_LABEL)
             }

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -273,6 +273,17 @@ pub fn run(
 }
 
 impl ExtensionArgs {
+    pub(crate) fn is_runner_resident_read_command(&self) -> bool {
+        matches!(self.command, ExtensionCommand::Show { .. })
+    }
+
+    pub(crate) fn runner_resident_read_command_label(&self) -> &'static str {
+        match self.command {
+            ExtensionCommand::Show { .. } => "extension show",
+            _ => "extension",
+        }
+    }
+
     pub(crate) fn is_update_command(&self) -> bool {
         matches!(
             self.command,

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1972,7 +1972,7 @@ mod tests {
     }
 
     #[test]
-    fn other_extension_commands_stay_local_only() {
+    fn extension_show_routes_to_explicit_lab_runner() {
         let cli = Cli::parse_from([
             "homeboy",
             "--runner",
@@ -1981,6 +1981,22 @@ mod tests {
             "show",
             "wordpress",
         ]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(command.hot_label, "extension show");
+        assert!(command.portable);
+        assert!(!command.routing_policy.default_lab_offload);
+        assert!(command.unsupported_reason.is_none());
+        assert!(!command.routing_policy.requires_extension_parity);
+        assert!(command.required_extensions.is_empty());
+        assert!(!command.routing_policy.infer_source_path_tools);
+        assert!(cli.command.supports_lab_runner());
+    }
+
+    #[test]
+    fn extension_list_stays_local_only() {
+        let cli = Cli::parse_from(["homeboy", "--runner", "lab", "extension", "list"]);
 
         assert!(lab_offload_command(&cli.command).unwrap().is_none());
         assert!(!cli.command.supports_lab_runner());

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -34,6 +34,24 @@ pub(crate) fn remote_lab_output_file(checkout_root: &str) -> String {
     )
 }
 
+/// Remote structured-output path for runner-resident commands.
+///
+/// Runner-resident commands execute from the runner workspace root itself, not a
+/// synced checkout under that root. Keep their output inside `workspace_root` so
+/// daemon-mode file transfer can create/read it, while still keeping the file out
+/// of any materialized git checkout.
+pub(crate) fn remote_runner_resident_lab_output_file(workspace_root: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!(
+        "{}/.homeboy-artifacts/homeboy-lab-structured-output-{}.json",
+        workspace_root.trim_end_matches('/'),
+        nonce
+    )
+}
+
 /// Ensure the Homeboy-owned Lab artifact directory exists on the runner before
 /// a command writes its structured output there. The directory is a sibling of
 /// the checkout, so it is not created by workspace sync and must be made

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -62,7 +62,7 @@ pub(crate) fn run_runner_resident_lab_offload(
 
     let remote_output_file = request
         .output_file_requested
-        .then(|| remote_lab_output_file(runner_workspace_root));
+        .then(|| remote_runner_resident_lab_output_file(runner_workspace_root));
     if let Some(output_file) = remote_output_file.as_deref() {
         ensure_remote_lab_artifact_dir(runner_id, output_file)?;
     }

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -716,6 +716,19 @@ fn lab_structured_output_file_is_written_outside_the_checkout() {
 }
 
 #[test]
+fn runner_resident_structured_output_file_stays_inside_workspace_root() {
+    let workspace_root = "/srv/runner/workspaces";
+    let output_file = remote_runner_resident_lab_output_file(workspace_root);
+
+    assert!(
+        output_file.starts_with("/srv/runner/workspaces/.homeboy-artifacts/"),
+        "runner-resident output `{output_file}` must stay inside workspace root `{workspace_root}`"
+    );
+    assert!(output_file.ends_with(".json"));
+    assert!(output_file.contains("homeboy-lab-structured-output-"));
+}
+
+#[test]
 fn lab_cannot_proceed_error_names_runner_workspace_ref_dependency_and_fix_command() {
     // A bare dependency-resolution failure as it surfaces today, before
     // orchestration context is woven in.


### PR DESCRIPTION
## Summary
- Route `homeboy --runner <id> extension show <extension>` as a runner-resident Lab read instead of silently resolving local extension metadata.
- Keep other extension discovery commands local-only, while preserving explicit-runner routing for refresh/update/dev-run.
- Store runner-resident Lab structured output under `workspace_root/.homeboy-artifacts/` so daemon-mode file transfer can create/read the output path.

## Root cause
`extension refresh/install/update` were marked as explicit-runner Lab commands, but `extension show` was not. The global `--runner` flag appeared in help, but the command contract treated show as local-only, so `extension show nodejs` after a runner refresh could still display the controller's installed revision. While verifying the fix, runner-resident output also exposed a daemon transport bug: structured output was derived as a sibling of `workspace_root` (for example `/home/chubes/Developer-homeboy-artifacts`), but the runner file daemon only allows paths inside `workspace_root`.

## Tests
- `cargo fmt --check`
- `cargo test commands::infra::route::tests::extension_`
- `cargo test core::runner::lab::offload::tests::exec_errors::`
- Non-destructive verification: `cargo run -- --runner homeboy-lab extension show nodejs --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-nodejs-lab-show-after-fix.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Diagnosed the Homeboy Lab extension routing path, implemented the routing/output-path fix, ran focused verification, and drafted this PR description.
