### PR TITLE
Add unified check command

### DIFF
--- a/docs/commands/check.md
+++ b/docs/commands/check.md
@@ -1,0 +1,20 @@
+# Check
+
+`homeboy check` provides one entrypoint for Homeboy quality gates. Each gate
+uses the same arguments and implementation as its existing command.
+
+```sh
+homeboy check audit <component> [audit options]
+homeboy check lint <component> [lint options]
+homeboy check test <component> [test options]
+homeboy check build <component> [build options]
+homeboy check review <component> [review options]
+```
+
+The existing gate commands remain available. `check` is a dispatching
+entrypoint and does not change gate behavior or output.
+
+Related:
+
+- [Review](review.md)
+- [Commands index](commands-index.md)

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -6,6 +6,7 @@
 - [api](api.md)
 - [bench](bench.md) — performance benchmarks + p95 regression ratchet
 - [cargo](cargo.md) — extension-provided Cargo routing when installed
+- [check](check.md) — unified audit, lint, test, build, and review quality-gate entrypoint
 - [cleanup](cleanup.md) — declared reconstructable artifact cleanup across managed worktrees
 - [component](component.md)
 - [config](config.md)

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -4,10 +4,10 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use crate::commands::{
-    activity, agent_task, api, bench, cleanup, component, config, contract, daemon, db, deploy,
-    extension, file, fleet, fuzz, git, logs, observe, project, refactor, release, report, review,
-    rig, runner, runs, runtime, self_cmd, server, ssh, stack, status, trace, triage, tunnel,
-    upgrade, worktree,
+    activity, agent_task, api, bench, build, cleanup, component, config, contract, daemon, db,
+    deploy, extension, file, fleet, fuzz, git, lint, logs, observe, project, refactor, release,
+    report, review, rig, runner, runs, runtime, self_cmd, server, ssh, stack, status, test, trace,
+    triage, tunnel, upgrade, worktree,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -140,6 +140,8 @@ pub enum Commands {
     Report(report::ReportArgs),
     /// Run scoped audit + lint + test umbrella against PR-style changes
     Review(review::ReviewArgs),
+    /// Run a quality gate through one unified entrypoint
+    Check(CheckArgs),
     /// Structural refactoring (rename terms across codebase)
     Refactor(refactor::RefactorArgs),
     /// Manage local dev rigs (reproducible multi-component environments)
@@ -163,6 +165,26 @@ pub enum Commands {
     Api(api::ApiArgs),
     /// Upgrade Homeboy to the latest version
     Upgrade(upgrade::UpgradeArgs),
+}
+
+#[derive(Args)]
+pub struct CheckArgs {
+    #[command(subcommand)]
+    pub command: CheckCommand,
+}
+
+#[derive(Subcommand)]
+pub enum CheckCommand {
+    /// Audit code conventions and detect architectural drift
+    Audit(review::ReviewAuditArgs),
+    /// Lint a component
+    Lint(lint::LintArgs),
+    /// Run tests for a component
+    Test(test::TestArgs),
+    /// Run a local build quality gate for a component
+    Build(build::BuildArgs),
+    /// Run scoped audit + lint + test against PR-style changes
+    Review(review::ReviewArgs),
 }
 
 #[derive(Args)]
@@ -551,6 +573,7 @@ mod entry_command_impls {
                 Commands::Release(_) => "release",
                 Commands::Report(_) => "report",
                 Commands::Review(_) => "review",
+                Commands::Check(_) => "check",
                 Commands::Refactor(_) => "refactor",
                 Commands::Rig(_) => "rig",
                 Commands::Runner(_) => "runner",

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -232,7 +232,8 @@ impl Commands {
             | Commands::Runtime(_)
             | Commands::Worktree(_)
             | Commands::Tunnel(_)
-            | Commands::Stack(_) => registered_json_envelope_descriptor(self, output_file_mode),
+            | Commands::Stack(_)
+            | Commands::Check(_) => registered_json_envelope_descriptor(self, output_file_mode),
             Commands::Rig(_) => registered_json_envelope_descriptor(self, output_file_mode),
             Commands::Status(_)
             | Commands::Server(_)

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -668,6 +668,11 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             REVIEW_LAB_SUPPORT,
         ),
     ),
+    command_spec_with_output_notes(
+        "check",
+        CommandJsonFamily::Quality,
+        "unified compatibility entrypoint for audit, lint, test, build, and review quality gates",
+    ),
     CommandSpec {
         safety: CommandSafetySpec {
             mutates: true,

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -181,7 +181,27 @@ fn arg_takes_value(arg: &Arg) -> bool {
 
 /// Apply all argument normalizations in sequence.
 pub fn normalize(args: Vec<String>) -> Vec<String> {
-    mark_explicit_passthrough(normalize_review_audit_baseline(args))
+    mark_explicit_passthrough(normalize_review_audit_baseline(normalize_check_entrypoint(
+        args,
+    )))
+}
+
+fn normalize_check_entrypoint(mut args: Vec<String>) -> Vec<String> {
+    if !matches!(args.get(1).map(String::as_str), Some("check")) {
+        return args;
+    }
+
+    match args.get(2).map(String::as_str) {
+        Some("review") => {
+            args.drain(1..3);
+            args.insert(1, "review".to_string());
+        }
+        Some("audit" | "lint" | "test" | "build") => {
+            args[1] = "review".to_string();
+        }
+        _ => {}
+    }
+    args
 }
 
 fn normalize_review_audit_baseline(mut args: Vec<String>) -> Vec<String> {
@@ -286,6 +306,78 @@ mod normalize_tests {
 
     fn argv(parts: &[&str]) -> Vec<String> {
         parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn check_gates_normalize_to_existing_review_dispatch_paths() {
+        for gate in ["audit", "lint", "test", "build"] {
+            assert_eq!(
+                normalize(argv(&[
+                    "homeboy",
+                    "check",
+                    gate,
+                    "component",
+                    "--path",
+                    ".",
+                ])),
+                normalize(argv(&[
+                    "homeboy",
+                    "review",
+                    gate,
+                    "component",
+                    "--path",
+                    ".",
+                ])),
+            );
+        }
+
+        assert_eq!(
+            normalize(argv(&[
+                "homeboy",
+                "check",
+                "review",
+                "component",
+                "--changed-since",
+                "origin/main",
+            ])),
+            normalize(argv(&[
+                "homeboy",
+                "review",
+                "component",
+                "--changed-since",
+                "origin/main",
+            ])),
+        );
+    }
+
+    #[test]
+    fn check_parser_reuses_gate_argument_types() {
+        let parsed = Cli::try_parse_from(argv(&[
+            "homeboy",
+            "check",
+            "lint",
+            "component",
+            "--path",
+            ".",
+            "--changed-since",
+            "origin/main",
+        ]))
+        .expect("check lint should parse");
+
+        let Commands::Check(crate::cli_surface::CheckArgs {
+            command: crate::cli_surface::CheckCommand::Lint(args),
+        }) = parsed.command
+        else {
+            panic!("expected check lint command");
+        };
+        assert_eq!(args.comp.component.as_deref(), Some("component"));
+        assert_eq!(args.comp.path.as_deref(), Some("."));
+        assert_eq!(args.changed_since.as_deref(), Some("origin/main"));
+    }
+
+    #[test]
+    fn check_rejects_non_gate_subcommands() {
+        assert!(Cli::try_parse_from(argv(&["homeboy", "check", "bench"])).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `homeboy check` as a unified quality-gate entrypoint
- route audit, lint, test, build, and review through their existing parsers and dispatch paths
- preserve every existing top-level command for compatibility
- document and test the unified surface

## Testing
- `cargo test normalize_tests --lib`
- `cargo test cli_surface::tests --lib`
- `cargo check`
- targeted `rustfmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Architecture inspection, implementation, tests, documentation, and verification; Chris remains responsible for the submitted change.