### PR TITLE
Consolidate Lab dispatch projection

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -1071,6 +1071,10 @@ pub(super) fn apply_lab_contract_to_descriptor(
 }
 
 impl LabCommandContract {
+    pub const fn is_portable(self) -> bool {
+        matches!(self.portability, LabCommandPortability::Portable)
+    }
+
     pub(crate) fn into_route_contract(
         self,
         required_extensions: Vec<String>,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -41,12 +41,8 @@ pub const RUNNER_ARTIFACT_MANIFEST_SCHEMA: &str = crate::core::artifacts::ARTIFA
 pub const RUNNER_ARTIFACT_MANIFEST_FILE: &str = crate::core::artifacts::ARTIFACT_MANIFEST_FILE;
 pub const RUNNER_ARTIFACT_ROOT_DIR_SUFFIX: &str = "-homeboy-artifacts";
 
-/// Routing-policy flags shared by every Lab command representation
-/// (`LabCommandContract`, `LabRoutePlan`, `LabOffloadCommand`). These four
-/// booleans travel together as one cohesive policy as a command is resolved
-/// from its contract into a route plan and finally an offload command, so they
-/// live in a single embedded struct rather than being duplicated field-by-field
-/// across the three layers.
+/// Routing-policy flags owned by the Lab command contract and retained through
+/// route planning, offload, and runner dispatch.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LabRoutingPolicy {
     /// Whether the command offloads to a default Lab runner without an explicit

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -1086,7 +1086,7 @@ fn strip_component_target_args(
 mod tests {
     use super::*;
     use clap::Parser;
-    use homeboy::command_contract::lab_runner_supports_contract_label;
+    use homeboy::command_contract::{lab_runner_supports_contract_label, LabCommandPortability};
     use std::fs;
     use std::path::Path;
     use std::sync::{Mutex, MutexGuard, OnceLock};
@@ -1228,8 +1228,7 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "review lint");
-        assert!(command.portable);
-        assert!(command.unsupported_reason.is_none());
+        assert!(command.is_portable());
     }
 
     #[test]
@@ -1278,8 +1277,7 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "review lint");
-        assert!(command.portable);
-        assert!(command.unsupported_reason.is_none());
+        assert!(command.is_portable());
     }
 
     #[test]
@@ -1331,8 +1329,7 @@ mod tests {
 
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert_eq!(command.hot_label, "review test");
-        assert!(command.portable);
-        assert!(command.unsupported_reason.is_none());
+        assert!(command.is_portable());
     }
 
     #[test]
@@ -1977,7 +1974,7 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "rig check");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(!command.routing_policy.default_lab_offload);
         assert!(!command.routing_policy.infer_source_path_tools);
         assert!(cli.command.supports_lab_runner());
@@ -2018,7 +2015,7 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "rig check");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(command.routing_policy.default_lab_offload);
         assert!(!command.routing_policy.infer_source_path_tools);
     }
@@ -2030,8 +2027,7 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "review lint");
-        assert!(command.portable);
-        assert!(command.unsupported_reason.is_none());
+        assert!(command.is_portable());
         assert!(command.routing_policy.requires_extension_parity);
     }
 
@@ -2049,9 +2045,8 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "extension update");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(!command.routing_policy.default_lab_offload);
-        assert!(command.unsupported_reason.is_none());
         assert!(!command.routing_policy.requires_extension_parity);
         assert!(command.required_extensions.is_empty());
         assert!(!command.routing_policy.infer_source_path_tools);
@@ -2076,9 +2071,8 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "extension refresh");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(!command.routing_policy.default_lab_offload);
-        assert!(command.unsupported_reason.is_none());
         assert!(!command.routing_policy.requires_extension_parity);
         assert!(command.required_extensions.is_empty());
         assert!(!command.routing_policy.infer_source_path_tools);
@@ -2117,9 +2111,8 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "extension show");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(!command.routing_policy.default_lab_offload);
-        assert!(command.unsupported_reason.is_none());
         assert!(!command.routing_policy.requires_extension_parity);
         assert!(command.required_extensions.is_empty());
         assert!(!command.routing_policy.infer_source_path_tools);
