### PR TITLE
Make runner doctor remediation actionable

### DIFF
--- a/src/commands/runner/doctor/extension_parity.rs
+++ b/src/commands/runner/doctor/extension_parity.rs
@@ -84,11 +84,25 @@ pub fn check_from_probe(
     }
 
     if success {
-        return checks::ok_with_details(
+        add_extension_show_details(stdout, &mut details);
+        let copied_install = details.get("linked").map(String::as_str) == Some("false");
+        let mut check = checks::ok_with_details(
             "extension.parity",
-            format!("Extension '{extension_id}' resolves on the {target} runner"),
+            if copied_install {
+                format!(
+                    "Extension '{extension_id}' resolves on the {target} runner as a copied install"
+                )
+            } else {
+                format!("Extension '{extension_id}' resolves on the {target} runner")
+            },
             details,
         );
+        if copied_install {
+            check.remediation = Some(format!(
+                "No runner repair is needed when the copied install is current. Verify copied/current state with `{homeboy_command} extension diff-installed {extension_id}` on the runner; if stale, refresh it from source with `{homeboy_command} extension refresh <source> --id {extension_id}`."
+            ));
+        }
+        return check;
     }
 
     let diagnostics = diagnostic_tail(stderr, stdout);
@@ -138,4 +152,26 @@ fn json_error_message(output: &str) -> Option<String> {
         .map(str::trim)
         .filter(|message| !message.is_empty())
         .map(str::to_string)
+}
+
+fn add_extension_show_details(stdout: &str, details: &mut BTreeMap<String, String>) {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout.trim()) else {
+        return;
+    };
+    let extension = value
+        .pointer("/data/extension")
+        .or_else(|| value.get("extension"))
+        .unwrap_or(&value);
+    if let Some(linked) = extension.get("linked").and_then(|value| value.as_bool()) {
+        details.insert("linked".to_string(), linked.to_string());
+    }
+    if let Some(path) = extension.get("path").and_then(|value| value.as_str()) {
+        details.insert("path".to_string(), path.to_string());
+    }
+    if let Some(source_revision) = extension
+        .get("source_revision")
+        .and_then(|value| value.as_str())
+    {
+        details.insert("source_revision".to_string(), source_revision.to_string());
+    }
 }

