### PR TITLE
Centralize command registry routing

### DIFF
--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -215,42 +215,13 @@ impl Commands {
             ),
             Commands::Bench(args) => args.output_descriptor(output_file_mode),
             Commands::Fuzz(args) => args.output_descriptor(output_file_mode),
-            Commands::Refactor(_) => registered_json_envelope_descriptor(self, output_file_mode),
-            Commands::Release(_) => registered_json_envelope_descriptor(self, output_file_mode),
             Commands::Runner(args) if runner::is_compact_exec_stdout(args) => {
                 raw_ops_descriptor(CommandRawOutputMode::PlainText, output_file_mode)
             }
-            Commands::Activity(_)
-            | Commands::AgentTask(_)
-            | Commands::Project(_)
-            | Commands::Component(_)
-            | Commands::Config(_)
-            | Commands::Extension(_)
-            | Commands::Cleanup(_)
-            | Commands::Report(_)
-            | Commands::Runner(_)
-            | Commands::Runtime(_)
-            | Commands::Worktree(_)
-            | Commands::Tunnel(_)
-            | Commands::Stack(_) => registered_json_envelope_descriptor(self, output_file_mode),
-            Commands::Rig(_) => registered_json_envelope_descriptor(self, output_file_mode),
-            Commands::Status(_)
-            | Commands::Server(_)
-            | Commands::Db(_)
-            | Commands::Deps(_)
-            | Commands::File(_)
-            | Commands::Logs(_)
-            | Commands::Deploy(_)
-            | Commands::Daemon(_)
-            | Commands::Git(_)
-            | Commands::SelfCmd(_)
-            | Commands::Api(_)
-            | Commands::Upgrade(_)
-            | Commands::Ssh(_) => registered_json_envelope_descriptor(self, output_file_mode),
             Commands::Fleet(_) | Commands::Observe(_) | Commands::Contract(_) => {
                 unreachable!("adapter-backed command descriptor returned before legacy routing")
             }
-            Commands::Triage(_) => registered_json_envelope_descriptor(self, output_file_mode),
+            _ => registered_json_envelope_descriptor(self, output_file_mode),
         }
     }
 
@@ -319,4 +290,30 @@ fn registered_json_envelope_descriptor(
     registered_command(command.top_level_name())
         .expect("top-level command should be registered")
         .output_descriptor(output_file_mode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli_surface::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn representative_default_output_descriptors_come_from_command_registry() {
+        for spec in crate::command_contract::COMMAND_SPECS {
+            let Some(argv) = spec.representative_argv else {
+                continue;
+            };
+            let cli = Cli::try_parse_from(argv)
+                .unwrap_or_else(|error| panic!("failed to parse `{}`: {error}", spec.name));
+
+            assert_eq!(cli.command.top_level_name(), spec.name);
+            assert_eq!(
+                cli.command.output_descriptor(false),
+                spec.output_descriptor(CommandOutputFileMode::None),
+                "default output descriptor drifted for `{}`",
+                spec.name
+            );
+        }
+    }
 }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -348,7 +348,6 @@ fn unsupported_raw_command(message: &'static str) -> JsonRun {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::command_contract::CommandDispatchFamily;
     use crate::commands::agent_task::{
         AgentTaskArgs, AgentTaskCommand, AgentTaskControllerArgs, AgentTaskControllerCommand,
         AgentTaskControllerDispatchArgs, AgentTaskControllerRunFromSpecArgs, StatusArgs,
@@ -527,15 +526,22 @@ mod tests {
 
     #[test]
     fn json_dispatch_family_comes_from_command_registry() {
-        assert_eq!(
-            dispatch_family(&Commands::Contract(
-                crate::commands::contract::ContractArgs {
-                    command: crate::commands::contract::ContractCommand::Manifest(
-                        crate::commands::manifest::ManifestArgs {},
-                    ),
-                }
-            )),
-            CommandDispatchFamily::Workspace
-        );
+        use clap::Parser;
+
+        for spec in crate::command_contract::COMMAND_SPECS {
+            let Some(argv) = spec.representative_argv else {
+                continue;
+            };
+            let cli = crate::cli_surface::Cli::try_parse_from(argv)
+                .unwrap_or_else(|error| panic!("failed to parse `{}`: {error}", spec.name));
+
+            assert_eq!(cli.command.top_level_name(), spec.name);
+            assert_eq!(
+                dispatch_family(&cli.command),
+                spec.dispatch_family(),
+                "JSON dispatch family drifted for `{}`",
+                spec.name
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make `COMMAND_SPECS` the default owner for command output descriptors and JSON dispatch families
- remove 30 repeated fallback command variants from `Commands::output_descriptor`
- retain explicit handling only for specialized raw output, argument-sensitive commands, and adapter-backed invariants
- expand parity coverage from one hand-built command to registry-provided representative command fixtures

## Impact
- production code: 1 insertion, 30 deletions, **29 net lines removed**
- tests: expanded registry/output/dispatch parity coverage
- public CLI, safety, Lab behavior, output schemas, and docs remain unchanged

## Testing
- `cargo test --lib command_contract::output::tests`
- `cargo test --lib commands::json_output::tests`
- `cargo check --all-targets`
- changed-file `rustfmt --check`
- `git diff --check origin/main...HEAD`

A full library run completed 7,113 tests with 7,065 passing, 18 ignored, and 30 existing state-sensitive failures; both new parity tests passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Architecture analysis, registry consolidation, parity tests, rebasing, and verification; Chris remains responsible for the submitted change.