@@ -2150,7 +2143,7 @@ mod tests {
         assert!(local_policy.deny_local_execution());
         assert_eq!(command.hot_label, "fuzz doctor");
         assert!(lab_runner_supports_contract_label(command.hot_label));
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(!command.routing_policy.default_lab_offload);
         assert!(command.routing_policy.requires_extension_parity);
         assert!(command.routing_policy.read_only_polling);
@@ -2372,7 +2365,7 @@ mod tests {
 
             assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
             assert!(lab_runner_supports_contract_label(command.hot_label));
-            assert!(command.portable);
+            assert!(command.is_portable());
             assert!(command.routing_policy.default_lab_offload);
         }
     }
@@ -2391,7 +2384,7 @@ mod tests {
             "cargo test --locked",
         ]);
         let automatic_command = lab_offload_command(&automatic.command).unwrap().unwrap();
-        assert!(automatic_command.portable);
+        assert!(automatic_command.is_portable());
         assert!(automatic_command.routing_policy.default_lab_offload);
 
         let explicit = Cli::parse_from([
@@ -2409,7 +2402,7 @@ mod tests {
         ]);
         let explicit_command = lab_offload_command(&explicit.command).unwrap().unwrap();
         assert_eq!(explicit.runner.as_deref(), Some("homeboy-lab"));
-        assert!(explicit_command.portable);
+        assert!(explicit_command.is_portable());
 
         let lab_only = Cli::parse_from([
             "homeboy",
@@ -2428,12 +2421,10 @@ mod tests {
             lab_only.allow_local_fallback,
             lab_only.lab_only,
         );
-        assert!(
-            lab_offload_command(&lab_only.command)
-                .unwrap()
-                .unwrap()
-                .portable
-        );
+        assert!(lab_offload_command(&lab_only.command)
+            .unwrap()
+            .unwrap()
+            .is_portable());
         assert!(local_policy.deny_local_execution());
     }
 
@@ -2451,7 +2442,7 @@ mod tests {
 
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert!(lab_runner_supports_contract_label(command.hot_label));
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(!command.routing_policy.default_lab_offload);
         assert!(!command.routing_policy.requires_extension_parity);
         assert!(command.required_extensions.is_empty());
@@ -2486,7 +2477,7 @@ mod tests {
             command.hot_label,
             "agent-task controller from-spec --resume/run-from-spec/materialize"
         );
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(command.routing_policy.default_lab_offload);
         assert!(!command.routing_policy.requires_extension_parity);
         assert_eq!(
@@ -2536,7 +2527,7 @@ mod tests {
                 command.hot_label,
                 "agent-task controller from-spec --resume/run-from-spec/materialize"
             );
-            assert!(command.portable);
+            assert!(command.is_portable());
             assert!(command.routing_policy.default_lab_offload);
             assert!(command.routing_policy.infer_source_path_tools);
             assert!(!command.routing_policy.requires_extension_parity);
@@ -2604,7 +2595,7 @@ mod tests {
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert!(local_policy.deny_local_execution());
         assert_eq!(command.hot_label, "agent-task fanout run-plan");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(command.routing_policy.default_lab_offload);
         assert!(command.routing_policy.requires_extension_parity);
     }
@@ -2638,7 +2629,7 @@ mod tests {
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert!(local_policy.deny_local_execution());
         assert_eq!(command.hot_label, "agent-task fanout cook-batch");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(command.routing_policy.default_lab_offload);
         assert!(command.routing_policy.requires_extension_parity);
     }
@@ -2671,7 +2662,7 @@ mod tests {
 
             assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
             assert_eq!(command.hot_label, "agent-task fanout status/artifacts");
-            assert!(command.portable);
+            assert!(command.is_portable());
             assert!(!command.routing_policy.default_lab_offload);
             assert_eq!(
                 command.source_path_mode,
@@ -2707,7 +2698,7 @@ mod tests {
 
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert_eq!(command.hot_label, "tunnel service start");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(!command.routing_policy.default_lab_offload);
         assert_eq!(
             command.source_path_mode,
@@ -2740,7 +2731,7 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "tunnel preview-consumer run");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(!command.routing_policy.default_lab_offload);
     }
 
@@ -2751,8 +2742,7 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "review audit");
-        assert!(command.portable);
-        assert_eq!(command.unsupported_reason, None);
+        assert!(command.is_portable());
         assert!(command.routing_policy.requires_extension_parity);
     }
 
@@ -2763,8 +2753,7 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "review audit");
-        assert!(command.portable);
-        assert_eq!(command.unsupported_reason, None);
+        assert!(command.is_portable());
         assert!(command.routing_policy.requires_extension_parity);
     }
 
@@ -2775,8 +2764,10 @@ mod tests {
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "rig up");
-        assert!(!command.portable);
-        assert!(command.unsupported_reason.is_some());
+        assert!(matches!(
+            command.portability,
+            LabCommandPortability::LocalOnly(_)
+        ));
         assert!(!command.routing_policy.requires_extension_parity);
     }
 

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -820,8 +820,6 @@ mod tests {
                 false,
                 &[],
             ),
-            portable: true,
-            unsupported_reason: None,
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             workload: None,

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -814,17 +814,17 @@ mod tests {
         )
         .build();
         let command_contract = crate::core::runner::LabOffloadCommand {
-            hot_label: "tunnel preview-client start",
+            command: crate::command_contract::LabCommandContract::portable(
+                "tunnel preview-client start",
+                None,
+                false,
+                &[],
+            ),
             portable: true,
             unsupported_reason: None,
-            source_path_mode: crate::core::runner::LabOffloadSourcePathMode::CwdOrPathFlag,
-            workspace_mode_policy:
-                crate::core::runner::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-            secret_env_sources: Vec::new(),
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             workload: None,
-            routing_policy: crate::command_contract::LabRoutingPolicy::default(),
         };
         request.runner_workload = Some(crate::core::runner::workload::build_runner_workload(
             crate::core::runner::workload::RunnerWorkloadBuildInput {

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -9,8 +9,7 @@ use crate::command_contract::{
     LabWorkspaceModePolicy,
 };
 use crate::core::command_execution_plan::{
-    CommandPortability, CommandSourceMaterialization, CommandSourcePolicy, CommandWorkspacePolicy,
-    LabRoutePlan,
+    CommandSourceMaterialization, CommandSourcePolicy, CommandWorkspacePolicy, LabRoutePlan,
 };
 use crate::core::observation::records::RunEvidenceCommands;
 use crate::core::observation::RunStatus;
@@ -448,47 +447,17 @@ pub fn lab_route_plan_from_contract(contract: LabCommandContract) -> LabRoutePla
 pub fn lab_offload_command_from_route_contract(
     route_contract: LabCommandRouteContract,
 ) -> runners::LabOffloadCommand {
-    let hot_label = route_contract.command.hot_label;
     let portability = route_contract.command.portability;
-    let secret_env_sources = route_contract.command.secret_env_sources.to_vec();
-    let workload = route_contract.workload.clone();
-    let plan = lab_route_plan_from_route_contract(route_contract);
     runners::LabOffloadCommand {
-        hot_label,
-        portable: matches!(plan.portability, CommandPortability::Portable),
+        command: route_contract.command,
+        portable: matches!(portability, LabCommandPortability::Portable),
         unsupported_reason: match portability {
             LabCommandPortability::Portable => None,
             LabCommandPortability::LocalOnly(reason) => Some(reason),
         },
-        source_path_mode: match plan.source_policy {
-            CommandSourcePolicy::ControllerCwdOrExplicitPath
-            | CommandSourcePolicy::MaterializeControllerPath => {
-                runners::LabOffloadSourcePathMode::CwdOrPathFlag
-            }
-            CommandSourcePolicy::RunnerResident => {
-                runners::LabOffloadSourcePathMode::RunnerResident
-            }
-        },
-        workspace_mode_policy: match plan.workspace_policy {
-            CommandWorkspacePolicy::ChangedSinceGitElseSnapshot => {
-                runners::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot
-            }
-            CommandWorkspacePolicy::Git => runners::LabOffloadWorkspaceModePolicy::Git,
-            CommandWorkspacePolicy::GitCheckoutRequired => {
-                runners::LabOffloadWorkspaceModePolicy::GitCheckoutRequired
-            }
-            CommandWorkspacePolicy::RunnerResident => {
-                runners::LabOffloadWorkspaceModePolicy::RunnerResident
-            }
-            CommandWorkspacePolicy::Snapshot => {
-                runners::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot
-            }
-        },
-        secret_env_sources,
-        required_extensions: plan.required_extensions,
-        required_capabilities: plan.required_capabilities,
-        workload,
-        routing_policy: plan.routing_policy,
+        required_extensions: route_contract.required_extensions,
+        required_capabilities: route_contract.required_capabilities,
+        workload: route_contract.workload,
     }
 }
 
@@ -672,6 +641,7 @@ mod tests {
             vec!["wordpress".to_string(), "playwright".to_string()],
         );
 
+        assert_eq!(command.command, lab_contract());
         assert_eq!(command.hot_label, "trace");
         assert!(command.portable);
         assert!(command.routing_policy.default_lab_offload);

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -447,14 +447,8 @@ pub fn lab_route_plan_from_contract(contract: LabCommandContract) -> LabRoutePla
 pub fn lab_offload_command_from_route_contract(
     route_contract: LabCommandRouteContract,
 ) -> runners::LabOffloadCommand {
-    let portability = route_contract.command.portability;
     runners::LabOffloadCommand {
         command: route_contract.command,
-        portable: matches!(portability, LabCommandPortability::Portable),
-        unsupported_reason: match portability {
-            LabCommandPortability::Portable => None,
-            LabCommandPortability::LocalOnly(reason) => Some(reason),
-        },
         required_extensions: route_contract.required_extensions,
         required_capabilities: route_contract.required_capabilities,
         workload: route_contract.workload,
@@ -643,9 +637,8 @@ mod tests {
 
         assert_eq!(command.command, lab_contract());
         assert_eq!(command.hot_label, "trace");
-        assert!(command.portable);
+        assert!(command.is_portable());
         assert!(command.routing_policy.default_lab_offload);
-        assert_eq!(command.unsupported_reason, None);
         assert_eq!(
             command.workspace_mode_policy,
             runners::LabOffloadWorkspaceModePolicy::GitCheckoutRequired

--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -474,8 +474,6 @@ fn worker_local_workload_validation_uses_implicit_command_secret_names() {
                 false,
                 &[],
             ),
-            portable: true,
-            unsupported_reason: None,
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             workload: None,

--- a/src/core/runner/execution/tests/exec.rs
+++ b/src/core/runner/execution/tests/exec.rs
@@ -468,17 +468,17 @@ fn worker_local_workload_validation_uses_implicit_command_secret_names() {
         )
         .build();
         let command_contract = crate::core::runner::LabOffloadCommand {
-            hot_label: "tunnel preview-client start",
+            command: crate::command_contract::LabCommandContract::portable(
+                "tunnel preview-client start",
+                None,
+                false,
+                &[],
+            ),
             portable: true,
             unsupported_reason: None,
-            source_path_mode: crate::core::runner::LabOffloadSourcePathMode::CwdOrPathFlag,
-            workspace_mode_policy:
-                crate::core::runner::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-            secret_env_sources: Vec::new(),
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             workload: None,
-            routing_policy: crate::command_contract::LabRoutingPolicy::default(),
         };
         let workload = crate::core::runner::workload::build_runner_workload(
             crate::core::runner::workload::RunnerWorkloadBuildInput {

--- a/src/core/runner/lab/offload/execute.rs
+++ b/src/core/runner/lab/offload/execute.rs
@@ -63,17 +63,14 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         });
     };
 
-    if !contract.portable {
+    if let crate::command_contract::LabCommandPortability::LocalOnly(reason) = contract.portability
+    {
         if let Some(runner_id) = request.explicit_runner {
-            let message = contract.unsupported_reason.map_or_else(
-                || lab_runner_support_summary().unsupported_message,
-                |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
+            let message = format!(
+                "--runner is unavailable for this local-only resource-pressure command. {reason}"
             );
             return Err(unsupported_runner_error(runner_id, message));
         }
-        let reason = contract
-            .unsupported_reason
-            .unwrap_or("command is local-only");
         if request.local_policy.deny_local_execution() {
             return Err(local_execution_denied_error(reason, None));
         }

--- a/src/core/runner/lab/offload/tests/mod.rs
+++ b/src/core/runner/lab/offload/tests/mod.rs
@@ -28,37 +28,23 @@ mod workspace_sync;
 
 pub(super) fn portable_lab_command(label: &'static str) -> LabOffloadCommand {
     LabOffloadCommand {
-        hot_label: label,
+        command: crate::command_contract::LabCommandContract::portable(label, None, true, &[]),
         portable: true,
         unsupported_reason: None,
-        source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
-        workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-        secret_env_sources: Vec::new(),
         required_extensions: Vec::new(),
         required_capabilities: Vec::new(),
         workload: None,
-        routing_policy: crate::command_contract::LabRoutingPolicy {
-            default_lab_offload: true,
-            infer_source_path_tools: true,
-            release_gate: false,
-            requires_extension_parity: true,
-            read_only_polling: false,
-        },
     }
 }
 
 pub(super) fn local_only_lab_command(reason: &'static str) -> LabOffloadCommand {
     LabOffloadCommand {
-        hot_label: "rig up",
+        command: crate::command_contract::LabCommandContract::local_only("rig up", reason),
         portable: false,
         unsupported_reason: Some(reason),
-        source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
-        workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-        secret_env_sources: Vec::new(),
         required_extensions: Vec::new(),
         required_capabilities: Vec::new(),
         workload: None,
-        routing_policy: crate::command_contract::LabRoutingPolicy::default(),
     }
 }
 

--- a/src/core/runner/lab/offload/tests/mod.rs
+++ b/src/core/runner/lab/offload/tests/mod.rs
@@ -29,8 +29,6 @@ mod workspace_sync;
 pub(super) fn portable_lab_command(label: &'static str) -> LabOffloadCommand {
     LabOffloadCommand {
         command: crate::command_contract::LabCommandContract::portable(label, None, true, &[]),
-        portable: true,
-        unsupported_reason: None,
         required_extensions: Vec::new(),
         required_capabilities: Vec::new(),
         workload: None,
@@ -40,8 +38,6 @@ pub(super) fn portable_lab_command(label: &'static str) -> LabOffloadCommand {
 pub(super) fn local_only_lab_command(reason: &'static str) -> LabOffloadCommand {
     LabOffloadCommand {
         command: crate::command_contract::LabCommandContract::local_only("rig up", reason),
-        portable: false,
-        unsupported_reason: Some(reason),
         required_extensions: Vec::new(),
         required_capabilities: Vec::new(),
         workload: None,

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -69,34 +69,30 @@ pub struct LabJobOverrides {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabOffloadCommand {
-    pub hot_label: &'static str,
+    pub command: crate::command_contract::LabCommandContract,
     pub portable: bool,
     pub unsupported_reason: Option<&'static str>,
-    pub source_path_mode: LabOffloadSourcePathMode,
-    pub workspace_mode_policy: LabOffloadWorkspaceModePolicy,
-    pub secret_env_sources: Vec<crate::command_contract::LabSecretEnvSource>,
     pub required_extensions: Vec<String>,
     pub required_capabilities: Vec<crate::command_contract::RunnerWorkloadCapability>,
     pub workload: Option<crate::command_contract::LabRigWorkloadArguments>,
-    /// Routing-policy flags shared across the Lab command layers
-    /// (`default_lab_offload`, `infer_source_path_tools`, `release_gate`,
-    /// `requires_extension_parity`).
-    pub routing_policy: crate::command_contract::LabRoutingPolicy,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LabOffloadSourcePathMode {
-    CwdOrPathFlag,
-    RunnerResident,
+impl std::ops::Deref for LabOffloadCommand {
+    type Target = crate::command_contract::LabCommandContract;
+
+    fn deref(&self) -> &Self::Target {
+        &self.command
+    }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LabOffloadWorkspaceModePolicy {
-    ChangedSinceGitElseSnapshot,
-    Git,
-    GitCheckoutRequired,
-    RunnerResident,
+impl std::ops::DerefMut for LabOffloadCommand {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.command
+    }
 }
+
+pub type LabOffloadSourcePathMode = crate::command_contract::LabSourcePathMode;
+pub type LabOffloadWorkspaceModePolicy = crate::command_contract::LabWorkspaceModePolicy;
 
 pub enum LabOffloadOutcome {
     RunLocal {

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -70,8 +70,6 @@ pub struct LabJobOverrides {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabOffloadCommand {
     pub command: crate::command_contract::LabCommandContract,
-    pub portable: bool,
-    pub unsupported_reason: Option<&'static str>,
     pub required_extensions: Vec<String>,
     pub required_capabilities: Vec<crate::command_contract::RunnerWorkloadCapability>,
     pub workload: Option<crate::command_contract::LabRigWorkloadArguments>,

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -1874,16 +1874,20 @@ mod tests {
         );
         let workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
         let contract = LabOffloadCommand {
-            hot_label: "agent-task.run",
+            command: crate::command_contract::LabCommandContract {
+                workspace_mode_policy: LabOffloadWorkspaceModePolicy::GitCheckoutRequired,
+                ..crate::command_contract::LabCommandContract::portable(
+                    "agent-task.run",
+                    None,
+                    false,
+                    &[],
+                )
+            },
             portable: true,
             unsupported_reason: None,
-            source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
-            workspace_mode_policy: LabOffloadWorkspaceModePolicy::GitCheckoutRequired,
-            secret_env_sources: Vec::new(),
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             workload: None,
-            routing_policy: crate::command_contract::LabRoutingPolicy::default(),
         };
 
         let plan = provider_config_path_materialization_plan(
@@ -1958,16 +1962,21 @@ mod tests {
 
     fn test_lab_contract_with_agent_task_secrets() -> LabOffloadCommand {
         LabOffloadCommand {
-            hot_label: "agent-task.run",
+            command: crate::command_contract::LabCommandContract {
+                workspace_mode_policy: LabOffloadWorkspaceModePolicy::GitCheckoutRequired,
+                secret_env_sources: &[crate::command_contract::LabSecretEnvSource::AgentTask],
+                ..crate::command_contract::LabCommandContract::portable(
+                    "agent-task.run",
+                    None,
+                    false,
+                    &[],
+                )
+            },
             portable: true,
             unsupported_reason: None,
-            source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
-            workspace_mode_policy: LabOffloadWorkspaceModePolicy::GitCheckoutRequired,
-            secret_env_sources: vec![crate::command_contract::LabSecretEnvSource::AgentTask],
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             workload: None,
-            routing_policy: crate::command_contract::LabRoutingPolicy::default(),
         }
     }
 

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -1883,8 +1883,6 @@ mod tests {
                     &[],
                 )
             },
-            portable: true,
-            unsupported_reason: None,
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             workload: None,
@@ -1972,8 +1970,6 @@ mod tests {
                     &[],
                 )
             },
-            portable: true,
-            unsupported_reason: None,
             required_extensions: Vec::new(),
             required_capabilities: Vec::new(),
             workload: None,

--- a/src/core/runner/lab_capabilities.rs
+++ b/src/core/runner/lab_capabilities.rs
@@ -7,7 +7,7 @@ pub(super) fn lab_runner_capability_contract(
     source_path: &Path,
     command_prefix_required_tools: &[RunnerRequiredTool],
 ) -> Option<LabRunnerCapabilityContract> {
-    if !command.portable {
+    if !command.is_portable() {
         return None;
     }
 

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::process::Stdio;
 use std::time::Duration;
 
-use crate::command_contract::{lab_runner_unsupported_hint, lab_runner_unsupported_message};
+use crate::command_contract::{lab_runner_unsupported_hint, LabCommandPortability};
 use crate::core::{Error, ErrorCode, Result};
 
 use super::daemon_freshness::repair_or_fail;
@@ -103,7 +103,7 @@ fn preflight_lab_runner_availability_with(
 }
 
 pub(super) fn fail_if_no_default_runner_accepts_jobs(command: &LabOffloadCommand) -> Result<()> {
-    if !command.portable || !command.routing_policy.default_lab_offload {
+    if !command.is_portable() || !command.routing_policy.default_lab_offload {
         return Ok(());
     }
     let eligible = default_lab_runner_availability()?;
@@ -476,7 +476,7 @@ pub(super) fn resolve_lab_runner_selection(
     let release_gate_local_hot_allowed =
         crate::core::defaults::resolve_release_gate_local_hot_policy_from(&config).is_allowed();
     let default_runner = if explicit_runner.is_none()
-        && command.portable
+        && command.is_portable()
         && command.routing_policy.default_lab_offload
     {
         super::resolve_default_lab_runner()?
@@ -506,12 +506,8 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     default_runner: Option<String>,
 ) -> Result<Option<LabRunnerSelection>> {
     if let Some(runner_id) = explicit_runner {
-        if !command.portable {
-            let message = command
-                .unsupported_reason
-                .map_or_else(lab_runner_unsupported_message, |reason| {
-                    format!("--runner is unavailable for this hot command. {reason}")
-                });
+        if let LabCommandPortability::LocalOnly(reason) = command.portability {
+            let message = format!("--runner is unavailable for this hot command. {reason}");
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
@@ -548,7 +544,7 @@ pub(super) fn resolve_lab_runner_selection_from_default(
         return Ok(None);
     }
 
-    if force_hot && command.portable && !allow_local_hot {
+    if force_hot && command.is_portable() && !allow_local_hot {
         let Some(runner_id) = default_runner.as_ref() else {
             fail_if_local_bench_denied(command, deny_local_bench)?;
             return Ok(None);
@@ -588,7 +584,7 @@ pub(super) fn resolve_lab_runner_selection_from_default(
         }
     }
 
-    if force_hot || !command.portable {
+    if force_hot || !command.is_portable() {
         fail_if_local_bench_denied(command, deny_local_bench)?;
         return Ok(None);
     }

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -588,7 +588,6 @@ fn workspace_mode_policy_label(policy: LabOffloadWorkspaceModePolicy) -> &'stati
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::command_contract::LabRoutingPolicy;
     use crate::core::api_jobs::JobArtifactMetadata;
     use crate::core::plan::{HomeboyPlan, PlanKind};
 
@@ -598,22 +597,20 @@ mod tests {
 
     fn command() -> LabOffloadCommand {
         LabOffloadCommand {
-            hot_label: "trace",
+            command: crate::command_contract::LabCommandContract::portable(
+                "trace",
+                None,
+                true,
+                &[],
+            ),
             portable: true,
             unsupported_reason: None,
-            source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
-            workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-            secret_env_sources: Vec::new(),
             required_extensions: vec!["browser".to_string()],
             required_capabilities: vec![RunnerWorkloadCapability {
                 name: "playwright".to_string(),
                 required: true,
             }],
             workload: None,
-            routing_policy: LabRoutingPolicy {
-                requires_extension_parity: true,
-                ..LabRoutingPolicy::default()
-            },
         }
     }
 

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -603,8 +603,6 @@ mod tests {
                 true,
                 &[],
             ),
-            portable: true,
-            unsupported_reason: None,
             required_extensions: vec!["browser".to_string()],
             required_capabilities: vec![RunnerWorkloadCapability {
                 name: "playwright".to_string(),

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1435,17 +1435,17 @@ fn daemon_exec_derives_implicit_command_secret_names_before_workload_validation(
     )
     .build();
     let command_contract = crate::core::runner::LabOffloadCommand {
-        hot_label: "tunnel preview-client start",
+        command: crate::command_contract::LabCommandContract::portable(
+            "tunnel preview-client start",
+            None,
+            false,
+            &[],
+        ),
         portable: true,
         unsupported_reason: None,
-        source_path_mode: crate::core::runner::LabOffloadSourcePathMode::CwdOrPathFlag,
-        workspace_mode_policy:
-            crate::core::runner::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-        secret_env_sources: Vec::new(),
         required_extensions: Vec::new(),
         required_capabilities: Vec::new(),
         workload: None,
-        routing_policy: crate::command_contract::LabRoutingPolicy::default(),
     };
     let workload = crate::core::runner::workload::build_runner_workload(
         crate::core::runner::workload::RunnerWorkloadBuildInput {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1441,8 +1441,6 @@ fn daemon_exec_derives_implicit_command_secret_names_before_workload_validation(
             false,
             &[],
         ),
-        portable: true,
-        unsupported_reason: None,
         required_extensions: Vec::new(),
         required_capabilities: Vec::new(),
         workload: None,


### PR DESCRIPTION
## Summary
- embed the canonical Lab command contract directly in the offload command instead of projecting labels, policies, modes, and secret sources field by field
- remove duplicate portability and unsupported-reason storage and derive both from the command contract
- preserve route requirements and workload inputs while eliminating intermediate normalization

## Impact
- implementation: **40 net lines removed**, excluding test-fixture churn
- total: 116 additions, 199 deletions, **83 net lines removed**
- serialized RunnerWorkload schemas and dispatch metadata remain unchanged

## Testing
- Lab routing tests: 16 passed
- runner workload tests: 20 passed
- Lab offload suite: 135 passed, 1 unrelated current-main stale-daemon expectation failed (`runner_homeboy_metadata_carries_stale_daemon_details` expects reconnect-only guidance but current main emits refresh + reconnect)
- `cargo check --all-targets`
- scoped rustfmt on touched files
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Lab projection analysis, contract consolidation, portability deduplication, prerequisite isolation, rebasing, and verification; Chris remains responsible for the submitted change.