### PR TITLE
Derive command consumers from registry

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -1,4 +1,4 @@
-use clap::{ArgMatches, Command, CommandFactory, FromArgMatches};
+use clap::{ArgMatches, Command, CommandFactory};
 use std::io::IsTerminal;
 use std::sync::OnceLock;
 
@@ -164,8 +164,8 @@ impl CliRuntime {
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
 
-        let mut cli = match Cli::from_arg_matches(&matches) {
-            Ok(cli) => cli,
+        let (mut cli, command_spec) = match Cli::from_registered_arg_matches(&matches) {
+            Ok(parsed) => parsed,
             Err(err) => err.exit(),
         };
         commands::set_skip_deps_hydration(cli.skip_deps_hydration);
@@ -209,8 +209,12 @@ impl CliRuntime {
 
         run_startup_update_checks(&cli.command);
 
-        let exit_code =
-            commands::output_runtime::run_command(cli.command, &global, output_file.as_deref());
+        let exit_code = commands::output_runtime::run_command(
+            cli.command,
+            command_spec,
+            &global,
+            output_file.as_deref(),
+        );
         std::process::ExitCode::from(exit_code_to_u8(exit_code))
     }
 
@@ -1233,7 +1237,7 @@ mod tests {
             Some("/tmp/controller-result.json")
         );
 
-        let cli = Cli::from_arg_matches(&matches).expect("typed cli");
+        let (cli, _) = Cli::from_registered_arg_matches(&matches).expect("typed cli");
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
     }
 }

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Command, CommandFactory, Parser, Subcommand};
+use clap::{ArgMatches, Args, Command, CommandFactory, FromArgMatches, Parser, Subcommand};
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -78,6 +78,19 @@ pub struct Cli {
 
     #[command(subcommand)]
     pub command: Commands,
+}
+
+impl Cli {
+    pub fn from_registered_arg_matches(
+        matches: &ArgMatches,
+    ) -> Result<(Self, &'static crate::command_contract::CommandSpec), clap::Error> {
+        let cli = Self::from_arg_matches(matches)?;
+        let spec = matches
+            .subcommand_name()
+            .and_then(crate::command_contract::registered_command)
+            .expect("built-in top-level command should be registered");
+        Ok((cli, spec))
+    }
 }
 
 #[derive(Subcommand)]
@@ -518,51 +531,6 @@ mod entry_command_impls {
                 .iter()
                 .find(|entry| !entry.hidden && entry.matches(first))
                 .is_some_and(|entry| entry.contains_rest(rest))
-        }
-    }
-
-    impl Commands {
-        pub fn top_level_name(&self) -> &'static str {
-            match self {
-                Commands::Activity(_) => "activity",
-                Commands::AgentTask(_) => "agent-task",
-                Commands::Project(_) => "project",
-                Commands::Ssh(_) => "ssh",
-                Commands::Server(_) => "server",
-                Commands::Bench(_) => "bench",
-                Commands::Fuzz(_) => "fuzz",
-                Commands::Trace(_) => "trace",
-                Commands::Observe(_) => "observe",
-                Commands::Db(_) => "db",
-                Commands::Deps(_) => "deps",
-                Commands::File(_) => "file",
-                Commands::Fleet(_) => "fleet",
-                Commands::Logs(_) => "logs",
-                Commands::Triage(_) => "triage",
-                Commands::Deploy(_) => "deploy",
-                Commands::Component(_) => "component",
-                Commands::Config(_) => "config",
-                Commands::Contract(_) => "contract",
-                Commands::Daemon(_) => "daemon",
-                Commands::Extension(_) => "extension",
-                Commands::Status(_) => "status",
-                Commands::Cleanup(_) => "cleanup",
-                Commands::Git(_) => "git",
-                Commands::Release(_) => "release",
-                Commands::Report(_) => "report",
-                Commands::Review(_) => "review",
-                Commands::Refactor(_) => "refactor",
-                Commands::Rig(_) => "rig",
-                Commands::Runner(_) => "runner",
-                Commands::Runtime(_) => "runtime",
-                Commands::Worktree(_) => "worktree",
-                Commands::Tunnel(_) => "tunnel",
-                Commands::Runs(_) => "runs",
-                Commands::SelfCmd(_) => "self",
-                Commands::Stack(_) => "stack",
-                Commands::Api(_) => "api",
-                Commands::Upgrade(_) => "upgrade",
-            }
         }
     }
 }

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -15,7 +15,7 @@ use crate::cli_surface::Commands;
 use crate::commands::{adapter, file, logs, report, review, runner, runtime, trace};
 
 use super::lab::apply_lab_contract_to_descriptor;
