### PR TITLE
Persist terminal diagnostics when runner jobs disappear

### DIFF
--- a/src/core/runner/evidence/mirror.rs
+++ b/src/core/runner/evidence/mirror.rs
@@ -2,11 +2,11 @@ use std::fs;
 
 use serde_json::{json, Value};
 
-use crate::core::api_jobs::{Job, JobArtifactMetadata, JobEvent};
+use crate::core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobStatus};
 use crate::core::error::{Error, Result};
 use crate::core::execution_contract::{encode_uri_component, EXECUTION_CONTRACT};
 use crate::core::notification_route::NotificationRoute;
-use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
+use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord, RunStatus};
 use crate::core::redaction::redact_argv_display;
 use crate::core::runner::agent_task_lifecycle_event::{
     agent_task_run_plan_lifecycle_event_from_job_events,
@@ -137,6 +137,41 @@ pub fn mirror_daemon_job_progress(
         run_id,
         None,
     )
+}
+
+/// Records that the controller can no longer observe an accepted runner job.
+/// The remote job may still exist, but the controller-side lifecycle is terminal
+/// and includes the polling diagnostic instead of leaving a stale running mirror.
+pub fn terminalize_mirrored_daemon_job(
+    runner: &Runner,
+    cwd: &str,
+    command: &[String],
+    job: &Job,
+    run_id: Option<&str>,
+    diagnostic: &Value,
+) -> Result<RunRecord> {
+    let store = ObservationStore::open_initialized()?;
+    let mut terminal_job = job.clone();
+    terminal_job.status = JobStatus::Failed;
+    terminal_job.finished_at_ms = Some(terminal_job.updated_at_ms.max(terminal_job.created_at_ms));
+    let run = mirror_job_run(
+        &store,
+        runner,
+        cwd,
+        command,
+        &terminal_job,
+        &[],
+        &json!({}),
+        run_id,
+        None,
+    )?;
+    let mut metadata = run.metadata_json;
+    metadata["lab"]["controller_terminal"] = json!({
+        "status": "failed",
+        "reason": "runner_job_unobservable",
+        "diagnostic": diagnostic,
+    });
+    store.finish_run(&run.id, RunStatus::Fail, Some(metadata))
 }
 
 pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRecord>>> {

--- a/src/core/runner/evidence/mod.rs
+++ b/src/core/runner/evidence/mod.rs
@@ -18,6 +18,6 @@ pub use download::{download_remote_artifact, RemoteArtifactDownload};
 pub use mirror::{
     mirror_connected_runner_run, mirror_daemon_evidence, mirror_daemon_job_progress,
     mirror_reverse_broker_evidence, mirrored_runner_job_identity, refresh_mirrored_daemon_evidence,
-    runner_job_log_snapshot, RunnerJobLogSnapshot,
+    runner_job_log_snapshot, terminalize_mirrored_daemon_job, RunnerJobLogSnapshot,
 };
 pub(crate) use util::{local_job_run_id, runner_exec_run_label};

--- a/src/core/runner/execution/broker.rs
+++ b/src/core/runner/execution/broker.rs
@@ -167,7 +167,18 @@ pub(super) fn exec_via_reverse_broker(
         std::thread::sleep(Duration::from_millis(200));
         let job_id = job.id.to_string();
         job = fetch_daemon_job_resilient(&client, broker_url, &job_id).map_err(|err| {
-            daemon_job_context_error(&runner.id, &job_id, persisted_run_id.as_deref(), err)
+            terminal_runner_poll_failure(
+                runner,
+                &cwd,
+                &command,
+                &job,
+                "reverse_broker",
+                path_materialization_plan.as_ref(),
+                &source_snapshot,
+                &require_paths,
+                persisted_run_id.as_deref(),
+                err,
+            )
         })?;
     }
     let events = redact_runner_job_events(

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -18,6 +18,7 @@ use super::super::capabilities::{
 use super::super::daemon_http_get::daemon_get;
 use super::super::evidence::{
     local_job_run_id, mirror_daemon_evidence, mirror_daemon_job_progress, runner_exec_run_label,
+    terminalize_mirrored_daemon_job,
 };
 use super::super::resource_metrics::RunnerResourceMetrics;
 use super::super::{Runner, RunnerCapabilityPreflight, RunnerJob, RunnerKind};
@@ -183,7 +184,18 @@ pub(super) fn exec_via_daemon(
         std::thread::sleep(Duration::from_millis(200));
         let job_id = job.id.to_string();
         job = fetch_daemon_job_resilient(&client, local_url, &job_id).map_err(|err| {
-            daemon_job_context_error(&runner.id, &job_id, persisted_run_id.as_deref(), err)
+            terminal_runner_poll_failure(
+                runner,
+                &cwd,
+                &command,
+                &job,
+                "daemon",
+                path_materialization_plan.as_ref(),
+                &source_snapshot,
+                &require_paths,
+                persisted_run_id.as_deref(),
+                err,
+            )
         })?;
     }
     let job_id = job.id.to_string();
@@ -590,6 +602,73 @@ pub(super) fn daemon_job_context_error(
     }
     with_context.retryable = Some(true);
     with_context
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn terminal_runner_poll_failure(
+    runner: &Runner,
+    cwd: &str,
+    command: &[String],
+    job: &Job,
+    transport: &str,
+    path_materialization_plan: Option<&PathMaterializationPlan>,
+    source_snapshot: &SourceSnapshot,
+    _require_paths: &[String],
+    persisted_run_id: Option<&str>,
+    source: Error,
+) -> Error {
+    let job_id = job.id.to_string();
+    let mut error = daemon_job_context_error(&runner.id, &job_id, persisted_run_id, source);
+    error.retryable = Some(false);
+    error.details["status"] = Value::String("terminal_failure".to_string());
+    error.details["reason"] = Value::String("runner_job_unobservable".to_string());
+
+    let diagnostic = json!({
+        "error_code": error.code.as_str(),
+        "message": error.message.clone(),
+        "details": error.details.clone(),
+    });
+    let mirror_run_id = match terminalize_mirrored_daemon_job(
+        runner,
+        cwd,
+        command,
+        job,
+        persisted_run_id,
+        &diagnostic,
+    ) {
+        Ok(run) => Some(run.id),
+        Err(persistence_error) => {
+            error = error.with_hint(format!(
+                "Could not persist terminal controller diagnostics for runner job `{job_id}`: {}",
+                persistence_error.message
+            ));
+            None
+        }
+    };
+    let record = RunnerExecutionRecord::terminal(job_id.clone(), runner.id.clone(), transport, 1)
+        .with_job_id(job_id.clone())
+        .with_mirror_run_id(mirror_run_id.clone())
+        .with_path_materialization_plan(path_materialization_plan.cloned())
+        .with_orchestration_provenance(orchestration_target_provenance(
+            runner,
+            None,
+            Some(source_snapshot),
+            &[],
+        ))
+        .with_next_actions(runner_execution_next_actions(&runner.id, &job_id));
+    if let Err(persistence_error) = persist_runner_execution_transition(&record, cwd, command) {
+        error = error.with_hint(format!(
+            "Could not persist the terminal runner execution record for job `{job_id}`: {}",
+            persistence_error.message
+        ));
+    }
+    if let Some(run_id) = mirror_run_id {
+        error.details["persisted_run_id"] = Value::String(run_id.clone());
+        error = error.with_hint(format!(
+            "Persisted terminal controller diagnostics as run `{run_id}`; inspect it with `homeboy runs show {run_id}`."
+        ));
+    }
+    error
 }
 
 pub(super) fn lab_terminal_result_transport_error(

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -365,6 +365,66 @@ fn lab_offload_handoff_persists_run_when_job_is_accepted() {
 }
 
 #[test]
+fn accepted_job_that_disappears_persists_a_terminal_controller_failure() {
+    crate::test_support::with_isolated_home(|_| {
+        let runner = ssh_runner();
+        let job = running_job();
+        let job_id = job.id.to_string();
+        let command = vec![
+            "homeboy".to_string(),
+            "runtime".to_string(),
+            "refresh".to_string(),
+        ];
+        let run_id =
+            persist_lab_offload_handoff_run(&runner, "/srv/homeboy/project", &command, &job, None)
+                .expect("accepted handoff mirror");
+
+        let err = terminal_runner_poll_failure(
+            &runner,
+            "/srv/homeboy/project",
+            &command,
+            &job,
+            "daemon",
+            None,
+            &SourceSnapshot::existing_remote("lab", "/srv/homeboy/project", Some("/srv/homeboy")),
+            &[],
+            Some(&run_id),
+            Error::internal_unexpected("daemon returned no active job for the accepted id"),
+        );
+
+        assert_eq!(err.code, ErrorCode::RunnerControllerDisconnected);
+        assert_eq!(err.retryable, Some(false));
+        assert_eq!(err.details["status"], "terminal_failure");
+        assert_eq!(err.details["reason"], "runner_job_unobservable");
+        assert_eq!(err.details["persisted_run_id"], run_id);
+
+        let store = crate::core::observation::ObservationStore::open_initialized().expect("store");
+        let run = store
+            .get_run(&run_id)
+            .expect("read terminal mirror")
+            .expect("terminal mirror");
+        assert_eq!(run.status, "fail");
+        assert_eq!(run.metadata_json["lab"]["remote_job"]["id"], job_id);
+        assert_eq!(
+            run.metadata_json["lab"]["controller_terminal"]["reason"],
+            "runner_job_unobservable"
+        );
+
+        let records = store
+            .list_runs(crate::core::observation::RunListFilter {
+                kind: Some("runner_execution".to_string()),
+                ..Default::default()
+            })
+            .expect("runner execution records");
+        assert!(records.iter().any(|record| {
+            record.status == "fail"
+                && record.metadata_json["runner_execution_record"]["job_id"] == job_id
+                && record.metadata_json["runner_execution_record"]["status"] == "failed"
+        }));
+    });
+}
+
+#[test]
 fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
     crate::test_support::with_isolated_home(|_| {
         allow_unauthenticated_loopback_broker();


### PR DESCRIPTION
## Summary

Fixes #7933.

After a runner accepts an execution, daemon and reverse-broker polling failures now terminalize the controller-side lifecycle instead of leaving a durable mirror in `running` forever. The terminal result preserves the accepted job identity, records the polling diagnostic, marks the mirror failed, and persists a failed generic runner-execution record with recovery actions.

This is transport-generic and does not contain runtime, WordPress, or WP Codebox behavior. It unblocks the validation workflow associated with Extra-Chill/homeboy-extensions#2240.

## Testing

1. From a fresh checkout, run `cargo test accepted_job_that_disappears_persists_a_terminal_controller_failure -- --nocapture`.
2. Confirm the test simulates an accepted runner handoff followed by an unobservable job and verifies the durable mirror is `fail`, contains `lab.controller_terminal.reason=runner_job_unobservable`, and has a failed `runner_execution` record.
3. Run `cargo fmt --check`.

`cargo clippy --lib --tests -- -D warnings` remains blocked by existing baseline violations outside this change. The focused handoff-module run also has two pre-existing reverse-broker loopback submission timeouts; the new behavioral test passes.

## Rollout

No data migration is required. Deploy a Homeboy build containing this commit to both the controller and the runner daemon, then reconnect the runner so accepted jobs use the updated lifecycle code.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Investigated, drafted implementation, and ran verification with Chris responsible for review and merge.
