### PR TITLE
Add controller scratch cleanup lifecycle

### DIFF
--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -50,6 +50,7 @@ pub enum CleanupCategoryArg {
     RunnerDownloads,
     RemoteLabWorkspaces,
     RuntimeTmp,
+    ControllerScratch,
 }
 
 #[derive(Subcommand)]
@@ -276,6 +277,14 @@ const REMOTE_LAB_WORKSPACES_METADATA: CleanupInventoryCategoryMetadata =
         apply_command: "homeboy runner workspace prune <runner> --apply --passes 10",
     };
 
+const CONTROLLER_SCRATCH_METADATA: CleanupInventoryCategoryMetadata =
+    CleanupInventoryCategoryMetadata {
+        category: "controller_scratch",
+        include_arg: "controller-scratch",
+        dry_run_command: "homeboy cleanup --include controller-scratch",
+        apply_command: "homeboy cleanup --include controller-scratch --apply",
+    };
+
 fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
     let selected = CleanupCategorySelection::new(args.include, args.exclude);
     let apply = args.apply;
@@ -373,6 +382,20 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
             output.skipped_count,
             output.totals.planned_size_bytes,
             output.totals.removed_size_bytes,
+            output,
+        )?);
+    }
+
+    if selected.includes(CleanupCategoryArg::ControllerScratch) {
+        let output = homeboy::core::controller_scratch::cleanup(apply)?;
+        categories.push(category_from_output(
+            CONTROLLER_SCRATCH_METADATA,
+            apply,
+            output.candidate_count,
+            output.applied_count,
+            output.skipped_count,
+            output.estimated_bytes,
+            output.reclaimed_bytes,
             output,
         )?);
     }

--- a/src/core/agent_task_lifecycle/failure_recording.rs
+++ b/src/core/agent_task_lifecycle/failure_recording.rs
@@ -525,6 +525,11 @@ pub(crate) fn record_aggregate(
         aggregate,
         aggregate_path.display().to_string(),
     );
+    crate::core::controller_scratch::register_outcome_resources(
+        &record.run_id,
+        &aggregate.outcomes,
+    )?;
+    crate::core::controller_scratch::finalize_run(&record.run_id)?;
     store::write_record(record)?;
     Ok(record.clone())
 }

