### PR TITLE
Fix detached Lab cook lifecycle ownership

### DIFF
--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -463,6 +463,11 @@ pub struct AgentTaskCookArgs {
     #[command(flatten)]
     pub dispatch: DispatchArgs,
 
+    /// First-attempt lifecycle id injected by a controller when execution is
+    /// handed to a runner.
+    #[arg(long, hide = true)]
+    pub attempt_run_id: Option<String>,
+
     /// Repo-cooking goal. Alias for the dispatch prompt when --prompt is omitted.
     #[arg(long, value_name = "TEXT")]
     pub goal: Option<String>,

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -93,7 +93,11 @@ where
     }
     let requested_cook_id = dispatch_args.run_id.clone();
     if let Some(cook_id) = requested_cook_id.as_deref() {
-        dispatch_args.run_id = Some(agent_task_lifecycle::cook_attempt_run_id(cook_id, 1));
+        dispatch_args.run_id = Some(
+            args.attempt_run_id
+                .clone()
+                .unwrap_or_else(|| agent_task_lifecycle::cook_attempt_run_id(cook_id, 1)),
+        );
     }
     dispatch_args.core.queue_only = false;
     let (dispatch_value, _dispatch_exit) =

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -142,6 +142,7 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
                         resolved_provider_policy: None,
                     },
                 },
+                attempt_run_id: Some("cook-missing-provider-attempt-1-controller".to_string()),
                 goal: Some("cook fixture".to_string()),
                 to_worktree: "homeboy@fix-agent-task-runner-cook".to_string(),
                 provider_command: None,
@@ -167,11 +168,10 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
         assert_eq!(exit_code, 1);
         assert_eq!(value["schema"], "homeboy/agent-task-cook/v1");
         assert_eq!(value["cook_id"], "cook-missing-provider");
-        assert_ne!(value["latest_run_id"], "cook-missing-provider");
-        assert!(value["latest_run_id"]
-            .as_str()
-            .expect("latest run id")
-            .starts_with("cook-missing-provider-attempt-1-"));
+        assert_eq!(
+            value["latest_run_id"],
+            "cook-missing-provider-attempt-1-controller"
+        );
         assert_eq!(
             value["history_run_ids"].as_array().expect("history").len(),
             1
@@ -321,6 +321,7 @@ fn cook_applies_executor_commit_from_source_repo_to_distinct_target_repo() {
                         resolved_provider_policy: None,
                     },
                 },
+                attempt_run_id: None,
                 goal: None,
                 to_worktree: "fixture-component@promoted".to_string(),
                 provider_command: Some(format!("sh {}", provider.display())),

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -16,7 +16,8 @@ use crate::command_contract::{
 };
 use crate::core::agent_task::AgentTaskEvidenceRef;
 use crate::core::agent_task_lifecycle::{
-    record_runner_job_identity, AgentTaskArtifactRef, AgentTaskRunRecord, AgentTaskRunState,
+    cook_attempt_run_id, record_runner_job_identity, AgentTaskArtifactRef, AgentTaskRunRecord,
+    AgentTaskRunState,
 };
 use crate::core::agent_tasks::lifecycle as agent_task_lifecycle;
 use crate::core::agent_tasks::provider::{
@@ -618,6 +619,33 @@ pub(super) fn ensure_agent_task_dispatch_run_id_with(
         .insert_after(action_index, ["--run-id".to_string(), run_id.clone()])
         .into_args();
     Some((out, run_id))
+}
+
+/// Give a portable cook one first-attempt id before it crosses the Lab
+/// boundary. The cook id remains part of the command's public contract, while
+/// this id is the lifecycle record owned by the controller, daemon, and runner.
+pub(super) fn ensure_agent_task_lifecycle_identity_with(
+    args: &[String],
+    preferred: Option<&str>,
+) -> Option<(Vec<String>, String)> {
+    let (args, run_id) = ensure_agent_task_dispatch_run_id_with(args, preferred)?;
+    let invocation = CommandInvocation::for_subcommand(&args, "agent-task")?;
+    let action_index = invocation.child_index_matching(&["cook"])?;
+    let existing_attempt_run_id = invocation
+        .option_value_after(action_index, "--attempt-run-id")
+        .map(str::to_string);
+    if let Some(attempt_run_id) = existing_attempt_run_id {
+        return Some((args, attempt_run_id));
+    }
+
+    let attempt_run_id = cook_attempt_run_id(&run_id, 1);
+    let args = ArgEditor::new(&args)
+        .insert_after(
+            action_index,
+            ["--attempt-run-id".to_string(), attempt_run_id.clone()],
+        )
+        .into_args();
+    Some((args, attempt_run_id))
 }
 
 /// Resolves the stable per-run isolation token for an agent-task cook offload:
@@ -1363,6 +1391,26 @@ mod tests {
         // An explicit --run-id always wins over the preferred isolation token.
         assert_eq!(run_id, "explicit-run");
         assert_eq!(out, args);
+    }
+
+    #[test]
+    fn lab_cook_uses_one_first_attempt_identity_across_the_handoff() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--run-id".to_string(),
+            "cook-7970".to_string(),
+        ];
+
+        let (out, lifecycle_run_id) =
+            ensure_agent_task_lifecycle_identity_with(&args, None).expect("cook identity");
+
+        assert_eq!(out[3], "--attempt-run-id");
+        assert_eq!(out[4], lifecycle_run_id);
+        assert_eq!(out[5], "--run-id");
+        assert_eq!(out[6], "cook-7970");
+        assert!(lifecycle_run_id.starts_with("cook-7970-attempt-1-"));
     }
 
     #[test]

