### PR TITLE
Fix agent-task committed patch harvest

### DIFF
--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -184,3 +184,174 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
             .contains("workspace provider command"));
     });
 }
+
+#[derive(Clone)]
+struct CommittingExecutor {
+    workspace: std::path::PathBuf,
+}
+
+impl AgentTaskExecutorAdapter for CommittingExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        std::fs::write(self.workspace.join("agent-change.txt"), "committed work\n")
+            .expect("write executor change");
+        let status = Command::new("git")
+            .args(["add", "agent-change.txt"])
+            .current_dir(&self.workspace)
+            .status()
+            .expect("stage executor change");
+        assert!(status.success());
+        let status = Command::new("git")
+            .args(["commit", "-m", "agent: make committed change"])
+            .current_dir(&self.workspace)
+            .status()
+            .expect("commit executor change");
+        assert!(status.success());
+
+        AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: request.task_id,
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: Some("committed work".to_string()),
+            failure_classification: None,
+            artifacts: vec![
+                AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "agent-result".to_string(),
+                    kind: "agent_result".to_string(),
+                    name: Some("agent-result.json".to_string()),
+                    label: None,
+                    role: None,
+                    semantic_key: None,
+                    path: Some(self.workspace.join("plugin.php").display().to_string()),
+                    url: None,
+                    mime: Some("application/json".to_string()),
+                    size_bytes: None,
+                    sha256: None,
+                    metadata: Value::Null,
+                },
+                AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "transcript".to_string(),
+                    kind: "transcript".to_string(),
+                    name: Some("transcript.log".to_string()),
+                    label: None,
+                    role: None,
+                    semantic_key: None,
+                    path: Some(self.workspace.join("plugin.php").display().to_string()),
+                    url: None,
+                    mime: Some("text/plain".to_string()),
+                    size_bytes: None,
+                    sha256: None,
+                    metadata: Value::Null,
+                },
+            ],
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        }
+    }
+}
+
+#[test]
+fn cook_promotes_executor_commit_from_a_clean_workspace_without_patch_candidates() {
+    with_temp_home(|| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        init_runtime_component_checkout(&workspace);
+        let provider = temp.path().join("promotion-provider.sh");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{}\"}}'\n",
+                workspace.display()
+            ),
+        )
+        .expect("write promotion provider");
+
+        let (value, exit_code) = run_cook_with_executor(
+            AgentTaskCookArgs {
+                dispatch: DispatchArgs {
+                    prompt: Some("commit a change".to_string()),
+                    tasks: Vec::new(),
+                    cwd: Some(workspace.display().to_string()),
+                    workspace: None,
+                    repo: Some("fixture-component".to_string()),
+                    task_url: None,
+                    backend: Some("fixture".to_string()),
+                    selector: None,
+                    model: None,
+                    required_capabilities: Vec::new(),
+                    secret_env: Vec::new(),
+                    concurrency: 1,
+                    run_id: Some("cook-committed-work".to_string()),
+                    core: DispatchCoreArgs {
+                        tasks_json: None,
+                        provider_config: None,
+                        client_context: None,
+                        attempts: 1,
+                        queue_only: false,
+                        timeout_ms: None,
+                        resolved_provider_policy: None,
+                    },
+                },
+                goal: None,
+                to_worktree: "fixture-component@promoted".to_string(),
+                provider_command: Some(format!("sh {}", provider.display())),
+                gates: VerifyGateArgs {
+                    verify: vec!["true".to_string()],
+                    private_verify: Vec::new(),
+                    private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+                },
+                max_attempts: 1,
+                no_finalize: true,
+                base: "main".to_string(),
+                head: None,
+                title: None,
+                commit_message: None,
+                protected_branches: review::default_protected_branches(),
+                ai_tool: "OpenCode (GPT-5.6 Sol)".to_string(),
+                ai_used_for: "test".to_string(),
+            },
+            CommittingExecutor {
+                workspace: workspace.clone(),
+            },
+        )
+        .expect("cook completes");
+
+        assert_eq!(exit_code, 0, "{value:#}");
+        assert_eq!(value["status"], "green_no_finalize");
+        assert_eq!(
+            value["attempts"][0]["promotion"]["patch_artifact"]["id"],
+            "committed-changes"
+        );
+        assert_eq!(
+            value["attempts"][0]["promotion"]["changed_files"],
+            json!(["agent-change.txt"])
+        );
+        assert_eq!(
+            value["attempts"][0]["promotion"]["provenance"]["artifact_metadata"]["change_source"],
+            "local_commits"
+        );
+        assert_eq!(
+            value["attempts"][0]["promotion"]["provenance"]["artifact_metadata"]["commits"]
+                .as_array()
+                .map(Vec::len),
+            Some(1)
+        );
+        let status = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&workspace)
+            .output()
+            .expect("read workspace status");
+        assert!(String::from_utf8_lossy(&status.stdout).trim().is_empty());
+    });
+}

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -60,7 +60,23 @@ pub(crate) fn promote_with_provider(
         ));
     }
 
