### PR TITLE
fix: pipe portable promotion provider requests

### DIFF
--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -475,6 +475,15 @@ pub struct AgentTaskCookArgs {
     #[arg(long, value_name = "COMMAND")]
     pub provider_command: Option<String>,
 
+    /// One argument for an argv-safe external workspace provider invocation.
+    /// Repeat this option in provider argv order.
+    #[arg(
+        long = "provider-argv",
+        value_name = "ARG",
+        conflicts_with = "provider_command"
+    )]
+    pub provider_argv: Vec<String>,
+
     #[command(flatten)]
     pub gates: VerifyGateArgs,
 
@@ -775,6 +784,15 @@ pub struct PromoteArgs {
     /// External workspace provider command. When omitted, HOMEBOY_AGENT_TASK_PROMOTION_COMMAND is used.
     #[arg(long, value_name = "COMMAND")]
     pub provider_command: Option<String>,
+
+    /// One argument for an argv-safe external workspace provider invocation.
+    /// Repeat this option in provider argv order.
+    #[arg(
+        long = "provider-argv",
+        value_name = "ARG",
+        conflicts_with = "provider_command"
+    )]
+    pub provider_argv: Vec<String>,
 
     /// Outcome task id to select when SOURCE is an aggregate.
     #[arg(long, value_name = "TASK_ID")]

--- a/src/commands/agent_task/fanout.rs
+++ b/src/commands/agent_task/fanout.rs
@@ -550,6 +550,7 @@ impl BatchCookSpec {
                 to_worktree: self.to_worktree.clone(),
                 source_worktree_path,
                 provider_command: self.provider_command.clone(),
+                provider_invocation: None,
                 gates: VerifyGateOptions {
                     verify: self.verify.clone(),
                     private_verify: self.private_verify.clone(),

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -15,6 +15,7 @@ use homeboy::core::agent_tasks::provider::{
 };
 use homeboy::core::agent_tasks::service as agent_task_service;
 use homeboy::core::agent_tasks::{AgentTaskAggregate, AgentTaskAggregateReport, AgentTaskRequest};
+use homeboy::core::command_invocation::CommandInvocation;
 use homeboy::core::config;
 use homeboy::core::gate::HomeboyGateResult;
 
@@ -209,6 +210,10 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
         dry_run: args.dry_run,
         gates: args.gates.into(),
         provider_command: args.provider_command,
+        provider_invocation: (!args.provider_argv.is_empty()).then(|| CommandInvocation {
+            argv: args.provider_argv,
+            ..Default::default()
+        }),
     })?;
     let exit_code = if report.status == AgentTaskPromotionStatus::GateFailed {
         1

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -13,6 +13,7 @@ use homeboy::core::agent_tasks::scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan,
 };
 use homeboy::core::agent_tasks::service as agent_task_service;
