### PR TITLE
Tests: consolidate temp, Git, and artifact fixtures

### DIFF
--- a/src/commands/bench/tests/mod.rs
+++ b/src/commands/bench/tests/mod.rs
@@ -1,12 +1,11 @@
 use super::*;
-use crate::test_support::with_isolated_home;
+use crate::test_support::{git_fixture_output, run_git_fixture_command, with_isolated_home};
 use clap::error::ErrorKind;
 use clap::Parser;
 use homeboy::core::extension::bench::aggregate_comparison;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 use tempfile::TempDir;
 
@@ -248,39 +247,17 @@ fn install_git_rig_package(
     )
     .expect("write package rig");
 
-    git(&package_root, &["init", "-b", "main"]);
-    git(&package_root, &["config", "user.name", "Test User"]);
-    git(&package_root, &["config", "user.email", "test@example.com"]);
-    git(&package_root, &["add", "."]);
-    git(&package_root, &["commit", "-m", "Initial rig package"]);
-    let revision = git_output(&package_root, &["rev-parse", "--short", "HEAD"]);
+    run_git_fixture_command(&package_root, &["init", "-b", "main"]);
+    run_git_fixture_command(&package_root, &["config", "user.name", "Test User"]);
+    run_git_fixture_command(&package_root, &["config", "user.email", "test@example.com"]);
+    run_git_fixture_command(&package_root, &["add", "."]);
+    run_git_fixture_command(&package_root, &["commit", "-m", "Initial rig package"]);
+    let revision = git_fixture_output(&package_root, &["rev-parse", "--short", "HEAD"]);
     fs::write(package_root.join("untracked.txt"), "dirty\n").expect("dirty package");
 
     homeboy::core::rig::install(package_root.to_string_lossy().as_ref(), Some(rig_id), false)
         .expect("install rig package");
     (package_root, revision)
