### PR TITLE
fix: bind runner child reconciliation identity

### DIFF
--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -206,7 +206,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
         }
     }
     let before_liveness_reconciliation = record.clone();
-    reconcile_runner_job_state(&mut record);
+    reconcile_runner_job_state(&mut record)?;
     record.annotate_stale_running();
     if record != before_liveness_reconciliation {
         store::write_record(&record)?;
@@ -224,15 +224,15 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     Ok(record)
 }
 
-fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) {
+fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) -> Result<()> {
     if record.state != AgentTaskRunState::Running {
-        return;
+        return Ok(());
     }
     let (Some(runner_id), Some(job_id)) = (
         record.runner_id().map(str::to_string),
         record.runner_job_id().map(str::to_string),
     ) else {
-        return;
+        return Ok(());
     };
     let snapshot = match crate::core::runners::runner_job_log_snapshot(&runner_id, &job_id) {
         Ok(snapshot) => snapshot,
@@ -243,46 +243,95 @@ fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) {
             {
                 record.annotate_runner_disconnected();
             }
-            return;
+            return Ok(());
         }
     };
-    reconcile_runner_job_snapshot(record, &snapshot);
+    reconcile_runner_job_snapshot(record, &snapshot)
 }
 
 pub(crate) fn reconcile_runner_job_snapshot(
     record: &mut AgentTaskRunRecord,
     snapshot: &crate::core::runner::RunnerJobLogSnapshot,
-) {
+) -> Result<()> {
     if is_terminal_run_state(record.state) {
-        return;
+        return Ok(());
     }
+    validate_runner_job_snapshot(record, snapshot)?;
+    let mut reconciled = record.clone();
+    reconciled.record_runner_reachable();
     match snapshot.job.status {
         crate::core::api_jobs::JobStatus::Queued | crate::core::api_jobs::JobStatus::Running => {
-            record.updated_at = Some(now_timestamp());
-            update_lifecycle_heartbeat(record);
-            let last_seen_at = record.updated_at.clone();
-            let metadata = record.ensure_metadata_object();
+            reconciled.updated_at = Some(now_timestamp());
+            update_lifecycle_heartbeat(&mut reconciled);
+            let last_seen_at = reconciled.updated_at.clone();
+            let metadata = reconciled.ensure_metadata_object();
             metadata.insert("runner_job_status".to_string(), json!(snapshot.job.status));
             metadata.insert("runner_job_last_seen_at".to_string(), json!(last_seen_at));
+            store::write_record(&reconciled)?;
         }
         crate::core::api_jobs::JobStatus::Succeeded
         | crate::core::api_jobs::JobStatus::Failed
         | crate::core::api_jobs::JobStatus::Cancelled => {
-            if let Some(event) = crate::core::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(Some(&snapshot.events)).filter(|event| {
-                event.identity.runner_id == record.runner_id().unwrap_or_default()
-                    && event.identity.runner_job_id == record.runner_job_id().unwrap_or_default()
-            }) {
+            if let Some(event) = crate::core::runner::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(Some(&snapshot.events)) {
+                validate_terminal_child_identity(&reconciled, snapshot, &event)?;
                 let projection_plan = aggregate_projection_plan_from_outcomes(&event.aggregate);
-                let aggregate_path = store::aggregate_path(&record.run_id)
+                let aggregate_path = store::aggregate_path(&reconciled.run_id)
                     .map(|path| path.display().to_string())
                     .unwrap_or_else(|_| "aggregate.json".to_string());
-                apply_aggregate_to_record(record, &projection_plan, &event.aggregate, aggregate_path);
-                let _ = store::write_aggregate(&record.run_id, &event.aggregate);
+                apply_aggregate_to_record(&mut reconciled, &projection_plan, &event.aggregate, aggregate_path);
+                apply_runner_job_terminal_state(&mut reconciled, snapshot.job.status, &snapshot.events);
+                store::write_aggregate_and_record(&reconciled, &event.aggregate)?;
+            } else {
+                apply_runner_job_terminal_state(&mut reconciled, snapshot.job.status, &snapshot.events);
+                store::write_record(&reconciled)?;
             }
-            apply_runner_job_terminal_state(record, snapshot.job.status, &snapshot.events);
         }
     }
-    let _ = store::write_record(record);
+    *record = reconciled;
+    Ok(())
+}
+
+fn validate_runner_job_snapshot(
+    record: &AgentTaskRunRecord,
+    snapshot: &crate::core::runner::RunnerJobLogSnapshot,
+) -> Result<()> {
+    let expected_job_id = record.runner_job_id().unwrap_or_default();
+    if expected_job_id == snapshot.job.id.to_string() {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "runner_job_id",
+        format!(
+            "runner snapshot job {} does not match controller job {expected_job_id}",
+            snapshot.job.id
+        ),
+        Some(record.run_id.clone()),
+        None,
+    ))
+}
+
+fn validate_terminal_child_identity(
+    record: &AgentTaskRunRecord,
+    snapshot: &crate::core::runner::RunnerJobLogSnapshot,
+    event: &crate::core::runner::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
+) -> Result<()> {
+    let expected_runner_id = record.runner_id().unwrap_or_default();
+    let expected_job_id = record.runner_job_id().unwrap_or_default();
+    let expected_run_id = record.run_id.as_str();
+    if event.identity.runner_id == expected_runner_id
+        && event.identity.runner_job_id == expected_job_id
+        && snapshot.job.id.to_string() == expected_job_id
+        && event.identity.run_id.as_deref() == Some(expected_run_id)
+        && event.identity.persisted_run_id.as_deref() == Some(expected_run_id)
+    {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "runner_lifecycle_identity",
+        "terminal runner child lifecycle event does not match its controller run, persisted run, runner, and job identity",
+        Some(record.run_id.clone()),
+        None,
+    ))
 }
 
 fn is_terminal_run_state(state: AgentTaskRunState) -> bool {

--- a/src/core/agent_task_lifecycle/records.rs
+++ b/src/core/agent_task_lifecycle/records.rs
@@ -152,6 +152,16 @@ impl AgentTaskRunRecord {
         metadata.insert("retryable".to_string(), json!(true));
     }
 
+    /// A reachable runner job is authoritative liveness evidence. Clear only
+    /// the controller's disconnected/stale projection, not unrelated metadata.
+    pub(crate) fn record_runner_reachable(&mut self) {
+        let metadata = self.ensure_metadata_object();
+        metadata.insert("runner_liveness".to_string(), json!("reachable"));
+        metadata.remove("stale_running");
+        metadata.remove("stale_running_reason");
+        metadata.remove("retryable");
+    }
+
     pub(crate) fn owner_process_is_running(&self) -> bool {
         self.owner_pid()
             .is_some_and(crate::core::process::pid_is_running)

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -291,9 +291,9 @@ fn disconnected_proxy_projects_terminal_child_aggregate_once_reachable() {
         }];
         let snapshot = terminal_child_snapshot(&child_aggregate);
 
-        reconcile_runner_job_snapshot(&mut record, &snapshot);
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("terminal reconciliation");
         let once = record.clone();
-        reconcile_runner_job_snapshot(&mut record, &snapshot);
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("repeated reconciliation");
 
         assert_eq!(
             record, once,
@@ -302,13 +302,120 @@ fn disconnected_proxy_projects_terminal_child_aggregate_once_reachable() {
         assert_eq!(record.state, AgentTaskRunState::Succeeded);
         assert_eq!(record.artifact_refs[0].uri, "/runner/artifacts/patch.diff");
         assert_eq!(record.metadata["runner_job_status"], "succeeded");
-        assert!(record.metadata.get("runner_liveness").is_some());
+        assert_eq!(record.metadata["runner_liveness"], "reachable");
         let aggregate = store::read_aggregate("agent-task-disconnected-child")
             .expect("projected child aggregate");
         assert_eq!(
             aggregate.outcomes[0].diagnostics[0].class,
             "provider.attempt"
         );
+    });
+}
+
+#[test]
+fn reachable_running_child_clears_disconnected_liveness_and_refreshes_heartbeat() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-reconnected-running",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        record.annotate_runner_disconnected();
+        let disconnected_heartbeat = record.lifecycle.heartbeat.clone();
+
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.status = crate::core::api_jobs::JobStatus::Running;
+        snapshot.events.clear();
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("reachable reconciliation");
+
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert_eq!(record.metadata["runner_liveness"], "reachable");
+        assert!(record.metadata.get("stale_running").is_none());
+        assert!(record.metadata.get("stale_running_reason").is_none());
+        assert!(record.metadata.get("retryable").is_none());
+        assert_ne!(record.lifecycle.heartbeat, disconnected_heartbeat);
+    });
+}
+
+#[test]
+fn terminal_child_projection_rejects_mismatched_persisted_run_identity() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-disconnected-child",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let before = record.clone();
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.events[0].data.as_mut().expect("event data")["identity"]["persisted_run_id"] =
+            json!("another-controller-run");
+
+        let error = reconcile_runner_job_snapshot(&mut record, &snapshot)
+            .expect_err("mismatched child must be rejected");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(record, before);
+        assert!(store::read_aggregate(&record.run_id).is_err());
+    });
+}
+
+#[test]
+fn terminal_projection_rolls_back_aggregate_when_controller_persistence_fails() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-disconnected-child",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let before = record.clone();
+        let snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        store::fail_next_record_write_for_test();
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot)
+            .expect_err("controller persistence failure is surfaced");
+
+        assert_eq!(record, before);
+        let persisted = status(&record.run_id).expect("persisted controller record");
+        assert_eq!(persisted.state, AgentTaskRunState::Running);
+        assert!(persisted.artifact_refs.is_empty());
+        assert!(store::read_aggregate(&record.run_id).is_err());
+    });
+}
+
+#[test]
+fn terminal_runner_reconciliation_never_resurrects_a_controller_record() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-disconnected-child",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let terminal = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        reconcile_runner_job_snapshot(&mut record, &terminal).expect("terminal reconciliation");
+        let terminal_record = record.clone();
+
+        let mut running = terminal.clone();
+        running.job.status = crate::core::api_jobs::JobStatus::Running;
+        running.events.clear();
+        reconcile_runner_job_snapshot(&mut record, &running)
+            .expect("terminal records stay immutable");
+
+        assert_eq!(record, terminal_record);
     });
 }
 
