### PR TITLE
refactor: consolidate agent task gate statuses

### DIFF
--- a/src/core/agent_task_controller_service/actions.rs
+++ b/src/core/agent_task_controller_service/actions.rs
@@ -1516,12 +1516,12 @@ pub(super) fn execute_wait_for_controller_action(
 }
 
 /// A gate bundle blocks the loop (non-zero exit) when it failed outright or is
-/// still pending an external/manual result. Passed and non-blocking Warn
-/// bundles allow the loop to advance.
-fn gate_bundle_exit_code(status: AgentTaskGateBundleStatus) -> i32 {
+/// still pending an external/manual result. Satisfied bundles allow the loop
+/// to advance.
+fn gate_bundle_exit_code(status: AgentTaskLoopGateStatus) -> i32 {
     match status {
-        AgentTaskGateBundleStatus::Failed | AgentTaskGateBundleStatus::Pending => 1,
-        AgentTaskGateBundleStatus::Passed | AgentTaskGateBundleStatus::Warn => 0,
+        AgentTaskLoopGateStatus::Failed | AgentTaskLoopGateStatus::Pending => 1,
+        AgentTaskLoopGateStatus::Satisfied | AgentTaskLoopGateStatus::Missing => 0,
     }
 }
 
@@ -1568,7 +1568,7 @@ pub(super) fn execute_run_gates_action(
                 // arrived. Treat it as Pending (blocking) rather than a
                 // non-blocking Warn so a manual-only bundle never resolves to a
                 // false-green acceptance gate.
-                status: AgentTaskGateBundleStatus::Pending,
+                status: AgentTaskLoopGateStatus::Pending,
                 retryable: check.retryable,
                 classification: Some("manual_gate_requires_external_result".to_string()),
                 evidence: Vec::new(),
@@ -1577,7 +1577,7 @@ pub(super) fn execute_run_gates_action(
             AgentTaskGateBundleCheckKind::Api | AgentTaskGateBundleCheckKind::Tool => {
                 AgentTaskGateCheckResult {
                     check_id: check.check_id.clone(),
-                    status: AgentTaskGateBundleStatus::Failed,
+                    status: AgentTaskLoopGateStatus::Failed,
                     retryable: check.retryable,
                     classification: Some("unsupported_generic_gate_kind".to_string()),
                     evidence: Vec::new(),
@@ -1590,21 +1590,16 @@ pub(super) fn execute_run_gates_action(
 
     let status = if checks
         .iter()
-        .any(|check| check.status == AgentTaskGateBundleStatus::Failed)
+        .any(|check| check.status == AgentTaskLoopGateStatus::Failed)
     {
-        AgentTaskGateBundleStatus::Failed
+        AgentTaskLoopGateStatus::Failed
     } else if checks
         .iter()
-        .any(|check| check.status == AgentTaskGateBundleStatus::Pending)
+        .any(|check| check.status == AgentTaskLoopGateStatus::Pending)
     {
-        AgentTaskGateBundleStatus::Pending
-    } else if checks
-        .iter()
-        .any(|check| check.status == AgentTaskGateBundleStatus::Warn)
-    {
-        AgentTaskGateBundleStatus::Warn
+        AgentTaskLoopGateStatus::Pending
     } else {
-        AgentTaskGateBundleStatus::Passed
+        AgentTaskLoopGateStatus::Satisfied
     };
     let result = AgentTaskGateBundleResult {
         result_id: format!("gate-result-{}", record.gate_results.len() + 1),
@@ -1691,9 +1686,9 @@ pub(super) fn run_command_gate_check(
     let stderr = collect_capped_command_output(stderr, command, "stderr")?;
 
     let status = if !timed_out && exit_status.success() {
-        AgentTaskGateBundleStatus::Passed
+        AgentTaskLoopGateStatus::Satisfied
     } else {
-        AgentTaskGateBundleStatus::Failed
+        AgentTaskLoopGateStatus::Failed
     };
     Ok(AgentTaskGateCheckResult {
         check_id: check.check_id.clone(),

--- a/src/core/agent_task_controller_service/mod.rs
+++ b/src/core/agent_task_controller_service/mod.rs
@@ -20,10 +20,10 @@ use crate::core::agent_task::{
 use crate::core::agent_task_lifecycle as lifecycle;
 use crate::core::agent_task_loop_controller::{
     self as controller, AgentTaskGateBundle, AgentTaskGateBundleCheckKind,
-    AgentTaskGateBundleResult, AgentTaskGateBundleStatus, AgentTaskGateCheckResult,
-    AgentTaskLoopActionDiagnostic, AgentTaskLoopActionStatus, AgentTaskLoopArtifactRef,
-    AgentTaskLoopControllerRecord, AgentTaskLoopControllerState, AgentTaskLoopEntity,
-    AgentTaskLoopExternalEvent, AgentTaskLoopHistoryEvent, AgentTaskLoopPolicy,
+    AgentTaskGateBundleResult, AgentTaskGateCheckResult, AgentTaskLoopActionDiagnostic,
+    AgentTaskLoopActionStatus, AgentTaskLoopArtifactRef, AgentTaskLoopControllerRecord,
+    AgentTaskLoopControllerState, AgentTaskLoopEntity, AgentTaskLoopExternalEvent,
+    AgentTaskLoopGateStatus, AgentTaskLoopHistoryEvent, AgentTaskLoopPolicy,
     AgentTaskLoopPolicyAction, AgentTaskLoopPolicyActionRecord, AgentTaskLoopProvenanceRef,
     AgentTaskLoopRunRef, AgentTaskLoopRunnerAvailability, AgentTaskLoopRunnerExecutionTarget,
     AgentTaskLoopTaskLineage, AgentTaskLoopTerminalStatus, AgentTaskLoopTransition,

--- a/src/core/agent_task_controller_service/pr_ownership.rs
+++ b/src/core/agent_task_controller_service/pr_ownership.rs
@@ -34,12 +34,6 @@ pub(super) fn execute_own_pr_until_green_action(
         pr_number,
         ownership.path.clone(),
     )?;
-    let previous_retry_count = existing_pr_retry_count(record, &ownership.ownership_id);
-    let retry_count = if pr_needs_retry(&view.ci_state, view.review_decision.as_deref()) {
-        previous_retry_count.saturating_add(1)
-    } else {
-        previous_retry_count
-    };
     let update = AgentTaskPrOwnershipStatusUpdate {
         pr_number: Some(view.number),
         pr_url: Some(format!(
@@ -54,7 +48,6 @@ pub(super) fn execute_own_pr_until_green_action(
             .merge_state
             .clone()
             .or_else(|| Some(view.state.clone())),
-        retry_count,
         evidence: vec![AgentTaskLoopArtifactRef {
             uri: format!("github://{}/{}/pull/{}", view.owner, view.repo, view.number),
             kind: Some("github.pull_request".to_string()),
@@ -76,12 +69,6 @@ pub(super) fn execute_own_pr_until_green_action(
     ))
 }
 
-pub(super) fn pr_needs_retry(ci_state: &str, review_decision: Option<&str>) -> bool {
-    ci_state == "terminal_failed"
-        || ci_state == "stale"
-        || review_decision == Some("CHANGES_REQUESTED")
-}
-
 pub(super) fn find_pr_number(ownership: &AgentTaskPrOwnershipRequest) -> Result<Option<u64>> {
     let output = pr_find(
         ownership.component_id.as_deref(),
@@ -94,18 +81,6 @@ pub(super) fn find_pr_number(ownership: &AgentTaskPrOwnershipRequest) -> Result<
         },
     )?;
     Ok(output.items.into_iter().next().map(|item| item.number))
-}
-
-pub(super) fn existing_pr_retry_count(
-    record: &AgentTaskLoopControllerRecord,
-    ownership_id: &str,
-) -> u32 {
-    record
-        .pr_ownerships
-        .iter()
-        .find(|ownership| ownership.ownership_id == ownership_id)
-        .map(|ownership| ownership.retry_count)
-        .unwrap_or_default()
 }
 
 pub(super) fn queue_pr_ownership_follow_up(

--- a/src/core/agent_task_controller_service/tests/resume_tests.rs
+++ b/src/core/agent_task_controller_service/tests/resume_tests.rs
@@ -742,7 +742,7 @@ fn from_spec_resume_drives_workflow_lineage_then_blocks_on_pending_manual_gate()
         assert_eq!(result.value.controller.gate_results.len(), 1);
         assert_eq!(
             result.value.controller.gate_results[0].status,
-            AgentTaskGateBundleStatus::Pending
+            AgentTaskLoopGateStatus::Pending
         );
         let gate_action = result
             .value

--- a/src/core/agent_task_controller_service/tests/run_gates_tests.rs
+++ b/src/core/agent_task_controller_service/tests/run_gates_tests.rs
@@ -121,7 +121,7 @@ fn run_gates_blocks_on_pending_manual_check() {
         assert_eq!(loaded.gate_results.len(), 1);
         assert_eq!(
             loaded.gate_results[0].status,
-            AgentTaskGateBundleStatus::Pending
+            AgentTaskLoopGateStatus::Pending
         );
         assert_eq!(
             loaded.terminal_outcomes[0].status,
@@ -184,7 +184,7 @@ fn run_gates_executes_command_bundle_and_records_result() {
         assert_eq!(loaded.gate_results.len(), 1);
         assert_eq!(
             loaded.gate_results[0].status,
-            AgentTaskGateBundleStatus::Passed
+            AgentTaskLoopGateStatus::Satisfied
         );
     });
 }
@@ -206,7 +206,7 @@ fn command_gate_check_runs_from_configured_cwd() {
 
     let result = run_command_gate_check(&check).expect("command gate executed");
 
-    assert_eq!(result.status, AgentTaskGateBundleStatus::Passed);
+    assert_eq!(result.status, AgentTaskLoopGateStatus::Satisfied);
     assert_eq!(result.details["stdout"].as_str(), Some("ok"));
     assert_eq!(result.details["cwd"].as_str(), Some(cwd_path.as_str()));
 }
@@ -225,7 +225,7 @@ fn command_gate_check_caps_stored_stdout_and_records_truncation() {
 
     let result = run_command_gate_check(&check).expect("command gate executed");
 
-    assert_eq!(result.status, AgentTaskGateBundleStatus::Passed);
+    assert_eq!(result.status, AgentTaskLoopGateStatus::Satisfied);
     assert_eq!(result.details["stdout_truncated"].as_bool(), Some(true));
     assert_eq!(
         result.details["stdout_stored_bytes"].as_u64(),

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -18,7 +18,7 @@ use crate::core::agent_task_provider::{
     AgentTaskProviderCatalog,
 };
 use crate::core::agent_task_scheduler::{
-    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskProviderRotationPolicy,
+    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskProviderRotationPolicy,
     AgentTaskRetryPolicy, AgentTaskScheduler,
 };
 use crate::core::agent_task_service::{aggregate_exit_code, AgentTaskRunResult};
@@ -165,27 +165,13 @@ where
     catalog.enforce_runtime_preflight_checks_for_plan(&plan)?;
     preflight_dispatch_provider_secrets(&plan)?;
     preflight_plan_provider_config_with_providers(&plan, catalog.providers())?;
-    let submitted = lifecycle::submit_plan(&plan, request.run_id.as_deref())?;
-    let run_id = submitted.run_id.clone();
-
-    if request.core.queue_only {
-        return Ok(AgentTaskRunResult {
-            value: dispatch_report(submitted, None, true, backend_selection),
-            exit_code: 0,
-        });
-    }
-
-    lifecycle::mark_running(&run_id)?;
-    let aggregate = AgentTaskScheduler::new(executor)
-        .with_run_id(run_id.clone())
-        .run(plan.clone());
-    let record = lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
-    let exit_code = aggregate_exit_code(&aggregate);
-
-    Ok(AgentTaskRunResult {
-        value: dispatch_report(record, Some(aggregate), false, backend_selection),
-        exit_code,
-    })
+    run_dispatch_plan(
+        plan,
+        request.run_id.as_deref(),
+        request.core.queue_only,
+        backend_selection,
+        executor,
+    )
 }
 
 pub fn dispatch_with_provider_requirements<E>(
@@ -208,10 +194,32 @@ where
         &plan,
         &AgentTaskProviderCatalog::discover().providers,
     )?;
-    let submitted = lifecycle::submit_plan(&plan, request.run_id.as_deref())?;
+    run_dispatch_plan(
+        plan,
+        request.run_id.as_deref(),
+        request.core.queue_only,
+        backend_selection,
+        executor,
+    )
+}
+
+/// The only durable dispatch-to-scheduler path. Both provider-catalog entry
+/// points prepare a plan differently, then share lifecycle transitions,
+/// scheduler execution, aggregate persistence, and report construction here.
+fn run_dispatch_plan<E>(
+    plan: AgentTaskPlan,
+    requested_run_id: Option<&str>,
+    queue_only: bool,
+    backend_selection: Option<BackendSelection>,
+    executor: E,
+) -> Result<AgentTaskRunResult<AgentTaskDispatchReport>>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    let submitted = lifecycle::submit_plan(&plan, requested_run_id)?;
     let run_id = submitted.run_id.clone();
 
-    if request.core.queue_only {
+    if queue_only {
         return Ok(AgentTaskRunResult {
             value: dispatch_report(submitted, None, true, backend_selection),
             exit_code: 0,

--- a/src/core/agent_task_loop_controller/diagnostics.rs
+++ b/src/core/agent_task_loop_controller/diagnostics.rs
@@ -145,46 +145,34 @@ pub struct AgentTaskLoopFailedChildEvidenceRef {
     pub label: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum AgentTaskLoopAcceptanceGateStatus {
-    Satisfied,
-    Missing,
-    Failed,
-    Warning,
-    /// The gate recorded a result that is still awaiting an external/manual
-    /// signal. Treated as blocking (not acceptable) so a manual-only bundle
-    /// never resolves to a false-green acceptance gate.
-    Pending,
-}
-
 /// Canonical projection from a (possibly absent) recorded gate-bundle result
 /// status to the acceptance-gate status surfaced in diagnostics. An absent
 /// result maps to `Missing`; the present statuses map 1:1 onto their
 /// acceptance-gate equivalents. Routing every call site through this `From`
 /// keeps the projection in one place instead of hand-synced match arms.
-impl From<Option<AgentTaskGateBundleStatus>> for AgentTaskLoopAcceptanceGateStatus {
-    fn from(status: Option<AgentTaskGateBundleStatus>) -> Self {
+impl From<Option<AgentTaskLoopGateStatus>> for AgentTaskLoopGateStatus {
+    fn from(status: Option<AgentTaskLoopGateStatus>) -> Self {
         match status {
-            Some(AgentTaskGateBundleStatus::Passed) => AgentTaskLoopAcceptanceGateStatus::Satisfied,
-            Some(AgentTaskGateBundleStatus::Failed) => AgentTaskLoopAcceptanceGateStatus::Failed,
-            Some(AgentTaskGateBundleStatus::Warn) => AgentTaskLoopAcceptanceGateStatus::Warning,
-            Some(AgentTaskGateBundleStatus::Pending) => AgentTaskLoopAcceptanceGateStatus::Pending,
-            None => AgentTaskLoopAcceptanceGateStatus::Missing,
+            Some(status) => status,
+            None => AgentTaskLoopGateStatus::Missing,
         }
     }
 }
+
+/// Backwards-compatible source alias for the old diagnostics vocabulary.
+/// New policy, result, and diagnostic fields use `AgentTaskLoopGateStatus`.
+pub type AgentTaskLoopAcceptanceGateStatus = AgentTaskLoopGateStatus;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskLoopAcceptanceGateDiagnostic {
     pub bundle_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub entity_id: Option<String>,
-    pub status: AgentTaskLoopAcceptanceGateStatus,
+    pub status: AgentTaskLoopGateStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub result_status: Option<AgentTaskGateBundleStatus>,
+    pub result_status: Option<AgentTaskLoopGateStatus>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recorded_at: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -219,24 +207,24 @@ mod tests {
     #[test]
     fn acceptance_gate_status_bridges_from_bundle_status() {
         assert_eq!(
-            AgentTaskLoopAcceptanceGateStatus::from(Some(AgentTaskGateBundleStatus::Passed)),
-            AgentTaskLoopAcceptanceGateStatus::Satisfied
+            AgentTaskLoopGateStatus::from(Some(AgentTaskLoopGateStatus::Satisfied)),
+            AgentTaskLoopGateStatus::Satisfied
         );
         assert_eq!(
-            AgentTaskLoopAcceptanceGateStatus::from(Some(AgentTaskGateBundleStatus::Failed)),
-            AgentTaskLoopAcceptanceGateStatus::Failed
+            AgentTaskLoopGateStatus::from(Some(AgentTaskLoopGateStatus::Failed)),
+            AgentTaskLoopGateStatus::Failed
         );
         assert_eq!(
-            AgentTaskLoopAcceptanceGateStatus::from(Some(AgentTaskGateBundleStatus::Warn)),
-            AgentTaskLoopAcceptanceGateStatus::Warning
+            AgentTaskLoopGateStatus::from(Some(AgentTaskLoopGateStatus::Satisfied)),
+            AgentTaskLoopGateStatus::Satisfied
         );
         assert_eq!(
-            AgentTaskLoopAcceptanceGateStatus::from(Some(AgentTaskGateBundleStatus::Pending)),
-            AgentTaskLoopAcceptanceGateStatus::Pending
+            AgentTaskLoopGateStatus::from(Some(AgentTaskLoopGateStatus::Pending)),
+            AgentTaskLoopGateStatus::Pending
         );
         assert_eq!(
-            AgentTaskLoopAcceptanceGateStatus::from(None),
-            AgentTaskLoopAcceptanceGateStatus::Missing
+            AgentTaskLoopGateStatus::from(None),
+            AgentTaskLoopGateStatus::Missing
         );
     }
 }

--- a/src/core/agent_task_loop_controller/gate.rs
+++ b/src/core/agent_task_loop_controller/gate.rs
@@ -64,7 +64,7 @@ pub struct AgentTaskGateBundleResult {
     pub entity_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub run_id: Option<String>,
-    pub status: AgentTaskGateBundleStatus,
+    pub status: AgentTaskLoopGateStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub checks: Vec<AgentTaskGateCheckResult>,
     pub recorded_at: String,
@@ -72,16 +72,27 @@ pub struct AgentTaskGateBundleResult {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum AgentTaskGateBundleStatus {
-    Passed,
+pub enum AgentTaskLoopGateStatus {
+    /// A recorded gate result that satisfies the acceptance requirement.
+    ///
+    /// `passed`, `warn`, and `warning` were emitted by earlier controller
+    /// records. They retain their prior non-blocking behavior when read.
+    #[serde(alias = "passed", alias = "warn", alias = "warning")]
+    Satisfied,
+    /// The policy declared a gate, but no result has been recorded yet.
+    /// This is diagnostic-only and is never written into a gate result.
+    Missing,
     Failed,
-    Warn,
     /// The gate has a recorded result but cannot be considered acceptable yet:
     /// it requires an external result that has not arrived (for example a
     /// manual check awaiting a human/external signal). Pending gates block the
     /// loop rather than auto-passing as a non-blocking warning.
     Pending,
 }
+
+/// Backwards-compatible source alias for the old gate-result vocabulary.
+/// New policy, result, and diagnostic fields use `AgentTaskLoopGateStatus`.
+pub type AgentTaskGateBundleStatus = AgentTaskLoopGateStatus;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -112,7 +123,7 @@ pub struct AgentTaskLoopTerminalOutcome {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskGateCheckResult {
     pub check_id: String,
-    pub status: AgentTaskGateBundleStatus,
+    pub status: AgentTaskLoopGateStatus,
     #[serde(default)]
     pub retryable: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/core/agent_task_loop_controller/policy.rs
+++ b/src/core/agent_task_loop_controller/policy.rs
@@ -267,7 +267,6 @@ pub struct AgentTaskPrOwnershipStatusUpdate {
     pub ci_summary: Option<String>,
     pub review_decision: Option<String>,
     pub merge_state: Option<String>,
-    pub retry_count: u32,
     pub evidence: Vec<AgentTaskLoopArtifactRef>,
     pub missing_pr: bool,
 }
@@ -278,5 +277,66 @@ impl AgentTaskPrOwnershipStatusUpdate {
             ci_state: Some("tracking".to_string()),
             ..Self::default()
         }
+    }
+}
+
+impl AgentTaskPrOwnershipState {
+    /// Derive the durable state and retry count together so every PR-ownership
+    /// poll applies the same transition rule.
+    pub(crate) fn from_status_update(
+        status: &AgentTaskPrOwnershipStatusUpdate,
+        request: &AgentTaskPrOwnershipRequest,
+        previous_retry_count: u32,
+    ) -> (Self, u32) {
+        let retry_count = if status
+            .ci_state
+            .as_deref()
+            .is_some_and(|state| state == "terminal_failed" || state == "stale")
+            || status.review_decision.as_deref() == Some("CHANGES_REQUESTED")
+        {
+            previous_retry_count.saturating_add(1)
+        } else {
+            previous_retry_count
+        };
+
+        let state =
+            if status.missing_pr {
+                Self::MissingPr
+            } else if status
+                .merge_state
+                .as_deref()
+                .is_some_and(|state| state.eq_ignore_ascii_case("MERGED"))
+            {
+                Self::Merged
+            } else if status
+                .ci_state
+                .as_deref()
+                .is_some_and(|state| state == "terminal_failed" || state == "stale")
+                || status.review_decision.as_deref() == Some("CHANGES_REQUESTED")
+            {
+                if retry_count >= request.max_retries {
+                    Self::RetryLimitReached
+                } else {
+                    Self::ChangesRequested
+                }
+            } else if status.ci_state.as_deref().is_some_and(|state| {
+                state == "pending" || state == "no_checks" || state == "tracking"
+            }) {
+                Self::WaitingForChecks
+            } else if status
+                .ci_state
+                .as_deref()
+                .is_some_and(|state| state == "terminal_green")
+            {
+                if request.merge_required {
+                    Self::WaitingForMerge
+                } else {
+                    Self::GreenReady
+                }
+            } else {
+                Self::Tracking
+            };
+
+        (state, retry_count)
     }
 }

--- a/src/core/agent_task_loop_controller/record_impl.rs
+++ b/src/core/agent_task_loop_controller/record_impl.rs
@@ -455,7 +455,14 @@ impl AgentTaskLoopControllerRecord {
         entity_id: Option<String>,
         status: AgentTaskPrOwnershipStatusUpdate,
     ) -> AgentTaskPrOwnershipRecord {
-        let state = pr_ownership_state_from_status(&status, request);
+        let previous_retry_count = self
+            .pr_ownerships
+            .iter()
+            .find(|existing| existing.ownership_id == request.ownership_id)
+            .map(|existing| existing.retry_count)
+            .unwrap_or_default();
+        let (state, retry_count) =
+            AgentTaskPrOwnershipState::from_status_update(&status, request, previous_retry_count);
         let record = AgentTaskPrOwnershipRecord {
             ownership_id: request.ownership_id.clone(),
             entity_id: entity_id.clone(),
@@ -469,7 +476,7 @@ impl AgentTaskLoopControllerRecord {
             ci_summary: status.ci_summary.clone(),
             review_decision: status.review_decision.clone(),
             merge_state: status.merge_state.clone(),
-            retry_count: status.retry_count,
+            retry_count,
             max_retries: request.max_retries,
             merge_required: request.merge_required,
             last_checked_at: Some(now_timestamp()),
@@ -730,61 +737,4 @@ impl AgentTaskLoopControllerRecord {
             request,
         });
     }
-}
-
-pub(crate) fn pr_ownership_state_from_status(
-    status: &AgentTaskPrOwnershipStatusUpdate,
-    request: &AgentTaskPrOwnershipRequest,
-) -> AgentTaskPrOwnershipState {
-    if status.missing_pr {
-        return AgentTaskPrOwnershipState::MissingPr;
-    }
-    if status
-        .merge_state
-        .as_deref()
-        .is_some_and(|state| state.eq_ignore_ascii_case("MERGED"))
-    {
-        return AgentTaskPrOwnershipState::Merged;
-    }
-    if status
-        .ci_state
-        .as_deref()
-        .is_some_and(|state| state == "terminal_failed" || state == "stale")
-    {
-        return if status.retry_count >= request.max_retries {
-            AgentTaskPrOwnershipState::RetryLimitReached
-        } else {
-            AgentTaskPrOwnershipState::ChangesRequested
-        };
-    }
-    if status
-        .review_decision
-        .as_deref()
-        .is_some_and(|decision| decision == "CHANGES_REQUESTED")
-    {
-        return if status.retry_count >= request.max_retries {
-            AgentTaskPrOwnershipState::RetryLimitReached
-        } else {
-            AgentTaskPrOwnershipState::ChangesRequested
-        };
-    }
-    if status
-        .ci_state
-        .as_deref()
-        .is_some_and(|state| state == "pending" || state == "no_checks" || state == "tracking")
-    {
-        return AgentTaskPrOwnershipState::WaitingForChecks;
-    }
-    if status
-        .ci_state
-        .as_deref()
-        .is_some_and(|state| state == "terminal_green")
-    {
-        return if request.merge_required {
-            AgentTaskPrOwnershipState::WaitingForMerge
-        } else {
-            AgentTaskPrOwnershipState::GreenReady
-        };
-    }
-    AgentTaskPrOwnershipState::Tracking
 }

--- a/src/core/agent_task_loop_controller/service.rs
+++ b/src/core/agent_task_loop_controller/service.rs
@@ -46,15 +46,15 @@ where
         controller_next_commands(record, &controller_state, relevant_action.as_ref());
     let missing_acceptance_gate_count = acceptance_gates
         .iter()
-        .filter(|gate| gate.status == AgentTaskLoopAcceptanceGateStatus::Missing)
+        .filter(|gate| gate.status == AgentTaskLoopGateStatus::Missing)
         .count();
     let failed_acceptance_gate_count = acceptance_gates
         .iter()
-        .filter(|gate| gate.status == AgentTaskLoopAcceptanceGateStatus::Failed)
+        .filter(|gate| gate.status == AgentTaskLoopGateStatus::Failed)
         .count();
     let pending_acceptance_gate_count = acceptance_gates
         .iter()
-        .filter(|gate| gate.status == AgentTaskLoopAcceptanceGateStatus::Pending)
+        .filter(|gate| gate.status == AgentTaskLoopGateStatus::Pending)
         .count();
 
     for action in record
@@ -729,20 +729,18 @@ fn acceptance_gate_diagnostics(
                 .iter()
                 .rev()
                 .find(|result| result.bundle_id == bundle_id && result.entity_id == entity_id);
-            let status =
-                AgentTaskLoopAcceptanceGateStatus::from(result.map(|result| result.status));
+            let status = AgentTaskLoopGateStatus::from(result.map(|result| result.status));
             let problems = match status {
-                AgentTaskLoopAcceptanceGateStatus::Missing => {
+                AgentTaskLoopGateStatus::Missing => {
                     vec!["acceptance gate has no recorded result".to_string()]
                 }
-                AgentTaskLoopAcceptanceGateStatus::Failed => {
+                AgentTaskLoopGateStatus::Failed => {
                     vec!["acceptance gate recorded a failed result".to_string()]
                 }
-                AgentTaskLoopAcceptanceGateStatus::Pending => {
+                AgentTaskLoopGateStatus::Pending => {
                     vec!["acceptance gate is pending an external/manual result".to_string()]
                 }
-                AgentTaskLoopAcceptanceGateStatus::Satisfied
-                | AgentTaskLoopAcceptanceGateStatus::Warning => Vec::new(),
+                AgentTaskLoopGateStatus::Satisfied => Vec::new(),
             };
 
             AgentTaskLoopAcceptanceGateDiagnostic {

--- a/src/core/agent_task_loop_controller/tests.rs
+++ b/src/core/agent_task_loop_controller/tests.rs
@@ -815,7 +815,6 @@ fn pr_ownership_red_checks_increment_until_retry_limit() {
         AgentTaskPrOwnershipStatusUpdate {
             pr_number: Some(42),
             ci_state: Some("terminal_failed".to_string()),
-            retry_count: 1,
             ..AgentTaskPrOwnershipStatusUpdate::default()
         },
     );
@@ -825,7 +824,6 @@ fn pr_ownership_red_checks_increment_until_retry_limit() {
         AgentTaskPrOwnershipStatusUpdate {
             pr_number: Some(42),
             ci_state: Some("terminal_failed".to_string()),
-            retry_count: 2,
             ..AgentTaskPrOwnershipStatusUpdate::default()
         },
     );
@@ -834,6 +832,48 @@ fn pr_ownership_red_checks_increment_until_retry_limit() {
     assert_eq!(second.state, AgentTaskPrOwnershipState::RetryLimitReached);
     assert_eq!(record.pr_ownerships.len(), 1);
     assert_eq!(record.pr_ownerships[0].retry_count, 2);
+}
+
+#[test]
+fn persisted_gate_records_accept_legacy_status_vocabulary() {
+    let mut record = AgentTaskLoopControllerRecord::new("loop", "verify", "v1");
+    record.gate_results.push(AgentTaskGateBundleResult {
+        result_id: "gate-result-1".to_string(),
+        bundle_id: "quality".to_string(),
+        entity_id: None,
+        run_id: None,
+        status: AgentTaskLoopGateStatus::Satisfied,
+        checks: vec![AgentTaskGateCheckResult {
+            check_id: "check-1".to_string(),
+            status: AgentTaskLoopGateStatus::Satisfied,
+            retryable: false,
+            classification: None,
+            evidence: Vec::new(),
+            details: Value::Null,
+        }],
+        recorded_at: "2026-07-12T00:00:00Z".to_string(),
+    });
+    let mut persisted = serde_json::to_value(record).expect("record serializes");
+    persisted["gate_results"][0]["status"] = json!("passed");
+    persisted["gate_results"][0]["checks"][0]["status"] = json!("warn");
+
+    let loaded: AgentTaskLoopControllerRecord =
+        serde_json::from_value(persisted).expect("legacy record deserializes");
+
+    assert_eq!(
+        loaded.gate_results[0].status,
+        AgentTaskLoopGateStatus::Satisfied
+    );
+    assert_eq!(
+        loaded.gate_results[0].checks[0].status,
+        AgentTaskLoopGateStatus::Satisfied
+    );
+    let serialized = serde_json::to_value(loaded).expect("record reserializes");
+    assert_eq!(serialized["gate_results"][0]["status"], json!("satisfied"));
+    assert_eq!(
+        serialized["gate_results"][0]["checks"][0]["status"],
+        json!("satisfied")
+    );
 }
 
 #[test]

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -259,7 +259,7 @@ pub mod loop_controller {
         AgentTaskLoopControllerState, AgentTaskLoopControllerStatusReport,
         AgentTaskLoopDedupeRecord, AgentTaskLoopEntity, AgentTaskLoopExternalEvent,
         AgentTaskLoopFeedbackArtifact, AgentTaskLoopFeedbackStatus, AgentTaskLoopFindingPacket,
-        AgentTaskLoopHistoryEvent, AgentTaskLoopLocalFallbackPolicy,
+        AgentTaskLoopGateStatus, AgentTaskLoopHistoryEvent, AgentTaskLoopLocalFallbackPolicy,
         AgentTaskLoopPendingActionDiagnostic, AgentTaskLoopPolicy, AgentTaskLoopPolicyAction,
         AgentTaskLoopPolicyActionRecord, AgentTaskLoopProvenanceRef, AgentTaskLoopReviewFinding,
         AgentTaskLoopRunRef, AgentTaskLoopRunnerAvailability, AgentTaskLoopRunnerExecutionTarget,


### PR DESCRIPTION
## Summary
- Consolidate gate bundle results and acceptance diagnostics onto `AgentTaskLoopGateStatus`.
- Co-locate PR ownership retry accounting with durable state derivation.
- Route both durable dispatch entry points through one scheduler/lifecycle service path.

## Diffstat
`13 files changed, 212 insertions(+), 187 deletions(-)`

Part of #6761

## State mapping
| Previous vocabulary | Canonical representation |
| --- | --- |
| Gate bundle `passed` | `satisfied` |
| Gate bundle `failed` | `failed` |
| Gate bundle `warn` | `satisfied` |
| Gate bundle `pending` | `pending` |
| Acceptance gate `satisfied` | `satisfied` |
| Acceptance gate `missing` | `missing` |
| Acceptance gate `failed` | `failed` |
| Acceptance gate `warning` | `satisfied` |
| Acceptance gate `pending` | `pending` |
| PR ownership, controller, wait, terminal, and action states | unchanged; deferred as separate state machines |

## Persisted compatibility
Gate results, check results, controller records, and serialized diagnostic reports now use `AgentTaskLoopGateStatus`. Old persisted `passed`, `warn`, and `warning` strings deserialize through serde aliases and preserve their historical non-blocking behavior as `satisfied`; the new round-trip test covers a controller record with legacy result and check strings. New output converges only these strings: `passed` -> `satisfied`, `warn` -> `satisfied`, and `warning` -> `satisfied`. All other serialized controller vocabularies are unchanged.

The PR-ownership record format and its serialized state strings are unchanged. Retry count remains persisted on `AgentTaskPrOwnershipRecord`; computation moved from the controller service into the record-owned state transition.

The deferred action/controller/wait/PR-ownership/terminal enum family is documented on #6761 for the versioned policy/result/evidence work in #6677. Scheduler provider outcome classifications, including `stalled` and `rate_limited`, are unchanged.

## Verification
- `cargo build -j 3`
- `cargo test core::agent_task_loop_controller::tests -- --test-threads=1`
- `cargo test core::agent_task_controller_service::tests -- --test-threads=1`
- `cargo test core::agent_task_scheduler::tests -- --test-threads=1`
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (no new warnings; repository has 218 existing warnings)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Enum and scheduler-wrapper consolidation design and implementation, plus verification runs. Reviewed by Chris Huber.