--- a/src/core/controller_scratch.rs
+++ b/src/core/controller_scratch.rs
@@ -1,0 +1,526 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::agent_task::AgentTaskOutcome;
+use crate::core::observation::ObservationStore;
+use crate::core::{git, paths, Error, Result};
+
+pub const CONTROLLER_SCRATCH_SCHEMA: &str = "homeboy/controller-scratch/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ControllerScratchResource {
+    pub path: String,
+    pub run_id: String,
+    pub task_id: String,
+    pub root_bound: String,
+    pub owner_pid: u32,
+    pub reconstructable: bool,
+    pub retention: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finalized_at: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct ControllerScratchIndex {
+    #[serde(default = "schema")]
+    schema: String,
+    #[serde(default)]
+    resources: Vec<ControllerScratchResource>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ControllerScratchCleanupOutput {
+    pub command: &'static str,
+    pub mode: &'static str,
+    pub candidate_count: usize,
+    pub applied_count: usize,
+    pub skipped_count: usize,
+    pub estimated_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub candidates: Vec<ControllerScratchCandidate>,
+    pub skipped: Vec<ControllerScratchSkipped>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ControllerScratchCandidate {
+    pub path: String,
+    pub run_id: String,
+    pub task_id: String,
+    pub size_bytes: u64,
+    pub source_ref: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ControllerScratchSkipped {
+    pub path: String,
+    pub run_id: Option<String>,
+    pub reason: String,
+}
+
+/// Registers provider-created controller scratch returned in an outcome's
+/// `metadata.controller_scratch` object or array. Providers own materializing
+/// the path; Homeboy owns its durable lifecycle and cleanup policy.
+pub fn register_outcome_resources(run_id: &str, outcomes: &[AgentTaskOutcome]) -> Result<()> {
+    let mut index = read_index()?;
+    let mut changed = false;
+    for outcome in outcomes {
+        let values = outcome
+            .metadata
+            .get("controller_scratch")
+            .map(|value| {
+                value
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_else(|| vec![value.clone()])
+            })
+            .unwrap_or_default();
+        for value in values {
+            let Some(path) = value.get("path").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            let path = PathBuf::from(path).canonicalize().map_err(|error| {
+                Error::validation_invalid_argument(
+                    "controller_scratch.path",
+                    error.to_string(),
+                    Some(path.to_string()),
+                    None,
+                )
+            })?;
+            let root = value
+                .get("root_bound")
+                .and_then(serde_json::Value::as_str)
+                .map(PathBuf::from)
+                .unwrap_or_else(|| path.parent().unwrap_or(&path).to_path_buf())
+                .canonicalize()
+                .map_err(|error| {
+                    Error::validation_invalid_argument(
+                        "controller_scratch.root_bound",
+                        error.to_string(),
+                        None,
+                        None,
+                    )
+                })?;
+            if path == root || !path.starts_with(&root) {
+                return Err(Error::validation_invalid_argument(
+                    "controller_scratch.path",
+                    "scratch path must be contained by its declared root",
+                    Some(path.display().to_string()),
+                    None,
+                ));
+            }
+            let resource = ControllerScratchResource {
+                path: path.display().to_string(),
+                run_id: run_id.to_string(),
+                task_id: outcome.task_id.clone(),
+                root_bound: root.display().to_string(),
+                owner_pid: std::process::id(),
+                reconstructable: value
+                    .get("reconstructable")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false),
+                retention: value
+                    .get("retention")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("P7D")
+                    .to_string(),
+                source_ref: value
+                    .get("source_ref")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                finalized_at: None,
+            };
+            index
+                .resources
+                .retain(|existing| existing.path != resource.path);
+            index.resources.push(resource);
+            changed = true;
+        }
+    }
+    if changed {
+        write_index(&index)?;
+    }
+    Ok(())
+}
+
+/// Marks all resources owned by a terminal run as finalized, including failed
+/// and cancelled exits, so retention starts regardless of task outcome.
+pub fn finalize_run(run_id: &str) -> Result<()> {
+    let mut index = read_index()?;
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut changed = false;
+    for resource in &mut index.resources {
+        if resource.run_id == run_id {
+            if resource.finalized_at.is_none() {
+                resource.finalized_at = Some(now.clone());
+                changed = true;
+            }
+        }
+    }
+    if changed {
+        write_index(&index)?;
+    }
+    Ok(())
+}
+
+pub fn cleanup(apply: bool) -> Result<ControllerScratchCleanupOutput> {
+    let index = read_index()?;
+    let mut candidates = Vec::new();
+    let mut skipped = legacy_unknown_paths()?;
+    let mut applied_count = 0;
+    let mut reclaimed_bytes = 0;
+    for resource in index.resources {
+        let path = PathBuf::from(&resource.path);
+        if !path.exists() {
+            continue;
+        }
+        let reason = cleanup_block_reason(&resource, &path)?;
+        if let Some(reason) = reason {
+            skipped.push(ControllerScratchSkipped {
+                path: resource.path,
+                run_id: Some(resource.run_id),
+                reason,
+            });
+            continue;
+        }
+        let size_bytes = path_size(&path)?;
+        let candidate = ControllerScratchCandidate {
+            path: resource.path,
+            run_id: resource.run_id,
+            task_id: resource.task_id,
+            size_bytes,
+            source_ref: resource.source_ref,
+        };
+        if apply {
+            fs::remove_dir_all(&path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("remove {}", path.display())),
+                )
+            })?;
+            applied_count += 1;
+            reclaimed_bytes += size_bytes;
+        }
+        candidates.push(candidate);
+    }
+    let estimated_bytes = candidates
+        .iter()
+        .map(|candidate| candidate.size_bytes)
+        .sum();
+    Ok(ControllerScratchCleanupOutput {
+        command: "cleanup.controller-scratch",
+        mode: if apply { "apply" } else { "dry_run" },
+        candidate_count: candidates.len(),
+        applied_count,
+        skipped_count: skipped.len(),
+        estimated_bytes,
+        reclaimed_bytes,
+        candidates,
+        skipped,
+    })
+}
+
+fn cleanup_block_reason(
+    resource: &ControllerScratchResource,
+    path: &Path,
+) -> Result<Option<String>> {
+    if !resource.reconstructable {
+        return Ok(Some(
+            "resource is not explicitly reconstructable".to_string(),
+        ));
+    }
+    let root = PathBuf::from(&resource.root_bound).canonicalize().ok();
+    let canonical = path.canonicalize().ok();
+    if root.is_none()
+        || canonical.is_none()
+        || !canonical
+            .as_ref()
+            .is_some_and(|path| path.starts_with(root.as_ref().unwrap()))
+    {
+        return Ok(Some(
+            "resource escaped its registered root bound".to_string(),
+        ));
+    }
+    if crate::core::process::pid_is_running(resource.owner_pid) {
+        return Ok(Some("owner process is still running".to_string()));
+    }
+    let terminal = ObservationStore::open_initialized()?
+        .get_run(&resource.run_id)?
+        .map(|run| run.status != "running")
+        .unwrap_or(true);
+    if !terminal {
+        return Ok(Some("owning run is still active".to_string()));
+    }
+    if resource.finalized_at.is_none() {
+        return Ok(Some(
+            "resource has not been finalized by its owning run".to_string(),
+        ));
+    }
+    if !retention_expired(resource, path) {
+        return Ok(Some("retention has not expired".to_string()));
+    }
+    if git_dirty_or_unpushed(path) {
+        return Ok(Some("git checkout has dirty or unpushed state".to_string()));
+    }
+    Ok(None)
+}
+
+fn retention_expired(resource: &ControllerScratchResource, path: &Path) -> bool {
+    let seconds = resource
+        .retention
+        .strip_suffix('s')
+        .and_then(|value| value.parse::<i64>().ok())
+        .or_else(|| {
+            resource
+                .retention
+                .strip_prefix('P')
+                .and_then(|value| value.strip_suffix('D'))
+                .and_then(|value| value.parse::<i64>().ok())
+                .map(|days| days * 86400)
+        })
+        .unwrap_or(i64::MAX);
+    let reference = resource
+        .finalized_at
+        .as_deref()
+        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&chrono::Utc))
+        .or_else(|| {
+            fs::metadata(path)
+                .ok()?
+                .modified()
+                .ok()
+                .map(chrono::DateTime::<chrono::Utc>::from)
+        });
+    reference
+        .is_some_and(|time| chrono::Utc::now().signed_duration_since(time).num_seconds() >= seconds)
+}
+
+fn git_dirty_or_unpushed(path: &Path) -> bool {
+    let status = git::run_git(path, &["status", "--porcelain=v1"], "git status");
+    let Ok(status) = status else {
+        return true;
+    };
+    if !status.trim().is_empty() {
+        return true;
+    }
+    git::run_git(
+        path,
+        &["rev-list", "--count", "@{upstream}..HEAD"],
+        "git rev-list upstream",
+    )
+    .map(|count| count.trim() != "0")
+    .unwrap_or(true)
+}
+
+fn legacy_unknown_paths() -> Result<Vec<ControllerScratchSkipped>> {
+    let index = read_index()?;
+    let known: std::collections::HashSet<_> = index
+        .resources
+        .iter()
+        .map(|resource| resource.path.as_str())
+        .collect();
+    let root = std::env::temp_dir();
+    let entries = match fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let mut unknown = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if path.is_dir()
+            && (name.starts_with("homeboy-") || name.starts_with("opencode-"))
+            && !known.contains(path.to_string_lossy().as_ref())
+        {
+            unknown.push(ControllerScratchSkipped {
+                path: path.display().to_string(),
+                run_id: None,
+                reason: "legacy scratch path has no Homeboy ownership metadata; report-only"
+                    .to_string(),
+            });
+        }
+    }
+    Ok(unknown)
+}
+
+fn path_size(path: &Path) -> Result<u64> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("stat {}", path.display())))
+    })?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(metadata.len());
+    }
+    fs::read_dir(path)
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+        })?
+        .try_fold(metadata.len(), |total, entry| {
+            Ok(total
+                + path_size(
+                    &entry
+                        .map_err(|error| Error::internal_io(error.to_string(), None))?
+                        .path(),
+                )?)
+        })
+}
+
+fn index_path() -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?.join("controller-scratch/resources.json"))
+}
+fn read_index() -> Result<ControllerScratchIndex> {
+    let path = index_path()?;
+    match fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str(&raw).map_err(|error| {
+            Error::internal_json(error.to_string(), Some(path.display().to_string()))
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(ControllerScratchIndex {
+            schema: schema(),
+            resources: Vec::new(),
+        }),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some(path.display().to_string()),
+        )),
+    }
+}
+fn write_index(index: &ControllerScratchIndex) -> Result<()> {
+    let path = index_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+        })?;
+    }
+    let raw = serde_json::to_vec_pretty(index)
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    fs::write(path, raw).map_err(|error| Error::internal_io(error.to_string(), None))
+}
+fn schema() -> String {
+    CONTROLLER_SCRATCH_SCHEMA.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn resource(path: &Path, root: &Path) -> ControllerScratchResource {
+        ControllerScratchResource {
+            path: path.display().to_string(),
+            run_id: "missing-terminal-run".to_string(),
+            task_id: "task-1".to_string(),
+            root_bound: root.display().to_string(),
+            owner_pid: u32::MAX,
+            reconstructable: true,
+            retention: "0s".to_string(),
+            source_ref: None,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            finalized_at: Some(chrono::Utc::now().to_rfc3339()),
+        }
+    }
+
+    #[test]
+    fn active_owner_protects_expired_reconstructable_resource() {
+        let root = tempfile::tempdir().expect("root");
+        let scratch = root.path().join("scratch");
+        fs::create_dir(&scratch).expect("scratch");
+        let mut resource = resource(&scratch, root.path());
+        resource.owner_pid = std::process::id();
+
+        assert_eq!(
+            cleanup_block_reason(&resource, &scratch).expect("check"),
+            Some("owner process is still running".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_legacy_path_is_report_only() {
+        let root = tempfile::tempdir().expect("root");
+        let path = root.path().join("legacy");
+        fs::create_dir(&path).expect("legacy");
+        let resource = ControllerScratchResource {
+            reconstructable: false,
+            ..resource(&path, root.path())
+        };
+
+        assert_eq!(
+            cleanup_block_reason(&resource, &path).expect("check"),
+            Some("resource is not explicitly reconstructable".to_string())
+        );
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn dirty_or_unpushed_checkout_is_preserved() {
+        let root = tempfile::tempdir().expect("root");
+        let scratch = root.path().join("scratch");
+        fs::create_dir(&scratch).expect("scratch");
+        run_git(&scratch, &["init", "-b", "main"]);
+        fs::write(scratch.join("untracked.txt"), "dirty").expect("dirty file");
+        let resource = resource(&scratch, root.path());
+
+        assert_eq!(
+            cleanup_block_reason(&resource, &scratch).expect("check"),
+            Some("git checkout has dirty or unpushed state".to_string())
+        );
+        assert!(scratch.exists());
+    }
+
+    #[test]
+    fn terminal_reconstructable_resource_is_inventoried_and_removed_with_byte_accounting() {
+        crate::test_support::with_isolated_home(|_| {
+            let root = tempfile::tempdir().expect("root");
+            let scratch = root.path().join("scratch");
+            let remote = root.path().join("remote.git");
+            run_git(
+                root.path(),
+                &["init", "--bare", remote.to_str().expect("remote path")],
+            );
+            fs::create_dir(&scratch).expect("scratch");
+            fs::write(scratch.join("generated.txt"), "generated bytes").expect("content");
+            run_git(&scratch, &["init", "-b", "main"]);
+            run_git(&scratch, &["config", "user.email", "homeboy@example.test"]);
+            run_git(&scratch, &["config", "user.name", "Homeboy Test"]);
+            run_git(&scratch, &["add", "."]);
+            run_git(&scratch, &["commit", "-m", "initial"]);
+            run_git(
+                &scratch,
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    remote.to_str().expect("remote path"),
+                ],
+            );
+            run_git(&scratch, &["push", "-u", "origin", "main"]);
+            write_index(&ControllerScratchIndex {
+                schema: schema(),
+                resources: vec![resource(&scratch, root.path())],
+            })
+            .expect("resource index");
+
+            let inventory = cleanup(false).expect("inventory");
+            assert_eq!(inventory.candidate_count, 1);
+            assert!(inventory.estimated_bytes > 0);
+            assert_eq!(inventory.reclaimed_bytes, 0);
+
+            let applied = cleanup(true).expect("apply");
+            assert_eq!(applied.applied_count, 1);
+            assert_eq!(applied.reclaimed_bytes, inventory.estimated_bytes);
+            assert!(!scratch.exists());
+        });
+    }
+
+    fn run_git(cwd: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?}");
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -71,6 +71,7 @@ pub mod command_execution_plan;
 pub mod command_invocation;
 pub mod component;
 pub mod context;
+pub mod controller_scratch;
 pub mod daemon;
 pub mod db;
 pub mod deploy;


### PR DESCRIPTION
## Summary
- register provider-reported controller scratch paths in the durable agent-task lifecycle index
- finalize registered resources on terminal aggregate paths and expose `controller-scratch` through `homeboy cleanup`
- preserve active, non-reconstructable, dirty, unpushed, and legacy unknown paths; account for candidate and reclaimed bytes

## Testing
1. Run `cargo fmt --check`.
2. Run `cargo test controller_scratch --lib`.
3. Run `cargo build`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via OpenCode general subagent
- **Used for:** Implemented the controller scratch lifecycle registry, cleanup integration, and focused Rust tests under human direction.