### PR TITLE
Resolve Lab hydration scripts on the runner

### DIFF
--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -1,4 +1,5 @@
 use crate::core::component::{self, Component};
+use crate::core::extension;
 use crate::core::extension::build;
 use crate::core::{Error, Result};
 use serde::{Deserialize, Serialize};
@@ -260,8 +261,26 @@ pub struct DependencyInstallPlanStep {
     /// Matches the `package_manager` reported by `deps status` for the same
     /// provider.
     pub provider_id: String,
-    /// Full install argv (program + args) the provider would run.
-    pub command: Vec<String>,
+    /// Portable install invocation the runner can execute without receiving a
+    /// controller-local extension path.
+    pub invocation: DependencyInstallInvocation,
+}
+
+/// An install command suitable for crossing a controller/runner boundary.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DependencyInstallInvocation {
+    /// A provider command that does not reference an installed extension path.
+    Argv { argv: Vec<String> },
+    /// An extension-owned entrypoint. The runner resolves `entrypoint` inside
+    /// its own materialized copy of `extension_id` before executing `argv`.
+    ExtensionEntrypoint {
+        extension_id: String,
+        entrypoint: String,
+        /// The executable and argument list with the entrypoint removed.
+        argv: Vec<String>,
+        entrypoint_index: usize,
+    },
 }
 
 /// Detect dependency providers for a workspace path and return the install
@@ -288,11 +307,37 @@ pub fn dependency_install_plan(path: &Path) -> Result<Vec<DependencyInstallPlanS
         if let Some(command) = provider.install_command(&component, &resolved_path)? {
             steps.push(DependencyInstallPlanStep {
                 provider_id: status.package_manager,
-                command: command.argv(),
+                invocation: dependency_install_invocation(command.argv())?,
             });
         }
     }
     Ok(steps)
