### PR TITLE
Guide recovery for orphaned runner jobs

### DIFF
--- a/src/commands/runner/status.rs
+++ b/src/commands/runner/status.rs
@@ -921,7 +921,7 @@ pub(super) fn runner_status_operator_hints(report: &RunnerStatusReport) -> Vec<S
     }
     if report.stale_runner_job_count > 0 {
         hints.push(format!(
-            "Runner `{}` has {} stale runner job(s) that are no longer active. Inspect stale_runner_jobs before retrying affected durable runs.",
+            "Runner `{}` has {} stale runner job(s) that are no longer active. Inspect each durable run with its listed agent-task status command, then retry only recoverable work.",
             report.runner_id, report.stale_runner_job_count
         ));
     }
@@ -982,6 +982,28 @@ pub(super) fn runner_status_operator_commands(
         .iter()
         .chain(report.stale_runner_jobs.iter())
     {
+        if job.lifecycle_state.as_deref() == Some("recoverable_orphan") {
+            if let Some(run_id) = job.durable_run_id.as_deref() {
+                commands.push(RunnerOperatorCommand {
+                    scope: "agent_task_status",
+                    runner_id: report.runner_id.clone(),
+                    job_id: None,
+                    command: format!("homeboy agent-task status {run_id} --full"),
+                    description:
+                        "Inspect the durable orphaned agent-task run and its preserved evidence."
+                            .to_string(),
+                });
+                commands.push(RunnerOperatorCommand {
+                    scope: "agent_task_retry",
+                    runner_id: report.runner_id.clone(),
+                    job_id: None,
+                    command: format!("homeboy agent-task retry {run_id}"),
+                    description: "Create a fresh durable attempt after reviewing the orphaned run."
+                        .to_string(),
+                });
+            }
+            continue;
+        }
         commands.push(RunnerOperatorCommand {
             scope: "job_logs",
             runner_id: report.runner_id.clone(),

--- a/src/commands/runner/tests/status.rs
+++ b/src/commands/runner/tests/status.rs
@@ -36,7 +36,7 @@ fn runner_job_event_format_includes_sequence_kind_message_and_data() {
 
 #[test]
 fn reverse_runner_status_commands_include_lifecycle_operations() {
-    let report = RunnerStatusReport {
+    let mut report = RunnerStatusReport {
         runner_id: "homeboy-lab".to_string(),
         connected: true,
         state: runner::RunnerSessionState::Connected,
@@ -135,6 +135,23 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
     assert!(serialized.contains("homeboy runner job reconcile homeboy-lab"));
     assert!(serialized.contains("homeboy runner job artifacts homeboy-lab job-123 <artifact-id>"));
     assert!(!serialized.contains("curl -fsS"));
+
+    let mut orphan = report.active_runner_jobs[0].clone();
+    orphan.job_id = "orphaned-child-run-run-123".to_string();
+    orphan.lifecycle_state = Some("recoverable_orphan".to_string());
+    orphan.stale_reason = Some("child_run_running_without_active_runner_job".to_string());
+    orphan.retryable = Some(true);
+    report.active_runner_jobs.clear();
+    report.active_jobs.clear();
+    report.active_job_count = 0;
+    report.stale_runner_jobs = vec![orphan];
+    report.stale_runner_job_count = 1;
+
+    let commands = runner_status_operator_commands(&report);
+    let serialized = serde_json::to_string(&commands).expect("serialize orphan commands");
+    assert!(serialized.contains("homeboy agent-task status run-123 --full"));
+    assert!(serialized.contains("homeboy agent-task retry run-123"));
+    assert!(!serialized.contains("runner job logs"));
 }
 
 #[test]

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -491,7 +491,7 @@ fn orphaned_child_run_job(runner_id: &str, run: RunSummary) -> ActiveRunnerJobSu
         lifecycle: None,
         durable_run_id: Some(run.id),
         stale_reason: Some("child_run_running_without_active_runner_job".to_string()),
-        lifecycle_state: Some("stale".to_string()),
+        lifecycle_state: Some("recoverable_orphan".to_string()),
         retryable: Some(true),
         active_child_count: None,
         active_cell_count: None,
@@ -1792,7 +1792,7 @@ mod tests {
             job.stale_reason.as_deref(),
             Some("child_run_running_without_active_runner_job")
         );
-        assert_eq!(job.lifecycle_state.as_deref(), Some("stale"));
+        assert_eq!(job.lifecycle_state.as_deref(), Some("recoverable_orphan"));
         assert_eq!(job.retryable, Some(true));
     }
 


### PR DESCRIPTION
Fixes #7890.

## Root cause

Runner status synthesized `orphaned-child-run-*` job IDs for running observation records without active daemon jobs, classified them only as `stale`, and then generated `runner job logs` commands for those synthetic IDs. Those commands cannot resolve because no daemon job with that ID exists.

## Changes

- Classify these records explicitly as `recoverable_orphan` while preserving the durable run ID and evidence.
- Replace dead synthetic-job log commands with `agent-task status <run> --full`.
- Provide one explicit non-destructive recovery command: `agent-task retry <run>`.
- Clarify status guidance that active readiness and historical orphaned work are distinct.

## How to test

1. Run `cargo test orphaned_child_run_job_reports_stale_retryable_runner_state -- --test-threads=1`.
2. Run `cargo test reverse_runner_status_commands_include_lifecycle_operations -- --test-threads=1`.
3. Connect a runner that has a running observation record without a matching active daemon job.
4. Run `homeboy runner status <runner>`.
5. Confirm the stale record is classified `recoverable_orphan` and its operator commands use the durable agent-task ID, not the synthetic job ID.

## Verification

- `cargo fmt --check` passed.
- `cargo check` passed.
- Orphan classification test: 1 passed, 0 failed.
- Status command test: 1 passed, 0 failed.

## Backwards compatibility

The stale-job JSON remains additive except for the more precise `lifecycle_state` value. Consumers treating any non-active state as stale remain compatible. No evidence is deleted and no retry is automatic.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via OpenCode
- **Used for:** Implemented orphan classification, recovery commands, and regression coverage under Chris Huber's direction
