### PR TITLE
fix: bound status remote version probes

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use homeboy::core::component;
 use homeboy::core::context;
-use homeboy::core::deploy::{self, DeployConfig, ReleaseState, ReleaseStateStatus};
+use homeboy::core::deploy::{self, ReleaseState, ReleaseStateStatus};
 use homeboy::core::git;
 use homeboy::core::release::version;
 use homeboy::core::scope::{self, Scope};
@@ -191,6 +191,9 @@ pub struct ProjectStatusRow {
     pub component_id: String,
     pub local_version: Option<String>,
     pub remote_version: Option<String>,
+    /// Actionable evidence when the bounded remote version probe failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_version_diagnostic: Option<String>,
     /// Latest tag on origin. When this differs from local_version, the local
     /// checkout is stale and needs a pull.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -228,6 +231,8 @@ pub enum ProjectComponentDashboardStatus {
     Retired,
     /// Cannot determine status
     Unknown,
+    /// A bounded remote probe failed; local and git data remain available.
+    Degraded,
 }
 
 /// Output for the project status dashboard.
@@ -294,6 +299,8 @@ pub struct ProjectDashboardSummary {
     #[serde(default, skip_serializing_if = "is_zero")]
     pub retired: usize,
     pub unknown: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub degraded: usize,
 }
 
 fn is_zero(value: &usize) -> bool {
@@ -670,7 +677,13 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
 
     // Gather remote versions via deploy check mode (handles SSH internally)
     timer.begin("fetch_remote_versions");
-    let remote_versions = fetch_project_remote_versions(project_id);
+    let remote_probe = fetch_project_remote_versions(project_id, &components);
+    let remote_versions = remote_probe.versions;
+    let remote_diagnostics: HashMap<String, String> = remote_probe
+        .failures
+        .into_iter()
+        .map(|failure| (failure.component_id, failure.diagnostic))
+        .collect();
     timer.finish("fetch_remote_versions");
 
     let mut git_cache = StatusGitCache::default();
@@ -700,6 +713,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
         bundled: 0,
         retired: 0,
         unknown: 0,
+        degraded: 0,
     };
 
     timer.begin("build_dashboard_rows");
@@ -723,6 +737,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
                 component_id: comp.id.clone(),
                 local_version: local_versions.get(&comp.id).cloned(),
                 remote_version: None,
+                remote_version_diagnostic: None,
                 origin_version: None,
                 unreleased_commits: 0,
                 ahead_upstream: None,
@@ -749,7 +764,10 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
 
         // Determine dashboard status.
         // Priority: uncommitted > needs_release > docs_only > behind_upstream > outdated > current > unknown
