### PR TITLE
Fix nested Lab cook daemon recursion

### DIFF
--- a/src/core/runner/execution/process.rs
+++ b/src/core/runner/execution/process.rs
@@ -357,6 +357,11 @@ pub(crate) fn prepare_daemon_local_process(
     runner.env = runner_env.clone();
     env = runner_env;
     env.extend(request_env.clone());
+    // Daemon jobs already execute in the runner namespace. Nested Homeboy
+    // commands must stay local instead of treating the controller's runner
+    // configuration as another Lab offload target.
+    env.insert(RUNNER_HOSTED_EXEC_ENV.to_string(), "1".to_string());
+    env.insert(RUNNER_ID_ENV.to_string(), runner.id.clone());
     env.extend(resolve_runner_secret_env_for_plan(
         &runner.secret_env,
         &secret_env_plan,

--- a/src/core/runner/execution/tests/prepare.rs
+++ b/src/core/runner/execution/tests/prepare.rs
@@ -235,6 +235,47 @@ fn local_runner_prep_does_not_mark_commands_as_runner_hosted() {
 }
 
 #[test]
+fn daemon_worker_marks_nested_cook_as_runner_hosted() {
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("project");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        let mut runner = local_runner(workspace.display().to_string());
+        runner.id = "homeboy-lab".to_string();
+
+        let plan = prepare_daemon_local_process(RunnerProcessRequest {
+            runner_id: "homeboy-lab".to_string(),
+            runner: Some(runner),
+            cwd: Some(workspace.display().to_string()),
+            project_id: None,
+            command: vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ],
+            env: Default::default(),
+            secret_env_names: Vec::new(),
+            secret_env_plan: None,
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: true,
+        })
+        .expect("prepare daemon worker process");
+
+        assert_eq!(
+            plan.env.get(RUNNER_HOSTED_EXEC_ENV).map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            plan.env.get(RUNNER_ID_ENV).map(String::as_str),
+            Some("homeboy-lab")
+        );
+    });
+}
+
+#[test]
 fn runner_prep_drops_undeclared_sensitive_env() {
     crate::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary
- Mark daemon-launched commands as runner-hosted so nested Lab cooks execute in the already-materialized runner namespace.
- Preserve the assigned runner identity for the original controller handoff and its durable proxy run.

## How to test
1. Clone `Extra-Chill/homeboy`, check out this branch, and run `cargo fmt --check`.
2. Run `cargo test daemon_worker_marks_nested_cook_as_runner_hosted --lib`.
3. Run `cargo test controller_proxy_status_and_logs_resolve_before_runner_child_is_known --lib`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and openai/gpt-5.6-sol
- **Used for:** Investigated the daemon-worker Lab handoff, drafted the runner-namespace guard and regression coverage, and ran focused verification.
