### PR TITLE
Fix bench rig wrapper diagnostics

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -114,6 +114,16 @@ the other capabilities.
   run the same component + workload + iteration count against each rig in
   sequence and emit a cross-rig comparison envelope. See "Cross-rig
   comparison" below.
+- Rig package discovery expects a package root containing `rig.json` or
+  `rigs/<id>/rig.json`. Install reusable rigs with
+  `homeboy rig install <package-path> --id <rig-id>`, or run Homeboy from
+  inside a local package checkout that contains the requested rig. `--path`
+  overrides the component checkout used by the workload; it does not make an
+  arbitrary component directory a rig package.
+- Rig components still need an extension provider for `bench` unless the rig
+  component itself declares extensions. Link one with
+  `homeboy component set <component> --extension <extension_id>` and inspect
+  installed extensions with `homeboy extension list`.
 - `--rig-concurrency <N>`: For multi-rig comparisons, run up to `N` rigs
   concurrently. Default `1` preserves sequential CI behavior. Values greater
   than `1` are opt-in and preserve output ordering by the selected rig order.

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -116,7 +116,7 @@ impl BenchArgs {
 
         let mut extension_ids = BTreeSet::new();
         for rig_id in &run.rig {
-            let spec = rig::load(rig_id)?;
+            let spec = rig::RigSourceContext::load_for_invocation(rig_id)?.spec;
             let workload_extension_ids =
                 rig::extension_ids_for_workloads(&spec, rig::RigWorkloadKind::Bench);
             for extension_id in &workload_extension_ids {
@@ -807,7 +807,7 @@ fn run_cross_rig_bench(
 }
 
 fn rig_axes(rig_id: &str) -> homeboy::core::Result<Option<BTreeMap<String, String>>> {
-    let spec = rig::load(rig_id)?;
+    let spec = rig::RigSourceContext::load_for_invocation(rig_id)?.spec;
     let Some(bench) = spec.bench else {
         return Ok(None);
     };

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -154,7 +154,7 @@ pub(super) fn validate_profile_available_for_rigs(
     let mut available_by_rig = Vec::new();
 
     for rig_id in rig_ids {
-        let spec = rig::load(rig_id)?;
+        let spec = rig::RigSourceContext::load_for_invocation(rig_id)?.spec;
         if !spec.bench_profiles.contains_key(profile) {
             missing.push(rig_id.clone());
         }

--- a/src/commands/bench/tests/cross_rig_tests.rs
+++ b/src/commands/bench/tests/cross_rig_tests.rs
@@ -239,3 +239,121 @@ fn cross_rig_profile_selects_profile_for_each_rig() {
         }
     });
 }
+
+#[test]
+fn cross_rig_profile_uses_enclosing_local_rig_package() {
+    let _guard = current_dir_lock().lock().expect("lock current dir");
+    let original_dir = std::env::current_dir().expect("current dir");
+
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_a = tempfile::TempDir::new().expect("component a");
+        let component_b = tempfile::TempDir::new().expect("component b");
+        let local_package = tempfile::TempDir::new().expect("local package");
+        write_local_rig_package(
+            local_package.path(),
+            "rig-a",
+            "studio",
+            component_a.path(),
+            "local-a",
+        );
+        write_local_rig_package(
+            local_package.path(),
+            "rig-b",
+            "studio",
+            component_b.path(),
+            "local-b",
+        );
+        std::fs::write(
+            local_package.path().join("workloads/local-a.bench.mjs"),
+            "// fixture\n",
+        )
+        .expect("write local a mjs workload");
+        std::fs::write(
+            local_package.path().join("workloads/local-b.bench.mjs"),
+            "// fixture\n",
+        )
+        .expect("write local b mjs workload");
+
+        std::fs::write(
+            local_package.path().join("rigs/rig-a/rig.json"),
+            format!(
+                r#"{{
+                    "components": {{
+                        "studio": {{
+                            "path": "{}",
+                            "extensions": {{ "fixture-bench": {{}} }}
+                        }}
+                    }},
+                    "bench": {{ "default_component": "studio" }},
+                    "bench_profiles": {{ "substrate": ["local-a"] }},
+                    "bench_workloads": {{ "fixture-bench": [
+                        {{ "id": "local-a", "path": "workloads/local-a.bench.mjs" }}
+                    ] }}
+                }}"#,
+                component_a.path().display()
+            ),
+        )
+        .expect("write local rig a profile");
+        std::fs::write(
+            local_package.path().join("rigs/rig-b/rig.json"),
+            format!(
+                r#"{{
+                    "components": {{
+                        "studio": {{
+                            "path": "{}",
+                            "extensions": {{ "fixture-bench": {{}} }}
+                        }}
+                    }},
+                    "bench": {{ "default_component": "studio" }},
+                    "bench_profiles": {{ "substrate": ["local-b"] }},
+                    "bench_workloads": {{ "fixture-bench": [
+                        {{ "id": "local-b", "path": "workloads/local-b.bench.mjs" }}
+                    ] }}
+                }}"#,
+                component_b.path().display()
+            ),
+        )
+        .expect("write local rig b profile");
+        std::env::set_current_dir(local_package.path()).expect("enter local package");
+
+        let result = run(
+            run_args_with_profile(
+                None,
+                vec!["rig-a".to_string(), "rig-b".to_string()],
+                "substrate",
+            ),
+            &GlobalArgs {},
+        );
+        std::env::set_current_dir(&original_dir).expect("restore current dir");
+        let (output, exit_code) = result.expect("cross-rig local package profile should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::Comparison(result) => {
+                assert_eq!(result.rigs.len(), 2);
+                assert_eq!(
+                    result.rigs[0]
+                        .results
+                        .as_ref()
+                        .expect("rig a results")
+                        .scenarios[0]
+                        .id,
+                    "local-a"
+                );
+                assert_eq!(
+                    result.rigs[1]
+                        .results
+                        .as_ref()
+                        .expect("rig b results")
+                        .scenarios[0]
+                        .id,
+                    "local-b"
+                );
+            }
+            _ => panic!("expected comparison output"),
+        }
+    });
+
+    std::env::set_current_dir(original_dir).expect("restore current dir");
+}

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -236,8 +236,11 @@ pub(crate) fn extension_guidance_hints(
     vec![
         link_hint,
         "List installed extensions: homeboy extension list".to_string(),
+        format!(
+            "Component config lives at ~/.config/homeboy/components/{}.json or in a portable homeboy.json discovered from the component path.",
+            component.id
+        ),
         "The component path resolved correctly; the requested command needs an extension provider.".to_string(),
-        "Use `scripts.build` for component-owned build commands; component-level `build_command` is unsupported.".to_string(),
     ]
 }
 

