### PR TITLE
Fix release blocking command normalization

### DIFF
--- a/.github/release-quality-policy.sh
+++ b/.github/release-quality-policy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+is_blocking_command() {
+  local command="$1"
+  local configured
+  local canonical
+
+  IFS=',' read -r -a configured_commands <<< "${BLOCKING_COMMANDS}"
+  for configured in "${configured_commands[@]}"; do
+    canonical="$(printf '%s' "${configured}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+    canonical="${canonical#review}"
+    if [ "${canonical}" = "${command}" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+failed=0
+
+check_command() {
+  local command="$1"
+  local result="$2"
+
+  if is_blocking_command "${command}"; then
+    if [ "${result}" = "success" ]; then
+      echo "::notice::Release-blocking command ${command} passed"
+    else
+      echo "::error::Release-blocking command ${command} finished with result: ${result}"
+      failed=1
+    fi
+  else
+    echo "::notice::Command ${command} is tracked but not release-blocking (result: ${result})"
+  fi
+}
+
+check_command audit "${AUDIT_RESULT}"
+check_command lint "${LINT_RESULT}"
+check_command test "${TEST_RESULT}"
+
+exit "${failed}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,35 +421,7 @@ jobs:
           LINT_RESULT: ${{ needs.gate-lint.result }}
           TEST_RESULT: ${{ needs.gate-test.result }}
         run: |
-          set -euo pipefail
-
-          normalized="$(printf '%s' "${BLOCKING_COMMANDS}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
-          blocking=",${normalized},"
-          failed=0
-
-          check_command() {
-            local command="$1"
-            local result="$2"
-
-            if [[ "${blocking}" == *",${command},"* ]]; then
-              if [ "${result}" = "success" ]; then
-                echo "::notice::Release-blocking command ${command} passed"
-              else
-                echo "::error::Release-blocking command ${command} finished with result: ${result}"
-                failed=1
-              fi
-            else
-              echo "::notice::Command ${command} is tracked but not release-blocking (result: ${result})"
-            fi
-          }
-
-          check_command audit "${AUDIT_RESULT}"
-          check_command lint "${LINT_RESULT}"
-          check_command test "${TEST_RESULT}"
-
-          if [ "${failed}" -ne 0 ]; then
-            exit 1
-          fi
+          bash .github/release-quality-policy.sh
 
   # ── Step 4: Version bump + changelog + tag ──
   prepare:

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -78,7 +78,8 @@ fn release_quality_policy_defaults_to_lint_and_test_blocking() {
     assert!(release_quality_policy_script().contains("check_command audit"));
     assert!(release_quality_policy_script().contains("check_command lint"));
     assert!(release_quality_policy_script().contains("check_command test"));
-    assert!(release_quality_policy_script().contains("Command ${command} is tracked but not release-blocking"));
+    assert!(release_quality_policy_script()
+        .contains("Command ${command} is tracked but not release-blocking"));
 }
 
 #[test]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -2,6 +2,26 @@ fn release_workflow() -> &'static str {
     include_str!("../.github/workflows/release.yml")
 }
 
+fn release_quality_policy_script() -> &'static str {
+    include_str!("../.github/release-quality-policy.sh")
+}
+
+fn release_quality_policy(
+    blocking_commands: &str,
+    audit_result: &str,
+    lint_result: &str,
+    test_result: &str,
+) -> std::process::Output {
+    std::process::Command::new("bash")
+        .arg(".github/release-quality-policy.sh")
+        .env("BLOCKING_COMMANDS", blocking_commands)
+        .env("AUDIT_RESULT", audit_result)
+        .env("LINT_RESULT", lint_result)
+        .env("TEST_RESULT", test_result)
+        .output()
+        .expect("release quality policy should run")
+}
+
 fn job_section<'a>(workflow: &'a str, job: &str) -> &'a str {
     let marker = format!("  {job}:\n");
     let start = workflow
@@ -51,13 +71,27 @@ fn release_quality_policy_defaults_to_lint_and_test_blocking() {
     let policy = job_section(release_workflow(), "release-quality-policy");
 
     assert!(policy.contains("BLOCKING_COMMANDS: ${{ env.RELEASE_BLOCKING_COMMANDS }}"));
+    assert!(policy.contains("bash .github/release-quality-policy.sh"));
     assert!(policy.contains(
         "AUDIT_RESULT: ${{ needs.gate-audit.outputs.audit-result || needs.gate-audit.result }}"
     ));
-    assert!(policy.contains("check_command audit"));
-    assert!(policy.contains("check_command lint"));
-    assert!(policy.contains("check_command test"));
-    assert!(policy.contains("Command ${command} is tracked but not release-blocking"));
+    assert!(release_quality_policy_script().contains("check_command audit"));
+    assert!(release_quality_policy_script().contains("check_command lint"));
+    assert!(release_quality_policy_script().contains("check_command test"));
+    assert!(release_quality_policy_script().contains("Command ${command} is tracked but not release-blocking"));
+}
+
+#[test]
+fn release_quality_policy_blocks_review_test_failures_and_allows_passing_gates() {
+    let failed = release_quality_policy("review lint,review test", "failure", "success", "failure");
+
+    assert!(!failed.status.success());
+    assert!(String::from_utf8_lossy(&failed.stdout)
+        .contains("Release-blocking command test finished with result: failure"));
+
+    let passed = release_quality_policy("review lint,review test", "failure", "success", "success");
+
+    assert!(passed.status.success());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- canonicalize configured release-blocking review commands before comparing gate result keys
- make a failed configured `review test` stop the release-quality-policy job before Prepare Release
- add executable regression coverage for failed and passing review gates

Closes #7880

## Testing
1. Run `cargo test --test release_workflow_test`.
2. Confirm all 13 release workflow tests pass, including the policy failure/pass regression.
3. Run `cargo fmt --check` and `git diff --check`.

Additional local signal: `cargo test` completed with 7,168 passing tests and 34 pre-existing environment/fixture failures outside the release workflow changes; CI will validate on its clean runner.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.6-terra)
- **Used for:** Audited the release workflow policy, implemented canonical gate normalization and regression coverage, and ran verification with Chris retaining responsibility for the change.