### PR TITLE
Consolidate rig extension requirements

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -117,17 +117,11 @@ impl BenchArgs {
         let mut extension_ids = BTreeSet::new();
         for rig_id in &run.rig {
             let spec = rig::RigSourceContext::load_for_invocation(rig_id)?.spec;
-            let workload_extension_ids =
-                rig::extension_ids_for_workloads(&spec, rig::RigWorkloadKind::Bench);
-            for extension_id in &workload_extension_ids {
-                extension_ids.extend(rig::env_provider_extensions_for_extension_workloads(
-                    &spec,
-                    rig::RigWorkloadKind::Bench,
-                    extension_id,
-                ));
-            }
-            extension_ids.extend(workload_extension_ids);
-            extension_ids.extend(bench_component_extension_ids(&spec, run.comp.id()));
+            extension_ids.extend(rig::required_extension_ids_for_workload(
+                &spec,
+                rig::RigWorkloadKind::Bench,
+                run.comp.id(),
+            ));
         }
         Ok(extension_ids.into_iter().collect())
     }
@@ -139,38 +133,6 @@ impl BenchArgs {
             Some(BenchCommand::List(_)) => None,
         }
     }
-}
-
-fn bench_component_extension_ids(spec: &RigSpec, explicit_component: Option<&str>) -> Vec<String> {
-    let component_ids = explicit_component
-        .map(|id| vec![id.to_string()])
-        .or_else(|| {
-            spec.bench
-                .as_ref()
-                .map(|bench| {
-                    if bench.components.is_empty() {
-                        bench.default_component.iter().cloned().collect()
-                    } else {
-                        bench.components.clone()
-                    }
-                })
-                .filter(|ids: &Vec<String>| !ids.is_empty())
-        });
-    let Some(component_ids) = component_ids else {
-        return Vec::new();
-    };
-
-    let mut extension_ids = BTreeSet::new();
-    for component_id in component_ids {
-        if let Some(extensions) = spec
-            .components
-            .get(&component_id)
-            .and_then(|component| component.extensions.as_ref())
-        {
-            extension_ids.extend(extensions.keys().cloned());
-        }
-    }
-    extension_ids.into_iter().collect()
 }
 
 #[derive(Subcommand)]

--- a/src/commands/fuzz/types.rs
+++ b/src/commands/fuzz/types.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand, ValueEnum};
@@ -10,7 +9,7 @@ use crate::command_contract::{
     FUZZ_DOCTOR_LAB_LABEL, FUZZ_LAB_LABEL,
 };
 use homeboy::core::fuzz::FuzzGateProfile;
-use homeboy::core::rig::{self, RigSpec};
+use homeboy::core::rig;
 
 #[derive(Args)]
 pub struct FuzzArgs {
@@ -126,39 +125,11 @@ fn lab_required_rig_extension_ids(
         return Ok(Vec::new());
     };
     let spec = rig::load(rig_id)?;
-    let mut extension_ids = BTreeSet::new();
-    let workload_extension_ids =
-        rig::extension_ids_for_workloads(&spec, rig::RigWorkloadKind::Fuzz);
-    for extension_id in &workload_extension_ids {
-        extension_ids.extend(rig::env_provider_extensions_for_extension_workloads(
-            &spec,
-            rig::RigWorkloadKind::Fuzz,
-            extension_id,
-        ));
-    }
-    extension_ids.extend(workload_extension_ids);
-    extension_ids.extend(fuzz_component_extension_ids(&spec, component_id));
-    Ok(extension_ids.into_iter().collect())
-}
-
-fn fuzz_component_extension_ids(spec: &RigSpec, explicit_component: Option<&str>) -> Vec<String> {
-    let component_id = explicit_component.map(str::to_string).or_else(|| {
-        spec.fuzz
-            .as_ref()
-            .and_then(|fuzz| fuzz.default_component.clone())
-    });
-    let Some(component_id) = component_id else {
-        return Vec::new();
-    };
-
-    let mut extension_ids: Vec<String> = spec
-        .components
-        .get(&component_id)
-        .and_then(|component| component.extensions.as_ref())
-        .map(|extensions| extensions.keys().cloned().collect())
-        .unwrap_or_default();
-    extension_ids.sort();
-    extension_ids
+    Ok(rig::required_extension_ids_for_workload(
+        &spec,
+        rig::RigWorkloadKind::Fuzz,
+        component_id,
+    ))
 }
 
 #[derive(Subcommand)]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -104,8 +104,9 @@ pub use state::{
 };
 pub use workloads::{
     check_groups_for_bench_scenarios, check_groups_for_extension_workloads,
-    env_provider_extensions_for_extension_workloads, extension_ids_for_workloads,
-    extension_workload_inputs, invocation_requirements_for_extension_workloads,
+    component_extension_ids_for_workload, env_provider_extensions_for_extension_workloads,
+    extension_ids_for_workloads, extension_workload_inputs,
+    invocation_requirements_for_extension_workloads, required_extension_ids_for_workload,
     runner_capabilities_for_extension, trace_dependencies_for_extension,
     workload_path_expansions_for_extension, workloads_for_extension, RigExtensionWorkloadInputs,
     RigWorkloadKind, RigWorkloadPathExpansion,

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -37,6 +37,63 @@ pub fn extension_ids_for_workloads(rig_spec: &RigSpec, kind: RigWorkloadKind) ->
     ids
 }
 
