### PR TITLE
Fix detached Lab cook promotion

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -35,8 +35,9 @@ pub use args::{
     AgentTaskFanoutSubmitBatchArgs, AgentTaskLoopArgs, AgentTaskLoopCommand,
     AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs, AgentTaskLoopStatusArgs, CancelArgs,
     CompileLoopArgs, ContractArgs, ContractFormat, DiagnoseArgs, EvidenceArgs, FinalizePrArgs,
-    GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs, ProvidersArgs, ReplayProviderBoundaryArgs,
-    RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    GateFeedbackArgs, LatestArgs, ListArgs, PromoteArgs, PromotionProviderArgs, ProvidersArgs,
+    ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs,
+    VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
@@ -78,6 +79,9 @@ pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::Fanout(fanout_args) => fanout::fanout(fanout_args),
         AgentTaskCommand::Review(review_args) => review::review(review_args),
         AgentTaskCommand::Promote(promote_args) => review::promote_artifact(promote_args),
+        AgentTaskCommand::PromotionProvider(provider_args) => {
+            run::promotion_provider(provider_args)
+        }
         AgentTaskCommand::FinalizePr(finalize_args) => review::finalize_pull_request(finalize_args),
         AgentTaskCommand::GateFeedback(feedback_args) => review::gate_feedback(feedback_args),
         AgentTaskCommand::Providers(providers_args) => review::providers(providers_args),

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -250,6 +250,9 @@ pub enum AgentTaskCommand {
     Review(ReviewArgs),
     /// Review: promote a completed generic patch artifact into a managed worktree.
     Promote(PromoteArgs),
+    /// Internal adapter that applies a promotion patch to an already materialized workspace.
+    #[command(hide = true)]
+    PromotionProvider(PromotionProviderArgs),
     /// Review: finalize a green cook run into a review-ready pull request.
     FinalizePr(FinalizePrArgs),
     /// Review: convert deterministic gate results into a cook retry or stop decision.
@@ -514,6 +517,13 @@ pub struct AgentTaskCookArgs {
         value_name = "TEXT"
     )]
     pub ai_used_for: String,
+}
+
+#[derive(Args, Debug)]
+pub struct PromotionProviderArgs {
+    /// Materialized Git workspace that receives the promotion patch.
+    #[arg(long, value_name = "PATH")]
+    pub workspace: String,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -2,6 +2,7 @@
 //! resume, and retry.
 
 use serde_json::Value;
+use std::io::Read;
 use std::path::Path;
 use std::process::Command;
 
@@ -14,7 +15,10 @@ use homeboy::core::agent_tasks::scheduler::{
 use homeboy::core::agent_tasks::service as agent_task_service;
 
 use super::super::CmdResult;
-use super::args::{AgentTaskCookArgs, RetryArgs, RunArgs, RunPlanArgs, StatusArgs, SubmitArgs};
+use super::args::{
+    AgentTaskCookArgs, PromotionProviderArgs, RetryArgs, RunArgs, RunPlanArgs, StatusArgs,
+    SubmitArgs,
+};
 
 /// Serialize a completed run aggregate and, when the run did not fully succeed,
 /// surface a prominent top-level `failure_reasons` summary so the operator sees
@@ -34,6 +38,31 @@ fn aggregate_value_with_failure_reasons(aggregate: &AgentTaskAggregate) -> Value
 
 pub(super) fn run_cook(args: AgentTaskCookArgs) -> CmdResult<Value> {
     run_cook_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
+}
+
+pub(super) fn promotion_provider(args: PromotionProviderArgs) -> CmdResult<Value> {
+    let mut request = String::new();
+    std::io::stdin()
+        .read_to_string(&mut request)
+        .map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some("read agent-task promotion provider request".to_string()),
+            )
+        })?;
+    homeboy::core::agent_task_promotion::apply_materialized_workspace_patch(
+        Path::new(&args.workspace),
+        &request,
+    )
+    .and_then(|response| {
+        serde_json::from_str(&response).map_err(|error| {
+            homeboy::core::Error::internal_json(
+                error.to_string(),
+                Some("serialize agent-task promotion provider response".to_string()),
+            )
+        })
+    })
+    .map(|value| (value, 0))
 }
 
 pub(super) fn run_cook_with_executor<E>(args: AgentTaskCookArgs, executor: E) -> CmdResult<Value>

