### PR TITLE
Fix retry after failed Lab agent-task handoff

### DIFF
--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -16,6 +16,7 @@ fn controller_proxy_status_and_logs_resolve_before_runner_child_is_known() {
                 runner_id: "homeboy-lab",
                 remote_workspace: "/runner/workspace/repo",
                 remote_command: &command,
+                durable_plan: None,
             },
         )
         .expect("controller proxy persisted");
@@ -56,6 +57,7 @@ fn controller_proxy_run_uses_transport_recovery_without_provider_dispatch() {
                 runner_id: "remote-runner-42",
                 remote_workspace: "/runner/workspace/repo",
                 remote_command: &command,
+                durable_plan: None,
             },
         )
         .expect("controller proxy persisted");
@@ -99,6 +101,7 @@ fn controller_proxy_resume_uses_transport_recovery_without_provider_dispatch() {
                 runner_id: "remote-runner-42",
                 remote_workspace: "/runner/workspace/repo",
                 remote_command: &command,
+                durable_plan: None,
             },
         )
         .expect("controller proxy persisted");
@@ -137,6 +140,7 @@ fn run_next_leaves_transport_proxy_queued_for_runner_recovery() {
                 runner_id: "remote-runner-42",
                 remote_workspace: "/runner/workspace/repo",
                 remote_command: &command,
+                durable_plan: None,
             },
         )
         .expect("controller proxy persisted");

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -94,6 +94,15 @@ pub fn route_after_parse(
         .as_ref()
         .map(|handoff| handoff.args.as_slice())
         .unwrap_or(normalized_args);
+    let cook_plan = if lab_command.is_some() && inferred_runner_id.is_some() {
+        materialize_agent_task_cook_plan(cli)?
+    } else {
+        None
+    };
+    let durable_agent_task_plan = retry_handoff
+        .as_ref()
+        .map(|handoff| &handoff.plan)
+        .or(cook_plan.as_ref());
     let observer = lab_dispatch_observer(cli, normalized_args, inferred_runner_id.as_deref());
     let active_run_id = observer
         .run_id()
@@ -143,6 +152,7 @@ pub fn route_after_parse(
                 .lab_route_contract()?
                 .is_some_and(|contract| contract.command.routing_policy.read_only_polling),
             local_output_file: output_file,
+            durable_agent_task_plan,
             job_overrides,
         },
         inferred_runner_id.as_deref(),
@@ -180,6 +190,27 @@ pub fn route_after_parse(
             Ok(Some(output.exit_code))
         }
     }
+}
+
+/// Materialize a cook's scheduler plan on the controller before the Lab
+/// handoff. The handoff record is transport state; this plan is the durable
+/// user task a later retry must execute.
+fn materialize_agent_task_cook_plan(
+    cli: &Cli,
+) -> homeboy::core::Result<Option<homeboy::core::agent_tasks::scheduler::AgentTaskPlan>> {
+    let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+        command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
+    }) = &cli.command
+    else {
+        return Ok(None);
+    };
+    let mut dispatch = cook.dispatch.clone();
+    if dispatch.prompt.is_none() {
+        dispatch.prompt = cook.goal.clone();
+    }
+    let request =
+        homeboy::core::agent_tasks::dispatch_service::resolve_dispatch_request(dispatch.into())?;
+    homeboy::core::agent_tasks::dispatch_service::build_dispatch_plan(&request).map(Some)
 }
 
 fn lab_route_dispatch_timeout(

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -669,6 +669,9 @@ pub struct LabOffloadProxyPlan<'a> {
     pub runner_id: &'a str,
     pub remote_workspace: &'a str,
     pub remote_command: &'a [String],
+    /// The user task plan, materialized on the controller before the temporary
+    /// runner handoff is recorded.
+    pub durable_plan: Option<&'a AgentTaskPlan>,
 }
 
 /// Persist the controller-owned parent before handing an agent-task workload to
@@ -680,6 +683,7 @@ pub fn record_lab_offload_planned(input: LabOffloadProxyPlan<'_>) -> Result<Agen
         input.runner_id,
         input.remote_workspace,
         input.remote_command,
+        input.durable_plan,
     )
 }
 
