### PR TITLE
fix: repair dead legacy daemon lease

### DIFF
--- a/src/commands/git/tests.rs
+++ b/src/commands/git/tests.rs
@@ -89,15 +89,9 @@ fn pr_readiness_flags_parse() {
 
 #[test]
 fn issue_find_path_flag_parses() {
-    let cli = TestCli::try_parse_from([
-        "git",
-        "issue",
-        "find",
-        "homeboy",
-        "--path",
-        "/tmp/homeboy",
-    ])
-    .expect("issue find flags parse");
+    let cli =
+        TestCli::try_parse_from(["git", "issue", "find", "homeboy", "--path", "/tmp/homeboy"])
+            .expect("issue find flags parse");
 
     match cli.command {
         GitCommand::Issue(IssueArgs {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::command_contract::RunnerWorkload;
@@ -180,6 +180,17 @@ struct DaemonLeaseValidation {
     invalid_pid: Option<u32>,
 }
 
+/// The only pre-schema lease shape that can be repaired during daemon start.
+/// Keeping this separate from `DaemonState` prevents legacy data from becoming
+/// a supported format for normal reads, status, or stop operations.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyDaemonState {
+    address: String,
+    pid: u32,
+    state_path: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HttpResponse {
     pub status_code: u16,
@@ -262,6 +273,95 @@ pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
 
 fn state_path() -> Result<PathBuf> {
     paths::daemon_state_file()
+}
+
+pub(super) fn repair_legacy_lease_for_start() -> Result<bool> {
+    let path = state_path()?;
+    let content = match fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(format!("read {}", path.display())),
+            ))
+        }
+    };
+
+    // Current leases continue through the regular lifecycle without a legacy
+    // compatibility branch.
+    if serde_json::from_str::<DaemonState>(&content).is_ok() {
+        return Ok(false);
+    }
+
+    let legacy: LegacyDaemonState = serde_json::from_str(&content).map_err(|error| {
+        legacy_lease_repair_error(
+            &path,
+            format!("state is neither the current schema nor the known pre-schema shape: {error}"),
+        )
+    })?;
+    if legacy.state_path != path.display().to_string() {
+        return Err(legacy_lease_repair_error(
+            &path,
+            format!(
+                "legacy state_path `{}` does not match the expected state path",
+                legacy.state_path
+            ),
+        ));
+    }
+    let endpoint: SocketAddr = legacy.address.parse().map_err(|error| {
+        legacy_lease_repair_error(
+            &path,
+            format!("legacy address `{}` is invalid: {error}", legacy.address),
+        )
+    })?;
+    if pid_is_running(legacy.pid) {
+        return Err(legacy_lease_repair_error(
+            &path,
+            format!("legacy daemon pid {} is still running", legacy.pid),
+        ));
+    }
+    if TcpStream::connect_timeout(&endpoint, Duration::from_millis(200)).is_ok() {
+        return Err(legacy_lease_repair_error(
+            &path,
+            format!("legacy daemon endpoint {} is still reachable", endpoint),
+        ));
+    }
+
+    let evidence_path = path.with_file_name(format!(
+        "{}.legacy-lease-{}.json",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("state.json"),
+        Uuid::new_v4()
+    ));
+    fs::rename(&path, &evidence_path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "archive legacy daemon lease {} to {}",
+                path.display(),
+                evidence_path.display()
+            )),
+        )
+    })?;
+    Ok(true)
+}
+
+fn legacy_lease_repair_error(path: &Path, problem: impl Into<String>) -> Error {
+    Error::validation_invalid_argument(
+        "daemon_lease",
+        format!(
+            "daemon lease at {} cannot be safely repaired: {}",
+            path.display(),
+            problem.into()
+        ),
+        Some(path.display().to_string()),
+        Some(vec![format!(
+            "Inspect {} and verify its recorded PID and endpoint before retrying `homeboy daemon start`",
+            path.display()
+        )]),
+    )
 }
 
 pub fn read_status() -> Result<DaemonStatus> {

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -14,8 +14,8 @@ use crate::core::error::{Error, Result};
 use crate::core::execution_contract::encode_uri_component;
 
 use super::{
-    acquire_daemon_operation_lock, parse_bind_addr, read_status, stop_unlocked, DaemonStartResult,
-    DAEMON_STARTUP_TOKEN_ENV,
+    acquire_daemon_operation_lock, parse_bind_addr, read_status, repair_legacy_lease_for_start,
+    stop_unlocked, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Outcome of a daemon byte-endpoint artifact download.
@@ -35,6 +35,7 @@ pub fn start_background(addr: &str) -> Result<DaemonStartResult> {
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
 
+    let _repaired_legacy_lease = repair_legacy_lease_for_start()?;
     let existing = read_status()?;
     if existing.state.is_some() || existing.stale_reason.is_some() {
         let _ = stop_unlocked()?;

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -36,6 +36,19 @@ fn write_daemon_state_for_test(state: &DaemonState) {
     std::fs::write(&path, serde_json::to_string(state).expect("state json")).expect("write state");
 }
 
+fn write_legacy_daemon_state_for_test(pid: u32, address: &str) -> (std::path::PathBuf, String) {
+    let path = state_path().expect("state path");
+    let content = serde_json::json!({
+        "address": address,
+        "pid": pid,
+        "state_path": path.display().to_string(),
+    })
+    .to_string();
+    std::fs::create_dir_all(path.parent().expect("state parent")).expect("state dir");
+    std::fs::write(&path, &content).expect("write legacy state");
+    (path, content)
+}
+
 fn create_local_runner_for_file_api(id: &str, workspace_root: &std::path::Path) {
     crate::core::runner::create(
         &serde_json::json!({
@@ -364,6 +377,92 @@ fn test_pid_is_running_rejects_impossible_pid_and_drives_status() {
         .as_deref()
         .unwrap_or_default()
         .contains("invalid daemon lease"));
+}
+
+#[test]
+fn start_repair_archives_dead_known_legacy_lease() {
+    let _home = HomeGuard::new();
+    let (path, content) = write_legacy_daemon_state_for_test(u32::MAX, "127.0.0.1:1");
+
+    assert!(repair_legacy_lease_for_start().expect("repair legacy lease"));
+    assert!(
+        !path.exists(),
+        "legacy lease should be replaced by daemon startup"
+    );
+    let evidence: Vec<_> = std::fs::read_dir(path.parent().expect("state parent"))
+        .expect("state dir")
+        .filter_map(std::result::Result::ok)
+        .map(|entry| entry.path())
+        .filter(|candidate| {
+            candidate
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("state.json.legacy-lease-"))
+        })
+        .collect();
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(
+        std::fs::read_to_string(&evidence[0]).expect("evidence"),
+        content
+    );
+}
+
+#[test]
+fn start_repair_refuses_live_legacy_owner_pid_or_endpoint() {
+    let _home = HomeGuard::new();
+    let (path, _) = write_legacy_daemon_state_for_test(std::process::id(), "127.0.0.1:1");
+
+    let pid_error = repair_legacy_lease_for_start().expect_err("live pid is refused");
+    assert_eq!(pid_error.code.as_str(), "validation.invalid_argument");
+    assert!(pid_error.message.contains("still running"));
+    assert!(path.exists());
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+    std::fs::write(
+        &path,
+        serde_json::json!({
+            "address": listener.local_addr().expect("address").to_string(),
+            "pid": u32::MAX,
+            "state_path": path.display().to_string(),
+        })
+        .to_string(),
+    )
+    .expect("write legacy state");
+
+    let endpoint_error = repair_legacy_lease_for_start().expect_err("live endpoint is refused");
+    assert_eq!(endpoint_error.code.as_str(), "validation.invalid_argument");
+    assert!(endpoint_error.message.contains("still reachable"));
+    assert!(path.exists());
+}
+
+#[test]
+fn start_repair_refuses_unknown_corrupt_lease_with_actionable_diagnostic() {
+    let _home = HomeGuard::new();
+    let path = state_path().expect("state path");
+    std::fs::create_dir_all(path.parent().expect("state parent")).expect("state dir");
+    std::fs::write(&path, r#"{"pid":4294967295,"broken":true}"#).expect("write corrupt lease");
+
+    let error = repair_legacy_lease_for_start().expect_err("unknown corrupt lease is refused");
+
+    assert_eq!(error.code.as_str(), "validation.invalid_argument");
+    assert!(error
+        .message
+        .contains("neither the current schema nor the known pre-schema shape"));
+    assert!(serialized_contains(&error.details, "Inspect"));
+    assert!(
+        path.exists(),
+        "unknown state must remain for operator inspection"
+    );
+}
+
+#[test]
+fn start_repair_leaves_current_schema_lease_for_normal_lifecycle() {
+    let _home = HomeGuard::new();
+    let state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
+    write_daemon_state_for_test(&state);
+
+    assert!(!repair_legacy_lease_for_start().expect("current lease is not repaired"));
+    assert_eq!(read_status().expect("status").state.expect("state"), state);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- repair only the exact pre-schema daemon lease shape after its PID and endpoint are confirmed dead
- archive the legacy lease as diagnostic evidence before normal daemon startup publishes the current schema
- refuse live owners and unknown/corrupt state with typed, actionable diagnostics

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test --lib start_repair -- --nocapture`
- `cargo test` (7,095 passed; 29 pre-existing unrelated failures)

Closes #7786

## AI assistance
AI assistance: Yes
Tool: OpenCode
Model: openai/gpt-5.6-terra