### PR TITLE
Fix Lab dependency hydration without deps extensions

### DIFF
--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -288,7 +288,9 @@ pub enum DependencyInstallInvocation {
 ///
 /// Reuses [`provider::resolve_dependency_providers_optional`] (the detection
 /// behind `homeboy deps install`) so a manifest detected by an existing provider
-/// surfaces its install command here.
+/// surfaces its install command here. A linked extension set that does not
+/// provide dependency support is equivalent to no provider for this optional
+/// planning surface; invalid explicit capability ownership still fails.
 /// Providers whose install cannot be expressed as a standalone shell command
 /// (component-script/extension providers) are omitted. Returns an empty vector
 /// when no provider detects the workspace.
@@ -300,7 +302,20 @@ pub enum DependencyInstallInvocation {
 pub fn dependency_install_plan(path: &Path) -> Result<Vec<DependencyInstallPlanStep>> {
     let (component, resolved_path) =
         resolve_component_path(None, Some(&path.display().to_string()))?;
-    let providers = provider::resolve_dependency_providers_optional(&component, &resolved_path)?;
+    let providers =
+        match provider::resolve_dependency_providers_optional(&component, &resolved_path) {
+            Ok(providers) => providers,
+            Err(error) => {
+                if !extension::has_linked_extension_for_capability(
+                    &component,
+                    crate::core::extension::ExtensionCapability::Deps,
+                )? {
+                    Vec::new()
+                } else {
+                    return Err(error);
+                }
+            }
+        };
     let mut steps = Vec::new();
     for provider in providers {
         let status = provider.status(&component, &resolved_path, None)?;

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -368,6 +368,33 @@ pub fn resolve_extension_for_capability(
     }
 }
 
+/// Whether a linked extension can provide a capability without requiring one.
+///
+/// Callers that can safely skip an optional capability use this to distinguish
+/// an absent provider from invalid explicit capability ownership.
+pub(crate) fn has_linked_extension_for_capability(
+    component: &Component,
+    capability: ExtensionCapability,
+) -> Result<bool> {
+    let Some(extensions) = component.extensions.as_ref() else {
+        return Ok(false);
+    };
+    if extensions.is_empty() {
+        return Ok(false);
+    }
+    if explicit_capability_extension(component, capability).is_some() {
+        resolve_extension_for_capability(component, capability)?;
+        return Ok(true);
+    }
+
+    for extension_id in extensions.keys() {
+        if capability.has_manifest_support(&load_extension(extension_id)?) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 pub fn resolve_execution_context(
     component: &Component,
     capability: ExtensionCapability,

--- a/src/core/runner/lab/offload/hydration.rs
+++ b/src/core/runner/lab/offload/hydration.rs
@@ -412,6 +412,37 @@ mod tests {
         assert_eq!(output.schema, HYDRATION_SCHEMA);
     }
 
+    #[test]
+    fn hydration_skips_when_linked_extensions_do_not_provide_dependencies() {
+        crate::test_support::with_isolated_home(|home| {
+            let extension_dir = home.path().join(".config/homeboy/extensions/fixture");
+            std::fs::create_dir_all(&extension_dir).expect("extension directory");
+            std::fs::write(
+                extension_dir.join("fixture.json"),
+                r#"{"name":"Fixture","version":"1.0.0","test":{"extension_script":"test.sh"}}"#,
+            )
+            .expect("extension manifest");
+
+            let project = tempfile::tempdir().expect("project tempdir");
+            std::fs::write(
+                project.path().join("homeboy.json"),
+                r#"{"id":"fixture","extensions":{"fixture":{}}}"#,
+            )
+            .expect("component config");
+            let remote = tempfile::tempdir().expect("remote workspace");
+
+            let output = hydrate_lab_workspace_dependencies(
+                "unused-runner",
+                &project.path().display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect("no applicable dependency provider skips hydration");
+
+            assert_eq!(output.status, "skipped_no_provider");
+            assert!(output.steps.is_empty());
+        });
+    }
+
     /// The event-emission shape a hydration step records: provider id, command,
     /// duration, exit status, plus the runner job id and event count from the
     /// underlying `exec` job stream.


### PR DESCRIPTION
## Summary
- Treat the absence of a linked extension that provides the optional `deps` capability as an empty Lab dependency hydration plan.
- Keep declared manifest, adapter, script, and valid extension dependency providers unchanged.
- Preserve invalid explicit capability ownership and extension-load failures as errors.

## Evidence
- **Source relationship:** Rebased `fix/7843-agent-task-native-deps` onto fetched `origin/main` at `252ec424d40fac848c1efcaca282f9a0c5453e1e` before implementation.
- **Change kind:** Generic dependency-provider selection for optional Lab workspace hydration; no ecosystem or framework behavior was added.
- **Verification capability:** `git diff --check` passed. Local Cargo tests, formatting, clippy, and all Cargo commands were skipped at user request; CI is authoritative.
- **Bounded runtime change:** The issue failure is produced when optional dependency planning reaches extension capability resolution after no manifest, adapter, or script provider applies. The new predicate only turns a linked extension set with no `deps` capability into the established empty-plan path. Explicit invalid capability ownership and extension-loading errors remain failures; runner RSS guards and safety limits are untouched.

## Tests
- Added Lab hydration regression coverage for a component whose linked extension provides `test`, but not `deps`; it asserts `skipped_no_provider` without attempting runner execution.
- Not run locally at user request. CI is authoritative.

Closes #7843

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode; general coding subagent
- **Used for:** Runner failure analysis, implementation, and regression coverage.