+use homeboy::core::command_invocation::CommandInvocation;
 
 use super::super::CmdResult;
 use super::args::{
@@ -122,6 +123,10 @@ where
             to_worktree: args.to_worktree,
             source_worktree_path,
             provider_command: args.provider_command,
+            provider_invocation: (!args.provider_argv.is_empty()).then(|| CommandInvocation {
+                argv: args.provider_argv,
+                ..Default::default()
+            }),
             gates: args.gates.into(),
             max_attempts: args.max_attempts,
             no_finalize: args.no_finalize,

--- a/src/commands/agent_task/tests/promotion_review.rs
+++ b/src/commands/agent_task/tests/promotion_review.rs
@@ -145,6 +145,7 @@ fn cook_returns_durable_id_when_promotion_provider_is_missing() {
                 goal: Some("cook fixture".to_string()),
                 to_worktree: "homeboy@fix-agent-task-runner-cook".to_string(),
                 provider_command: None,
+                provider_argv: Vec::new(),
                 gates: VerifyGateArgs {
                     verify: vec!["cargo test --lib".to_string()],
                     private_verify: Vec::new(),
@@ -324,6 +325,7 @@ fn cook_applies_executor_commit_from_source_repo_to_distinct_target_repo() {
                 goal: None,
                 to_worktree: "fixture-component@promoted".to_string(),
                 provider_command: Some(format!("sh {}", provider.display())),
+                provider_argv: Vec::new(),
                 gates: VerifyGateArgs {
                     verify: vec!["true".to_string()],
                     private_verify: Vec::new(),

--- a/src/core/agent_task_promotion/apply.rs
+++ b/src/core/agent_task_promotion/apply.rs
@@ -74,17 +74,20 @@ pub fn apply_materialized_workspace_patch(workspace: &Path, request_json: &str) 
         ));
     }
     validate_provider_workspace_path(workspace)?;
-    let output = Command::new("git")
+    let mut command = Command::new("git");
+    command
         .arg("-C")
         .arg(workspace)
-        .args(["apply", "--whitespace=nowarn", &request.patch_path])
-        .output()
-        .map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some("apply agent-task promotion patch".to_string()),
-            )
-        })?;
+        .args(["apply", "--whitespace=nowarn", &request.patch_path]);
+    if request.dry_run {
+        command.arg("--check");
+    }
+    let output = command.output().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("apply agent-task promotion patch".to_string()),
+        )
+    })?;
     if !output.status.success() {
         return Err(Error::validation_invalid_argument(
             "promotion_provider.patch",
@@ -116,6 +119,8 @@ pub(crate) struct AgentTaskPromotionApplyRequest {
     pub(crate) to_workspace: String,
     pub(crate) patch_path: String,
     pub(crate) changed_files: Vec<String>,
+    #[serde(default)]
+    pub(crate) dry_run: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -156,8 +161,11 @@ impl ExternalPromotionWorkspaceProvider {
     pub(crate) fn from_options(options: &AgentTaskPromotionOptions) -> Self {
         Self {
             invocation: options
-                .provider_command
+                .provider_invocation
                 .clone()
+                .or_else(|| options
+                    .provider_command
+                    .clone()
                 .or_else(|| std::env::var(PROMOTION_PROVIDER_COMMAND_ENV).ok())
                 .map(|command| {
                     eprintln!(
@@ -168,7 +176,7 @@ impl ExternalPromotionWorkspaceProvider {
                         display: Some(command),
                         ..Default::default()
                     }
-                }),
+                })),
         }
     }
 }
@@ -309,8 +317,22 @@ pub(crate) fn run_provider_command(
             Some(vec![report.stderr.clone()]),
         ));
     }
-    let response: AgentTaskPromotionApplyResponse =
+    let response_value: serde_json::Value =
         serde_json::from_str(&full_stdout).map_err(|error| {
+            Error::validation_invalid_json(
+                error,
+                Some("agent-task promotion provider response".to_string()),
+                Some(report.stdout.clone()),
+            )
+        })?;
+    // Homeboy commands emit the standard result envelope. Accept its data
+    // payload while retaining direct provider responses as the generic contract.
+    let response_value = response_value
+        .get("data")
+        .cloned()
+        .unwrap_or(response_value);
+    let response: AgentTaskPromotionApplyResponse = serde_json::from_value(response_value)
+        .map_err(|error| {
             Error::validation_invalid_json(
                 error,
                 Some("agent-task promotion provider response".to_string()),

--- a/src/core/agent_task_promotion/promote.rs
+++ b/src/core/agent_task_promotion/promote.rs
@@ -142,7 +142,7 @@ pub(crate) fn promote_with_provider(
 
     let mut command_evidence = Vec::new();
     let mut applied_worktree_path = None;
-    if !options.dry_run {
+    {
         let normalized_patch_file;
         let provider_patch_path = if normalized_patch.content == patch {
             patch_path.display().to_string()
@@ -155,9 +155,12 @@ pub(crate) fn promote_with_provider(
             to_workspace: options.to_worktree.clone(),
             patch_path: provider_patch_path,
             changed_files: changed_files.clone(),
+            dry_run: options.dry_run,
         })?;
         command_evidence.extend(target.command_evidence);
-        applied_worktree_path = Some(target.path);
+        if !options.dry_run {
+            applied_worktree_path = Some(target.path);
+        }
     }
 
     let gates = if let Some(worktree_path) = applied_worktree_path.as_deref() {
@@ -225,18 +228,15 @@ fn promote_committed_changes(
         &options.to_worktree,
     )?;
     let mut command_evidence = Vec::new();
-    let applied_worktree_path = if options.dry_run {
-        None
-    } else {
-        let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
-            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
-            to_workspace: options.to_worktree.clone(),
-            patch_path: committed_patch.patch_path.display().to_string(),
-            changed_files: normalized_patch.changed_files.clone(),
-        })?;
-        command_evidence.extend(target.command_evidence);
-        Some(target.path)
-    };
+    let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
+        schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+        to_workspace: options.to_worktree.clone(),
+        patch_path: committed_patch.patch_path.display().to_string(),
+        changed_files: normalized_patch.changed_files.clone(),
+        dry_run: options.dry_run,
+    })?;
+    command_evidence.extend(target.command_evidence);
+    let applied_worktree_path = (!options.dry_run).then_some(target.path);
     let gates = if let Some(path) = applied_worktree_path.as_deref() {
         run_promotion_gates(options, provider, path)?
     } else {

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -317,6 +317,7 @@ fn promote_reports_no_changes_for_empty_patch_metadata() {
                 private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
             },
             provider_command: None,
+            provider_invocation: None,
         },
         &mut provider,
     )
@@ -369,6 +370,7 @@ fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
                 private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
             },
             provider_command: None,
+            provider_invocation: None,
         },
         &mut provider,
     )
