### PR TITLE
fix: package verified source for deploy refs

### DIFF
--- a/src/core/deploy/execution/preflight.rs
+++ b/src/core/deploy/execution/preflight.rs
@@ -116,7 +116,24 @@ pub(super) fn resolve_preflight_artifact_path(
             artifact_pattern,
             Some(Path::new(&component.local_path)),
         ) {
-            Ok(path) => path,
+            Ok(path) => {
+                if config.requested_ref.is_some()
+                    && !path.starts_with(Path::new(&component.local_path))
+                {
+                    return Err(failed_preflight_artifact_result(
+                        component,
+                        base_path,
+                        local_version,
+                        remote_version,
+                        build_exit_code,
+                        format!(
+                            "Exact-ref artifact '{}' is outside verified source tree '{}'; refusing to deploy unverified package bytes",
+                            path.display(), component.local_path
+                        ),
+                    ));
+                }
+                path
+            }
             Err(e) => {
                 let error_msg = if config.skip_build {
                     format!("{}. Release build may have failed.", e)

--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -123,6 +123,9 @@ pub(super) fn deploy_components(
         .iter()
         .map(|checkout| (checkout.component.id.clone(), checkout.identity.clone()))
         .collect();
+    for checkout in &exact_ref_checkouts {
+        checkout.verify()?;
+    }
     let components = if exact_ref_checkouts.is_empty() {
         components
     } else {
@@ -352,7 +355,13 @@ fn prepare_component_deployments(
     let mut failures = Vec::new();
 
     for component in components {
-        let component = crate::core::project::apply_component_overrides(component, project);
+        let source_path = component.local_path.clone();
+        let mut component = crate::core::project::apply_component_overrides(component, project);
+        if config.requested_ref.is_some() {
+            // Project overrides configure deployment behavior, but an exact-ref
+            // checkout is the authoritative source tree for every build stage.
+            component.local_path = source_path;
+        }
         let effective_config = config.clone();
 
         match prepare_component_deploy(
@@ -1209,6 +1218,72 @@ mod tests {
             "unexpected error: {:?}",
             failures[0].error
         );
+    }
+
+    #[test]
+    fn exact_ref_preflight_packages_verified_subpath_not_stale_checkout_artifact() {
+        let repo = TempDir::new().expect("repo");
+        let root = repo.path();
+        let component_path = root.join("packages/plugin");
+        std::fs::create_dir_all(&component_path).expect("component path");
+        run_git(root, &["init", "-q"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+
+        std::fs::write(component_path.join("target-marker.txt"), "target\n")
+            .expect("target marker");
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-q", "-m", "target"]);
+        run_git(root, &["branch", "target"]);
+
+        std::fs::remove_file(component_path.join("target-marker.txt")).expect("remove target");
+        std::fs::write(component_path.join("stale-marker.txt"), "stale\n")
+            .expect("stale marker");
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-q", "-m", "stale"]);
+
+        let stale_artifact = component_path.join("dist/plugin.zip");
+        std::fs::create_dir_all(stale_artifact.parent().expect("artifact parent"))
+            .expect("dist");
+        let stale_file = std::fs::File::create(&stale_artifact).expect("stale artifact");
+        let mut stale_zip = zip::ZipWriter::new(stale_file);
+        use std::io::Write;
+        stale_zip
+            .start_file("plugin/stale-marker.txt", zip::write::FileOptions::default())
+            .expect("stale entry");
+        stale_zip.write_all(b"stale\n").expect("stale bytes");
+        stale_zip.finish().expect("finish stale zip");
+
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: component_path.to_string_lossy().to_string(),
+            build_artifact: Some(stale_artifact.to_string_lossy().to_string()),
+            extract_command: Some("unzip -o {{artifact}}".to_string()),
+            ..Component::default()
+        };
+        let checkout = ExactRefCheckout::materialize(&component, "target")
+            .expect("materialize target ref");
+        checkout.verify().expect("verify target ref");
+        let mut config = base_deploy_config();
+        config.requested_ref = Some("target".to_string());
+        config.force = true;
+        let prepared = prepare_component_deployments(
+            &[checkout.component.clone()],
+            &config,
+            &Project::default(),
+            "/srv/site",
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .expect("prepare exact-ref artifact");
+
+        let file = std::fs::File::open(
+            prepared[0].artifact_path.as_ref().expect("artifact path"),
+        )
+        .expect("open artifact");
+        let mut archive = zip::ZipArchive::new(file).expect("read artifact");
+        assert!(archive.by_name("plugin/packages/plugin/target-marker.txt").is_ok());
+        assert!(archive.by_name("plugin/packages/plugin/stale-marker.txt").is_err());
     }
 
     fn deployed_result(id: &str) -> ComponentDeployResult {

--- a/src/core/deploy/orchestration_ref_checkout.rs
+++ b/src/core/deploy/orchestration_ref_checkout.rs
@@ -83,12 +83,37 @@ impl ExactRefCheckout {
 
         let mut materialized = component.clone();
         materialized.local_path = materialized_path.to_string_lossy().to_string();
+        materialized.build_artifact = component.build_artifact.as_deref().map(|artifact| {
+            rebase_source_path(artifact, Path::new(&component.local_path), &materialized_path)
+        });
         Ok(Self {
             component: materialized,
             identity,
             source_root,
             worktree_path,
         })
+    }
+
+    pub(super) fn verify(&self) -> Result<()> {
+        let actual_sha = git::run_git(
+            &self.worktree_path,
+            &["rev-parse", "--verify", "HEAD^{commit}"],
+            "verify exact deploy ref worktree",
+        )?
+        .trim()
+        .to_string();
+        if actual_sha != self.identity.resolved_sha {
+            return Err(Error::validation_invalid_argument(
+                "ref",
+                format!(
+                    "Materialized source verification failed for component '{}': expected commit '{}', found '{}'",
+                    self.component.id, self.identity.resolved_sha, actual_sha
+                ),
+                None,
+                None,
+            ));
+        }
+        Ok(())
     }
 
     fn cleanup(&mut self) {
@@ -100,6 +125,17 @@ impl ExactRefCheckout {
         );
         let _ = std::fs::remove_dir_all(&self.worktree_path);
     }
+}
+
+fn rebase_source_path(value: &str, original_root: &Path, materialized_root: &Path) -> String {
+    let path = Path::new(value);
+    if !path.is_absolute() {
+        return value.to_string();
+    }
+
+    path.strip_prefix(original_root)
+        .map(|relative| materialized_root.join(relative).to_string_lossy().to_string())
+        .unwrap_or_else(|_| value.to_string())
 }
 
 impl Drop for ExactRefCheckout {
@@ -275,6 +311,29 @@ mod tests {
             resolve_exact_ref(&component, "missing-ref").expect_err("missing ref should fail");
         assert!(err.message.contains("Cannot resolve --ref 'missing-ref'"));
         assert!(err.message.contains(&identity.source));
+    }
+
+    #[test]
+    fn materialized_ref_verification_rejects_a_different_checkout_head() {
+        let repo = fixture_repo();
+        let component = fixture_component(repo.path());
+        std::fs::write(repo.path().join("other.txt"), "other\n").expect("other payload");
+        git(repo.path(), &["add", "other.txt"]);
+        commit(repo.path(), "other commit");
+        let other_sha = git_output(repo.path(), &["rev-parse", "HEAD"]);
+        let checkout = ExactRefCheckout::materialize(&component, "accepted")
+            .expect("materialize accepted branch");
+        git(
+            Path::new(&checkout.component.local_path),
+            &["checkout", "--detach", &other_sha],
+        );
+
+        let error = checkout
+            .verify()
+            .expect_err("changed materialized HEAD must fail closed");
+        assert!(error
+            .message
+            .contains("Materialized source verification failed"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Materialize `deploy --ref` sources as verified detached worktrees and preserve that materialized path through project override application.
- Rebase absolute artifact paths to the materialized source tree, validate exact-ref artifacts stay within it, and complete all local artifact preflight before remote mutation.
- Add a nested-component fixture regression that verifies the package contains the target marker and excludes the stale-checkout marker.

Fixes #7841

## Verification
- Local Cargo formatting/tests were skipped at user request; CI is authoritative.
- `git diff --check` passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode; general coding subagent
- **Used for:** Deployment incident analysis, implementation, and regression coverage