### PR TITLE
Fix detached Lab cook pre-acceptance lifecycle

### DIFF
--- a/src/core/agent_task_lifecycle/tests.rs
+++ b/src/core/agent_task_lifecycle/tests.rs
@@ -163,6 +163,83 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
 }
 
 #[test]
+fn detached_cook_attempt_proxy_advances_after_daemon_acceptance() {
+    with_isolated_home(|_| {
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        let attempt_run_id = "cook-7970-attempt-1-controller";
+        let queued = record_lab_offload_phase(
+            attempt_run_id,
+            "homeboy-lab",
+            "materializing",
+            None,
+            None,
+            None,
+            Some(&test_plan()),
+        )
+        .expect("pre-acceptance attempt record");
+
+        assert_eq!(queued.state, AgentTaskRunState::Queued);
+        assert_eq!(queued.metadata["phase"], "materializing");
+        assert!(queued.metadata.get("runner_job_id").is_none());
+
+        let accepted = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: attempt_run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-7970",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("daemon acceptance advances the same attempt");
+
+        assert_eq!(accepted.run_id, attempt_run_id);
+        assert_eq!(accepted.state, AgentTaskRunState::Running);
+        assert_eq!(accepted.metadata["runner_job_id"], "job-7970");
+        assert_eq!(
+            accepted.metadata["runner_execution_record"]["status"],
+            "running"
+        );
+    });
+}
+
+#[test]
+fn detached_cook_preacceptance_failure_terminalizes_attempt_proxy() {
+    with_isolated_home(|_| {
+        let attempt_run_id = "cook-7970-attempt-1-staging-failure";
+        let plan = test_plan();
+        record_lab_offload_phase(
+            attempt_run_id,
+            "homeboy-lab",
+            "materializing",
+            None,
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("pre-acceptance attempt record");
+
+        record_pre_execution_failure(
+            attempt_run_id,
+            &plan,
+            "lab_workspace_stage",
+            &Error::internal_unexpected("workspace materialization failed"),
+        )
+        .expect("terminal staging failure");
+
+        let record = status(attempt_run_id).expect("terminal attempt record");
+        assert_eq!(record.state, AgentTaskRunState::Failed);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "lab_workspace_stage"
+        );
+        assert!(record.metadata.get("runner_job_id").is_none());
+    });
+}
+
+#[test]
 fn failed_lab_handoff_retry_recovers_the_materialized_user_plan() {
     with_isolated_home(|_| {
         let mut plan = test_plan();

--- a/src/core/runner/lab/offload/inner.rs
+++ b/src/core/runner/lab/offload/inner.rs
@@ -816,10 +816,18 @@ pub(crate) fn run_lab_offload_inner(
     }
     let source_checkout = lab_source_checkout_metadata(&source_path);
     let run_isolation_token = agent_task_dispatch_run_isolation_token(request.normalized_args);
+    // Cook's public run id identifies the retry series. Persist pre-acceptance
+    // Lab progress under its first attempt id so daemon acceptance advances the
+    // same canonical lifecycle record instead of leaving a queued proxy behind.
+    let pre_acceptance_run_id = ensure_agent_task_lifecycle_identity_with(
+        request.normalized_args,
+        run_isolation_token.as_deref(),
+    )
+    .map(|(_, run_id)| run_id);
     let provider_rotation =
         serde_json::to_value(crate::core::defaults::load_config().agent_task.rotation)
             .unwrap_or(serde_json::Value::Null);
-    if let Some(run_id) = run_isolation_token.as_deref() {
+    if let Some(run_id) = pre_acceptance_run_id.as_deref() {
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,
             runner_id,
@@ -995,7 +1003,7 @@ pub(crate) fn run_lab_offload_inner(
 
     let capability_preflight: Option<RunnerCapabilityPreflight> = capability_plan.map(Into::into);
     let workspace_sync_timer = overhead.phase(LabOffloadPhase::WorkspaceSync);
-    let workspace_stage = prepare_lab_offload_workspace_stage(
+    let workspace_stage = match prepare_lab_offload_workspace_stage(
         &request,
         &contract,
         plan,
@@ -1005,7 +1013,24 @@ pub(crate) fn run_lab_offload_inner(
         &command_prefix.argv,
         Some(&runner_workspace_root),
         run_isolation_token,
-    )?;
+    ) {
+        Ok(stage) => stage,
+        Err(error) => {
+            if let Some(run_id) = pre_acceptance_run_id.as_deref() {
+                if let Ok(plan) = agent_task_lifecycle::load_plan(run_id) {
+                    // Staging is still controller-side. Make a failed handoff
+                    // actionable instead of retaining an unclaimed proxy.
+                    let _ = agent_task_lifecycle::record_pre_execution_failure(
+                        run_id,
+                        &plan,
+                        "lab_workspace_stage",
+                        &error,
+                    );
+                }
+            }
+            return Err(error);
+        }
+    };
     workspace_sync_timer.finish();
     let LabOffloadWorkspaceStage {
         plan: next_plan,
@@ -1030,6 +1055,11 @@ pub(crate) fn run_lab_offload_inner(
         runtime_overlay_metadata,
     } = workspace_stage;
     plan = next_plan;
+    if agent_task_run_id != pre_acceptance_run_id {
+        return Err(Error::internal_unexpected(
+            "Lab workspace staging changed the pre-acceptance agent-task lifecycle identity",
+        ));
+    }
     if let Some(run_id) = agent_task_run_id.as_deref() {
         agent_task_lifecycle::record_lab_offload_phase(
             run_id,


### PR DESCRIPTION
## Summary
- Record detached Lab cook staging under the first-attempt lifecycle ID rather than the public cook series ID.
- Bind daemon acceptance to that same record and reject a staging identity mismatch.
- Terminalize workspace-stage failures with actionable pre-execution evidence instead of retaining an unclaimed queued proxy.

Closes #7970

## Testing
1. Run `cargo fmt --check`.
2. Run `cargo test lab_cook_uses_one_first_attempt_identity_across_the_handoff --lib`.
3. Run `cargo test detached_cook_attempt_proxy_advances_after_daemon_acceptance --lib`.
4. Run `cargo test detached_cook_preacceptance_failure_terminalizes_attempt_proxy --lib`.
5. Run `cargo test --lib` for the full library suite. The local run exceeded the 15-minute limit after existing unrelated failures in `core::code_audit::tests::dead_code_reference_fingerprints_include_rust_singleton_and_index_files`, `core::code_audit::entry::audit_runtime_regression_test::audit_runtime_regression_matches_snapshot`, and `core::deploy::orchestration::tests::exact_ref_preflight_packages_verified_subpath_not_stale_checkout_artifact`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed the detached Lab lifecycle split, drafted the focused repair and tests, and ran verification with Chris directing the task.