### PR TITLE
Fix Lab offload observation lifecycle

### DIFF
--- a/src/commands/runs/handlers.rs
+++ b/src/commands/runs/handlers.rs
@@ -35,8 +35,8 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
     }
 
     let store = ObservationStore::open_initialized()?;
-    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     runs_service::refresh_running_mirrored_daemon_evidence_best_effort(&store);
+    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     // `--running` is shorthand for `--status running`; the two are mutually
     // exclusive at the CLI layer so this never overrides an explicit status.
     let status = if args.running {
@@ -111,9 +111,9 @@ fn active_runner_job_run_summary(job: api_jobs::ActiveRunnerJobSummary) -> RunSu
 
 pub fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
+    runs_service::refresh_running_mirrored_daemon_evidence_best_effort(&store);
     reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     let run = runs_service::require_run(&store, run_id)?;
-    runs_service::refresh_mirrored_daemon_evidence_best_effort(&run.id);
     let run = runs_service::require_run(&store, &run.id)?;
     let run = run_detail(&store, run)?;
     let actionable = actionable_for_run_detail(&run);

--- a/src/commands/runs/reconcile.rs
+++ b/src/commands/runs/reconcile.rs
@@ -5,7 +5,8 @@ use std::path::{Path, PathBuf};
 
 use homeboy::core::engine::run_dir;
 use homeboy::core::observation::{
-    run_owner_pid, runs_service, ObservationStore, RunListFilter, RunRecord, RunStatus,
+    run_has_active_remote_job, run_owner_pid, runs_service, ObservationStore, RunListFilter,
+    RunRecord, RunStatus,
 };
 use homeboy::core::process::pid_is_running;
 
@@ -131,6 +132,10 @@ fn stale_running_reason<F>(run: &RunRecord, pid_is_alive: &F) -> Option<&'static
 where
     F: Fn(u32) -> bool,
 {
+    if run_has_active_remote_job(run) {
+        return None;
+    }
+
     if let Some(owner_pid) = run_owner_pid(run) {
         return (!pid_is_alive(owner_pid)).then_some("owner_process_not_running");
     }
@@ -558,5 +563,28 @@ mod tests {
             .as_deref()
             .expect("status note")
             .contains("owner process is not running"));
+    }
+
+    #[test]
+    fn active_remote_job_is_not_reconciled_when_controller_owner_exits() {
+        let run = RunRecord {
+            id: "run-1".to_string(),
+            kind: "bench".to_string(),
+            component_id: Some("homeboy".to_string()),
+            started_at: "2026-07-12T00:00:00Z".to_string(),
+            finished_at: None,
+            status: "running".to_string(),
+            command: Some("homeboy bench".to_string()),
+            cwd: Some("/tmp".to_string()),
+            homeboy_version: Some("test".to_string()),
+            git_sha: None,
+            rig_id: None,
+            metadata_json: serde_json::json!({
+                "homeboy_run_owner": { "pid": u32::MAX },
+                "lab": { "remote_job_status": "running" }
+            }),
+        };
+
+        assert_eq!(stale_running_reason(&run, &|_| false), None);
     }
 }