@@ -2025,6 +2132,7 @@ fn terminal_child_snapshot(
                 "identity": {
                     "runner_id": "homeboy-lab",
                     "runner_job_id": job_id.to_string(),
+                    "persisted_run_id": "agent-task-disconnected-child",
                     "run_id": "agent-task-disconnected-child",
                 },
                 "aggregate": aggregate,

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -1,6 +1,9 @@
 use std::fs;
 use std::path::PathBuf;
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use serde_json::{json, Value};
 
 use super::{
@@ -11,6 +14,9 @@ use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use crate::core::engine::local_files::write_json_file as write_json;
 use crate::core::observation::{ObservationStore, RunListFilter, RunRecord, RunStatus};
 use crate::core::{paths, Error, ErrorCode, Result};
+
+#[cfg(test)]
+static FAIL_NEXT_RECORD_WRITE: AtomicBool = AtomicBool::new(false);
 
 pub(super) fn write_plan(run_id: &str, plan: &AgentTaskPlan) -> Result<PathBuf> {
     let path = run_dir(run_id)?.join("plan.json");
@@ -39,13 +45,69 @@ pub(super) fn aggregate_path(run_id: &str) -> Result<PathBuf> {
 }
 
 pub(super) fn write_record(record: &AgentTaskRunRecord) -> Result<()> {
+    #[cfg(test)]
+    if FAIL_NEXT_RECORD_WRITE.swap(false, Ordering::SeqCst) {
+        return Err(Error::internal_io(
+            "injected lifecycle record persistence failure",
+            Some(record.run_id.clone()),
+        ));
+    }
+    write_record_with_aggregate(record, read_mirrored_aggregate(&record.run_id)?)
+}
+
+/// Persist an aggregate and its controller projection as one recoverable unit.
+/// If the controller write fails, restore the previously visible aggregate so
+/// status, logs, and artifacts continue to describe the same lifecycle state.
+pub(super) fn write_aggregate_and_record(
+    record: &AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+) -> Result<PathBuf> {
+    let previous = read_aggregate(&record.run_id).ok();
+    let path = match write_aggregate(&record.run_id, aggregate) {
+        Ok(path) => path,
+        Err(error) => {
+            restore_aggregate(&record.run_id, previous.as_ref())?;
+            return Err(error);
+        }
+    };
+    if let Err(error) = write_record(record) {
+        restore_aggregate(&record.run_id, previous.as_ref())?;
+        return Err(error);
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+pub(super) fn fail_next_record_write_for_test() {
+    FAIL_NEXT_RECORD_WRITE.store(true, Ordering::SeqCst);
+}
+
+fn restore_aggregate(run_id: &str, aggregate: Option<&AgentTaskAggregate>) -> Result<()> {
+    let path = aggregate_path(run_id)?;
+    match aggregate {
+        Some(aggregate) => {
+            write_json(&path, aggregate)?;
+        }
+        None if path.exists() => fs::remove_file(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?,
+        None => {}
+    }
+    let record = read_record(run_id)?;
+    write_record_with_aggregate(&record, aggregate.cloned())
+}
+
+fn write_record_with_aggregate(
+    record: &AgentTaskRunRecord,
+    aggregate: Option<AgentTaskAggregate>,
+) -> Result<()> {
     let store = ObservationStore::open_initialized()?;
     let metadata_json = merge_observation_metadata(
         store
             .get_run(&record.run_id)?
             .map(|run| run.metadata_json)
             .unwrap_or_else(|| json!({})),
-        observation_metadata(record, read_mirrored_aggregate(&record.run_id)?)?,
+        observation_metadata(record, aggregate)?,
     );
     store.upsert_imported_run(&RunRecord {
         id: record.run_id.clone(),

--- a/src/core/runner/agent_task_lifecycle_event.rs
+++ b/src/core/runner/agent_task_lifecycle_event.rs
@@ -119,6 +119,7 @@ pub(crate) fn agent_task_run_plan_lifecycle_event_from_workload_result(
         identity: AgentTaskDispatchIdentity {
             runner_id: runner_id.to_string(),
             runner_job_id: runner_job_id.to_string(),
+            persisted_run_id: Some(agent_task.run_id.clone()),
             run_id: Some(agent_task.run_id.clone()),
             ..AgentTaskDispatchIdentity::default()
         },


### PR DESCRIPTION
## Summary
- Clear disconnected/stale liveness projection and refresh the heartbeat when a runner-backed child is reachable and still active.
- Bind terminal aggregate projection to the controller run, persisted run, runner, and job identities before mutation.
- Persist terminal aggregate and controller state as a recoverable unit, rolling aggregate visibility back when persistence fails.

Fixes #7926

## Testing
1. From a fresh checkout, run `cargo test agent_task_lifecycle --lib --no-fail-fast`.
2. Run `cargo check`.
3. Run `cargo fmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.