### PR TITLE
fix: block cook when executor require graph is unresolved on disk

### DIFF
--- a/src/commands/agent_task/doctor.rs
+++ b/src/commands/agent_task/doctor.rs
@@ -100,6 +100,11 @@ fn provider_stage(args: &AgentTaskDoctorArgs) -> ProviderStage {
     let provider_ready;
     let mapping_value;
 
+    // When a concrete provider is selected, record its executor require-graph
+    // resolution so the verdict reflects on-disk runtime health, not just
+    // declared contract metadata (#7736).
+    let mut executor_resolution_value = Value::Null;
+
     match (selected_backend.as_deref(), backend_match) {
         (None, _) => {
             provider_ready = false;
@@ -113,7 +118,53 @@ fn provider_stage(args: &AgentTaskDoctorArgs) -> ProviderStage {
         }
         (Some(backend), Some((count, selected))) => {
             if let Some(provider) = selected {
-                provider_ready = true;
+                // Provider contract mapping succeeded. Before calling the cook
+                // ready, verify the selected provider's executor entrypoint
+                // actually loads its module require graph on disk — a stale or
+                // partial runtime install (e.g. a shared runtime package never
+                // materialized) passes contract discovery but crashes every cook
+                // with MODULE_NOT_FOUND (#7736).
+                match homeboy::core::agent_tasks::provider::probe_provider_executor_resolves(provider)
+                {
+                    homeboy::core::agent_tasks::provider::ProviderExecutorResolution::Resolved => {
+                        provider_ready = true;
+                        executor_resolution_value = json!({ "status": "resolved" });
+                    }
+                    homeboy::core::agent_tasks::provider::ProviderExecutorResolution::Skipped {
+                        reason,
+                    } => {
+                        // The executor runtime does not implement the dry-load
+                        // probe; fall back to contract readiness (prior
+                        // behavior) rather than inventing a failure.
+                        provider_ready = true;
+                        executor_resolution_value =
+                            json!({ "status": "skipped", "reason": reason });
+                    }
+                    homeboy::core::agent_tasks::provider::ProviderExecutorResolution::Unresolved {
+                        command,
+                        detail,
+                    } => {
+                        provider_ready = false;
+                        executor_resolution_value = json!({
+                            "status": "unresolved",
+                            "command": command,
+                            "detail": detail,
+                        });
+                        blocker = Some(json!({
+                            "stage": "provider_contracts",
+                            "code": "executor_require_graph_unresolved",
+                            "message": format!(
+                                "Provider `{}` (backend `{backend}`) is declared but its executor could not load its runtime require graph on disk",
+                                provider.id
+                            ),
+                            "remediation": "Reinstall the runtime so shared runtime packages are materialized (e.g. `homeboy extension refresh <homeboy-extensions source> --id <extension>`), then rerun doctor",
+                            "details": {
+                                "command": command,
+                                "detail": detail,
+                            },
+                        }));
+                    }
+                }
                 mapping_value = json!({
                     "selected_backend": backend,
                     "selector": args.selector,
@@ -165,6 +216,7 @@ fn provider_stage(args: &AgentTaskDoctorArgs) -> ProviderStage {
         "providers": providers,
         "diagnostics": executor.diagnostics(),
         "backend_mapping": mapping_value,
+        "executor_resolution": executor_resolution_value,
         "secret_env": secret_env,
     });
 

--- a/src/commands/agent_task/doctor.rs
+++ b/src/commands/agent_task/doctor.rs
@@ -31,7 +31,15 @@ use super::args::AgentTaskDoctorArgs;
 /// Run the cook readiness repair chain and return a combined verdict.
 pub(crate) fn doctor(args: AgentTaskDoctorArgs) -> CmdResult<Value> {
     let provider_stage = provider_stage(&args);
-    let runner_stage = runner_stage(&args)?;
+    let runner_stage = if provider_stage.ready {
+        runner_stage(&args)?
+    } else {
+        json!({
+            "status": "skipped",
+            "checks": [],
+            "skipped_reason": "provider contract readiness failed before runner checks",
+        })
+    };
 
     let verdict = combine_verdict(&provider_stage, &runner_stage);
     let exit_code = if verdict.ready { 0 } else { 1 };
@@ -100,11 +108,6 @@ fn provider_stage(args: &AgentTaskDoctorArgs) -> ProviderStage {
     let provider_ready;
     let mapping_value;
 
-    // When a concrete provider is selected, record its executor require-graph
-    // resolution so the verdict reflects on-disk runtime health, not just
-    // declared contract metadata (#7736).
-    let mut executor_resolution_value = Value::Null;
-
     match (selected_backend.as_deref(), backend_match) {
         (None, _) => {
             provider_ready = false;
@@ -118,53 +121,7 @@ fn provider_stage(args: &AgentTaskDoctorArgs) -> ProviderStage {
         }
         (Some(backend), Some((count, selected))) => {
             if let Some(provider) = selected {
-                // Provider contract mapping succeeded. Before calling the cook
-                // ready, verify the selected provider's executor entrypoint
-                // actually loads its module require graph on disk — a stale or
-                // partial runtime install (e.g. a shared runtime package never
-                // materialized) passes contract discovery but crashes every cook
-                // with MODULE_NOT_FOUND (#7736).
-                match homeboy::core::agent_tasks::provider::probe_provider_executor_resolves(provider)
-                {
-                    homeboy::core::agent_tasks::provider::ProviderExecutorResolution::Resolved => {
-                        provider_ready = true;
-                        executor_resolution_value = json!({ "status": "resolved" });
-                    }
-                    homeboy::core::agent_tasks::provider::ProviderExecutorResolution::Skipped {
-                        reason,
-                    } => {
-                        // The executor runtime does not implement the dry-load
-                        // probe; fall back to contract readiness (prior
-                        // behavior) rather than inventing a failure.
-                        provider_ready = true;
-                        executor_resolution_value =
-                            json!({ "status": "skipped", "reason": reason });
-                    }
-                    homeboy::core::agent_tasks::provider::ProviderExecutorResolution::Unresolved {
-                        command,
-                        detail,
-                    } => {
-                        provider_ready = false;
-                        executor_resolution_value = json!({
-                            "status": "unresolved",
-                            "command": command,
-                            "detail": detail,
-                        });
-                        blocker = Some(json!({
-                            "stage": "provider_contracts",
-                            "code": "executor_require_graph_unresolved",
-                            "message": format!(
-                                "Provider `{}` (backend `{backend}`) is declared but its executor could not load its runtime require graph on disk",
-                                provider.id
-                            ),
-                            "remediation": "Reinstall the runtime so shared runtime packages are materialized (e.g. `homeboy extension refresh <homeboy-extensions source> --id <extension>`), then rerun doctor",
-                            "details": {
-                                "command": command,
-                                "detail": detail,
-                            },
-                        }));
-                    }
-                }
+                provider_ready = true;
                 mapping_value = json!({
                     "selected_backend": backend,
                     "selector": args.selector,
@@ -216,7 +173,6 @@ fn provider_stage(args: &AgentTaskDoctorArgs) -> ProviderStage {
         "providers": providers,
         "diagnostics": executor.diagnostics(),
         "backend_mapping": mapping_value,
-        "executor_resolution": executor_resolution_value,
         "secret_env": secret_env,
     });
 
@@ -239,6 +195,8 @@ fn runner_stage(args: &AgentTaskDoctorArgs) -> homeboy::core::Result<Value> {
             path: args.path.clone(),
             extensions: args.extensions.clone(),
             required_tools: args.required_tools.clone(),
+            agent_backend: args.backend.clone(),
+            agent_selector: args.selector.clone(),
             scope: RunnerDoctorScope::LabOffload,
             repair: args.repair,
         },
@@ -313,9 +271,15 @@ fn first_runner_error(runner: &Value) -> Option<Value> {
         .iter()
         .find(|check| check.get("status").and_then(Value::as_str) == Some(error_label))
         .map(|check| {
+            let check_id = check.get("id").and_then(Value::as_str).unwrap_or_default();
+            let code = if check_id.starts_with("agent_task.provider_executor_resolution.") {
+                json!("executor_require_graph_unresolved")
+            } else {
+                check.get("id").cloned().unwrap_or(Value::Null)
+            };
             json!({
                 "stage": "runner_readiness",
-                "code": check.get("id").cloned().unwrap_or(Value::Null),
+                "code": code,
                 "message": check.get("message").cloned().unwrap_or(Value::Null),
                 "remediation": check.get("remediation").cloned().unwrap_or(Value::Null),
                 "details": check.get("details").cloned().unwrap_or(Value::Null),

--- a/src/commands/runner/dispatch.rs
+++ b/src/commands/runner/dispatch.rs
@@ -123,6 +123,8 @@ pub fn run(
                 path,
                 extensions: required_extensions,
                 required_tools,
+                agent_backend: None,
+                agent_selector: None,
                 scope: scope.into(),
                 repair,
             },

--- a/src/commands/runner/doctor/local.rs
+++ b/src/commands/runner/doctor/local.rs
@@ -154,6 +154,15 @@ pub fn report(
         "Create the artifact root or configure HOMEBOY_ARTIFACT_ROOT to a writable directory",
     ));
 
+    if options.scope == RunnerDoctorScope::LabOffload {
+        let catalog = homeboy::core::agent_tasks::provider::AgentTaskProviderCatalog::discover();
+        checks.extend(probes::local_provider_executor_resolution_checks(
+            catalog.providers(),
+            options.agent_backend.as_deref(),
+            options.agent_selector.as_deref(),
+        ));
+    }
+
     let homeboy_command = homeboy.path.as_deref().unwrap_or("homeboy");
     for extension_id in normalized_extension_ids(&options.extensions) {
         checks.push(extension_parity::local_check(

--- a/src/commands/runner/doctor/mod.rs
+++ b/src/commands/runner/doctor/mod.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use homeboy::core::agent_tasks::provider::{
-    AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
+    AgentTaskExecutorProvider, AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
 };
 use homeboy::core::engine::shell;
 use homeboy::core::runners::{
@@ -33,6 +33,8 @@ pub struct RunnerDoctorOptions {
     pub path: Option<String>,
     pub extensions: Vec<String>,
     pub required_tools: Vec<String>,
+    pub agent_backend: Option<String>,
+    pub agent_selector: Option<String>,
     pub scope: RunnerDoctorScope,
     pub repair: bool,
 }

--- a/src/commands/runner/doctor/probes.rs
+++ b/src/commands/runner/doctor/probes.rs
@@ -396,6 +396,213 @@ pub fn provider_readiness_checks(
         .collect()
 }
 
+pub fn local_provider_executor_resolution_checks(
+    providers: &[AgentTaskExecutorProvider],
+    selected_backend: Option<&str>,
+    selected_provider_id: Option<&str>,
+) -> Vec<RunnerCheck> {
+    selected_provider_executor_resolution_providers(
+        providers,
+        selected_backend,
+        selected_provider_id,
+    )
+    .into_iter()
+    .map(local_provider_executor_resolution_check)
+    .collect()
+}
+
+pub fn remote_provider_executor_resolution_checks(
+    client: &SshClient,
+    providers: &[AgentTaskExecutorProvider],
+    selected_backend: Option<&str>,
+    selected_provider_id: Option<&str>,
+) -> Vec<RunnerCheck> {
+    selected_provider_executor_resolution_providers(
+        providers,
+        selected_backend,
+        selected_provider_id,
+    )
+    .into_iter()
+    .map(|provider| remote_provider_executor_resolution_check(client, provider))
+    .collect()
+}
+
+fn selected_provider_executor_resolution_providers<'a>(
+    providers: &'a [AgentTaskExecutorProvider],
+    selected_backend: Option<&str>,
+    selected_provider_id: Option<&str>,
+) -> Vec<&'a AgentTaskExecutorProvider> {
+    providers
+        .iter()
+        .filter(|provider| {
+            selected_backend.is_none_or(|backend| provider.backend == backend)
+                && selected_provider_id.is_none_or(|provider_id| provider.id == provider_id)
+        })
+        .collect()
+}
+
+fn local_provider_executor_resolution_check(provider: &AgentTaskExecutorProvider) -> RunnerCheck {
+    match homeboy::core::agent_tasks::provider::probe_provider_executor_resolves(provider) {
+        homeboy::core::agent_tasks::provider::ProviderExecutorResolution::Resolved => {
+            provider_executor_resolution_ok_check(provider, None)
+        }
+        homeboy::core::agent_tasks::provider::ProviderExecutorResolution::Skipped { reason } => {
+            provider_executor_resolution_skipped_check(provider, reason)
+        }
+        homeboy::core::agent_tasks::provider::ProviderExecutorResolution::Unresolved {
+            command,
+            detail,
+        } => provider_executor_resolution_error_check(provider, command, detail),
+    }
+}
+
+fn remote_provider_executor_resolution_check(
+    client: &SshClient,
+    provider: &AgentTaskExecutorProvider,
+) -> RunnerCheck {
+    let Some((program, args, cwd)) =
+        crate::core::agent_task_provider::provider_command_parts(provider)
+    else {
+        return provider_executor_resolution_skipped_check(
+            provider,
+            format!("provider '{}' has no resolvable command", provider.id),
+        );
+    };
+
+    let program_name = Path::new(&program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program.as_str());
+    if program_name != "node" && program_name != "nodejs" {
+        return provider_executor_resolution_skipped_check(
+            provider,
+            format!(
+                "provider '{}' executor program '{program_name}' does not implement the --provider-contract dry-load probe",
+                provider.id
+            ),
+        );
+    }
+
+    let command_display =
+        crate::core::agent_task_provider::render_provider_command_display(provider);
+    let shell_command = provider_executor_resolution_remote_shell(&program, &args, cwd.as_deref());
+    let output = client.execute(&shell_command);
+    if output.success {
+        return provider_executor_resolution_ok_check(provider, Some(command_display));
+    }
+
+    let detail = if output.timed_out {
+        "executor resolution probe timed out".to_string()
+    } else {
+        first_stderr_lines(
+            output
+                .stderr
+                .trim()
+                .split_once("__homeboy_probe_status=")
+                .map(|(stderr, _)| stderr.trim())
+                .unwrap_or_else(|| output.stderr.trim()),
+            8,
+        )
+    };
+    provider_executor_resolution_error_check(provider, command_display, detail)
+}
+
+fn provider_executor_resolution_remote_shell(
+    program: &str,
+    args: &[String],
+    cwd: Option<&Path>,
+) -> String {
+    let mut argv = Vec::with_capacity(args.len() + 2);
+    argv.push(common::shell_word(program));
+    argv.extend(args.iter().map(|arg| common::shell_word(arg)));
+    argv.push(common::shell_word("--provider-contract"));
+    let invocation = argv.join(" ");
+    let invocation = if let Some(cwd) = cwd {
+        format!(
+            "cd {} && {invocation}",
+            common::shell_word(&cwd.to_string_lossy())
+        )
+    } else {
+        invocation
+    };
+
+    // Keep the remote SSH command bounded even if an executor ignores the
+    // dry-load flag and waits for input. Stdin is closed and stderr is captured.
+    format!(
+        "tmp=$(mktemp 2>/dev/null || printf '/tmp/homeboy-provider-probe-$$'); ({invocation}) </dev/null >/dev/null 2>\"$tmp\" & pid=$!; (sleep 20; kill \"$pid\" 2>/dev/null) & killer=$!; wait \"$pid\"; rc=$?; kill \"$killer\" 2>/dev/null; cat \"$tmp\" >&2; rm -f \"$tmp\"; exit \"$rc\""
+    )
+}
+
+fn provider_executor_resolution_ok_check(
+    provider: &AgentTaskExecutorProvider,
+    command: Option<String>,
+) -> RunnerCheck {
+    let mut details = provider_executor_resolution_details(provider);
+    if let Some(command) = command {
+        details.insert("command".to_string(), command);
+    }
+    checks::ok_with_details(
+        format!("agent_task.provider_executor_resolution.{}", provider.id),
+        format!(
+            "Provider `{}` executor require graph resolves on the runner",
+            provider.id
+        ),
+        details,
+    )
+}
+
+fn provider_executor_resolution_skipped_check(
+    provider: &AgentTaskExecutorProvider,
+    reason: String,
+) -> RunnerCheck {
+    let mut details = provider_executor_resolution_details(provider);
+    details.insert("skip_reason".to_string(), reason.clone());
+    checks::ok_with_details(
+        format!("agent_task.provider_executor_resolution.{}", provider.id),
+        format!(
+            "Provider `{}` executor require graph probe was skipped: {reason}",
+            provider.id
+        ),
+        details,
+    )
+}
+
+fn provider_executor_resolution_error_check(
+    provider: &AgentTaskExecutorProvider,
+    command: String,
+    detail: String,
+) -> RunnerCheck {
+    let mut details = provider_executor_resolution_details(provider);
+    details.insert("command".to_string(), command);
+    details.insert("detail".to_string(), detail);
+    checks::error(
+        format!("agent_task.provider_executor_resolution.{}", provider.id),
+        format!(
+            "Provider `{}` is declared but its executor could not load its runtime require graph on the runner",
+            provider.id
+        ),
+        Some("Reinstall the runtime so shared runtime packages are materialized (e.g. `homeboy extension refresh <homeboy-extensions source> --id <extension>`), then rerun doctor".to_string()),
+        details,
+    )
+}
+
+fn provider_executor_resolution_details(
+    provider: &AgentTaskExecutorProvider,
+) -> BTreeMap<String, String> {
+    let mut details = BTreeMap::new();
+    details.insert("provider_id".to_string(), provider.id.clone());
+    details.insert("backend".to_string(), provider.backend.clone());
+    details
+}
+
+fn first_stderr_lines(stderr: &str, max: usize) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        return "executor exited non-zero while loading its module require graph".to_string();
+    }
+    trimmed.lines().take(max).collect::<Vec<_>>().join("\n")
+}
+
 /// #3818: report the state of every extension-declared managed runner
 /// source checkout. Surfaces a missing checkout (error) or a checkout that
 /// tracks a different remote than the declared canonical remote (warning)

--- a/src/commands/runner/doctor/remote.rs
+++ b/src/commands/runner/doctor/remote.rs
@@ -183,6 +183,13 @@ pub fn report(
             local_homeboy_version,
             &homeboy,
         ));
+        let catalog = homeboy::core::agent_tasks::provider::AgentTaskProviderCatalog::discover();
+        checks.extend(probes::remote_provider_executor_resolution_checks(
+            client,
+            catalog.providers(),
+            options.agent_backend.as_deref(),
+            options.agent_selector.as_deref(),
+        ));
         checks.extend(probes::provider_readiness_checks(
             client,
             &homeboy::core::agent_tasks::provider::provider_runner_readiness_contracts(),

--- a/src/commands/runner/doctor/tests/provider.rs
+++ b/src/commands/runner/doctor/tests/provider.rs
@@ -1,8 +1,10 @@
 use super::super::*;
 use homeboy::core::agent_tasks::provider::{
-    AgentTaskProviderEnvPathReadiness, AgentTaskProviderRunnerReadiness,
+    AgentTaskExecutorProvider, AgentTaskProviderEnvPathReadiness, AgentTaskProviderRunnerReadiness,
 };
+use serde_json::json;
 use std::collections::BTreeMap;
+use std::io::Write;
 use types::RunnerDoctorStatus;
 
 #[test]
@@ -127,4 +129,68 @@ fn path_within_canonical_root_is_segment_aware() {
     ));
     // Empty root is treated as "no canonical constraint".
     assert!(probes::path_within_canonical_root("/anywhere", ""));
+}
+
+#[test]
+fn local_provider_executor_resolution_check_blocks_broken_require_graph() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("broken-executor.cjs");
+    let mut file = std::fs::File::create(&script).expect("create script");
+    file.write_all(b"require('./missing-shared-runtime-package');\n")
+        .expect("write script");
+    let provider = node_provider("test.node.provider", "test", &script);
+
+    let checks = probes::local_provider_executor_resolution_checks(
+        &[provider],
+        Some("test"),
+        Some("test.node.provider"),
+    );
+
+    assert_eq!(checks.len(), 1);
+    let check = &checks[0];
+    assert_eq!(check.status, RunnerDoctorStatus::Error);
+    assert!(check.id.contains("test.node.provider"));
+    assert!(check.message.contains("could not load"));
+    assert!(check.details.get("detail").is_some_and(
+        |detail| detail.contains("MODULE_NOT_FOUND") || detail.contains("Cannot find module")
+    ));
+}
+
+#[test]
+fn local_provider_executor_resolution_check_filters_to_selected_provider() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let selected_script = dir.path().join("selected-executor.cjs");
+    std::fs::write(
+        &selected_script,
+        "if (process.argv.includes('--provider-contract')) process.exit(0); process.exit(2);\n",
+    )
+    .expect("write selected script");
+    let other_script = dir.path().join("other-executor.cjs");
+    std::fs::write(&other_script, "require('./missing-package');\n").expect("write other script");
+    let selected = node_provider("selected.provider", "test", &selected_script);
+    let other = node_provider("other.provider", "other", &other_script);
+
+    let checks = probes::local_provider_executor_resolution_checks(
+        &[selected, other],
+        Some("test"),
+        Some("selected.provider"),
+    );
+
+    assert_eq!(checks.len(), 1);
+    assert_eq!(checks[0].status, RunnerDoctorStatus::Ok);
+    assert_eq!(
+        checks[0].details.get("provider_id").map(String::as_str),
+        Some("selected.provider")
+    );
+}
+
+fn node_provider(id: &str, backend: &str, script: &std::path::Path) -> AgentTaskExecutorProvider {
+    serde_json::from_value(json!({
+        "id": id,
+        "backend": backend,
+        "invocation": {
+            "argv": ["node", script.display().to_string()]
+        }
+    }))
+    .expect("provider parses")
 }

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -31,7 +31,7 @@ use crate::core::secret_env_plan::{SecretEnvPlan, SecretEnvStatus};
 use crate::core::{agent_runtime_manifest, component, defaults, extension, Error};
 
 mod catalog;
-mod command_runner;
+pub(crate) mod command_runner;
 mod config_preflight;
 mod executor;
 mod fixtures;
@@ -49,6 +49,7 @@ mod workspace_types;
 mod tests;
 
 pub use catalog::*;
+pub(crate) use command_runner::{probe_provider_executor_resolves, ProviderExecutorResolution};
 pub(crate) use config_preflight::preflight_plan_provider_config_with_providers;
 pub(crate) use resolution::{
     resolve_provider_for_backend, role_aliases_for_executor, role_aliases_for_provider,

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -49,7 +49,10 @@ mod workspace_types;
 mod tests;
 
 pub use catalog::*;
-pub(crate) use command_runner::{probe_provider_executor_resolves, ProviderExecutorResolution};
+pub(crate) use command_runner::{
+    probe_provider_executor_resolves, provider_command_parts, render_provider_command_display,
+    ProviderExecutorResolution,
+};
 pub(crate) use config_preflight::preflight_plan_provider_config_with_providers;
 pub(crate) use resolution::{
     resolve_provider_for_backend, role_aliases_for_executor, role_aliases_for_provider,
@@ -77,9 +80,8 @@ use catalog::{
 };
 #[cfg(test)]
 use command_runner::{
-    is_transient_provider_error, provider_command_env, provider_command_parts,
-    render_provider_command_display, run_provider_command, run_provider_command_once,
-    PROVIDER_TRANSIENT_MAX_ATTEMPTS,
+    is_transient_provider_error, provider_command_env, run_provider_command,
+    run_provider_command_once, PROVIDER_TRANSIENT_MAX_ATTEMPTS,
 };
 #[cfg(test)]
 use fixtures::fixture_artifact;

--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -709,7 +709,7 @@ fn runtime_path_provenance(provider: &AgentTaskExecutorProvider) -> Value {
         "extension_path": provider.extension_path.as_deref(),
     })
 }
-pub(super) fn render_provider_command_display(provider: &AgentTaskExecutorProvider) -> String {
+pub(crate) fn render_provider_command_display(provider: &AgentTaskExecutorProvider) -> String {
     if let Some(display) = provider.invocation.display.as_deref() {
         return render_provider_command_template(display, provider);
     }
@@ -752,7 +752,7 @@ fn render_provider_invocation_argv(provider: &AgentTaskExecutorProvider) -> Vec<
         .collect()
 }
 
-pub(super) fn provider_command_parts(
+pub(crate) fn provider_command_parts(
     provider: &AgentTaskExecutorProvider,
 ) -> Option<(String, Vec<String>, Option<PathBuf>)> {
     let (argv, cwd) = if !provider.invocation.argv.is_empty() {
@@ -799,10 +799,7 @@ pub(crate) enum ProviderExecutorResolution {
     Skipped { reason: String },
     /// The executor entrypoint failed to load: its require graph does not
     /// resolve on disk (e.g. a shared runtime package was never materialized).
-    Unresolved {
-        command: String,
-        detail: String,
-    },
+    Unresolved { command: String, detail: String },
 }
 
 /// Grace window for the `--provider-contract` dry load. This only parses the
@@ -916,7 +913,9 @@ pub(crate) fn probe_provider_executor_resolves(
             String::from_utf8_lossy(&buffer).trim().to_string()
         })
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "executor exited non-zero while loading its module require graph".to_string());
+        .unwrap_or_else(|| {
+            "executor exited non-zero while loading its module require graph".to_string()
+        });
 
     ProviderExecutorResolution::Unresolved {
         command,
@@ -928,11 +927,7 @@ pub(crate) fn probe_provider_executor_resolves(
 /// actionable `MODULE_NOT_FOUND` / require-stack context without dumping an
 /// unbounded trace.
 fn first_stderr_lines(stderr: &str, max: usize) -> String {
-    stderr
-        .lines()
-        .take(max)
-        .collect::<Vec<_>>()
-        .join("\n")
+    stderr.lines().take(max).collect::<Vec<_>>().join("\n")
 }
 
 pub(super) fn provider_command_env(
@@ -1114,8 +1109,7 @@ process.exit(2);
         match probe_provider_executor_resolves(&provider) {
             ProviderExecutorResolution::Unresolved { detail, .. } => {
                 assert!(
-                    detail.contains("MODULE_NOT_FOUND")
-                        || detail.contains("Cannot find module"),
+                    detail.contains("MODULE_NOT_FOUND") || detail.contains("Cannot find module"),
                     "expected module resolution failure in detail, got: {detail}"
                 );
             }

--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -786,6 +786,155 @@ pub(super) fn provider_command_parts(
     Some((program, parts.collect(), cwd))
 }
 
+/// Result of probing whether a provider's executor entrypoint actually loads on
+/// disk — i.e. its module require graph resolves against the materialized
+/// runtime layout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProviderExecutorResolution {
+    /// The executor entrypoint loaded and printed its provider contract; the
+    /// require graph resolves.
+    Resolved,
+    /// The probe could not be run (no command parts, or the invocation is not a
+    /// runtime we can safely dry-load). Not a failure — nothing to assert.
+    Skipped { reason: String },
+    /// The executor entrypoint failed to load: its require graph does not
+    /// resolve on disk (e.g. a shared runtime package was never materialized).
+    Unresolved {
+        command: String,
+        detail: String,
+    },
+}
+
+/// Grace window for the `--provider-contract` dry load. This only parses the
+/// executor module and prints a static contract, so it returns near-instantly;
+/// the timeout only guards against a pathological hang.
+const EXECUTOR_RESOLUTION_PROBE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Probe whether a provider's executor entrypoint resolves its module require
+/// graph on disk, without executing an agent task.
+///
+/// Every CLI-runtime executor wrapper resolves its full `require()` chain at
+/// module load (top-level requires run before any argument handling) and
+/// implements a `--provider-contract` flag that prints the static provider
+/// contract and exits 0 *before* reading any request from stdin. Invoking the
+/// wrapper with `--provider-contract` and closed stdin therefore forces the
+/// entire require graph to load: if a shared runtime package (e.g.
+/// `agent-task-contracts`) was never materialized next to the runtime, Node
+/// aborts at load with `MODULE_NOT_FOUND` and exits non-zero — exactly the
+/// failure that would otherwise only surface mid-cook as empty provider stdout.
+///
+/// This is the on-disk resolution check the doctor readiness verdict was
+/// missing (Extra-Chill/homeboy#7736): provider *contract* discovery reads
+/// declared metadata and never loads the executor, so a partially-materialized
+/// install passed readiness while every cook crashed.
+pub(crate) fn probe_provider_executor_resolves(
+    provider: &AgentTaskExecutorProvider,
+) -> ProviderExecutorResolution {
+    let command = render_provider_command_display(provider);
+    let Some((program, args, cwd)) = provider_command_parts(provider) else {
+        return ProviderExecutorResolution::Skipped {
+            reason: format!("provider '{}' has no resolvable command", provider.id),
+        };
+    };
+
+    // Only node-runtime executors implement the `--provider-contract` dry-load
+    // contract. Other runtimes are skipped rather than probed with a flag they
+    // do not understand (which could block reading stdin). Core stays
+    // runtime-agnostic: it keys off the resolved program basename, not a
+    // hard-coded ecosystem/provider name.
+    let program_name = Path::new(&program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program.as_str());
+    let is_node_runtime = program_name == "node" || program_name == "nodejs";
+    if !is_node_runtime {
+        return ProviderExecutorResolution::Skipped {
+            reason: format!(
+                "provider '{}' executor program '{program_name}' does not implement the --provider-contract dry-load probe",
+                provider.id
+            ),
+        };
+    }
+
+    let mut probe_args = args.clone();
+    probe_args.push("--provider-contract".to_string());
+
+    let mut command_builder = Command::new(&program);
+    command_builder
+        .args(&probe_args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    if let Some(cwd) = cwd {
+        command_builder.current_dir(cwd);
+    }
+
+    let mut child = match command_builder.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return ProviderExecutorResolution::Unresolved {
+                command: command.clone(),
+                detail: format!("failed to spawn executor probe: {error}"),
+            };
+        }
+    };
+
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if started.elapsed() >= EXECUTOR_RESOLUTION_PROBE_TIMEOUT {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return ProviderExecutorResolution::Unresolved {
+                        command,
+                        detail: "executor resolution probe timed out".to_string(),
+                    };
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(error) => {
+                return ProviderExecutorResolution::Unresolved {
+                    command,
+                    detail: format!("executor resolution probe wait failed: {error}"),
+                };
+            }
+        }
+    };
+
+    if status.success() {
+        return ProviderExecutorResolution::Resolved;
+    }
+
+    let stderr = child
+        .stderr
+        .take()
+        .map(|mut stderr| {
+            let mut buffer = Vec::new();
+            let _ = std::io::Read::read_to_end(&mut stderr, &mut buffer);
+            String::from_utf8_lossy(&buffer).trim().to_string()
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "executor exited non-zero while loading its module require graph".to_string());
+
+    ProviderExecutorResolution::Unresolved {
+        command,
+        detail: first_stderr_lines(&stderr, 8),
+    }
+}
+
+/// Keep the first `max` lines of captured stderr so the blocker carries the
+/// actionable `MODULE_NOT_FOUND` / require-stack context without dumping an
+/// unbounded trace.
+fn first_stderr_lines(stderr: &str, max: usize) -> String {
+    stderr
+        .lines()
+        .take(max)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 pub(super) fn provider_command_env(
     request: &AgentTaskRequest,
     provider: &AgentTaskExecutorProvider,
@@ -894,5 +1043,118 @@ pub(super) fn failure_outcome(
         workflow: None,
         follow_up: None,
         metadata: Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod executor_resolution_tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Build a minimal node-runtime provider whose invocation runs the given
+    /// script path under `node`, mirroring how installed CLI executor wrappers
+    /// are invoked (`node <wrapper>.cjs`).
+    fn node_provider(script: &std::path::Path) -> AgentTaskExecutorProvider {
+        let mut provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "id": "test.node.provider",
+            "backend": "test",
+            "invocation": {
+                "argv": ["node", script.display().to_string()],
+            },
+        }))
+        .expect("provider parses");
+        // Ensure no legacy string command path is taken.
+        provider.command.clear();
+        provider
+    }
+
+    fn write_script(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        let mut file = std::fs::File::create(&path).expect("create script");
+        file.write_all(body.as_bytes()).expect("write script");
+        path
+    }
+
+    #[test]
+    fn resolved_when_provider_contract_dry_load_exits_zero() {
+        let dir = tempfile::tempdir().expect("dir");
+        // Emulates a healthy executor wrapper: handles --provider-contract
+        // before reading stdin, after resolving its (here trivial) require graph.
+        let script = write_script(
+            dir.path(),
+            "healthy-executor.cjs",
+            r#"if (process.argv.includes('--provider-contract')) {
+  process.stdout.write(JSON.stringify({ id: 'test.node.provider' }));
+  process.exit(0);
+}
+process.exit(2);
+"#,
+        );
+        let provider = node_provider(&script);
+
+        assert_eq!(
+            probe_provider_executor_resolves(&provider),
+            ProviderExecutorResolution::Resolved
+        );
+    }
+
+    #[test]
+    fn unresolved_when_require_graph_is_broken() {
+        let dir = tempfile::tempdir().expect("dir");
+        // Emulates the #7736 failure: a top-level require of a runtime package
+        // that was never materialized. Node aborts at module load with
+        // MODULE_NOT_FOUND before any argument handling runs.
+        let script = write_script(
+            dir.path(),
+            "broken-executor.cjs",
+            "require('./this-shared-runtime-package-was-never-materialized');\n",
+        );
+        let provider = node_provider(&script);
+
+        match probe_provider_executor_resolves(&provider) {
+            ProviderExecutorResolution::Unresolved { detail, .. } => {
+                assert!(
+                    detail.contains("MODULE_NOT_FOUND")
+                        || detail.contains("Cannot find module"),
+                    "expected module resolution failure in detail, got: {detail}"
+                );
+            }
+            other => panic!("expected Unresolved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skipped_for_non_node_runtime() {
+        // A provider whose program is not a node runtime does not implement the
+        // --provider-contract dry-load contract and must be skipped, not failed.
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "id": "test.binary.provider",
+            "backend": "test",
+            "invocation": { "argv": ["/usr/bin/some-native-executor", "--json"] },
+        }))
+        .expect("provider parses");
+
+        match probe_provider_executor_resolves(&provider) {
+            ProviderExecutorResolution::Skipped { reason } => {
+                assert!(reason.contains("does not implement the --provider-contract"));
+            }
+            other => panic!("expected Skipped, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skipped_when_provider_has_no_command() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "id": "test.empty.provider",
+            "backend": "test",
+        }))
+        .expect("provider parses");
+
+        match probe_provider_executor_resolves(&provider) {
+            ProviderExecutorResolution::Skipped { reason } => {
+                assert!(reason.contains("no resolvable command"));
+            }
+            other => panic!("expected Skipped, got {other:?}"),
+        }
     }
 }

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -308,8 +308,8 @@ pub mod provider {
         AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
     };
     pub(crate) use super::super::agent_task_provider::{
-        provider_runner_secret_env_for_plan_with_providers,
-        provider_secret_sources_for_plan_with_providers,
+        probe_provider_executor_resolves, provider_runner_secret_env_for_plan_with_providers,
+        provider_secret_sources_for_plan_with_providers, ProviderExecutorResolution,
     };
 }
 


### PR DESCRIPTION
## Summary

Closes Extra-Chill/homeboy#7736. `agent-task doctor` could report **"Cook is ready"** even when the selected provider executor could not actually load on disk. A stale or partial runtime install could pass declared provider-contract discovery and simple runner path checks, while every cook crashed before the agent ran with `MODULE_NOT_FOUND`.

## Fix

Adds an executor require-graph resolution probe for runner readiness. For selected Node-based provider executors, Homeboy invokes the executor entrypoint with `--provider-contract`, closed stdin, discarded stdout, bounded execution, and captured stderr. That loads the executor module graph without running an agent task.

- Healthy executor: reports `agent_task.provider_executor_resolution.<provider>` as ok.
- Broken require graph: runner doctor emits an error check and `agent-task doctor` returns blocked with blocker code `executor_require_graph_unresolved`.
- Unsupported/non-Node executor or missing command parts: probe is skipped as ok rather than inventing a failure.

The check is wired through both local and remote runner-doctor paths, and `agent-task doctor` passes its selected backend/selector into runner readiness so unrelated providers do not block the selected cook path.

## Architecture

Core remains runtime-agnostic: the probe keys off the resolved executable basename (`node`/`nodejs`) and the provider-declared `--provider-contract` behavior, not hard-coded backend names.

## Verification

- `cargo fmt --check`
- `cargo test executor_resolution_tests --lib`
- `cargo test commands::runner::doctor::tests::provider`
- `cargo test commands::agent_task::doctor::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Reviewed the PR, identified and committed the missing runner-doctor integration, updated PR metadata, and ran targeted verification under Chris's direction.
