### PR TITLE
Fix controller proxy runner resume

### DIFF
--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -213,7 +213,11 @@ fn transport_proxy_recovery_command(value: &Value) -> Option<String> {
         .and_then(Value::as_str);
     Some(match job_id {
         Some(job_id) => format!("homeboy runner job logs {runner_id} {job_id} --follow"),
-        None => format!("homeboy runner connect {runner_id}"),
+        None => value
+            .get("run_id")
+            .and_then(Value::as_str)
+            .map(|run_id| format!("homeboy agent-task run {run_id}"))
+            .unwrap_or_else(|| format!("homeboy runner connect {runner_id}")),
     })
 }
 
@@ -234,6 +238,22 @@ mod transport_proxy_tests {
         assert_eq!(
             transport_proxy_recovery_command(&value),
             Some("homeboy runner job logs runner-transport-42 job-42 --follow".to_string())
+        );
+    }
+
+    #[test]
+    fn unbound_transport_proxy_recovery_action_resumes_the_durable_run() {
+        let value = json!({
+            "run_id": "agent-task-proxy-42",
+            "metadata": {
+                "kind": "lab_offload_controller_proxy",
+                "runner_id": "homeboy-lab"
+            }
+        });
+
+        assert_eq!(
+            transport_proxy_recovery_command(&value),
+            Some("homeboy agent-task run agent-task-proxy-42".to_string())
         );
     }
 }

--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -128,6 +128,60 @@ fn controller_proxy_resume_uses_transport_recovery_without_provider_dispatch() {
 }
 
 #[test]
+fn controller_proxy_run_resumes_on_its_recorded_runner_workspace() {
+    with_temp_home(|| {
+        let workspace = tempfile::tempdir().expect("runner workspace");
+        let continuation = workspace.path().join("runner-continuation");
+        homeboy::core::runners::create(r#"{"id":"lab-local","kind":"local"}"#, false)
+            .expect("local runner created");
+        let command = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "pwd > {} && touch {}",
+                continuation.display(),
+                continuation.display()
+            ),
+        ];
+        agent_task_lifecycle::record_lab_offload_planned(
+            homeboy::core::agent_tasks::lifecycle::LabOffloadProxyPlan {
+                run_id: "run-cli-runner-resume-proxy",
+                runner_id: "lab-local",
+                remote_workspace: &workspace.path().display().to_string(),
+                remote_command: &command,
+            },
+        )
+        .expect("controller proxy persisted");
+
+        let executor = CapturingExecutor::default();
+        let error = run_submitted_with_executor(
+            "run-cli-runner-resume-proxy".to_string(),
+            None,
+            executor.clone(),
+        )
+        .expect_err("runner continuation awaits its durable result");
+        assert!(continuation.exists(), "recorded command ran on the runner");
+        assert_eq!(
+            std::fs::read_to_string(&continuation)
+                .expect("runner continuation cwd")
+                .trim(),
+            workspace
+                .path()
+                .canonicalize()
+                .expect("canonical runner workspace")
+                .display()
+                .to_string()
+        );
+        assert!(error.message.contains("was resumed on its recorded runner"));
+        assert!(executor
+            .observed_request
+            .lock()
+            .expect("executor lock")
+            .is_none());
+    });
+}
+
+#[test]
 fn run_next_leaves_transport_proxy_queued_for_runner_recovery() {
     with_temp_home(|| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -254,6 +254,10 @@ fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) -> Result<()> {
 /// inspectable, but must never reach provider lookup on the controller.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TransportProxyRecovery {
+    Resumed {
+        record: AgentTaskRunRecord,
+        next_action: String,
+    },
     Reconciled {
         record: AgentTaskRunRecord,
         next_action: String,
@@ -267,15 +271,17 @@ pub enum TransportProxyRecovery {
 impl TransportProxyRecovery {
     pub fn record(&self) -> &AgentTaskRunRecord {
         match self {
-            Self::Reconciled { record, .. } | Self::ReconnectRequired { record, .. } => record,
+            Self::Resumed { record, .. }
+            | Self::Reconciled { record, .. }
+            | Self::ReconnectRequired { record, .. } => record,
         }
     }
 
     pub fn next_action(&self) -> &str {
         match self {
-            Self::Reconciled { next_action, .. } | Self::ReconnectRequired { next_action, .. } => {
-                next_action
-            }
+            Self::Resumed { next_action, .. }
+            | Self::Reconciled { next_action, .. }
+            | Self::ReconnectRequired { next_action, .. } => next_action,
         }
     }
 }
@@ -298,11 +304,7 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
     metadata.insert("runner_id".to_string(), json!(&runner_id));
 
     let Some(runner_job_id) = runner_job_id else {
-        store::write_record(&record)?;
-        return Ok(Some(TransportProxyRecovery::ReconnectRequired {
-            record,
-            next_action: format!("homeboy runner connect {runner_id}"),
-        }));
+        return resume_transport_proxy_on_runner(record, runner_id);
     };
 
     metadata.insert("runner_job_id".to_string(), json!(&runner_job_id));
@@ -327,6 +329,76 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
             }))
         }
     }
