### PR TITLE
Stream structured workload progress from runner jobs

### DIFF
--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -97,6 +97,26 @@ the wrapper process group is terminated and the runner command returns failure
 evidence promptly instead of waiting forever. Runners may include `message`,
 `error`, `summary`, or `failure.message` for the stderr detail surfaced by core.
 
+## Structured workload progress
+
+A child command can report durable, live workload progress by writing one
+newline-delimited stdout record with this exact prefix and JSON envelope:
+
+```text
+HOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"import","current_item":"fixture-a","completed":1,"total":5,"metadata":{"source":"matrix"}}
+```
+
+`phase`, `current_item`, `completed`, `total`, and `metadata` are optional;
+the envelope must contain at least one of them. When both counters are present,
+`completed` cannot exceed `total`. Homeboy redacts the envelope and appends it
+as a durable `progress` job event immediately, so
+`homeboy runner job logs <runner-id> <job-id> --follow` displays it before the
+command exits.
+
+The envelope accepts only these fields and never controls job lifecycle. Lines
+that are malformed, use another schema, or include terminal-state fields stay
+ordinary bounded stdout and cannot change the runner job status.
+
 ## Failure context
 
 Runner exec results expose a generic `failure_context` object when the executed

--- a/src/core/engine/command.rs
+++ b/src/core/engine/command.rs
@@ -2,6 +2,7 @@
 
 use std::io::{self, Read};
 use std::process::{Child, Command, ExitStatus, Output};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -9,6 +10,9 @@ use crate::core::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_CAPTURE_LIMIT_BYTES: usize = 4 * 1024 * 1024;
+const MAX_OBSERVED_LINE_BYTES: usize = 64 * 1024;
+
+pub type StdoutLineObserver = Arc<dyn Fn(&str) + Send + Sync + 'static>;
 
 pub fn run(program: &str, args: &[&str], context: &str) -> Result<String> {
     let output = Command::new(program).args(args).output().map_err(|e| {
@@ -140,12 +144,29 @@ pub fn wait_with_bounded_output(
 pub fn wait_with_bounded_output_until_cancelled(
     child: &mut Child,
     byte_limit: usize,
+    is_cancelled: impl FnMut() -> bool,
+) -> io::Result<BoundedCommandOutput> {
+    wait_with_bounded_output_until_cancelled_with_stdout_observer(
+        child,
+        byte_limit,
+        is_cancelled,
+        None,
+    )
+}
+
+pub fn wait_with_bounded_output_until_cancelled_with_stdout_observer(
+    child: &mut Child,
+    byte_limit: usize,
     mut is_cancelled: impl FnMut() -> bool,
+    stdout_line_observer: Option<StdoutLineObserver>,
 ) -> io::Result<BoundedCommandOutput> {
     let stdout = child.stdout.take();
     let stderr = child.stderr.take();
-    let stdout_handle =
-        stdout.map(|stream| thread::spawn(move || capture_tail(stream, byte_limit)));
+    let stdout_handle = stdout.map(|stream| {
+        thread::spawn(move || {
+            capture_tail_with_stdout_observer(stream, byte_limit, stdout_line_observer)
+        })
+    });
     let stderr_handle =
         stderr.map(|stream| thread::spawn(move || capture_tail(stream, byte_limit)));
 
@@ -247,6 +268,46 @@ fn capture_tail(mut stream: impl Read, byte_limit: usize) -> io::Result<BoundedS
             break;
         }
         capture.push(&buf[..n]);
+    }
+    Ok(capture.finish())
+}
+
+fn capture_tail_with_stdout_observer(
+    mut stream: impl Read,
+    byte_limit: usize,
+    observer: Option<StdoutLineObserver>,
+) -> io::Result<BoundedStreamCapture> {
+    let mut capture = TailCapture::new(byte_limit);
+    let mut pending = Vec::new();
+    let mut discard_until_newline = false;
+    let mut buf = [0_u8; 8192];
+    loop {
+        let n = stream.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        let chunk = &buf[..n];
+        capture.push(chunk);
+        if let Some(observer) = observer.as_ref() {
+            for byte in chunk {
+                if discard_until_newline {
+                    if *byte == b'\n' {
+                        discard_until_newline = false;
+                    }
+                    continue;
+                }
+                if *byte == b'\n' {
+                    let line = String::from_utf8_lossy(&pending);
+                    observer(line.trim_end_matches('\r'));
+                    pending.clear();
+                } else if pending.len() < MAX_OBSERVED_LINE_BYTES {
+                    pending.push(*byte);
+                } else {
+                    pending.clear();
+                    discard_until_newline = true;
+                }
+            }
+        }
     }
     Ok(capture.finish())
 }

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -639,6 +639,7 @@ pub(crate) struct PreparedRunnerProcess {
     pub cwd: String,
     pub command: Vec<String>,
     pub env: HashMap<String, String>,
+    pub secret_env_names: Vec<String>,
     pub source_snapshot: SourceSnapshot,
     pub require_paths: Vec<String>,
 }

--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
+use std::sync::Arc;
 
+use crate::core::engine::command::StdoutLineObserver;
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 use crate::core::redaction::{redact_argv, RedactionPolicy};
@@ -271,6 +273,7 @@ pub(crate) fn prepare_runner_process(
         cwd,
         command: request.command,
         env,
+        secret_env_names: secret_env_plan.secret_env_names(),
         source_snapshot,
         require_paths: request.require_paths,
     })
@@ -377,6 +380,7 @@ pub(crate) fn prepare_daemon_local_process(
         cwd,
         command: request.command,
         env,
+        secret_env_names: secret_env_plan.secret_env_names(),
         source_snapshot,
         require_paths: request.require_paths,
     })
