### PR TITLE
fix: bound release auto-refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,6 +346,7 @@ jobs:
   gate-refactor:
     name: Auto-refactor
     continue-on-error: true
+    timeout-minutes: 35
     needs:
       - check
       - gate-build
@@ -399,6 +400,7 @@ jobs:
           autofix: 'true'
           autofix-mode: always
           autofix-open-pr: 'true'
+          execution-timeout-seconds: '1800'
           app-token: ${{ steps.app-token.outputs.token }}
 
   release-quality-policy:

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -38,6 +38,8 @@ fn release_refactor_gate_enables_non_pr_repair_path() {
     assert!(gate_refactor.contains("Only release-blocking commands are repaired"));
     assert!(gate_refactor.contains("autofix-open-pr: 'true'"));
     assert!(gate_refactor.contains("continue-on-error: true"));
+    assert!(gate_refactor.contains("timeout-minutes: 35"));
+    assert!(gate_refactor.contains("execution-timeout-seconds: '1800'"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Caps the advisory Release `Auto-refactor` job at 35 minutes, so it cannot hold the publishing workflow indefinitely.
- Passes a 30-minute action execution budget to the reusable autofix phase.
- Keeps existing job and step `continue-on-error` semantics unchanged.

Depends on Extra-Chill/homeboy-action#274, which adds the `execution-timeout-seconds` contract, minute-level liveness notices, and actionable timeout evidence. The job-level timeout is effective independently.

## Testing

1. Run `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`.\n2. Run `cargo test --test release_workflow_test`.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** OpenCode, openai/gpt-5.6-terra\n- **Used for:** Implemented the Release workflow consumer configuration and static coverage with human-directed task requirements.