### PR TITLE
refactor: consolidate command output envelopes

### DIFF
--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -17,7 +17,7 @@ use homeboy::core::refactor::auto::transaction::{
 };
 
 use super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs};
-use super::{CmdResult, GlobalArgs};
+use super::{CmdResult, CommandReport, GlobalArgs};
 
 #[derive(Args)]
 pub struct CiArgs {
@@ -241,12 +241,7 @@ pub enum CiOutput {
     Triage(CiFailureTriageOutput),
 }
 
-#[derive(Debug, Serialize)]
-pub struct CiDifferentialGateCommandOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub decision: DifferentialGateDecision,
-}
+pub type CiDifferentialGateCommandOutput = CommandReport<DifferentialGateDecision>;
 
 #[derive(Debug, Serialize)]
 pub struct CiScopeCommandOutput {
@@ -259,12 +254,7 @@ pub struct CiScopeCommandOutput {
     pub command_flags: std::collections::BTreeMap<String, Vec<String>>,
 }
 
-#[derive(Debug, Serialize)]
-pub struct CiPlanCommandOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub plan: CiPlan,
-}
+pub type CiPlanCommandOutput = CommandReport<CiPlan>;
 
 #[derive(Debug, Serialize)]
 pub struct CiAutofixCommandOutput {
@@ -318,7 +308,7 @@ fn run_differential_gate(
     Ok((
         CiOutput::DifferentialGate(CiDifferentialGateCommandOutput {
             command: "ci.differential-gate",
-            decision,
+            report: decision,
         }),
         exit_code,
     ))
@@ -343,7 +333,7 @@ fn run_plan(args: CiPlanArgs, _global: &GlobalArgs) -> CmdResult<CiOutput> {
     Ok((
         CiOutput::Plan(CiPlanCommandOutput {
             command: "ci.plan",
-            plan,
+            report: plan,
         }),
         0,
     ))
@@ -717,8 +707,8 @@ mod tests {
             panic!("expected ci differential gate output");
         };
         assert_eq!(output.command, "ci.differential-gate");
-        assert_eq!(output.decision.status, "baseline_red");
-        assert!(output.decision.passed);
+        assert_eq!(output.report.status, "baseline_red");
+        assert!(output.report.passed);
     }
 
     #[test]
@@ -738,8 +728,8 @@ mod tests {
         let CiOutput::DifferentialGate(output) = output else {
             panic!("expected ci differential gate output");
         };
-        assert_eq!(output.decision.status, "failed");
-        assert!(!output.decision.passed);
+        assert_eq!(output.report.status, "failed");
+        assert!(!output.report.passed);
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,17 @@
 use base64::Engine;
 use clap::Args;
+use serde::Serialize;
 use serde_json::{Map, Value};
 
 pub type CmdResult<T> = homeboy::core::Result<(T, i32)>;
+
+/// Common JSON envelope for commands whose report is flattened into the root object.
+#[derive(Debug, Serialize)]
+pub struct CommandReport<T> {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub report: T,
+}
 
 pub(crate) use crate::core::markdown::escape_markdown_table_cell;
 
@@ -274,6 +283,47 @@ pub(crate) use infra::summary_json;
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[derive(Serialize)]
+    struct SnapshotReport {
+        status: &'static str,
+        count: u8,
+    }
+
+    #[derive(Serialize)]
+    struct LegacyCommandReport<T> {
+        command: &'static str,
+        #[serde(flatten)]
+        report: T,
+    }
+
+    #[test]
+    fn command_report_matches_legacy_envelope_snapshot() {
+        let output = CommandReport {
+            command: "stack.status",
+            report: SnapshotReport {
+                status: "clean",
+                count: 2,
+            },
+        };
+        let legacy_output = LegacyCommandReport {
+            command: "stack.status",
+            report: SnapshotReport {
+                status: "clean",
+                count: 2,
+            },
+        };
+
+        let serialized = serde_json::to_string(&output).expect("serialize command report");
+        assert_eq!(
+            serialized,
+            serde_json::to_string(&legacy_output).expect("serialize legacy command report")
+        );
+        assert_eq!(
+            serialized,
+            r#"{"command":"stack.status","status":"clean","count":2}"#
+        );
+    }
 
     #[test]
     fn merge_dynamic_args_accepts_explicit_json() {

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -421,7 +421,7 @@ fn release_lock(rig_id: &str, force: bool) -> CmdResult<RigCommandOutput> {
     Ok((
         RigCommandOutput::ReleaseLock(RigReleaseLockOutput {
             command: "rig.release_lock",
-            outcome,
+            report: outcome,
         }),
         0,
     ))

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -6,6 +6,7 @@
 use serde::Serialize;
 
 use crate::commands::bench::{BenchOutput, RigRunBenchPlan};
+use crate::commands::CommandReport;
 use homeboy::core::rig::{self, RigResourcesSpec, RigSpec};
 
 /// Tagged union of every rig command's output.
@@ -42,12 +43,7 @@ pub struct RigRunOutput {
     pub bench: Option<BenchOutput>,
 }
 
-#[derive(Serialize)]
-pub struct RigReleaseLockOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub outcome: rig::ReleaseLeaseOutcome,
-}
+pub type RigReleaseLockOutput = CommandReport<rig::ReleaseLeaseOutcome>;
 
 #[derive(Serialize)]
 pub struct RigListOutput {
@@ -86,12 +82,7 @@ pub struct RigShowOutput {
     pub resources: RigResourcesSpec,
 }
 
-#[derive(Serialize)]
-pub struct RigUpOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: rig::UpReport,
-}
+pub type RigUpOutput = CommandReport<rig::UpReport>;
 
 #[derive(Serialize)]
 pub struct RigUpPlanOutput {
@@ -115,40 +106,11 @@ pub struct RigUpPlanStep {
     pub runner_exec_command: String,
 }
 
-#[derive(Serialize)]
-pub struct RigCheckOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: rig::CheckReport,
-}
-
-#[derive(Serialize)]
-pub struct RigDownOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: rig::DownReport,
-}
-
-#[derive(Serialize)]
-pub struct RigRepairOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: rig::RepairReport,
-}
-
-#[derive(Serialize)]
-pub struct RigSyncOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: rig::RigStackSyncReport,
-}
-
-#[derive(Serialize)]
-pub struct RigStatusOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: rig::RigStatusReport,
-}
+pub type RigCheckOutput = CommandReport<rig::CheckReport>;
+pub type RigDownOutput = CommandReport<rig::DownReport>;
+pub type RigRepairOutput = CommandReport<rig::RepairReport>;
+pub type RigSyncOutput = CommandReport<rig::RigStackSyncReport>;
+pub type RigStatusOutput = CommandReport<rig::RigStatusReport>;
 
 #[derive(Serialize)]
 pub struct RigInstallOutput {
@@ -180,19 +142,8 @@ pub struct RigInstalledStackSummary {
     pub source_revision: Option<String>,
 }
 
-#[derive(Serialize)]
-pub struct RigUpdateOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: rig::RigSourceUpdateResult,
-}
-
-#[derive(Serialize)]
-pub struct RigSourcesOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: RigSourcesReport,
-}
+pub type RigUpdateOutput = CommandReport<rig::RigSourceUpdateResult>;
+pub type RigSourcesOutput = CommandReport<RigSourcesReport>;
 
 #[derive(Serialize)]
 #[serde(tag = "variant", content = "payload", rename_all = "snake_case")]