--- a/src/core/runner/lab/offload/mod.rs
+++ b/src/core/runner/lab/offload/mod.rs
@@ -118,7 +118,7 @@ use super::super::workload::{
     RunnerWorkloadBuildInput,
 };
 use super::agent_task_bridge::{
-    agent_task_dispatch_run_isolation_token, ensure_agent_task_dispatch_run_id_with,
+    agent_task_dispatch_run_isolation_token, ensure_agent_task_lifecycle_identity_with,
     lab_pre_dispatch_failure_message, mirror_agent_task_run_plan_lifecycle,
     parse_offloaded_agent_task_handoff_from_outputs, sync_inline_agent_task_file,
 };

--- a/src/core/runner/lab/offload/resident.rs
+++ b/src/core/runner/lab/offload/resident.rs
@@ -73,7 +73,7 @@ pub(crate) fn run_runner_resident_lab_offload(
     let remapped_args = inject_agent_task_resolved_provider_policy_in_args(&remapped_args)?;
     let run_isolation_token = agent_task_dispatch_run_isolation_token(request.normalized_args);
     let (remapped_args, agent_task_run_id) =
-        ensure_agent_task_dispatch_run_id_with(&remapped_args, run_isolation_token.as_deref())
+        ensure_agent_task_lifecycle_identity_with(&remapped_args, run_isolation_token.as_deref())
             .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
     let mut command = vec![homeboy_path.to_string()];
     if remote_output_file.is_some() && !args_contain_output_file(request.normalized_args) {

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -419,7 +419,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         &remote_cwd,
     );
     let (remapped_args, agent_task_run_id) =
-        ensure_agent_task_dispatch_run_id_with(&remapped_args, run_isolation_token.as_deref())
+        ensure_agent_task_lifecycle_identity_with(&remapped_args, run_isolation_token.as_deref())
             .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
 
     let remote_output_file = request


### PR DESCRIPTION
## Summary
- Generate one first-attempt lifecycle id before a cook crosses the Lab boundary.
- Pass that id through the daemon workload and runner-side cook so controller status and logs resolve the accepted remote run.
- Cover the Lab handoff identity and runner-side lifecycle consumption.

Closes #7970

## Testing
1. Run `cargo fmt --check`.
2. Run `cargo test lab_cook_uses_one_first_attempt_identity_across_the_handoff --lib`.
3. Run `cargo test cook_returns_durable_id_when_promotion_provider_is_missing --lib`.
4. Run `cargo test --lib` for the repository library suite. The suite exceeded the 15-minute local limit and reported existing failures in `core::code_audit::entry::audit_runtime_regression_test::audit_runtime_regression_matches_snapshot` and `core::deploy::orchestration::tests::exact_ref_preflight_packages_verified_subpath_not_stale_checkout_artifact`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the detached Lab lifecycle split, drafted the focused repair and tests, and ran verification with Chris directing the task.