### PR TITLE
Add explicit extension capability ownership

### DIFF
--- a/docs/reference/schemas/portable-config.md
+++ b/docs/reference/schemas/portable-config.md
@@ -80,8 +80,9 @@ homeboy component create --local-path /path/to/repo --changelog-target "CHANGELO
 | `changelog_target` | Path to changelog file |
 | `scripts` | Optional component-owned `lint`, `test`, `build`, `bench`, and `trace` shell commands |
 | `extensions` | Extension configuration (e.g., `{"wordpress": {}}`) |
+| `capability_extensions` | Optional explicit extension ownership by capability label (e.g., `{"deps": "nodejs"}`) when more than one linked extension supports the same capability |
 
-Build, lint, test, bench, and trace behavior resolves from `scripts.<capability>` first, then linked extensions. Use `scripts.build` for component-owned shell builds; component-level `build_command` is not supported.
+Build, lint, test, bench, trace, and deps behavior resolves from `scripts.<capability>` first, then linked extensions. When multiple linked extensions support the same capability, set `capability_extensions.<capability>` to the owning extension. Use `scripts.build` for component-owned shell builds; component-level `build_command` is not supported.
 
 Use `deploy_together` for coupled components that are versioned or built separately but must stay in sync at runtime. When a deploy selection includes one member of a declared group without the rest, Homeboy fails the plan before building or uploading.
 

