### PR TITLE
fix: preserve local source identity for runner upgrades

### DIFF
--- a/src/core/runner/workspace/materializer.rs
+++ b/src/core/runner/workspace/materializer.rs
@@ -240,7 +240,7 @@ fn dest_child_path(path: &str) -> String {
 fn git_checkout_command(head: &str, branch: Option<&str>) -> String {
     if let Some(branch) = branch {
         format!(
-            "git -C \"$tmp\" checkout -B {branch} {head} && git -C \"$tmp\" config branch.{branch}.remote origin && git -C \"$tmp\" config branch.{branch}.merge refs/heads/{branch}",
+            "git -C \"$tmp\" checkout -B {branch} {head}",
             branch = shell::quote_arg(branch),
             head = shell::quote_arg(head),
         )

--- a/src/core/runner/workspace/tests/materializer.rs
+++ b/src/core/runner/workspace/tests/materializer.rs
@@ -58,7 +58,8 @@ fn workspace_materializer_builds_git_bundle_checkout_command() {
     assert!(command.contains("git clone \"$bundle\" \"$tmp\""));
     assert!(command.contains("remote set-url origin https://github.com/Extra-Chill/homeboy.git"));
     assert!(command.contains("checkout -B main abc123"));
-    assert!(command.contains("config branch.main.merge refs/heads/main"));
+    assert!(!command.contains("config branch.main.remote origin"));
+    assert!(!command.contains("config branch.main.merge refs/heads/main"));
     assert!(command.contains("git -C \"$tmp\" reset --hard abc123"));
     assert!(command.contains("Homeboy Lab refused to overwrite a dirty runner workspace"));
     assert!(command.contains("exit 97"));

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -594,54 +594,10 @@ fn prepare_source_workspace_for_upgrade(workspace_root: &Path) -> Result<()> {
         return Ok(());
     }
 
-    run_git_command(workspace_root, &["fetch", "origin"])?;
+    // A caller-selected source path is an immutable build input. In particular,
+    // worktree branches may be local-only or detached and must not be rewritten
+    // to an origin branch before the source build or runner materialization.
     ensure_clean_source_workspace(workspace_root)?;
-
-    let Some(default_branch) = origin_default_branch(workspace_root)? else {
-        if git_command_success(workspace_root, &["symbolic-ref", "-q", "HEAD"])?
-            && git_command_success(
-                workspace_root,
-                &[
-                    "rev-parse",
-                    "--abbrev-ref",
-                    "--symbolic-full-name",
-                    "@{upstream}",
-                ],
-            )?
-        {
-            run_git_command(workspace_root, &["pull", "--ff-only"])?;
-            return Ok(());
-        }
-
-        return Err(Error::validation_invalid_argument(
-            "source_path",
-            "Cannot determine origin default branch for source checkout",
-            Some(workspace_root.display().to_string()),
-            None,
-        )
-        .with_hint("Ensure the source checkout has an origin remote with a HEAD ref."));
-    };
-
-    let origin_ref = format!("origin/{default_branch}");
-    if !git_command_success(workspace_root, &["symbolic-ref", "-q", "HEAD"])? {
-        run_git_command(workspace_root, &["checkout", "--detach", &origin_ref])?;
-        return Ok(());
-    }
-
-    let current_branch = git_command_stdout(workspace_root, &["branch", "--show-current"])?;
-    if current_branch.trim() != default_branch {
-        run_git_command(workspace_root, &["checkout", "--detach", &origin_ref])?;
-        return Ok(());
-    }
-
-    run_git_command(
-        workspace_root,
-        &["branch", "--set-upstream-to", &origin_ref, &default_branch],
-    )?;
-    run_git_command(
-        workspace_root,
-        &["pull", "--ff-only", "origin", &default_branch],
-    )
 }
 
 fn ensure_clean_source_workspace(workspace_root: &Path) -> Result<()> {
@@ -659,36 +615,6 @@ fn ensure_clean_source_workspace(workspace_root: &Path) -> Result<()> {
     .with_hint("Commit, stash, or discard local changes before running source upgrade."))
 }
 
-fn origin_default_branch(workspace_root: &Path) -> Result<Option<String>> {
-    let remote_head = git_command_stdout_optional(
-        workspace_root,
-        &[
-            "symbolic-ref",
-            "--quiet",
-            "--short",
-            "refs/remotes/origin/HEAD",
-        ],
-    )?;
-    if let Some(branch) = remote_head
-        .as_deref()
-        .and_then(|head| head.trim().strip_prefix("origin/"))
-        .filter(|branch| !branch.is_empty())
-    {
-        return Ok(Some(branch.to_string()));
-    }
-
-    let ls_remote =
-        git_command_stdout_optional(workspace_root, &["ls-remote", "--symref", "origin", "HEAD"])?;
-    Ok(ls_remote.and_then(|output| {
-        output.lines().find_map(|line| {
-            line.strip_prefix("ref: refs/heads/")
-                .and_then(|rest| rest.split_whitespace().next())
-                .filter(|branch| !branch.is_empty())
-                .map(str::to_string)
-        })
-    }))
-}
-
 fn git_command_success(workspace_root: &Path, args: &[&str]) -> Result<bool> {
     Ok(
         run_git_output(workspace_root, args, "prepare source checkout")?
@@ -699,21 +625,6 @@ fn git_command_success(workspace_root: &Path, args: &[&str]) -> Result<bool> {
 
 fn git_command_stdout(workspace_root: &Path, args: &[&str]) -> Result<String> {
     run_git(workspace_root, args, "prepare source checkout").map(|stdout| stdout.trim().to_string())
-}
-
-fn git_command_stdout_optional(workspace_root: &Path, args: &[&str]) -> Result<Option<String>> {
-    let output = run_git_output(workspace_root, args, "prepare source checkout")?;
-    if !output.status.success() {
-        return Ok(None);
-    }
-
-    Ok(Some(
-        String::from_utf8_lossy(&output.stdout).trim().to_string(),
-    ))
-}
-
-fn run_git_command(workspace_root: &Path, args: &[&str]) -> Result<()> {
-    run_git(workspace_root, args, "prepare source checkout").map(|_| ())
 }
 
 const DETACHED_SOURCE_GIT_PULL_GUARD: &str = r#"git() {
@@ -1748,7 +1659,7 @@ mod tests {
     }
 
     #[test]
-    fn source_upgrade_preparation_resets_detached_checkout_to_origin_default() {
+    fn source_upgrade_preparation_preserves_detached_checkout_identity() {
         let remote = tempfile::tempdir().expect("remote tempdir");
         git(
             remote.path(),
@@ -1794,9 +1705,7 @@ mod tests {
         prepare_source_workspace_for_upgrade(checkout.path()).expect("prepare detached checkout");
 
         let prepared_head = git_stdout(checkout.path(), &["rev-parse", "HEAD"]);
-        let origin_head = git_stdout(checkout.path(), &["rev-parse", "origin/main"]);
-        assert_ne!(prepared_head, stale_head);
-        assert_eq!(prepared_head, origin_head);
+        assert_eq!(prepared_head, stale_head);
         assert_eq!(
             git_stdout(checkout.path(), &["branch", "--show-current"]),
             ""
@@ -1804,7 +1713,7 @@ mod tests {
     }
 
     #[test]
-    fn source_upgrade_preparation_detaches_worktree_when_default_branch_checked_out_elsewhere() {
+    fn source_upgrade_preparation_preserves_local_only_worktree_branch() {
         let remote = tempfile::tempdir().expect("remote tempdir");
         git(
             remote.path(),
@@ -1868,15 +1777,16 @@ mod tests {
             "test setup should reproduce branch ownership failure"
         );
 
+        let source_head = git_stdout(&source_worktree, &["rev-parse", "HEAD"]);
         prepare_source_workspace_for_upgrade(&source_worktree).expect("prepare source worktree");
 
         assert_eq!(
             git_stdout(&source_worktree, &["branch", "--show-current"]),
-            ""
+            "feature-upgrade-source"
         );
         assert_eq!(
             git_stdout(&source_worktree, &["rev-parse", "HEAD"]),
-            git_stdout(&source_worktree, &["rev-parse", "origin/main"])
+            source_head
         );
     }
 

--- a/src/core/upgrade/runners/source_checkout.rs
+++ b/src/core/upgrade/runners/source_checkout.rs
@@ -149,17 +149,9 @@ pub fn runner_source_checkout_prepare_options(
 
 pub fn runner_source_checkout_prepare_script() -> &'static str {
     r#"set -e
-git fetch origin
-if git symbolic-ref -q HEAD >/dev/null && git rev-parse --abbrev-ref --symbolic-full-name @{upstream} >/dev/null 2>&1; then
-  git pull --ff-only
-  exit 0
-fi
-remote_head="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD || true)"
-if [ -z "$remote_head" ]; then
-  echo "Cannot determine origin default branch for source checkout" >&2
-  exit 1
-fi
-git checkout --detach "$remote_head"
+# Source sync already materializes the controller-selected commit. Do not fetch,
+# pull, or rewrite it: the source may be detached or on a local-only branch.
+git rev-parse --verify HEAD >/dev/null
 "#
 }
 

--- a/src/core/upgrade/runners/tests.rs
+++ b/src/core/upgrade/runners/tests.rs
@@ -1091,7 +1091,7 @@ fn source_runner_upgrade_realigns_to_same_version_source_checkout_identity() {
 }
 
 #[test]
-fn runner_source_prepare_fast_forwards_attached_upstream_branch() {
+fn runner_source_prepare_preserves_local_only_branch_identity() {
     let fixture = remote_source_fixture();
     let checkout = fixture.root.path().join("attached");
     run_git(
@@ -1102,20 +1102,21 @@ fn runner_source_prepare_fast_forwards_attached_upstream_branch() {
             checkout.to_str().unwrap(),
         ],
     );
-    let expected_head = add_remote_commit(&fixture.seed, "remote update");
+    run_git(&checkout, &["switch", "-c", "ops/install-7851"]);
+    let expected_head = git_stdout(&checkout, &["rev-parse", "HEAD"]);
+    add_remote_commit(&fixture.seed, "remote update");
 
     run_source_prepare_script(&checkout);
 
-    assert_eq!(git_stdout(&checkout, &["branch", "--show-current"]), "main");
-    assert_eq!(git_stdout(&checkout, &["rev-parse", "HEAD"]), expected_head);
     assert_eq!(
-        git_stdout(&checkout, &["rev-parse", "origin/main"]),
-        expected_head
+        git_stdout(&checkout, &["branch", "--show-current"]),
+        "ops/install-7851"
     );
+    assert_eq!(git_stdout(&checkout, &["rev-parse", "HEAD"]), expected_head);
 }
 
 #[test]
-fn runner_source_prepare_updates_detached_checkout_to_remote_default() {
+fn runner_source_prepare_preserves_detached_source_identity() {
     let fixture = remote_source_fixture();
     let checkout = fixture.root.path().join("detached");
     run_git(
@@ -1127,7 +1128,8 @@ fn runner_source_prepare_updates_detached_checkout_to_remote_default() {
         ],
     );
     run_git(&checkout, &["checkout", "--detach", "HEAD"]);
-    let expected_head = add_remote_commit(&fixture.seed, "remote update");
+    let expected_head = git_stdout(&checkout, &["rev-parse", "HEAD"]);
+    add_remote_commit(&fixture.seed, "remote update");
 
     run_source_prepare_script(&checkout);
 
@@ -1158,7 +1160,8 @@ fn runner_source_prepare_detached_checkout_ignores_default_branch_checked_out_el
             "HEAD",
         ],
     );
-    let expected_head = add_remote_commit(&fixture.seed, "remote update");
+    let expected_head = git_stdout(&detached, &["rev-parse", "HEAD"]);
+    add_remote_commit(&fixture.seed, "remote update");
 
     run_source_prepare_script(&detached);
 


### PR DESCRIPTION
## Summary
- preserve the caller-selected source checkout during source upgrades
- keep controller-materialized local branches free of synthetic origin tracking
- cover local-only and detached source preparation while retaining no-provider hydration skips

Fixes #7843

## Testing
1. `git diff --check`
2. Cargo tests and formatting not run per request; CI is authoritative.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode; general coding subagent
- **Used for:** Runner/source-upgrade analysis, implementation, and regression coverage