### PR TITLE
fix(lab): preserve daemon job identity across handoff

### DIFF
--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -297,8 +297,29 @@ pub(super) fn preflight_runner_capability_plan(
 pub(super) fn fetch_daemon_job(client: &Client, local_url: &str, job_id: &str) -> Result<Job> {
     let data = daemon_get(client, local_url, &format!("/jobs/{job_id}"))?;
     let body = canonical_daemon_body(&data, "daemon job response")?;
-    serde_json::from_value(body["job"].clone())
-        .map_err(|err| Error::internal_json(err.to_string(), Some("parse daemon job".to_string())))
+    let job: Job = serde_json::from_value(body["job"].clone()).map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse daemon job".to_string()))
+    })?;
+    validate_daemon_job_identity(job_id, &job)?;
+    Ok(job)
+}
+
+pub(super) fn validate_daemon_job_identity(requested_job_id: &str, job: &Job) -> Result<()> {
+    let returned_job_id = job.id.to_string();
+    if returned_job_id == requested_job_id {
+        return Ok(());
+    }
+
+    Err(Error::new(
+        ErrorCode::InternalUnexpected,
+        format!(
+            "runner daemon returned job `{returned_job_id}` while polling requested job `{requested_job_id}`"
+        ),
+        json!({
+            "requested_job_id": requested_job_id,
+            "returned_job_id": returned_job_id,
+        }),
+    ))
 }
 
 pub(super) fn detached_handoff_output(

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -1082,6 +1082,42 @@ fn daemon_polling_error_for_known_job_is_recoverable_runner_disconnect() {
 }
 
 #[test]
+fn daemon_polling_rejects_a_response_for_a_different_job() {
+    let requested_job_id = uuid::Uuid::new_v4();
+    let returned_job_id = uuid::Uuid::new_v4();
+    let job = Job {
+        id: returned_job_id,
+        operation: "runner.exec".to_string(),
+        status: JobStatus::Running,
+        created_at_ms: 0,
+        updated_at_ms: 0,
+        started_at_ms: None,
+        finished_at_ms: None,
+        event_count: 0,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        stale_reason: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+    };
+
+    let err =
+        super::super::daemon::validate_daemon_job_identity(&requested_job_id.to_string(), &job)
+            .expect_err("mismatched daemon response must not replace the tracked job");
+
+    assert_eq!(
+        err.details["requested_job_id"],
+        requested_job_id.to_string()
+    );
+    assert_eq!(err.details["returned_job_id"], returned_job_id.to_string());
+}
+
+#[test]
 fn daemon_exec_request_failed_error_handles_null_payload_with_reconnect_hint() {
     // The historical #3631/#3624 symptom: a stale/restarting daemon answers
     // with an empty/null error payload. We must never surface a bare `null`,

--- a/src/core/runner/lab/offload/errors.rs
+++ b/src/core/runner/lab/offload/errors.rs
@@ -178,14 +178,26 @@ pub(crate) fn in_flight_daemon_disconnect_error(
     disconnected
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn in_flight_daemon_disconnect_outcome(
     plan: HomeboyPlan,
     runner_id: &str,
     job_id: &str,
     run_id: &str,
+    remote_workspace: &str,
+    remote_command: &[String],
     reason: &str,
     err: &Error,
-) -> LabOffloadOutcome {
+) -> Result<LabOffloadOutcome> {
+    // The daemon job remains durable when the controller disconnects, so retain
+    // the typed lifecycle record needed to inspect and recover this run locally.
+    agent_task_lifecycle::record_detached_lab_run(agent_task_lifecycle::DetachedLabRunRecord {
+        run_id,
+        runner_id,
+        runner_job_id: job_id,
+        remote_workspace,
+        remote_command,
+    })?;
     let plan = with_step(
         plan,
         PlanStep::builder("lab.exec.detached", "lab.exec.detached", PlanStepStatus::PartialSuccess)
@@ -230,13 +242,13 @@ pub(crate) fn in_flight_daemon_disconnect_outcome(
         "Runner job: homeboy runner job logs {runner_id} {job_id} --follow\n"
     ));
 
-    LabOffloadOutcome::Offloaded {
+    Ok(LabOffloadOutcome::Offloaded {
         plan,
         stdout: format!("{stdout}\n"),
         stderr,
         exit_code: 0,
         output_file_content: None,
-    }
+    })
 }
 
 pub(crate) fn automatic_capability_fallback(

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -372,14 +372,16 @@ pub(crate) fn exec_lab_context(
                 );
                 if let Some(job_id) = health.job_id.as_deref() {
                     if let Some(run_id) = context.agent_task_run_id.as_deref() {
-                        return Ok(in_flight_daemon_disconnect_outcome(
+                        return in_flight_daemon_disconnect_outcome(
                             context.plan,
                             runner_id,
                             job_id,
                             run_id,
+                            &remote_cwd,
+                            &context.remote_command,
                             &reason,
                             &err,
-                        ));
+                        );
                     }
                     return Err(in_flight_daemon_disconnect_error(
                         runner_id, job_id, None, &reason, &err,

--- a/src/core/runner/lab/offload/tests/workspace_sync.rs
+++ b/src/core/runner/lab/offload/tests/workspace_sync.rs
@@ -393,51 +393,66 @@ fn in_flight_daemon_disconnect_error_surfaces_inspection_commands() {
 
 #[test]
 fn in_flight_daemon_disconnect_outcome_marks_durable_run_detached() {
-    let source = Error::new(
-        ErrorCode::InternalUnexpected,
-        "query runner daemon: error sending request for url (http://127.0.0.1:63203/jobs/job-123)",
-        serde_json::json!({
-            "runner_id": "homeboy-lab",
-            "job_id": "job-123",
-        }),
-    );
+    crate::test_support::with_isolated_home(|_| {
+        let source = Error::new(
+            ErrorCode::InternalUnexpected,
+            "query runner daemon: error sending request for url (http://127.0.0.1:63203/jobs/job-123)",
+            serde_json::json!({
+                "runner_id": "homeboy-lab",
+                "job_id": "job-123",
+            }),
+        );
+        let remote_command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        let outcome = in_flight_daemon_disconnect_outcome(
+            base_lab_plan(Some(&portable_lab_command("agent-task cook"))),
+            "homeboy-lab",
+            "job-123",
+            "run-123",
+            "/runner/workspace/homeboy",
+            &remote_command,
+            "runner daemon health check failed",
+            &source,
+        )
+        .expect("detached lifecycle record");
 
-    let outcome = in_flight_daemon_disconnect_outcome(
-        base_lab_plan(Some(&portable_lab_command("agent-task cook"))),
-        "homeboy-lab",
-        "job-123",
-        "run-123",
-        "runner daemon health check failed",
-        &source,
-    );
+        let LabOffloadOutcome::Offloaded {
+            plan,
+            stdout,
+            stderr,
+            exit_code,
+            output_file_content,
+        } = outcome
+        else {
+            panic!("expected detached offloaded outcome");
+        };
 
-    let LabOffloadOutcome::Offloaded {
-        plan,
-        stdout,
-        stderr,
-        exit_code,
-        output_file_content,
-    } = outcome
-    else {
-        panic!("expected detached offloaded outcome");
-    };
-
-    assert_eq!(exit_code, 0);
-    assert!(output_file_content.is_none());
-    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json stdout");
-    assert_eq!(json["success"], serde_json::json!(true));
-    assert_eq!(json["data"]["status"], "dispatched_detached");
-    assert_eq!(json["data"]["followup_required"], true);
-    assert_eq!(json["data"]["durable_run_id"], "run-123");
-    assert_eq!(json["data"]["runner_id"], "homeboy-lab");
-    assert_eq!(json["data"]["job_id"], "job-123");
-    assert_eq!(
-        json["data"]["retrieval_commands"]["status"],
-        "homeboy agent-task status run-123"
-    );
-    assert!(stderr.contains("durable agent-task run `run-123` continues remotely"));
-    assert!(stderr.contains("homeboy agent-task logs run-123"));
-    assert!(plan.steps.iter().any(
-        |step| step.id == "lab.exec.detached" && step.status == PlanStepStatus::PartialSuccess
-    ));
+        assert_eq!(exit_code, 0);
+        assert!(output_file_content.is_none());
+        let json: serde_json::Value = serde_json::from_str(&stdout).expect("json stdout");
+        assert_eq!(json["success"], serde_json::json!(true));
+        assert_eq!(json["data"]["status"], "dispatched_detached");
+        assert_eq!(json["data"]["followup_required"], true);
+        assert_eq!(json["data"]["durable_run_id"], "run-123");
+        assert_eq!(json["data"]["runner_id"], "homeboy-lab");
+        assert_eq!(json["data"]["job_id"], "job-123");
+        assert_eq!(
+            json["data"]["retrieval_commands"]["status"],
+            "homeboy agent-task status run-123"
+        );
+        assert!(stderr.contains("durable agent-task run `run-123` continues remotely"));
+        assert!(stderr.contains("homeboy agent-task logs run-123"));
+        assert!(plan
+            .steps
+            .iter()
+            .any(|step| step.id == "lab.exec.detached"
+                && step.status == PlanStepStatus::PartialSuccess));
+        let record = crate::core::agent_task_lifecycle::status("run-123")
+            .expect("inspectable agent-task record");
+        assert_eq!(record.metadata["runner_id"], "homeboy-lab");
+        assert_eq!(record.metadata["runner_job_id"], "job-123");
+    });
 }


### PR DESCRIPTION
## Summary
- reject daemon poll responses whose job ID differs from the dispatched job
- write the typed agent-task lifecycle record before returning a controller-disconnect recovery outcome
- cover identity mismatch and inspectable disconnect recovery

Closes #7848

## Validation
- `cargo fmt --check`
- targeted daemon identity and controller-disconnect tests
- `cargo clippy --all-targets`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode, openai/gpt-5.6-terra
- **Used for:** Investigated the handoff/lifecycle paths, implemented the focused fix, and added regression coverage.

Chris remains responsible for every line.