### PR TITLE
Enforce bounded terminal-run artifact retention

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -38,6 +38,7 @@ the higher-level system model and core/extension boundary, see
 - `settings` — Generic extension and executor settings, addressed through `/settings/...`.
 - `release_gate` — Routing safety policy for release-gate hot commands.
 - `artifact_root` — Optional directory where persisted run artifacts are copied. Override per command with `homeboy --artifact-root <dir>` or per process with `HOMEBOY_ARTIFACT_ROOT`.
+- `retention` — Bounded cleanup policy shared by terminal-run evidence and runtime resources.
 - `update_check` — Enable automatic update check on startup (default: true). Disable with `homeboy config set /update_check false` or set `HOMEBOY_NO_UPDATE_CHECK=1`.
 - `resident_services` — Long-running services to restart after `homeboy upgrade` swaps the on-disk binary.
 
@@ -55,6 +56,12 @@ variables.
 
 - `preferred_runner` — Default Lab runner ID.
 - `runner_workspace_ttl` — Optional workspace retention duration for runner materialization.
+
+### `RetentionConfig`
+
+- `terminal_run_days` — Age threshold before terminal persisted-run artifacts are eligible for cleanup (default: 30). Active and unknown run states remain protected.
+- `runtime_tmp_days` — Age threshold for Homeboy runtime temporary entries (default: 7).
+- `limit` — Maximum persisted-run artifact records inspected per aggregate cleanup invocation (default: 1000).
 
 ### `TriageConfig`
 

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -37,6 +37,14 @@ pub struct CleanupArgs {
     #[arg(long, value_enum, value_delimiter = ',')]
     pub exclude: Vec<CleanupCategoryArg>,
 
+    /// Override the configured terminal-run retention window for this invocation.
+    #[arg(long, value_name = "DAYS")]
+    pub older_than_days: Option<i64>,
+
+    /// Override the configured maximum number of persisted artifacts inspected.
+    #[arg(long, value_name = "N")]
+    pub limit: Option<i64>,
+
     #[command(subcommand)]
     pub command: Option<CleanupCommand>,
 }
