### PR TITLE
Register runner rig installs on controller

### DIFF
--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -59,6 +59,12 @@ pub fn route_after_parse(
             return Ok(Some(exit_code));
         }
         if args.is_runner_source_management_command() {
+            if let Some((source, id, all)) = args.runner_install_request() {
+                // Lab routing resolves rig components and path inputs on the
+                // controller before dispatch, so runner-targeted installs must
+                // keep the controller registry pointed at the same source.
+                homeboy::core::rig::install(source, id, all)?;
+            }
             let (stdout, stderr, exit_code) =
                 run_rig_source_management_on_runner(runner_id, normalized_args, output_file)?;
             if !stderr.is_empty() {

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -54,6 +54,15 @@ impl RigArgs {
         )
     }
 
+    pub(crate) fn runner_install_request(&self) -> Option<(&str, Option<&str>, bool)> {
+        match &self.command {
+            RigCommand::Install {
+                source, id, all, ..
+            } => Some((source, id.as_deref(), *all)),
+            _ => None,
+        }
+    }
+
     pub(crate) fn up_dry_run_rig_id(&self) -> Option<&str> {
         match &self.command {
             RigCommand::Up {
@@ -1039,6 +1048,24 @@ mod tests {
                 .expect("rig sync should parse");
 
         assert!(cli.rig.is_runner_source_management_command());
+    }
+
+    #[test]
+    fn exposes_runner_install_request_for_controller_registration() {
+        let cli = TestCli::try_parse_from([
+            "homeboy",
+            "install",
+            "/tmp/rig-package",
+            "--id",
+            "fixture-matrix",
+            "--reinstall",
+        ])
+        .expect("rig install should parse");
+
+        assert_eq!(
+            cli.rig.runner_install_request(),
+            Some(("/tmp/rig-package", Some("fixture-matrix"), false))
+        );
     }
 
     #[test]

--- a/src/core/runner/execution/extension_parity.rs
+++ b/src/core/runner/execution/extension_parity.rs
@@ -429,6 +429,9 @@ fn dev_sync_extension_overlay(
         if overlay.id != extension_id {
             continue;
         }
+        if !Path::new(&overlay.source_path).is_dir() {
+            continue;
+        }
         matches += 1;
         overlay.duplicate_records = matches.saturating_sub(1);
         if selected
@@ -1115,7 +1118,7 @@ fn extension_parity_diagnostic_tail(stderr: &str, stdout: &str) -> String {
 mod tests {
     use super::{
         controller_extension_metadata_required_error, controller_local_source_path,
-        ensure_extension_materialized, plan_extension_parity,
+        dev_sync_extension_overlay, ensure_extension_materialized, plan_extension_parity,
         record_materialized_extension_overlay, remote_extension_core_compatibility,
         remote_extension_ready_status, remote_extension_setting_ids,
         remote_extension_source_revision, requested_setting_keys_for_command,
@@ -1687,6 +1690,16 @@ mod tests {
             &remote_stdout,
         )
         .expect("matching dev overlay hash should pass parity");
+    }
+
+    #[test]
+    fn dev_overlay_ignores_deleted_controller_source() {
+        let deleted = tempfile::tempdir().expect("deleted source dir");
+        let deleted_path = deleted.path().display().to_string();
+        drop(deleted);
+        let runner = runner_with_overlay("nodejs", &deleted_path, "stale-hash");
+
+        assert!(dev_sync_extension_overlay(&runner, "nodejs").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- register runner-targeted rig installs in the controller registry before remote execution
- keep controller rig materialization aligned with the selected Lab runner source
- expose and test the parsed runner install request

Fixes #7899.

## How to test
1. Run `cargo test exposes_runner_install_request_for_controller_registration`.
2. Configure a linked rig ID to point at a removed local checkout.
3. Run `homeboy rig install /path/to/fresh/package --id <rig-id> --reinstall --runner <lab> --lab-only`.
4. Run `homeboy bench --rig <rig-id> --runner <lab> --lab-only` and confirm controller materialization uses the fresh source rather than rejecting the stale registration.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the controller/runner registry split and implemented the source-registration fix and focused coverage with Chris.