### PR TITLE
Fix atomic terminal agent-task persistence

### DIFF
--- a/src/core/agent_task_lifecycle/failure_recording.rs
+++ b/src/core/agent_task_lifecycle/failure_recording.rs
@@ -297,68 +297,73 @@ pub fn record_remote_dispatch_failure(
         aggregate.events = events_for_outcomes(&aggregate.outcomes);
     }
 
-    let (mut record, remote_run_id, remote_plan_path, remote_aggregate_path) =
-        if let Some(record_value) = envelope.get("record") {
-            let mut record: AgentTaskRunRecord = serde_json::from_value(record_value.clone())
-                .map_err(|error| {
-                    Error::internal_json(
-                        error.to_string(),
-                        Some("parse offloaded agent-task dispatch record".to_string()),
-                    )
-                })?;
-            let remote_run_id = record.run_id.clone();
-            let remote_plan_path = record.plan_path.clone();
-            let remote_aggregate_path = record.aggregate_path.clone();
-            let plan = store::read_plan_path(&record.plan_path).unwrap_or_else(|_| {
-                synthetic_remote_dispatch_plan(&run_id, &failure, envelope, &aggregate)
+    let (
+        mut record,
+        remote_run_id,
+        remote_plan_path,
+        remote_aggregate_path,
+        needs_atomic_terminal_commit,
+    ) = if let Some(record_value) = envelope.get("record") {
+        let mut record: AgentTaskRunRecord =
+            serde_json::from_value(record_value.clone()).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse offloaded agent-task dispatch record".to_string()),
+                )
+            })?;
+        let remote_run_id = record.run_id.clone();
+        let remote_plan_path = record.plan_path.clone();
+        let remote_aggregate_path = record.aggregate_path.clone();
+        let plan = store::read_plan_path(&record.plan_path).unwrap_or_else(|_| {
+            synthetic_remote_dispatch_plan(&run_id, &failure, envelope, &aggregate)
+        });
+        record.run_id = run_id.clone();
+        record.plan_path = store::write_plan(&run_id, &plan)?.display().to_string();
+        apply_aggregate_to_record(
+            &mut record,
+            &plan,
+            &aggregate,
+            store::aggregate_path(&run_id)?.display().to_string(),
+        );
+        (
+            record,
+            remote_run_id,
+            remote_plan_path,
+            remote_aggregate_path,
+            true,
+        )
+    } else {
+        let remote_run_id = envelope
+            .get("run_id")
+            .and_then(Value::as_str)
+            .unwrap_or(failure.identity.run_id)
+            .to_string();
+        let remote_plan_path = envelope
+            .get("plan_path")
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| {
+                envelope
+                    .get("plan_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or(&aggregate.plan_id)
+                    .to_string()
             });
-            record.run_id = run_id.clone();
-            record.plan_path = store::write_plan(&run_id, &plan)?.display().to_string();
-            apply_aggregate_to_record(
-                &mut record,
-                &plan,
-                &aggregate,
-                store::write_aggregate(&run_id, &aggregate)?
-                    .display()
-                    .to_string(),
-            );
-            (
-                record,
-                remote_run_id,
-                remote_plan_path,
-                remote_aggregate_path,
-            )
-        } else {
-            let remote_run_id = envelope
-                .get("run_id")
-                .and_then(Value::as_str)
-                .unwrap_or(failure.identity.run_id)
-                .to_string();
-            let remote_plan_path = envelope
-                .get("plan_path")
-                .and_then(Value::as_str)
-                .map(ToString::to_string)
-                .unwrap_or_else(|| {
-                    envelope
-                        .get("plan_id")
-                        .and_then(Value::as_str)
-                        .unwrap_or(&aggregate.plan_id)
-                        .to_string()
-                });
-            let remote_aggregate_path = envelope
-                .get("aggregate_path")
-                .and_then(Value::as_str)
-                .map(ToString::to_string);
-            let plan = synthetic_remote_dispatch_plan(&run_id, &failure, envelope, &aggregate);
-            let mut record = submit_plan(&plan, Some(&run_id))?;
-            record_aggregate(&mut record, &plan, &aggregate)?;
-            (
-                record,
-                remote_run_id,
-                remote_plan_path,
-                remote_aggregate_path,
-            )
-        };
+        let remote_aggregate_path = envelope
+            .get("aggregate_path")
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+        let plan = synthetic_remote_dispatch_plan(&run_id, &failure, envelope, &aggregate);
+        let mut record = submit_plan(&plan, Some(&run_id))?;
+        record_aggregate(&mut record, &plan, &aggregate)?;
+        (
+            record,
+            remote_run_id,
+            remote_plan_path,
+            remote_aggregate_path,
+            false,
+        )
+    };
 
     let provider_run_ids: Vec<String> = record
         .provider_handles