@@ -691,10 +695,16 @@ pub fn record_lab_offload_phase(
     remote_workspace: Option<&str>,
     source_checkout: Option<&Value>,
     provider_rotation: Option<&Value>,
+    durable_plan: Option<&AgentTaskPlan>,
 ) -> Result<AgentTaskRunRecord> {
     let placeholder_workspace = remote_workspace.unwrap_or("pending");
-    let mut record =
-        record_lab_offload_proxy(requested_run_id, runner_id, placeholder_workspace, &[])?;
+    let mut record = record_lab_offload_proxy(
+        requested_run_id,
+        runner_id,
+        placeholder_workspace,
+        &[],
+        durable_plan,
+    )?;
     record.updated_at = Some(now_timestamp());
     let metadata = record.ensure_metadata_object();
     metadata.insert("phase".to_string(), json!(phase));
@@ -791,6 +801,7 @@ fn record_lab_offload_proxy(
     runner_id: &str,
     remote_workspace: &str,
     remote_command: &[String],
+    durable_plan: Option<&AgentTaskPlan>,
 ) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(requested_run_id);
     let input = DetachedLabRunRecord {
@@ -823,10 +834,10 @@ fn record_lab_offload_proxy(
             if error.code == ErrorCode::InternalJsonError
                 && store::record_lacks_typed_metadata(&run_id)? =>
         {
-            submit_plan(&plan, Some(&run_id))?
+            submit_plan(durable_plan.unwrap_or(&plan), Some(&run_id))?
         }
         Err(error) if error.code == ErrorCode::ValidationInvalidArgument => {
-            submit_plan(&plan, Some(&run_id))?
+            submit_plan(durable_plan.unwrap_or(&plan), Some(&run_id))?
         }
         Err(error) => return Err(error),
     };
@@ -953,6 +964,26 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
             crate::core::notification_route::NOTIFICATION_ROUTE_METADATA_KEY.to_string(),
             serde_json::to_value(route).expect("notification route is serializable"),
         );
+    }
+    let retry_origin = [
+        "runner_id",
+        "runner_job_id",
+        "remote_workspace",
+        "remote_command",
+        "runner_execution_record",
+        "pre_execution_failure",
+        "runner_job_events",
+    ]
+    .into_iter()
+    .filter_map(|key| {
+        source
+            .metadata
+            .get(key)
+            .map(|value| (key.to_string(), value.clone()))
+    })
+    .collect::<serde_json::Map<_, _>>();
+    if !retry_origin.is_empty() {
+        metadata.insert("retry_origin".to_string(), Value::Object(retry_origin));
     }
     metadata.insert("retry_of".to_string(), json!(source.run_id));
     metadata.insert("retry_requested_at".to_string(), json!(now_timestamp()));

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -121,6 +121,7 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
+            durable_plan: None,
         })
         .expect("controller proxy recorded before handoff");
 
@@ -162,6 +163,55 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
 }
 
 #[test]
