### PR TITLE
Fix rig fuzz lab extension resolution

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1287,9 +1287,7 @@ impl Commands {
         let mut extension_ids = BTreeSet::new();
         match self {
             Commands::Bench(args) => extension_ids.extend(args.lab_required_extension_ids()?),
-            Commands::Fuzz(args) => {
-                extension_ids.extend(args.extension_override_ids().iter().cloned())
-            }
+            Commands::Fuzz(args) => extension_ids.extend(args.lab_required_extension_ids()?),
             Commands::Review(args) => {
                 extension_ids.extend(args.extension_override.extensions.clone());
                 match args.command.as_ref() {

--- a/src/commands/fuzz/tests/workload_tests.rs
+++ b/src/commands/fuzz/tests/workload_tests.rs
@@ -225,6 +225,169 @@ fn resolve_fuzz_context_infers_single_rig_fuzz_workload_extension() {
 }
 
 #[test]
+fn resolve_fuzz_context_reports_explicit_extension_without_fuzz_capability() {
+    with_isolated_home(|home| {
+        let extension_dir = home.path().join(".config/homeboy/extensions/generic");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("generic.json"),
+            serde_json::json!({
+                "name": "generic",
+                "version": "0.0.0",
+                "test": { "extension_script": "test.sh" }
+            })
+            .to_string(),
+        )
+        .expect("extension manifest");
+        let component_dir = tempfile::tempdir().expect("component dir");
+        let spec: RigSpec = serde_json::from_value(serde_json::json!({
+            "id": "package-fuzz",
+            "components": {
+                "package": {
+                    "path": component_dir.path().to_string_lossy()
+                }
+            },
+            "fuzz": { "default_component": "package" },
+            "fuzz_workloads": {
+                "generic": [{ "path": "fuzz/parser.json" }]
+            }
+        }))
+        .expect("parse rig spec");
+        let context = FuzzRigContext {
+            spec,
+            package_root: Some(home.path().join("rig-package")),
+        };
+        let comp = PositionalComponentArgs {
+            component: Some("package".to_string()),
+            path: None,
+        };
+        let extension_override = ExtensionOverrideArgs {
+            extensions: vec!["generic".to_string()],
+        };
+
+        let err = resolve_fuzz_context(
+            "package",
+            &comp,
+            &SettingArgs::default(),
+            &extension_override,
+            homeboy::core::extension::ExtensionCapability::Fuzz,
+            Some(&context),
+        )
+        .expect_err("old extension manifest should fail explicitly");
+
+        assert!(err.message.contains(
+            "explicit extension override 'generic' is installed but does not declare fuzz support"
+        ));
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("Upgrade or refresh the runner extension")));
+    });
+}
+
+#[test]
+fn fuzz_lab_required_extensions_include_rig_workload_and_component_extensions() {
+    with_isolated_home(|home| {
+        let rig_dir = home.path().join(".config/homeboy/rigs");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("package-fuzz.json"),
+            serde_json::json!({
+                "id": "package-fuzz",
+                "components": {
+                    "package": {
+                        "path": "/tmp/package",
+                        "extensions": {
+                            "component-helper": { "settings": {} }
+                        }
+                    }
+                },
+                "fuzz": { "default_component": "package" },
+                "fuzz_workloads": {
+                    "generic": [
+                        {
+                            "path": "fuzz/parser.json",
+                            "env_provider_extensions": ["runtime-helper"]
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .expect("write rig");
+        let args = FuzzArgs {
+            command: None,
+            run: FuzzRunArgs {
+                comp: PositionalComponentArgs {
+                    component: None,
+                    path: None,
+                },
+                rig: Some("package-fuzz".to_string()),
+                extension_override: ExtensionOverrideArgs::default(),
+                setting_args: SettingArgs::default(),
+                workload_id: None,
+                profile: Some("lab".to_string()),
+                shared_state: None,
+                run_id: None,
+                tracker_refs: vec![],
+                seed: None,
+                inventory: None,
+                sequence_plan: None,
+                require_case_log: false,
+                require_coverage_summary: false,
+                require_result_envelope: false,
+                max_duration: None,
+                gate_profile: FuzzGateProfileArg::Measurement,
+                allow_destructive: false,
+                isolation: FuzzIsolationArg::Shared,
+                isolation_proof: None,
+                allow_local_destructive_fuzz: false,
+                expect_metric: vec![],
+                action_model: None,
+                exploration_policy: None,
+                args: vec![],
+            },
+        };
+
+        let required = args
+            .lab_required_extension_ids()
+            .expect("resolve lab required extensions");
+
+        assert_eq!(
+            required,
+            vec![
+                "component-helper".to_string(),
+                "generic".to_string(),
+                "runtime-helper".to_string()
+            ]
+        );
+    });
+}
+
+#[test]
+fn fuzz_list_lab_required_extensions_preserve_explicit_extension_override() {
+    let args = FuzzArgs {
+        command: Some(FuzzCommand::List(FuzzListArgs {
+            comp: PositionalComponentArgs {
+                component: Some("package".to_string()),
+                path: None,
+            },
+            rig: None,
+            extension_override: ExtensionOverrideArgs {
+                extensions: vec!["generic".to_string()],
+            },
+            setting_args: SettingArgs::default(),
+        })),
+        run: fuzz_run_args_with_run_id("unused"),
+    };
+
+    let required = args
+        .lab_required_extension_ids()
+        .expect("resolve explicit list extension");
+
+    assert_eq!(required, vec!["generic".to_string()]);
+}
+
+#[test]
 fn resolve_profile_workload_id_uses_single_fuzz_profile_entry() {
     let spec: RigSpec = serde_json::from_value(serde_json::json!({
         "id": "package-fuzz",

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand, ValueEnum};
@@ -9,6 +10,7 @@ use crate::command_contract::{
     FUZZ_LAB_LABEL,
 };
 use homeboy::core::fuzz::FuzzGateProfile;
+use homeboy::core::rig::{self, RigSpec};
 
 #[derive(Args)]
 pub struct FuzzArgs {
@@ -51,10 +53,32 @@ impl FuzzArgs {
         ) || matches!(&self.command, Some(FuzzCommand::Plan(plan)) if plan.execute)
     }
 
-    pub fn extension_override_ids(&self) -> &[String] {
+    pub(crate) fn lab_required_extension_ids(&self) -> homeboy::core::Result<Vec<String>> {
+        if let Some(FuzzCommand::List(list)) = &self.command {
+            if !list.extension_override.extensions.is_empty() {
+                return Ok(list.extension_override.extensions.clone());
+            }
+            return lab_required_rig_extension_ids(list.rig.as_deref(), list.comp.id());
+        }
+
+        let Some(run) = self.run_args_for_lab_offload() else {
+            return Ok(Vec::new());
+        };
+        if !run.extension_override.extensions.is_empty() {
+            return Ok(run.extension_override.extensions.clone());
+        }
+
+        lab_required_rig_extension_ids(run.rig.as_deref(), run.comp.id())
+    }
+
+    fn run_args_for_lab_offload(&self) -> Option<&FuzzRunArgs> {
         match &self.command {
-            Some(FuzzCommand::List(list)) => list.extension_override.extensions.as_slice(),
-            _ => self.run.extension_override.extensions.as_slice(),
+            None => Some(&self.run),
+            Some(FuzzCommand::Run(run)) => Some(run),
+            Some(FuzzCommand::RunCampaign(plan)) => Some(&plan.run),
+            Some(FuzzCommand::Plan(plan)) => plan.execute.then_some(&plan.run),
+            Some(FuzzCommand::List(_)) => None,
+            _ => None,
         }
     }
 
@@ -81,6 +105,49 @@ impl FuzzArgs {
             _ => None,
         }
     }
+}
+
+fn lab_required_rig_extension_ids(
+    rig_id: Option<&str>,
+    component_id: Option<&str>,
+) -> homeboy::core::Result<Vec<String>> {
+    let Some(rig_id) = rig_id else {
+        return Ok(Vec::new());
+    };
+    let spec = rig::load(rig_id)?;
+    let mut extension_ids = BTreeSet::new();
+    let workload_extension_ids =
+        rig::extension_ids_for_workloads(&spec, rig::RigWorkloadKind::Fuzz);
+    for extension_id in &workload_extension_ids {
+        extension_ids.extend(rig::env_provider_extensions_for_extension_workloads(
+            &spec,
+            rig::RigWorkloadKind::Fuzz,
+            extension_id,
+        ));
+    }
+    extension_ids.extend(workload_extension_ids);
+    extension_ids.extend(fuzz_component_extension_ids(&spec, component_id));
+    Ok(extension_ids.into_iter().collect())
+}
+
+fn fuzz_component_extension_ids(spec: &RigSpec, explicit_component: Option<&str>) -> Vec<String> {
+    let component_id = explicit_component.map(str::to_string).or_else(|| {
+        spec.fuzz
+            .as_ref()
+            .and_then(|fuzz| fuzz.default_component.clone())
+    });
+    let Some(component_id) = component_id else {
+        return Vec::new();
+    };
+
+    let mut extension_ids: Vec<String> = spec
+        .components
+        .get(&component_id)
+        .and_then(|component| component.extensions.as_ref())
+        .map(|extensions| extensions.keys().cloned().collect())
+        .unwrap_or_default();
+    extension_ids.sort();
+    extension_ids
 }
 
 #[derive(Subcommand)]

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -184,7 +184,45 @@ fn add_extension_override_hints(
     mut err: Error,
     extension_overrides: &[String],
     declared_extension_ids: &[String],
+    capability: ExtensionCapability,
 ) -> Error {
+    if !extension_overrides.is_empty()
+        && err.code == ErrorCode::ValidationInvalidArgument
+        && err
+            .details
+            .get("problem")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|problem| problem.contains("has no linked extensions that provide"))
+    {
+        let override_list = extension_overrides.join(", ");
+        let mut explicit_err = Error::validation_invalid_argument(
+            "extension",
+            format!(
+                "explicit extension override '{}' is installed but does not declare {} support",
+                override_list,
+                capability.label()
+            ),
+            Some(override_list),
+            None,
+        )
+        .with_hint(format!(
+            "Upgrade or refresh the runner extension so its manifest declares {} support, then retry.",
+            capability.label()
+        ))
+        .with_hint(
+            "If this command was offloaded to Lab, run the runner extension refresh/update workflow on that runner.".to_string(),
+        );
+
+        if !declared_extension_ids.is_empty() {
+            explicit_err = explicit_err.with_hint(format!(
+                "Component declares extensions: {}",
+                declared_extension_ids.join(", ")
+            ));
+        }
+
+        return explicit_err;
+    }
+
     if extension_overrides.is_empty() || err.code != ErrorCode::ExtensionNotFound {
         return err;
     }
@@ -266,6 +304,7 @@ pub fn resolve_with_component(
                             err,
                             &options.extension_overrides,
                             &declared_extension_ids,
+                            capability,
                         )
                     })?;
                 let accepted_setting_keys = ext_context.accepted_setting_keys.clone();


### PR DESCRIPTION
## Summary
- Include rig-declared fuzz workload, env-provider, and selected rig component extensions in Lab extension parity for rig-backed fuzz commands.
- Preserve explicit `fuzz list --extension` parity while allowing rig-backed list/run paths to infer required runner extensions.
- Report explicit extension overrides whose installed manifest lacks requested capability as stale/missing capability metadata instead of saying the component has no linked provider.

## Tests
- `CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test commands::fuzz::tests::workload_tests -- --nocapture`
- `CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test core::extension::tests::fuzz_manifest_support_does_not_require_execution_script`
- `CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test lab_required`
- `CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo check --tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed Homeboy fuzz lab extension resolution, implemented the fix, added regression coverage, and ran focused verification.