### PR TITLE
Improve runs artifact listing commands

### DIFF
--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -21,9 +21,9 @@ use super::bench::run_contains_scenario;
 use super::common::{run_summaries_with_artifact_indexes, RunSummary};
 use super::types::{
     actionable_for_run_detail, actionable_for_run_list, RunDetail, RunsArtifactArgs,
-    RunsArtifactCommand, RunsArtifactGetArgs, RunsArtifactGetOutput, RunsArtifactPathGuide,
-    RunsArtifactPullEntry, RunsArtifactPullSummary, RunsArtifactsArgs, RunsArtifactsOutput,
-    RunsDirectoryArtifactPublicationGuidance, RunsEnvKeyOutput, RunsEnvOutput,
+    RunsArtifactCommand, RunsArtifactCommandHint, RunsArtifactGetArgs, RunsArtifactGetOutput,
+    RunsArtifactPathGuide, RunsArtifactPullEntry, RunsArtifactPullSummary, RunsArtifactsArgs,
+    RunsArtifactsOutput, RunsDirectoryArtifactPublicationGuidance, RunsEnvKeyOutput, RunsEnvOutput,
     RunsEnvSourceLayerOutput, RunsEnvSummary, RunsFieldSelectionOutput, RunsListArgs,
     RunsListOutput, RunsOutput, RunsResumePlanOutput, RunsSelectedField, RunsShowOutput,
 };
@@ -234,6 +234,7 @@ pub fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutput> {
             run_id: run_id.clone(),
             runner_id: None,
             path_guide: RunsArtifactPathGuide::for_listing(&run_id, None),
+            next_commands: artifact_get_command_hints(&run_id, &artifacts),
             artifacts,
             resource_lifecycle_index,
             directory_publication,
@@ -244,6 +245,71 @@ pub fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutput> {
         }),
         0,
     ))