-    let artifact = select_patch_artifact(&outcome, options.artifact_id.as_deref())?;
+    let artifact = match select_patch_artifact(&outcome, options.artifact_id.as_deref()) {
+        Ok(artifact) => artifact,
+        Err(error) if options.artifact_id.is_none() && !outcome_has_patch_artifacts(&outcome) => {
+            if let Some(committed_patch) = committed_changes_patch(&options)? {
+                return promote_committed_changes(
+                    &options,
+                    provider,
+                    &source_kind,
+                    &outcome,
+                    None,
+                    committed_patch,
+                );
+            }
+            return Err(error);
+        }
+        Err(error) => return Err(error),
+    };
     let patch_path = resolve_artifact_path(&artifact, options.source_path.as_deref())?;
     let patch = std::fs::read_to_string(&patch_path).map_err(|error| {
         Error::internal_io(
@@ -71,70 +87,14 @@ pub(crate) fn promote_with_provider(
     validate_artifact_content(&artifact, &patch)?;
     if patch.trim().is_empty() {
         if let Some(committed_patch) = committed_changes_patch(&options)? {
-            let normalized_patch = normalize_promotion_patch(
-                &std::fs::read_to_string(&committed_patch.patch_path).map_err(|error| {
-                    Error::internal_io(
-                        error.to_string(),
-                        Some(format!(
-                            "read committed changes promotion patch {}",
-                            committed_patch.patch_path.display()
-                        )),
-                    )
-                })?,
-                &options.to_worktree,
-            )?;
-            let mut command_evidence = Vec::new();
-            let applied_worktree_path = if options.dry_run {
-                None
-            } else {
-                let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
-                    schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
-                    to_workspace: options.to_worktree.clone(),
-                    patch_path: committed_patch.patch_path.display().to_string(),
-                    changed_files: normalized_patch.changed_files.clone(),
-                })?;
-                command_evidence.extend(target.command_evidence);
-                Some(target.path)
-            };
-            let gates = if let Some(path) = applied_worktree_path.as_deref() {
-                run_promotion_gates(&options, provider, path)?
-            } else {
-                PromotionGateRun::without_gates(options.dry_run)
-            };
-            let target = AgentTaskPromotionTarget::from_worktree(
-                options.to_worktree.clone(),
-                applied_worktree_path.as_deref(),
+            return promote_committed_changes(
+                &options,
+                provider,
+                &source_kind,
+                &outcome,
+                Some(&artifact),
+                committed_patch,
             );
-            let operator_notification = promotion_notification(gates.status, &target);
-
-            return Ok(AgentTaskPromotionReport {
-                schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
-                status: gates.status,
-                source: promotion_source(&source_kind, &outcome, &options),
-                to_worktree: options.to_worktree,
-                target,
-                patch_artifact: AgentTaskPromotionArtifactRef {
-                    id: "committed-changes".to_string(),
-                    kind: "patch".to_string(),
-                    path: committed_patch.patch_path.display().to_string(),
-                    sha256: Some(committed_patch.sha256),
-                },
-                changed_files: normalized_patch.changed_files,
-                command_evidence,
-                deterministic_gates: gates.deterministic_gates,
-                gate_results: gates.gate_results,
-                provenance: json!({
-                    "source_schema": outcome.schema,
-                    "artifact_metadata": artifact.metadata,
-                    "worktree_path": applied_worktree_path,
-                    "dependencies_materialized": gates.dependencies_materialized,
-                    "change_source": "local_commits",
-                    "base_ref": committed_patch.base_ref,
-                    "commit_range": committed_patch.commit_range,
-                    "commits": committed_patch.commits,
-                }),
-                operator_notification,
-            });
         }
         let status = AgentTaskPromotionStatus::NoChanges;
         let target = AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), None);
@@ -220,6 +180,87 @@ pub(crate) fn promote_with_provider(
             "artifact_metadata": artifact.metadata,
             "worktree_path": applied_worktree_path,
             "dependencies_materialized": gates.dependencies_materialized,
+        }),
+        operator_notification,
+    })
+}
+
+fn outcome_has_patch_artifacts(outcome: &AgentTaskOutcome) -> bool {
+    outcome
+        .artifacts
+        .iter()
+        .any(|artifact| is_actionable_patch_artifact(artifact) || is_empty_patch_artifact(artifact))
+}
+
+fn promote_committed_changes(
+    options: &AgentTaskPromotionOptions,
+    provider: &mut impl AgentTaskPromotionWorkspaceProvider,
+    source_kind: &str,
+    outcome: &AgentTaskOutcome,
+    artifact: Option<&AgentTaskArtifact>,
+    committed_patch: CommittedChangesPatch,
+) -> Result<AgentTaskPromotionReport> {
+    let normalized_patch = normalize_promotion_patch(
+        &std::fs::read_to_string(&committed_patch.patch_path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "read committed changes promotion patch {}",
+                    committed_patch.patch_path.display()
+                )),
+            )
+        })?,
+        &options.to_worktree,
+    )?;
+    let mut command_evidence = Vec::new();
+    let applied_worktree_path = if options.dry_run {
+        None
+    } else {
+        let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: options.to_worktree.clone(),
+            patch_path: committed_patch.patch_path.display().to_string(),
+            changed_files: normalized_patch.changed_files.clone(),
+        })?;
+        command_evidence.extend(target.command_evidence);
+        Some(target.path)
+    };
+    let gates = if let Some(path) = applied_worktree_path.as_deref() {
+        run_promotion_gates(options, provider, path)?
+    } else {
+        PromotionGateRun::without_gates(options.dry_run)
+    };
+    let target = AgentTaskPromotionTarget::from_worktree(
+        options.to_worktree.clone(),
+        applied_worktree_path.as_deref(),
+    );
+    let operator_notification = promotion_notification(gates.status, &target);
+
+    Ok(AgentTaskPromotionReport {
+        schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+        status: gates.status,
+        source: promotion_source(source_kind, outcome, options),
+        to_worktree: options.to_worktree.clone(),
+        target,
+        patch_artifact: AgentTaskPromotionArtifactRef {
+            id: "committed-changes".to_string(),
+            kind: "patch".to_string(),
+            path: committed_patch.patch_path.display().to_string(),
+            sha256: Some(committed_patch.sha256),
+        },
+        changed_files: normalized_patch.changed_files,
+        command_evidence,
+        deterministic_gates: gates.deterministic_gates,
+        gate_results: gates.gate_results,
+        provenance: json!({
+            "source_schema": outcome.schema,
+            "artifact_metadata": artifact.map(|artifact| artifact.metadata.clone()).unwrap_or(Value::Null),
+            "worktree_path": applied_worktree_path,
+            "dependencies_materialized": gates.dependencies_materialized,
+            "change_source": "local_commits",
+            "base_ref": committed_patch.base_ref,
+            "commit_range": committed_patch.commit_range,
+            "commits": committed_patch.commits,
         }),
         operator_notification,
     })