+}
+
+fn dependency_install_invocation(argv: Vec<String>) -> Result<DependencyInstallInvocation> {
+    for extension in extension::load_all_extensions()? {
+        let Some(root) = extension.extension_path else {
+            continue;
+        };
+        for (entrypoint_index, value) in argv.iter().enumerate() {
+            let path = Path::new(value);
+            if !path.is_absolute() {
+                continue;
+            }
+            if let Ok(entrypoint) = path.strip_prefix(&root) {
+                let entrypoint = entrypoint.to_string_lossy().to_string();
+                let mut portable_argv = argv;
+                portable_argv.remove(entrypoint_index);
+                return Ok(DependencyInstallInvocation::ExtensionEntrypoint {
+                    extension_id: extension.id,
+                    entrypoint,
+                    argv: portable_argv,
+                    entrypoint_index,
+                });
+            }
+        }
+    }
+    Ok(DependencyInstallInvocation::Argv { argv })
 }
 
 fn rebuild_component(component: &Component, path: &Path) -> Result<DependencyCommandResult> {
@@ -403,5 +448,46 @@ fn combine_provider_statuses(
         component_path: path.display().to_string(),
         package_manager,
         packages,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_owned_install_path_becomes_portable_invocation() {
+        crate::test_support::with_isolated_home(|home| {
+            let extension_id = "fixture-runtime";
+            let extension_root = home
+                .path()
+                .join(".config/homeboy/extensions")
+                .join(extension_id);
+            std::fs::create_dir_all(extension_root.join("scripts")).expect("extension root");
+            std::fs::write(
+                extension_root.join(format!("{extension_id}.json")),
+                r#"{"name":"Fixture runtime","version":"1.0.0"}"#,
+            )
+            .expect("extension manifest");
+            let invocation = dependency_install_invocation(vec![
+                "sh".to_string(),
+                extension_root
+                    .join("scripts/install.sh")
+                    .display()
+                    .to_string(),
+                "install".to_string(),
+            ])
+            .expect("portable invocation");
+
+            assert_eq!(
+                invocation,
+                DependencyInstallInvocation::ExtensionEntrypoint {
+                    extension_id: extension_id.to_string(),
+                    entrypoint: "scripts/install.sh".to_string(),
+                    argv: vec!["sh".to_string(), "install".to_string()],
+                    entrypoint_index: 1,
+                }
+            );
+        });
     }
 }

--- a/src/core/runner/lab/offload/hydration.rs
+++ b/src/core/runner/lab/offload/hydration.rs
@@ -18,6 +18,7 @@
 use serde::Serialize;
 
 use crate::core::deps;
+use crate::core::engine::shell;
 use crate::core::{Error, Result};
 
 use super::*;
@@ -94,6 +95,7 @@ pub(crate) fn hydrate_lab_workspace_dependencies(
 
     let mut steps = Vec::new();
     for plan_step in plan {
+        let command = runner_hydration_command(&plan_step.invocation)?;
         let started = std::time::Instant::now();
         let (output, exit_code) = exec(
             runner_id,
@@ -101,13 +103,13 @@ pub(crate) fn hydrate_lab_workspace_dependencies(
             // Homeboy-routed command, so dispatch it raw exactly as produced.
             // Hydration is a workspace-setup sub-step of the agent-task offload,
             // so do not mirror it as a standalone controller-side run record.
-            RunnerExecOptions::raw_command(plan_step.command.clone())
+            RunnerExecOptions::raw_command(command.clone())
                 .with_cwd(remote_path)
                 .without_evidence_mirror(),
         )?;
         let step = LabWorkspaceHydrationStep {
             provider_id: plan_step.provider_id.clone(),
-            command: plan_step.command.clone(),
+            command,
             duration_ms: started.elapsed().as_millis() as u64,
             exit_code,
             stdout: output.stdout,
@@ -127,6 +129,69 @@ pub(crate) fn hydrate_lab_workspace_dependencies(
         workspace: remote_path.to_string(),
         steps,
     })
+}
+
+/// Convert the controller-created declaration into runner-owned argv. Extension
+/// entrypoints are deliberately resolved by the runner shell from its HOME,
+/// never from the controller's absolute extension installation path.
+fn runner_hydration_command(invocation: &deps::DependencyInstallInvocation) -> Result<Vec<String>> {
+    match invocation {
+        deps::DependencyInstallInvocation::Argv { argv } => Ok(argv.clone()),
+        deps::DependencyInstallInvocation::ExtensionEntrypoint {
+            extension_id,
+            entrypoint,
+            argv,
+            entrypoint_index,
+        } => {
+            if *entrypoint_index > argv.len() {
+                return Err(Error::validation_invalid_argument(
+                    "lab_workspace_dependency_hydration",
+                    "extension dependency invocation has an invalid entrypoint position",
+                    None,
+                    None,
+                ));
+            }
+            if std::path::Path::new(entrypoint)
+                .components()
+                .any(|component| {
+                    matches!(
+                        component,
+                        std::path::Component::ParentDir | std::path::Component::RootDir
+                    )
+                })
+            {
+                return Err(Error::validation_invalid_argument(
+                    "lab_workspace_dependency_hydration",
+                    "extension dependency entrypoint must be a relative path inside its extension",
+                    Some(entrypoint.clone()),
+                    None,
+                ));
+            }
+            let resolved_argv = argv
+                .iter()
+                .enumerate()
+                .flat_map(|(index, value)| {
+                    let mut value = vec![shell::quote_arg(value)];
+                    if index == *entrypoint_index {
+                        value.insert(0, "\"$entrypoint\"".to_string());
+                    }
+                    value
+                })
+                .chain((*entrypoint_index == argv.len()).then(|| "\"$entrypoint\"".to_string()))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let command = format!(
+                "extension_root=\"${{HOME}}/.config/homeboy/extensions/\"{}; entrypoint=\"$extension_root\"/{}; if test ! -f \"$entrypoint\"; then printf '%s\\n' {} >&2; exit 127; fi; exec {}",
+                shell::quote_arg(extension_id),
+                shell::quote_arg(entrypoint),
+                shell::quote_arg(&format!(
+                    "Lab dependency hydration requires runner-local extension `{extension_id}` entrypoint `{entrypoint}`. Install or refresh that extension on the runner."
+                )),
+                resolved_argv,
+            );
+            Ok(vec!["sh".to_string(), "-c".to_string(), command])
+        }
+    }
 }
 
 /// Build the pre-executor failure for a hydration step that exited non-zero.
@@ -510,6 +575,112 @@ mod tests {
                     .expect("hydration marker"),
                 "hydrated\n"
             );
+        });
+    }
+
+    #[test]
+    fn hydration_resolves_extension_entrypoint_from_runner_home() {
+        crate::test_support::with_isolated_home(|controller_home| {
+            let runner_home = tempfile::tempdir().expect("runner home");
+            let extension_id = "fixture-runtime";
+            let entrypoint = "scripts/install.sh";
+            let runner_script = runner_home
+                .path()
+                .join(".config/homeboy/extensions")
+                .join(extension_id)
+                .join(entrypoint);
+            std::fs::create_dir_all(runner_script.parent().expect("script parent"))
+                .expect("runner extension directory");
+            std::fs::write(
+                &runner_script,
+                "#!/bin/sh\nprintf '%s\\n' \"$1\" > hydrated-by-runner-extension.txt\n",
+            )
+            .expect("runner extension script");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut mode = std::fs::metadata(&runner_script)
+                    .expect("script metadata")
+                    .permissions();
+                mode.set_mode(0o755);
+                std::fs::set_permissions(&runner_script, mode).expect("chmod script");
+            }
+            crate::core::runner::create(
+                &serde_json::json!({
+                    "id": "lab-local",
+                    "kind": "local",
+                    "env": { "HOME": runner_home.path() },
+                })
+                .to_string(),
+                false,
+            )
+            .expect("create local runner");
+            let workspace = tempfile::tempdir().expect("workspace");
+            let invocation = deps::DependencyInstallInvocation::ExtensionEntrypoint {
+                extension_id: extension_id.to_string(),
+                entrypoint: entrypoint.to_string(),
+                argv: vec!["sh".to_string(), "install".to_string()],
+                entrypoint_index: 1,
+            };
+
+            let command = runner_hydration_command(&invocation).expect("runner command");
+            assert!(!command
+                .join(" ")
+                .contains(&controller_home.path().display().to_string()));
+            let (output, exit_code) = exec(
+                "lab-local",
+                RunnerExecOptions::raw_command(command)
+                    .with_cwd(&workspace.path().display().to_string())
+                    .without_evidence_mirror(),
+            )
+            .expect("runner executes extension entrypoint");
+
+            assert_eq!(exit_code, 0, "{}", output.stderr);
+            assert_eq!(
+                std::fs::read_to_string(workspace.path().join("hydrated-by-runner-extension.txt"))
+                    .expect("runner extension marker"),
+                "install\n"
+            );
+        });
+    }
+
+    #[test]
+    fn hydration_missing_runner_extension_entrypoint_fails_actionably() {
+        crate::test_support::with_isolated_home(|_controller_home| {
+            let runner_home = tempfile::tempdir().expect("runner home");
+            crate::core::runner::create(
+                &serde_json::json!({
+                    "id": "lab-local",
+                    "kind": "local",
+                    "env": { "HOME": runner_home.path() },
+                })
+                .to_string(),
+                false,
+            )
+            .expect("create local runner");
+            let workspace = tempfile::tempdir().expect("workspace");
+            let invocation = deps::DependencyInstallInvocation::ExtensionEntrypoint {
+                extension_id: "missing-runtime".to_string(),
+                entrypoint: "scripts/install.sh".to_string(),
+                argv: vec!["sh".to_string(), "install".to_string()],
+                entrypoint_index: 1,
+            };
+            let command = runner_hydration_command(&invocation).expect("runner command");
+            let (output, exit_code) = exec(
+                "lab-local",
+                RunnerExecOptions::raw_command(command)
+                    .with_cwd(&workspace.path().display().to_string())
+                    .without_evidence_mirror(),
+            )
+            .expect("runner executes command");
+
+            assert_eq!(exit_code, 127);
+            assert!(output
+                .stderr
+                .contains("runner-local extension `missing-runtime`"));
+            assert!(output
+                .stderr
+                .contains("Install or refresh that extension on the runner"));
         });
     }
 


### PR DESCRIPTION
## Summary
- carry portable dependency hydration as typed extension-relative invocations
- resolve hydration entrypoints against runner-local extension materialization
- fail actionably when runner-local extension scripts are absent

Closes #7778

## Validation
- Targeted distinct controller/runner-root hydration tests
- Source build and runner branch binary verification
- DMC #340 Lab-only cook acceptance with deterministic verification gate

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-terra, orchestrated by openai/gpt-5.6-sol
- **Used for:** Implementation, tests, and Lab verification under Chris Huber direction.