### PR TITLE
Fix runner dev-overlay metadata reconciliation

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1234,8 +1234,14 @@ impl RunnerWorkloadCommandFamily {
             {
                 Self::Quality
             }
-            LINT_LAB_LABEL | TEST_LAB_LABEL | AUDIT_LAB_LABEL | REVIEW_LAB_LABEL
-            | BENCH_LAB_LABEL | FUZZ_LAB_LABEL | FUZZ_DOCTOR_LAB_LABEL | TRACE_LAB_LABEL
+            LINT_LAB_LABEL
+            | TEST_LAB_LABEL
+            | AUDIT_LAB_LABEL
+            | REVIEW_LAB_LABEL
+            | BENCH_LAB_LABEL
+            | FUZZ_LAB_LABEL
+            | FUZZ_DOCTOR_LAB_LABEL
+            | TRACE_LAB_LABEL
             | RIG_RUN_LAB_LABEL => Self::Quality,
             REFACTOR_LAB_LABEL | RIG_CHECK_LAB_LABEL | RUNTIME_REFRESH_LAB_LABEL => Self::Workspace,
             label if label.starts_with("tunnel") => Self::Service,

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1083,116 +1083,117 @@ fn enqueue_exec_job(
         request.runner_workload.as_ref(),
         request.metadata.as_ref(),
     );
-    let runner = job_store.run_background_with_source_snapshot_metadata_and_path_materialization_plan(
-        operation,
-        source_snapshot.clone(),
-        run_ref_metadata,
-        path_materialization_plan.clone(),
-        move |job| {
-            job.progress(json!({
-                "phase": "started",
-                "runner_id": plan.runner.id,
-                "cwd": plan.cwd,
-                "command": plan.command,
-                "capture_patch": request.capture_patch,
-                "job_id": job.job_id(),
-                "source_snapshot": source_snapshot,
-                "path_materialization_plan": path_materialization_plan,
-            }))?;
-            let baseline = if request.capture_patch {
-                Some(capture_baseline(&plan.cwd)?)
-            } else {
-                None
-            };
-            let progress_job = job.clone();
-            let progress_sink = Arc::new(move |data| {
-                let _ = progress_job.progress(data);
-            });
-            let process_output = execute_runner_process_until_cancelled_with_progress(
-                &plan,
-                || job.is_cancelled(),
-                Some(progress_sink),
-            )?;
-            let stdout = process_output.stdout.clone();
-            let stderr = process_output.stderr.clone();
-            let exit_code = process_output.exit_code;
-            let metrics = process_output.metrics.clone();
-            let capture = process_output.capture.clone();
-            if job.is_cancelled() {
-                let _ = job.progress(json!({
-                    "phase": "cancelled",
+    let runner = job_store
+        .run_background_with_source_snapshot_metadata_and_path_materialization_plan(
+            operation,
+            source_snapshot.clone(),
+            run_ref_metadata,
+            path_materialization_plan.clone(),
+            move |job| {
+                job.progress(json!({
+                    "phase": "started",
+                    "runner_id": plan.runner.id,
+                    "cwd": plan.cwd,
+                    "command": plan.command,
+                    "capture_patch": request.capture_patch,
+                    "job_id": job.job_id(),
+                    "source_snapshot": source_snapshot,
+                    "path_materialization_plan": path_materialization_plan,
+                }))?;
+                let baseline = if request.capture_patch {
+                    Some(capture_baseline(&plan.cwd)?)
+                } else {
+                    None
+                };
+                let progress_job = job.clone();
+                let progress_sink = Arc::new(move |data| {
+                    let _ = progress_job.progress(data);
+                });
+                let process_output = execute_runner_process_until_cancelled_with_progress(
+                    &plan,
+                    || job.is_cancelled(),
+                    Some(progress_sink),
+                )?;
+                let stdout = process_output.stdout.clone();
+                let stderr = process_output.stderr.clone();
+                let exit_code = process_output.exit_code;
+                let metrics = process_output.metrics.clone();
+                let capture = process_output.capture.clone();
+                if job.is_cancelled() {
+                    let _ = job.progress(json!({
+                        "phase": "cancelled",
+                        "exit_code": exit_code,
+                        "metrics": metrics.clone(),
+                    }));
+                    return Ok(json!({
+                        "runner_id": plan.runner.id.clone(),
+                        "cwd": plan.cwd.clone(),
+                        "command": plan.command.clone(),
+                        "exit_code": exit_code,
+                        "stdout": stdout,
+                        "stderr": stderr,
+                        "source_snapshot": source_snapshot,
+                        "path_materialization_plan": path_materialization_plan,
+                        "metrics": metrics,
+                        "capture": capture,
+                        "status": JobStatus::Cancelled,
+                    }));
+                }
+                if !stdout.is_empty() {
+                    job.stdout(stdout.clone())?;
+                }
+                if !stderr.is_empty() {
+                    job.stderr(stderr.clone())?;
+                }
+                job.progress(json!({
+                    "phase": "finished",
                     "exit_code": exit_code,
                     "metrics": metrics.clone(),
-                }));
-                return Ok(json!({
-                    "runner_id": plan.runner.id.clone(),
-                    "cwd": plan.cwd.clone(),
-                    "command": plan.command.clone(),
+                }))?;
+                let patch = if let Some(baseline) = baseline {
+                    Some(capture_patch_report(
+                        job.job_id(),
+                        &plan.runner.id,
+                        &plan.cwd,
+                        &plan.command,
+                        source_snapshot.as_ref(),
+                        &baseline,
+                        exit_code,
+                    )?)
+                } else {
+                    None
+                };
+                let result = json!({
+                    "runner_id": plan.runner.id,
+                    "cwd": plan.cwd,
+                    "command": plan.command,
                     "exit_code": exit_code,
                     "stdout": stdout,
                     "stderr": stderr,
                     "source_snapshot": source_snapshot,
                     "path_materialization_plan": path_materialization_plan,
+                    "patch": patch,
                     "metrics": metrics,
                     "capture": capture,
-                    "status": JobStatus::Cancelled,
-                }));
-            }
-            if !stdout.is_empty() {
-                job.stdout(stdout.clone())?;
-            }
-            if !stderr.is_empty() {
-                job.stderr(stderr.clone())?;
-            }
-            job.progress(json!({
-                "phase": "finished",
-                "exit_code": exit_code,
-                "metrics": metrics.clone(),
-            }))?;
-            let patch = if let Some(baseline) = baseline {
-                Some(capture_patch_report(
-                    job.job_id(),
-                    &plan.runner.id,
-                    &plan.cwd,
-                    &plan.command,
-                    source_snapshot.as_ref(),
-                    &baseline,
-                    exit_code,
-                )?)
-            } else {
-                None
-            };
-            let result = json!({
-                "runner_id": plan.runner.id,
-                "cwd": plan.cwd,
-                "command": plan.command,
-                "exit_code": exit_code,
-                "stdout": stdout,
-                "stderr": stderr,
-                "source_snapshot": source_snapshot,
-                "path_materialization_plan": path_materialization_plan,
-                "patch": patch,
-                "metrics": metrics,
-                "capture": capture,
-            });
-            if exit_code != 0 {
-                job.result(result.clone())?;
-                return Err(Error::remote_command_failed(RemoteCommandFailedDetails {
-                    command: plan.command.join(" "),
-                    exit_code,
-                    stdout,
-                    stderr,
-                    target: TargetDetails {
-                        project_id: None,
-                        server_id: Some(plan.runner.id.clone()),
-                        host: None,
-                    },
-                }));
-            }
+                });
+                if exit_code != 0 {
+                    job.result(result.clone())?;
+                    return Err(Error::remote_command_failed(RemoteCommandFailedDetails {
+                        command: plan.command.join(" "),
+                        exit_code,
+                        stdout,
+                        stderr,
+                        target: TargetDetails {
+                            project_id: None,
+                            server_id: Some(plan.runner.id.clone()),
+                            host: None,
+                        },
+                    }));
+                }
 
-            Ok(result)
-        },
-    );
+                Ok(result)
+            },
+        );
     let job = job_store.get(runner.job_id)?;
 
     Ok(json!({

--- a/src/core/runner/execution/extension_parity.rs
+++ b/src/core/runner/execution/extension_parity.rs
@@ -327,6 +327,8 @@ struct DevSyncExtensionOverlay {
     id: String,
     source_path: String,
     content_hash: String,
+    source_revision: Option<String>,
+    synced_at: Option<String>,
     #[serde(default)]
     duplicate_records: usize,
 }
@@ -340,9 +342,9 @@ fn dev_sync_extension_overlay(
         .get("dev_sync")?
         .get("extensions")?
         .as_array()?;
-    let mut selected = None;
+    let mut selected: Option<(usize, DevSyncExtensionOverlay)> = None;
     let mut matches: usize = 0;
-    for value in extensions {
+    for (index, value) in extensions.iter().enumerate() {
         let Ok(mut overlay) = serde_json::from_value::<DevSyncExtensionOverlay>(value.clone())
         else {
             continue;
@@ -352,12 +354,33 @@ fn dev_sync_extension_overlay(
         }
         matches += 1;
         overlay.duplicate_records = matches.saturating_sub(1);
-        selected = Some(overlay);
+        if selected
+            .as_ref()
+            .is_none_or(|(selected_index, selected_overlay)| {
+                overlay_is_newer(index, &overlay, *selected_index, selected_overlay)
+            })
+        {
+            selected = Some((index, overlay));
+        }
     }
-    selected.map(|mut overlay| {
+    selected.map(|(_, mut overlay)| {
         overlay.duplicate_records = matches.saturating_sub(1);
         overlay
     })
+}
+
+fn overlay_is_newer(
+    index: usize,
+    overlay: &DevSyncExtensionOverlay,
+    selected_index: usize,
+    selected: &DevSyncExtensionOverlay,
+) -> bool {
+    match (overlay.synced_at.as_deref(), selected.synced_at.as_deref()) {
+        (Some(current), Some(previous)) if current != previous => current > previous,
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        _ => index > selected_index,
+    }
 }
 
 fn unsupported_runner_extension_setting_error(
@@ -529,7 +552,11 @@ fn record_materialized_extension_overlay(
     runner.resources.insert("dev_sync".to_string(), dev_sync);
     let patch = serde_json::json!({ "resources": runner.resources });
     let _updated = matches!(
-        merge(Some(runner_id), &patch.to_string(), &[])?,
+        merge(
+            Some(runner_id),
+            &patch.to_string(),
+            &["resources".to_string()],
+        )?,
         MergeOutput::Single(_)
     );
     Ok(())
@@ -821,7 +848,12 @@ fn validate_dev_overlay_extension_revision(
     }
 
     let remote_revision = remote_extension_source_revision(remote_stdout);
-    if remote_revision.as_deref() == Some(overlay.content_hash.as_str()) {
+    let recorded_revision = overlay
+        .source_revision
+        .as_deref()
+        .filter(|revision| !revision.trim().is_empty())
+        .unwrap_or(&overlay.content_hash);
+    if remote_revision.as_deref() == Some(recorded_revision) {
         return Ok(());
     }
 
@@ -863,6 +895,7 @@ fn dev_overlay_mismatch_error(
                 "runner_id": runner_id,
                 "extension_id": extension_id,
                 "recorded_content_hash": overlay.content_hash,
+                "recorded_source_revision": overlay.source_revision.as_deref().unwrap_or("<missing>"),
                 "current_content_hash": current_hash,
                 "runner_extension_source_revision": remote_revision.unwrap_or("<missing>"),
                 "source_path": overlay.source_path,
@@ -871,6 +904,7 @@ fn dev_overlay_mismatch_error(
             },
             "tried": [
                 format!("Recorded dev overlay content_hash: {}", overlay.content_hash),
+                format!("Recorded dev overlay source_revision: {}", overlay.source_revision.as_deref().unwrap_or("<missing>")),
                 format!("Current local extension content_hash: {current_hash}"),
                 format!("Runner extension source_revision: {}", remote_revision.unwrap_or("<missing>")),
                 format!("Duplicate recorded dev overlays for this id: {}", overlay.duplicate_records),
@@ -1428,6 +1462,120 @@ mod tests {
             &remote_stdout,
         )
         .expect("latest duplicate dev overlay metadata should be authoritative");
+    }
+
+    #[test]
+    fn revision_parity_uses_newest_synced_duplicate_dev_overlay_record() {
+        let stale_dir = tempfile::tempdir().expect("stale source dir");
+        fs::write(stale_dir.path().join("nodejs.json"), r#"{"id":"nodejs"}"#)
+            .expect("stale manifest");
+        fs::write(stale_dir.path().join("run.sh"), "echo stale\n").expect("stale source");
+        let stale_hash = crate::core::runner::extension_source_content_hash(stale_dir.path())
+            .expect("stale hash");
+
+        let current_dir = tempfile::tempdir().expect("current source dir");
+        fs::write(current_dir.path().join("nodejs.json"), r#"{"id":"nodejs"}"#)
+            .expect("current manifest");
+        fs::write(current_dir.path().join("run.sh"), "echo current\n").expect("current source");
+        let current_hash = crate::core::runner::extension_source_content_hash(current_dir.path())
+            .expect("current hash");
+
+        let mut runner = runner_with_overlay("other", "/tmp/other", "unused");
+        runner.resources.insert(
+            "dev_sync".to_string(),
+            serde_json::json!({
+                "schema": "homeboy/runner-dev-sync/v1",
+                "extensions": [
+                    {"id": "nodejs", "source_path": current_dir.path().display().to_string(), "content_hash": current_hash, "source_revision": "current-rev", "synced_at": "2026-07-07T12:00:00Z"},
+                    {"id": "nodejs", "source_path": stale_dir.path().display().to_string(), "content_hash": stale_hash, "source_revision": "stale-rev", "synced_at": "2026-07-07T11:00:00Z"}
+                ]
+            }),
+        );
+        let remote_stdout = r#"{"success":true,"data":{"extension":{"id":"nodejs","source_revision":"current-rev"}}}"#;
+
+        validate_runner_extension_revision(
+            "homeboy-lab",
+            &runner,
+            "homeboy",
+            "nodejs",
+            remote_stdout,
+        )
+        .expect("newest synced duplicate dev overlay metadata should be authoritative");
+    }
+
+    #[test]
+    fn revision_parity_accepts_matching_dev_overlay_source_revision() {
+        let tempdir = tempfile::tempdir().expect("source dir");
+        fs::write(tempdir.path().join("nodejs.json"), r#"{"id":"nodejs"}"#).expect("manifest");
+        fs::write(tempdir.path().join("run.sh"), "echo hi\n").expect("source file");
+        let hash = crate::core::runner::extension_source_content_hash(tempdir.path())
+            .expect("content hash");
+        let mut runner =
+            runner_with_overlay("nodejs", &tempdir.path().display().to_string(), &hash);
+        runner.resources.insert(
+            "dev_sync".to_string(),
+            serde_json::json!({
+                "schema": "homeboy/runner-dev-sync/v1",
+                "extensions": [{
+                    "id": "nodejs",
+                    "source_path": tempdir.path().display().to_string(),
+                    "content_hash": hash,
+                    "source_revision": "8317270c0b2241326ff42ed648e4e5b447dbead2"
+                }]
+            }),
+        );
+        let remote_stdout = r#"{"success":true,"data":{"extension":{"id":"nodejs","source_revision":"8317270c0b2241326ff42ed648e4e5b447dbead2"}}}"#;
+
+        validate_runner_extension_revision(
+            "homeboy-lab",
+            &runner,
+            "homeboy",
+            "nodejs",
+            remote_stdout,
+        )
+        .expect("matching dev overlay source revision should pass parity");
+    }
+
+    #[test]
+    fn revision_parity_rejects_stale_dev_overlay_source_revision() {
+        let tempdir = tempfile::tempdir().expect("source dir");
+        fs::write(tempdir.path().join("nodejs.json"), r#"{"id":"nodejs"}"#).expect("manifest");
+        fs::write(tempdir.path().join("run.sh"), "echo hi\n").expect("source file");
+        let hash = crate::core::runner::extension_source_content_hash(tempdir.path())
+            .expect("content hash");
+        let mut runner =
+            runner_with_overlay("nodejs", &tempdir.path().display().to_string(), &hash);
+        runner.resources.insert(
+            "dev_sync".to_string(),
+            serde_json::json!({
+                "schema": "homeboy/runner-dev-sync/v1",
+                "extensions": [{
+                    "id": "nodejs",
+                    "source_path": tempdir.path().display().to_string(),
+                    "content_hash": hash,
+                    "source_revision": "8317270c0b2241326ff42ed648e4e5b447dbead2"
+                }]
+            }),
+        );
+        let remote_stdout = r#"{"success":true,"data":{"extension":{"id":"nodejs","source_revision":"b44a15b01"}}}"#;
+
+        let err = validate_runner_extension_revision(
+            "homeboy-lab",
+            &runner,
+            "homeboy",
+            "nodejs",
+            remote_stdout,
+        )
+        .expect_err("stale dev overlay source revision should fail parity");
+
+        assert_eq!(
+            err.details["diagnostic"]["recorded_source_revision"].as_str(),
+            Some("8317270c0b2241326ff42ed648e4e5b447dbead2")
+        );
+        assert_eq!(
+            err.details["diagnostic"]["runner_extension_source_revision"].as_str(),
+            Some("b44a15b01")
+        );
     }
 
     #[test]

--- a/src/core/runner/homeboy_refresh.rs
+++ b/src/core/runner/homeboy_refresh.rs
@@ -433,7 +433,11 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
         .as_ref()
         .map(|output| output.updated_fields.clone())
         .unwrap_or_default();
-    if let MergeOutput::Single(result) = merge(Some(&options.runner_id), &patch.to_string(), &[])? {
+    if let MergeOutput::Single(result) = merge(
+        Some(&options.runner_id),
+        &patch.to_string(),
+        &["resources".to_string()],
+    )? {
         updated_fields.extend(result.updated_fields);
     }
 
@@ -1090,6 +1094,50 @@ mod tests {
         assert_eq!(extensions.len(), 1);
         assert_eq!(extensions[0]["source_path"], "/newer/nodejs");
         assert_eq!(extensions[0]["content_hash"], "newer");
+    }
+
+    #[test]
+    fn dev_sync_resource_replacement_persists_reconciled_overlay_records() {
+        test_support::with_isolated_home(|_| {
+            crate::core::runner::create(
+                r#"{
+                    "id": "lab-local",
+                    "kind": "local",
+                    "workspace_root": "/runner/ws",
+                    "resources": {
+                        "dev_sync": {
+                            "schema": "homeboy/runner-dev-sync/v1",
+                            "extensions": [
+                                {"id": "nodejs", "source_path": "/old/nodejs", "content_hash": "old"},
+                                {"id": "nodejs", "source_path": "/newer/nodejs", "content_hash": "newer"}
+                            ]
+                        }
+                    }
+                }"#,
+                false,
+            )
+            .expect("create runner");
+
+            let runner = crate::core::runner::load("lab-local").expect("load runner");
+            let dev_sync =
+                updated_dev_sync_resource(runner.resources.get("dev_sync").cloned(), None, &[])
+                    .expect("reconcile dev-sync resource");
+            let patch = serde_json::json!({ "resources": { "dev_sync": dev_sync } });
+
+            crate::core::runner::merge(
+                Some("lab-local"),
+                &patch.to_string(),
+                &["resources".to_string()],
+            )
+            .expect("replace resources");
+
+            let runner = crate::core::runner::load("lab-local").expect("reload runner");
+            let extensions = runner.resources["dev_sync"]["extensions"]
+                .as_array()
+                .expect("extensions array");
+            assert_eq!(extensions.len(), 1);
+            assert_eq!(extensions[0]["source_path"], "/newer/nodejs");
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes Extra-Chill/homeboy#7729.

- Persist runner dev-sync metadata with replacement semantics for resources, so a de-duplicated dev_sync.extensions array actually removes stale duplicate records instead of being union-appended by config merge.
- Apply the same replacement behavior when parity auto-materializes a controller snapshot overlay.
- Resolve duplicate dev-overlay records deterministically by newest synced_at, falling back to array order for older records.
- Validate dev-overlay parity against recorded source_revision when available, while continuing to use content_hash to catch local overlay content drift.
- Include recorded_source_revision in mismatch diagnostics.

## Tests

- cargo test runner::homeboy_refresh::tests::dev_sync_resource
- cargo test runner::execution::extension_parity::tests::revision_parity

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the runner dev-overlay metadata write/preflight paths, implemented the fix, added regression tests, and prepared the PR.
