### PR TITLE
fix: persist controller agent-task offload runs

### DIFF
--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -3,6 +3,50 @@
 use super::support::*;
 
 #[test]
+fn controller_proxy_status_and_logs_resolve_before_runner_child_is_known() {
+    with_temp_home(|| {
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        agent_task_lifecycle::record_lab_offload_planned(
+            homeboy::core::agent_tasks::lifecycle::LabOffloadProxyPlan {
+                run_id: "run-cli-controller-proxy",
+                runner_id: "homeboy-lab",
+                remote_workspace: "/runner/workspace/repo",
+                remote_command: &command,
+            },
+        )
+        .expect("controller proxy persisted");
+
+        let (status_value, status_exit) = status(StatusArgs {
+            run_id: "run-cli-controller-proxy".to_string(),
+            bridge: false,
+            since_cursor: None,
+            full: true,
+        })
+        .expect("controller status resolves");
+        let (logs_value, logs_exit) = logs(StatusArgs {
+            run_id: "run-cli-controller-proxy".to_string(),
+            bridge: false,
+            since_cursor: None,
+            full: false,
+        })
+        .expect("controller logs resolve");
+
+        assert_eq!(status_exit, 0);
+        assert_eq!(logs_exit, 0);
+        assert_eq!(status_value["state"], "queued");
+        assert_eq!(
+            status_value["metadata"]["runner_execution_record"]["status"],
+            "planned"
+        );
+        assert_eq!(logs_value["run_id"], "run-cli-controller-proxy");
+    });
+}
+
+#[test]
 fn submit_run_status_reports_terminal_state() {
     with_temp_home(|| {
         let plan = AgentTaskPlan::new(

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -271,9 +271,34 @@ pub(crate) fn apply_runner_job_terminal_state(
             task.state = task_state;
         }
     }
+    let runner_identity = record
+        .runner_id()
+        .zip(record.runner_job_id())
+        .map(|(runner_id, runner_job_id)| (runner_id.to_string(), runner_job_id.to_string()));
+    let agent_task_run_id = record.run_id.clone();
     let metadata = record.ensure_metadata_object();
     metadata.insert("runner_job_status".to_string(), json!(status));
     metadata.insert("runner_job_events".to_string(), json!(events));
+    if let Some((runner_id, runner_job_id)) = runner_identity {
+        metadata.insert(
+            "runner_execution_record".to_string(),
+            serde_json::to_value(
+                crate::core::runner_execution_envelope::RunnerExecutionRecord::terminal(
+                    &runner_job_id,
+                    &runner_id,
+                    "daemon",
+                    if status == crate::core::api_jobs::JobStatus::Succeeded {
+                        0
+                    } else {
+                        1
+                    },
+                )
+                .with_job_id(&runner_job_id)
+                .with_agent_task_run_id(agent_task_run_id),
+            )
+            .unwrap_or(Value::Null),
+        );
+    }
     metadata.insert(
         "retryable".to_string(),
         json!(run_state != AgentTaskRunState::Succeeded),
@@ -354,6 +379,26 @@ pub struct DetachedLabRunRecord<'a> {
     pub remote_command: &'a [String],
 }
 
+#[derive(Debug, Clone)]
+pub struct LabOffloadProxyPlan<'a> {
+    pub run_id: &'a str,
+    pub runner_id: &'a str,
+    pub remote_workspace: &'a str,
+    pub remote_command: &'a [String],
+}
+
+/// Persist the controller-owned parent before handing an agent-task workload to
+/// a Lab. The runner owns child execution; this record owns the stable local
+/// identity and is reconciled from that child once it is accepted.
+pub fn record_lab_offload_planned(input: LabOffloadProxyPlan<'_>) -> Result<AgentTaskRunRecord> {
+    record_lab_offload_proxy(
+        &input.run_id,
+        input.runner_id,
+        input.remote_workspace,
+        input.remote_command,
+    )
+}
+
 pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(input.run_id);
     let plan = detached_lab_plan(&run_id, &input);
@@ -370,6 +415,27 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
         }
         Err(error) => return Err(error),
     };
