### PR TITLE
fix: rotate stalled agent-task providers

### DIFF
--- a/src/core/agent_task/outcome.rs
+++ b/src/core/agent_task/outcome.rs
@@ -99,6 +99,11 @@ pub enum AgentTaskFailureClassification {
     /// generic rate-limit text). Distinct from transient so callers can
     /// respect retry-after hints and the scheduler can rotate when the
     /// pinned model is throttled.
+    #[serde(
+        alias = "provider_quota",
+        alias = "quota_exceeded",
+        alias = "rate_limit"
+    )]
     RateLimited,
     PolicyDenied,
     CapabilityMissing,

--- a/src/core/agent_task/outcome.rs
+++ b/src/core/agent_task/outcome.rs
@@ -91,6 +91,15 @@ pub enum AgentTaskFailureClassification {
     /// bounded backoff because the same request can succeed on a later attempt.
     Transient,
     Timeout,
+    /// Provider attempt produced no output/progress within the configured
+    /// liveness window. Distinguishes a silent hang from a wall-clock timeout
+    /// so the scheduler can rotate instead of waiting indefinitely.
+    Stalled,
+    /// Provider or backend explicitly signaled a rate limit (HTTP 429 or
+    /// generic rate-limit text). Distinct from transient so callers can
+    /// respect retry-after hints and the scheduler can rotate when the
+    /// pinned model is throttled.
+    RateLimited,
     PolicyDenied,
     CapabilityMissing,
     InvalidInput,

--- a/src/core/agent_task/policy.rs
+++ b/src/core/agent_task/policy.rs
@@ -162,10 +162,6 @@ pub struct AgentTaskLimits {
     /// classified as stalled/rate_limited so rotation can advance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub liveness_timeout_ms: Option<u64>,
-    /// Upper bound for explicit rate-limit backoff hints (e.g. HTTP
-    /// `Retry-After`) when retrying a rate-limited attempt.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_backoff_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_output_bytes: Option<u64>,
 }

--- a/src/core/agent_task/policy.rs
+++ b/src/core/agent_task/policy.rs
@@ -157,6 +157,15 @@ pub struct AgentTaskLimits {
     pub timeout_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_runtime_ms: Option<u64>,
+    /// Per-attempt liveness deadline: if the provider produces no
+    /// stdout/stderr progress within this window, the attempt is killed and
+    /// classified as stalled/rate_limited so rotation can advance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub liveness_timeout_ms: Option<u64>,
+    /// Upper bound for explicit rate-limit backoff hints (e.g. HTTP
+    /// `Retry-After`) when retrying a rate-limited attempt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_backoff_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_output_bytes: Option<u64>,
 }

--- a/src/core/agent_task/tests.rs
+++ b/src/core/agent_task/tests.rs
@@ -48,6 +48,7 @@ fn request_round_trips_generic_agent_task_shape() {
         limits: AgentTaskLimits {
             timeout_ms: Some(300_000),
             max_runtime_ms: Some(240_000),
+            liveness_timeout_ms: None,
             max_output_bytes: Some(1_000_000),
         },
         expected_artifacts: vec!["patch".to_string(), "report".to_string()],

--- a/src/core/agent_task_aggregate.rs
+++ b/src/core/agent_task_aggregate.rs
@@ -324,6 +324,8 @@ fn reconcile_outcome(
             AgentTaskFailureClassification::Provider
                 | AgentTaskFailureClassification::Transient
                 | AgentTaskFailureClassification::Timeout
+                | AgentTaskFailureClassification::Stalled
+                | AgentTaskFailureClassification::RateLimited
         )
     ) {
         return (

--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -436,6 +436,8 @@ fn agent_task_failure_classifications() -> Vec<String> {
         AgentTaskFailureClassification::Provider,
         AgentTaskFailureClassification::Transient,
         AgentTaskFailureClassification::Timeout,
+        AgentTaskFailureClassification::Stalled,
+        AgentTaskFailureClassification::RateLimited,
         AgentTaskFailureClassification::PolicyDenied,
         AgentTaskFailureClassification::CapabilityMissing,
         AgentTaskFailureClassification::InvalidInput,

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -930,6 +930,7 @@ mod tests {
                         },
                     ],
                     max_attempts: Some(2),
+                    ..Default::default()
                 },
             );
             defaults::save_config(&config).expect("save config");

--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -5,6 +5,9 @@ use super::runner_readiness::{
 use super::secrets::{provider_secret_env_plan_with_status, provider_secret_sources};
 use super::*;
 use crate::core::agent_task_executor_evidence::link_latest_executor_evidence;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 const EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 16 * 1024;
 const REDACTED_VALUE: &str = "[redacted]";
@@ -288,37 +291,116 @@ pub(super) fn run_provider_command_once(
         }
     };
 
+    let stdout_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let stderr_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let last_progress: Arc<AtomicU64> = Arc::new(AtomicU64::new(now_unix_ms()));
+
+    let stdout_reader = child.stdout.take().map(|stdout| {
+        spawn_output_reader(
+            stdout,
+            Arc::clone(&stdout_buffer),
+            Arc::clone(&last_progress),
+        )
+    });
+    let stderr_reader = child.stderr.take().map(|stderr| {
+        spawn_output_reader(
+            stderr,
+            Arc::clone(&stderr_buffer),
+            Arc::clone(&last_progress),
+        )
+    });
+
     if let Some(mut stdin) = child.stdin.take() {
-        let _ = std::io::Write::write_all(&mut stdin, &input);
+        let _ = Write::write_all(&mut stdin, &input);
     }
 
-    let output = {
-        let started = Instant::now();
-        loop {
-            match child.try_wait() {
-                Ok(Some(_status)) => break child.wait_with_output(),
-                Ok(None) if started.elapsed() >= process_timeout => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return failure_outcome(
-                        request,
-                        AgentTaskOutcomeStatus::Timeout,
-                        AgentTaskFailureClassification::Timeout,
-                        "agent_task.provider_timeout",
-                        format!(
-                            "provider '{}' exceeded timeout_ms={}",
-                            provider.id, requested_timeout_ms
-                        ),
-                        json!({ "provider": provider.id, "command": command, "timeout_ms": requested_timeout_ms, "process_timeout_ms": process_timeout.as_millis() }),
-                    );
+    let started = Instant::now();
+    let liveness_timeout = request
+        .limits
+        .liveness_timeout_ms
+        .map(Duration::from_millis);
+    let liveness_timed_out = loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => break false,
+            Ok(None) => {
+                let elapsed = started.elapsed();
+                if elapsed >= process_timeout {
+                    break false;
                 }
-                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
-                Err(error) => break Err(error),
+                if let Some(liveness) = liveness_timeout {
+                    let progress_age = Duration::from_millis(
+                        now_unix_ms().saturating_sub(last_progress.load(Ordering::SeqCst)),
+                    );
+                    if progress_age >= liveness {
+                        break true;
+                    }
+                    // Wake up at the earlier of process timeout and liveness deadline.
+                    let remaining_liveness = liveness.saturating_sub(progress_age);
+                    let sleep_for = remaining_liveness
+                        .min(process_timeout - elapsed)
+                        .min(Duration::from_millis(50));
+                    if sleep_for > Duration::ZERO {
+                        std::thread::sleep(sleep_for);
+                    }
+                    continue;
+                }
+                std::thread::sleep(Duration::from_millis(10));
             }
+            Err(_) => break false,
         }
     };
 
-    let Ok(output) = output else {
+    let (status, killed_for_liveness) = if liveness_timed_out {
+        let _ = child.kill();
+        let _ = child.wait();
+        (None, true)
+    } else {
+        // Child exited on its own or hit the wall-clock timeout. If it hit the
+        // wall-clock timeout, try_wait would still return Ok(None) and the loop
+        // above would break only when elapsed >= process_timeout; kill it.
+        if started.elapsed() >= process_timeout {
+            let _ = child.kill();
+        }
+        match child.wait() {
+            Ok(status) => (Some(status), false),
+            Err(_) => (None, false),
+        }
+    };
+
+    if let Some(handle) = stdout_reader {
+        let _ = handle.join();
+    }
+    if let Some(handle) = stderr_reader {
+        let _ = handle.join();
+    }
+
+    let stdout_bytes = stdout_buffer.lock().expect("stdout buffer").clone();
+    let stderr_bytes = stderr_buffer.lock().expect("stderr buffer").clone();
+    let stdout = String::from_utf8_lossy(&stdout_bytes).trim().to_string();
+    let stderr = String::from_utf8_lossy(&stderr_bytes).trim().to_string();
+
+    if killed_for_liveness {
+        let (status, classification, message) =
+            classify_stall_or_rate_limit(&stdout, &stderr, &provider.id, requested_timeout_ms);
+        return failure_outcome(
+            request,
+            status,
+            classification,
+            "agent_task.provider_liveness_timeout",
+            message,
+            json!({
+                "provider": provider.id,
+                "command": command,
+                "timeout_ms": requested_timeout_ms,
+                "process_timeout_ms": process_timeout.as_millis(),
+                "liveness_timeout_ms": request.limits.liveness_timeout_ms,
+                "stdout_bytes": stdout_bytes.len(),
+                "stderr_bytes": stderr_bytes.len(),
+            }),
+        );
+    }
+
+    let Some(status) = status else {
         return failure_outcome(
             request,
             AgentTaskOutcomeStatus::ProviderError,
@@ -329,8 +411,19 @@ pub(super) fn run_provider_command_once(
         );
     };
 
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if started.elapsed() >= process_timeout {
+        return failure_outcome(
+            request,
+            AgentTaskOutcomeStatus::Timeout,
+            AgentTaskFailureClassification::Timeout,
+            "agent_task.provider_timeout",
+            format!(
+                "provider '{}' exceeded timeout_ms={}",
+                provider.id, requested_timeout_ms
+            ),
+            json!({ "provider": provider.id, "command": command, "timeout_ms": requested_timeout_ms, "process_timeout_ms": process_timeout.as_millis() }),
+        );
+    }
     if stdout.is_empty() {
         return failure_outcome(
             request,

--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -8,6 +8,7 @@ use crate::core::agent_task_executor_evidence::link_latest_executor_evidence;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 16 * 1024;
 const REDACTED_VALUE: &str = "[redacted]";
@@ -76,6 +77,10 @@ fn outcome_is_transient(outcome: &AgentTaskOutcome) -> bool {
 /// provider blip. Leaves permanent provider failures untouched so they keep
 /// failing fast.
 fn classify_transient_provider_outcome(outcome: &mut AgentTaskOutcome) {
+    if outcome_text_is_rate_limited(outcome) {
+        outcome.failure_classification = Some(AgentTaskFailureClassification::RateLimited);
+        return;
+    }
     let already_transient =
         outcome.failure_classification == Some(AgentTaskFailureClassification::Transient);
     let provider_failure = matches!(
@@ -96,6 +101,17 @@ fn classify_transient_provider_outcome(outcome: &mut AgentTaskOutcome) {
     if outcome_text_is_transient(outcome) {
         outcome.failure_classification = Some(AgentTaskFailureClassification::Transient);
     }
+}
+
+fn outcome_text_is_rate_limited(outcome: &AgentTaskOutcome) -> bool {
+    outcome
+        .summary
+        .as_deref()
+        .is_some_and(is_rate_limited_provider_error)
+        || outcome.diagnostics.iter().any(|diagnostic| {
+            is_rate_limited_provider_error(&diagnostic.message)
+                || is_rate_limited_provider_error(&diagnostic.data.to_string())
+        })
 }
 
 /// Gather the human-facing text of an outcome (summary, diagnostic messages,
@@ -124,7 +140,7 @@ fn outcome_text_is_transient(outcome: &AgentTaskOutcome) -> bool {
 /// failure. Matching is case-insensitive.
 pub(super) fn is_transient_provider_error(text: &str) -> bool {
     let lowered = text.to_ascii_lowercase();
-    const TRANSIENT_PATTERNS: [&str; 16] = [
+    const TRANSIENT_PATTERNS: [&str; 15] = [
         "curl error 28",
         "operation timed out",
         "timed out",
@@ -140,7 +156,6 @@ pub(super) fn is_transient_provider_error(text: &str) -> bool {
         "service unavailable",
         "bad gateway",
         "gateway timeout",
-        "too many requests",
     ];
 
     if TRANSIENT_PATTERNS
@@ -150,14 +165,31 @@ pub(super) fn is_transient_provider_error(text: &str) -> bool {
         return true;
     }
 
-    // HTTP 5xx and 429 status codes are transient; 4xx (except 429) are not.
+    // HTTP 5xx status codes are transient; rate-limit 429 is distinct so the
+    // scheduler can rotate rather than retry the same throttled provider.
     transient_status_code(&lowered)
 }
 
-/// Detect a transient HTTP status code (5xx or 429) mentioned in error text,
-/// while leaving permanent 4xx codes (400/401/403/404/422) non-retryable.
+pub(super) fn is_rate_limited_provider_error(text: &str) -> bool {
+    let lowered = text.to_ascii_lowercase();
+    [
+        "too many requests",
+        "rate limit",
+        "rate-limit",
+        "provider_quota",
+        "provider quota",
+        "quota exceeded",
+        "exceeded your quota",
+    ]
+    .iter()
+    .any(|pattern| lowered.contains(pattern))
+        || contains_status_code_token(&lowered, "429")
+}
+
+/// Detect a transient HTTP 5xx status code mentioned in error text, while
+/// leaving permanent 4xx codes and rate-limit 429 non-retryable here.
 fn transient_status_code(lowered: &str) -> bool {
-    const TRANSIENT_CODES: [&str; 7] = ["429", "500", "502", "503", "504", "522", "524"];
+    const TRANSIENT_CODES: [&str; 6] = ["500", "502", "503", "504", "522", "524"];
     TRANSIENT_CODES
         .iter()
         .any(|code| contains_status_code_token(lowered, code))
@@ -319,20 +351,20 @@ pub(super) fn run_provider_command_once(
         .limits
         .liveness_timeout_ms
         .map(Duration::from_millis);
-    let liveness_timed_out = loop {
+    let (status, killed_for_liveness, timed_out) = loop {
         match child.try_wait() {
-            Ok(Some(_status)) => break false,
+            Ok(Some(status)) => break (Some(status), false, false),
             Ok(None) => {
                 let elapsed = started.elapsed();
                 if elapsed >= process_timeout {
-                    break false;
+                    break (None, false, true);
                 }
                 if let Some(liveness) = liveness_timeout {
                     let progress_age = Duration::from_millis(
                         now_unix_ms().saturating_sub(last_progress.load(Ordering::SeqCst)),
                     );
                     if progress_age >= liveness {
-                        break true;
+                        break (None, true, false);
                     }
                     // Wake up at the earlier of process timeout and liveness deadline.
                     let remaining_liveness = liveness.saturating_sub(progress_age);
@@ -346,26 +378,14 @@ pub(super) fn run_provider_command_once(
                 }
                 std::thread::sleep(Duration::from_millis(10));
             }
-            Err(_) => break false,
+            Err(_) => break (None, false, false),
         }
     };
 
-    let (status, killed_for_liveness) = if liveness_timed_out {
+    if killed_for_liveness || timed_out {
         let _ = child.kill();
         let _ = child.wait();
-        (None, true)
-    } else {
-        // Child exited on its own or hit the wall-clock timeout. If it hit the
-        // wall-clock timeout, try_wait would still return Ok(None) and the loop
-        // above would break only when elapsed >= process_timeout; kill it.
-        if started.elapsed() >= process_timeout {
-            let _ = child.kill();
-        }
-        match child.wait() {
-            Ok(status) => (Some(status), false),
-            Err(_) => (None, false),
-        }
-    };
+    }
 
     if let Some(handle) = stdout_reader {
         let _ = handle.join();
@@ -400,18 +420,7 @@ pub(super) fn run_provider_command_once(
         );
     }
 
-    let Some(status) = status else {
-        return failure_outcome(
-            request,
-            AgentTaskOutcomeStatus::ProviderError,
-            AgentTaskFailureClassification::Provider,
-            "agent_task.provider_io_failed",
-            "provider command failed while collecting output".to_string(),
-            json!({ "provider": provider.id, "command": command }),
-        );
-    };
-
-    if started.elapsed() >= process_timeout {
+    if timed_out {
         return failure_outcome(
             request,
             AgentTaskOutcomeStatus::Timeout,
@@ -424,6 +433,16 @@ pub(super) fn run_provider_command_once(
             json!({ "provider": provider.id, "command": command, "timeout_ms": requested_timeout_ms, "process_timeout_ms": process_timeout.as_millis() }),
         );
     }
+    let Some(status) = status else {
+        return failure_outcome(
+            request,
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskFailureClassification::Provider,
+            "agent_task.provider_io_failed",
+            "provider command failed while collecting output".to_string(),
+            json!({ "provider": provider.id, "command": command }),
+        );
+    };
     if stdout.is_empty() {
         return failure_outcome(
             request,
@@ -435,7 +454,7 @@ pub(super) fn run_provider_command_once(
                 &provider.id,
                 &provider.backend,
                 &command,
-                &output.status,
+                &status,
                 &stdout,
                 &stderr,
                 &provider_output_redactions(request, provider),
@@ -455,7 +474,7 @@ pub(super) fn run_provider_command_once(
                 request,
                 provider,
                 &command,
-                &output.status,
+                &status,
                 &stdout,
                 &stderr,
             );
@@ -474,13 +493,72 @@ pub(super) fn run_provider_command_once(
                 &provider.id,
                 &provider.backend,
                 &command,
-                &output.status,
+                &status,
                 &stdout,
                 &stderr,
                 &provider_output_redactions(request, provider),
             ),
         ),
     }
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+fn spawn_output_reader<R>(
+    mut reader: R,
+    buffer: Arc<Mutex<Vec<u8>>>,
+    last_progress: Arc<AtomicU64>,
+) -> std::thread::JoinHandle<()>
+where
+    R: Read + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let mut chunk = [0; 4096];
+        loop {
+            let Ok(read) = reader.read(&mut chunk) else {
+                break;
+            };
+            if read == 0 {
+                break;
+            }
+            buffer.lock().expect("output buffer").extend(&chunk[..read]);
+            last_progress.store(now_unix_ms(), Ordering::SeqCst);
+        }
+    })
+}
+
+fn classify_stall_or_rate_limit(
+    stdout: &str,
+    stderr: &str,
+    provider_id: &str,
+    requested_timeout_ms: u64,
+) -> (
+    AgentTaskOutcomeStatus,
+    AgentTaskFailureClassification,
+    String,
+) {
+    let output = format!("{stdout}\n{stderr}");
+    if is_rate_limited_provider_error(&output) {
+        return (
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskFailureClassification::RateLimited,
+            format!("provider '{provider_id}' reported a rate limit before becoming unresponsive"),
+        );
+    }
+    (
+        AgentTaskOutcomeStatus::ProviderError,
+        AgentTaskFailureClassification::Stalled,
+        format!(
+            "provider '{provider_id}' produced no stdout/stderr progress before timeout_ms={requested_timeout_ms}"
+        ),
+    )
 }
 
 fn executor_process_diagnostic_data(

--- a/src/core/agent_task_provider/tests/outcome_tests.rs
+++ b/src/core/agent_task_provider/tests/outcome_tests.rs
@@ -372,6 +372,30 @@ fn failed_outcome_with_run_result(run_result: Value) -> AgentTaskOutcome {
 }
 
 #[test]
+fn typed_provider_quota_normalizes_to_rate_limited_and_preserves_retry_hint() {
+    let outcome: AgentTaskOutcome = serde_json::from_value(json!({
+        "schema": AGENT_TASK_OUTCOME_SCHEMA,
+        "task_id": "quota-task",
+        "status": "provider_error",
+        "failure_classification": "provider_quota",
+        "summary": "quota exceeded",
+        "metadata": { "retry_after_ms": 1500 }
+    }))
+    .expect("OpenCode quota outcome is accepted");
+
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::RateLimited)
+    );
+    assert_eq!(outcome.metadata["retry_after_ms"], json!(1500));
+    assert_eq!(
+        serde_json::to_value(outcome).expect("serialize normalized outcome")
+            ["failure_classification"],
+        json!("rate_limited")
+    );
+}
+
+#[test]
 fn empty_failed_run_result_surfaces_explanatory_diagnostic() {
     // Mirrors the #4105 repro: a failed run-result that is an empty shell.
     let mut outcome = failed_outcome_with_run_result(json!({

--- a/src/core/agent_task_provider/tests/scheduler_tests.rs
+++ b/src/core/agent_task_provider/tests/scheduler_tests.rs
@@ -1,5 +1,8 @@
 use super::common::{request, script};
 use super::*;
+use crate::core::agent_task_scheduler::{
+    AgentTaskAggregateStatus, AgentTaskProviderRotationEntry, AgentTaskProviderRotationPolicy,
+};
 use std::sync::Mutex;
 
 static DEFAULT_TIMEOUT_ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -251,6 +254,66 @@ fn provider_default_timeout_returns_structured_outcome_without_explicit_timeout(
 }
 
 #[test]
+fn stalled_provider_is_killed_and_rotates_to_configured_fallback() {
+    let pid_path = unique_state_path("stalled-child");
+    let _ = fs::remove_file(&pid_path);
+    let pid = pid_path.to_string_lossy().replace('\\', "\\\\");
+    let primary_command = format!(
+        "node {}",
+        script(&format!(
+            "let fs=require('fs'); fs.writeFileSync('{pid}', String(process.pid)); setInterval(() => {{}}, 1000);"
+        ))
+    );
+    let fallback_command = format!(
+        "node {}",
+        script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'fallback completed'}));")
+    );
+    let (request, primary) = request("task-stalled-rotation", primary_command);
+    let mut fallback = primary.clone();
+    fallback.id = "fallback.provider".to_string();
+    fallback.backend = "fallback".to_string();
+    fallback.command = fallback_command;
+    let scheduler =
+        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+            primary, fallback,
+        ]));
+    let mut plan = AgentTaskPlan::new("plan-stalled-rotation", vec![request]);
+    plan.options.rotation = Some(AgentTaskProviderRotationPolicy {
+        entries: vec![AgentTaskProviderRotationEntry {
+            backend: Some("fallback".to_string()),
+            ..AgentTaskProviderRotationEntry::default()
+        }],
+        liveness_timeout_ms: Some(50),
+        ..AgentTaskProviderRotationPolicy::default()
+    });
+
+    let aggregate = scheduler.run(plan);
+
+    assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+    let attempts = aggregate.outcomes[0]
+        .metadata
+        .pointer("/provider_rotation/attempts")
+        .and_then(Value::as_array)
+        .expect("rotation evidence");
+    assert_eq!(attempts.len(), 2);
+    assert_eq!(attempts[0]["failure_classification"], json!("stalled"));
+    assert_eq!(attempts[1]["backend"], json!("fallback"));
+
+    let child_pid = fs::read_to_string(&pid_path).expect("stalled child wrote pid");
+    assert!(
+        !std::process::Command::new("kill")
+            .args(["-0", child_pid.trim()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("check child process")
+            .success(),
+        "liveness timeout must reap the provider child"
+    );
+    let _ = fs::remove_file(&pid_path);
+}
+
+#[test]
 fn provider_can_return_timeout_payload_during_wrapper_grace() {
     let command = format!(
         "node {}",
@@ -453,7 +516,7 @@ fn is_transient_provider_error_classifies_transient_and_permanent_text() {
     assert!(is_transient_provider_error("connection reset by peer"));
     assert!(is_transient_provider_error("503 Service Unavailable"));
     assert!(is_transient_provider_error("HTTP 502 Bad Gateway"));
-    assert!(is_transient_provider_error("429 Too Many Requests"));
+    assert!(!is_transient_provider_error("429 Too Many Requests"));
 
     // Permanent failures must not be treated as transient.
     assert!(!is_transient_provider_error(

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -530,11 +530,6 @@ mod config {
         /// the wall-clock `timeout_ms` / `max_runtime_ms` limits.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub liveness_timeout_ms: Option<u64>,
-        /// Upper bound for explicit rate-limit backoff hints (e.g. HTTP
-        /// `Retry-After`). Prevents a misbehaving backend from delaying the
-        /// rotation chain indefinitely.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub max_backoff_ms: Option<u64>,
     }
 
     impl AgentTaskProviderRotationPolicy {

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -506,13 +506,13 @@ mod config {
     /// Operator-configured provider rotation policy for agent-task execution.
     ///
     /// On a rotation-eligible failure (provider capacity classifications only:
-    /// `provider`, `transient`, `timeout`), the scheduler re-dispatches the same
-    /// task contract with the next entry in the chain until entries are
-    /// exhausted or the attempt bound is reached. Task-level failures
-    /// (`execution_failed`, `policy_denied`, `invalid_input`,
-    /// `capability_missing`) never rotate so a provider swap cannot mask a real
-    /// task failure or policy denial. The policy is pure operator data — core
-    /// hardcodes no provider or model names (#6978).
+    /// `provider`, `transient`, `timeout`, `stalled`, `rate_limited`), the
+    /// scheduler re-dispatches the same task contract with the next entry in the
+    /// chain until entries are exhausted or the attempt bound is reached.
+    /// Task-level failures (`execution_failed`, `policy_denied`,
+    /// `invalid_input`, `capability_missing`) never rotate so a provider swap
+    /// cannot mask a real task failure or policy denial. The policy is pure
+    /// operator data — core hardcodes no provider or model names (#6978).
     #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
     pub struct AgentTaskProviderRotationPolicy {
         /// Ordered rotation chain. The first attempt always uses the task's own
@@ -524,6 +524,17 @@ mod config {
         /// Defaults to `entries.len() + 1` when unset.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub max_attempts: Option<u32>,
+        /// Per-attempt liveness deadline: if the provider process produces no
+        /// stdout/stderr progress within this window, the attempt is killed and
+        /// treated as a rotation-eligible stall. When unset, attempts only obey
+        /// the wall-clock `timeout_ms` / `max_runtime_ms` limits.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub liveness_timeout_ms: Option<u64>,
+        /// Upper bound for explicit rate-limit backoff hints (e.g. HTTP
+        /// `Retry-After`). Prevents a misbehaving backend from delaying the
+        /// rotation chain indefinitely.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub max_backoff_ms: Option<u64>,
     }
 
     impl AgentTaskProviderRotationPolicy {

--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -90,14 +90,20 @@ where
         } else {
             Vec::new()
         };
+        let plan_rotation = plan.options.rotation.clone();
         let mut queued: VecDeque<ScheduledTask> = plan
             .tasks
             .drain(..)
-            .map(|request| ScheduledTask {
-                request,
-                attempt: 1,
-                rotation_index: 0,
-                rotation_attempts: Vec::new(),
+            .map(|mut request| {
+                if let Some(policy) = plan_rotation.as_ref() {
+                    AgentTaskScheduleSupport::apply_rotation_policy_limits(&mut request, policy);
+                }
+                ScheduledTask {
+                    request,
+                    attempt: 1,
+                    rotation_index: 0,
+                    rotation_attempts: Vec::new(),
+                }
             })
             .collect();
         let mut running: Vec<RunningTask> = Vec::new();
@@ -444,7 +450,11 @@ where
                             );
                             let entry = &policy.entries[running_task.rotation_index];
                             let mut request = running_task.request;
-                            AgentTaskScheduleSupport::apply_rotation_entry(&mut request, entry);
+                            AgentTaskScheduleSupport::apply_rotation_entry(
+                                &mut request,
+                                entry,
+                                policy,
+                            );
                             request.parent_plan_id = Some(plan.plan_id.clone());
                             let next_attempt = result.attempt + 1;
                             events.push(event(

--- a/src/core/agent_task_scheduler/scheduling.rs
+++ b/src/core/agent_task_scheduler/scheduling.rs
@@ -1023,10 +1023,10 @@ impl AgentTaskScheduleSupport {
     }
 
     /// Rotation triggers only on provider capacity failures (`provider`,
-    /// `transient`, `timeout` classifications). Task-level failures
-    /// (`execution_failed`, `policy_denied`, `invalid_input`,
-    /// `capability_missing`, `unknown`) never rotate so a provider swap cannot
-    /// mask a real task failure or policy denial (#6978).
+    /// `transient`, `timeout`, `stalled`, `rate_limited` classifications).
+    /// Task-level failures (`execution_failed`, `policy_denied`,
+    /// `invalid_input`, `capability_missing`, `unknown`) never rotate so a
+    /// provider swap cannot mask a real task failure or policy denial (#6978).
     pub(super) fn should_rotate_provider(
         outcome: &AgentTaskOutcome,
         policy: &AgentTaskProviderRotationPolicy,
@@ -1047,6 +1047,8 @@ impl AgentTaskScheduleSupport {
                     AgentTaskFailureClassification::Provider
                         | AgentTaskFailureClassification::Transient
                         | AgentTaskFailureClassification::Timeout
+                        | AgentTaskFailureClassification::Stalled
+                        | AgentTaskFailureClassification::RateLimited
                 )
             )
     }
@@ -1054,10 +1056,13 @@ impl AgentTaskScheduleSupport {
     /// Apply one rotation entry onto the re-dispatched request's executor.
     /// Unset entry fields inherit the failing attempt's values; the entry's
     /// `provider_config` object is merged over the executor config, mirroring
-    /// the dispatch provider-config layering.
+    /// the dispatch provider-config layering. Also copies policy-level
+    /// liveness/backoff limits into the request so the provider runner can
+    /// enforce them per attempt.
     pub(super) fn apply_rotation_entry(
         request: &mut AgentTaskRequest,
         entry: &AgentTaskProviderRotationEntry,
+        policy: &AgentTaskProviderRotationPolicy,
     ) {
         let executor = &mut request.executor;
         if let Some(backend) = &entry.backend {
@@ -1098,6 +1103,22 @@ impl AgentTaskScheduleSupport {
             {
                 selection.ai_provider_id = Some(provider.to_string());
             }
+        }
+        Self::apply_rotation_policy_limits(request, policy);
+    }
+
+    /// Copy policy-level liveness/backoff limits into the request when the
+    /// request does not already set them. Keeps per-task or per-entry
+    /// overrides authoritative.
+    pub(super) fn apply_rotation_policy_limits(
+        request: &mut AgentTaskRequest,
+        policy: &AgentTaskProviderRotationPolicy,
+    ) {
+        if request.limits.liveness_timeout_ms.is_none() {
+            request.limits.liveness_timeout_ms = policy.liveness_timeout_ms;
+        }
+        if request.limits.max_backoff_ms.is_none() {
+            request.limits.max_backoff_ms = policy.max_backoff_ms;
         }
     }
 

--- a/src/core/agent_task_scheduler/scheduling.rs
+++ b/src/core/agent_task_scheduler/scheduling.rs
@@ -1056,9 +1056,9 @@ impl AgentTaskScheduleSupport {
     /// Apply one rotation entry onto the re-dispatched request's executor.
     /// Unset entry fields inherit the failing attempt's values; the entry's
     /// `provider_config` object is merged over the executor config, mirroring
-    /// the dispatch provider-config layering. Also copies policy-level
-    /// liveness/backoff limits into the request so the provider runner can
-    /// enforce them per attempt.
+    /// the dispatch provider-config layering. Also copies the policy-level
+    /// liveness limit into the request so the provider runner can enforce it
+    /// per attempt.
     pub(super) fn apply_rotation_entry(
         request: &mut AgentTaskRequest,
         entry: &AgentTaskProviderRotationEntry,
@@ -1107,18 +1107,14 @@ impl AgentTaskScheduleSupport {
         Self::apply_rotation_policy_limits(request, policy);
     }
 
-    /// Copy policy-level liveness/backoff limits into the request when the
-    /// request does not already set them. Keeps per-task or per-entry
-    /// overrides authoritative.
+    /// Copy the policy-level liveness limit into the request when the request
+    /// does not already set it. Keeps a per-task override authoritative.
     pub(super) fn apply_rotation_policy_limits(
         request: &mut AgentTaskRequest,
         policy: &AgentTaskProviderRotationPolicy,
     ) {
         if request.limits.liveness_timeout_ms.is_none() {
             request.limits.liveness_timeout_ms = policy.liveness_timeout_ms;
-        }
-        if request.limits.max_backoff_ms.is_none() {
-            request.limits.max_backoff_ms = policy.max_backoff_ms;
         }
     }
 

--- a/src/core/agent_task_scheduler/tests/scheduling_tests.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests.rs
@@ -341,6 +341,7 @@ mod provider_rotation_tests {
         AgentTaskProviderRotationPolicy {
             entries,
             max_attempts: None,
+            ..AgentTaskProviderRotationPolicy::default()
         }
     }
 
@@ -429,10 +430,30 @@ mod provider_rotation_tests {
     }
 
     #[test]
+    fn primary_success_does_not_rotate() {
+        let executor = RotationScriptedExecutor::new(vec![success()]);
+        let calls = Arc::clone(&executor.calls);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(aggregate.outcomes[0]
+            .metadata
+            .pointer("/provider_rotation")
+            .is_none());
+    }
+
+    #[test]
     fn rotates_on_transient_and_timeout_classifications() {
         for classification in [
             AgentTaskFailureClassification::Transient,
             AgentTaskFailureClassification::Timeout,
+            AgentTaskFailureClassification::Stalled,
+            AgentTaskFailureClassification::RateLimited,
         ] {
             let status = if classification == AgentTaskFailureClassification::Timeout {
                 AgentTaskOutcomeStatus::Timeout
@@ -546,6 +567,7 @@ mod provider_rotation_tests {
                 entry("fallback-backend-c"),
             ],
             max_attempts: Some(2),
+            ..AgentTaskProviderRotationPolicy::default()
         });
 
         let aggregate = scheduler.run(plan);


### PR DESCRIPTION
Closes #7743

## Summary
- normalize OpenCode `provider_quota` and rate-limit failures as rotation-eligible `rate_limited` outcomes while preserving executor retry metadata
- enforce generic per-attempt stdout/stderr liveness deadlines with child-process cleanup and fallback rotation evidence
- cover quota/transient/stall rotation, primary success, exhaustion evidence, and provider-child cleanup

## Verification
- `cargo fmt`
- `cargo check`
- `cargo test core::agent_task_provider::tests::scheduler_tests -- --test-threads=1`
- `cargo test core::agent_task_provider::tests::outcome_tests -- --test-threads=1`
- `cargo test core::agent_task_scheduler::tests::scheduling_tests -- --test-threads=1`
- `cargo test` (fails on unrelated existing workspace/environment tests; focused affected suites pass)

## AI Disclosure
Implemented with OpenCode using `openai/gpt-5.6-terra`.