### PR TITLE
Persist Lab cooks before materialization

### DIFF
--- a/src/commands/agent_task/tests/lifecycle.rs
+++ b/src/commands/agent_task/tests/lifecycle.rs
@@ -152,6 +152,7 @@ fn controller_proxy_run_resumes_on_its_recorded_runner_workspace() {
                 runner_id: "lab-local",
                 remote_workspace: &workspace.path().display().to_string(),
                 remote_command: &command,
+                durable_plan: None,
             },
         )
         .expect("controller proxy persisted");

--- a/src/core/agent_task_lifecycle/lifecycle_ops.rs
+++ b/src/core/agent_task_lifecycle/lifecycle_ops.rs
@@ -794,6 +794,34 @@ pub fn record_lab_offload_phase(
     Ok(record)
 }
 
+/// Record child setup executions against the controller proxy. A staging job
+/// can outlive the foreground caller, so its runner IDs belong to the durable
+/// phase record rather than only transient command output.
+pub fn record_lab_offload_phase_executions(
+    run_id: &str,
+    phase: &str,
+    execution_ids: impl IntoIterator<Item = String>,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let execution_ids: Vec<String> = execution_ids
+        .into_iter()
+        .filter(|id| !id.trim().is_empty())
+        .collect();
+    record.updated_at = Some(now_timestamp());
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("phase".to_string(), json!(phase));
+    metadata.insert(
+        "materialization_execution_ids".to_string(),
+        json!(execution_ids),
+    );
+    metadata.insert(
+        "materialization_resume".to_string(),
+        json!("resume reuses the controller proxy and recorded completed staging"),
+    );
+    store::write_record(&record)?;
+    Ok(record)
+}
+
 pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(input.run_id);
     let plan = detached_lab_plan(&run_id, &input);
@@ -916,8 +944,12 @@ fn record_lab_offload_proxy(
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
     metadata.insert("runner_id".to_string(), json!(runner_id));
-    metadata.insert("remote_workspace".to_string(), json!(remote_workspace));
-    metadata.insert("remote_command".to_string(), json!(remote_command));
+    if remote_workspace != "pending" {
+        metadata.insert("remote_workspace".to_string(), json!(remote_workspace));
+    }
+    if !remote_command.is_empty() {
+        metadata.insert("remote_command".to_string(), json!(remote_command));
+    }
     metadata.insert("retryable".to_string(), json!(true));
     metadata.insert(
         "runner_execution_record".to_string(),

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -4,9 +4,9 @@
 use super::*;
 use crate::core::agent_task::{
     AgentTaskArtifactDeclaration, AgentTaskExecutionHandle, AgentTaskExecutor, AgentTaskLimits,
-    AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence,
-    AgentTaskWorkflowStepStatus, AgentTaskWorkspace, AgentTaskSourceRef, AGENT_TASK_REQUEST_SCHEMA,
-    AGENT_TASK_WORKFLOW_SCHEMA,
+    AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkflowEvidence,
+    AgentTaskWorkflowStepEvidence, AgentTaskWorkflowStepStatus, AgentTaskWorkspace,
+    AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
 };
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
@@ -269,14 +269,20 @@ fn slow_materialization_remains_discoverable_with_source_identity_and_is_idempot
             "agent-task".to_string(),
             "cook".to_string(),
         ];
+        let mut durable_plan = test_plan();
+        durable_plan.tasks[0].task_id = "https://github.com/example/project/issues/42".to_string();
+        durable_plan.tasks[0].source_refs = vec![AgentTaskSourceRef {
+            kind: "task".to_string(),
+            uri: "https://github.com/example/project/issues/42".to_string(),
+            revision: None,
+        }];
         let started = std::time::Instant::now();
         let first = record_lab_offload_planned(LabOffloadProxyPlan {
             run_id: "slow-materialization",
             runner_id: "homeboy-lab",
             remote_workspace: "pending-materialization",
             remote_command: &command,
-            task_id: Some("https://github.com/example/project/issues/42"),
-            task_source: Some("https://github.com/example/project/issues/42"),
+            durable_plan: Some(&durable_plan),
         })
         .expect("proxy persisted before staging");
 
@@ -291,18 +297,13 @@ fn slow_materialization_remains_discoverable_with_source_identity_and_is_idempot
             visible.tasks[0].task_id,
             "https://github.com/example/project/issues/42"
         );
-        assert_eq!(
-            visible.metadata["task_source"],
-            "https://github.com/example/project/issues/42"
-        );
 
         let resumed = record_lab_offload_planned(LabOffloadProxyPlan {
             run_id: "slow-materialization",
             runner_id: "homeboy-lab",
             remote_workspace: "pending-materialization",
             remote_command: &command,
-            task_id: Some("https://github.com/example/project/issues/42"),
-            task_source: Some("https://github.com/example/project/issues/42"),
+            durable_plan: Some(&durable_plan),
         })
         .expect("resume does not duplicate staging record");
         assert_eq!(resumed.run_id, first.run_id);

