### PR TITLE
Consolidate output dispatch

### DIFF
--- a/src/commands/infra/adapter.rs
+++ b/src/commands/infra/adapter.rs
@@ -6,7 +6,6 @@ use crate::command_contract::{
 
 use crate::cli_surface::Commands;
 
-use crate::commands::output_runtime::CommandRun;
 use crate::commands::{contract, fleet, observe, GlobalArgs};
 
 pub(crate) type JsonHandlerResult = (homeboy::core::Result<Value>, i32);
@@ -133,30 +132,6 @@ pub(crate) fn command_adapter(
     }
 }
 
-pub(crate) fn run_command_output(
-    command: Commands,
-    command_name: &'static str,
-    global: &GlobalArgs,
-    output_file_mode: CommandOutputFileMode,
-) -> Result<CommandRun, Commands> {
-    let (stdout_result, exit_code) = run_json_output(command, global, output_file_mode)?;
-
-    Ok(CommandRun::from_command_stdout_result(
-        command_name,
-        stdout_result,
-        exit_code,
-    ))
-}
-
-pub(crate) fn run_json_output(
-    command: Commands,
-    global: &GlobalArgs,
-    output_file_mode: CommandOutputFileMode,
-) -> Result<JsonHandlerResult, Commands> {
-    let adapter = command_adapter(command, output_file_mode)?;
-    Ok(adapter.run(global))
-}
-
 pub(crate) fn output_descriptor(
     command: &Commands,
     output_file_mode: CommandOutputFileMode,
@@ -231,41 +206,6 @@ mod tests {
             CommandOutputFileMode::None,
         )
         .is_ok());
-    }
-
-    #[test]
-    fn run_command_output_routes_migrated_json_command() {
-        let run = run_command_output(
-            parsed_command(&["homeboy", "contract", "manifest"]),
-            "contract",
-            &GlobalArgs {},
-            CommandOutputFileMode::None,
-        )
-        .unwrap_or_else(|_| panic!("contract should route through adapter JSON output"));
-
-        assert_eq!(run.command, "contract");
-        assert_eq!(run.exit_code, 0);
-        let value = run.stdout_result.expect("manifest should dispatch as JSON");
-        assert_eq!(value["command"], "contract.manifest");
-        assert!(value["commands"].is_array());
-    }
-
-    #[test]
-    fn run_json_output_matches_adapter_bound_execution() {
-        let command = parsed_command(&["homeboy", "contract", "manifest"]);
-        let (adapter_stdout, adapter_exit_code) = command_adapter(
-            parsed_command(&["homeboy", "contract", "manifest"]),
-            CommandOutputFileMode::None,
-        )
-        .unwrap_or_else(|_| panic!("contract should bind an adapter"))
-        .run(&GlobalArgs {});
-
-        let (helper_stdout, helper_exit_code) =
-            run_json_output(command, &GlobalArgs {}, CommandOutputFileMode::None)
-                .unwrap_or_else(|_| panic!("contract should route through adapter helper"));
-
-        assert_eq!(helper_exit_code, adapter_exit_code);
-        assert_eq!(helper_stdout.unwrap(), adapter_stdout.unwrap());
     }
 
     #[test]

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -31,124 +31,114 @@ pub fn run_command_output(
     output_file: Option<&str>,
 ) -> CommandRun {
     crate::commands::utils::tty::status("homeboy is working...");
-    let run = match adapter::run_command_output(
-        command,
-        spec.name,
-        global,
-        crate::command_contract::CommandOutputFileMode::None,
-    ) {
-        Ok(run) => run,
-        Err(command) => match command {
-            Commands::AgentTask(args) => {
-                let run_from_spec_output_ref =
-                    agent_task_controller_run_from_spec_output_ref_eligible(&args, output_file);
-                let summary_kind = agent_task_summary_kind_for_output(&args);
-                let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), spec, global);
-                let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
-                    if let Some(output_file) = run_from_spec_output_ref {
-                        return render_controller_run_from_spec_output_ref(
-                            payload,
-                            exit_code,
-                            output_file,
-                        );
-                    }
+    let run = match command {
+        Commands::AgentTask(args) => {
+            let run_from_spec_output_ref =
+                agent_task_controller_run_from_spec_output_ref_eligible(&args, output_file);
+            let summary_kind = agent_task_summary_kind_for_output(&args);
+            let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), spec, global);
+            let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
+                if let Some(output_file) = run_from_spec_output_ref {
+                    return render_controller_run_from_spec_output_ref(
+                        payload,
+                        exit_code,
+                        output_file,
+                    );
+                }
 
-                    summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
-                });
+                summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
+            });
 
