### PR TITLE
Preserve runner jobs across reconnects

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -24,6 +24,11 @@ enum DaemonCommand {
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
     },
+    /// Return the current live daemon or start one when no live daemon exists
+    EnsureRunning {
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
     /// Run the local daemon in the foreground
     Serve {
         /// Local bind address. Defaults to an OS-selected loopback port.
@@ -74,6 +79,7 @@ pub struct DaemonArtifactGetArgs {
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum DaemonOutput {
     Start(DaemonStartResult),
+    EnsureRunning(DaemonStartResult),
     Serve(DaemonStartResult),
     Stop(DaemonStopResult),
     Status(DaemonStatus),
@@ -99,6 +105,10 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
         DaemonCommand::Start { addr } => {
             Ok((DaemonOutput::Start(daemon::start_background(&addr)?), 0))
         }
+        DaemonCommand::EnsureRunning { addr } => Ok((
+            DaemonOutput::EnsureRunning(daemon::ensure_running(&addr)?),
+            0,
+        )),
         DaemonCommand::Serve { addr } => serve(&addr),
         DaemonCommand::Stop => Ok((DaemonOutput::Stop(daemon::stop()?), 0)),
         DaemonCommand::Status => Ok((DaemonOutput::Status(daemon::read_status()?), 0)),

--- a/src/core/api_jobs/mod.rs
+++ b/src/core/api_jobs/mod.rs
@@ -40,6 +40,25 @@ mod tests {
     }
 
     #[test]
+    fn active_count_reads_durable_jobs_without_reconciling_them() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("open store");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("start job");
+
+        assert_eq!(
+            JobStore::active_count_at_path(&path).expect("active count"),
+            1
+        );
+        assert_eq!(
+            store.get(job.id).expect("job remains present").status,
+            JobStatus::Running,
+            "status inspection must not reconcile an in-flight daemon job"
+        );
+    }
+
+    #[test]
     fn test_create_with_source_snapshot() {
         let store = JobStore::default();
         let snapshot =

--- a/src/core/api_jobs/store.rs
+++ b/src/core/api_jobs/store.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -62,6 +63,27 @@ pub struct JobHandle {
 }
 
 impl JobStore {
+    /// Count non-terminal jobs without opening or reconciling the durable store.
+    ///
+    /// Daemon status runs in a separate CLI process, so using [`Self::open`]
+    /// here would reconcile live jobs as though the daemon had restarted.
+    pub(crate) fn active_count_at_path(path: impl Into<PathBuf>) -> Result<usize> {
+        let path = path.into();
+        if !path.exists() {
+            return Ok(0);
+        }
+        let content = fs::read_to_string(&path).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
+        })?;
+        let durable: DurableJobStore = serde_json::from_str(&content)
+            .map_err(|err| Error::config_invalid_json(path.display().to_string(), err))?;
+        Ok(durable
+            .jobs
+            .into_iter()
+            .filter(|stored| matches!(stored.job.status, JobStatus::Queued | JobStatus::Running))
+            .count())
+    }
+
     pub(crate) fn open(path: impl Into<PathBuf>) -> Result<Self> {
         Self::open_with_event_retention(path, DEFAULT_EVENT_RETENTION_LIMIT)
     }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
-use std::time::{Duration, UNIX_EPOCH};
+use std::time::{Duration, Instant, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::command_contract::RunnerWorkload;
@@ -36,7 +36,8 @@ mod remote_runner;
 pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
-    artifact_content_url, fetch_artifact_to_path, start_background, ArtifactFetchOutcome,
+    artifact_content_url, ensure_running, fetch_artifact_to_path, start_background,
+    ArtifactFetchOutcome,
 };
 use patch_capture::{capture_baseline, capture_patch_report};
 
@@ -152,7 +153,7 @@ impl DaemonLeaseIdentity {
 }
 
 #[derive(Debug)]
-struct DaemonOperationLock {
+pub(super) struct DaemonOperationLock {
     path: PathBuf,
 }
 
@@ -368,12 +369,13 @@ pub fn read_status() -> Result<DaemonStatus> {
     let path = state_path()?;
     let state_path = path.display().to_string();
     let validation = validate_lease_file(&path)?;
+    let active_jobs = JobStore::active_count_at_path(paths::daemon_jobs_file()?)?;
 
     Ok(DaemonStatus {
         running: validation.running && validation.fresh && validation.reachable,
         fresh: validation.fresh,
         reachable: validation.reachable,
-        freshness: freshness_report_from_validation(&validation, 0),
+        freshness: freshness_report_from_validation(&validation, active_jobs),
         stale_reason: validation.stale_reason,
         state: validation.state,
         state_path,
@@ -1717,6 +1719,40 @@ fn acquire_daemon_operation_lock() -> Result<DaemonOperationLock> {
         Error::internal_io(e.to_string(), Some(format!("write {}", path.display())))
     })?;
     Ok(DaemonOperationLock { path })
+}
+
+/// `ensure-running` is idempotent, so a concurrent caller can wait briefly for
+/// the first caller to publish its daemon lease instead of failing spuriously.
+/// Destructive lifecycle operations continue using the fail-fast acquisition.
+pub(super) fn acquire_daemon_operation_lock_for_ensure(
+    wait: Duration,
+) -> Result<DaemonOperationLock> {
+    const RETRY: Duration = Duration::from_millis(50);
+    let deadline = Instant::now() + wait;
+    loop {
+        match acquire_daemon_operation_lock() {
+            Ok(lock) => return Ok(lock),
+            Err(err)
+                if err
+                    .message
+                    .contains("daemon lifecycle operation already in progress")
+                    && Instant::now() < deadline =>
+            {
+                std::thread::sleep(RETRY);
+            }
+            Err(err)
+                if err
+                    .message
+                    .contains("daemon lifecycle operation already in progress") =>
+            {
+                return Err(Error::internal_unexpected(format!(
+                    "timed out after {}s waiting for daemon ensure-running lifecycle lock; another caller may still be starting the daemon",
+                    wait.as_secs()
+                )));
+            }
+            Err(err) => return Err(err),
+        }
+    }
 }
 
 impl Drop for DaemonOperationLock {

--- a/src/core/daemon/control.rs
+++ b/src/core/daemon/control.rs
@@ -12,10 +12,12 @@ use std::time::{Duration, Instant};
 
 use crate::core::error::{Error, Result};
 use crate::core::execution_contract::encode_uri_component;
+use crate::core::process::pid_is_running;
 
 use super::{
-    acquire_daemon_operation_lock, parse_bind_addr, read_status, repair_legacy_lease_for_start,
-    stop_unlocked, DaemonStartResult, DAEMON_STARTUP_TOKEN_ENV,
+    acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
+    read_status, repair_legacy_lease_for_start, stop_unlocked, DaemonStartResult,
+    DAEMON_STARTUP_TOKEN_ENV,
 };
 
 /// Outcome of a daemon byte-endpoint artifact download.
@@ -34,7 +36,55 @@ pub struct ArtifactFetchOutcome {
 pub fn start_background(addr: &str) -> Result<DaemonStartResult> {
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
+    start_background_unlocked(addr)
+}
 
+/// Return a live daemon under the lifecycle lock, or start one when its lease
+/// is absent or its recorded PID is dead.
+pub fn ensure_running(addr: &str) -> Result<DaemonStartResult> {
+    ensure_running_with_wait(addr, Duration::from_secs(5))
+}
+
+fn ensure_running_with_wait(addr: &str, wait: Duration) -> Result<DaemonStartResult> {
+    parse_bind_addr(addr)?;
+    ensure_running_with_operations(
+        wait,
+        acquire_daemon_operation_lock_for_ensure,
+        read_status,
+        pid_is_running,
+        || start_background_unlocked(addr),
+    )
+}
+
+fn ensure_running_with_operations<Lock, AcquireLock, ReadStatus, PidIsRunning, Start>(
+    wait: Duration,
+    acquire_lock: AcquireLock,
+    read_status: ReadStatus,
+    pid_is_running: PidIsRunning,
+    start: Start,
+) -> Result<DaemonStartResult>
+where
+    AcquireLock: FnOnce(Duration) -> Result<Lock>,
+    ReadStatus: FnOnce() -> Result<super::DaemonStatus>,
+    PidIsRunning: FnOnce(u32) -> bool,
+    Start: FnOnce() -> Result<DaemonStartResult>,
+{
+    let _lock = acquire_lock(wait)?;
+    let status = read_status()?;
+    if let Some(state) = status.state {
+        if pid_is_running(state.pid) {
+            return Ok(DaemonStartResult {
+                pid: state.pid,
+                address: state.address,
+                state_path: state.state_path,
+                lease_id: state.lease_id,
+            });
+        }
+    }
+    start()
+}
+
+fn start_background_unlocked(addr: &str) -> Result<DaemonStartResult> {
     let _repaired_legacy_lease = repair_legacy_lease_for_start()?;
     let existing = read_status()?;
     if existing.state.is_some() || existing.stale_reason.is_some() {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -79,7 +79,8 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
     };
     let version = identity.version.clone();
 
-    let daemon = ensure_remote_daemon(&client, homeboy);
+    let previous_session = read_session(runner_id)?;
+    let daemon = ensure_remote_daemon(&client, homeboy, previous_session.as_ref());
     let Ok(daemon) = daemon else {
         return Ok(failed_connect(
             runner_id,
@@ -944,54 +945,89 @@ mod remote_daemon {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub(super) struct RemoteDaemon {
         pub(super) address: String,
         pub(super) pid: Option<u32>,
         pub(super) lease_id: Option<String>,
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub(super) struct RemoteDaemonStatus {
         pub(super) daemon: Option<RemoteDaemon>,
         pub(super) stale_reason: Option<String>,
+        pub(super) fresh: bool,
+        pub(super) reachable: bool,
+        pub(super) active_jobs: usize,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(super) enum RemoteDaemonConnectAction {
+        Reattach,
+        Start,
     }
 
     pub(super) fn ensure_remote_daemon(
         client: &SshClient,
         homeboy: &str,
+        previous_session: Option<&RunnerSession>,
     ) -> std::result::Result<RemoteDaemon, String> {
         let status = remote_daemon_status(client, homeboy)?;
-        if let Some(stale_reason) = status.stale_reason {
-            log_status!(
-                "runner",
-                "Remote managed daemon lease is stale ({stale_reason}); restarting it"
-            );
-            remote_daemon_stop(client, homeboy)?;
-            return remote_daemon_start(client, homeboy);
+        match remote_daemon_connect_action(previous_session, &status)? {
+            RemoteDaemonConnectAction::Reattach => {
+                return status.daemon.ok_or_else(|| {
+                    "remote daemon reattach selected without a daemon lease".to_string()
+                });
+            }
+            RemoteDaemonConnectAction::Start => {
+                return remote_daemon_ensure_running(client, homeboy)
+            }
         }
-        if let Some(daemon) = status.daemon {
-            return Ok(daemon);
-        }
-        remote_daemon_start(client, homeboy)
     }
 
-    /// Stop a remote homeboy daemon over SSH, surfacing a command-failure message on
-    /// non-zero exit. Shared by the connection and connection-daemon refresh paths
-    /// so the stop command + error handling lives in one place (#5362).
-    pub(super) fn remote_daemon_stop(
-        client: &SshClient,
-        homeboy: &str,
-    ) -> std::result::Result<(), String> {
-        let command = format!("{} daemon stop", shell::quote_arg(homeboy));
-        let output = client.execute(&command);
-        if !output.success {
-            return Err(command_failure_message(
-                "remote daemon stop failed while refreshing stale daemon",
-                &output,
+    pub(super) fn remote_daemon_connect_action(
+        previous_session: Option<&RunnerSession>,
+        status: &RemoteDaemonStatus,
+    ) -> std::result::Result<RemoteDaemonConnectAction, String> {
+        let healthy = status.fresh && status.reachable;
+        if status.active_jobs > 0 && !healthy {
+            return Err(format!(
+                "remote daemon has {} active job(s) but cannot be safely reattached (fresh={}, reachable={}, reason={:?}); refusing implicit replacement",
+                status.active_jobs, status.fresh, status.reachable, status.stale_reason
             ));
         }
-        Ok(())
+
+        let Some(daemon) = status.daemon.as_ref() else {
+            return Ok(RemoteDaemonConnectAction::Start);
+        };
+
+        if healthy {
+            if let Some(session) = previous_session.filter(|session| {
+                session.mode == RunnerTunnelMode::DirectSsh
+                    && session.role == RunnerSessionRole::Controller
+            }) {
+                if session.remote_daemon_lease_id.is_none() {
+                    if session.remote_daemon_pid == daemon.pid
+                        && session.remote_daemon_address.as_deref() == Some(daemon.address.as_str())
+                    {
+                        return Ok(RemoteDaemonConnectAction::Reattach);
+                    }
+                    return Err("persisted direct-SSH runner session has no daemon lease and does not match the live daemon PID/address; refusing replacement".to_string());
+                }
+                let expected_lease = session.remote_daemon_lease_id.as_deref().expect("checked");
+                let actual_lease = daemon.lease_id.as_deref().ok_or_else(|| {
+                    "live remote daemon did not report a lease; refusing to replace it".to_string()
+                })?;
+                if expected_lease != actual_lease {
+                    return Err(format!(
+                        "live remote daemon lease `{actual_lease}` does not match persisted session lease `{expected_lease}`; refusing to replace the live daemon"
+                    ));
+                }
+            }
+            return Ok(RemoteDaemonConnectAction::Reattach);
+        }
+
+        Ok(RemoteDaemonConnectAction::Start)
     }
 
     pub(super) fn remote_daemon_status(
@@ -1001,28 +1037,22 @@ mod remote_daemon {
         let command = format!("{} daemon status", shell::quote_arg(homeboy));
         let output = client.execute(&command);
         if !output.success {
-            return Ok(RemoteDaemonStatus {
-                daemon: None,
-                stale_reason: Some(command_failure_message(
-                    "remote daemon status failed",
-                    &output,
-                )),
-            });
+            return Err(command_failure_message(
+                "remote daemon status failed",
+                &output,
+            ));
         }
         let envelope = parse_envelope(&output.stdout)
             .map_err(|err| format!("remote daemon status returned invalid JSON: {}", err))?;
         if !envelope.success {
-            return Ok(RemoteDaemonStatus {
-                daemon: None,
-                stale_reason: None,
-            });
+            return Err(format!(
+                "remote daemon status returned an error: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ));
         }
-        let Some(data) = envelope.data else {
-            return Ok(RemoteDaemonStatus {
-                daemon: None,
-                stale_reason: None,
-            });
-        };
+        let data = envelope
+            .data
+            .ok_or_else(|| "remote daemon status returned no data".to_string())?;
         let stale_reason = data
             .get("stale_reason")
             .and_then(Value::as_str)
@@ -1033,8 +1063,14 @@ mod remote_daemon {
             .unwrap_or(false)
         {
             return Ok(RemoteDaemonStatus {
-                daemon: None,
+                daemon: data.get("state").map(remote_daemon_from_state),
                 stale_reason,
+                fresh: data.get("fresh").and_then(Value::as_bool).unwrap_or(false),
+                reachable: data
+                    .get("reachable")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                active_jobs: remote_daemon_active_jobs(&data),
             });
         }
         let Some(state) = data.get("state") else {
@@ -1044,54 +1080,81 @@ mod remote_daemon {
                     stale_reason
                         .unwrap_or_else(|| "remote daemon status has no lease state".to_string()),
                 ),
+                fresh: data.get("fresh").and_then(Value::as_bool).unwrap_or(false),
+                reachable: data
+                    .get("reachable")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                active_jobs: remote_daemon_active_jobs(&data),
             });
         };
         Ok(RemoteDaemonStatus {
-            daemon: Some(RemoteDaemon {
-                address: state
-                    .get("address")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
-                pid: state
-                    .get("pid")
-                    .and_then(Value::as_u64)
-                    .and_then(|pid| u32::try_from(pid).ok()),
-                lease_id: state
-                    .get("lease_id")
-                    .and_then(Value::as_str)
-                    .map(str::to_string),
-            }),
+            daemon: Some(remote_daemon_from_state(state)),
             stale_reason,
+            fresh: data.get("fresh").and_then(Value::as_bool).unwrap_or(false),
+            reachable: data
+                .get("reachable")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            active_jobs: remote_daemon_active_jobs(&data),
         })
     }
 
-    pub(super) fn remote_daemon_start(
+    fn remote_daemon_from_state(state: &Value) -> RemoteDaemon {
+        RemoteDaemon {
+            address: state
+                .get("address")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            pid: state
+                .get("pid")
+                .and_then(Value::as_u64)
+                .and_then(|pid| u32::try_from(pid).ok()),
+            lease_id: state
+                .get("lease_id")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        }
+    }
+
+    pub(super) fn remote_daemon_active_jobs(data: &Value) -> usize {
+        data.pointer("/freshness/active_jobs")
+            .and_then(Value::as_u64)
+            .and_then(|count| usize::try_from(count).ok())
+            .unwrap_or(0)
+    }
+
+    pub(super) fn remote_daemon_ensure_running(
         client: &SshClient,
         homeboy: &str,
     ) -> std::result::Result<RemoteDaemon, String> {
         let command = format!(
-            "{} daemon start --addr 127.0.0.1:0",
+            "{} daemon ensure-running --addr 127.0.0.1:0",
             shell::quote_arg(homeboy)
         );
         let output = client.execute(&command);
         if !output.success {
             return Err(command_failure_message(
-                "remote daemon startup failed",
+                "remote daemon ensure-running failed",
                 &output,
             ));
         }
-        let envelope = parse_envelope(&output.stdout)
-            .map_err(|err| format!("remote daemon start returned invalid JSON: {}", err))?;
+        let envelope = parse_envelope(&output.stdout).map_err(|err| {
+            format!(
+                "remote daemon ensure-running returned invalid JSON: {}",
+                err
+            )
+        })?;
         if !envelope.success {
             return Err(format!(
-                "remote daemon start failed: {}",
+                "remote daemon ensure-running failed: {}",
                 envelope.error.unwrap_or(Value::Null)
             ));
         }
         let data = envelope
             .data
-            .ok_or_else(|| "remote daemon start returned no data".to_string())?;
+            .ok_or_else(|| "remote daemon ensure-running returned no data".to_string())?;
         Ok(RemoteDaemon {
             address: data
                 .get("address")
@@ -1364,6 +1427,133 @@ mod tests {
                 .unwrap(),
             "127.0.0.1:49152"
         );
+    }
+
+    #[test]
+    fn reads_remote_active_job_count_from_daemon_freshness() {
+        let status = serde_json::json!({
+            "freshness": { "active_jobs": 2 }
+        });
+
+        assert_eq!(remote_daemon_active_jobs(&status), 2);
+    }
+
+    #[test]
+    fn reattaches_active_daemon_without_changing_lease_or_pid() {
+        let session = direct_ssh_session("lease-active");
+        let status = remote_daemon_status_for_test(true, true, 1, "lease-active", 4242);
+
+        let action = remote_daemon_connect_action(Some(&session), &status).expect("reattach");
+
+        assert_eq!(action, RemoteDaemonConnectAction::Reattach);
+        let daemon = status.daemon.expect("daemon");
+        assert_eq!(daemon.lease_id.as_deref(), Some("lease-active"));
+        assert_eq!(daemon.pid, Some(4242));
+        assert_eq!(
+            status.active_jobs, 1,
+            "active job must not trigger replacement"
+        );
+    }
+
+    #[test]
+    fn tunnel_only_failure_reattaches_the_persisted_daemon() {
+        let mut session = direct_ssh_session("lease-tunnel");
+        session.tunnel_pid = Some(999_999);
+        session.local_url = Some("http://127.0.0.1:1".to_string());
+        let status = remote_daemon_status_for_test(true, true, 0, "lease-tunnel", 4343);
+
+        assert_eq!(
+            remote_daemon_connect_action(Some(&session), &status).expect("reattach"),
+            RemoteDaemonConnectAction::Reattach
+        );
+    }
+
+    #[test]
+    fn stale_daemon_without_jobs_routes_to_safe_replacement() {
+        let status = remote_daemon_status_for_test(false, true, 0, "lease-stale", 4444);
+
+        assert_eq!(
+            remote_daemon_connect_action(None, &status).expect("replace stale daemon"),
+            RemoteDaemonConnectAction::Start
+        );
+    }
+
+    #[test]
+    fn refuses_to_replace_unreachable_daemon_with_active_jobs() {
+        let status = remote_daemon_status_for_test(false, true, 1, "lease-busy", 4545);
+
+        let err = remote_daemon_connect_action(None, &status).expect_err("refuse replacement");
+
+        assert!(err.contains("1 active job(s)"));
+        assert!(err.contains("refusing implicit replacement"));
+    }
+
+    #[test]
+    fn dead_recorded_daemon_routes_to_idempotent_ensure_start() {
+        let status = RemoteDaemonStatus {
+            daemon: None,
+            stale_reason: Some("daemon lease pid is not running".to_string()),
+            fresh: false,
+            reachable: false,
+            active_jobs: 0,
+        };
+
+        assert_eq!(
+            remote_daemon_connect_action(Some(&direct_ssh_session("lease-dead")), &status)
+                .expect("ensure start"),
+            RemoteDaemonConnectAction::Start
+        );
+    }
+
+    #[test]
+    fn first_connect_routes_to_idempotent_ensure_start_when_no_daemon_exists() {
+        let status = RemoteDaemonStatus {
+            daemon: None,
+            stale_reason: None,
+            fresh: false,
+            reachable: false,
+            active_jobs: 0,
+        };
+
+        assert_eq!(
+            remote_daemon_connect_action(None, &status).expect("ensure start"),
+            RemoteDaemonConnectAction::Start
+        );
+    }
+
+    #[test]
+    fn refuses_to_replace_live_daemon_with_a_different_persisted_lease() {
+        let session = direct_ssh_session("lease-recorded");
+        let status = remote_daemon_status_for_test(true, true, 0, "lease-live", 4646);
+
+        let err =
+            remote_daemon_connect_action(Some(&session), &status).expect_err("lease mismatch");
+
+        assert!(err.contains("does not match persisted session lease"));
+        assert!(err.contains("refusing to replace"));
+    }
+
+    #[test]
+    fn legacy_session_adopts_consistent_live_daemon_identity() {
+        let mut session = direct_ssh_session("lease-old");
+        session.remote_daemon_lease_id = None;
+        let status = remote_daemon_status_for_test(true, true, 1, "lease-live", 4242);
+
+        assert_eq!(
+            remote_daemon_connect_action(Some(&session), &status).expect("adopt live lease"),
+            RemoteDaemonConnectAction::Reattach
+        );
+    }
+
+    #[test]
+    fn legacy_session_refuses_pid_reuse_with_different_daemon_identity() {
+        let mut session = direct_ssh_session("lease-old");
+        session.remote_daemon_lease_id = None;
+        let status = remote_daemon_status_for_test(true, true, 0, "lease-live", 5555);
+
+        assert!(remote_daemon_connect_action(Some(&session), &status)
+            .expect_err("identity mismatch")
+            .contains("does not match the live daemon PID/address"));
     }
 
     #[test]
@@ -1908,6 +2098,49 @@ mod tests {
             retryable: Some(false),
             active_child_count: None,
             active_cell_count: None,
+        }
+    }
+
+    fn direct_ssh_session(lease_id: &str) -> RunnerSession {
+        RunnerSession {
+            runner_id: "homeboy-lab".to_string(),
+            mode: RunnerTunnelMode::DirectSsh,
+            role: RunnerSessionRole::Controller,
+            server_id: Some("homeboy-lab".to_string()),
+            controller_id: None,
+            broker_url: None,
+            remote_daemon_address: Some("127.0.0.1:49152".to_string()),
+            local_port: Some(49153),
+            local_url: Some("http://127.0.0.1:49153".to_string()),
+            tunnel_pid: Some(1234),
+            remote_daemon_pid: Some(4242),
+            remote_daemon_lease_id: Some(lease_id.to_string()),
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: Some("homeboy test+abc123".to_string()),
+            connected_at: Utc::now().to_rfc3339(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+        }
+    }
+
+    fn remote_daemon_status_for_test(
+        fresh: bool,
+        reachable: bool,
+        active_jobs: usize,
+        lease_id: &str,
+        pid: u32,
+    ) -> RemoteDaemonStatus {
+        RemoteDaemonStatus {
+            daemon: Some(RemoteDaemon {
+                address: "127.0.0.1:49152".to_string(),
+                pid: Some(pid),
+                lease_id: Some(lease_id.to_string()),
+            }),
+            stale_reason: (!fresh).then(|| "daemon is stale".to_string()),
+            fresh,
+            reachable,
+            active_jobs,
         }
     }
 }

--- a/src/core/runner/connection_daemon.rs
+++ b/src/core/runner/connection_daemon.rs
@@ -10,11 +10,10 @@ use crate::core::server::{Server, SshClient};
 
 use super::super::session::RunnerStaleRuntimePath;
 use super::{
-    failed_connect, open_loopback_tunnel, parse_loopback_daemon_addr, remote_daemon_start,
-    remote_daemon_stop, reserve_loopback_port, terminate_pid, wait_for_tcp, RemoteDaemon,
+    failed_connect, open_loopback_tunnel, parse_loopback_daemon_addr, reserve_loopback_port,
+    terminate_pid, wait_for_tcp, RemoteDaemon,
 };
 use crate::core::runner::connection::remote_daemon::parse_json_from_mixed_stdout;
-use crate::core::runner::daemon_freshness::repair_or_fail;
 use crate::core::runner::{RunnerConnectReport, RunnerFailureKind};
 use std::collections::BTreeMap;
 
@@ -26,8 +25,8 @@ struct DaemonVersionResponse {
 
 pub(super) fn connect_remote_daemon(
     server: &Server,
-    client: &SshClient,
-    homeboy: &str,
+    _client: &SshClient,
+    _homeboy: &str,
     daemon: RemoteDaemon,
     expected_version: &str,
     expected_identity: &str,
@@ -48,52 +47,20 @@ pub(super) fn connect_remote_daemon(
     let (local_port, tunnel_pid, local_url) =
         open_daemon_tunnel(server, &daemon, runner_id, session_path)?;
     match daemon_freshness_report(&local_url, expected_version, expected_identity) {
-        Ok(report) if report.fresh => Ok((local_port, tunnel_pid, local_url, daemon)),
-        Ok(report) if repair_or_fail(&report).is_ok() => {
-            if let Some(pid) = tunnel_pid {
-                terminate_pid(pid);
-            }
-            if let Err(message) = remote_daemon_stop(client, homeboy) {
-                return Err(failed_connect(
-                    runner_id,
-                    session_path.to_path_buf(),
-                    RunnerFailureKind::DaemonStartupFailure,
-                    message,
-                ));
-            }
-            let daemon = match remote_daemon_start(client, homeboy) {
-                Ok(daemon) => daemon,
-                Err(message) => {
-                    return Err(failed_connect(
-                        runner_id,
-                        session_path.to_path_buf(),
-                        RunnerFailureKind::DaemonStartupFailure,
-                        message,
-                    ));
-                }
-            };
-            let (local_port, tunnel_pid, local_url) =
-                open_daemon_tunnel(server, &daemon, runner_id, session_path)?;
-            match daemon_freshness_report(&local_url, expected_version, expected_identity) {
-                Ok(report) if report.fresh => {}
-                Ok(report) => {
-                    return Err(failed_after_tunnel(
-                        tunnel_pid,
-                        format!(
-                            "remote daemon restarted but still reports stale Homeboy build: {:?}",
-                            report.stale_reason_code
-                        ),
-                    ));
-                }
-                Err(message) => {
-                    return Err(failed_after_tunnel(tunnel_pid, message));
-                }
-            }
+        Ok(report) if report.fresh && report.lease_id == daemon.lease_id => {
             Ok((local_port, tunnel_pid, local_url, daemon))
         }
+        Ok(report) if report.fresh => Err(failed_after_tunnel(
+            tunnel_pid,
+            format!(
+                "remote daemon lease changed before tunnel validation (expected {:?}, got {:?}); refusing to write session",
+                daemon.lease_id, report.lease_id
+            ),
+        )),
+        Ok(report) if report.lease_id == daemon.lease_id => Ok((local_port, tunnel_pid, local_url, daemon)),
         Ok(report) => Err(failed_after_tunnel(
             tunnel_pid,
-            repair_or_fail(&report).unwrap_err(),
+            format!("remote daemon health lease changed or is unavailable: {:?}", report.lease_id),
         )),
         Err(message) => Err(failed_after_tunnel(tunnel_pid, message)),
     }

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -1,8 +1,20 @@
 use std::io::{Read, Write};
 use std::net::TcpListener;
+use std::sync::{Arc, Barrier, Mutex};
+use std::time::Duration;
 
-use super::{artifact_content_url, fetch_artifact_to_path};
+use super::{artifact_content_url, ensure_running_with_operations, fetch_artifact_to_path};
+use crate::core::build_identity::BuildIdentity;
+use crate::core::daemon::{
+    DaemonFreshnessReport, DaemonRuntimeSnapshot, DaemonStaleReasonCode, DaemonState, DaemonStatus,
+};
 use crate::test_support::with_isolated_home;
+
+#[derive(Default)]
+struct FakeEnsureState {
+    daemon: Option<super::DaemonStartResult>,
+    starts: usize,
+}
 
 #[test]
 fn artifact_content_url_builds_encoded_daemon_byte_alias() {
@@ -53,4 +65,165 @@ fn fetch_artifact_to_path_downloads_daemon_byte_alias() {
         assert_eq!(outcome.sha256.as_deref(), Some("abc123"));
         assert_eq!(std::fs::read(&output).expect("output"), br#"{"ok":true}"#);
     });
+}
+
+#[test]
+fn ensure_running_times_out_when_lifecycle_lock_remains_held() {
+    with_isolated_home(|_| {
+        let _lock = super::super::acquire_daemon_operation_lock().expect("hold lifecycle lock");
+
+        let err = ensure_running_with_operations(
+            Duration::from_millis(10),
+            super::super::acquire_daemon_operation_lock_for_ensure,
+            || unreachable!("lock acquisition should time out first"),
+            |_| unreachable!("lock acquisition should time out first"),
+            || unreachable!("lock acquisition should time out first"),
+        )
+        .expect_err("ensure should time out behind held lock");
+
+        assert!(err.message.contains("timed out"));
+        assert!(err.message.contains("ensure-running lifecycle lock"));
+    });
+}
+
+#[test]
+fn ensure_running_returns_stale_live_daemon_without_starting_duplicate() {
+    with_isolated_home(|_| {
+        let daemon = fake_daemon(4242, "lease-stale");
+        let state = Arc::new(Mutex::new(FakeEnsureState {
+            daemon: Some(daemon.clone()),
+            starts: 0,
+        }));
+        let read_state = Arc::clone(&state);
+        let start_state = Arc::clone(&state);
+
+        let attached = ensure_running_with_operations(
+            Duration::from_millis(50),
+            super::super::acquire_daemon_operation_lock_for_ensure,
+            move || {
+                Ok(fake_status(
+                    read_state.lock().expect("state").daemon.clone(),
+                    false,
+                ))
+            },
+            |pid| pid == daemon.pid,
+            move || {
+                let mut state = start_state.lock().expect("state");
+                state.starts += 1;
+                Ok(fake_daemon(4343, "unexpected-replacement"))
+            },
+        )
+        .expect("attach stale live daemon");
+
+        assert_eq!(attached, daemon);
+        assert_eq!(state.lock().expect("state").starts, 0);
+    });
+}
+
+#[test]
+fn ensure_running_concurrent_callers_converge_on_same_daemon() {
+    with_isolated_home(|_| {
+        let daemon = fake_daemon(4242, "lease-shared");
+        let state = Arc::new(Mutex::new(FakeEnsureState::default()));
+        let barrier = Arc::new(Barrier::new(3));
+        let first =
+            ensure_with_fake_operations(Arc::clone(&barrier), Arc::clone(&state), daemon.clone());
+        let second = ensure_with_fake_operations(Arc::clone(&barrier), Arc::clone(&state), daemon);
+        barrier.wait();
+
+        let first = first.join().expect("first thread").expect("first ensure");
+        let second = second
+            .join()
+            .expect("second thread")
+            .expect("second ensure");
+        assert_eq!(first.pid, second.pid);
+        assert_eq!(first.lease_id, second.lease_id);
+        assert_eq!(first.address, second.address);
+        assert_eq!(state.lock().expect("state").starts, 1);
+    });
+}
+
+fn ensure_with_fake_operations(
+    barrier: Arc<Barrier>,
+    state: Arc<Mutex<FakeEnsureState>>,
+    daemon: super::DaemonStartResult,
+) -> std::thread::JoinHandle<crate::core::error::Result<super::DaemonStartResult>> {
+    std::thread::spawn(move || {
+        barrier.wait();
+        let read_state = Arc::clone(&state);
+        let start_state = Arc::clone(&state);
+        let daemon_pid = daemon.pid;
+        ensure_running_with_operations(
+            Duration::from_secs(1),
+            super::super::acquire_daemon_operation_lock_for_ensure,
+            move || {
+                Ok(fake_status(
+                    read_state.lock().expect("state").daemon.clone(),
+                    true,
+                ))
+            },
+            move |pid| pid == daemon_pid,
+            move || {
+                let mut state = start_state.lock().expect("state");
+                state.starts += 1;
+                state.daemon = Some(daemon.clone());
+                Ok(daemon)
+            },
+        )
+    })
+}
+
+fn fake_daemon(pid: u32, lease_id: &str) -> super::DaemonStartResult {
+    super::DaemonStartResult {
+        pid,
+        address: "127.0.0.1:49152".to_string(),
+        state_path: "/fake/daemon-state.json".to_string(),
+        lease_id: lease_id.to_string(),
+    }
+}
+
+fn fake_status(daemon: Option<super::DaemonStartResult>, fresh: bool) -> DaemonStatus {
+    let stale_reason_code = (!fresh).then_some(DaemonStaleReasonCode::VersionMismatch);
+    DaemonStatus {
+        running: fresh,
+        fresh,
+        reachable: true,
+        freshness: DaemonFreshnessReport {
+            fresh,
+            stale_reason_code,
+            restartable: !fresh,
+            lease_id: daemon.as_ref().map(|daemon| daemon.lease_id.clone()),
+            binary_hash: None,
+            runtime_paths: None,
+            active_jobs: 0,
+            repair_plan: Vec::new(),
+        },
+        stale_reason: (!fresh).then(|| "simulated stale daemon".to_string()),
+        state: daemon.map(fake_daemon_state),
+        state_path: "/fake/daemon-state.json".to_string(),
+    }
+}
+
+fn fake_daemon_state(daemon: super::DaemonStartResult) -> DaemonState {
+    DaemonState {
+        schema: "homeboy.daemon.session_lease.v1".to_string(),
+        lease_id: daemon.lease_id,
+        startup_token: "fake-startup-token".to_string(),
+        address: daemon.address,
+        pid: daemon.pid,
+        state_path: daemon.state_path,
+        started_at: "2026-01-01T00:00:00Z".to_string(),
+        last_seen_at: "2026-01-01T00:00:00Z".to_string(),
+        build_identity: BuildIdentity {
+            version: "test".to_string(),
+            git_commit: None,
+            git_dirty: None,
+            display: "homeboy test".to_string(),
+        },
+        binary_sha256: None,
+        runtime_paths: DaemonRuntimeSnapshot {
+            loaded_at: "2026-01-01T00:00:00Z".to_string(),
+            paths: Vec::new(),
+        },
+    }
 }


### PR DESCRIPTION
## Summary
- reattach dropped direct-SSH controller tunnels to the existing daemon lease instead of replacing live daemons
- add idempotent `daemon ensure-running` for absent/dead startup and concurrent first connects
- validate tunneled daemon lease before persisting the controller session
- expose read-only durable active-job counts without reconciling or terminalizing jobs

Fixes #7961.

## How to test
1. Check out this branch with Rust installed.
2. Run `cargo test ensure_running_ --lib` and confirm all three tests pass.
3. Run `cargo test core::runner::connection::tests:: -- --test-threads=1` and confirm all 33 tests pass.
4. Run `cargo check` and `cargo fmt --check`.
5. Run `git diff --check origin/main...HEAD`.
6. Confirm the ensure tests prove concurrent callers converge on one daemon identity, stale live daemons are retained without duplicate startup, and bounded lock timeout is explicit.

## Behavior
An existing direct-SSH session never implicitly stops or replaces a live daemon. It recreates only the local tunnel and validates the live lease. Dead or absent daemons use atomic `ensure-running`; concurrent callers return the same PID, address, and lease.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the reconnect data-loss path, drafted the lease-safe lifecycle implementation and deterministic concurrency tests, and reviewed race conditions. Chris reviewed and owns the change.