### PR TITLE
fix: preserve explicit source upgrades without upstream

### DIFF
--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -63,6 +63,7 @@ pub(crate) fn annotate_truncation(detail: &str, capture: &StreamCaptureMetadata)
 pub(crate) fn execute_upgrade(
     method: InstallMethod,
     source_path: Option<&Path>,
+    explicit_source_path: bool,
     force: bool,
     previous_build_identity: Option<&str>,
 ) -> Result<(bool, Option<String>, Option<String>, Option<String>)> {
@@ -88,7 +89,7 @@ pub(crate) fn execute_upgrade(
             let cmd = source_upgrade_command_for_prepared_workspace(
                 &defaults.install_methods.source.upgrade_command,
                 &workspace_root,
-                source_path.is_some(),
+                explicit_source_path,
             )?;
             run_source_upgrade_command(&cmd, &workspace_root, SOURCE_UPGRADE_TIMEOUT)?;
             let replacement_target = active_binary_path().ok();
@@ -731,15 +732,24 @@ fn git_command_stdout(workspace_root: &Path, args: &[&str]) -> Result<String> {
     run_git(workspace_root, args, "prepare source checkout").map(|stdout| stdout.trim().to_string())
 }
 
-const EXPLICIT_SOURCE_GIT_PULL_GUARD: &str = r#"git() {
-  for homeboy_git_arg in "$@"; do
-    if [ "$homeboy_git_arg" = "pull" ]; then
-      echo "Skipping git pull for explicitly selected source checkout"
-      return 0
-    fi
-  done
-  command git "$@"
-}"#;
+const EXPLICIT_SOURCE_GIT_UPDATE_GUARD: &str = r#"HOMEBOY_REAL_GIT="$(command -v git)"
+HOMEBOY_GIT_GUARD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-git-guard.XXXXXX")"
+cat > "$HOMEBOY_GIT_GUARD_DIR/git" <<'HOMEBOY_GIT_GUARD'
+#!/bin/sh
+for homeboy_git_arg in "$@"; do
+  case "$homeboy_git_arg" in
+    pull|fetch|reset)
+      echo "Skipping git $homeboy_git_arg for explicitly selected source checkout"
+      exit 0
+      ;;
+  esac
+done
+exec "$HOMEBOY_REAL_GIT" "$@"
+HOMEBOY_GIT_GUARD
+chmod 700 "$HOMEBOY_GIT_GUARD_DIR/git"
+export HOMEBOY_REAL_GIT
+PATH="$HOMEBOY_GIT_GUARD_DIR:$PATH"
+export PATH"#;
 
 fn source_upgrade_command_for_prepared_workspace(
     upgrade_command: &str,
@@ -757,7 +767,7 @@ fn source_upgrade_command_for_prepared_workspace(
     }
 
     Ok(format!(
-        "{EXPLICIT_SOURCE_GIT_PULL_GUARD}\n\n{upgrade_command}"
+        "{EXPLICIT_SOURCE_GIT_UPDATE_GUARD}\n\n(\n{upgrade_command}\n)\nhomeboy_upgrade_status=$?\nrm -rf \"$HOMEBOY_GIT_GUARD_DIR\"\nexit $homeboy_upgrade_status"
     ))
 }
 
@@ -1948,7 +1958,8 @@ mod tests {
             true,
         )
         .expect("explicit source command");
-        assert!(command.contains("Skipping git pull for explicitly selected source checkout"));
+        assert!(command
+            .contains("Skipping git $homeboy_git_arg for explicitly selected source checkout"));
     }
 
     #[test]
@@ -2028,9 +2039,10 @@ mod tests {
         )
         .expect("source command");
 
-        assert!(command.contains("Skipping git pull for explicitly selected source checkout"));
-        assert!(command.contains("command git \"$@\""));
-        assert!(command.ends_with("git pull --ff-only\ncargo build --release"));
+        assert!(command
+            .contains("Skipping git $homeboy_git_arg for explicitly selected source checkout"));
+        assert!(command.contains("HOMEBOY_GIT_GUARD_DIR"));
+        assert!(command.contains("git pull --ff-only\ncargo build --release"));
     }
 
     #[test]
@@ -2052,8 +2064,44 @@ mod tests {
         )
         .expect("source command");
 
