### PR TITLE
fix: normalize directory deploy permissions

### DIFF
--- a/src/core/defaults/builtins.rs
+++ b/src/core/defaults/builtins.rs
@@ -142,7 +142,7 @@ pub(super) fn default_local_permissions() -> PermissionModes {
 pub(super) fn default_remote_permissions() -> PermissionModes {
     PermissionModes {
         file_mode: "g+w".to_string(),
-        dir_mode: "g+w".to_string(),
+        dir_mode: "g+ws".to_string(),
     }
 }
 

--- a/src/core/deploy/permissions.rs
+++ b/src/core/deploy/permissions.rs
@@ -140,7 +140,26 @@ fn fix_deployed_ownership(
             chown_output.exit_code,
             chown_output.stderr
         );
-        // Don't fail the deploy - chown is best-effort
+
+        // An unprivileged deploy user cannot change the owner, but can often
+        // apply the target parent's group. Preserve multi-writer access even
+        // when the best-effort owner normalization is unavailable.
+        if let Some((_, group)) = owner.rsplit_once(':') {
+            let chgrp_cmd = format!(
+                "chgrp -R {} {} 2>/dev/null",
+                shell::quote_arg(group),
+                quoted_path
+            );
+            let chgrp_output = ssh_client.execute(&chgrp_cmd);
+            if !chgrp_output.success {
+                log_status!(
+                    "deploy",
+                    "Warning: chgrp failed (exit {}): {}",
+                    chgrp_output.exit_code,
+                    chgrp_output.stderr
+                );
+            }
+        }
     }
 }
 

--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -115,6 +115,11 @@ pub(super) fn deploy_artifact(
         if !result.success {
             return Ok(result);
         }
+
+        // Directory artifacts bypass the extraction branch below, so normalize
+        // them here instead of preserving the build user's ownership and modes.
+        log_status!("deploy", "Fixing file permissions");
+        permissions::fix_deployed_permissions(ssh_client, remote_path, remote_owner)?;
     } else {
         // Validate: archive artifacts require an extract command
         let is_archive = local_path
@@ -532,6 +537,42 @@ mod tests {
     fn test_deploy_via_git_keeps_framework_safety_policy_external() {
         assert!(DANGEROUS_PATH_SUFFIXES.contains(&"/vendor"));
         assert!(!DANGEROUS_PATH_SUFFIXES.contains(&"/wp-content/plugins"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_directory_artifact_normalizes_group_write_and_setgid() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let source = temp.path().join("source");
+        let target = temp.path().join("plugins").join("sample-plugin");
+        fs::create_dir_all(&source).expect("source dir");
+        fs::create_dir_all(target.parent().expect("target parent")).expect("target parent dir");
+        fs::write(source.join("plugin.php"), "<?php").expect("source file");
+        fs::set_permissions(source.join("plugin.php"), fs::Permissions::from_mode(0o644))
+            .expect("source permissions");
+
+        let result = deploy_artifact(
+            &local_client(),
+            &source,
+            target.to_str().expect("target path"),
+            None,
+            None,
+            None,
+        )
+        .expect("deploy result");
+
+        assert!(result.success, "{}", result.error.unwrap_or_default());
+        let file_mode = fs::metadata(target.join("plugin.php"))
+            .expect("target file")
+            .permissions()
+            .mode();
+        let dir_mode = fs::metadata(&target)
+            .expect("target dir")
+            .permissions()
+            .mode();
+        assert_ne!(0, file_mode & 0o020, "deployed file should be group-writable");
+        assert_ne!(0, dir_mode & 0o020, "deployed dir should be group-writable");
+        assert_ne!(0, dir_mode & 0o2000, "deployed dir should inherit its group");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- normalize ownership and modes after directory-artifact rsync deploys, matching archive/override strategies
- fall back to the target parent's group when an unprivileged deploy user cannot change file ownership
- preserve group inheritance by applying setgid to deployed directories
- add focused regression coverage for group-write and setgid on directory deploys

Fixes #7746.

## Verification
- `git diff --check` passes
- Rust tests were not run on the production VPS: this host is not an approved Rust build environment and currently has no Homeboy Lab runner configured
- a direct Cargo attempt was stopped; it reached a pre-existing shared Cargo-cache permission error before compiling Homeboy

## Scope
No release or deploy performed. The change reuses Homeboy's existing generic parent-owner/group discovery and does not hardcode a web-server identity.