@@ -180,9 +188,20 @@ pub struct CleanupInventoryOutput {
     pub skipped_count: usize,
     pub estimated_bytes: u64,
     pub reclaimed_bytes: u64,
+    pub retention: CleanupRetentionManifest,
     pub categories: Vec<CleanupInventoryCategory>,
     #[serde(rename = "_homeboy_actionable")]
     pub actionable: CommandActionableMetadata,
+}
+
+/// Stable, serialized policy snapshot for a cleanup plan or apply result.
+#[derive(Debug, Serialize)]
+pub struct CleanupRetentionManifest {
+    pub schema: &'static str,
+    pub terminal_run_days: i64,
+    pub runtime_tmp_days: u64,
+    pub limit: i64,
+    pub terminal_run_guard: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -279,6 +298,17 @@ const REMOTE_LAB_WORKSPACES_METADATA: CleanupInventoryCategoryMetadata =
 fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
     let selected = CleanupCategorySelection::new(args.include, args.exclude);
     let apply = args.apply;
+    let configured = defaults::load_config().retention;
+    let terminal_run_days = args.older_than_days.unwrap_or(configured.terminal_run_days);
+    let limit = args.limit.unwrap_or(configured.limit);
+    if terminal_run_days < 0 || limit < 1 {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "retention",
+            "--older-than-days must be zero or greater and --limit must be positive",
+            None,
+            None,
+        ));
+    }
     let mut categories = Vec::new();
 
     if selected.includes(CleanupCategoryArg::RepoArtifacts) {
@@ -317,13 +347,14 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
         let persisted =
             runs_service::cleanup_persisted_artifacts(PersistedArtifactCleanupOptions {
                 apply,
-                older_than_days: 30,
+                older_than_days: terminal_run_days,
                 run_id: None,
                 kind: None,
                 artifact_type: None,
                 run_kind: None,
                 component_id: None,
-                limit: 1000,
+                limit,
+                terminal_only: true,
             })?;
         let resources = runs_resources(RunsResourcesArgs {
             cleanup_plan: true,
@@ -364,7 +395,12 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
     }
 
     if selected.includes(CleanupCategoryArg::RuntimeTmp) {
-        let output = engine::temp::cleanup_runtime_tmp(apply, 7, None, 1000)?;
+        let output = engine::temp::cleanup_runtime_tmp(
+            apply,
+            configured.runtime_tmp_days,
+            None,
+            usize::try_from(limit).unwrap_or(usize::MAX),
+        )?;
         categories.push(category_from_output(
             RUNTIME_TMP_METADATA,
             apply,
@@ -407,6 +443,13 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
         skipped_count,
         estimated_bytes,
         reclaimed_bytes,
+        retention: CleanupRetentionManifest {
+            schema: "homeboy/retention-manifest/v1",
+            terminal_run_days,
+            runtime_tmp_days: configured.runtime_tmp_days,
+            limit,
+            terminal_run_guard: true,
+        },
         categories,
         actionable,
     })

--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -847,6 +847,7 @@ pub fn cleanup_persisted(args: RunsArtifactCleanupPersistedArgs) -> CmdResult<Ru
         run_kind: args.run_kind,
         component_id: args.component_id,
         limit: args.limit,
+        terminal_only: true,
     })?;
 
     Ok((
@@ -1391,6 +1392,8 @@ mod tests {
                     apply: false,
                     include: vec![crate::commands::cleanup::CleanupCategoryArg::RunnerDownloads],
                     exclude: Vec::new(),
+                    older_than_days: None,
+                    limit: None,
                     command: None,
                 },
                 &crate::commands::GlobalArgs {},
@@ -1457,6 +1460,32 @@ mod tests {
                 .expect("artifact");
             let stored_path = PathBuf::from(&artifact.path);
             assert!(stored_path.exists());
+
+            // The retention contract never reaps evidence while its run owns an
+            // active lease, even when the age threshold is zero.
+            let active = cleanup_persisted(RunsArtifactCleanupPersistedArgs {
+                apply: true,
+                older_than_days: 0,
+                run_id: Some(run.id.clone()),
+                kind: None,
+                artifact_type: None,
+                run_kind: None,
+                component_id: None,
+                limit: 100,
+            })
+            .expect("active cleanup")
+            .0;
+            let RunsOutput::ArtifactCleanupPersisted(active) = active else {
+                panic!("unexpected output");
+            };
+            assert_eq!(active.removed_record_count, 0);
+            assert_eq!(active.rows[0].run_status, "running");
+            assert_eq!(active.rows[0].action, "skip");
+            assert!(stored_path.exists());
+
+            store
+                .finish_run(&run.id, RunStatus::Pass, None)
+                .expect("finish run");
 
             let dry = cleanup_persisted(RunsArtifactCleanupPersistedArgs {
                 apply: false,

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -77,6 +77,11 @@ pub struct HomeboyConfig {
     #[serde(default)]
     pub release_gate: ReleaseGateConfig,
 
+    /// Bounded retention policy shared by terminal run evidence and runtime
+    /// resources. Individual commands may request a narrower scope.
+    #[serde(default)]
+    pub retention: RetentionConfig,
+
     /// Directory where persisted run artifacts are copied.
     ///
     /// Defaults to the machine-local product data directory under
@@ -140,11 +145,48 @@ impl Default for HomeboyConfig {
             github_hosts: HashMap::new(),
             settings: HashMap::new(),
             release_gate: ReleaseGateConfig::default(),
+            retention: RetentionConfig::default(),
             artifact_root: None,
             update_check: true,
             resident_services: Vec::new(),
         }
     }
+}
+
+/// Safe default retention windows for resources created by Homeboy commands.
+///
+/// This is deliberately resource-oriented: controller scratch ownership has a
+/// separate lifecycle contract and is not inferred from these paths.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RetentionConfig {
+    #[serde(default = "default_terminal_run_retention_days")]
+    pub terminal_run_days: i64,
+    #[serde(default = "default_runtime_tmp_retention_days")]
+    pub runtime_tmp_days: u64,
+    #[serde(default = "default_retention_limit")]
+    pub limit: i64,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            terminal_run_days: default_terminal_run_retention_days(),
+            runtime_tmp_days: default_runtime_tmp_retention_days(),
+            limit: default_retention_limit(),
+        }
+    }
+}
+
+fn default_terminal_run_retention_days() -> i64 {
+    30
+}
+
+fn default_runtime_tmp_retention_days() -> u64 {
+    7
+}
+
+fn default_retention_limit() -> i64 {
+    1000
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -85,6 +85,8 @@ pub struct PersistedArtifactCleanupOptions {
     pub run_kind: Option<String>,
     pub component_id: Option<String>,
     pub limit: i64,
+    /// Only terminal, known run states may release persisted evidence.
+    pub terminal_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -109,6 +111,7 @@ pub struct PersistedArtifactCleanupRow {
     pub artifact_id: String,
     pub run_id: String,
     pub run_kind: String,
+    pub run_status: String,
     pub component_id: Option<String>,
     pub kind: String,
     #[serde(rename = "type")]
@@ -880,7 +883,8 @@ mod persisted_cleanup {
         let mut skipped_count = 0;
 
         for candidate in candidates.iter() {
-            let mut row = classify_persisted_artifact(candidate, &artifact_root)?;
+            let mut row =
+                classify_persisted_artifact(candidate, &artifact_root, options.terminal_only)?;
             if row.action == "remove" {
                 planned_record_count += 1;
                 planned_size_bytes += row.size_bytes;
@@ -927,12 +931,20 @@ mod persisted_cleanup {
     fn classify_persisted_artifact(
         candidate: &ArtifactCleanupCandidateRecord,
         artifact_root: &Path,
+        terminal_only: bool,
     ) -> Result<PersistedArtifactCleanupRow> {
         let artifact = &candidate.artifact;
         let path = persisted_artifact_path_from_record(artifact_root, &artifact.path);
         let mut exists = false;
         let mut size_bytes = 0;
-        let (action, reason) = if artifact.artifact_type == "url"
+        let (action, reason) = if terminal_only
+            && !RunStatus::from_label(&candidate.run_status).is_some_and(RunStatus::is_terminal)
+        {
+            (
+                "skip",
+                "owning run is active or has an unknown lifecycle state",
+            )
+        } else if artifact.artifact_type == "url"
             || crate::core::runners::is_remote_runner_artifact_path(&artifact.path)
             || EXECUTION_CONTRACT
                 .artifacts
@@ -957,6 +969,7 @@ mod persisted_cleanup {
             artifact_id: artifact.id.clone(),
             run_id: artifact.run_id.clone(),
             run_kind: candidate.run_kind.clone(),
+            run_status: candidate.run_status.clone(),
             component_id: candidate.component_id.clone(),
             kind: artifact.kind.clone(),
             artifact_type: artifact.artifact_type.clone(),


### PR DESCRIPTION
## Summary
- add a configurable retention policy for terminal persisted-run artifacts and runtime temporary resources
- require persisted artifact cleanup to retain active or unknown run evidence
- emit a deterministic retention-policy manifest with aggregate cleanup byte accounting

Closes #7502

## Testing
1. Run `cargo fmt --check`.
2. Run `cargo test cleanup_persisted_plans_and_removes_local_artifacts --lib` to verify active evidence is protected and terminal evidence is reclaimed.
3. Run `cargo test cleanup_front_door_accepts_include_exclude_without_subcommand --lib`.
4. Run `cargo check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via OpenCode general subagent
- **Used for:** Implementing the retention configuration, terminal-state guard, deterministic cleanup output, tests, and verification.