### PR TITLE
refactor: centralize ops command registrations

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -18,6 +18,7 @@
 //!   variants to discriminators and golden fixtures.
 
 mod constants;
+mod descriptors;
 mod lab;
 mod output;
 mod public_variants;

--- a/src/command_contract/descriptors.rs
+++ b/src/command_contract/descriptors.rs
@@ -1,0 +1,44 @@
+//! Declarative registrations for command families migrated off parallel fan-out lists.
+
+/// Expands the Ops command descriptors into a consumer macro.
+///
+/// Each row owns the command module, parsed Clap variant, contract metadata, and
+/// JSON handler binding. Consumers select the fields they need while preserving
+/// command-owned dynamic output and Lab predicates.
+#[macro_export]
+macro_rules! ops_command_descriptors {
+    ($consumer:ident) => {
+        $consumer! {
+            (ssh, Ssh, crate::commands::ssh::SshArgs, command_spec("ssh", CommandJsonFamily::Ops), crate::commands::ssh::run),
+            (server, Server, crate::commands::server::ServerArgs, CommandSpec { subcommand_safety: SERVER_SUBCOMMAND_SAFETY, ..command_spec("server", CommandJsonFamily::Ops) }, crate::commands::server::run),
+            (db, Db, crate::commands::db::DbArgs, command_spec("db", CommandJsonFamily::Ops), crate::commands::db::run),
+            (file, File, crate::commands::file::FileArgs, CommandSpec { subcommand_safety: FILE_SUBCOMMAND_SAFETY, ..command_spec("file", CommandJsonFamily::Ops) }, crate::commands::file::run),
+            (logs, Logs, crate::commands::logs::LogsArgs, command_spec("logs", CommandJsonFamily::Ops), crate::commands::logs::run),
+            (triage, Triage, crate::commands::triage::TriageArgs, command_spec_with_safety("triage", CommandJsonFamily::Ops, operator_safety(None, TRIAGE_DANGEROUS_FLAGS)), crate::commands::triage::run),
+            (deploy, Deploy, crate::commands::deploy::DeployArgs, command_spec_with_safety("deploy", CommandJsonFamily::Ops, operator_safety(Some("--dry-run"), DEPLOY_DANGEROUS_FLAGS)), crate::commands::deploy::run),
+            (daemon, Daemon, crate::commands::daemon::DaemonArgs, command_spec("daemon", CommandJsonFamily::Ops), crate::commands::daemon::run),
+            (status, Status, crate::commands::status::StatusArgs, command_spec("status", CommandJsonFamily::Ops), crate::commands::status::run),
+            (git, Git, crate::commands::git::GitArgs, command_spec("git", CommandJsonFamily::Ops), crate::commands::git::run),
+            (self_cmd, SelfCmd, crate::commands::self_cmd::SelfArgs, command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation"), crate::commands::self_cmd::run),
+            (api, Api, crate::commands::api::ApiArgs, CommandSpec { subcommand_safety: API_SUBCOMMAND_SAFETY, ..command_spec("api", CommandJsonFamily::Ops) }, crate::commands::api::run),
+            (upgrade, Upgrade, crate::commands::upgrade::UpgradeArgs, command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS)), crate::commands::upgrade::run),
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! ops_command_descriptor {
+    (ssh, $consumer:ident) => { $consumer!((ssh, Ssh, crate::commands::ssh::SshArgs, command_spec("ssh", CommandJsonFamily::Ops), crate::commands::ssh::run)) };
+    (server, $consumer:ident) => { $consumer!((server, Server, crate::commands::server::ServerArgs, CommandSpec { subcommand_safety: SERVER_SUBCOMMAND_SAFETY, ..command_spec("server", CommandJsonFamily::Ops) }, crate::commands::server::run)) };
+    (db, $consumer:ident) => { $consumer!((db, Db, crate::commands::db::DbArgs, command_spec("db", CommandJsonFamily::Ops), crate::commands::db::run)) };
+    (file, $consumer:ident) => { $consumer!((file, File, crate::commands::file::FileArgs, CommandSpec { subcommand_safety: FILE_SUBCOMMAND_SAFETY, ..command_spec("file", CommandJsonFamily::Ops) }, crate::commands::file::run)) };
+    (logs, $consumer:ident) => { $consumer!((logs, Logs, crate::commands::logs::LogsArgs, command_spec("logs", CommandJsonFamily::Ops), crate::commands::logs::run)) };
+    (triage, $consumer:ident) => { $consumer!((triage, Triage, crate::commands::triage::TriageArgs, command_spec_with_safety("triage", CommandJsonFamily::Ops, operator_safety(None, TRIAGE_DANGEROUS_FLAGS)), crate::commands::triage::run)) };
+    (deploy, $consumer:ident) => { $consumer!((deploy, Deploy, crate::commands::deploy::DeployArgs, command_spec_with_safety("deploy", CommandJsonFamily::Ops, operator_safety(Some("--dry-run"), DEPLOY_DANGEROUS_FLAGS)), crate::commands::deploy::run)) };
+    (daemon, $consumer:ident) => { $consumer!((daemon, Daemon, crate::commands::daemon::DaemonArgs, command_spec("daemon", CommandJsonFamily::Ops), crate::commands::daemon::run)) };
+    (status, $consumer:ident) => { $consumer!((status, Status, crate::commands::status::StatusArgs, command_spec("status", CommandJsonFamily::Ops), crate::commands::status::run)) };
+    (git, $consumer:ident) => { $consumer!((git, Git, crate::commands::git::GitArgs, command_spec("git", CommandJsonFamily::Ops), crate::commands::git::run)) };
+    (self_cmd, $consumer:ident) => { $consumer!((self_cmd, SelfCmd, crate::commands::self_cmd::SelfArgs, command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation"), crate::commands::self_cmd::run)) };
+    (api, $consumer:ident) => { $consumer!((api, Api, crate::commands::api::ApiArgs, CommandSpec { subcommand_safety: API_SUBCOMMAND_SAFETY, ..command_spec("api", CommandJsonFamily::Ops) }, crate::commands::api::run)) };
+    (upgrade, $consumer:ident) => { $consumer!((upgrade, Upgrade, crate::commands::upgrade::UpgradeArgs, command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS)), crate::commands::upgrade::run)) };
+}

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -585,6 +585,12 @@ const COMPONENT_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
     ),
 ];
 
+macro_rules! registered_ops_spec {
+    (($module:ident, $variant:ident, $args:path, $spec:expr, $handler:path)) => {
+        $spec
+    };
+}
+
 pub const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec {
         output_notes: "unified active/recent activity read model in the standard JSON envelope",
@@ -605,11 +611,8 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         subcommand_safety: PROJECT_SUBCOMMAND_SAFETY,
         ..command_spec("project", CommandJsonFamily::Workspace)
     },
-    command_spec("ssh", CommandJsonFamily::Ops),
-    CommandSpec {
-        subcommand_safety: SERVER_SUBCOMMAND_SAFETY,
-        ..command_spec("server", CommandJsonFamily::Ops)
-    },
+    crate::ops_command_descriptor!(ssh, registered_ops_spec),
+    crate::ops_command_descriptor!(server, registered_ops_spec),
     command_spec_with_representative_argv(
         &["homeboy", "bench"],
         lab_command_spec_with_summary(
@@ -645,30 +648,19 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         )
     },
     command_spec("observe", CommandJsonFamily::Quality),
-    command_spec("db", CommandJsonFamily::Ops),
+    crate::ops_command_descriptor!(db, registered_ops_spec),
     CommandSpec {
         subcommand_safety: DEPS_SUBCOMMAND_SAFETY,
         ..command_spec("deps", CommandJsonFamily::Ops)
     },
-    CommandSpec {
-        subcommand_safety: FILE_SUBCOMMAND_SAFETY,
-        ..command_spec("file", CommandJsonFamily::Ops)
-    },
+    crate::ops_command_descriptor!(file, registered_ops_spec),
     CommandSpec {
         subcommand_safety: FLEET_SUBCOMMAND_SAFETY,
         ..command_spec("fleet", CommandJsonFamily::Ops)
     },
-    command_spec("logs", CommandJsonFamily::Ops),
-    command_spec_with_safety(
-        "triage",
-        CommandJsonFamily::Ops,
-        operator_safety(None, TRIAGE_DANGEROUS_FLAGS),
-    ),
-    command_spec_with_safety(
-        "deploy",
-        CommandJsonFamily::Ops,
-        operator_safety(Some("--dry-run"), DEPLOY_DANGEROUS_FLAGS),
-    ),
+    crate::ops_command_descriptor!(logs, registered_ops_spec),
+    crate::ops_command_descriptor!(triage, registered_ops_spec),
+    crate::ops_command_descriptor!(deploy, registered_ops_spec),
     CommandSpec {
         subcommand_safety: COMPONENT_SUBCOMMAND_SAFETY,
         ..command_spec("component", CommandJsonFamily::Workspace)
@@ -682,7 +674,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         CommandJsonFamily::Workspace,
         "lists, shows, exports constants, exports schemas, validates, normalizes, and emits Homeboy-owned contract metadata and command manifests through the central contract surface",
     ),
-    command_spec("daemon", CommandJsonFamily::Ops),
+    crate::ops_command_descriptor!(daemon, registered_ops_spec),
     command_spec_with_representative_argv(
         &["homeboy", "extension", "refresh", "."],
         lab_command_spec_with_summary(
@@ -692,7 +684,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             EXTENSION_LAB_SUPPORT,
         ),
     ),
-    command_spec("status", CommandJsonFamily::Ops),
+    crate::ops_command_descriptor!(status, registered_ops_spec),
     command_spec_with_output_notes_and_safety(
         "cleanup",
         CommandJsonFamily::Workspace,
@@ -705,7 +697,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             dangerous_flags: CLEANUP_DANGEROUS_FLAGS,
         },
     ),