-use super::spec::registered_command;
+use super::spec::CommandSpec;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandResponseMode {
@@ -134,12 +134,16 @@ pub struct CommandResponsePlan {
 }
 
 impl Commands {
-    pub fn descriptor(&self, has_output_file: bool) -> CommandDescriptor {
-        self.output_descriptor(has_output_file)
+    pub fn descriptor(&self, spec: &CommandSpec, has_output_file: bool) -> CommandDescriptor {
+        self.output_descriptor(spec, has_output_file)
             .with_lab_contract(self.lab_contract())
     }
 
-    pub fn output_descriptor(&self, has_output_file: bool) -> CommandOutputDescriptor {
+    pub fn output_descriptor(
+        &self,
+        spec: &CommandSpec,
+        has_output_file: bool,
+    ) -> CommandOutputDescriptor {
         let output_file_mode = if !has_output_file {
             CommandOutputFileMode::None
         } else {
@@ -221,12 +225,12 @@ impl Commands {
             Commands::Fleet(_) | Commands::Observe(_) | Commands::Contract(_) => {
                 unreachable!("adapter-backed command descriptor returned before legacy routing")
             }
-            _ => registered_json_envelope_descriptor(self, output_file_mode),
+            _ => spec.output_descriptor(output_file_mode),
         }
     }
 
-    pub fn response_plan(&self, has_output_file: bool) -> CommandResponsePlan {
-        let descriptor = self.output_descriptor(has_output_file);
+    pub fn response_plan(&self, spec: &CommandSpec, has_output_file: bool) -> CommandResponsePlan {
+        let descriptor = self.output_descriptor(spec, has_output_file);
 
         CommandResponsePlan {
             stdout: match descriptor.response_mode {
@@ -237,12 +241,17 @@ impl Commands {
         }
     }
 
-    pub fn response_mode(&self, has_output_file: bool) -> CommandResponseMode {
-        self.output_descriptor(has_output_file).response_mode
+    pub fn response_mode(&self, spec: &CommandSpec, has_output_file: bool) -> CommandResponseMode {
+        self.output_descriptor(spec, has_output_file).response_mode
     }
 
-    pub fn output_file_mode(&self, has_output_file: bool) -> CommandOutputFileMode {
-        self.output_descriptor(has_output_file).output_file_mode
+    pub fn output_file_mode(
+        &self,
+        spec: &CommandSpec,
+        has_output_file: bool,
+    ) -> CommandOutputFileMode {
+        self.output_descriptor(spec, has_output_file)
+            .output_file_mode
     }
 
     pub fn consumes_output_file_as_command_arg(&self) -> bool {
@@ -283,20 +292,11 @@ fn markdown_or_json_response(markdown: bool) -> CommandResponseMode {
     }
 }
 
-fn registered_json_envelope_descriptor(
-    command: &Commands,
-    output_file_mode: CommandOutputFileMode,
-) -> CommandOutputDescriptor {
-    registered_command(command.top_level_name())
-        .expect("top-level command should be registered")
-        .output_descriptor(output_file_mode)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::cli_surface::Cli;
-    use clap::Parser;
+    use clap::{CommandFactory, FromArgMatches};
 
     #[test]
     fn representative_default_output_descriptors_come_from_command_registry() {
@@ -304,12 +304,14 @@ mod tests {
             let Some(argv) = spec.representative_argv else {
                 continue;
             };
-            let cli = Cli::try_parse_from(argv)
+            let matches = Cli::command()
+                .try_get_matches_from(argv)
                 .unwrap_or_else(|error| panic!("failed to parse `{}`: {error}", spec.name));
+            assert_eq!(matches.subcommand_name(), Some(spec.name));
+            let cli = Cli::from_arg_matches(&matches).expect("validated arguments should parse");
 
-            assert_eq!(cli.command.top_level_name(), spec.name);
             assert_eq!(
-                cli.command.output_descriptor(false),
+                cli.command.output_descriptor(spec, false),
                 spec.output_descriptor(CommandOutputFileMode::None),
                 "default output descriptor drifted for `{}`",
                 spec.name

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -1773,7 +1773,7 @@ fn display_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli_surface::{current_command_surface, Commands};
+    use crate::cli_surface::current_command_surface;
     use serde_json::json;
     use tempfile::TempDir;
 
@@ -1897,17 +1897,6 @@ mod tests {
             .unwrap()
             .iter()
             .any(|contract| contract["id"] == HOST_MUTATION_LIFECYCLE_SCHEMA));
-    }
-
-    #[test]
-    fn contract_command_name_is_registered_for_json_dispatch() {
-        let command = Commands::Contract(ContractArgs {
-            command: ContractCommand::Export(ContractExportArgs {
-                dir: PathBuf::from("contracts"),
-            }),
-        });
-
-        assert_eq!(command.top_level_name(), "contract");
     }
 
     #[test]

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Subcommand};
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -167,18 +167,23 @@ struct CommandAnalysisJobRunner;
 
 impl AnalysisJobRunner for CommandAnalysisJobRunner {
     fn run_analysis_job(&self, argv: Vec<String>) -> homeboy::core::Result<AnalysisJobRunOutput> {
-        let cli = crate::cli_surface::Cli::try_parse_from(argv).map_err(|error| {
-            homeboy::core::Error::validation_invalid_argument(
-                "body",
-                error.to_string(),
-                None,
-                Some(vec![
-                    "Use the documented JSON request body contract for this endpoint".to_string(),
-                ]),
-            )
-        })?;
+        let matches = crate::cli_surface::Cli::command()
+            .try_get_matches_from(argv)
+            .map_err(|error| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "body",
+                    error.to_string(),
+                    None,
+                    Some(vec![
+                        "Use the documented JSON request body contract for this endpoint"
+                            .to_string(),
+                    ]),
+                )
+            })?;
+        let (cli, spec) = crate::cli_surface::Cli::from_registered_arg_matches(&matches)
+            .expect("validated arguments should produce a typed CLI");
         let global = crate::commands::GlobalArgs {};
-        let (result, exit_code) = crate::commands::json_output::run(cli.command, &global);
+        let (result, exit_code) = crate::commands::json_output::run(cli.command, spec, &global);
         Ok(AnalysisJobRunOutput {
             exit_code,
             output: result?,

--- a/src/commands/infra/adapter.rs
+++ b/src/commands/infra/adapter.rs
@@ -135,10 +135,10 @@ pub(crate) fn command_adapter(
 
 pub(crate) fn run_command_output(
     command: Commands,
+    command_name: &'static str,
     global: &GlobalArgs,
     output_file_mode: CommandOutputFileMode,
 ) -> Result<CommandRun, Commands> {
-    let command_name = command.top_level_name();
     let (stdout_result, exit_code) = run_json_output(command, global, output_file_mode)?;
 
     Ok(CommandRun::from_command_stdout_result(
@@ -237,6 +237,7 @@ mod tests {
     fn run_command_output_routes_migrated_json_command() {
         let run = run_command_output(
             parsed_command(&["homeboy", "contract", "manifest"]),
+            "contract",
             &GlobalArgs {},
             CommandOutputFileMode::None,
         )
@@ -290,22 +291,29 @@ mod tests {
     #[test]
     fn migrated_adapter_output_descriptors_match_command_contracts() {
         let commands = [
-            parsed_command(&["homeboy", "fleet", "list"]),
-            parsed_command(&["homeboy", "observe", "demo", "--watch-process", "sleep"]),
-            parsed_command(&["homeboy", "contract", "manifest"]),
+            ("fleet", parsed_command(&["homeboy", "fleet", "list"])),
+            (
+                "observe",
+                parsed_command(&["homeboy", "observe", "demo", "--watch-process", "sleep"]),
+            ),
+            (
+                "contract",
+                parsed_command(&["homeboy", "contract", "manifest"]),
+            ),
         ];
         let output_file_modes = [
             CommandOutputFileMode::None,
             CommandOutputFileMode::GenericEnvelope,
         ];
 
-        for command in commands {
+        for (name, command) in commands {
+            let spec = crate::command_contract::registered_command(name).unwrap();
             for output_file_mode in output_file_modes {
                 let has_output_file = output_file_mode != CommandOutputFileMode::None;
 
                 assert_eq!(
                     output_descriptor(&command, output_file_mode),
-                    Some(command.output_descriptor(has_output_file))
+                    Some(command.output_descriptor(spec, has_output_file))
                 );
             }
         }

--- a/src/commands/infra/output_runtime.rs
+++ b/src/commands/infra/output_runtime.rs
@@ -137,17 +137,18 @@ impl<'a> OutputService<'a> {
 
 pub fn run_command(
     command: Commands,
+    spec: &'static crate::command_contract::CommandSpec,
     global: &GlobalArgs,
     requested_output_file: Option<&str>,
 ) -> i32 {
     let output_file = command_runtime_output_file(&command, requested_output_file);
-    let plan = command.response_plan(output_file.is_some());
+    let plan = command.response_plan(spec, output_file.is_some());
     let output_service = OutputService::new(output_file);
 
     match crate::commands::raw_output::prepare_command_run(command, global, plan.stdout) {
         crate::commands::raw_output::CommandRunPreparation::Handled(exit_code) => exit_code,
         crate::commands::raw_output::CommandRunPreparation::Json(command) => {
-            let run = run_json(*command, global, plan.output_file, output_file);
+            let run = run_json(*command, spec, global, plan.output_file, output_file);
             output_service.emit_run(run, plan.output_file)
         }
         crate::commands::raw_output::CommandRunPreparation::Raw(run) => {
@@ -202,6 +203,7 @@ pub fn command_runtime_output_file<'a>(
 
 pub fn run_json(
     command: Commands,
+    spec: &crate::command_contract::CommandSpec,
     global: &GlobalArgs,
     mode: CommandOutputFileMode,
     output_file: Option<&str>,
@@ -221,7 +223,7 @@ pub fn run_json(
             }
         }
         (_, command) => {
-            crate::commands::json_output::run_command_output(command, global, output_file)
+            crate::commands::json_output::run_command_output(command, spec, global, output_file)
         }
     }
 }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use crate::cli_surface::Commands;
-use crate::command_contract::{registered_command, CommandDispatchFamily};
+use crate::command_contract::{CommandDispatchFamily, CommandSpec};
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
 use super::output_runtime::{CommandPresentation, CommandRun};
@@ -14,22 +14,26 @@ mod workspace;
 type JsonRun = (homeboy::core::Result<Value>, i32);
 
 /// Dispatch a command to its handler and map the structured result to JSON.
-pub fn run(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
+pub fn run(
+    command: Commands,
+    spec: &CommandSpec,
+    global: &GlobalArgs,
+) -> (homeboy::core::Result<Value>, i32) {
     crate::commands::utils::tty::status("homeboy is working...");
 
-    dispatch(command, global)
+    dispatch(command, spec, global)
 }
 
 pub fn run_command_output(
     command: Commands,
+    spec: &CommandSpec,
     global: &GlobalArgs,
     output_file: Option<&str>,
 ) -> CommandRun {
     crate::commands::utils::tty::status("homeboy is working...");
-    let command_name = command.top_level_name();
-
     let run = match adapter::run_command_output(
         command,
+        spec.name,
         global,
         crate::command_contract::CommandOutputFileMode::None,
     ) {
@@ -39,7 +43,7 @@ pub fn run_command_output(
                 let run_from_spec_output_ref =
                     agent_task_controller_run_from_spec_output_ref_eligible(&args, output_file);
                 let summary_kind = agent_task_summary_kind_for_output(&args);
-                let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), global);
+                let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), spec, global);
                 let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
                     if let Some(output_file) = run_from_spec_output_ref {
                         return render_controller_run_from_spec_output_ref(
@@ -61,7 +65,7 @@ pub fn run_command_output(
             }
             Commands::Runner(args) => runner::run_command_output(args, global),
             Commands::Activity(args) => {
-                let (stdout_result, exit_code) = dispatch(Commands::Activity(args), global);
+                let (stdout_result, exit_code) = dispatch(Commands::Activity(args), spec, global);
                 let summary_stdout = stdout_result
                     .as_ref()
                     .ok()
@@ -76,7 +80,7 @@ pub fn run_command_output(
             }
             Commands::Bench(args) => {
                 let summarize = bench_summary_eligible(&args);
-                let (stdout_result, exit_code) = dispatch(Commands::Bench(args), global);
+                let (stdout_result, exit_code) = dispatch(Commands::Bench(args), spec, global);
                 let summary_stdout = summarize
                     .then(|| {
                         stdout_result
@@ -95,7 +99,7 @@ pub fn run_command_output(
             }
             Commands::Cleanup(args) => {
                 let summarize = cleanup_summary_eligible(&args);
-                let (stdout_result, exit_code) = dispatch(Commands::Cleanup(args), global);
+                let (stdout_result, exit_code) = dispatch(Commands::Cleanup(args), spec, global);
                 let summary_stdout = summarize
                     .then(|| {
                         stdout_result
@@ -116,7 +120,7 @@ pub fn run_command_output(
                 let summarize_show = runs_show_summary_eligible(&args);
                 let summarize_dossier = runs_dossier_summary_eligible(&args);
                 let summarize_proof = runs_proof_summary_eligible(&args);
-                let (stdout_result, exit_code) = dispatch(Commands::Runs(args), global);
+                let (stdout_result, exit_code) = dispatch(Commands::Runs(args), spec, global);
                 let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
                     if let Some(rendered) =
                         super::runs_summary::render_runs_field_selection(payload)
@@ -141,13 +145,13 @@ pub fn run_command_output(
                 )
             }
             command => {
-                let (stdout_result, exit_code) = dispatch(command, global);
+                let (stdout_result, exit_code) = dispatch(command, spec, global);
                 CommandRun::from_stdout_result(stdout_result, exit_code)
             }
         },
     };
 
-    run.with_command(command_name)
+    run.with_command(spec.name)
 }
 
 fn agent_task_controller_run_from_spec_output_ref_eligible<'a>(
@@ -310,7 +314,11 @@ fn agent_task_summary_kind_for_output_mode(
     }
 }
 
-fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
+fn dispatch(
+    command: Commands,
+    spec: &CommandSpec,
+    global: &GlobalArgs,
+) -> (homeboy::core::Result<Value>, i32) {
     let command = match adapter::run_json_output(
         command,
         global,
@@ -320,7 +328,7 @@ fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Va
         Err(command) => command,
     };
 
-    match dispatch_family(&command) {
+    match spec.dispatch_family() {
         CommandDispatchFamily::Quality => quality::dispatch(command, global),
         CommandDispatchFamily::Workspace => workspace::dispatch(command, global),
         CommandDispatchFamily::Ops => ops::dispatch(command, global),
@@ -328,12 +336,6 @@ fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Va
             unsupported_raw_command("List command uses raw output mode")
         }
     }
-}
-
-fn dispatch_family(command: &Commands) -> CommandDispatchFamily {
-    registered_command(command.top_level_name())
-        .map(|spec| spec.dispatch_family())
-        .expect("top-level command should be registered")
 }
 
 fn map<T: serde::Serialize>(result: super::CmdResult<T>) -> JsonRun {
@@ -361,6 +363,7 @@ mod tests {
                     crate::commands::manifest::ManifestArgs {},
                 ),
             }),
+            crate::command_contract::registered_command("contract").unwrap(),
             &GlobalArgs {},
         );
 
@@ -380,7 +383,11 @@ mod tests {
             })
         };
 
-        let (dispatch_stdout, dispatch_exit_code) = dispatch(command(), &GlobalArgs {});
+        let (dispatch_stdout, dispatch_exit_code) = dispatch(
+            command(),
+            crate::command_contract::registered_command("contract").unwrap(),
+            &GlobalArgs {},
+        );
         let (adapter_stdout, adapter_exit_code) = adapter::run_json_output(
             command(),
             &GlobalArgs {},
@@ -522,26 +529,5 @@ mod tests {
             agent_task_controller_run_from_spec_output_ref_eligible(&args, None),
             None
         );
-    }
-
-    #[test]
-    fn json_dispatch_family_comes_from_command_registry() {
-        use clap::Parser;
-
-        for spec in crate::command_contract::COMMAND_SPECS {
-            let Some(argv) = spec.representative_argv else {
-                continue;
-            };
-            let cli = crate::cli_surface::Cli::try_parse_from(argv)
-                .unwrap_or_else(|error| panic!("failed to parse `{}`: {error}", spec.name));
-
-            assert_eq!(cli.command.top_level_name(), spec.name);
-            assert_eq!(
-                dispatch_family(&cli.command),
-                spec.dispatch_family(),
-                "JSON dispatch family drifted for `{}`",
-                spec.name
-            );
-        }
     }
 }


### PR DESCRIPTION
## Summary
- resolve command identity and `CommandSpec` once from Clap `ArgMatches`
- thread the resolved spec through runtime, output planning, adapters, JSON dispatch, and daemon execution
- delete the 38-arm `Commands::top_level_name()` match
- remove duplicate output-descriptor and JSON dispatch-family registry lookups

## Impact
- 8 files changed
- 115 insertions, 151 deletions
- **36 net production lines removed**
- no public CLI or runtime behavior changes

## Testing
- command output contract tests: 1 passed
- output runtime tests: 9 passed
- adapter tests: 9 passed
- JSON output tests: 6 passed
- CLI runtime tests: 13 passed
- `cargo check --all-targets`
- touched-file `rustfmt --check`
- `git diff --check origin/main...HEAD`

Repository-wide formatting still reports the known unrelated mismatch in `src/core/deploy/safety_and_artifact.rs`; that file is unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Architecture analysis, command identity consolidation, tests, rebasing, and verification; Chris remains responsible for the submitted change.