### PR TITLE
fix: split runner extension parity phases

### DIFF
--- a/src/core/runner/execution/extension_parity.rs
+++ b/src/core/runner/execution/extension_parity.rs
@@ -4,6 +4,7 @@ use crate::core::extension;
 use crate::core::output::MergeOutput;
 use crate::core::server::{self, SshClient};
 
+use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
 #[cfg(test)]
@@ -84,7 +85,73 @@ fn push_setting_key(keys: &mut Vec<String>, value: &str) {
     }
 }
 
-pub(super) fn validate_runner_extension_parity(
+pub(super) fn plan_extension_parity(
+    runner_id: &str,
+    runner: &Runner,
+    cwd: &str,
+    required_extensions: &[String],
+    requested_setting_keys: &[String],
+    accepted_setting_keys: &[String],
+) -> Result<ExtensionParityPlan> {
+    let homeboy_path = remote_runner_homeboy_path(runner, "runner extension parity preflight")?;
+    let mut steps = Vec::new();
+    for extension_id in required_extensions {
+        if let Some(step) = plan_runner_extension_parity(
+            runner_id,
+            runner,
+            cwd,
+            homeboy_path,
+            extension_id,
+            requested_setting_keys,
+            accepted_setting_keys,
+        )? {
+            steps.push(step);
+        }
+    }
+
+    Ok(ExtensionParityPlan {
+        runner_id: runner_id.to_string(),
+        homeboy_path: homeboy_path.to_string(),
+        steps,
+    })
+}
+
+pub(super) fn ensure_extension_materialized(plan: &ExtensionParityPlan) -> Result<()> {
+    if plan.steps.is_empty() {
+        return Ok(());
+    }
+
+    record_extension_parity_ensure_trail(plan, "running", None, None)?;
+    let runner = load(&plan.runner_id)?;
+    for step in &plan.steps {
+        let result =
+            materialize_runner_extension(&runner, &plan.homeboy_path, &step.materialization);
+        match result {
+            Ok(provenance) => {
+                if matches!(
+                    step.materialization.source,
+                    RunnerExtensionMaterializationSource::ControllerSnapshot { .. }
+                ) {
+                    record_materialized_extension_overlay(&plan.runner_id, provenance)?;
+                }
+                record_extension_parity_ensure_trail(plan, "running", Some(&step.id), None)?;
+            }
+            Err(err) => {
+                record_extension_parity_ensure_trail(plan, "failed", Some(&step.id), Some(&err))?;
+                return Err(runner_extension_materialization_error(
+                    &plan.runner_id,
+                    &plan.homeboy_path,
+                    &step.id,
+                    err,
+                    step.parity_error.clone(),
+                ));
+            }
+        }
+    }
+    record_extension_parity_ensure_trail(plan, "success", None, None)
+}
+
+pub(super) fn validate_extension_ready(
     runner_id: &str,
     runner: &Runner,
     cwd: &str,
@@ -92,29 +159,45 @@ pub(super) fn validate_runner_extension_parity(
     requested_setting_keys: &[String],
     accepted_setting_keys: &[String],
 ) -> Result<()> {
+    let homeboy_path = remote_runner_homeboy_path(runner, "runner extension parity validation")?;
     for extension_id in required_extensions {
-        validate_runner_extension(
+        validate_runner_extension_ready_state(
             runner_id,
             runner,
             cwd,
+            homeboy_path,
             extension_id,
             requested_setting_keys,
             accepted_setting_keys,
         )?;
     }
-
     Ok(())
 }
 
-fn validate_runner_extension(
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct ExtensionParityPlan {
+    runner_id: String,
+    homeboy_path: String,
+    steps: Vec<ExtensionParityPlanStep>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ExtensionParityPlanStep {
+    id: String,
+    materialization: RunnerExtensionMaterializationRequest,
+    #[serde(skip)]
+    parity_error: Error,
+}
+
+fn plan_runner_extension_parity(
     runner_id: &str,
     runner: &Runner,
     cwd: &str,
+    homeboy_path: &str,
     extension_id: &str,
     requested_setting_keys: &[String],
     accepted_setting_keys: &[String],
-) -> Result<()> {
-    let homeboy_path = remote_runner_homeboy_path(runner, "runner extension parity preflight")?;
+) -> Result<Option<ExtensionParityPlanStep>> {
     let output = show_runner_extension(runner, cwd, homeboy_path, extension_id)?;
 
     if output.success {
@@ -133,57 +216,28 @@ fn validate_runner_extension(
             extension_id,
             &output.stdout,
         )?;
-        if let Err(err) = validate_runner_extension_revision(
+        return match validate_runner_extension_revision(
             runner_id,
             runner,
             homeboy_path,
             extension_id,
             &output.stdout,
         ) {
-            if !is_stale_runner_extension_parity_error(&err) {
-                return Err(err);
+            Ok(()) => Ok(None),
+            Err(err) if is_stale_runner_extension_parity_error(&err) => {
+                Ok(Some(ExtensionParityPlanStep {
+                    id: extension_id.to_string(),
+                    materialization: runner_extension_materialization_request(
+                        runner_id,
+                        homeboy_path,
+                        extension_id,
+                        err.clone(),
+                    )?,
+                    parity_error: err,
+                }))
             }
-            sync_runner_extension_revision(
-                runner_id,
-                runner,
-                cwd,
-                homeboy_path,
-                extension_id,
-                err,
-            )?;
-            let refreshed = show_runner_extension(runner, cwd, homeboy_path, extension_id)?;
-            if refreshed.success {
-                validate_runner_extension_parity_status(
-                    runner_id,
-                    homeboy_path,
-                    extension_id,
-                    &refreshed.stdout,
-                )?;
-                validate_runner_extension_settings(
-                    runner_id,
-                    homeboy_path,
-                    extension_id,
-                    &refreshed.stdout,
-                    requested_setting_keys,
-                    accepted_setting_keys,
-                )?;
-                validate_runner_extension_core_compatibility(
-                    runner_id,
-                    homeboy_path,
-                    extension_id,
-                    &refreshed.stdout,
-                )?;
-                return Ok(());
-            }
-            return Err(missing_runner_extension_error(
-                runner_id,
-                homeboy_path,
-                extension_id,
-                &refreshed.stderr,
-                &refreshed.stdout,
-            ));
-        }
-        return Ok(());
+            Err(err) => Err(err),
+        };
     }
 
     Err(missing_runner_extension_error(
@@ -195,21 +249,44 @@ fn validate_runner_extension(
     ))
 }
 
-/// Runs the full readiness + source-revision parity validation against a single
-/// `extension show` stdout payload. Both the initial preflight and the
-/// post-sync refresh re-check the same two parity invariants against their
-/// respective stdout, so they share this helper.
-fn validate_runner_extension_parity_status(
+fn validate_runner_extension_ready_state(
     runner_id: &str,
+    runner: &Runner,
+    cwd: &str,
     homeboy_path: &str,
     extension_id: &str,
-    remote_stdout: &str,
+    requested_setting_keys: &[String],
+    accepted_setting_keys: &[String],
 ) -> Result<()> {
+    let output = show_runner_extension(runner, cwd, homeboy_path, extension_id)?;
+    if !output.success {
+        return Err(missing_runner_extension_error(
+            runner_id,
+            homeboy_path,
+            extension_id,
+            &output.stderr,
+            &output.stdout,
+        ));
+    }
+    let remote_stdout = &output.stdout;
     validate_runner_extension_ready(runner_id, homeboy_path, extension_id, remote_stdout)?;
-    let runner = super::super::load(runner_id)?;
     validate_runner_extension_revision(
         runner_id,
-        &runner,
+        runner,
+        homeboy_path,
+        extension_id,
+        remote_stdout,
+    )?;
+    validate_runner_extension_settings(
+        runner_id,
+        homeboy_path,
+        extension_id,
+        remote_stdout,
+        requested_setting_keys,
+        accepted_setting_keys,
+    )?;
+    validate_runner_extension_core_compatibility(
+        runner_id,
         homeboy_path,
         extension_id,
         remote_stdout,
@@ -461,14 +538,12 @@ fn missing_runner_extension_error(
     )
 }
 
-fn sync_runner_extension_revision(
+fn runner_extension_materialization_request(
     runner_id: &str,
-    runner: &Runner,
-    _cwd: &str,
     homeboy_path: &str,
     extension_id: &str,
     parity_error: Error,
-) -> Result<()> {
+) -> Result<RunnerExtensionMaterializationRequest> {
     let local_revision = extension::read_source_revision(extension_id)
         .filter(|revision| !revision.trim().is_empty())
         .ok_or_else(|| parity_error.clone())?;
@@ -496,31 +571,60 @@ fn sync_runner_extension_revision(
                 git_ref: local_revision.clone(),
             }
         };
-    let records_dev_overlay = matches!(
-        &materialization_source,
-        RunnerExtensionMaterializationSource::ControllerSnapshot { .. }
+    Ok(RunnerExtensionMaterializationRequest {
+        id: extension_id.to_string(),
+        revision: local_revision,
+        source: materialization_source,
+    })
+}
+
+fn record_extension_parity_ensure_trail(
+    plan: &ExtensionParityPlan,
+    status: &str,
+    completed_step: Option<&str>,
+    error: Option<&Error>,
+) -> Result<()> {
+    let mut runner = load(&plan.runner_id)?;
+    let mut resources = runner.resources;
+    let completed_steps = plan
+        .steps
+        .iter()
+        .map(|step| {
+            let step_status = if completed_step == Some(step.id.as_str()) && status == "failed" {
+                "failed"
+            } else if completed_step == Some(step.id.as_str()) || status == "success" {
+                "success"
+            } else {
+                "ready"
+            };
+            serde_json::json!({
+                "id": step.id,
+                "kind": "runner.extension_parity.materialize",
+                "status": step_status,
+                "materialization": step.materialization,
+            })
+        })
+        .collect::<Vec<_>>();
+    resources.insert(
+        "extension_parity".to_string(),
+        serde_json::json!({
+            "schema": "homeboy/runner-extension-parity/v1",
+            "status": status,
+            "steps": completed_steps,
+            "error": error.map(|value| serde_json::json!({
+                "code": value.code.as_str(),
+                "message": value.message,
+                "details": value.details,
+            })),
+        }),
     );
-    let provenance = materialize_runner_extension(
-        runner,
-        homeboy_path,
-        &RunnerExtensionMaterializationRequest {
-            id: extension_id.to_string(),
-            revision: local_revision,
-            source: materialization_source,
-        },
-    )
-    .map_err(|err| {
-        runner_extension_materialization_error(
-            runner_id,
-            homeboy_path,
-            extension_id,
-            err,
-            parity_error,
-        )
-    })?;
-    if records_dev_overlay {
-        record_materialized_extension_overlay(runner_id, provenance)?;
-    }
+    runner.resources = resources;
+    let patch = serde_json::json!({ "resources": runner.resources });
+    let replace_fields = vec!["resources".to_string()];
+    let _updated = matches!(
+        merge(Some(&plan.runner_id), &patch.to_string(), &replace_fields)?,
+        MergeOutput::Single(_)
+    );
     Ok(())
 }
 
@@ -1011,16 +1115,22 @@ fn extension_parity_diagnostic_tail(stderr: &str, stdout: &str) -> String {
 mod tests {
     use super::{
         controller_extension_metadata_required_error, controller_local_source_path,
+        ensure_extension_materialized, plan_extension_parity,
         record_materialized_extension_overlay, remote_extension_core_compatibility,
         remote_extension_ready_status, remote_extension_setting_ids,
         remote_extension_source_revision, requested_setting_keys_for_command,
-        runner_extension_sync_command, validate_runner_extension_core_compatibility,
-        validate_runner_extension_ready, validate_runner_extension_revision,
-        validate_runner_extension_settings,
+        runner_extension_sync_command, validate_extension_ready,
+        validate_runner_extension_core_compatibility, validate_runner_extension_ready,
+        validate_runner_extension_revision, validate_runner_extension_settings,
+        ExtensionParityPlan, ExtensionParityPlanStep,
     };
     use crate::test_support::with_isolated_home;
 
-    use crate::core::runner::{Runner, RunnerKind};
+    use crate::core::error::Error;
+    use crate::core::runner::{
+        Runner, RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
+        RunnerKind,
+    };
     use std::collections::HashMap;
     use std::fs;
 
@@ -1048,6 +1158,177 @@ mod tests {
             resources,
             policy: Default::default(),
         }
+    }
+
+    #[test]
+    fn extension_parity_plan_describes_materialization_without_mutating_runner_state() {
+        with_isolated_home(|home| {
+            let source = tempfile::tempdir().expect("controller source");
+            fs::write(
+                source.path().join("rust.json"),
+                r#"{"name":"rust","version":"1.0.0"}"#,
+            )
+            .expect("source manifest");
+            let extension_dir = home.path().join(".config/homeboy/extensions/rust");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join("rust.json"),
+                format!(
+                    r#"{{"name":"rust","version":"1.0.0","source_url":"{}"}}"#,
+                    source.path().display()
+                ),
+            )
+            .expect("extension manifest");
+            fs::write(extension_dir.join(".source-revision"), "abc123\n").expect("revision");
+            let command = home.path().join("extension-show");
+            fs::write(
+                &command,
+                "#!/bin/sh\nprintf '%s\\n' '{\"success\":true,\"data\":{\"extension\":{\"id\":\"rust\",\"ready\":true,\"source_revision\":\"old456\"}}}'\n",
+            )
+            .expect("write command");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&command, fs::Permissions::from_mode(0o755))
+                    .expect("make command executable");
+            }
+            let mut runner = runner_with_overlay("other", "/tmp/other", "unused");
+            runner.settings.homeboy_path = Some(command.display().to_string());
+            let resources_before = runner.resources.clone();
+
+            let plan =
+                plan_extension_parity("homeboy-lab", &runner, "/", &["rust".to_string()], &[], &[])
+                    .expect("plan stale extension");
+
+            assert_eq!(plan.steps.len(), 1);
+            assert_eq!(plan.steps[0].id, "rust");
+            assert!(matches!(
+                plan.steps[0].materialization.source,
+                RunnerExtensionMaterializationSource::ControllerSnapshot { .. }
+            ));
+            assert_eq!(runner.resources, resources_before);
+        });
+    }
+
+    #[test]
+    fn failed_extension_parity_ensure_records_the_planned_step() {
+        with_isolated_home(|_| {
+            crate::core::runner::create(
+                r#"{"id":"homeboy-lab","kind":"local","workspace_root":"/runner/ws"}"#,
+                false,
+            )
+            .expect("create runner");
+            let plan = ExtensionParityPlan {
+                runner_id: "homeboy-lab".to_string(),
+                homeboy_path: "/usr/bin/false".to_string(),
+                steps: vec![ExtensionParityPlanStep {
+                    id: "rust".to_string(),
+                    materialization: RunnerExtensionMaterializationRequest {
+                        id: "rust".to_string(),
+                        revision: "abc123".to_string(),
+                        source: RunnerExtensionMaterializationSource::RunnerPath {
+                            path: "/runner/extensions/rust".to_string(),
+                        },
+                    },
+                    parity_error: Error::internal_unexpected("stale extension parity".to_string()),
+                }],
+            };
+
+            ensure_extension_materialized(&plan).expect_err("materialization fails");
+
+            let runner = crate::core::runner::load("homeboy-lab").expect("runner trail");
+            assert_eq!(runner.resources["extension_parity"]["status"], "failed");
+            assert_eq!(
+                runner.resources["extension_parity"]["steps"][0]["id"],
+                "rust"
+            );
+            assert_eq!(
+                runner.resources["extension_parity"]["steps"][0]["status"],
+                "failed"
+            );
+        });
+    }
+
+    #[test]
+    fn extension_parity_ensure_applies_planned_materialization() {
+        with_isolated_home(|home| {
+            let workspace = tempfile::tempdir().expect("runner workspace");
+            crate::core::runner::create(
+                &format!(
+                    r#"{{"id":"homeboy-lab","kind":"local","workspace_root":"{}"}}"#,
+                    workspace.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+            let command = home.path().join("extension-install");
+            fs::write(&command, "#!/bin/sh\nexit 0\n").expect("write command");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&command, fs::Permissions::from_mode(0o755))
+                    .expect("make command executable");
+            }
+            let plan = ExtensionParityPlan {
+                runner_id: "homeboy-lab".to_string(),
+                homeboy_path: command.display().to_string(),
+                steps: vec![ExtensionParityPlanStep {
+                    id: "rust".to_string(),
+                    materialization: RunnerExtensionMaterializationRequest {
+                        id: "rust".to_string(),
+                        revision: "abc123".to_string(),
+                        source: RunnerExtensionMaterializationSource::RunnerPath {
+                            path: "/runner/extensions/rust".to_string(),
+                        },
+                    },
+                    parity_error: Error::internal_unexpected("stale extension parity".to_string()),
+                }],
+            };
+
+            ensure_extension_materialized(&plan).expect("apply materialization");
+
+            let runner = crate::core::runner::load("homeboy-lab").expect("runner trail");
+            assert_eq!(runner.resources["extension_parity"]["status"], "success");
+            assert_eq!(
+                runner.resources["extension_parity"]["steps"][0]["status"],
+                "success"
+            );
+        });
+    }
+
+    #[test]
+    fn extension_ready_validation_does_not_mutate_runner_state() {
+        with_isolated_home(|home| {
+            let extension_dir = home.path().join(".config/homeboy/extensions/rust");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(extension_dir.join(".source-revision"), "abc123\n").expect("revision");
+            crate::core::runner::create(
+                r#"{"id":"homeboy-lab","kind":"local","workspace_root":"/runner/ws","resources":{"keep":{"enabled":true}}}"#,
+                false,
+            )
+            .expect("create runner");
+            let command = home.path().join("extension-show");
+            fs::write(
+                &command,
+                "#!/bin/sh\nprintf '%s\\n' '{\"success\":true,\"data\":{\"extension\":{\"id\":\"rust\",\"ready\":true,\"source_revision\":\"abc123\"}}}'\n",
+            )
+            .expect("write command");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&command, fs::Permissions::from_mode(0o755))
+                    .expect("make command executable");
+            }
+            let mut runner = crate::core::runner::load("homeboy-lab").expect("runner");
+            runner.settings.homeboy_path = Some(command.display().to_string());
+            let resources_before = runner.resources.clone();
+
+            validate_extension_ready("homeboy-lab", &runner, "/", &["rust".to_string()], &[], &[])
+                .expect("validate ready extension");
+
+            let after = crate::core::runner::load("homeboy-lab").expect("runner after validation");
+            assert_eq!(after.resources, resources_before);
+        });
     }
 
     #[test]

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -57,8 +57,8 @@ mod worker;
 mod tests;
 
 use extension_parity::{
-    requested_setting_keys_for_command, required_extensions_for_command,
-    validate_runner_extension_parity,
+    ensure_extension_materialized, plan_extension_parity, requested_setting_keys_for_command,
+    required_extensions_for_command, validate_extension_ready,
 };
 use policy::remote_execution_preflight;
 
@@ -682,7 +682,17 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
     let requested_setting_keys = requested_setting_keys_for_command(&options.command);
     let accepted_extension_settings = options.accepted_extension_settings.clone();
 
-    validate_runner_extension_parity(
+    let extension_parity_plan = plan_extension_parity(
+        runner_id,
+        &runner,
+        &cwd,
+        &required_extensions,
+        &requested_setting_keys,
+        &accepted_extension_settings,
+    )?;
+    ensure_extension_materialized(&extension_parity_plan)?;
+    let runner = super::load(runner_id)?;
+    validate_extension_ready(
         runner_id,
         &runner,
         &cwd,

--- a/src/core/runner/execution/worker.rs
+++ b/src/core/runner/execution/worker.rs
@@ -8,8 +8,8 @@ use super::super::capabilities::{
 use super::super::{load, Runner, RunnerCapabilityPreflight, RunnerKind};
 
 use super::extension_parity::{
-    requested_setting_keys_for_command, required_extensions_for_command,
-    validate_runner_extension_parity,
+    ensure_extension_materialized, plan_extension_parity, requested_setting_keys_for_command,
+    required_extensions_for_command, validate_extension_ready,
 };
 use super::policy::{validate_runner_policy, RunnerPolicyRequest};
 
@@ -78,9 +78,19 @@ pub(super) fn exec_worker_local_with_process_output(
     );
     let requested_setting_keys = requested_setting_keys_for_command(&options.command);
     let accepted_extension_settings = options.accepted_extension_settings.clone();
-    validate_runner_extension_parity(
+    let extension_parity_plan = plan_extension_parity(
         runner_id,
         &plan.runner,
+        &plan.cwd,
+        &required_extensions,
+        &requested_setting_keys,
+        &accepted_extension_settings,
+    )?;
+    ensure_extension_materialized(&extension_parity_plan)?;
+    let runner = load(runner_id)?;
+    validate_extension_ready(
+        runner_id,
+        &runner,
         &plan.cwd,
         &required_extensions,
         &requested_setting_keys,

--- a/src/core/runner/extension_materialization.rs
+++ b/src/core/runner/extension_materialization.rs
@@ -18,14 +18,14 @@ use super::{
     copy_snapshot_to_directory, exec, Runner, RunnerExecOptions, RunnerFileTransfer, RunnerKind,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct RunnerExtensionMaterializationRequest {
     pub(crate) id: String,
     pub(crate) revision: String,
     pub(crate) source: RunnerExtensionMaterializationSource,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) enum RunnerExtensionMaterializationSource {
     RemoteGit { url: String, git_ref: String },
     ControllerSnapshot { local_path: PathBuf },
@@ -431,7 +431,12 @@ fn runner_path_provenance(
         dirty_fingerprint: None,
         synced_at: chrono::Utc::now().to_rfc3339(),
         dev_overlay: false,
-        lifecycle: dev_extension_lifecycle(runner_id, path, &request.id),
+        lifecycle: installed_extension_lifecycle(
+            runner_id,
+            path,
+            &request.id,
+            "linked_runner_path",
+        ),
         materialization_source: Some(serde_json::json!({
             "kind": "runner_path",
             "path": path,
@@ -456,7 +461,12 @@ fn remote_git_provenance(
         dirty_fingerprint: None,
         synced_at: chrono::Utc::now().to_rfc3339(),
         dev_overlay: false,
-        lifecycle: dev_extension_lifecycle(runner_id, url, &request.id),
+        lifecycle: installed_extension_lifecycle(
+            runner_id,
+            url,
+            &request.id,
+            "remote_git_checkout",
+        ),
         materialization_source: Some(serde_json::json!({
             "kind": "remote_git",
             "url": url,
@@ -552,6 +562,28 @@ pub(crate) fn dev_extension_lifecycle(
             shell_arg(extension_id)
         )),
         status: ResourceLifecycleResourceStatus::Active,
+    }
+}
+
+fn installed_extension_lifecycle(
+    runner_id: &str,
+    source: &str,
+    extension_id: &str,
+    source_kind: &str,
+) -> ResourceLifecycleRecord {
+    ResourceLifecycleRecord {
+        owner: format!("runner.extension.{source_kind}"),
+        run_id: format!("runner-extension-{runner_id}-{extension_id}"),
+        runner_id: Some(runner_id.to_string()),
+        path: source.to_string(),
+        root_bound: None,
+        kind: "runner_installed_extension".to_string(),
+        ttl: None,
+        cleanup_policy: ResourceCleanupPolicy::Preserve,
+        evidence_retention: ResourceEvidenceRetention::Metadata,
+        cleanup_intent: Default::default(),
+        cleanup_command: None,
+        status: ResourceLifecycleResourceStatus::Retained,
     }
 }
 
@@ -710,6 +742,14 @@ mod tests {
             provenance.materialization_source.as_ref().unwrap()["kind"],
             "remote_git"
         );
+        assert_eq!(
+            provenance.lifecycle.owner,
+            "runner.extension.remote_git_checkout"
+        );
+        assert_eq!(
+            provenance.lifecycle.cleanup_policy,
+            ResourceCleanupPolicy::Preserve
+        );
     }
 
     #[test]
@@ -749,6 +789,15 @@ mod tests {
                 "abc123",
                 "--replace"
             ]
+        );
+        let provenance = runner_path_provenance(&runner.id, &request, "/runner/extensions/rust");
+        assert_eq!(
+            provenance.lifecycle.owner,
+            "runner.extension.linked_runner_path"
+        );
+        assert_eq!(
+            provenance.lifecycle.status,
+            ResourceLifecycleResourceStatus::Retained
         );
     }
 


### PR DESCRIPTION
## Summary
- Split runner extension parity into explicit plan, ensure, and read-only validate phases.
- Persist the planned materialization steps and ensure status under `runner.resources.extension_parity` before applying changes.
- Give linked runner paths and remote Git checkouts preserved installed-extension lifecycle records instead of dev-overlay lifecycle records.

## Diffstat
`4 files changed, 450 insertions(+), 100 deletions(-)`

Fixes #7697

## Phase split
Planning inspects runner extension state and returns only stale-extension materialization actions without changing runner state. Ensure intentionally records a `homeboy/runner-extension-parity/v1` trail, materializes each action, and updates the recorded step status. Validation performs a fresh read-only runner inspection after ensure so success behavior remains the same for runner exec, local worker execution, Lab offload, and rig materialization paths that compose through runner exec. A mid-ensure failure leaves the failed action, source request, and original materialization error in the runner resource trail.

## Failure trail example
`runner.resources.extension_parity = { schema: "homeboy/runner-extension-parity/v1", status: "failed", steps: [{ id: "rust", kind: "runner.extension_parity.materialize", status: "failed" }], error: { ... } }`

## Scoped-out items
None. The materialization source-mode sub-item is addressed here: controller snapshots retain dev-overlay lifecycle behavior, while linked runner paths and remote Git checkouts now record preserved installed-extension lifecycles.

## Verification
- `cargo test extension_parity --lib -j 3`
- `cargo test extension_materialization --lib -j 3`
- `cargo build -j 3`
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (no new warnings; existing repository warning set remains)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Refactor design and implementation of the plan/ensure/validate split, plus verification runs. Reviewed by Chris Huber.