--- a/src/core/rig/discovery.rs
+++ b/src/core/rig/discovery.rs
@@ -105,7 +105,15 @@ fn discover_rigs_matching(
                 package_path.display()
             ),
             Some(package_path.to_string_lossy().to_string()),
-            None,
+            Some(vec![
+                format!("Expected one of: {}/rig.json", package_path.display()),
+                format!(
+                    "Expected one of: {}/rigs/<id>/rig.json",
+                    package_path.display()
+                ),
+                "Install a package-shaped source with: homeboy rig install <package-path> --id <rig-id>".to_string(),
+                "For command-local package discovery, run Homeboy from inside a checkout that contains rigs/<id>/rig.json.".to_string(),
+            ]),
         ));
     }
 

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -1043,6 +1043,11 @@ fn rig_workload_command(args: &[String]) -> Option<RigWorkloadCommand> {
 }
 
 fn load_primary_rig_spec(primary_source_path: &Path, rig_id: &str) -> Result<Option<rig::RigSpec>> {
+    if !primary_source_path.join("rig.json").is_file() && !primary_source_path.join("rigs").is_dir()
+    {
+        return Ok(None);
+    }
+
     let Some(discovered) = rig::discover_rigs(primary_source_path)?
         .into_iter()
         .find(|candidate| candidate.id == rig_id)
@@ -1383,6 +1388,17 @@ mod tests {
                 "wordpress-fixture".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn primary_rig_lookup_ignores_component_checkout_without_rig_package_shape() {
+        let checkout = tempfile::TempDir::new().expect("checkout");
+        std::fs::create_dir_all(checkout.path().join("src")).expect("checkout content");
+
+        let spec = load_primary_rig_spec(checkout.path(), "fixture-matrix")
+            .expect("lookup should not fail for a plain component checkout");
+
+        assert!(spec.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Use invocation-aware rig loading for bench lab extension discovery, cross-rig profile validation, and cross-rig axis lookup so local rig package checkouts behave consistently.
- Treat Lab primary workspaces without a rig package shape as no primary rig package instead of failing discovery while staging runner commands.
- Improve rig package and extension-provider diagnostics, and document the generic bench rig package contract.

## Validation
- 
running 1 test
test commands::bench::tests::cross_rig_tests::cross_rig_profile_uses_enclosing_local_rig_package ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 7073 filtered out; finished in 3.69s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
- 
running 1 test
test core::runner::lab::offload::workspace_stage::tests::primary_rig_lookup_ignores_component_checkout_without_rig_package_shape ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 7073 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
- 
running 7 tests
test commands::bench::tests::cross_rig_tests::cross_rig_reverse_order_flips_reference_and_execution_order ... ok
test commands::bench::tests::cross_rig_tests::cross_rig_profile_requires_every_rig_to_define_profile ... ok
test commands::bench::tests::cross_rig_tests::cross_rig_runs_preserve_run_level_summaries_after_selection ... ok
test commands::bench::tests::cross_rig_tests::cross_rig_json_summary_omits_full_results_payload ... ok
test commands::bench::tests::cross_rig_tests::cross_rig_profile_selects_profile_for_each_rig ... ok
test commands::bench::tests::cross_rig_tests::cross_rig_run_passes_selector_to_each_rig ... ok
test commands::bench::tests::cross_rig_tests::cross_rig_profile_uses_enclosing_local_rig_package ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 7067 filtered out; finished in 17.05s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
- 
running 18 tests
test core::runner::lab::offload::workspace_stage::tests::final_remote_command_rewrites_shared_state_to_runner_artifact_dir ... ok
test core::runner::lab::offload::workspace_stage::tests::primary_rig_lookup_ignores_component_checkout_without_rig_package_shape ... ok
test core::runner::lab::offload::workspace_stage::tests::final_remote_command_remaps_declared_passthrough_path_inputs_when_staged ... ok
test core::runner::lab::offload::workspace_stage::tests::final_remote_command_remaps_bench_env_subdirectory_under_extra_workspace ... ok
test core::runner::lab::offload::workspace_stage::tests::declared_rig_path_inputs_stage_json_setting_paths ... ok
test core::runner::lab::offload::workspace_stage::tests::final_remote_command_remaps_bench_env_path_settings ... ok
test core::runner::lab::offload::workspace_stage::tests::lab_execution_path_materialization_plan_projects_standard_workspace_mappings ... ok
test core::runner::lab::offload::workspace_stage::tests::final_remote_command_remaps_requested_primary_source_path_alias_in_passthrough_args ... ok
test core::runner::lab::offload::workspace_stage::tests::provider_config_materialization_plan_projects_lab_policy_and_mappings ... ok
test core::runner::lab::offload::workspace_stage::tests::final_remote_command_keeps_explicit_extension_override ... ok
test core::runner::lab::offload::workspace_stage::tests::final_remote_command_forwards_required_bench_extension ... ok
test core::runner::lab::offload::workspace_stage::tests::runner_command_plan_for_primary_fuzz_rig_preserves_campaign_workload ... ok
test core::runner::lab::offload::workspace_stage::tests::preflight_agent_task_secret_env_before_workspace_stage_fails_missing_controller_secret ... ok
test core::runner::lab::offload::workspace_stage::tests::final_remote_command_forwards_rig_bench_env_provider_extension ... ok
test core::runner::lab::offload::workspace_stage::tests::final_remote_command_forwards_rig_component_bench_extension ... ok
test core::runner::lab::offload::workspace_stage::tests::declared_rig_path_inputs_stage_passthrough_flags_and_settings ... ok
test core::runner::lab::offload::workspace_stage::tests::runner_command_plan_for_primary_fuzz_rig_adds_workload_and_component_extensions ... ok
test core::runner::lab::offload::workspace_stage::tests::runner_command_plan_for_primary_rig_adds_env_provider_extension_and_remaps_settings ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 7056 filtered out; finished in 0.49s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
- 

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigated Homeboy bench/rig wrapper failures, implemented generic code/docs/tests, and prepared this PR.