+    if matches!(
+        record.state,
+        AgentTaskRunState::Succeeded
+            | AgentTaskRunState::PartialFailure
+            | AgentTaskRunState::Failed
+            | AgentTaskRunState::Cancelled
+    ) {
+        // A retry of the controller-side handoff must not resurrect a terminal
+        // proxy. Its child identity is immutable once terminal state is known.
+        if record.runner_id() == Some(input.runner_id)
+            && record.runner_job_id() == Some(input.runner_job_id)
+        {
+            return Ok(record);
+        }
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!("agent-task run '{}' is already terminal", record.run_id),
+            Some(record.run_id),
+            None,
+        ));
+    }
     record.updated_at = Some(now_timestamp());
     set_run_state(&mut record, AgentTaskRunState::Running);
     update_lifecycle_heartbeat(&mut record);
@@ -387,9 +453,86 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
         json!(input.remote_workspace),
     );
     metadata.insert("remote_command".to_string(), json!(input.remote_command));
+    metadata.insert(
+        "runner_execution_record".to_string(),
+        serde_json::to_value(
+            crate::core::runner_execution_envelope::RunnerExecutionRecord::in_flight(
+                input.runner_job_id,
+                input.runner_id,
+                "daemon",
+            )
+            .with_job_id(input.runner_job_id)
+            .with_agent_task_run_id(&run_id),
+        )
+        .unwrap_or(Value::Null),
+    );
     metadata.insert("retryable".to_string(), json!(true));
     metadata.remove("stale_running");
     metadata.remove("stale_running_reason");
+    store::write_record(&record)?;
+    Ok(record)
+}
+
+fn record_lab_offload_proxy(
+    requested_run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+    remote_command: &[String],
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(requested_run_id);
+    let input = DetachedLabRunRecord {
+        run_id: &run_id,
+        runner_id,
+        // This placeholder is removed immediately below. Keeping construction
+        // centralized lets the proxy and bound child share one plan shape.
+        runner_job_id: "unbound",
+        remote_workspace,
+        remote_command,
+    };
+    let mut plan = detached_lab_plan(&run_id, &input);
+    let task = &mut plan.tasks[0];
+    if let Some(inputs) = task.inputs.as_object_mut() {
+        inputs.remove("runner_job_id");
+    }
+    task.source_refs.clear();
+    if let Some(materialization) = task.workspace.materialization.as_object_mut() {
+        materialization.remove("runner_job_id");
+    }
+    if let Some(metadata) = task.metadata.as_object_mut() {
+        metadata.remove("runner_job_id");
+    }
+    if let Some(metadata) = plan.metadata.as_object_mut() {
+        metadata.remove("runner_job_id");
+    }
+    let mut record = match store::read_record(&run_id) {
+        Ok(record) => record,
+        Err(error)
+            if error.code == ErrorCode::InternalJsonError
+                && store::record_lacks_typed_metadata(&run_id)? =>
+        {
+            submit_plan(&plan, Some(&run_id))?
+        }
+        Err(error) if error.code == ErrorCode::ValidationInvalidArgument => {
+            submit_plan(&plan, Some(&run_id))?
+        }
+        Err(error) => return Err(error),
+    };
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
+    metadata.insert("runner_id".to_string(), json!(runner_id));
+    metadata.insert("remote_workspace".to_string(), json!(remote_workspace));
+    metadata.insert("remote_command".to_string(), json!(remote_command));
+    metadata.insert("retryable".to_string(), json!(true));
+    metadata.insert(
+        "runner_execution_record".to_string(),
+        serde_json::to_value(
+            crate::core::runner_execution_envelope::RunnerExecutionRecord::planned(
+                &run_id, runner_id, "daemon",
+            )
+            .with_agent_task_run_id(&run_id),
+        )
+        .unwrap_or(Value::Null),
+    );
     store::write_record(&record)?;
     Ok(record)
 }

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -109,6 +109,129 @@ fn detached_lab_handoff_persists_inspectable_running_record() {
 }
 
 #[test]
+fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
+    with_isolated_home(|_| {
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        let planned = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "agent-task-controller-proxy",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("controller proxy recorded before handoff");
+
+        assert_eq!(planned.state, AgentTaskRunState::Queued);
+        assert!(planned.metadata.get("runner_job_id").is_none());
+        assert!(load_plan("agent-task-controller-proxy")
+            .expect("proxy plan")
+            .tasks[0]
+            .inputs
+            .get("runner_job_id")
+            .is_none());
+        assert_eq!(
+            planned.metadata["runner_execution_record"]["status"],
+            "planned"
+        );
+        assert_eq!(
+            logs("agent-task-controller-proxy")
+                .expect("logs resolve")
+                .events
+                .len(),
+            1
+        );
+
+        let running = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-controller-proxy",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("accepted child binds proxy");
+        assert_eq!(running.state, AgentTaskRunState::Running);
+        assert_eq!(running.metadata["runner_job_id"], "job-123");
+        assert_eq!(
+            running.metadata["runner_execution_record"]["status"],
+            "running"
+        );
+    });
+}
+
+#[test]
+fn runner_terminal_reconciliation_is_idempotent_and_preserves_execution_owner() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-terminal-proxy",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-456",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let mut record = status("agent-task-terminal-proxy").expect("status");
+        apply_runner_job_terminal_state(
+            &mut record,
+            crate::core::api_jobs::JobStatus::Succeeded,
+            &[],
+        );
+        store::write_record(&record).expect("terminal record");
+
+        let retry = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-terminal-proxy",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-456",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("same child handoff is idempotent");
+        assert_eq!(retry.state, AgentTaskRunState::Succeeded);
+        assert_eq!(
+            retry.metadata["runner_execution_record"]["status"],
+            "succeeded"
+        );
+        assert_eq!(
+            retry.metadata["runner_execution_record"]["job_id"],
+            "job-456"
+        );
+    });
+}
+
+#[test]
+fn controller_proxy_becomes_terminal_when_handoff_fails_before_child_creation() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "agent-task-handoff-failure",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("planned proxy");
+        let plan = load_plan("agent-task-handoff-failure").expect("proxy plan");
+        record_pre_execution_failure(
+            "agent-task-handoff-failure",
+            &plan,
+            "lab_handoff",
+            &Error::internal_unexpected("runner rejected handoff"),
+        )
+        .expect("handoff failure recorded");
+
+        let record = status("agent-task-handoff-failure").expect("terminal status");
+        assert_eq!(record.state, AgentTaskRunState::Failed);
+        assert_eq!(record.metadata["runner_id"], "homeboy-lab");
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "lab_handoff"
+        );
+    });
+}
+
+#[test]
 fn detached_runner_failure_transitions_parent_and_task_terminal() {
     let plan = test_plan();
     let mut record = AgentTaskRunRecord {

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -236,13 +236,14 @@ pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
         cook_attempt_run_id, cook_index, list_records, load_plan, logs, mark_resuming,
-        mark_running, record_completed_run, record_cook_attempt, record_pre_dispatch_failure,
-        record_pre_execution_failure, record_promotion, record_remote_dispatch_failure,
-        record_run_aggregate, retry, run_record_exists, run_status, status, submit_plan,
-        AgentTaskArtifactRef, AgentTaskCookIndex, AgentTaskCookIndexAttempt,
-        AgentTaskEventEnvelope, AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure,
-        AgentTaskRunArtifacts, AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord,
-        AgentTaskRunState, AgentTaskRunStatus, AgentTaskRunTask,
+        mark_running, record_completed_run, record_cook_attempt, record_detached_lab_run,
+        record_lab_offload_planned, record_pre_dispatch_failure, record_pre_execution_failure,
+        record_promotion, record_remote_dispatch_failure, record_run_aggregate, retry,
+        run_record_exists, run_status, status, submit_plan, AgentTaskArtifactRef,
+        AgentTaskCookIndex, AgentTaskCookIndexAttempt, AgentTaskEventEnvelope,
+        AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts,
+        AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState,
+        AgentTaskRunStatus, AgentTaskRunTask, DetachedLabRunRecord, LabOffloadProxyPlan,
     };
 }
 

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -348,6 +348,20 @@ pub(crate) fn exec_lab_context(
         .overhead
         .record(LabOffloadPhase::Preflight, pre_dispatch_started.elapsed());
 
+    // Persist the controller parent before the daemon accepts a child. This is
+    // intentionally before `exec`: a controller timeout must leave status and
+    // logs resolvable without reading the runner's private lifecycle store.
+    if let Some(run_id) = context.agent_task_run_id.as_deref() {
+        agent_task_lifecycle::record_lab_offload_planned(
+            agent_task_lifecycle::LabOffloadProxyPlan {
+                run_id,
+                runner_id,
+                remote_workspace: &remote_cwd,
+                remote_command: &context.remote_command,
+            },
+        )?;
+    }
+
     let remote_exec_started = std::time::Instant::now();
     let exec_result = exec(
         runner_id,
@@ -362,7 +376,25 @@ pub(crate) fn exec_lab_context(
             if let Some(workspace) = context.materialized_workspace.as_mut() {
                 workspace.preserve();
             }
-            if let Some(health) = runner_daemon_health_failure(&err) {
+            let health = runner_daemon_health_failure(&err);
+            if health
+                .as_ref()
+                .and_then(|health| health.job_id.as_deref())
+                .is_none()
+            {
+                if let Some(run_id) = context.agent_task_run_id.as_deref() {
+                    // The controller parent already exists, so a failed handoff
+                    // must terminalize it rather than leave a queued ghost.
+                    let plan = agent_task_lifecycle::load_plan(run_id)?;
+                    agent_task_lifecycle::record_pre_execution_failure(
+                        run_id,
+                        &plan,
+                        "lab_handoff",
+                        &err,
+                    )?;
+                }
+            }
+            if let Some(health) = health {
                 let reason = health.reason.clone();
                 context.plan = with_step(
                     context.plan,

--- a/src/core/runner_execution_envelope.rs
+++ b/src/core/runner_execution_envelope.rs
@@ -540,6 +540,11 @@ impl RunnerExecutionRecord {
         self
     }
 
+    pub fn with_agent_task_run_id(mut self, agent_task_run_id: impl Into<String>) -> Self {
+        self.agent_task_run_id = Some(agent_task_run_id.into());
+        self
+    }
+
     pub fn with_artifact_refs(
         mut self,
         artifact_refs: impl IntoIterator<Item = RunnerExecutionArtifactRef>,

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -597,7 +597,7 @@ fn prepare_source_workspace_for_upgrade(workspace_root: &Path) -> Result<()> {
     // A caller-selected source path is an immutable build input. In particular,
     // worktree branches may be local-only or detached and must not be rewritten
     // to an origin branch before the source build or runner materialization.
-    ensure_clean_source_workspace(workspace_root)?;
+    ensure_clean_source_workspace(workspace_root)
 }
 
 fn ensure_clean_source_workspace(workspace_root: &Path) -> Result<()> {


### PR DESCRIPTION
## Summary
- Persist a controller-owned agent-task proxy before Lab handoff, then bind the accepted runner job to the same durable lifecycle record.
- Project planned, running, and terminal states through the existing `RunnerExecutionRecord`; runner job state is authoritative for child execution while the controller owns the parent record, status, logs, and evidence references.
- Keep reconciliation idempotent: the same child may be rebound safely, while a terminal proxy cannot be resurrected or rebound to another child. Handoff failures terminalize the controller proxy when no runner child exists.

## Operator flow
Before: `homeboy agent-task status <run>` and `logs <run>` could fail with missing `agent_task_run` metadata until operators queried the Lab host directly.

After: the controller exposes queued/planned state before dispatch, running state plus runner/job identity after acceptance, and terminal success/failure after reconciliation. `homeboy agent-task status|logs <run>` stays controller-resolvable throughout.

## Verification
1. Run `cargo build -j3`.
2. Run `cargo test agent_task_lifecycle --lib -j3`.
3. Run `cargo test controller_proxy_status_and_logs_resolve_before_runner_child_is_known --lib -j3`.
4. `cargo clippy --lib --tests -- -D warnings` remains blocked by existing repository-wide warnings; it reported no diagnostics in changed files.

Fixes #7817

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 (terra) via opencode, orchestrated by Claude (claude-fable-5)
- **Used for:** Root-cause analysis, lifecycle reconciliation implementation, and verification. Reviewed by Chris Huber.