--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::core::agent_task::{
     AgentTaskArtifactDeclaration, AgentTaskExecutionHandle, AgentTaskExecutor, AgentTaskLimits,
     AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence,
-    AgentTaskWorkflowStepStatus, AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA,
+    AgentTaskWorkflowStepStatus, AgentTaskWorkspace, AgentTaskSourceRef, AGENT_TASK_REQUEST_SCHEMA,
     AGENT_TASK_WORKFLOW_SCHEMA,
 };
 use crate::core::agent_task_scheduler::{
@@ -258,6 +258,71 @@ fn controller_proxy_records_pre_execution_phase_progress() {
         let loaded = status("agent-task-pre-execution").expect("status resolves during setup");
         assert_eq!(loaded.metadata["phase"], "hydrating");
         assert_eq!(loaded.metadata["provider_state"], "pending");
+    });
+}
+
+#[test]
+fn slow_materialization_remains_discoverable_with_source_identity_and_is_idempotent() {
+    with_isolated_home(|_| {
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        let started = std::time::Instant::now();
+        let first = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "slow-materialization",
+            runner_id: "homeboy-lab",
+            remote_workspace: "pending-materialization",
+            remote_command: &command,
+            task_id: Some("https://github.com/example/project/issues/42"),
+            task_source: Some("https://github.com/example/project/issues/42"),
+        })
+        .expect("proxy persisted before staging");
+
+        // Deliberately exceed a caller's short wait budget after the durable
+        // write, as a workspace/dependency materializer can in production.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert!(started.elapsed() > std::time::Duration::from_millis(1));
+
+        let visible = status("slow-materialization").expect("immediately discoverable");
+        assert_eq!(visible.run_id, first.run_id);
+        assert_eq!(
+            visible.tasks[0].task_id,
+            "https://github.com/example/project/issues/42"
+        );
+        assert_eq!(
+            visible.metadata["task_source"],
+            "https://github.com/example/project/issues/42"
+        );
+
+        let resumed = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "slow-materialization",
+            runner_id: "homeboy-lab",
+            remote_workspace: "pending-materialization",
+            remote_command: &command,
+            task_id: Some("https://github.com/example/project/issues/42"),
+            task_source: Some("https://github.com/example/project/issues/42"),
+        })
+        .expect("resume does not duplicate staging record");
+        assert_eq!(resumed.run_id, first.run_id);
+        let persisted = load_plan("slow-materialization").expect("one persisted plan");
+        assert_eq!(persisted.tasks.len(), 1);
+        assert_eq!(
+            persisted.tasks[0].source_refs[0].uri,
+            "https://github.com/example/project/issues/42"
+        );
+
+        let with_child = record_lab_offload_phase_executions(
+            "slow-materialization",
+            "hydrating",
+            ["runner-job-42".to_string()],
+        )
+        .expect("child staging job recorded");
+        assert_eq!(
+            with_child.metadata["materialization_execution_ids"],
+            json!(["runner-job-42"])
+        );
     });
 }
 

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -1074,6 +1074,19 @@ pub(crate) fn run_lab_offload_inner(
     )?;
     plan = dependency_hydration.plan;
     if let Some(run_id) = agent_task_run_id.as_deref() {
+        let execution_ids = match &dependency_hydration.record {
+            LabWorkspaceHydrationRecord::Applied(output) => output
+                .steps
+                .iter()
+                .filter_map(|step| step.job_id.clone())
+                .collect(),
+            LabWorkspaceHydrationRecord::NotApplied { .. } => Vec::new(),
+        };
+        agent_task_lifecycle::record_lab_offload_phase_executions(
+            run_id,
+            "hydrating",
+            execution_ids,
+        )?;
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,
             runner_id,

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -119,9 +119,8 @@ use super::super::workload::{
 };
 use super::agent_task_bridge::{
     agent_task_dispatch_run_isolation_token, ensure_agent_task_dispatch_run_id_with,
-    lab_pre_dispatch_failure_message,
-    mirror_agent_task_run_plan_lifecycle, parse_offloaded_agent_task_handoff_from_outputs,
-    sync_inline_agent_task_file,
+    lab_pre_dispatch_failure_message, mirror_agent_task_run_plan_lifecycle,
+    parse_offloaded_agent_task_handoff_from_outputs, sync_inline_agent_task_file,
 };
 use super::evidence::terminal_lab_run_evidence;
 use super::fallback::{

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -119,8 +119,9 @@ use super::super::workload::{
 };
 use super::agent_task_bridge::{
     agent_task_dispatch_run_isolation_token, ensure_agent_task_dispatch_run_id_with,
-    lab_pre_dispatch_failure_message, mirror_agent_task_run_plan_lifecycle,
-    parse_offloaded_agent_task_handoff_from_outputs, sync_inline_agent_task_file,
+    lab_pre_dispatch_failure_message,
+    mirror_agent_task_run_plan_lifecycle, parse_offloaded_agent_task_handoff_from_outputs,
+    sync_inline_agent_task_file,
 };
 use super::evidence::terminal_lab_run_evidence;
 use super::fallback::{


### PR DESCRIPTION
## Summary
- persist the controller proxy run before slow Lab workspace and dependency materialization begins
- preserve exact source/task identity and materialization phase for discovery after caller timeout
- make resumed handoffs reuse completed staging rather than duplicating it
- add deterministic slow-materialization lifecycle coverage

Closes #7969.

## How to test
1. Start from a fresh checkout of this branch with Rust installed.
2. Run `cargo fmt --check`.
3. Run `cargo test slow_materialization_remains_discoverable --lib`.
4. Run `cargo test controller_proxy --lib`.
5. Confirm the slow fixture exposes a durable run before materialization completes and resume preserves the same identity.

## Compatibility
This changes controller/runner lifecycle timing only. Existing agent-task plan and outcome schemas remain compatible; runs become visible earlier with additional materialization-phase evidence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the pre-materialization durability gap, drafted the lifecycle implementation and regression tests, and rebased it over the overlapping #7973 fix. Chris reviewed and owns the change.