### PR TITLE
Fix runner dev overlay metadata replacement

### DIFF
--- a/src/core/runner/execution/extension_parity.rs
+++ b/src/core/runner/execution/extension_parity.rs
@@ -327,6 +327,8 @@ struct DevSyncExtensionOverlay {
     id: String,
     source_path: String,
     content_hash: String,
+    #[serde(default)]
+    duplicate_records: usize,
 }
 
 fn dev_sync_extension_overlay(
@@ -338,9 +340,23 @@ fn dev_sync_extension_overlay(
         .get("dev_sync")?
         .get("extensions")?
         .as_array()?;
-    extensions.iter().find_map(|value| {
-        let overlay: DevSyncExtensionOverlay = serde_json::from_value(value.clone()).ok()?;
-        (overlay.id == extension_id).then_some(overlay)
+    let mut selected = None;
+    let mut matches: usize = 0;
+    for value in extensions {
+        let Ok(mut overlay) = serde_json::from_value::<DevSyncExtensionOverlay>(value.clone())
+        else {
+            continue;
+        };
+        if overlay.id != extension_id {
+            continue;
+        }
+        matches += 1;
+        overlay.duplicate_records = matches.saturating_sub(1);
+        selected = Some(overlay);
+    }
+    selected.map(|mut overlay| {
+        overlay.duplicate_records = matches.saturating_sub(1);
+        overlay
     })
 }
 
@@ -850,12 +866,14 @@ fn dev_overlay_mismatch_error(
                 "current_content_hash": current_hash,
                 "runner_extension_source_revision": remote_revision.unwrap_or("<missing>"),
                 "source_path": overlay.source_path,
+                "duplicate_dev_overlay_records": overlay.duplicate_records,
                 "remediation_command": command,
             },
             "tried": [
                 format!("Recorded dev overlay content_hash: {}", overlay.content_hash),
                 format!("Current local extension content_hash: {current_hash}"),
                 format!("Runner extension source_revision: {}", remote_revision.unwrap_or("<missing>")),
+                format!("Duplicate recorded dev overlays for this id: {}", overlay.duplicate_records),
                 format!("Re-sync the dev overlay before dispatch: {command}"),
             ]
         }),
@@ -1369,6 +1387,47 @@ mod tests {
             &remote_stdout,
         )
         .expect("matching dev overlay hash should pass parity");
+    }
+
+    #[test]
+    fn revision_parity_uses_latest_duplicate_dev_overlay_record() {
+        let stale_dir = tempfile::tempdir().expect("stale source dir");
+        fs::write(stale_dir.path().join("nodejs.json"), r#"{"id":"nodejs"}"#)
+            .expect("stale manifest");
+        fs::write(stale_dir.path().join("run.sh"), "echo stale\n").expect("stale source");
+        let stale_hash = crate::core::runner::extension_source_content_hash(stale_dir.path())
+            .expect("stale hash");
+
+        let current_dir = tempfile::tempdir().expect("current source dir");
+        fs::write(current_dir.path().join("nodejs.json"), r#"{"id":"nodejs"}"#)
+            .expect("current manifest");
+        fs::write(current_dir.path().join("run.sh"), "echo current\n").expect("current source");
+        let current_hash = crate::core::runner::extension_source_content_hash(current_dir.path())
+            .expect("current hash");
+
+        let mut runner = runner_with_overlay("other", "/tmp/other", "unused");
+        runner.resources.insert(
+            "dev_sync".to_string(),
+            serde_json::json!({
+                "schema": "homeboy/runner-dev-sync/v1",
+                "extensions": [
+                    {"id": "nodejs", "source_path": stale_dir.path().display().to_string(), "content_hash": stale_hash},
+                    {"id": "nodejs", "source_path": current_dir.path().display().to_string(), "content_hash": current_hash}
+                ]
+            }),
+        );
+        let remote_stdout = format!(
+            r#"{{"success":true,"data":{{"extension":{{"id":"nodejs","source_revision":"{current_hash}"}}}}}}"#
+        );
+
+        validate_runner_extension_revision(
+            "homeboy-lab",
+            &runner,
+            "homeboy",
+            "nodejs",
+            &remote_stdout,
+        )
+        .expect("latest duplicate dev overlay metadata should be authoritative");
     }
 
     #[test]

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -421,15 +421,12 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
     let extensions = sync_extension_overlays(&options.runner_id, &plan)?;
 
     let mut runner = load(&options.runner_id)?;
-    runner.resources.insert(
-        "dev_sync".to_string(),
-        serde_json::json!({
-            "schema": "homeboy/runner-dev-sync/v1",
-            "homeboy": binary.clone(),
-            "extensions": extensions,
-            "extensions_deferred": [],
-        }),
-    );
+    let dev_sync = updated_dev_sync_resource(
+        runner.resources.get("dev_sync").cloned(),
+        binary.clone(),
+        &extensions,
+    )?;
+    runner.resources.insert("dev_sync".to_string(), dev_sync);
     let patch = serde_json::json!({ "resources": runner.resources });
     let mut updated_fields = refresh_output
         .as_ref()
@@ -525,6 +522,68 @@ fn sync_extension_overlays(
         )?);
     }
     Ok(overlays)