+}
+
+/// Resume an unbound proxy where the controller never learned the runner job
+/// identity. The persisted command and workspace belong to the runner, so this
+/// must execute through the runner rather than through the local scheduler.
+fn resume_transport_proxy_on_runner(
+    mut record: AgentTaskRunRecord,
+    runner_id: String,
+) -> Result<Option<TransportProxyRecovery>> {
+    let Some(remote_workspace) = record
+        .metadata
+        .get("remote_workspace")
+        .and_then(Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+    else {
+        store::write_record(&record)?;
+        return Ok(Some(TransportProxyRecovery::ReconnectRequired {
+            record,
+            next_action: format!("homeboy runner connect {runner_id}"),
+        }));
+    };
+    let Some(remote_command) = record
+        .metadata
+        .get("remote_command")
+        .and_then(Value::as_array)
+        .map(|command| {
+            command
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .filter(|command| !command.is_empty())
+    else {
+        store::write_record(&record)?;
+        return Ok(Some(TransportProxyRecovery::ReconnectRequired {
+            record,
+            next_action: format!("homeboy runner connect {runner_id}"),
+        }));
+    };
+
+    if !crate::core::runners::exists(&runner_id) {
+        store::write_record(&record)?;
+        return Ok(Some(TransportProxyRecovery::ReconnectRequired {
+            record,
+            next_action: format!("homeboy runner connect {runner_id}"),
+        }));
+    }
+
+    let (_, exit_code) = crate::core::runners::exec(
+        &runner_id,
+        crate::core::runners::RunnerExecOptions {
+            cwd: Some(remote_workspace.to_string()),
+            command: remote_command,
+            run_id: Some(record.run_id.clone()),
+            ..Default::default()
+        },
+    )?;
+    if exit_code != 0 {
+        return Err(Error::internal_unexpected(format!(
+            "runner continuation for agent-task run '{}' exited with status {exit_code}",
+            record.run_id
+        )));
+    }
+
+    record = store::read_record(&record.run_id)?;
+    Ok(Some(TransportProxyRecovery::Resumed {
+        next_action: format!("homeboy agent-task status {} --full", record.run_id),
+        record,
+    }))
 }
 
 pub(crate) fn reconcile_transport_proxy_snapshot(

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -27,6 +27,26 @@ pub struct AgentTaskRunResult<T> {
     pub exit_code: i32,
 }
 
+fn transport_proxy_recovery_error(recovery: agent_task_lifecycle::TransportProxyRecovery) -> Error {
+    let recovery_message = match &recovery {
+        agent_task_lifecycle::TransportProxyRecovery::Resumed { .. } => {
+            "was resumed on its recorded runner; await its durable result"
+        }
+        _ => "is owned by runner transport recovery; provider execution was not attempted",
+    };
+    Error::validation_invalid_argument(
+        "run_id",
+        format!(
+            "agent-task run '{}' {recovery_message}",
+            recovery.record().run_id,
+        ),
+        Some(recovery.record().run_id.clone()),
+        None,
+    )
+    .with_hint(format!("Next: {}", recovery.next_action()))
+    .with_retryable(true)
+}
+
 pub fn read_plan(spec: &str) -> Result<AgentTaskPlan> {
     let raw = config::read_json_spec_to_string(spec)?;
     let mut plan: AgentTaskPlan = serde_json::from_str(&raw).map_err(|error| {
@@ -95,19 +115,7 @@ where
                 value: aggregate,
             });
         }
-        return Err(
-            Error::validation_invalid_argument(
-                "run_id",
-                format!(
-                    "agent-task run '{}' is owned by runner transport recovery; provider execution was not attempted",
-                    recovery.record().run_id
-                ),
-                Some(recovery.record().run_id.clone()),
-                None,
-            )
-            .with_hint(format!("Next: {}", recovery.next_action()))
-            .with_retryable(true),
-        );
+        return Err(transport_proxy_recovery_error(recovery));
     }
     let mut plan = agent_task_lifecycle::load_plan(&run_id)?;
     if let Some(timeout_ms) = timeout_ms {
@@ -147,19 +155,7 @@ where
                 value: aggregate,
             });
         }
-        return Err(
-            Error::validation_invalid_argument(
-                "run_id",
-                format!(
-                    "agent-task run '{}' is owned by runner transport recovery; provider execution was not attempted",
-                    recovery.record().run_id
-                ),
-                Some(recovery.record().run_id.clone()),
-                None,
-            )
-            .with_hint(format!("Next: {}", recovery.next_action()))
-            .with_retryable(true),
-        );
+        return Err(transport_proxy_recovery_error(recovery));
     }
     agent_task_lifecycle::mark_resuming(&run_id)?;
     run_claimed(run_id, executor)


### PR DESCRIPTION
## Summary
- Resume unbound Lab controller proxies through their recorded runner, workspace, and command before local scheduler preparation.
- Keep committed-change harvesting off runner-only paths and retain the generic detached-cook promotion adapter from #7952.
- Advertise `homeboy agent-task run <id>` as the recovery action for unbound proxies.

Closes #7960

## How to test
1. Run `cargo test commands::agent_task::tests::lifecycle:: --lib` from a fresh checkout.
2. Run `cargo test core::agent_task_lifecycle::tests:: --lib` from a fresh checkout.
3. Run `cargo test commands::agent_task::status::transport_proxy_tests:: --lib` from a fresh checkout.
4. Run `cargo fmt --check` and `cargo check` from a fresh checkout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.6 Sol)
- **Used for:** Implementation and regression tests under Chris's direction.