### PR TITLE
feat: deploy components from an exact Git ref

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```sh
-homeboy deploy [<project_id>|<component_id>] [<component_ids...>] [-p|--project <id>] [-c|--component <id>]... [--all] [--outdated|--behind-upstream] [--check] [--dry-run] [--apply] [--json '<spec>']
+homeboy deploy [<project_id>|<component_id>] [<component_ids...>] [-p|--project <id>] [-c|--component <id>]... [--all] [--outdated|--behind-upstream] [--head|--ref <git-ref-or-sha>] [--check] [--dry-run] [--apply] [--json '<spec>']
 # If no component IDs are provided, you must use --all, --outdated, --behind-upstream, or --check.
 
 # Multi-project deployment
@@ -33,7 +33,7 @@ Options:
   - Shows all components for the project with version comparison status.
   - Combines with `--outdated` or component IDs to filter results.
 - `--dry-run`: preview what would be deployed without executing (no build, no upload)
-- `--apply`: confirm real deploys that use dangerous modes such as `--head` or `--force`
+- `--apply`: confirm real deploys that use dangerous modes such as `--head`, `--ref`, or `--force`
 - `--force`: deploy even with uncommitted changes
 - `--json`: JSON input spec for bulk operations (`{"component_ids": ["component-id", ...]}`)
 - `--projects`: deploy to multiple projects (comma-separated). When using this flag, all positional arguments are treated as component IDs. Each project deployment builds independently.
@@ -43,9 +43,14 @@ Options:
 - `--version <version>`: assert the expected local component version before deploying; aborts on mismatch.
 - `--no-pull`: skip the automatic pull before deploy.
 - `--head`: deploy the current branch `HEAD` instead of the latest tag.
+- `--ref <git-ref-or-sha>`: resolve a commit from each component's declared Git repository and deploy that exact immutable tree. The configured checkout's current branch and `HEAD` do not affect resolution.
 - `--tagged`: force tag-based deploy and ignore reusable build artifacts.
 
-Real deploys with `--head` or `--force` require `--apply`. Preview and status commands (`--dry-run` or `--check`) do not require `--apply`.
+Real deploys with `--head`, `--ref`, or `--force` require `--apply`. Preview and status commands (`--dry-run` or `--check`) do not require `--apply`.
+
+`--ref` is an explicit source selector and conflicts with `--head`, `--tagged`, `--version`, `--outdated`, `--behind-upstream`, and `--check`. Without `--ref`, release and `--head` selection behave as before. File sources and `deploy_strategy: "git"` are rejected because those strategies cannot package and upload the selected Git tree.
+
+Homeboy resolves `<git-ref-or-sha>^{commit}` in the repository containing the declared component `local_path`, pins the full commit SHA, and uses a detached temporary worktree for local build and packaging. It never checks out the requested ref in the configured source checkout. A branch or tag must already be available in that declared repository; use an explicit remote-tracking ref when that is the intended source. Missing, non-commit, or ambiguous refs fail before build or remote mutation.
 
 Components can declare `deploy_together` in their component config. When any selected component belongs to a deploy-together group, Homeboy requires the full group in the same deploy plan and fails before build/upload if only part of the group was selected. Use explicit component IDs for the whole group or `--all` for the project.
 
@@ -93,7 +98,10 @@ If no component IDs are provided and none of `--all`, `--outdated`, `--behind-up
         "has_uncommitted_changes": false,
         "baseline_ref": "v0.9.15"
       },
-      "deployed_ref": "<tag-or-branch>|null"
+      "deployed_ref": "<tag-or-branch>|null",
+      "requested_ref": "<operator-provided-ref>",
+      "resolved_sha": "<full-commit-sha>",
+      "source": "<declared-git-repository>"
     }
   ],
   "summary": { "total": 1, "succeeded": 0, "failed": 0, "skipped": 0 }
@@ -107,6 +115,7 @@ Notes:
 - `artifact_path` is the component build artifact path as configured; it may be relative but must include a filename.
 - Deploy output does not include `build_command`. Builds are resolved from the linked extension, and deploy records only build/deploy exit codes plus the artifact path used.
 - `deployed_ref` is omitted when no tag or branch ref was deployed.
+- `requested_ref`, `resolved_sha`, and `source` are persisted for `--ref` deploy evidence and omitted for other source modes. `build_provenance.built_from_ref` and `build_provenance.built_from_commit` carry the same identity.
 
 Note: `build_exit_code`/`deploy_exit_code` are numbers when present (not strings).
 