-        let dashboard_status = match release_status {
+        let dashboard_status = if remote_diagnostics.contains_key(&comp.id) {
+            ProjectComponentDashboardStatus::Degraded
+        } else {
+            match release_status {
             ReleaseStateStatus::Uncommitted => ProjectComponentDashboardStatus::Uncommitted,
             ReleaseStateStatus::NeedsRelease => ProjectComponentDashboardStatus::NeedsRelease,
             ReleaseStateStatus::DocsOnly => ProjectComponentDashboardStatus::DocsOnly,
@@ -770,6 +788,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
                 }
             }
             ReleaseStateStatus::Unknown => ProjectComponentDashboardStatus::Unknown,
+            }
         };
 
         match &dashboard_status {
@@ -785,12 +804,14 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
             ProjectComponentDashboardStatus::Bundled => summary.bundled += 1,
             ProjectComponentDashboardStatus::Retired => summary.retired += 1,
             ProjectComponentDashboardStatus::Unknown => summary.unknown += 1,
+            ProjectComponentDashboardStatus::Degraded => summary.degraded += 1,
         }
 
         rows.push(ProjectStatusRow {
             component_id: comp.id.clone(),
             local_version: local_ver,
             remote_version: remote_ver,
+            remote_version_diagnostic: remote_diagnostics.get(&comp.id).cloned(),
             origin_version: drift.and_then(|d| d.latest_origin_tag.clone()),
             unreleased_commits,
             ahead_upstream: drift.and_then(|d| d.ahead),
@@ -1089,22 +1110,19 @@ fn default_origin_branch(path: &str) -> Option<String> {
 ///
 /// Uses deploy check mode internally, which handles SSH resolution.
 /// Returns empty map on failure (e.g., no server configured, SSH unavailable).
-fn fetch_project_remote_versions(project_id: &str) -> std::collections::HashMap<String, String> {
-    let config = DeployConfig::check_all_no_pull_head();
-
-    match deploy::run(project_id, &config) {
-        Ok(result) => result
-            .results
-            .into_iter()
-            .filter_map(|r| r.remote_version.map(|v| (r.id, v)))
-            .collect(),
+fn fetch_project_remote_versions(
+    project_id: &str,
+    components: &[component::Component],
+) -> deploy::RemoteVersionProbeResult {
+    match deploy::fetch_project_remote_versions(project_id, components) {
+        Ok(result) => result,
         Err(_) => {
             homeboy::log_status!(
                 "status",
                 "Warning: could not fetch remote versions for project '{}' — showing local data only",
                 project_id
             );
-            std::collections::HashMap::new()
+            deploy::RemoteVersionProbeResult::default()
         }
     }
 }

--- a/src/commands/status/dashboard_table.rs
+++ b/src/commands/status/dashboard_table.rs
@@ -62,6 +62,7 @@ pub(super) fn log_dashboard_table(rows: &[ProjectStatusRow]) {
             ProjectComponentDashboardStatus::Bundled => "📦 bundled",
             ProjectComponentDashboardStatus::Retired => "🗄️  retired",
             ProjectComponentDashboardStatus::Unknown => "❓ unknown",
+            ProjectComponentDashboardStatus::Degraded => "⚠️  degraded",
         };
 
         eprintln!(
@@ -78,6 +79,9 @@ pub(super) fn log_dashboard_table(rows: &[ProjectStatusRow]) {
             remote_w = widths.remote,
             origin_w = widths.origin,
         );
+        if let Some(diagnostic) = &row.remote_version_diagnostic {
+            eprintln!("    remote probe: {diagnostic}");
+        }
     }
 }
 

--- a/src/core/deploy/effect.rs
+++ b/src/core/deploy/effect.rs
@@ -43,7 +43,8 @@ pub(super) fn remote_version_after_deploy_effect(
         Some(project),
         base_path,
         client,
-    );
+    )
+    .versions;
     let observed = observed_versions.get(&component.id).cloned().ok_or_else(|| {
         format!(
             "Deploy command completed for '{}' at '{}', but Homeboy could not read remote_version from the applied tree. Refusing to report success from stale pre-deploy observations.",

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -27,6 +27,7 @@ pub use types::{
     ProjectDeployResult, ReleaseState, ReleaseStateBuckets, ReleaseStateStatus,
 };
 pub use version_overrides::fetch_remote_versions;
+pub use version_overrides::{RemoteVersionProbeFailure, RemoteVersionProbeResult};
 
 use crate::core::component;
 use crate::core::context::resolve_project_ssh_with_base_path;
@@ -42,6 +43,23 @@ pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestratio
     project::validate_deploy_component_local_paths(&project, &config.component_ids)?;
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)?;
     orchestration::deploy_components(config, &project, &ctx, &base_path)
+}
+
+/// Read deployed component versions without running deploy planning or git
+/// checks. Status uses this narrow probe to keep timeout diagnostics attached to
+/// the affected dashboard component.
+pub fn fetch_project_remote_versions(
+    project_id: &str,
+    components: &[component::Component],
+) -> Result<RemoteVersionProbeResult> {
+    let project = project::load(project_id)?;
+    let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)?;
+    Ok(version_overrides::fetch_remote_versions_for_project(
+        components,
+        Some(&project),
+        &base_path,
+        &ctx.client,
+    ))
 }
 
 /// Deploy components across multiple projects.

--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -143,6 +143,7 @@ pub(super) fn deploy_components(
     let remote_versions =
         if config.outdated || config.behind_upstream || config.dry_run || config.check {
             fetch_remote_versions_for_project(&components, Some(&project), base_path, &ctx.client)
+                .versions
         } else {
             HashMap::new()
         };

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -150,7 +150,8 @@ pub(super) fn plan_component_deploys(
         }));
     } else if config.outdated {
         let remote_versions =
-            fetch_remote_versions_for_project(all_components, Some(project), base_path, client);
+            fetch_remote_versions_for_project(all_components, Some(project), base_path, client)
+                .versions;
         steps.extend(plan_outdated_steps(all_components, &remote_versions));
     } else if config.behind_upstream {
         let mut git_probe_cache = GitProbeCache::default();

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::time::Duration;
 
 use super::permissions;
 use crate::core::component::{Component, VersionTarget};
@@ -20,6 +21,20 @@ use crate::core::server::SshClient;
 use super::path_roots::resolve_effective_remote_path;
 use super::transfer::scp_file;
 use super::types::{DeployEffect, DeployResult};
+
+const REMOTE_VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone)]
+pub struct RemoteVersionProbeFailure {
+    pub component_id: String,
+    pub diagnostic: String,
+}
+
+#[derive(Debug, Default)]
+pub struct RemoteVersionProbeResult {
+    pub versions: HashMap<String, String>,
+    pub failures: Vec<RemoteVersionProbeFailure>,
+}
 
 /// Detect if a component's artifact is a CLI binary matching the currently
 /// running process name. Used to print a post-deploy hint for self-deploy.
