### PR TITLE
Centralize review quality routing

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1287,14 +1287,7 @@ impl Commands {
             Commands::Bench(args) => extension_ids.extend(args.lab_required_extension_ids()?),
             Commands::Fuzz(args) => extension_ids.extend(args.lab_required_extension_ids()?),
             Commands::Review(args) => {
-                extension_ids.extend(args.extension_override.extensions.clone());
-                if let Some(overrides) = args
-                    .command
-                    .as_ref()
-                    .and_then(|command| command.extension_override_ids())
-                {
-                    extension_ids.extend(overrides.iter().cloned());
-                }
+                extension_ids.extend(args.effective_extension_override_ids().iter().cloned());
                 extension_ids.extend(review_lab_extension_ids(args)?);
             }
             Commands::AgentTask(args) => extension_ids.extend(agent_task_lab_extension_ids(args)?),
@@ -1327,11 +1320,6 @@ mod extension_ids {
     pub(crate) fn review_lab_extension_ids(
         args: &crate::commands::review::ReviewArgs,
     ) -> crate::core::Result<Vec<String>> {
-        let extension_overrides = args
-            .command
-            .as_ref()
-            .and_then(|command| command.extension_override_ids())
-            .unwrap_or(&args.extension_override.extensions);
         let resolve_for = |capability: Option<ExtensionCapability>| {
             let component_args = args.effective_component_args();
             execution_context::resolve(&ResolveOptions {
@@ -1341,7 +1329,7 @@ mod extension_ids {
                 settings_overrides: Vec::new(),
                 settings_profile_json_overrides: Vec::new(),
                 settings_json_overrides: Vec::new(),
-                extension_overrides: extension_overrides.to_vec(),
+                extension_overrides: args.effective_extension_override_ids().to_vec(),
             })
         };
 

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1288,17 +1288,12 @@ impl Commands {
             Commands::Fuzz(args) => extension_ids.extend(args.lab_required_extension_ids()?),
             Commands::Review(args) => {
                 extension_ids.extend(args.extension_override.extensions.clone());
-                match args.command.as_ref() {
-                    Some(crate::commands::review::ReviewCommand::Audit(audit_args)) => {
-                        extension_ids.extend(audit_args.audit.extension_override.extensions.clone())
-                    }
-                    Some(crate::commands::review::ReviewCommand::Lint(lint_args)) => {
-                        extension_ids.extend(lint_args.extension_override.extensions.clone())
-                    }
-                    Some(crate::commands::review::ReviewCommand::Test(test_args)) => {
-                        extension_ids.extend(test_args.extension_override.extensions.clone())
-                    }
-                    _ => {}
+                if let Some(overrides) = args
+                    .command
+                    .as_ref()
+                    .and_then(|command| command.extension_override_ids())
+                {
+                    extension_ids.extend(overrides.iter().cloned());
                 }
                 extension_ids.extend(review_lab_extension_ids(args)?);
             }
@@ -1332,18 +1327,11 @@ mod extension_ids {
     pub(crate) fn review_lab_extension_ids(
         args: &crate::commands::review::ReviewArgs,
     ) -> crate::core::Result<Vec<String>> {
-        let extension_overrides = match args.command.as_ref() {
-            Some(crate::commands::review::ReviewCommand::Audit(audit_args)) => {
-                audit_args.audit.extension_override.extensions.clone()
-            }
-            Some(crate::commands::review::ReviewCommand::Lint(lint_args)) => {
-                lint_args.extension_override.extensions.clone()
-            }
-            Some(crate::commands::review::ReviewCommand::Test(test_args)) => {
-                test_args.extension_override.extensions.clone()
-            }
-            _ => args.extension_override.extensions.clone(),
-        };
+        let extension_overrides = args
+            .command
+            .as_ref()
+            .and_then(|command| command.extension_override_ids())
+            .unwrap_or(&args.extension_override.extensions);
         let resolve_for = |capability: Option<ExtensionCapability>| {
             let component_args = args.effective_component_args();
             execution_context::resolve(&ResolveOptions {
@@ -1353,7 +1341,7 @@ mod extension_ids {
                 settings_overrides: Vec::new(),
                 settings_profile_json_overrides: Vec::new(),
                 settings_json_overrides: Vec::new(),
-                extension_overrides: extension_overrides.clone(),
+                extension_overrides: extension_overrides.to_vec(),
             })
         };
 

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1303,6 +1303,7 @@ mod tests {
 
     #[test]
     fn rig_up_dry_run_with_runner_emits_runner_exec_plan() {
+        let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
         crate::test_support::with_isolated_home(|home| {
             runners::create(
                 r#"{"id":"homeboy-lab","kind":"local","homeboy_path":"/runner/bin/homeboy-patched"}"#,

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -311,19 +311,21 @@ fn inject_lab_changed_files(
     command: &Commands,
     normalized_args: &[String],
 ) -> homeboy::core::Result<Option<Vec<String>>> {
-    let Some((component_id, path_override, changed_since, changed_only)) =
-        changed_scope_request(command)
-    else {
+    let Commands::Review(args) = command else {
+        return Ok(None);
+    };
+    let Some(component_args) = args.lab_changed_scope_component_args() else {
         return Ok(None);
     };
     if has_lab_changed_files_json(normalized_args) {
         return Ok(None);
     }
-    if changed_since.is_some() || !changed_only {
-        return Ok(None);
-    }
 
-    let source_path = resolve_changed_scope_source_path(component_id, path_override)?;
+    let target = component::resolve_target(TargetSpec::new(
+        component_args.component.as_deref(),
+        component_args.path.as_deref(),
+    ))?;
+    let source_path = target.source_path.to_string_lossy();
     let changed_files = git::get_dirty_files(&source_path)?;
     let payload = serde_json::to_string(&changed_files).map_err(|error| {
         homeboy::core::Error::internal_unexpected(format!(
@@ -343,55 +345,10 @@ fn inject_lab_changed_files(
     Ok(Some(rewritten))
 }
 
-type ChangedScopeRequest<'a> = (
-    Option<&'a String>,
-    Option<&'a String>,
-    Option<&'a str>,
-    bool,
-);
-
-fn changed_scope_request(command: &Commands) -> Option<ChangedScopeRequest<'_>> {
-    match command {
-        Commands::Review(args) => match &args.command {
-            Some(crate::commands::review::ReviewCommand::Lint(lint_args)) => Some((
-                lint_args.comp.component.as_ref(),
-                lint_args.comp.path.as_ref(),
-                lint_args.changed_since.as_deref(),
-                lint_args.changed_only,
-            )),
-            Some(crate::commands::review::ReviewCommand::Test(test_args)) => Some((
-                test_args.comp.component.as_ref(),
-                test_args.comp.path.as_ref(),
-                test_args.changed_since.as_deref(),
-                false,
-            )),
-            None => Some((
-                args.comp.component.as_ref(),
-                args.comp.path.as_ref(),
-                args.changed_since.as_deref(),
-                args.changed_only,
-            )),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
 fn has_lab_changed_files_json(args: &[String]) -> bool {
     args.iter().any(|arg| {
         arg == "--lab-changed-files-json" || arg.starts_with("--lab-changed-files-json=")
     })
-}
-
-fn resolve_changed_scope_source_path(
-    component_id: Option<&String>,
-    path_override: Option<&String>,
-) -> homeboy::core::Result<String> {
-    let target = component::resolve_target(TargetSpec::new(
-        component_id.map(String::as_str),
-        path_override.map(String::as_str),
-    ))?;
-    Ok(target.source_path.to_string_lossy().to_string())
 }
 
 /// Build the Lab dispatch observer for the parsed command. Only `trace`
@@ -947,21 +904,13 @@ fn rewrite_ad_hoc_lab_workspace_to_path(
         return None;
     }
 
-    let needs_path = match command {
-        Commands::Review(args) => match &args.command {
-            Some(crate::commands::review::ReviewCommand::Audit(audit_args)) => {
-                audit_args.audit.comp.component.is_none() && audit_args.audit.comp.path.is_none()
-            }
-            Some(crate::commands::review::ReviewCommand::Lint(lint_args)) => {
-                lint_args.comp.component.is_none() && lint_args.comp.path.is_none()
-            }
-            Some(crate::commands::review::ReviewCommand::Test(test_args)) => {
-                test_args.comp.component.is_none() && test_args.comp.path.is_none()
-            }
-            _ => false,
-        },
-        _ => false,
-    };
+    let needs_path = matches!(
+        command,
+        Commands::Review(args)
+            if args.nested_component_args().is_some_and(|component| {
+                component.component.is_none() && component.path.is_none()
+            })
+    );
     if !needs_path {
         return None;
     }
@@ -1251,7 +1200,6 @@ mod tests {
             panic!("expected review command");
         };
 
-        assert_eq!(args.lab_label(), "review lint");
         assert_eq!(
             args.effective_component_args().component.as_deref(),
             Some("data-machine")
@@ -2803,17 +2751,6 @@ mod tests {
         ];
 
         assert!(rewrite_component_target_to_path(&cli.command, &normalized).is_none());
-    }
-
-    #[test]
-    fn changed_scope_source_path_uses_shared_target_resolution() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().to_string_lossy().to_string();
-
-        let source_path = resolve_changed_scope_source_path(None, Some(&path))
-            .expect("path override should resolve through TargetSpec");
-
-        assert_eq!(source_path, path);
     }
 
     #[test]

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -112,12 +112,14 @@ pub enum ReviewCommand {
 }
 
 impl ReviewCommand {
-    pub(crate) fn extension_override_ids(&self) -> Option<&[String]> {
+    fn lab_label(&self) -> &'static str {
         match self {
-            Self::Audit(args) => Some(&args.audit.extension_override.extensions),
-            Self::Lint(args) => Some(&args.extension_override.extensions),
-            Self::Test(args) => Some(&args.extension_override.extensions),
-            Self::AuditBaseline(_) | Self::Build(_) | Self::Ci(_) => None,
+            Self::Audit(_) => "review audit",
+            Self::AuditBaseline(_) => "review audit-baseline",
+            Self::Lint(_) => "review lint",
+            Self::Test(_) => "review test",
+            Self::Build(_) => "review build",
+            Self::Ci(_) => "review ci",
         }
     }
 }
@@ -131,6 +133,38 @@ pub struct ReviewAuditArgs {
 const REVIEW_SCOPED_LAB_UNSUPPORTED_REASON: &str = "Scoped review runs stay local because their audit, lint, and test substeps use changed-file scopes that are not represented consistently in the current Lab portability contract yet.";
 
 impl ReviewArgs {
+    pub(crate) fn nested_component_args(&self) -> Option<&PositionalComponentArgs> {
+        match self.command.as_ref()? {
+            ReviewCommand::Audit(args) => Some(&args.audit.comp),
+            ReviewCommand::Lint(args) => Some(&args.comp),
+            ReviewCommand::Test(args) => Some(&args.comp),
+            ReviewCommand::AuditBaseline(_) | ReviewCommand::Build(_) | ReviewCommand::Ci(_) => {
+                None
+            }
+        }
+    }
+
+    pub(crate) fn effective_extension_override_ids(&self) -> &[String] {
+        match self.command.as_ref() {
+            Some(ReviewCommand::Audit(args)) => &args.audit.extension_override.extensions,
+            Some(ReviewCommand::Lint(args)) => &args.extension_override.extensions,
+            Some(ReviewCommand::Test(args)) => &args.extension_override.extensions,
+            _ => &self.extension_override.extensions,
+        }
+    }
+
+    pub(crate) fn lab_changed_scope_component_args(&self) -> Option<&PositionalComponentArgs> {
+        match self.command.as_ref() {
+            Some(ReviewCommand::Lint(args))
+                if args.changed_only && args.changed_since.is_none() =>
+            {
+                Some(&args.comp)
+            }
+            None if self.changed_only && self.changed_since.is_none() => Some(&self.comp),
+            _ => None,
+        }
+    }
+
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
         if let Some(command) = &self.command {
             return match command {
@@ -147,7 +181,7 @@ impl ReviewArgs {
                 ReviewCommand::AuditBaseline(_)
                 | ReviewCommand::Build(_)
                 | ReviewCommand::Ci(_) => Some(LabCommandContract::local_only(
-                    self.lab_label(),
+                    command.lab_label(),
                     "this nested review subcommand has no portable Lab contract",
                 )),
             };
@@ -162,25 +196,8 @@ impl ReviewArgs {
         }
     }
 
-    pub(crate) fn lab_label(&self) -> &'static str {
-        match self.command.as_ref() {
-            Some(ReviewCommand::Audit(_)) => "review audit",
-            Some(ReviewCommand::Lint(_)) => "review lint",
-            Some(ReviewCommand::Test(_)) => "review test",
-            Some(ReviewCommand::Build(_)) => "review build",
-            Some(ReviewCommand::Ci(_)) => "review ci",
-            Some(ReviewCommand::AuditBaseline(_)) => "review audit-baseline",
-            None => REVIEW_LAB_LABEL,
-        }
-    }
-
-    pub(crate) fn effective_component_args(&self) -> PositionalComponentArgs {
-        match self.command.as_ref() {
-            Some(ReviewCommand::Audit(args)) => args.audit.comp.clone(),
-            Some(ReviewCommand::Lint(args)) => args.comp.clone(),
-            Some(ReviewCommand::Test(args)) => args.comp.clone(),
-            _ => self.comp.clone(),
-        }
+    pub(crate) fn effective_component_args(&self) -> &PositionalComponentArgs {
+        self.nested_component_args().unwrap_or(&self.comp)
     }
 }
 
@@ -633,7 +650,7 @@ fn build_audit_args(
     review_context: &ReviewExecutionContext,
 ) -> audit::AuditArgs {
     audit::AuditArgs {
-        comp: args.effective_component_args(),
+        comp: args.effective_component_args().clone(),
         extension_override: args.extension_override.clone(),
         conventions: false,
         only: Vec::new(),
@@ -661,7 +678,7 @@ fn selected_audit_profile(args: &ReviewArgs, review_context: &ReviewExecutionCon
 
 fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -> lint::LintArgs {
     lint::LintArgs {
-        comp: args.effective_component_args(),
+        comp: args.effective_component_args().clone(),
         summary: args.summary,
         file: None,
         glob: None,
@@ -686,7 +703,7 @@ fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -
 
 fn build_test_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -> test::TestArgs {
     test::TestArgs {
-        comp: args.effective_component_args(),
+        comp: args.effective_component_args().clone(),
         extension_override: args.extension_override.clone(),
         skip_lint: true,
         coverage: false,

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -111,6 +111,17 @@ pub enum ReviewCommand {
     Ci(ci::CiArgs),
 }
 
+impl ReviewCommand {
+    pub(crate) fn extension_override_ids(&self) -> Option<&[String]> {
+        match self {
+            Self::Audit(args) => Some(&args.audit.extension_override.extensions),
+            Self::Lint(args) => Some(&args.extension_override.extensions),
+            Self::Test(args) => Some(&args.extension_override.extensions),
+            Self::AuditBaseline(_) | Self::Build(_) | Self::Ci(_) => None,
+        }
+    }
+}
+
 #[derive(Args)]
 pub struct ReviewAuditArgs {
     #[command(flatten)]


### PR DESCRIPTION
## Summary
- centralize nested review component, extension, changed-scope, and Lab-label selection in review command plumbing
- remove the route-owned `ChangedScopeRequest` adapter and repeated nested command matching
- preserve the complete public CLI and output contracts
- isolate the rig dry-run route test from Homeboy's process-global Lab subprocess sentinel

## Impact
- 3 files changed
- 70 insertions, 128 deletions
- **58 net lines removed**
- no public behavior or compatibility changes

## Testing
- full route suite serially: 70 passed
- review tests: 20 passed
- Lab contract tests: 5 passed
- focused nested-review, changed-scope, workspace rewrite, and component rewrite tests passed
- `cargo check --all-targets`
- `git diff --check origin/main...HEAD`

Repository-wide `cargo fmt --check` still reports the existing mismatch in `src/core/deploy/safety_and_artifact.rs`; all touched files pass formatting.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Architecture analysis, refactoring, root-cause diagnosis, tests, and verification; Chris remains responsible for the submitted change.