### PR TITLE
fix: preserve provider policy across Lab offload

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -190,6 +190,9 @@ mod runner_workload_types {
         pub run_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub plan_ref: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub resolved_provider_policy:
+            Option<crate::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy>,
         pub dispatch_kind: RunnerWorkloadAgentTaskDispatchKind,
         pub lifecycle_mirror_policy: RunnerWorkloadAgentTaskLifecycleMirrorPolicy,
     }

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -518,6 +518,7 @@ impl BatchCookSpec {
                 attempts: self.attempts,
                 queue_only: false,
                 timeout_ms: None,
+                resolved_provider_policy: None,
             },
         };
         let title = self

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -139,6 +139,7 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
                         attempts: 1,
                         queue_only: false,
                         timeout_ms: None,
+                        resolved_provider_policy: None,
                     },
                 },
                 goal: Some("cook fixture".to_string()),

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -32,6 +32,22 @@ pub struct DispatchCoreArgs {
     /// Provider wall-clock timeout in milliseconds. Defaults to Homeboy's provider timeout.
     #[arg(long = "timeout-ms", value_name = "MS")]
     pub timeout_ms: Option<u64>,
+
+    #[arg(
+        long = "resolved-provider-policy",
+        hide = true,
+        value_name = "JSON",
+        value_parser = parse_resolved_provider_policy
+    )]
+    pub resolved_provider_policy:
+        Option<homeboy::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy>,
+}
+
+fn parse_resolved_provider_policy(
+    raw: &str,
+) -> Result<homeboy::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy, String> {
+    serde_json::from_str(raw)
+        .map_err(|error| format!("invalid resolved provider policy JSON: {error}"))
 }
 
 impl From<DispatchCoreArgs> for DispatchCoreInputs {
@@ -43,6 +59,7 @@ impl From<DispatchCoreArgs> for DispatchCoreInputs {
             attempts: args.attempts,
             queue_only: args.queue_only,
             timeout_ms: args.timeout_ms,
+            resolved_provider_policy: args.resolved_provider_policy,
         }
     }
 }
@@ -136,6 +153,7 @@ mod tests {
     use super::*;
     use crate::test_support::with_isolated_home;
     use homeboy::core::agent_task::AgentTaskRequest;
+    use homeboy::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy;
     use homeboy::core::agent_task_prompts;
     use homeboy::core::agent_tasks::dispatch_service;
     use homeboy::core::agent_tasks::scheduler::AgentTaskPlan;
@@ -242,6 +260,7 @@ mod tests {
                     attempts: 1,
                     queue_only: false,
                     timeout_ms: None,
+                    resolved_provider_policy: None,
                 },
             }
             .into(),
@@ -276,6 +295,7 @@ mod tests {
                     attempts: 1,
                     queue_only: false,
                     timeout_ms: None,
+                    resolved_provider_policy: None,
                 },
             }
             .into(),
@@ -284,6 +304,34 @@ mod tests {
         .expect_err("missing backend should fail");
 
         assert!(error.message.contains("requires --backend"));
+    }
+
+    #[test]
+    fn submitted_provider_policy_ignores_runner_default_backend() {
+        let mut args = dispatch_args(DispatchArgOverrides::default());
+        args.backend = None;
+        args.model = Some("controller-model".to_string());
+        args.required_capabilities = vec!["runner-capability".to_string()];
+        args.secret_env = vec!["RUNNER_SECRET".to_string()];
+        args.core.resolved_provider_policy = Some(ResolvedAgentTaskProviderPolicy {
+            backend: "controller-backend".to_string(),
+            selector: Some("controller-selector".to_string()),
+            model: Some("controller-model".to_string()),
+            rotation: None,
+            retry: Default::default(),
+            liveness_timeout_ms: None,
+        });
+
+        let request = dispatch_service::resolve_dispatch_request_with_default(args.into(), |_| {
+            Ok(Some("runner-backend".to_string()))
+        })
+        .expect("submitted policy request");
+
+        assert_eq!(request.backend, "controller-backend");
+        assert_eq!(request.selector.as_deref(), Some("controller-selector"));
+        assert_eq!(request.model.as_deref(), Some("controller-model"));
+        assert_eq!(request.required_capabilities, ["runner-capability"]);
+        assert_eq!(request.secret_env, ["RUNNER_SECRET"]);
     }
 
     struct NoopExecutor;
@@ -356,6 +404,7 @@ mod tests {
                 },
                 queue_only: overrides.core.queue_only,
                 timeout_ms: overrides.core.timeout_ms,