-}
-
-fn git(repo: &std::path::Path, args: &[&str]) {
-    let status = Command::new("git")
-        .args(args)
-        .current_dir(repo)
-        .status()
-        .expect("run git");
-    assert!(status.success(), "git {:?} failed", args);
-}
-
-fn git_output(repo: &std::path::Path, args: &[&str]) -> String {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(repo)
-        .output()
-        .expect("run git");
-    assert!(output.status.success(), "git {:?} failed", args);
-    String::from_utf8(output.stdout)
-        .expect("git output utf8")
-        .trim()
-        .to_string()
 }
 
 fn write_local_rig_package(

--- a/src/commands/fuzz/inspect.rs
+++ b/src/commands/fuzz/inspect.rs
@@ -185,7 +185,7 @@ fn fuzz_inspect_evidence_ref(artifact: &ArtifactRecord) -> Option<EvidenceRef> {
 #[cfg(test)]
 mod tests {
     use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
-    use homeboy::test_support::with_isolated_home;
+    use homeboy::test_support::{with_isolated_home, ArtifactRootOverrideGuard};
 
     use super::super::types::FuzzInspectArgs;
     use super::run_inspect;
@@ -204,8 +204,8 @@ mod tests {
     #[test]
     fn inspect_prints_raw_fuzz_results_for_fuzz_run() {
         with_isolated_home(|home| {
-            let artifact_root = home.path().join("agent-readable-artifacts");
-            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run("fuzz", serde_json::json!({ "exit_code": 1 })))
@@ -243,15 +243,14 @@ mod tests {
                 .as_deref()
                 .unwrap()
                 .contains("runs artifact get"));
-            homeboy::core::set_artifact_root_override(None);
         });
     }
 
     #[test]
     fn inspect_resolves_raw_results_through_lab_runner_job() {
         with_isolated_home(|home| {
-            let artifact_root = home.path().join("agent-readable-artifacts");
-            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
             let store = ObservationStore::open_initialized().expect("store");
             let remote_job_id = "remote-job-inspect-5997";
             let runner_run = store
@@ -303,15 +302,14 @@ mod tests {
                     .and_then(|v| v.as_str()),
                 Some("lab-raw")
             );
-            homeboy::core::set_artifact_root_override(None);
         });
     }
 
     #[test]
     fn inspect_raw_flag_returns_text_body() {
         with_isolated_home(|home| {
-            let artifact_root = home.path().join("agent-readable-artifacts");
-            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run("fuzz", serde_json::json!({})))
@@ -331,15 +329,14 @@ mod tests {
             assert_eq!(output.status, "ok");
             assert!(output.result.is_none());
             assert_eq!(output.raw.as_deref(), Some("{\"ok\":true}"));
-            homeboy::core::set_artifact_root_override(None);
         });
     }
 
     #[test]
     fn inspect_discovers_canonical_envelope_with_generic_artifact_kind() {
         with_isolated_home(|home| {
-            let artifact_root = home.path().join("agent-readable-artifacts");
-            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run("fuzz", serde_json::json!({})))
@@ -397,15 +394,14 @@ mod tests {
             let summary = output.envelope_summary.expect("envelope summary");
             assert_eq!(summary.gate_status, "passed");
             assert_eq!(summary.campaign_id, "campaign-1");
-            homeboy::core::set_artifact_root_override(None);
         });
     }
 
     #[test]
     fn inspect_reports_not_found_without_raw_artifact() {
         with_isolated_home(|home| {
-            let artifact_root = home.path().join("agent-readable-artifacts");
-            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run("fuzz", serde_json::json!({})))
@@ -424,7 +420,6 @@ mod tests {
                 .next_steps
                 .iter()
                 .any(|step| step.contains("runs evidence")));
-            homeboy::core::set_artifact_root_override(None);
         });
     }
 }

--- a/src/core/agent_task_service/tests.rs
+++ b/src/core/agent_task_service/tests.rs
@@ -591,27 +591,15 @@ impl AgentTaskExecutorAdapter for CapturingExecutor {
 
 fn create_git_repo(path: &Path) {
     std::fs::create_dir_all(path).expect("repo dir");
-    run_git(path, &["init", "-q"]);
-    run_git(path, &["config", "user.email", "homeboy@example.com"]);
-    run_git(path, &["config", "user.name", "Homeboy Test"]);
-    std::fs::write(path.join("README.md"), "initial\n").expect("readme");
-    run_git(path, &["add", "."]);
-    run_git(path, &["commit", "-q", "-m", "initial"]);
-}
-
-fn run_git(dir: &Path, args: &[&str]) {
-    let output = std::process::Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .expect("run git");
-    assert!(
-        output.status.success(),
-        "git {:?} failed: stdout={} stderr={}",
-        args,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+    crate::test_support::run_git_fixture_command(path, &["init", "-q"]);
+    crate::test_support::run_git_fixture_command(
+        path,
+        &["config", "user.email", "homeboy@example.com"],
     );
+    crate::test_support::run_git_fixture_command(path, &["config", "user.name", "Homeboy Test"]);
+    std::fs::write(path.join("README.md"), "initial\n").expect("readme");
+    crate::test_support::run_git_fixture_command(path, &["add", "."]);
+    crate::test_support::run_git_fixture_command(path, &["commit", "-q", "-m", "initial"]);
 }
 
 fn write_component_registration(home: &Path, id: &str, local_path: &Path) {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -35,6 +35,21 @@ pub(crate) struct AuditHomeGuard {
     _guard: MutexGuard<'static, ()>,
 }
 
+pub(crate) struct ArtifactRootOverrideGuard;
+
+impl ArtifactRootOverrideGuard {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        crate::core::set_artifact_root_override(Some(path));
+        Self
+    }
+}
+
+impl Drop for ArtifactRootOverrideGuard {
+    fn drop(&mut self) {
+        crate::core::set_artifact_root_override(None);
+    }
+}
+
 impl AuditGuard {
     pub(crate) fn new() -> Self {
         let home_guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
@@ -217,7 +232,7 @@ fn shared_empty_git_repo_template() -> &'static Path {
     SHARED_EMPTY_GIT_REPO_TEMPLATE
         .get_or_init(|| {
             let temp = TempDir::new().expect("git template tempdir");
-            run_git_fixture_command(temp.path(), &["init", "-q"]);
+            run_git_template_command(temp.path(), &["init", "-q"]);
             temp
         })
         .path()
@@ -227,11 +242,11 @@ fn shared_committed_git_repo_template() -> &'static Path {
     SHARED_COMMITTED_GIT_REPO_TEMPLATE
         .get_or_init(|| {
             let temp = TempDir::new().expect("committed git template tempdir");
-            run_git_fixture_command(temp.path(), &["init", "-q"]);
+            run_git_template_command(temp.path(), &["init", "-q"]);
             std::fs::write(temp.path().join("README.md"), "# homeboy test fixture\n")
                 .expect("git template readme");
-            run_git_fixture_command(temp.path(), &["add", "README.md"]);
-            run_git_fixture_command(temp.path(), &["commit", "-q", "-m", "test fixture"]);
+            run_git_template_command(temp.path(), &["add", "README.md"]);
+            run_git_template_command(temp.path(), &["commit", "-q", "-m", "test fixture"]);
             temp
         })
         .path()
@@ -252,17 +267,57 @@ fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn run_git_fixture_command(repo: &Path, args: &[&str]) {
-    let status = Command::new("git")
+pub(crate) fn run_git_fixture_command(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("git fixture command");
+    assert!(
+        output.status.success(),
+        "git fixture command {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_git_template_command(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
         .args(args)
         .current_dir(repo)
         .env("GIT_AUTHOR_NAME", "homeboy-test")
         .env("GIT_AUTHOR_EMAIL", "homeboy-test@example.invalid")
         .env("GIT_COMMITTER_NAME", "homeboy-test")
         .env("GIT_COMMITTER_EMAIL", "homeboy-test@example.invalid")
-        .status()
+        .output()
+        .expect("git template command");
+    assert!(
+        output.status.success(),
+        "git template command {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+pub(crate) fn git_fixture_output(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
         .expect("git fixture command");
-    assert!(status.success(), "git fixture command {:?} failed", args);
+    assert!(
+        output.status.success(),
+        "git fixture command {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git fixture output utf8")
+        .trim()
+        .to_string()
 }
 
 fn minimal_source_grammar() -> &'static str {

--- a/tests/commands/refactor_test.rs
+++ b/tests/commands/refactor_test.rs
@@ -1,32 +1,20 @@
-use std::fs;
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use homeboy::core::refactor;
 
-fn tmp_dir(name: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir().join(format!("homeboy-refactor-{name}-{nanos}"))
-}
+#[path = "../support/mod.rs"]
+#[allow(dead_code)]
+mod support;
 
 #[test]
 fn test_build_plan() {
-    let root = tmp_dir("missing");
-    fs::create_dir_all(&root).unwrap();
+    let root = support::temp_dir("refactor-missing");
 
-    let result = refactor::build_plan("src/missing.rs", &root, "grouped", true);
+    let result = refactor::build_plan("src/missing.rs", root.path(), "grouped", true);
     assert!(result.is_err());
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn test_apply_plan_skeletons() {
-    let root = tmp_dir("skeletons");
-    fs::create_dir_all(&root).unwrap();
+    let root = support::temp_dir("refactor-skeletons");
 
     let plan = refactor::DecomposePlan {
         file: "src/core/deploy.rs".to_string(),
@@ -55,10 +43,8 @@ fn test_apply_plan_skeletons() {
         warnings: vec![],
     };
 
-    let created = refactor::apply_plan_skeletons(&plan, &root).unwrap();
+    let created = refactor::apply_plan_skeletons(&plan, root.path()).unwrap();
     assert_eq!(created.len(), 2);
-    assert!(root.join("src/core/deploy/types.inc").exists());
-    assert!(root.join("src/core/deploy/execution.inc").exists());
-
-    let _ = fs::remove_dir_all(root);
+    assert!(root.path().join("src/core/deploy/types.inc").exists());
+    assert!(root.path().join("src/core/deploy/execution.inc").exists());
 }

--- a/tests/core/refactor/decompose_test.rs
+++ b/tests/core/refactor/decompose_test.rs
@@ -1,36 +1,27 @@
-use std::fs;
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use homeboy::core::extension::ParsedItem;
 use homeboy::core::refactor::{self, DecomposeGroup, DecomposePlan};
+use std::fs;
 
-fn tmp_dir(name: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("clock should be after epoch")
-        .as_nanos();
-    std::env::temp_dir().join(format!("homeboy-decompose-{name}-{nanos}"))
-}
+#[path = "../../support/mod.rs"]
+#[allow(dead_code)]
+mod support;
 
 #[test]
 fn test_build_plan() {
-    let root = tmp_dir("build-plan");
-    fs::create_dir_all(root.join("src")).expect("create source dir");
-    fs::write(root.join("src/mod.rs"), "pub fn run() {}\n").expect("write source file");
+    let root = support::temp_dir("decompose-build-plan");
+    fs::create_dir_all(root.path().join("src")).expect("create source dir");
+    fs::write(root.path().join("src/mod.rs"), "pub fn run() {}\n").expect("write source file");
 
-    let plan = refactor::build_plan("src/mod.rs", &root, "grouped", true).expect("build plan");
+    let plan =
+        refactor::build_plan("src/mod.rs", root.path(), "grouped", true).expect("build plan");
     assert_eq!(plan.file, "src/mod.rs");
     assert_eq!(plan.strategy, "grouped");
     assert!(plan.audit_safe);
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn test_apply_plan_skeletons() {
-    let root = tmp_dir("apply-skeletons");
-    fs::create_dir_all(&root).expect("create root");
+    let root = support::temp_dir("decompose-apply-skeletons");
 
     let plan = DecomposePlan {
         file: "src/core/deploy.rs".to_string(),
@@ -52,16 +43,13 @@ fn test_apply_plan_skeletons() {
         warnings: vec![],
     };
 
-    let created = refactor::apply_plan_skeletons(&plan, &root).expect("apply skeletons");
+    let created = refactor::apply_plan_skeletons(&plan, root.path()).expect("apply skeletons");
     assert_eq!(created, vec!["src/core/deploy/execution.inc".to_string()]);
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn test_apply_plan_empty_groups() {
-    let root = tmp_dir("apply-plan-empty");
-    fs::create_dir_all(&root).expect("create root");
+    let root = support::temp_dir("decompose-apply-plan-empty");
 
     let plan = DecomposePlan {
         file: "src/core/deploy.rs".to_string(),
@@ -79,46 +67,42 @@ fn test_apply_plan_empty_groups() {
         warnings: vec![],
     };
 
-    let preview = refactor::apply_plan(&plan, &root, false).expect("preview apply");
+    let preview = refactor::apply_plan(&plan, root.path(), false).expect("preview apply");
     assert!(preview.is_empty());
 
-    let applied = refactor::apply_plan(&plan, &root, true).expect("apply");
+    let applied = refactor::apply_plan(&plan, root.path(), true).expect("apply");
     assert!(applied.is_empty());
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn test_group_items() {
-    let root = tmp_dir("group-items");
-    fs::create_dir_all(root.join("src/core")).expect("create source dir");
+    let root = support::temp_dir("decompose-group-items");
+    fs::create_dir_all(root.path().join("src/core")).expect("create source dir");
     fs::write(
-        root.join("src/core/deploy.rs"),
+        root.path().join("src/core/deploy.rs"),
         "pub struct Config {}\nfn run() {}\n",
     )
     .expect("write source file");
 
-    let plan = refactor::build_plan("src/core/deploy.rs", &root, "grouped", true)
+    let plan = refactor::build_plan("src/core/deploy.rs", root.path(), "grouped", true)
         .expect("build grouped plan");
     let groups = plan.groups;
     assert!(groups.iter().any(|g| g.name == "types"));
     assert!(groups.iter().any(|g| g.name == "execution"));
     assert!(groups.iter().all(|g| g.suggested_target.ends_with(".inc")));
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn test_group_items_dedupes_duplicate_names() {
-    let root = tmp_dir("group-items-dedup");
-    fs::create_dir_all(root.join("src/core")).expect("create source dir");
+    let root = support::temp_dir("decompose-group-items-dedup");
+    fs::create_dir_all(root.path().join("src/core")).expect("create source dir");
     fs::write(
-        root.join("src/core/upgrade.rs"),
+        root.path().join("src/core/upgrade.rs"),
         "pub enum InstallMethod { A }\npub enum InstallMethod { A }\n",
     )
     .expect("write source file");
 
-    let plan = refactor::build_plan("src/core/upgrade.rs", &root, "grouped", true)
+    let plan = refactor::build_plan("src/core/upgrade.rs", root.path(), "grouped", true)
         .expect("build grouped plan");
     let groups = plan.groups;
     let types = groups
@@ -126,24 +110,20 @@ fn test_group_items_dedupes_duplicate_names() {
         .find(|group| group.name == "types")
         .expect("types group");
     assert_eq!(types.item_names, vec!["InstallMethod".to_string()]);
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn test_parse_items() {
     // Unknown extension should return None without trying extension scripts.
-    let root = tmp_dir("parse-items-unknown");
-    fs::create_dir_all(root.join("src")).expect("create source dir");
-    fs::write(root.join("src/example.unknown"), "content\n").expect("write source file");
+    let root = support::temp_dir("decompose-parse-items-unknown");
+    fs::create_dir_all(root.path().join("src")).expect("create source dir");
+    fs::write(root.path().join("src/example.unknown"), "content\n").expect("write source file");
 
-    let plan =
-        refactor::build_plan("src/example.unknown", &root, "grouped", true).expect("build plan");
+    let plan = refactor::build_plan("src/example.unknown", root.path(), "grouped", true)
+        .expect("build plan");
     assert_eq!(plan.total_items, 0);
     assert!(plan
         .warnings
         .iter()
         .any(|warning| warning.contains("No refactor parser available")));
-
-    let _ = fs::remove_dir_all(root);
 }

--- a/tests/refactor_transform_test.rs
+++ b/tests/refactor_transform_test.rs
@@ -1,22 +1,16 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use homeboy::core::refactor;
 
-fn tmp_dir(name: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir().join(format!("homeboy-refactor-{name}-{nanos}"))
-}
+#[allow(dead_code)]
+mod support;
 
 #[test]
 fn transform_output_samples_match_details_at_scale() {
-    let root = tmp_dir("transform-scale");
-    let src = root.join("src");
+    let root = support::temp_dir("refactor-transform-scale");
+    let src = root.path().join("src");
     fs::create_dir_all(&src).unwrap();
 
     for file_index in 0..200 {
@@ -29,7 +23,7 @@ fn transform_output_samples_match_details_at_scale() {
 
     let set = refactor::ad_hoc_transform("OLD", "NEW", "src/**/*.txt", "line");
     let result = refactor::apply_transforms(
-        &root,
+        root.path(),
         "ad-hoc",
         &set,
         false,
@@ -54,19 +48,18 @@ fn transform_output_samples_match_details_at_scale() {
 
     let json = serde_json::to_string(&result).unwrap();
     assert!(json.len() < 60_000, "json output was {} bytes", json.len());
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn transform_output_can_include_full_match_details() {
-    let root = tmp_dir("transform-full-details");
-    let src = root.join("src");
+    let root = support::temp_dir("refactor-transform-full-details");
+    let src = root.path().join("src");
     fs::create_dir_all(&src).unwrap();
     fs::write(src.join("file.txt"), "OLD one\nOLD two\nOLD three\n").unwrap();
 
     let set = refactor::ad_hoc_transform("OLD", "NEW", "src/**/*.txt", "line");
-    let result = refactor::apply_transforms(&root, "ad-hoc", &set, false, None, None).unwrap();
+    let result =
+        refactor::apply_transforms(root.path(), "ad-hoc", &set, false, None, None).unwrap();
     let rule = &result.rules[0];
 
     assert_eq!(rule.replacement_count, 3);
@@ -74,23 +67,21 @@ fn transform_output_can_include_full_match_details() {
     assert!(!rule.matches_truncated);
     assert_eq!(rule.omitted_match_count, 0);
     assert_eq!(rule.match_detail_limit, None);
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn rename_defaults_to_cwd_git_worktree_without_component_metadata() {
-    let root = tmp_dir("rename-cwd");
-    fs::create_dir_all(root.join("src")).unwrap();
+    let root = support::temp_dir("refactor-rename-cwd");
+    fs::create_dir_all(root.path().join("src")).unwrap();
     fs::write(
-        root.join("src/lib.rs"),
+        root.path().join("src/lib.rs"),
         "pub fn old_name() -> i32 { 1 }\npub fn call() -> i32 { old_name() }\n",
     )
     .unwrap();
 
     let git_init = Command::new("git")
         .arg("init")
-        .current_dir(&root)
+        .current_dir(root.path())
         .output()
         .expect("git init");
     assert!(
@@ -103,8 +94,8 @@ fn rename_defaults_to_cwd_git_worktree_without_component_metadata() {
         .args([
             "refactor", "rename", "--from", "old_name", "--to", "new_name", "--write",
         ])
-        .current_dir(&root)
-        .env("HOME", &root)
+        .current_dir(root.path())
+        .env("HOME", root.path())
         .output()
         .expect("run homeboy refactor rename");
 
@@ -114,11 +105,9 @@ fn rename_defaults_to_cwd_git_worktree_without_component_metadata() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let source = fs::read_to_string(root.join("src/lib.rs")).unwrap();
+    let source = fs::read_to_string(root.path().join("src/lib.rs")).unwrap();
     assert!(source.contains("new_name"));
     assert!(!source.contains("old_name"));
-
-    let _ = fs::remove_dir_all(root);
 }
 
 fn homeboy_bin() -> PathBuf {


### PR DESCRIPTION
## Summary
- replace timestamped refactor temp directories and manual cleanup with shared RAII `tempfile` support
- share checked Git command/output primitives across bench and agent-task fixtures while preserving branch, identity, commit, and dirty-worktree variants
- add a scoped artifact-root override guard and adopt it in fuzz inspect tests
- diffstat: 7 files changed, 141 insertions(+), 171 deletions(-) (net -30 LOC)

Fixes #7774

## Constraint compliance
- No production command, flag, help text, JSON schema, or error text changed; all changes are test-only.
- Bench output serialization remained guarded by the existing `commands::bench::tests::output_tests` coverage included in the 93-test bench module run.
- Git fixture behavior was preserved: bench remains explicit `main` with its configured identity and dirty worktree; agent-task remains implicit-branch with its configured identity; generic shared templates retain their existing template-only identity.
- `cargo run -j 3 -- --help` succeeded for this worktree. The primary-checkout command was denied by the environment permission boundary, so byte comparison was skipped; CI remains the final arbiter.

## Verification
- `cargo build -j 3`
- `cargo test -j 3 --test refactor_transform_test`
- `cargo test -j 3 commands::bench::tests::` (93 passed)
- `cargo test -j 3 core::agent_task_service::tests::service_materializes_component_worktree_before_provider_dispatch`
- `cargo test -j 3 commands::fuzz::inspect::tests::` (5 passed)
- targeted bench Git fixture and agent-task Git fixture reruns after identity separation
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (existing baseline: 208 warnings; no new warnings observed)

## Skipped items
- Kept rig and stack domain helpers, including `bare_source_path`: they are actively used and intentionally encode explicit-main, bare-clone/push, persistent-identity, and revision behavior.
- Kept committed/empty shared Git templates: both are active and their differing repository states are intentional.
- Kept runs bundle `tempfile::tempdir` usage: it is already RAII-based, not the timestamp/manual-cleanup pattern described by the issue.
- Kept non-executable `write_script` helpers that are invoked through interpreters; converting them to an executable writer would change fixture semantics.
- Nested `tests/commands/refactor_test.rs` and `tests/core/refactor/decompose_test.rs` are not registered Cargo test targets on this branch; their filters execute zero tests. They were migrated mechanically, while the registered refactor transform target passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (sol) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation of the consolidation described in the issue, plus verification runs. Reviewed by Chris Huber.