### PR TITLE
Consolidate runner workspace projection

### DIFF
--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -973,12 +973,6 @@ pub(crate) fn run_lab_offload_inner(
         runtime_overlay_metadata,
     } = workspace_stage;
     plan = next_plan;
-    let execution_context = LabExecutionContext::new(
-        remote_cwd.clone(),
-        Some(source_snapshot.clone()),
-        path_materialization_plan,
-    );
-
     let cleanup_policy = if agent_task_run_id.is_some() {
         WorkspaceCleanupPolicy::PreserveAlways
     } else {
@@ -1053,8 +1047,7 @@ pub(crate) fn run_lab_offload_inner(
     lab_metadata["dependency_hydration"] =
         dependency_hydration_metadata(&dependency_hydration.record);
     lab_metadata["workspace_materialization_plan"] =
-        serde_json::to_value(&execution_context.path_materialization_plan)
-            .unwrap_or(serde_json::json!(null));
+        serde_json::to_value(&path_materialization_plan).unwrap_or(serde_json::json!(null));
     lab_metadata["workspace_resource_lifecycle"] =
         serde_json::to_value(&workspace_resource_lifecycle).unwrap_or(serde_json::json!(null));
     lab_metadata["materialization_proof"] = lab_materialization_proof_metadata(
@@ -1108,7 +1101,7 @@ pub(crate) fn run_lab_offload_inner(
             status: "offloaded",
             remote_workspace: Some(&remote_cwd),
             fallback_reason: None,
-            workspace_mapping_ref: execution_context.workspace_mapping_ref(),
+            workspace_mapping_ref: path_materialization_plan.mapping_ref(),
             proof_id: lab_metadata
                 .get("proof")
                 .and_then(|proof| proof.get("id"))
@@ -1153,10 +1146,9 @@ pub(crate) fn run_lab_offload_inner(
         .filter(|(name, value)| env_delta_before_secret_handoff.get(*name) != Some(*value))
         .map(|(name, value)| (name.clone(), value.clone()))
         .collect::<std::collections::HashMap<_, _>>();
-    let path_remaps = path_remaps_from_workspace_mapping(
-        &workspace_mapping,
-        Some(&source_path),
-        Some(&remote_cwd),
+    let path_remaps = path_remaps_from_materialization_plan(
+        &path_materialization_plan,
+        Some((&source_path, &remote_cwd)),
     );
     exec_lab_context(LabDispatchExecutionContext {
         request: &request,
@@ -1194,7 +1186,7 @@ pub(crate) fn run_lab_offload_inner(
         ],
         secret_env_handoff,
         source_snapshot: Some(source_snapshot),
-        path_materialization_plan: Some(execution_context.path_materialization_plan.clone()),
+        path_materialization_plan: Some(path_materialization_plan),
         capability_preflight,
         provider_preflight: Some(LabProviderPreflightContext {
             command_prefix_argv: command_prefix.argv,

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -150,5 +150,4 @@ pub(crate) use overhead::*;
 pub(crate) use path_materialization::*;
 pub(crate) use resident::*;
 pub(crate) use telemetry::*;
-pub(crate) use types::LabExecutionContext;
 pub(crate) use workspace_stage::*;

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -89,11 +89,8 @@ pub(crate) fn run_runner_resident_lab_offload(
     );
 
     let source_path = lab_offload_source_path(request.normalized_args)?;
-    let execution_context = LabExecutionContext::new(
-        runner_workspace_root.to_string(),
-        None,
-        runner_resident_path_materialization_plan(runner_workspace_root, &source_syncs),
-    );
+    let path_materialization_plan =
+        runner_resident_path_materialization_plan(runner_workspace_root, &source_syncs);
 
     eprintln!(
         "Lab offload: running `{}` on runner `{}` in `{}`.",
@@ -118,8 +115,7 @@ pub(crate) fn run_runner_resident_lab_offload(
         "command_paths": "runner_side",
     });
     lab_metadata["workspace_materialization_plan"] =
-        serde_json::to_value(&execution_context.path_materialization_plan)
-            .unwrap_or(serde_json::json!(null));
+        serde_json::to_value(&path_materialization_plan).unwrap_or(serde_json::json!(null));
     lab_metadata["job_scoped_overrides"] = job_scoped_overrides_metadata(&request.job_overrides);
     let secret_env_handoff = build_lab_secret_env_handoff_plan(
         &contract.secret_env_sources,
@@ -137,9 +133,9 @@ pub(crate) fn run_runner_resident_lab_offload(
             runner_mode: status_tunnel_mode(runner_status).metadata_value(),
             assignment_source: selection.source.metadata_value(),
             status: "offloaded",
-            remote_workspace: Some(&execution_context.remote_cwd),
+            remote_workspace: Some(runner_workspace_root),
             fallback_reason: None,
-            workspace_mapping_ref: execution_context.workspace_mapping_ref(),
+            workspace_mapping_ref: path_materialization_plan.mapping_ref(),
             proof_id: None,
         },
         &command,
@@ -148,8 +144,10 @@ pub(crate) fn run_runner_resident_lab_offload(
         runner_workload_agent_task_from_command(&command, agent_task_run_id.as_deref());
     runner_workload.required_secrets.secret_env_plan = secret_env_handoff.secret_env_plan.clone();
     lab_metadata["secret_env_handoff"] = secret_env_handoff.diagnostics.clone();
-    let path_remaps =
-        path_remaps_from_workspace_mapping(&[], Some(&source_path), Some(runner_workspace_root));
+    let path_remaps = path_remaps_from_materialization_plan(
+        &path_materialization_plan,
+        Some((&source_path, runner_workspace_root)),
+    );
     lab_metadata["runner_workload"] =
         serde_json::to_value(&runner_workload).unwrap_or(serde_json::json!(null));
 
@@ -179,7 +177,7 @@ pub(crate) fn run_runner_resident_lab_offload(
         }],
         secret_env_handoff,
         source_snapshot: None,
-        path_materialization_plan: Some(execution_context.path_materialization_plan.clone()),
+        path_materialization_plan: Some(path_materialization_plan),
         capability_preflight: None,
         provider_preflight: None,
         path_remaps,
@@ -272,10 +270,11 @@ mod tests {
             "FIXTURE_ROOT".to_string(),
             fixture_root.display().to_string(),
         )]);
-        let path_remaps = path_remaps_from_workspace_mapping(
-            &[],
-            Some(&source),
-            Some("/srv/homeboy/_lab_workspaces/homeboy"),
+        let plan =
+            runner_resident_path_materialization_plan("/srv/homeboy/_lab_workspaces/homeboy", &[]);
+        let path_remaps = path_remaps_from_materialization_plan(
+            &plan,
+            Some((&source, "/srv/homeboy/_lab_workspaces/homeboy")),
         );
 
         let err = preflight_lab_offload_remote_dispatch_paths(

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -3,8 +3,6 @@
 use std::collections::HashMap;
 
 use crate::core::plan::HomeboyPlan;
-use crate::core::runner_execution_envelope::PathMaterializationPlan;
-use crate::core::source_snapshot::SourceSnapshot;
 
 pub use crate::command_contract::LabLocalExecutionPolicy;
 
@@ -33,31 +31,6 @@ pub struct LabOffloadRequest<'a> {
     /// handle survives a local shell timeout/interruption (#5684).
     pub local_output_file: Option<&'a str>,
     pub job_overrides: LabJobOverrides,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct LabExecutionContext {
-    pub(crate) remote_cwd: String,
-    pub(crate) source_snapshot: Option<SourceSnapshot>,
-    pub(crate) path_materialization_plan: PathMaterializationPlan,
-}
-
-impl LabExecutionContext {
-    pub(crate) fn new(
-        remote_cwd: impl Into<String>,
-        source_snapshot: Option<SourceSnapshot>,
-        path_materialization_plan: PathMaterializationPlan,
-    ) -> Self {
-        Self {
-            remote_cwd: remote_cwd.into(),
-            source_snapshot,
-            path_materialization_plan,
-        }
-    }
-
-    pub(crate) fn workspace_mapping_ref(&self) -> Option<&'static str> {
-        (!self.path_materialization_plan.entries.is_empty()).then_some("path_materialization_plan")
-    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -361,10 +361,14 @@ fn prepare_lab_offload_workspace_stage_inner(
     // to their synced remote locations, using every local->remote pair recorded
     // during workspace sync. Without this the remote sandbox cannot resolve the
     // workspace or runtime components a hand-authored cook config references.
-    let path_remaps = path_remaps_from_workspace_mapping(
+    let provider_config_materialization_plan = workspace_path_materialization_plan(
         &workspace_mapping,
-        Some(source_path),
-        Some(&remote_cwd),
+        PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG,
+        lab_path_materialization_mode(contract, sync_mode),
+    );
+    let path_remaps = path_remaps_from_materialization_plan(
+        &provider_config_materialization_plan,
+        Some((source_path, &remote_cwd)),
     );
     preflight_provider_config_source_cli_dependencies(&offload_args, &synced.excludes)?;
     preflight_provider_config_paths_materialized_in_args(&offload_args, &path_remaps)?;
@@ -372,8 +376,6 @@ fn prepare_lab_offload_workspace_stage_inner(
         &offload_args,
         &remote_cwd,
     );
-    let provider_config_materialization_plan =
-        provider_config_path_materialization_plan(contract, sync_mode, &workspace_mapping);
     let remapped_args = remap_provider_config_with_materialization_plan_in_args(
         &remapped_args,
         &provider_config_materialization_plan,
@@ -393,10 +395,37 @@ fn prepare_lab_offload_workspace_stage_inner(
             synced_entry.step_id,
         );
     }
-    let path_remaps = path_remaps_from_workspace_mapping(
+    let late_path_input_workspaces = lab_path_input_extra_workspaces(
+        &remapped_args,
+        contract.workload.as_ref(),
+        Path::new(&synced.local_path),
+    )?;
+    let late_synced_path_settings = sync_extra_lab_workspaces(
+        runner_id,
+        &synced.local_path,
+        late_path_input_workspaces,
+        &mut workspace_mapping,
+    )?;
+    if !late_synced_path_settings.is_empty() {
+        plan = with_step(
+            plan,
+            PlanStep::ready("lab.sync_late_path_settings", "lab.sync_late_path_settings")
+                .inputs(
+                    PlanValues::new()
+                        .json("count", late_synced_path_settings.len())
+                        .json("workspaces", &late_synced_path_settings),
+                )
+                .build(),
+        );
+    }
+    let path_materialization_plan = workspace_path_materialization_plan(
         &workspace_mapping,
-        Some(source_path),
-        Some(&remote_cwd),
+        PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
+        sync_mode.label(),
+    );
+    let path_remaps = path_remaps_from_materialization_plan(
+        &path_materialization_plan,
+        Some((source_path, &remote_cwd)),
     );
     let remapped_args = remap_path_settings_in_args(&remapped_args, &path_remaps);
     let remapped_args = remap_lab_at_file_args(&remapped_args, &at_file_specs);
@@ -429,9 +458,6 @@ fn prepare_lab_offload_workspace_stage_inner(
             .inputs(PlanValues::new().json("argv", &redact_argv(&command)))
             .build(),
     );
-    let path_materialization_plan =
-        lab_execution_path_materialization_plan(sync_mode, &workspace_mapping);
-
     Ok(LabOffloadWorkspaceStage {
         plan,
         sync_mode,
@@ -456,20 +482,39 @@ fn prepare_lab_offload_workspace_stage_inner(
     })
 }
 
-pub(crate) fn lab_execution_path_materialization_plan(
-    sync_mode: RunnerWorkspaceSyncMode,
+pub(crate) fn workspace_path_materialization_plan(
     workspace_mapping: &[LabWorkspaceMappingEntry],
+    owner: &str,
+    materialization_mode: impl Into<String>,
 ) -> PathMaterializationPlan {
+    let materialization_mode = materialization_mode.into();
     PathMaterializationPlan::new(workspace_mapping.iter().map(|entry| {
         PathMaterializationEntry::new(
             entry.role(),
-            PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
+            owner,
             Some(entry.local_path().to_string()),
             entry.remote_path(),
-            sync_mode.label(),
+            &materialization_mode,
             PATH_MATERIALIZATION_STATUS_MATERIALIZED,
         )
     }))
+}
+
+pub(crate) fn path_remaps_from_materialization_plan(
+    plan: &PathMaterializationPlan,
+    primary_fallback: Option<(&Path, &str)>,
+) -> Vec<LabPathRemap> {
+    let mut remaps: Vec<LabPathRemap> = plan.path_remaps().into_iter().map(Into::into).collect();
+    if let Some((local, remote)) = primary_fallback {
+        let local = local.display().to_string();
+        if !local.trim().is_empty() && !remaps.iter().any(|remap| remap.local == local) {
+            remaps.push(LabPathRemap {
+                local,
+                remote: remote.to_string(),
+            });
+        }
+    }
+    remaps
 }
 
 fn preflight_agent_task_secret_env_before_workspace_stage(
@@ -563,51 +608,6 @@ pub(crate) fn validate_lab_source_snapshot_handoff(
                 .collect(),
         ),
     ))
-}
-
-pub(crate) fn path_remaps_from_workspace_mapping(
-    workspace_mapping: &[LabWorkspaceMappingEntry],
-    primary_source_path: Option<&Path>,
-    primary_remote_path: Option<&str>,
-) -> Vec<LabPathRemap> {
-    let mut remaps = workspace_mapping
-        .iter()
-        .map(|entry| LabPathRemap {
-            local: entry.local_path().to_string(),
-            remote: entry.remote_path().to_string(),
-        })
-        .collect::<Vec<_>>();
-
-    if let (Some(source_path), Some(remote_path)) = (primary_source_path, primary_remote_path) {
-        let source_path = source_path.display().to_string();
-        if !source_path.trim().is_empty() && !remaps.iter().any(|remap| remap.local == source_path)
-        {
-            remaps.push(LabPathRemap {
-                local: source_path,
-                remote: remote_path.to_string(),
-            });
-        }
-    }
-
-    remaps
-}
-
-fn provider_config_path_materialization_plan(
-    contract: &LabOffloadCommand,
-    sync_mode: RunnerWorkspaceSyncMode,
-    workspace_mapping: &[LabWorkspaceMappingEntry],
-) -> PathMaterializationPlan {
-    let materialization_mode = lab_path_materialization_mode(contract, sync_mode);
-    PathMaterializationPlan::new(workspace_mapping.iter().map(|entry| {
-        PathMaterializationEntry::new(
-            entry.role(),
-            PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG,
-            Some(entry.local_path().to_string()),
-            entry.remote_path(),
-            materialization_mode.clone(),
-            PATH_MATERIALIZATION_STATUS_MATERIALIZED,
-        )
-    }))
 }
 
 fn lab_path_materialization_mode(
@@ -1515,10 +1515,14 @@ mod tests {
         let remote_workspace = "/home/chubes/Developer/_lab_workspaces/static-site-importer";
         let synced = test_synced_workspace(canonical_synced_source, remote_workspace);
         let workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
-        let path_remaps = path_remaps_from_workspace_mapping(
+        let plan = workspace_path_materialization_plan(
             &workspace_mapping,
-            Some(requested_source),
-            Some(remote_workspace),
+            PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
+            RunnerWorkspaceSyncMode::Snapshot.label(),
+        );
+        let path_remaps = path_remaps_from_materialization_plan(
+            &plan,
+            Some((requested_source, remote_workspace)),
         );
         let args = vec![
             "homeboy".to_string(),
@@ -1766,10 +1770,10 @@ mod tests {
             workload: None,
         };
 
-        let plan = provider_config_path_materialization_plan(
-            &contract,
-            RunnerWorkspaceSyncMode::Git,
+        let plan = workspace_path_materialization_plan(
             &workspace_mapping,
+            PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG,
+            lab_path_materialization_mode(&contract, RunnerWorkspaceSyncMode::Git),
         );
 
         assert_eq!(plan.entries.len(), 1);
@@ -1787,16 +1791,17 @@ mod tests {
     }
 
     #[test]
-    fn lab_execution_path_materialization_plan_projects_standard_workspace_mappings() {
+    fn workspace_path_materialization_plan_projects_standard_workspace_mappings() {
         let synced = test_synced_workspace(
             "/controller/workspaces/homeboy",
             "/runner/workspaces/homeboy",
         );
         let workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
 
-        let plan = lab_execution_path_materialization_plan(
-            RunnerWorkspaceSyncMode::Snapshot,
+        let plan = workspace_path_materialization_plan(
             &workspace_mapping,
+            PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
+            RunnerWorkspaceSyncMode::Snapshot.label(),
         );
 
         assert_eq!(plan.entries.len(), 1);

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -395,29 +395,6 @@ fn prepare_lab_offload_workspace_stage_inner(
             synced_entry.step_id,
         );
     }
-    let late_path_input_workspaces = lab_path_input_extra_workspaces(
-        &remapped_args,
-        contract.workload.as_ref(),
-        Path::new(&synced.local_path),
-    )?;
-    let late_synced_path_settings = sync_extra_lab_workspaces(
-        runner_id,
-        &synced.local_path,
-        late_path_input_workspaces,
-        &mut workspace_mapping,
-    )?;
-    if !late_synced_path_settings.is_empty() {
-        plan = with_step(
-            plan,
-            PlanStep::ready("lab.sync_late_path_settings", "lab.sync_late_path_settings")
-                .inputs(
-                    PlanValues::new()
-                        .json("count", late_synced_path_settings.len())
-                        .json("workspaces", &late_synced_path_settings),
-                )
-                .build(),
-        );
-    }
     let path_materialization_plan = workspace_path_materialization_plan(
         &workspace_mapping,
         PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,

--- a/src/core/runner/lab_args/path_remap.rs
+++ b/src/core/runner/lab_args/path_remap.rs
@@ -18,6 +18,15 @@ pub(in crate::core::runner) struct LabPathRemap {
     pub remote: String,
 }
 
+impl From<crate::core::runner_execution_envelope::PathMaterializationPathRemap> for LabPathRemap {
+    fn from(remap: crate::core::runner_execution_envelope::PathMaterializationPathRemap) -> Self {
+        Self {
+            local: remap.local_path,
+            remote: remap.remote_path,
+        }
+    }
+}
+
 /// Order remap pairs most-specific-first so a longer local prefix wins over a
 /// shorter one it is nested under (and, for equal-length locals, the longer
 /// remote wins). Every Lab arg rewriter must remap against this ordering so the

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -138,20 +138,12 @@ pub(in crate::core::runner) fn remap_provider_config_with_materialization_plan_i
     args: &[String],
     plan: &PathMaterializationPlan,
 ) -> Result<Vec<String>> {
-    let mappings = provider_config_path_remaps_from_materialization_plan(plan);
-    remap_provider_config_in_args(args, &mappings)
-}
-
-fn provider_config_path_remaps_from_materialization_plan(
-    plan: &PathMaterializationPlan,
-) -> Vec<LabPathRemap> {
-    plan.path_remaps()
+    let mappings = plan
+        .path_remaps()
         .into_iter()
-        .map(|remap| LabPathRemap {
-            local: remap.local_path,
-            remote: remap.remote_path,
-        })
-        .collect()
+        .map(Into::into)
+        .collect::<Vec<_>>();
+    remap_provider_config_in_args(args, &mappings)
 }
 
 pub(in crate::core::runner) fn inject_agent_task_default_provider_config_in_args(

--- a/src/core/runner/workload.rs
+++ b/src/core/runner/workload.rs
@@ -386,6 +386,13 @@ fn validate_runner_workload_result_refs(workload: &RunnerWorkload) -> Result<()>
         }
     }
 
+    if workload.workspace_mappings.mapping_ref != workload.result_refs.workspace_mapping_ref {
+        return Err(workload_error(
+            "runner_workload.result_refs.workspace_mapping_ref",
+            "runner workload workspace mapping references do not match".to_string(),
+        ));
+    }
+
     if workload
         .result_refs
         .artifacts
@@ -744,6 +751,11 @@ mod tests {
                 "{}",
                 case.name
             );
+            assert_eq!(
+                workload.result_refs.workspace_mapping_ref, workload.workspace_mappings.mapping_ref,
+                "{}",
+                case.name
+            );
         }
     }
 
@@ -957,6 +969,42 @@ mod tests {
         )
         .expect_err("drifted command label must fail");
         assert_eq!(err.details["field"], "runner_workload.kind.command_label");
+    }
+
+    #[test]
+    fn runner_workload_validation_rejects_workspace_mapping_reference_drift() {
+        let plan = plan();
+        let command = command();
+        let mut workload = build_runner_workload(RunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &command,
+            capture_patch: true,
+            mutation_flag: None,
+            allow_dirty_lab_workspace: false,
+            runner_id: "lab-a",
+            runner_mode: "direct_ssh",
+            assignment_source: "explicit",
+            status: "offloaded",
+            remote_workspace: Some("/srv/homeboy/work"),
+            fallback_reason: None,
+            workspace_mapping_ref: Some("path_materialization_plan"),
+            proof_id: None,
+        });
+        workload.result_refs.workspace_mapping_ref = Some("workspace_mapping".to_string());
+
+        let err = validate_runner_workload_dispatch(
+            Some(&workload),
+            "lab-a",
+            Some("/srv/homeboy/work"),
+            &["homeboy".to_string(), "trace".to_string()],
+            &SecretEnvPlan::default(),
+            true,
+        )
+        .expect_err("drifted workspace mapping reference must fail");
+        assert_eq!(
+            err.details["field"],
+            "runner_workload.result_refs.workspace_mapping_ref"
+        );
     }
 
     #[test]

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -331,6 +331,10 @@ impl PathMaterializationPlan {
             .collect()
     }
 
+    pub fn mapping_ref(&self) -> Option<&'static str> {
+        (!self.entries.is_empty()).then_some("path_materialization_plan")
+    }
+
     pub fn projection(&self) -> PathMaterializationPlanProjection {
         PathMaterializationPlanProjection {
             schema: self.schema.clone(),


### PR DESCRIPTION
## Summary
- make PathMaterializationPlan the canonical workspace mapping and remap projection
- remove the temporary LabExecutionContext wrapper and duplicate provider/execution mapping builders
- derive workload mapping references and argument remaps directly from the canonical plan

## Impact
- implementation: **50 net lines removed**, excluding tests
- total: 138 additions, 140 deletions
- preserves serialized schemas, local/remote paths, roles, identities, materialization modes, evidence metadata, and diagnostics

## Testing
- runner workload tests: 21 passed
- standard workspace mapping projection test: passed
- runner-resident materialization test: passed
- provider-config, alias-remap, and metadata tests: passed
- `cargo check --all-targets`
- scoped rustfmt on touched files
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Workspace projection analysis, canonical plan consolidation, parity validation, rebasing, and verification; Chris remains responsible for the submitted change.