+fn failed_lab_handoff_retry_recovers_the_materialized_user_plan() {
+    with_isolated_home(|_| {
+        let mut plan = test_plan();
+        plan.plan_id = "materialized-cook-plan".to_string();
+        plan.tasks[0].instructions = "implement the original user task".to_string();
+        plan.tasks[0].workspace.root = Some("/materialized/worktree".to_string());
+        let record = record_lab_offload_phase(
+            "failed-lab-cook",
+            "homeboy-lab",
+            "materializing",
+            None,
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("controller records user plan before pending handoff");
+        let persisted = load_plan(&record.run_id).expect("persisted user plan");
+        record_pre_execution_failure(
+            &record.run_id,
+            &persisted,
+            "lab_handoff",
+            &Error::internal_unexpected("runner daemon restarted"),
+        )
+        .expect("terminal handoff failure");
+
+        let retry = retry(&record.run_id, Some("failed-lab-cook-retry")).expect("retry record");
+        let recovered = load_plan(&retry.run_id).expect("recovered plan");
+
+        assert_eq!(recovered, plan);
+        assert_eq!(
+            recovered.tasks[0].workspace.root.as_deref(),
+            Some("/materialized/worktree")
+        );
+        assert!(!serde_json::to_string(&recovered)
+            .expect("plan json")
+            .contains("pending"));
+        assert_eq!(retry.metadata["retry_origin"]["runner_id"], "homeboy-lab");
+        assert_eq!(
+            retry.metadata["retry_origin"]["remote_workspace"],
+            "pending"
+        );
+        assert_eq!(
+            retry.metadata["retry_origin"]["pre_execution_failure"]["phase"],
+            "lab_handoff"
+        );
+    });
+}
+
+#[test]
 fn controller_proxy_records_pre_execution_phase_progress() {
     with_isolated_home(|_| {
         let source = json!({
@@ -175,6 +225,7 @@ fn controller_proxy_records_pre_execution_phase_progress() {
             None,
             Some(&source),
             Some(&json!({"entries": [{"model": "openai/gpt-5.6-terra"}]})),
+            None,
         )
         .expect("materialization phase persisted");
 
@@ -194,6 +245,7 @@ fn controller_proxy_records_pre_execution_phase_progress() {
             "hydrating",
             Some("/runner/workspace/repo"),
             Some(&source),
+            None,
             None,
         )
         .expect("hydration phase persisted");
@@ -519,6 +571,7 @@ fn controller_proxy_becomes_terminal_when_handoff_fails_before_child_creation() 
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
+            durable_plan: None,
         })
         .expect("planned proxy");
         let plan = load_plan("agent-task-handoff-failure").expect("proxy plan");
@@ -549,6 +602,7 @@ fn transport_proxy_snapshot_reconciliation_advances_queued_lifecycle() {
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
+            durable_plan: None,
         })
         .expect("planned proxy");
         let job_id = "00000000-0000-0000-0000-000000000123";

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -43,6 +43,7 @@ pub struct LabRoutingRequest<'a> {
     /// Controller-local `--output` path forwarded to the offload executor so the
     /// durable agent-task run id can be persisted before long execution (#5684).
     pub local_output_file: Option<&'a str>,
+    pub durable_agent_task_plan: Option<&'a crate::core::agent_task_scheduler::AgentTaskPlan>,
     pub job_overrides: runners::LabJobOverrides,
 }
 
@@ -67,6 +68,7 @@ pub(crate) fn route_lab_offload(
         output_file_requested: request.output_file_requested,
         read_only_polling: request.read_only_polling,
         local_output_file: request.local_output_file,
+        durable_agent_task_plan: request.durable_agent_task_plan,
         job_overrides: request.job_overrides,
     })
 }
@@ -521,6 +523,7 @@ fn execute_lab_offload_with_timeout(
     let output_file_requested = request.output_file_requested;
     let read_only_polling = request.read_only_polling;
     let local_output_file = request.local_output_file.map(str::to_string);
+    let durable_agent_task_plan = request.durable_agent_task_plan.cloned();
     let job_overrides = request.job_overrides;
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
@@ -538,6 +541,7 @@ fn execute_lab_offload_with_timeout(
             output_file_requested,
             read_only_polling,
             local_output_file: local_output_file.as_deref(),
+            durable_agent_task_plan: durable_agent_task_plan.as_ref(),
             job_overrides,
         });
         let _ = tx.send(result);
@@ -724,6 +728,7 @@ mod tests {
             output_file_requested: false,
             read_only_polling: false,
             local_output_file: None,
+            durable_agent_task_plan: None,
             job_overrides: runners::LabJobOverrides::default(),
         })
         .unwrap();
@@ -1024,6 +1029,7 @@ mod tests {
                 output_file_requested: false,
                 read_only_polling: false,
                 local_output_file: None,
+                durable_agent_task_plan: None,
                 job_overrides: runners::LabJobOverrides::default(),
             },
             None,

--- a/src/core/runner/evidence/tests/mod.rs
+++ b/src/core/runner/evidence/tests/mod.rs
@@ -308,6 +308,7 @@ fn mirroring_lab_job_preserves_agent_task_lifecycle_metadata() {
                 runner_id: "lab",
                 remote_workspace: "/srv/homeboy/project",
                 remote_command: &command,
+                durable_plan: None,
             },
         )
         .expect("planned controller proxy");

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -362,6 +362,7 @@ pub(crate) fn exec_lab_context(
                 runner_id,
                 remote_workspace: &remote_cwd,
                 remote_command: &context.remote_command,
+                durable_plan: request.durable_agent_task_plan,
             },
         )?;
     }
