### PR TITLE
Reconcile detached runner terminal state

### DIFF
--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -169,6 +169,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
             record = reconciled;
         }
     }
+    reconcile_runner_job_terminal_state(&mut record);
     record.annotate_stale_running();
     if requested_run_id != record.run_id {
         if let Ok(index) = store::read_cook_index(&requested_run_id) {
@@ -181,6 +182,66 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
         }
     }
     Ok(record)
+}
+
+fn reconcile_runner_job_terminal_state(record: &mut AgentTaskRunRecord) {
+    if record.state != AgentTaskRunState::Running {
+        return;
+    }
+    let (Some(runner_id), Some(job_id)) = (
+        record.runner_id().map(str::to_string),
+        record.runner_job_id().map(str::to_string),
+    ) else {
+        return;
+    };
+    let Ok(snapshot) = crate::core::runners::runner_job_log_snapshot(&runner_id, &job_id) else {
+        return;
+    };
+    if !matches!(
+        snapshot.job.status,
+        crate::core::api_jobs::JobStatus::Succeeded
+            | crate::core::api_jobs::JobStatus::Failed
+            | crate::core::api_jobs::JobStatus::Cancelled
+    ) {
+        return;
+    }
+    apply_runner_job_terminal_state(record, snapshot.job.status, &snapshot.events);
+    let _ = store::write_record(record);
+}
+
+pub(crate) fn apply_runner_job_terminal_state(
+    record: &mut AgentTaskRunRecord,
+    status: crate::core::api_jobs::JobStatus,
+    events: &[crate::core::api_jobs::JobEvent],
+) {
+    let (run_state, task_state) = match status {
+        crate::core::api_jobs::JobStatus::Succeeded => {
+            (AgentTaskRunState::Succeeded, AgentTaskState::Succeeded)
+        }
+        crate::core::api_jobs::JobStatus::Cancelled => {
+            (AgentTaskRunState::Cancelled, AgentTaskState::Cancelled)
+        }
+        crate::core::api_jobs::JobStatus::Failed => {
+            (AgentTaskRunState::Failed, AgentTaskState::Failed)
+        }
+        _ => return,
+    };
+    record.updated_at = Some(now_timestamp());
+    set_run_state(record, run_state);
+    for task in &mut record.tasks {
+        if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
+            task.state = task_state;
+        }
+    }
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("runner_job_status".to_string(), json!(status));
+    metadata.insert("runner_job_events".to_string(), json!(events));
+    metadata.insert(
+        "retryable".to_string(),
+        json!(run_state != AgentTaskRunState::Succeeded),
+    );
+    metadata.remove("stale_running");
+    metadata.remove("stale_running_reason");
 }
 
 pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRunStatus> {

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -100,6 +100,37 @@ fn detached_lab_handoff_persists_inspectable_running_record() {
 }
 
 #[test]
+fn detached_runner_failure_transitions_parent_and_task_terminal() {
+    let plan = test_plan();
+    let mut record = AgentTaskRunRecord {
+        schema: schemas::RUN.to_string(),
+        run_id: "detached-run".to_string(),
+        plan_id: plan.plan_id.clone(),
+        state: AgentTaskRunState::Running,
+        submitted_at: now_timestamp(),
+        updated_at: None,
+        plan_path: "plan.json".to_string(),
+        aggregate_path: None,
+        totals: None,
+        tasks: plan.tasks.iter().map(queued_task).collect(),
+        artifact_refs: Vec::new(),
+        provider_handles: Vec::new(),
+        latest_executor_evidence: None,
+        lifecycle: lifecycle_for_submitted_plan(&plan),
+        metadata: json!({ "runner_id": "homeboy-lab", "runner_job_id": "job-123" }),
+    };
+    record.tasks[0].state = AgentTaskState::Running;
+
+    apply_runner_job_terminal_state(&mut record, crate::core::api_jobs::JobStatus::Failed, &[]);
+
+    assert_eq!(record.state, AgentTaskRunState::Failed);
+    assert_eq!(record.tasks[0].state, AgentTaskState::Failed);
+    assert_eq!(record.lifecycle.execution.state, RunExecutionState::Failed);
+    assert_eq!(record.metadata["runner_job_status"], "failed");
+    assert_eq!(record.metadata["retryable"], true);
+}
+
+#[test]
 fn detached_lab_handoff_upgrades_existing_observation_record() {
     with_isolated_home(|_| {
         let store = crate::core::observation::ObservationStore::open_initialized()


### PR DESCRIPTION
## Summary
- query authoritative runner-job evidence when reading a detached running agent task
- transition parent lifecycle and active tasks to the runner terminal state
- persist terminal job events, retryability, and synchronized lifecycle timestamps

Closes #7760.

## Verification
- `cargo test core::agent_task_lifecycle:: -- --nocapture` (38 passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Root-cause analysis, implementation, regression coverage, and verification drafted in collaboration with Chris Huber.