### PR TITLE
fix: repair promisor commit graph bundle closure

### DIFF
--- a/src/core/runner/workspace/git.rs
+++ b/src/core/runner/workspace/git.rs
@@ -14,7 +14,50 @@ pub(super) fn git_snapshot(
     local_path: &Path,
     changed_since_base: Option<&str>,
     git_fetch_refs: Vec<String>,
+    controller_routed_git: bool,
 ) -> Result<GitSnapshot> {
+    let head = git_output(local_path, &["rev-parse", "HEAD"])?;
+    let branch = git_output(local_path, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .ok()
+        .filter(|branch| branch != "HEAD");
+    if !controller_routed_git {
+        ensure_clean_git_working_tree(local_path, changed_since_base)?;
+    }
+    let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"])?;
+    if remote_url.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "remote.origin.url",
+            "git workspace sync requires remote.origin.url",
+            None,
+            None,
+        ));
+    }
+    if controller_routed_git
+        || branch.is_none()
+        || super::super::source_materialization::requires_controller_routed_workspace_sync(
+            &remote_url,
+        )
+    {
+        let refs = controller_bundle_refs(&head, changed_since_base, &git_fetch_refs);
+        repair_controller_bundle_commit_closure(local_path, &refs)?;
+    }
+    if controller_routed_git {
+        ensure_clean_git_working_tree(local_path, changed_since_base)?;
+    }
+
+    Ok(GitSnapshot {
+        remote_url,
+        head,
+        branch,
+        changed_since_base: changed_since_base.map(str::to_string),
+        git_fetch_refs,
+    })
+}
+
+fn ensure_clean_git_working_tree(
+    local_path: &Path,
+    changed_since_base: Option<&str>,
+) -> Result<()> {
     let status = git_output(local_path, &["status", "--porcelain=v1"])?;
     if !status.trim().is_empty() {
         if changed_since_base.is_some() {
@@ -46,26 +89,7 @@ pub(super) fn git_snapshot(
             ]),
         ));
     }