@@ -244,7 +253,10 @@ Use `--dry-run` to see what would be deployed without executing:
 homeboy deploy myproject --outdated --dry-run
 homeboy deploy myproject --behind-upstream --dry-run
 homeboy deploy myproject my-plugin --version 1.2.3 --tagged --dry-run
+homeboy deploy myproject my-plugin --ref origin/reviewed-branch --dry-run
 ```
+
+An exact-ref dry-run resolves the ref without fetching, checking out, creating a worktree, building, or uploading. Each planned result reports the requested ref, resolved SHA, declared source repository, packaging plan, and remote destination.
 
 ## Check Component Status
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -45,7 +45,7 @@ pub struct DeployArgs {
     /// Preview what would be deployed without executing
     #[arg(long)]
     pub dry_run: bool,
-    /// Confirm dangerous deploy modes like --head or --force
+    /// Confirm dangerous deploy modes like --head, --ref, or --force
     #[arg(long)]
     pub apply: bool,
     /// Check component status without building or deploying
@@ -75,6 +75,13 @@ pub struct DeployArgs {
     /// Deploy from current branch HEAD instead of the latest tag
     #[arg(long)]
     pub head: bool,
+    /// Deploy an exact Git ref resolved from the declared component repository
+    #[arg(
+        long = "ref",
+        value_name = "GIT_REF_OR_SHA",
+        conflicts_with_all = ["head", "tagged", "version", "outdated", "behind_upstream", "check"]
+    )]
+    pub requested_ref: Option<String>,
     /// Force local tag-based build/deploy, ignoring reusable release assets
     #[arg(long)]
     pub tagged: bool,
@@ -205,15 +212,23 @@ pub fn run(
 // === Argument resolution helpers ===
 
 fn validate_apply_boundary(args: &DeployArgs) -> homeboy::core::Result<()> {
-    if args.apply || args.dry_run || args.check || (!args.head && !args.force) {
+    if args.apply
+        || args.dry_run
+        || args.check
+        || (!args.head && args.requested_ref.is_none() && !args.force)
+    {
         return Ok(());
     }
 
-    let dangerous_flags = [(args.head, "--head"), (args.force, "--force")]
-        .into_iter()
-        .filter_map(|(enabled, flag)| enabled.then_some(flag))
-        .collect::<Vec<_>>()
-        .join(" and ");
+    let dangerous_flags = [
+        (args.head, "--head"),
+        (args.requested_ref.is_some(), "--ref"),
+        (args.force, "--force"),
+    ]
+    .into_iter()
+    .filter_map(|(enabled, flag)| enabled.then_some(flag))
+    .collect::<Vec<_>>()
+    .join(" and ");
 
     Err(homeboy::core::Error::validation_invalid_argument(
         "apply",
@@ -344,6 +359,7 @@ fn build_config(args: &DeployArgs, skip_build: bool) -> DeployConfig {
         expected_version: args.version.clone(),
         no_pull: args.no_pull,
         head: args.head,
+        requested_ref: args.requested_ref.clone(),
         tagged: args.tagged,
     }
 }

--- a/src/core/deploy/execution/mod.rs
+++ b/src/core/deploy/execution/mod.rs
@@ -158,6 +158,7 @@ mod tests {
             expected_version: None,
             no_pull: false,
             head: false,
+            requested_ref: None,
             tagged: false,
         };
 
@@ -214,6 +215,7 @@ mod tests {
             expected_version: None,
             no_pull: false,
             head: true,
+            requested_ref: None,
             tagged: false,
         };
 
@@ -243,6 +245,7 @@ mod tests {
             expected_version: None,
             no_pull: false,
             head: false,
+            requested_ref: None,
             tagged: true,
         };
 
@@ -283,6 +286,7 @@ mod tests {
             expected_version: Some("1.2.3".to_string()),
             no_pull: false,
             head: false,
+            requested_ref: None,
             tagged: false,
         };
 
@@ -323,6 +327,7 @@ mod tests {
             expected_version: Some("1.2.3".to_string()),
             no_pull: false,
             head: false,
+            requested_ref: None,
             tagged: false,
         };
 
@@ -354,6 +359,7 @@ mod tests {
             expected_version: Some("1.2.3".to_string()),
             no_pull: false,
             head: false,
+            requested_ref: None,
             tagged: false,
         };
 
@@ -398,6 +404,7 @@ mod tests {
             expected_version: Some("1.2.3".to_string()),
             no_pull: false,
             head: false,
+            requested_ref: None,
             tagged: false,
         };
 
@@ -467,6 +474,7 @@ mod tests {
             expected_version: None,
             no_pull: false,
             head: true,
+            requested_ref: None,
             tagged: false,
         };
 

--- a/src/core/deploy/execution/release_plan.rs
+++ b/src/core/deploy/execution/release_plan.rs
@@ -27,6 +27,9 @@ pub(crate) fn release_artifact_plan(
     if config.head {
         return local_release_artifact_plan("--head deploys the current checkout");
     }
+    if config.requested_ref.is_some() {
+        return local_release_artifact_plan("--ref deploys an exact materialized commit");
+    }
     if config.tagged {
         return local_release_artifact_plan("--tagged forces a local tag build");
     }

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -2,6 +2,7 @@ mod effect;
 mod execution;
 mod generated_artifacts;
 mod orchestration;
+mod orchestration_ref_checkout;
 mod orchestration_tag_checkout;
 mod path_roots;
 pub(crate) mod permissions;
@@ -150,6 +151,7 @@ pub fn run_multi(
             expected_version: config.expected_version.clone(),
             no_pull: config.no_pull,
             head: config.head,
+            requested_ref: config.requested_ref.clone(),
             tagged: config.tagged,
         };
 
@@ -283,6 +285,7 @@ mod tests {
             expected_version: None,
             no_pull: false,
             head: false,
+            requested_ref: None,
             tagged: false,
         }
     }

--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -9,6 +9,7 @@ use crate::core::release::version;
 use super::execution::{
     execute_preflighted_component_deploy, prepare_component_deploy, PreparedComponentDeploy,
 };
+use super::orchestration_ref_checkout::{ExactRefCheckout, ExactRefIdentity};
 use super::orchestration_tag_checkout::{checkout_deploy_tags, restore_branches};
 use super::path_roots::{project_with_detected_path_roots, resolve_effective_remote_path};
 use super::planning::{load_project_components, plan_components};
@@ -104,6 +105,33 @@ pub(super) fn deploy_components(
 
     validate_effective_remote_paths(&components, &project, base_path)?;
 
+    // Resolve first, then materialize immutable detached worktrees for real deploys.
+    // Dry-run resolves in `run_dry_run_mode` and never creates a worktree.
+    let exact_ref_checkouts = if !config.dry_run {
+        if let Some(requested_ref) = config.requested_ref.as_deref() {
+            components
+                .iter()
+                .map(|component| ExactRefCheckout::materialize(component, requested_ref))
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+    let exact_ref_identities: HashMap<String, ExactRefIdentity> = exact_ref_checkouts
+        .iter()
+        .map(|checkout| (checkout.component.id.clone(), checkout.identity.clone()))
+        .collect();
+    let components = if exact_ref_checkouts.is_empty() {
+        components
+    } else {
+        exact_ref_checkouts
+            .iter()
+            .map(|checkout| checkout.component.clone())
+            .collect()
+    };
+
     // Gather versions
     let mut local_versions: HashMap<String, String> = components
         .iter()
@@ -140,7 +168,7 @@ pub(super) fn deploy_components(
     }
 
     // Sync: pull latest changes before deploying (unless --no-pull or --skip-build)
-    if !config.no_pull && !config.skip_build {
+    if config.requested_ref.is_none() && !config.no_pull && !config.skip_build {
         sync_components(&components)?;
     }
 
@@ -149,17 +177,17 @@ pub(super) fn deploy_components(
         warn_non_default_branch(&components, config)?;
     }
 
-    if !config.force {
+    if config.requested_ref.is_none() && !config.force {
         check_uncommitted_changes(&components)?;
     }
 
     // Check for HEAD-vs-tag gap before the tag checkout.
-    if !config.head && !config.skip_build {
+    if config.requested_ref.is_none() && !config.head && !config.skip_build {
         check_unreleased_commits(&components, config)?;
     }
 
     // Checkout the deploy tag for each component (unless --head or --skip-build).
-    let tag_checkouts = if !config.head && !config.skip_build {
+    let tag_checkouts = if config.requested_ref.is_none() && !config.head && !config.skip_build {
         checkout_deploy_tags(&components, config.expected_version.as_deref())?
     } else {
         Vec::new()
@@ -219,7 +247,10 @@ pub(super) fn deploy_components(
 
         // Record which git ref was deployed. The same label feeds build provenance
         // so `deployed_ref` and `build_provenance.built_from_ref` never disagree.
-        let deployed_ref = if let Some(checkout) = tag_checkouts
+        let exact_ref_identity = exact_ref_identities.get(&component.id);
+        let deployed_ref = if let Some(identity) = exact_ref_identity {
+            Some(identity.requested_ref.clone())
+        } else if let Some(checkout) = tag_checkouts
             .iter()
             .find(|c| c.component_id == component.id)
         {
@@ -239,10 +270,20 @@ pub(super) fn deploy_components(
         if let Some(ref git_ref) = deployed_ref {
             result = result.with_deployed_ref(git_ref.clone());
         }
+        if let Some(identity) = exact_ref_identity {
+            result = result.with_exact_ref_identity(
+                &identity.requested_ref,
+                &identity.resolved_sha,
+                &identity.source,
+            );
+        }
 
         // Attach explicit build provenance to every result, regardless of strategy.
         let mut build_provenance = prepared.build_provenance.clone();
         build_provenance.built_from_ref = deployed_ref;
+        if let Some(identity) = exact_ref_identity {
+            build_provenance.built_from_commit = Some(identity.resolved_sha.clone());
+        }
         result = result.with_build_provenance(build_provenance);
 
         if result.status == "deployed" {
@@ -409,6 +450,7 @@ mod tests {
             expected_version: None,
             no_pull: false,
             head: false,
+            requested_ref: None,
             tagged: false,
         }
     }

--- a/src/core/deploy/orchestration/modes.rs
+++ b/src/core/deploy/orchestration/modes.rs
@@ -5,6 +5,7 @@ use crate::core::error::{Error, Result};
 use crate::core::project::Project;
 
 use super::super::execution::{release_artifact_plan, ReleaseArtifactPlan};
+use super::super::orchestration_ref_checkout::resolve_exact_ref;
 use super::super::orchestration_tag_checkout::{deploy_tag_for_version, TagCheckout};
 use super::super::planning::{
     calculate_component_status_with_git_cache, calculate_release_state, ExtensionSkippedComponent,
@@ -114,6 +115,21 @@ pub(super) fn run_dry_run_mode(
                     remote_versions.get(&c.id).cloned(),
                 )
                 .with_source_identity(c, config.head);
+            if let Some(requested_ref) = config.requested_ref.as_deref() {
+                let identity = resolve_exact_ref(c, requested_ref)?;
+                result = result.with_exact_ref_identity(
+                    &identity.requested_ref,
+                    &identity.resolved_sha,
+                    &identity.source,
+                );
+                result.warnings.push(format!(
+                    "source: {}; requested ref: {}; resolved SHA: {}; plan: materialize detached temporary worktree and build exact commit; destination: {}",
+                    identity.source,
+                    identity.requested_ref,
+                    identity.resolved_sha,
+                    result.remote_path.as_deref().unwrap_or("unresolved")
+                ));
+            }
             if let Some(deploy_ref) = planned_deploy_ref(c, config)? {
                 result = result.with_deployed_ref(deploy_ref);
             }
@@ -173,6 +189,10 @@ fn planned_deploy_ref(component: &Component, config: &DeployConfig) -> Result<Op
     }
 
     let path = &component.local_path;
+    if let Some(requested_ref) = config.requested_ref.as_deref() {
+        resolve_exact_ref(component, requested_ref)?;
+        return Ok(Some(requested_ref.to_string()));
+    }
     if config.head {
         return Ok(crate::core::engine::command::run_in_optional(
             path,
@@ -230,5 +250,115 @@ fn latest_deploy_tag(component: &Component, expected_version: Option<&str>) -> R
             "Could not read version tags for '{}': {}",
             component.id, err
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::process::Command;
+
+    #[test]
+    fn exact_ref_dry_run_reports_identity_plan_and_destination_without_mutation() {
+        let repo = tempfile::tempdir().expect("repo");
+        git(repo.path(), &["init", "-q"]);
+        git(repo.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            repo.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        std::fs::write(repo.path().join("payload.txt"), "reviewed\n").expect("payload");
+        git(repo.path(), &["add", "payload.txt"]);
+        git(repo.path(), &["commit", "-q", "-m", "reviewed"]);
+        git(repo.path(), &["branch", "reviewed"]);
+        let sha = git_output(repo.path(), &["rev-parse", "reviewed"]);
+        let before_status = git_output(repo.path(), &["status", "--porcelain=v1"]);
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: repo.path().to_string_lossy().to_string(),
+            remote_path: "components/fixture".to_string(),
+            build_artifact: Some("build/fixture.zip".to_string()),
+            ..Component::default()
+        };
+        let config = DeployConfig {
+            component_ids: vec!["fixture".to_string()],
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: true,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            expected_version: None,
+            no_pull: false,
+            head: false,
+            requested_ref: Some("reviewed".to_string()),
+            tagged: false,
+        };
+
+        let result = run_dry_run_mode(
+            std::slice::from_ref(&component),
+            &HashMap::new(),
+            &HashMap::new(),
+            &Project::default(),
+            "/srv/site",
+            &config,
+        )
+        .expect("dry-run plan");
+        let evidence = &result.results[0];
+
+        assert_eq!(evidence.status, "planned");
+        assert_eq!(evidence.requested_ref.as_deref(), Some("reviewed"));
+        assert_eq!(evidence.resolved_sha.as_deref(), Some(sha.as_str()));
+        assert_eq!(
+            evidence.remote_path.as_deref(),
+            Some("/srv/site/components/fixture")
+        );
+        assert!(evidence.warnings.iter().any(|warning| {
+            warning.contains("materialize detached temporary worktree")
+                && warning.contains("destination: /srv/site/components/fixture")
+        }));
+        assert_eq!(
+            git_output(repo.path(), &["status", "--porcelain=v1"]),
+            before_status
+        );
+        assert_eq!(
+            git_output(repo.path(), &["worktree", "list", "--porcelain"])
+                .matches("worktree ")
+                .count(),
+            1
+        );
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(path: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("utf8")
+            .trim()
+            .to_string()
     }
 }

--- a/src/core/deploy/orchestration_ref_checkout.rs
+++ b/src/core/deploy/orchestration_ref_checkout.rs
@@ -1,0 +1,362 @@
+use std::path::{Path, PathBuf};
+
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::git;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ExactRefIdentity {
+    pub requested_ref: String,
+    pub resolved_sha: String,
+    pub source: String,
+}
+
+pub(super) struct ExactRefCheckout {
+    pub component: Component,
+    pub identity: ExactRefIdentity,
+    source_root: PathBuf,
+    worktree_path: PathBuf,
+}
+
+pub(super) fn resolve_exact_ref(
+    component: &Component,
+    requested_ref: &str,
+) -> Result<ExactRefIdentity> {
+    validate_component_source(component)?;
+    let source_root = source_root(component)?;
+    let resolved_sha = resolve_commit(&source_root, requested_ref, &component.id)?;
+    Ok(ExactRefIdentity {
+        requested_ref: requested_ref.to_string(),
+        resolved_sha,
+        source: source_root.to_string_lossy().to_string(),
+    })
+}
+
+impl ExactRefCheckout {
+    pub(super) fn materialize(component: &Component, requested_ref: &str) -> Result<Self> {
+        let identity = resolve_exact_ref(component, requested_ref)?;
+        let source_root = PathBuf::from(&identity.source);
+        let component_prefix = git::get_component_path_prefix(&component.local_path);
+        let parent = std::env::temp_dir().join("homeboy-deploy-ref");
+        std::fs::create_dir_all(&parent).map_err(|err| {
+            Error::internal_io(
+                format!("Failed to create exact-ref deploy temp directory: {err}"),
+                Some("deploy.ref.temp".to_string()),
+            )
+        })?;
+        let worktree_path = parent.join(uuid::Uuid::new_v4().to_string());
+        let worktree_arg = worktree_path.to_string_lossy().to_string();
+        git::run_git(
+            &source_root,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                &worktree_arg,
+                &identity.resolved_sha,
+            ],
+            "materialize exact deploy ref",
+        )?;
+
+        let materialized_path = component_prefix
+            .as_deref()
+            .map(|prefix| worktree_path.join(prefix))
+            .unwrap_or_else(|| worktree_path.clone());
+        if !materialized_path.exists() {
+            let mut checkout = Self {
+                component: component.clone(),
+                identity,
+                source_root,
+                worktree_path,
+            };
+            checkout.cleanup();
+            return Err(Error::validation_invalid_argument(
+                "ref",
+                format!(
+                    "Resolved ref does not contain the declared component path for '{}'",
+                    component.id
+                ),
+                None,
+                None,
+            ));
+        }
+
+        let mut materialized = component.clone();
+        materialized.local_path = materialized_path.to_string_lossy().to_string();
+        Ok(Self {
+            component: materialized,
+            identity,
+            source_root,
+            worktree_path,
+        })
+    }
+
+    fn cleanup(&mut self) {
+        let worktree = self.worktree_path.to_string_lossy().to_string();
+        let _ = git::run_git(
+            &self.source_root,
+            &["worktree", "remove", "--force", &worktree],
+            "remove exact deploy ref worktree",
+        );
+        let _ = std::fs::remove_dir_all(&self.worktree_path);
+    }
+}
+
+impl Drop for ExactRefCheckout {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+fn validate_component_source(component: &Component) -> Result<()> {
+    if component.is_file_component() {
+        return Err(unsupported_source(
+            component,
+            "file deploy sources are not Git trees",
+        ));
+    }
+    if component.deploy_config().is_git_deploy() {
+        return Err(unsupported_source(
+            component,
+            "deploy_strategy 'git' updates a remote checkout instead of packaging the selected tree",
+        ));
+    }
+    Ok(())
+}
+
+fn unsupported_source(component: &Component, reason: &str) -> Error {
+    Error::validation_invalid_argument(
+        "ref",
+        format!(
+            "Component '{}' does not support --ref: {reason}",
+            component.id
+        ),
+        None,
+        None,
+    )
+}
+
+fn source_root(component: &Component) -> Result<PathBuf> {
+    git::get_git_root(&component.local_path)
+        .map(PathBuf::from)
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "ref",
+                format!(
+                    "Cannot use --ref for component '{}': declared source '{}' is not a Git repository",
+                    component.id, component.local_path
+                ),
+                None,
+                None,
+            )
+        })
+}
+
+fn resolve_commit(source_root: &Path, requested_ref: &str, component_id: &str) -> Result<String> {
+    if requested_ref.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "ref",
+            "--ref must not be empty",
+            None,
+            None,
+        ));
+    }
+    let commit_ref = format!("{requested_ref}^{{commit}}");
+    git::run_git(
+        source_root,
+        &["rev-parse", "--verify", &commit_ref],
+        "resolve exact deploy ref",
+    )
+    .map(|sha| sha.trim().to_string())
+    .map_err(|_| {
+        Error::validation_invalid_argument(
+            "ref",
+            format!(
+                "Cannot resolve --ref '{}' to an unambiguous commit in declared repository '{}' for component '{}'",
+                requested_ref,
+                source_root.display(),
+                component_id
+            ),
+            None,
+            None,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn exact_sha_branch_and_tag_resolve_to_immutable_commit() {
+        let repo = fixture_repo();
+        let component = fixture_component(repo.path());
+        let sha = git_output(repo.path(), &["rev-parse", "HEAD"]);
+
+        assert_eq!(
+            resolve_exact_ref(&component, &sha)
+                .expect("exact SHA")
+                .resolved_sha,
+            sha
+        );
+        assert_eq!(
+            resolve_exact_ref(&component, "accepted")
+                .expect("branch")
+                .resolved_sha,
+            sha
+        );
+        assert_eq!(
+            resolve_exact_ref(&component, "v1.0.0")
+                .expect("tag")
+                .resolved_sha,
+            sha
+        );
+    }
+
+    #[test]
+    fn materialized_ref_is_independent_of_stale_checkout_head_and_does_not_mutate_it() {
+        let repo = fixture_repo();
+        let component = fixture_component(repo.path());
+        let accepted_sha = git_output(repo.path(), &["rev-parse", "accepted"]);
+        std::fs::write(repo.path().join("payload.txt"), "newer checkout\n").expect("write");
+        git(repo.path(), &["add", "payload.txt"]);
+        commit(repo.path(), "new checkout head");
+        let checkout_head = git_output(repo.path(), &["rev-parse", "HEAD"]);
+        assert_ne!(accepted_sha, checkout_head);
+
+        let worktree_path = {
+            let checkout = ExactRefCheckout::materialize(&component, "accepted")
+                .expect("materialize accepted branch");
+            assert_eq!(checkout.identity.resolved_sha, accepted_sha);
+            assert_eq!(
+                std::fs::read_to_string(
+                    Path::new(&checkout.component.local_path).join("payload.txt")
+                )
+                .expect("materialized payload"),
+                "accepted\n"
+            );
+            PathBuf::from(&checkout.component.local_path)
+        };
+
+        assert!(
+            !worktree_path.exists(),
+            "temporary worktree should be removed"
+        );
+        assert_eq!(
+            git_output(repo.path(), &["rev-parse", "HEAD"]),
+            checkout_head
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("payload.txt")).expect("checkout payload"),
+            "newer checkout\n"
+        );
+    }
+
+    #[test]
+    fn dry_resolution_is_read_only_and_unresolvable_refs_fail_clearly() {
+        let repo = fixture_repo();
+        let component = fixture_component(repo.path());
+        let before = git_output(repo.path(), &["status", "--porcelain=v1"]);
+        let identity = resolve_exact_ref(&component, "accepted").expect("resolve branch");
+
+        assert_eq!(identity.requested_ref, "accepted");
+        assert_eq!(
+            Path::new(&identity.source)
+                .canonicalize()
+                .expect("canonical source"),
+            repo.path().canonicalize().expect("canonical repo")
+        );
+        assert_eq!(
+            git_output(repo.path(), &["status", "--porcelain=v1"]),
+            before
+        );
+        let err =
+            resolve_exact_ref(&component, "missing-ref").expect_err("missing ref should fail");
+        assert!(err.message.contains("Cannot resolve --ref 'missing-ref'"));
+        assert!(err.message.contains(&identity.source));
+    }
+
+    #[test]
+    fn exact_ref_rejects_incompatible_deploy_source_types() {
+        let repo = fixture_repo();
+        let mut component = fixture_component(repo.path());
+        component.deploy_strategy = Some("git".to_string());
+        let git_error = resolve_exact_ref(&component, "accepted")
+            .expect_err("git deploy strategy should be rejected");
+        assert!(git_error
+            .message
+            .contains("deploy_strategy 'git' updates a remote checkout"));
+
+        component.deploy_strategy = Some("file".to_string());
+        component.local_path = repo
+            .path()
+            .join("payload.txt")
+            .to_string_lossy()
+            .to_string();
+        let file_error = resolve_exact_ref(&component, "accepted")
+            .expect_err("file deploy strategy should be rejected");
+        assert!(file_error.message.contains("file deploy sources"));
+    }
+
+    fn fixture_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().expect("repo");
+        git(repo.path(), &["init", "-q"]);
+        git(repo.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            repo.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        std::fs::write(repo.path().join("payload.txt"), "accepted\n").expect("payload");
+        git(repo.path(), &["add", "payload.txt"]);
+        commit(repo.path(), "accepted");
+        git(repo.path(), &["branch", "accepted"]);
+        git(repo.path(), &["tag", "v1.0.0"]);
+        repo
+    }
+
+    fn fixture_component(path: &Path) -> Component {
+        Component {
+            id: "fixture".to_string(),
+            local_path: path.to_string_lossy().to_string(),
+            build_artifact: Some("build/fixture.zip".to_string()),
+            ..Component::default()
+        }
+    }
+
+    fn commit(path: &Path, message: &str) {
+        git(path, &["commit", "-q", "-m", message]);
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?}: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(path: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?}: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("utf8")
+            .trim()
+            .to_string()
+    }
+}

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -968,6 +968,7 @@ mod tests {
             expected_version: None,
             no_pull: false,
             head: false,
+            requested_ref: None,
             tagged: false,
         }
     }

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -75,6 +75,8 @@ pub struct DeployConfig {
     pub no_pull: bool,
     /// Deploy from current branch HEAD instead of latest tag
     pub head: bool,
+    /// Resolve and deploy this Git ref from each component's declared repository.
+    pub requested_ref: Option<String>,
     /// Force tag-based deploy, ignoring any reusable build artifacts
     pub tagged: bool,
 }
@@ -96,6 +98,7 @@ impl DeployConfig {
             expected_version: None,
             no_pull: true,
             head: true,
+            requested_ref: None,
             tagged: false,
         }
     }
@@ -316,6 +319,15 @@ pub struct ComponentDeployResult {
     /// The git ref (tag or branch) that was built and deployed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deployed_ref: Option<String>,
+    /// Operator-provided exact source selector.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_ref: Option<String>,
+    /// Immutable commit selected before packaging.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_sha: Option<String>,
+    /// Declared repository used to resolve the requested ref.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
     /// Explicit build provenance: source/ref, whether a fresh build ran, and the
     /// identity of the artifact that shipped.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -348,6 +360,9 @@ impl ComponentDeployResult {
             deploy_exit_code: None,
             release_state: None,
             deployed_ref: None,
+            requested_ref: None,
+            resolved_sha: None,
+            source: None,
             build_provenance: None,
         }
     }
@@ -434,6 +449,21 @@ impl ComponentDeployResult {
 
     pub(super) fn with_deployed_ref(mut self, git_ref: String) -> Self {
         self.deployed_ref = Some(git_ref);
+        self
+    }
+
+    pub(super) fn with_exact_ref_identity(
+        mut self,
+        requested_ref: &str,
+        resolved_sha: &str,
+        source: &str,
+    ) -> Self {
+        self.requested_ref = Some(requested_ref.to_string());
+        self.resolved_sha = Some(resolved_sha.to_string());
+        self.source = Some(source.to_string());
+        self.deployed_ref = Some(requested_ref.to_string());
+        self.git_head = Some(resolved_sha.to_string());
+        self.local_path = Some(source.to_string());
         self
     }
 
@@ -753,6 +783,28 @@ mod tests {
         let result = deploy_result().with_deployed_ref("v1.2.3".to_string());
 
         assert_eq!(result.deployed_ref.as_deref(), Some("v1.2.3"));
+    }
+
+    #[test]
+    fn exact_ref_identity_is_persisted_in_serialized_deploy_evidence() {
+        let result = deploy_result().with_exact_ref_identity(
+            "origin/reviewed",
+            "0123456789abcdef0123456789abcdef01234567",
+            "/repos/component",
+        );
+        let evidence = serde_json::to_value(result).expect("serialize deploy evidence");
+
+        assert_eq!(evidence["requested_ref"], "origin/reviewed");
+        assert_eq!(
+            evidence["resolved_sha"],
+            "0123456789abcdef0123456789abcdef01234567"
+        );
+        assert_eq!(evidence["source"], "/repos/component");
+        assert_eq!(evidence["deployed_ref"], "origin/reviewed");
+        assert_eq!(
+            evidence["git_head"],
+            "0123456789abcdef0123456789abcdef01234567"
+        );
     }
 
     #[test]

--- a/src/core/release/deployment.rs
+++ b/src/core/release/deployment.rs
@@ -147,6 +147,7 @@ fn release_deployment_config(component_id: &str, expected_version: Option<&str>)
         expected_version: expected_version.map(str::to_string),
         no_pull: false,
         head: false,
+        requested_ref: None,
         tagged: true,
     }
 }

--- a/tests/commands/deploy_test.rs
+++ b/tests/commands/deploy_test.rs
@@ -63,6 +63,71 @@ fn deploy_head_dry_run_does_not_require_apply() {
 }
 
 #[test]
+fn deploy_ref_requires_apply_for_real_deploy() {
+    let result = run(
+        deploy_args(|args| {
+            args.target_id = Some("project-a".to_string());
+            args.component_ids = vec!["component-a".to_string()];
+            args.requested_ref = Some("accepted-commit".to_string());
+        }),
+        &GlobalArgs {},
+    );
+
+    let err = match result {
+        Ok(_) => panic!("--ref real deploy should require --apply"),
+        Err(err) => err,
+    };
+    assert!(err
+        .message
+        .contains("Real deploys with --ref require explicit --apply"));
+}
+
+#[test]
+fn deploy_parser_accepts_exact_ref() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "deploy",
+        "project-a",
+        "component-a",
+        "--ref",
+        "release-candidate",
+        "--dry-run",
+    ])
+    .expect("--ref should parse");
+
+    let Commands::Deploy(args) = cli.command else {
+        panic!("expected deploy command");
+    };
+    assert_eq!(args.requested_ref.as_deref(), Some("release-candidate"));
+}
+
+#[test]
+fn deploy_ref_rejects_every_other_source_selector() {
+    for conflicting in [
+        vec!["--head"],
+        vec!["--tagged"],
+        vec!["--version", "1.2.3"],
+        vec!["--outdated"],
+        vec!["--behind-upstream"],
+        vec!["--check"],
+    ] {
+        let mut argv = vec![
+            "homeboy",
+            "deploy",
+            "project-a",
+            "component-a",
+            "--ref",
+            "accepted-commit",
+        ];
+        argv.extend(conflicting.iter().copied());
+        assert!(
+            Cli::try_parse_from(argv).is_err(),
+            "--ref should conflict with {conflicting:?}"
+        );
+    }
+}
+
+#[test]
 fn multi_project_resolves_positional_components() {
     let (components, config) = resolve_multi_args(&deploy_args(|args| {
         args.projects = Some(vec!["project-a".to_string(), "project-b".to_string()]);
@@ -166,6 +231,7 @@ fn deploy_args(mut customize: impl FnMut(&mut DeployArgs)) -> DeployArgs {
         version: None,
         no_pull: false,
         head: false,
+        requested_ref: None,
         tagged: false,
     };
     customize(&mut args);


### PR DESCRIPTION
Closes #7815

## Summary
- add `homeboy deploy --ref <git-ref-or-sha>` backed by a detached temporary worktree
- record requested refs and immutable commit SHAs in deploy output and build provenance
- cover ref resolution, stale-checkout independence, dry-run behavior, conflicts, and evidence identity

## Testing
- `cargo fmt --check`
- `cargo test --locked exact_ref`
- `cargo test --locked deploy_ref`
- `cargo test --locked exact_sha_branch_and_tag_resolve_to_immutable_commit`
- `cargo test --locked materialized_ref_is_independent_of_stale_checkout_head`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode; general coding subagent
- **Used for:** Deployment architecture analysis, implementation, and behavioral tests