@@ -311,11 +352,9 @@ fn promotion_source(
 }
 
 struct CommittedChangesPatch {
-    worktree_path: PathBuf,
     base_ref: String,
     patch_path: PathBuf,
     sha256: String,
-    changed_files: Vec<String>,
     commit_range: String,
     commits: Vec<Value>,
 }
@@ -374,11 +413,9 @@ fn committed_changes_patch(
         )
     })?;
     Ok(Some(CommittedChangesPatch {
-        worktree_path: worktree_path.to_path_buf(),
         base_ref,
         patch_path,
         sha256,
-        changed_files,
         commit_range,
         commits,
     }))

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -352,6 +352,67 @@ fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
 }
 
 #[test]
+fn promote_exports_committed_changes_when_executor_reports_no_patch_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "homeboy@example.test"]);
+    git(&repo, &["config", "user.name", "Homeboy Test"]);
+    git(&repo, &["checkout", "-b", "main"]);
+    std::fs::write(repo.join("lib.rs"), "old\n").expect("write base file");
+    git(&repo, &["add", "lib.rs"]);
+    git(&repo, &["commit", "-m", "base"]);
+    let base = git_head(&repo, "HEAD");
+    std::fs::write(repo.join("lib.rs"), "new\n").expect("write committed change");
+    git(&repo, &["commit", "-am", "agent: committed change"]);
+
+    let source_path = temp.path().join("outcome.json");
+    let source = serde_json::json!({
+        "schema": AGENT_TASK_OUTCOME_SCHEMA,
+        "task_id": "task-1",
+        "status": "succeeded",
+        "artifacts": []
+    })
+    .to_string();
+    std::fs::write(&source_path, &source).expect("write source");
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(repo.clone()),
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run-no-artifact".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: Some("main".to_string()),
+            task_base_sha: Some(base),
+            to_worktree: "repo@promoted".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+        },
+        &mut provider,
+    )
+    .expect("committed changes are promoted without a patch artifact");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(report.patch_artifact.id, "committed-changes");
+    assert_eq!(report.changed_files, vec!["lib.rs"]);
+    assert_eq!(report.provenance["change_source"], "local_commits");
+    assert_eq!(
+        report.provenance["commits"].as_array().map(Vec::len),
+        Some(1)
+    );
+    assert!(report.provenance["artifact_metadata"].is_null());
+    assert_eq!(provider.apply_calls.len(), 1);
+}
+
+#[test]
 fn promote_exports_all_agent_commits_after_the_recorded_task_base() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path().join("repo");
