### PR TITLE
fix(rig): declare static lint package policy

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -935,6 +935,23 @@ mod tests {
     }
 
     #[test]
+    fn rig_lint_manifest_declares_static_read_only_behavior() {
+        let manifest = current_command_safety_manifest();
+        let lint = manifest
+            .find_path(&["rig", "lint"])
+            .expect("rig lint must be present in the command safety manifest");
+
+        assert!(!lint.mutates);
+        assert!(!lint.operator);
+        assert!(lint.output.structured);
+        assert!(lint
+            .output
+            .notes
+            .contains("without evaluating the live environment"));
+        assert_eq!(lint.docs.path.as_deref(), Some("docs/commands/rig.md"));
+    }
+
+    #[test]
     fn documented_docs_surface_matches_manifest_and_parser() {
         let readme = std::fs::read_to_string(
             std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("README.md"),

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -511,6 +511,7 @@ const PROJECT_MUTATING_PATHS: &[&str] = &[
 ];
 const COMPONENT_MUTATING_PATHS: &[&str] = &["create", "set", "delete", "rename", "setup"];
 const COMPONENT_GUARDED_PATHS: &[&str] = &["reconcile", "artifacts"];
+const RIG_STATIC_LINT_PATHS: &[&str] = &["lint", "package lint"];
 
 const DEPS_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
     DEPS_MUTATING_PATHS,
@@ -584,6 +585,11 @@ const COMPONENT_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
         "default output is non-mutating; pass --apply to repair or remove artifacts",
     ),
 ];
+const RIG_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
+    RIG_STATIC_LINT_PATHS,
+    CommandSafetySpec::read_only(),
+    "reads rig package files and emits the standard JSON lint report without evaluating the live environment",
+)];
 
 pub const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec {
@@ -741,15 +747,18 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             ),
         )
     },
-    command_spec_with_representative_argv(
-        &["homeboy", "rig", "check", "example-rig"],
-        lab_command_spec_with_summary(
-            "rig",
-            CommandJsonFamily::Workspace,
-            "portable Lab offload is available for rig check workflows",
-            RIG_LAB_SUPPORT,
-        ),
-    ),
+    CommandSpec {
+        subcommand_safety: RIG_SUBCOMMAND_SAFETY,
+        ..command_spec_with_representative_argv(
+            &["homeboy", "rig", "check", "example-rig"],
+            lab_command_spec_with_summary(
+                "rig",
+                CommandJsonFamily::Workspace,
+                "portable Lab offload is available for rig check workflows",
+                RIG_LAB_SUPPORT,
+            ),
+        )
+    },
     command_spec("runner", CommandJsonFamily::Workspace),
     command_spec_with_representative_argv(
         &[

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -1357,6 +1357,56 @@ mod tests {
     }
 
     #[test]
+    fn lint_all_reports_static_package_violations_without_live_evaluation() {
+        let temp = tempfile::TempDir::new().expect("package");
+        let rig_dir = temp.path().join("rigs").join("static-only");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "static-only",
+                "requirements": { "executables": [{ "executable": "does-not-exist" }] },
+                "extends": "../../missing-template.json"
+            }"#,
+        )
+        .expect("write rig");
+        fs::write(temp.path().join("broken.json"), "{").expect("write invalid JSON");
+        fs::write(
+            temp.path().join("conflicted.txt"),
+            "<<<<<<< ours\nvalue\n=======\nother\n>>>>>>> theirs\n",
+        )
+        .expect("write conflict");
+
+        let (output, exit_code) = lint(
+            &temp.path().to_string_lossy(),
+            None,
+            true,
+            Some(RigLintFormat::Json),
+        )
+        .expect("rig lint returns a static failure report");
+
+        assert_eq!(exit_code, 1);
+        let json = serde_json::to_value(output).expect("serialize lint output");
+        let steps = json["payload"]["pipeline"]["steps"]
+            .as_array()
+            .expect("lint steps");
+        assert!(steps.iter().any(|step| {
+            step["label"] == "rig package has no unresolved conflict markers"
+                && step["status"] == "fail"
+        }));
+        assert!(steps.iter().any(|step| {
+            step["label"] == "rig package JSON specs parse" && step["status"] == "fail"
+        }));
+        assert!(steps.iter().any(|step| {
+            step["label"] == "rig package template specs materialize" && step["status"] == "fail"
+        }));
+        assert!(
+            steps.iter().all(|step| step["kind"] == "rig-package-lint"),
+            "lint-only must not resolve requirements or execute the check pipeline"
+        );
+    }
+
+    #[test]
     fn up_dry_run_runner_plan_emits_command_only_runner_exec_steps() {
         crate::test_support::with_isolated_home(|home| {
             runners::create(

--- a/src/core/rig/lint.rs
+++ b/src/core/rig/lint.rs
@@ -15,9 +15,13 @@ use crate::core::error::{Error, Result};
 
 /// Structural, dependency, and generated directories the generic rig package lint never descends into.
 const STRUCTURAL_IGNORED_DIRECTORIES: &[&str] = &[
+    ".claude",
+    ".datamachine",
     ".git",
     ".homeboy",
     ".next",
+    ".opencode",
+    ".sampleplugin",
     ".venv",
     "bower_components",
     "build",
@@ -946,6 +950,18 @@ mod tests {
 
         assert!(policy.ignored_directory(OsStr::new("vendor")));
         assert!(policy.ignored_directory(OsStr::new("node_modules")));
+    }
+
+    #[test]
+    fn lint_ignores_shared_rig_package_metadata_directories() {
+        let policy = IgnorePolicy::new(&[]);
+
+        for directory in [".claude", ".datamachine", ".opencode", ".sampleplugin"] {
+            assert!(
+                policy.ignored_directory(OsStr::new(directory)),
+                "{directory} should be ignored by the generic package walk"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Make the rig package linter ignore the unified metadata-directory set, including homeboy-rigs top-level `.datamachine`.
- Declare `rig lint` and `rig package lint` as static, read-only command-contract paths with structured JSON output and existing rig command documentation.
- Cover conflict markers, malformed JSON, failed template materialization, and a nonexistent executable in one lint-only regression; the report contains only `rig-package-lint` steps.

## Diffstat
```text
4 files changed, 101 insertions(+), 9 deletions(-)
```

Fixes #6825

## Surface Choice
`homeboy rig lint <target> [--all]` is the existing dedicated lint-only surface. It is preferable to an additional `rig check --lint-only` flag because it keeps live health evaluation and package-static validation as distinct operations, while `--all` walks a package/repository root once instead of starting a check for each rig.

## CI Usage
In homeboy-rigs CI, use:
```sh
homeboy rig lint . --all
```
This only reads package files; it does not resolve component checkouts, probe executables, or run live check-pipeline steps.

Converging `homeboy-rigs/scripts/lint-rig-packages.mjs` onto this surface remains #6783 follow-up work and is intentionally not included here.

## Verification
- `cargo build -j 3`
- Focused rig lint and command-manifest tests
- `cargo clippy --all-targets -j 3 2>&1 | tail -20` (no new warnings)
- `cargo run -j 3 -- rig lint --help`
- `cargo run -j 3 -- rig lint tests/fixtures/rig-package-subpath/packages/studio --all`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Lint-only surface design and implementation, plus verification runs. Reviewed by Chris Huber.