@@ -82,32 +97,34 @@ pub fn fetch_remote_versions(
     base_path: &str,
     client: &SshClient,
 ) -> HashMap<String, String> {
-    fetch_remote_versions_for_project(components, None, base_path, client)
+    fetch_remote_versions_for_project(components, None, base_path, client).versions
 }
 
-pub(super) fn fetch_remote_versions_for_project(
+pub(crate) fn fetch_remote_versions_for_project(
     components: &[Component],
     project: Option<&Project>,
     base_path: &str,
     client: &SshClient,
-) -> HashMap<String, String> {
-    let mut versions = HashMap::new();
+) -> RemoteVersionProbeResult {
+    let mut result = RemoteVersionProbeResult::default();
 
     for component in components {
         // Try standard version-file approach first
-        if let Some(ver) = fetch_version_from_file(component, project, base_path, client) {
-            versions.insert(component.id.clone(), ver);
+        if let Some(ver) =
+            fetch_version_from_file(component, project, base_path, client, &mut result)
+        {
+            result.versions.insert(component.id.clone(), ver);
             continue;
         }
 
         // Fallback: for CLI binaries (has build_artifact, no remote_path),
         // try running the binary with --version on the remote server.
-        if let Some(ver) = fetch_version_from_binary(component, client) {
-            versions.insert(component.id.clone(), ver);
+        if let Some(ver) = fetch_version_from_binary(component, client, &mut result) {
+            result.versions.insert(component.id.clone(), ver);
         }
     }
 
-    versions
+    result
 }
 
 /// Try to fetch version by reading a version file on the remote server.
@@ -116,6 +133,7 @@ fn fetch_version_from_file(
     project: Option<&Project>,
     base_path: &str,
     client: &SshClient,
+    result: &mut RemoteVersionProbeResult,
 ) -> Option<String> {
     let version_targets = component.version_targets.as_ref()?;
 
@@ -140,7 +158,21 @@ fn fetch_version_from_file(
                 continue;
             }
 
-            let output = client.execute(&format!("cat '{}' 2>/dev/null", remote_path));
+            let output = client.execute_with_timeout(
+                &format!("cat '{}' 2>/dev/null", remote_path),
+                REMOTE_VERSION_PROBE_TIMEOUT,
+            );
+            if output.timed_out {
+                result.failures.push(RemoteVersionProbeFailure {
+                    component_id: component.id.clone(),
+                    diagnostic: format!(
+                        "remote version probe timed out after {}s while reading {}",
+                        REMOTE_VERSION_PROBE_TIMEOUT.as_secs(),
+                        remote_path
+                    ),
+                });
+                return None;
+            }
             if output.success {
                 if let Some(version) =
                     parse_component_version(&output.stdout, pattern, &remote_file)
@@ -172,7 +204,11 @@ fn remote_version_file_candidates(target: &VersionTarget) -> Vec<String> {
 ///
 /// This handles CLI binary components (like homeboy itself) that are installed
 /// as executables without a parseable version file on the remote server.
-fn fetch_version_from_binary(component: &Component, client: &SshClient) -> Option<String> {
+fn fetch_version_from_binary(
+    component: &Component,
+    client: &SshClient,
+    result: &mut RemoteVersionProbeResult,
+) -> Option<String> {
     let artifact = component.build_artifact.as_ref()?;
 
     // Extract binary name from build_artifact path (e.g., "target/release/homeboy" → "homeboy")
@@ -186,10 +222,21 @@ fn fetch_version_from_binary(component: &Component, client: &SshClient) -> Optio
     ];
 
     for candidate in &candidates {
-        let output = client.execute(&format!(
-            "{} --version 2>/dev/null",
-            shell::quote_path(candidate)
-        ));
+        let output = client.execute_with_timeout(
+            &format!("{} --version 2>/dev/null", shell::quote_path(candidate)),
+            REMOTE_VERSION_PROBE_TIMEOUT,
+        );
+        if output.timed_out {
+            result.failures.push(RemoteVersionProbeFailure {
+                component_id: component.id.clone(),
+                diagnostic: format!(
+                    "remote binary version probe timed out after {}s for {}",
+                    REMOTE_VERSION_PROBE_TIMEOUT.as_secs(),
+                    candidate
+                ),
+            });
+            return None;
+        }
         if output.success {
             let stdout = output.stdout.trim();
             // Parse "binary_name X.Y.Z" or just "X.Y.Z"
@@ -764,7 +811,10 @@ mod tests {
             &local_client(),
         );
 
-        assert_eq!(versions.get("fixture").map(String::as_str), Some("2.3.4"));
+        assert_eq!(
+            versions.versions.get("fixture").map(String::as_str),
+            Some("2.3.4")
+        );
     }
 
     #[test]
@@ -799,7 +849,22 @@ mod tests {
             &local_client(),
         );
 
-        assert_eq!(versions.get("fixture").map(String::as_str), Some("3.4.5"));
+        assert_eq!(
+            versions.versions.get("fixture").map(String::as_str),
+            Some("3.4.5")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_version_probe_timeout_is_bounded_and_cleans_up() {
+        let started = std::time::Instant::now();
+        let output = local_client().execute_with_timeout("sleep 30", Duration::from_millis(100));
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(output.timed_out);
+        assert!(!output.success);
+        assert!(output.stderr.contains("terminated child process group"));
     }
 
     #[test]

--- a/src/core/server/client/ssh_client.rs
+++ b/src/core/server/client/ssh_client.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
@@ -13,7 +15,8 @@ use super::super::{
 };
 use super::host::{is_local_host, is_transient_ssh_error};
 use super::local_exec::{
-    execute_local_command, execute_local_command_interactive, execute_local_command_with_stdin,
+    execute_local_command, execute_local_command_in_dir_with_timeout,
+    execute_local_command_interactive, execute_local_command_with_stdin,
 };
 use super::{CommandOutput, SshClient};
 
@@ -327,6 +330,107 @@ impl SshClient {
     pub fn execute(&self, command: &str) -> CommandOutput {
         let effective = self.prepend_env(command);
         self.execute_with_stdin(&effective, SshStdin::None)
+    }
+
+    /// Execute a short, read-only probe with a hard wall-clock deadline.
+    ///
+    /// Status/version checks must return partial diagnostics instead of allowing
+    /// an unavailable remote command to block the entire dashboard.
+    pub fn execute_with_timeout(&self, command: &str, timeout: Duration) -> CommandOutput {
+        let effective = self.prepend_env(command);
+        if self.is_local {
+            return execute_local_command_in_dir_with_timeout(&effective, None, None, timeout);
+        }
+
+        let args = self.build_ssh_args(Some(&effective), false);
+        let mut cmd = Command::new("ssh");
+        cmd.args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        crate::core::server::process_cleanup::configure_process_group_cleanup(&mut cmd);
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                return CommandOutput {
+                    stdout: String::new(),
+                    stderr: format!("SSH error: {err}"),
+                    success: false,
+                    exit_code: -1,
+                    timed_out: false,
+                    child_resource: None,
+                }
+            }
+        };
+        let pid = child.id();
+        let stdout = child.stdout.take().map(|mut pipe| {
+            thread::spawn(move || {
+                let mut bytes = Vec::new();
+                let _ = pipe.read_to_end(&mut bytes);
+                String::from_utf8_lossy(&bytes).to_string()
+            })
+        });
+        let stderr = child.stderr.take().map(|mut pipe| {
+            thread::spawn(move || {
+                let mut bytes = Vec::new();
+                let _ = pipe.read_to_end(&mut bytes);
+                String::from_utf8_lossy(&bytes).to_string()
+            })
+        });
+        let started = Instant::now();
+        let mut timed_out = false;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) if started.elapsed() < timeout => thread::sleep(Duration::from_millis(25)),
+                Ok(None) => {
+                    timed_out = true;
+                    #[cfg(unix)]
+                    unsafe {
+                        libc::kill(-(pid as i32), libc::SIGTERM);
+                    }
+                    thread::sleep(Duration::from_millis(100));
+                    #[cfg(unix)]
+                    unsafe {
+                        libc::kill(-(pid as i32), libc::SIGKILL);
+                    }
+                    #[cfg(not(unix))]
+                    {
+                        let _ = child.kill();
+                    }
+                    let _ = child.wait();
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+        let status = child.wait().ok();
+        let stdout = stdout
+            .and_then(|handle| handle.join().ok())
+            .unwrap_or_default();
+        let mut stderr = stderr
+            .and_then(|handle| handle.join().ok())
+            .unwrap_or_default();
+        if timed_out {
+            if !stderr.is_empty() && !stderr.ends_with('\n') {
+                stderr.push('\n');
+            }
+            stderr.push_str(&format!(
+                "Homeboy remote probe timed out after {}ms; terminated child process group.",
+                timeout.as_millis()
+            ));
+        }
+        CommandOutput {
+            stdout,
+            stderr,
+            success: !timed_out && status.is_some_and(|status| status.success()),
+            exit_code: if timed_out {
+                124
+            } else {
+                status.and_then(|status| status.code()).unwrap_or(-1)
+            },
+            timed_out,
+            child_resource: None,
+        }
     }
 
     /// Execute `command` with secret env vars delivered over stdin instead of


### PR DESCRIPTION
## Summary
- Bound each status remote version-file and binary probe to five seconds.
- Return a complete dashboard with a per-component `degraded` status and timeout diagnostic when a probe expires.
- Terminate timed-out local and SSH process groups, while preserving healthy component results and phase timings.

Closes #7889

## Root cause
`homeboy status <project>` entered `fetch_remote_versions` through deploy check mode. Its remote version reads called unbounded SSH/local shell execution, so one hung command prevented the dashboard from rendering.

## How to test
1. Run `cargo test core::deploy::version_overrides::tests::remote_version_probe_timeout_is_bounded_and_cleans_up --lib`.
2. Confirm the timed probe returns in under two seconds, reports a timeout, and reports process-group cleanup.
3. Run `cargo test core::deploy::version_overrides::tests::test_fetch_remote_versions_for_project --lib`.
4. Confirm a healthy remote version probe still returns the component version.
5. Run `cargo test commands::status::tests --lib`.
6. Confirm status command behavior and timing output tests pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode direct general coding subagent
- **Used for:** Root-cause analysis, implementation, and focused regression tests; Chris reviews and owns the change.