### PR TITLE
feat: persist run-scoped notification routes

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -168,6 +168,22 @@ impl CliRuntime {
             Ok(parsed) => parsed,
             Err(err) => err.exit(),
         };
+        let notification_route = if let (Some(transport), Some(route)) = (
+            cli.notification_transport.as_deref(),
+            cli.notification_route.as_deref(),
+        ) {
+            Some(
+                match crate::core::notification_route::NotificationRoute::new(transport, route) {
+                    Ok(route) => route,
+                    Err(err) => {
+                        output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                        return std::process::ExitCode::from(2);
+                    }
+                },
+            )
+        } else {
+            None
+        };
         commands::set_skip_deps_hydration(cli.skip_deps_hydration);
         normalize_runs_runner_options(&mut cli, &normalized);
 
@@ -209,12 +225,14 @@ impl CliRuntime {
 
         run_startup_update_checks(&cli.command);
 
-        let exit_code = commands::output_runtime::run_command(
-            cli.command,
-            command_spec,
-            &global,
-            output_file.as_deref(),
-        );
+        let exit_code = crate::core::notification_route::with_current(notification_route, || {
+            commands::output_runtime::run_command(
+                cli.command,
+                command_spec,
+                &global,
+                output_file.as_deref(),
+            )
+        });
         std::process::ExitCode::from(exit_code_to_u8(exit_code))
     }
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -23,6 +23,26 @@ pub struct Cli {
     #[arg(long, global = true, value_name = "PATH")]
     pub output: Option<PathBuf>,
 
+    /// Installed notification transport for this run. Pair with
+    /// `--notification-route`; the route is opaque, non-secret data owned by
+    /// that transport.
+    #[arg(
+        long,
+        global = true,
+        requires = "notification_route",
+        value_name = "TRANSPORT"
+    )]
+    pub notification_transport: Option<String>,
+
+    /// Opaque, non-secret destination for `--notification-transport`.
+    #[arg(
+        long,
+        global = true,
+        requires = "notification_transport",
+        value_name = "ROUTE"
+    )]
+    pub notification_route: Option<String>,
+
     /// Suppress resource policy warnings for intentionally hot commands.
     #[arg(long, global = true)]
     pub force_hot: bool,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -161,6 +161,10 @@ mod runner_workload_types {
         pub kind: RunnerWorkloadKind,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub agent_task: Option<RunnerWorkloadAgentTask>,
+        /// Opaque origin route copied into detached work so terminal mirroring
+        /// retains the initiating destination.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub notification_route: Option<crate::core::notification_route::NotificationRoute>,
         pub workspace_mappings: RunnerWorkloadWorkspaceMappings,
         pub required_capabilities: Vec<RunnerWorkloadCapability>,
         pub required_secrets: RunnerWorkloadSecrets,

--- a/src/commands/activity.rs
+++ b/src/commands/activity.rs
@@ -432,6 +432,8 @@ fn maybe_notify(
             body: format!("{} {}", item.kind, item.id),
             status,
             run_id: item.id.clone(),
+            transport: None,
+            route: None,
         },
         args.notify_command.as_deref(),
     ))

--- a/src/commands/contract.rs
+++ b/src/commands/contract.rs
@@ -1606,10 +1606,7 @@ static CONTRACT_SCHEMAS: &[ContractSchema] = &[
     contract_schema!(LOOP_RUN_SCHEMA, LoopRunRecord),
     contract_schema!(LOOP_ITERATION_SCHEMA, LoopIterationRecord),
     contract_schema!(LOOP_EVIDENCE_SCHEMA, LoopEvidenceRecord),
-    contract_schema!(
-        RUNNER_EXECUTION_ENVELOPE_SCHEMA,
-        RunnerExecutionEnvelope
-    ),
+    contract_schema!(RUNNER_EXECUTION_ENVELOPE_SCHEMA, RunnerExecutionEnvelope),
     contract_schema!(RUNNER_EXECUTION_RECORD_SCHEMA, RunnerExecutionRecord),
     contract_schema!(PATH_MATERIALIZATION_PLAN_SCHEMA, PathMaterializationPlan),
     contract_schema!(RUN_OUTCOME_ENVELOPE_SCHEMA, RunOutcomeEnvelope),

--- a/src/commands/runs/watch.rs
+++ b/src/commands/runs/watch.rs
@@ -239,7 +239,11 @@ fn maybe_notify(args: &RunsWatchArgs, result: &WatchResult) -> Option<NotifyOutc
     if !args.notify || result.conclusion != WatchConclusion::Terminal {
         return None;
     }
-    let event = NotifyEvent::run_completed(&args.run_id, &result.run.status);
+    let route = homeboy::core::notification_route::NotificationRoute::from_metadata(
+        &result.run.metadata_json,
+    );
+    let event =
+        NotifyEvent::run_completed_with_route(&args.run_id, &result.run.status, route.as_ref());
     Some(notify::dispatch(&event, args.notify_command.as_deref()))
 }
 