+                resolved_provider_policy: overrides.core.resolved_provider_policy,
             },
         }
     }

--- a/src/core/agent_task_controller_service/request.rs
+++ b/src/core/agent_task_controller_service/request.rs
@@ -52,6 +52,7 @@ pub fn controller_request_dispatch_command(
             attempts: optional_u32(dispatch, "attempts")?.unwrap_or(1),
             queue_only: optional_bool(dispatch, "queue_only").unwrap_or(false),
             timeout_ms: optional_u64(dispatch, "timeout_ms")?,
+            resolved_provider_policy: None,
         },
     };
 

--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -84,6 +84,24 @@ pub fn build_dispatch_plan_with_provider_requirements(
     let client_context = dispatch_client_context(request)?;
     let mut provider_config =
         dispatch_provider_config(request, &repo, workspace_target.as_ref(), &client_context)?;
+    let policy_backend = request
+        .core
+        .resolved_provider_policy
+        .as_ref()
+        .map(|policy| policy.backend.clone())
+        .unwrap_or_else(|| request.backend.clone());
+    let policy_selector = request
+        .core
+        .resolved_provider_policy
+        .as_ref()
+        .and_then(|policy| policy.selector.clone())
+        .or_else(|| request.selector.clone());
+    let policy_model = request
+        .core
+        .resolved_provider_policy
+        .as_ref()
+        .and_then(|policy| policy.model.clone())
+        .or_else(|| request.model.clone());
     let component_contracts = dispatch_component_contracts(&provider_config, &client_context)?;
     // Resolve + materialize the declared runtime dependency graph at known refs
     // and preflight-fail before dispatch when a required runtime dependency is
@@ -132,19 +150,19 @@ pub fn build_dispatch_plan_with_provider_requirements(
             group_key: repo.clone(),
             parent_plan_id: None,
             executor: AgentTaskExecutor {
-                backend: request.backend.clone(),
-                selector: request.selector.clone(),
+                backend: policy_backend.clone(),
+                selector: policy_selector.clone(),
                 runtime_selection: Some(AgentTaskRuntimeSelection {
                     runtime_id: None,
-                    executor_backend: Some(request.backend.clone()),
-                    executor_provider_id: request.selector.clone(),
+                    executor_backend: Some(policy_backend.clone()),
+                    executor_provider_id: policy_selector.clone(),
                     ai_provider_id: config_string(&provider_config, "provider"),
-                    model: request.model.clone(),
+                    model: policy_model.clone(),
                     substrate_ref: None,
                 }),
                 required_capabilities: request.required_capabilities.clone(),
                 secret_env: secret_env.clone(),
-                model: request.model.clone(),
+                model: policy_model.clone(),
                 config: provider_config.clone(),
             },
             instructions,
@@ -210,14 +228,28 @@ pub fn build_dispatch_plan_with_provider_requirements(
     plan.group_key = repo.clone();
     plan.options.max_concurrency = request.concurrency.max(1);
     plan.options.timeout_ms = request.core.timeout_ms;
-    plan.options.retry = AgentTaskRetryPolicy {
-        max_attempts: request.core.attempts.max(1),
-        ..AgentTaskRetryPolicy::default()
+    plan.options.retry = request
+        .core
+        .resolved_provider_policy
+        .as_ref()
+        .map(|policy| policy.retry.clone())
+        .unwrap_or(AgentTaskRetryPolicy {
+            max_attempts: request.core.attempts.max(1),
+            ..AgentTaskRetryPolicy::default()
+        });
+    // A submitted controller policy is authoritative, including an explicitly
+    // absent rotation. Per-task `metadata.provider_rotation` still overrides it.
+    plan.options.rotation = match &request.core.resolved_provider_policy {
+        Some(policy) => policy.rotation.clone(),
+        None => defaults::load_config().agent_task.rotation,
     };
-    // Global provider rotation policy (`agent_task.rotation` in Homeboy config)
-    // flows into the plan options; per-task `metadata.provider_rotation`
-    // overrides it at dispatch time (#6978).
-    plan.options.rotation = defaults::load_config().agent_task.rotation;
+    if let Some(policy) = &request.core.resolved_provider_policy {
+        for task in &mut plan.tasks {
+            if task.limits.liveness_timeout_ms.is_none() {
+                task.limits.liveness_timeout_ms = policy.liveness_timeout_ms;
+            }
+        }
+    }
     plan.metadata = serde_json::json!({
         "kind": "agent-task-dispatch",
         "repo": repo,
@@ -958,6 +990,149 @@ mod tests {
             let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
                 prompt: Some("Cook without rotation.".to_string()),
                 repo: Some("sample-plugin".to_string()),
+                ..DispatchRequestOverrides::default()
+            }))
+            .expect("dispatch plan");
+
+            assert!(plan.options.rotation.is_none());
+        });
+    }
+
+    #[test]
+    fn submitted_provider_policy_preserves_controller_execution_policy() {
+        with_isolated_home(|_| {
+            let mut runner_config = defaults::load_config();
+            runner_config.agent_task.rotation = Some(
+                crate::core::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                    entries: vec![
+                        crate::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            backend: Some("runner-fallback".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            );
+            defaults::save_config(&runner_config).expect("save runner config");
+
+            let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+                prompt: Some("Cook with controller policy.".to_string()),
+                backend: Some("controller-backend".to_string()),
+                model: Some("controller-model".to_string()),
+                required_capabilities: vec!["runner-capability".to_string()],
+                secret_env: vec!["RUNNER_SECRET".to_string()],
+                core: DispatchCoreInputs {
+                    resolved_provider_policy: Some(
+                        crate::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy {
+                            backend: "controller-backend".to_string(),
+                            selector: Some("controller-selector".to_string()),
+                            model: Some("controller-model".to_string()),
+                            rotation: Some(
+                                crate::core::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                                    entries: vec![
+                                        crate::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                                            backend: Some("controller-fallback".to_string()),
+                                            model: Some("fallback-model".to_string()),
+                                            ..Default::default()
+                                        },
+                                    ],
+                                    max_attempts: Some(2),
+                                    liveness_timeout_ms: Some(45_000),
+                                },
+                            ),
+                            retry: AgentTaskRetryPolicy {
+                                max_attempts: 2,
+                                ..Default::default()
+                            },
+                            liveness_timeout_ms: Some(45_000),
+                        },
+                    ),
+                    ..DispatchCoreInputs::default()
+                },
+                ..DispatchRequestOverrides::default()
+            }))
+            .expect("dispatch plan");
+
+            let task = &plan.tasks[0];
+            assert_eq!(task.executor.backend, "controller-backend");
+            assert_eq!(
+                task.executor.selector.as_deref(),
+                Some("controller-selector")
+            );
+            assert_eq!(task.executor.model.as_deref(), Some("controller-model"));
+            assert_eq!(task.executor.required_capabilities, ["runner-capability"]);
+            assert_eq!(task.executor.secret_env, ["RUNNER_SECRET"]);
+            assert_eq!(task.limits.liveness_timeout_ms, Some(45_000));
+            assert_eq!(plan.options.retry.max_attempts, 2);
+            assert_eq!(
+                plan.options
+                    .rotation
+                    .as_ref()
+                    .expect("controller rotation")
+                    .entries[0]
+                    .backend
+                    .as_deref(),
+                Some("controller-fallback")
+            );
+
+            let runner_catalog = crate::core::agent_task_provider::AgentTaskProviderCatalog {
+                providers: vec![serde_json::from_value(serde_json::json!({
+                    "id": "controller-selector",
+                    "backend": "controller-backend",
+                    "capabilities": ["runner-capability"],
+                    "runner_readiness": [{
+                        "id": "runner-secrets",
+                        "label": "Runner secrets",
+                        "secret_env": ["RUNNER_LOCAL_SECRET"]
+                    }]
+                }))
+                .expect("runner provider")],
+                ..Default::default()
+            };
+            let mut plan = plan;
+            runner_catalog.apply_provider_runner_secret_env_contracts(&mut plan);
+            assert_eq!(
+                plan.tasks[0].executor.secret_env,
+                ["RUNNER_LOCAL_SECRET", "RUNNER_SECRET"]
+            );
+        });
+    }
+
+    #[test]
+    fn submitted_provider_policy_without_rotation_ignores_runner_rotation() {
+        with_isolated_home(|_| {
+            let mut runner_config = defaults::load_config();
+            runner_config.agent_task.rotation = Some(
+                crate::core::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                    entries: vec![
+                        crate::core::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            backend: Some("runner-fallback".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            );
+            defaults::save_config(&runner_config).expect("save runner config");
+
+            let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+                prompt: Some("Cook with no rotation.".to_string()),
+                core: DispatchCoreInputs {
+                    resolved_provider_policy: Some(
+                        crate::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy {
+                            backend: "controller-backend".to_string(),
+                            selector: None,
+                            model: None,
+                            rotation: None,
+                            retry: AgentTaskRetryPolicy {
+                                max_attempts: 1,
+                                ..Default::default()
+                            },
+                            liveness_timeout_ms: None,
+                        },
+                    ),
+                    ..DispatchCoreInputs::default()
+                },
                 ..DispatchRequestOverrides::default()
             }))
             .expect("dispatch plan");
@@ -1728,6 +1903,7 @@ mod tests {
                 },
                 queue_only: overrides.core.queue_only,
                 timeout_ms: overrides.core.timeout_ms,
+                resolved_provider_policy: overrides.core.resolved_provider_policy,
             },
             backend_selection: None,
         }

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -4,7 +4,7 @@
 //! typed dispatch request, plan construction, provider preflight, durable
 //! lifecycle transitions, and scheduler orchestration.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::agent_task_dispatch_plan::{