@@ -388,7 +393,11 @@ pub fn record_remote_dispatch_failure(
     );
     metadata.insert("provider_run_ids".to_string(), json!(provider_run_ids));
 
-    store::write_record(&record)?;
+    if needs_atomic_terminal_commit {
+        store::write_aggregate_and_record(&record, &aggregate)?;
+    } else {
+        store::write_record(&record)?;
+    }
     Ok(Some(record))
 }
 
@@ -518,7 +527,7 @@ pub(crate) fn record_aggregate(
     plan: &AgentTaskPlan,
     aggregate: &AgentTaskAggregate,
 ) -> Result<AgentTaskRunRecord> {
-    let aggregate_path = store::write_aggregate(&record.run_id, aggregate)?;
+    let aggregate_path = store::aggregate_path(&record.run_id)?;
     apply_aggregate_to_record(
         record,
         plan,
@@ -530,7 +539,7 @@ pub(crate) fn record_aggregate(
         &aggregate.outcomes,
     )?;
     crate::core::controller_scratch::finalize_run(&record.run_id)?;
-    store::write_record(record)?;
+    store::write_aggregate_and_record(record, aggregate)?;
     Ok(record.clone())
 }
 

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -367,7 +367,7 @@ fn terminal_child_projection_rejects_mismatched_persisted_run_identity() {
 }
 
 #[test]
-fn terminal_projection_rolls_back_aggregate_when_controller_persistence_fails() {
+fn terminal_projection_keeps_prior_commit_when_interrupted_before_commit() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];
         let mut record = record_detached_lab_run(DetachedLabRunRecord {
@@ -394,6 +394,61 @@ fn terminal_projection_rolls_back_aggregate_when_controller_persistence_fails() 
 }
 
 #[test]
+fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retry_is_idempotent() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-disconnected-child",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        store::interrupt_after_terminal_commit_for_test();
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot)
+            .expect_err("interruption after the committed envelope is surfaced");
+
+        assert_eq!(
+            store::read_record("agent-task-disconnected-child")
+                .expect("committed controller projection")
+                .state,
+            AgentTaskRunState::Succeeded
+        );
+        let (status_record, log, artifacts) = std::thread::scope(|scope| {
+            let status_reader = scope.spawn(|| status("agent-task-disconnected-child"));
+            let log_reader = scope.spawn(|| logs("agent-task-disconnected-child"));
+            let artifact_reader = scope.spawn(|| artifacts("agent-task-disconnected-child"));
+            (
+                status_reader
+                    .join()
+                    .expect("status reader")
+                    .expect("committed status"),
+                log_reader
+                    .join()
+                    .expect("log reader")
+                    .expect("committed log"),
+                artifact_reader
+                    .join()
+                    .expect("artifact reader")
+                    .expect("committed artifacts"),
+            )
+        });
+        assert_eq!(status_record.state, AgentTaskRunState::Succeeded);
+        assert_eq!(log.events[0].state, AgentTaskState::Succeeded);
+        assert!(artifacts.artifacts.is_empty());
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("idempotent retry");
+        assert_eq!(record.state, AgentTaskRunState::Succeeded);
+        assert!(store::aggregate_path(&record.run_id)
+            .expect("aggregate path")
+            .exists());
+    });
+}
+
+#[test]
 fn terminal_runner_reconciliation_never_resurrects_a_controller_record() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];
@@ -405,9 +460,18 @@ fn terminal_runner_reconciliation_never_resurrects_a_controller_record() {
             remote_command: &command,
         })
         .expect("running proxy");
+        let before = record.clone();
         let terminal = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
         reconcile_runner_job_snapshot(&mut record, &terminal).expect("terminal reconciliation");
         let terminal_record = record.clone();
+
+        store::write_record(&before).expect("stale running writer is ignored");
+        assert_eq!(
+            status(&record.run_id)
+                .expect("terminal state remains committed")
+                .state,
+            AgentTaskRunState::Succeeded
+        );
 
         let mut running = terminal.clone();
         running.job.status = crate::core::api_jobs::JobStatus::Running;

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -17,6 +17,8 @@ use crate::core::{paths, Error, ErrorCode, Result};
 
 #[cfg(test)]
 static FAIL_NEXT_RECORD_WRITE: AtomicBool = AtomicBool::new(false);
