### PR TITLE
Annotate landing PRs with local worktrees

### DIFF
--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -25,6 +25,7 @@ When no command is provided, `homeboy triage` defaults to `homeboy triage worksp
 - `fleet` — triage unique components used across a fleet
 - `rig` — triage components declared in a local rig spec
 - `workspace` — triage every configured project, rig, and registered component once per repo
+- `landing` — summarize mergeability/check blockers for an explicit PR fleet or branch pattern
 
 See [Scope model](../architecture/scope-model.md) for how these scopes relate to
 component-first, target-first, environment, and workspace commands.
@@ -63,6 +64,19 @@ Supported `--until` states:
 Watch output is structured JSON with `command: "triage.watch"`, final watched target states, and an `events` array. Events include `watch.started`, `item.state_changed`, `pr.commit.pushed`, `pr.ci.transitioned`, `pr.merged`, optional `pr.merge_requested`, and `watch.exit`.
 
 `--auto-merge` uses the GitHub REST merge endpoint with `--merge-method squash` by default. When `--auto-merge` is passed without `--until`, Homeboy watches for `green-mergeable`. This avoids depending on `gh pr merge`'s GraphQL path for the actual merge operation.
+
+## Landing PR Fleets
+
+`homeboy triage landing` is the compact holding dashboard for many PR branches. It accepts explicit PR refs, source branch patterns, issue-linked PRs, and normal Homeboy scopes. Each PR row includes the PR URL, base/head branch, mergeability, check classification, next suggested command, and matching local task worktrees when they exist.
+
+```sh
+homeboy triage landing Extra-Chill/homeboy#2238 Automattic/static-site-importer#118 --drilldown
+homeboy triage landing --repo Extra-Chill/homeboy --branch 'fixture/*' --drilldown
+homeboy triage landing --workspace --branch 'e2e/*' --limit 100 --output ./landing-fleet.json
+homeboy triage landing --repo Extra-Chill/homeboy --ordered 2238 2239 2240
+```
+
+When a PR head branch matches a persisted `homeboy worktree` record for the same GitHub repo, the JSON row gains `local_worktrees` entries with the task worktree ID, local path, branch, base ref, dirty state, unpushed commit count, safety reasons, and optional task/run provenance. The summary also reports `local_worktrees`, `local_worktrees_dirty`, and `local_worktrees_unpushed` counts so an orchestrator can quickly see which PRs need local cleanup or pushes before landing.
 
 ## Output Signals
 

--- a/src/core/triage/landing.rs
+++ b/src/core/triage/landing.rs
@@ -3,10 +3,12 @@
 
 use std::collections::BTreeSet;
 
+use crate::core::component;
 use crate::core::deploy::release_download::{parse_github_url, GitHubRepo};
 use crate::core::error::{Error, Result};
 use crate::core::observation::TriagePullRequestSignals;
 use crate::core::scope::ScopeOutput;
+use crate::core::worktree::{self, TaskWorktreeRecord, TaskWorktreeState};
 
 use super::gh::{ensure_gh_ready, non_empty, run_gh, summarize_checks};
 use super::observation::usize_to_i64;
@@ -15,9 +17,9 @@ use super::shared::{
     latest_comment_at, latest_review_at, RawNamedNode, RawPr, RawPrHeadRepository,
 };
 use super::types::{
-    TriageLandingCheckState, TriageLandingClassification, TriageLandingMergeabilityState,
-    TriageLandingOptions, TriageLandingOutput, TriageLandingPr, TriageLandingRebasePlan,
-    TriageLandingSummary, TriageUnresolved,
+    TriageLandingCheckState, TriageLandingClassification, TriageLandingLocalWorktree,
+    TriageLandingMergeabilityState, TriageLandingOptions, TriageLandingOutput, TriageLandingPr,
+    TriageLandingRebasePlan, TriageLandingSummary, TriageUnresolved,
 };
 
 pub fn landing(options: TriageLandingOptions) -> Result<TriageLandingOutput> {
@@ -57,6 +59,8 @@ pub fn landing(options: TriageLandingOptions) -> Result<TriageLandingOutput> {
         pull_requests.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.number.cmp(&b.number)));
         pull_requests.dedup_by(|a, b| a.repo == b.repo && a.number == b.number);
     }
+    let local_worktrees = landing_local_worktrees_for(&pull_requests);
+    annotate_local_worktrees(&mut pull_requests, &local_worktrees);
     let summary = summarize_landing(&pull_requests);
 
     Ok(TriageLandingOutput {
@@ -336,8 +340,86 @@ fn raw_pr_to_landing_pr(item: RawPr, repo: &GitHubRepo, drilldown: bool) -> Tria
         classification,
         suggested_next_command: landing_next_command(classification, repo, item.number),
         dependent_rebase: None,
+        local_worktrees: Vec::new(),
         signals,
         check_failures,
+    }
+}
+
+fn landing_local_worktrees_for(items: &[TriageLandingPr]) -> Vec<TriageLandingLocalWorktree> {
+    let wanted: BTreeSet<(String, String)> = items
+        .iter()
+        .filter_map(|item| {
+            let branch = item.head_branch.as_ref()?;
+            let repo = item.head_repo.as_ref().unwrap_or(&item.repo);
+            Some((repo.clone(), branch.clone()))
+        })
+        .collect();
+    if wanted.is_empty() {
+        return Vec::new();
+    }
+    let Ok(list) = worktree::list() else {
+        return Vec::new();
+    };
+    list.worktrees
+        .into_iter()
+        .filter(|record| record.state == TaskWorktreeState::Active)
+        .filter(|record| {
+            worktree_record_repo(record)
+                .is_some_and(|repo| wanted.contains(&(repo, record.branch.clone())))
+        })
+        .filter_map(|record| landing_local_worktree(record).ok())
+        .collect()
+}
+
+fn landing_local_worktree(record: TaskWorktreeRecord) -> Result<TriageLandingLocalWorktree> {
+    let repo = worktree_record_repo(&record).ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "task worktree component has no GitHub remote: {}",
+            record.component_id
+        ))
+    })?;
+    let safety = worktree::status(&record.id)?.safety;
+    Ok(TriageLandingLocalWorktree {
+        id: record.id,
+        component_id: record.component_id,
+        repo,
+        path: record.worktree_path,
+        branch: record.branch,
+        base_ref: record.base_ref,
+        dirty: safety.dirty,
+        unpushed_commits: safety.unpushed_commits,
+        safe: safety.safe,
+        reasons: safety.reasons,
+        task_url: record.task_url,
+        run_id: record.run_id,
+    })
+}
+
+fn worktree_record_repo(record: &TaskWorktreeRecord) -> Option<String> {
+    let component = component::load(&record.component_id).ok()?;
+    let remote = component
+        .triage_remote_url
+        .as_deref()
+        .or(component.remote_url.as_deref())?;
+    let repo = parse_github_url(remote)?;
+    Some(format!("{}/{}", repo.owner, repo.repo))
+}
+
+pub(super) fn annotate_local_worktrees(
+    items: &mut [TriageLandingPr],
+    worktrees: &[TriageLandingLocalWorktree],
+) {
+    for item in items {
+        let Some(head_branch) = item.head_branch.as_deref() else {
+            continue;
+        };
+        let head_repo = item.head_repo.as_deref().unwrap_or(item.repo.as_str());
+        item.local_worktrees = worktrees
+            .iter()
+            .filter(|worktree| worktree.repo == head_repo && worktree.branch == head_branch)
+            .cloned()
+            .collect();
     }
 }
 
@@ -504,6 +586,17 @@ fn summarize_landing(items: &[TriageLandingPr]) -> TriageLandingSummary {
         ..Default::default()
     };
     for item in items {
+        summary.local_worktrees += item.local_worktrees.len();
+        summary.local_worktrees_dirty += item
+            .local_worktrees
+            .iter()
+            .filter(|worktree| worktree.dirty)
+            .count();
+        summary.local_worktrees_unpushed += item
+            .local_worktrees
+            .iter()
+            .filter(|worktree| worktree.unpushed_commits > 0)
+            .count();
         match item.mergeability_state {
             TriageLandingMergeabilityState::Clean => summary.mergeability_clean += 1,
             TriageLandingMergeabilityState::Conflicting => summary.mergeability_conflicting += 1,

--- a/src/core/triage/mod.rs
+++ b/src/core/triage/mod.rs
@@ -22,11 +22,11 @@ pub use types::{
     TriageAction, TriageCheckFailure, TriageCiCheckStateCounts, TriageCiReadiness,
     TriageCiReadinessBuckets, TriageCommandOutput, TriageComponentReport, TriageIssueBucket,
     TriageIssueItem, TriageLandingCheckState, TriageLandingClassification,
-    TriageLandingMergeabilityState, TriageLandingOptions, TriageLandingOutput, TriageLandingPr,
-    TriageLandingRebasePlan, TriageLandingSummary, TriageLinkedPr, TriageObservationChangedItem,
-    TriageObservationComparison, TriageObservationItemRef, TriageObservationOutput, TriageOptions,
-    TriageOutput, TriagePrBucket, TriagePrItem, TriageRepo, TriageRepoRef, TriageSummary,
-    TriageUnresolved,
+    TriageLandingLocalWorktree, TriageLandingMergeabilityState, TriageLandingOptions,
+    TriageLandingOutput, TriageLandingPr, TriageLandingRebasePlan, TriageLandingSummary,
+    TriageLinkedPr, TriageObservationChangedItem, TriageObservationComparison,
+    TriageObservationItemRef, TriageObservationOutput, TriageOptions, TriageOutput, TriagePrBucket,
+    TriagePrItem, TriageRepo, TriageRepoRef, TriageSummary, TriageUnresolved,
 };
 
 pub use watch::{
@@ -50,10 +50,10 @@ mod test_reexports {
     pub(super) use crate::core::observation::TriagePullRequestSignals;
 
     pub(super) use super::landing::{
-        annotate_ordered_dependent_rebases, branch_matches, classify_landing_pr,
-        dedupe_landing_prs_preserving_order, dependent_rebase_plan, is_bare_pr_number,
-        landing_check_state, landing_mergeability_state, parse_landing_pr, parse_landing_pr_ref,
-        LandingPrRef,
+        annotate_local_worktrees, annotate_ordered_dependent_rebases, branch_matches,
+        classify_landing_pr, dedupe_landing_prs_preserving_order, dependent_rebase_plan,
+        is_bare_pr_number, landing_check_state, landing_mergeability_state, parse_landing_pr,
+        parse_landing_pr_ref, LandingPrRef,
     };
     pub(super) use super::report::{
         build_actions, dedupe_refs_by_repo, fetch_component_report, issue_bucket,

--- a/src/core/triage/tests/pull_requests.rs
+++ b/src/core/triage/tests/pull_requests.rs
@@ -550,6 +550,58 @@ fn branch_matcher_supports_simple_globs_and_contains() {
 }
 
 #[test]
+fn landing_annotations_match_local_worktrees_by_head_repo_and_branch() {
+    let mut items = vec![
+        landing_pr(
+            10,
+            "Extra-Chill/homeboy",
+            "main",
+            "feature/ready",
+            "Extra-Chill/homeboy",
+        ),
+        landing_pr(
+            11,
+            "Extra-Chill/homeboy",
+            "main",
+            "feature/fork",
+            "contributor/homeboy",
+        ),
+    ];
+    let worktrees = vec![
+        landing_worktree(
+            "homeboy@ready",
+            "Extra-Chill/homeboy",
+            "feature/ready",
+            false,
+            0,
+        ),
+        landing_worktree(
+            "homeboy@fork",
+            "contributor/homeboy",
+            "feature/fork",
+            true,
+            2,
+        ),
+        landing_worktree(
+            "homeboy@other",
+            "Extra-Chill/homeboy",
+            "feature/other",
+            false,
+            0,
+        ),
+    ];
+
+    annotate_local_worktrees(&mut items, &worktrees);
+
+    assert_eq!(items[0].local_worktrees.len(), 1);
+    assert_eq!(items[0].local_worktrees[0].id, "homeboy@ready");
+    assert_eq!(items[1].local_worktrees.len(), 1);
+    assert_eq!(items[1].local_worktrees[0].id, "homeboy@fork");
+    assert!(items[1].local_worktrees[0].dirty);
+    assert_eq!(items[1].local_worktrees[0].unpushed_commits, 2);
+}
+
+#[test]
 fn parse_prs_flags_clean_with_zero_checks_as_not_reported() {
     // Reproduces the #4872 force-push window: GitHub reports mergeStateStatus
     // CLEAN with an empty statusCheckRollup before CI registers on the new head.
@@ -699,7 +751,31 @@ fn landing_pr(
             "homeboy triage --watch {repo}#{number} --until green-mergeable"
         ),
         dependent_rebase: None,
+        local_worktrees: Vec::new(),
         signals: TriagePullRequestSignals::default(),
         check_failures: Vec::new(),
+    }
+}
+
+fn landing_worktree(
+    id: &str,
+    repo: &str,
+    branch: &str,
+    dirty: bool,
+    unpushed_commits: u32,
+) -> TriageLandingLocalWorktree {
+    TriageLandingLocalWorktree {
+        id: id.to_string(),
+        component_id: "homeboy".to_string(),
+        repo: repo.to_string(),
+        path: format!("/tmp/{id}"),
+        branch: branch.to_string(),
+        base_ref: "origin/main".to_string(),
+        dirty,
+        unpushed_commits,
+        safe: !dirty && unpushed_commits == 0,
+        reasons: Vec::new(),
+        task_url: None,
+        run_id: None,
     }
 }

--- a/src/core/triage/types.rs
+++ b/src/core/triage/types.rs
@@ -57,6 +57,9 @@ pub struct TriageLandingOutput {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct TriageLandingSummary {
     pub total: usize,
+    pub local_worktrees: usize,
+    pub local_worktrees_dirty: usize,
+    pub local_worktrees_unpushed: usize,
     pub merged: usize,
     pub clean_mergeable: usize,
     pub mergeability_clean: usize,
@@ -92,10 +95,31 @@ pub struct TriageLandingPr {
     pub suggested_next_command: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dependent_rebase: Option<TriageLandingRebasePlan>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub local_worktrees: Vec<TriageLandingLocalWorktree>,
     #[serde(flatten)]
     pub signals: TriagePullRequestSignals,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub check_failures: Vec<TriageCheckFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TriageLandingLocalWorktree {
+    pub id: String,
+    pub component_id: String,
+    pub repo: String,
+    pub path: String,
+    pub branch: String,
+    pub base_ref: String,
+    pub dirty: bool,
+    pub unpushed_commits: u32,
+    pub safe: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary
- annotate `homeboy triage landing` PR rows with matching persisted task worktrees
- expose local worktree path, branch, dirty/unpushed safety signals, reasons, and task/run provenance in JSON
- document `triage landing` examples for PR fleet operators

## Why
Holding many E2E/evidence PR branches needs one generic view that connects GitHub PR state to the local branch/worktree that may still need cleanup or a push. This keeps the feature in Homeboy's generic triage/worktree model instead of adding product-specific fleet logic.

## Tests
- `cargo fmt --check`
- `cargo check --lib` (passes with existing dead-code warnings)
- `CARGO_BUILD_JOBS=1 cargo test landing_annotations_match_local_worktrees_by_head_repo_and_branch` attempted; test compilation did not finish within 3 minutes under current machine load after earlier attempts hit Cargo lock contention and one OS SIGKILL from concurrent Rust builds.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Inspected Homeboy command surfaces, implemented the triage/worktree annotation, added tests/docs, and ran verification commands.