### PR TITLE
fix: reconcile disconnected runner children

### DIFF
--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -177,24 +177,32 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     let requested_run_id = sanitize_run_id(run_id);
     let resolved_run_id = resolve_run_id(run_id)?;
     let mut record = store::read_record(&resolved_run_id)?;
-    if let (Ok(aggregate), Ok(plan)) = (
-        store::read_aggregate(&record.run_id),
-        store::read_plan_path(&record.plan_path),
-    ) {
-        let aggregate_path = store::aggregate_path(&record.run_id)
-            .map(|path| path.display().to_string())
-            .unwrap_or_else(|_| "aggregate.json".to_string());
-        let mut reconciled = record.clone();
-        apply_aggregate_to_record(&mut reconciled, &plan, &aggregate, aggregate_path);
+    if !is_terminal_run_state(record.state) {
+        if let (Ok(aggregate), Ok(plan)) = (
+            store::read_aggregate(&record.run_id),
+            store::read_plan_path(&record.plan_path),
+        ) {
+            let aggregate_path = store::aggregate_path(&record.run_id)
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|_| "aggregate.json".to_string());
+            let mut reconciled = record.clone();
+            let projection_plan = aggregate_projection_plan(&plan, &aggregate);
+            apply_aggregate_to_record(
+                &mut reconciled,
+                &projection_plan,
+                &aggregate,
+                aggregate_path,
+            );
 
-        if reconciled != record {
-            if let Err(error) = store::write_record(&reconciled) {
-                reconciled
-                    .ensure_metadata_object()
-                    .insert("finalization_error".to_string(), json!(error.message));
+            if reconciled != record {
+                if let Err(error) = store::write_record(&reconciled) {
+                    reconciled
+                        .ensure_metadata_object()
+                        .insert("finalization_error".to_string(), json!(error.message));
+                }
+
+                record = reconciled;
             }
-
-            record = reconciled;
         }
     }
     let before_liveness_reconciliation = record.clone();
@@ -226,9 +234,28 @@ fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) {
     ) else {
         return;
     };
-    let Ok(snapshot) = crate::core::runners::runner_job_log_snapshot(&runner_id, &job_id) else {
-        return;
+    let snapshot = match crate::core::runners::runner_job_log_snapshot(&runner_id, &job_id) {
+        Ok(snapshot) => snapshot,
+        Err(_) => {
+            if crate::core::runners::status(&runner_id)
+                .map(|status| !status.connected)
+                .unwrap_or(false)
+            {
+                record.annotate_runner_disconnected();
+            }
+            return;
+        }
     };
+    reconcile_runner_job_snapshot(record, &snapshot);
+}
+
+pub(crate) fn reconcile_runner_job_snapshot(
+    record: &mut AgentTaskRunRecord,
+    snapshot: &crate::core::runner::RunnerJobLogSnapshot,
+) {
+    if is_terminal_run_state(record.state) {
+        return;
+    }
     match snapshot.job.status {
         crate::core::api_jobs::JobStatus::Queued | crate::core::api_jobs::JobStatus::Running => {
             record.updated_at = Some(now_timestamp());
@@ -241,10 +268,83 @@ fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) {
         crate::core::api_jobs::JobStatus::Succeeded
         | crate::core::api_jobs::JobStatus::Failed
         | crate::core::api_jobs::JobStatus::Cancelled => {
+            if let Some(event) = crate::core::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(Some(&snapshot.events)).filter(|event| {
+                event.identity.runner_id == record.runner_id().unwrap_or_default()
+                    && event.identity.runner_job_id == record.runner_job_id().unwrap_or_default()
+            }) {
+                let projection_plan = aggregate_projection_plan_from_outcomes(&event.aggregate);
+                let aggregate_path = store::aggregate_path(&record.run_id)
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|_| "aggregate.json".to_string());
+                apply_aggregate_to_record(record, &projection_plan, &event.aggregate, aggregate_path);
+                let _ = store::write_aggregate(&record.run_id, &event.aggregate);
+            }
             apply_runner_job_terminal_state(record, snapshot.job.status, &snapshot.events);
         }
     }
     let _ = store::write_record(record);
+}
+
+fn is_terminal_run_state(state: AgentTaskRunState) -> bool {
+    matches!(
+        state,
+        AgentTaskRunState::Succeeded
+            | AgentTaskRunState::PartialFailure
+            | AgentTaskRunState::Failed
+            | AgentTaskRunState::Cancelled
+    )
+}
+
+fn aggregate_projection_plan(
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+) -> AgentTaskPlan {
+    if aggregate.outcomes.iter().all(|outcome| {
+        plan.tasks
+            .iter()
+            .any(|task| task.task_id == outcome.task_id)
+    }) {
+        return plan.clone();
+    }
+    aggregate_projection_plan_from_outcomes(aggregate)
+}
+
+fn aggregate_projection_plan_from_outcomes(aggregate: &AgentTaskAggregate) -> AgentTaskPlan {
+    let tasks = aggregate
+        .outcomes
+        .iter()
+        .map(|outcome| AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: outcome.task_id.clone(),
+            group_key: Some("runner-child".to_string()),
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: outcome
+                    .metadata
+                    .get("provider")
+                    .and_then(Value::as_str)
+                    .unwrap_or("runner-child")
+                    .to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: Value::Null,
+            },
+            instructions: outcome.summary.clone().unwrap_or_default(),
+            inputs: Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: outcome.metadata.clone(),
+        })
+        .collect();
+    AgentTaskPlan::new(&aggregate.plan_id, tasks)
 }
 
 pub(crate) fn apply_runner_job_terminal_state(

--- a/src/core/agent_task_lifecycle/records.rs
+++ b/src/core/agent_task_lifecycle/records.rs
@@ -135,6 +135,23 @@ impl AgentTaskRunRecord {
         metadata.insert("retryable".to_string(), json!(true));
     }
 
+    /// A controller cannot infer progress from a runner connection that is no
+    /// longer available. Preserve the last confirmed heartbeat as evidence,
+    /// while making its liveness explicitly unknown.
+    pub(crate) fn annotate_runner_disconnected(&mut self) {
+        if self.state != AgentTaskRunState::Running || !self.is_runner_backed() {
+            return;
+        }
+        let metadata = self.ensure_metadata_object();
+        metadata.insert("runner_liveness".to_string(), json!("disconnected"));
+        metadata.insert("stale_running".to_string(), json!(true));
+        metadata.insert(
+            "stale_running_reason".to_string(),
+            json!("runner_disconnected"),
+        );
+        metadata.insert("retryable".to_string(), json!(true));
+    }
+
     pub(crate) fn owner_process_is_running(&self) -> bool {
         self.owner_pid()
             .is_some_and(crate::core::process::pid_is_running)

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -250,6 +250,96 @@ fn runner_terminal_reconciliation_is_idempotent_and_preserves_execution_owner() 
 }
 
 #[test]
+fn disconnected_proxy_projects_terminal_child_aggregate_once_reachable() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-disconnected-child",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let mut record = status("agent-task-disconnected-child").expect("status");
+        let heartbeat = record
+            .lifecycle
+            .heartbeat
+            .clone()
+            .expect("confirmed heartbeat");
+
+        record.annotate_runner_disconnected();
+        assert_eq!(record.metadata["runner_liveness"], "disconnected");
+        assert_eq!(
+            record.metadata["stale_running_reason"],
+            "runner_disconnected"
+        );
+        assert_eq!(record.lifecycle.heartbeat, Some(heartbeat));
+
+        let child_plan = test_plan();
+        let mut child_aggregate = succeeded_aggregate(&child_plan);
+        child_aggregate.outcomes[0].artifacts = vec![artifact_ref_artifact(
+            "patch",
+            "patch",
+            None,
+            Some("/runner/artifacts/patch.diff"),
+        )];
+        child_aggregate.outcomes[0].diagnostics = vec![AgentTaskDiagnostic {
+            class: "provider.attempt".to_string(),
+            message: "attempt 1 succeeded".to_string(),
+            data: json!({ "attempt": 1 }),
+        }];
+        let snapshot = terminal_child_snapshot(&child_aggregate);
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot);
+        let once = record.clone();
+        reconcile_runner_job_snapshot(&mut record, &snapshot);
+
+        assert_eq!(
+            record, once,
+            "repeated terminal reconciliation is idempotent"
+        );
+        assert_eq!(record.state, AgentTaskRunState::Succeeded);
+        assert_eq!(record.artifact_refs[0].uri, "/runner/artifacts/patch.diff");
+        assert_eq!(record.metadata["runner_job_status"], "succeeded");
+        assert!(record.metadata.get("runner_liveness").is_some());
+        let aggregate = store::read_aggregate("agent-task-disconnected-child")
+            .expect("projected child aggregate");
+        assert_eq!(
+            aggregate.outcomes[0].diagnostics[0].class,
+            "provider.attempt"
+        );
+    });
+}
+
+#[test]
+fn disconnected_runner_marks_nonterminal_proxy_stale_without_advancing_heartbeat() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-disconnected-running",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-789",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let heartbeat = record.lifecycle.heartbeat.clone();
+
+        record.annotate_runner_disconnected();
+
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert_eq!(record.lifecycle.heartbeat, heartbeat);
+        assert_eq!(record.metadata["runner_liveness"], "disconnected");
+        assert_eq!(record.metadata["stale_running"], true);
+        assert_eq!(
+            record.metadata["stale_running_reason"],
+            "runner_disconnected"
+        );
+    });
+}
+
+#[test]
 fn controller_proxy_becomes_terminal_when_handoff_fails_before_child_creation() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];
