### PR TITLE
fix: resolve provider-managed cook targets

### DIFF
--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use crate::core::{git, worktree};
+use crate::core::{git, worktree, worktree_providers};
 use crate::core::{Error, Result};
 
 use super::path_remap::{remap_local_path, LabPathRemap};
@@ -40,7 +40,7 @@ pub(in crate::core::runner) fn lab_offload_source_path(args: &[String]) -> Resul
                     None,
                 )
             })?;
-            return worktree::resolve(value).map(|record| PathBuf::from(record.worktree_path));
+            return resolve_to_worktree_source_path(value);
         }
         if let Some(value) = arg.strip_prefix("--path=") {
             return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
@@ -49,12 +49,20 @@ pub(in crate::core::runner) fn lab_offload_source_path(args: &[String]) -> Resul
             return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
         }
         if let Some(value) = arg.strip_prefix("--to-worktree=") {
-            return worktree::resolve(value).map(|record| PathBuf::from(record.worktree_path));
+            return resolve_to_worktree_source_path(value);
         }
     }
 
     std::env::current_dir()
         .map_err(|err| Error::internal_io(err.to_string(), Some("read cwd".to_string())))
+}
+
+fn resolve_to_worktree_source_path(value: &str) -> Result<PathBuf> {
+    match worktree::resolve_if_present(value)? {
+        Some(record) => Ok(PathBuf::from(record.worktree_path)),
+        None => worktree_providers::resolve_worktree_provider_handle(value)
+            .map(|worktree| PathBuf::from(worktree.path)),
+    }
 }
 
 fn extension_refresh_local_source_path(args: &[String]) -> Option<PathBuf> {

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -69,6 +69,79 @@ mod lab_source_path_tests {
             );
         });
     }
