### PR TITLE
fix: consume declarative dependency adapters

### DIFF
--- a/src/core/deps_provider.rs
+++ b/src/core/deps_provider.rs
@@ -1,9 +1,9 @@
 use crate::core::component::Component;
 use crate::core::deps::{DependencyCommandResult, DependencyPackage, DependencyUpdateResult};
 use crate::core::extension::{self, ExtensionCapability, ExtensionExecutionContext};
-use crate::core::{Error, Result};
+use crate::core::{paths, Error, Result};
 use serde::Deserialize;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -74,6 +74,7 @@ impl DependencyProviderCommand {
 
 pub(crate) enum DependencyProvider {
     Manifest(ManifestDependencyProvider),
+    Adapter(AdapterDependencyProvider),
     // Boxed: `ExtensionDependencyProvider` carries a full execution context and
     // is far larger than the other (zero-sized) variants, so storing it inline
     // would bloat every `DependencyProvider` value (clippy::large_enum_variant).
@@ -94,6 +95,7 @@ impl DependencyProvider {
         };
         match self {
             DependencyProvider::Manifest(provider) => provider.status(request),
+            DependencyProvider::Adapter(provider) => provider.status(request),
             DependencyProvider::Extension(provider) => provider.status(request),
             DependencyProvider::ComponentScript(provider) => provider.status(request),
         }
@@ -109,6 +111,7 @@ impl DependencyProvider {
         let request = DependencyProviderPackageRequest { package };
         match self {
             DependencyProvider::Manifest(provider) => provider.handles_package(request),
+            DependencyProvider::Adapter(provider) => provider.handles_package(request),
             DependencyProvider::Extension(provider) => provider.handles_package(request),
             DependencyProvider::ComponentScript(provider) => provider.handles_package(request),
         }
@@ -128,6 +131,7 @@ impl DependencyProvider {
         };
         match self {
             DependencyProvider::Manifest(provider) => provider.update(request),
+            DependencyProvider::Adapter(provider) => provider.update(request),
             DependencyProvider::Extension(provider) => provider.update(request),
             DependencyProvider::ComponentScript(provider) => provider.update(request),
         }
@@ -141,6 +145,7 @@ impl DependencyProvider {
         let context = DependencyProviderContext { component, path };
         match self {
             DependencyProvider::Manifest(provider) => provider.install(context),
+            DependencyProvider::Adapter(provider) => provider.install(context),
             DependencyProvider::ComponentScript(provider) => provider.install(context),
             DependencyProvider::Extension(provider) => provider.install(context),
         }
@@ -154,6 +159,7 @@ impl DependencyProvider {
         let context = DependencyProviderContext { component, path };
         match self {
             DependencyProvider::Manifest(provider) => provider.install_command(context),
+            DependencyProvider::Adapter(provider) => provider.install_command(context),
             DependencyProvider::ComponentScript(provider) => provider.install_command(context),
             DependencyProvider::Extension(provider) => provider.install_command(context),
         }
@@ -172,7 +178,7 @@ pub(crate) fn resolve_dependency_providers(
             format!("No dependency provider found for {}", path.display()),
             None,
             Some(vec![
-                "Declare a dependency provider with homeboy-deps.json, a component deps script, or an extension deps provider".to_string(),
+                "Declare a dependency provider with homeboy-deps.json, an installed dependency adapter, a component deps script, or an extension deps provider".to_string(),
                 "Core no longer detects built-in dependency providers; package ecosystems must be declared outside core".to_string(),
             ]),
         ));
@@ -192,9 +198,25 @@ pub(crate) fn resolve_dependency_providers_optional(
 ) -> Result<Vec<DependencyProvider>> {
     let mut providers = Vec::new();
 
+    let local_adapter_providers = AdapterDependencyProvider::load_local(path)?;
+    if !local_adapter_providers.is_empty() {
+        return Ok(local_adapter_providers
+            .into_iter()
+            .map(DependencyProvider::Adapter)
+            .collect());
+    }
+
     if let Some(provider) = ManifestDependencyProvider::load(path)? {
         providers.push(DependencyProvider::Manifest(provider));
         return Ok(providers);
+    }
+
+    let adapter_providers = AdapterDependencyProvider::load(path)?;
+    if !adapter_providers.is_empty() {
+        return Ok(adapter_providers
+            .into_iter()
+            .map(DependencyProvider::Adapter)
+            .collect());
     }
 
     if component.has_script(ExtensionCapability::Deps) {
@@ -243,6 +265,482 @@ pub(crate) fn dependency_provider_snapshot(
     }
 
     Ok(snapshot)
+}
+
+const DEPENDENCY_ADAPTER_INDEX: &str = "dependency-adapters/index.json";
+const DEPENDENCY_ADAPTER_INDEX_SCHEMA: &str = "homeboy-extension/dependency-adapter-index/v1";
+const DEPENDENCY_ADAPTER_MANIFEST_SCHEMA: &str = "homeboy-extension/dependency-adapter-manifest/v1";
+
+#[derive(Debug, Clone)]
+pub(crate) struct AdapterDependencyProvider {
+    adapter: InstalledDependencyAdapter,
+}
+
+impl AdapterDependencyProvider {
+    fn load_local(path: &Path) -> Result<Vec<Self>> {
+        let manifest_path = path.join(DEPENDENCY_ADAPTER_MANIFEST);
+        if !manifest_path.is_file() || !is_dependency_adapter_manifest(&manifest_path)? {
+            return Ok(Vec::new());
+        }
+        let adapter = read_installed_dependency_adapter(&manifest_path)?;
+        Ok(adapter
+            .matches(path)
+            .then(|| adapter.providers(path))
+            .unwrap_or_default()
+            .into_iter()
+            .map(|adapter| Self { adapter })
+            .collect())
+    }
+
+    fn load(path: &Path) -> Result<Vec<Self>> {
+        let extensions_dir = paths::extensions()?;
+        let Ok(entries) = fs::read_dir(extensions_dir) else {
+            return Ok(Vec::new());
+        };
+
+        let mut adapters = Vec::new();
+        let mut seen_manifests = HashSet::new();
+        for entry in entries.flatten() {
+            let index_path = entry.path().join(DEPENDENCY_ADAPTER_INDEX);
+            if !index_path.is_file() {
+                continue;
+            }
+            for manifest in read_dependency_adapter_index(&index_path)? {
+                let manifest_path = index_path
+                    .parent()
+                    .expect("dependency adapter index has a parent")
+                    .join(&manifest.path);
+                if !seen_manifests.insert(manifest_path.clone()) {
+                    continue;
+                }
+                let adapter = read_installed_dependency_adapter(&manifest_path)?;
+                if adapter.id != manifest.id || adapter.ecosystem != manifest.ecosystem {
+                    return Err(Error::validation_invalid_argument(
+                        "dependency_adapter_index.manifests",
+                        format!(
+                            "Dependency adapter index entry '{}' does not match manifest '{}'",
+                            manifest.id, adapter.id
+                        ),
+                        Some(manifest_path.display().to_string()),
+                        None,
+                    ));
+                }
+                if adapter.matches(path) {
+                    adapters.extend(adapter.providers(path));
+                }
+            }
+        }
+        Ok(adapters
+            .into_iter()
+            .map(|adapter| Self { adapter })
+            .collect())
+    }
+
+    fn status_with_filter(&self, package_filter: Option<&str>) -> Result<ProviderDependencyStatus> {
+        if let Some(command) = &self.adapter.package_manager().commands.status {
+            self.run(command, "status")?;
+        }
+        Ok(ProviderDependencyStatus {
+            package_manager: self.adapter.package_manager().id.clone(),
+            dependency_identities: self.adapter.package_identity()?,
+            packages: self
+                .adapter
+                .packages()?
+                .into_iter()
+                .filter(|package| package_filter.is_none_or(|filter| filter == package.name))
+                .collect(),
+        })
+    }
+
+    fn command(&self, command: &AdapterCommand) -> DependencyProviderCommand {
+        // Adapter commands are declared as shell command strings by the v1 contract.
+        DependencyProviderCommand::new(
+            "sh",
+            vec!["-c".to_string(), command.command.clone()],
+            self.adapter.project_path.clone(),
+        )
+    }
+
+    fn run(&self, command: &AdapterCommand, operation: &str) -> Result<DependencyCommandResult> {
+        if command.requires_lockfile
+            && !self
+                .adapter
+                .lockfile_priority
+                .iter()
+                .any(|lockfile| self.adapter.project_path.join(lockfile).exists())
+        {
+            return Err(Error::validation_invalid_argument(
+                "dependency_provider",
+                format!(
+                    "Dependency adapter '{}' requires one of its declared lockfiles before {}",
+                    self.adapter.package_manager().id,
+                    operation
+                ),
+                None,
+                None,
+            ));
+        }
+        run_adapter_command(
+            &self.command(command),
+            operation,
+            &command.success_exit_codes,
+        )
+    }
+
+    fn status(
+        &self,
+        request: DependencyProviderStatusRequest<'_>,
+    ) -> Result<ProviderDependencyStatus> {
+        self.status_with_filter(request.package_filter)
+    }
+
+    fn handles_package(&self, request: DependencyProviderPackageRequest<'_>) -> Result<bool> {
+        Ok(self
+            .adapter
+            .packages()?
+            .iter()
+            .any(|package| package.name == request.package)
+            || self.adapter.package_manager().commands.update.is_some())
+    }
+
+    fn update(
+        &self,
+        request: DependencyProviderUpdateRequest<'_>,
+    ) -> Result<DependencyUpdateResult> {
+        let Some(command) = &self.adapter.package_manager().commands.update else {
+            return Err(Error::validation_invalid_argument(
+                "dependency_provider",
+                format!(
+                    "Dependency adapter '{}' does not define an update command",
+                    self.adapter.package_manager().id
+                ),
+                Some(self.adapter.package_manager().id.clone()),
+                None,
+            ));
+        };
+        let before = self
+            .status_with_filter(Some(request.package))?
+            .packages
+            .into_iter()
+            .next();
+        let result = self.run(command, "update")?;
+        let after = self
+            .status_with_filter(Some(request.package))?
+            .packages
+            .into_iter()
+            .next();
+        Ok(dependency_update_result(
+            request,
+            self.adapter.package_manager().id.clone(),
+            result,
+            before,
+            after,
+        ))
+    }
+
+    fn install(
+        &self,
+        _context: DependencyProviderContext<'_>,
+    ) -> Result<Option<DependencyCommandResult>> {
+        let Some(command) = &self.adapter.package_manager().commands.install else {
+            return Ok(None);
+        };
+        Ok(Some(self.run(command, "install")?))
+    }
+
+    fn install_command(
+        &self,
+        _context: DependencyProviderContext<'_>,
+    ) -> Result<Option<DependencyProviderCommand>> {
+        Ok(self
+            .adapter
+            .package_manager()
+            .commands
+            .install
+            .as_ref()
+            .map(|command| self.command(command)))
+    }
+}
+
+fn is_dependency_adapter_manifest(path: &Path) -> Result<bool> {
+    let raw = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    let value: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+        Error::validation_invalid_json(e, Some(path.display().to_string()), Some(raw))
+    })?;
+    Ok(value.get("schema").and_then(serde_json::Value::as_str)
+        == Some(DEPENDENCY_ADAPTER_MANIFEST_SCHEMA))
+}
+
+#[derive(Debug, Deserialize)]
+struct DependencyAdapterIndex {
+    schema: String,
+    manifests: Vec<DependencyAdapterIndexEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DependencyAdapterIndexEntry {
+    id: String,
+    ecosystem: String,
+    path: PathBuf,
+}
+
+fn read_dependency_adapter_index(path: &Path) -> Result<Vec<DependencyAdapterIndexEntry>> {
+    let raw = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    let index: DependencyAdapterIndex = serde_json::from_str(&raw).map_err(|e| {
+        Error::validation_invalid_json(e, Some(path.display().to_string()), Some(raw))
+    })?;
+    if index.schema != DEPENDENCY_ADAPTER_INDEX_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "dependency_adapter_index.schema",
+            format!(
+                "Unsupported dependency adapter index schema '{}'",
+                index.schema
+            ),
+            Some(index.schema),
+            None,
+        ));
+    }
+    for entry in &index.manifests {
+        if entry.id.trim().is_empty()
+            || entry.ecosystem.trim().is_empty()
+            || entry.path.as_os_str().is_empty()
+            || entry.path.is_absolute()
+            || entry
+                .path
+                .components()
+                .any(|part| matches!(part, std::path::Component::ParentDir))
+        {
+            return Err(Error::validation_invalid_argument(
+                "dependency_adapter_index.manifests",
+                "Dependency adapter index entries require an id, ecosystem, and relative path"
+                    .to_string(),
+                None,
+                None,
+            ));
+        }
+    }
+    Ok(index.manifests)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct InstalledDependencyAdapter {
+    schema: String,
+    id: String,
+    version: u64,
+    ecosystem: String,
+    project_signals: AdapterProjectSignals,
+    #[serde(default)]
+    lockfile_priority: Vec<String>,
+    #[serde(default)]
+    package_managers: Vec<AdapterPackageManager>,
+    #[serde(skip)]
+    project_path: PathBuf,
+}
+
+impl InstalledDependencyAdapter {
+    fn matches(&self, path: &Path) -> bool {
+        let mut matched = self
+            .project_signals
+            .root_files
+            .iter()
+            .map(|file| path.join(file).exists());
+        match self.project_signals.root_match.as_deref().unwrap_or("all") {
+            "any" => matched.any(|matched| matched),
+            _ => matched.all(|matched| matched),
+        }
+    }
+
+    fn providers(&self, path: &Path) -> Vec<Self> {
+        let mut package_managers = self.package_managers.clone();
+        package_managers.sort_by_key(|manager| manager.selection.priority);
+        let selected = package_managers
+            .iter()
+            .find(|manager| manager.selection_matches(path))
+            .or_else(|| {
+                package_managers
+                    .iter()
+                    .find(|manager| manager.selection.default)
+            });
+        selected
+            .cloned()
+            .map(|package_manager| {
+                let mut adapter = self.clone();
+                adapter.project_path = path.to_path_buf();
+                adapter.package_managers = vec![package_manager];
+                adapter
+            })
+            .into_iter()
+            .collect()
+    }
+
+    fn package_manager(&self) -> &AdapterPackageManager {
+        &self.package_managers[0]
+    }
+
+    fn package_identity(&self) -> Result<Vec<String>> {
+        let Some(identity) = &self.package_manager().package_identity else {
+            return Ok(Vec::new());
+        };
+        let value = read_adapter_json(&self.project_path.join(&identity.manifest))?;
+        Ok(value
+            .get(&identity.name)
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .into_iter()
+            .collect())
+    }
+
+    fn packages(&self) -> Result<Vec<DependencyPackage>> {
+        let Some(identity) = &self.package_manager().package_identity else {
+            return Ok(Vec::new());
+        };
+        let value = read_adapter_json(&self.project_path.join(&identity.manifest))?;
+        let mut packages = Vec::new();
+        for section in &identity.dependencies {
+            let Some(dependencies) = value.get(section).and_then(serde_json::Value::as_object)
+            else {
+                continue;
+            };
+            packages.extend(dependencies.iter().filter_map(|(name, constraint)| {
+                constraint.as_str().map(|constraint| DependencyPackage {
+                    name: name.clone(),
+                    manifest_section: Some(section.clone()),
+                    constraint: Some(constraint.to_string()),
+                    locked_version: None,
+                    locked_reference: None,
+                })
+            }));
+        }
+        Ok(packages)
+    }
+}
+
+fn read_installed_dependency_adapter(path: &Path) -> Result<InstalledDependencyAdapter> {
+    let raw = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    let adapter: InstalledDependencyAdapter = serde_json::from_str(&raw).map_err(|e| {
+        Error::validation_invalid_json(e, Some(path.display().to_string()), Some(raw))
+    })?;
+    if adapter.schema != DEPENDENCY_ADAPTER_MANIFEST_SCHEMA
+        || adapter.id.trim().is_empty()
+        || adapter.ecosystem.trim().is_empty()
+        || adapter.version == 0
+        || adapter.project_signals.root_files.is_empty()
+    {
+        return Err(Error::validation_invalid_argument(
+            "dependency_adapter_manifest",
+            "Dependency adapter manifests require a supported schema, id, version, ecosystem, and project root signals".to_string(),
+            None,
+            None,
+        ));
+    }
+    if !matches!(
+        adapter.project_signals.root_match.as_deref(),
+        None | Some("any") | Some("all")
+    ) {
+        return Err(Error::validation_invalid_argument(
+            "dependency_adapter_manifest.project_signals.root_match",
+            "Dependency adapter root_match must be 'any' or 'all'".to_string(),
+            None,
+            None,
+        ));
+    }
+    for manager in &adapter.package_managers {
+        if manager.id.trim().is_empty()
+            || !matches!(
+                manager.selection.search.as_deref(),
+                None | Some("project-root") | Some("upward")
+            )
+            || [
+                manager.commands.status.as_ref(),
+                manager.commands.install.as_ref(),
+                manager.commands.update.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            .any(|command| command.command.trim().is_empty())
+        {
+            return Err(Error::validation_invalid_argument(
+                "dependency_adapter_manifest.package_managers",
+                "Dependency adapter package managers require an id, supported search mode, and non-empty commands".to_string(),
+                None,
+                None,
+            ));
+        }
+    }
+    Ok(adapter)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AdapterProjectSignals {
+    root_files: Vec<String>,
+    root_match: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AdapterPackageManager {
+    id: String,
+    selection: AdapterSelection,
+    #[serde(default)]
+    commands: AdapterCommands,
+    #[serde(default)]
+    package_identity: Option<AdapterPackageIdentity>,
+}
+
+impl AdapterPackageManager {
+    fn selection_matches(&self, path: &Path) -> bool {
+        self.selection
+            .files
+            .iter()
+            .any(|file| match self.selection.search.as_deref() {
+                Some("upward") => path
+                    .ancestors()
+                    .any(|directory| directory.join(file).exists()),
+                _ => path.join(file).exists(),
+            })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AdapterSelection {
+    priority: u64,
+    #[serde(default)]
+    files: Vec<String>,
+    search: Option<String>,
+    #[serde(default)]
+    default: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct AdapterCommands {
+    status: Option<AdapterCommand>,
+    install: Option<AdapterCommand>,
+    update: Option<AdapterCommand>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AdapterCommand {
+    command: String,
+    #[serde(default)]
+    success_exit_codes: Vec<i32>,
+    #[serde(default)]
+    requires_lockfile: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AdapterPackageIdentity {
+    manifest: PathBuf,
+    name: String,
+    dependencies: Vec<String>,
+}
+
+fn read_adapter_json(path: &Path) -> Result<serde_json::Value> {
+    let raw = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    serde_json::from_str(&raw)
+        .map_err(|e| Error::validation_invalid_json(e, Some(path.display().to_string()), Some(raw)))
 }
 
 const DEPENDENCY_ADAPTER_MANIFEST: &str = "homeboy-deps.json";
@@ -752,6 +1250,53 @@ pub(crate) fn run_dependency_provider_command(
     })
 }
 
+fn run_adapter_command(
+    command: &DependencyProviderCommand,
+    operation: &str,
+    success_exit_codes: &[i32],
+) -> Result<DependencyCommandResult> {
+    let output = Command::new(&command.program)
+        .args(&command.args)
+        .current_dir(&command.cwd)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(e.to_string(), Some("run dependency adapter".to_string()))
+        })?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let status = output.status.code();
+    let allowed = success_exit_codes
+        .is_empty()
+        .then(|| output.status.success())
+        .unwrap_or_else(|| status.is_some_and(|code| success_exit_codes.contains(&code)));
+    if !allowed {
+        return Err(Error::validation_invalid_argument(
+            "dependency_provider",
+            format!(
+                "Dependency adapter {} failed with status {}: {}",
+                operation,
+                output.status,
+                first_non_empty_line(&stderr)
+                    .or_else(|| first_non_empty_line(&stdout))
+                    .unwrap_or("no output")
+            ),
+            None,
+            Some(vec![format!(
+                "Run manually in {}: {}",
+                command.cwd.display(),
+                command.argv().join(" ")
+            )]),
+        ));
+    }
+    Ok(DependencyCommandResult {
+        command: command.argv(),
+        skipped: false,
+        status,
+        stdout,
+        stderr,
+    })
+}
+
 #[derive(Debug, Deserialize)]
 struct ExtensionStatusOutput {
     package_manager: String,
@@ -781,6 +1326,7 @@ mod tests {
     use super::*;
     use crate::core::component::Component;
     use crate::core::extension::ExtensionCapability;
+    use crate::core::paths;
     use std::fs;
     use tempfile::tempdir;
 
@@ -851,6 +1397,240 @@ esac
             .unwrap();
         assert_eq!(command.argv(), vec!["fixture-pm", "install", "--locked"]);
         assert_eq!(command.cwd, component_path);
+    }
+
+    #[test]
+    fn reads_valid_dependency_adapter_index_and_rejects_malformed_indexes() {
+        let dir = tempdir().unwrap();
+        let valid = dir.path().join("index.json");
+        fs::write(
+            &valid,
+            r#"{
+                "schema": "homeboy-extension/dependency-adapter-index/v1",
+                "manifests": [{ "id": "fixture", "ecosystem": "fixture", "path": "fixture.json" }]
+            }"#,
+        )
+        .unwrap();
+        let entries = read_dependency_adapter_index(&valid).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, PathBuf::from("fixture.json"));
+
+        let malformed = dir.path().join("malformed.json");
+        fs::write(&malformed, "{ not json }").unwrap();
+        assert!(read_dependency_adapter_index(&malformed).is_err());
+    }
+
+    #[test]
+    fn registry_adapter_precedes_scripts_but_scripts_resolve_without_a_registry() {
+        crate::test_support::with_isolated_home(|_| {
+            let dir = tempdir().unwrap();
+            let project = dir.path().join("project");
+            fs::create_dir_all(&project).unwrap();
+            fs::write(
+                project.join("fixture.json"),
+                r#"{"name":"fixture/project"}"#,
+            )
+            .unwrap();
+            let mut component = Component::new(
+                "fixture".to_string(),
+                project.display().to_string(),
+                String::new(),
+                None,
+            );
+            component.scripts = Some(crate::core::component::ComponentScriptsConfig {
+                deps: vec!["true".to_string()],
+                ..Default::default()
+            });
+
+            let providers = resolve_dependency_providers_optional(&component, &project).unwrap();
+            assert!(matches!(
+                providers.as_slice(),
+                [DependencyProvider::ComponentScript(_)]
+            ));
+
+            fs::write(
+                project.join(DEPENDENCY_ADAPTER_MANIFEST),
+                r#"{
+                    "schema": "homeboy-extension/dependency-adapter-manifest/v1",
+                    "id": "fixture",
+                    "version": 1,
+                    "ecosystem": "fixture",
+                    "project_signals": { "root_files": ["fixture.json"] },
+                    "capabilities": {},
+                    "package_managers": [{
+                        "id": "fixture-pm",
+                        "selection": { "priority": 1, "default": true },
+                        "install": { "intent": "install" },
+                        "commands": {},
+                        "outputs": [{ "kind": "directory", "path": "deps" }]
+                    }]
+                }"#,
+            )
+            .unwrap();
+            let providers = resolve_dependency_providers_optional(&component, &project).unwrap();
+            assert!(matches!(
+                providers.as_slice(),
+                [DependencyProvider::Adapter(_)]
+            ));
+            fs::remove_file(project.join(DEPENDENCY_ADAPTER_MANIFEST)).unwrap();
+
+            let adapter_dir = paths::extensions()
+                .unwrap()
+                .join("fixture-extension/dependency-adapters");
+            fs::create_dir_all(&adapter_dir).unwrap();
+            fs::write(
+                adapter_dir.join("index.json"),
+                r#"{
+                    "schema": "homeboy-extension/dependency-adapter-index/v1",
+                    "manifests": [{ "id": "fixture", "ecosystem": "fixture", "path": "fixture.json" }]
+                }"#,
+            )
+            .unwrap();
+            fs::write(
+                adapter_dir.join("fixture.json"),
+                r#"{
+                    "schema": "homeboy-extension/dependency-adapter-manifest/v1",
+                    "id": "fixture",
+                    "version": 1,
+                    "ecosystem": "fixture",
+                    "project_signals": { "root_files": ["fixture.json"] },
+                    "capabilities": {},
+                    "package_managers": [{
+                        "id": "fixture-pm",
+                        "selection": { "priority": 1, "default": true },
+                        "install": { "intent": "install" },
+                        "commands": {},
+                        "outputs": [{ "kind": "directory", "path": "deps" }]
+                    }]
+                }"#,
+            )
+            .unwrap();
+
+            let providers = resolve_dependency_providers_optional(&component, &project).unwrap();
+            assert!(matches!(
+                providers.as_slice(),
+                [DependencyProvider::Adapter(_)]
+            ));
+
+            fs::write(
+                project.join(DEPENDENCY_ADAPTER_MANIFEST),
+                r#"{
+                    "provider": "legacy-fixture",
+                    "commands": { "install": { "argv": ["true"] } }
+                }"#,
+            )
+            .unwrap();
+            let providers = resolve_dependency_providers_optional(&component, &project).unwrap();
+            assert!(matches!(
+                providers.as_slice(),
+                [DependencyProvider::Manifest(_)]
+            ));
+        });
+    }
+
+    #[test]
+    fn registry_adapter_dispatches_declared_commands() {
+        crate::test_support::with_isolated_home(|_| {
+            let dir = tempdir().unwrap();
+            let project = dir.path().join("project");
+            fs::create_dir_all(&project).unwrap();
+            fs::write(
+                project.join("fixture.json"),
+                r#"{"name":"fixture/project","dependencies":{"fixture/package":"^1.0"}}"#,
+            )
+            .unwrap();
+            fs::write(
+                project.join("adapter.sh"),
+                "#!/bin/sh\nprintf '%s\\n' \"$1\" >> adapter.log\n",
+            )
+            .unwrap();
+            make_executable(&project.join("adapter.sh"));
+
+            let adapter_dir = paths::extensions()
+                .unwrap()
+                .join("fixture-extension/dependency-adapters");
+            fs::create_dir_all(&adapter_dir).unwrap();
+            fs::write(
+                adapter_dir.join("index.json"),
+                r#"{
+                    "schema": "homeboy-extension/dependency-adapter-index/v1",
+                    "manifests": [{ "id": "fixture", "ecosystem": "fixture", "path": "fixture.json" }]
+                }"#,
+            )
+            .unwrap();
+            fs::write(
+                adapter_dir.join("fixture.json"),
+                r#"{
+                    "schema": "homeboy-extension/dependency-adapter-manifest/v1",
+                    "id": "fixture",
+                    "version": 1,
+                    "ecosystem": "fixture",
+                    "project_signals": { "root_files": ["fixture.json"] },
+                    "capabilities": {},
+                    "package_managers": [{
+                        "id": "fixture-pm",
+                        "selection": { "priority": 1, "default": true },
+                        "install": { "intent": "install" },
+                        "commands": {
+                            "status": { "command": "sh adapter.sh status" },
+                            "install": { "command": "sh adapter.sh install" },
+                            "update": { "command": "sh adapter.sh update" }
+                        },
+                        "package_identity": {
+                            "manifest": "fixture.json",
+                            "name": "name",
+                            "version": "version",
+                            "dependencies": ["dependencies"]
+                        },
+                        "outputs": [{ "kind": "directory", "path": "deps" }]
+                    }]
+                }"#,
+            )
+            .unwrap();
+
+            let component = Component::new(
+                "fixture".to_string(),
+                project.display().to_string(),
+                String::new(),
+                None,
+            );
+            let providers = resolve_dependency_providers_optional(&component, &project).unwrap();
+            let DependencyProvider::Adapter(provider) = &providers[0] else {
+                panic!("expected registry adapter");
+            };
+            let status = provider
+                .status(DependencyProviderStatusRequest {
+                    context: DependencyProviderContext {
+                        component: &component,
+                        path: &project,
+                    },
+                    package_filter: None,
+                })
+                .unwrap();
+            assert_eq!(status.package_manager, "fixture-pm");
+            assert_eq!(status.dependency_identities, vec!["fixture/project"]);
+            assert_eq!(status.packages[0].name, "fixture/package");
+            provider
+                .install(DependencyProviderContext {
+                    component: &component,
+                    path: &project,
+                })
+                .unwrap();
+            provider
+                .update(DependencyProviderUpdateRequest {
+                    context: DependencyProviderContext {
+                        component: &component,
+                        path: &project,
+                    },
+                    package: "fixture/package",
+                    constraint: None,
+                })
+                .unwrap();
+            assert_eq!(
+                fs::read_to_string(project.join("adapter.log")).unwrap(),
+                "status\ninstall\nstatus\nupdate\nstatus\n"
+            );
+        });
     }
 
     fn make_executable(path: &Path) {

--- a/src/core/extension/manifest_config.rs
+++ b/src/core/extension/manifest_config.rs
@@ -229,6 +229,17 @@ pub struct DepsConfig {
     pub extension_script: Option<String>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::DepsConfig;
+
+    #[test]
+    fn deps_config_preserves_the_legacy_extension_script_contract() {
+        let config: DepsConfig = serde_json::from_str(r#"{"extension_script":"deps.sh"}"#).unwrap();
+        assert_eq!(config.extension_script.as_deref(), Some("deps.sh"));
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LintConfig {
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- Load `dependency-adapters/index.json` from installed extension directories, validate indexed manifests, match `project_signals`, select the declared package manager, and dispatch its status/install/update commands.
- Accept the same adapter shape directly in `homeboy-deps.json`, while preserving the existing legacy manifest parser and component/extension dependency providers.
- Add focused registry parsing, precedence, dispatch, and legacy `DepsConfig` compatibility tests.

## Diffstat
`2 files changed, 794 insertions(+), 3 deletions(-)`

## Precedence and Dispatch
Resolution is now: legacy or adapter-shaped `homeboy-deps.json`, matching installed dependency adapters, component deps script, then extension deps capability. A matching registry returns its selected providers so legacy fallback providers retain their prior behavior whenever no adapter matches. Adapter commands execute in the project root; declared success exit codes and lockfile requirements are honored. Package identities and declared dependency maps are read from `package_identity`.

## Extension Contract Gaps
The shipped v1 contract does not define the execution grammar for scalar `commands.*.command`, so core executes it using `sh -c`. It also has no mapping for Homeboy's requested update package and optional constraint, so core runs the declared update command without appending undeclared arguments. The manifest schema does not include a schema document for `index.json`. These gaps are recorded on #7701; no extension files were changed.

## Verification
- `cargo build -j 3`
- `cargo test --lib core::deps::provider::tests --no-fail-fast`
- `cargo test --lib core::extension::manifest_config::tests --no-fail-fast`
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (existing repository warnings only; no warnings from changed files)

Fixes #7701

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation of declarative dependency-adapter registry consumption in core, plus verification runs. Reviewed by Chris Huber.