@@ -822,6 +823,7 @@ pub(crate) fn run_lab_offload_inner(
             None,
             Some(&source_checkout),
             Some(&provider_rotation),
+            request.durable_agent_task_plan,
         )?;
     }
     let homeboy_path = remote_runner_homeboy_path(&runner, "Lab offload preflight")?;
@@ -1032,6 +1034,7 @@ pub(crate) fn run_lab_offload_inner(
             Some(&remote_cwd),
             Some(&source_checkout),
             Some(&provider_rotation),
+            request.durable_agent_task_plan,
         )?;
     }
     let cleanup_policy = if agent_task_run_id.is_some() {
@@ -1074,6 +1077,7 @@ pub(crate) fn run_lab_offload_inner(
             Some(&remote_cwd),
             Some(&source_checkout),
             Some(&provider_rotation),
+            request.durable_agent_task_plan,
         )?;
     }
 

--- a/src/core/runner/lab/offload/tests/exec_errors.rs
+++ b/src/core/runner/lab/offload/tests/exec_errors.rs
@@ -374,6 +374,7 @@ fn plan_records_skipped_auto_offload() {
         output_file_requested: false,
         read_only_polling: false,
         local_output_file: None,
+        durable_agent_task_plan: None,
         job_overrides: LabJobOverrides::default(),
     })
     .expect("outcome");
@@ -403,6 +404,7 @@ fn lab_only_refuses_local_execution_without_lab_contract() {
         output_file_requested: false,
         read_only_polling: false,
         local_output_file: None,
+        durable_agent_task_plan: None,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -435,6 +437,7 @@ fn lab_only_refuses_local_only_rig_install_with_actionable_boundary() {
         output_file_requested: false,
         read_only_polling: false,
         local_output_file: None,
+        durable_agent_task_plan: None,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -469,6 +472,7 @@ fn build_runner_error_gives_managed_runner_replacement() {
         output_file_requested: false,
         read_only_polling: false,
         local_output_file: None,
+        durable_agent_task_plan: None,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -512,6 +516,7 @@ fn build_lab_only_error_gives_managed_runner_replacement() {
         output_file_requested: false,
         read_only_polling: false,
         local_output_file: None,
+        durable_agent_task_plan: None,
         job_overrides: LabJobOverrides::default(),
     });
 
@@ -557,6 +562,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
         output_file_requested: false,
         read_only_polling: false,
         local_output_file: None,
+        durable_agent_task_plan: None,
         job_overrides: LabJobOverrides::default(),
     });
 

--- a/src/core/runner/lab/offload/types.rs
+++ b/src/core/runner/lab/offload/types.rs
@@ -30,6 +30,9 @@ pub struct LabOffloadRequest<'a> {
     /// run id immediately (before long-running provider execution starts) so the
     /// handle survives a local shell timeout/interruption (#5684).
     pub local_output_file: Option<&'a str>,
+    /// The controller-materialized task plan to retain if this offload creates
+    /// a durable agent-task record before the runner accepts its child job.
+    pub durable_agent_task_plan: Option<&'a crate::core::agent_task_scheduler::AgentTaskPlan>,
     pub job_overrides: LabJobOverrides,
 }
 

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -2052,6 +2052,7 @@ mod tests {
                 output_file_requested: false,
                 read_only_polling: false,
                 local_output_file: None,
+                durable_agent_task_plan: None,
                 job_overrides: LabJobOverrides::default(),
             };
             let contract = LabOffloadCommand {


### PR DESCRIPTION
## Summary
- persist the controller-materialized agent-task plan before Lab setup creates a transport proxy
- retry the original plan and worktree rather than a pending Lab-handoff envelope
- retain runner and failed-handoff diagnostics under `retry_origin`

Fixes #7962

## How to test
1. Run `cargo check`.
2. Run `cargo test --lib core::agent_task_lifecycle::tests::failed_lab_handoff_retry_recovers_the_materialized_user_plan --no-fail-fast`.
3. Confirm the test retries a terminal Lab handoff using the original plan/worktree and rejects the `pending` proxy workspace.

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --lib -- -D warnings` (blocked by pre-existing warnings outside this change)
- Focused test command exceeded the local full lib-test build window before execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Collaborated on the durable Lab handoff plan persistence, retry behavior, and behavioral tests.