### PR TITLE
Fix runner extension refresh source revision metadata

### DIFF
--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -1392,6 +1392,8 @@ mod tests {
     use super::*;
     use crate::test_support::with_isolated_home;
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
 
     #[test]
     fn extension_runtime_diagnostics_reports_generic_materialization_guidance() {
@@ -1554,6 +1556,41 @@ mod tests {
                 extension.contract_producers[0].produces[0].kind,
                 homeboy::core::extension::ExtensionContractProducerOutputKind::RunnerEnvelopeAddition
             );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extension_show_reports_symlink_sidecar_source_revision_before_copied_marker() {
+        with_isolated_home(|home| {
+            let extension_id = "nodejs";
+            let extensions_dir = home.path().join(".config/homeboy/extensions");
+            let source_dir = home
+                .path()
+                .join(".config/homeboy/extension-sources/nodejs/nodejs");
+            fs::create_dir_all(&source_dir).expect("source dir");
+            fs::write(
+                source_dir.join("nodejs.json"),
+                r#"{"name":"Node.js extension","version":"1.0.0"}"#,
+            )
+            .expect("manifest");
+            fs::write(source_dir.join(".source-revision"), "stale-marker\n")
+                .expect("copied stale marker");
+            fs::create_dir_all(&extensions_dir).expect("extensions dir");
+            symlink(&source_dir, extensions_dir.join(extension_id)).expect("extension symlink");
+            fs::write(
+                extensions_dir.join(".nodejs.source-revision"),
+                "fresh-revision\n",
+            )
+            .expect("sidecar revision");
+
+            let (output, exit_code) = show_extension(extension_id).expect("show extension");
+
+            assert_eq!(exit_code, 0);
+            let ExtensionOutput::Show { extension } = output else {
+                panic!("expected extension show output");
+            };
+            assert_eq!(extension.source_revision.as_deref(), Some("fresh-revision"));
         });
     }
 

--- a/src/core/extension/lifecycle/mod.rs
+++ b/src/core/extension/lifecycle/mod.rs
@@ -1,5 +1,6 @@
 use crate::core::engine::identifier;
 use crate::core::error::{Error, Result};
+use crate::core::git;
 use crate::core::paths;
 use std::path::{Path, PathBuf};
 
@@ -162,6 +163,12 @@ pub fn refresh(
         None => derive_id_from_url(source)?,
     };
 
+    let local_source_revision = if is_git_url(source) {
+        None
+    } else {
+        git::short_head_revision(&absolute_source_path(source)?)
+    };
+    let effective_revision = revision.or(local_source_revision.as_deref());
     let install_source = durable_refresh_source(source, &extension_id)?;
 
     let extension_dir = paths::extension(&extension_id)?;
@@ -172,7 +179,8 @@ pub fn refresh(
         false
     };
 
-    let installed = install_with_revision(&install_source, Some(&extension_id), revision)?;
+    let installed =
+        install_with_revision(&install_source, Some(&extension_id), effective_revision)?;
 
     Ok(RefreshResult {
         extension_id: installed.extension_id,
@@ -820,6 +828,46 @@ exec '{}' "$@"
             assert!(home
                 .join(".config/homeboy/extensions/dependency-adapters/examples/nodejs.json")
                 .exists());
+        });
+    }
+
+    #[test]
+    fn refresh_local_git_source_reports_current_revision_over_copied_marker() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            let _remote = match prepare_git_extension_repo(&source, "nodejs") {
+                Some(remote) => remote,
+                None => return,
+            };
+            let source_revision =
+                git_output(&source, &["rev-parse", "--short", "HEAD"]).expect("source revision");
+            fs::write(source.join("nodejs/.source-revision"), "stale-marker\n")
+                .expect("stale copied marker");
+
+            let result = refresh(
+                &source.join("nodejs").to_string_lossy(),
+                Some("nodejs"),
+                None,
+            )
+            .expect("refresh should install from local git source");
+
+            assert_eq!(
+                result.source_revision.as_deref(),
+                Some(source_revision.as_str())
+            );
+            assert_eq!(
+                read_source_revision("nodejs").as_deref(),
+                Some(source_revision.as_str())
+            );
+            assert_eq!(
+                fs::read_to_string(result.path.join(".source-revision"))
+                    .expect("copied source marker")
+                    .trim(),
+                "stale-marker",
+                "fixture keeps the copied stale marker that used to win reporting"
+            );
         });
     }
 

--- a/src/core/extension/lifecycle/update.rs
+++ b/src/core/extension/lifecycle/update.rs
@@ -136,11 +136,11 @@ pub(crate) fn write_source_metadata(
     source_revision: Option<String>,
 ) {
     let metadata_dir = source_metadata_dir(extension_dir);
+    let revision_path = metadata_dir.join(source_metadata_file(extension_dir, "revision"));
     if let Some(rev) = source_revision {
-        let _ = std::fs::write(
-            metadata_dir.join(source_metadata_file(extension_dir, "revision")),
-            rev,
-        );
+        let _ = std::fs::write(revision_path, rev);
+    } else {
+        let _ = std::fs::remove_file(revision_path);
     }
     let _ = std::fs::write(
         metadata_dir.join(source_metadata_file(extension_dir, "url")),
@@ -153,10 +153,16 @@ pub fn read_source_url(extension_dir: &Path) -> Option<String> {
 }
 
 fn read_source_metadata_value(extension_dir: &Path, kind: &str) -> Option<String> {
-    for path in [
-        extension_dir.join(format!(".source-{kind}")),
-        source_metadata_dir(extension_dir).join(source_metadata_file(extension_dir, kind)),
-    ] {
+    let sidecar =
+        source_metadata_dir(extension_dir).join(source_metadata_file(extension_dir, kind));
+    let embedded = extension_dir.join(format!(".source-{kind}"));
+    let paths = if extension_dir.is_symlink() {
+        [sidecar, embedded]
+    } else {
+        [embedded, sidecar]
+    };
+
+    for path in paths {
         if let Some(value) = std::fs::read_to_string(path)
             .ok()
             .map(|s| s.trim().to_string())


### PR DESCRIPTION
## Summary

Fixes runner extension refresh metadata so a successful refresh records and reports the active source revision instead of preserving stale copied metadata from a durable local-source cache.

Fixes #7731.

## Changes

- Carry the original local source checkout revision through `extension refresh` before copying into Homeboy's durable extension source cache.
- Prefer symlink sidecar metadata over copied `.source-revision` markers when `extension show` reports an installed linked extension revision.
- Clear stale installed revision sidecar metadata when a new install has no revision.
- Add focused regression coverage for refresh metadata and `extension show` reporting.

## Verification

```bash
cargo fmt
cargo test refresh_local_git_source_reports_current_revision_over_copied_marker
cargo test extension_show_reports_symlink_sidecar_source_revision_before_copied_marker
cargo test revision_parity_accepts_matching_dev_overlay_source_revision
git diff --check
```

Note: `cargo test source_revision` also ran, but it includes unrelated `core::runner::workspace::tests::git::git_sync_of_detached_extension_source_preserves_source_revision`, which failed because this machine is critically low on free disk space. The focused tests above passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigated the refresh metadata path, implemented the fix, and added focused tests with Chris reviewing/owning the result.
