### PR TITLE
Fix Rust formatting in extension exit-code test

### DIFF
--- a/src/core/extension/lint/run/tests/exit_code.rs
+++ b/src/core/extension/lint/run/tests/exit_code.rs
@@ -55,12 +55,13 @@ fn failed_producer_amid_warnings_forces_failure() {
 
 #[test]
 fn crashed_zero_finding_producer_remains_failure() {
-    let producer_summaries = vec![
-        FindingProducerSummary::new("phpstan", "error").finding_count(0),
-    ];
+    let producer_summaries = vec![FindingProducerSummary::new("phpstan", "error").finding_count(0)];
     let runner_exit_code = normalize_empty_finding_exit_code(1, false, &[], &producer_summaries);
 
-    assert_eq!(normalize_producer_exit_code(runner_exit_code, &producer_summaries), 1);
+    assert_eq!(
+        normalize_producer_exit_code(runner_exit_code, &producer_summaries),
+        1
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- format the extension lint exit-code test with the repository Rust formatter

Closes #7917

## Testing
1. Run `cargo fmt --check`.
2. Run `cargo test crashed_zero_finding_producer_remains_failure`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode, OpenAI gpt-5.6-terra
- **Used for:** Reproducing the formatter failure, applying the scoped formatter output, and running focused verification.