-                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                    CommandPresentation {
-                        stdout: summary_stdout,
-                        stderr: None,
-                    },
-                )
-            }
-            Commands::Runner(args) => runner::run_command_output(args, global),
-            Commands::Activity(args) => {
-                let (stdout_result, exit_code) = dispatch(Commands::Activity(args), spec, global);
-                let summary_stdout = stdout_result
-                    .as_ref()
-                    .ok()
-                    .and_then(super::activity::render_activity_summary);
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                CommandPresentation {
+                    stdout: summary_stdout,
+                    stderr: None,
+                },
+            )
+        }
+        Commands::Runner(args) => runner::run_command_output(args, global),
+        Commands::Activity(args) => {
+            let (stdout_result, exit_code) = dispatch(Commands::Activity(args), spec, global);
+            let summary_stdout = stdout_result
+                .as_ref()
+                .ok()
+                .and_then(super::activity::render_activity_summary);
 
-                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                    CommandPresentation {
-                        stdout: summary_stdout,
-                        stderr: None,
-                    },
-                )
-            }
-            Commands::Bench(args) => {
-                let summarize = bench_summary_eligible(&args);
-                let (stdout_result, exit_code) = dispatch(Commands::Bench(args), spec, global);
-                let summary_stdout = summarize
-                    .then(|| {
-                        stdout_result
-                            .as_ref()
-                            .ok()
-                            .and_then(super::bench_summary::render_bench_summary)
-                    })
-                    .flatten();
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                CommandPresentation {
+                    stdout: summary_stdout,
+                    stderr: None,
+                },
+            )
+        }
+        Commands::Bench(args) => {
+            let summarize = bench_summary_eligible(&args);
+            let (stdout_result, exit_code) = dispatch(Commands::Bench(args), spec, global);
+            let summary_stdout = summarize
+                .then(|| {
+                    stdout_result
+                        .as_ref()
+                        .ok()
+                        .and_then(super::bench_summary::render_bench_summary)
+                })
+                .flatten();
 
-                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                    CommandPresentation {
-                        stdout: summary_stdout,
-                        stderr: None,
-                    },
-                )
-            }
-            Commands::Cleanup(args) => {
-                let summarize = cleanup_summary_eligible(&args);
-                let (stdout_result, exit_code) = dispatch(Commands::Cleanup(args), spec, global);
-                let summary_stdout = summarize
-                    .then(|| {
-                        stdout_result
-                            .as_ref()
-                            .ok()
-                            .and_then(super::cleanup::render_cleanup_summary)
-                    })
-                    .flatten();
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                CommandPresentation {
+                    stdout: summary_stdout,
+                    stderr: None,
+                },
+            )
+        }
+        Commands::Cleanup(args) => {
+            let summarize = cleanup_summary_eligible(&args);
+            let (stdout_result, exit_code) = dispatch(Commands::Cleanup(args), spec, global);
+            let summary_stdout = summarize
+                .then(|| {
+                    stdout_result
+                        .as_ref()
+                        .ok()
+                        .and_then(super::cleanup::render_cleanup_summary)
+                })
+                .flatten();
 
-                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                    CommandPresentation {
-                        stdout: summary_stdout,
-                        stderr: None,
-                    },
-                )
-            }
-            Commands::Runs(args) => {
-                let summarize_show = runs_show_summary_eligible(&args);
-                let summarize_dossier = runs_dossier_summary_eligible(&args);
-                let summarize_proof = runs_proof_summary_eligible(&args);
-                let (stdout_result, exit_code) = dispatch(Commands::Runs(args), spec, global);
-                let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
-                    if let Some(rendered) =
-                        super::runs_summary::render_runs_field_selection(payload)
-                    {
-                        Some(rendered)
-                    } else if summarize_show {
-                        super::runs_summary::render_runs_show_summary(payload)
-                    } else if summarize_dossier {
-                        super::runs_dossier_summary::render_runs_dossier_summary(payload)
-                    } else if summarize_proof {
-                        super::runs_proof_summary::render_runs_proof_summary(payload)
-                    } else {
-                        None
-                    }
-                });
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                CommandPresentation {
+                    stdout: summary_stdout,
+                    stderr: None,
+                },
+            )
+        }
+        Commands::Runs(args) => {
+            let summarize_show = runs_show_summary_eligible(&args);
+            let summarize_dossier = runs_dossier_summary_eligible(&args);
+            let summarize_proof = runs_proof_summary_eligible(&args);
+            let (stdout_result, exit_code) = dispatch(Commands::Runs(args), spec, global);
+            let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
+                if let Some(rendered) = super::runs_summary::render_runs_field_selection(payload) {
+                    Some(rendered)
+                } else if summarize_show {
+                    super::runs_summary::render_runs_show_summary(payload)
+                } else if summarize_dossier {
+                    super::runs_dossier_summary::render_runs_dossier_summary(payload)
+                } else if summarize_proof {
+                    super::runs_proof_summary::render_runs_proof_summary(payload)
+                } else {
+                    None
+                }
+            });
 
