### PR TITLE
Reuse core path helpers

### DIFF
--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -8,6 +8,7 @@ use homeboy::core::extension::{
     self, extension_ready_status, is_extension_linked, load_extension, run_setup, ExtensionSummary,
     UpdateEntry,
 };
+use homeboy::core::git;
 use homeboy::core::project::{self, Project};
 use homeboy::core::runners::{self, RunnerKind};
 use homeboy::core::server::{self, SshClient};
@@ -725,7 +726,7 @@ fn parse_runner_diff_installed(stdout: &str) -> homeboy::core::Result<Vec<Instal
 }
 
 fn installed_extension_diff(summary: ExtensionSummary) -> InstalledExtensionDiff {
-    let checkout_head_revision = git_head_revision(Path::new(&summary.path));
+    let checkout_head_revision = git::head_sha_short(Path::new(&summary.path));
     let manifest_path = manifest_path_for_summary(&summary);
     let source_url = read_source_url_metadata(&summary.path);
     let source_path = source_url.as_deref().and_then(local_source_path);
@@ -789,7 +790,11 @@ fn local_source_path(source: &str) -> Option<String> {
     if looks_like_remote_source(source) {
         return None;
     }
-    Some(shellexpand::tilde(source).to_string())
+    Some(
+        homeboy::core::expand_tilde_path(source)
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 fn looks_like_remote_source(source: &str) -> bool {
@@ -846,25 +851,6 @@ fn installed_extension_diff_next_command(summary: &ExtensionSummary, status: &st
         "unready" => format!("homeboy extension setup {}", shell_arg(&summary.id)),
         _ => format!("homeboy extension show {}", shell_arg(&summary.id)),
     }
-}
-
-fn git_head_revision(path: &Path) -> Option<String> {
-    if path.as_os_str().is_empty() || !path.exists() {
-        return None;
-    }
-    let output = Command::new("git")
-        .args(["-C"])
-        .arg(path)
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    String::from_utf8(output.stdout)
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
 }
 
 fn show_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -481,7 +481,7 @@ fn collect_local_paths(value: &Value, paths: &mut Vec<PathBuf>) {
             for (key, value) in map {
                 if matches!(key.as_str(), "local_path" | "localPath") {
                     if let Some(path) = value.as_str().filter(|path| !path.trim().is_empty()) {
-                        paths.push(expand_user_path(path));
+                        paths.push(homeboy::core::expand_tilde_path(path));
                     }
                 }
                 collect_local_paths(value, paths);
@@ -494,10 +494,6 @@ fn collect_local_paths(value: &Value, paths: &mut Vec<PathBuf>) {
         }
         _ => {}
     }
-}
-
-fn expand_user_path(path: &str) -> PathBuf {
-    PathBuf::from(shellexpand::tilde(path).into_owned())
 }
 
 fn path_is_at_or_inside(parent: &Path, path: &Path) -> bool {

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -885,7 +885,7 @@ fn rig_owned_trace_workload_expansion_warnings(
         id,
     )
     .into_iter()
-    .filter(|expansion| !path_is_under(&expansion.expanded_path, root))
+    .filter(|expansion| !homeboy::core::local_path_is_contained(root, &expansion.expanded_path))
     .map(|expansion| {
         let freshness = if expansion.expanded_path.is_file() {
             " If this is stale, refresh/reinstall the rig package or sync edits to the executed path before rerunning."
@@ -901,12 +901,6 @@ fn rig_owned_trace_workload_expansion_warnings(
         )
     })
     .collect()
-}
-
-fn path_is_under(path: &Path, root: &Path) -> bool {
-    let normalized_path = path.components().collect::<PathBuf>();
-    let normalized_root = root.components().collect::<PathBuf>();
-    normalized_path == normalized_root || normalized_path.starts_with(normalized_root)
 }
 
 #[derive(Clone)]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -196,6 +196,11 @@ pub fn artifact_root() -> Result<std::path::PathBuf> {
     paths::artifact_root()
 }
 
+/// Expand a leading tilde in a local path.
+pub fn expand_tilde_path(path: impl AsRef<std::path::Path>) -> std::path::PathBuf {
+    paths::expand_tilde_path(path)
+}
+
 /// Resolve a remote path against an optional project base path.
 pub fn join_remote_path(base_path: Option<&str>, path: &str) -> Result<String> {
     paths::join_remote_path(base_path, path)

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -115,26 +115,27 @@ pub fn artifact_root() -> Result<PathBuf> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .clone()
     {
-        return Ok(expand_path(path));
+        return Ok(expand_tilde_path(path));
     }
 
     if let Ok(path) = env::var("HOMEBOY_ARTIFACT_ROOT") {
         if !path.trim().is_empty() {
-            return Ok(expand_path(PathBuf::from(path)));
+            return Ok(expand_tilde_path(path));
         }
     }
 
     if let Some(path) = crate::core::defaults::load_config().artifact_root {
         if !path.trim().is_empty() {
-            return Ok(expand_path(PathBuf::from(path)));
+            return Ok(expand_tilde_path(path));
         }
     }
 
     Ok(homeboy_data()?.join("artifacts"))
 }
 
-fn expand_path(path: PathBuf) -> PathBuf {
-    let raw = path.to_string_lossy();
+/// Expand a leading tilde in a local path.
+pub fn expand_tilde_path(path: impl AsRef<Path>) -> PathBuf {
+    let raw = path.as_ref().to_string_lossy();
     PathBuf::from(shellexpand::tilde(&raw).into_owned())
 }
 
@@ -424,6 +425,17 @@ mod tests {
             assert_eq!(
                 artifact_root().expect("artifact root"),
                 home.path().join(".local/share/homeboy/artifacts")
+            );
+        });
+    }
+
+    #[test]
+    fn expand_tilde_path_uses_home_and_preserves_other_paths() {
+        with_isolated_home(|home| {
+            assert_eq!(expand_tilde_path("~/source"), home.path().join("source"));
+            assert_eq!(
+                expand_tilde_path("relative/source"),
+                PathBuf::from("relative/source")
             );
         });
     }

--- a/src/core/runner/rig_materialization/mod.rs
+++ b/src/core/runner/rig_materialization/mod.rs
@@ -855,7 +855,7 @@ fn required_component_subpath(
 }
 
 fn normalize_path_for_prefix(path: &Path) -> PathBuf {
-    path.components().collect()
+    crate::core::paths::normalize_local_path(path)
 }
 
 fn lab_offload_rig_ids(args: &[String]) -> Vec<String> {


### PR DESCRIPTION
## Summary
- expose a focused core tilde-expansion path primitive and reuse it in status and extension flows
- reuse core lexical path normalization/containment in trace and runner rig materialization
- reuse the core short-HEAD Git query in extension diff reporting
- diffstat: 6 files changed, 32 insertions, 39 deletions (net -7 LOC)

Fixes #7769

## Constraint compliance
- Preserved `status` canonicalized containment unchanged, including its symlink semantics; only its tilde expansion now delegates to core.
- Preserved extension JSON output via all 8 `commands::extension` tests, including installed extension diff contract coverage.
- Preserved trace warning behavior via both `rig_trace_workload_expansion` tests.
- Added focused `expand_tilde_path` regression coverage for HOME expansion and unchanged relative paths.
- `cargo build -j 3` passes after rebasing onto current `origin/main`.
- Focused path, status, extension, trace warning, and rig materialization tests pass. The broad trace filter had 72 passes and 2 known environment-sensitive rig-validation failures; the directly changed trace tests pass independently.
- `cargo clippy --all-targets -j 3` completes with the existing baseline warnings and no new warning attributable to this change.
- Branch `--help` generation succeeds. Primary-checkout byte comparison was skipped because the environment denied the read-only primary build invocation.

## Skipped items
- None. The issue's former `src/core/runner/exec.rs` helper had moved to `src/core/runner/rig_materialization/mod.rs`; its verified equivalent now delegates to core normalization.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (sol) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation of the consolidation described in the issue, plus verification runs. Reviewed by Chris Huber.