### PR TITLE
Clarify hot command runner evidence

### DIFF
--- a/docs/workflows/capture-evidence.md
+++ b/docs/workflows/capture-evidence.md
@@ -81,6 +81,19 @@ Reviewer-facing evidence should point to a reachable artifact, PR comment, issue
 
 For runner, static HTML, and matrix workflows, publish stdout and generated files into persisted artifacts before sharing evidence. See [Artifact loop for runner and matrix workflows](../operations/artifact-loop-runner-matrix.md).
 
+## 7. Host-Local Fixture Evidence
+
+When an evidence command depends on a fixture file that only exists on the controller filesystem, run it intentionally on the controller instead of letting automatic Lab routing move the command to a runner:
+
+```bash
+homeboy --force-hot --allow-local-hot --output homeboy-results/fixture.json \
+  <hot-command> --fixture /absolute/path/to/local.fixture
+```
+
+Use this for one-off local fixture proof where the fixture is not committed, not synced as a declared path input, and not materialized by the command's Lab contract. The JSON evidence records `resource_policy.runner_selection.reason`; expect `force_hot_local` for intentional local fixture runs, `default_lab_runner` for automatic Lab routing, and `local_no_default_runner` when no default Lab runner was selected.
+
+For repeatable PR evidence, prefer committing the fixture or declaring the path input so Lab can materialize it generically. Use `--runner <id>` only when the fixture path is portable to that runner or the command contract materializes it.
+
 ## Reference
 
 - [bench command](../commands/bench.md)

--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -557,6 +557,8 @@ fn preflight_hot_command(cli: &Cli, output_file: Option<&str>) -> Option<i32> {
                         warning.as_ref()
                     },
                     cli.force_hot,
+                    default_lab_runner.as_deref(),
+                    runner_hosted,
                 ),
             );
             if let Some(warning) = warning.as_ref() {

--- a/src/commands/bench/observation/tests.rs
+++ b/src/commands/bench/observation/tests.rs
@@ -928,6 +928,8 @@ fn bench_observation_persists_resource_policy_warning_for_hot_machine() {
             &synthetic,
             Some(&warning),
             false,
+            Some("homeboy-lab"),
+            false,
         ));
 
         let run_dir = RunDir::create().expect("run dir");
