### PR TITLE
Fix detached agent-task ghost-run liveness

### DIFF
--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -175,6 +175,20 @@ fn attach_agent_task_status_actionable(value: &mut Value, run_id: &str) {
         CommandNextAction::new("review run", review_command).with_kind(CommandNextActionKind::Show),
     );
 
+    if value
+        .pointer("/metadata/stale_running")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        metadata.next_actions.push(
+            CommandNextAction::new(
+                "reconcile stale run",
+                "homeboy agent-task active --reconcile".to_string(),
+            )
+            .with_kind(CommandNextActionKind::Repair),
+        );
+    }
+
     attach_actionable_metadata(value, metadata);
 }
 
@@ -954,6 +968,7 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
         "risk_flags": risk_flags,
         "execution_location": execution_location(record),
         "queue_visibility": queue_visibility(record),
+        "liveness": liveness_summary(record),
         "full_command": format!("homeboy agent-task status {run_id} --full"),
     });
 
@@ -984,6 +999,35 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
         }
     }
     summary
+}
+
+fn liveness_summary(record: &Value) -> Value {
+    let metadata = record.get("metadata").unwrap_or(&Value::Null);
+    let provider_handle_count = record
+        .get("provider_handles")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let stale = metadata
+        .get("stale_running")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    json!({
+        "status": if stale { "stale" } else { "active" },
+        "heartbeat_last_seen_at": record.pointer("/lifecycle/heartbeat/last_seen_at"),
+        "runner_job_status": metadata.get("runner_job_status"),
+        "runner_job_last_seen_at": metadata.get("runner_job_last_seen_at"),
+        "provider_boundary": {
+            "status": if provider_handle_count == 0 { "absent" } else { "recorded" },
+            "provider_handle_count": provider_handle_count,
+        },
+        "stale_reason": metadata.get("stale_running_reason"),
+        "next_action": if stale {
+            "homeboy agent-task active --reconcile"
+        } else {
+            "homeboy agent-task status <run-id> --full"
+        },
+    })
 }
 
 fn execution_location(record: &Value) -> Value {
@@ -1562,6 +1606,27 @@ mod tests {
             "agent-task-run-2",
         );
         assert_eq!(remote["execution_location"], "runner:homeboy-lab");
+
+        let stale = compact_status_summary(
+            &json!({
+                "run_id": "agent-task-ghost",
+                "state": "running",
+                "tasks": [],
+                "provider_handles": [],
+                "lifecycle": { "heartbeat": { "last_seen_at": "2026-07-12T23:28:28Z" } },
+                "metadata": {
+                    "stale_running": true,
+                    "stale_running_reason": "runner_job_unverified_after_daemon_restart"
+                }
+            }),
+            "agent-task-ghost",
+        );
+        assert_eq!(stale["liveness"]["status"], "stale");
+        assert_eq!(stale["liveness"]["provider_boundary"]["status"], "absent");
+        assert_eq!(
+            stale["liveness"]["next_action"],
+            "homeboy agent-task active --reconcile"
+        );
     }
 
     #[test]

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -197,8 +197,12 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
             record = reconciled;
         }
     }
-    reconcile_runner_job_terminal_state(&mut record);
+    let before_liveness_reconciliation = record.clone();
+    reconcile_runner_job_state(&mut record);
     record.annotate_stale_running();
