### PR TITLE
Fix artifact CSS capture diagnostics

### DIFF
--- a/src/core/artifact_dom_boxes.rs
+++ b/src/core/artifact_dom_boxes.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::env;
 use std::io::ErrorKind;
 use std::net::TcpListener;
@@ -33,6 +34,12 @@ pub struct DomBoxEntrypointReport {
     pub page_path: String,
     pub page_url: String,
     pub viewport: DomBoxViewport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dom_css_loaded: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dom_capture_valid: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stylesheet_status: Option<Value>,
     pub elements: Vec<DomBoxElement>,
 }
 
@@ -77,6 +84,9 @@ pub(crate) struct BrowserEntrypointReport {
     page_path: String,
     page_url: String,
     viewport: DomBoxViewport,
+    dom_css_loaded: Option<bool>,
+    dom_capture_valid: Option<bool>,
+    stylesheet_status: Option<Value>,
     elements: Vec<BrowserElement>,
 }
 
@@ -181,6 +191,9 @@ pub(crate) fn shape_report(
                 page_path: entrypoint.page_path,
                 page_url: entrypoint.page_url,
                 viewport: entrypoint.viewport,
+                dom_css_loaded: entrypoint.dom_css_loaded,
+                dom_capture_valid: entrypoint.dom_capture_valid,
+                stylesheet_status: entrypoint.stylesheet_status,
                 elements: entrypoint
                     .elements
                     .into_iter()
@@ -356,6 +369,9 @@ mod tests {
                         height: 900,
                         device_scale_factor: 1,
                     },
+                    dom_css_loaded: Some(true),
+                    dom_capture_valid: Some(true),
+                    stylesheet_status: Some(serde_json::json!({ "body_margin": "0px" })),
                     elements: vec![BrowserElement {
                         node_id: "12:34".to_string(),
                         node_name: Some("Footer text".to_string()),
@@ -373,6 +389,16 @@ mod tests {
         assert_eq!(
             report.entrypoints[0].elements[0].text_sample,
             "Footer text with"
+        );
+        assert_eq!(report.entrypoints[0].dom_css_loaded, Some(true));
+        assert_eq!(report.entrypoints[0].dom_capture_valid, Some(true));
+        assert_eq!(
+            report.entrypoints[0]
+                .stylesheet_status
+                .as_ref()
+                .and_then(|status| status.get("body_margin"))
+                .and_then(|value| value.as_str()),
+            Some("0px")
         );
         assert_eq!(report.entrypoints[0].elements[0].node_id, "12:34");
     }

--- a/src/core/artifact_metadata.rs
+++ b/src/core/artifact_metadata.rs
@@ -33,6 +33,8 @@ pub(crate) fn content_type_from_path(path: &Path) -> Option<String> {
         "json" => "application/json",
         "md" | "markdown" => "text/markdown",
         "html" | "htm" => "text/html",
+        "css" => "text/css",
+        "js" | "mjs" => "text/javascript",
         "txt" | "log" => "text/plain",
         "csv" => "text/csv",
         "xml" => "application/xml",
@@ -42,6 +44,9 @@ pub(crate) fn content_type_from_path(path: &Path) -> Option<String> {
         "jpg" | "jpeg" => "image/jpeg",
         "gif" => "image/gif",
         "svg" => "image/svg+xml",
+        "webp" => "image/webp",
+        "woff" => "font/woff",
+        "woff2" => "font/woff2",
         _ => return None,
     };
     Some(mime.to_string())

--- a/src/core/artifact_origin.rs
+++ b/src/core/artifact_origin.rs
@@ -382,6 +382,23 @@ mod tests {
     }
 
     #[test]
+    fn serves_css_with_stylesheet_content_type() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("workflow-bench/site/style.css");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, b"body{margin:0}").expect("write css");
+
+        let response = response_for_request(temp.path(), "HEAD", "/workflow-bench/site/style.css")
+            .expect("response");
+
+        assert_eq!(response.status, 200);
+        assert!(response.body.is_empty());
+        assert!(response
+            .headers
+            .contains(&("content-type".to_string(), "text/css".to_string())));
+    }
+
+    #[test]
     fn handles_playground_preflight_without_file_read() {
         let temp = tempfile::tempdir().expect("tempdir");
         let response = response_for_request(


### PR DESCRIPTION
## Summary
- Serve CSS, JS, WebP, and font artifacts with browser-usable MIME types from artifact origins.
- Preserve provider CSS/capture diagnostics in DOM-box reports.
- Add regression coverage for artifact-origin CSS content type.

## Validation
- `cargo test artifact_origin`
- `cargo test artifact_dom_boxes`
- Patched capture evidence for Fisiostetic reports `dom_css_loaded=true`, `dom_capture_valid=true`, and `stylesheet_status.body_margin=0px`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosed the artifact-origin CSS MIME issue, drafted the scoped fix, ran targeted validation, and prepared this PR.