--- a/src/core/agent_task_batch.rs
+++ b/src/core/agent_task_batch.rs
@@ -141,6 +141,7 @@ pub struct AgentTaskBatchChildIssue {
     pub problem: String,
 }
 
+/// Child runs inherit the current run-scoped notification route at submission.
 pub fn submit_plan_batch(
     plan: &AgentTaskPlan,
     requested_batch_id: Option<&str>,
@@ -543,6 +544,32 @@ mod tests {
         let status = status("batch/audit").expect("batch status");
         assert_eq!(status.totals.queued, 2);
         assert_eq!(status.commands.run_next, "homeboy agent-task run-next");
+    }
+
+    #[test]
+    fn batch_children_inherit_the_scoped_notification_route() {
+        let _lock = TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _env = isolated_homeboy_data();
+        let plan = AgentTaskPlan::new("fanout/routes", vec![request("a"), request("b")]);
+        let route = crate::core::notification_route::NotificationRoute::new(
+            "extension",
+            "opaque-parent-route",
+        )
+        .expect("route");
+
+        let batch = crate::core::notification_route::with_current(Some(route), || {
+            submit_plan_batch(&plan, Some("batch-routes")).expect("batch submitted")
+        });
+
+        for child in batch.child_runs {
+            let record = agent_task_lifecycle::status(&child.run_id).expect("child record");
+            assert_eq!(
+                record.metadata["notification_route"]["route"],
+                "opaque-parent-route"
+            );
+        }
     }
 
     #[test]

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -21,6 +21,9 @@ pub fn submit_plan(
             metadata["runner_id"] = json!(runner_id);
         }
     }
