### PR TITLE
refactor: remove filesystem trait

### DIFF
--- a/src/core/component/inventory/listing.rs
+++ b/src/core/component/inventory/listing.rs
@@ -1,5 +1,4 @@
 use crate::core::component::{discover_from_portable, portable::read_portable_config, Component};
-use crate::core::engine::local_files::FileSystem;
 use crate::core::error::{Error, Result};
 use crate::core::extension;
 use crate::core::project;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,5 +1,5 @@
 use crate::core::engine::identifier;
-use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::local_files;
 use crate::core::engine::text::levenshtein;
 use crate::core::error::Error;
 use crate::core::output::{

--- a/src/core/config/json_io.rs
+++ b/src/core/config/json_io.rs
@@ -1,4 +1,4 @@
-use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::local_files;
 use crate::core::error::Error;
 use crate::core::Result;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};

--- a/src/core/engine/local_files.rs
+++ b/src/core/engine/local_files.rs
@@ -19,15 +19,6 @@ impl Entry {
     }
 }
 
-/// Trait for file system operations - local or remote
-pub trait FileSystem {
-    fn read(&self, path: &Path) -> Result<String>;
-    fn write(&self, path: &Path, content: &str) -> Result<()>;
-    fn list(&self, dir: &Path) -> Result<Vec<Entry>>;
-    fn delete(&self, path: &Path) -> Result<()>;
-    fn ensure_dir(&self, dir: &Path) -> Result<()>;
-}
-
 /// Local filesystem implementation
 pub struct LocalFs;
 
@@ -35,16 +26,8 @@ impl LocalFs {
     pub fn new() -> Self {
         Self
     }
-}
 
-impl Default for LocalFs {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl FileSystem for LocalFs {
-    fn read(&self, path: &Path) -> Result<String> {
+    pub fn read(&self, path: &Path) -> Result<String> {
         fs::read_to_string(path).map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 Error::internal_io(
@@ -57,11 +40,11 @@ impl FileSystem for LocalFs {
         })
     }
 
-    fn write(&self, path: &Path, content: &str) -> Result<()> {
+    pub fn write(&self, path: &Path, content: &str) -> Result<()> {
         write_file_atomic(path, content, "write file")
     }
 
-    fn list(&self, dir: &Path) -> Result<Vec<Entry>> {
+    pub fn list(&self, dir: &Path) -> Result<Vec<Entry>> {
         if !dir.exists() {
             return Ok(Vec::new());
         }
@@ -79,7 +62,7 @@ impl FileSystem for LocalFs {
         Ok(result)
     }
 
-    fn delete(&self, path: &Path) -> Result<()> {
+    pub fn delete(&self, path: &Path) -> Result<()> {
         if !path.exists() {
             return Err(Error::internal_io(
                 format!("File not found: {}", path.display()),
@@ -91,13 +74,19 @@ impl FileSystem for LocalFs {
             .map_err(|e| Error::internal_io(e.to_string(), Some("delete file".to_string())))
     }
 
-    fn ensure_dir(&self, dir: &Path) -> Result<()> {
+    pub fn ensure_dir(&self, dir: &Path) -> Result<()> {
         if !dir.exists() {
             fs::create_dir_all(dir).map_err(|e| {
                 Error::internal_io(e.to_string(), Some("create directory".to_string()))
             })?;
         }
         Ok(())
+    }
+}
+
+impl Default for LocalFs {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/core/extension/lifecycle/install_sources.rs
+++ b/src/core/extension/lifecycle/install_sources.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use crate::core::agent_runtime_manifest::validate_installed_extension_agent_runtime_provider_discovery;
 use crate::core::config::{self, from_str};
-use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::local_files;
 use crate::core::error::{Error, Result};
 use crate::core::git;
 use crate::core::paths;

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -1,6 +1,6 @@
 use crate::core::agent_runtime_manifest::validate_installed_extension_agent_runtime_provider_discovery;
 use crate::core::config::{self, from_str};
-use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::local_files;
 use crate::core::error::{Error, Result};
 use crate::core::git;
 use crate::core::paths;

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -1,6 +1,6 @@
 use crate::core::component::ScopedExtensionConfig;
 use crate::core::config::{self, ConfigEntity};
-use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::local_files;
 use crate::core::error::{Error, Result};
 use crate::core::output::{CreateOutput, MergeOutput, RemoveResult};
 use crate::core::paths;

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -13,7 +13,6 @@
 //! inside each `run_*` function is unchanged; only the plumbing is different.
 
 use crate::core::component::Component;
-use crate::core::engine::local_files::FileSystem;
 use crate::core::engine::validation;
 use crate::core::error::{Error, Result};
 use crate::core::release::{changelog as release_changelog, version};

--- a/src/core/release/planning_changelog.rs
+++ b/src/core/release/planning_changelog.rs
@@ -1,5 +1,4 @@
 use crate::core::component::Component;
-use crate::core::engine::local_files::FileSystem;
 use crate::core::error::{Error, Result};
 use crate::core::git;
 use crate::core::release::changelog;

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -21,7 +21,7 @@ pub use types::{
 use crate::core::component::{self, Component, VersionTarget};
 use crate::core::config::{from_str, set_json_pointer, to_string_pretty};
 use crate::core::engine::hooks::{self, HookFailureMode};
-use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::local_files;
 use crate::core::engine::text;
 use crate::core::error::{Error, Result};
 use crate::core::extension::ExtensionManifest;

--- a/src/core/release/version/default_pattern_for_file.rs
+++ b/src/core/release/version/default_pattern_for_file.rs
@@ -2,7 +2,7 @@
 
 use crate::core::component::{self, Component, VersionTarget};
 use crate::core::engine::codebase_scan;
-use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::local_files;
 use crate::core::engine::text;
 use crate::core::error::{Error, Result};
 use crate::core::extension::load_all_extensions;

--- a/src/core/runtime_package.rs
+++ b/src/core/runtime_package.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::core::agent_runtime_manifest::AgentRuntimeManifest;
 use crate::core::config;
 use crate::core::engine::identifier;
-use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::local_files;
 use crate::core::error::{Error, Result};
 use crate::core::{git, paths};
 

--- a/src/core/server/keys.rs
+++ b/src/core/server/keys.rs
@@ -1,4 +1,4 @@
-use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::local_files;
 use crate::core::error::{Error, Result};
 use serde::Serialize;
 use std::process::Command;


### PR DESCRIPTION
## Summary
- Replace the single-implementation `FileSystem` trait with inherent `LocalFs` methods.
- Remove trait imports from all direct consumers without changing CLI behavior.

## Diffstat
13 files changed, 20 insertions(+), 34 deletions(-)

Fixes #7789

## Constraint Compliance
- CLI commands, flags, help text, and JSON schemas are unchanged.
- Repository-wide search found one production `LocalFs` implementation and no generic or dynamic trait consumer.
- The remaining `FileSystem` reference is an unrelated parser-fixture trait in `core_fingerprint` tests.

## Skipped Items
- No issue implementation items were skipped. The unrelated code-audit fixture trait remains because it validates parser handling of trait declarations and is not a `LocalFs` seam.

## Verification
- `cargo build -j 3`
- `cargo test -j 3 core::engine::local_files`
- `cargo test --test deps_test --no-run -j 3`
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (211 baseline warnings; no new warnings from this change)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation of the consolidation described in the issue, plus verification runs. Reviewed by Chris Huber.