@@ -202,12 +153,7 @@ pub enum RigSourcesReport {
     Refresh(rig::RigSourceUpdateResult),
 }
 
-#[derive(Serialize)]
-pub struct RigAppOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: rig::AppLauncherReport,
-}
+pub type RigAppOutput = CommandReport<rig::AppLauncherReport>;
 
 #[cfg(test)]
 mod tests {

--- a/src/commands/stack.rs
+++ b/src/commands/stack.rs
@@ -11,7 +11,7 @@ use homeboy::core::stack::{
     StackPrEntry, StackSpec, StatusOutput, SyncOutput,
 };
 
-use super::CmdResult;
+use super::{CmdResult, CommandReport};
 
 #[derive(Args)]
 pub struct StackArgs {
@@ -189,54 +189,13 @@ pub struct StackMutationOutput {
     pub stack: StackSpec,
 }
 
-#[derive(Serialize)]
-pub struct StackApplyOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: ApplyOutput,
-}
-
-#[derive(Serialize)]
-pub struct StackRebaseOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: RebaseOutput,
-}
-
-#[derive(Serialize)]
-pub struct StackStatusOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: StatusOutput,
-}
-
-#[derive(Serialize)]
-pub struct StackSyncOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: SyncOutput,
-}
-
-#[derive(Serialize)]
-pub struct StackPushOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: PushOutput,
-}
-
-#[derive(Serialize)]
-pub struct StackDiffOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: DiffOutput,
-}
-
-#[derive(Serialize)]
-pub struct StackInspectOutput {
-    pub command: &'static str,
-    #[serde(flatten)]
-    pub report: InspectOutput,
-}
+pub type StackApplyOutput = CommandReport<ApplyOutput>;
+pub type StackRebaseOutput = CommandReport<RebaseOutput>;
+pub type StackStatusOutput = CommandReport<StatusOutput>;
+pub type StackSyncOutput = CommandReport<SyncOutput>;
+pub type StackPushOutput = CommandReport<PushOutput>;
+pub type StackDiffOutput = CommandReport<DiffOutput>;
+pub type StackInspectOutput = CommandReport<InspectOutput>;
 
 pub fn run(args: StackArgs, _global: &super::GlobalArgs) -> CmdResult<StackCommandOutput> {
     match args.command {


### PR DESCRIPTION
## Summary
- Consolidate identical flattened `command` report envelopes used by stack, rig, and CI commands into `CommandReport<T>`.
- Preserve the existing command output type names as aliases and keep command JSON field order and payload serialization unchanged.

## Diffstat
```
5 files changed, 79 insertions(+), 134 deletions(-)
```

Fixes #7790

## Constraint compliance
- Added a byte-for-byte JSON snapshot test comparing `CommandReport<T>` with the legacy flattened envelope and asserting the expected serialized JSON.
- Verified focused library tests for the shared snapshot, CI differential gate, rig output, and rig sources; `cargo build -j 3` passed.
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` reported the existing 208-warning baseline and no diagnostics from this change.

## Skipped items
- Stack list/show/mutation outputs, rig list/show/run/install/up-plan outputs, and CI list/scope/autofix/run outputs remain separate because their named payload fields, optional fields, tags, or additional fields are not identical flattened envelopes.
- The full focused `cargo test -j 3 <filter>` invocation is blocked by unrelated `tests/deps_test.rs` references to the removed `DependencyInstallPlanStep.command` field. Equivalent affected library tests passed with `--lib`; full test execution remains CI-owned.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation of the consolidation described in the issue, plus verification runs. Reviewed by Chris Huber.