+    if let Some(route) = crate::core::notification_route::current() {
+        route.insert_into_metadata(&mut metadata);
+    }
 
     let record = AgentTaskRunRecord {
         schema: schemas::RUN.to_string(),
@@ -41,6 +44,16 @@ pub fn submit_plan(
     };
     store::write_record(&record)?;
     Ok(record)
+}
+
+/// Bind an inherited route when a detached workload recreates an agent-task run.
+pub fn persist_notification_route(
+    run_id: &str,
+    route: &crate::core::notification_route::NotificationRoute,
+) -> Result<()> {
+    let mut record = store::read_record(run_id)?;
+    route.insert_into_metadata(&mut record.metadata);
+    store::write_record(&record)
 }
 
 pub fn record_completed_run(
@@ -449,6 +462,16 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
     let plan = store::read_plan_path(&source.plan_path)?;
     let mut retry = submit_plan(&plan, requested_run_id)?;
     let metadata = retry.ensure_metadata_object();
+    if let Some(route) =
+        crate::core::notification_route::NotificationRoute::from_metadata(&source.metadata)
+    {
+        // Retries are new durable runs, but retain the initiating route. Resume
+        // operates on the same record and therefore needs no copy.
+        metadata.insert(
+            crate::core::notification_route::NOTIFICATION_ROUTE_METADATA_KEY.to_string(),
+            serde_json::to_value(route).expect("notification route is serializable"),
+        );
+    }
     metadata.insert("retry_of".to_string(), json!(source.run_id));
     metadata.insert("retry_requested_at".to_string(), json!(now_timestamp()));
     store::write_record(&retry)?;

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -1107,6 +1107,12 @@ fn retry_submits_new_run_from_existing_plan() {
     with_isolated_home(|_| {
         let plan = test_plan();
         submit_plan(&plan, Some("run-original")).expect("submitted");
+        let mut source = store::read_record("run-original").expect("source");
+        source.metadata["notification_route"] = json!({
+            "transport": "extension",
+            "route": "opaque-origin"
+        });
+        store::write_record(&source).expect("route persisted");
 
         let record = retry("run-original", Some("run-retry")).expect("retry submitted");
         let loaded_plan = load_plan("run-retry").expect("retry plan loaded");
@@ -1114,6 +1120,10 @@ fn retry_submits_new_run_from_existing_plan() {
         assert_eq!(record.run_id, "run-retry");
         assert_eq!(record.state, AgentTaskRunState::Queued);
         assert_eq!(record.metadata["retry_of"], json!("run-original"));
+        assert_eq!(
+            record.metadata["notification_route"]["route"],
+            "opaque-origin"
+        );
         assert_eq!(loaded_plan.plan_id, "plan-a");
     });
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -616,13 +616,21 @@ fn completion_notify_loop(interval: std::time::Duration) {
             }
             let running_after = list_running_run_ids(&store);
             for completed_id in tracker.observe(running_after) {
-                let status = store
-                    .get_run(&completed_id)
-                    .ok()
-                    .flatten()
-                    .map(|run| run.status)
-                    .unwrap_or_else(|| "unknown".to_string());
-                let event = crate::core::notify::NotifyEvent::run_completed(&completed_id, &status);
+                let run = store.get_run(&completed_id).ok().flatten();
+                let status = run
+                    .as_ref()
+                    .map(|run| run.status.as_str())
+                    .unwrap_or("unknown");
+                let route = run.as_ref().and_then(|run| {
+                    crate::core::notification_route::NotificationRoute::from_metadata(
+                        &run.metadata_json,
+                    )
+                });
+                let event = crate::core::notify::NotifyEvent::run_completed_with_route(
+                    &completed_id,
+                    status,
+                    route.as_ref(),
+                );
                 let _ = crate::core::notify::dispatch(&event, None);
             }
         }

--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -570,9 +570,17 @@ mod tests {
             .expect("target dir")
             .permissions()
             .mode();
-        assert_ne!(0, file_mode & 0o020, "deployed file should be group-writable");
+        assert_ne!(
+            0,
+            file_mode & 0o020,
+            "deployed file should be group-writable"
+        );
         assert_ne!(0, dir_mode & 0o020, "deployed dir should be group-writable");
-        assert_ne!(0, dir_mode & 0o2000, "deployed dir should inherit its group");
+        assert_ne!(
+            0,
+            dir_mode & 0o2000,
+            "deployed dir should inherit its group"
+        );
     }
 
     #[test]

--- a/src/core/extension/dev_run.rs
+++ b/src/core/extension/dev_run.rs
@@ -446,6 +446,7 @@ fn extension_dev_run_workload(
             command_family: RunnerWorkloadCommandFamily::from_command_label(command_label),
         },
         agent_task: None,
+        notification_route: crate::core::notification_route::current(),
         workspace_mappings: RunnerWorkloadWorkspaceMappings {
             source_path_mode: "snapshot".to_string(),
             workspace_mode_policy: "snapshot_unique_workspace".to_string(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -103,6 +103,7 @@ pub mod lifecycle;
 pub mod loop_lifecycle;
 pub(crate) mod markdown;
 pub mod matrix_artifact_summary;
+pub mod notification_route;
 pub mod notify;
 pub mod observation;
 pub mod output;

--- a/src/core/notification_route.rs
+++ b/src/core/notification_route.rs
@@ -1,0 +1,140 @@
+//! Transport-neutral, run-scoped notification routing.
+
+use std::cell::RefCell;
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::error::{Error, Result};
+
+pub const NOTIFICATION_ROUTE_METADATA_KEY: &str = "notification_route";
+
+thread_local! {
+    static CURRENT_NOTIFICATION_ROUTE: RefCell<Option<NotificationRoute>> = const { RefCell::new(None) };
+}
+
+/// An opaque, non-secret destination owned by an installed notification transport.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationRoute {
+    pub transport: String,
+    pub route: String,
+}
+
+impl NotificationRoute {
+    pub fn new(transport: impl Into<String>, route: impl Into<String>) -> Result<Self> {
+        let route = Self {
+            transport: transport.into(),
+            route: route.into(),
+        };
+        route.validate()?;
+        Ok(route)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let valid_transport = !self.transport.is_empty()
+            && self.transport.len() <= 64
+            && self
+                .transport
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+        if !valid_transport {
+            return Err(Error::validation_invalid_argument(
+                "notification_transport",
+                "must contain 1-64 ASCII letters, digits, '.', '_' or '-'",
+                Some(self.transport.clone()),
+                None,
+            ));
+        }
+        if self.route.is_empty()
+            || self.route.len() > 4096
+            || self.route.chars().any(char::is_control)
+            || contains_credential_syntax(&self.route)
+        {
+            return Err(Error::validation_invalid_argument(
+                "notification_route",
+                "must be a non-empty, at most 4096-character opaque non-secret value without control characters or credential syntax",
+                Some(self.route.clone()),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn from_metadata(metadata: &serde_json::Value) -> Option<Self> {
+        serde_json::from_value(metadata.get(NOTIFICATION_ROUTE_METADATA_KEY)?.clone())
+            .ok()
+            .filter(|route: &Self| route.validate().is_ok())
+    }
+
+    pub fn insert_into_metadata(&self, metadata: &mut serde_json::Value) {
+        if !metadata.is_object() {
+            *metadata = serde_json::json!({});
+        }
+        metadata[NOTIFICATION_ROUTE_METADATA_KEY] =
+            serde_json::to_value(self).expect("notification route is serializable");
+    }
+}
+
+fn contains_credential_syntax(route: &str) -> bool {
+    let lowercase = route.to_ascii_lowercase();
+    lowercase.contains("authorization=")
+        || lowercase.contains("password=")
+        || lowercase.contains("secret=")
+        || lowercase.contains("token=")
+        || lowercase
+            .split_once("://")
+            .is_some_and(|(_, remainder)| remainder.contains('@'))
+}
+
+/// Run work with a route bound only to the current execution thread.
+pub fn with_current<T>(route: Option<NotificationRoute>, operation: impl FnOnce() -> T) -> T {
+    CURRENT_NOTIFICATION_ROUTE.with(|current| {
+        let previous = current.replace(route);
+        let result = operation();
+        current.replace(previous);
+        result
+    })
+}
+
+pub fn current() -> Option<NotificationRoute> {
+    CURRENT_NOTIFICATION_ROUTE.with(|current| current.borrow().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn route_round_trips_through_metadata() {
+        let route = NotificationRoute::new("extension", "opaque/thread 42").expect("route");
+        let mut metadata = serde_json::json!({"existing": true});
+        route.insert_into_metadata(&mut metadata);
+        assert_eq!(NotificationRoute::from_metadata(&metadata), Some(route));
+    }
+
+    #[test]
+    fn malformed_route_is_rejected() {
+        assert!(NotificationRoute::new("bad transport", "route").is_err());
+        assert!(NotificationRoute::new("extension", "").is_err());
+        assert!(NotificationRoute::new("extension", "line\nbreak").is_err());
+        assert!(NotificationRoute::new("extension", "token=credential").is_err());
+    }
+
+    #[test]
+    fn concurrent_scopes_do_not_cross_deliver_routes() {
+        let first = std::thread::spawn(|| {
+            with_current(
+                Some(NotificationRoute::new("extension", "first").unwrap()),
+                || current().unwrap().route,
+            )
+        });
+        let second = std::thread::spawn(|| {
+            with_current(
+                Some(NotificationRoute::new("extension", "second").unwrap()),
+                || current().unwrap().route,
+            )
+        });
+        assert_eq!(first.join().unwrap(), "first");
+        assert_eq!(second.join().unwrap(), "second");
+        assert!(current().is_none());
+    }
+}

--- a/src/core/notify.rs
+++ b/src/core/notify.rs
@@ -13,6 +13,7 @@
 
 use std::process::Command;
 
+use crate::core::notification_route::NotificationRoute;
 use serde::Serialize;
 
 /// Environment variable holding the notify command template.
@@ -24,7 +25,7 @@ use serde::Serialize;
 /// tokenization, the event controls values.
 ///
 /// Supported placeholders: `{run_id}`, `{status}`, `{title}`, `{body}`,
-/// `{message}` (title + " — " + body).
+/// `{message}` (title + " — " + body), `{transport}`, and `{route}`.
 ///
 /// Examples:
 /// - `notify-send {title} {body}`
@@ -39,6 +40,10 @@ pub struct NotifyEvent {
     pub status: String,
     pub title: String,
     pub body: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
 }
 
 impl NotifyEvent {
@@ -49,7 +54,22 @@ impl NotifyEvent {
             status: status.to_string(),
             title: format!("homeboy run {status}"),
             body: format!("Run {run_id} finished with status {status}"),
+            transport: None,
+            route: None,
         }
+    }
+
+    pub fn run_completed_with_route(
+        run_id: &str,
+        status: &str,
+        route: Option<&NotificationRoute>,
+    ) -> Self {
+        let mut event = Self::run_completed(run_id, status);
+        if let Some(route) = route {
+            event.transport = Some(route.transport.clone());
+            event.route = Some(route.route.clone());
+        }
+        event
     }
 
     fn message(&self) -> String {
@@ -63,6 +83,8 @@ impl NotifyEvent {
             .replace("{title}", &self.title)
             .replace("{body}", &self.body)
             .replace("{message}", &self.message())
+            .replace("{transport}", self.transport.as_deref().unwrap_or(""))
+            .replace("{route}", self.route.as_deref().unwrap_or(""))
     }
 }
 
@@ -205,6 +227,24 @@ mod tests {
         assert_eq!(
             argv[3],
             "homeboy run pass — Run run-123 finished with status pass"
+        );
+    }
+
+    #[test]
+    fn render_argv_keeps_route_as_one_argv_value() {
+        let route = NotificationRoute::new("extension", "thread 42; not a command").expect("route");
+        let event = NotifyEvent::run_completed_with_route("run-123", "pass", Some(&route));
+        assert_eq!(
+            render_argv("notify {transport} {route}", &event),
+            ["notify", "extension", "thread 42; not a command"]
+        );
+    }
+
+    #[test]
+    fn route_less_events_remain_compatible_with_route_placeholders() {
+        assert_eq!(
+            render_argv("notify {transport} {route}", &event()),
+            ["notify"]
         );
     }
 

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -297,6 +297,33 @@ mod tests {
     }
 
     #[test]
+    fn terminal_reconciliation_preserves_bound_notification_route() {
+        with_isolated_home(|_| {
+            let route = crate::core::notification_route::NotificationRoute::new(
+                "extension",
+                "opaque-route",
+            )
+            .expect("route");
+            let observation =
+                crate::core::notification_route::with_current(Some(route), || active_observation());
+            let run_id = observation.run_id().to_string();
+
+            observation
+                .finish_with_merged_metadata(RunStatus::Pass, serde_json::json!({"exit_code": 0}));
+
+            let run = ObservationStore::open_initialized()
+                .expect("store")
+                .get_run(&run_id)
+                .expect("read run")
+                .expect("run exists");
+            assert_eq!(
+                run.metadata_json["notification_route"]["route"],
+                "opaque-route"
+            );
+        });
+    }
+
+    #[test]
     fn test_finish_error_with_merged_metadata_sets_error_status() {
         with_isolated_home(|_| {
             let observation = active_observation();

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -25,6 +25,7 @@ pub use lifecycle::{
 
 pub use loop_inventory_run::persist_loop_inventory_run;
 
+pub use crate::core::notification_route::NotificationRoute;
 pub use budget_findings::finding_records_from_budget;
 pub use context::{RunContext, RunProvenance};
 pub use observed_workflow::{

--- a/src/core/observation/store/runs.rs
+++ b/src/core/observation/store/runs.rs
@@ -41,9 +41,12 @@ impl ObservationStore {
 
     pub fn start_run_with_context(
         &self,
-        run: NewRunRecord,
+        mut run: NewRunRecord,
         context: RunContext,
     ) -> Result<RunRecord> {
+        if let Some(route) = crate::core::notification_route::current() {
+            route.insert_into_metadata(&mut run.metadata_json);
+        }
         validate_required("kind", &run.kind)?;
         let id = Uuid::new_v4().to_string();
         let started_at = chrono::Utc::now().to_rfc3339();
@@ -99,7 +102,23 @@ impl ObservationStore {
         validate_required("run_id", run_id)?;
         let finished_at = chrono::Utc::now().to_rfc3339();
         let rows = match metadata_json {
-            Some(metadata_json) => {
+            Some(mut metadata_json) => {
+                // Terminal reconciliation often supplies fresh evidence metadata.
+                // Keep the route that was durably bound before execution unless a
+                // caller explicitly supplies a replacement route.
+                if crate::core::notification_route::NotificationRoute::from_metadata(&metadata_json)
+                    .is_none()
+                {
+                    if let Some(existing) = self.get_run(run_id)? {
+                        if let Some(route) =
+                            crate::core::notification_route::NotificationRoute::from_metadata(
+                                &existing.metadata_json,
+                            )
+                        {
+                            route.insert_into_metadata(&mut metadata_json);
+                        }
+                    }
+                }
                 let serialized = serialize_metadata(&metadata_json)?;
                 execute_with_retry("finish run record with metadata", || {
                     self.connection.execute(
@@ -302,6 +321,20 @@ impl ObservationStore {
 
     pub fn upsert_imported_run(&self, run: &RunRecord) -> Result<()> {
         validate_required("run.id", &run.id)?;
+        let mut run = run.clone();
+        if crate::core::notification_route::NotificationRoute::from_metadata(&run.metadata_json)
+            .is_none()
+        {
+            if let Some(existing) = self.get_run(&run.id)? {
+                if let Some(route) =
+                    crate::core::notification_route::NotificationRoute::from_metadata(
+                        &existing.metadata_json,
+                    )
+                {
+                    route.insert_into_metadata(&mut run.metadata_json);
+                }
+            }
+        }
         let metadata_json = serialize_metadata(&run.metadata_json)?;
         execute_with_retry("upsert imported run record", || {
             self.connection.execute(

--- a/src/core/runner/evidence/mirror.rs
+++ b/src/core/runner/evidence/mirror.rs
@@ -5,6 +5,7 @@ use serde_json::{json, Value};
 use crate::core::api_jobs::{Job, JobArtifactMetadata, JobEvent};
 use crate::core::error::{Error, Result};
 use crate::core::execution_contract::{encode_uri_component, EXECUTION_CONTRACT};
+use crate::core::notification_route::NotificationRoute;
 use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::core::redaction::redact_argv_display;
 use crate::core::runner::agent_task_lifecycle_event::{
@@ -44,10 +45,22 @@ pub fn mirror_daemon_evidence(
     events: &[JobEvent],
     result: &Value,
     run_id: Option<&str>,
+    notification_route: Option<&NotificationRoute>,
 ) -> Result<Option<MirroredDaemonEvidence>> {
     let store = ObservationStore::open_initialized()?;
-    let local_job_run = mirror_job_run(&store, runner, cwd, command, job, events, result, run_id)?;
-    let remote_runs = mirror_remote_observation_runs(&store, runner, job, result)?;
+    let local_job_run = mirror_job_run(
+        &store,
+        runner,
+        cwd,
+        command,
+        job,
+        events,
+        result,
+        run_id,
+        notification_route,
+    )?;
+    let remote_runs =
+        mirror_remote_observation_runs(&store, runner, job, result, notification_route)?;
     let patch = mirrored_patch_result(&store, runner, job, result.get("patch"))?;
     let primary_run = primary_mirrored_run(&remote_runs).unwrap_or(local_job_run);
     Ok(Some(MirroredDaemonEvidence {
@@ -65,9 +78,20 @@ pub fn mirror_reverse_broker_evidence(
     events: &[JobEvent],
     result: &Value,
     run_id: Option<&str>,
+    notification_route: Option<&NotificationRoute>,
 ) -> Result<Option<MirroredDaemonEvidence>> {
     let store = ObservationStore::open_initialized()?;
-    let mut run = mirror_job_run(&store, runner, cwd, command, job, events, result, run_id)?;
+    let mut run = mirror_job_run(
+        &store,
+        runner,
+        cwd,
+        command,
+        job,
+        events,
+        result,
+        run_id,
+        notification_route,
+    )?;
     let artifacts = mirror_reverse_broker_artifacts(&store, runner, broker_url, &run.id, job)?;
 
     let mut metadata = run.metadata_json.clone();
@@ -111,6 +135,7 @@ pub fn mirror_daemon_job_progress(
         events,
         &json!({}),
         run_id,
+        None,
     )
 }
 
@@ -132,9 +157,11 @@ pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRe
         .as_ref()
         .map(|command| vec![command.clone()])
         .unwrap_or_default();
-    mirror_job_run(&store, &runner, cwd, &command, &job, &events, &result, None)?;
+    mirror_job_run(
+        &store, &runner, cwd, &command, &job, &events, &result, None, None,
+    )?;
     Ok(Some(mirror_remote_observation_runs(
-        &store, &runner, &job, &result,
+        &store, &runner, &job, &result, None,
     )?))
 }
 
@@ -257,6 +284,7 @@ pub(super) fn mirror_job_run(
     events: &[JobEvent],
     result: &Value,
     run_id: Option<&str>,
+    notification_route: Option<&NotificationRoute>,
 ) -> Result<RunRecord> {
     let inferred_label = runner_exec_run_label(command);
     let agent_task_lifecycle_event = agent_task_run_plan_lifecycle_event_from_value(result)
@@ -290,6 +318,10 @@ pub(super) fn mirror_job_run(
         rig_id: None,
         metadata_json: json!({ "lab": lab }),
     };
+    let mut run = run;
+    if let Some(notification_route) = notification_route {
+        notification_route.insert_into_metadata(&mut run.metadata_json);
+    }
     import_run_if_absent(store, &run)?;
     store.get_run(&run.id)?.ok_or_else(|| {
         Error::internal_unexpected(format!(
@@ -304,10 +336,17 @@ fn mirror_remote_observation_runs(
     runner: &Runner,
     job: &Job,
     result: &Value,
+    notification_route: Option<&NotificationRoute>,
 ) -> Result<Vec<RunRecord>> {
     let explicit_run_ids = explicit_observation_run_ids(result, job);
     if !explicit_run_ids.is_empty() {
-        return mirror_remote_observation_runs_by_id(store, runner, job, &explicit_run_ids);
+        return mirror_remote_observation_runs_by_id(
+            store,
+            runner,
+            job,
+            &explicit_run_ids,
+            notification_route,
+        );
     }
 
     let data = daemon_api_get(&runner.id, "/runs?limit=100")?;
@@ -331,7 +370,10 @@ fn mirror_remote_observation_runs(
         let Some(detail) = detail_body.get("run") else {
             continue;
         };
-        let run = remote_detail_to_run_record(detail, runner, Some(job))?;
+        let mut run = remote_detail_to_run_record(detail, runner, Some(job))?;
+        if let Some(notification_route) = notification_route {
+            notification_route.insert_into_metadata(&mut run.metadata_json);
+        }
         import_run_if_absent(store, &run)?;
         for artifact in remote_detail_artifacts(detail, runner, &run.id)? {
             import_artifact_if_absent(store, &artifact)?;
@@ -346,6 +388,7 @@ fn mirror_remote_observation_runs_by_id(
     runner: &Runner,
     job: &Job,
     run_ids: &[String],
+    notification_route: Option<&NotificationRoute>,
 ) -> Result<Vec<RunRecord>> {
     let mut mirrored = Vec::new();
     for run_id in run_ids {
@@ -357,7 +400,10 @@ fn mirror_remote_observation_runs_by_id(
         let Some(detail) = detail_body.get("run") else {
             continue;
         };
-        let run = remote_detail_to_run_record(detail, runner, Some(job))?;
+        let mut run = remote_detail_to_run_record(detail, runner, Some(job))?;
+        if let Some(notification_route) = notification_route {
+            notification_route.insert_into_metadata(&mut run.metadata_json);
+        }
         import_run_if_absent(store, &run)?;
         for artifact in remote_detail_artifacts(detail, runner, &run.id)? {
             import_artifact_if_absent(store, &artifact)?;

--- a/src/core/runner/evidence/tests/mod.rs
+++ b/src/core/runner/evidence/tests/mod.rs
@@ -155,6 +155,13 @@ fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
             &events,
             &json!({"exit_code":0,"output":{"command":"bench"}}),
             None,
+            Some(
+                &crate::core::notification_route::NotificationRoute::new(
+                    "extension",
+                    "opaque-origin-route",
+                )
+                .expect("route"),
+            ),
         )
         .expect("mirror job");
         assert_eq!(run.kind, "runner-exec");
@@ -171,6 +178,10 @@ fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
         assert_eq!(
             run.metadata_json["lab"]["agent_task_lifecycle_event"]["aggregate"]["plan_id"].as_str(),
             Some("plan-from-result")
+        );
+        assert_eq!(
+            run.metadata_json["notification_route"]["route"],
+            "opaque-origin-route"
         );
     });
 }
@@ -216,6 +227,7 @@ fn runner_exec_matrix_summary_run_names_come_from_command_domain() {
             &job,
             &[],
             &json!({"exit_code":0}),
+            None,
             None,
         )
         .expect("mirror job");
@@ -269,6 +281,7 @@ fn runner_exec_explicit_run_id_overrides_inferred_name() {
             &[],
             &json!({}),
             Some("ssi-fixture-matrix-summary"),
+            None,
         )
         .expect("mirror job");
 

--- a/src/core/runner/execution/broker.rs
+++ b/src/core/runner/execution/broker.rs
@@ -167,6 +167,9 @@ pub(super) fn exec_via_reverse_broker(
             &events,
             &result,
             run_id.as_deref(),
+            runner_workload
+                .as_ref()
+                .and_then(|workload| workload.notification_route.as_ref()),
         )?
     } else {
         None

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -187,6 +187,9 @@ pub(super) fn exec_via_daemon(
             &events,
             &result,
             run_id.as_deref(),
+            runner_workload
+                .as_ref()
+                .and_then(|workload| workload.notification_route.as_ref()),
         )?
     } else {
         None

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -28,6 +28,7 @@ use crate::core::api_jobs::JobEvent;
 #[cfg(test)]
 use crate::core::api_jobs::JobEventKind;
 use crate::core::artifact_manifest::ArtifactManifest;
+use crate::core::notification_route::NotificationRoute;
 use crate::core::runner::agent_task_lifecycle_event::{
     agent_task_run_plan_lifecycle_event_from_job_events, is_agent_task_run_plan_envelope,
     parse_offloaded_run_plan_envelope,
@@ -111,19 +112,31 @@ pub(super) fn sync_inline_agent_task_file(
 pub(super) fn mirror_agent_task_run_plan_lifecycle(
     args: &[String],
     agent_task: Option<&RunnerWorkloadAgentTask>,
+    notification_route: Option<&NotificationRoute>,
     stdout: &str,
     output_file_content: Option<&str>,
     job_events: Option<&[JobEvent]>,
 ) -> Result<()> {
     if let Some(agent_task) = agent_task {
-        return mirror_typed_agent_task_run_plan_lifecycle(agent_task, job_events);
+        return mirror_typed_agent_task_run_plan_lifecycle(
+            agent_task,
+            notification_route,
+            job_events,
+        );
     }
 
-    mirror_legacy_agent_task_run_plan_lifecycle(args, stdout, output_file_content, job_events)
+    mirror_legacy_agent_task_run_plan_lifecycle(
+        args,
+        notification_route,
+        stdout,
+        output_file_content,
+        job_events,
+    )
 }
 
 fn mirror_typed_agent_task_run_plan_lifecycle(
     agent_task: &RunnerWorkloadAgentTask,
+    notification_route: Option<&NotificationRoute>,
     job_events: Option<&[JobEvent]>,
 ) -> Result<()> {
     if agent_task.lifecycle_mirror_policy
@@ -140,11 +153,17 @@ fn mirror_typed_agent_task_run_plan_lifecycle(
     let Some(event) = agent_task_run_plan_lifecycle_event_from_job_events(job_events) else {
         return Ok(());
     };
-    mirror_agent_task_run_plan_aggregate(plan_spec, &agent_task.run_id, event.aggregate)
+    mirror_agent_task_run_plan_aggregate(
+        plan_spec,
+        &agent_task.run_id,
+        event.aggregate,
+        notification_route,
+    )
 }
 
 fn mirror_legacy_agent_task_run_plan_lifecycle(
     args: &[String],
+    notification_route: Option<&NotificationRoute>,
     stdout: &str,
     output_file_content: Option<&str>,
     job_events: Option<&[JobEvent]>,
@@ -161,7 +180,7 @@ fn mirror_legacy_agent_task_run_plan_lifecycle(
         Some(event) => event.aggregate,
         None => legacy_agent_task_run_plan_aggregate(stdout, output_file_content)?,
     };
-    mirror_agent_task_run_plan_aggregate(&plan_spec, &run_id, aggregate)
+    mirror_agent_task_run_plan_aggregate(&plan_spec, &run_id, aggregate, notification_route)
 }
 
 fn legacy_agent_task_run_plan_aggregate(
@@ -194,6 +213,7 @@ fn mirror_agent_task_run_plan_aggregate(
     plan_spec: &str,
     run_id: &str,
     aggregate: AgentTaskAggregate,
+    notification_route: Option<&NotificationRoute>,
 ) -> Result<()> {
     let raw_plan = config::read_json_spec_to_string(plan_spec)?;
     let plan: AgentTaskPlan = serde_json::from_str(&raw_plan).map_err(|error| {
@@ -203,6 +223,9 @@ fn mirror_agent_task_run_plan_aggregate(
         )
     })?;
     agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
+    if let Some(notification_route) = notification_route {
+        crate::core::agent_task_lifecycle::persist_notification_route(run_id, notification_route)?;
+    }
     agent_task_lifecycle::mark_running(run_id)?;
     agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
     Ok(())
@@ -951,7 +974,7 @@ mod tests {
             lifecycle_mirror_policy: RunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
         };
 
-        mirror_agent_task_run_plan_lifecycle(&args, Some(&agent_task), stdout, None, None)
+        mirror_agent_task_run_plan_lifecycle(&args, Some(&agent_task), None, stdout, None, None)
             .expect("typed path does not parse stdout fallback");
     }
 
@@ -1003,6 +1026,7 @@ mod tests {
             mirror_agent_task_run_plan_lifecycle(
                 &[],
                 Some(&agent_task),
+                None,
                 "not json and should not be parsed",
                 None,
                 Some(&events),
@@ -1040,7 +1064,7 @@ mod tests {
                 "\"outcomes\":[]}}"
             );
 
-            mirror_agent_task_run_plan_lifecycle(&args, None, stdout, None, None)
+            mirror_agent_task_run_plan_lifecycle(&args, None, None, stdout, None, None)
                 .expect("legacy mirror uses stdout fallback");
         });
     }

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -272,6 +272,10 @@ pub(crate) fn exec_lab_context(
         .runner_workload
         .as_ref()
         .and_then(|workload| workload.agent_task.clone());
+    let notification_route = context
+        .runner_workload
+        .as_ref()
+        .and_then(|workload| workload.notification_route.clone());
 
     let base_env = build_lab_offload_env_with_passthroughs(&context.lab_metadata);
     context.lab_metadata["env_resolution"] = lab_env_resolution_report(
@@ -541,6 +545,7 @@ pub(crate) fn exec_lab_context(
     mirror_agent_task_run_plan_lifecycle(
         request.normalized_args,
         agent_task_workload.as_ref(),
+        notification_route.as_ref(),
         &stdout,
         output_file_content.as_deref(),
         exec_output.job_events.as_deref(),

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -352,6 +352,7 @@ mod tests {
                 command_family: RunnerWorkloadCommandFamily::Quality,
             },
             agent_task: None,
+            notification_route: None,
             workspace_mappings: RunnerWorkloadWorkspaceMappings {
                 source_path_mode: "cwd_or_path_flag".to_string(),
                 workspace_mode_policy: "changed_since_git_else_snapshot".to_string(),

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -64,6 +64,7 @@ fn build_runner_workload_with_command_label(
             command_family,
         },
         agent_task: None,
+        notification_route: crate::core::notification_route::current(),
         workspace_mappings: RunnerWorkloadWorkspaceMappings {
             source_path_mode: source_path_mode_label(input.command.source_path_mode).to_string(),
             workspace_mode_policy: workspace_mode_policy_label(input.command.workspace_mode_policy)

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -907,6 +907,7 @@ mod tests {
                 command_family: RunnerWorkloadCommandFamily::Quality,
             },
             agent_task: None,
+            notification_route: None,
             workspace_mappings: RunnerWorkloadWorkspaceMappings {
                 source_path_mode: "cwd_or_path_flag".to_string(),
                 workspace_mode_policy: "git".to_string(),


### PR DESCRIPTION
## Summary
- Add validated, transport-neutral run-scoped notification routes bound through typed thread-local execution scope.
- Persist routes through observation records, detached workloads, Lab evidence mirroring, terminal reconciliation, retries, and agent-task children.
- Expose global route inputs and safe notification command placeholders while preserving route-less behavior.

## Verification
- `cargo fmt --all`
- `cargo check`
- Focused route, reconciliation, inheritance, retry, mirror, and argv placeholder tests passed.
- `cargo test` started 7,132 tests and exceeded the 120-second practical limit; eight Lab/route tests that failed during the parallel run passed in isolated reruns.
- Unrelated failures remain reproducible in `commands::bench::observation::tests::bench_observation_mirrors_url_artifact_from_run_artifacts_dir` (unexpected configured artifact URL) and `commands::runner::status::tests::stale_daemon_status_hint_labels_control_plane_and_job_binary` (environment/version-dependent refresh hint).

Closes #7787

## AI assistance
Implemented with OpenCode (`openai/gpt-5.6-terra`).
