### PR TITLE
refactor: remove legacy bench helper installation

### DIFF
--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -26,7 +26,6 @@ struct RuntimeHelper {
     filename: &'static str,
     content: &'static str,
     env_var: &'static str,
-    legacy_fallback: bool,
 }
 
 const HELPERS: &[RuntimeHelper] = &[
@@ -34,79 +33,66 @@ const HELPERS: &[RuntimeHelper] = &[
         filename: "runner-steps.sh",
         content: assets::RUNNER_STEPS_SH,
         env_var: RUNNER_STEPS_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "runner-prelude.sh",
         content: assets::RUNNER_PRELUDE_SH,
         env_var: RUNNER_PRELUDE_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "command-capture.sh",
         content: assets::COMMAND_CAPTURE_SH,
         env_var: COMMAND_CAPTURE_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "bash-preflight.sh",
         content: assets::BASH_PREFLIGHT_SH,
         env_var: BASH_PREFLIGHT_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "failure-trap.sh",
         content: assets::FAILURE_TRAP_SH,
         env_var: FAILURE_TRAP_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "write-test-results.sh",
         content: assets::WRITE_TEST_RESULTS_SH,
         env_var: WRITE_TEST_RESULTS_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "emit-lint-finding.sh",
         content: assets::EMIT_LINT_FINDING_SH,
         env_var: EMIT_LINT_FINDING_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "emit-test-failure.sh",
         content: assets::EMIT_TEST_FAILURE_SH,
         env_var: EMIT_TEST_FAILURE_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "sidecar-writer.sh",
         content: assets::SIDECAR_WRITER_SH,
         env_var: SIDECAR_WRITER_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "resolve-context.sh",
         content: assets::RESOLVE_CONTEXT_SH,
         env_var: RESOLVE_CONTEXT_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "disposable-local-db.sh",
         content: assets::DISPOSABLE_LOCAL_DB_SH,
         env_var: DISPOSABLE_LOCAL_DB_ENV,
-        legacy_fallback: false,
     },
     RuntimeHelper {
         filename: "bench-helper.sh",
         content: assets::BENCH_HELPER_SH,
         env_var: BENCH_HELPER_SH_ENV,
-        legacy_fallback: true,
     },
     RuntimeHelper {
         filename: "bench-helper.mjs",
         content: assets::BENCH_HELPER_JS,
         env_var: BENCH_HELPER_JS_ENV,
-        legacy_fallback: true,
     },
 ];
 
@@ -115,8 +101,6 @@ struct DeclaredRuntimeHelper {
     filename: String,
     source: String,
     env_var: String,
-    #[serde(default)]
-    legacy_fallback: bool,
 }
 
 /// Write a single runtime helper to disk if it's missing or stale.
@@ -172,19 +156,6 @@ fn declared_helpers() -> Result<Vec<DeclaredRuntimeHelper>> {
     })
 }
 
-#[cfg(not(windows))]
-fn legacy_runtime_dir() -> Result<Option<PathBuf>> {
-    let home = env::var("HOME").map_err(|_| {
-        Error::internal_unexpected("HOME environment variable not set on Unix-like system")
-    })?;
-    Ok(Some(PathBuf::from(home).join(".homeboy").join("runtime")))
-}
-
-#[cfg(windows)]
-fn legacy_runtime_dir() -> Result<Option<PathBuf>> {
-    Ok(None)
-}
-
 /// Ensure all runtime helpers are written and return (env_var, path) pairs.
 pub fn ensure_all_helpers() -> Result<Vec<(String, String)>> {
     let runtime_dir = paths::homeboy()
@@ -197,24 +168,9 @@ pub fn ensure_all_helpers() -> Result<Vec<(String, String)>> {
         )
     })?;
 
