### PR TITLE
Persist cook phases before Lab dispatch

### DIFF
--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -406,6 +406,7 @@ pub fn record_lab_offload_phase(
     phase: &str,
     remote_workspace: Option<&str>,
     source_checkout: Option<&Value>,
+    provider_rotation: Option<&Value>,
 ) -> Result<AgentTaskRunRecord> {
     let placeholder_workspace = remote_workspace.unwrap_or("pending");
     let mut record =
@@ -419,6 +420,9 @@ pub fn record_lab_offload_phase(
     }
     if let Some(source_checkout) = source_checkout {
         metadata.insert("source_checkout".to_string(), source_checkout.clone());
+    }
+    if let Some(provider_rotation) = provider_rotation {
+        metadata.insert("provider_rotation".to_string(), provider_rotation.clone());
     }
     store::write_record(&record)?;
     Ok(record)

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -399,6 +399,31 @@ pub fn record_lab_offload_planned(input: LabOffloadProxyPlan<'_>) -> Result<Agen
     )
 }
 
+/// Persist controller-owned setup progress before a runner job exists.
+pub fn record_lab_offload_phase(
+    requested_run_id: &str,
+    runner_id: &str,
+    phase: &str,
+    remote_workspace: Option<&str>,
+    source_checkout: Option<&Value>,
+) -> Result<AgentTaskRunRecord> {
+    let placeholder_workspace = remote_workspace.unwrap_or("pending");
+    let mut record =
+        record_lab_offload_proxy(requested_run_id, runner_id, placeholder_workspace, &[])?;
+    record.updated_at = Some(now_timestamp());
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("phase".to_string(), json!(phase));
+    metadata.insert("provider_state".to_string(), json!("pending"));
+    if let Some(remote_workspace) = remote_workspace {
+        metadata.insert("remote_workspace".to_string(), json!(remote_workspace));
+    }
+    if let Some(source_checkout) = source_checkout {
+        metadata.insert("source_checkout".to_string(), source_checkout.clone());
+    }
+    store::write_record(&record)?;
+    Ok(record)
+}
+
 pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(input.run_id);
     let plan = detached_lab_plan(&run_id, &input);

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -162,6 +162,48 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
 }
 
 #[test]
+fn controller_proxy_records_pre_execution_phase_progress() {
+    with_isolated_home(|_| {
+        let source = json!({
+            "branch": "main",
+            "head": "abc123",
+        });
+        let materializing = record_lab_offload_phase(
+            "agent-task-pre-execution",
+            "homeboy-lab",
+            "materializing",
+            None,
+            Some(&source),
+        )
+        .expect("materialization phase persisted");
+
+        assert_eq!(materializing.state, AgentTaskRunState::Queued);
+        assert_eq!(materializing.metadata["phase"], "materializing");
+        assert_eq!(materializing.metadata["provider_state"], "pending");
+        assert_eq!(materializing.metadata["source_checkout"]["head"], "abc123");
+        assert!(materializing.metadata.get("runner_job_id").is_none());
+
+        let hydrating = record_lab_offload_phase(
+            "agent-task-pre-execution",
+            "homeboy-lab",
+            "hydrating",
+            Some("/runner/workspace/repo"),
+            Some(&source),
+        )
+        .expect("hydration phase persisted");
+        assert_eq!(hydrating.metadata["phase"], "hydrating");
+        assert_eq!(
+            hydrating.metadata["remote_workspace"],
+            "/runner/workspace/repo"
+        );
+
+        let loaded = status("agent-task-pre-execution").expect("status resolves during setup");
+        assert_eq!(loaded.metadata["phase"], "hydrating");
+        assert_eq!(loaded.metadata["provider_state"], "pending");
+    });
+}
+
+#[test]
 fn runner_terminal_reconciliation_is_idempotent_and_preserves_execution_owner() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -174,6 +174,7 @@ fn controller_proxy_records_pre_execution_phase_progress() {
             "materializing",
             None,
             Some(&source),
+            Some(&json!({"entries": [{"model": "openai/gpt-5.6-terra"}]})),
         )
         .expect("materialization phase persisted");
 
