### PR TITLE
refactor: share git component path arguments

### DIFF
--- a/src/commands/git/args.rs
+++ b/src/commands/git/args.rs
@@ -1,5 +1,12 @@
 use clap::{Args, Subcommand};
 
+#[derive(Args)]
+pub(super) struct ComponentPathArgs {
+    /// Workspace path to discover the component from a portable homeboy.json
+    #[arg(long, value_name = "PATH")]
+    pub(super) path: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // `git issue` subcommand tree
 // ---------------------------------------------------------------------------
@@ -55,9 +62,8 @@ pub(super) enum IssueCommand {
         #[arg(long, value_name = "PATH")]
         body_file: Option<String>,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Find issues matching filters (dedup primitive)
     Find {
@@ -80,9 +86,8 @@ pub(super) enum IssueCommand {
         #[arg(long, default_value_t = 30)]
         limit: usize,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Close an existing issue with a typed reason
     Close {
@@ -108,9 +113,8 @@ pub(super) enum IssueCommand {
         #[arg(long, value_name = "PATH")]
         comment_file: Option<String>,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Edit an existing issue's title, body, or labels
     Edit {
@@ -141,9 +145,8 @@ pub(super) enum IssueCommand {
         #[arg(long = "remove-label", value_name = "LABEL")]
         remove_labels: Vec<String>,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
 }
 
@@ -188,9 +191,8 @@ pub(super) enum PrCommand {
         #[arg(long)]
         draft: bool,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Edit an existing PR's title or body
     Edit {
@@ -213,9 +215,8 @@ pub(super) enum PrCommand {
         #[arg(long, value_name = "PATH")]
         body_file: Option<String>,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Find PRs matching filters
     Find {
@@ -238,9 +239,8 @@ pub(super) enum PrCommand {
         #[arg(long, default_value_t = 30)]
         limit: usize,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Explain PR merge readiness without attempting a merge
     Readiness {
@@ -251,9 +251,8 @@ pub(super) enum PrCommand {
         #[arg(short, long)]
         number: u64,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Post a comment on a PR. Three modes:
     ///
@@ -330,9 +329,8 @@ pub(super) enum PrCommand {
         #[arg(long, requires = "comment_key", value_delimiter = ',')]
         section_order: Option<Vec<String>>,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Report and optionally land a fleet of pull requests.
     Fleet {
@@ -355,9 +353,8 @@ pub(super) enum PrCommand {
         #[arg(long, default_value = "squash")]
         merge_method: String,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Compare GitHub mergeability with local git merge-tree evidence.
     ReconcileMergeability {
@@ -368,9 +365,8 @@ pub(super) enum PrCommand {
         #[arg(short, long)]
         number: u64,
 
-        /// Workspace path to discover the component from a portable homeboy.json
-        #[arg(long, value_name = "PATH")]
-        path: Option<String>,
+        #[command(flatten)]
+        path_args: ComponentPathArgs,
     },
     /// Evaluate PR open/merge policy.
     Policy(PrPolicyArgs),

--- a/src/commands/git/issue.rs
+++ b/src/commands/git/issue.rs
@@ -3,7 +3,7 @@ use homeboy::core::git::{
     IssueFindOptions,
 };
 
-use super::args::{IssueArgs, IssueCommand};
+use super::args::{ComponentPathArgs, IssueArgs, IssueCommand};
 use super::helpers::{parse_issue_close_reason, parse_issue_state, resolve_body};
 use super::output::GitCommandOutput;
 use crate::commands::CmdResult;
@@ -39,8 +39,9 @@ pub(super) fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
             number,
             body,
             body_file,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let body = resolve_body(body, body_file)?.ok_or_else(|| {
                 homeboy::core::Error::validation_invalid_argument(
                     "body",
@@ -61,8 +62,9 @@ pub(super) fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
             label,
             state,
             limit,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let state = parse_issue_state(&state)?;
             let output = git::issue_find(
                 Some(&component_id),
@@ -82,8 +84,9 @@ pub(super) fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
             reason,
             comment,
             comment_file,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let reason = parse_issue_close_reason(&reason)?;
             let comment = resolve_body(comment, comment_file)?;
             let output = git::issue_close(
@@ -105,8 +108,9 @@ pub(super) fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
             body_file,
             add_labels,
             remove_labels,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let body = resolve_body(body, body_file)?;
             let output = git::issue_edit(
                 Some(&component_id),

--- a/src/commands/git/pr.rs
+++ b/src/commands/git/pr.rs
@@ -5,7 +5,7 @@ use homeboy::core::git::{
     PrRefreshStrategy,
 };
 
-use super::args::{PrArgs, PrCommand, PrPolicyArgs, PrPolicyCommand};
+use super::args::{ComponentPathArgs, PrArgs, PrCommand, PrPolicyArgs, PrPolicyCommand};
 use super::helpers::{parse_pr_state, read_lines_file, resolve_body};
 use super::output::GitCommandOutput;
 use crate::commands::CmdResult;
@@ -24,8 +24,9 @@ pub(super) fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             body,
             body_file,
             draft,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let body = resolve_body(body, body_file)?.unwrap_or_default();
             let output = git::pr_create(
                 Some(&component_id),
@@ -46,8 +47,9 @@ pub(super) fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             title,
             body,
             body_file,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let body = resolve_body(body, body_file)?;
             let output = git::pr_edit(
                 Some(&component_id),
@@ -66,8 +68,9 @@ pub(super) fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             head,
             state,
             limit,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let state = parse_pr_state(&state)?;
             let output = git::pr_find(
                 Some(&component_id),
@@ -84,8 +87,9 @@ pub(super) fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
         PrCommand::Readiness {
             component_id,
             number,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let output = git::pr_readiness(Some(&component_id), number, path)?;
             let exit = if output.readiness.mergeable { 0 } else { 1 };
             Ok((GitCommandOutput::PrReadiness(output), exit))
@@ -102,8 +106,9 @@ pub(super) fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             footer,
             footer_file,
             section_order,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let body = resolve_body(body, body_file)?.ok_or_else(|| {
                 homeboy::core::Error::validation_invalid_argument(
                     "body",
@@ -156,8 +161,9 @@ pub(super) fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             update_branches,
             apply,
             merge_method,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             if refs.is_empty() {
                 return Err(homeboy::core::Error::validation_missing_argument(vec![
                     "at least one PR number or URL".to_string(),
@@ -179,8 +185,9 @@ pub(super) fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
         PrCommand::ReconcileMergeability {
             component_id,
             number,
-            path,
+            path_args,
         } => {
+            let ComponentPathArgs { path } = path_args;
             let output = git::pr_reconcile_mergeability(
                 Some(&component_id),
                 PrMergeabilityReconcileOptions { number, path },

--- a/src/commands/git/tests.rs
+++ b/src/commands/git/tests.rs
@@ -1,4 +1,4 @@
-use super::args::{PrArgs, PrCommand};
+use super::args::{ComponentPathArgs, IssueArgs, IssueCommand, PrArgs, PrCommand};
 use super::GitCommand;
 use clap::Parser;
 
@@ -76,7 +76,7 @@ fn pr_readiness_flags_parse() {
                 PrCommand::Readiness {
                     component_id,
                     number,
-                    path,
+                    path_args: ComponentPathArgs { path },
                 },
         }) => {
             assert_eq!(component_id, "homeboy");
@@ -84,5 +84,33 @@ fn pr_readiness_flags_parse() {
             assert_eq!(path.as_deref(), Some("/tmp/homeboy"));
         }
         _ => panic!("expected pr readiness command"),
+    }
+}
+
+#[test]
+fn issue_find_path_flag_parses() {
+    let cli = TestCli::try_parse_from([
+        "git",
+        "issue",
+        "find",
+        "homeboy",
+        "--path",
+        "/tmp/homeboy",
+    ])
+    .expect("issue find flags parse");
+
+    match cli.command {
+        GitCommand::Issue(IssueArgs {
+            command:
+                IssueCommand::Find {
+                    component_id,
+                    path_args: ComponentPathArgs { path },
+                    ..
+                },
+        }) => {
+            assert_eq!(component_id, "homeboy");
+            assert_eq!(path.as_deref(), Some("/tmp/homeboy"));
+        }
+        _ => panic!("expected issue find command"),
     }
 }


### PR DESCRIPTION
## Summary
- Extract the byte-identical `--path` Clap argument used by four issue and seven PR subcommands.
- Preserve each command-specific body/text argument, short flag, validation, and exit behavior.
- Add parser coverage for the shared issue path argument.

## Diffstat
```
4 files changed, 83 insertions(+), 48 deletions(-)
```

Fixes #7791

## Verification
- `cargo build -j 3`
- `cargo test --lib -j 3 commands::git` (4 passed)
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (208 existing warnings; no new warnings)
- Byte-compared pre-change and post-change `--help` output for all 27 `git` command surfaces; all outputs are identical.

## Skipped consolidation
- Body/text fields were left command-local where help text, short flags, or requirements differ. The shared resolver already existed in `helpers.rs`, so no behavior change was needed.
- `issue create --path` retains its distinct help text and remains command-local.
- PR refresh and policy path options retain their distinct help text and remain command-local.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation of the consolidation described in the issue, plus verification runs. Reviewed by Chris Huber.