### PR TITLE
Consolidate workload component selection

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -1081,28 +1081,12 @@ fn resolve_list_component_id(
     args: &BenchListArgs,
     rig_spec: Option<&RigSpec>,
 ) -> homeboy::core::Result<String> {
-    if let Some(id) = args.comp.id() {
-        return Ok(id.to_string());
-    }
-
     if let Some(spec) = rig_spec {
-        if let Some(default) = spec
-            .bench
-            .as_ref()
-            .and_then(|bench| matrix::bench_component_ids(bench).into_iter().next())
-        {
-            return Ok(default);
-        }
-
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "bench.default_component",
-            format!(
-                "rig '{}' does not declare bench.default_component; pass a component id or add bench.default_component to the rig spec",
-                spec.id
-            ),
-            None,
-            None,
-        ));
+        return rig::required_component_id_for_workload(
+            spec,
+            rig::RigWorkloadKind::Bench,
+            args.comp.id(),
+        );
     }
 
     args.comp.resolve_id()

--- a/src/commands/fuzz/workloads.rs
+++ b/src/commands/fuzz/workloads.rs
@@ -91,28 +91,12 @@ pub(super) fn resolve_component_id(
     comp: &PositionalComponentArgs,
     rig_spec: Option<&RigSpec>,
 ) -> homeboy::core::Result<String> {
-    if let Some(id) = comp.id() {
-        return Ok(id.to_string());
-    }
-
     if let Some(spec) = rig_spec {
-        if let Some(default) = spec
-            .fuzz
-            .as_ref()
-            .and_then(|fuzz| fuzz.default_component.as_deref())
-        {
-            return Ok(default.to_string());
-        }
-
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "fuzz.default_component",
-            format!(
-                "rig '{}' does not declare fuzz.default_component; pass a component id or add fuzz.default_component to the rig spec",
-                spec.id
-            ),
-            None,
-            None,
-        ));
+        return rig::required_component_id_for_workload(
+            spec,
+            rig::RigWorkloadKind::Fuzz,
+            comp.id(),
+        );
     }
 
     comp.resolve_id()

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -104,9 +104,10 @@ pub use state::{
 };
 pub use workloads::{
     check_groups_for_bench_scenarios, check_groups_for_extension_workloads,
-    component_extension_ids_for_workload, env_provider_extensions_for_extension_workloads,
-    extension_ids_for_workloads, extension_workload_inputs,
-    invocation_requirements_for_extension_workloads, required_extension_ids_for_workload,
+    component_extension_ids_for_workload, component_ids_for_workload,
+    env_provider_extensions_for_extension_workloads, extension_ids_for_workloads,
+    extension_workload_inputs, invocation_requirements_for_extension_workloads,
+    required_component_id_for_workload, required_extension_ids_for_workload,
     runner_capabilities_for_extension, trace_dependencies_for_extension,
     workload_path_expansions_for_extension, workloads_for_extension, RigExtensionWorkloadInputs,
     RigWorkloadKind, RigWorkloadPathExpansion,

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use crate::core::engine::invocation::InvocationRequirements;
+use crate::core::{Error, Result};
 
 use super::spec::{RigSpec, TraceDependencySpec};
 
@@ -25,6 +26,58 @@ pub struct RigExtensionWorkloadInputs {
     pub workload_paths: Vec<PathBuf>,
     pub env_provider_extensions: Vec<String>,
     pub invocation_requirements: InvocationRequirements,
+}
+
+pub fn component_ids_for_workload(
+    rig_spec: &RigSpec,
+    kind: RigWorkloadKind,
+    explicit_component: Option<&str>,
+) -> Vec<String> {
+    if let Some(component) = explicit_component {
+        return vec![component.to_string()];
+    }
+
+    match kind {
+        RigWorkloadKind::Bench => match rig_spec.bench.as_ref() {
+            Some(bench) if !bench.components.is_empty() => bench.components.clone(),
+            Some(bench) => bench.default_component.iter().cloned().collect(),
+            None => Vec::new(),
+        },
+        RigWorkloadKind::Fuzz => rig_spec
+            .fuzz
+            .iter()
+            .flat_map(|fuzz| fuzz.default_component.iter().cloned())
+            .collect(),
+        RigWorkloadKind::Trace => Vec::new(),
+    }
+}
+
+pub fn required_component_id_for_workload(
+    rig_spec: &RigSpec,
+    kind: RigWorkloadKind,
+    explicit_component: Option<&str>,
+) -> Result<String> {
+    if let Some(component) = component_ids_for_workload(rig_spec, kind, explicit_component)
+        .into_iter()
+        .next()
+    {
+        return Ok(component);
+    }
+
+    let setting = match kind {
+        RigWorkloadKind::Bench => "bench.default_component",
+        RigWorkloadKind::Fuzz => "fuzz.default_component",
+        RigWorkloadKind::Trace => "trace.default_component",
+    };
+    Err(Error::validation_invalid_argument(
+        setting,
+        format!(
+            "rig '{}' does not declare {setting}; pass a component id or add {setting} to the rig spec",
+            rig_spec.id
+        ),
+        None,
+        None,
+    ))
 }
 
 pub fn extension_ids_for_workloads(rig_spec: &RigSpec, kind: RigWorkloadKind) -> Vec<String> {
@@ -65,24 +118,7 @@ pub fn component_extension_ids_for_workload(
     kind: RigWorkloadKind,
     explicit_component: Option<&str>,
 ) -> Vec<String> {
-    let component_ids = explicit_component
-        .map(|id| vec![id.to_string()])
-        .or_else(|| match kind {
-            RigWorkloadKind::Bench => rig_spec.bench.as_ref().map(|bench| {
-                if bench.components.is_empty() {
-                    bench.default_component.iter().cloned().collect()
-                } else {
-                    bench.components.clone()
-                }
-            }),
-            RigWorkloadKind::Fuzz => rig_spec
-                .fuzz
-                .as_ref()
-                .and_then(|fuzz| fuzz.default_component.as_ref())
-                .map(|component| vec![component.clone()]),
-            RigWorkloadKind::Trace => None,
-        })
-        .unwrap_or_default();
+    let component_ids = component_ids_for_workload(rig_spec, kind, explicit_component);
 
     component_ids
         .iter()

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -731,10 +731,10 @@ impl RunnerCommandPlan {
         route_required_extensions: &[String],
         primary_source_path: &Path,
     ) -> Result<Self> {
-        let rig_extensions = rig_required_extensions_from_primary_rig(args, primary_source_path)?;
+        let rig_extensions = rig_extensions_from_primary_rig(args, primary_source_path, true)?;
         let accepted_settings = rig_accepted_settings_from_primary_rig(args, primary_source_path)?;
         let rig_dispatch_extensions =
-            rig_dispatch_extensions_from_primary_rig(args, primary_source_path)?;
+            rig_extensions_from_primary_rig(args, primary_source_path, false)?;
         let mut required_extensions = std::collections::BTreeSet::new();
         required_extensions.extend(route_required_extensions.iter().cloned());
         required_extensions.extend(rig_extensions);
@@ -755,7 +755,7 @@ fn rig_declared_path_input_extra_workspaces(
     args: &[String],
     primary_source_path: &Path,
 ) -> Result<Vec<ExtraLabWorkspace>> {
-    if rig_workload_command(args) != Some(RigWorkloadCommand::Bench) {
+    if !args.iter().any(|arg| arg == "bench") {
         return Ok(Vec::new());
     }
 
@@ -916,7 +916,7 @@ fn rig_accepted_settings_from_primary_rig(
     args: &[String],
     primary_source_path: &Path,
 ) -> Result<Vec<String>> {
-    if rig_workload_command(args) != Some(RigWorkloadCommand::Bench) {
+    if !args.iter().any(|arg| arg == "bench") {
         return Ok(Vec::new());
     }
 
@@ -938,23 +938,23 @@ fn rig_accepted_settings_from_primary_rig(
     Ok(accepted_settings.into_iter().collect())
 }
 
-fn rig_required_extensions_from_primary_rig(
+fn rig_extensions_from_primary_rig(
     args: &[String],
     primary_source_path: &Path,
+    required: bool,
 ) -> Result<Vec<String>> {
-    let Some(command) = rig_workload_command(args) else {
+    let command = if args.iter().any(|arg| arg == "bench") {
+        rig::RigWorkloadKind::Bench
+    } else if args.iter().any(|arg| arg == "fuzz") {
+        rig::RigWorkloadKind::Fuzz
+    } else {
         return Ok(Vec::new());
     };
-
-    let rig_ids = rig_ids_from_args(args);
-    if rig_ids.is_empty() {
-        return Ok(Vec::new());
-    }
 
     let explicit_component = rig_workload_component_from_args(args, command);
     let explicit_extensions = extension_overrides_from_args(args);
     let mut extension_ids = std::collections::BTreeSet::new();
-    for rig_id in rig_ids {
+    for rig_id in rig_ids_from_args(args) {
         let Some(spec) = load_primary_rig_spec(primary_source_path, &rig_id)? else {
             continue;
         };
@@ -962,77 +962,29 @@ fn rig_required_extensions_from_primary_rig(
             extension_ids.extend(explicit_extensions.iter().cloned());
             continue;
         }
-        extension_ids.extend(rig::required_extension_ids_for_workload(
-            &spec,
-            command.workload_kind(),
-            explicit_component.as_deref(),
-        ));
-    }
-
-    Ok(extension_ids.into_iter().collect())
-}
-
-fn rig_dispatch_extensions_from_primary_rig(
-    args: &[String],
-    primary_source_path: &Path,
-) -> Result<Vec<String>> {
-    let Some(command) = rig_workload_command(args) else {
-        return Ok(Vec::new());
-    };
-
-    let rig_ids = rig_ids_from_args(args);
-    if rig_ids.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let explicit_component = rig_workload_component_from_args(args, command);
-    let explicit_extensions = extension_overrides_from_args(args);
-    let mut extension_ids = std::collections::BTreeSet::new();
-    for rig_id in rig_ids {
-        let Some(spec) = load_primary_rig_spec(primary_source_path, &rig_id)? else {
-            continue;
-        };
-        if !explicit_extensions.is_empty() {
-            extension_ids.extend(explicit_extensions.iter().cloned());
+        if required {
+            extension_ids.extend(rig::required_extension_ids_for_workload(
+                &spec,
+                command,
+                explicit_component.as_deref(),
+            ));
             continue;
         }
-        let workload_extensions = rig::extension_ids_for_workloads(&spec, command.workload_kind());
-        if workload_extensions.len() == 1 {
-            extension_ids.extend(workload_extensions);
-        }
+        let workload_extensions = rig::extension_ids_for_workloads(&spec, command);
+        extension_ids.extend(
+            (workload_extensions.len() == 1)
+                .then_some(workload_extensions)
+                .into_iter()
+                .flatten(),
+        );
         extension_ids.extend(rig::component_extension_ids_for_workload(
             &spec,
-            command.workload_kind(),
+            command,
             explicit_component.as_deref(),
         ));
     }
 
     Ok(extension_ids.into_iter().collect())
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum RigWorkloadCommand {
-    Bench,
-    Fuzz,
-}
-
-impl RigWorkloadCommand {
-    fn workload_kind(self) -> rig::RigWorkloadKind {
-        match self {
-            Self::Bench => rig::RigWorkloadKind::Bench,
-            Self::Fuzz => rig::RigWorkloadKind::Fuzz,
-        }
-    }
-}
-
-fn rig_workload_command(args: &[String]) -> Option<RigWorkloadCommand> {
-    if args.iter().any(|arg| arg == "bench") {
-        return Some(RigWorkloadCommand::Bench);
-    }
-    if args.iter().any(|arg| arg == "fuzz") {
-        return Some(RigWorkloadCommand::Fuzz);
-    }
-    None
 }
 
 fn load_primary_rig_spec(primary_source_path: &Path, rig_id: &str) -> Result<Option<rig::RigSpec>> {
@@ -1098,7 +1050,7 @@ fn values_for_flag(args: &[String], flag: &str) -> Vec<String> {
 
 fn rig_workload_component_from_args(
     args: &[String],
-    command: RigWorkloadCommand,
+    command: rig::RigWorkloadKind,
 ) -> Option<String> {
     let mut command_seen = false;
     let mut subcommand_seen = false;
@@ -1173,13 +1125,13 @@ fn rig_workload_component_from_args(
         if !command_seen {
             if matches!(
                 (command, arg.as_str()),
-                (RigWorkloadCommand::Bench, "bench") | (RigWorkloadCommand::Fuzz, "fuzz")
+                (rig::RigWorkloadKind::Bench, "bench") | (rig::RigWorkloadKind::Fuzz, "fuzz")
             ) {
                 command_seen = true;
             }
             continue;
         }
-        if matches!(command, RigWorkloadCommand::Fuzz)
+        if matches!(command, rig::RigWorkloadKind::Fuzz)
             && !subcommand_seen
             && matches!(arg.as_str(), "list" | "run" | "plan" | "run-campaign")
         {
@@ -1188,8 +1140,9 @@ fn rig_workload_component_from_args(
         }
         if arg.starts_with('-') {
             let takes_value = match command {
-                RigWorkloadCommand::Bench => flags_with_values.contains(&arg.as_str()),
-                RigWorkloadCommand::Fuzz => fuzz_flags_with_values.contains(&arg.as_str()),
+                rig::RigWorkloadKind::Bench => flags_with_values.contains(&arg.as_str()),
+                rig::RigWorkloadKind::Fuzz => fuzz_flags_with_values.contains(&arg.as_str()),
+                rig::RigWorkloadKind::Trace => false,
             };
             if takes_value {
                 skip_next = true;

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -3,10 +3,51 @@ use std::path::PathBuf;
 use crate::core::rig::spec::RigSpec;
 use crate::core::rig::{
     check_groups_for_extension_workloads, env_provider_extensions_for_extension_workloads,
-    extension_ids_for_workloads, extension_workload_inputs, required_extension_ids_for_workload,
-    runner_capabilities_for_extension, trace_dependencies_for_extension,
-    workload_path_expansions_for_extension, workloads_for_extension, RigWorkloadKind,
+    extension_ids_for_workloads, extension_workload_inputs, required_component_id_for_workload,
+    required_extension_ids_for_workload, runner_capabilities_for_extension,
+    trace_dependencies_for_extension, workload_path_expansions_for_extension,
+    workloads_for_extension, RigWorkloadKind,
 };
+
+#[test]
+fn workload_component_selection_preserves_command_policy() {
+    let rig_spec: RigSpec = serde_json::from_value(serde_json::json!({
+        "id": "selection",
+        "bench": {
+            "default_component": "bench-default",
+            "components": ["bench-first", "bench-second"]
+        },
+        "fuzz": { "default_component": "fuzz-default" },
+        "trace": { "default_component": "trace-default" }
+    }))
+    .expect("parse rig spec");
+
+    assert_eq!(
+        required_component_id_for_workload(&rig_spec, RigWorkloadKind::Bench, Some("explicit"))
+            .expect("explicit component"),
+        "explicit"
+    );
+    assert_eq!(
+        super::component_ids_for_workload(&rig_spec, RigWorkloadKind::Bench, None),
+        vec!["bench-first", "bench-second"]
+    );
+    assert_eq!(
+        required_component_id_for_workload(&rig_spec, RigWorkloadKind::Fuzz, None)
+            .expect("fuzz default"),
+        "fuzz-default"
+    );
+    assert!(super::component_ids_for_workload(&rig_spec, RigWorkloadKind::Trace, None).is_empty());
+}
+
+#[test]
+fn missing_workload_component_keeps_command_specific_diagnostic() {
+    let rig_spec: RigSpec =
+        serde_json::from_value(serde_json::json!({ "id": "missing" })).expect("parse rig spec");
+
+    let bench_error = required_component_id_for_workload(&rig_spec, RigWorkloadKind::Bench, None)
+        .expect_err("bench component is required");
+    assert!(bench_error.message.contains("bench.default_component"));
+}
 
 #[test]
 fn test_bench_workloads_for_extension_filters_and_expands_paths() {


### PR DESCRIPTION
## Summary
- centralize explicit/default component selection in rig workload ownership
- reuse the same bench and fuzz selection policy from commands and Lab extension staging
- consolidate duplicate Lab required/dispatch extension collection without changing their distinct rules

## Impact
- production: **42 net lines removed**
- total: 144 additions, 145 deletions
- preserves explicit overrides, bench multi-component order, fuzz defaults, missing-default diagnostics, and Lab dispatch behavior

## Testing
- component policy and missing-diagnostic tests: passed
- fuzz default-component test: passed
- bench default-component/list test: passed
- Lab fuzz workload/component extension test: passed
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Component-selection ownership analysis, consolidation, behavioral parity tests, rebasing, and verification; Chris remains responsible for the submitted change.