### PR TITLE
Fix promisor hydration for private Lab bundles

### DIFF
--- a/src/core/runner/workspace/git.rs
+++ b/src/core/runner/workspace/git.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::process::Command;
+use std::process::Stdio;
 
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
@@ -130,6 +131,7 @@ pub(super) fn materialize_git_from_controller_bundle(
     let bundle_path = bundle_dir.path().join("workspace.bundle");
 
     let refs = controller_bundle_refs("HEAD", changed_since_base, git_fetch_refs);
+    hydrate_controller_bundle_objects(local_path, &refs)?;
 
     let output = Command::new("git")
         .arg("bundle")
@@ -187,6 +189,71 @@ pub(super) fn materialize_git_from_controller_bundle(
     };
 
     result
+}
+
+/// Resolve the exact object closure locally before `git bundle` can invoke a
+/// promisor remote itself. The controller is the only participant allowed to
+/// use the source checkout's authenticated transport.
+fn hydrate_controller_bundle_objects(local_path: &Path, refs: &[String]) -> Result<()> {
+    let mut object_list = Command::new("git")
+        .args(["rev-list", "--objects", "--no-object-names"])
+        .args(refs)
+        .current_dir(local_path)
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("list git bundle objects".to_string()))
+        })?;
+    let mut hydrate = Command::new("git")
+        .args(["cat-file", "--batch-check"])
+        .current_dir(local_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("hydrate git bundle objects".to_string()),
+            )
+        })?;
+
+    let mut object_list_stdout = object_list
+        .stdout
+        .take()
+        .expect("piped git object list stdout");
+    let mut hydrate_stdin = hydrate
+        .stdin
+        .take()
+        .expect("piped git object hydration stdin");
+    std::io::copy(&mut object_list_stdout, &mut hydrate_stdin).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("stream git bundle objects".to_string()),
+        )
+    })?;
+    drop(hydrate_stdin);
+
+    let object_list_status = object_list.wait().map_err(|err| {
+        Error::internal_io(err.to_string(), Some("list git bundle objects".to_string()))
+    })?;
+    if !object_list_status.success() {
+        return Err(Error::internal_unexpected(
+            "list git bundle objects failed while resolving the controller object closure",
+        ));
+    }
+    let hydrate_status = hydrate.wait().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("hydrate git bundle objects".to_string()),
+        )
+    })?;
+    if !hydrate_status.success() {
+        return Err(Error::internal_unexpected(
+            "hydrate git bundle objects failed while resolving the controller object closure",
+        ));
+    }
+
+    Ok(())
 }
 
 fn controller_bundle_refs(
@@ -252,7 +319,7 @@ fn materialize_git_bundle_piped(
     run_shell_command(&command, action)
 }
 
-fn git_bundle_install_command(
+pub(crate) fn git_bundle_install_command(
     remote_path: &str,
     head: &str,
     branch: Option<&str>,

--- a/src/core/runner/workspace/materializer.rs
+++ b/src/core/runner/workspace/materializer.rs
@@ -96,6 +96,9 @@ impl WorkspaceMaterializer {
         );
         if self.bundle {
             prefix.push_str("; bundle=\"${dest}.bundle.$$\"");
+            // Bundles are controller-complete transfers. A runner must not
+            // lazily recover a missing object from the source remote.
+            prefix.push_str("; export GIT_NO_LAZY_FETCH=1");
         }
         if self.capture_owner {
             prefix.push_str("; ");

--- a/src/core/runner/workspace/tests/git.rs
+++ b/src/core/runner/workspace/tests/git.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use std::process::Command;
 
 use super::git;
-use crate::core::runner::workspace::git::{git_snapshot, materialize_git_command};
+use crate::core::runner::workspace::git::{
+    git_bundle_install_command, git_snapshot, materialize_git_command,
+};
 use crate::core::runner::workspace::sync::sync_workspace;
 use crate::core::runner::workspace::types::{RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
 use crate::core::runner::workspace::util::git_output;
@@ -11,32 +13,54 @@ use crate::core::runner::workspace::util::git_output;
 #[test]
 fn controller_routed_git_sync_materializes_private_unavailable_remote_with_changed_since_base() {
     crate::test_support::with_isolated_home(|_| {
+        let origin = tempfile::tempdir().expect("origin tempdir");
+        let author = tempfile::tempdir().expect("author tempdir");
         let source = tempfile::tempdir().expect("source tempdir");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
-        git(source.path(), &["init"]);
-        git(source.path(), &["config", "user.email", "test@example.com"]);
-        git(source.path(), &["config", "user.name", "Test User"]);
-        fs::write(source.path().join("file.txt"), "base\n").expect("write file");
-        git(source.path(), &["add", "."]);
-        git(source.path(), &["commit", "-m", "base"]);
-        let base = git_output(source.path(), &["rev-parse", "HEAD"]).expect("base revision");
-        let branch =
-            git_output(source.path(), &["branch", "--show-current"]).expect("source branch");
-        fs::write(source.path().join("file.txt"), "head\n").expect("write file");
-        git(source.path(), &["commit", "-am", "head"]);
+        git(origin.path(), &["init", "--bare"]);
+        git(origin.path(), &["config", "uploadpack.allowFilter", "true"]);
+        git(author.path(), &["init", "-b", "main"]);
+        git(author.path(), &["config", "user.email", "test@example.com"]);
+        git(author.path(), &["config", "user.name", "Test User"]);
+        fs::write(author.path().join("base-only.txt"), "base\n").expect("write base file");
+        git(author.path(), &["add", "."]);
+        git(author.path(), &["commit", "-m", "base"]);
+        let base = git_output(author.path(), &["rev-parse", "HEAD"]).expect("base revision");
+        let base_blob = git_output(author.path(), &["rev-parse", "HEAD:base-only.txt"])
+            .expect("base blob revision");
+        fs::remove_file(author.path().join("base-only.txt")).expect("remove base file");
+        fs::write(author.path().join("file.txt"), "head\n").expect("write head file");
+        git(author.path(), &["add", "."]);
+        git(author.path(), &["commit", "-m", "head"]);
+        git(
+            author.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                &format!("file://{}", origin.path().display()),
+            ],
+        );
+        git(author.path(), &["push", "origin", "main"]);
         git(
             source.path(),
-            &["checkout", "-b", "unrelated-private-history", &base],
+            &[
+                "clone",
+                "--filter=blob:none",
+                &format!("file://{}", origin.path().display()),
+                ".",
+            ],
         );
-        fs::write(source.path().join("private.txt"), "unrelated\n").expect("write private");
-        git(source.path(), &["add", "."]);
-        git(
-            source.path(),
-            &["commit", "-m", "unrelated private history"],
+        assert!(
+            git_output(
+                source.path(),
+                &["rev-list", "--objects", "--missing=print", &base]
+            )
+            .expect("list promised objects")
+            .contains(&format!("?{base_blob}")),
+            "the partial source fixture must omit the base-only blob"
         );
-        let unrelated = git_output(source.path(), &["rev-parse", "HEAD"]).expect("unrelated");
-        git(source.path(), &["tag", "unrelated-private-tag"]);
-        git(source.path(), &["checkout", &branch]);
+        git(source.path(), &["remote", "rename", "origin", "controller"]);
         git(
             source.path(),
             &[
@@ -104,11 +128,22 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
         );
         assert_eq!(git_output(remote, &["rev-parse", &base]).unwrap(), base);
         assert_eq!(
+            git_output(remote, &["cat-file", "-e", &base_blob]).unwrap(),
+            ""
+        );
+        assert_eq!(
             git_output(remote, &["merge-base", &base, "HEAD"]).unwrap(),
             base
         );
-        assert!(git_output(remote, &["rev-parse", "unrelated-private-tag"]).is_err());
-        assert!(git_output(remote, &["cat-file", "-e", &unrelated]).is_err());
+        assert!(
+            !git_output(
+                source.path(),
+                &["rev-list", "--objects", "--missing=print", &base]
+            )
+            .expect("list hydrated objects")
+            .contains(&format!("?{base_blob}")),
+            "the controller must hydrate the promised object before bundling"
+        );
     });
 }
 
@@ -457,6 +492,19 @@ fn git_materialization_fetches_changed_since_base_before_checkout() {
     assert!(command.contains("checkout --detach abc123"));
     assert!(command.contains("reset --hard"));
     assert!(command.contains("reset --hard abc123"));
+}
+
+#[test]
+fn git_bundle_materialization_disables_lazy_fetches() {
+    let command = git_bundle_install_command(
+        "/srv/homeboy/_lab_workspaces/homeboy-abc",
+        "abc123",
+        None,
+        "https://github.example.invalid/example-org/private-source.git",
+        false,
+    );
+
+    assert!(command.contains("export GIT_NO_LAZY_FETCH=1"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- hydrate the bounded HEAD, resolved changed-since base, and requested-ref object closure on the authenticated controller before creating a Lab git bundle
- disable lazy object fetching while the runner installs controller-complete bundles
- cover a partial/promisor source with a deliberately missing base blob and an unusable runner origin

Fixes #7932.

## How to test
1. Check out this branch from a fresh clone with Rust and Git installed.
2. Run `cargo test --lib core::runner::workspace`.
3. Run `cargo test --lib stage_routes_changed_since_private_source_through_controller_bundle`.
4. Run `cargo fmt --check`.
5. Confirm all commands pass. The workspace suite creates a filtered promisor clone with a promised base-only blob, verifies controller hydration before bundle creation, and materializes the bundle with an unavailable runner `origin`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the promisor bundle failure, drafted the controller hydration and offline materialization changes, and added regression coverage. Chris reviewed and owns the change.