@@ -438,6 +440,7 @@ fn promote_exports_committed_changes_when_executor_reports_no_patch_artifact() {
             dry_run: false,
             gates: VerifyGateOptions::default(),
             provider_command: None,
+            provider_invocation: None,
         },
         &mut provider,
     )
@@ -490,6 +493,7 @@ fn promote_exports_all_agent_commits_after_the_recorded_task_base() {
             dry_run: false,
             gates: VerifyGateOptions::default(),
             provider_command: None,
+            provider_invocation: None,
         },
         &mut FakePromotionWorkspaceProvider {
             workspace_path: Some(repo.clone()),
@@ -542,6 +546,7 @@ fn committed_change_promotion_rejects_a_non_ancestor_task_base() {
             dry_run: false,
             gates: VerifyGateOptions::default(),
             provider_command: None,
+            provider_invocation: None,
         },
         &mut FakePromotionWorkspaceProvider::default(),
     )
@@ -649,35 +654,45 @@ fn select_patch_artifact_requires_unambiguous_patch() {
 }
 
 #[test]
-fn promote_dry_run_reports_selected_patch_without_provider_mutation() {
+fn promote_dry_run_validates_provider_request_without_applying() {
     let temp = tempfile::tempdir().expect("tempdir");
     let (source_path, source) = write_patch_source(&temp);
 
-    let report = promote(AgentTaskPromotionOptions {
-        source,
-        source_run_id: None,
-        source_path: Some(source_path),
-        source_worktree_path: None,
-        base_ref: None,
-        task_base_sha: None,
-        to_worktree: "repo@promoted-task".to_string(),
-        task_id: None,
-        artifact_id: None,
-        dry_run: true,
-        gates: VerifyGateOptions {
-            verify: Vec::new(),
-            private_verify: Vec::new(),
-            private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(temp.path().join("controlled-worktree")),
+        ..Default::default()
+    };
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: None,
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            to_worktree: "repo@promoted-task".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: true,
+            gates: VerifyGateOptions {
+                verify: Vec::new(),
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+            },
+            provider_command: None,
+            provider_invocation: None,
         },
-        provider_command: None,
-    })
+        &mut provider,
+    )
     .expect("dry-run promotion report");
 
     assert_eq!(report.status, AgentTaskPromotionStatus::DryRun);
     assert_eq!(report.source.task_id, "task-1");
     assert_eq!(report.patch_artifact.id, "patch");
     assert_eq!(report.changed_files, vec!["src/lib.rs"]);
