### PR TITLE
fix: recover runner transport agent-task proxies

### DIFF
--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -175,6 +175,13 @@ fn attach_agent_task_status_actionable(value: &mut Value, run_id: &str) {
         CommandNextAction::new("review run", review_command).with_kind(CommandNextActionKind::Show),
     );
 
+    if let Some(command) = transport_proxy_recovery_command(value) {
+        metadata.next_actions.push(
+            CommandNextAction::new("recover runner transport", command)
+                .with_kind(CommandNextActionKind::Repair),
+        );
+    }
+
     if value
         .pointer("/metadata/stale_running")
         .and_then(Value::as_bool)
@@ -190,6 +197,45 @@ fn attach_agent_task_status_actionable(value: &mut Value, run_id: &str) {
     }
 
     attach_actionable_metadata(value, metadata);
+}
+
+fn transport_proxy_recovery_command(value: &Value) -> Option<String> {
+    let kind = value.pointer("/metadata/kind").and_then(Value::as_str)?;
+    if !kind.ends_with("_controller_proxy") {
+        return None;
+    }
+    let runner_id = value
+        .pointer("/metadata/runner_id")
+        .and_then(Value::as_str)?;
+    let job_id = value
+        .pointer("/metadata/runner_job_id")
+        .or_else(|| value.pointer("/metadata/runner_execution_record/job_id"))
+        .and_then(Value::as_str);
+    Some(match job_id {
+        Some(job_id) => format!("homeboy runner job logs {runner_id} {job_id} --follow"),
+        None => format!("homeboy runner connect {runner_id}"),
+    })
+}
+
+#[cfg(test)]
+mod transport_proxy_tests {
+    use super::*;
+
+    #[test]
+    fn transport_proxy_recovery_action_uses_runner_identity_not_provider_backend() {
+        let value = json!({
+            "metadata": {
+                "kind": "remote_controller_proxy",
+                "runner_id": "runner-transport-42",
+                "runner_execution_record": { "job_id": "job-42" }
+            }
+        });
+
+        assert_eq!(
+            transport_proxy_recovery_command(&value),
+            Some("homeboy runner job logs runner-transport-42 job-42 --follow".to_string())
+        );
+    }
 }
 
 fn attach_agent_task_discovery_actionable(value: &mut Value) {

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -47,6 +47,82 @@ fn controller_proxy_status_and_logs_resolve_before_runner_child_is_known() {
 }
 
 #[test]
+fn controller_proxy_run_uses_transport_recovery_without_provider_dispatch() {
+    with_temp_home(|| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        agent_task_lifecycle::record_lab_offload_planned(
+            homeboy::core::agent_tasks::lifecycle::LabOffloadProxyPlan {
+                run_id: "run-cli-transport-proxy",
+                runner_id: "remote-runner-42",
+                remote_workspace: "/runner/workspace/repo",
+                remote_command: &command,
+            },
+        )
+        .expect("controller proxy persisted");
+        let executor = CapturingExecutor::default();
+
+        let error = run_submitted_with_executor(
+            "run-cli-transport-proxy".to_string(),
+            None,
+            executor.clone(),
+        )
+        .expect_err("transport proxy needs runner recovery");
+
+        assert!(error
+            .message
+            .contains("provider execution was not attempted"));
+        assert!(error
+            .hints
+            .iter()
+            .any(|hint| hint.message == "Next: homeboy runner connect remote-runner-42"));
+        assert!(executor
+            .observed_request
+            .lock()
+            .expect("executor lock")
+            .is_none());
+
+        let record =
+            agent_task_lifecycle::status("run-cli-transport-proxy").expect("proxy state preserved");
+        assert_eq!(record.state, AgentTaskRunState::Queued);
+        assert_eq!(record.metadata["retryable"], true);
+        assert_eq!(record.metadata["transport_recovery"], "required");
+    });
+}
+
+#[test]
+fn run_next_leaves_transport_proxy_queued_for_runner_recovery() {
+    with_temp_home(|| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        agent_task_lifecycle::record_lab_offload_planned(
+            homeboy::core::agent_tasks::lifecycle::LabOffloadProxyPlan {
+                run_id: "run-cli-queued-proxy",
+                runner_id: "remote-runner-42",
+                remote_workspace: "/runner/workspace/repo",
+                remote_command: &command,
+            },
+        )
+        .expect("controller proxy persisted");
+        let executor = CapturingExecutor::default();
+
+        let (_, exit_code) =
+            run_next_with_executor(executor.clone()).expect("run-next skips proxy");
+
+        assert_eq!(exit_code, 0);
+        assert!(executor
+            .observed_request
+            .lock()
+            .expect("executor lock")
+            .is_none());
+        assert_eq!(
+            agent_task_lifecycle::status("run-cli-queued-proxy")
+                .expect("proxy status")
+                .state,
+            AgentTaskRunState::Queued
+        );
+    });
+}
+
+#[test]
 fn submit_run_status_reports_terminal_state() {
     with_temp_home(|| {
         let plan = AgentTaskPlan::new(

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -997,6 +997,9 @@ fn resume_command_executes_existing_run() {
 #[test]
 fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
     with_temp_home(|| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        init_runtime_component_checkout(workspace.path());
+        let workspace_root = workspace.path().display().to_string();
         let observed_request = Arc::new(Mutex::new(None));
         let executor = CapturingExecutor {
             observed_request: Arc::clone(&observed_request),
@@ -1010,7 +1013,7 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
             Some("https://github.com/example/sample-agent-runtime/issues/179".to_string());
         plan.tasks[0].workspace.cleanup = Some("preserve".to_string());
         plan.tasks[0].workspace.materialization = json!({
-            "root": "/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance"
+            "root": workspace_root
         });
 
         let (_value, exit_code) =
@@ -1028,7 +1031,7 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
         );
         assert_eq!(
             observed.workspace.root.as_deref(),
-            Some("/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance")
+            Some(workspace_root.as_str())
         );
         assert_eq!(
             observed.workspace.slug.as_deref(),

--- a/src/commands/agent_task/tests/support.rs
+++ b/src/commands/agent_task/tests/support.rs
@@ -24,7 +24,7 @@ pub(in crate::commands::agent_task) use super::super::controller::{
 };
 pub(in crate::commands::agent_task) use super::super::run::{
     retry, run_cook_with_executor, run_loaded_plan, run_next_with_executor,
-    run_resume_with_executor, run_submitted, submit,
+    run_resume_with_executor, run_submitted, run_submitted_with_executor, submit,
 };
 pub(in crate::commands::agent_task) use super::super::status::{
     cancel, diagnose, evidence, logs, replay_provider_boundary, status,

--- a/src/commands/agent_task_summary/mod.rs
+++ b/src/commands/agent_task_summary/mod.rs
@@ -121,12 +121,32 @@ fn render_status_summary(payload: &Value) -> Option<String> {
     if let Some(path) = aggregate_path.filter(|_| metrics.non_empty_patches > 0) {
         lines.push(format!("Aggregate: {path}"));
         lines.push(format!("Next: homeboy agent-task review {run_id}"));
-    } else if state == "queued" {
+    } else if state == "queued" && !is_transport_proxy(payload) {
         lines.push(format!("Next: homeboy agent-task run {run_id}"));
+    } else if let Some(action) = transport_proxy_next_action(payload) {
+        lines.push(format!("Next: {action}"));
     } else {
         lines.push(format!("Next: homeboy agent-task logs {run_id}"));
     }
     Some(finish(lines))
+}
+
+fn is_transport_proxy(payload: &Value) -> bool {
+    string_value(payload, &["metadata", "kind"])
+        .is_some_and(|kind| kind.ends_with("_controller_proxy"))
+}
+
+fn transport_proxy_next_action(payload: &Value) -> Option<String> {
+    if !is_transport_proxy(payload) {
+        return None;
+    }
+    let runner_id = string_value(payload, &["metadata", "runner_id"])?;
+    let job_id = string_value(payload, &["metadata", "runner_job_id"])
+        .or_else(|| string_value(payload, &["metadata", "runner_execution_record", "job_id"]));
+    Some(match job_id {
+        Some(job_id) => format!("homeboy runner job logs {runner_id} {job_id} --follow"),
+        None => format!("homeboy runner connect {runner_id}"),
+    })
 }
 
 fn render_logs_summary(payload: &Value) -> Option<String> {
@@ -811,6 +831,25 @@ mod tests {
         assert!(summary.contains("Patch candidates: 0 non-empty / 0 empty\n"));
         assert!(summary.contains("Artifacts: 0\n"));
         assert!(summary.contains("Next: homeboy agent-task run homeboy-4345\n"));
+    }
+
+    #[test]
+    fn status_summary_never_advertises_provider_run_for_transport_proxy() {
+        let payload = json!({
+            "run_id": "homeboy-transport",
+            "state": "queued",
+            "tasks": [{ "task_id": "homeboy-transport" }],
+            "artifact_refs": [],
+            "metadata": {
+                "kind": "remote_controller_proxy",
+                "runner_id": "runner-transport-42"
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(!summary.contains("homeboy agent-task run homeboy-transport"));
+        assert!(summary.contains("Next: homeboy runner connect runner-transport-42"));
     }
 
     #[test]

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -130,7 +130,7 @@ where
 pub fn claim_next_queued_run() -> Result<Option<AgentTaskRunRecord>> {
     let mut queued: Vec<AgentTaskRunRecord> = store::read_records()?
         .into_iter()
-        .filter(|record| record.state == AgentTaskRunState::Queued)
+        .filter(|record| record.state == AgentTaskRunState::Queued && !is_transport_proxy(record))
         .collect();
     queued.sort_by(|left, right| {
         left.submitted_at
@@ -225,7 +225,7 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
 }
 
 fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) {
-    if record.state != AgentTaskRunState::Running {
+    if is_terminal_run_state(record.state) {
         return;
     }
     let (Some(runner_id), Some(job_id)) = (
@@ -247,6 +247,141 @@ fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) {
         }
     };
     reconcile_runner_job_snapshot(record, &snapshot);
+}
+
+/// A controller proxy is a transport handoff, not an agent provider task. Its
+/// synthetic plan task identifies the runner so the durable record remains
+/// inspectable, but must never reach provider lookup on the controller.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TransportProxyRecovery {
+    Reconciled {
+        record: AgentTaskRunRecord,
+        next_action: String,
+    },
+    ReconnectRequired {
+        record: AgentTaskRunRecord,
+        next_action: String,
+    },
+}
+
+impl TransportProxyRecovery {
+    pub fn record(&self) -> &AgentTaskRunRecord {
+        match self {
+            Self::Reconciled { record, .. } | Self::ReconnectRequired { record, .. } => record,
+        }
+    }
+
+    pub fn next_action(&self) -> &str {
+        match self {
+            Self::Reconciled { next_action, .. } | Self::ReconnectRequired { next_action, .. } => {
+                next_action
+            }
+        }
+    }
+}
+
+/// Reconnect a transport-owned proxy through its durable runner execution
+/// record. `None` means the run is a normal scheduler-owned plan.
+pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyRecovery>> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    if !is_transport_proxy(&record) {
+        return Ok(None);
+    }
+
+    let Some(runner_id) = transport_proxy_runner_id(&record) else {
+        return Ok(None);
+    };
+    let runner_job_id = transport_proxy_runner_job_id(&record);
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("retryable".to_string(), json!(true));
+    metadata.insert("transport_recovery".to_string(), json!("required"));
+    metadata.insert("runner_id".to_string(), json!(&runner_id));
+
+    let Some(runner_job_id) = runner_job_id else {
+        store::write_record(&record)?;
+        return Ok(Some(TransportProxyRecovery::ReconnectRequired {
+            record,
+            next_action: format!("homeboy runner connect {runner_id}"),
+        }));
+    };
+
+    metadata.insert("runner_job_id".to_string(), json!(&runner_job_id));
+
+    match crate::core::runners::runner_job_log_snapshot(&runner_id, &runner_job_id) {
+        Ok(snapshot) => {
+            reconcile_transport_proxy_snapshot(&mut record, &snapshot);
+            store::write_record(&record)?;
+            Ok(Some(TransportProxyRecovery::Reconciled {
+                record,
+                next_action: format!(
+                    "homeboy runner job logs {runner_id} {runner_job_id} --follow"
+                ),
+            }))
+        }
+        Err(_) => {
+            record.annotate_runner_disconnected();
+            store::write_record(&record)?;
+            Ok(Some(TransportProxyRecovery::ReconnectRequired {
+                record,
+                next_action: format!("homeboy runner connect {runner_id}"),
+            }))
+        }
+    }
+}
+
+pub(crate) fn reconcile_transport_proxy_snapshot(
+    record: &mut AgentTaskRunRecord,
+    snapshot: &crate::core::runner::RunnerJobLogSnapshot,
+) {
+    if record.state == AgentTaskRunState::Queued {
+        set_run_state(record, AgentTaskRunState::Running);
+        for task in &mut record.tasks {
+            if task.state == AgentTaskState::Queued {
+                task.state = AgentTaskState::Running;
+            }
+        }
+    }
+    reconcile_runner_job_snapshot(record, snapshot);
+}
+
+fn is_transport_proxy(record: &AgentTaskRunRecord) -> bool {
+    record
+        .metadata
+        .get("kind")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| kind.ends_with("_controller_proxy"))
+}
+
+fn transport_proxy_runner_id(record: &AgentTaskRunRecord) -> Option<String> {
+    record.runner_id().map(str::to_string).or_else(|| {
+        record
+            .metadata
+            .get("runner_execution_record")
+            .and_then(|value| {
+                serde_json::from_value::<
+                    crate::core::runner_execution_envelope::RunnerExecutionRecord,
+                >(value.clone())
+                .ok()
+            })
+            .map(|execution| execution.runner_id)
+            .filter(|runner_id| !runner_id.trim().is_empty())
+    })
+}
+
+fn transport_proxy_runner_job_id(record: &AgentTaskRunRecord) -> Option<String> {
+    record.runner_job_id().map(str::to_string).or_else(|| {
+        record
+            .metadata
+            .get("runner_execution_record")
+            .and_then(|value| {
+                serde_json::from_value::<
+                    crate::core::runner_execution_envelope::RunnerExecutionRecord,
+                >(value.clone())
+                .ok()
+            })
+            .and_then(|execution| execution.job_id)
+            .filter(|job_id| !job_id.trim().is_empty())
+    })
 }
 
 pub(crate) fn reconcile_runner_job_snapshot(
@@ -806,6 +941,13 @@ pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
         artifacts: aggregate_artifacts(aggregate.as_ref()),
         evidence_refs: aggregate_evidence_refs(aggregate.as_ref(), latest_executor_evidence),
     })
+}
+
+/// Read the aggregate after a transport reconciliation completed it without
+/// scheduling the controller-side synthetic handoff task.
+pub fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
+    let run_id = resolve_run_id(run_id)?;
+    store::read_aggregate(&run_id)
 }
 
 pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -370,6 +370,46 @@ fn controller_proxy_becomes_terminal_when_handoff_fails_before_child_creation() 
 }
 
 #[test]
+fn transport_proxy_snapshot_reconciliation_advances_queued_lifecycle() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "agent-task-disconnected-child",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("planned proxy");
+        let job_id = "00000000-0000-0000-0000-000000000123";
+        let metadata = record.ensure_metadata_object();
+        metadata.insert("runner_job_id".to_string(), json!(job_id));
+        metadata.insert(
+            "runner_execution_record".to_string(),
+            serde_json::to_value(
+                crate::core::runner_execution_envelope::RunnerExecutionRecord::in_flight(
+                    job_id,
+                    "homeboy-lab",
+                    "daemon",
+                )
+                .with_job_id(job_id),
+            )
+            .expect("execution record"),
+        );
+
+        let aggregate = succeeded_aggregate(&test_plan());
+        reconcile_transport_proxy_snapshot(&mut record, &terminal_child_snapshot(&aggregate));
+
+        assert_eq!(record.state, AgentTaskRunState::Succeeded);
+        assert_eq!(record.tasks[0].state, AgentTaskState::Succeeded);
+        assert_eq!(record.metadata["runner_job_status"], "succeeded");
+        assert_eq!(
+            record.metadata["runner_execution_record"]["status"],
+            "succeeded"
+        );
+    });
+}
+
+#[test]
 fn detached_runner_failure_transitions_parent_and_task_terminal() {
     let plan = test_plan();
     let mut record = AgentTaskRunRecord {

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -88,6 +88,27 @@ pub fn run_submitted_with_timeout<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
+    if let Some(recovery) = agent_task_lifecycle::recover_transport_proxy(&run_id)? {
+        if let Ok(aggregate) = agent_task_lifecycle::read_aggregate(&recovery.record().run_id) {
+            return Ok(AgentTaskRunResult {
+                exit_code: aggregate_exit_code(&aggregate),
+                value: aggregate,
+            });
+        }
+        return Err(
+            Error::validation_invalid_argument(
+                "run_id",
+                format!(
+                    "agent-task run '{}' is owned by runner transport recovery; provider execution was not attempted",
+                    recovery.record().run_id
+                ),
+                Some(recovery.record().run_id.clone()),
+                None,
+            )
+            .with_hint(format!("Next: {}", recovery.next_action()))
+            .with_retryable(true),
+        );
+    }
     let mut plan = agent_task_lifecycle::load_plan(&run_id)?;
     if let Some(timeout_ms) = timeout_ms {
         plan.options.timeout_ms = Some(timeout_ms);


### PR DESCRIPTION
## Summary
- classify durable controller proxy records as runner transport recovery rather than provider work
- reconcile a declared runner job before scheduler dispatch, and preserve retryable proxy state with a reconnect action when no job can be reached
- keep queued transport proxies out of `agent-task run-next` and replace generic run guidance with executable runner recovery commands

Fixes #7937

## Testing
1. From a fresh checkout, run `cargo fmt --check`.
2. Run `cargo test controller_proxy_run_uses_transport_recovery_without_provider_dispatch --lib`.
3. Run `cargo test run_next_leaves_transport_proxy_queued_for_runner_recovery --lib`.
4. Run `cargo test transport_proxy_snapshot_reconciliation_advances_queued_lifecycle --lib`.
5. Run `cargo test agent_task --lib -- --test-threads=1`.

## Compatibility
- Existing non-proxy agent-task runs retain their scheduler/provider behavior.
- Controller records whose metadata kind ends in `_controller_proxy` now use their declared runner execution identity for recovery instead of treating a runner identifier as an extension provider.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode, OpenAI gpt-5.6-terra
- **Used for:** Investigated the persisted proxy lifecycle, implemented the transport-aware recovery guard, and added behavioral coverage with human-directed requirements.