### PR TITLE
test(lab): cover Lab dependency hydration skip without deps providers

### DIFF
--- a/src/core/runner/lab/offload/hydration.rs
+++ b/src/core/runner/lab/offload/hydration.rs
@@ -412,6 +412,49 @@ mod tests {
         assert_eq!(output.schema, HYDRATION_SCHEMA);
     }
 
+    /// End-to-end hydration skips when the component links an extension that
+    /// does not provide the optional `deps` capability (e.g. a native toolchain
+    /// such as cargo that resolves dependencies itself during build/test).
+    /// Regression for the no-deps-provider skip path: a missing optional `deps`
+    /// provider must soft-skip instead of failing the cook (#7843, #7832).
+    #[test]
+    fn hydration_skips_when_linked_extensions_do_not_provide_dependencies() {
+        crate::test_support::with_isolated_home(|home| {
+            let project = tempfile::tempdir().expect("project tempdir");
+            let extension_id = "fixture-non-deps";
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions")
+                .join(extension_id);
+            std::fs::create_dir_all(&extension_dir).expect("extension dir");
+            std::fs::write(
+                extension_dir.join(format!("{extension_id}.json")),
+                r#"{"name":"Fixture non-deps","version":"1.0.0"}"#,
+            )
+            .expect("extension manifest");
+            std::fs::write(
+                project.path().join("homeboy.json"),
+                format!(
+                    r#"{{"id":"fixture","local_path":"{}","extensions":{{"{extension_id}":{{}}}}}}"#,
+                    project.path().display()
+                ),
+            )
+            .expect("component manifest");
+            let remote = tempfile::tempdir().expect("remote workspace");
+
+            let output = hydrate_lab_workspace_dependencies(
+                "unused-runner",
+                &project.path().display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect("no applicable dependency provider skips hydration");
+
+            assert_eq!(output.status, "skipped_no_provider");
+            assert!(output.steps.is_empty());
+            assert_eq!(output.workspace, remote.path().display().to_string());
+        });
+    }
+
     /// The event-emission shape a hydration step records: provider id, command,
     /// duration, exit status, plus the runner job id and event count from the
     /// underlying `exec` job stream.


### PR DESCRIPTION
## Summary

Adds the missing end-to-end regression coverage for the Lab dependency-hydration skip path. **No runtime change.**

## Context (task premise was stale — please read)

Investigation of #7843 against current `origin/main` (`13e8eaf42`) shows the runtime failure is already fixed upstream:

- **#7843 is CLOSED**, fixed by merged **#7852** (`c43f3cf5a`). #7852 changed `resolve_dependency_providers_optional` to use `resolve_execution_context_if_available`, so a component whose linked extensions lack `deps` yields an empty provider list → empty `dependency_install_plan` → `hydrate_lab_workspace_dependencies` returns `skipped_no_provider`. The reported error (`Component 'homeboy' has no linked extensions that provide deps support`) can no longer occur in the Lab hydration path.
- **#7832** (open, same root cause/error) is resolved by the same #7852 runtime fix.
- **PR #7854** (`fix/7843-agent-task-native-deps`) is open and redundant: its runtime change (try/catch in `dependency_install_plan` + `has_linked_extension_for_capability`) duplicates #7852 and is **broader** than the source evidence — it swallows *any* `resolve_dependency_providers_optional` error when a non-deps extension is linked, which could mask unrelated provider/manifest/adapter failures. Recommend closing #7854 in favor of #7852's targeted fix.

## Change

- New test `hydration_skips_when_linked_extensions_do_not_provide_dependencies` in `src/core/runner/lab/offload/hydration.rs`.
- Builds a portable component that links an extension with no `deps` capability (mirroring a native toolchain such as cargo, which resolves dependencies itself during build/test), calls `hydrate_lab_workspace_dependencies` end-to-end, and asserts `status == "skipped_no_provider"` with no steps and no runner execution.
- #7852 already covered this at the `dependency_install_plan` unit layer; this test proves the behavior at the hydration layer the issue actually reports.

## Evidence

- **Source relationship:** branch created from fetched `origin/main` at `13e8eaf42`; one commit on top, test-only.
- **Change kind:** regression test only; no production/runtime code touched.
- **Verification capability:** `git diff --check` passed. Local Cargo formatting, tests, clippy, and all other Cargo commands were skipped at user request; CI is authoritative.
- **Scope:** no runner RSS guard, lifecycle policy, safety limit, or provider-selection runtime behavior changed. The runtime change is intentionally absent (not broader than the source evidence) because #7852 already landed it.

Refs #7843, #7832.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode; general coding subagent
- **Used for:** Runner failure analysis, implementation, and regression coverage.