@@ -18,12 +18,30 @@ use crate::core::agent_task_provider::{
     AgentTaskProviderCatalog,
 };
 use crate::core::agent_task_scheduler::{
-    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskScheduler,
+    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskProviderRotationPolicy,
+    AgentTaskRetryPolicy, AgentTaskScheduler,
 };
 use crate::core::agent_task_service::{aggregate_exit_code, AgentTaskRunResult};
 use crate::core::{Error, Result};
 
 pub const DISPATCH_RESULT_SCHEMA: &str = "homeboy/agent-task-dispatch/v1";
+
+/// Controller-compiled provider execution policy carried across a Lab handoff.
+/// Runner-local configuration may satisfy this policy's capabilities and secrets,
+/// but must not select a different provider policy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedAgentTaskProviderPolicy {
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotation: Option<AgentTaskProviderRotationPolicy>,
+    pub retry: AgentTaskRetryPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub liveness_timeout_ms: Option<u64>,
+}
 
 /// Where the effective agent-task backend selection came from. Surfaced before
 /// dispatch so operators can see whether the backend was an explicit override or
@@ -74,6 +92,8 @@ pub struct DispatchCoreInputs {
     pub queue_only: bool,
     /// Optional provider wall-clock timeout in milliseconds.
     pub timeout_ms: Option<u64>,
+    /// Internal Lab handoff input, compiled on the controller.
+    pub resolved_provider_policy: Option<ResolvedAgentTaskProviderPolicy>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -294,10 +314,13 @@ fn resolve_dispatch_request_with_default_and_config(
     config_default: impl FnOnce() -> Option<String>,
 ) -> Result<AgentTaskDispatchRequest> {
     let config_default = config_default();
-    let (backend, source) = match command.backend {
-        Some(backend) => (backend, BackendSelectionSource::Cli),
-        None => {
-            let resolved = default_backend(command.repo.as_deref())?.ok_or_else(|| {
+    let submitted_policy = command.core.resolved_provider_policy.clone();
+    let (backend, source) = match submitted_policy.as_ref() {
+        Some(policy) => (policy.backend.clone(), BackendSelectionSource::Policy),
+        None => match command.backend.clone() {
+            Some(backend) => (backend, BackendSelectionSource::Cli),
+            None => {
+                let resolved = default_backend(command.repo.as_deref())?.ok_or_else(|| {
                 Error::validation_invalid_argument(
                     "backend",
                     "agent-task cook requires --backend because no default backend policy is configured",
@@ -307,17 +330,18 @@ fn resolve_dispatch_request_with_default_and_config(
                     ]),
                 )
             })?;
-            // The policy resolver prefers component/extension defaults over the
-            // Homeboy config default; if the resolved value matches the config
-            // default we attribute it to config, otherwise to higher-priority
-            // component/extension policy.
-            let source = if config_default.as_deref() == Some(resolved.as_str()) {
-                BackendSelectionSource::Config
-            } else {
-                BackendSelectionSource::Policy
-            };
-            (resolved, source)
-        }
+                // The policy resolver prefers component/extension defaults over the
+                // Homeboy config default; if the resolved value matches the config
+                // default we attribute it to config, otherwise to higher-priority
+                // component/extension policy.
+                let source = if config_default.as_deref() == Some(resolved.as_str()) {
+                    BackendSelectionSource::Config
+                } else {
+                    BackendSelectionSource::Policy
+                };
+                (resolved, source)
+            }
+        },
     };
 
     let overrides_default = source == BackendSelectionSource::Cli
@@ -341,8 +365,14 @@ fn resolve_dispatch_request_with_default_and_config(
         repo: command.repo,
         task_url: command.task_url,
         backend,
-        selector: command.selector,
-        model: command.model,
+        selector: submitted_policy
+            .as_ref()
+            .and_then(|policy| policy.selector.clone())
+            .or(command.selector),
+        model: submitted_policy
+            .as_ref()
+            .and_then(|policy| policy.model.clone())
+            .or(command.model),
         required_capabilities: command.required_capabilities,
         secret_env: command.secret_env,
         concurrency: command.concurrency,

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -946,6 +946,7 @@ mod tests {
         let agent_task = RunnerWorkloadAgentTask {
             run_id: "run-typed-no-event".to_string(),
             plan_ref: Some("@/tmp/plan.json".to_string()),
+            resolved_provider_policy: None,
             dispatch_kind: crate::command_contract::RunnerWorkloadAgentTaskDispatchKind::RunPlan,
             lifecycle_mirror_policy: RunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
         };
@@ -967,6 +968,7 @@ mod tests {
             let agent_task = RunnerWorkloadAgentTask {
                 run_id: "run-typed-workload".to_string(),
                 plan_ref: Some(format!("@{}", plan_path.display())),
+                resolved_provider_policy: None,
                 dispatch_kind:
                     crate::command_contract::RunnerWorkloadAgentTaskDispatchKind::RunPlan,
                 lifecycle_mirror_policy:

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -64,7 +64,8 @@ use super::super::execution::{
 };
 use super::super::lab_apply::apply_lab_offload_patch;
 use super::super::lab_args::{
-    inject_agent_task_default_provider_config_in_args, lab_at_file_specs, lab_offload_source_path,
+    inject_agent_task_default_provider_config_in_args,
+    inject_agent_task_resolved_provider_policy_in_args, lab_at_file_specs, lab_offload_source_path,
     materialize_agent_task_specs_in_args, preflight_provider_config_paths_materialized_in_args,
     provider_config_runtime_manifest, remap_lab_at_file_args, remap_path_settings_in_args,
     remap_provider_config_with_materialization_plan_in_args, rewrite_lab_offload_args,

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -70,6 +70,7 @@ pub(crate) fn run_runner_resident_lab_offload(
         request.normalized_args,
         remote_output_file.as_deref(),
     );
+    let remapped_args = inject_agent_task_resolved_provider_policy_in_args(&remapped_args)?;
     let run_isolation_token = agent_task_dispatch_run_isolation_token(request.normalized_args);
     let (remapped_args, agent_task_run_id) =
         ensure_agent_task_dispatch_run_id_with(&remapped_args, run_isolation_token.as_deref())

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -116,6 +116,7 @@ fn prepare_lab_offload_workspace_stage_inner(
     }
     let offload_args =
         inject_agent_task_default_provider_config_in_args(&changed_since_preflight.args)?;
+    let offload_args = inject_agent_task_resolved_provider_policy_in_args(&offload_args)?;
     let runner = load(runner_id)?;
     preflight_agent_task_secret_env_before_workspace_stage(
         contract,

--- a/src/core/runner/lab_args/mod.rs
+++ b/src/core/runner/lab_args/mod.rs
@@ -41,6 +41,7 @@ pub(super) use path_remap::{remap_path_settings_in_args, LabPathRemap};
 pub(super) use provider_config::remap_provider_config_in_args;
 pub(super) use provider_config::{
     inject_agent_task_default_provider_config_in_args,
+    inject_agent_task_resolved_provider_policy_in_args,
     preflight_provider_config_paths_materialized_in_args, provider_config_runtime_manifest,
     remap_provider_config_with_materialization_plan_in_args,
 };

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -8,11 +8,18 @@ use std::path::Path;
 
 use serde_json::Value;
 
+use crate::cli_surface::{Cli, Commands};
+use crate::commands::agent_task::AgentTaskCommand;
 use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
+use crate::core::agent_task_dispatch_service::{
+    resolve_dispatch_request, AgentTaskDispatchCommand, ResolvedAgentTaskProviderPolicy,
+};
+use crate::core::agent_tasks::scheduler::AgentTaskRetryPolicy;
 use crate::core::config::read_json_spec_to_string;
 use crate::core::defaults;
 use crate::core::runner_execution_envelope::PathMaterializationPlan;
 use crate::core::{Error, Result};
+use clap::Parser;
 
 use super::envelope::{ArgValue, ExecutionEnvelope};
 use super::path_remap::{remap_local_path, remap_paths_in_value, LabPathRemap};
@@ -186,6 +193,74 @@ pub(in crate::core::runner) fn inject_agent_task_default_provider_config_in_args
     if !inserted {
         out.push("--provider-config".to_string());
         out.push(config);
+    }
+    Ok(out)
+}
+
+/// Compile controller-side provider selection before Lab serializes argv. The
+/// runner receives typed data and cannot reinterpret omitted flags using its own
+/// defaults, while capability and secret discovery remain runner-local.
+pub(in crate::core::runner) fn inject_agent_task_resolved_provider_policy_in_args(
+    args: &[String],
+) -> Result<Vec<String>> {
+    if !is_agent_task_dispatch_or_cook(args)
+        || args.iter().any(|arg| arg == "--resolved-provider-policy")
+        || args
+            .iter()
+            .any(|arg| arg.starts_with("--resolved-provider-policy="))
+    {
+        return Ok(args.to_vec());
+    }
+
+    let cli = Cli::try_parse_from(args).map_err(|error| {
+        Error::validation_invalid_argument(
+            "agent-task",
+            "failed to parse agent-task arguments while compiling Lab provider policy",
+            Some(error.to_string()),
+            None,
+        )
+    })?;
+    let dispatch: AgentTaskDispatchCommand = match cli.command {
+        Commands::AgentTask(agent_task) => match agent_task.command {
+            AgentTaskCommand::Cook(args) => args.dispatch.into(),
+            _ => return Ok(args.to_vec()),
+        },
+        _ => return Ok(args.to_vec()),
+    };
+    let request = resolve_dispatch_request(dispatch)?;
+    let rotation = defaults::load_config().agent_task.rotation;
+    let policy = ResolvedAgentTaskProviderPolicy {
+        backend: request.backend,
+        selector: request.selector,
+        model: request.model,
+        retry: AgentTaskRetryPolicy {
+            max_attempts: request.core.attempts.max(1),
+            ..AgentTaskRetryPolicy::default()
+        },
+        liveness_timeout_ms: rotation
+            .as_ref()
+            .and_then(|policy| policy.liveness_timeout_ms),
+        rotation,
+    };
+    let encoded = serde_json::to_string(&policy).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize resolved Lab agent-task provider policy".to_string()),
+        )
+    })?;
+    let mut out = Vec::with_capacity(args.len() + 2);
+    let mut inserted = false;
+    for arg in args {
+        if !inserted && arg == "--" {
+            out.push("--resolved-provider-policy".to_string());
+            out.push(encoded.clone());
+            inserted = true;
+        }
+        out.push(arg.clone());
+    }
+    if !inserted {
+        out.push("--resolved-provider-policy".to_string());
+        out.push(encoded);
     }
     Ok(out)
 }

--- a/src/core/runner/lab_args/tests.rs
+++ b/src/core/runner/lab_args/tests.rs
@@ -1,6 +1,9 @@
 //! Tests for Lab offload argument rewriting.
 
 use super::*;
+use crate::core::agent_task_scheduler::{
+    AgentTaskProviderRotationEntry, AgentTaskProviderRotationPolicy,
+};
 use crate::core::defaults;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -904,6 +907,7 @@ mod provider_config_remap_tests {
 
 mod provider_config_default_injection_tests {
     use super::*;
+    use crate::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy;
 
     #[test]
     fn injects_default_provider_config_for_agent_task_cook() {
@@ -1012,6 +1016,111 @@ mod provider_config_default_injection_tests {
 
             let out = inject_agent_task_default_provider_config_in_args(&args).expect("inject");
             assert_eq!(out, args);
+        });
+    }
+
+    #[test]
+    fn controller_provider_policy_survives_runner_default_drift_and_serializes_rotation() {
+        crate::test_support::with_isolated_home(|_| {
+            defaults::save_config(&defaults::HomeboyConfig {
+                agent_task: defaults::AgentTaskConfig {
+                    default_backend: Some("controller-backend".to_string()),
+                    rotation: Some(AgentTaskProviderRotationPolicy {
+                        entries: vec![
+                            AgentTaskProviderRotationEntry {
+                                backend: Some("fallback-a".to_string()),
+                                model: Some("model-a".to_string()),
+                                ..AgentTaskProviderRotationEntry::default()
+                            },
+                            AgentTaskProviderRotationEntry {
+                                backend: Some("fallback-b".to_string()),
+                                model: Some("model-b".to_string()),
+                                ..AgentTaskProviderRotationEntry::default()
+                            },
+                        ],
+                        max_attempts: Some(3),
+                        liveness_timeout_ms: Some(45_000),
+                    }),
+                    ..defaults::AgentTaskConfig::default()
+                },
+                ..defaults::HomeboyConfig::default()
+            })
+            .expect("save config");
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--prompt".to_string(),
+                "fix it".to_string(),
+                "--to-worktree".to_string(),
+                "sample@fix".to_string(),
+                "--verify".to_string(),
+                "cargo check".to_string(),
+                "--model".to_string(),
+                "primary-model".to_string(),
+            ];
+
+            let out = inject_agent_task_resolved_provider_policy_in_args(&args).expect("inject");
+            let index = out
+                .iter()
+                .position(|arg| arg == "--resolved-provider-policy")
+                .expect("policy flag")
+                + 1;
+            let policy: ResolvedAgentTaskProviderPolicy =
+                serde_json::from_str(&out[index]).expect("policy");
+
+            assert_eq!(policy.backend, "controller-backend");
+            assert_eq!(policy.model.as_deref(), Some("primary-model"));
+            assert_eq!(policy.retry.max_attempts, 1);
+            assert_eq!(policy.liveness_timeout_ms, Some(45_000));
+            assert_eq!(
+                policy
+                    .rotation
+                    .as_ref()
+                    .expect("rotation")
+                    .entries
+                    .iter()
+                    .filter_map(|entry| entry.model.as_deref())
+                    .collect::<Vec<_>>(),
+                vec!["model-a", "model-b"]
+            );
+        });
+    }
+
+    #[test]
+    fn explicit_backend_is_compiled_into_controller_provider_policy() {
+        crate::test_support::with_isolated_home(|_| {
+            defaults::save_config(&defaults::HomeboyConfig {
+                agent_task: defaults::AgentTaskConfig {
+                    default_backend: Some("controller-default".to_string()),
+                    ..defaults::AgentTaskConfig::default()
+                },
+                ..defaults::HomeboyConfig::default()
+            })
+            .expect("save config");
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--prompt".to_string(),
+                "fix it".to_string(),
+                "--to-worktree".to_string(),
+                "sample@fix".to_string(),
+                "--verify".to_string(),
+                "cargo check".to_string(),
+                "--backend".to_string(),
+                "explicit-backend".to_string(),
+            ];
+            let out = inject_agent_task_resolved_provider_policy_in_args(&args).expect("inject");
+            let index = out
+                .iter()
+                .position(|arg| arg == "--resolved-provider-policy")
+                .expect("policy flag")
+                + 1;
+            let policy: ResolvedAgentTaskProviderPolicy =
+                serde_json::from_str(&out[index]).expect("policy");
+
+            assert_eq!(policy.backend, "explicit-backend");
         });
     }
 }

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -7,6 +7,7 @@ use crate::command_contract::{
     RunnerWorkloadSecrets, RunnerWorkloadState, RunnerWorkloadWorkspaceMappings,
     RUNNER_WORKLOAD_SCHEMA,
 };
+use crate::core::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy;
 use crate::core::error::{Error, Result};
 use crate::core::plan::HomeboyPlan;
 use crate::core::secret_env_plan::SecretEnvPlan;
@@ -141,12 +142,14 @@ pub(crate) fn runner_workload_agent_task_from_command(
         "cook" => run_id.map(|run_id| RunnerWorkloadAgentTask {
             run_id: run_id.to_string(),
             plan_ref: None,
+            resolved_provider_policy: resolved_provider_policy_from_command(args),
             dispatch_kind: RunnerWorkloadAgentTaskDispatchKind::Cook,
             lifecycle_mirror_policy: RunnerWorkloadAgentTaskLifecycleMirrorPolicy::None,
         }),
         "dispatch" => run_id.map(|run_id| RunnerWorkloadAgentTask {
             run_id: run_id.to_string(),
             plan_ref: None,
+            resolved_provider_policy: resolved_provider_policy_from_command(args),
             dispatch_kind: RunnerWorkloadAgentTaskDispatchKind::Dispatch,
             lifecycle_mirror_policy: RunnerWorkloadAgentTaskLifecycleMirrorPolicy::None,
         }),
@@ -158,6 +161,7 @@ pub(crate) fn runner_workload_agent_task_from_command(
             Some(RunnerWorkloadAgentTask {
                 run_id: record_run_id,
                 plan_ref: Some(plan_ref),
+                resolved_provider_policy: None,
                 dispatch_kind: RunnerWorkloadAgentTaskDispatchKind::RunPlan,
                 lifecycle_mirror_policy:
                     RunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
@@ -165,6 +169,13 @@ pub(crate) fn runner_workload_agent_task_from_command(
         }
         _ => None,
     }
+}
+
+fn resolved_provider_policy_from_command(
+    args: &[String],
+) -> Option<ResolvedAgentTaskProviderPolicy> {
+    option_value_after(args, 0, "--resolved-provider-policy")
+        .and_then(|raw| serde_json::from_str(&raw).ok())
 }
 
 fn option_value_after(args: &[String], start_index: usize, option: &str) -> Option<String> {
@@ -1408,5 +1419,18 @@ mod tests {
             workload.result_refs.artifacts[0].name.as_deref(),
             Some("trace.zip")
         );
+    }
+
+    #[test]
+    fn legacy_agent_task_workload_decodes_without_provider_policy() {
+        let agent_task: RunnerWorkloadAgentTask = serde_json::from_value(serde_json::json!({
+            "run_id": "legacy-run",
+            "plan_ref": null,
+            "dispatch_kind": "cook",
+            "lifecycle_mirror_policy": "none"
+        }))
+        .expect("legacy workload agent-task contract");
+
+        assert!(agent_task.resolved_provider_policy.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- compile controller-resolved backend, model, rotation, retry, and liveness policy into the Lab handoff
- keep submitted policy authoritative on the runner while resolving runner-local capabilities and secrets locally
- retain legacy workload compatibility and cover CLI, rotation, precedence, and runner-local contract behavior

Closes #7752

## Verification
- `cargo fmt`
- `cargo check`
- focused provider-policy, rotation, runner-workload, and provider scheduler tests passed
- `cargo test`: 7,071 passed, 29 failed, 18 ignored. The affected failures passed in isolation: `runner_workload_kind_comes_from_dispatched_command_for_lab_shapes`, `scheduler_dispatches_extension_provider_command`, and `stalled_provider_is_killed_and_rotates_to_configured_fallback`.

Full-suite failures unrelated to this diff:
- `commands::bench::observation::tests::bench_observation_mirrors_url_artifact_from_run_artifacts_dir`
- `commands::infra::adapter::tests::run_json_output_matches_adapter_bound_execution`
- `commands::infra::route::tests::changed_scope_lint_is_lab_portable`
- `commands::infra::route::tests::explicit_runner_for_changed_scope_test_is_lab_portable`
- `commands::infra::route::tests::lab_command_preserves_portable_contract_shape`
- `commands::infra::route::tests::lab_command_with_mutation_flag_stays_portable_for_patch_capture`
- `commands::infra::route::tests::lab_command_with_ratchet_stays_portable_for_patch_capture`
- `commands::infra::route::tests::nested_review_lint_dispatch_uses_matching_lab_label`
- `commands::infra::route::tests::rig_up_dry_run_with_runner_emits_runner_exec_plan`
- `commands::runner::status::tests::stale_daemon_status_hint_labels_control_plane_and_job_binary`
- `commands::trace::tests::trace_compare_variant_resolves_named_variants`
- `commands::trace::tests::trace_run_resolves_named_variants_and_reports_unknown_names`
- `core::agent_task_lifecycle::tests::cancel_run_signals_live_running_record`
- `core::agent_task_provider::tests::scheduler_tests::scheduler_dispatches_extension_provider_command`
- `core::agent_task_provider::tests::scheduler_tests::scheduler_normalizes_malformed_provider_output`
- `core::agent_task_provider::tests::scheduler_tests::stalled_provider_is_killed_and_rotates_to_configured_fallback`
- `core::code_audit::entry::audit_runtime_regression_test::audit_runtime_regression_matches_snapshot`
- `core::extension::bench::parsing::tests::rejects_duplicate_scenario_ids_from_same_basename_subdirs`
- `core::extension::bench::parsing::tests::selected_parse_still_rejects_selected_duplicate_scenario_ids`
- `core::extension::build::tests::resolve_build_command_guides_unconfigured_components`
- `core::extension::tests::extension_guidance_hints_point_to_supported_paths`
- `core::observation::store::store_test::store_init_tests::initialization_is_idempotent`
- `core::observation::store::store_test::store_init_tests::initialization_is_safe_under_concurrent_setup`
- `core::observation::store::store_test::store_init_tests::initialization_recovers_when_artifact_type_migration_was_interrupted`
- `core::observation::store::store_test::store_init_tests::test_open_initialized`
- `core::rig::install::install_test::install_flows::installed_rig_check_reports_package_lint_failures`
- `core::rig::install::install_test::install_flows::run_lint_reports_package_conflict_markers`
- `core::runner::lab::offload::tests::capability_metadata::runner_homeboy_metadata_carries_stale_daemon_details`
- `core::runner::workload::tests::runner_workload_kind_comes_from_dispatched_command_for_lab_shapes`

## AI assistance
- OpenCode using `openai/gpt-5.6-terra` assisted with implementation and verification.