-    assert!(report.command_evidence.is_empty());
+    assert_eq!(provider.apply_calls.len(), 1);
+    assert!(provider.apply_calls[0].dry_run);
+    assert_eq!(report.command_evidence.len(), 1);
     assert!(report.deterministic_gates.is_empty());
 }
 
@@ -709,6 +724,7 @@ fn promote_applies_patch_with_fake_workspace_provider() {
                 private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,
             },
             provider_command: None,
+            provider_invocation: None,
         },
         &mut provider,
     )
@@ -790,6 +806,7 @@ fn promote_verification_failure_keeps_the_applied_target_recoverable() {
                 private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
             },
             provider_command: None,
+            provider_invocation: None,
         },
         &mut provider,
     )
@@ -853,6 +870,7 @@ fn promote_materializes_worktree_dependencies_before_verify_gate() {
                     private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
                 },
                 provider_command: None,
+                provider_invocation: None,
             },
             &mut provider,
         )
@@ -917,6 +935,7 @@ fn promote_applies_normalized_lab_sandbox_patch_with_fake_workspace_provider() {
                 private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,
             },
             provider_command: None,
+            provider_invocation: None,
         },
         &mut provider,
     )
@@ -955,6 +974,7 @@ fn promote_requires_provider_for_apply() {
             private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
         },
         provider_command: None,
+        provider_invocation: None,
     })
     .expect_err("missing provider rejected");
 
@@ -983,6 +1003,7 @@ fn promotion_options_keep_flat_verify_gate_serialized_shape() {
             private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,
         },
         provider_command: None,
+        provider_invocation: None,
     };
 
     let value = serde_json::to_value(&options).expect("serialize options");