+}
+
+fn artifact_get_command_hints(
+    run_id: &str,
+    artifacts: &[homeboy::core::observation::ArtifactRecord],
+) -> Vec<RunsArtifactCommandHint> {
+    artifacts
+        .iter()
+        .map(|artifact| {
+            let token = preferred_artifact_token(artifact, artifacts);
+            RunsArtifactCommandHint {
+                artifact_id: artifact.id.clone(),
+                kind: artifact.kind.clone(),
+                get_command: format!(
+                    "homeboy runs artifact get {} {}",
+                    shell_arg(run_id),
+                    shell_arg(&token)
+                ),
+                token,
+            }
+        })
+        .collect()
+}
+
+fn preferred_artifact_token(
+    artifact: &homeboy::core::observation::ArtifactRecord,
+    artifacts: &[homeboy::core::observation::ArtifactRecord],
+) -> String {
+    if let Some(name) = artifact.metadata_json.get("name").and_then(Value::as_str) {
+        if token_is_unique(name, artifacts) {
+            return name.to_string();
+        }
+    }
+    if token_is_unique(&artifact.kind, artifacts) {
+        return artifact.kind.clone();
+    }
+    artifact.id.clone()
+}
+
+fn token_is_unique(token: &str, artifacts: &[homeboy::core::observation::ArtifactRecord]) -> bool {
+    artifacts
+        .iter()
+        .filter(|artifact| {
+            artifact.id == token
+                || artifact.kind == token
+                || artifact.metadata_json.get("name").and_then(Value::as_str) == Some(token)
+                || artifact
+                    .metadata_json
+                    .get("original_manifest_id")
+                    .and_then(Value::as_str)
+                    == Some(token)
+        })
+        .count()
+        == 1
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | ':'))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
 }
 
 fn directory_publication_guidance_for_artifacts(

--- a/src/commands/runs/remote.rs
+++ b/src/commands/runs/remote.rs
@@ -77,6 +77,7 @@ pub fn runner_artifacts(runner_id: &str, run_id: &str) -> CmdResult<RunsOutput> 
             runner_id: Some(runner_id.to_string()),
             path_guide: RunsArtifactPathGuide::for_listing(run_id, Some(runner_id)),
             artifacts,
+            next_commands: Vec::new(),
             resource_lifecycle_index,
             directory_publication,
             preview_entrypoints: Vec::new(),

--- a/src/commands/runs/tests/mod.rs
+++ b/src/commands/runs/tests/mod.rs
@@ -813,6 +813,76 @@ fn artifacts_command_marks_directory_publication_status_and_command() {
 }
 
 #[test]
+fn artifacts_command_lists_copy_paste_get_commands_with_names() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+            .expect("run");
+        let named_path = home.path().join("named-report.json");
+        std::fs::write(&named_path, br#"{"named":true}"#).expect("named artifact");
+        let named = store
+            .record_artifact_with_metadata(
+                &run.id,
+                "bench_results",
+                &named_path,
+                serde_json::json!({ "name": "readable-report" }),
+            )
+            .expect("named record");
+        let duplicate_path = home.path().join("duplicate-report.json");
+        std::fs::write(&duplicate_path, br#"{"duplicate":true}"#).expect("duplicate artifact");
+        let duplicate = store
+            .record_artifact(&run.id, "bench_results", &duplicate_path)
+            .expect("duplicate record");
+
+        let (output, _) = artifacts(&run.id).expect("artifacts");
+
+        let RunsOutput::Artifacts(output) = output else {
+            panic!("expected artifacts output");
+        };
+        let named_command = output
+            .next_commands
+            .iter()
+            .find(|command| command.artifact_id == named.id)
+            .expect("named command");
+        assert_eq!(named_command.token, "readable-report");
+        assert_eq!(
+            named_command.get_command,
+            format!("homeboy runs artifact get {} readable-report", run.id)
+        );
+        let duplicate_command = output
+            .next_commands
+            .iter()
+            .find(|command| command.artifact_id == duplicate.id)
+            .expect("duplicate command");
+        assert_eq!(duplicate_command.token, duplicate.id);
+        assert_eq!(
+            duplicate_command.get_command,
+            format!("homeboy runs artifact get {} {}", run.id, duplicate.id)
+        );
+
+        let downloaded = home.path().join("downloaded-named.json");
+        let (output, _) = artifact_get(RunsArtifactGetArgs {
+            run_id: run.id.clone(),
+            artifact_id: "readable-report".to_string(),
+            runner: None,
+            output: Some(downloaded.clone()),
+            field: Vec::new(),
+        })
+        .expect("get by readable name");
+        let RunsOutput::ArtifactGet(output) = output else {
+            panic!("expected artifact get output");
+        };
+        assert_eq!(output.artifact_id, named.id);
+        assert_eq!(
+            std::fs::read(&downloaded).expect("downloaded named"),
+            br#"{"named":true}"#
+        );
+    });
+}
+
+#[test]
 fn artifact_get_copies_registered_file_without_raw_path_lookup() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();

--- a/src/commands/runs/types.rs
+++ b/src/commands/runs/types.rs
@@ -289,10 +289,20 @@ pub struct RunsArtifactsOutput {
     pub matrix_summary: Option<MatrixArtifactSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fuzz_result_envelopes: Vec<FuzzResultEnvelopeArtifactInspection>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_commands: Vec<RunsArtifactCommandHint>,
     /// Present only when `--pull` was requested. Summarizes the best-effort
     /// retrieval of each artifact's bytes to the operator-local artifact root.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pull: Option<RunsArtifactPullSummary>,
+}
+
+#[derive(Serialize)]
+pub struct RunsArtifactCommandHint {
+    pub artifact_id: String,
+    pub kind: String,
+    pub token: String,
+    pub get_command: String,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Fixes #7664.\n\n## Summary\n- Add copy/paste `homeboy runs artifact get` commands to `homeboy runs artifacts` output.\n- Prefer a unique metadata `name`, then unique artifact `kind`, and fall back to the UUID only when needed.\n- Cover command output and readable-name lookup with tests.\n\n## Testing\n- `cargo fmt --check`\n- Attempted: `cargo test runs::tests::artifact` and `cargo test --lib runs::tests::artifact`; both timed out during Rust compilation in this worktree before tests executed.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** openai/gpt-5.5 via OpenCode\n- **Used for:** Implemented the small artifact UX change, added tests, and prepared the PR.\n