### PR TITLE
Route adapter execution dispatch

### DIFF
--- a/src/commands/infra/adapter.rs
+++ b/src/commands/infra/adapter.rs
@@ -139,14 +139,22 @@ pub(crate) fn run_command_output(
     output_file_mode: CommandOutputFileMode,
 ) -> Result<CommandRun, Commands> {
     let command_name = command.top_level_name();
-    let adapter = command_adapter(command, output_file_mode)?;
-    let (stdout_result, exit_code) = adapter.run(global);
+    let (stdout_result, exit_code) = run_json_output(command, global, output_file_mode)?;
 
     Ok(CommandRun::from_command_stdout_result(
         command_name,
         stdout_result,
         exit_code,
     ))
+}
+
+pub(crate) fn run_json_output(
+    command: Commands,
+    global: &GlobalArgs,
+    output_file_mode: CommandOutputFileMode,
+) -> Result<JsonHandlerResult, Commands> {
+    let adapter = command_adapter(command, output_file_mode)?;
+    Ok(adapter.run(global))
 }
 
 pub(crate) fn output_descriptor(
@@ -239,6 +247,24 @@ mod tests {
         let value = run.stdout_result.expect("manifest should dispatch as JSON");
         assert_eq!(value["command"], "contract.manifest");
         assert!(value["commands"].is_array());
+    }
+
+    #[test]
+    fn run_json_output_matches_adapter_bound_execution() {
+        let command = parsed_command(&["homeboy", "contract", "manifest"]);
+        let (adapter_stdout, adapter_exit_code) = command_adapter(
+            parsed_command(&["homeboy", "contract", "manifest"]),
+            CommandOutputFileMode::None,
+        )
+        .unwrap_or_else(|_| panic!("contract should bind an adapter"))
+        .run(&GlobalArgs {});
+
+        let (helper_stdout, helper_exit_code) =
+            run_json_output(command, &GlobalArgs {}, CommandOutputFileMode::None)
+                .unwrap_or_else(|_| panic!("contract should route through adapter helper"));
+
+        assert_eq!(helper_exit_code, adapter_exit_code);
+        assert_eq!(helper_stdout.unwrap(), adapter_stdout.unwrap());
     }
 
     #[test]

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -323,11 +323,12 @@ fn agent_task_summary_kind_for_output_mode(
 }
 
 fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
-    let command = match adapter::command_adapter(
+    let command = match adapter::run_json_output(
         command,
+        global,
         crate::command_contract::CommandOutputFileMode::None,
     ) {
-        Ok(adapter) => return adapter.run(global),
+        Ok(result) => return result,
         Err(command) => command,
     };
 
@@ -380,6 +381,28 @@ mod tests {
         let value = result.expect("manifest should dispatch as JSON");
         assert_eq!(value["command"], "contract.manifest");
         assert!(value["commands"].is_array());
+    }
+
+    #[test]
+    fn public_dispatch_matches_adapter_execution_for_migrated_contract() {
+        let command = || {
+            Commands::Contract(crate::commands::contract::ContractArgs {
+                command: crate::commands::contract::ContractCommand::Manifest(
+                    crate::commands::manifest::ManifestArgs {},
+                ),
+            })
+        };
+
+        let (dispatch_stdout, dispatch_exit_code) = dispatch(command(), &GlobalArgs {});
+        let (adapter_stdout, adapter_exit_code) = adapter::run_json_output(
+            command(),
+            &GlobalArgs {},
+            crate::command_contract::CommandOutputFileMode::None,
+        )
+        .unwrap_or_else(|_| panic!("contract should route through adapter helper"));
+
+        assert_eq!(dispatch_exit_code, adapter_exit_code);
+        assert_eq!(dispatch_stdout.unwrap(), adapter_stdout.unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add an adapter-owned JSON execution helper for already adapter-backed commands.
- Route JSON dispatch through the adapter helper before legacy family dispatch.
- Add focused equivalence coverage for adapter helper execution and public JSON dispatch.

## Tests
- cargo fmt --check
- cargo test commands::infra::adapter::tests --lib
- cargo test commands::json_output::tests --lib
- cargo test command_contract --lib
- cargo test commands::infra --lib -- --test-threads=1 (fails: commands::infra::route::tests::rig_up_dry_run_with_runner_emits_runner_exec_plan expected Some(0), got None)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified the adapter execution dispatch consolidation.