### PR TITLE
Fix private Lab workspace materialization

### DIFF
--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -146,7 +146,9 @@ fn prepare_lab_offload_workspace_stage_inner(
         RunnerWorkspaceSyncOptions {
             path: source_path.display().to_string(),
             mode: sync_mode,
-            controller_routed_git: false,
+            // Lab already has the authenticated controller checkout. Ship its
+            // refs instead of requiring the runner to clone or fetch the source.
+            controller_routed_git: sync_mode == RunnerWorkspaceSyncMode::Git,
             changed_since_base: changed_since_preflight.resolved_base.clone(),
             git_fetch_refs: git_fetch_refs.clone(),
             snapshot_includes: Vec::new(),
@@ -798,6 +800,8 @@ fn command_accepts_extension_override(arg: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
 
     fn rig_workload(
         kind: crate::command_contract::LabRigWorkloadKind,
@@ -1873,6 +1877,149 @@ mod tests {
                 std::env::remove_var(self.name);
             }
         }
+    }
+
+    #[test]
+    fn stage_routes_changed_since_private_source_through_controller_bundle() {
+        crate::test_support::with_isolated_home(|_| {
+            let source = tempfile::tempdir().expect("source checkout");
+            let runner_root = tempfile::tempdir().expect("runner workspace root");
+            git(source.path(), &["init"]);
+            git(source.path(), &["config", "user.email", "test@example.com"]);
+            git(source.path(), &["config", "user.name", "Test User"]);
+            std::fs::write(source.path().join("file.txt"), "base\n").expect("write base");
+            git(source.path(), &["add", "."]);
+            git(source.path(), &["commit", "-m", "base"]);
+            let base = git_output(source.path(), &["rev-parse", "HEAD"]);
+            git(source.path(), &["branch", "base"]);
+            std::fs::write(source.path().join("file.txt"), "head\n").expect("write head");
+            git(source.path(), &["commit", "-am", "head"]);
+            git(
+                source.path(),
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://github.example.invalid/example-org/private-source.git",
+                ],
+            );
+
+            let bin = tempfile::tempdir().expect("git wrapper dir");
+            let wrapper = bin.path().join("git");
+            std::fs::write(
+                &wrapper,
+                "#!/bin/sh\nif [ \"$1\" = \"ls-remote\" ]; then printf '%s\\trefs/heads/base\\n' \"$HOMEBOY_TEST_LS_REMOTE_BASE\"; exit 0; fi\nexec \"$HOMEBOY_TEST_REAL_GIT\" \"$@\"\n",
+            )
+            .expect("write git wrapper");
+            std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755))
+                .expect("make git wrapper executable");
+            let prior_path = std::env::var("PATH").expect("PATH");
+            let prior_real_git = std::env::var("HOMEBOY_TEST_REAL_GIT").ok();
+            let prior_base = std::env::var("HOMEBOY_TEST_LS_REMOTE_BASE").ok();
+            std::env::set_var("HOMEBOY_TEST_REAL_GIT", "/usr/bin/git");
+            std::env::set_var("HOMEBOY_TEST_LS_REMOTE_BASE", &base);
+            std::env::set_var("PATH", format!("{}:{prior_path}", bin.path().display()));
+
+            crate::core::runner::create(
+                &format!(
+                    r#"{{"id":"lab-controller-bundle-stage","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+            let args = vec![
+                "homeboy".to_string(),
+                "audit".to_string(),
+                "--changed-since".to_string(),
+                "base".to_string(),
+            ];
+            let request = LabOffloadRequest {
+                command: None,
+                normalized_args: &args,
+                explicit_runner: Some("lab-controller-bundle-stage"),
+                force_hot: false,
+                local_policy: LabLocalExecutionPolicy::from_flags(false, false, false),
+                allow_dirty_lab_workspace: false,
+                skip_deps_hydration: false,
+                capture_patch: false,
+                mutation_flag: None,
+                detach_after_handoff: false,
+                output_file_requested: false,
+                read_only_polling: false,
+                local_output_file: None,
+                job_overrides: LabJobOverrides::default(),
+            };
+            let contract = LabOffloadCommand {
+                command: crate::command_contract::LabCommandContract::portable(
+                    "audit",
+                    None,
+                    false,
+                    &[],
+                ),
+                required_extensions: Vec::new(),
+                required_capabilities: Vec::new(),
+                workload: None,
+            };
+            let runner_workspace_root = runner_root.path().display().to_string();
+            let stage = prepare_lab_offload_workspace_stage(
+                &request,
+                &contract,
+                crate::core::runner::lab_plan::base_lab_plan(Some(&contract)),
+                "lab-controller-bundle-stage",
+                source.path(),
+                "homeboy",
+                &["homeboy".to_string()],
+                Some(&runner_workspace_root),
+                None,
+            );
+            std::env::set_var("PATH", prior_path);
+            match prior_real_git {
+                Some(value) => std::env::set_var("HOMEBOY_TEST_REAL_GIT", value),
+                None => std::env::remove_var("HOMEBOY_TEST_REAL_GIT"),
+            }
+            match prior_base {
+                Some(value) => std::env::set_var("HOMEBOY_TEST_LS_REMOTE_BASE", value),
+                None => std::env::remove_var("HOMEBOY_TEST_LS_REMOTE_BASE"),
+            }
+
+            let stage = stage.expect("controller bundle stage");
+            assert!(
+                stage
+                    .synced
+                    .materialization_plan
+                    .declared_inputs
+                    .controller_routed_git
+            );
+            assert_eq!(
+                stage.changed_since_preflight.resolved_base.as_deref(),
+                Some(base.as_str())
+            );
+            assert!(stage.remapped_args.contains(&base));
+            assert_eq!(
+                git_output(Path::new(&stage.remote_cwd), &["rev-parse", &base]),
+                base
+            );
+        });
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(output.status.success(), "git {} failed", args.join(" "));
+    }
+
+    fn git_output(path: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(output.status.success());
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
     }
 
     fn test_synced_workspace(local_path: &str, remote_path: &str) -> RunnerWorkspaceSyncOutput {

--- a/src/core/runner/workspace/git.rs
+++ b/src/core/runner/workspace/git.rs
@@ -129,15 +129,7 @@ pub(super) fn materialize_git_from_controller_bundle(
     })?;
     let bundle_path = bundle_dir.path().join("workspace.bundle");
 