@@ -181,6 +182,10 @@ fn controller_proxy_records_pre_execution_phase_progress() {
         assert_eq!(materializing.metadata["phase"], "materializing");
         assert_eq!(materializing.metadata["provider_state"], "pending");
         assert_eq!(materializing.metadata["source_checkout"]["head"], "abc123");
+        assert_eq!(
+            materializing.metadata["provider_rotation"]["entries"][0]["model"],
+            "openai/gpt-5.6-terra"
+        );
         assert!(materializing.metadata.get("runner_job_id").is_none());
 
         let hydrating = record_lab_offload_phase(
@@ -189,6 +194,7 @@ fn controller_proxy_records_pre_execution_phase_progress() {
             "hydrating",
             Some("/runner/workspace/repo"),
             Some(&source),
+            None,
         )
         .expect("hydration phase persisted");
         assert_eq!(hydrating.metadata["phase"], "hydrating");

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -237,13 +237,14 @@ pub mod lifecycle {
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
         cook_attempt_run_id, cook_index, list_records, load_plan, logs, mark_resuming,
         mark_running, record_completed_run, record_cook_attempt, record_detached_lab_run,
-        record_lab_offload_planned, record_pre_dispatch_failure, record_pre_execution_failure,
-        record_promotion, record_remote_dispatch_failure, record_run_aggregate, retry,
-        run_record_exists, run_status, status, submit_plan, AgentTaskArtifactRef,
-        AgentTaskCookIndex, AgentTaskCookIndexAttempt, AgentTaskEventEnvelope,
-        AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts,
-        AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState,
-        AgentTaskRunStatus, AgentTaskRunTask, DetachedLabRunRecord, LabOffloadProxyPlan,
+        record_lab_offload_phase, record_lab_offload_planned, record_pre_dispatch_failure,
+        record_pre_execution_failure, record_promotion, record_remote_dispatch_failure,
+        record_run_aggregate, retry, run_record_exists, run_status, status, submit_plan,
+        AgentTaskArtifactRef, AgentTaskCookIndex, AgentTaskCookIndexAttempt,
+        AgentTaskEventEnvelope, AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure,
+        AgentTaskRunArtifacts, AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord,
+        AgentTaskRunState, AgentTaskRunStatus, AgentTaskRunTask, DetachedLabRunRecord,
+        LabOffloadProxyPlan,
     };
 }
 

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -806,6 +806,16 @@ pub(crate) fn run_lab_offload_inner(
         messages.push(warning);
     }
     let source_checkout = lab_source_checkout_metadata(&source_path);
+    let run_isolation_token = agent_task_dispatch_run_isolation_token(request.normalized_args);
+    if let Some(run_id) = run_isolation_token.as_deref() {
+        agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            runner_id,
+            "materializing",
+            None,
+            Some(&source_checkout),
+        )?;
+    }
     let homeboy_path = remote_runner_homeboy_path(&runner, "Lab offload preflight")?;
     let require_exact_runner_version = require_exact_runner_version(&runner.settings);
     let runner_homeboy = lab_runner_homeboy_metadata(runner_id, homeboy_path, &runner_status);
@@ -980,6 +990,7 @@ pub(crate) fn run_lab_offload_inner(
         homeboy_path,
         &command_prefix.argv,
         Some(&runner_workspace_root),
+        run_isolation_token,
     )?;
     workspace_sync_timer.finish();
     let LabOffloadWorkspaceStage {
@@ -1005,6 +1016,15 @@ pub(crate) fn run_lab_offload_inner(
         runtime_overlay_metadata,
     } = workspace_stage;
     plan = next_plan;
+    if let Some(run_id) = agent_task_run_id.as_deref() {
+        agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            runner_id,
+            "hydrating",
+            Some(&remote_cwd),
+            Some(&source_checkout),
+        )?;
+    }
     let cleanup_policy = if agent_task_run_id.is_some() {
         WorkspaceCleanupPolicy::PreserveAlways
     } else {
@@ -1037,6 +1057,15 @@ pub(crate) fn run_lab_offload_inner(
         plan,
     )?;
     plan = dependency_hydration.plan;
+    if let Some(run_id) = agent_task_run_id.as_deref() {
+        agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            runner_id,
+            "dispatching",
+            Some(&remote_cwd),
+            Some(&source_checkout),
+        )?;
+    }
 
     eprintln!(
         "Lab offload: running `{}` on runner `{}` in `{}`.",

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -807,6 +807,9 @@ pub(crate) fn run_lab_offload_inner(
     }
     let source_checkout = lab_source_checkout_metadata(&source_path);
     let run_isolation_token = agent_task_dispatch_run_isolation_token(request.normalized_args);
+    let provider_rotation =
+        serde_json::to_value(crate::core::defaults::load_config().agent_task.rotation)
+            .unwrap_or(serde_json::Value::Null);
     if let Some(run_id) = run_isolation_token.as_deref() {
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,
@@ -814,6 +817,7 @@ pub(crate) fn run_lab_offload_inner(
             "materializing",
             None,
             Some(&source_checkout),
+            Some(&provider_rotation),
         )?;
     }
     let homeboy_path = remote_runner_homeboy_path(&runner, "Lab offload preflight")?;
@@ -1023,6 +1027,7 @@ pub(crate) fn run_lab_offload_inner(
             "hydrating",
             Some(&remote_cwd),
             Some(&source_checkout),
+            Some(&provider_rotation),
         )?;
     }
     let cleanup_policy = if agent_task_run_id.is_some() {
@@ -1064,6 +1069,7 @@ pub(crate) fn run_lab_offload_inner(
             "dispatching",
             Some(&remote_cwd),
             Some(&source_checkout),
+            Some(&provider_rotation),
         )?;
     }
 

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -44,6 +44,7 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
     homeboy_path: &str,
     command_prefix_argv: &[String],
     runner_workspace_root: Option<&str>,
