### PR TITLE
Fix Lab hydration without dependency providers

### DIFF
--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -561,4 +561,35 @@ mod tests {
             );
         });
     }
+
+    #[test]
+    fn dependency_install_plan_skips_linked_extensions_without_deps_support() {
+        crate::test_support::with_isolated_home(|home| {
+            let project = tempfile::tempdir().expect("project tempdir");
+            let extension_id = "fixture-non-deps";
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions")
+                .join(extension_id);
+            std::fs::create_dir_all(&extension_dir).expect("extension dir");
+            std::fs::write(
+                extension_dir.join(format!("{extension_id}.json")),
+                r#"{"name":"Fixture non-deps","version":"1.0.0"}"#,
+            )
+            .expect("extension manifest");
+            std::fs::write(
+                project.path().join("homeboy.json"),
+                format!(
+                    r#"{{"id":"fixture","local_path":"{}","extensions":{{"{extension_id}":{{}}}}}}"#,
+                    project.path().display()
+                ),
+            )
+            .expect("component manifest");
+
+            let plan = dependency_install_plan(project.path())
+                .expect("unrelated linked extensions do not require dependency hydration");
+
+            assert!(plan.is_empty());
+        });
+    }
 }

--- a/src/core/deps_provider.rs
+++ b/src/core/deps_provider.rs
@@ -231,12 +231,12 @@ pub(crate) fn resolve_dependency_providers_optional(
         .map(|extensions| !extensions.is_empty())
         .unwrap_or(false)
     {
-        match extension::resolve_execution_context(component, ExtensionCapability::Deps) {
-            Ok(context) => providers.push(DependencyProvider::Extension(Box::new(
+        if let Some(context) =
+            extension::resolve_execution_context_if_available(component, ExtensionCapability::Deps)?
+        {
+            providers.push(DependencyProvider::Extension(Box::new(
                 ExtensionDependencyProvider { context },
-            ))),
-            Err(err) if providers.is_empty() => return Err(err),
-            Err(_) => {}
+            )));
         }
     }
 

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -279,15 +279,6 @@ fn explicit_capability_extension(
         .filter(|extension_id| !extension_id.is_empty())
 }
 
-fn linked_extensions(
-    component: &Component,
-) -> Result<&HashMap<String, crate::core::component::ScopedExtensionConfig>> {
-    component
-        .extensions
-        .as_ref()
-        .ok_or_else(|| no_extensions_error(component))
-}
-
 pub fn extract_component_extension_settings(
     component: &Component,
     extension_id: &str,
@@ -310,9 +301,29 @@ pub fn resolve_extension_for_capability(
     component: &Component,
     capability: ExtensionCapability,
 ) -> Result<String> {
-    let extensions = linked_extensions(component)?;
+    match resolve_extension_for_capability_if_available(component, capability)? {
+        Some(extension_id) => Ok(extension_id),
+        None if component
+            .extensions
+            .as_ref()
+            .is_none_or(|extensions| extensions.is_empty()) => Err(no_extensions_error(component)),
+        None => Err(capability_missing_error(component, capability)),
+    }
+}
+
+/// Resolve a capability only when one of the component's linked extensions
+/// advertises it. This lets optional consumers skip a capability that the
+/// component has not opted into without weakening validation of explicit or
+/// ambiguous capability ownership.
+fn resolve_extension_for_capability_if_available(
+    component: &Component,
+    capability: ExtensionCapability,
+) -> Result<Option<String>> {
+    let Some(extensions) = component.extensions.as_ref() else {
+        return Ok(None);
+    };
     if extensions.is_empty() {
-        return Err(no_extensions_error(component));
+        return Ok(None);
     }
 
     if let Some(extension_id) = explicit_capability_extension(component, capability) {
@@ -349,7 +360,7 @@ pub fn resolve_extension_for_capability(
             ));
         }
 
-        return Ok(extension_id.to_string());
+        return Ok(Some(extension_id.to_string()));
     }
 
     let mut matching = Vec::new();
@@ -362,8 +373,8 @@ pub fn resolve_extension_for_capability(
     }
 
     match matching.len() {
-        0 => Err(capability_missing_error(component, capability)),
-        1 => Ok(matching.remove(0)),
+        0 => Ok(None),
+        1 => Ok(Some(matching.remove(0))),
         _ => Err(capability_ambiguous_error(component, capability, &matching)),
     }
 }
@@ -373,6 +384,28 @@ pub fn resolve_execution_context(
     capability: ExtensionCapability,
 ) -> Result<ExtensionExecutionContext> {
     let extension_id = resolve_extension_for_capability(component, capability)?;
+    execution_context_for_extension(component, capability, extension_id)
+}
+
+/// Resolve an execution context when a linked extension provides `capability`.
+/// A missing optional capability is represented as `Ok(None)`; malformed
+/// explicit ownership and ambiguous providers remain validation errors.
+pub(crate) fn resolve_execution_context_if_available(
+    component: &Component,
+    capability: ExtensionCapability,
+) -> Result<Option<ExtensionExecutionContext>> {
+    let Some(extension_id) = resolve_extension_for_capability_if_available(component, capability)?
+    else {
+        return Ok(None);
+    };
+    execution_context_for_extension(component, capability, extension_id).map(Some)
+}
+
+fn execution_context_for_extension(
+    component: &Component,
+    capability: ExtensionCapability,
+    extension_id: String,
+) -> Result<ExtensionExecutionContext> {
     let manifest = load_extension(&extension_id)?;
     let script_path = capability
         .script_path(&manifest)


### PR DESCRIPTION
Fixes #7843.

## Evidence
- Source relationship: branch started at current `origin/main` commit `252ec424d40fac848c1efcaca282f9a0c5453e1e`; this PR adds one commit on top.
- Change kind: generic optional-capability resolution. Lab hydration now receives an empty dependency plan when linked extensions do not provide `deps`; explicit invalid ownership and ambiguous provider validation remain errors.
- Regression coverage: `dependency_install_plan_skips_linked_extensions_without_deps_support` builds a portable component with a linked extension that lacks `deps` and asserts an empty plan.
- Verification capability: `git diff --check` passed. Local Cargo formatting, tests, clippy, and all other Cargo commands were skipped at user request; CI is authoritative.
- Scope: no runner RSS guard, lifecycle policy, or global safety gate changed. The runtime behavior is limited to the source-proven optional-provider case: no applicable `deps` capability produces no hydration step.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode; general coding subagent
- **Used for:** Runner failure analysis, implementation, and regression coverage.