### PR TITLE
Export deps capability helpers

### DIFF
--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -44,7 +44,9 @@ pub use capability::{
     resolve_execution_context, resolve_extension_for_capability, ExtensionCapability,
     ExtensionExecutionContext, ScenarioRunnerOptions,
 };
-pub(crate) use capability::{extension_guidance_hints, stderr_tail};
+pub(crate) use capability::{
+    extension_guidance_hints, has_linked_extension_for_capability, stderr_tail,
+};
 pub(crate) use compiler_warning_contract::{
     extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
     CompilerWarningContract,

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -45,7 +45,8 @@ pub use capability::{
     ExtensionExecutionContext, ScenarioRunnerOptions,
 };
 pub(crate) use capability::{
-    extension_guidance_hints, has_linked_extension_for_capability, stderr_tail,
+    extension_guidance_hints, has_linked_extension_for_capability,
+    resolve_execution_context_if_available, stderr_tail,
 };
 pub(crate) use compiler_warning_contract::{
     extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,


### PR DESCRIPTION
## Summary
- export the linked-extension capability helper through the extension facade used by `deps`
- export the optional execution-context resolver used by `deps_provider`
- restore current `main` all-target compilation after the native deps changes

## Testing
- `cargo check --all-targets`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Identifying the current-main compile regression, isolating the missing facade exports, and verification; Chris remains responsible for the submitted change.