@@ -403,6 +407,8 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
         &mut command,
         is_cancelled,
         progress_sink,
+        &plan.env,
+        &plan.secret_env_names,
         plan.runner.settings.concurrency_limit,
     )
 }
@@ -494,12 +500,29 @@ pub(super) fn command_output_until_cancelled_with_progress(
     command: &mut std::process::Command,
     is_cancelled: impl FnMut() -> bool,
     progress_sink: Option<RunnerCommandProgressSink>,
+    env: &HashMap<String, String>,
+    secret_env_names: &[String],
     concurrency_limit: Option<usize>,
 ) -> Result<ProcessOutput> {
+    let stdout_line_observer = progress_sink.as_ref().map(|sink| {
+        let sink = Arc::clone(sink);
+        let env = env.clone();
+        let secret_env_names = secret_env_names.to_vec();
+        Arc::new(move |line: &str| {
+            if let Some(progress) = crate::core::runner::progress::parse_child_progress_line(
+                line,
+                &env,
+                &secret_env_names,
+            ) {
+                sink(progress);
+            }
+        }) as StdoutLineObserver
+    });
     let measured = measured_command_output_until_cancelled_with_progress(
         command,
         is_cancelled,
         progress_sink,
+        stdout_line_observer,
         concurrency_limit,
     )?;
     let output = measured.output;

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -47,6 +47,7 @@ pub use managed_source::{
 mod offload_changed_since;
 mod offload_metadata;
 mod origin_refs;
+mod progress;
 mod resource_metrics;
 mod rig_materialization;
 mod runtime_materialization_status;

--- a/src/core/runner/progress.rs
+++ b/src/core/runner/progress.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::core::redaction::RedactionPolicy;
+
+pub(crate) const RUNNER_PROGRESS_LINE_PREFIX: &str = "HOMEBOY_RUNNER_PROGRESS ";
+pub(crate) const RUNNER_PROGRESS_SCHEMA: &str = "homeboy/runner-progress/v1";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChildProgressEnvelope {
+    schema: String,
+    #[serde(default)]
+    phase: Option<String>,
+    #[serde(default)]
+    current_item: Option<String>,
+    #[serde(default)]
+    completed: Option<u64>,
+    #[serde(default)]
+    total: Option<u64>,
+    #[serde(default)]
+    metadata: Option<Value>,
+}
+
+pub(crate) fn parse_child_progress_line(
+    line: &str,
+    env: &HashMap<String, String>,
+    secret_env_names: &[String],
+) -> Option<Value> {
+    let payload = line.strip_prefix(RUNNER_PROGRESS_LINE_PREFIX)?;
+    let envelope: ChildProgressEnvelope = serde_json::from_str(payload).ok()?;
+    if envelope.schema != RUNNER_PROGRESS_SCHEMA
+        || envelope
+            .phase
+            .as_ref()
+            .is_some_and(|value| value.trim().is_empty() || value.len() > 2048)
+        || envelope
+            .current_item
+            .as_ref()
+            .is_some_and(|value| value.trim().is_empty() || value.len() > 8192)
+        || envelope
+            .completed
+            .zip(envelope.total)
+            .is_some_and(|(completed, total)| completed > total)
+        || (envelope.phase.is_none()
+            && envelope.current_item.is_none()
+            && envelope.completed.is_none()
+            && envelope.total.is_none()
+            && envelope.metadata.is_none())
+    {
+        return None;
+    }
+
+    let value = json!({
+        "schema": RUNNER_PROGRESS_SCHEMA,
+        "phase": envelope.phase,
+        "current_item": envelope.current_item,
+        "completed": envelope.completed,
+        "total": envelope.total,
+        "metadata": envelope.metadata,
+    });
+    Some(redact_progress_value(value, env, secret_env_names))
+}
+
+fn redact_progress_value(
+    value: Value,
+    env: &HashMap<String, String>,
+    secret_env_names: &[String],
+) -> Value {
+    let policy = RedactionPolicy::default();
+    let mut secrets = env
+        .iter()
+        .filter_map(|(name, value)| {
+            (!value.is_empty()
+                && (policy.is_sensitive_key(name)
+                    || secret_env_names.iter().any(|secret| secret == name)))
+            .then_some(value.as_str())
+        })
+        .collect::<Vec<_>>();
+    secrets.sort_by_key(|value| std::cmp::Reverse(value.len()));
+    redact_progress_strings(policy.redact_json(&value), &secrets, policy.replacement())
+}
+
+fn redact_progress_strings(value: Value, secrets: &[&str], replacement: &str) -> Value {
+    match value {
+        Value::String(mut value) => {
+            for secret in secrets {
+                value = value.replace(secret, replacement);
+            }
+            Value::String(value)
+        }
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(|value| redact_progress_strings(value, secrets, replacement))
+                .collect(),
+        ),
+        Value::Object(values) => Value::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, redact_progress_strings(value, secrets, replacement)))
+                .collect(),
+        ),
+        value => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_and_redacts_a_valid_child_progress_envelope() {
+        let mut env = HashMap::new();
+        env.insert("TOKEN".to_string(), "secret-value".to_string());
+        let line = format!(
+            "{RUNNER_PROGRESS_LINE_PREFIX}{{\"schema\":\"{RUNNER_PROGRESS_SCHEMA}\",\"phase\":\"import\",\"current_item\":\"secret-value\",\"completed\":1,\"total\":3,\"metadata\":{{\"token\":\"abc\"}}}}"
+        );
+
+        let event = parse_child_progress_line(&line, &env, &["TOKEN".to_string()])
+            .expect("valid progress event");
+
+        assert_eq!(event["phase"], "import");
+        assert_eq!(event["current_item"], "[REDACTED]");
+        assert_eq!(event["metadata"]["token"], "[REDACTED]");
+    }
+
+    #[test]
+    fn rejects_malformed_and_terminal_state_forging_lines() {
+        let env = HashMap::new();
+        assert!(parse_child_progress_line("ordinary output", &env, &[]).is_none());
+        assert!(parse_child_progress_line(
+            &format!("{RUNNER_PROGRESS_LINE_PREFIX}{{not-json}}"),
+            &env,
+            &[]
+        )
+        .is_none());
+        assert!(parse_child_progress_line(
+            &format!("{RUNNER_PROGRESS_LINE_PREFIX}{{\"schema\":\"{RUNNER_PROGRESS_SCHEMA}\",\"phase\":\"done\",\"status\":\"succeeded\"}}"),
+            &env,
+            &[]
+        )
+        .is_none());
+    }
+}

