### PR TITLE
fix: offload agent-task promotion to Lab

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -26,10 +26,11 @@ use super::spec::{
     AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL, AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL,
     AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL, AGENT_TASK_FANOUT_RUN_PLAN_LAB_LABEL,
     AGENT_TASK_FANOUT_STATUS_LAB_LABEL, AGENT_TASK_FANOUT_SUBMIT_BATCH_LAB_LABEL,
-    AGENT_TASK_PROVIDERS_LAB_LABEL, AGENT_TASK_RUN_LAB_LABEL, AGENT_TASK_STATUS_LAB_LABEL,
-    AUDIT_LAB_LABEL, BENCH_LAB_LABEL, COMMAND_SPECS, FUZZ_DOCTOR_LAB_LABEL, FUZZ_LAB_LABEL,
-    LINT_LAB_LABEL, REFACTOR_LAB_LABEL, REVIEW_LAB_LABEL, RIG_CHECK_LAB_LABEL, RIG_RUN_LAB_LABEL,
-    RUNTIME_REFRESH_LAB_LABEL, TEST_LAB_LABEL, TRACE_LAB_LABEL,
+    AGENT_TASK_PROMOTE_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL, AGENT_TASK_RUN_LAB_LABEL,
+    AGENT_TASK_STATUS_LAB_LABEL, AUDIT_LAB_LABEL, BENCH_LAB_LABEL, COMMAND_SPECS,
+    FUZZ_DOCTOR_LAB_LABEL, FUZZ_LAB_LABEL, LINT_LAB_LABEL, REFACTOR_LAB_LABEL, REVIEW_LAB_LABEL,
+    RIG_CHECK_LAB_LABEL, RIG_RUN_LAB_LABEL, RUNTIME_REFRESH_LAB_LABEL, TEST_LAB_LABEL,
+    TRACE_LAB_LABEL,
 };
 
 pub const RUNNER_WORKLOAD_SCHEMA: &str = "homeboy/runner-workload/v1";
@@ -818,6 +819,14 @@ impl Commands {
             )
             .with_secret_env_sources(LAB_AGENT_TASK_SECRET_ENV_SOURCES),
             Commands::AgentTask(agent_task::AgentTaskArgs {
+                command: agent_task::AgentTaskCommand::Promote(_),
+            }) => LabCommandContract::portable(
+                AGENT_TASK_PROMOTE_LAB_LABEL,
+                None,
+                false,
+                LAB_NO_EXTRA_CAPABILITIES,
+            ),
+            Commands::AgentTask(agent_task::AgentTaskArgs {
                 command: agent_task::AgentTaskCommand::Providers(_),
             }) => LabCommandContract::explicit_runner_simple(AGENT_TASK_PROVIDERS_LAB_LABEL),
             Commands::AgentTask(agent_task::AgentTaskArgs {
@@ -1475,6 +1484,33 @@ mod low_noise_polling_tests {
             .expect("no-finalize cook should remain portable");
 
         assert_eq!(contract.portability, LabCommandPortability::Portable);
+    }
+
+    #[test]
+    fn agent_task_promote_with_runner_only_source_remains_lab_portable() {
+        let command = parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "promote",
+            "/runner/artifacts/aggregate.json",
+            "--to-worktree",
+            "homeboy@fix-7964",
+            "--runner",
+            "homeboy-lab",
+            "--lab-only",
+            "--dry-run",
+        ]);
+
+        let contract = command
+            .lab_contract()
+            .expect("promote contract should support Lab offload");
+
+        assert_eq!(contract.hot_label, AGENT_TASK_PROMOTE_LAB_LABEL);
+        assert_eq!(contract.portability, LabCommandPortability::Portable);
+        assert_eq!(
+            contract.workspace_mode_policy,
+            LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot
+        );
     }
 
     #[test]

