### PR TITLE
Fix selected scenario visual artifact fixtures

### DIFF
--- a/src/commands/bench/tests/mod.rs
+++ b/src/commands/bench/tests/mod.rs
@@ -54,7 +54,7 @@ if [ -n "$HOMEBOY_BENCH_EXTRA_WORKLOADS" ]; then
   done
   IFS="$old_ifs"
 else
-  all_scenarios="in-tree slow"
+  all_scenarios="in-tree slow visual"
 fi
 
 # Rig-declared workload selection is owned by Homeboy core because the core
@@ -76,8 +76,14 @@ JSON
 
 comma=""
 for scenario in $selected; do
+  artifacts=""
+  if [ "$scenario" = "visual" ]; then
+    visual_comparison_dir="$HOMEBOY_BENCH_RESULTS_FILE.visual-comparisons/$scenario"
+    mkdir -p "$visual_comparison_dir"
+    artifacts=", \"artifacts\": { \"visual_comparison_dir\": { \"path\": \"$visual_comparison_dir\", \"type\": \"directory\" } }"
+  fi
   cat >> "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
-    $comma{ "id": "$scenario", "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0}, "metrics": { "p95_ms": 1.0, "warmup_iterations": ${HOMEBOY_BENCH_WARMUP_ITERATIONS:--1} } }
+    $comma{ "id": "$scenario", "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0}, "metrics": { "p95_ms": 1.0, "warmup_iterations": ${HOMEBOY_BENCH_WARMUP_ITERATIONS:--1} }$artifacts }
 JSON
   comma=",
 "

--- a/src/commands/bench/tests/scenario_run_tests.rs
+++ b/src/commands/bench/tests/scenario_run_tests.rs
@@ -98,6 +98,61 @@ fn run_selects_single_scenario() {
 }
 
 #[test]
+fn selected_visual_scenario_emits_a_non_empty_comparison_directory() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_registered_component(home, "studio", component_dir.path());
+
+        let (output, exit_code) = run(
+            run_args(Some("studio"), Vec::new(), vec!["visual".to_string()]),
+            &GlobalArgs {},
+        )
+        .expect("selected visual bench should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::Single(result) => {
+                let mut results = result.results.expect("results");
+                let scenario = results.scenarios.remove(0);
+                let path = scenario.artifacts["visual_comparison_dir"]
+                    .path
+                    .as_deref()
+                    .expect("visual comparison directory path");
+                assert!(!path.trim().is_empty());
+                assert!(std::path::Path::new(path).is_dir());
+            }
+            _ => panic!("expected single output"),
+        }
+    });
+}
+
+#[test]
+fn selected_non_visual_scenario_omits_optional_comparison_artifacts() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_registered_component(home, "studio", component_dir.path());
+
+        let (output, exit_code) = run(
+            run_args(Some("studio"), Vec::new(), vec!["slow".to_string()]),
+            &GlobalArgs {},
+        )
+        .expect("selected non-visual bench should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::Single(result) => {
+                let mut results = result.results.expect("results");
+                let scenario = results.scenarios.remove(0);
+                assert!(!scenario.artifacts.contains_key("visual_comparison_dir"));
+            }
+            _ => panic!("expected single output"),
+        }
+    });
+}
+
+#[test]
 fn selected_scenario_workload_failure_preserves_runner_error() {
     with_isolated_home(|home| {
         write_failing_bench_extension(home);


### PR DESCRIPTION
## Summary
- emit a real visual comparison directory only for the selected visual bench fixture
- retain optional visual artifacts as omitted for non-visual scenarios
- cover selected visual, non-visual, and malformed-artifact diagnostics

Closes #7985

## Testing
1. `cargo fmt --check`
2. `cargo test commands::bench::tests::scenario_run_tests --lib`
3. `cargo clippy --lib`

`cargo clippy --lib -- -D warnings` remains blocked by 189 pre-existing crate-wide warnings outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-terra
- **Used for:** Inspected the issue and fixture contract, implemented the focused regression coverage, and ran verification.