-    let mut refs = vec![
-        head.to_string(),
-        "--branches".to_string(),
-        "--tags".to_string(),
-    ];
-    if let Some(base) = changed_since_base {
-        refs.push(base.to_string());
-    }
-    refs.extend(git_fetch_refs.iter().cloned());
+    let refs = controller_bundle_refs("HEAD", changed_since_base, git_fetch_refs);
 
     let output = Command::new("git")
         .arg("bundle")
@@ -195,6 +187,33 @@ pub(super) fn materialize_git_from_controller_bundle(
     };
 
     result
+}
+
+fn controller_bundle_refs(
+    head: &str,
+    changed_since_base: Option<&str>,
+    git_fetch_refs: &[String],
+) -> Vec<String> {
+    let mut refs = vec![head.to_string()];
+    if let Some(base) = changed_since_base {
+        push_unique_bundle_ref(&mut refs, base);
+    }
+    for git_ref in git_fetch_refs {
+        // A fetch refspec may name a destination for runner-side fetches. A
+        // bundle only needs its controller-local source ref.
+        let source_ref = git_ref
+            .trim_start_matches('+')
+            .split_once(':')
+            .map_or(git_ref.as_str(), |(source, _)| source);
+        push_unique_bundle_ref(&mut refs, source_ref);
+    }
+    refs
+}
+
+fn push_unique_bundle_ref(refs: &mut Vec<String>, git_ref: &str) {
+    if !git_ref.trim().is_empty() && !refs.iter().any(|existing| existing == git_ref) {
+        refs.push(git_ref.to_string());
+    }
 }
 
 fn validate_controller_git_bundle_source(local_path: &Path) -> Result<()> {

--- a/src/core/runner/workspace/tests/git.rs
+++ b/src/core/runner/workspace/tests/git.rs
@@ -9,18 +9,8 @@ use crate::core::runner::workspace::types::{RunnerWorkspaceSyncMode, RunnerWorks
 use crate::core::runner::workspace::util::git_output;
 
 #[test]
-fn git_sync_for_private_remote_materializes_controller_bundle_checkout() {
+fn controller_routed_git_sync_materializes_private_unavailable_remote_with_changed_since_base() {
     crate::test_support::with_isolated_home(|_| {
-        // Recognize `github.example.com` as a private/proxied source host so the
-        // sync takes the hermetic controller-bundle path
-        // (`materialize_git_from_controller_bundle`) instead of attempting a
-        // real `git clone` over SSH. This keeps the test fully hermetic: it
-        // exercises private-remote materialization without reaching the
-        // network. `with_isolated_home` serializes env-mutating tests via a
-        // global lock, so setting/clearing this env var here is race-free.
-        let prior_private_hosts = std::env::var("HOMEBOY_PRIVATE_PROXIED_SOURCE_HOSTS").ok();
-        std::env::set_var("HOMEBOY_PRIVATE_PROXIED_SOURCE_HOSTS", "github.example.com");
-
         let source = tempfile::tempdir().expect("source tempdir");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         git(source.path(), &["init"]);
@@ -29,13 +19,31 @@ fn git_sync_for_private_remote_materializes_controller_bundle_checkout() {
         fs::write(source.path().join("file.txt"), "base\n").expect("write file");
         git(source.path(), &["add", "."]);
         git(source.path(), &["commit", "-m", "base"]);
+        let base = git_output(source.path(), &["rev-parse", "HEAD"]).expect("base revision");
+        let branch =
+            git_output(source.path(), &["branch", "--show-current"]).expect("source branch");
+        fs::write(source.path().join("file.txt"), "head\n").expect("write file");
+        git(source.path(), &["commit", "-am", "head"]);
+        git(
+            source.path(),
+            &["checkout", "-b", "unrelated-private-history", &base],
+        );
+        fs::write(source.path().join("private.txt"), "unrelated\n").expect("write private");
+        git(source.path(), &["add", "."]);
+        git(
+            source.path(),
+            &["commit", "-m", "unrelated private history"],
+        );
+        let unrelated = git_output(source.path(), &["rev-parse", "HEAD"]).expect("unrelated");
+        git(source.path(), &["tag", "unrelated-private-tag"]);
+        git(source.path(), &["checkout", &branch]);
         git(
             source.path(),
             &[
                 "remote",
                 "add",
                 "origin",
-                "git@github.example.com:example-org/conductor.git",
+                "https://github.example.invalid/example-org/private-source.git",
             ],
         );
 
@@ -53,21 +61,14 @@ fn git_sync_for_private_remote_materializes_controller_bundle_checkout() {
             RunnerWorkspaceSyncOptions {
                 path: source.path().display().to_string(),
                 mode: RunnerWorkspaceSyncMode::Git,
-                controller_routed_git: false,
-                changed_since_base: None,
+                controller_routed_git: true,
+                changed_since_base: Some(base.clone()),
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
                 run_isolation_token: None,
             },
         );
-
-        // Restore the prior env value before asserting so a failure does not
-        // leak the override into subsequent tests.
-        match prior_private_hosts {
-            Some(value) => std::env::set_var("HOMEBOY_PRIVATE_PROXIED_SOURCE_HOSTS", value),
-            None => std::env::remove_var("HOMEBOY_PRIVATE_PROXIED_SOURCE_HOSTS"),
-        }
 
         let (output, exit_code) = sync_result.expect("sync workspace");
 
@@ -90,17 +91,24 @@ fn git_sync_for_private_remote_materializes_controller_bundle_checkout() {
             git_output(remote, &["rev-parse", "--is-inside-work-tree"]).unwrap(),
             "true"
         );
-        // The controller-bundle path repoints origin at the real (private)
-        // remote URL without fetching from it, proving the checkout was
-        // materialized from the local bundle rather than a network clone.
+        // The controller-bundle path repoints origin without fetching it. The
+        // source URL is deliberately unavailable from the runner, so this
+        // proves materialization did not fall back to a network clone.
         assert_eq!(
             git_output(remote, &["config", "--get", "remote.origin.url"]).unwrap(),
-            "git@github.example.com:example-org/conductor.git"
+            "https://github.example.invalid/example-org/private-source.git"
         );
         assert_eq!(
             fs::read_to_string(remote.join("file.txt")).expect("read synced file"),
-            "base\n"
+            "head\n"
         );
+        assert_eq!(git_output(remote, &["rev-parse", &base]).unwrap(), base);
+        assert_eq!(
+            git_output(remote, &["merge-base", &base, "HEAD"]).unwrap(),
+            base
+        );
+        assert!(git_output(remote, &["rev-parse", "unrelated-private-tag"]).is_err());
+        assert!(git_output(remote, &["cat-file", "-e", &unrelated]).is_err());
     });
 }
 


### PR DESCRIPTION
## Summary
- route Git-mode Lab workspaces through the authenticated controller checkout instead of cloning or fetching on the runner
- limit controller bundles to `HEAD`, the resolved changed-since base, and explicitly requested fetch refs
- prove private/unavailable remotes materialize without leaking unrelated local branch or tag history

Fixes #7716.

## How to test
1. Check out this branch on a machine with Rust installed.
2. Run `cargo test --lib core::runner::workspace::tests::git`.
3. Run `cargo test --lib stage_routes_changed_since_private_source_through_controller_bundle`.
4. Confirm both commands pass. The stage test uses an unavailable source remote, exercises the production Lab staging decision, and verifies the rewritten changed-since commit is reachable in the materialized runner checkout.
5. Run `git diff --check origin/main...HEAD` and confirm it exits successfully.

## Notes
`cargo fmt --check` currently reports an unrelated pre-existing formatting difference in `src/core/extension/lint/run/tests/exit_code.rs`; all files changed by this PR pass `rustfmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the Lab materialization failure, drafted the implementation and regression tests, and reviewed the bundle security boundary. Chris reviewed and owns the change.