### PR TITLE
Fix extension dev-run Lab lifecycle handoff

### DIFF
--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -274,6 +274,10 @@ pub fn run(
 }
 
 impl ExtensionArgs {
+    pub(crate) fn owns_runner_execution(&self) -> bool {
+        matches!(self.command, ExtensionCommand::DevRun { .. })
+    }
+
     pub(crate) fn is_runner_resident_read_command(&self) -> bool {
         matches!(self.command, ExtensionCommand::Show { .. })
     }

--- a/src/commands/infra/route.rs
+++ b/src/commands/infra/route.rs
@@ -903,6 +903,9 @@ fn is_command_local_runner_option(command: &Commands) -> bool {
         Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
             command: crate::commands::agent_task::AgentTaskCommand::Doctor(_),
         }) => true,
+        // This command coordinates its own sync and runner executions. Routing
+        // the coordinator itself would make its child executions re-enter Lab.
+        Commands::Extension(args) => args.owns_runner_execution(),
         Commands::Fuzz(args) => args.consumes_runner_as_plan_input(),
         _ => false,
     }
@@ -2179,6 +2182,32 @@ mod tests {
 
         let outcome = route_after_parse(&cli, &normalized, None)
             .expect("extension update without --runner should not offload");
+
+        assert_eq!(outcome, None);
+        assert!(std::env::var(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV).is_err());
+    }
+
+    #[test]
+    fn extension_dev_run_keeps_its_runner_workflow_on_the_controller() {
+        let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
+        let normalized = vec![
+            "homeboy".to_string(),
+            "extension".to_string(),
+            "dev-run".to_string(),
+            "wordpress".to_string(),
+            "--source".to_string(),
+            "/tmp/wordpress".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "homeboy".to_string(),
+            "extension".to_string(),
+            "show".to_string(),
+            "wordpress".to_string(),
+        ];
+        let cli = Cli::parse_from(&normalized);
+
+        let outcome = route_after_parse(&cli, &normalized, None)
+            .expect("dev-run should execute its own runner lifecycle");
 
         assert_eq!(outcome, None);
         assert!(std::env::var(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV).is_err());

--- a/src/core/extension/dev_run.rs
+++ b/src/core/extension/dev_run.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 
 use crate::command_contract::{
-    RunnerExecutionProjection, RunnerWorkload, RunnerWorkloadAssignment,
+    RunnerExecutionProjection, RunnerWorkload, RunnerWorkloadArtifactRef, RunnerWorkloadAssignment,
     RunnerWorkloadCommandFamily, RunnerWorkloadKind, RunnerWorkloadMutationPolicy,
     RunnerWorkloadResultRefs, RunnerWorkloadSecrets, RunnerWorkloadState,
     RunnerWorkloadWorkspaceMappings, RUNNER_WORKLOAD_SCHEMA,
@@ -501,8 +501,27 @@ fn extension_dev_run_execution_outcome(
     runner_workload: &RunnerWorkload,
     output: &RunnerExecOutput,
 ) -> ExtensionDevRunExecutionOutcome {
+    let mut runner_workload = runner_workload.clone();
+    runner_workload.result_refs.job_id = output.job_id.clone();
+    runner_workload.result_refs.mirror_run_id = output.mirror_run_id.clone();
+    runner_workload.result_refs.artifacts = output
+        .execution_record
+        .as_ref()
+        .map(|record| {
+            record
+                .artifact_refs
+                .iter()
+                .map(|artifact| RunnerWorkloadArtifactRef {
+                    id: artifact.id.clone(),
+                    name: artifact.name.clone(),
+                    path: artifact.path.clone(),
+                    url: artifact.url.clone(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     ExtensionDevRunExecutionOutcome {
-        runner_workload: runner_workload.clone(),
+        runner_workload,
         execution_record: output
             .execution_record
             .as_ref()
@@ -789,6 +808,26 @@ mod tests {
                 .command_outcome
                 .as_ref()
                 .expect("command outcome")
+                .runner_workload
+                .result_refs
+                .job_id,
+            Some("job-homeboy-extension-run-demo".to_string())
+        );
+        assert_eq!(
+            output
+                .command_outcome
+                .as_ref()
+                .expect("command outcome")
+                .runner_workload
+                .result_refs
+                .mirror_run_id,
+            Some("run-homeboy-extension-run-demo".to_string())
+        );
+        assert_eq!(
+            output
+                .command_outcome
+                .as_ref()
+                .expect("command outcome")
                 .execution_record
                 .as_ref()
                 .expect("command execution projection")
@@ -918,8 +957,9 @@ mod tests {
     }
 
     fn exec_output(runner_id: &str, command: Vec<String>, exit_code: i32) -> RunnerExecOutput {
+        let execution_id = command.join("-");
         let execution_record = Some(RunnerExecutionRecord::terminal(
-            format!("exec-{runner_id}-{}", command.join("-")),
+            format!("exec-{runner_id}-{execution_id}"),
             runner_id,
             "local",
             exit_code,
@@ -938,9 +978,9 @@ mod tests {
             source_snapshot: None,
             job: None,
             runner_job: None,
-            job_id: None,
+            job_id: Some(format!("job-{execution_id}")),
             job_events: None,
-            mirror_run_id: None,
+            mirror_run_id: Some(format!("run-{execution_id}")),
             patch: None,
             mutation_artifacts: None,
             artifacts: Vec::new(),

--- a/src/core/runner/execution/broker.rs
+++ b/src/core/runner/execution/broker.rs
@@ -177,6 +177,7 @@ pub(super) fn exec_via_reverse_broker(
                 &source_snapshot,
                 &require_paths,
                 persisted_run_id.as_deref(),
+                None,
                 err,
             )
         })?;

--- a/src/core/runner/execution/daemon.rs
+++ b/src/core/runner/execution/daemon.rs
@@ -44,6 +44,7 @@ pub(super) fn exec_via_daemon(
     detach_after_handoff: bool,
     mirror_evidence: bool,
     print_handoff_output: bool,
+    accepted_daemon_identity: Option<String>,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
         .no_proxy()
@@ -194,6 +195,7 @@ pub(super) fn exec_via_daemon(
                 &source_snapshot,
                 &require_paths,
                 persisted_run_id.as_deref(),
+                accepted_daemon_identity.as_deref(),
                 err,
             )
         })?;
@@ -615,6 +617,7 @@ pub(super) fn terminal_runner_poll_failure(
     source_snapshot: &SourceSnapshot,
     _require_paths: &[String],
     persisted_run_id: Option<&str>,
+    accepted_daemon_identity: Option<&str>,
     source: Error,
 ) -> Error {
     let job_id = job.id.to_string();
@@ -622,6 +625,16 @@ pub(super) fn terminal_runner_poll_failure(
     error.retryable = Some(false);
     error.details["status"] = Value::String("terminal_failure".to_string());
     error.details["reason"] = Value::String("runner_job_unobservable".to_string());
+    let current_daemon_identity = super::super::status(&runner.id).ok().and_then(|status| {
+        status
+            .session
+            .and_then(|session| session.homeboy_build_identity)
+    });
+    if let Some(transition) =
+        daemon_identity_transition(accepted_daemon_identity, current_daemon_identity.as_deref())
+    {
+        error.details["daemon_identity_transition"] = transition;
+    }
 
     let diagnostic = json!({
         "error_code": error.code.as_str(),
@@ -669,6 +682,22 @@ pub(super) fn terminal_runner_poll_failure(
         ));
     }
     error
+}
+
+pub(super) fn daemon_identity_transition(
+    accepted_identity: Option<&str>,
+    current_identity: Option<&str>,
+) -> Option<Value> {
+    let (Some(from), Some(to)) = (accepted_identity, current_identity) else {
+        return None;
+    };
+    (from != to).then(|| {
+        json!({
+            "status": "changed",
+            "accepted_daemon_build_identity": from,
+            "observed_daemon_build_identity": to,
+        })
+    })
 }
 
 pub(super) fn lab_terminal_result_transport_error(

--- a/src/core/runner/execution/mod.rs
+++ b/src/core/runner/execution/mod.rs
@@ -831,6 +831,10 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 options.detach_after_handoff,
                 options.mirror_evidence,
                 options.print_handoff,
+                connected
+                    .session
+                    .as_ref()
+                    .and_then(|session| session.homeboy_build_identity.clone()),
             )
         }
         RunnerTransport::ReverseBroker(handle) => {

--- a/src/core/runner/execution/tests/handoff.rs
+++ b/src/core/runner/execution/tests/handoff.rs
@@ -389,6 +389,7 @@ fn accepted_job_that_disappears_persists_a_terminal_controller_failure() {
             &SourceSnapshot::existing_remote("lab", "/srv/homeboy/project", Some("/srv/homeboy")),
             &[],
             Some(&run_id),
+            None,
             Error::internal_unexpected("daemon returned no active job for the accepted id"),
         );
 
@@ -422,6 +423,26 @@ fn accepted_job_that_disappears_persists_a_terminal_controller_failure() {
                 && record.metadata_json["runner_execution_record"]["status"] == "failed"
         }));
     });
+}
+
+#[test]
+fn daemon_identity_transition_reports_a_restarted_control_plane() {
+    let transition = super::super::daemon::daemon_identity_transition(
+        Some("homeboy 0.283.1+95ce06c58b95"),
+        Some("homeboy 0.283.1+a5b333e9f905"),
+    )
+    .expect("daemon identities changed");
+
+    assert_eq!(transition["status"], "changed");
+    assert_eq!(
+        transition["accepted_daemon_build_identity"],
+        "homeboy 0.283.1+95ce06c58b95"
+    );
+    assert_eq!(
+        transition["observed_daemon_build_identity"],
+        "homeboy 0.283.1+a5b333e9f905"
+    );
+    assert!(super::super::daemon::daemon_identity_transition(Some("same"), Some("same")).is_none());
 }
 
 #[test]
@@ -994,6 +1015,7 @@ fn daemon_exec_failure_without_error_field_is_actionable() {
         false,
         true,
         true,
+        None,
     )
     .expect_err("daemon exec failure");
 
@@ -1241,6 +1263,7 @@ fn daemon_exec_empty_envelope_over_http_is_actionable_not_null() {
         false,
         true,
         true,
+        None,
     )
     .expect_err("daemon exec failure");
 


### PR DESCRIPTION
## Summary

Fixes #7983.

`extension dev-run` already owns a controller-side runner workflow: it syncs source, probes the runner, refreshes the extension, and runs the requested command. Top-level Lab routing wrapped that coordinator in another daemon job, then its child work synchronously submitted back to the same daemon. This nested dispatch can deadlock and prevents a terminal envelope.

This change keeps controller-owned runner workflows local while retaining their normal remote stage executions. Each stage now projects its accepted runner job, mirrored run, and artifacts into the workload outcome. If an accepted daemon job becomes unobservable, terminal evidence also records a detected daemon build-identity transition.

## Testing

1. From a fresh checkout, run `cargo test extension_dev_run_keeps_its_runner_workflow_on_the_controller -- --nocapture`.
2. Run `cargo test executes_probe_refresh_and_command_with_provenance -- --nocapture` and confirm the command workload outcome includes its runner job and mirrored-run identifiers.
3. Run `cargo test accepted_job_that_disappears_persists_a_terminal_controller_failure -- --nocapture` and `cargo test daemon_identity_transition_reports_a_restarted_control_plane -- --nocapture`.
4. Run `cargo fmt --check` and `cargo check`.

## Rollout

Deploy this Homeboy controller build. No data migration is required. Runner daemons do not need a coordinated upgrade for the routing correction; reconnect a runner after deploying a new daemon build when daemon identity or configured executable drift is reported.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Investigated the control-plane defect, drafted the generic lifecycle repair and tests, and ran focused verification with Chris responsible for review and merge.