### PR TITLE
Document PR fleet holding workflow

### DIFF
--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -116,6 +116,7 @@ homeboy triage --mine --drilldown
 homeboy triage component homeboy --failing-checks --drilldown
 homeboy triage component --path /Users/me/Developer/homeboy
 homeboy triage component homeboy --path ./homeboy --failing-checks
+homeboy triage landing --repo owner/repo 123 124 --drilldown
 ```
 
 ## Related
@@ -123,3 +124,4 @@ homeboy triage component homeboy --path ./homeboy --failing-checks
 - [status](status.md)
 - [runs](runs.md)
 - [review](review.md)
+- [Hold a PR fleet](../workflows/hold-a-pr-fleet.md)

--- a/docs/commands/worktree.md
+++ b/docs/commands/worktree.md
@@ -10,6 +10,8 @@ Manage component-backed task worktrees for generic Homeboy workflows.
 - `homeboy worktree remove <id> [--force]`
 - `homeboy worktree cleanup [--force] [--cleanup-artifacts]`
 
+For multi-PR orchestration, start with `homeboy --output homeboy-results/worktrees.json worktree list`, then pair each branch with `homeboy triage landing 'owner/repo#number' --drilldown` and any recorded `homeboy runs evidence <run-id>` output. See [Hold a PR fleet](../workflows/hold-a-pr-fleet.md) for the full local-plus-remote handoff loop.
+
 ## Safety
 
 Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. `--force` only bypasses dirty/unpushed checks; primary checkout and containment gates always apply.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ Task-oriented guides for using Homeboy:
 - [Set up extensions](workflows/set-up-extensions.md)
 - [Run agent task loops](workflows/run-agent-task-loops.md)
 - [Manage local environments](workflows/manage-local-environments.md)
+- [Hold a PR fleet](workflows/hold-a-pr-fleet.md)
 - [Release a component](workflows/release-a-component.md)
 - [Deploy and operate fleets](workflows/deploy-and-operate-fleets.md)
 

--- a/docs/workflows/hold-a-pr-fleet.md
+++ b/docs/workflows/hold-a-pr-fleet.md
@@ -1,0 +1,115 @@
+# Hold A PR Fleet
+
+Use worktree, triage, review, and runs commands when you are holding many PR branches at once and need a concise operator view. This workflow is for local PR-fleet orchestration before merge or cleanup, not deployment.
+
+## Use This When
+
+- Many branches are open across one or more repos.
+- You need local worktree state and remote PR state in the same handoff.
+- Reviewers need links to tests, run artifacts, or blockers without reading shell scrollback.
+- You need to decide which branches are ready, blocked, stale, dirty, or safe to clean up.
+
+## 1. Start With The Local Fleet Ledger
+
+List the worktrees before checking GitHub. The list output is the local source of truth for branch names, task URLs, run IDs, cleanup policy, and whether a worktree still exists.
+
+```bash
+homeboy worktree list
+homeboy --output homeboy-results/worktrees.json worktree list
+```
+
+For each branch that looks stale, dirty, or ready to remove, inspect the safety report instead of guessing from directory names:
+
+```bash
+homeboy worktree status <worktree-id>
+```
+
+Use the JSON output as the orchestration ledger. The useful fleet-holding fields are:
+
+- `id` - stable local worktree handle.
+- `component_id` - repo/component owner for the branch.
+- `worktree_path` - local checkout path for targeted verification.
+- `branch` - branch to match against PR heads.
+- `task_url` - issue, PR, or tracker URL attached at creation time.
+- `run_id` - persisted Homeboy run that produced or verified the branch.
+- `cleanup_policy` and `state` - cleanup intent and lifecycle state.
+
+## 2. Check Remote PR Landing State
+
+Use `triage landing` when you have explicit PR refs. It classifies mergeability, checks, draft state, and review blockers in one read-only dashboard.
+
+```bash
+homeboy triage landing \
+  'owner/repo#123' \
+  'owner/repo#124' \
+  --drilldown
+```
+
+For one repo, bare numbers are acceptable when the repo is explicit:
+
+```bash
+homeboy triage landing --repo owner/repo 123 124 --drilldown
+```
+
+Persist the remote dashboard next to the local worktree ledger:
+
+```bash
+homeboy --output homeboy-results/landing.json triage landing --repo owner/repo --drilldown
+```
+
+Use `triage --watch` only for a small number of PRs that are actively moving. The snapshot commands above are better for broad fleet handoffs.
+
+## 3. Refresh Evidence Only Where Needed
+
+Run review from the worktree path so the evidence matches the branch being held:
+
+```bash
+homeboy review <component-id> --path <worktree-path> --changed-since origin/main --summary
+homeboy --output homeboy-results/<branch>-review.json review <component-id> --path <worktree-path> --changed-since origin/main --summary
+```
+
+When a branch has a recorded `run_id`, read the stable proof and evidence registry before rerunning expensive checks:
+
+```bash
+homeboy runs proof <run-id>
+homeboy runs evidence <run-id>
+homeboy runs artifacts <run-id>
+```
+
+Attach or link the durable artifact/evidence refs in the PR. Treat local-only paths as operator notes, not reviewer-facing evidence.
+
+## 4. Classify Each Branch
+
+Keep the handoff small by assigning one state per branch:
+
+- `ready` - clean worktree, pushed branch, green checks, mergeable PR, current evidence.
+- `blocked` - failing checks, requested changes, conflict, missing evidence, or an explicit issue/PR dependency.
+- `needs-refresh` - stale base, unknown checks, outdated evidence, or missing latest run proof.
+- `dirty-local` - uncommitted changes or unpushed commits in the worktree.
+- `cleanup-candidate` - merged/closed branch with a safe worktree status.
+
+A concise fleet handoff usually needs only branch, PR URL, local state, remote state, evidence ref, and next action.
+
+## 5. Clean Up Deliberately
+
+Preview cleanup first:
+
+```bash
+homeboy worktree cleanup --dry-run
+```
+
+Remove one safe worktree when the branch is merged or no longer needed:
+
+```bash
+homeboy worktree remove <worktree-id> --cleanup-branch
+```
+
+Use `--force` and unmerged branch cleanup flags only as explicit operator decisions after reading the safety report.
+
+## Reference
+
+- [worktree command](../commands/worktree.md)
+- [triage command](../commands/triage.md)
+- [review command](../commands/review.md)
+- [runs command](../commands/runs.md)
+- [Capture evidence](capture-evidence.md)

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -12,6 +12,7 @@ Workflow docs are task-oriented. They explain which Homeboy commands to use toge
 - [Set up extensions](set-up-extensions.md) - install extension behavior and understand the core/extension contract boundary.
 - [Run agent task loops](run-agent-task-loops.md) - operate durable multi-agent loops, controllers, events, retries, and human handoffs.
 - [Manage local environments](manage-local-environments.md) - operate rigs, combined-fixes stacks, and task worktrees.
+- [Hold a PR fleet](hold-a-pr-fleet.md) - keep many worktree-backed PR branches, blockers, and evidence refs organized.
 - [Release a component](release-a-component.md) - plan and apply releases from component metadata and commit history.
 - [Deploy and operate fleets](deploy-and-operate-fleets.md) - inspect project targets, preview deploys, and operate fleets safely.
 


### PR DESCRIPTION
## Summary
- Add a focused workflow for holding many worktree-backed PR branches.
- Link the workflow from the docs index, workflows index, worktree command docs, and triage command docs.
- Document the generic local-plus-remote loop: worktree ledger, landing triage, review evidence, run evidence, branch classification, and cleanup.

## Tests
- `cargo check`
- `cargo test --lib docs` timed out after compile warnings while running under the tool timeout; no test failure was reported.
- `cargo run --quiet -- self docs workflows/hold-a-pr-fleet` timed out after compile warnings under the tool timeout; no command result was produced.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Inspected the existing Homeboy command surfaces, drafted the generic PR-fleet holding workflow, updated doc links, and ran verification commands.