+#[cfg(test)]
+static INTERRUPT_AFTER_TERMINAL_COMMIT: AtomicBool = AtomicBool::new(false);
 
 pub(super) fn write_plan(run_id: &str, plan: &AgentTaskPlan) -> Result<PathBuf> {
     let path = run_dir(run_id)?.join("plan.json");
@@ -31,13 +33,14 @@ pub(super) fn read_plan_path(path: &str) -> Result<AgentTaskPlan> {
 pub(super) fn write_aggregate(run_id: &str, aggregate: &AgentTaskAggregate) -> Result<PathBuf> {
     let path = run_dir(run_id)?.join("aggregate.json");
     write_json(&path, aggregate)?;
-    mirror_aggregate(run_id, aggregate)?;
     Ok(path)
 }
 
 pub(super) fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
-    read_json(&aggregate_path(run_id)?)
-        .or_else(|error| read_mirrored_aggregate(run_id)?.ok_or(error))
+    match read_mirrored_aggregate(run_id)? {
+        Some(aggregate) => Ok(aggregate),
+        None => read_json(&aggregate_path(run_id)?),
+    }
 }
 
 pub(super) fn aggregate_path(run_id: &str) -> Result<PathBuf> {
@@ -45,36 +48,25 @@ pub(super) fn aggregate_path(run_id: &str) -> Result<PathBuf> {
 }
 
 pub(super) fn write_record(record: &AgentTaskRunRecord) -> Result<()> {
-    #[cfg(test)]
-    if FAIL_NEXT_RECORD_WRITE.swap(false, Ordering::SeqCst) {
-        return Err(Error::internal_io(
-            "injected lifecycle record persistence failure",
-            Some(record.run_id.clone()),
-        ));
-    }
     write_record_with_aggregate(record, read_mirrored_aggregate(&record.run_id)?)
 }
 
-/// Persist an aggregate and its controller projection as one recoverable unit.
-/// If the controller write fails, restore the previously visible aggregate so
-/// status, logs, and artifacts continue to describe the same lifecycle state.
+/// Commit the controller projection and child aggregate in one observation row.
+/// The JSON aggregate is a post-commit cache: readers use the committed row, so
+/// interruption before or after cache persistence exposes a complete state.
 pub(super) fn write_aggregate_and_record(
     record: &AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
 ) -> Result<PathBuf> {
-    let previous = read_aggregate(&record.run_id).ok();
-    let path = match write_aggregate(&record.run_id, aggregate) {
-        Ok(path) => path,
-        Err(error) => {
-            restore_aggregate(&record.run_id, previous.as_ref())?;
-            return Err(error);
-        }
-    };
-    if let Err(error) = write_record(record) {
-        restore_aggregate(&record.run_id, previous.as_ref())?;
-        return Err(error);
+    write_record_with_aggregate(record, Some(aggregate.clone()))?;
+    #[cfg(test)]
+    if INTERRUPT_AFTER_TERMINAL_COMMIT.swap(false, Ordering::SeqCst) {
+        return Err(Error::internal_io(
+            "injected interruption after terminal lifecycle commit",
+            Some(record.run_id.clone()),
+        ));
     }
-    Ok(path)
+    write_aggregate(&record.run_id, aggregate)
 }
 
 #[cfg(test)]
@@ -82,25 +74,22 @@ pub(super) fn fail_next_record_write_for_test() {
     FAIL_NEXT_RECORD_WRITE.store(true, Ordering::SeqCst);
 }
 
-fn restore_aggregate(run_id: &str, aggregate: Option<&AgentTaskAggregate>) -> Result<()> {
-    let path = aggregate_path(run_id)?;
-    match aggregate {
-        Some(aggregate) => {
-            write_json(&path, aggregate)?;
-        }
-        None if path.exists() => fs::remove_file(&path).map_err(|error| {
-            Error::internal_io(error.to_string(), Some(path.display().to_string()))
-        })?,
-        None => {}
-    }
-    let record = read_record(run_id)?;
-    write_record_with_aggregate(&record, aggregate.cloned())
+#[cfg(test)]
+pub(super) fn interrupt_after_terminal_commit_for_test() {
+    INTERRUPT_AFTER_TERMINAL_COMMIT.store(true, Ordering::SeqCst);
 }
 
 fn write_record_with_aggregate(
     record: &AgentTaskRunRecord,
     aggregate: Option<AgentTaskAggregate>,
 ) -> Result<()> {
+    #[cfg(test)]
+    if FAIL_NEXT_RECORD_WRITE.swap(false, Ordering::SeqCst) {
+        return Err(Error::internal_io(
+            "injected lifecycle record persistence failure",
+            Some(record.run_id.clone()),
+        ));
+    }
     let store = ObservationStore::open_initialized()?;
     let metadata_json = merge_observation_metadata(
         store
@@ -109,7 +98,7 @@ fn write_record_with_aggregate(
             .unwrap_or_else(|| json!({})),
         observation_metadata(record, aggregate)?,
     );
-    store.upsert_imported_run(&RunRecord {
+    store.upsert_imported_run_preserving_terminal(&RunRecord {
         id: record.run_id.clone(),
         kind: "agent-task".to_string(),
         component_id: plan_id_component(record),
@@ -246,30 +235,6 @@ fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
             error.to_string(),
             Some(format!("parse agent-task run {}", run.id)),
         )
-    })
-}
-
-fn mirror_aggregate(run_id: &str, aggregate: &AgentTaskAggregate) -> Result<()> {
-    let record = match read_record(run_id) {
-        Ok(record) => record,
-        Err(error) if error.code == ErrorCode::ValidationInvalidArgument => return Ok(()),
-        Err(error) => return Err(error),
-    };
-    let store = ObservationStore::open_initialized()?;
-    let metadata_json = observation_metadata(&record, Some(aggregate.clone()))?;
-    store.upsert_imported_run(&RunRecord {
-        id: record.run_id.clone(),
-        kind: "agent-task".to_string(),
-        component_id: plan_id_component(&record),
-        started_at: record.submitted_at.clone(),
-        finished_at: terminal_finished_at(&record),
-        status: run_status(record.state).to_string(),
-        command: Some("homeboy agent-task".to_string()),
-        cwd: None,
-        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        git_sha: None,
-        rig_id: None,
-        metadata_json,
     })
 }
 

--- a/src/core/observation/store/runs.rs
+++ b/src/core/observation/store/runs.rs
@@ -320,6 +320,20 @@ impl ObservationStore {
     }
 
     pub fn upsert_imported_run(&self, run: &RunRecord) -> Result<()> {
+        self.upsert_imported_run_with_terminal_guard(run, false)
+    }
+
+    /// Upsert an imported projection without allowing a stale in-flight writer
+    /// to replace a settled observation.
+    pub fn upsert_imported_run_preserving_terminal(&self, run: &RunRecord) -> Result<()> {
+        self.upsert_imported_run_with_terminal_guard(run, true)
+    }
+
+    fn upsert_imported_run_with_terminal_guard(
+        &self,
+        run: &RunRecord,
+        preserve_terminal: bool,
+    ) -> Result<()> {
         validate_required("run.id", &run.id)?;
         let mut run = run.clone();
         if crate::core::notification_route::NotificationRoute::from_metadata(&run.metadata_json)
@@ -336,9 +350,15 @@ impl ObservationStore {
             }
         }
         let metadata_json = serialize_metadata(&run.metadata_json)?;
+        let terminal_guard = if preserve_terminal {
+            " WHERE runs.status = 'running' OR ?6 != 'running'"
+        } else {
+            ""
+        };
         execute_with_retry("upsert imported run record", || {
             self.connection.execute(
-                r#"
+                &format!(
+                    r#"
                 INSERT INTO runs(
                     id,
                     kind,
@@ -365,7 +385,9 @@ impl ObservationStore {
                     git_sha = excluded.git_sha,
                     rig_id = excluded.rig_id,
                     metadata_json = excluded.metadata_json
-                "#,
+                {terminal_guard}
+                "#
+                ),
                 params![
                     run.id,
                     run.kind,


### PR DESCRIPTION
## Summary
- commit each terminal child aggregate and controller projection in one observation-store row
- treat `aggregate.json` as a post-commit cache and keep status, logs, and artifacts on the committed observation envelope
- prevent stale running writes from replacing terminal observations

Fixes #7939

## Testing
1. From a fresh checkout, run `cargo test core::agent_task_lifecycle::tests --lib`.
2. Run `cargo check`.
3. Run `cargo fmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.