@@ -969,6 +971,8 @@ fn bench_observation_persists_resource_policy_warning_for_hot_machine() {
         assert_eq!(policy["severity"], "hot");
         assert_eq!(policy["force_hot"], false);
         assert_eq!(policy["warned"], true);
+        assert_eq!(policy["runner_selection"]["runner_id"], "homeboy-lab");
+        assert_eq!(policy["runner_selection"]["reason"], "default_lab_runner");
         assert!(policy["message"]
             .as_str()
             .expect("message string")
@@ -995,6 +999,8 @@ fn bench_observation_records_force_hot_bypass() {
             &synthetic,
             Some(&warning),
             true,
+            Some("homeboy-lab"),
+            false,
         ));
 
         let run_dir = RunDir::create().expect("run dir");
@@ -1035,6 +1041,7 @@ fn bench_observation_records_force_hot_bypass() {
         assert_eq!(policy["severity"], "hot");
         assert_eq!(policy["force_hot"], true);
         assert_eq!(policy["warned"], true);
+        assert_eq!(policy["runner_selection"]["reason"], "force_hot_local");
 
         resource_policy::reset_captured_context_for_test();
     });

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -63,8 +63,19 @@ pub struct ResourcePolicyContext {
     /// Human-readable warning message produced by the policy, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    /// Controller-side routing decision available at resource-policy preflight.
+    pub runner_selection: ResourcePolicyRunnerSelection,
     /// Structured host snapshot used to derive the severity.
     pub host: ResourcePolicyHostSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourcePolicyRunnerSelection {
+    /// Runner selected before command execution, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
+    /// Why this command is expected to run locally or through Lab.
+    pub reason: String,
 }
 
 /// Subset of the doctor resource report that explains why the resource policy
@@ -112,13 +123,18 @@ impl ResourcePolicyContext {
         resources: &DoctorOutput,
         warning: Option<&ResourcePolicyWarning>,
         force_hot: bool,
+        default_runner: Option<&str>,
+        runner_hosted: bool,
     ) -> Self {
+        let runner_selection =
+            runner_selection_context(command, force_hot, default_runner, runner_hosted);
         Self {
             command: command.label.to_string(),
             severity: severity_str(resources.recommendation).to_string(),
             force_hot,
             warned: warning.is_some(),
             message: warning.map(|warning| warning.message.clone()),
+            runner_selection,
             host: ResourcePolicyHostSnapshot {
                 load_severity: severity_str(resources.load.recommendation).to_string(),
                 load_one: resources.load.one,
@@ -143,6 +159,42 @@ impl ResourcePolicyContext {
     /// `metadata_json["resource_policy"]`.
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+}
+
+fn runner_selection_context(
+    command: HotCommand,
+    force_hot: bool,
+    default_runner: Option<&str>,
+    runner_hosted: bool,
+) -> ResourcePolicyRunnerSelection {
+    if runner_hosted {
+        return ResourcePolicyRunnerSelection {
+            runner_id: None,
+            reason: "runner_hosted".to_string(),
+        };
+    }
+    if force_hot {
+        return ResourcePolicyRunnerSelection {
+            runner_id: None,
+            reason: "force_hot_local".to_string(),
+        };
+    }
+    if command.lab_offload_supported {
+        if let Some(runner_id) = default_runner {
+            return ResourcePolicyRunnerSelection {
+                runner_id: Some(runner_id.to_string()),
+                reason: "default_lab_runner".to_string(),
+            };
+        }
+        return ResourcePolicyRunnerSelection {
+            runner_id: None,
+            reason: "local_no_default_runner".to_string(),
+        };
+    }
+    ResourcePolicyRunnerSelection {
+        runner_id: None,
+        reason: "local_only_contract".to_string(),
     }
 }
 
@@ -636,6 +688,8 @@ mod tests {
             &resources,
             Some(&warning),
             false,
+            Some("homeboy-lab"),
+            false,
         );
 
         assert_eq!(context.command, "bench");
@@ -647,6 +701,13 @@ mod tests {
             .as_deref()
             .expect("message")
             .contains("Resource policy warning"));
+        assert_eq!(
+            context.runner_selection,
+            ResourcePolicyRunnerSelection {
+                runner_id: Some("homeboy-lab".to_string()),
+                reason: "default_lab_runner".to_string(),
+            }
+        );
         assert_eq!(context.host.load_severity, "hot");
         assert_eq!(context.host.load_one, Some(9.0));
         assert_eq!(context.host.cpu_count, 4);
@@ -666,12 +727,16 @@ mod tests {
             &resources,
             Some(&warning),
             true,
+            Some("homeboy-lab"),
+            false,
         );
 
         assert!(context.force_hot);
         assert!(context.warned);
         assert_eq!(context.severity, "hot");
         assert!(context.message.is_some());
+        assert_eq!(context.runner_selection.reason, "force_hot_local");
+        assert_eq!(context.runner_selection.runner_id, None);
     }
 
     #[test]
@@ -683,12 +748,15 @@ mod tests {
             &resources,
             None,
             false,
+            None,
+            false,
         );
 
         assert_eq!(context.severity, "ok");
         assert!(!context.warned);
         assert!(context.message.is_none());
         assert!(!context.force_hot);
+        assert_eq!(context.runner_selection.reason, "local_no_default_runner");
     }
 
     #[test]
@@ -703,6 +771,8 @@ mod tests {
         let context = ResourcePolicyContext::from_evaluation(
             lab_supported_hot("bench"),
             &resources,
+            None,
+            false,
             None,
             false,
         );
@@ -721,6 +791,8 @@ mod tests {
             &resources,
             Some(&warning),
             false,
+            Some("homeboy-lab"),
+            false,
         );
         let value = context.to_json();
 
@@ -729,6 +801,8 @@ mod tests {
         assert_eq!(value["force_hot"], false);
         assert_eq!(value["warned"], true);
         assert!(value["message"].is_string());
+        assert_eq!(value["runner_selection"]["runner_id"], "homeboy-lab");
+        assert_eq!(value["runner_selection"]["reason"], "default_lab_runner");
         assert_eq!(value["host"]["load_severity"], "hot");
         assert_eq!(value["host"]["cpu_count"], 4);
     }


### PR DESCRIPTION
## Summary
- Add resource_policy.runner_selection to persisted hot-command evidence so artifacts show whether preflight selected a default Lab runner, forced local execution, runner-hosted execution, or no default runner.
- Document the local fixture evidence pattern for host-only inputs using --force-hot --allow-local-hot.
- Extend focused resource-policy and bench observation tests for the new evidence field.

## Validation
- cargo fmt
- cargo test commands::utils::resource_policy
- cargo test bench_observation_persists_resource_policy_warning_for_hot_machine && cargo test bench_observation_records_force_hot_bypass

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Inspected Homeboy Lab/local routing policy, implemented the evidence metadata/docs/tests, and ran focused validation.