### PR TITLE
test: exercise committed harvest metadata failure

### DIFF
--- a/src/core/agent_task_scheduler/mod.rs
+++ b/src/core/agent_task_scheduler/mod.rs
@@ -640,6 +640,14 @@ fn harvest_committed_patch(
     outcome: &mut AgentTaskOutcome,
     running: &RunningTask,
 ) -> Result<(), HarvestError> {
+    harvest_committed_patch_with_metadata(outcome, running, committed_change_metadata_for_range)
+}
+
+fn harvest_committed_patch_with_metadata(
+    outcome: &mut AgentTaskOutcome,
+    running: &RunningTask,
+    collect_metadata: impl FnOnce(&Path, &str) -> Result<Vec<serde_json::Value>, HarvestError>,
+) -> Result<(), HarvestError> {
     if outcome.status != AgentTaskOutcomeStatus::Succeeded
         || outcome.artifacts.iter().any(|artifact| {
             is_actionable_patch_artifact(artifact) || is_empty_patch_artifact(artifact)
@@ -692,16 +700,7 @@ fn harvest_committed_patch(
         &range,
         Vec::new(),
     ));
-    let commits = git_output(
-        root,
-        &[
-            "log",
-            "--reverse",
-            "--format=%H%x1f%an%x1f%ae%x1f%s",
-            &format!("{base}..HEAD"),
-        ],
-    )?;
-    let commits = committed_change_metadata(&commits);
+    let commits = collect_metadata(root, &range)?;
     outcome
         .artifacts
         .last_mut()
@@ -713,6 +712,17 @@ fn harvest_committed_patch(
         "commits": commits,
     });
     Ok(())
+}
+
+fn committed_change_metadata_for_range(
+    cwd: &Path,
+    range: &str,
+) -> Result<Vec<serde_json::Value>, HarvestError> {
+    let output = git_output(
+        cwd,
+        &["log", "--reverse", "--format=%H%x1f%an%x1f%ae%x1f%s", range],
+    )?;
+    Ok(committed_change_metadata(&output))
 }
 
 fn committed_patch_artifact(
@@ -894,37 +904,102 @@ fn committed_harvest_failure(
 #[cfg(test)]
 mod committed_harvest_tests {
     use super::*;
+    use crate::core::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+
+    fn git(cwd: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("git command runs");
+        assert!(output.status.success(), "git {args:?} failed");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
 
     #[test]
     fn git_metadata_failure_after_patch_creation_preserves_the_patch_artifact() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("workspace");
+        git(&workspace, &["init", "-b", "main"]);
+        git(&workspace, &["config", "user.email", "test@example.com"]);
+        git(&workspace, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(workspace.join("file.txt"), "base\n").expect("base file");
+        git(&workspace, &["add", "file.txt"]);
+        git(&workspace, &["commit", "-m", "base"]);
+        let base = git(&workspace, &["rev-parse", "HEAD"]);
+        std::fs::write(workspace.join("file.txt"), "committed change\n").expect("change");
+        git(&workspace, &["commit", "-am", "agent change"]);
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "task-1".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: serde_json::Value::Null,
+            },
+            instructions: String::new(),
+            inputs: serde_json::Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace {
+                root: Some(workspace.display().to_string()),
+                ..Default::default()
+            },
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            metadata: serde_json::Value::Null,
+        };
+        let running = RunningTask {
+            task_id: "task-1".to_string(),
+            request,
+            workspace_key: None,
+            executor_key: "test".to_string(),
+            model_key: None,
+            resource_units: 1,
+            attempt: 1,
+            started_at: Instant::now(),
+            timeout_ms: None,
+            rotation_index: 0,
+            rotation_attempts: Vec::new(),
+            task_base_sha: Some(base),
+        };
         let mut outcome = committed_harvest_preflight_outcome("task-1".to_string());
-        outcome.artifacts.push(committed_patch_artifact(
-            Path::new("artifacts/committed.patch"),
-            "diff --git a/file b/file\n",
-            "base",
-            "base..HEAD",
-            Vec::new(),
-        ));
-
-        let error = git_output(
-            Path::new("artifacts/committed.patch"),
-            &["log", "--format=%H", "base..HEAD"],
-        )
-        .expect_err("metadata command fails after patch attachment");
+        outcome.status = AgentTaskOutcomeStatus::Succeeded;
+        let error = harvest_committed_patch_with_metadata(&mut outcome, &running, |_, _| {
+            Err(HarvestError::Git {
+                command: "git log injected metadata failure".to_string(),
+                message: "injected failure".to_string(),
+            })
+        })
+        .expect_err("metadata command fails after the real patch is attached");
+        let patch_path = outcome.artifacts[0].path.clone().expect("patch path");
+        assert!(Path::new(&patch_path).is_file());
         let failed = committed_harvest_failure(outcome, error);
 
         assert_eq!(failed.status, AgentTaskOutcomeStatus::Failed);
         assert_eq!(failed.artifacts[0].id, "committed-changes");
         assert_eq!(
             failed.artifacts[0].path.as_deref(),
-            Some("artifacts/committed.patch")
+            Some(patch_path.as_str())
         );
         assert!(failed.evidence_refs.iter().any(|evidence| {
             evidence.uri == "homeboy://agent-task/committed-harvest-preflight"
         }));
         assert!(failed.diagnostics.iter().any(|diagnostic| {
             diagnostic.class == "agent_task.committed_harvest_git_failed"
-                && diagnostic.data["command"] == "git log --format=%H base..HEAD"
+                && diagnostic.data["command"] == "git log injected metadata failure"
         }));
     }
 }

--- a/src/core/agent_task_scheduler/tests/scheduling_tests.rs
+++ b/src/core/agent_task_scheduler/tests/scheduling_tests.rs
@@ -331,6 +331,30 @@ mod concurrency_tests {
         assert_eq!(max_seen.load(Ordering::SeqCst), 1);
     }
 
+    #[test]
+    fn canonicalizes_non_git_workspace_paths_without_git_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let child = workspace.join("child");
+        fs::create_dir(&workspace).expect("workspace");
+        fs::create_dir(&child).expect("child");
+        let mut root_request = request("root");
+        root_request.workspace.root = Some(workspace.display().to_string());
+        let mut equivalent_request = request("equivalent");
+        equivalent_request.workspace.root = Some(workspace.join(".").display().to_string());
+        let mut child_request = request("child");
+        child_request.workspace.root = Some(child.display().to_string());
+
+        assert_eq!(
+            AgentTaskScheduleSupport::workspace_key(&root_request),
+            AgentTaskScheduleSupport::workspace_key(&equivalent_request)
+        );
+        assert_ne!(
+            AgentTaskScheduleSupport::workspace_key(&root_request),
+            AgentTaskScheduleSupport::workspace_key(&child_request)
+        );
+    }
+
     #[derive(Clone)]
     struct LateMutatingExecutor {
         workspace: std::path::PathBuf,


### PR DESCRIPTION
Fixes #7955.

## Summary
- Add a narrowly scoped committed-harvest metadata collector seam while preserving the production Git log command.
- Exercise the real harvest path against a temporary Git worktree and committed change, forcing failure only after patch attachment.
- Cover canonical non-Git workspace identity fallback.

## How to test
1. Clone this repository and check out `fix/7927-harden-committed-harvest`.
2. Run `cargo test git_metadata_failure_after_patch_creation_preserves_the_patch_artifact --lib`; it creates a temporary Git worktree, makes a commit, executes actual harvest, injects the post-attachment metadata failure, and verifies the real artifact and diagnostic.
3. Run `cargo test canonicalizes_non_git_workspace_paths_without_git_identity --lib`; it verifies equivalent canonical non-Git paths share identity and child paths remain distinct.
4. Run `cargo test agent_task_scheduler::tests::scheduling_tests::concurrency_tests --lib`.
5. Run `cargo test agent_task_scheduler::tests::scheduling_tests::timeout_tests --lib`.
6. Run `cargo check` and `cargo fmt --check`.

## Backwards-compatibility impact
None. The metadata collector seam preserves the existing production Git command and behavior; it enables deterministic regression coverage.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.