--- a/src/commands/runs/watch.rs
+++ b/src/commands/runs/watch.rs
@@ -90,10 +90,9 @@ struct StorePoller<'a> {
 
 impl RunPoller for StorePoller<'_> {
     fn poll(&self, run_id: &str) -> homeboy::core::Result<RunRecord> {
+        runs_service::refresh_running_mirrored_daemon_evidence_best_effort(self.store);
         reconcile::reconcile_owned_stale_running_runs(self.store, 1000)?;
-        let run = runs_service::require_run(self.store, run_id)?;
-        runs_service::refresh_mirrored_daemon_evidence_best_effort(&run.id);
-        runs_service::require_run(self.store, &run.id)
+        runs_service::require_run(self.store, run_id)
     }
 }
 

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -260,6 +260,12 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     let plan = detached_lab_plan(&run_id, &input);
     let mut record = match store::read_record(&run_id) {
         Ok(record) => record,
+        Err(error)
+            if error.code == ErrorCode::InternalJsonError
+                && store::record_lacks_typed_metadata(&run_id)? =>
+        {
+            submit_plan(&plan, Some(&run_id))?
+        }
         Err(error) if error.code == ErrorCode::ValidationInvalidArgument => {
             submit_plan(&plan, Some(&run_id))?
         }

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -100,6 +100,53 @@ fn detached_lab_handoff_persists_inspectable_running_record() {
 }
 
 #[test]
+fn detached_lab_handoff_upgrades_existing_observation_record() {
+    with_isolated_home(|_| {
+        let store = crate::core::observation::ObservationStore::open_initialized()
+            .expect("observation store");
+        store
+            .upsert_imported_run(&crate::core::observation::RunRecord {
+                id: "agent-task-detached".to_string(),
+                kind: "agent-task".to_string(),
+                component_id: Some("homeboy".to_string()),
+                started_at: "2026-07-12T00:00:00Z".to_string(),
+                finished_at: None,
+                status: "running".to_string(),
+                command: Some("homeboy agent-task cook".to_string()),
+                cwd: None,
+                homeboy_version: Some("test".to_string()),
+                git_sha: None,
+                rig_id: None,
+                metadata_json: json!({
+                    "lab": {
+                        "remote_job_id": "job-123",
+                        "remote_job_status": "running"
+                    }
+                }),
+            })
+            .expect("pre-existing observation");
+
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-detached",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &["homeboy".to_string(), "agent-task".to_string()],
+        })
+        .expect("detached handoff recorded");
+
+        let loaded = status("agent-task-detached").expect("typed status resolves");
+        let observation = store
+            .get_run("agent-task-detached")
+            .expect("read observation")
+            .expect("observation exists");
+        assert_eq!(loaded.state, AgentTaskRunState::Running);
+        assert_eq!(observation.metadata_json["lab"]["remote_job_id"], "job-123");
+        assert!(observation.metadata_json.get("agent_task_run").is_some());
+    });
+}
+
+#[test]
 fn cook_index_keeps_repeated_attempts_unique_with_stable_latest_alias() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -40,7 +40,13 @@ pub(super) fn aggregate_path(run_id: &str) -> Result<PathBuf> {
 
 pub(super) fn write_record(record: &AgentTaskRunRecord) -> Result<()> {
     let store = ObservationStore::open_initialized()?;
-    let metadata_json = observation_metadata(record, read_mirrored_aggregate(&record.run_id)?)?;
+    let metadata_json = merge_observation_metadata(
+        store
+            .get_run(&record.run_id)?
+            .map(|run| run.metadata_json)
+            .unwrap_or_else(|| json!({})),
+        observation_metadata(record, read_mirrored_aggregate(&record.run_id)?)?,
+    );
     store.upsert_imported_run(&RunRecord {
         id: record.run_id.clone(),
         kind: "agent-task".to_string(),
@@ -106,6 +112,12 @@ pub(super) fn record_exists(run_id: &str) -> Result<bool> {
         .is_some())
 }
 
+pub(super) fn record_lacks_typed_metadata(run_id: &str) -> Result<bool> {
+    Ok(ObservationStore::open_initialized()?
+        .get_run(run_id)?
+        .is_some_and(|run| run.metadata_json.get("agent_task_run").is_none()))
+}
+
 pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
     let store = ObservationStore::open_initialized()?;
     let filter = RunListFilter {
@@ -142,6 +154,18 @@ fn observation_metadata(
         "agent_task_run": record_json,
         "agent_task_aggregate": aggregate,
     }))
+}
+
+fn merge_observation_metadata(mut existing: Value, typed: Value) -> Value {
+    if !existing.is_object() {
+        existing = json!({ "homeboy_original_metadata": existing });
+    }
+    if let (Some(existing), Some(typed)) = (existing.as_object_mut(), typed.as_object()) {
+        for (key, value) in typed {
+            existing.insert(key.clone(), value.clone());
+        }
+    }
+    existing
 }
 
 fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -124,6 +124,10 @@ pub fn running_status_note(run: &RunRecord) -> Option<String> {
         return None;
     }
 
+    if run_has_active_remote_job(run) {
+        return None;
+    }
+
     let Some(owner_pid) = run_owner_pid(run) else {
         return Some(
             "running status has no owner metadata; run may predate reconciliation support"
@@ -139,6 +143,14 @@ pub fn running_status_note(run: &RunRecord) -> Option<String> {
                 .to_string(),
         )
     }
+}
+
+pub fn run_has_active_remote_job(run: &RunRecord) -> bool {
+    run.metadata_json
+        .pointer("/lab/remote_job_status")
+        .or_else(|| run.metadata_json.pointer("/lab/remote_job/status"))
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|status| matches!(status, "queued" | "running"))
 }
 
 pub fn run_owner_pid(run: &RunRecord) -> Option<u32> {
@@ -223,6 +235,12 @@ mod tests {
             .as_deref()
             .expect("status note")
             .contains("owner process is not running"));
+
+        let active_remote = running_run(serde_json::json!({
+            "homeboy_run_owner": { "pid": u32::MAX },
+            "lab": { "remote_job_status": "running" }
+        }));
+        assert!(running_status_note(&active_remote).is_none());
     }
 
     #[test]

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -19,8 +19,8 @@ mod test_findings;
 pub mod timeline;
 
 pub use lifecycle::{
-    finish_run_best_effort, merge_metadata, run_owner_pid, running_status_note, ActiveObservation,
-    ACTIVE_RUN_ID_ENV,
+    finish_run_best_effort, merge_metadata, run_has_active_remote_job, run_owner_pid,
+    running_status_note, ActiveObservation, ACTIVE_RUN_ID_ENV,
 };
 
 pub use loop_inventory_run::persist_loop_inventory_run;


### PR DESCRIPTION
## Summary
- preserve Lab observation metadata when detached agent-task handoff upgrades an existing run ID into the typed lifecycle record
- treat queued/running remote Lab jobs as the active owner instead of falsely reconciling them from a dead controller PID
- refresh mirrored runner evidence before automatic stale reconciliation in list, show, and watch paths

Closes #7741.

## Root cause
Lab offload creates the observation run before the detached agent-task lifecycle record. Reusing that run ID caused `record_detached_lab_run()` to parse the generic observation as typed `agent_task_run` metadata and fail. Separately, run reconciliation treated the controller PID as authoritative even when persisted Lab evidence showed the remote job was still queued or running. Read paths also reconciled before refreshing runner evidence.

This split the cross-boundary lifecycle: the accepted remote job continued while the controller record either failed typed hydration or presented as stale.

## Verification
- `cargo fmt --check`
- `cargo test core::agent_task_lifecycle:: -- --nocapture` (37 passed)
- `cargo test commands::runs:: -- --nocapture` (169 passed)
- `cargo clippy --all-targets --all-features -- -D warnings` (blocked by 170+ existing unrelated warnings on `main`; no reported finding originated in this change)

## Reproduction evidence
- SSI bench run `aebd08e8-baea-4932-9924-d60bb9d153af`
- deterministic relaunch `21658fc5-81fb-4bf6-bc73-d26efd825667`
- detached agent-task cook `agent-task-63f5358f-92a2-4284-9f9f-0367ef35463b`, runner job `000d37ce-7a59-4d22-8099-1b3c8ac27789`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Root-cause analysis, implementation, regression coverage, and verification drafted in collaboration with Chris Huber.
