### PR TITLE
fix: route agent-task cook to Lab

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -675,8 +675,6 @@ pub(crate) const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local bec
 pub(crate) const RIG_SOURCE_MANAGEMENT_LAB_UNSUPPORTED_REASON: &str = "rig source-management commands (`rig install`, `rig update`, `rig sync`, and `rig sources`) manage the controller's local rig registry and may read arbitrary local package paths. They are not Lab-portable yet. Install or refresh the rig locally first, then run Lab-compatible verification with `homeboy rig check <rig-id> --runner <runner-id>` or `homeboy rig run <rig-id> --runner <runner-id>`.";
 const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
-const AGENT_TASK_COOK_FINALIZATION_CONTROLLER_REASON: &str =
-    "agent-task cook finalization commits, pushes, and opens/updates GitHub PRs from the trusted controller; use --no-finalize for Lab patch evidence and finalize from the controller";
 const AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON: &str =
     "agent-task fanout cook-batch --dry-run is controller-local planning; it does not execute cooks and should not offload or materialize the controller cwd";
 
@@ -788,12 +786,6 @@ impl Commands {
             }) if !args.gates.has_deterministic_gate() => LabCommandContract::local_only(
                 AGENT_TASK_RUN_LAB_LABEL,
                 AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON,
-            ),
-            Commands::AgentTask(agent_task::AgentTaskArgs {
-                command: agent_task::AgentTaskCommand::Cook(args),
-            }) if !args.no_finalize => LabCommandContract::local_only(
-                AGENT_TASK_RUN_LAB_LABEL,
-                AGENT_TASK_COOK_FINALIZATION_CONTROLLER_REASON,
             ),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
@@ -1430,7 +1422,7 @@ mod low_noise_polling_tests {
     }
 
     #[test]
-    fn agent_task_cook_finalization_is_controller_owned() {
+    fn agent_task_cook_with_controller_finalization_remains_lab_portable() {
         let command = parsed_command(&[
             "homeboy",
             "agent-task",
@@ -1445,12 +1437,10 @@ mod low_noise_polling_tests {
 
         let contract = command
             .lab_contract()
-            .expect("cook contract should explain controller-owned finalization");
+            .expect("cook contract should support controller-owned finalization after offload");
 
-        assert_eq!(
-            contract.portability,
-            LabCommandPortability::LocalOnly(AGENT_TASK_COOK_FINALIZATION_CONTROLLER_REASON)
-        );
+        assert_eq!(contract.portability, LabCommandPortability::Portable);
+        assert!(contract.routing_policy.default_lab_offload);
     }
 
     #[test]

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -2255,6 +2255,66 @@ mod tests {
     }
 
     #[test]
+    fn agent_task_cook_supports_automatic_explicit_and_lab_only_routing() {
+        let automatic = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "homeboy@cook-routing",
+            "--verify",
+            "cargo test --locked",
+        ]);
+        let automatic_command = lab_offload_command(&automatic.command).unwrap().unwrap();
+        assert!(automatic_command.portable);
+        assert!(automatic_command.routing_policy.default_lab_offload);
+
+        let explicit = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "homeboy-lab",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "homeboy@cook-routing",
+            "--verify",
+            "cargo test --locked",
+        ]);
+        let explicit_command = lab_offload_command(&explicit.command).unwrap().unwrap();
+        assert_eq!(explicit.runner.as_deref(), Some("homeboy-lab"));
+        assert!(explicit_command.portable);
+
+        let lab_only = Cli::parse_from([
+            "homeboy",
+            "--lab-only",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "homeboy@cook-routing",
+            "--verify",
+            "cargo test --locked",
+        ]);
+        let local_policy = runners::LabLocalExecutionPolicy::from_flags(
+            lab_only.allow_local_hot,
+            lab_only.allow_local_fallback,
+            lab_only.lab_only,
+        );
+        assert!(
+            lab_offload_command(&lab_only.command)
+                .unwrap()
+                .unwrap()
+                .portable
+        );
+        assert!(local_policy.deny_local_execution());
+    }
+
+    #[test]
     fn agent_task_providers_supports_explicit_runner_discovery() {
         let cli = Cli::parse_from([
             "homeboy",

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -575,6 +575,47 @@ mod tests {
     }
 
     #[test]
+    fn verified_agent_task_cook_automatically_selects_default_lab_on_warm_controller() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "homeboy@cook-routing",
+            "--verify",
+            "cargo test --locked",
+        ]);
+        let command = hot_command(&cli.command).expect("verified cook is hot");
+        let resources = resources(ResourceRecommendation::Warm);
+        let warning = evaluate_with_runner_hint(command, &resources, Some("homeboy-lab"))
+            .expect("warm controller warns before routing");
+        let context = ResourcePolicyContext::from_evaluation(
+            command,
+            &resources,
+            Some(&warning),
+            false,
+            Some("homeboy-lab"),
+            false,
+        );
+
+        assert!(command.lab_offload_supported);
+        assert_eq!(command.label, "agent-task cook/run-plan/retry --run");
+        assert_eq!(
+            context.runner_selection,
+            ResourcePolicyRunnerSelection {
+                runner_id: Some("homeboy-lab".to_string()),
+                reason: "default_lab_runner".to_string(),
+            }
+        );
+        assert!(
+            non_interactive_preflight_error(&warning, false, false, None, Some("homeboy-lab"))
+                .is_none()
+        );
+    }
+
+    #[test]
     fn does_not_warn_when_machine_is_ok() {
         assert!(evaluate(
             lab_supported_hot("bench"),


### PR DESCRIPTION
## Summary
- classify verified agent-task cook as a portable Lab workload, including controller-owned finalization
- allow warm-controller resource policy to select configured Lab runners automatically
- cover automatic, explicit runner, and lab-only routing behavior

## Verification
- `cargo fmt --check`
- `cargo test --lib agent_task_cook`
- `cargo test --lib` (7054 passed; 30 pre-existing environment-sensitive failures outside this change)

Closes #7740

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-terra
- **Used for:** Implementation and regression tests under developer direction.