+
+    #[test]
+    fn lab_source_path_uses_provider_managed_cook_target_without_adopting_it() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace = tempfile::tempdir().expect("workspace");
+            let initialized = std::process::Command::new("git")
+                .args(["init", "-b", "cook-target"])
+                .current_dir(workspace.path())
+                .output()
+                .expect("initialize git repository");
+            assert!(initialized.status.success());
+            let provider_dir = tempfile::tempdir().expect("provider dir");
+            let script = provider_dir.path().join("provider");
+            std::fs::write(
+                &script,
+                format!(
+                    "#!/bin/sh\nprintf '%s\\n' '{}'\n",
+                    serde_json::json!({
+                        "worktrees": [{
+                            "handle": "fixture@cook-target",
+                            "path": workspace.path(),
+                            "branch": "cook-target",
+                            "safety": { "dirty": false, "unpushed": false, "primary": false }
+                        }]
+                    })
+                ),
+            )
+            .expect("write provider script");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut permissions = std::fs::metadata(&script)
+                    .expect("script metadata")
+                    .permissions();
+                permissions.set_mode(0o755);
+                std::fs::set_permissions(&script, permissions).expect("make script executable");
+            }
+            let mut worktree_providers = HashMap::new();
+            worktree_providers.insert(
+                "fixture".to_string(),
+                defaults::WorktreeProviderConfig {
+                    enabled: true,
+                    kind: defaults::WorktreeProviderKind::Command,
+                    apply_enabled: false,
+                    commands: defaults::WorktreeProviderCommands {
+                        list: Some(vec![script.display().to_string()]),
+                        ..Default::default()
+                    },
+                },
+            );
+            defaults::save_config(&defaults::HomeboyConfig {
+                worktree_providers,
+                ..defaults::HomeboyConfig::default()
+            })
+            .expect("save provider config");
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--to-worktree".to_string(),
+                "fixture@cook-target".to_string(),
+            ];
+
+            assert_eq!(
+                lab_offload_source_path(&args).expect("provider target resolves before dispatch"),
+                workspace.path()
+            );
+            let record_path = crate::core::paths::homeboy_data()
+                .expect("homeboy data")
+                .join("task-worktrees/fixture_cook-target.json");
+            assert!(!record_path.exists(), "provider target must not be adopted");
+        });
+    }
 }
 
 mod runner_resident_tests {

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -339,6 +339,17 @@ pub fn resolve(id: &str) -> Result<TaskWorktreeRecord> {
     read_record(&metadata_dir()?, id)
 }
 
+/// Returns `None` only when no Homeboy task-worktree record exists. Callers
+/// that support an external provider can use this to avoid masking corrupt
+/// Homeboy records with a provider fallback.
+pub fn resolve_if_present(id: &str) -> Result<Option<TaskWorktreeRecord>> {
+    let path = record_path(&metadata_dir()?, id);
+    if !path.exists() {
+        return Ok(None);
+    }
+    read_record_path(&path).map(Some)
+}
+
 pub fn resolve_workspace_ref(handle: &str) -> Result<WorkspaceRefRecord> {
     if let Ok(record) = read_record(&metadata_dir()?, handle) {
         return Ok(WorkspaceRefRecord::Task(record));

--- a/src/core/worktree_providers.rs
+++ b/src/core/worktree_providers.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::defaults::{self, HomeboyConfig, WorktreeProviderConfig, WorktreeProviderKind};
@@ -67,6 +67,198 @@ pub struct WorktreeProviderRunRef {
     pub run_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_command: Option<String>,
+}
+
+/// A workspace returned by a command worktree provider's `list` command.
+///
+/// The command must return JSON with a `worktrees` array (optionally nested in
+/// `data`). Each matching row must include all fields below so Homeboy never
+/// guesses safety state for an externally managed destination.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct WorktreeProviderHandle {
+    pub handle: String,
+    pub path: String,
+    pub branch: String,
+    pub safety: WorktreeProviderHandleSafety,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct WorktreeProviderHandleSafety {
+    pub dirty: bool,
+    pub unpushed: bool,
+    pub primary: bool,
+}
+
+/// Resolve an externally managed worktree handle without creating or adopting
+/// a Homeboy record. This is intentionally a lookup-only boundary.
+pub fn resolve_worktree_provider_handle(handle: &str) -> Result<WorktreeProviderHandle> {
+    resolve_worktree_provider_handle_from_config(handle, &defaults::load_config())
+}
+
+pub fn resolve_worktree_provider_handle_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderHandle> {
+    let mut provider_ids = config
+        .worktree_providers
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    provider_ids.sort();
+    let mut attempted = Vec::new();
+
+    for provider_id in provider_ids {
+        let provider = &config.worktree_providers[&provider_id];
+        if !provider.enabled {
+            continue;
+        }
+        let Some(command) = provider.commands.list.as_ref() else {
+            continue;
+        };
+        attempted.push(provider_id.clone());
+        let worktrees = run_provider_list_command(&provider_id, command)?;
+        if let Some(worktree) = worktrees.into_iter().find(|item| item.handle == handle) {
+            validate_provider_handle(&provider_id, &worktree)?;
+            return Ok(worktree);
+        }
+    }
+
+    let configured = if attempted.is_empty() {
+        "no enabled worktree provider has commands.list configured".to_string()
+    } else {
+        format!("checked provider(s): {}", attempted.join(", "))
+    };
+    Err(Error::validation_invalid_argument(
+        "to_worktree",
+        format!(
+            "worktree handle `{handle}` is not a Homeboy task worktree and was not returned by a configured worktree provider ({configured})"
+        ),
+        Some(handle.to_string()),
+        Some(vec![
+            "Create the destination through its workspace provider, or use an existing Homeboy task worktree handle.".to_string(),
+            "Configure an enabled worktree provider commands.list command that returns typed worktree path, branch, and safety metadata.".to_string(),
+        ]),
+    ))
+}
+
+fn run_provider_list_command(
+    provider_id: &str,
+    command: &[String],
+) -> Result<Vec<WorktreeProviderHandle>> {
+    let (program, args) = command
+        .split_first()
+        .filter(|(program, _)| !program.trim().is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "worktree_providers.commands.list",
+                format!(
+                    "worktree provider `{provider_id}` list command must include an executable"
+                ),
+                Some(provider_id.to_string()),
+                None,
+            )
+        })?;
+    let output = Command::new(program).args(args).output().map_err(|error| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!("worktree provider `{provider_id}` list command could not start: {error}"),
+            Some(provider_id.to_string()),
+            None,
+        )
+    })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` list command failed with exit code {}",
+                output.status.code().unwrap_or(1)
+            ),
+            Some(provider_id.to_string()),
+            Some(vec![String::from_utf8_lossy(&output.stderr)
+                .trim()
+                .to_string()]),
+        ));
+    }
+    let value: Value = serde_json::from_slice(&output.stdout).map_err(|error| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` list command returned invalid JSON: {error}"
+            ),
+            Some(provider_id.to_string()),
+            None,
+        )
+    })?;
+    let worktrees = value.get("worktrees").or_else(|| value.get("data").and_then(|data| data.get("worktrees"))).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!("worktree provider `{provider_id}` list response must include a worktrees array"),
+            Some(provider_id.to_string()),
+            None,
+        )
+    })?;
+    serde_json::from_value::<Vec<WorktreeProviderHandle>>(worktrees.clone()).map_err(|error| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` returned invalid worktree metadata: {error}"
+            ),
+            Some(provider_id.to_string()),
+            None,
+        )
+    })
+}
+
+fn validate_provider_handle(provider_id: &str, worktree: &WorktreeProviderHandle) -> Result<()> {
+    let path = std::path::PathBuf::from(&worktree.path);
+    if !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` resolved `{}` to a missing directory {}",
+                worktree.handle,
+                path.display()
+            ),
+            Some(worktree.handle.clone()),
+            None,
+        ));
+    }
+    if worktree.branch.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` resolved `{}` without a branch",
+                worktree.handle
+            ),
+            Some(worktree.handle.clone()),
+            None,
+        ));
+    }
+    let blocked = [
+        (worktree.safety.dirty, "dirty"),
+        (worktree.safety.unpushed, "unpushed"),
+        (worktree.safety.primary, "primary"),
+    ]
+    .into_iter()
+    .filter_map(|(blocked, name)| blocked.then_some(name))
+    .collect::<Vec<_>>();
+    if !blocked.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!("worktree provider `{provider_id}` marked `{}` as {}; refusing to cook into an unsafe destination", worktree.handle, blocked.join(", ")),
+            Some(worktree.handle.clone()),
+            Some(vec!["Use a clean, pushed, non-primary provider-managed worktree on the intended branch.".to_string()]),
+        ));
+    }
+    if crate::core::git::current_branch(&path).as_deref() != Some(worktree.branch.as_str()) {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!("worktree provider `{provider_id}` branch metadata for `{}` does not match the checkout branch", worktree.handle),
+            Some(worktree.handle.clone()),
+            Some(vec![format!("Provider reported branch `{}`; refresh provider metadata and retry.", worktree.branch)]),
+        ));
+    }
+    Ok(())
 }
 
 pub fn cleanup_worktree_providers(
@@ -650,6 +842,66 @@ mod tests {
     }
 
     #[test]
+    fn resolves_a_clean_provider_managed_handle_without_a_homeboy_record() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let script = fake_list_provider_script(serde_json::json!({
+            "worktrees": [{
+                "handle": "fixture@cook-target",
+                "path": workspace.path(),
+                "branch": "cook-target",
+                "safety": { "dirty": false, "unpushed": false, "primary": false }
+            }]
+        }));
+        let handle = resolve_worktree_provider_handle_from_config(
+            "fixture@cook-target",
+            &config_with_provider(WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                commands: WorktreeProviderCommands {
+                    list: Some(vec![script]),
+                    ..Default::default()
+                },
+            }),
+        )
+        .expect("provider handle resolves");
+
+        assert_eq!(handle.path, workspace.path().display().to_string());
+        assert_eq!(handle.branch, "cook-target");
+    }
+
+    #[test]
+    fn rejects_provider_handles_with_unsafe_safety_metadata() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let script = fake_list_provider_script(serde_json::json!({
+            "worktrees": [{
+                "handle": "fixture@cook-target",
+                "path": workspace.path(),
+                "branch": "cook-target",
+                "safety": { "dirty": true, "unpushed": false, "primary": false }
+            }]
+        }));
+        let err = resolve_worktree_provider_handle_from_config(
+            "fixture@cook-target",
+            &config_with_provider(WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                commands: WorktreeProviderCommands {
+                    list: Some(vec![script]),
+                    ..Default::default()
+                },
+            }),
+        )
+        .expect_err("dirty provider handle must be rejected");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("dirty"));
+    }
+
+    #[test]
     fn provider_apply_captures_phase_progress_and_durable_refs() {
         let script = fake_provider_script_with_refs();
         let output = cleanup_worktree_providers_from_config(
@@ -720,6 +972,24 @@ mod tests {
         .expect("write script");
         make_executable(&script);
         script.to_string_lossy().to_string()
+    }
+
+    fn fake_list_provider_script(output: Value) -> String {
+        let dir = tempfile::tempdir().expect("tempdir").keep();
+        let script = dir.join("provider");
+        fs::write(&script, format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", output))
+            .expect("write script");
+        make_executable(&script);
+        script.to_string_lossy().to_string()
+    }
+
+    fn git_init(path: &std::path::Path, branch: &str) {
+        let output = std::process::Command::new("git")
+            .args(["init", "-b", branch])
+            .current_dir(path)
+            .output()
+            .expect("initialize git repository");
+        assert!(output.status.success());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- resolve `--to-worktree` through configured command worktree providers only when no Homeboy task record exists
- require provider path, branch, and clean/pushed/non-primary safety metadata before Lab pre-dispatch
- preserve provider promotion provenance for finalization targeting

## Testing
- `cargo test lab_source_path_uses_provider_managed_cook_target_without_adopting_it --lib`
- `cargo test resolves_a_clean_provider_managed_handle_without_a_homeboy_record --lib`
- `cargo test rejects_provider_handles_with_unsafe_safety_metadata --lib`
- `cargo test promote_applies_patch_with_fake_workspace_provider --lib`

Closes #7750

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-terra, orchestrated by openai/gpt-5.6-sol
- **Used for:** Implemented and verified provider-managed cook target resolution under Chris Huber direction.