@@ -1117,6 +1138,7 @@ fn provider_command_response_supplies_workspace_and_evidence() {
         to_workspace: "target-workspace".to_string(),
         patch_path: temp.path().join("changes.patch").display().to_string(),
         changed_files: vec!["src/lib.rs".to_string()],
+        dry_run: false,
     };
     let workspace = run_provider_command(
         &CommandInvocation {

--- a/src/core/agent_task_promotion/types.rs
+++ b/src/core/agent_task_promotion/types.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::agent_task_gate::{AgentTaskGateReport, VerifyGateOptions};
+use crate::core::command_invocation::CommandInvocation;
 use crate::core::gate::HomeboyGateResult;
 use crate::core::stream_capture::StreamCaptureMetadata;
 
@@ -37,6 +38,10 @@ pub struct AgentTaskPromotionOptions {
     pub gates: VerifyGateOptions,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_command: Option<String>,
+    /// Structured provider invocation. This preserves argv boundaries for
+    /// portable providers; `provider_command` remains a deprecated fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_invocation: Option<CommandInvocation>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/core/agent_task_service/cook.rs
+++ b/src/core/agent_task_service/cook.rs
@@ -18,6 +18,7 @@ use crate::core::agent_task_promotion::{
     promote, AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
 use crate::core::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskPlan};
+use crate::core::command_invocation::CommandInvocation;
 use crate::core::{config, Error, Result};
 
 use super::execution::run_loaded_plan;
@@ -30,6 +31,7 @@ pub struct AgentTaskCookServiceOptions {
     pub to_worktree: String,
     pub source_worktree_path: Option<PathBuf>,
     pub provider_command: Option<String>,
+    pub provider_invocation: Option<CommandInvocation>,
     /// Shared deterministic verification gate fields, factored out of the
     /// per-field duplication that previously spanned the loop/promote types.
     pub gates: VerifyGateOptions,
@@ -335,6 +337,7 @@ fn promote_attempt(
         dry_run: false,
         gates: options.gates.clone(),
         provider_command: options.provider_command.clone(),
+        provider_invocation: options.provider_invocation.clone(),
     })
 }
 

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -660,10 +660,12 @@ fn inject_materialized_promotion_provider(
     if !matches!(
         args.get(agent_task_index + 1).map(String::as_str),
         Some("cook" | "promote")
-    ) || args
-        .iter()
-        .any(|arg| arg == "--provider-command" || arg.starts_with("--provider-command="))
-    {
+    ) || args.iter().any(|arg| {
+        arg == "--provider-command"
+            || arg.starts_with("--provider-command=")
+            || arg == "--provider-argv"
+            || arg.starts_with("--provider-argv=")
+    }) {
         return args;
     }
     let Some(homeboy_path) = homeboy_path.filter(|path| !path.trim().is_empty()) else {
@@ -677,8 +679,10 @@ fn inject_materialized_promotion_provider(
     args.splice(
         insert_at..insert_at,
         [
-            "--provider-command".to_string(),
-            format!("{homeboy_path} agent-task promotion-provider --workspace {workspace}"),
+            format!("--provider-argv={homeboy_path}"),
+            "--provider-argv=agent-task".to_string(),
+            "--provider-argv=promotion-provider".to_string(),
+            format!("--provider-argv=--workspace={workspace}"),
         ],
     );
     args
@@ -1482,8 +1486,10 @@ mod tests {
                 "homeboy@fix-7913",
                 "--verify",
                 "cargo test --lib",
-                "--provider-command",
-                "/runner/bin/homeboy agent-task promotion-provider --workspace /runner/workspaces/homeboy",
+                "--provider-argv=/runner/bin/homeboy",
+                "--provider-argv=agent-task",
+                "--provider-argv=promotion-provider",
+                "--provider-argv=--workspace=/runner/workspaces/homeboy",
             ]
         );
     }
@@ -1538,10 +1544,13 @@ mod tests {
             );
 
             assert!(command.contains(&"/runner/artifacts/detached/aggregate.json".to_string()));
-            assert!(command.windows(2).any(|args| args == [
-                "--provider-command",
-                "/runner/bin/homeboy agent-task promotion-provider --workspace /runner/workspaces/homeboy-fix-7964",
-            ]));
+            assert!(command.windows(4).any(|args| args
+                == [
+                    "--provider-argv=/runner/bin/homeboy",
+                    "--provider-argv=agent-task",
+                    "--provider-argv=promotion-provider",
+                    "--provider-argv=--workspace=/runner/workspaces/homeboy-fix-7964",
+                ]));
             assert!(!command.iter().any(|arg| arg.contains("/Users/")));
         }
     }

--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -1,0 +1,141 @@
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const PATCH: &str =
+    "diff --git a/src.txt b/src.txt\n--- a/src.txt\n+++ b/src.txt\n@@ -1 +1 @@\n-old\n+new\n";
+
+#[test]
+fn promotion_provider_receives_request_for_dry_run_apply_and_recoverable_gate_failure() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace with spaces");
+    std::fs::create_dir(&workspace).expect("workspace");
+    git(&workspace, &["init"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["config", "user.name", "Test User"]);
+    std::fs::write(workspace.join("src.txt"), "old\n").expect("source");
+    git(&workspace, &["add", "src.txt"]);
+    git(&workspace, &["commit", "-m", "initial"]);
+
+    let patch = temp.path().join("changes.patch");
+    std::fs::write(&patch, PATCH).expect("patch");
+    let source = temp.path().join("outcome.json");
+    std::fs::write(
+        &source,
+        serde_json::json!({
+            "schema": "homeboy/agent-task-outcome/v1",
+            "task_id": "task-1",
+            "status": "succeeded",
+            "artifacts": [{
+                "schema": "homeboy/agent-task-artifact/v1",
+                "id": "patch",
+                "kind": "patch",
+                "path": patch,
+                "size_bytes": PATCH.len(),
+                "sha256": sha256(PATCH),
+            }],
+        })
+        .to_string(),
+    )
+    .expect("outcome");
+
+    let dry_run = promote(&source, &workspace, true, None);
+    assert_eq!(
+        dry_run.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&dry_run.stdout),
+        String::from_utf8_lossy(&dry_run.stderr)
+    );
+    let dry_run = output(&dry_run);
+    assert_eq!(dry_run["status"], "dry_run");
+    assert_eq!(
+        dry_run["command_evidence"][0]["command"][0],
+        homeboy_bin().display().to_string()
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("src.txt")).unwrap(),
+        "old\n"
+    );
+
+    let applied = promote(&source, &workspace, false, None);
+    assert_eq!(applied.status.code(), Some(0));
+    let applied = output(&applied);
+    assert_eq!(applied["status"], "applied");
+    assert_eq!(applied["target"]["path"], workspace.display().to_string());
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("src.txt")).unwrap(),
+        "new\n"
+    );
+
+    git(
+        &workspace,
+        &["apply", "-R", patch.to_str().expect("patch path")],
+    );
+    let failed = promote(&source, &workspace, false, Some("false"));
+    assert_eq!(failed.status.code(), Some(1));
+    let failed = output(&failed);
+    assert_eq!(failed["status"], "gate_failed");
+    assert_eq!(failed["target"]["path"], workspace.display().to_string());
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("src.txt")).unwrap(),
+        "new\n"
+    );
+}
+
+fn promote(
+    source: &Path,
+    workspace: &Path,
+    dry_run: bool,
+    verify: Option<&str>,
+) -> std::process::Output {
+    let binary = homeboy_bin();
+    let mut command = Command::new(&binary);
+    command
+        .args(["--force-hot", "--allow-local-hot", "agent-task", "promote"])
+        .arg(source)
+        .args(["--to-worktree", "fixture@promotion-provider"])
+        .arg(format!("--provider-argv={}", binary.display()))
+        .arg("--provider-argv=agent-task")
+        .arg("--provider-argv=promotion-provider")
+        .arg(format!(
+            "--provider-argv=--workspace={}",
+            workspace.display()
+        ))
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1");
+    if dry_run {
+        command.arg("--dry-run");
+    }
+    if let Some(verify) = verify {
+        command.args(["--verify", verify]);
+    }
+    command.output().expect("run promotion")
+}
+
+fn output(output: &std::process::Output) -> Value {
+    let value: Value = serde_json::from_slice(&output.stdout).expect("promotion JSON");
+    assert_eq!(value["success"], output.status.success());
+    value["data"].clone()
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn sha256(value: &str) -> String {
+    use sha2::{Digest, Sha256};
+    format!("{:x}", Sha256::digest(value.as_bytes()))
+}


### PR DESCRIPTION
Fixes #7974.

## Summary
- Use repeated argv-safe provider arguments for portable promotion adapters and pipe the complete promotion request to provider stdin.
- Validate the provider request during dry runs with `git apply --check`, without mutating the target workspace.
- Accept Homeboy command-result provider envelopes and add end-to-end coverage for the shipped provider subprocess.

## How to test
1. Run `cargo test agent_task_promotion --lib --no-fail-fast`.
2. Run `cargo test runner_only_promotion_uses_materialized_target_adapter_for_dry_run_and_apply --lib --no-fail-fast`.
3. Run `cargo test --test agent_task_promotion_provider --no-fail-fast`.
4. Run `cargo check`.
5. Run `cargo fmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.