--- a/src/command_contract/spec.rs
+++ b/src/command_contract/spec.rs
@@ -73,6 +73,7 @@ impl CommandSafetySpec {
 pub const DEFAULT_LAB_UNSUPPORTED_NOTES: &str =
     "not declared as Lab-routable in the command registry";
 pub(crate) const AGENT_TASK_RUN_LAB_LABEL: &str = "agent-task cook/run-plan/retry --run";
+pub(crate) const AGENT_TASK_PROMOTE_LAB_LABEL: &str = "agent-task promote";
 pub(crate) const AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL: &str =
     "agent-task controller from-spec --resume/run-from-spec/materialize";
 pub(crate) const AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL: &str = "agent-task controller resume";
@@ -249,6 +250,11 @@ const AGENT_TASK_LAB_SUPPORT: &[CommandLabSupportSummary] = &[
         contract_labels: &[AGENT_TASK_RUN_LAB_LABEL],
         message_label: "agent-task cook/run-plan",
         hint_label: "agent-task cook/run-plan",
+    },
+    CommandLabSupportSummary {
+        contract_labels: &[AGENT_TASK_PROMOTE_LAB_LABEL],
+        message_label: AGENT_TASK_PROMOTE_LAB_LABEL,
+        hint_label: AGENT_TASK_PROMOTE_LAB_LABEL,
     },
     CommandLabSupportSummary {
         contract_labels: &[

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -31,7 +31,19 @@ use super::types::{
 
 pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
     let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
-    promote_with_provider(options, &mut provider)
+    let mut report = promote_with_provider(options, &mut provider)?;
+    if let Ok(runner_id) = std::env::var("HOMEBOY_LAB_RUNNER_ID") {
+        if !runner_id.trim().is_empty() {
+            report.provenance["lab_offload"] = json!({
+                "runner_id": runner_id,
+                "source_aggregate": report.source.path,
+                "source_artifact": report.patch_artifact.path,
+                "target_worktree": report.to_worktree,
+                "target_workspace": report.target.path,
+            });
+        }
+    }
+    Ok(report)
 }
 
 pub(crate) fn promote_with_provider(

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -44,6 +44,7 @@ struct FakePromotionWorkspaceProvider {
         AgentTaskGateVisibility,
         AgentTaskGateRevealPolicy,
     )>,
+    verify_exit_code: i32,
 }
 
 impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
@@ -89,7 +90,7 @@ impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
         Ok(AgentTaskGateReport::new(
             format!("gate-{index}"),
             vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
-            0,
+            self.verify_exit_code,
             String::new(),
             String::new(),
             None,
@@ -756,6 +757,50 @@ fn promote_applies_patch_with_fake_workspace_provider() {
         report.deterministic_gates[1].visibility,
         AgentTaskGateVisibility::Private
     );
+}
+
+#[test]
+fn promote_verification_failure_keeps_the_applied_target_recoverable() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let worktree_path = temp.path().join("fresh-managed-target");
+    std::fs::create_dir(&worktree_path).expect("create target");
+    git(&worktree_path, &["init"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(worktree_path.clone()),
+        verify_exit_code: 1,
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("runner-only-run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "homeboy@fix-7964".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["false".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: None,
+        },
+        &mut provider,
+    )
+    .expect("verification failure is a recoverable promotion report");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::GateFailed);
+    assert!(report.status.patch_promoted());
+    assert_eq!(report.target.path.as_deref(), worktree_path.to_str());
+    assert_eq!(provider.apply_calls.len(), 1);
+    assert_eq!(provider.verify_calls.len(), 1);
+    assert_eq!(report.operator_notification.status, "blocked");
 }
 
 #[test]

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -238,6 +238,10 @@ fn lab_runner_exec_options(
         super::super::super::RUNNER_LAB_HANDOFF_ENV.to_string(),
         "1".to_string(),
     );
+    env.insert(
+        "HOMEBOY_LAB_RUNNER_ID".to_string(),
+        context.runner_id.to_string(),
+    );
     RunnerExecOptions {
         cwd: Some(context.remote_cwd.clone()),
         project_id: None,

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -410,9 +410,9 @@ fn prepare_lab_offload_workspace_stage_inner(
     );
     let remapped_args = remap_path_settings_in_args(&remapped_args, &path_remaps);
     let remapped_args = remap_lab_at_file_args(&remapped_args, &at_file_specs);
-    // The target worktree is already materialized on the runner. Give detached
-    // cooks a local adapter so promotion, gates, and finalization stay on that
-    // workspace instead of requiring a controller-side provider command.
+    // The target worktree is already materialized on the runner. Give portable
+    // cooks and promotions a local adapter so applying patches and verification
+    // stay on that workspace instead of requiring a controller-side provider.
     let remapped_args = inject_materialized_promotion_provider(
         remapped_args,
         command_prefix_argv.first().map(String::as_str),
@@ -657,12 +657,12 @@ fn inject_materialized_promotion_provider(
     let Some(agent_task_index) = args.iter().position(|arg| arg == "agent-task") else {
         return args;
     };
-    if args
-        .get(agent_task_index + 1)
-        .is_none_or(|arg| arg != "cook")
-        || args
-            .iter()
-            .any(|arg| arg == "--provider-command" || arg.starts_with("--provider-command="))
+    if !matches!(
+        args.get(agent_task_index + 1).map(String::as_str),
+        Some("cook" | "promote")
+    ) || args
+        .iter()
+        .any(|arg| arg == "--provider-command" || arg.starts_with("--provider-command="))
     {
         return args;
     }
@@ -1505,6 +1505,45 @@ mod tests {
             ),
             args
         );
+    }
+
+    #[test]
+    fn runner_only_promotion_uses_materialized_target_adapter_for_dry_run_and_apply() {
+        for dry_run in [true, false] {
+            let mut args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "promote".to_string(),
+                "/runner/artifacts/detached/aggregate.json".to_string(),
+                "--to-worktree".to_string(),
+                "homeboy@fix-7964".to_string(),
+            ];
+            if dry_run {
+                args.push("--dry-run".to_string());
+            } else {
+                args.extend(["--verify".to_string(), "cargo test --lib".to_string()]);
+            }
+
+            let command = build_lab_offload_remote_command(
+                &["/runner/bin/homeboy".to_string()],
+                &inject_materialized_promotion_provider(
+                    args,
+                    Some("/runner/bin/homeboy"),
+                    "/runner/workspaces/homeboy-fix-7964",
+                ),
+                "/runner/workspaces/homeboy-fix-7964",
+                &[],
+                None,
+                &command_plan(&[]),
+            );
+
+            assert!(command.contains(&"/runner/artifacts/detached/aggregate.json".to_string()));
+            assert!(command.windows(2).any(|args| args == [
+                "--provider-command",
+                "/runner/bin/homeboy agent-task promotion-provider --workspace /runner/workspaces/homeboy-fix-7964",
+            ]));
+            assert!(!command.iter().any(|arg| arg.contains("/Users/")));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #7964.

## Summary
- Register `agent-task promote` as a portable Lab command.
- Materialize the managed target on the selected runner while retaining runner-side aggregate and patch artifact paths in place.
- Use the existing materialized-workspace promotion adapter remotely and include runner, source, artifact, and target provenance in promotion reports.

## How to test
1. Run `cargo test agent_task_promote_with_runner_only_source_remains_lab_portable --lib`.
2. Run `cargo test runner_only_promotion_uses_materialized_target_adapter_for_dry_run_and_apply --lib`.
3. Run `cargo test promote_verification_failure_keeps_the_applied_target_recoverable --lib`.
4. Run `cargo check`.
5. Run `cargo fmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.