### PR TITLE
Resolve external worktrees by handle

### DIFF
--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -198,6 +198,10 @@ impl Default for WorktreeProviderKind {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorktreeProviderCommands {
+    /// Targeted handle lookup. Each `{handle}` argument is replaced with the
+    /// requested handle. The result uses `list_result_mapping` and may contain one item.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolve: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub list: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/core/worktree_providers.rs
+++ b/src/core/worktree_providers.rs
@@ -114,6 +114,15 @@ pub fn resolve_worktree_provider_handle_from_config(
         if !provider.enabled {
             continue;
         }
+        if let Some(command) = provider.commands.resolve.as_ref() {
+            attempted.push(provider_id.clone());
+            let worktrees = run_provider_resolve_command(&provider_id, provider, command, handle)?;
+            if let Some(worktree) = worktrees.into_iter().find(|item| item.handle == handle) {
+                validate_provider_handle(&provider_id, &worktree)?;
+                return Ok(worktree);
+            }
+            continue;
+        }
         let Some(command) = provider.commands.list.as_ref() else {
             continue;
         };
@@ -141,6 +150,19 @@ pub fn resolve_worktree_provider_handle_from_config(
             "Configure an enabled worktree provider commands.list command that returns typed worktree path, branch, and safety metadata.".to_string(),
         ]),
     ))
+}
+
+fn run_provider_resolve_command(
+    provider_id: &str,
+    provider: &WorktreeProviderConfig,
+    command: &[String],
+    handle: &str,
+) -> Result<Vec<WorktreeProviderHandle>> {
+    let command = command
+        .iter()
+        .map(|argument| argument.replace("{handle}", handle))
+        .collect::<Vec<_>>();
+    run_provider_list_command(provider_id, provider, &command)
 }
 
 fn run_provider_list_command(
@@ -963,7 +985,7 @@ mod tests {
     }
 
     #[test]
-    fn resolves_a_clean_provider_managed_handle_without_a_homeboy_record() {
+    fn resolves_a_clean_provider_managed_handle_with_targeted_command() {
         let workspace = tempfile::tempdir().expect("workspace");
         git_init(workspace.path(), "cook-target");
         let script = fake_list_provider_script(serde_json::json!({
@@ -981,7 +1003,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 commands: WorktreeProviderCommands {
-                    list: Some(vec![script]),
+                    resolve: Some(vec![script, "{handle}".to_string()]),
                     ..Default::default()
                 },
                 list_result_mapping: Some(worktrees_mapping()),


### PR DESCRIPTION
Fixes #7909. Adds an optional generic `commands.resolve` template with `{handle}` substitution. Targeted results use the existing explicit list mapping and safety validation; providers without it retain list fallback. Verification: `cargo check` and all 10 worktree-provider tests passed.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** GPT-5.6 Sol via OpenCode\n- **Used for:** Generic provider contract implementation and tests under Chris Huber direction.