### PR TITLE
fix: bound project deploy execution phases

### DIFF
--- a/src/core/deploy/orchestration_ref_checkout.rs
+++ b/src/core/deploy/orchestration_ref_checkout.rs
@@ -1,8 +1,11 @@
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
 use crate::core::git;
+
+const REMOTE_REF_QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ExactRefIdentity {
@@ -247,11 +250,18 @@ fn resolve_remote_commit(
     let transport_env = component_transport_env(component, &remote_url);
 
     if is_full_sha(requested_ref) {
-        if git::run_git_with_env(
+        log_status!(
+            "deploy",
+            "phase=exact_ref_fetch component={} ref={}",
+            component_id,
+            requested_ref
+        );
+        if git::run_git_with_env_timeout(
             source_root,
             &["fetch", "--no-tags", &remote, requested_ref],
             "fetch exact deploy SHA",
             &transport_env,
+            REMOTE_REF_QUERY_TIMEOUT,
         )
         .is_ok()
         {
@@ -285,11 +295,18 @@ fn resolve_remote_commit(
         component_id,
         &transport_env,
     )?;
-    git::run_git_with_env(
+    log_status!(
+        "deploy",
+        "phase=exact_ref_fetch component={} ref={}",
+        component_id,
+        requested_ref
+    );
+    git::run_git_with_env_timeout(
         source_root,
         &["fetch", "--no-tags", &remote, &remote_ref],
         "fetch named exact deploy ref",
         &transport_env,
+        REMOTE_REF_QUERY_TIMEOUT,
     )
     .map_err(|err| remote_transport_error(&remote, component_id, &err))?;
     let sha = git::run_git(
@@ -322,11 +339,18 @@ fn resolve_named_remote_ref(
     } else {
         vec!["ls-remote", "--refs", remote, requested_ref]
     };
-    let output = git::run_git_with_env(
+    log_status!(
+        "deploy",
+        "phase=exact_ref_remote_query component={} ref={}",
+        component_id,
+        requested_ref
+    );
+    let output = git::run_git_with_env_timeout(
         source_root,
         &args,
         "query named exact deploy ref",
         transport_env,
+        REMOTE_REF_QUERY_TIMEOUT,
     )
     .map_err(|err| remote_transport_error(remote, component_id, &err))?;
     let candidates: Vec<&str> = output

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::core::artifact_inputs::{self, ResolvedArtifactInput};
 use crate::core::component::{self, Component};
@@ -15,6 +16,9 @@ use crate::core::extension::{
 use crate::core::output::{BulkResult, BulkResultBuilder};
 use crate::core::paths;
 use crate::core::server::execute_local_command_in_dir;
+
+const DEFAULT_BUILD_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const BUILD_TIMEOUT_ENV: &str = "HOMEBOY_BUILD_TIMEOUT_SECS";
 
 mod artifact;
 
@@ -501,8 +505,15 @@ fn execute_build_component(
     // Execute via ExtensionRunner — uses the full exec context protocol (settings,
     // project info, context version) instead of the minimal env var set.
     let run_dir = RunDir::create()?;
+    let build_timeout = build_timeout();
+    log_status!(
+        "build",
+        "phase=build component={} timeout={}s; streaming build output",
+        comp.id,
+        build_timeout.as_secs()
+    );
     let runner_output = if let ResolvedBuildCommand::ComponentScript { .. } = &resolved {
-        crate::core::extension::component_script::run_component_scripts_with_run_dir(
+        crate::core::extension::component_script::run_component_scripts_with_run_dir_and_timeout(
             comp,
             extension::ExtensionCapability::Build,
             &validated_path,
@@ -510,6 +521,7 @@ fn execute_build_component(
             true,
             &build_env(changed_since, changed_scope.as_ref()),
             &[],
+            Some(build_timeout),
         )?
         .into()
     } else if let Some(context) = build_context {
@@ -518,6 +530,7 @@ fn execute_build_component(
             .working_dir(&local_path_str)
             .command_override(build_cmd.clone())
             .with_run_dir(&run_dir)
+            .timeout(Some(build_timeout))
             // Legacy env var for backward compat with existing build scripts
             .env("HOMEBOY_PLUGIN_PATH", &comp.local_path);
         for (key, value) in build_env(changed_since, changed_scope.as_ref()) {
@@ -532,6 +545,7 @@ fn execute_build_component(
             .working_dir(&local_path_str)
             .command_override(build_cmd.clone())
             .with_run_dir(&run_dir)
+            .timeout(Some(build_timeout))
             .env("HOMEBOY_PLUGIN_PATH", &comp.local_path);
         for (key, value) in build_env(changed_since, changed_scope.as_ref()) {
             runner = runner.env(&key, &value);
@@ -560,6 +574,18 @@ fn execute_build_component(
         },
         runner_output.exit_code,
     ))
+}
+
+fn build_timeout() -> Duration {
+    build_timeout_from(std::env::var(BUILD_TIMEOUT_ENV).ok().as_deref())
+}
+
+fn build_timeout_from(value: Option<&str>) -> Duration {
+    value
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_BUILD_TIMEOUT)
 }
 
 fn resolve_changed_scope(
@@ -813,6 +839,18 @@ fn run_pre_build_scripts(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_timeout_preserves_long_default_and_accepts_override() {
+        assert_eq!(build_timeout_from(None), Duration::from_secs(30 * 60));
+        assert_eq!(build_timeout_from(Some("7200")), Duration::from_secs(7200));
+        assert_eq!(build_timeout_from(Some("0")), Duration::from_secs(30 * 60));
+        assert_eq!(
+            build_timeout_from(Some("invalid")),
+            Duration::from_secs(30 * 60)
+        );
+    }
+
     #[test]
     fn is_json_input_detects_json() {
         assert!(is_json_input(r#"{"componentIds": ["a"]}"#));

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::core::component::Component;
 use crate::core::engine::invocation::{InvocationGuard, InvocationRequirements};
@@ -55,16 +56,25 @@ pub fn run_component_scripts(
     source_path: &Path,
     passthrough: bool,
 ) -> Result<ComponentScriptOutput> {
-    run_component_scripts_with_env(component, capability, source_path, passthrough, &[], &[])
+    run_component_scripts_with_env_and_timeout(
+        component,
+        capability,
+        source_path,
+        passthrough,
+        &[],
+        &[],
+        None,
+    )
 }
 
-pub(crate) fn run_component_scripts_with_env(
+fn run_component_scripts_with_env_and_timeout(
     component: &Component,
     capability: ExtensionCapability,
     source_path: &Path,
     passthrough: bool,
     extra_env: &[(String, String)],
     script_args: &[String],
+    timeout: Option<Duration>,
 ) -> Result<ComponentScriptOutput> {
     let commands = component.script_commands(capability);
     if commands.is_empty() {
@@ -108,7 +118,7 @@ pub(crate) fn run_component_scripts_with_env(
             super::execution::CapabilityScriptOptions {
                 passthrough,
                 stderr_passthrough: false,
-                timeout: None,
+                timeout,
             },
         )?;
 
@@ -141,6 +151,25 @@ pub(crate) fn run_component_scripts_with_env(
     })
 }
 
+pub(crate) fn run_component_scripts_with_env(
+    component: &Component,
+    capability: ExtensionCapability,
+    source_path: &Path,
+    passthrough: bool,
+    extra_env: &[(String, String)],
+    script_args: &[String],
+) -> Result<ComponentScriptOutput> {
+    run_component_scripts_with_env_and_timeout(
+        component,
+        capability,
+        source_path,
+        passthrough,
+        extra_env,
+        script_args,
+        None,
+    )
+}
+
 pub(crate) fn run_component_scripts_with_run_dir(
     component: &Component,
     capability: ExtensionCapability,
@@ -150,17 +179,40 @@ pub(crate) fn run_component_scripts_with_run_dir(
     extra_env: &[(String, String)],
     script_args: &[String],
 ) -> Result<ComponentScriptOutput> {
+    run_component_scripts_with_run_dir_and_timeout(
+        component,
+        capability,
+        source_path,
+        run_dir,
+        passthrough,
+        extra_env,
+        script_args,
+        None,
+    )
+}
+
+pub(crate) fn run_component_scripts_with_run_dir_and_timeout(
+    component: &Component,
+    capability: ExtensionCapability,
+    source_path: &Path,
+    run_dir: &RunDir,
+    passthrough: bool,
+    extra_env: &[(String, String)],
+    script_args: &[String],
+    timeout: Option<Duration>,
+) -> Result<ComponentScriptOutput> {
     let mut env = run_dir.legacy_env_vars();
     let invocation = InvocationGuard::acquire(run_dir, &InvocationRequirements::default())?;
     env.extend(invocation.env_vars());
     env.extend(extra_env.iter().cloned());
-    let mut output = run_component_scripts_with_env(
+    let mut output = run_component_scripts_with_env_and_timeout(
         component,
         capability,
         source_path,
         passthrough,
         &env,
         script_args,
+        timeout,
     )?;
     output.extension_phase_timings = super::runner::read_extension_phase_timings(run_dir.path())?;
     Ok(output)

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -82,7 +82,7 @@ pub use primitives::{
     clone_repo, clone_repo_at_ref, commit_staged_with_author, default_branch_name,
     default_remote_branch, get_component_path_prefix, get_git_root, git_probe_path,
     has_staged_changes, is_workdir_clean_or_not_git, pull_repo, resolve_default_remote, run_git,
-    run_git_output, run_git_output_with_env, run_git_with_env, stage_all,
+    run_git_output, run_git_output_with_env, run_git_with_env, run_git_with_env_timeout, stage_all,
     update_to_remote_default_branch,
 };
 pub(crate) use primitives::{is_git_repo, is_tracked_path, list_tracked_markdown_files};

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 use crate::core::engine::command;
 use crate::core::error::{Error, GitCommandFailedDetails, Result};
@@ -121,6 +122,92 @@ pub fn run_git_with_env(
         ));
     }
 
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Run Git with a deadline, terminating its isolated process group on expiry.
+///
+/// Remote Git operations can wait indefinitely for a transport or credential
+/// helper. Callers use this only for bounded interactive command phases.
+pub fn run_git_with_env_timeout(
+    git_root: &Path,
+    args: &[&str],
+    context: &str,
+    env: &[(String, String)],
+    timeout: Duration,
+) -> Result<String> {
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .current_dir(git_root)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    command::isolate_process_tree(&mut command);
+    let mut child = command.spawn().map_err(|error| {
+        Error::git_command_failed_with_details(
+            git_failure_message(context, &error.to_string()),
+            GitCommandFailedDetails {
+                command: git_command_display(args),
+                cwd: git_cwd_display(git_root),
+                exit_code: None,
+                stdout: String::new(),
+                stderr: String::new(),
+                io_error: Some(error.to_string()),
+            },
+        )
+    })?;
+    let started = Instant::now();
+    let mut timed_out = false;
+    let output = command::wait_with_bounded_output_until_cancelled(
+        &mut child,
+        command::DEFAULT_CAPTURE_LIMIT_BYTES,
+        || {
+            timed_out = started.elapsed() >= timeout;
+            timed_out
+        },
+    )
+    .map_err(|error| {
+        Error::git_command_failed_with_details(
+            git_failure_message(context, &error.to_string()),
+            GitCommandFailedDetails {
+                command: git_command_display(args),
+                cwd: git_cwd_display(git_root),
+                exit_code: None,
+                stdout: String::new(),
+                stderr: String::new(),
+                io_error: Some(error.to_string()),
+            },
+        )
+    })?
+    .into_output();
+    if !output.status.success() {
+        let mut stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        if timed_out {
+            if !stderr.is_empty() {
+                stderr.push('\n');
+            }
+            stderr.push_str(&format!(
+                "Git phase timed out after {}s; terminated child process group.",
+                timeout.as_secs()
+            ));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Err(Error::git_command_failed_with_details(
+            git_failure_message(context, if stderr.is_empty() { &stdout } else { &stderr }),
+            GitCommandFailedDetails {
+                command: git_command_display(args),
+                cwd: git_cwd_display(git_root),
+                exit_code: output.status.code(),
+                stdout,
+                stderr,
+                io_error: None,
+            },
+        ));
+    }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
@@ -446,6 +533,28 @@ mod tests {
         assert!(err.details["io_error"].as_str().is_some());
         assert_eq!(err.details["stdout"], "");
         assert_eq!(err.details["stderr"], "");
+    }
+
+    #[test]
+    fn bounded_git_command_terminates_hung_child_process_group() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        git(dir.path(), &["init", "-q"]);
+        git(dir.path(), &["config", "alias.hang", "!sleep 10"]);
+
+        let started = Instant::now();
+        let err = run_git_with_env_timeout(
+            dir.path(),
+            &["hang"],
+            "test hung Git phase",
+            &[],
+            Duration::from_millis(50),
+        )
+        .expect_err("hung Git alias should time out");
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(err.details["stderr"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("timed out")));
     }
 
     #[test]

--- a/src/core/server/health.rs
+++ b/src/core/server/health.rs
@@ -6,6 +6,9 @@
 use super::SshClient;
 use crate::core::project::Project;
 use serde::Serialize;
+use std::time::Duration;
+
+const PROJECT_HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 // ============================================================================
 // Types
@@ -116,7 +119,12 @@ fn collect_server_health(client: &SshClient, services: &[String]) -> ServerHealt
     }
 
     let compound_cmd = cmd_parts.join(" && ");
-    let output = client.execute(&compound_cmd);
+    log_status!(
+        "project",
+        "phase=health_probe timeout={}s",
+        PROJECT_HEALTH_PROBE_TIMEOUT.as_secs()
+    );
+    let output = client.execute_with_timeout(&compound_cmd, PROJECT_HEALTH_PROBE_TIMEOUT);
 
     if !output.success && output.stdout.is_empty() {
         // Total SSH failure — return empty health


### PR DESCRIPTION
## Summary
- bound exact-ref remote Git query and fetch phases, terminating child process groups on timeout
- bound project health probing and emit phase diagnostics
- apply a configurable, streaming 30-minute default build timeout to extension and component build scripts

Fixes #7931

## Testing
1. Run `cargo test bounded_git_command_terminates_hung_child_process_group`.
2. Run `cargo test exact_sha_branch_and_tag_resolve_to_immutable_commit`.
3. Run `cargo test build_timeout_preserves_long_default_and_accepts_override`.
4. Run `cargo check`.
5. Run `cargo fmt --check` and `git diff --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode direct general coding subagent, OpenAI GPT-5.6 Sol
- **Used for:** Traced the blocking command paths, drafted the bounded execution changes and regression tests, and ran the focused verification commands.