@@ -411,6 +472,7 @@ fn committed_change_promotion_rejects_a_non_ancestor_task_base() {
     git(&repo, &["init"]);
     git(&repo, &["config", "user.email", "agent@example.test"]);
     git(&repo, &["config", "user.name", "Agent"]);
+    git(&repo, &["checkout", "-b", "main"]);
     std::fs::write(repo.join("file.txt"), "base\n").expect("base");
     git(&repo, &["add", "."]);
     git(&repo, &["commit", "-m", "base"]);
@@ -418,7 +480,7 @@ fn committed_change_promotion_rejects_a_non_ancestor_task_base() {
     std::fs::write(repo.join("file.txt"), "unrelated\n").expect("unrelated");
     git(&repo, &["commit", "-am", "unrelated"]);
     let unrelated = git_head(&repo, "HEAD");
-    git(&repo, &["checkout", "master"]);
+    git(&repo, &["checkout", "main"]);
     std::fs::write(repo.join("file.txt"), "agent\n").expect("agent");
     git(&repo, &["commit", "-am", "agent"]);
     let (source_path, source) = write_empty_patch_source(&temp);

--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -312,6 +314,7 @@ where
                     continue;
                 }
                 let task_id = request.task_id.clone();
+                let task_base_sha = workspace_git_head(&request);
                 let executor_key = executor_key(&request);
                 let executor = Arc::clone(&self.executor);
                 let plan_id = plan.plan_id.clone();
@@ -341,6 +344,7 @@ where
                     timeout_ms: Some(task_timeout_ms),
                     rotation_index: scheduled.rotation_index,
                     rotation_attempts: scheduled.rotation_attempts,
+                    task_base_sha,
                 });
 
                 thread::spawn(move || {
@@ -391,10 +395,10 @@ where
                     let Some(running_task) = running_task else {
                         continue;
                     };
-                    let outcome = AgentTaskScheduleSupport::normalize_outcome(
-                        result.outcome,
-                        Some(&running_task),
-                    );
+                    let mut outcome = result.outcome;
+                    harvest_committed_patch(&mut outcome, &running_task);
+                    let outcome =
+                        AgentTaskScheduleSupport::normalize_outcome(outcome, Some(&running_task));
                     let state = AgentTaskScheduleSupport::state_for_outcome(&outcome);
                     events.push(event(
                         &outcome.task_id,
@@ -554,6 +558,9 @@ struct RunningTask {
     rotation_index: usize,
     /// Ordered evidence for prior dispatch attempts under a rotation policy.
     rotation_attempts: Vec<AgentTaskProviderRotationAttempt>,
+    /// Workspace HEAD captured immediately before the executor runs. It bounds
+    /// any committed patch candidate to this dispatch attempt.
+    task_base_sha: Option<String>,
 }
 
 struct TaskResult {
@@ -565,6 +572,135 @@ struct TaskResult {
 enum SchedulerEvent {
     TaskResult(TaskResult),
     Cancellation,
+}
+
+fn workspace_git_head(request: &AgentTaskRequest) -> Option<String> {
+    let root = request.workspace.root.as_deref()?;
+    git_output(Path::new(root), &["rev-parse", "HEAD"])
+}
+
+fn harvest_committed_patch(outcome: &mut AgentTaskOutcome, running: &RunningTask) {
+    if outcome.status != AgentTaskOutcomeStatus::Succeeded
+        || outcome.artifacts.iter().any(|artifact| {
+            is_actionable_patch_artifact(artifact) || is_empty_patch_artifact(artifact)
+        })
+    {
+        return;
+    }
+    let Some(base) = running.task_base_sha.as_deref() else {
+        return;
+    };
+    let Some(root) = running.request.workspace.root.as_deref().map(Path::new) else {
+        return;
+    };
+    let Some(head) = git_output(root, &["rev-parse", "HEAD"]) else {
+        return;
+    };
+    if head == base || !git_is_ancestor(root, base, "HEAD") {
+        return;
+    }
+    let Some(patch) = git_output(
+        root,
+        &[
+            "diff",
+            "--binary",
+            "--full-index",
+            "--find-renames",
+            base,
+            "HEAD",
+        ],
+    ) else {
+        return;
+    };
+    if patch.trim().is_empty() {
+        return;
+    }
+    let Some(path) = committed_patch_path(root, base, &head) else {
+        return;
+    };
+    if std::fs::write(&path, patch.as_bytes()).is_err() {
+        return;
+    }
+    let commits = git_output(
+        root,
+        &[
+            "log",
+            "--reverse",
+            "--format=%H%x1f%an%x1f%ae%x1f%s",
+            &format!("{base}..HEAD"),
+        ],
+    )
+    .map(|output| committed_change_metadata(&output))
+    .unwrap_or_default();
+    let range = format!("{base}..HEAD");
+    outcome.artifacts.push(AgentTaskArtifact {
+        schema: crate::core::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+        id: "committed-changes".to_string(),
+        kind: "patch".to_string(),
+        name: Some("committed-changes.patch".to_string()),
+        label: Some("executor committed changes".to_string()),
+        role: Some("patch".to_string()),
+        semantic_key: None,
+        path: Some(path.display().to_string()),
+        url: None,
+        mime: Some("text/x-patch".to_string()),
+        size_bytes: Some(patch.len() as u64),
+        sha256: None,
+        metadata: serde_json::json!({
+            "change_source": "local_commits",
+            "base_ref": base,
+            "commit_range": range,
+            "commits": commits,
+        }),
+    });
+}
+
+fn committed_patch_path(root: &Path, base: &str, head: &str) -> Option<PathBuf> {
+    let git_dir = git_output(root, &["rev-parse", "--git-dir"])?;
+    let git_dir = PathBuf::from(git_dir);
+    let git_dir = if git_dir.is_absolute() {
+        git_dir
+    } else {
+        root.join(git_dir)
+    };
+    let dir = git_dir.join("homeboy-agent-task");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir.join(format!("committed-changes-{base}-{head}.patch")))
+}
+
+fn committed_change_metadata(output: &str) -> Vec<serde_json::Value> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split('\u{1f}');
+            Some(serde_json::json!({
+                "sha": fields.next()?,
+                "author_name": fields.next()?,
+                "author_email": fields.next()?,
+                "subject": fields.next()?,
+            }))
+        })
+        .collect()
+}
+
+fn git_is_ancestor(cwd: &Path, base: &str, head: &str) -> bool {
+    Command::new("git")
+        .args(["merge-base", "--is-ancestor", base, head])
+        .current_dir(cwd)
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn git_output(cwd: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 /// Record a finalized outcome in the completed-by-task index and the ordered


### PR DESCRIPTION
Fixes #7816.

Agent-task now snapshots a Git workspace HEAD immediately before executor dispatch. A succeeded executor that leaves no patch artifact but creates commits contributes a durable `base..HEAD` patch candidate with commit-range metadata, so normal artifact validation and cook promotion can continue. Explicit and ambiguous patch artifacts keep their existing behavior, and a non-ancestor base is still rejected.

## Testing
1. Run `cargo test commands::agent_task::tests::promotion_review::cook_promotes_executor_commit_from_a_clean_workspace_without_patch_candidates --lib`.
2. Confirm the test executor commits its only change, leaves `git status --porcelain` empty, and the cook report reaches `green_no_finalize` with `committed-changes` as the promoted patch artifact.
3. Run `cargo test agent_task_promotion::tests::promote_reports_no_changes_for_empty_patch_metadata --lib` and confirm an unchanged empty patch remains `NoChanges`.
4. Run `cargo test agent_task_promotion::tests::committed_change_promotion_rejects_a_non_ancestor_task_base --lib` and confirm an unrelated commit base is rejected.
5. Run `cargo check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.