### PR TITLE
fix: preserve agent task run metadata across Lab offload

### DIFF
--- a/src/core/runner/evidence/mirror.rs
+++ b/src/core/runner/evidence/mirror.rs
@@ -302,6 +302,35 @@ pub(super) fn mirror_job_run(
     if let Some(event) = agent_task_lifecycle_event {
         lab["agent_task_lifecycle_event"] = event;
     }
+    if let Some(run_id) = run_id {
+        if store
+            .get_run(run_id)?
+            .is_some_and(|existing| existing.metadata_json.get("agent_task_run").is_some())
+        {
+            crate::core::agent_task_lifecycle::record_detached_lab_run(
+                crate::core::agent_task_lifecycle::DetachedLabRunRecord {
+                    run_id,
+                    runner_id: &runner.id,
+                    runner_job_id: &job.id.to_string(),
+                    remote_workspace: cwd,
+                    remote_command: command,
+                },
+            )?;
+            let mut metadata_json = store
+                .get_run(run_id)?
+                .ok_or_else(|| {
+                    Error::internal_unexpected(format!(
+                        "agent-task run {run_id} disappeared while mirroring Lab evidence"
+                    ))
+                })?
+                .metadata_json;
+            metadata_json["lab"] = lab;
+            if let Some(notification_route) = notification_route {
+                notification_route.insert_into_metadata(&mut metadata_json);
+            }
+            return store.update_run_metadata(run_id, metadata_json);
+        }
+    }
     let run = RunRecord {
         id: run_id
             .map(str::to_string)

--- a/src/core/runner/evidence/tests/mod.rs
+++ b/src/core/runner/evidence/tests/mod.rs
@@ -294,6 +294,89 @@ fn runner_exec_explicit_run_id_overrides_inferred_name() {
 }
 
 #[test]
+fn mirroring_lab_job_preserves_agent_task_lifecycle_metadata() {
+    crate::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        crate::core::agent_task_lifecycle::record_lab_offload_planned(
+            crate::core::agent_task_lifecycle::LabOffloadProxyPlan {
+                run_id: "agent-task-lab-mirror",
+                runner_id: "lab",
+                remote_workspace: "/srv/homeboy/project",
+                remote_command: &command,
+            },
+        )
+        .expect("planned controller proxy");
+        let job_id = Uuid::new_v4();
+        let job = Job {
+            id: job_id,
+            operation: "exec".to_string(),
+            status: JobStatus::Running,
+            created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_001_000,
+            started_at_ms: Some(1_700_000_000_000),
+            finished_at_ms: None,
+            event_count: 0,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            stale_reason: None,
+            target_runner_id: None,
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+        };
+
+        mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/srv/homeboy/project",
+            &command,
+            &job,
+            &[],
+            &json!({}),
+            Some("agent-task-lab-mirror"),
+            None,
+        )
+        .expect("mirror Lab job");
+        let terminal_job = Job {
+            status: JobStatus::Succeeded,
+            finished_at_ms: Some(1_700_000_002_000),
+            ..job.clone()
+        };
+        let run = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/srv/homeboy/project",
+            &command,
+            &terminal_job,
+            &[],
+            &json!({"exit_code": 0}),
+            Some("agent-task-lab-mirror"),
+            None,
+        )
+        .expect("mirror terminal Lab job");
+        let lifecycle = crate::core::agent_task_lifecycle::status("agent-task-lab-mirror")
+            .expect("typed lifecycle remains readable");
+
+        assert_eq!(run.kind, "agent-task");
+        assert!(run.metadata_json.get("agent_task_run").is_some());
+        assert_eq!(lifecycle.metadata["runner_id"], "lab");
+        assert_eq!(lifecycle.metadata["runner_job_id"], job_id.to_string());
+        assert_eq!(
+            run.metadata_json["lab"]["remote_job"]["id"],
+            job_id.to_string()
+        );
+    });
+}
+
+#[test]
 fn test_mirrored_patch_result_reports_accessible_artifact_token() {
     crate::test_support::with_isolated_home(|_| {
         let store = ObservationStore::open_initialized().expect("store");


### PR DESCRIPTION
Closes #7887

## Root cause
The controller created a typed `agent_task_run` observation record under the durable cook run ID. Lab evidence mirroring later reused that same ID for a generic `runner-exec` upsert, replacing `metadata_json` and deleting the typed lifecycle payload required by status and finalization.

## Fix
When a mirror target is an existing typed agent-task run, bind the accepted Lab job through the lifecycle handoff operation and merge Lab evidence into the existing observation metadata. Generic runner mirrors retain their prior behavior.

## Regression tests
1. Run `cargo test --lib core::runner::evidence::tests::mirroring_lab_job_preserves_agent_task_lifecycle_metadata`. It creates the persisted controller proxy, mirrors both running and successful Lab job evidence under its durable ID, then verifies lifecycle rehydration, runner/job identity, typed metadata, and Lab evidence.
2. Run `cargo test --lib core::agent_task_lifecycle::tests::controller_proxy_is_queued_before_handoff_then_binds_runner_child`. It verifies the existing proxy-to-runner handoff contract.
3. Run `cargo test --lib core::runner::evidence::tests` to exercise the complete evidence-mirroring module.

## Backwards compatibility
No schema or CLI contract changes. Existing generic runner-exec mirroring is unchanged. Existing typed agent-task records now retain their lifecycle metadata and gain merged Lab evidence instead of being converted to generic runner records.

## Test results
- `cargo fmt --check`: passed.
- `cargo test --lib core::runner::evidence::tests`: passed, 15 passed; 0 failed; 7,205 filtered out.
- `cargo test --lib core::runner::evidence::tests::mirroring_lab_job_preserves_agent_task_lifecycle_metadata`: passed, 1 passed; 0 failed; 7,219 filtered out.
- `cargo test --lib core::agent_task_lifecycle::tests::controller_proxy_is_queued_before_handoff_then_binds_runner_child`: passed, 1 passed; 0 failed; 7,219 filtered out.
- `cargo test --lib`: started 7,220 tests but exceeded the 600-second command limit after unrelated release tests reported failures.
- `RUST_TEST_THREADS=1 cargo test --lib`: exceeded the 1,200-second command limit; unrelated rig-install lint tests reported failures before timeout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-terra
- **Used for:** Investigation, implementation, and regression coverage.