### PR TITLE
Refactor typed JSON file readers

### DIFF
--- a/src/commands/report/failure_digest.rs
+++ b/src/commands/report/failure_digest.rs
@@ -119,16 +119,7 @@ fn render_failure_digest(context: &FailureDigestContext) -> String {
 mod detail {
     use super::*;
     pub fn read_json_spec_value(spec: &str, context: &str) -> homeboy::core::Result<Value> {
-        let raw = if Path::new(spec).exists() {
-            std::fs::read_to_string(spec).map_err(|e| {
-                homeboy::core::Error::internal_unexpected(format!("Failed to read {}: {}", spec, e))
-            })?
-        } else {
-            homeboy::core::config::read_json_spec_to_string(spec)?
-        };
-        serde_json::from_str(&raw).map_err(|e| {
-            homeboy::core::Error::validation_invalid_json(e, Some(context.to_string()), Some(raw))
-        })
+        homeboy::core::config::read_json_value_spec_with_bare_path(spec, context)
     }
 
     pub fn normalize_object(value: Value) -> Map<String, Value> {
@@ -187,15 +178,15 @@ mod detail {
 
     pub fn read_command_json(output_dir: &Path, command: &str) -> Option<Value> {
         let path = output_dir.join(format!("{command}.json"));
-        let raw = std::fs::read_to_string(path).ok()?;
-        serde_json::from_str(&raw).ok()
+        homeboy::core::config::try_read_json_file(&path)
     }
 
     pub fn read_json_file(path: &Path) -> Result<Value, String> {
-        let raw = std::fs::read_to_string(path)
-            .map_err(|error| format!("failed to read {}: {}", path.display(), error))?;
-        serde_json::from_str(&raw)
-            .map_err(|error| format!("failed to parse {}: {}", path.display(), error))
+        homeboy::core::config::read_json_file_with(
+            path,
+            |error| format!("failed to read {}: {}", path.display(), error),
+            |error, _| format!("failed to parse {}: {}", path.display(), error),
+        )
     }
 
     pub fn envelope_parts(value: Option<Value>) -> (Map<String, Value>, Map<String, Value>) {

--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -249,8 +249,7 @@ mod helpers {
     use super::*;
 
     pub(super) fn read_json_file(path: &Path) -> Option<Value> {
-        let raw = std::fs::read_to_string(path).ok()?;
-        serde_json::from_str(&raw).ok()
+        homeboy::core::config::try_read_json_file(path)
     }
 
     pub(super) fn read_json_artifact(output_dir: &Path, filenames: &[&str]) -> Option<Value> {
@@ -286,16 +285,7 @@ mod helpers {
     }
 
     pub(super) fn read_json_spec_value(spec: &str, context: &str) -> homeboy::core::Result<Value> {
-        let raw = if Path::new(spec).exists() {
-            std::fs::read_to_string(spec).map_err(|e| {
-                homeboy::core::Error::internal_unexpected(format!("Failed to read {}: {}", spec, e))
-            })?
-        } else {
-            homeboy::core::config::read_json_spec_to_string(spec)?
-        };
-        serde_json::from_str(&raw).map_err(|e| {
-            homeboy::core::Error::validation_invalid_json(e, Some(context.to_string()), Some(raw))
-        })
+        homeboy::core::config::read_json_value_spec_with_bare_path(spec, context)
     }
 
     pub(super) fn read_metadata(

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -938,19 +938,22 @@ fn write_json(path: PathBuf, value: &impl Serialize) -> homeboy::core::Result<()
 }
 
 fn read_json<T: for<'de> Deserialize<'de>>(path: PathBuf) -> homeboy::core::Result<T> {
-    let raw = fs::read_to_string(&path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("read observation bundle file {}", path.display())),
-        )
-    })?;
-    serde_json::from_str(&raw).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some(format!("parse observation bundle file {}", path.display())),
-            Some(raw),
-        )
-    })
+    homeboy::core::config::read_json_file_with(
+        &path,
+        |e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read observation bundle file {}", path.display())),
+            )
+        },
+        |e, raw| {
+            Error::validation_invalid_json(
+                e,
+                Some(format!("parse observation bundle file {}", path.display())),
+                Some(raw),
+            )
+        },
+    )
 }
 
 fn read_optional_json<T: for<'de> Deserialize<'de> + Default>(

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -6,26 +6,22 @@ use std::path::{Path, PathBuf};
 /// Read a `homeboy.json` portable config from a repo directory.
 pub(crate) fn read_portable_config(repo_path: &Path) -> Result<Option<Value>> {
     let config_path = repo_path.join("homeboy.json");
-    if !config_path.exists() {
-        return Ok(None);
-    }
-
-    let content = std::fs::read_to_string(&config_path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("read {}", config_path.display())),
-        )
-    })?;
-
-    let value: Value = serde_json::from_str(&content).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some("parse homeboy.json".to_string()),
-            Some(content.chars().take(200).collect::<String>()),
-        )
-    })?;
-
-    Ok(Some(value))
+    crate::core::config::read_optional_json_file_with(
+        &config_path,
+        |e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read {}", config_path.display())),
+            )
+        },
+        |e, content| {
+            Error::validation_invalid_json(
+                e,
+                Some("parse homeboy.json".to_string()),
+                Some(content.chars().take(200).collect::<String>()),
+            )
+        },
+    )
 }
 
 fn explicit_id_hints() -> Vec<String> {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -15,8 +15,9 @@ mod json_io;
 mod json_ops;
 mod json_pointer;
 pub(crate) use json_io::{
-    from_str, is_json_array, is_json_input, parse_bulk_ids, read_json_spec_to_string,
-    to_string_pretty,
+    from_str, is_json_array, is_json_input, parse_bulk_ids, read_json_file_with,
+    read_json_spec_to_string, read_json_value_spec_with_bare_path, read_optional_json_file_with,
+    to_string_pretty, try_read_json_file,
 };
 pub use json_io::{serialize_with_id, to_json_string};
 pub use json_ops::collect_array_fields;

--- a/src/core/config/json_io.rs
+++ b/src/core/config/json_io.rs
@@ -5,6 +5,36 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::io::Read;
 use std::path::Path;
 
+pub(crate) fn read_json_file_with<T, E>(
+    path: &Path,
+    map_read_error: impl FnOnce(std::io::Error) -> E,
+    map_parse_error: impl FnOnce(serde_json::Error, String) -> E,
+) -> std::result::Result<T, E>
+where
+    T: DeserializeOwned,
+{
+    let raw = std::fs::read_to_string(path).map_err(map_read_error)?;
+    serde_json::from_str(&raw).map_err(|error| map_parse_error(error, raw))
+}
+
+pub(crate) fn read_optional_json_file_with<T, E>(
+    path: &Path,
+    map_read_error: impl FnOnce(std::io::Error) -> E,
+    map_parse_error: impl FnOnce(serde_json::Error, String) -> E,
+) -> std::result::Result<Option<T>, E>
+where
+    T: DeserializeOwned,
+{
+    if !path.exists() {
+        return Ok(None);
+    }
+    read_json_file_with(path, map_read_error, map_parse_error).map(Some)
+}
+
+pub(crate) fn try_read_json_file<T: DeserializeOwned>(path: &Path) -> Option<T> {
+    read_json_file_with(path, |_| (), |_, _| ()).ok()
+}
+
 /// Parse JSON string into typed value.
 pub(crate) fn from_str<T: DeserializeOwned>(s: &str) -> Result<T> {
     serde_json::from_str(s)
@@ -74,6 +104,21 @@ pub fn read_json_spec_to_string(spec: &str) -> Result<String> {
     Ok(spec.to_string())
 }
 
+/// Read a JSON value spec, preserving the report commands' legacy bare-path support.
+pub(crate) fn read_json_value_spec_with_bare_path(
+    spec: &str,
+    context: &str,
+) -> Result<serde_json::Value> {
+    let raw = if Path::new(spec).exists() {
+        std::fs::read_to_string(spec)
+            .map_err(|e| Error::internal_unexpected(format!("Failed to read {}: {}", spec, e)))?
+    } else {
+        read_json_spec_to_string(spec)?
+    };
+    serde_json::from_str(&raw)
+        .map_err(|e| Error::validation_invalid_json(e, Some(context.to_string()), Some(raw)))
+}
+
 /// Detect if input is JSON object (starts with '{').
 pub(crate) fn is_json_input(input: &str) -> bool {
     input.trim_start().starts_with('{')
@@ -115,6 +160,47 @@ pub(crate) fn parse_bulk_ids(json_spec: &str) -> Result<BulkIdsInput> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+
+    fn temp_json_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("homeboy-json-{}-{}", std::process::id(), name))
+    }
+
+    #[test]
+    fn typed_json_reader_preserves_strict_optional_and_lossy_modes() {
+        let path = temp_json_path("reader.json");
+        fs::write(&path, r#"{"value":7}"#).unwrap();
+        let value: serde_json::Value =
+            read_json_file_with(&path, |e| e.to_string(), |e, _| e.to_string()).unwrap();
+        assert_eq!(value["value"], 7);
+
+        fs::write(&path, "not json").unwrap();
+        assert!(read_optional_json_file_with::<serde_json::Value, _>(
+            &path,
+            |e| e.to_string(),
+            |e, _| e.to_string(),
+        )
+        .is_err());
+        assert!(try_read_json_file::<serde_json::Value>(&path).is_none());
+
+        fs::remove_file(&path).unwrap();
+        assert!(read_optional_json_file_with::<serde_json::Value, _>(
+            &path,
+            |e| e.to_string(),
+            |e, _| e.to_string(),
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn json_value_spec_accepts_legacy_bare_path() {
+        let path = temp_json_path("bare-spec.json");
+        fs::write(&path, r#"{"source":"file"}"#).unwrap();
+        let value = read_json_value_spec_with_bare_path(path.to_str().unwrap(), "results").unwrap();
+        fs::remove_file(path).unwrap();
+        assert_eq!(value["source"], "file");
+    }
 
     #[test]
     fn parse_bulk_ids_accepts_json_array() {

--- a/src/core/rig/json_config.rs
+++ b/src/core/rig/json_config.rs
@@ -1,3 +1,4 @@
+use crate::core::config::read_json_file_with;
 use crate::core::error::{Error, Result};
 use serde::de::DeserializeOwned;
 use std::fs;
@@ -72,19 +73,11 @@ where
             Error::internal_io(e.to_string(), Some(context.into()))
         })?
     {
-        let content = match fs::read_to_string(&entry.path) {
-            Ok(content) => content,
-            Err(err) => {
-                invalid.push(InvalidJsonConfig {
-                    id: entry.id,
-                    path: entry.path,
-                    error: err.to_string(),
-                });
-                continue;
-            }
-        };
-
-        match serde_json::from_str::<T>(&content) {
+        match read_json_file_with::<T, _>(
+            &entry.path,
+            |error| error.to_string(),
+            |error, _| error.to_string(),
+        ) {
             Ok(value) => valid.push(ParsedJsonConfig {
                 id: entry.id,
                 value,


### PR DESCRIPTION
## Summary
- Promote shared typed JSON file readers with strict, optional, and lossy/collect-invalid-compatible error mapping modes.
- Consolidate report JSON spec parsing while preserving legacy bare-path, `@file`, inline, and stdin behavior.
- Reuse the reader in observation bundles, portable component config, and rig JSON collection without normalizing caller-specific diagnostics.
- Diffstat: 7 files, 136 insertions, 76 deletions (net +60 LOC, including regression tests).

Fixes #7773

## Constraint compliance
- CLI commands, flags, help text, and JSON schemas are unchanged.
- Report bare-path behavior is regression-tested by `json_value_spec_accepts_legacy_bare_path`; existing failure/performance digest suites guard rendered behavior and diagnostics.
- Strict, optional, and lossy behavior is regression-tested by `typed_json_reader_preserves_strict_optional_and_lossy_modes`.
- Existing rig source and schema tests verify collect-invalid behavior, sorting/classification, and raw parse diagnostics.
- Caller-owned error mappers preserve observation bundle, portable config, report, and rig error text/raw-input policies.

## Verification
- `cargo build -j 3`
- `cargo test -j 3 core::config::json_io::tests`
- `cargo test -j 3 core::component::portable`
- `cargo test -j 3 commands::runs::bundle`
- `cargo test -j 3 sources_list_`
- `cargo test -j 3 core::rig::schema_error_tests`
- `cargo test -j 3 --test report_failure_digest_test`
- `cargo test -j 3 --test report_performance_digest_test`
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (208 existing baseline warnings; no new warning from these changes)
- Worktree `cargo run -j 3 -- --help` succeeded. Primary-checkout build permission was denied by the execution environment, so byte comparison was skipped; CI is the final arbiter.

## Skipped sub-items
- Fuzz, resource lifecycle, loop-sync, hotspot, reconciliation, and inventory readers were verified as intentionally different rather than duplicates. They retain custom error codes/messages, semantic validation, or collection fallback behavior, so consolidating them would risk contractual behavior changes.
- Rig `list`/`list_ids` were left unchanged because malformed JSON intentionally has different visibility semantics there.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (sol) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation of the consolidation described in the issue, plus verification runs. Reviewed by Chris Huber.