### PR TITLE
refactor: share remote root normalization

### DIFF
--- a/src/core/runner/workspace/pull.rs
+++ b/src/core/runner/workspace/pull.rs
@@ -193,11 +193,7 @@ fn normalize_remote_path(path: &str) -> Result<String> {
             None,
         ));
     }
-    Ok(if path.is_empty() {
-        "/".to_string()
-    } else {
-        path.to_string()
-    })
+    Ok(crate::core::paths::normalize_remote_root(path))
 }
 
 fn normalize_includes(includes: &[String]) -> Result<Vec<String>> {


### PR DESCRIPTION
## Summary
- Reuse the shared core lexical remote-root normalizer for workspace-pull paths.

## Diffstat
- `src/core/runner/workspace/pull.rs` | 6 +-----
- 1 file changed, 1 insertion(+), 5 deletions(-)

Fixes #7792

## Constraint compliance
- Preserves workspace-pull validation and exact error messages.
- Keeps filesystem canonicalization and deletion/symlink safety checks separate.
- Reuses only the shared lexical remote-root normalization helper introduced by #7765.

## Skipped sub-items
- No implementation sub-items skipped; #7792 requires only this consolidation.
- Full test suite skipped as requested; PR CI is authoritative. The broader filtered test command was blocked by an unrelated existing compile error in `tests/deps_test.rs` because `DependencyInstallPlanStep.command` no longer exists.

## Verification
- `cargo build -j 3`
- `cargo test -j 3 --lib workspace::pull` (3 passed)
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (no new warnings; 208 existing warnings)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation of the consolidation described in the issue, plus verification runs. Reviewed by Chris Huber.