### PR TITLE
Consolidate atomic JSON persistence

### DIFF
--- a/src/core/agent_task_loop_controller/service.rs
+++ b/src/core/agent_task_loop_controller/service.rs
@@ -1,7 +1,7 @@
 use super::*;
+use crate::core::engine::local_files::write_json_file as write_json;
 use crate::core::{agent_task_lifecycle, paths, Error, Result};
 use chrono::{DateTime, Utc};
-use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
@@ -827,20 +827,6 @@ fn read_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T> {
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
     serde_json::from_str(&raw)
         .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
-}
-
-fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<()> {
-    let parent = path.parent().ok_or_else(|| {
-        Error::internal_unexpected(format!("path has no parent: {}", path.display()))
-    })?;
-    fs::create_dir_all(parent).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(parent.display().to_string()))
-    })?;
-    let json = serde_json::to_string_pretty(value).map_err(|error| {
-        Error::internal_json(error.to_string(), Some(path.display().to_string()))
-    })?;
-    fs::write(path, format!("{json}\n"))
-        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
 }
 
 pub fn controller_record_path(loop_id: &str) -> Result<PathBuf> {

--- a/src/core/engine/local_files.rs
+++ b/src/core/engine/local_files.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use serde::Serialize;
+
 use crate::core::error::{Error, Result};
 
 /// Entry returned from directory listing
@@ -56,30 +58,7 @@ impl FileSystem for LocalFs {
     }
 
     fn write(&self, path: &Path, content: &str) -> Result<()> {
-        // Atomic write: write to temp file, then rename
-        let parent = path.parent().ok_or_else(|| {
-            Error::internal_io(
-                format!("Invalid path: {}", path.display()),
-                Some("write file".to_string()),
-            )
-        })?;
-
-        let filename = path.file_name().ok_or_else(|| {
-            Error::internal_io(
-                format!("Invalid path: {}", path.display()),
-                Some("write file".to_string()),
-            )
-        })?;
-
-        let tmp_path = unique_temp_path(parent, filename.to_string_lossy().as_ref());
-
-        fs::write(&tmp_path, content)
-            .map_err(|e| Error::internal_io(e.to_string(), Some("write temp file".to_string())))?;
-
-        fs::rename(&tmp_path, path)
-            .map_err(|e| Error::internal_io(e.to_string(), Some("rename temp file".to_string())))?;
-
-        Ok(())
+        write_file_atomic(path, content, "write file")
     }
 
     fn list(&self, dir: &Path) -> Result<Vec<Entry>> {
@@ -187,6 +166,20 @@ pub fn write_file_atomic(path: &Path, content: &str, operation: &str) -> Result<
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("{} (rename)", operation))))?;
 
     Ok(())
+}
+
+/// Create parent directories and atomically persist pretty-printed JSON.
+pub(crate) fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        Error::internal_unexpected(format!("path has no parent: {}", path.display()))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+    })?;
+    let json = serde_json::to_string_pretty(value).map_err(|error| {
+        Error::internal_json(error.to_string(), Some(path.display().to_string()))
+    })?;
+    write_file_atomic(path, &format!("{json}\n"), &path.display().to_string())
 }
 
 fn unique_temp_path(parent: &Path, filename: &str) -> PathBuf {
@@ -319,5 +312,18 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.code.as_str(), "internal.io_error");
+    }
+
+    #[test]
+    fn write_json_file_creates_parents_and_preserves_pretty_format() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested/state.json");
+
+        write_json_file(&path, &serde_json::json!({ "name": "homeboy" })).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(path).unwrap(),
+            "{\n  \"name\": \"homeboy\"\n}\n"
+        );
     }
 }

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
 
-use serde::Serialize;
 use serde_json::{json, Value};
 
 use super::{
@@ -9,6 +8,7 @@ use super::{
     AgentTaskRunState,
 };
 use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
+use crate::core::engine::local_files::write_json_file as write_json;
 use crate::core::observation::{ObservationStore, RunListFilter, RunRecord, RunStatus};
 use crate::core::{paths, Error, ErrorCode, Result};
 
@@ -274,20 +274,6 @@ fn read_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T> {
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
     serde_json::from_str(&raw)
         .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
-}
-
-fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<()> {
-    let parent = path.parent().ok_or_else(|| {
-        Error::internal_unexpected(format!("path has no parent: {}", path.display()))
-    })?;
-    fs::create_dir_all(parent).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(parent.display().to_string()))
-    })?;
-    let json = serde_json::to_string_pretty(value).map_err(|error| {
-        Error::internal_json(error.to_string(), Some(path.display().to_string()))
-    })?;
-    fs::write(path, format!("{json}\n"))
-        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
 }
 
 fn run_dir(run_id: &str) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
- Delegate `LocalFs::write` to the shared atomic write path.
- Add one core helper for create-parent, pretty-JSON, trailing-newline, atomic persistence.
- Reuse it from lifecycle and loop-controller stores.
- Diffstat: 3 files changed, 32 insertions, 54 deletions (22 net lines removed).

Fixes #7770

## Constraint compliance
- CLI commands, flags, help text, and JSON output schemas are unchanged.
- Exact persisted pretty-JSON bytes, including the trailing newline, are regression-tested by `write_json_file_creates_parents_and_preserves_pretty_format`.
- Existing lifecycle and loop-controller persistence behavior was exercised by focused module suites.
- `cargo run -j 3 -- --help` succeeded in this worktree. The byte comparison against the primary checkout was skipped because execution in the primary checkout was denied by tool permission; CI remains the final arbiter.
- `CHANGELOG.md` was not modified.

## Verification
- `cargo build -j 3`
- `cargo test -j 3 core::engine::local_files` (9 passed)
- `cargo test -j 3 core::agent_task_loop_controller` (28 passed)
- `cargo test -j 3 core::agent_task_lifecycle` (38 passed)
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (baseline warnings only; no new warnings)
- `cargo run -j 3 -- --help > /tmp/help-7770.txt`

## Skipped items
- No issue sub-items were skipped.
- Primary-checkout help byte comparison was skipped due to tool permission denial.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (sol) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation of the consolidation described in the issue, plus verification runs. Reviewed by Chris Huber.