+    run_isolation_token: Option<String>,
 ) -> Result<LabOffloadWorkspaceStage> {
     // Capture the orchestration facts known *before* staging so any
     // Lab-cannot-proceed error bubbling out of the pre-execution/dispatch path
@@ -66,6 +67,7 @@ pub(crate) fn prepare_lab_offload_workspace_stage(
         homeboy_path,
         command_prefix_argv,
         runner_workspace_root,
+        run_isolation_token,
     )
     .map_err(|error| enrich_lab_cannot_proceed_error(error, &context))
 }
@@ -80,6 +82,7 @@ fn prepare_lab_offload_workspace_stage_inner(
     homeboy_path: &str,
     command_prefix_argv: &[String],
     runner_workspace_root: Option<&str>,
+    run_isolation_token: Option<String>,
 ) -> Result<LabOffloadWorkspaceStage> {
     let sync_mode = lab_workspace_sync_mode(
         contract.workspace_mode_policy,
@@ -138,7 +141,6 @@ fn prepare_lab_offload_workspace_stage_inner(
     // can observe its leftover untracked artifacts (#4393). Resolve the
     // agent-task run id (existing or freshly generated) up front and fold it
     // into the workspace identity so each run gets a clean, isolated directory.
-    let run_isolation_token = agent_task_dispatch_run_isolation_token(request.normalized_args);
     let synced = sync_workspace(
         runner_id,
         RunnerWorkspaceSyncOptions {


### PR DESCRIPTION
Fixes #7891.
Fixes #7892.

## Root cause

The controller created its durable Lab proxy only inside `exec_lab_context`, after workspace materialization and dependency hydration had completed. During those Homeboy-owned setup phases, the caller's cook ID had no lifecycle record and status could not explain the active work or provider policy.

## Changes

- Resolve the stable caller-supplied agent-task run ID before workspace staging and pass that same identity through materialization.
- Persist a controller-owned proxy at the start of materialization.
- Update its phase through `materializing`, `hydrating`, and `dispatching`.
- Record runner identity, source checkout metadata, remote workspace when known, configured provider rotation candidates, and truthful `provider_state: pending` before model execution.
- Preserve the existing #7758 attempt/rotation history and #7894 runner-child handoff/reconciliation contract under the same caller ID.

## How to test

1. Run `cargo test controller_proxy_records_pre_execution_phase_progress -- --test-threads=1`.
2. Run `cargo test core::agent_task_lifecycle::tests -- --test-threads=1`.
3. Start `homeboy agent-task cook --runner <runner> --lab-only --run-id test-preflight ...` against a workspace that requires materialization.
4. While workspace setup is active, run `homeboy agent-task status test-preflight --full`.
5. Confirm status resolves before provider dispatch and reports `metadata.phase` as `materializing` or `hydrating`, `metadata.provider_state` as `pending`, configured `metadata.provider_rotation`, the selected runner, and source checkout identity.
6. Confirm the same caller-ID record advances to `dispatching`, binds the runner child after daemon acceptance, and retains provider attempt history if rotation occurs.

## Verification

- `cargo fmt --check` passed.
- `cargo check` passed.
- New focused test passed: 1 passed, 0 failed.
- Agent-task lifecycle suite passed: 42 passed, 0 failed.
- `cargo test --lib`: 7,171 passed, 34 failed, 18 ignored. The 34 failures are existing environment/baseline failures across extension discovery, fixture configuration, signal timing, and unrelated deploy/audit tests; the affected lifecycle suite is green.

## Backwards compatibility

Additive metadata only. Existing run IDs, runner handoff records, attempt history, and status consumers remain valid. Commands without an agent-task run ID do not create a proxy.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via OpenCode
- **Used for:** Implemented pre-execution lifecycle persistence, provider provenance, and regression coverage under Chris Huber's direction
