### PR TITLE
Consolidate output envelope projection

### DIFF
--- a/src/commands/infra/output_runtime.rs
+++ b/src/commands/infra/output_runtime.rs
@@ -74,6 +74,19 @@ impl CommandRun {
             raw_stdout: Some(raw_stdout),
         }
     }
+
+    pub(crate) fn output_file_result(
+        &self,
+        mode: CommandOutputFileMode,
+    ) -> &homeboy::core::Result<Value> {
+        match mode {
+            CommandOutputFileMode::TraceJsonSummaryArtifact => self
+                .output_file_result
+                .as_ref()
+                .unwrap_or(&self.stdout_result),
+            _ => &self.stdout_result,
+        }
+    }
 }
 
 pub struct OutputService<'a> {
@@ -86,15 +99,10 @@ impl<'a> OutputService<'a> {
     }
 
     pub fn emit_json_result(&self, result: homeboy::core::Result<Value>, exit_code: i32) {
-        let run = CommandRun::from_stdout_result(result, exit_code);
-        self.write_output_file(&run, CommandOutputFileMode::GenericEnvelope);
-        output::print_json_result_for_command(
-            run.stdout_result,
-            run.exit_code,
-            &run.command,
-            presentation_envelope(run.presentation),
-        )
-        .ok();
+        self.emit_run(
+            CommandRun::from_stdout_result(result, exit_code),
+            CommandOutputFileMode::GenericEnvelope,
+        );
     }
 
     pub fn emit_run(&self, run: CommandRun, mode: CommandOutputFileMode) -> i32 {
@@ -145,16 +153,17 @@ pub fn run_command(
     let plan = command.response_plan(spec, output_file.is_some());
     let output_service = OutputService::new(output_file);
 
-    match crate::commands::raw_output::prepare_command_run(command, global, plan.stdout) {
-        crate::commands::raw_output::CommandRunPreparation::Handled(exit_code) => exit_code,
+    let run = match crate::commands::raw_output::prepare_command_run(command, global, plan.stdout) {
+        crate::commands::raw_output::CommandRunPreparation::Handled(exit_code) => return exit_code,
         crate::commands::raw_output::CommandRunPreparation::Json(command) => {
-            let run = run_json(*command, spec, global, plan.output_file, output_file);
-            output_service.emit_run(run, plan.output_file)
+            return output_service.emit_run(
+                run_json(*command, spec, global, plan.output_file, output_file),
+                plan.output_file,
+            );
         }
-        crate::commands::raw_output::CommandRunPreparation::Raw(run) => {
-            output_service.emit_run(run, plan.output_file)
-        }
-    }
+        crate::commands::raw_output::CommandRunPreparation::Raw(run) => run,
+    };
+    output_service.emit_run(run, plan.output_file)
 }
 
 pub fn emit_json_result(
@@ -240,18 +249,10 @@ pub fn write_output_file(run: &CommandRun, mode: CommandOutputFileMode, path: Op
                 output::write_json_to_file(&run.stdout_result, path, run.exit_code);
             }
         }
-        CommandOutputFileMode::TraceJsonSummaryArtifact => {
+        CommandOutputFileMode::TraceJsonSummaryArtifact
+        | CommandOutputFileMode::GenericEnvelope => {
             output::write_json_to_file_for_command(
-                select_output_file_result(run, mode),
-                path,
-                run.exit_code,
-                &run.command,
-                presentation_envelope(run.presentation.clone()),
-            );
-        }
-        CommandOutputFileMode::GenericEnvelope => {
-            output::write_json_to_file_for_command(
-                &run.stdout_result,
+                run.output_file_result(mode),
                 path,
                 run.exit_code,
                 &run.command,
@@ -272,21 +273,6 @@ fn presentation_envelope(
         stdout: presentation.stdout,
         stderr: presentation.stderr,
     })
-}
-
-pub fn select_output_file_result(
-    run: &CommandRun,
-    mode: CommandOutputFileMode,
-) -> &homeboy::core::Result<Value> {
-    match mode {
-        CommandOutputFileMode::TraceJsonSummaryArtifact => run
-            .output_file_result
-            .as_ref()
-            .unwrap_or(&run.stdout_result),
-        CommandOutputFileMode::None
-        | CommandOutputFileMode::ReviewStableArtifact
-        | CommandOutputFileMode::GenericEnvelope => &run.stdout_result,
-    }
 }
 
 #[cfg(test)]
@@ -333,7 +319,7 @@ mod tests {
         let run = run_with_output_file_result(Some(Ok(json!({ "kind": "summary" }))));
 
         assert_eq!(
-            select_output_file_result(&run, CommandOutputFileMode::TraceJsonSummaryArtifact)
+            run.output_file_result(CommandOutputFileMode::TraceJsonSummaryArtifact)
                 .as_ref()
                 .unwrap(),
             &json!({ "kind": "summary" })
@@ -345,7 +331,7 @@ mod tests {
         let run = run_with_output_file_result(None);
 
         assert_eq!(
-            select_output_file_result(&run, CommandOutputFileMode::TraceJsonSummaryArtifact)
+            run.output_file_result(CommandOutputFileMode::TraceJsonSummaryArtifact)
                 .as_ref()
                 .unwrap(),
             &json!({ "kind": "stdout" })
@@ -357,7 +343,7 @@ mod tests {
         let run = run_with_output_file_result(Some(Ok(json!({ "kind": "summary" }))));
 
         assert_eq!(
-            select_output_file_result(&run, CommandOutputFileMode::GenericEnvelope)
+            run.output_file_result(CommandOutputFileMode::GenericEnvelope)
                 .as_ref()
                 .unwrap(),
             &json!({ "kind": "stdout" })
@@ -374,7 +360,7 @@ mod tests {
 
         assert_eq!(run.presentation.stdout.as_deref(), Some("short summary\n"));
         assert_eq!(
-            select_output_file_result(&run, CommandOutputFileMode::GenericEnvelope)
+            run.output_file_result(CommandOutputFileMode::GenericEnvelope)
                 .as_ref()
                 .unwrap(),
             &json!({ "kind": "stdout" })

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -140,23 +140,7 @@ pub fn route_after_parse(
             }
             Ok(None)
         }
-        LabRouteOutcome::InFlight(output) => {
-            if !output.stderr.is_empty() {
-                eprint!("{}", output.stderr);
-            }
-            if let Some(path) = output_file {
-                write_offloaded_stdout(
-                    path,
-                    output
-                        .output_file_content
-                        .as_deref()
-                        .unwrap_or(&output.stdout),
-                )?;
-            }
-            print!("{}", output.stdout);
-            Ok(Some(output.exit_code))
-        }
-        LabRouteOutcome::Offloaded(output) => {
+        LabRouteOutcome::InFlight(output) | LabRouteOutcome::Offloaded(output) => {
             if !output.stderr.is_empty() {
                 eprint!("{}", output.stderr);
             }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -350,8 +350,7 @@ mod tests {
         assert_eq!(run.exit_code, 7);
         assert_eq!(run.presentation.stdout.as_deref(), Some("3 items\n"));
         assert_eq!(
-            super::super::output_runtime::select_output_file_result(
-                &run,
+            run.output_file_result(
                 crate::command_contract::CommandOutputFileMode::GenericEnvelope,
             )
             .as_ref()

--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -37,30 +37,6 @@ pub fn prepare_command_run(
     }
 }
 
-pub fn run_and_print(
-    command: Commands,
-    global: &GlobalArgs,
-    mode: CommandRawOutputMode,
-) -> RawExecution {
-    if let CommandRawOutputMode::InteractivePassthrough = mode {
-        return validate_interactive_tty(command);
-    }
-
-    let raw_run =
-        run(command, global, mode).expect("markdown and plain-text modes should return raw output");
-
-    RawExecution::Handled(match raw_run.raw_stdout.expect("raw mode has raw stdout") {
-        Ok(content) => {
-            print!("{}", content);
-            raw_run.exit_code
-        }
-        Err(err) => {
-            output::print_result::<serde_json::Value>(Err(err)).ok();
-            1
-        }
-    })
-}
-
 pub fn run(
     command: Commands,
     global: &GlobalArgs,

--- a/tests/output_dispatch.rs
+++ b/tests/output_dispatch.rs
@@ -16,10 +16,10 @@ fn adapter_backed_contract_preserves_stdout_and_output_file_envelopes() {
     assert_eq!(output.status.code(), Some(0));
     assert!(output.stderr.is_empty());
 
+    let output_file_bytes = std::fs::read(&output_path).expect("manifest output file");
+    assert_eq!(output.stdout, output_file_bytes);
     let stdout: Value = serde_json::from_slice(&output.stdout).expect("stdout JSON");
-    let output_file: Value =
-        serde_json::from_slice(&std::fs::read(&output_path).expect("manifest output file"))
-            .expect("output file JSON");
+    let output_file: Value = serde_json::from_slice(&output_file_bytes).expect("output file JSON");
     assert_eq!(stdout, output_file);
     assert_eq!(stdout["success"], true);
     assert_eq!(stdout["data"]["command"], "contract.manifest");

--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -56,10 +56,10 @@ fn validation_error_writes_json_output_file() {
         String::from_utf8_lossy(&output.stderr)
     );
 
+    let output_file_bytes = std::fs::read(&output_path).expect("read output file");
+    assert_eq!(output.stdout, output_file_bytes);
     let stdout_json: Value = serde_json::from_slice(&output.stdout).expect("stdout json");
-    let file_json: Value =
-        serde_json::from_str(&std::fs::read_to_string(&output_path).expect("read output file"))
-            .expect("output file json");
+    let file_json: Value = serde_json::from_slice(&output_file_bytes).expect("output file json");
 
     assert_eq!(file_json, stdout_json);
     assert_eq!(file_json["schema"], "homeboy/command-result/v3");


### PR DESCRIPTION
## Summary
- make `CommandRun` own output-file payload projection
- collapse duplicate success/error envelope emission into one `OutputService` path
- remove the obsolete parallel raw-output printer
- merge byte-identical Lab stdout relay branches without routing Lab bytes through local serialization

## Impact
- 6 files changed
- 41 insertions, 96 deletions
- **55 net lines removed**
- stdout/stderr bytes, JSON schemas, output files, command labels, exit codes, and Lab behavior remain unchanged

## Testing
- output runtime tests: 9 passed
- output dispatch integration test: 1 passed
- output error integration tests: 5 passed
- raw output test: passed
- adapter tests: 31 passed
- response tests: 15 passed
- Lab exact-byte relay test: passed
- `cargo check --all-targets`
- touched-file formatting and `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Output-envelope analysis, consolidation, byte-parity tests, and verification; Chris remains responsible for the submitted change.