### PR TITLE
fix: return source workspace preparation result

### DIFF
--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -597,7 +597,7 @@ fn prepare_source_workspace_for_upgrade(workspace_root: &Path) -> Result<()> {
     // A caller-selected source path is an immutable build input. In particular,
     // worktree branches may be local-only or detached and must not be rewritten
     // to an origin branch before the source build or runner materialization.
-    ensure_clean_source_workspace(workspace_root)?;
+    ensure_clean_source_workspace(workspace_root)
 }
 
 fn ensure_clean_source_workspace(workspace_root: &Path) -> Result<()> {


### PR DESCRIPTION
## Summary
- return the clean-workspace validation result from source-upgrade preparation
- preserve local and detached source identity behavior from #7866

Fixes #7871

## Verification
1. Run `cargo check`.
2. Run `git diff --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode; general coding subagent
- **Used for:** Compile regression diagnosis, implementation, and focused verification