-    command_spec("git", CommandJsonFamily::Ops),
+    crate::ops_command_descriptor!(git, registered_ops_spec),
     command_spec_with_output_notes_and_safety(
         "release",
         CommandJsonFamily::Workspace,
@@ -798,22 +790,10 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         CommandJsonFamily::Workspace,
         "inspects persisted evidence, artifacts, artifact postprocessing, and finding reconciliation workflows",
     ),
-    command_spec_with_output_notes(
-        "self",
-        CommandJsonFamily::Ops,
-        "inspects the active Homeboy runtime and renders built-in CLI documentation",
-    ),
+    crate::ops_command_descriptor!(self_cmd, registered_ops_spec),
     command_spec("stack", CommandJsonFamily::Workspace),
-    CommandSpec {
-        subcommand_safety: API_SUBCOMMAND_SAFETY,
-        ..command_spec("api", CommandJsonFamily::Ops)
-    },
-    command_spec_with_output_notes_and_safety(
-        "upgrade",
-        CommandJsonFamily::Ops,
-        "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used",
-        operator_safety(None, UPGRADE_DANGEROUS_FLAGS),
-    ),
+    crate::ops_command_descriptor!(api, registered_ops_spec),
+    crate::ops_command_descriptor!(upgrade, registered_ops_spec),
 ];
 
 pub const COMMAND_DOC_REGISTRY: &[CommandDocSpec] = &[

--- a/src/commands/json_output/ops.rs
+++ b/src/commands/json_output/ops.rs
@@ -1,27 +1,24 @@
 use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
-use crate::commands::{
-    api, daemon, db, deploy, file, git, logs, self_cmd, server, ssh, status, triage, upgrade,
-    GlobalArgs,
-};
+use crate::commands::GlobalArgs;
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
-        Commands::Status(args) => map(status::run(args, global)),
-        Commands::Ssh(args) => map(ssh::run(args, global)),
-        Commands::Server(args) => map(server::run(args, global)),
-        Commands::Db(args) => map(db::run(args, global)),
         Commands::Deps(args) => map(args.run()),
-        Commands::File(args) => map(file::run(args, global)),
-        Commands::Logs(args) => map(logs::run(args, global)),
-        Commands::Triage(args) => map(triage::run(args, global)),
-        Commands::Deploy(args) => map(deploy::run(args, global)),
-        Commands::Daemon(args) => map(daemon::run(args, global)),
-        Commands::Git(args) => map(git::run(args, global)),
-        Commands::SelfCmd(args) => map(self_cmd::run(args, global)),
-        Commands::Api(args) => map(api::run(args, global)),
-        Commands::Upgrade(args) => map(upgrade::run(args, global)),
-        _ => unreachable!("command routed to wrong JSON output family"),
+        command => dispatch_registered(command, global),
     }
