### PR TITLE
Avoid repeated inventory scans in file path resolution

### DIFF
--- a/src/core/project/path_resolution.rs
+++ b/src/core/project/path_resolution.rs
@@ -56,6 +56,10 @@ fn resolve_with_path_roots(
     base_path_value: &str,
     path: &str,
 ) -> crate::core::error::Result<Option<String>> {
+    if project.path_roots.is_empty() {
+        return Ok(None);
+    }
+
     for rule in project_remote_path_root_rules(project) {
         if !path_matches_prefix(path, &rule.path_prefix) {
             continue;
@@ -97,11 +101,19 @@ fn project_remote_path_root_rules(project: &Project) -> Vec<RemotePathRootRule> 
         extension_ids.extend(extensions.keys().cloned());
     }
 
-    // Attached components only carry IDs at the project layer; load each to read
-    // the extensions declared in its repo-owned metadata. Failures are
-    // non-fatal — a missing component must not break file path resolution.
+    // Build the inventory once. component::load() rebuilds the full inventory,
+    // so calling it for every attachment makes file operations scale as
+    // attachments × workspace size.
+    let components: HashMap<_, _> = component::list()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|component| (component.id.clone(), component))
+        .collect();
+
+    // Attached components only carry IDs at the project layer. Missing
+    // components remain non-fatal for ad-hoc file path resolution.
     for attachment in &project.components {
-        if let Ok(loaded) = component::load(&attachment.id) {
+        if let Some(loaded) = components.get(&attachment.id) {
             if let Some(extensions) = &loaded.extensions {
                 extension_ids.extend(extensions.keys().cloned());
             }


### PR DESCRIPTION
## Summary
- skip extension inventory entirely when a project has no configured path roots
- build component inventory once when managed path-root resolution is required
- preserve missing-component and unmanaged-path fallback behavior

Fixes #7761.

## Root cause
Relative file paths ran `component::load()` once per project attachment. Each call rebuilt the complete component inventory. On the WP Build project, 10 attachments multiplied a large worktree inventory scan until file operations appeared hung. Projects without `path_roots` paid this cost even though managed-root resolution could not apply.

## Live verification
Using the patched binary against `wp-build-runtime`:
- before: relative `file read` exceeded 60s
- after one-inventory fix: 19.9s
- after empty-path-roots fast path: 3.66s, including SSH
- missing file returns a classified `READ_FAILED` error instead of hanging

## Tests
- `cargo test path_resolution_test` (7 passed)
- `cargo test file_read_json_includes_size_metadata` (passed)
- `cargo build --bin homeboy`
- `cargo fmt --check` remains blocked by an unrelated pre-existing formatting diff in `src/core/deploy/safety_and_artifact.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause investigation, implementation, regression tests, and live verification