### PR TITLE
Remove rustc-proven dead code

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -17,10 +17,7 @@ use super::utils::args::{
 use super::utils::observed_workflow::WorkflowObservationAdapter;
 use super::utils::response::actionable_metadata_value_for_run_ref;
 use super::{CmdResult, GlobalArgs};
-use crate::command_contract::{
-    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
-    AUDIT_LAB_LABEL,
-};
+use crate::command_contract::{LabCommandContract, AUDIT_LAB_LABEL};
 
 const AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`audit --changed-since` is not Lab-portable yet because changed-since audit depends on git base refs that the current Lab workspace sync may not have fetched.";
 
@@ -70,13 +67,6 @@ pub struct AuditArgs {
 }
 
 impl AuditArgs {
-    pub(crate) fn output_descriptor(
-        &self,
-        output_file_mode: CommandOutputFileMode,
-    ) -> CommandOutputDescriptor {
-        CommandOutputDescriptor::json_envelope(CommandJsonFamily::Quality, output_file_mode)
-    }
-
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
         if self.changed_since.is_some() {
             return Some(LabCommandContract::local_only(

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -272,18 +272,6 @@ fn runs_proof_summary_eligible(args: &crate::commands::runs::RunsArgs) -> bool {
     args.proof_summary_eligible() && !homeboy::core::lab_routing::is_lab_offload_subprocess()
 }
 
-fn ci_triage_summary_eligible(args: &crate::commands::ci::CiArgs) -> bool {
-    matches!(&args.command, crate::commands::ci::CiCommand::Triage(_))
-        && !homeboy::core::lab_routing::is_lab_offload_subprocess()
-}
-
-fn render_ci_triage_summary(payload: &Value) -> Option<String> {
-    payload
-        .get("human_summary")
-        .and_then(Value::as_str)
-        .map(|summary| format!("{}\n", summary))
-}
-
 /// Whether `homeboy bench` should render the compact human summary instead
 /// of dumping the full JSON envelope. The full payload is kept for `--json`,
 /// for non-run subcommands, and for lab-offload subprocesses (whose stdout

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -23,10 +23,7 @@ use super::utils::args::{
 use super::utils::observed_workflow::{ObservedWorkflowRunner, WorkflowObservationAdapter};
 use super::utils::response::actionable_metadata_value_for_run_ref;
 use super::{CmdResult, GlobalArgs};
-use crate::command_contract::{
-    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, CommandPortabilityContract,
-    LabCommandContract, LINT_LAB_LABEL,
-};
+use crate::command_contract::{LabCommandContract, LINT_LAB_LABEL};
 
 #[derive(Args)]
 pub struct LintArgs {
@@ -96,13 +93,6 @@ pub struct LintArgs {
 }
 
 impl LintArgs {
-    pub(crate) fn output_descriptor(
-        &self,
-        output_file_mode: CommandOutputFileMode,
-    ) -> CommandOutputDescriptor {
-        CommandOutputDescriptor::json_envelope(CommandJsonFamily::Quality, output_file_mode)
-    }
-
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
         if self.is_full_workspace_run()
             || self.changed_since.is_some()
@@ -122,10 +112,6 @@ impl LintArgs {
         }
 
         None
-    }
-
-    pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
-        CommandPortabilityContract::lab_optional(self.lab_contract())
     }
 
     pub fn is_full_workspace_run(&self) -> bool {

--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -204,10 +204,6 @@ fn scalar_label(value: &Value) -> Option<String> {
 pub struct ArtifactJsonRow {
     pub run: RunRecord,
     pub artifact_kind: String,
-    /// Local path on disk. Held for diagnostics so callers can mention which
-    /// file produced a finding; not currently consumed by core primitives.
-    #[allow(dead_code)]
-    pub artifact_path: String,
     pub json: Value,
 }
 
@@ -304,7 +300,6 @@ pub fn load_artifact_rows(
         rows.push(ArtifactJsonRow {
             run,
             artifact_kind: artifact.kind,
-            artifact_path: artifact.path,
             json,
         });
     }
@@ -488,25 +483,21 @@ mod tests {
             ArtifactJsonRow {
                 run: sample_run("a"),
                 artifact_kind: "k".into(),
-                artifact_path: "/dev/null".into(),
                 json: serde_json::json!({ "kind": "alpha" }),
             },
             ArtifactJsonRow {
                 run: sample_run("b"),
                 artifact_kind: "k".into(),
-                artifact_path: "/dev/null".into(),
                 json: serde_json::json!({ "kind": "alpha" }),
             },
             ArtifactJsonRow {
                 run: sample_run("c"),
                 artifact_kind: "k".into(),
-                artifact_path: "/dev/null".into(),
                 json: serde_json::json!({ "kind": "beta" }),
             },
             ArtifactJsonRow {
                 run: sample_run("d"),
                 artifact_kind: "k".into(),
-                artifact_path: "/dev/null".into(),
                 json: serde_json::json!({ "other": true }),
             },
         ];

--- a/src/commands/runs/query.rs
+++ b/src/commands/runs/query.rs
@@ -325,7 +325,6 @@ mod tests {
                 metadata_json: Value::Null,
             },
             artifact_kind: kind.into(),
-            artifact_path: "/dev/null".into(),
             json,
         }
     }

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -23,10 +23,7 @@ use super::utils::args::{
 use super::utils::observed_workflow::ObservedWorkflowRunner;
 use super::utils::response::actionable_metadata_value_for_run_ref;
 use super::{CmdResult, GlobalArgs};
-use crate::command_contract::{
-    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
-    TEST_LAB_LABEL,
-};
+use crate::command_contract::{LabCommandContract, TEST_LAB_LABEL};
 use homeboy::core::validation_progress::validation_progress_metadata;
 
 #[derive(Args)]
@@ -95,13 +92,6 @@ pub struct TestArgs {
 }
 
 impl TestArgs {
-    pub(crate) fn output_descriptor(
-        &self,
-        output_file_mode: CommandOutputFileMode,
-    ) -> CommandOutputDescriptor {
-        CommandOutputDescriptor::json_envelope(CommandJsonFamily::Quality, output_file_mode)
-    }
-
     pub(crate) fn lab_contract(&self) -> LabCommandContract {
         LabCommandContract::portable(TEST_LAB_LABEL, self.write.then_some("--write"), true, &[])
             .release_gate()


### PR DESCRIPTION
Fixes #7706

## Summary
- Remove unused command output descriptor helpers for audit, lint, and test.
- Remove unused lint portability helper.
- Remove unused CI triage JSON summary helpers.
- Remove unused artifact_path storage from ArtifactJsonRow and its fixtures.

## Verification
- cargo build
- cargo check --all-targets

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT 5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Deleted rustc-proven dead code from an audited finding; human reviews every line.