### PR TITLE
fix(core): derive lint result from producer status

### DIFF
--- a/src/core/extension/lint/run/exit_code.rs
+++ b/src/core/extension/lint/run/exit_code.rs
@@ -22,8 +22,20 @@ pub(super) fn normalize_empty_finding_exit_code(
     }
 }
 
-pub(super) fn normalize_finding_exit_code(exit_code: i32, lint_findings: &[HomeboyFinding]) -> i32 {
-    if !lint_findings.is_empty() && exit_code == 0 {
+pub(super) fn normalize_producer_exit_code(
+    exit_code: i32,
+    producer_summaries: &[FindingProducerSummary],
+) -> i32 {
+    if exit_code >= 2 || producer_summaries.is_empty() {
+        return exit_code;
+    }
+
+    if producer_summaries
+        .iter()
+        .all(|summary| summary.status == "passed")
+    {
+        0
+    } else if exit_code == 0 {
         1
     } else {
         exit_code

--- a/src/core/extension/lint/run/tests/exit_code.rs
+++ b/src/core/extension/lint/run/tests/exit_code.rs
@@ -1,7 +1,6 @@
 use super::super::exit_code::{
-    effective_lint_exit_code, normalize_empty_finding_exit_code, normalize_finding_exit_code,
+    effective_lint_exit_code, normalize_empty_finding_exit_code, normalize_producer_exit_code,
 };
-use super::lint_finding;
 use crate::core::finding::FindingProducerSummary;
 
 #[test]
@@ -30,10 +29,38 @@ fn empty_filtered_findings_do_not_hide_infrastructure_errors() {
 }
 
 #[test]
-fn findings_force_failure_when_runner_exits_cleanly() {
-    let exit_code = normalize_finding_exit_code(0, &[lint_finding("a", "security", "rule")]);
+fn passed_producers_keep_warning_findings_non_blocking() {
+    let producer_summaries = vec![
+        FindingProducerSummary::new("phpcs", "passed").finding_count(49),
+        FindingProducerSummary::new("eslint", "passed").finding_count(1),
+        FindingProducerSummary::new("phpstan", "passed").finding_count(0),
+    ];
+    let exit_code = normalize_producer_exit_code(0, &producer_summaries);
+
+    assert_eq!(exit_code, 0);
+}
+
+#[test]
+fn failed_producer_amid_warnings_forces_failure() {
+    let producer_summaries = vec![
+        FindingProducerSummary::new("phpcs", "passed").finding_count(49),
+        FindingProducerSummary::new("eslint", "failed").finding_count(1),
+        FindingProducerSummary::new("phpstan", "passed").finding_count(0),
+    ];
+
+    let exit_code = normalize_producer_exit_code(0, &producer_summaries);
 
     assert_eq!(exit_code, 1);
+}
+
+#[test]
+fn crashed_zero_finding_producer_remains_failure() {
+    let producer_summaries = vec![
+        FindingProducerSummary::new("phpstan", "error").finding_count(0),
+    ];
+    let runner_exit_code = normalize_empty_finding_exit_code(1, false, &[], &producer_summaries);
+
+    assert_eq!(normalize_producer_exit_code(runner_exit_code, &producer_summaries), 1);
 }
 
 #[test]

--- a/src/core/extension/lint/run/workflow.rs
+++ b/src/core/extension/lint/run/workflow.rs
@@ -2,7 +2,7 @@
 //! baseline lifecycle, assembles hints, and constructs results.
 
 use super::exit_code::{
-    effective_lint_exit_code, normalize_empty_finding_exit_code, normalize_finding_exit_code,
+    effective_lint_exit_code, normalize_empty_finding_exit_code, normalize_producer_exit_code,
 };
 use super::findings::{
     build_lint_producer_summaries, build_lint_summary, filter_findings_to_scoped_files,
@@ -132,7 +132,7 @@ pub fn run_main_lint_workflow(
         &lint_findings,
         &producer_summaries,
     );
-    let lint_exit_code = normalize_finding_exit_code(runner_exit_code, &lint_findings);
+    let lint_exit_code = normalize_producer_exit_code(runner_exit_code, &producer_summaries);
 
     // Baseline lifecycle
     let (baseline_comparison, baseline_exit_override) =


### PR DESCRIPTION
Closes Extra-Chill/homeboy-extensions#2234
Closes #7915

## Root Cause

Core converted any successful runner result with one or more parsed findings into a failure. After WordPress producers began correctly reporting warnings as non-blocking, that raw-count rule still failed all-passed runs with advisory warnings.

## Before / After

Before: `PHPCS passed (49 warnings)`, `ESLint passed (1 warning)`, and `PHPStan passed (0)` produced an overall lint failure with 50 findings.

After: aggregate success follows declared producer statuses. Warning findings remain reported and counted; failed or crashed producers still fail the run, including failures with zero findings.

## Test Matrix

- PASS: `bash wordpress/scripts/lint/phpcs-warnings-gate-smoke.sh`
- PASS: `bash wordpress/scripts/lint/lint-producers-smoke.sh`
- PASS: `bash wordpress/tests/phpstan-integrity-guard-smoke.sh`
- PASS: `bash wordpress/tests/phpstan-relative-dependency-path-smoke.sh`
- BLOCKED: `cargo test core::extension::lint --lib` could not read the pre-existing Cargo registry cache at `/home/opencode/.cargo/registry/.../fnv-1.0.7/lib.rs` (permission denied).
- UNAVAILABLE: `cargo-fmt` and `rustfmt` are not installed; changed Rust formatting was applied manually.

No releases, deploys, or live extension installs were touched.