--- a/src/core/agent_task_promotion/apply.rs
+++ b/src/core/agent_task_promotion/apply.rs
@@ -48,6 +48,68 @@ pub(crate) const AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA: &str =
 pub(crate) const AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA: &str =
     "homeboy/agent-task-promotion-apply-response/v1";
 
+/// Apply a promotion-provider request to an already materialized Git workspace.
+///
+/// Lab uses this adapter after it has safely staged the target workspace on the
+/// runner, so promotion stays within the runner without requiring a controller
+/// workspace provider.
+pub fn apply_materialized_workspace_patch(workspace: &Path, request_json: &str) -> Result<String> {
+    let request: AgentTaskPromotionApplyRequest =
+        serde_json::from_str(request_json).map_err(|error| {
+            Error::validation_invalid_json(
+                error,
+                Some("agent-task promotion provider request".to_string()),
+                None,
+            )
+        })?;
+    if request.schema != AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "promotion_provider.request.schema",
+            format!(
+                "expected {}, got {}",
+                AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, request.schema
+            ),
+            None,
+            None,
+        ));
+    }
+    validate_provider_workspace_path(workspace)?;
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(["apply", "--whitespace=nowarn", &request.patch_path])
+        .output()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("apply agent-task promotion patch".to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "promotion_provider.patch",
+            format!(
+                "could not apply promotion patch in {}: {}",
+                workspace.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+            Some(request.patch_path),
+            None,
+        ));
+    }
+    serde_json::to_string(&AgentTaskPromotionApplyResponse {
+        schema: AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA.to_string(),
+        workspace_path: workspace.display().to_string(),
+        command_evidence: Vec::new(),
+    })
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize promotion provider response".to_string()),
+        )
+    })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct AgentTaskPromotionApplyRequest {
     pub(crate) schema: String,

--- a/src/core/agent_task_promotion/mod.rs
+++ b/src/core/agent_task_promotion/mod.rs
@@ -11,6 +11,7 @@ mod apply;
 mod promote;
 mod types;
 
+pub use apply::apply_materialized_workspace_patch;
 pub use promote::promote;
 pub use types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -174,6 +174,48 @@ fn git(cwd: &Path, args: &[&str]) {
 }
 
 #[test]
+fn materialized_workspace_promotion_adapter_applies_patch_and_returns_workspace() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("create workspace");
+    git(&workspace, &["init"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["config", "user.name", "Test User"]);
+    std::fs::write(workspace.join("src.txt"), "old\n").expect("write source");
+    git(&workspace, &["add", "src.txt"]);
+    git(&workspace, &["commit", "-m", "initial"]);
+    let patch = temp.path().join("changes.patch");
+    std::fs::write(
+        &patch,
+        "diff --git a/src.txt b/src.txt\n--- a/src.txt\n+++ b/src.txt\n@@ -1 +1 @@\n-old\n+new\n",
+    )
+    .expect("write patch");
+
+    let response = super::apply_materialized_workspace_patch(
+        &workspace,
+        &serde_json::json!({
+            "schema": AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
+            "to_workspace": "homeboy@fix-7913",
+            "patch_path": patch,
+            "changed_files": ["src.txt"]
+        })
+        .to_string(),
+    )
+    .expect("adapter applies patch");
+    let response: Value = serde_json::from_str(&response).expect("adapter response JSON");
+
+    assert_eq!(
+        response["schema"],
+        AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA
+    );
+    assert_eq!(response["workspace_path"], workspace.display().to_string());
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("src.txt")).unwrap(),
+        "new\n"
+    );
+}
+
+#[test]
 fn validate_patch_extracts_safe_changed_files() {
     let patch = normalize_promotion_patch(VALID_PATCH, "repo@promoted-task").expect("valid patch");
 

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -410,6 +410,14 @@ fn prepare_lab_offload_workspace_stage_inner(
     );
     let remapped_args = remap_path_settings_in_args(&remapped_args, &path_remaps);
     let remapped_args = remap_lab_at_file_args(&remapped_args, &at_file_specs);
+    // The target worktree is already materialized on the runner. Give detached
+    // cooks a local adapter so promotion, gates, and finalization stay on that
+    // workspace instead of requiring a controller-side provider command.
+    let remapped_args = inject_materialized_promotion_provider(
+        remapped_args,
+        command_prefix_argv.first().map(String::as_str),
+        &remote_cwd,
+    );
     let (remapped_args, agent_task_run_id) =
         ensure_agent_task_dispatch_run_id_with(&remapped_args, run_isolation_token.as_deref())
             .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
@@ -639,6 +647,41 @@ fn build_lab_offload_remote_command(
     let remote_args = inject_required_extension_args(remote_args, &plan.command_extensions);
     command.extend(remote_args.into_iter().skip(1));
     command
+}
+
+fn inject_materialized_promotion_provider(
+    mut args: Vec<String>,
+    homeboy_path: Option<&str>,
+    workspace: &str,
+) -> Vec<String> {
+    let Some(agent_task_index) = args.iter().position(|arg| arg == "agent-task") else {
+        return args;
+    };
+    if args
+        .get(agent_task_index + 1)
+        .is_none_or(|arg| arg != "cook")
+        || args
+            .iter()
+            .any(|arg| arg == "--provider-command" || arg.starts_with("--provider-command="))
+    {
+        return args;
+    }
+    let Some(homeboy_path) = homeboy_path.filter(|path| !path.trim().is_empty()) else {
+        return args;
+    };
+
+    let insert_at = args
+        .iter()
+        .position(|arg| arg == "--")
+        .unwrap_or(args.len());
+    args.splice(
+        insert_at..insert_at,
+        [
+            "--provider-command".to_string(),
+            format!("{homeboy_path} agent-task promotion-provider --workspace {workspace}"),
+        ],
+    );
+    args
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1400,6 +1443,67 @@ mod tests {
                 "--rig".to_string(),
                 "wordpress-fixture".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn detached_cook_gets_materialized_workspace_promotion_provider() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--to-worktree".to_string(),
+            "homeboy@fix-7913".to_string(),
+            "--verify".to_string(),
+            "cargo test --lib".to_string(),
+        ];
+
+        let command = build_lab_offload_remote_command(
+            &["/runner/bin/homeboy".to_string()],
+            &inject_materialized_promotion_provider(
+                args,
+                Some("/runner/bin/homeboy"),
+                "/runner/workspaces/homeboy",
+            ),
+            "/runner/workspaces/homeboy",
+            &[],
+            None,
+            &command_plan(&[]),
+        );
+
+        assert_eq!(
+            command,
+            vec![
+                "/runner/bin/homeboy",
+                "--force-hot",
+                "agent-task",
+                "cook",
+                "--to-worktree",
+                "homeboy@fix-7913",
+                "--verify",
+                "cargo test --lib",
+                "--provider-command",
+                "/runner/bin/homeboy agent-task promotion-provider --workspace /runner/workspaces/homeboy",
+            ]
+        );
+    }
+
+    #[test]
+    fn detached_cook_preserves_explicit_promotion_provider() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--provider-command=custom-provider".to_string(),
+        ];
+
+        assert_eq!(
+            inject_materialized_promotion_provider(
+                args.clone(),
+                Some("/runner/bin/homeboy"),
+                "/runner/workspaces/homeboy",
+            ),
+            args
         );
     }
 


### PR DESCRIPTION
## Summary
- inject a generic, runner-local promotion adapter into detached Lab `agent-task cook` commands when no provider was supplied
- apply promotion patches directly to the already-materialized Git workspace and return the normal provider response
- preserve explicit caller providers and cover command remapping plus promotion application

Closes #7913
Related #7897 and #7898.

## Testing
1. Start from a fresh checkout of this branch and run `cargo fmt --check`.
2. Run `cargo test detached_cook_` to verify remapped Lab cooks receive the materialized-workspace provider and preserve an explicit provider.
3. Run `cargo test materialized_workspace_promotion_adapter_applies_patch_and_returns_workspace` to verify the adapter applies a patch and returns the provider response.
4. Run `cargo test cook_applies_executor_commit_from_source_repo_to_distinct_target_repo` to verify the cook promotion and deterministic verification flow.
5. Run `cargo check --all-targets`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.6 Sol)
- **Used for:** Implementation and tests under Chris's direction.