-    let head = git_output(local_path, &["rev-parse", "HEAD"])?;
-    let branch = git_output(local_path, &["rev-parse", "--abbrev-ref", "HEAD"])
-        .ok()
-        .filter(|branch| branch != "HEAD");
-    let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"])?;
-    if remote_url.trim().is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "remote.origin.url",
-            "git workspace sync requires remote.origin.url",
-            None,
-            None,
-        ));
-    }
-    Ok(GitSnapshot {
-        remote_url,
-        head,
-        branch,
-        changed_since_base: changed_since_base.map(str::to_string),
-        git_fetch_refs,
-    })
+    Ok(())
 }
 
 pub(super) fn materialize_git(
@@ -196,7 +220,16 @@ pub(super) fn materialize_git_from_controller_bundle(
 /// use the source checkout's authenticated transport.
 fn hydrate_controller_bundle_objects(local_path: &Path, refs: &[String]) -> Result<()> {
     let mut object_list = Command::new("git")
-        .args(["rev-list", "--objects", "--no-object-names"])
+        // A stale commit graph can name promisor objects that do not exist in
+        // the local database. Walk the repaired closure from real objects so
+        // Git can use the controller's promisor transport when needed.
+        .args([
+            "-c",
+            "core.commitGraph=false",
+            "rev-list",
+            "--objects",
+            "--no-object-names",
+        ])
         .args(refs)
         .current_dir(local_path)
         .stdout(Stdio::piped())
@@ -254,6 +287,72 @@ fn hydrate_controller_bundle_objects(local_path: &Path, refs: &[String]) -> Resu
     }
 
     Ok(())
+}
+
+fn repair_controller_bundle_commit_closure(local_path: &Path, refs: &[String]) -> Result<()> {
+    if let Some(remote) = promisor_remote(local_path)? {
+        refetch_controller_bundle_commits(local_path, &remote, refs)?;
+    }
+    Ok(())
+}
+
+/// Rebuild the selected commit and tree closure before asking Git to walk it.
+/// A commit graph can retain entries for promisor objects that are no longer in
+/// the local object database, in which case `rev-list` cannot trigger its own
+/// lazy fetch.
+fn refetch_controller_bundle_commits(
+    local_path: &Path,
+    remote: &str,
+    refs: &[String],
+) -> Result<()> {
+    let output = Command::new("git")
+        .args(["fetch", "--refetch", "--no-tags", "--filter=blob:none"])
+        .arg(remote)
+        .args(refs)
+        .current_dir(local_path)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("refetch controller git bundle commits".to_string()),
+            )
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(Error::internal_unexpected(format!(
+        "refetch controller git bundle commits failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    )))
+}
+
+fn promisor_remote(local_path: &Path) -> Result<Option<String>> {
+    let output = Command::new("git")
+        .args(["config", "--get-regexp", r"^remote\..*\.promisor$"])
+        .current_dir(local_path)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("read git promisor remote".to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let remote = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| {
+            let (key, value) = line.split_once(char::is_whitespace)?;
+            if value.trim() != "true" {
+                return None;
+            }
+            key.strip_prefix("remote.")?.strip_suffix(".promisor")
+        })
+        .map(str::to_string);
+    Ok(remote)
 }
 
 fn controller_bundle_refs(

--- a/src/core/runner/workspace/sync.rs
+++ b/src/core/runner/workspace/sync.rs
@@ -183,6 +183,7 @@ pub fn sync_workspace(
                 &local_path,
                 options.changed_since_base.as_deref(),
                 options.git_fetch_refs.clone(),
+                options.controller_routed_git,
             )?;
             let remote_path = deterministic_remote_path(
                 workspace_root,

--- a/src/core/runner/workspace/tests/git.rs
+++ b/src/core/runner/workspace/tests/git.rs
@@ -32,6 +32,15 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
         fs::write(author.path().join("file.txt"), "head\n").expect("write head file");
         git(author.path(), &["add", "."]);
         git(author.path(), &["commit", "-m", "head"]);
+        let head = git_output(author.path(), &["rev-parse", "HEAD"]).expect("head revision");
+        git(author.path(), &["checkout", "-b", "unrelated", &base]);
+        fs::write(author.path().join("unrelated.txt"), "unrelated\n")
+            .expect("write unrelated file");
+        git(author.path(), &["add", "."]);
+        git(author.path(), &["commit", "-m", "unrelated"]);
+        let unrelated =
+            git_output(author.path(), &["rev-parse", "HEAD"]).expect("unrelated revision");
+        git(author.path(), &["checkout", &head]);
         git(
             author.path(),
             &[
@@ -41,7 +50,7 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
                 &format!("file://{}", origin.path().display()),
             ],
         );
-        git(author.path(), &["push", "origin", "main"]);
+        git(author.path(), &["push", "origin", "main", "unrelated"]);
         git(
             source.path(),
             &[
@@ -60,6 +69,14 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
             .contains(&format!("?{base_blob}")),
             "the partial source fixture must omit the base-only blob"
         );
+        git(
+            source.path(),
+            &[
+                "fetch",
+                "origin",
+                "refs/heads/unrelated:refs/remotes/origin/unrelated",
+            ],
+        );
         git(source.path(), &["remote", "rename", "origin", "controller"]);
         git(
             source.path(),
@@ -70,7 +87,31 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
                 "https://github.example.invalid/example-org/private-source.git",
             ],
         );
-
+        git(source.path(), &["commit-graph", "write", "--reachable"]);
+        assert!(
+            source
+                .path()
+                .join(".git/objects/info/commit-graph")
+                .exists(),
+            "the fixture must retain a commit graph after its objects are removed"
+        );
+        remove_local_packs(source.path());
+        assert!(
+            git_without_lazy_fetch(
+                source.path(),
+                &["cat-file", "-e", &format!("{base}^{{commit}}")]
+            )
+            .is_err(),
+            "the fixture must leave a commit-graph entry whose object is absent locally"
+        );
+        assert!(
+            git_without_lazy_fetch(
+                source.path(),
+                &["cat-file", "-e", &format!("{unrelated}^{{commit}}")],
+            )
+            .is_err(),
+            "the fixture must leave unrelated promisor objects absent locally"
+        );
         crate::core::runner::create(
             &format!(
                 r#"{{"id":"lab-local-git-bundle","kind":"local","workspace_root":"{}"}}"#,
@@ -144,7 +185,45 @@ fn controller_routed_git_sync_materializes_private_unavailable_remote_with_chang
             .contains(&format!("?{base_blob}")),
             "the controller must hydrate the promised object before bundling"
         );
+        assert!(
+            git_without_lazy_fetch(
+                source.path(),
+                &["cat-file", "-e", &format!("{unrelated}^{{commit}}")],
+            )
+            .is_err(),
+            "the controller must not hydrate unrelated refs"
+        );
+        assert!(
+            git_without_lazy_fetch(
+                remote,
+                &["cat-file", "-e", &format!("{unrelated}^{{commit}}")]
+            )
+            .is_err(),
+            "the runner bundle must not include unrelated refs"
+        );
     });
+}
+
+fn remove_local_packs(path: &Path) {
+    let pack_dir = path.join(".git/objects/pack");
+    for entry in fs::read_dir(pack_dir).expect("read object pack directory") {
+        let entry = entry.expect("read object pack entry");
+        fs::remove_file(entry.path()).expect("remove local object pack entry");
+    }
+}
+
+fn git_without_lazy_fetch(path: &Path, args: &[&str]) -> std::result::Result<(), String> {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_NO_LAZY_FETCH", "1")
+        .current_dir(path)
+        .output()
+        .expect("run git without lazy fetch");
+    output
+        .status
+        .success()
+        .then_some(())
+        .ok_or_else(|| String::from_utf8_lossy(&output.stderr).to_string())
 }
 
 #[test]
@@ -602,7 +681,7 @@ fn git_materialization_override_is_noisy_but_allows_reset() {
 fn dirty_git_sync_without_changed_since_reports_supported_remediation() {
     let source = super::dirty_git_repo();
 
-    let err = match git_snapshot(source.path(), None, Vec::new()) {
+    let err = match git_snapshot(source.path(), None, Vec::new(), false) {
         Ok(_) => panic!("dirty git sync should fail"),
         Err(err) => err,
     };
@@ -625,7 +704,7 @@ fn dirty_git_sync_without_changed_since_reports_supported_remediation() {
 fn dirty_changed_since_git_sync_explains_snapshot_is_unavailable() {
     let source = super::dirty_git_repo();
 
-    let err = match git_snapshot(source.path(), Some("abc123"), Vec::new()) {
+    let err = match git_snapshot(source.path(), Some("abc123"), Vec::new(), false) {
         Ok(_) => panic!("dirty changed-since git sync should fail"),
         Err(err) => err,
     };


### PR DESCRIPTION
Closes #7953

## Summary
- refetch the exact controller bundle refs from the configured promisor remote before controller-side Git inspection
- disable stale commit-graph traversal for the bounded object walk, then hydrate the selected closure before creating the runner bundle
- cover a partial checkout whose commit graph references locally absent objects while unrelated refs remain absent from both controller hydration and the runner bundle

## How to test
1. Start from a fresh checkout of this branch with Rust and Git installed.
2. Run `cargo fmt --check`.
3. Run `cargo test core::runner::workspace::tests::git -- --nocapture`.
4. Confirm all 14 workspace Git tests pass, including `controller_routed_git_sync_materializes_private_unavailable_remote_with_changed_since_base`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode, openai/gpt-5.6-sol
- **Used for:** Collaboratively implemented the bounded promisor closure repair and regression fixture; Chris remains responsible for the change.