### PR TITLE
fix: fetch missing exact deploy refs from remote

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -50,7 +50,7 @@ Real deploys with `--head`, `--ref`, or `--force` require `--apply`. Preview and
 
 `--ref` is an explicit source selector and conflicts with `--head`, `--tagged`, `--version`, `--outdated`, `--behind-upstream`, and `--check`. Without `--ref`, release and `--head` selection behave as before. File sources and `deploy_strategy: "git"` are rejected because those strategies cannot package and upload the selected Git tree.
 
-Homeboy resolves `<git-ref-or-sha>^{commit}` in the repository containing the declared component `local_path`, pins the full commit SHA, and uses a detached temporary worktree for local build and packaging. It never checks out the requested ref in the configured source checkout. A branch or tag must already be available in that declared repository; use an explicit remote-tracking ref when that is the intended source. Missing, non-commit, or ambiguous refs fail before build or remote mutation.
+Homeboy resolves `<git-ref-or-sha>^{commit}` in the repository containing the declared component `local_path`. If that checkout lacks the object, it fetches only the requested SHA or a single matching named ref through the checkout's configured Git remote, using the existing Git transport and credential policy. It pins the full commit SHA and uses a detached temporary worktree for local build and packaging without changing the configured checkout's branch, index, or worktree. Missing, non-commit, ambiguous, and unauthenticated refs fail before build or remote mutation. A dry run may add the resolved object to the local Git object database but does not build, deploy, or create a worktree.
 
 Components can declare `deploy_together` in their component config. When any selected component belongs to a deploy-together group, Homeboy requires the full group in the same deploy plan and fails before build/upload if only part of the group was selected. Use explicit component IDs for the whole group or `--all` for the project.
 
@@ -101,7 +101,8 @@ If no component IDs are provided and none of `--all`, `--outdated`, `--behind-up
       "deployed_ref": "<tag-or-branch>|null",
       "requested_ref": "<operator-provided-ref>",
       "resolved_sha": "<full-commit-sha>",
-      "source": "<declared-git-repository>"
+      "source": "<declared-git-repository-or-configured-remote>",
+      "resolution_mode": "local|remote_sha|remote_named_ref"
     }
   ],
   "summary": { "total": 1, "succeeded": 0, "failed": 0, "skipped": 0 }
@@ -115,7 +116,7 @@ Notes:
 - `artifact_path` is the component build artifact path as configured; it may be relative but must include a filename.
 - Deploy output does not include `build_command`. Builds are resolved from the linked extension, and deploy records only build/deploy exit codes plus the artifact path used.
 - `deployed_ref` is omitted when no tag or branch ref was deployed.
-- `requested_ref`, `resolved_sha`, and `source` are persisted for `--ref` deploy evidence and omitted for other source modes. `build_provenance.built_from_ref` and `build_provenance.built_from_commit` carry the same identity.
+- `requested_ref`, `resolved_sha`, `source`, and `resolution_mode` are persisted for `--ref` deploy evidence and omitted for other source modes. `build_provenance.built_from_ref` and `build_provenance.built_from_commit` carry the same identity.
 
 Note: `build_exit_code`/`deploy_exit_code` are numbers when present (not strings).
 
@@ -256,7 +257,7 @@ homeboy deploy myproject my-plugin --version 1.2.3 --tagged --dry-run
 homeboy deploy myproject my-plugin --ref origin/reviewed-branch --dry-run
 ```
 
-An exact-ref dry-run resolves the ref without fetching, checking out, creating a worktree, building, or uploading. Each planned result reports the requested ref, resolved SHA, declared source repository, packaging plan, and remote destination.
+An exact-ref dry-run resolves the ref without checking out, creating a worktree, building, or uploading. When the configured checkout lacks the requested object, it may fetch that object through the declared remote. Each planned result reports the requested ref, resolved SHA, source, resolution mode, packaging plan, and remote destination.
 
 ## Check Component Status
 

--- a/src/core/deploy/orchestration/mod.rs
+++ b/src/core/deploy/orchestration/mod.rs
@@ -279,6 +279,7 @@ pub(super) fn deploy_components(
                 &identity.requested_ref,
                 &identity.resolved_sha,
                 &identity.source,
+                &identity.resolution_mode,
             );
         }
 