-        assert!(command.contains("Skipping git pull for explicitly selected source checkout"));
-        assert!(command.ends_with("git pull --ff-only\ncargo build --release"));
+        assert!(command
+            .contains("Skipping git $homeboy_git_arg for explicitly selected source checkout"));
+        assert!(command.contains("git pull --ff-only\ncargo build --release"));
+    }
+
+    #[test]
+    fn explicit_source_upgrade_runs_build_phase_without_upstream_on_local_branch_or_detached_head()
+    {
+        for detached in [false, true] {
+            let checkout = source_workspace_with_package_name("homeboy");
+            git(checkout.path(), &["init", "--initial-branch", "local-only"]);
+            git(
+                checkout.path(),
+                &["config", "user.email", "test@example.com"],
+            );
+            git(checkout.path(), &["config", "user.name", "Homeboy Test"]);
+            git(checkout.path(), &["add", "."]);
+            git(checkout.path(), &["commit", "-m", "initial"]);
+            if detached {
+                git(checkout.path(), &["switch", "--detach", "HEAD"]);
+            }
+
+            let build_marker = checkout.path().join("build-phase");
+            let upgrade_command = format!(
+                "set -e\ngit fetch origin\ngit reset --hard origin/main\nsh -c 'git pull --ff-only'\nprintf built > {}",
+                shell_quote_path(&build_marker)
+            );
+            let command = source_upgrade_command_for_prepared_workspace(
+                &upgrade_command,
+                checkout.path(),
+                true,
+            )
+            .expect("explicit source command");
+
+            run_source_upgrade_command(&command, checkout.path(), Duration::from_secs(5))
+                .expect("guarded upgrade command reaches build phase");
+            assert_eq!(std::fs::read_to_string(build_marker).unwrap(), "built");
+        }
     }
 
     #[test]

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -199,10 +199,11 @@ pub fn run_upgrade_with_method(
             let (runners_updated, runners_skipped) = if skip_runners {
                 (vec![], vec![])
             } else {
-                runners::upgrade_configured_runners(
+                runners::upgrade_configured_runners_with_explicit_source_path(
                     force,
                     runner_method_override,
                     source_upgrade_path.as_deref(),
+                    source_path.is_some(),
                     runner_targets,
                     &extensions_updated,
                 )?
@@ -250,6 +251,7 @@ pub fn run_upgrade_with_method(
     let (success, new_version, new_build_identity, source_revision) = execute_upgrade(
         install_method,
         source_upgrade_path.as_deref(),
+        source_path.is_some(),
         force,
         previous_build_identity.as_deref(),
     )?;
@@ -267,10 +269,11 @@ pub fn run_upgrade_with_method(
 
     let (runners_updated, runners_skipped) = if upgrade_completed && !skip_runners {
         upgrade_phase("refreshing configured runners");
-        runners::upgrade_configured_runners(
+        runners::upgrade_configured_runners_with_explicit_source_path(
             force,
             runner_method_override,
             source_upgrade_path.as_deref(),
+            source_path.is_some(),
             runner_targets,
             &extensions_updated,
         )?

--- a/src/core/upgrade/runners/orchestration.rs
+++ b/src/core/upgrade/runners/orchestration.rs
@@ -39,6 +39,46 @@ pub fn upgrade_configured_runners(
     ))
 }
 
+pub fn upgrade_configured_runners_with_explicit_source_path(
+    force: bool,
+    method_override: Option<InstallMethod>,
+    source_path: Option<&Path>,
+    explicit_source_path: bool,
+    runner_targets: &[String],
+    extension_updates: &[ExtensionUpgradeEntry],
+) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
+    if !explicit_source_path {
+        return upgrade_configured_runners(
+            force,
+            method_override,
+            source_path,
+            runner_targets,
+            extension_updates,
+        );
+    }
+
+    let runners = runner_upgrade_targets(runner_targets)?;
+    if runners.is_empty() {
+        return Ok((vec![], vec![]));
+    }
+
+    crate::log_status!(
+        "upgrade",
+        "Updating {} configured runner(s)...",
+        runners.len()
+    );
+    Ok(upgrade_runners_with_executor_and_source_materializer(
+        &runners,
+        force,
+        method_override,
+        source_path,
+        extension_updates,
+        runner::exec,
+        runner::status,
+        materialize_explicit_runner_source_path,
+    ))
+}
+
 pub fn runner_upgrade_targets(runner_targets: &[String]) -> Result<Vec<Runner>> {
     if !runner_targets.is_empty() {
         return runner_targets

--- a/src/core/upgrade/runners/source_checkout.rs
+++ b/src/core/upgrade/runners/source_checkout.rs
@@ -189,3 +189,27 @@ pub fn materialize_runner_source_path(runner: &Runner, source_path: &Path) -> Re
 
     Ok(output.remote_path)
 }
+
+pub fn materialize_explicit_runner_source_path(
+    runner: &Runner,
+    source_path: &Path,
+) -> Result<String> {
+    let (output, _) = runner::sync_workspace(
+        &runner.id,
+        RunnerWorkspaceSyncOptions {
+            path: source_path.display().to_string(),
+            // An explicit source path is a selected build input, not a remote
+            // branch to refresh. SnapshotGit retains a local Git identity for
+            // the source build without fetching or resetting either checkout.
+            mode: RunnerWorkspaceSyncMode::SnapshotGit,
+            controller_routed_git: false,
+            changed_since_base: None,
+            git_fetch_refs: Vec::new(),
+            snapshot_includes: Vec::new(),
+            allow_dirty_lab_workspace: false,
+            run_isolation_token: None,
+        },
+    )?;
+
+    Ok(output.remote_path)
+}

--- a/src/core/upgrade/runners/tests.rs
+++ b/src/core/upgrade/runners/tests.rs
@@ -160,8 +160,10 @@ fn materializes_forced_source_upgrade_path_before_forwarding_to_runner() {
         calls[1].1.as_deref(),
         Some("/home/user/Developer/_lab_workspaces/homeboy-source")
     );
-    assert!(calls[1].0[2].contains("git fetch origin"));
-    assert!(calls[1].0[2].contains("git checkout --detach"));
+    assert!(calls[1].0[2].contains("git rev-parse --verify HEAD"));
+    assert!(!calls[1].0[2].contains("git fetch"));
+    assert!(!calls[1].0[2].contains("git pull"));
+    assert!(!calls[1].0[2].contains("git reset"));
     assert_eq!(
         calls[2].0,
         vec![


### PR DESCRIPTION
## Summary
- preserve whether `--source-path` was explicitly supplied through source upgrade and configured-runner orchestration
- guard explicit source build commands from `git pull`, `fetch`, and `reset`, including nested shell commands
- snapshot explicit source paths for runner upgrades while retaining the existing implicit Git-sync policy

Fixes #7882

## Testing
1. Run `cargo test core::upgrade::execution::tests --lib`.
2. Run `cargo test materializes_forced_source_upgrade_path_before_forwarding_to_runner --lib`.
3. Run `cargo check`.
4. Run `git diff --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode direct general coding subagent
- **Used for:** Traced the source-upgrade orchestration, implemented the explicit-source guard and runner policy, and added focused regression coverage.