@@ -1897,6 +1987,50 @@ fn test_plan() -> AgentTaskPlan {
             metadata: Value::Null,
         }],
     )
+}
+
+fn terminal_child_snapshot(
+    aggregate: &AgentTaskAggregate,
+) -> crate::core::runner::RunnerJobLogSnapshot {
+    let job_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000123").expect("job id");
+    crate::core::runner::RunnerJobLogSnapshot {
+        job: crate::core::api_jobs::Job {
+            id: job_id,
+            operation: "agent-task".to_string(),
+            status: crate::core::api_jobs::JobStatus::Succeeded,
+            created_at_ms: 1,
+            updated_at_ms: 2,
+            started_at_ms: Some(1),
+            finished_at_ms: Some(2),
+            event_count: 1,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            stale_reason: None,
+            target_runner_id: None,
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+        },
+        events: vec![crate::core::api_jobs::JobEvent {
+            sequence: 1,
+            job_id,
+            kind: crate::core::api_jobs::JobEventKind::Progress,
+            timestamp_ms: 2,
+            message: Some("agent-task lifecycle event".to_string()),
+            data: Some(json!({
+                "schema": "homeboy/agent-task-run-plan-lifecycle-event/v1",
+                "identity": {
+                    "runner_id": "homeboy-lab",
+                    "runner_job_id": job_id.to_string(),
+                    "run_id": "agent-task-disconnected-child",
+                },
+                "aggregate": aggregate,
+            })),
+        }],
+    }
 }
 
 fn succeeded_aggregate(plan: &AgentTaskPlan) -> AgentTaskAggregate {

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -10,7 +10,7 @@ use crate::core::error::{Error, Result};
 use crate::core::output::{BatchResult, CreateOutput, CreateResult, MergeOutput, MergeResult};
 use crate::core::server::{self, RunnerPolicy, RunnerSecretEnvRef, RunnerSettings, ServerRunner};
 
-mod agent_task_lifecycle_event;
+pub(crate) mod agent_task_lifecycle_event;
 mod apply;
 mod broker_auth;
 mod broker_http;


### PR DESCRIPTION
## Summary
- Reconcile a terminal runner child lifecycle event into its controller-owned agent-task proxy after the runner becomes reachable again.
- Preserve child aggregate artifacts and diagnostics, expose disconnected runner liveness without advancing the last confirmed heartbeat, and keep terminal records immutable on repeated reconciliation.

Fixes #7919

## Testing
1. From a fresh checkout of this branch, run `cargo test disconnected_proxy_projects_terminal_child_aggregate_once_reachable --lib`.
2. Run `cargo test disconnected_runner_marks_nonterminal_proxy_stale_without_advancing_heartbeat --lib`.
3. Run `cargo check`.
4. Run `cargo fmt --check`. It currently reports a pre-existing formatting difference in `src/core/extension/lint/run/tests/exit_code.rs`, outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.