### PR TITLE
fix: hand off runner-local artifact roots

### DIFF
--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -43,9 +43,10 @@ pub use policy::{
     AgentToolPolicyRule, AgentToolRequest, AgentToolResult, AgentToolResultStatus,
 };
 pub use request::{
-    AgentTaskComponentContract, AgentTaskExecutionHandle, AgentTaskExecutionHandleKind,
-    AgentTaskExecutionState, AgentTaskExecutorCapabilities, AgentTaskPreparedWorkspace,
-    AgentTaskProgress, AgentTaskProgressEvent, AgentTaskRequest, AgentTaskStart,
+    AgentTaskArtifactsPathProvenance, AgentTaskComponentContract, AgentTaskExecutionHandle,
+    AgentTaskExecutionHandleKind, AgentTaskExecutionState, AgentTaskExecutorCapabilities,
+    AgentTaskExecutorRequest, AgentTaskPreparedWorkspace, AgentTaskProgress,
+    AgentTaskProgressEvent, AgentTaskRequest, AgentTaskStart,
 };
 pub use schema::{
     AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA, AGENT_TASK_MATRIX_PLAN_SCHEMA,

--- a/src/core/agent_task/request.rs
+++ b/src/core/agent_task/request.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use std::path::PathBuf;
 
 use super::schema::request_schema;
 use super::{
@@ -139,6 +140,34 @@ pub struct AgentTaskRequest {
     pub artifact_declarations: Vec<AgentTaskArtifactDeclaration>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
+}
+
+/// Provider-facing request materialized on the host that executes the task.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentTaskExecutorRequest {
+    #[serde(flatten)]
+    pub request: AgentTaskRequest,
+    pub artifacts_path: PathBuf,
+    pub artifacts_path_provenance: AgentTaskArtifactsPathProvenance,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskArtifactsPathProvenance {
+    pub owner: String,
+    pub locality: String,
+    pub plan_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub task_id: String,
+    pub attempt: u32,
+}
+
+impl std::ops::Deref for AgentTaskExecutorRequest {
+    type Target = AgentTaskRequest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.request
+    }
 }
 
 impl AgentTaskRequest {

--- a/src/core/agent_task_executor_evidence.rs
+++ b/src/core/agent_task_executor_evidence.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
-use crate::core::agent_task::{AgentTaskEvidenceRef, AgentTaskOutcome, AgentTaskRequest};
+use crate::core::agent_task::{AgentTaskEvidenceRef, AgentTaskExecutorRequest, AgentTaskOutcome};
 use crate::core::redaction::RedactionPolicy;
 
 /// Evidence kind for the latest raw executor request (input piped to the
@@ -50,7 +50,7 @@ pub const EXECUTOR_RESULT_FILE: &str = "executor-result.json";
 /// contracts, runtime/component paths, model/provider metadata, and typed
 /// artifact expectations.
 pub(crate) fn link_latest_executor_evidence(
-    request: &AgentTaskRequest,
+    request: &AgentTaskExecutorRequest,
     outcome: &mut AgentTaskOutcome,
     run_id: Option<&str>,
 ) {
@@ -128,7 +128,7 @@ fn sanitize_task_id(task_id: &str) -> String {
 /// important fields. `redact_json` only rewrites known-sensitive keys, so
 /// component contracts, runtime/component paths, model/provider metadata, and
 /// typed artifact expectations are retained.
-fn redacted_request_value(request: &AgentTaskRequest, policy: &RedactionPolicy) -> Value {
+fn redacted_request_value(request: &AgentTaskExecutorRequest, policy: &RedactionPolicy) -> Value {
     match serde_json::to_value(request) {
         Ok(value) => policy.redact_json(&value),
         Err(error) => json!({
@@ -183,7 +183,8 @@ mod tests {
     use super::*;
     use crate::core::agent_task::{
         AgentTaskComponentContract, AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcomeStatus,
-        AgentTaskPolicy, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA,
+        AGENT_TASK_REQUEST_SCHEMA,
     };
     use serde_json::Map;
     use std::sync::Mutex;
@@ -255,7 +256,7 @@ mod tests {
     #[test]
     fn links_executor_input_and_result_evidence_refs() {
         with_artifact_root(|_| {
-            let request = test_request();
+            let request = executor_test_request();
             let mut outcome = test_outcome();
             link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
 
@@ -277,10 +278,26 @@ mod tests {
         });
     }
 
+    fn executor_test_request() -> AgentTaskExecutorRequest {
+        let request = test_request();
+        AgentTaskExecutorRequest {
+            artifacts_path: PathBuf::from("/runner/artifacts/task"),
+            artifacts_path_provenance: crate::core::agent_task::AgentTaskArtifactsPathProvenance {
+                owner: "homeboy".to_string(),
+                locality: "runner".to_string(),
+                plan_id: "plan-1".to_string(),
+                run_id: Some("run-1".to_string()),
+                task_id: request.task_id.clone(),
+                attempt: 1,
+            },
+            request,
+        }
+    }
+
     #[test]
     fn persisted_input_redacts_secrets_but_retains_contracts_paths_and_artifacts() {
         with_artifact_root(|_| {
-            let request = test_request();
+            let request = executor_test_request();
             let mut outcome = test_outcome();
             link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
 
@@ -304,13 +321,16 @@ mod tests {
             assert!(raw.contains("runtime_component_paths"));
             assert!(raw.contains("claude-sonnet"));
             assert!(raw.contains("component_contracts"));
+            assert!(raw.contains("/runner/artifacts/task"));
+            assert!(raw.contains("artifacts_path_provenance"));
+            assert!(raw.contains("\"locality\": \"runner\""));
         });
     }
 
     #[test]
     fn re_linking_does_not_duplicate_evidence_refs() {
         with_artifact_root(|_| {
-            let request = test_request();
+            let request = executor_test_request();
             let mut outcome = test_outcome();
             link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
             let first = outcome.evidence_refs.len();
@@ -343,7 +363,7 @@ mod tests {
     #[test]
     fn repeated_child_runs_with_same_task_id_keep_distinct_evidence_paths() {
         with_artifact_root(|_| {
-            let request = test_request();
+            let request = executor_test_request();
             let mut first_outcome = test_outcome();
             let mut second_outcome = test_outcome();
 

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -10,11 +10,11 @@ use serde_json::{json, Value};
 
 use crate::core::agent_runtime_manifest::AgentRuntimeDiscoveryDiagnostic;
 use crate::core::agent_task::{
-    AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskExecutionState,
-    AgentTaskFailureClassification, AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskRequest,
-    AgentTaskTypedArtifact, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
-    AGENT_TASK_REQUEST_SCHEMA, AGENT_TOOL_POLICY_SCHEMA, AGENT_TOOL_REQUEST_SCHEMA,
-    AGENT_TOOL_RESULT_SCHEMA,
+    AgentTaskArtifact, AgentTaskArtifactsPathProvenance, AgentTaskDiagnostic, AgentTaskEvidenceRef,
+    AgentTaskExecutionState, AgentTaskExecutorRequest, AgentTaskFailureClassification,
+    AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskRequest, AgentTaskTypedArtifact,
+    AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+    AGENT_TOOL_POLICY_SCHEMA, AGENT_TOOL_REQUEST_SCHEMA, AGENT_TOOL_RESULT_SCHEMA,
 };
 use crate::core::agent_task_gate_executor::{is_repo_local_gate_request, run_repo_local_gate_task};
 use crate::core::agent_task_scheduler::{

--- a/src/core/agent_task_provider/command_runner.rs
+++ b/src/core/agent_task_provider/command_runner.rs
@@ -37,14 +37,14 @@ const PROVIDER_TRANSIENT_BASE_BACKOFF_MS: u64 = 250;
 /// escalating backoff. Permanent failures (auth, validation, malformed input,
 /// capability gaps) fail fast on the first attempt. Each retry is surfaced in
 /// the returned outcome diagnostics so the behaviour is visible in run output.
-pub(super) fn run_provider_command(
-    request: &AgentTaskRequest,
+pub(super) fn run_materialized_provider_command(
+    request: &AgentTaskExecutorRequest,
     provider: &AgentTaskExecutorProvider,
     run_id: Option<&str>,
 ) -> AgentTaskOutcome {
     let mut attempt = 1;
     loop {
-        let mut outcome = run_provider_command_once(request, provider);
+        let mut outcome = run_materialized_provider_command_once(request, provider);
         classify_transient_provider_outcome(&mut outcome);
 
         let retryable = outcome_is_transient(&outcome);
@@ -223,8 +223,8 @@ fn annotate_transient_retry(outcome: &mut AgentTaskOutcome, attempts: u32, exhau
     });
 }
 
-pub(super) fn run_provider_command_once(
-    request: &AgentTaskRequest,
+pub(super) fn run_materialized_provider_command_once(
+    request: &AgentTaskExecutorRequest,
     provider: &AgentTaskExecutorProvider,
 ) -> AgentTaskOutcome {
     let command = render_provider_command_display(provider);
@@ -250,8 +250,8 @@ pub(super) fn run_provider_command_once(
     );
     let process_timeout = timeout_with_grace(requested_timeout_ms);
     let mut provider_request = request.clone();
-    provider_request.limits.timeout_ms = Some(requested_timeout_ms);
-    provider_request.normalize_artifact_declarations();
+    provider_request.request.limits.timeout_ms = Some(requested_timeout_ms);
+    provider_request.request.normalize_artifact_declarations();
     let input = match serde_json::to_vec(&provider_request) {
         Ok(input) => input,
         Err(error) => {
@@ -499,6 +499,43 @@ pub(super) fn run_provider_command_once(
                 &provider_output_redactions(request, provider),
             ),
         ),
+    }
+}
+
+#[cfg(test)]
+pub(super) fn run_provider_command(
+    request: &AgentTaskRequest,
+    provider: &AgentTaskExecutorProvider,
+    run_id: Option<&str>,
+) -> AgentTaskOutcome {
+    let materialized = test_executor_request(request);
+    run_materialized_provider_command(&materialized, provider, run_id)
+}
+
+#[cfg(test)]
+pub(super) fn run_provider_command_once(
+    request: &AgentTaskRequest,
+    provider: &AgentTaskExecutorProvider,
+) -> AgentTaskOutcome {
+    let materialized = test_executor_request(request);
+    run_materialized_provider_command_once(&materialized, provider)
+}
+
+#[cfg(test)]
+fn test_executor_request(request: &AgentTaskRequest) -> AgentTaskExecutorRequest {
+    AgentTaskExecutorRequest {
+        request: request.clone(),
+        artifacts_path: std::env::temp_dir()
+            .join("homeboy-agent-task-provider-tests")
+            .join(crate::core::paths::sanitize_path_segment(&request.task_id)),
+        artifacts_path_provenance: AgentTaskArtifactsPathProvenance {
+            owner: "homeboy".to_string(),
+            locality: "runner".to_string(),
+            plan_id: "provider-unit-test".to_string(),
+            run_id: None,
+            task_id: request.task_id.clone(),
+            attempt: 1,
+        },
     }
 }
 

--- a/src/core/agent_task_provider/executor.rs
+++ b/src/core/agent_task_provider/executor.rs
@@ -1,4 +1,4 @@
-use super::command_runner::{failure_outcome, run_provider_command};
+use super::command_runner::{failure_outcome, run_materialized_provider_command};
 use super::fixtures::run_fixture_provider;
 use super::*;
 
@@ -8,8 +8,29 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
         request: AgentTaskRequest,
         context: AgentTaskExecutionContext,
     ) -> AgentTaskOutcome {
+        let request = match materialize_executor_request(request, &context) {
+            Ok(request) => request,
+            Err((request, path, error)) => {
+                return failure_outcome(
+                    &request,
+                    AgentTaskOutcomeStatus::ProviderError,
+                    AgentTaskFailureClassification::Provider,
+                    "agent_task.artifacts_path_materialization_failed",
+                    format!(
+                        "Homeboy could not materialize the runner-local executor artifact directory '{}': {error}",
+                        path.display()
+                    ),
+                    json!({
+                        "artifacts_path": path,
+                        "locality": "runner",
+                        "owner": "homeboy",
+                        "remediation": "Ensure the runner artifact root exists on the execution host and is writable by the Homeboy process."
+                    }),
+                )
+            }
+        };
         if request.executor.backend == "fixture" {
-            return run_fixture_provider(&request);
+            return run_fixture_provider(&request, &request.artifacts_path);
         }
         if is_repo_local_gate_request(&request) {
             return run_repo_local_gate_task(&request);
@@ -52,8 +73,125 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             );
         }
 
-        run_provider_command(&request, provider, context.run_id.as_deref())
+        run_materialized_provider_command(&request, provider, context.run_id.as_deref())
     }
+}
+
+fn materialize_executor_request(
+    request: AgentTaskRequest,
+    context: &AgentTaskExecutionContext,
+) -> Result<AgentTaskExecutorRequest, (AgentTaskRequest, PathBuf, std::io::Error)> {
+    let root = match crate::core::artifacts::root() {
+        Ok(root) => root,
+        Err(error) => {
+            return Err((
+                request,
+                PathBuf::from("<unresolved-runner-artifact-root>"),
+                std::io::Error::other(error.to_string()),
+            ))
+        }
+    };
+    materialize_executor_request_at_root(request, context, root)
+}
+
+fn materialize_executor_request_at_root(
+    request: AgentTaskRequest,
+    context: &AgentTaskExecutionContext,
+    root: PathBuf,
+) -> Result<AgentTaskExecutorRequest, (AgentTaskRequest, PathBuf, std::io::Error)> {
+    let path = root
+        .join("agent-task")
+        .join("executor-artifacts")
+        .join(crate::core::paths::sanitize_path_segment(
+            context.run_id.as_deref().unwrap_or(&context.plan_id),
+        ))
+        .join(crate::core::paths::sanitize_path_segment(&request.task_id))
+        .join(format!("attempt-{}", context.attempt));
+
+    if let Err(error) = ensure_writable_directory(&path) {
+        return Err((request, path, error));
+    }
+
+    let provenance = AgentTaskArtifactsPathProvenance {
+        owner: "homeboy".to_string(),
+        locality: "runner".to_string(),
+        plan_id: context.plan_id.clone(),
+        run_id: context.run_id.clone(),
+        task_id: request.task_id.clone(),
+        attempt: context.attempt,
+    };
+    Ok(AgentTaskExecutorRequest {
+        request,
+        artifacts_path: path,
+        artifacts_path_provenance: provenance,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
+    };
+
+    #[test]
+    fn materialization_fails_before_execution_when_runner_root_is_not_a_directory() {
+        let blocked_root = tempfile::NamedTempFile::new().expect("blocked artifact root");
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "blocked-artifacts".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: Value::Null,
+            },
+            instructions: "run".to_string(),
+            inputs: Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: Value::Null,
+        };
+        let context = AgentTaskExecutionContext {
+            plan_id: "blocked-plan".to_string(),
+            run_id: Some("blocked-run".to_string()),
+            attempt: 1,
+            cancellation: Default::default(),
+        };
+
+        let (_, path, error) = materialize_executor_request_at_root(
+            request,
+            &context,
+            blocked_root.path().to_path_buf(),
+        )
+        .expect_err("file root must fail");
+
+        assert!(path.starts_with(blocked_root.path()));
+        assert!(!error.to_string().is_empty());
+    }
+}
+
+fn ensure_writable_directory(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)?;
+    if !std::fs::metadata(path)?.is_dir() {
+        return Err(std::io::Error::other(
+            "materialized path is not a directory",
+        ));
+    }
+    let probe = path.join(format!(".homeboy-write-probe-{}", std::process::id()));
+    std::fs::write(&probe, b"")?;
+    std::fs::remove_file(probe)?;
+    Ok(())
 }
 
 fn provider_resolution_failure_outcome(

--- a/src/core/agent_task_provider/fixtures.rs
+++ b/src/core/agent_task_provider/fixtures.rs
@@ -1,51 +1,21 @@
 use super::command_runner::failure_outcome;
 use super::*;
 
-pub(super) fn run_fixture_provider(request: &AgentTaskRequest) -> AgentTaskOutcome {
+pub(super) fn run_fixture_provider(
+    request: &AgentTaskRequest,
+    artifact_root: &Path,
+) -> AgentTaskOutcome {
     let mode = request
         .executor
         .config
         .get("mode")
         .and_then(Value::as_str)
         .unwrap_or("success");
-    let artifact_root = fixture_artifact_root(request);
-    if let Err(error) = std::fs::create_dir_all(&artifact_root) {
-        return failure_outcome(
-            request,
-            AgentTaskOutcomeStatus::ProviderError,
-            AgentTaskFailureClassification::Provider,
-            "agent_task.fixture_artifact_root_failed",
-            error.to_string(),
-            json!({ "artifact_root": artifact_root.display().to_string() }),
-        );
-    }
-
     match mode {
-        "empty_patch" => fixture_empty_patch_outcome(request, &artifact_root),
-        "empty_runtime_bundle" => fixture_empty_runtime_bundle_outcome(request, &artifact_root),
-        _ => fixture_success_outcome(request, &artifact_root),
+        "empty_patch" => fixture_empty_patch_outcome(request, artifact_root),
+        "empty_runtime_bundle" => fixture_empty_runtime_bundle_outcome(request, artifact_root),
+        _ => fixture_success_outcome(request, artifact_root),
     }
-}
-
-fn fixture_artifact_root(request: &AgentTaskRequest) -> PathBuf {
-    request
-        .executor
-        .config
-        .get("artifact_root")
-        .and_then(Value::as_str)
-        .map(|path| {
-            let path = PathBuf::from(path);
-            if path.is_absolute() {
-                path
-            } else {
-                std::env::current_dir()
-                    .unwrap_or_else(|_| PathBuf::from("."))
-                    .join(path)
-            }
-        })
-        .unwrap_or_else(|| {
-            std::env::temp_dir().join(format!("homeboy-agent-task-fixture-{}", request.task_id))
-        })
 }
 
 fn fixture_success_outcome(request: &AgentTaskRequest, artifact_root: &Path) -> AgentTaskOutcome {

--- a/src/core/agent_task_provider/tests/scheduler_tests.rs
+++ b/src/core/agent_task_provider/tests/scheduler_tests.rs
@@ -30,6 +30,74 @@ fn scheduler_dispatches_extension_provider_command() {
 }
 
 #[test]
+fn executor_materializes_runner_local_artifacts_for_no_op_and_editing_requests() {
+    let runner_root = crate::core::artifacts::root().expect("runner artifact root");
+    {
+        let controller_root = tempfile::tempdir().expect("controller root");
+        let command = format!(
+            "node {}",
+            script("let fs=require('fs'); let path=require('path'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let valid=path.isAbsolute(req.artifacts_path)&&fs.statSync(req.artifacts_path).isDirectory()&&req.artifacts_path_provenance.owner==='homeboy'&&req.artifacts_path_provenance.locality==='runner'&&!req.artifacts_path.startsWith(req.executor.config.controller_root); fs.writeFileSync(path.join(req.artifacts_path, req.task_id+'.txt'),'captured'); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:valid?(req.executor.config.no_op?'no_op':'succeeded'):'failed',summary:req.artifacts_path,artifacts:[]}));")
+        );
+        let (mut no_op, provider) = request("task-no-op", command);
+        no_op.executor.config = json!({
+            "controller_root": controller_root.path(),
+            "no_op": true
+        });
+        let mut editing = no_op.clone();
+        editing.task_id = "task-editing".to_string();
+        editing.executor.config["no_op"] = json!(false);
+        let scheduler =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]))
+            .with_run_id("runner-local-artifact-run");
+
+        let aggregate = scheduler.run(AgentTaskPlan::new(
+            "runner-local-artifact-plan",
+            vec![no_op, editing],
+        ));
+
+        assert_eq!(aggregate.outcomes[0].status, AgentTaskOutcomeStatus::NoOp);
+        assert_eq!(
+            aggregate.outcomes[1].status,
+            AgentTaskOutcomeStatus::Succeeded
+        );
+        for outcome in &aggregate.outcomes {
+            let path = PathBuf::from(outcome.summary.as_deref().expect("artifacts path"));
+            assert!(path.starts_with(&runner_root));
+            assert!(!path.starts_with(controller_root.path()));
+            assert!(path.join(format!("{}.txt", outcome.task_id)).is_file());
+        }
+        assert_ne!(aggregate.outcomes[0].summary, aggregate.outcomes[1].summary);
+    }
+}
+
+#[test]
+fn executor_artifact_paths_are_distinct_per_run() {
+    {
+        let command = format!(
+            "node {}",
+            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:req.artifacts_path}));")
+        );
+        let (request, provider) = request("same-task", command);
+        let first =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider.clone(),
+            ]))
+            .with_run_id("run-one")
+            .run(AgentTaskPlan::new("plan", vec![request.clone()]));
+        let second =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]))
+            .with_run_id("run-two")
+            .run(AgentTaskPlan::new("plan", vec![request]));
+
+        assert_ne!(first.outcomes[0].summary, second.outcomes[0].summary);
+    }
+}
+
+#[test]
 fn scheduler_reports_missing_extension_provider() {
     let (request, _provider) = request("task-missing-provider", "unused".to_string());
     let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::default());


### PR DESCRIPTION
## Summary
- materialize an absolute, writable artifact directory on the task execution host before provider dispatch
- enrich the provider-facing request with artifact-path ownership/locality provenance and persist it in executor evidence
- route fixture artifacts through the same runner-owned boundary and fail deterministically when materialization is impossible
- cover no-op/editing requests, per-run isolation, evidence retention, and direct materialization failure without mutating process-global artifact-root state

Closes #7011

## Validation
- `cargo fmt --check`
- `cargo check --tests`
- `cargo test core::agent_task_provider::tests -- --test-threads=1` (91 passed; serialized because unrelated concurrent worktree builds starved existing short-timeout provider tests and existing config-global tests race in parallel)
- `cargo test core::agent_task_executor_evidence::tests -- --test-threads=1` (6 passed)
- targeted materialization failure, runner-local no-op/editing, and per-run path tests

## AI Disclosure
This change was completed with OpenCode using `openai/gpt-5.6-sol`. The agent inspected and preserved the existing implementation, repaired the self-contained boundary test, ran validation, reviewed the final diff, and prepared this pull request. Human review remains required.