--- a/src/core/deploy/orchestration/modes.rs
+++ b/src/core/deploy/orchestration/modes.rs
@@ -121,10 +121,12 @@ pub(super) fn run_dry_run_mode(
                     &identity.requested_ref,
                     &identity.resolved_sha,
                     &identity.source,
+                    &identity.resolution_mode,
                 );
                 result.warnings.push(format!(
-                    "source: {}; requested ref: {}; resolved SHA: {}; plan: materialize detached temporary worktree and build exact commit; destination: {}",
+                    "source: {}; resolution mode: {}; requested ref: {}; resolved SHA: {}; plan: materialize detached temporary worktree and build exact commit; destination: {}",
                     identity.source,
+                    identity.resolution_mode,
                     identity.requested_ref,
                     identity.resolved_sha,
                     result.remote_path.as_deref().unwrap_or("unresolved")

--- a/src/core/deploy/orchestration_ref_checkout.rs
+++ b/src/core/deploy/orchestration_ref_checkout.rs
@@ -9,6 +9,7 @@ pub(super) struct ExactRefIdentity {
     pub requested_ref: String,
     pub resolved_sha: String,
     pub source: String,
+    pub resolution_mode: String,
 }
 
 pub(super) struct ExactRefCheckout {
@@ -24,18 +25,19 @@ pub(super) fn resolve_exact_ref(
 ) -> Result<ExactRefIdentity> {
     validate_component_source(component)?;
     let source_root = source_root(component)?;
-    let resolved_sha = resolve_commit(&source_root, requested_ref, &component.id)?;
+    let resolution = resolve_commit(&source_root, requested_ref, &component.id)?;
     Ok(ExactRefIdentity {
         requested_ref: requested_ref.to_string(),
-        resolved_sha,
-        source: source_root.to_string_lossy().to_string(),
+        resolved_sha: resolution.sha,
+        source: resolution.source,
+        resolution_mode: resolution.mode,
     })
 }
 
 impl ExactRefCheckout {
     pub(super) fn materialize(component: &Component, requested_ref: &str) -> Result<Self> {
         let identity = resolve_exact_ref(component, requested_ref)?;
-        let source_root = PathBuf::from(&identity.source);
+        let source_root = source_root(component)?;
         let component_prefix = git::get_component_path_prefix(&component.local_path);
         let parent = std::env::temp_dir().join("homeboy-deploy-ref");
         std::fs::create_dir_all(&parent).map_err(|err| {
@@ -197,7 +199,17 @@ fn source_root(component: &Component) -> Result<PathBuf> {
         })
 }
 
-fn resolve_commit(source_root: &Path, requested_ref: &str, component_id: &str) -> Result<String> {
+struct ResolvedCommit {
+    sha: String,
+    source: String,
+    mode: String,
+}
+
+fn resolve_commit(
+    source_root: &Path,
+    requested_ref: &str,
+    component_id: &str,
+) -> Result<ResolvedCommit> {
     if requested_ref.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "ref",
@@ -207,25 +219,150 @@ fn resolve_commit(source_root: &Path, requested_ref: &str, component_id: &str) -
         ));
     }
     let commit_ref = format!("{requested_ref}^{{commit}}");
-    git::run_git(
+    if let Ok(sha) = git::run_git(
         source_root,
         &["rev-parse", "--verify", &commit_ref],
         "resolve exact deploy ref",
+    ) {
+        return Ok(ResolvedCommit {
+            sha: sha.trim().to_string(),
+            source: source_root.to_string_lossy().to_string(),
+            mode: "local".to_string(),
+        });
+    }
+
+    resolve_remote_commit(source_root, requested_ref, component_id)
+}
+
+fn resolve_remote_commit(
+    source_root: &Path,
+    requested_ref: &str,
+    component_id: &str,
+) -> Result<ResolvedCommit> {
+    let remote = git::resolve_default_remote(source_root);
+    if git::remote_url(source_root, &remote).is_none() {
+        return Err(unresolvable_ref(requested_ref, source_root, component_id));
+    }
+
+    if is_full_sha(requested_ref) {
+        if git::run_git(
+            source_root,
+            &["fetch", "--no-tags", &remote, requested_ref],
+            "fetch exact deploy SHA",
+        )
+        .is_ok()
+        {
+            let fetched = git::run_git(
+                source_root,
+                &[
+                    "rev-parse",
+                    "--verify",
+                    &format!("{requested_ref}^{{commit}}"),
+                ],
+                "verify fetched exact deploy SHA",
+            )
+            .map_err(|_| unresolvable_ref(requested_ref, source_root, component_id))?
+            .trim()
+            .to_string();
+            if fetched.eq_ignore_ascii_case(requested_ref) {
+                return Ok(ResolvedCommit {
+                    sha: fetched,
+                    source: format!("remote:{remote}"),
+                    mode: "remote_sha".to_string(),
+                });
+            }
+            return Err(unresolvable_ref(requested_ref, source_root, component_id));
+        }
+    }
+
+    let remote_ref = resolve_named_remote_ref(source_root, &remote, requested_ref, component_id)?;
+    git::run_git(
+        source_root,
+        &["fetch", "--no-tags", &remote, &remote_ref],
+        "fetch named exact deploy ref",
     )
-    .map(|sha| sha.trim().to_string())
-    .map_err(|_| {
-        Error::validation_invalid_argument(
+    .map_err(|_| remote_transport_error(&remote, component_id))?;
+    let sha = git::run_git(
+        source_root,
+        &["rev-parse", "--verify", "FETCH_HEAD^{commit}"],
+        "verify fetched named exact deploy ref",
+    )
+    .map_err(|_| unresolvable_ref(requested_ref, source_root, component_id))?
+    .trim()
+    .to_string();
+    Ok(ResolvedCommit {
+        sha,
+        source: format!("remote:{remote}"),
+        mode: "remote_named_ref".to_string(),
+    })
+}
+
+fn resolve_named_remote_ref(
+    source_root: &Path,
+    remote: &str,
+    requested_ref: &str,
+    component_id: &str,
+) -> Result<String> {
+    let output = git::run_git(
+        source_root,
+        &["ls-remote", "--refs", remote, requested_ref],
+        "query named exact deploy ref",
+    )
+    .map_err(|_| remote_transport_error(remote, component_id))?;
+    let candidates: Vec<&str> = output
+        .lines()
+        .filter_map(|line| line.split_whitespace().nth(1))
+        .filter(|reference| remote_ref_matches(reference, requested_ref))
+        .collect();
+    match candidates.as_slice() {
+        [reference] => Ok((*reference).to_string()),
+        [] => Err(unresolvable_ref(requested_ref, source_root, component_id)),
+        _ => Err(Error::validation_invalid_argument(
             "ref",
             format!(
-                "Cannot resolve --ref '{}' to an unambiguous commit in declared repository '{}' for component '{}'",
-                requested_ref,
-                source_root.display(),
-                component_id
+                "Cannot resolve --ref '{}' unambiguously from declared Git remote '{}' for component '{}'",
+                requested_ref, remote, component_id
             ),
             None,
             None,
-        )
-    })
+        )),
+    }
+}
+
+fn remote_ref_matches(reference: &str, requested_ref: &str) -> bool {
+    reference == requested_ref
+        || reference == format!("refs/heads/{requested_ref}")
+        || reference == format!("refs/tags/{requested_ref}")
+}
+
+fn is_full_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn unresolvable_ref(requested_ref: &str, source_root: &Path, component_id: &str) -> Error {
+    Error::validation_invalid_argument(
+        "ref",
+        format!(
+            "Cannot resolve --ref '{}' to an unambiguous commit in declared repository '{}' for component '{}'",
+            requested_ref,
+            source_root.display(),
+            component_id
+        ),
+        None,
+        None,
+    )
+}
+
+fn remote_transport_error(remote: &str, component_id: &str) -> Error {
+    Error::validation_invalid_argument(
+        "ref",
+        format!(
+            "Unable to query declared Git remote '{}' for component '{}'. Check the remote URL and configured Git authentication.",
+            remote, component_id
+        ),
+        None,
+        None,
+    )
 }
 
 #[cfg(test)]
@@ -323,6 +460,57 @@ mod tests {
     }
 
     #[test]
+    fn stale_checkout_fetches_exact_sha_and_named_ref_without_changing_head_or_index() {
+        let fixture = remote_fixture();
+        let sha_checkout = stale_clone(&fixture);
+        let sha_component = fixture_component(&sha_checkout);
+        let sha_head = git_output(&sha_checkout, &["rev-parse", "HEAD"]);
+        let sha_index = git_output(&sha_checkout, &["write-tree"]);
+
+        let sha_identity = resolve_exact_ref(&sha_component, &fixture.target_sha)
+            .expect("fetch exact SHA from remote");
+        assert_eq!(sha_identity.resolved_sha, fixture.target_sha);
+        assert_eq!(sha_identity.source, "remote:origin");
+        assert_eq!(sha_identity.resolution_mode, "remote_sha");
+        assert_eq!(git_output(&sha_checkout, &["rev-parse", "HEAD"]), sha_head);
+        assert_eq!(git_output(&sha_checkout, &["write-tree"]), sha_index);
+
+        let named_checkout = stale_clone(&fixture);
+        let named_component = fixture_component(&named_checkout);
+        let named_head = git_output(&named_checkout, &["rev-parse", "HEAD"]);
+        let named_index = git_output(&named_checkout, &["write-tree"]);
+        let checkout = ExactRefCheckout::materialize(&named_component, "accepted")
+            .expect("fetch and materialize named remote ref");
+        assert_eq!(checkout.identity.resolved_sha, fixture.target_sha);
+        assert_eq!(checkout.identity.resolution_mode, "remote_named_ref");
+        assert_eq!(
+            git_output(&named_checkout, &["rev-parse", "HEAD"]),
+            named_head
+        );
+        assert_eq!(git_output(&named_checkout, &["write-tree"]), named_index);
+    }
+
+    #[test]
+    fn missing_remote_ref_and_transport_failure_are_actionable() {
+        let fixture = remote_fixture();
+        let checkout = stale_clone(&fixture);
+        let component = fixture_component(&checkout);
+        let missing = resolve_exact_ref(&component, "missing-ref").expect_err("missing ref");
+        assert!(missing
+            .message
+            .contains("Cannot resolve --ref 'missing-ref'"));
+
+        git(
+            &checkout,
+            &["remote", "set-url", "origin", "/missing/remote.git"],
+        );
+        let transport =
+            resolve_exact_ref(&component, "also-missing").expect_err("transport failure");
+        assert!(transport.message.contains("configured Git authentication"));
+        assert!(transport.message.contains("remote 'origin'"));
+    }
+
+    #[test]
     fn materialized_ref_verification_rejects_a_different_checkout_head() {
         let repo = fixture_repo();
         let component = fixture_component(repo.path());
@@ -390,6 +578,95 @@ mod tests {
             build_artifact: Some("build/fixture.zip".to_string()),
             ..Component::default()
         }
+    }
+
+    struct RemoteFixture {
+        _root: tempfile::TempDir,
+        remote: PathBuf,
+        target_sha: String,
+    }
+
+    fn remote_fixture() -> RemoteFixture {
+        let root = tempfile::tempdir().expect("fixture root");
+        let remote = root.path().join("remote.git");
+        let seed = root.path().join("seed");
+        git(
+            root.path(),
+            &[
+                "init",
+                "--bare",
+                "--initial-branch=main",
+                remote.to_str().unwrap(),
+            ],
+        );
+        git(
+            root.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                seed.to_str().unwrap(),
+            ],
+        );
+        git(&seed, &["config", "user.name", "Homeboy Test"]);
+        git(&seed, &["config", "user.email", "homeboy@example.test"]);
+        std::fs::write(seed.join("payload.txt"), "stale\n").expect("stale payload");
+        git(&seed, &["add", "payload.txt"]);
+        commit(&seed, "stale");
+        git(&seed, &["push", "-q", "origin", "main"]);
+        let stale_clone = root.path().join("stale-template");
+        git(
+            root.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                stale_clone.to_str().unwrap(),
+            ],
+        );
+        std::fs::write(seed.join("payload.txt"), "accepted\n").expect("accepted payload");
+        git(&seed, &["add", "payload.txt"]);
+        commit(&seed, "accepted");
+        let target_sha = git_output(&seed, &["rev-parse", "HEAD"]);
+        git(&seed, &["branch", "accepted"]);
+        git(&seed, &["push", "-q", "origin", "main", "accepted"]);
+        RemoteFixture {
+            _root: root,
+            remote,
+            target_sha,
+        }
+    }
+
+    fn stale_clone(fixture: &RemoteFixture) -> PathBuf {
+        let checkout = fixture
+            .remote
+            .parent()
+            .expect("fixture parent")
+            .join(uuid::Uuid::new_v4().to_string());
+        let stale_template = fixture
+            .remote
+            .parent()
+            .expect("fixture parent")
+            .join("stale-template");
+        git(
+            fixture.remote.parent().expect("fixture parent"),
+            &[
+                "clone",
+                "-q",
+                stale_template.to_str().unwrap(),
+                checkout.to_str().unwrap(),
+            ],
+        );
+        git(
+            &checkout,
+            &[
+                "remote",
+                "set-url",
+                "origin",
+                fixture.remote.to_str().unwrap(),
+            ],
+        );
+        checkout
     }
 
     fn commit(path: &Path, message: &str) {

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -328,6 +328,9 @@ pub struct ComponentDeployResult {
     /// Declared repository used to resolve the requested ref.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    /// Whether exact-ref identity came from the checkout or its configured remote.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution_mode: Option<String>,
     /// Explicit build provenance: source/ref, whether a fresh build ran, and the
     /// identity of the artifact that shipped.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -363,6 +366,7 @@ impl ComponentDeployResult {
             requested_ref: None,
             resolved_sha: None,
             source: None,
+            resolution_mode: None,
             build_provenance: None,
         }
     }
@@ -457,10 +461,12 @@ impl ComponentDeployResult {
         requested_ref: &str,
         resolved_sha: &str,
         source: &str,
+        resolution_mode: &str,
     ) -> Self {
         self.requested_ref = Some(requested_ref.to_string());
         self.resolved_sha = Some(resolved_sha.to_string());
         self.source = Some(source.to_string());
+        self.resolution_mode = Some(resolution_mode.to_string());
         self.deployed_ref = Some(requested_ref.to_string());
         self.git_head = Some(resolved_sha.to_string());
         self.local_path = Some(source.to_string());
@@ -791,6 +797,7 @@ mod tests {
             "origin/reviewed",
             "0123456789abcdef0123456789abcdef01234567",
             "/repos/component",
+            "local",
         );
         let evidence = serde_json::to_value(result).expect("serialize deploy evidence");
 
@@ -800,6 +807,7 @@ mod tests {
             "0123456789abcdef0123456789abcdef01234567"
         );
         assert_eq!(evidence["source"], "/repos/component");
+        assert_eq!(evidence["resolution_mode"], "local");
         assert_eq!(evidence["deployed_ref"], "origin/reviewed");
         assert_eq!(
             evidence["git_head"],


### PR DESCRIPTION
## Summary
- resolve missing `deploy --ref` objects through the checkout's configured Git remote without checking out or updating the source branch/index
- support direct immutable SHA fetches and single unambiguous named remote refs, then verify a commit before detached materialization
- report source and resolution mode in exact-ref evidence and dry-run output

Fixes #7815.

## Production reproduction
On Homeboy `0.283.1+225f2bf04ac2`, the following dry run failed before package assembly or remote mutation because the configured `wp-build` checkout lacked an accepted GHE commit:

```sh
homeboy deploy wp-build-runtime wp-build site-forge --ref bfee3820dcc34dd0837932f65607f139dabda46d --dry-run
```

The accepted commit and tree were authenticated through the declared repository, but local-only `rev-parse` rejected the ref. This change fetches the requested immutable object through the existing configured Git remote, preserves the checkout state, and binds the fetched commit to the detached package worktree.

## How to test
1. Run `cargo test core::deploy::orchestration_ref_checkout::tests --lib`.
2. Confirm the stale-checkout fixture resolves an absent SHA and named remote ref from a local bare remote.
3. Confirm the test verifies the checkout HEAD and index remain unchanged, unknown refs fail clearly, and transport/auth failures name the configured remote with remediation.
4. Run `cargo test core::deploy::orchestration::modes::tests --lib`.
5. Run `cargo check` and `cargo fmt --check`.

## Backwards compatibility
No exposed API or configuration changes. Existing locally resolvable exact refs, release deploys, and `--head` behavior retain their current paths; only missing exact refs gain a configured-remote resolution fallback.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode direct general coding
- **Used for:** Implemented the generic Git remote exact-ref resolution flow, regression tests, documentation, and verification with Chris's direction.