-                CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
-                    CommandPresentation {
-                        stdout: summary_stdout,
-                        stderr: None,
-                    },
-                )
-            }
-            command => {
-                let (stdout_result, exit_code) = dispatch(command, spec, global);
-                CommandRun::from_stdout_result(stdout_result, exit_code)
-            }
-        },
+            CommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                CommandPresentation {
+                    stdout: summary_stdout,
+                    stderr: None,
+                },
+            )
+        }
+        command => {
+            let (stdout_result, exit_code) = dispatch(command, spec, global);
+            CommandRun::from_stdout_result(stdout_result, exit_code)
+        }
     };
 
     run.with_command(spec.name)
@@ -319,12 +309,11 @@ fn dispatch(
     spec: &CommandSpec,
     global: &GlobalArgs,
 ) -> (homeboy::core::Result<Value>, i32) {
-    let command = match adapter::run_json_output(
+    let command = match adapter::command_adapter(
         command,
-        global,
         crate::command_contract::CommandOutputFileMode::None,
     ) {
-        Ok(result) => return result,
+        Ok(adapter) => return adapter.run(global),
         Err(command) => command,
     };
 
@@ -371,32 +360,6 @@ mod tests {
         let value = result.expect("manifest should dispatch as JSON");
         assert_eq!(value["command"], "contract.manifest");
         assert!(value["commands"].is_array());
-    }
-
-    #[test]
-    fn public_dispatch_matches_adapter_execution_for_migrated_contract() {
-        let command = || {
-            Commands::Contract(crate::commands::contract::ContractArgs {
-                command: crate::commands::contract::ContractCommand::Manifest(
-                    crate::commands::manifest::ManifestArgs {},
-                ),
-            })
-        };
-
-        let (dispatch_stdout, dispatch_exit_code) = dispatch(
-            command(),
-            crate::command_contract::registered_command("contract").unwrap(),
-            &GlobalArgs {},
-        );
-        let (adapter_stdout, adapter_exit_code) = adapter::run_json_output(
-            command(),
-            &GlobalArgs {},
-            crate::command_contract::CommandOutputFileMode::None,
-        )
-        .unwrap_or_else(|_| panic!("contract should route through adapter helper"));
-
-        assert_eq!(dispatch_exit_code, adapter_exit_code);
-        assert_eq!(dispatch_stdout.unwrap(), adapter_stdout.unwrap());
     }
 
     #[test]

--- a/tests/output_dispatch.rs
+++ b/tests/output_dispatch.rs
@@ -1,0 +1,31 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn adapter_backed_contract_preserves_stdout_and_output_file_envelopes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output_path = dir.path().join("manifest.json");
+    let output = Command::new(homeboy_bin())
+        .args(["contract", "manifest", "--output"])
+        .arg(&output_path)
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run contract manifest");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(output.stderr.is_empty());
+
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("stdout JSON");
+    let output_file: Value =
+        serde_json::from_slice(&std::fs::read(&output_path).expect("manifest output file"))
+            .expect("output file JSON");
+    assert_eq!(stdout, output_file);
+    assert_eq!(stdout["success"], true);
+    assert_eq!(stdout["data"]["command"], "contract.manifest");
+    assert!(stdout["data"]["commands"].is_array());
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
## Summary
- remove duplicate adapter result wrappers and adapter routing
- execute adapter-backed commands once inside the shared JSON dispatch path
- preserve explicit raw, streaming, summarized, Lab, output-file, and presentation paths
- add an end-to-end adapter-backed output contract test

## Impact
- production: 107 insertions, 204 deletions, **97 net lines removed**
- tests: 31 lines added
- total: **66 net lines removed**
- no public CLI, schema, output, or exit-code changes

## Testing
- adapter tests: 7 passed
- JSON dispatch tests: 5 passed
- raw output tests: 1 passed
- output runtime tests: 9 passed
- output dispatch integration test: 1 passed
- `cargo check --all-targets`
- touched-file `rustfmt --check`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Output architecture analysis, dispatch consolidation, behavioral testing, and verification; Chris remains responsible for the submitted change.