### PR TITLE
Use full source revision for runner extension refresh

### DIFF
--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -81,7 +81,7 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
 ) -> Vec<String> {
     let extension_refresh_revision = extension_refresh_local_source_path(args)
         .filter(|_| !extension_refresh_has_ref(args))
-        .and_then(|source| git::short_head_revision(&source));
+        .and_then(|source| git::head_sha(&source));
     let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
     ordered.sort_by_key(|mapping| {
         (

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1701,8 +1701,7 @@ mod lab_args_rewrite_tests {
         if !git(source.path(), &["init", "--quiet"]) || !commit_all(source.path(), "init") {
             return;
         }
-        let revision =
-            git_output(source.path(), &["rev-parse", "--short", "HEAD"]).expect("source revision");
+        let revision = git_output(source.path(), &["rev-parse", "HEAD"]).expect("source revision");
         let local_source = source.path().display().to_string();
         let remote_source = "/runner/workspaces/nodejs";
         let args = vec![


### PR DESCRIPTION
## Summary

Use the full source commit SHA when Lab offload propagates a local-source `extension refresh` revision.

Follow-up for #7731, #7732, and #7733.

## Why

After #7733, runner refresh passed `--ref f89b4297` and installed metadata reported `source_revision: f89b4297`. Bench preflight then correctly reached parity but still blocked because the active dev-overlay record stores the full source revision:

```text
recorded_source_revision: f89b4297414d3148e7545dbd82ccdef9cb8d07c0
runner_extension_source_revision: f89b4297
```

The correct fix is to propagate the full source HEAD as `--ref`, so the installed metadata matches the active dev-overlay record exactly.

## Verification

```bash
cargo fmt
cargo test lab_args_rewrite_extension_refresh
git diff --check
```

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Verified post-merge runner behavior, identified the short/full revision mismatch, and implemented the focused fix.