--- a/src/core/runner/resource_metrics.rs
+++ b/src/core/runner/resource_metrics.rs
@@ -7,8 +7,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::core::engine::command::{
-    isolate_process_tree, wait_with_bounded_output, wait_with_bounded_output_until_cancelled,
-    CommandCaptureMetadata, DEFAULT_CAPTURE_LIMIT_BYTES,
+    isolate_process_tree, wait_with_bounded_output,
+    wait_with_bounded_output_until_cancelled_with_stdout_observer, CommandCaptureMetadata,
+    StdoutLineObserver, DEFAULT_CAPTURE_LIMIT_BYTES,
 };
 use crate::core::error::{Error, Result};
 
@@ -125,6 +126,7 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
     command: &mut Command,
     mut is_cancelled: impl FnMut() -> bool,
     progress_sink: Option<RunnerCommandProgressSink>,
+    stdout_line_observer: Option<StdoutLineObserver>,
     concurrency_limit: Option<usize>,
 ) -> Result<MeasuredOutput> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
@@ -142,17 +144,21 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
         Some(Arc::clone(&guard_violation)),
         concurrency_limit,
     );
-    let bounded_output =
-        wait_with_bounded_output_until_cancelled(&mut child, DEFAULT_CAPTURE_LIMIT_BYTES, || {
+    let bounded_output = wait_with_bounded_output_until_cancelled_with_stdout_observer(
+        &mut child,
+        DEFAULT_CAPTURE_LIMIT_BYTES,
+        || {
             is_cancelled()
                 || guard_violation
                     .lock()
                     .expect("resource guard mutex poisoned")
                     .is_some()
-        })
-        .map_err(|err| {
-            Error::internal_io(err.to_string(), Some("wait for runner command".to_string()))
-        })?;
+        },
+        stdout_line_observer,
+    )
+    .map_err(|err| {
+        Error::internal_io(err.to_string(), Some("wait for runner command".to_string()))
+    })?;
     let capture = bounded_output.capture.clone();
     let output = bounded_output.into_output();
     let metrics = collector.finish(started.elapsed());