+}
+
+fn dispatch_registered(command: Commands, global: &GlobalArgs) -> JsonRun {
+    macro_rules! registered_ops_dispatch {
+        ($(($module:ident, $variant:ident, $args:path, $spec:expr, $handler:path),)*) => {
+            match command {
+                $(Commands::$variant(args) => map($handler(args, global)),)*
+                _ => unreachable!("command routed to wrong JSON output family"),
+            }
+        };
+    }
+
+    crate::ops_command_descriptors!(registered_ops_dispatch)
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -205,7 +205,6 @@ pub mod activity;
 pub mod agent_task;
 pub(crate) mod agent_task_dispatch;
 pub(crate) mod agent_task_summary;
-pub mod api;
 pub mod artifact_postprocess;
 pub mod audit;
 pub mod audit_baseline;
@@ -217,19 +216,13 @@ pub mod cleanup;
 pub mod component;
 pub mod config;
 pub mod contract;
-pub mod daemon;
-pub mod db;
-pub mod deploy;
 pub mod docs;
 pub mod extension;
-pub mod file;
 pub mod fleet;
 pub mod fuzz;
-pub mod git;
 pub mod issues;
 pub mod json_output;
 pub mod lint;
-pub mod logs;
 pub mod observe;
 pub mod project;
 pub mod raw_output;
@@ -244,19 +237,21 @@ pub mod runner;
 pub mod runs;
 pub(crate) mod runs_proof_summary;
 pub(crate) mod runs_summary;
-pub mod self_cmd;
-pub mod server;
-pub mod ssh;
 pub mod stack;
-pub mod status;
 pub mod test;
 pub mod trace;
-pub mod triage;
 pub mod tunnel;
 pub mod undo;
-pub mod upgrade;
 pub mod utils;
 pub mod worktree;
+
+macro_rules! register_ops_command_modules {
+    ($(($module:ident, $variant:ident, $args:path, $spec:expr, $handler:path),)*) => {
+        $(pub mod $module;)*
+    };
+}
+
+crate::ops_command_descriptors!(register_ops_command_modules);
 
 // Command-runtime infrastructure: the routing, adapter, output/response,
 // manifest, and summary plumbing that turns a parsed `Commands` value into a


### PR DESCRIPTION
## Summary
- Introduce an Ops command descriptor macro that carries the command module, typed `Commands` variant, `CommandSpec`, and JSON handler binding.
- Migrate the 13 module-backed Ops commands while preserving `deps` as its local `Cli` implementation.
- Preserve `COMMAND_SPECS` ordering and all existing dynamic raw-output and Lab predicates.

Part of #7516

## Diffstat
```text
5 files changed, 87 insertions(+), 70 deletions(-)
```

## Fan-out migration
| Registration concern | Before | After |
| --- | --- | --- |
| Ops command module | 13 `pub mod` lines in `commands/mod.rs` | Generated from `ops_command_descriptors!` |
| Ops metadata row | 13 inline `COMMAND_SPECS` rows | Descriptor-selected `CommandSpec` rows, preserving registry order |
| Ops JSON handler | 13 arms plus module imports in `json_output/ops.rs` | Generated dispatch match from `ops_command_descriptors!` |
| Typed Clap variant | Manual `Commands` enum variants | The descriptor carries the exact variant/type binding; enum migration remains for the next slice to preserve byte-identical command ordering |

## Remaining migration plan
This is the representative Ops-family migration. Workspace and quality families retain their existing module, Clap, spec, and dispatch fan-out. Migrate their descriptors next, then move the `Commands` enum variants into the descriptor expansion once a single ordered top-level descriptor list can preserve the help surface.

## Verification
1. `cargo build -j 3`
2. Focused parser, command-contract, JSON-dispatch, public-variant, and output-dispatch tests
3. `cargo clippy --all-targets -j 3 2>&1 | tail -20` (no new warnings; repository baseline reports 220 warnings)
4. Byte-compared `cargo run -j 3 -- --help` before and after: identical SHA-256 `2f9b810a7e118ccf21c4363764bccf00fdecb45a2766872f786c9d9ff99692da`
5. Byte-compared representative `status`, `ssh`, and `self` help outputs before and after: identical

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Descriptor consolidation implementation and verification runs. Reviewed by Chris Huber.