--- a/src/core/component/model.rs
+++ b/src/core/component/model.rs
@@ -73,6 +73,12 @@ pub struct Component {
     pub build_artifact: Option<String>,
     pub build_command: Option<String>,
     pub extensions: Option<HashMap<String, ScopedExtensionConfig>>,
+    /// Explicit extension ownership by capability label.
+    ///
+    /// When multiple linked extensions advertise the same capability, Homeboy
+    /// requires the component to choose the owner here instead of guessing.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub capability_extensions: HashMap<String, String>,
     pub version_targets: Option<Vec<VersionTarget>>,
     pub changelog_target: Option<String>,
     pub changelog_next_section_label: Option<String>,
@@ -174,6 +180,8 @@ struct RawComponent {
     build_command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     extensions: Option<HashMap<String, ScopedExtensionConfig>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    capability_extensions: HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     version_targets: Option<Vec<VersionTarget>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -246,6 +254,7 @@ impl From<RawComponent> for Component {
             build_artifact: raw.build_artifact,
             build_command: raw.build_command,
             extensions: raw.extensions,
+            capability_extensions: raw.capability_extensions,
             version_targets: raw.version_targets,
             changelog_target: raw.changelog_target,
             changelog_next_section_label: raw.changelog_next_section_label,
@@ -291,6 +300,7 @@ impl From<Component> for RawComponent {
             build_artifact: c.build_artifact,
             build_command: c.build_command,
             extensions: c.extensions,
+            capability_extensions: c.capability_extensions,
             version_targets: c.version_targets,
             changelog_target: c.changelog_target,
             changelog_next_section_label: c.changelog_next_section_label,
@@ -341,6 +351,7 @@ impl Component {
             build_artifact,
             build_command: None,
             extensions: None,
+            capability_extensions: HashMap::new(),
             version_targets: None,
             changelog_target: None,
             changelog_next_section_label: None,

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -267,6 +267,18 @@ fn capability_ambiguous_error(
     ))
 }
 
+fn explicit_capability_extension(
+    component: &Component,
+    capability: ExtensionCapability,
+) -> Option<&str> {
+    component
+        .capability_extensions
+        .get(capability.label())
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|extension_id| !extension_id.is_empty())
+}
+
 fn linked_extensions(
     component: &Component,
 ) -> Result<&HashMap<String, crate::core::component::ScopedExtensionConfig>> {
@@ -301,6 +313,43 @@ pub fn resolve_extension_for_capability(
     let extensions = linked_extensions(component)?;
     if extensions.is_empty() {
         return Err(no_extensions_error(component));
+    }
+
+    if let Some(extension_id) = explicit_capability_extension(component, capability) {
+        if !extensions.contains_key(extension_id) {
+            return Err(Error::validation_invalid_argument(
+                format!("capability_extensions.{}", capability.label()),
+                format!(
+                    "Component '{}' selects extension '{}' for {} support, but it is not linked",
+                    component.id,
+                    extension_id,
+                    capability.label()
+                ),
+                Some(extension_id.to_string()),
+                Some(vec![format!(
+                    "Add '{}' to extensions or choose one of: {}",
+                    extension_id,
+                    extensions.keys().cloned().collect::<Vec<_>>().join(", ")
+                )]),
+            ));
+        }
+
+        let manifest = load_extension(extension_id)?;
+        if !capability.has_manifest_support(&manifest) {
+            return Err(Error::validation_invalid_argument(
+                format!("capability_extensions.{}", capability.label()),
+                format!(
+                    "Component '{}' selects extension '{}' for {} support, but that extension does not provide it",
+                    component.id,
+                    extension_id,
+                    capability.label()
+                ),
+                Some(extension_id.to_string()),
+                None,
+            ));
+        }
+
+        return Ok(extension_id.to_string());
     }
 
     let mut matching = Vec::new();
@@ -373,4 +422,88 @@ pub fn resolve_execution_context(
         settings: extract_component_extension_settings(component, &extension_id),
         accepted_setting_keys: manifest.accepted_setting_keys(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::component::ScopedExtensionConfig;
+
+    fn write_extension_manifest(home: &Path, extension_id: &str, capability: &str) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(extension_id);
+        std::fs::create_dir_all(&extension_dir).expect("extension dir");
+        std::fs::write(
+            extension_dir.join(format!("{extension_id}.json")),
+            format!(
+                r#"{{"name":"{extension_id}","version":"1.0.0","{capability}":{{"extension_script":"{capability}.sh"}}}}"#
+            ),
+        )
+        .expect("extension manifest");
+    }
+
+    fn component_with_extensions(extension_ids: &[&str]) -> Component {
+        let extensions = extension_ids
+            .iter()
+            .map(|extension_id| {
+                (
+                    (*extension_id).to_string(),
+                    ScopedExtensionConfig::default(),
+                )
+            })
+            .collect();
+
+        Component {
+            id: "consumer".to_string(),
+            extensions: Some(extensions),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn explicit_capability_extension_resolves_ambiguous_deps_owner() {
+        crate::test_support::with_isolated_home(|home| {
+            write_extension_manifest(home.path(), "wordpress", "deps");
+            write_extension_manifest(home.path(), "nodejs", "deps");
+
+            let mut component = component_with_extensions(&["wordpress", "nodejs"]);
+            let err = resolve_extension_for_capability(&component, ExtensionCapability::Deps)
+                .expect_err("multiple deps providers should be ambiguous without ownership");
+            assert!(err
+                .message
+                .contains("multiple linked extensions with deps support"));
+
+            component
+                .capability_extensions
+                .insert("deps".to_string(), "nodejs".to_string());
+
+            assert_eq!(
+                resolve_extension_for_capability(&component, ExtensionCapability::Deps).unwrap(),
+                "nodejs"
+            );
+        });
+    }
+
+    #[test]
+    fn explicit_capability_extension_must_be_linked_and_supported() {
+        crate::test_support::with_isolated_home(|home| {
+            write_extension_manifest(home.path(), "nodejs", "deps");
+            write_extension_manifest(home.path(), "wordpress", "bench");
+
+            let mut component = component_with_extensions(&["nodejs"]);
+            component
+                .capability_extensions
+                .insert("deps".to_string(), "wordpress".to_string());
+            let err = resolve_extension_for_capability(&component, ExtensionCapability::Deps)
+                .expect_err("selected extension must be linked");
+            assert!(err.message.contains("but it is not linked"));
+
+            component = component_with_extensions(&["wordpress"]);
+            component
+                .capability_extensions
+                .insert("deps".to_string(), "wordpress".to_string());
+            let err = resolve_extension_for_capability(&component, ExtensionCapability::Deps)
+                .expect_err("selected extension must provide selected capability");
+            assert!(err.message.contains("does not provide it"));
+        });
+    }
 }


### PR DESCRIPTION
## Summary\n\n- add `capability_extensions` to component config for per-capability extension ownership\n- validate explicit selections are linked and provide the requested capability\n- document the portable `homeboy.json` contract\n\nFixes #7721.\n\n## Verification\n\n- `cargo test explicit_capability_extension --lib`\n- `git diff --check`\n\nFull `cargo test --lib` compiled and ran, but this checkout has unrelated/environment-sensitive failures (missing local `rust` extension fixture, rig state, observation DB count expectations, and runner status expectation drift). The new focused resolver coverage passes.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** openai/gpt-5.5 via OpenCode\n- **Used for:** Investigated the SSI/Homeboy deps-extension ambiguity, implemented the Homeboy contract/resolver change, added tests, and drafted this PR description.