--- a/src/core/runner/worker/tests/support.rs
+++ b/src/core/runner/worker/tests/support.rs
@@ -303,7 +303,7 @@ fn handle_request(store: &JobStore, request: &MockRequest) -> Value {
                 request.body["claim_id"].as_str().expect("event claim id"),
                 JobEventKind::Progress,
                 request.body["message"].as_str().map(ToString::to_string),
-                None,
+                request.body.get("data").cloned(),
             )
             .expect("append event");
         return serde_json::json!({

--- a/src/core/runner/worker/tests/worker_tests.rs
+++ b/src/core/runner/worker/tests/worker_tests.rs
@@ -117,6 +117,57 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
 }
 
 #[test]
+fn reverse_worker_streams_redacted_child_progress_without_trusting_stdout_lifecycle_fields() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let store = JobStore::default();
+        let mut request = run_id_echo_request();
+        request.command[2] = "printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"import\",\"current_item\":\"%s\",\"completed\":1,\"total\":2,\"metadata\":{\"api_key\":\"%s\"}}\\n' \"$TOKEN\" \"$TOKEN\"; printf 'HOMEBOY_RUNNER_PROGRESS {not-json}\\n'; printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"done\",\"status\":\"succeeded\"}\\n'; sleep 0.1; dd if=/dev/zero bs=1024 count=4097 2>/dev/null; printf tail".to_string();
+        request
+            .env
+            .insert("TOKEN".to_string(), "child-secret".to_string());
+        request.secret_env_names = vec!["TOKEN".to_string()];
+        store.submit_remote_runner_job(request).expect("submit job");
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+
+        let (output, exit_code) =
+            run_reverse_worker(worker_options(broker_url)).expect("run worker");
+
+        assert_eq!(exit_code, 0);
+        let job = output.job.expect("job");
+        handle.join().expect("mock broker joins");
+        let events = store.events(job.id).expect("persisted events");
+        let progress_index = events
+            .iter()
+            .position(|event| event.kind == JobEventKind::Progress && event.data.is_some())
+            .expect("child progress event persisted before finish");
+        let result_index = events
+            .iter()
+            .position(|event| event.kind == JobEventKind::Result)
+            .expect("result event");
+        assert!(
+            progress_index < result_index,
+            "progress must stream before terminal result"
+        );
+        let progress = events[progress_index].data.as_ref().expect("progress data");
+        assert_eq!(progress["phase"], "import");
+        assert_eq!(progress["current_item"], "[REDACTED]");
+        assert_eq!(progress["metadata"]["api_key"], "[REDACTED]");
+        assert!(events.iter().all(|event| event.kind != JobEventKind::Status
+            || event.message.as_deref() != Some("succeeded")));
+        let result = result_event_data(&store, job.id);
+        assert!(result["stdout"].as_str().expect("stdout").ends_with("tail"));
+        assert_eq!(result["capture"]["stdout"]["truncated"], true);
+        assert!(
+            result["capture"]["stdout"]["bytes_retained"]
+                .as_u64()
+                .unwrap()
+                <= 4 * 1024 * 1024
+        );
+    });
+}
+
+#[test]
 fn reverse_worker_injects_lifecycle_run_id_into_claimed_job_env() {
     test_support::with_isolated_home(|_| {
         create_shell_runner();


### PR DESCRIPTION
## Summary
- Parse versioned child progress envelopes from stdout while retaining the existing bounded capture.
- Redact accepted fields and persist them as live durable runner `progress` events.
- Reject malformed, unknown-field, and lifecycle-forging records as ordinary stdout.

Closes #7870

## Protocol
A child writes one newline-delimited stdout record:
```text
HOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"import","current_item":"fixture-a","completed":1,"total":5,"metadata":{"source":"matrix"}}
```
Only `schema`, `phase`, `current_item`, `completed`, `total`, and `metadata` are accepted. The process exit code remains the sole terminal-state authority.

## How to test
1. Run `cargo test reverse_worker_streams_redacted_child_progress_without_trusting_stdout_lifecycle_fields --lib`.
2. Run `cargo test`.
3. Both commands are currently blocked before test execution by the unrelated baseline compile error in `src/core/upgrade/execution.rs:592`: `prepare_source_workspace_for_upgrade` returns `()` instead of `Result<()>`.
4. After that baseline is repaired, confirm the focused test persists a redacted child event before the result event, retains malformed/forged records as bounded stdout, and preserves terminal lifecycle ownership.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode, openai/gpt-5.6-sol
- **Used for:** Implemented the protocol, stream capture integration, documentation, and behavioral test coverage with human direction.