+    if record != before_liveness_reconciliation {
+        store::write_record(&record)?;
+    }
     if requested_run_id != record.run_id {
         if let Ok(index) = store::read_cook_index(&requested_run_id) {
             let metadata = record.ensure_metadata_object();
@@ -212,7 +216,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     Ok(record)
 }
 
-fn reconcile_runner_job_terminal_state(record: &mut AgentTaskRunRecord) {
+fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) {
     if record.state != AgentTaskRunState::Running {
         return;
     }
@@ -225,15 +229,21 @@ fn reconcile_runner_job_terminal_state(record: &mut AgentTaskRunRecord) {
     let Ok(snapshot) = crate::core::runners::runner_job_log_snapshot(&runner_id, &job_id) else {
         return;
     };
-    if !matches!(
-        snapshot.job.status,
+    match snapshot.job.status {
+        crate::core::api_jobs::JobStatus::Queued | crate::core::api_jobs::JobStatus::Running => {
+            record.updated_at = Some(now_timestamp());
+            update_lifecycle_heartbeat(record);
+            let last_seen_at = record.updated_at.clone();
+            let metadata = record.ensure_metadata_object();
+            metadata.insert("runner_job_status".to_string(), json!(snapshot.job.status));
+            metadata.insert("runner_job_last_seen_at".to_string(), json!(last_seen_at));
+        }
         crate::core::api_jobs::JobStatus::Succeeded
-            | crate::core::api_jobs::JobStatus::Failed
-            | crate::core::api_jobs::JobStatus::Cancelled
-    ) {
-        return;
+        | crate::core::api_jobs::JobStatus::Failed
+        | crate::core::api_jobs::JobStatus::Cancelled => {
+            apply_runner_job_terminal_state(record, snapshot.job.status, &snapshot.events);
+        }
     }
-    apply_runner_job_terminal_state(record, snapshot.job.status, &snapshot.events);
     let _ = store::write_record(record);
 }
 
@@ -362,6 +372,7 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     };
     record.updated_at = Some(now_timestamp());
     set_run_state(&mut record, AgentTaskRunState::Running);
+    update_lifecycle_heartbeat(&mut record);
     for task in &mut record.tasks {
         if task.state == AgentTaskState::Queued {
             task.state = AgentTaskState::Running;

--- a/src/core/agent_task_lifecycle/records.rs
+++ b/src/core/agent_task_lifecycle/records.rs
@@ -121,9 +121,17 @@ impl AgentTaskRunRecord {
         } else {
             "missing_runner_pid"
         };
+        let provider_handle_count = self.provider_handles.len();
         let metadata = self.ensure_metadata_object();
         metadata.insert("stale_running".to_string(), json!(true));
         metadata.insert("stale_running_reason".to_string(), json!(reason));
+        metadata.insert(
+            "provider_boundary".to_string(),
+            json!({
+                "status": if provider_handle_count == 0 { "absent" } else { "recorded" },
+                "provider_handle_count": provider_handle_count,
+            }),
+        );
         metadata.insert("retryable".to_string(), json!(true));
     }
 

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -94,6 +94,15 @@ fn detached_lab_handoff_persists_inspectable_running_record() {
         assert_eq!(loaded.metadata["runner_id"], "homeboy-lab");
         assert_eq!(loaded.metadata["runner_job_id"], "job-123");
         assert!(loaded.metadata.get("stale_running").is_none());
+        assert!(loaded.lifecycle.heartbeat.is_some());
+        assert_eq!(
+            loaded
+                .lifecycle
+                .heartbeat
+                .as_ref()
+                .map(|heartbeat| heartbeat.last_seen_at.as_str()),
+            loaded.updated_at.as_deref()
+        );
         assert_eq!(log.events.len(), 1);
         assert!(artifacts.evidence_refs.is_empty());
     });
@@ -1166,6 +1175,14 @@ fn status_marks_running_run_without_owner_as_stale() {
             loaded.metadata["stale_running_reason"],
             "missing_runner_pid"
         );
+        assert_eq!(loaded.metadata["provider_boundary"]["status"], "absent");
+
+        // Read-side reconciliation persists the classification, so repeated
+        // status reads converge instead of reviving a ghost run as active.
+        let persisted = store::read_record("run-stale-missing-owner").expect("persisted record");
+        assert_eq!(persisted.metadata["stale_running"], json!(true));
+        let repeated = status("run-stale-missing-owner").expect("repeated status loaded");
+        assert_eq!(repeated.metadata["stale_running"], json!(true));
     });
 }
 


### PR DESCRIPTION
Closes #7865

## Summary
- persist a lifecycle heartbeat when detached Lab agent-task handoff starts
- refresh durable heartbeat only after runner daemon confirms the remote job is queued or running
- persist stale classification on read-side reconciliation and surface stale liveness, provider-boundary absence, and recovery action in compact status
- preserve terminal runner job reconciliation and add handoff/stale idempotency regression coverage

## How to test
1. Run `cargo test core::agent_task_lifecycle::tests` from a fresh checkout.
2. Confirm detached handoff records contain a lifecycle heartbeat matching `updated_at`.
3. Confirm repeated status reads of a stale run retain `stale_running`, report `liveness.status: stale`, show `provider_boundary.status: absent`, and suggest `homeboy agent-task active --reconcile`.

## Verification
- `git diff --check`
- Cargo tests and formatting intentionally not run locally; CI is authoritative.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode; general coding subagent
- **Used for:** Lifecycle incident analysis, implementation, and regression coverage