### PR TITLE
Propagate runner extension refresh source ref

### DIFF
--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use crate::core::worktree;
+use crate::core::{git, worktree};
 use crate::core::{Error, Result};
 
 use super::path_remap::{remap_local_path, LabPathRemap};
@@ -79,6 +79,9 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
     mappings: &[LabPathRemap],
     remote_output_file: Option<&str>,
 ) -> Vec<String> {
+    let extension_refresh_revision = extension_refresh_local_source_path(args)
+        .filter(|_| !extension_refresh_has_ref(args))
+        .and_then(|source| git::short_head_revision(&source));
     let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
     ordered.sort_by_key(|mapping| {
         (
@@ -182,10 +185,38 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
         }
         stripped.push(remap_lab_offload_arg(arg, &ordered));
     }
+    if let Some(revision) = extension_refresh_revision {
+        stripped.push("--ref".to_string());
+        stripped.push(revision);
+    }
     if !has_force_hot {
         stripped.insert(1, "--force-hot".to_string());
     }
     stripped
+}
+
+fn extension_refresh_has_ref(args: &[String]) -> bool {
+    let Some(refresh_index) = args
+        .windows(2)
+        .position(|window| matches!(window, [command, subcommand] if command == "extension" && subcommand == "refresh"))
+    else {
+        return false;
+    };
+
+    let mut iter = args.iter().skip(refresh_index + 3);
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--ref" {
+            return iter.next().is_some();
+        }
+        if arg.starts_with("--ref=") {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn remote_lab_shared_state_dir(remote_path: &str) -> String {

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1549,6 +1549,44 @@ mod path_settings_tests {
 
 mod lab_args_rewrite_tests {
     use super::*;
+    use std::process::Command;
+
+    fn git(dir: &std::path::Path, args: &[&str]) -> bool {
+        Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    fn commit_all(dir: &std::path::Path, message: &str) -> bool {
+        git(dir, &["add", "."])
+            && git(
+                dir,
+                &[
+                    "-c",
+                    "user.name=Test",
+                    "-c",
+                    "user.email=test@example.com",
+                    "commit",
+                    "-m",
+                    message,
+                ],
+            )
+    }
+
+    fn git_output(dir: &std::path::Path, args: &[&str]) -> Option<String> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .ok()?;
+        output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
 
     #[test]
     fn lab_args_rewrite_preserves_nested_review_quality_command_label() {
@@ -1651,6 +1689,94 @@ mod lab_args_rewrite_tests {
                 "opencode".to_string(),
                 "--source".to_string(),
                 "/runner/workspaces/homeboy-extensions".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn lab_args_rewrite_extension_refresh_adds_local_source_revision_ref() {
+        let source = tempfile::tempdir().expect("source dir");
+        std::fs::write(source.path().join("nodejs.json"), r#"{"name":"Node.js"}"#)
+            .expect("manifest");
+        if !git(source.path(), &["init", "--quiet"]) || !commit_all(source.path(), "init") {
+            return;
+        }
+        let revision =
+            git_output(source.path(), &["rev-parse", "--short", "HEAD"]).expect("source revision");
+        let local_source = source.path().display().to_string();
+        let remote_source = "/runner/workspaces/nodejs";
+        let args = vec![
+            "homeboy".to_string(),
+            "extension".to_string(),
+            "refresh".to_string(),
+            local_source.clone(),
+            "--id".to_string(),
+            "nodejs".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "--lab-only".to_string(),
+        ];
+        let mappings = vec![LabPathRemap {
+            local: local_source,
+            remote: remote_source.to_string(),
+        }];
+
+        assert_eq!(
+            rewrite_lab_offload_args(&args, remote_source, &mappings, None),
+            vec![
+                "homeboy".to_string(),
+                "--force-hot".to_string(),
+                "extension".to_string(),
+                "refresh".to_string(),
+                remote_source.to_string(),
+                "--id".to_string(),
+                "nodejs".to_string(),
+                "--ref".to_string(),
+                revision,
+            ]
+        );
+    }
+
+    #[test]
+    fn lab_args_rewrite_extension_refresh_preserves_explicit_ref() {
+        let source = tempfile::tempdir().expect("source dir");
+        std::fs::write(source.path().join("nodejs.json"), r#"{"name":"Node.js"}"#)
+            .expect("manifest");
+        if !git(source.path(), &["init", "--quiet"]) || !commit_all(source.path(), "init") {
+            return;
+        }
+        let local_source = source.path().display().to_string();
+        let remote_source = "/runner/workspaces/nodejs";
+        let args = vec![
+            "homeboy".to_string(),
+            "extension".to_string(),
+            "refresh".to_string(),
+            local_source.clone(),
+            "--id".to_string(),
+            "nodejs".to_string(),
+            "--ref".to_string(),
+            "operator-ref".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "--lab-only".to_string(),
+        ];
+        let mappings = vec![LabPathRemap {
+            local: local_source,
+            remote: remote_source.to_string(),
+        }];
+
+        assert_eq!(
+            rewrite_lab_offload_args(&args, remote_source, &mappings, None),
+            vec![
+                "homeboy".to_string(),
+                "--force-hot".to_string(),
+                "extension".to_string(),
+                "refresh".to_string(),
+                remote_source.to_string(),
+                "--id".to_string(),
+                "nodejs".to_string(),
+                "--ref".to_string(),
+                "operator-ref".to_string(),
             ]
         );
     }


### PR DESCRIPTION
## Summary

Propagates the controller-known local source revision into Lab runner `extension refresh` commands by appending `--ref <source HEAD>` when the operator did not provide `--ref`.

Follow-up for #7731 and #7732.

## Why

Post-merge verification of #7732 showed runner refresh still installed nodejs without `source_revision` because the runner command received a synced snapshot path with no git checkout:

```text
source checkout `/Users/chubes/Developer/homeboy-extensions/nodejs` at HEAD@f89b4297414d clean
final_argv=`... extension refresh /home/chubes/Developer/_lab_workspaces/nodejs-... --id nodejs`
```

The lifecycle metadata fix from #7732 correctly records/report revisions when provided, but Lab offload also needs to pass the source revision it already knows.

## Changes

- Detect local-source `homeboy extension refresh` during Lab offload argument rewrite.
- Append `--ref <source HEAD>` to the runner-side command when no explicit `--ref` was supplied.
- Preserve operator-provided `--ref` unchanged.
- Add focused remapper tests for implicit and explicit refresh refs.

## Verification

```bash
cargo fmt
cargo test lab_args_rewrite_extension_refresh
cargo test refresh_local_git_source_reports_current_revision_over_copied_marker
cargo test extension_show_reports_symlink_sidecar_source_revision_before_copied_marker
git diff --check
```

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Traced the Lab offload refresh argument path, implemented source-ref propagation, and added regression tests.
