### PR TITLE
Fix extension-only dev-sync binary selection

### DIFF
--- a/src/core/runner/extension_materialization.rs
+++ b/src/core/runner/extension_materialization.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -77,9 +78,19 @@ pub(crate) fn materialize_runner_extension(
     homeboy_path: &str,
     request: &RunnerExtensionMaterializationRequest,
 ) -> Result<RunnerExtensionMaterializationProvenance> {
+    materialize_runner_extension_with_env(runner, homeboy_path, None, request)
+}
+
+pub(crate) fn materialize_runner_extension_with_env(
+    runner: &Runner,
+    homeboy_path: &str,
+    env: Option<HashMap<String, String>>,
+    request: &RunnerExtensionMaterializationRequest,
+) -> Result<RunnerExtensionMaterializationProvenance> {
     materialize_runner_extension_with_exec(
         runner,
         homeboy_path,
+        env,
         request,
         &mut |runner_id, options| exec(runner_id, options),
     )
@@ -88,6 +99,7 @@ pub(crate) fn materialize_runner_extension(
 pub(crate) fn materialize_runner_extension_with_exec(
     runner: &Runner,
     homeboy_path: &str,
+    env: Option<HashMap<String, String>>,
     request: &RunnerExtensionMaterializationRequest,
     exec_runner: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(super::RunnerExecOutput, i32)>,
 ) -> Result<RunnerExtensionMaterializationProvenance> {
@@ -113,7 +125,7 @@ pub(crate) fn materialize_runner_extension_with_exec(
                 "--ref".to_string(),
                 plan.content_hash.clone(),
             ];
-            run_materialization_command(runner, command, exec_runner)?;
+            run_materialization_command(runner, env.as_ref(), command, exec_runner)?;
             Ok(controller_snapshot_provenance(&runner.id, &plan))
         }
         RunnerExtensionMaterializationSource::RunnerPath { path } => {
@@ -127,19 +139,25 @@ pub(crate) fn materialize_runner_extension_with_exec(
                 "--ref".to_string(),
                 request.revision.clone(),
             ];
-            run_materialization_command(runner, command, exec_runner)?;
+            run_materialization_command(runner, env.as_ref(), command, exec_runner)?;
             Ok(runner_path_provenance(&runner.id, request, path))
         }
         RunnerExtensionMaterializationSource::RemoteGit { url, git_ref } => {
-            let exists = runner_extension_exists(runner, homeboy_path, &request.id, exec_runner)
-                .map_err(|detail| {
-                    Error::validation_invalid_argument(
-                        "extensions",
-                        detail,
-                        Some(request.id.clone()),
-                        None,
-                    )
-                })?;
+            let exists = runner_extension_exists(
+                runner,
+                env.as_ref(),
+                homeboy_path,
+                &request.id,
+                exec_runner,
+            )
+            .map_err(|detail| {
+                Error::validation_invalid_argument(
+                    "extensions",
+                    detail,
+                    Some(request.id.clone()),
+                    None,
+                )
+            })?;
             let mut command = vec![
                 homeboy_path.to_string(),
                 "extension".to_string(),
@@ -153,7 +171,7 @@ pub(crate) fn materialize_runner_extension_with_exec(
             if exists {
                 command.push("--replace".to_string());
             }
-            run_materialization_command(runner, command, exec_runner)?;
+            run_materialization_command(runner, env.as_ref(), command, exec_runner)?;
             Ok(remote_git_provenance(
                 &runner.id, request, url, git_ref, exists,
             ))
@@ -241,10 +259,14 @@ fn upload_snapshot(
 
 fn run_materialization_command(
     runner: &Runner,
+    env: Option<&HashMap<String, String>>,
     command: Vec<String>,
     exec_runner: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(super::RunnerExecOutput, i32)>,
 ) -> Result<()> {
-    let result = exec_runner(&runner.id, runner_exec_options(runner, command.clone()));
+    let result = exec_runner(
+        &runner.id,
+        runner_exec_options(runner, env, command.clone()),
+    );
     match result {
         Ok((_output, 0)) => Ok(()),
         Ok((output, exit_code)) => Err(Error::validation_invalid_argument(
@@ -267,6 +289,7 @@ fn run_materialization_command(
 
 pub(crate) fn runner_extension_exists(
     runner: &Runner,
+    env: Option<&HashMap<String, String>>,
     homeboy_path: &str,
     extension_id: &str,
     exec_runner: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(super::RunnerExecOutput, i32)>,
@@ -275,6 +298,7 @@ pub(crate) fn runner_extension_exists(
         &runner.id,
         runner_exec_options(
             runner,
+            env,
             vec![
                 homeboy_path.to_string(),
                 "extension".to_string(),
@@ -300,8 +324,13 @@ pub(crate) fn runner_extension_exists(
     }
 }
 
-fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecOptions {
-    RunnerExecOptions::diagnostic_raw_command(command).with_env(runner.env.clone())
+fn runner_exec_options(
+    runner: &Runner,
+    env: Option<&HashMap<String, String>>,
+    command: Vec<String>,
+) -> RunnerExecOptions {
+    RunnerExecOptions::diagnostic_raw_command(command)
+        .with_env(env.cloned().unwrap_or_else(|| runner.env.clone()))
 }
 
 fn runner_exec_detail(output: &super::RunnerExecOutput) -> String {
@@ -618,6 +647,7 @@ mod tests {
         let provenance = materialize_runner_extension_with_exec(
             &runner,
             "homeboy",
+            None,
             &request,
             &mut |_runner_id, options| {
                 commands.push(options.command.clone());
@@ -657,6 +687,7 @@ mod tests {
         materialize_runner_extension_with_exec(
             &runner,
             "homeboy",
+            None,
             &request,
             &mut |_runner_id, options| {
                 command = options.command;
@@ -694,5 +725,38 @@ mod tests {
             .synced_source_path
             .starts_with("/runner/ws/_lab_workspaces/dev-extensions/rust/"));
         assert!(plan.synced_source_path.ends_with('/'));
+    }
+
+    #[test]
+    fn materialization_can_use_explicit_command_env() {
+        let runner = runner();
+        let request = RunnerExtensionMaterializationRequest {
+            id: "rust".to_string(),
+            revision: "abc123".to_string(),
+            source: RunnerExtensionMaterializationSource::RunnerPath {
+                path: "/runner/extensions/rust".to_string(),
+            },
+        };
+        let mut env = std::collections::HashMap::new();
+        env.insert("PATH".to_string(), "/usr/local/bin:/usr/bin".to_string());
+        let mut captured_env = std::collections::HashMap::new();
+
+        materialize_runner_extension_with_exec(
+            &runner,
+            "homeboy",
+            Some(env),
+            &request,
+            &mut |_runner_id, options| {
+                captured_env = options.env;
+                Ok((output(), 0))
+            },
+        )
+        .expect("materializes");
+
+        assert_eq!(
+            captured_env.get("PATH").map(String::as_str),
+            Some("/usr/local/bin:/usr/bin")
+        );
+        assert_eq!(captured_env.get("HOMEBOY_COMMAND"), None);
     }
 }

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -13,7 +13,7 @@ use crate::core::git::{run_git, run_git_output};
 use crate::core::output::MergeOutput;
 
 use super::{
-    connect, disconnect, exec, load, materialize_runner_extension, merge,
+    connect, disconnect, exec, load, materialize_runner_extension_with_env, merge,
     normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
     RunnerCapabilityPreflight, RunnerExecOptions, RunnerExtensionMaterializationRequest,
     RunnerExtensionMaterializationSource, RunnerFileTransfer,
@@ -508,11 +508,13 @@ fn sync_extension_overlays(
     plan: &RunnerDevSyncPlan,
 ) -> Result<Vec<RunnerDevSyncExtensionProvenance>> {
     let runner = load(runner_id)?;
+    let homeboy_env = installed_homeboy_env(&runner.env, runner.settings.homeboy_path.as_deref());
     let mut overlays = Vec::new();
     for extension in &plan.extensions {
-        overlays.push(materialize_runner_extension(
+        overlays.push(materialize_runner_extension_with_env(
             &runner,
-            runner.settings.homeboy_path.as_deref().unwrap_or("homeboy"),
+            "homeboy",
+            Some(homeboy_env.clone()),
             &RunnerExtensionMaterializationRequest {
                 id: extension.id.clone(),
                 revision: extension.content_hash.clone(),
@@ -523,6 +525,33 @@ fn sync_extension_overlays(
         )?);
     }
     Ok(overlays)
+}
+
+fn installed_homeboy_env(
+    env: &std::collections::HashMap<String, String>,
+    configured_homeboy_path: Option<&str>,
+) -> std::collections::HashMap<String, String> {
+    let mut env = env.clone();
+    env.remove("HOMEBOY_COMMAND");
+    let Some(configured_homeboy_path) = configured_homeboy_path else {
+        return env;
+    };
+    let configured_homeboy_path = Path::new(configured_homeboy_path);
+    if !configured_homeboy_path.is_absolute() {
+        return env;
+    }
+    let Some(parent) = configured_homeboy_path.parent().and_then(Path::to_str) else {
+        return env;
+    };
+    if let Some(path) = env.get_mut("PATH") {
+        let filtered = path
+            .split(':')
+            .filter(|part| *part != parent)
+            .collect::<Vec<_>>()
+            .join(":");
+        *path = filtered;
+    }
+    env
 }
 
 fn materialize_script(source: &str, git_ref: &str, target_dir: &str, binary_path: &str) -> String {
@@ -929,6 +958,32 @@ mod tests {
             assert_eq!(plan.extensions.len(), 1);
             assert_eq!(plan.extensions[0].id, "nodejs");
         });
+    }
+
+    #[test]
+    fn extension_only_dev_sync_scrubs_dev_binary_env() {
+        let mut env = std::collections::HashMap::new();
+        env.insert(
+            "PATH".to_string(),
+            "/runner/ws/_homeboy_binaries/dev/darwin:/usr/local/bin:/usr/bin".to_string(),
+        );
+        env.insert(
+            "HOMEBOY_COMMAND".to_string(),
+            "/runner/ws/_homeboy_binaries/dev/darwin/homeboy".to_string(),
+        );
+        env.insert("KEEP".to_string(), "yes".to_string());
+
+        let scrubbed = installed_homeboy_env(
+            &env,
+            Some("/runner/ws/_homeboy_binaries/dev/darwin/homeboy"),
+        );
+
+        assert_eq!(scrubbed.get("HOMEBOY_COMMAND"), None);
+        assert_eq!(
+            scrubbed.get("PATH").map(String::as_str),
+            Some("/usr/local/bin:/usr/bin")
+        );
+        assert_eq!(scrubbed.get("KEEP").map(String::as_str), Some("yes"));
     }
 
     #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -105,9 +105,9 @@ pub use execution::{
 };
 pub(crate) use extension_materialization::extension_source_content_hash;
 pub(crate) use extension_materialization::{
-    materialize_runner_extension, materialize_runner_extension_with_exec,
-    plan_controller_snapshot_extension, RunnerExtensionMaterializationRequest,
-    RunnerExtensionMaterializationSource,
+    materialize_runner_extension, materialize_runner_extension_with_env,
+    materialize_runner_extension_with_exec, plan_controller_snapshot_extension,
+    RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
 };
 pub(crate) use git_dependency_materialization::{
     dependency_cache_save, dependency_cache_save_request, materialize_git_dependency,

--- a/src/core/upgrade/runners/extensions.rs
+++ b/src/core/upgrade/runners/extensions.rs
@@ -49,7 +49,8 @@ pub fn sync_runner_extensions(
                 git_ref: source_revision.to_string(),
             },
         };
-        let result = materialize_runner_extension_with_exec(runner, homeboy_path, &request, exec);
+        let result =
+            materialize_runner_extension_with_exec(runner, homeboy_path, None, &request, exec);
         match result {
             Ok(_provenance) => {
                 crate::log_status!(


### PR DESCRIPTION
## Summary
- Run extension-only `runner dev-sync --extensions ...` materialization through the runner-installed `homeboy` command instead of the configured dev-binary path.
- Scrub stale dev-binary `HOMEBOY_COMMAND` and matching `PATH` entries from extension overlay refresh command env.
- Preserve explicit binary dev-sync behavior and existing extension materialization callers.

Fixes #7683.

## Testing
- `cargo fmt --check`
- `cargo test extension_only_dev_sync_scrubs_dev_binary_env`
- `cargo test materialization_can_use_explicit_command_env`
- `cargo test core::runner::homeboy_refresh::tests`
- `cargo test core::runner::extension_materialization::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the Homeboy runner dev-sync cross-platform failure, implemented the scoped command/env selection fix, added regression coverage, and ran targeted verification.