--- a/src/commands/runner/doctor/probes.rs
+++ b/src/commands/runner/doctor/probes.rs
@@ -248,14 +248,11 @@ pub(super) fn homeboy_path_shadow_check(
         || !version_is_older(bare_version, configured_version)
     {
         if configured_command != "homeboy" && configured_path != bare_path {
-            return Some(checks::warning_with_details(
+            return Some(checks::ok_with_details(
                 "lab.homeboy.path_shadow",
                 format!(
-                    "Configured runner Homeboy at {configured_path} differs from bare PATH `homeboy` at {bare_path}"
+                    "Runner uses configured Homeboy at {configured_path}; bare PATH `homeboy` resolves to {bare_path}"
                 ),
-                Some(format!(
-                    "Fix PATH ordering on server `{server_id}` or update runner `{runner_id}` so configured homeboy_path and bare `homeboy` resolve to the same binary"
-                )),
                 details,
             ));
         }
@@ -263,16 +260,19 @@ pub(super) fn homeboy_path_shadow_check(
         return None;
     }
 
-    Some(checks::warning_with_details(
+    Some(checks::ok(
         "lab.homeboy.path_shadow",
         format!(
-            "Configured runner Homeboy {configured_version} at {configured_path} is newer than bare PATH `homeboy` {bare_version} at {bare_path}"
+            "Runner uses configured Homeboy {configured_version} at {configured_path}; bare PATH `homeboy` is older ({bare_version} at {bare_path})"
         ),
         Some(format!(
-            "Fix PATH ordering on server `{server_id}` or update/remove the stale bare `homeboy`; keep runner `{runner_id}` configured with `{configured_command}` until bare `homeboy` resolves current"
+            "No runner repair is needed while jobs use configured homeboy_path `{configured_command}`. To clean up interactive PATH skew, run `homeboy ssh {server_id} -- 'command -v homeboy && homeboy --version'` and update/remove the stale bare `homeboy`."
         )),
-        details,
     ))
+    .map(|mut check| {
+        check.details = details;
+        check
+    })
 }
 
 fn version_is_older(candidate: &str, baseline: &str) -> bool {

--- a/src/commands/runner/doctor/tests/extension_parity.rs
+++ b/src/commands/runner/doctor/tests/extension_parity.rs
@@ -71,6 +71,35 @@ fn extension_parity_check_reports_resolved_extension() {
 }
 
 #[test]
+fn extension_parity_check_reports_copied_extension_as_actionable_ok() {
+    let check = extension_parity::check_from_probe(
+        "remote",
+        "homeboy",
+        None,
+        "rust",
+        true,
+        "",
+        r#"{"success":true,"data":{"extension":{"id":"rust","linked":false,"path":"/runner/extensions/rust","source_revision":"abc123"}}}"#,
+    );
+
+    assert_eq!(check.id, "extension.parity");
+    assert_eq!(check.status, RunnerDoctorStatus::Ok);
+    assert!(check.message.contains("copied install"));
+    assert_eq!(
+        check.details.get("linked").map(String::as_str),
+        Some("false")
+    );
+    assert_eq!(
+        check.details.get("source_revision").map(String::as_str),
+        Some("abc123")
+    );
+    assert!(check
+        .remediation
+        .as_deref()
+        .is_some_and(|value| value.contains("extension diff-installed rust")));
+}
+
+#[test]
 fn normalizes_requested_extensions_before_parity_checks() {
     assert_eq!(
         normalized_extension_ids(&[

--- a/src/commands/runner/doctor/tests/homeboy_path.rs
+++ b/src/commands/runner/doctor/tests/homeboy_path.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use types::{HomeboyProbe, RunnerDoctorStatus};
 
 #[test]
-fn lab_homeboy_path_shadow_warns_when_bare_homeboy_is_older() {
+fn lab_homeboy_path_shadow_is_ok_when_configured_homeboy_is_current() {
     let mut details = BTreeMap::new();
     details.insert(
         "configured_command".to_string(),
@@ -38,7 +38,7 @@ fn lab_homeboy_path_shadow_warns_when_bare_homeboy_is_older() {
     .expect("stale bare homeboy warning");
 
     assert_eq!(check.id, "lab.homeboy.path_shadow");
-    assert_eq!(check.status, RunnerDoctorStatus::Warning);
+    assert_eq!(check.status, RunnerDoctorStatus::Ok);
     assert!(check.message.contains("0.229.9"));
     assert!(check.message.contains("0.228.22"));
     assert_eq!(
@@ -52,11 +52,11 @@ fn lab_homeboy_path_shadow_warns_when_bare_homeboy_is_older() {
     assert!(check
         .remediation
         .as_deref()
-        .is_some_and(|value| value.contains("Fix PATH ordering")));
+        .is_some_and(|value| value.contains("No runner repair is needed")));
 }
 
 #[test]
-fn lab_homeboy_path_shadow_warns_when_bare_homeboy_resolves_different_path() {
+fn lab_homeboy_path_shadow_is_ok_when_configured_and_bare_paths_differ_but_version_matches() {
     let mut details = BTreeMap::new();
     details.insert(
         "configured_command".to_string(),
@@ -91,7 +91,7 @@ fn lab_homeboy_path_shadow_warns_when_bare_homeboy_resolves_different_path() {
     .expect("different bare homeboy path warning");
 
     assert_eq!(check.id, "lab.homeboy.path_shadow");
-    assert_eq!(check.status, RunnerDoctorStatus::Warning);
+    assert_eq!(check.status, RunnerDoctorStatus::Ok);
     assert!(check.message.contains("/home/user/.cargo/bin/homeboy"));
     assert!(check.message.contains("/home/user/.local/bin/homeboy"));
     assert_eq!(
@@ -102,10 +102,7 @@ fn lab_homeboy_path_shadow_warns_when_bare_homeboy_resolves_different_path() {
         check.details.get("bare_path").map(String::as_str),
         Some("/home/user/.local/bin/homeboy")
     );
-    assert!(check
-        .remediation
-        .as_deref()
-        .is_some_and(|value| value.contains("configured homeboy_path and bare `homeboy`")));
+    assert!(check.remediation.is_none());
 }
 
 #[test]

--- a/src/commands/runner/refresh_plan.rs
+++ b/src/commands/runner/refresh_plan.rs
@@ -404,7 +404,26 @@ fn lab_homeboy_provenance_from_parts(
                         .or(active_daemon.version.as_deref())
                         .unwrap_or("unknown")
                 ),
-                action: "rebuild the controller binary or refresh/reconnect the runner so both phases report the intended Homeboy identity".to_string(),
+                action: format!(
+                    "run `{}`; if active jobs are still running, wait for them or inspect with `{}` before reconnecting",
+                    shell_join(&[
+                        "homeboy",
+                        "runner",
+                        "refresh-homeboy",
+                        runner_id,
+                        "--ref",
+                        &format!("v{}", controller_identity.version),
+                        "--reconnect"
+                    ]),
+                    shell_join(&[
+                        "homeboy",
+                        "runner",
+                        "doctor",
+                        runner_id,
+                        "--scope",
+                        "lab-offload"
+                    ])
+                ),
             });
         } else if active_daemon
             .build_identity
@@ -422,7 +441,18 @@ fn lab_homeboy_provenance_from_parts(
                         .as_deref()
                         .unwrap_or("unknown")
                 ),
-                action: "rebuild the controller binary or refresh/reconnect the runner before relying on commit-specific Lab behavior".to_string(),
+                action: format!(
+                    "run `{}`; same-version build drift can be intentional for origin/main-style runner builds, but Lab proof should use matching controller and runner identities",
+                    shell_join(&[
+                        "homeboy",
+                        "runner",
+                        "refresh-homeboy",
+                        runner_id,
+                        "--ref",
+                        &format!("v{}", controller_identity.version),
+                        "--reconnect"
+                    ])
+                ),
             });
         }
     } else if let Some(error) = status_error {
@@ -1127,7 +1157,50 @@ mod tests {
             .contains("executes the runner job"));
         assert!(provenance.diagnostics[1]
             .action
-            .contains("refresh/reconnect the runner"));
+            .contains("homeboy runner refresh-homeboy lab-runner --ref v0.265.0 --reconnect"));
+        assert!(provenance.diagnostics[1]
+            .action
+            .contains("homeboy runner doctor lab-runner --scope lab-offload"));
+    }
+
+    #[test]
+    fn homeboy_provenance_same_version_build_drift_mentions_origin_main_style_builds() {
+        let controller_identity = BuildIdentity {
+            version: "0.265.0".to_string(),
+            git_commit: Some("controller123".to_string()),
+            git_dirty: Some(false),
+            display: "homeboy 0.265.0+controller123".to_string(),
+        };
+
+        let provenance = lab_homeboy_provenance_from_parts(
+            "lab-runner",
+            controller_identity,
+            Some("/controller/homeboy".to_string()),
+            Some("/runner/homeboy".to_string()),
+            Some(LabHomeboyBinaryIdentity {
+                role: "active_daemon",
+                owner: "runner",
+                path: None,
+                version: Some("0.265.0".to_string()),
+                build_identity: Some("homeboy 0.265.0+origin-main".to_string()),
+                dirty: None,
+                purpose: "test daemon",
+            }),
+            None,
+            None,
+        );
+
+        assert_eq!(provenance.diagnostics.len(), 1);
+        assert_eq!(
+            provenance.diagnostics[0].code,
+            "controller_daemon_build_drift"
+        );
+        assert!(provenance.diagnostics[0]
+            .action
+            .contains("origin/main-style runner builds"));
+        assert!(provenance.diagnostics[0]
+            .action
+            .contains("homeboy runner refresh-homeboy lab-runner --ref v0.265.0 --reconnect"));
     }
 
     #[test]

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -1474,11 +1474,14 @@ mod tests {
         );
         assert_eq!(
             warning.refresh_command,
-            "homeboy runner disconnect homeboy-lab && homeboy runner connect homeboy-lab"
+            format!(
+                "homeboy runner refresh-homeboy homeboy-lab --ref v{} --reconnect && homeboy runner disconnect homeboy-lab && homeboy runner connect homeboy-lab",
+                env!("CARGO_PKG_VERSION")
+            )
         );
         assert!(warning.message.contains("daemon control plane"));
         assert!(warning.message.contains("job command binary"));
-        assert!(warning.message.contains("run refresh_command"));
+        assert!(warning.message.contains("active jobs are drained"));
         assert_eq!(
             warning.recovery_commands,
             vec![

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -570,9 +570,14 @@ impl RunnerStaleDaemonWarning {
         session_homeboy_build_identity: Option<String>,
         current_homeboy_build_identity: Option<String>,
     ) -> Self {
-        let recovery_commands = [
-            format!("homeboy runner disconnect {}", runner_id),
-            format!("homeboy runner connect {}", runner_id),
+        let recovery_commands = vec![
+            format!(
+                "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
+                shell::quote_arg(runner_id),
+                env!("CARGO_PKG_VERSION")
+            ),
+            format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
+            format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
         ];
         Self {
             severity: "warning",
@@ -585,18 +590,10 @@ impl RunnerStaleDaemonWarning {
             session_homeboy_build_identity,
             current_homeboy_build_identity,
             refresh_command: recovery_commands.join(" && "),
-            message: "connected runner daemon control plane was started by a different Homeboy build than the configured job command binary; run refresh_command to restart the active daemon".to_string(),
+            message: "connected runner daemon control plane was started by a different Homeboy build than the configured job command binary; run recovery_commands in order when runner active jobs are drained".to_string(),
             stale_runtime_paths: Vec::new(),
             changed_runtime_paths: Vec::new(),
-            recovery_commands: vec![
-                format!(
-                    "homeboy runner refresh-homeboy {} --ref v{} --reconnect",
-                    shell::quote_arg(runner_id),
-                    env!("CARGO_PKG_VERSION")
-                ),
-                format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
-                format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
-            ],
+            recovery_commands,
         }
     }
 


### PR DESCRIPTION
## Summary
- Treat stale bare PATH `homeboy` as non-blocking when the runner uses an explicit configured Homeboy binary, and make the cleanup action explicit.
- Surface copied extension install details from `extension show` and point operators at `extension diff-installed` before refresh.
- Expand refresh-plan/stale-daemon diagnostics with concrete refresh/reconnect commands, origin/main-style build drift language, and active-job drain guidance.

Fixes #7661

## Testing
- `cargo fmt --check`
- `RUSTFLAGS="-C debuginfo=0" cargo test -j1 runner::doctor::tests::extension_parity`
- `RUSTFLAGS="-C debuginfo=0" cargo test -j1 runner::doctor::tests::homeboy_path`
- `RUSTFLAGS="-C debuginfo=0" cargo test -j1 refresh_plan::tests`
- `RUSTFLAGS="-C debuginfo=0" cargo test -j1 runner_availability`
- `RUSTFLAGS="-C debuginfo=0" cargo test -j1 active_job_poll`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Resumed the issue worktree, implemented runner doctor remediation messaging/test updates, and ran local verification.