### PR TITLE
Prevent recursive Lab handoffs

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -128,6 +128,7 @@ impl CliRuntime {
     }
 
     fn run_matches(&self, matches: ArgMatches, normalized: Vec<String>) -> std::process::ExitCode {
+        crate::core::runner::consume_runner_lab_handoff_control_env();
         let global = GlobalArgs {};
 
         // Extract --output early so it's available for all code paths (including

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -1418,6 +1418,10 @@ mod tests {
         request
             .env
             .insert("TOKEN_A".to_string(), "secret".to_string());
+        request.env.insert(
+            crate::core::runner::RUNNER_LAB_HANDOFF_ENV.to_string(),
+            "1".to_string(),
+        );
         request.secret_env_names = vec!["TOKEN_A".to_string()];
         request.secret_env_plan = SecretEnvPlan::from_secret_env_names(["TOKEN_B".to_string()]);
         request.require_paths = vec!["/srv/extrachill/cache".to_string()];
@@ -1438,6 +1442,9 @@ mod tests {
         assert_eq!(dispatch.command, vec!["sh", "-c", "printf ok"]);
         assert_eq!(dispatch.cwd.as_deref(), Some("/srv/extrachill"));
         assert_eq!(dispatch.env["PUBLIC_VALUE"], "visible");
+        assert!(!dispatch
+            .env
+            .contains_key(crate::core::runner::RUNNER_LAB_HANDOFF_ENV));
         assert_eq!(dispatch.require_paths, vec!["/srv/extrachill/cache"]);
         assert!(dispatch.source_snapshot.is_some());
         assert_eq!(
@@ -1454,6 +1461,10 @@ mod tests {
         assert_eq!(lifecycle.active_child_count, Some(2));
         assert_eq!(lifecycle.active_cell_count, Some(3));
         assert_eq!(envelope.result_refs.run_id.as_deref(), Some("run-123"));
+        assert!(!request
+            .public_metadata()
+            .env
+            .contains_key(crate::core::runner::RUNNER_LAB_HANDOFF_ENV));
     }
 
     #[test]

--- a/src/core/api_jobs/remote_runner.rs
+++ b/src/core/api_jobs/remote_runner.rs
@@ -156,7 +156,11 @@ impl RemoteRunnerJobRequest {
             operation: request.operation,
             command: request.command,
             cwd: request.cwd,
-            env: request.env,
+            env: request
+                .env
+                .into_iter()
+                .filter(|(name, _)| !crate::core::runner::is_internal_control_env(name))
+                .collect(),
             source_snapshot: request.source_snapshot,
             require_paths: request.require_paths,
         });
@@ -194,6 +198,9 @@ impl RemoteRunnerJobRequest {
 
     pub(crate) fn public_metadata(&self) -> Self {
         let mut public = self.clone();
+        public
+            .env
+            .retain(|name, _| !crate::core::runner::is_internal_control_env(name));
         let mut secret_env_name_values = self.secret_env_plan.secret_env_names();
         secret_env_name_values.extend(self.secret_env_names.clone());
         let secret_env_names = secret_env_name_values

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -5,6 +5,7 @@
 //! thresholds. The public/in-crate surface is preserved via the re-exports
 //! below so callers continue to reference `runner::execution::<item>`.
 
+use std::cell::Cell;
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -39,7 +40,33 @@ pub(crate) const RUNNER_EXEC_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_EXEC_WAIT_
 /// in flight and uncancelled (#6891).
 pub(crate) const RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT";
 pub(crate) const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
+/// Internal, per-command marker that prevents an accepted Lab handoff from
+/// selecting another Lab runner on the runner host.
+pub(crate) const RUNNER_LAB_HANDOFF_ENV: &str = "HOMEBOY_RUNNER_LAB_HANDOFF";
 pub(crate) const RUNNER_ID_ENV: &str = "HOMEBOY_RUNNER_ID";
+
+thread_local! {
+    static RUNNER_LAB_HANDOFF_ACTIVE: Cell<bool> = const { Cell::new(false) };
+}
+
+pub(crate) fn consume_runner_lab_handoff_control_env() {
+    let handoff = std::env::var(RUNNER_LAB_HANDOFF_ENV).ok();
+    std::env::remove_var(RUNNER_LAB_HANDOFF_ENV);
+    RUNNER_LAB_HANDOFF_ACTIVE.with(|state| state.set(handoff.as_deref() == Some("1")));
+}
+
+pub(crate) fn runner_lab_handoff_active() -> bool {
+    RUNNER_LAB_HANDOFF_ACTIVE.with(Cell::get)
+}
+
+#[cfg(test)]
+pub(crate) fn set_runner_lab_handoff_active_for_test(active: bool) {
+    RUNNER_LAB_HANDOFF_ACTIVE.with(|state| state.set(active));
+}
+
+pub(crate) fn is_internal_control_env(name: &str) -> bool {
+    name == RUNNER_LAB_HANDOFF_ENV
+}
 
 mod broker;
 mod daemon;

--- a/src/core/runner/execution/redaction.rs
+++ b/src/core/runner/execution/redaction.rs
@@ -103,6 +103,7 @@ pub(super) fn redact_runner_exec_json(
         Value::Object(object) => Value::Object(
             object
                 .iter()
+                .filter(|(key, _)| !super::is_internal_control_env(key))
                 .map(|(key, value)| {
                     (
                         key.clone(),

--- a/src/core/runner/execution/tests/prepare.rs
+++ b/src/core/runner/execution/tests/prepare.rs
@@ -170,7 +170,7 @@ fn ssh_runner_prep_preserves_explicit_path() {
 }
 
 #[test]
-fn ssh_runner_prep_marks_commands_as_runner_hosted() {
+fn ssh_runner_prep_preserves_internal_lab_handoff_marker() {
     crate::test_support::with_isolated_home(|_| {
         let plan = prepare_runner_process(RunnerProcessRequest {
             runner_id: "lab".to_string(),
@@ -182,7 +182,10 @@ fn ssh_runner_prep_marks_commands_as_runner_hosted() {
                 "agent-task".to_string(),
                 "cook".to_string(),
             ],
-            env: Default::default(),
+            env: std::collections::HashMap::from([(
+                RUNNER_LAB_HANDOFF_ENV.to_string(),
+                "1".to_string(),
+            )]),
             secret_env_names: Vec::new(),
             secret_env_plan: None,
             capture_patch: false,
@@ -195,6 +198,10 @@ fn ssh_runner_prep_marks_commands_as_runner_hosted() {
 
         assert_eq!(
             plan.env.get(RUNNER_HOSTED_EXEC_ENV).map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            plan.env.get(RUNNER_LAB_HANDOFF_ENV).map(String::as_str),
             Some("1")
         );
         assert_eq!(plan.env.get(RUNNER_ID_ENV).map(String::as_str), Some("lab"));
@@ -301,7 +308,7 @@ fn runner_prep_allows_declared_sensitive_env() {
 }
 
 #[test]
-fn daemon_prep_allows_unrelated_runner_side_secret_for_non_secret_command() {
+fn daemon_prep_preserves_lab_handoff_marker_and_unrelated_runner_side_secret() {
     crate::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("project");
@@ -324,7 +331,10 @@ fn daemon_prep_allows_unrelated_runner_side_secret_for_non_secret_command() {
                 "refactor".to_string(),
                 "--help".to_string(),
             ],
-            env: Default::default(),
+            env: std::collections::HashMap::from([(
+                RUNNER_LAB_HANDOFF_ENV.to_string(),
+                "1".to_string(),
+            )]),
             secret_env_names: Vec::new(),
             secret_env_plan: None,
             capture_patch: false,
@@ -336,6 +346,10 @@ fn daemon_prep_allows_unrelated_runner_side_secret_for_non_secret_command() {
         .expect("unrelated runner-side secret should not block non-secret command");
 
         assert!(!plan.env.contains_key("OPENAI_API_KEY"));
+        assert_eq!(
+            plan.env.get(RUNNER_LAB_HANDOFF_ENV).map(String::as_str),
+            Some("1")
+        );
     });
 }
 

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -231,9 +231,13 @@ pub(crate) struct LabDispatchExecutionContext<'a> {
 
 fn lab_runner_exec_options(
     context: &LabDispatchExecutionContext<'_>,
-    env: std::collections::HashMap<String, String>,
+    mut env: std::collections::HashMap<String, String>,
     secret_env_names: Vec<String>,
 ) -> RunnerExecOptions {
+    env.insert(
+        super::super::super::RUNNER_LAB_HANDOFF_ENV.to_string(),
+        "1".to_string(),
+    );
     RunnerExecOptions {
         cwd: Some(context.remote_cwd.clone()),
         project_id: None,

--- a/src/core/runner/lab/offload/tests/selection.rs
+++ b/src/core/runner/lab/offload/tests/selection.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::core::runner::set_runner_lab_handoff_active_for_test;
 
 #[test]
 fn lab_runner_selection_keeps_explicit_runner_precedence() {
@@ -253,6 +254,41 @@ fn lab_runner_selection_allow_local_hot_overrides_default_runner_gate() {
     )
     .expect("selection")
     .is_none());
+}
+
+#[test]
+fn lab_runner_selection_does_not_reoffload_runner_handoffs() {
+    set_runner_lab_handoff_active_for_test(true);
+
+    let agent_task = resolve_lab_runner_selection_from_default(
+        &portable_lab_command("agent-task cook"),
+        None,
+        false,
+        false,
+        false,
+        false,
+        Some("lab-default".to_string()),
+    );
+    let release_gate = resolve_lab_runner_selection_from_default(
+        &release_gate_lab_command("release-gate"),
+        None,
+        false,
+        false,
+        false,
+        false,
+        Some("lab-default".to_string()),
+    );
+
+    set_runner_lab_handoff_active_for_test(false);
+
+    assert!(
+        agent_task.expect("agent task selection").is_none(),
+        "agent task stays on the accepting runner"
+    );
+    assert!(
+        release_gate.expect("release gate selection").is_none(),
+        "release gate stays on the accepting runner"
+    );
 }
 
 #[test]

--- a/src/core/runner/lab_arg_tests.rs
+++ b/src/core/runner/lab_arg_tests.rs
@@ -36,6 +36,35 @@ fn rewrites_lab_offload_path_and_strips_runner_and_output_flags() {
 }
 
 #[test]
+fn lab_offload_preserves_global_option_values_and_passthrough_force_hot() {
+    let input = args(&[
+        "homeboy",
+        "--runner-env",
+        "HOMEBOY_TEST_MARKER=1",
+        "agent-task",
+        "cook",
+        "--",
+        "--force-hot",
+    ]);
+
+    let rewritten = rewrite_lab_offload_args(&input, "/runner/workspaces/homeboy", &[], None);
+
+    assert_eq!(
+        rewritten,
+        args(&[
+            "homeboy",
+            "--force-hot",
+            "--runner-env",
+            "HOMEBOY_TEST_MARKER=1",
+            "agent-task",
+            "cook",
+            "--",
+            "--force-hot",
+        ])
+    );
+}
+
+#[test]
 fn maps_command_output_path_to_runner_output_path() {
     let input = args(&[
         "homeboy",

--- a/src/core/runner/lab_args/offload.rs
+++ b/src/core/runner/lab_args/offload.rs
@@ -100,7 +100,10 @@ pub(in crate::core::runner) fn rewrite_lab_offload_args(
     let mut stripped = Vec::with_capacity(args.len());
     let mut iter = args.iter().peekable();
     let mut passthrough = false;
-    let has_force_hot = args.iter().any(|arg| arg == "--force-hot");
+    let has_force_hot = args
+        .iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| arg == "--force-hot");
     let preserve_runner_arg = is_extension_dev_run(args);
     while let Some(arg) = iter.next() {
         if arg == EXPLICIT_PASSTHROUGH_SENTINEL {
@@ -312,7 +315,10 @@ pub(in crate::core::runner) fn rewrite_runner_resident_lab_offload_args(
     let mut stripped = Vec::with_capacity(args.len());
     let mut iter = args.iter().peekable();
     let mut passthrough = false;
-    let has_force_hot = args.iter().any(|arg| arg == "--force-hot");
+    let has_force_hot = args
+        .iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| arg == "--force-hot");
     while let Some(arg) = iter.next() {
         if arg == EXPLICIT_PASSTHROUGH_SENTINEL {
             continue;

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -523,6 +523,10 @@ pub(super) fn resolve_lab_runner_selection_from_default(
         }));
     }
 
+    if super::runner_lab_handoff_active() {
+        return Ok(None);
+    }
+
     if allow_local_hot && !force_hot {
         return Err(Error::validation_invalid_argument(
             "allow_local_hot",

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -94,10 +94,14 @@ pub use evidence::{
     refresh_mirrored_daemon_evidence, reportable_artifact_evidence_path, runner_job_log_snapshot,
     RemoteArtifactDownload, RunnerJobLogSnapshot,
 };
+pub(crate) use execution::is_internal_control_env;
+#[cfg(test)]
+pub(crate) use execution::set_runner_lab_handoff_active_for_test;
+pub(crate) use execution::{consume_runner_lab_handoff_control_env, runner_lab_handoff_active};
 pub(crate) use execution::{
     daemon_api_get, execute_runner_process_until_cancelled_with_progress,
     prepare_daemon_local_process, runner_exec_secret_env_plan, RunnerProcessRequest,
-    RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV,
+    RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_LAB_HANDOFF_ENV,
 };
 pub use execution::{
     daemon_api_post, exec, runner_exec_failure_error, runner_job_cancel, RunnerExecDiagnostics,


### PR DESCRIPTION
## Summary
- mark commands already accepted by Lab with a one-shot internal execution control
- consume the marker before routing and remove it before descendant workloads start
- exclude internal controls from public and persisted runner evidence
- preserve explicit runner precedence and passthrough argument semantics

Fixes #7929.

## How to test
1. Check out this branch with Rust installed.
2. Run `cargo test lab_arg_tests --lib` and confirm 18 tests pass.
3. Run `cargo test lab_runner_selection --lib` and confirm 13 tests pass, including agent-task and release-gate handoffs staying local on the accepting runner.
4. Run `cargo test remote_runner_request_compiles_canonical_execution_envelope --lib` and confirm internal controls are absent from public and persisted metadata.
5. Run `cargo test runner_resident --lib` and `cargo test final_remote_command --lib`; confirm 12 and 10 tests pass.
6. Run `cargo fmt --check && git diff --check origin/main...HEAD` and confirm both exit successfully.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the recursive Lab routing failure, drafted the one-shot handoff control and regression tests, and reviewed transport and evidence boundaries. Chris reviewed and owns the change.