-    let legacy_runtime_dir = legacy_runtime_dir().unwrap_or(None);
-    if let Some(ref legacy_dir) = legacy_runtime_dir {
-        fs::create_dir_all(legacy_dir).map_err(|e| {
-            Error::internal_io(
-                e.to_string(),
-                Some("create legacy homeboy runtime directory".to_string()),
-            )
-        })?;
-    }
-
     let mut env_pairs = Vec::with_capacity(HELPERS.len());
     for helper in HELPERS {
         let path = ensure_helper(&runtime_dir, helper)?;
-        if helper.legacy_fallback {
-            if let Some(ref legacy_dir) = legacy_runtime_dir {
-                ensure_helper(legacy_dir, helper)?;
-            }
-        }
         env_pairs.push((
             helper.env_var.to_string(),
             path.to_string_lossy().to_string(),
@@ -223,11 +179,6 @@ pub fn ensure_all_helpers() -> Result<Vec<(String, String)>> {
 
     for helper in declared_helpers()? {
         let path = ensure_declared_helper(&runtime_dir, &helper)?;
-        if helper.legacy_fallback {
-            if let Some(ref legacy_dir) = legacy_runtime_dir {
-                ensure_declared_helper(legacy_dir, &helper)?;
-            }
-        }
         env_pairs.push((helper.env_var, path.to_string_lossy().to_string()));
     }
 

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -578,44 +578,6 @@ fn sidecar_writer_supports_annotation_source_files() {
 }
 
 #[test]
-fn ensure_all_helpers_writes_legacy_bench_fallbacks() {
-    with_isolated_home(|home| {
-        ensure_all_helpers().expect("all helpers should be written");
-
-        for filename in [
-            "bench-helper.sh".to_string(),
-            "bench-helper.mjs".to_string(),
-        ] {
-            let path = home.path().join(".homeboy").join("runtime").join(filename);
-            assert!(
-                path.exists(),
-                "legacy bench helper fallback should exist: {}",
-                path.display()
-            );
-        }
-
-        assert!(
-            !home
-                .path()
-                .join(".homeboy")
-                .join("runtime")
-                .join("runner-steps.sh")
-                .exists(),
-            "legacy runtime dir should only carry bench fallbacks"
-        );
-        assert!(
-            !home
-                .path()
-                .join(".homeboy")
-                .join("runtime")
-                .join("bash-preflight.sh")
-                .exists(),
-            "legacy runtime dir should not carry bash preflight"
-        );
-    });
-}
-
-#[test]
 fn bash_preflight_helper_accepts_current_bash() {
     let dir = tempfile::tempdir().expect("tempdir");
     let helper_path = dir.path().join("bash-preflight.sh");


### PR DESCRIPTION
## Summary
- Remove the legacy `$HOME/.homeboy/runtime/bench-helper.{sh,mjs}` installation and its dedicated test.
- Keep embedded bench helpers and `HOMEBOY_RUNTIME_BENCH_HELPER_SH` / `HOMEBOY_RUNTIME_BENCH_HELPER_JS` environment exports intact.

## Diffstat
`2 files changed, 87 deletions(-)`

Fixes #7793

## Gate re-verification
- The refreshed local `homeboy-extensions` checkout contains no hard-coded `$HOME/.homeboy/runtime/bench-helper.*` paths. Its Node.js, Rust, and WordPress bench runners require `HOMEBOY_RUNTIME_BENCH_HELPER_SH` and, where needed, `HOMEBOY_RUNTIME_BENCH_HELPER_JS`.
- `gh search code "bench-helper" --owner Extra-Chill` returned stale indexed pre-#2227 snippets showing legacy fallback paths. Direct GitHub contents API reads of the default branch for each reported runner confirm they now require the environment variables, so no current dependent remains.

## Compatibility
Bench extensions must use `homeboy-extensions >= v3.23.42` after this change. Older released extensions reference the removed legacy helper paths.

Homeboy supports an optional extension-manifest `requires.homeboy` semver constraint and validates it before capability and runtime execution. Extensions without that declaration are allowed; Homeboy does not infer or centrally pin a minimum extension version. `homeboy-extensions` should declare the appropriate `requires.homeboy` constraint when this core change is released.

## Verification
- `cargo test core::extension::runtime_helper` (28 passed)
- `cargo test core::extension::lifecycle` (39 passed)
- `cargo build -j 3`
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (completed; 211 pre-existing warnings reported, no new warnings from this change)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Gate re-verification and removal of the legacy runtime helper installation path, plus verification runs. Reviewed by Chris Huber.