### PR TITLE
Mark invalid artifact DOM CSS diagnostics

### DIFF
--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -70,6 +70,8 @@ homeboy tunnel artifact-origin serve --bind 127.0.0.1:7351
 
 The same path convention covers `report.html`, `report.md`, `evidence.json`, compact Sample Runtime replay files such as `blueprint.after.json`, and external bundle files such as `files/runtime-snapshot.json`.
 
+`artifact-origin dom-boxes` reports mark each entrypoint with provider CSS diagnostics. When `dom_css_loaded`, `dom_capture_valid`, or an object-shaped `stylesheet_status` is missing or invalid, Homeboy writes `dom_capture_valid: false` and `dom_capture_invalid_reason` so operators can reject untrustworthy DOM evidence without inspecting provider internals.
+
 ## Service Tunnels
 
 Declare a private service reachable from a configured SSH server:

--- a/src/core/artifact_dom_boxes.rs
+++ b/src/core/artifact_dom_boxes.rs
@@ -39,6 +39,8 @@ pub struct DomBoxEntrypointReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dom_capture_valid: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub dom_capture_invalid_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stylesheet_status: Option<Value>,
     pub elements: Vec<DomBoxElement>,
 }
@@ -187,27 +189,86 @@ pub(crate) fn shape_report(
         entrypoints: browser
             .entrypoints
             .into_iter()
-            .map(|entrypoint| DomBoxEntrypointReport {
-                page_path: entrypoint.page_path,
-                page_url: entrypoint.page_url,
-                viewport: entrypoint.viewport,
-                dom_css_loaded: entrypoint.dom_css_loaded,
-                dom_capture_valid: entrypoint.dom_capture_valid,
-                stylesheet_status: entrypoint.stylesheet_status,
-                elements: entrypoint
-                    .elements
-                    .into_iter()
-                    .map(|element| DomBoxElement {
-                        node_id: element.node_id,
-                        node_name: element.node_name,
-                        selector: element.selector,
-                        tag: element.tag,
-                        text_sample: truncate_text_sample(&element.text_sample, text_sample_limit),
-                        bounding_client_rect: element.bounding_client_rect,
-                    })
-                    .collect(),
+            .map(|entrypoint| {
+                let diagnostics = normalize_capture_diagnostics(
+                    entrypoint.dom_css_loaded,
+                    entrypoint.dom_capture_valid,
+                    &entrypoint.stylesheet_status,
+                );
+                DomBoxEntrypointReport {
+                    page_path: entrypoint.page_path,
+                    page_url: entrypoint.page_url,
+                    viewport: entrypoint.viewport,
+                    dom_css_loaded: diagnostics.dom_css_loaded,
+                    dom_capture_valid: diagnostics.dom_capture_valid,
+                    dom_capture_invalid_reason: diagnostics.dom_capture_invalid_reason,
+                    stylesheet_status: entrypoint.stylesheet_status,
+                    elements: entrypoint
+                        .elements
+                        .into_iter()
+                        .map(|element| DomBoxElement {
+                            node_id: element.node_id,
+                            node_name: element.node_name,
+                            selector: element.selector,
+                            tag: element.tag,
+                            text_sample: truncate_text_sample(
+                                &element.text_sample,
+                                text_sample_limit,
+                            ),
+                            bounding_client_rect: element.bounding_client_rect,
+                        })
+                        .collect(),
+                }
             })
             .collect(),
+    }
+}
+
+struct NormalizedCaptureDiagnostics {
+    dom_css_loaded: Option<bool>,
+    dom_capture_valid: Option<bool>,
+    dom_capture_invalid_reason: Option<String>,
+}
+
+fn normalize_capture_diagnostics(
+    dom_css_loaded: Option<bool>,
+    dom_capture_valid: Option<bool>,
+    stylesheet_status: &Option<Value>,
+) -> NormalizedCaptureDiagnostics {
+    let mut problems = Vec::new();
+    if dom_css_loaded.is_none() {
+        problems.push("dom_css_loaded missing".to_string());
+    }
+    if dom_capture_valid.is_none() {
+        problems.push("dom_capture_valid missing".to_string());
+    }
+    match stylesheet_status {
+        Some(Value::Object(_)) => {}
+        Some(_) => problems.push("stylesheet_status must be an object".to_string()),
+        None => problems.push("stylesheet_status missing".to_string()),
+    }
+    if dom_css_loaded == Some(false) {
+        problems.push("provider reported CSS was not loaded".to_string());
+    }
+    if dom_capture_valid == Some(false) {
+        problems.push("provider reported DOM capture invalid".to_string());
+    }
+
+    if problems.is_empty() {
+        NormalizedCaptureDiagnostics {
+            dom_css_loaded,
+            dom_capture_valid,
+            dom_capture_invalid_reason: None,
+        }
+    } else {
+        NormalizedCaptureDiagnostics {
+            dom_css_loaded,
+            dom_capture_valid: Some(false),
+            dom_capture_invalid_reason: Some(format!(
+                "provider CSS diagnostics invalid: {}",
+                problems.join("; ")
+            )),
+        }
     }
 }
 
@@ -392,6 +453,7 @@ mod tests {
         );
         assert_eq!(report.entrypoints[0].dom_css_loaded, Some(true));
         assert_eq!(report.entrypoints[0].dom_capture_valid, Some(true));
+        assert_eq!(report.entrypoints[0].dom_capture_invalid_reason, None);
         assert_eq!(
             report.entrypoints[0]
                 .stylesheet_status
@@ -401,6 +463,72 @@ mod tests {
             Some("0px")
         );
         assert_eq!(report.entrypoints[0].elements[0].node_id, "12:34");
+    }
+
+    #[test]
+    fn marks_missing_provider_css_diagnostics_invalid() {
+        let report = shape_report(
+            Path::new("/artifact"),
+            BrowserReport {
+                entrypoints: vec![BrowserEntrypointReport {
+                    page_path: "/page.html".to_string(),
+                    page_url: "http://127.0.0.1/page.html".to_string(),
+                    viewport: DomBoxViewport {
+                        width: 1440,
+                        height: 900,
+                        device_scale_factor: 1,
+                    },
+                    dom_css_loaded: None,
+                    dom_capture_valid: None,
+                    stylesheet_status: None,
+                    elements: Vec::new(),
+                }],
+            },
+            16,
+        );
+
+        let entrypoint = &report.entrypoints[0];
+        assert_eq!(entrypoint.dom_capture_valid, Some(false));
+        let reason = entrypoint
+            .dom_capture_invalid_reason
+            .as_deref()
+            .expect("invalid reason");
+        assert!(reason.contains("dom_css_loaded missing"));
+        assert!(reason.contains("dom_capture_valid missing"));
+        assert!(reason.contains("stylesheet_status missing"));
+    }
+
+    #[test]
+    fn marks_invalid_provider_css_diagnostics_invalid() {
+        let report = shape_report(
+            Path::new("/artifact"),
+            BrowserReport {
+                entrypoints: vec![BrowserEntrypointReport {
+                    page_path: "/page.html".to_string(),
+                    page_url: "http://127.0.0.1/page.html".to_string(),
+                    viewport: DomBoxViewport {
+                        width: 1440,
+                        height: 900,
+                        device_scale_factor: 1,
+                    },
+                    dom_css_loaded: Some(false),
+                    dom_capture_valid: Some(true),
+                    stylesheet_status: Some(serde_json::json!("not diagnostic object")),
+                    elements: Vec::new(),
+                }],
+            },
+            16,
+        );
+
+        let entrypoint = &report.entrypoints[0];
+        assert_eq!(entrypoint.dom_css_loaded, Some(false));
+        assert_eq!(entrypoint.dom_capture_valid, Some(false));
+        let reason = entrypoint
+            .dom_capture_invalid_reason
+            .as_deref()
+            .expect("invalid reason");
+        assert!(reason.contains("stylesheet_status must be an object"));
+        assert!(reason.contains("provider reported CSS was not loaded"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Marks artifact-origin DOM-box entries invalid when provider CSS diagnostics are missing or malformed.
- Adds dom_capture_invalid_reason so operators can reject untrustworthy DOM evidence without reading provider internals.
- Documents the DOM-box diagnostic behavior for artifact-origin reports.

## Testing
- cargo fmt --check
- Attempted cargo test core::artifact_dom_boxes::tests three times; full test binary compilation did not reach execution before tool timeout.
- Attempted cargo test --lib core::artifact_dom_boxes::tests; rustc was killed by the OS with SIGKILL.
- Attempted cargo check --lib; rustc was killed by the OS with SIGKILL.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated artifact DOM-box report shaping, implemented the diagnostic normalization and focused tests, ran available verification, and drafted this PR.