### PR TITLE
Fix changed-only lint paths in Lab dispatch

### DIFF
--- a/src/core/runner/lab_arg_tests.rs
+++ b/src/core/runner/lab_arg_tests.rs
@@ -1,6 +1,6 @@
 use super::super::lab_args::{
     lab_offload_source_path, rewrite_lab_offload_args, rewrite_runner_resident_lab_offload_args,
-    EXPLICIT_PASSTHROUGH_SENTINEL,
+    LabPathRemap, EXPLICIT_PASSTHROUGH_SENTINEL,
 };
 
 fn args(items: &[&str]) -> Vec<String> {
@@ -182,8 +182,6 @@ fn leaves_relative_passthrough_path_args_untouched() {
 
 #[test]
 fn remaps_synced_source_paths_in_passthrough_args() {
-    use super::super::lab_args::LabPathRemap;
-
     let input = args(&[
         "homeboy",
         "bench",
@@ -229,6 +227,63 @@ fn remaps_synced_source_paths_in_passthrough_args() {
             "--batch-size",
             "1",
         ])
+    );
+}
+
+#[test]
+fn preserves_repo_relative_changed_files_through_lab_dispatch_rewrite() {
+    let input = args(&[
+        "homeboy",
+        "review",
+        "lint",
+        "--path",
+        "/Users/user/Developer/project",
+        "--changed-only",
+        "--lab-changed-files-json",
+        "[\"inc/Workspace/WorkspaceWorktreeCleanupEngine.php\",\"tests/worktree-retention-apply-protections.php\"]",
+    ]);
+    let mappings = vec![LabPathRemap {
+        local: "/Users/user/Developer/project".to_string(),
+        remote: "/runner/workspaces/project".to_string(),
+    }];
+
+    let rewritten = rewrite_lab_offload_args(&input, "/runner/workspaces/project", &mappings, None);
+
+    assert_eq!(
+        rewritten,
+        args(&[
+            "homeboy",
+            "--force-hot",
+            "review",
+            "lint",
+            "--path",
+            "/runner/workspaces/project",
+            "--changed-only",
+            "--lab-changed-files-json",
+            "[\"inc/Workspace/WorkspaceWorktreeCleanupEngine.php\",\"tests/worktree-retention-apply-protections.php\"]",
+        ])
+    );
+}
+
+#[test]
+fn normalizes_changed_file_paths_to_the_remote_workspace_coordinate_system() {
+    let input = args(&[
+        "homeboy",
+        "review",
+        "lint",
+        "--lab-changed-files-json",
+        "[\"/Users/user/Developer/project/src/lib.rs\"]",
+    ]);
+    let mappings = vec![LabPathRemap {
+        local: "/Users/user/Developer/project".to_string(),
+        remote: "/runner/workspaces/project".to_string(),
+    }];
+
+    let rewritten = rewrite_lab_offload_args(&input, "/runner/workspaces/project", &mappings, None);
+
+    assert_eq!(
+        rewritten.last().map(String::as_str),
+        Some("[\"src/lib.rs\"]")
     );
 }
 

--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -1,7 +1,7 @@
 //! Lab offload argument rewriting: resolve the offload source path and strip /
 //! rewrite controller-only flags so a command can run on the remote runner.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::core::{git, worktree, worktree_providers};
 use crate::core::{Error, Result};
@@ -113,6 +113,20 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
         if arg == "--" {
             passthrough = true;
             stripped.push(arg.clone());
+            continue;
+        }
+        if arg == "--lab-changed-files-json" {
+            stripped.push(arg.clone());
+            if let Some(value) = iter.next() {
+                stripped.push(remap_lab_changed_files_json(value, remote_path, &ordered));
+            }
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--lab-changed-files-json=") {
+            stripped.push(format!(
+                "--lab-changed-files-json={}",
+                remap_lab_changed_files_json(value, remote_path, &ordered)
+            ));
             continue;
         }
         if arg == "--path" || arg == "--cwd" {
@@ -259,6 +273,30 @@ fn remap_lab_offload_arg(arg: &str, mappings: &[&LabPathRemap]) -> String {
     }
 
     remap_local_path(arg, mappings).unwrap_or_else(|| arg.to_string())
+}
+
+/// Changed-file payloads are repo-relative because lint scopes reconstruct
+/// absolute paths from the component root on the runner. Normalize any
+/// controller/runner absolute forms back into that shared repo-relative space.
+fn remap_lab_changed_files_json(
+    value: &str,
+    remote_path: &str,
+    mappings: &[&LabPathRemap],
+) -> String {
+    let Ok(mut files) = serde_json::from_str::<Vec<String>>(value) else {
+        return value.to_string();
+    };
+
+    for file in &mut files {
+        let mapped = remap_local_path(file, mappings).unwrap_or_else(|| file.clone());
+        if let Ok(relative) = Path::new(&mapped).strip_prefix(remote_path) {
+            *file = relative.to_string_lossy().to_string();
+        } else {
+            *file = mapped;
+        }
+    }
+
+    serde_json::to_string(&files).unwrap_or_else(|_| value.to_string())
 }
 
 pub(in crate::core::runner) fn rewrite_runner_resident_lab_offload_args(


### PR DESCRIPTION
## Summary
- treat `--lab-changed-files-json` as a first-class Lab dispatch payload
- preserve repository-relative changed files for runner-side lint scoping and normalize mapped absolute paths back to that coordinate system
- cover the reporter's changed-file payload and absolute-path normalization

Closes #7842

## Root cause
Lab argument rewriting handled individual path-bearing arguments but did not define a coordinate contract for the generated changed-file JSON payload. The payload must be repository-relative because the runner lint scoper resolves it against the synced workspace root.

## Verification
- `cargo fmt --check`
- `cargo test preserves_repo_relative_changed_files_through_lab_dispatch_rewrite --lib`
- `cargo test normalizes_changed_file_paths_to_the_remote_workspace_coordinate_system --lib`
- `cargo test core::runner::lab --lib` (352 passed; one unrelated stale-daemon recovery-command expectation failed)
- `cargo build --workspace`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Opus 4.5) via Kimaki/OpenCode subagent
- **Used for:** Root-cause analysis, implementation, and regression test for issue #7842