+pub fn required_extension_ids_for_workload(
+    rig_spec: &RigSpec,
+    kind: RigWorkloadKind,
+    explicit_component: Option<&str>,
+) -> Vec<String> {
+    let workload_extensions = extension_ids_for_workloads(rig_spec, kind);
+    let mut extension_ids = BTreeSet::new();
+    for extension_id in &workload_extensions {
+        extension_ids.extend(env_provider_extensions_for_extension_workloads(
+            rig_spec,
+            kind,
+            extension_id,
+        ));
+    }
+    extension_ids.extend(workload_extensions);
+    extension_ids.extend(component_extension_ids_for_workload(
+        rig_spec,
+        kind,
+        explicit_component,
+    ));
+    extension_ids.into_iter().collect()
+}
+
+pub fn component_extension_ids_for_workload(
+    rig_spec: &RigSpec,
+    kind: RigWorkloadKind,
+    explicit_component: Option<&str>,
+) -> Vec<String> {
+    let component_ids = explicit_component
+        .map(|id| vec![id.to_string()])
+        .or_else(|| match kind {
+            RigWorkloadKind::Bench => rig_spec.bench.as_ref().map(|bench| {
+                if bench.components.is_empty() {
+                    bench.default_component.iter().cloned().collect()
+                } else {
+                    bench.components.clone()
+                }
+            }),
+            RigWorkloadKind::Fuzz => rig_spec
+                .fuzz
+                .as_ref()
+                .and_then(|fuzz| fuzz.default_component.as_ref())
+                .map(|component| vec![component.clone()]),
+            RigWorkloadKind::Trace => None,
+        })
+        .unwrap_or_default();
+
+    component_ids
+        .iter()
+        .filter_map(|component_id| rig_spec.components.get(component_id))
+        .filter_map(|component| component.extensions.as_ref())
+        .flat_map(|extensions| extensions.keys().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
 pub fn workloads_for_extension(
     rig_spec: &RigSpec,
     kind: RigWorkloadKind,

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -962,17 +962,9 @@ fn rig_required_extensions_from_primary_rig(
             extension_ids.extend(explicit_extensions.iter().cloned());
             continue;
         }
-        for extension_id in rig::extension_ids_for_workloads(&spec, command.workload_kind()) {
-            extension_ids.insert(extension_id.clone());
-            extension_ids.extend(rig::env_provider_extensions_for_extension_workloads(
-                &spec,
-                command.workload_kind(),
-                &extension_id,
-            ));
-        }
-        extension_ids.extend(rig_component_extensions_from_workload_command(
+        extension_ids.extend(rig::required_extension_ids_for_workload(
             &spec,
-            command,
+            command.workload_kind(),
             explicit_component.as_deref(),
         ));
     }
@@ -1008,9 +1000,9 @@ fn rig_dispatch_extensions_from_primary_rig(
         if workload_extensions.len() == 1 {
             extension_ids.extend(workload_extensions);
         }
-        extension_ids.extend(rig_component_extensions_from_workload_command(
+        extension_ids.extend(rig::component_extension_ids_for_workload(
             &spec,
-            command,
+            command.workload_kind(),
             explicit_component.as_deref(),
         ));
     }
@@ -1060,42 +1052,6 @@ fn load_primary_rig_spec(primary_source_path: &Path, rig_id: &str) -> Result<Opt
         Some(discovered.id.as_str()),
     )?;
     Ok(Some(spec))
-}
-
-fn rig_component_extensions_from_workload_command(
-    spec: &rig::RigSpec,
-    command: RigWorkloadCommand,
-    explicit_component: Option<&str>,
-) -> Vec<String> {
-    let component_ids = explicit_component
-        .map(|id| vec![id.to_string()])
-        .or_else(|| match command {
-            RigWorkloadCommand::Bench => spec.bench.as_ref().map(|bench| {
-                if bench.components.is_empty() {
-                    bench.default_component.iter().cloned().collect()
-                } else {
-                    bench.components.clone()
-                }
-            }),
-            RigWorkloadCommand::Fuzz => spec
-                .fuzz
-                .as_ref()
-                .and_then(|fuzz| fuzz.default_component.as_ref())
-                .map(|component| vec![component.clone()]),
-        })
-        .unwrap_or_default();
-
-    let mut extension_ids = std::collections::BTreeSet::new();
-    for component_id in component_ids {
-        if let Some(extensions) = spec
-            .components
-            .get(&component_id)
-            .and_then(|component| component.extensions.as_ref())
-        {
-            extension_ids.extend(extensions.keys().cloned());
-        }
-    }
-    extension_ids.into_iter().collect()
 }
 
 fn rig_ids_from_args(args: &[String]) -> Vec<String> {

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -3,9 +3,9 @@ use std::path::PathBuf;
 use crate::core::rig::spec::RigSpec;
 use crate::core::rig::{
     check_groups_for_extension_workloads, env_provider_extensions_for_extension_workloads,
-    extension_ids_for_workloads, extension_workload_inputs, runner_capabilities_for_extension,
-    trace_dependencies_for_extension, workload_path_expansions_for_extension,
-    workloads_for_extension, RigWorkloadKind,
+    extension_ids_for_workloads, extension_workload_inputs, required_extension_ids_for_workload,
+    runner_capabilities_for_extension, trace_dependencies_for_extension,
+    workload_path_expansions_for_extension, workloads_for_extension, RigWorkloadKind,
 };
 
 #[test]
@@ -70,6 +70,38 @@ fn test_env_provider_extensions_for_extension_workloads_are_deduplicated() {
             "fixture-runtime",
         ),
         vec!["artifact-helper".to_string(), "fixture-runtime".to_string()]
+    );
+}
+
+#[test]
+fn required_workload_extensions_include_environment_and_default_components() {
+    let rig_spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "fixture-bench",
+            "components": {
+                "app": {
+                    "path": "/tmp/app",
+                    "extensions": { "component-helper": {}, "shared": {} }
+                }
+            },
+            "bench": { "components": ["app"] },
+            "bench_workloads": {
+                "shared": [{
+                    "path": "/tmp/one.bench.mjs",
+                    "env_provider_extensions": ["environment-helper", "shared"]
+                }]
+            }
+        }"#,
+    )
+    .expect("parse rig spec");
+
+    assert_eq!(
+        required_extension_ids_for_workload(&rig_spec, RigWorkloadKind::Bench, None),
+        vec![
+            "component-helper".to_string(),
+            "environment-helper".to_string(),
+            "shared".to_string(),
+        ]
     );
 }
 


### PR DESCRIPTION
## Summary
- centralize workload, environment-provider, and component extension dependency collection
- reuse the same rig resolver from bench, fuzz, and Lab staging
- retain explicit override behavior and Lab dispatch's single-workload rule at their caller boundaries

## Impact
- production: **53 net lines removed**
- total: 110 additions, 131 deletions
- removes three independent dependency-closure implementations

## Testing
- workload environment/default-component closure test: passed
- fuzz Lab dependency closure test: passed
- explicit extension override test: passed
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Rig extension ownership analysis, consolidation, behavioral parity tests, and verification; Chris remains responsible for the submitted change.