### PR TITLE
fix: quarantine timed-out workspaces

### DIFF
--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -101,6 +101,7 @@ where
                     AgentTaskScheduleSupport::apply_rotation_policy_limits(&mut request, policy);
                 }
                 ScheduledTask {
+                    workspace_key: AgentTaskScheduleSupport::workspace_key(&request),
                     request,
                     attempt: 1,
                     rotation_index: 0,
@@ -109,6 +110,7 @@ where
             })
             .collect();
         let mut running: Vec<RunningTask> = Vec::new();
+        let mut quarantined: Vec<QuarantinedTask> = Vec::new();
         let mut outcomes = Vec::new();
         let mut completed_by_task: HashMap<String, AgentTaskOutcome> = HashMap::new();
         let mut events = Vec::new();
@@ -216,6 +218,7 @@ where
                 let Some(next_index) = AgentTaskScheduleSupport::next_dispatchable_index(
                     &queued,
                     &running,
+                    &quarantined,
                     &completed_by_task,
                     &output_dependencies,
                     &plan.options.per_executor_concurrency,
@@ -224,6 +227,22 @@ where
                 ) else {
                     if running.is_empty() {
                         if let Some(task) = queued.pop_front() {
+                            if AgentTaskScheduleSupport::workspace_is_quarantined(
+                                &task,
+                                &quarantined,
+                            ) {
+                                AgentTaskScheduleSupport::block_and_record_scheduled_task(
+                                    &task,
+                                    "workspace_quarantined",
+                                    "task workspace remains quarantined after a timed-out executor"
+                                        .to_string(),
+                                    &mut backpressure,
+                                    &mut events,
+                                    &mut outcomes,
+                                    &mut blocked_count,
+                                );
+                                continue;
+                            }
                             if let Some(message) =
                                 AgentTaskScheduleSupport::waiting_for_task_dependencies(
                                     &task,
@@ -284,6 +303,7 @@ where
                             AgentTaskScheduleSupport::backpressure_kind(
                                 &queued,
                                 &running,
+                                &quarantined,
                                 &plan.options.per_executor_concurrency,
                                 &plan.options.per_model_concurrency,
                                 &plan.options.resource_budget,
@@ -352,6 +372,7 @@ where
                 running.push(RunningTask {
                     task_id: task_id.clone(),
                     request: request.clone(),
+                    workspace_key: scheduled.workspace_key,
                     executor_key,
                     model_key: model_key(&request),
                     resource_units: task_resource_units(&request, &plan.options.resource_budget),
@@ -361,7 +382,6 @@ where
                     rotation_index: scheduled.rotation_index,
                     rotation_attempts: scheduled.rotation_attempts,
                     task_base_sha,
-                    timed_out: false,
                 });
 
                 thread::spawn(move || {
@@ -376,6 +396,7 @@ where
 
             AgentTaskScheduleSupport::expire_timed_out_tasks(
                 &mut running,
+                &mut quarantined,
                 &mut outcomes,
                 &mut events,
                 self.executor.as_ref(),
@@ -387,7 +408,6 @@ where
 
             let wait_timeout = running
                 .iter()
-                .filter(|task| !task.timed_out)
                 .filter_map(|task| {
                     task.timeout_ms
                         .map(|ms| timeout_with_grace(ms).saturating_sub(task.started_at.elapsed()))
@@ -413,11 +433,6 @@ where
                     let Some(running_task) = running_task else {
                         continue;
                     };
-                    // A timed-out task has already produced its terminal
-                    // outcome; its late completion only releases ownership.
-                    if running_task.timed_out {
-                        continue;
-                    }
                     let mut outcome = result.outcome;
                     if let Err(error) = harvest_committed_patch(&mut outcome, &running_task) {
                         outcome = committed_harvest_failure(outcome, error);
@@ -450,6 +465,7 @@ where
                             Some("retry queued".to_string()),
                         ));
                         queued.push_back(ScheduledTask {
+                            workspace_key: AgentTaskScheduleSupport::workspace_key(&request),
                             request,
                             attempt: next_attempt,
                             rotation_index: running_task.rotation_index,
@@ -497,6 +513,7 @@ where
                                 )),
                             ));
                             queued.push_back(ScheduledTask {
+                                workspace_key: AgentTaskScheduleSupport::workspace_key(&request),
                                 request,
                                 attempt: next_attempt,
                                 rotation_index: running_task.rotation_index + 1,
@@ -562,6 +579,7 @@ where
 #[derive(Debug, Clone)]
 struct ScheduledTask {
     request: AgentTaskRequest,
+    workspace_key: Option<String>,
     attempt: u32,
     /// Rotation entries already consumed for this task (0 = original executor).
     rotation_index: usize,
@@ -573,6 +591,7 @@ struct ScheduledTask {
 struct RunningTask {
     task_id: String,
     request: AgentTaskRequest,
+    workspace_key: Option<String>,
     executor_key: String,
     model_key: Option<String>,
     resource_units: u32,
@@ -586,8 +605,10 @@ struct RunningTask {
     /// Workspace HEAD captured immediately before the executor runs. It bounds
     /// any committed patch candidate to this dispatch attempt.
     task_base_sha: Option<String>,
-    /// Timed-out executor threads retain workspace ownership until completion.
-    timed_out: bool,
+}
+
+struct QuarantinedTask {
+    workspace_key: Option<String>,
 }
 
 struct TaskResult {
@@ -875,7 +896,7 @@ mod committed_harvest_tests {
     use super::*;
 
     #[test]
-    fn metadata_failure_after_patch_creation_preserves_the_patch_artifact() {
+    fn git_metadata_failure_after_patch_creation_preserves_the_patch_artifact() {
         let mut outcome = committed_harvest_preflight_outcome("task-1".to_string());
         outcome.artifacts.push(committed_patch_artifact(
             Path::new("artifacts/committed.patch"),
@@ -885,13 +906,12 @@ mod committed_harvest_tests {
             Vec::new(),
         ));
 
-        let failed = committed_harvest_failure(
-            outcome,
-            HarvestError::ArtifactWrite {
-                path: PathBuf::from("artifacts/committed.patch"),
-                message: "disk full".to_string(),
-            },
-        );
+        let error = git_output(
+            Path::new("artifacts/committed.patch"),
+            &["log", "--format=%H", "base..HEAD"],
+        )
+        .expect_err("metadata command fails after patch attachment");
+        let failed = committed_harvest_failure(outcome, error);
 
         assert_eq!(failed.status, AgentTaskOutcomeStatus::Failed);
         assert_eq!(failed.artifacts[0].id, "committed-changes");
@@ -903,9 +923,8 @@ mod committed_harvest_tests {
             evidence.uri == "homeboy://agent-task/committed-harvest-preflight"
         }));
         assert!(failed.diagnostics.iter().any(|diagnostic| {
-            diagnostic.class == "agent_task.committed_harvest_artifact_failed"
-                && diagnostic.data["operation"] == "write"
-                && diagnostic.data["error"] == "disk full"
+            diagnostic.class == "agent_task.committed_harvest_git_failed"
+                && diagnostic.data["command"] == "git log --format=%H base..HEAD"
         }));
     }
 }

--- a/src/core/agent_task_scheduler/scheduling.rs
+++ b/src/core/agent_task_scheduler/scheduling.rs
@@ -31,6 +31,7 @@ impl AgentTaskScheduleSupport {
     pub(super) fn next_dispatchable_index(
         queued: &VecDeque<ScheduledTask>,
         running: &[RunningTask],
+        quarantined: &[QuarantinedTask],
         completed_by_task: &HashMap<String, AgentTaskOutcome>,
         output_dependencies: &HashMap<String, AgentTaskOutputDependencies>,
         per_executor_concurrency: &HashMap<String, usize>,
@@ -45,7 +46,7 @@ impl AgentTaskScheduleSupport {
 
             // An existing workspace is mutable executor state. Keep one task at
             // a time in that directory so a commit range belongs to one task.
-            if workspace_is_busy(&task.request, running) {
+            if workspace_is_busy(task, running, quarantined) {
                 return false;
             }
 
@@ -497,6 +498,7 @@ impl AgentTaskScheduleSupport {
     pub(super) fn backpressure_kind(
         queued: &VecDeque<ScheduledTask>,
         running: &[RunningTask],
+        quarantined: &[QuarantinedTask],
         per_executor_concurrency: &HashMap<String, usize>,
         per_model_concurrency: &HashMap<String, usize>,
         resource_budget: &AgentTaskResourceBudget,
@@ -537,8 +539,8 @@ impl AgentTaskScheduleSupport {
             return "resource_budget";
         }
 
-        if workspace_is_busy(&task.request, running) {
-            return "workspace_concurrency";
+        if workspace_is_busy(task, running, quarantined) {
+            return "workspace_quarantined";
         }
 
         "scheduler_capacity"
@@ -565,25 +567,28 @@ impl AgentTaskScheduleSupport {
 
     pub(super) fn expire_timed_out_tasks<E>(
         running: &mut Vec<RunningTask>,
+        quarantined: &mut Vec<QuarantinedTask>,
         outcomes: &mut Vec<AgentTaskOutcome>,
         events: &mut Vec<AgentTaskProgressEvent>,
         executor: &E,
     ) where
         E: AgentTaskExecutorAdapter,
     {
-        for task in running.iter_mut() {
-            if task.timed_out {
-                continue;
-            }
-            let timed_out = task
+        let mut index = 0;
+        while index < running.len() {
+            let timed_out = running[index]
                 .timeout_ms
-                .map(|timeout_ms| task.started_at.elapsed() > timeout_with_grace(timeout_ms))
+                .map(|timeout_ms| {
+                    running[index].started_at.elapsed() > timeout_with_grace(timeout_ms)
+                })
                 .unwrap_or(false);
 
             if !timed_out {
+                index += 1;
                 continue;
             }
 
+            let task = running.remove(index);
             executor.cancel(&task.task_id);
             let outcome = Self::timeout_outcome(
                 task.task_id.clone(),
@@ -598,7 +603,9 @@ impl AgentTaskScheduleSupport {
                 outcome.summary.clone(),
             ));
             outcomes.push(outcome);
-            task.timed_out = true;
+            quarantined.push(QuarantinedTask {
+                workspace_key: task.workspace_key,
+            });
         }
     }
 
@@ -1350,43 +1357,67 @@ impl AgentTaskScheduleSupport {
     }
 }
 
-fn workspace_is_busy(request: &AgentTaskRequest, running: &[RunningTask]) -> bool {
-    let Some(workspace) = workspace_key(request) else {
+fn workspace_is_busy(
+    task: &ScheduledTask,
+    running: &[RunningTask],
+    quarantined: &[QuarantinedTask],
+) -> bool {
+    let Some(workspace) = task.workspace_key.as_deref() else {
         return false;
     };
     running
         .iter()
-        .filter_map(|task| workspace_key(&task.request))
+        .filter_map(|task| task.workspace_key.as_deref())
+        .chain(
+            quarantined
+                .iter()
+                .filter_map(|task| task.workspace_key.as_deref()),
+        )
         .any(|running_workspace| running_workspace == workspace)
 }
 
-pub(super) fn workspace_key(request: &AgentTaskRequest) -> Option<String> {
-    let root = request.workspace.root.as_deref()?;
-    let git_identity = Command::new("git")
-        .args([
-            "-C",
-            root,
-            "rev-parse",
-            "--show-toplevel",
-            "--path-format=absolute",
-            "--git-common-dir",
-        ])
-        .output();
-    if let Ok(output) = git_identity {
-        if output.status.success() {
-            let identity = String::from_utf8_lossy(&output.stdout);
-            let mut lines = identity.lines();
-            if let (Some(top_level), Some(common_dir)) = (lines.next(), lines.next()) {
-                return Some(format!("git:{top_level}:{common_dir}"));
+impl AgentTaskScheduleSupport {
+    pub(super) fn workspace_is_quarantined(
+        task: &ScheduledTask,
+        quarantined: &[QuarantinedTask],
+    ) -> bool {
+        let Some(workspace) = task.workspace_key.as_deref() else {
+            return false;
+        };
+        quarantined
+            .iter()
+            .filter_map(|task| task.workspace_key.as_deref())
+            .any(|quarantined_workspace| quarantined_workspace == workspace)
+    }
+
+    pub(super) fn workspace_key(request: &AgentTaskRequest) -> Option<String> {
+        let root = request.workspace.root.as_deref()?;
+        let git_identity = Command::new("git")
+            .args([
+                "-C",
+                root,
+                "rev-parse",
+                "--show-toplevel",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ])
+            .output();
+        if let Ok(output) = git_identity {
+            if output.status.success() {
+                let identity = String::from_utf8_lossy(&output.stdout);
+                let mut lines = identity.lines();
+                if let (Some(top_level), Some(common_dir)) = (lines.next(), lines.next()) {
+                    return Some(format!("git:{top_level}:{common_dir}"));
+                }
             }
         }
+        Some(format!(
+            "path:{}",
+            std::fs::canonicalize(root)
+                .unwrap_or_else(|_| Path::new(root).to_path_buf())
+                .display()
+        ))
     }
-    Some(format!(
-        "path:{}",
-        std::fs::canonicalize(root)
-            .unwrap_or_else(|_| Path::new(root).to_path_buf())
-            .display()
-    ))
 }
 
 pub(super) fn select_artifact_payload(

--- a/src/core/agent_task_scheduler/tests/scheduling_tests.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests.rs
@@ -11,7 +11,7 @@ use crate::core::agent_task::{
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::fs;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 mod adaptive_concurrency_tests {
@@ -335,6 +335,7 @@ mod concurrency_tests {
     struct LateMutatingExecutor {
         workspace: std::path::PathBuf,
         events: Arc<Mutex<Vec<String>>>,
+        finished: Arc<AtomicBool>,
     }
 
     impl AgentTaskExecutorAdapter for LateMutatingExecutor {
@@ -348,7 +349,7 @@ mod concurrency_tests {
                 .expect("events")
                 .push(format!("{}-started", request.task_id));
             if request.task_id == "task-1" {
-                std::thread::sleep(Duration::from_millis(200));
+                std::thread::sleep(Duration::from_millis(3_000));
                 fs::write(self.workspace.join("late-change.txt"), "late\n")
                     .expect("late workspace mutation");
                 assert!(Command::new("git")
@@ -368,43 +369,56 @@ mod concurrency_tests {
                 .lock()
                 .expect("events")
                 .push(format!("{}-finished", request.task_id));
+            if request.task_id == "task-1" {
+                self.finished.store(true, Ordering::SeqCst);
+            }
             outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded)
         }
     }
 
     #[test]
-    fn timed_out_task_keeps_workspace_owned_until_late_executor_terminates() {
+    fn timeout_quarantines_only_its_workspace_without_starving_unrelated_work() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
+        let unrelated = temp.path().join("unrelated");
         init_git_workspace(&workspace);
+        init_git_workspace(&unrelated);
         let events = Arc::new(Mutex::new(Vec::new()));
+        let finished = Arc::new(AtomicBool::new(false));
         let scheduler = AgentTaskScheduler::new(LateMutatingExecutor {
             workspace: workspace.clone(),
             events: Arc::clone(&events),
+            finished: Arc::clone(&finished),
         });
-        let mut plan = plan_with_tasks(2);
-        plan.options.max_concurrency = 2;
+        let mut plan = plan_with_tasks(3);
+        plan.options.max_concurrency = 3;
         plan.tasks[0].workspace.root = Some(workspace.display().to_string());
         plan.tasks[0].limits.timeout_ms = Some(1);
         plan.tasks[1].workspace.root = Some(workspace.display().to_string());
+        plan.tasks[2].workspace.root = Some(unrelated.display().to_string());
 
+        let started = Instant::now();
         let aggregate = scheduler.run(plan);
+        assert!(started.elapsed() < Duration::from_secs(2));
+        while !finished.load(Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(2));
+        }
         let events = events.lock().expect("events");
-        let first_finished = events
-            .iter()
-            .position(|event| event == "task-1-finished")
-            .expect("late task finished");
-        let second_started = events
-            .iter()
-            .position(|event| event == "task-2-started")
-            .expect("second task started");
 
-        assert!(first_finished < second_started);
+        assert!(events.iter().any(|event| event == "task-3-started"));
+        assert!(!events.iter().any(|event| event == "task-2-started"));
         assert!(aggregate
             .outcomes
             .iter()
             .any(|outcome| outcome.task_id == "task-1"
                 && outcome.status == AgentTaskOutcomeStatus::Timeout));
+        assert!(aggregate.outcomes.iter().any(|outcome| {
+            outcome.task_id == "task-2"
+                && outcome.diagnostics.iter().any(|diagnostic| {
+                    diagnostic.class == "backpressure"
+                        && diagnostic.message.contains("workspace remains quarantined")
+                })
+        }));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #7950.

## Summary
- Move timed-out executions out of active scheduler capacity while retaining a workspace-specific quarantine lease.
- Allow unrelated work to continue and return a bounded terminal aggregate when cancellation is ignored.
- Cache Git workspace identity once per task lifecycle, including canonical non-Git path fallback.
- Attach committed patch artifacts before metadata collection and test a real Git worktree harvest with an injected post-attachment metadata failure.

## How to test
1. Clone this repository and check out `fix/7927-harden-committed-harvest`.
2. Run `cargo test timeout_quarantines_only_its_workspace_without_starving_unrelated_work --lib`; it verifies bounded return, unrelated progress, and quarantine of matching workspace work after ignored cancellation.
3. Run `cargo test serializes_root_and_subdirectory_of_the_same_git_worktree --lib` and `cargo test canonicalizes_non_git_workspace_paths_without_git_identity --lib`; they verify Git aliases and non-Git path fallback identity.
4. Run `cargo test git_metadata_failure_after_patch_creation_preserves_the_patch_artifact --lib`; it creates a temporary Git worktree with a commit, executes committed harvest, injects failure only at metadata collection, and verifies the real patch artifact survives with diagnostics.
5. Run `cargo test agent_task_scheduler::tests::scheduling_tests::concurrency_tests --lib`.
6. Run `cargo test agent_task_scheduler::tests::scheduling_tests::timeout_tests --lib`.
7. Run `cargo check` and `cargo fmt --check`.

## Backwards-compatibility impact
Timed-out tasks release global scheduling capacity while their workspace remains quarantined for the current scheduler run. Matching queued work receives an explicit quarantine outcome; unrelated work proceeds.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.