+}
+
+fn updated_dev_sync_resource(
+    existing: Option<Value>,
+    binary: Option<RunnerDevSyncBinaryProvenance>,
+    synced_extensions: &[RunnerDevSyncExtensionProvenance],
+) -> Result<Value> {
+    let mut dev_sync = existing.unwrap_or_else(|| serde_json::json!({}));
+    if !dev_sync.is_object() {
+        dev_sync = serde_json::json!({});
+    }
+
+    dev_sync["schema"] = Value::String("homeboy/runner-dev-sync/v1".to_string());
+    if let Some(binary) = binary {
+        dev_sync["homeboy"] = serde_json::to_value(binary)
+            .map_err(|err| Error::internal_json(err.to_string(), None))?;
+    } else if dev_sync.get("homeboy").is_none() {
+        dev_sync["homeboy"] = Value::Null;
+    }
+
+    let mut extensions = dev_sync
+        .get("extensions")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let synced_extension_ids = synced_extensions
+        .iter()
+        .map(|extension| extension.id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    extensions.retain(|entry| {
+        entry
+            .get("id")
+            .and_then(Value::as_str)
+            .is_none_or(|id| !synced_extension_ids.contains(id))
+    });
+    for extension in synced_extensions {
+        extensions.push(
+            serde_json::to_value(extension)
+                .map_err(|err| Error::internal_json(err.to_string(), None))?,
+        );
+    }
+    dev_sync["extensions"] = Value::Array(dedup_extension_metadata_by_id(extensions));
+    dev_sync["extensions_deferred"] = Value::Array(Vec::new());
+    Ok(dev_sync)
+}
+
+fn dedup_extension_metadata_by_id(extensions: Vec<Value>) -> Vec<Value> {
+    let mut deduped = Vec::new();
+    for extension in extensions {
+        let Some(extension_id) = extension.get("id").and_then(Value::as_str) else {
+            deduped.push(extension);
+            continue;
+        };
+        if let Some(index) = deduped
+            .iter()
+            .position(|entry: &Value| entry.get("id").and_then(Value::as_str) == Some(extension_id))
+        {
+            deduped.remove(index);
+        }
+        deduped.push(extension);
+    }
+    deduped
 }
 
 fn installed_homeboy_env(
@@ -923,6 +982,67 @@ mod tests {
             .synced_source_path
             .starts_with("/runner/ws/_lab_workspaces/dev-extensions/rust/"));
         assert!(plan[0].synced_source_path.ends_with('/'));
+    }
+
+    #[test]
+    fn dev_sync_resource_replaces_existing_extension_overlay_by_id() {
+        let existing = serde_json::json!({
+            "schema": "homeboy/runner-dev-sync/v1",
+            "homeboy": {"hash": "old-binary"},
+            "extensions": [
+                {"id": "nodejs", "source_path": "/old/nodejs", "content_hash": "old"},
+                {"id": "rust", "source_path": "/extensions/rust", "content_hash": "rust-hash"}
+            ]
+        });
+        let extension =
+            super::super::extension_materialization::RunnerExtensionMaterializationProvenance {
+                id: "nodejs".to_string(),
+                source_path: "/new/nodejs".to_string(),
+                synced_source_path: "/runner/ws/_lab_workspaces/dev-extensions/nodejs/newhash/"
+                    .to_string(),
+                content_hash: "new".to_string(),
+                source_revision: None,
+                dirty: false,
+                dirty_fingerprint: None,
+                synced_at: "2026-07-07T00:00:00Z".to_string(),
+                dev_overlay: true,
+                lifecycle: super::super::extension_materialization::dev_extension_lifecycle(
+                    "lab",
+                    "/runner/ws/_lab_workspaces/dev-extensions/nodejs/newhash/",
+                    "nodejs",
+                ),
+                materialization_source: None,
+            };
+
+        let updated = updated_dev_sync_resource(Some(existing), None, &[extension])
+            .expect("updates dev-sync resource");
+        let extensions = updated["extensions"].as_array().expect("extensions array");
+
+        assert_eq!(updated["homeboy"]["hash"], "old-binary");
+        assert_eq!(extensions.len(), 2);
+        assert_eq!(extensions[0]["id"], "rust");
+        assert_eq!(extensions[1]["id"], "nodejs");
+        assert_eq!(extensions[1]["source_path"], "/new/nodejs");
+        assert_eq!(extensions[1]["content_hash"], "new");
+    }
+
+    #[test]
+    fn dev_sync_resource_keeps_last_duplicate_overlay_for_same_id() {
+        let existing = serde_json::json!({
+            "schema": "homeboy/runner-dev-sync/v1",
+            "extensions": [
+                {"id": "nodejs", "source_path": "/old/nodejs", "content_hash": "old"},
+                {"id": "nodejs", "source_path": "/newer/nodejs", "content_hash": "newer"}
+            ]
+        });
+
+        let updated = updated_dev_sync_resource(Some(existing), None, &[])
+            .expect("normalizes dev-sync resource");
+        let extensions = updated["extensions"].as_array().expect("extensions array");
+
+        assert_eq!(extensions.len(), 1);
+        assert_eq!(extensions[0]["source_path"], "/newer/nodejs");
+        assert_eq!(extensions[0]["content_hash"], "newer");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace runner dev-sync extension overlay metadata by extension id instead of retaining stale duplicate records.
- Preserve existing dev-sync metadata for other extension ids when syncing one overlay.
- Make parity validation prefer the newest matching dev overlay record and report duplicate overlay count when a mismatch remains.

## Root cause
Repeated dev-syncs for the same extension id could leave multiple dev overlay metadata records. Parity validation selected the first matching id, so stale source_path metadata could be paired with newer runner-side source_revision/content hash state and raise runner_extension.dev_overlay_content_hash_mismatch.

## Tests
- cargo fmt --check
- cargo test dev_sync_resource
- cargo test revision_parity
- cargo test core::runner::homeboy_refresh
- cargo test core::runner::execution::extension_parity

## Verification
- Added synthetic nodejs duplicate-overlay coverage proving the latest same-id dev overlay record is authoritative.
- Local nodejs extension worktree was not present under /Users/chubes/Developer, so I could not run nodejs extension dev-sync verification directly.
- No destructive fuzz runs were executed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed runner dev-overlay metadata/parity handling, implemented the fix and tests, and ran verification.