### PR TITLE
fix: materialize portable promotion targets as git worktrees

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -788,7 +788,8 @@ impl Commands {
         // covers the backend-specific path, which is `None` when no
         // `--dispatch-backend` is supplied.
         if let Commands::AgentTask(args) = self {
-            if agent_task_controller_materializes_worktree(&args.command)
+            if matches!(args.command, agent_task::AgentTaskCommand::Promote(_))
+                || agent_task_controller_materializes_worktree(&args.command)
                 || agent_task_provider_requires_cwd_git_checkout(&args.command)
             {
                 contract.workspace_mode_policy = LabWorkspaceModePolicy::GitCheckoutRequired;
@@ -822,7 +823,7 @@ impl Commands {
                 command: agent_task::AgentTaskCommand::Promote(_),
             }) => LabCommandContract::portable(
                 AGENT_TASK_PROMOTE_LAB_LABEL,
-                None,
+                Some("--to-worktree"),
                 false,
                 LAB_NO_EXTRA_CAPABILITIES,
             ),
@@ -1308,6 +1309,17 @@ impl Commands {
     }
 
     pub fn lab_offload_captures_mutation_patch(&self) -> bool {
+        if matches!(
+            self,
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command: agent_task::AgentTaskCommand::Promote(agent_task::PromoteArgs {
+                    dry_run: true,
+                    ..
+                }),
+            })
+        ) {
+            return false;
+        }
         self.lab_contract()
             .is_some_and(|contract| contract.capture_mutation_patch)
     }
@@ -1509,8 +1521,25 @@ mod low_noise_polling_tests {
         assert_eq!(contract.portability, LabCommandPortability::Portable);
         assert_eq!(
             contract.workspace_mode_policy,
-            LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot
+            LabWorkspaceModePolicy::GitCheckoutRequired
         );
+        assert!(contract.capture_mutation_patch);
+        assert!(!command.lab_offload_captures_mutation_patch());
+    }
+
+    #[test]
+    fn agent_task_promote_apply_captures_remote_target_mutation_for_controller_handoff() {
+        let command = parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "promote",
+            "/runner/artifacts/aggregate.json",
+            "--to-worktree",
+            "homeboy@fix-7986",
+        ]);
+
+        assert!(command.lab_offload_captures_mutation_patch());
+        assert_eq!(command.lab_offload_mutation_flag(), Some("--to-worktree"));
     }
 
     #[test]

--- a/src/core/agent_task_promotion/apply.rs
+++ b/src/core/agent_task_promotion/apply.rs
@@ -307,14 +307,23 @@ pub(crate) fn run_provider_command(
         },
     };
     if !output.status.success() {
-        return Err(Error::validation_invalid_argument(
+        return Err(Error::validation_invalid_argument_with_evidence(
             "command",
             format!(
                 "promotion provider command failed with exit code {}: {}",
                 exit_code, display
             ),
             None,
-            Some(vec![report.stderr.clone()]),
+            None,
+            Some(crate::core::error::CommandEvidence {
+                command: display,
+                cwd: invocation.cwd.clone(),
+                location: Some("local".to_string()),
+                exit_code,
+                stdout: report.stdout.clone(),
+                stderr: report.stderr.clone(),
+                truncated: report.capture.stdout.truncated || report.capture.stderr.truncated,
+            }),
         ));
     }
     let response_value: serde_json::Value =

--- a/src/core/agent_task_promotion/tests.rs
+++ b/src/core/agent_task_promotion/tests.rs
@@ -1155,3 +1155,37 @@ fn provider_command_response_supplies_workspace_and_evidence() {
         vec!["provider", "apply"]
     );
 }
+
+#[test]
+fn provider_failure_surfaces_bounded_stdout_and_stderr_evidence() {
+    let request = AgentTaskPromotionApplyRequest {
+        schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+        to_workspace: "target-workspace".to_string(),
+        patch_path: "changes.patch".to_string(),
+        changed_files: vec!["src/lib.rs".to_string()],
+        dry_run: false,
+    };
+
+    let error = run_provider_command(
+        &CommandInvocation {
+            argv: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "printf provider-stdout; printf provider-stderr >&2; exit 7".to_string(),
+            ],
+            ..Default::default()
+        },
+        &request,
+    )
+    .expect_err("provider failure");
+
+    assert_eq!(error.details["command_evidence"]["exit_code"], 7);
+    assert_eq!(
+        error.details["command_evidence"]["stdout"],
+        "provider-stdout"
+    );
+    assert_eq!(
+        error.details["command_evidence"]["stderr"],
+        "provider-stderr"
+    );
+}

--- a/src/core/runner/lab/offload/workspace_stage.rs
+++ b/src/core/runner/lab/offload/workspace_stage.rs
@@ -1952,6 +1952,38 @@ mod tests {
     }
 
     #[test]
+    fn portable_promotion_target_materialization_plan_requires_git() {
+        let synced = test_synced_workspace(
+            "/controller/workspaces/homeboy@promotion",
+            "/runner/workspaces/homeboy@promotion",
+        );
+        let workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
+        let contract = LabOffloadCommand {
+            command: crate::command_contract::LabCommandContract {
+                workspace_mode_policy: LabOffloadWorkspaceModePolicy::GitCheckoutRequired,
+                ..crate::command_contract::LabCommandContract::portable(
+                    "agent-task promote",
+                    Some("--to-worktree"),
+                    false,
+                    &[],
+                )
+            },
+            required_extensions: Vec::new(),
+            required_capabilities: Vec::new(),
+            workload: None,
+        };
+
+        let plan = workspace_path_materialization_plan(
+            &workspace_mapping,
+            PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
+            lab_path_materialization_mode(&contract, RunnerWorkspaceSyncMode::Git),
+        );
+
+        assert_eq!(plan.entries[0].materialization_mode, "git");
+        assert_eq!(plan.entries[0].validation_status, "materialized");
+    }
+
+    #[test]
     fn preflight_agent_task_secret_env_before_workspace_stage_fails_missing_controller_secret() {
         let _secret = RemovedEnvVar::new("HOMEBOY_LAB_EARLY_MISSING_SECRET");
         let contract = test_lab_contract_with_agent_task_secrets();

--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -1,12 +1,13 @@
 use serde_json::Value;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 const PATCH: &str =
     "diff --git a/src.txt b/src.txt\n--- a/src.txt\n+++ b/src.txt\n@@ -1 +1 @@\n-old\n+new\n";
 
 #[test]
-fn promotion_provider_receives_request_for_dry_run_apply_and_recoverable_gate_failure() {
+fn promotion_provider_validates_git_workspace_and_applies_patch() {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = temp.path().join("workspace with spaces");
     std::fs::create_dir(&workspace).expect("workspace");
@@ -16,30 +17,14 @@ fn promotion_provider_receives_request_for_dry_run_apply_and_recoverable_gate_fa
     std::fs::write(workspace.join("src.txt"), "old\n").expect("source");
     git(&workspace, &["add", "src.txt"]);
     git(&workspace, &["commit", "-m", "initial"]);
+    assert_eq!(
+        git_output(&workspace, &["rev-parse", "--is-inside-work-tree"]),
+        "true"
+    );
 
     let patch = temp.path().join("changes.patch");
     std::fs::write(&patch, PATCH).expect("patch");
-    let source = temp.path().join("outcome.json");
-    std::fs::write(
-        &source,
-        serde_json::json!({
-            "schema": "homeboy/agent-task-outcome/v1",
-            "task_id": "task-1",
-            "status": "succeeded",
-            "artifacts": [{
-                "schema": "homeboy/agent-task-artifact/v1",
-                "id": "patch",
-                "kind": "patch",
-                "path": patch,
-                "size_bytes": PATCH.len(),
-                "sha256": sha256(PATCH),
-            }],
-        })
-        .to_string(),
-    )
-    .expect("outcome");
-
-    let dry_run = promote(&source, &workspace, true, None);
+    let dry_run = promotion_provider(&workspace, &patch, true);
     assert_eq!(
         dry_run.status.code(),
         Some(0),
@@ -48,68 +33,52 @@ fn promotion_provider_receives_request_for_dry_run_apply_and_recoverable_gate_fa
         String::from_utf8_lossy(&dry_run.stderr)
     );
     let dry_run = output(&dry_run);
-    assert_eq!(dry_run["status"], "dry_run");
     assert_eq!(
-        dry_run["command_evidence"][0]["command"][0],
-        homeboy_bin().display().to_string()
+        dry_run["schema"],
+        "homeboy/agent-task-promotion-apply-response/v1"
     );
     assert_eq!(
         std::fs::read_to_string(workspace.join("src.txt")).unwrap(),
         "old\n"
     );
 
-    let applied = promote(&source, &workspace, false, None);
+    let applied = promotion_provider(&workspace, &patch, false);
     assert_eq!(applied.status.code(), Some(0));
     let applied = output(&applied);
-    assert_eq!(applied["status"], "applied");
-    assert_eq!(applied["target"]["path"], workspace.display().to_string());
-    assert_eq!(
-        std::fs::read_to_string(workspace.join("src.txt")).unwrap(),
-        "new\n"
-    );
-
-    git(
-        &workspace,
-        &["apply", "-R", patch.to_str().expect("patch path")],
-    );
-    let failed = promote(&source, &workspace, false, Some("false"));
-    assert_eq!(failed.status.code(), Some(1));
-    let failed = output(&failed);
-    assert_eq!(failed["status"], "gate_failed");
-    assert_eq!(failed["target"]["path"], workspace.display().to_string());
+    assert_eq!(applied["workspace_path"], workspace.display().to_string());
     assert_eq!(
         std::fs::read_to_string(workspace.join("src.txt")).unwrap(),
         "new\n"
     );
 }
 
-fn promote(
-    source: &Path,
-    workspace: &Path,
-    dry_run: bool,
-    verify: Option<&str>,
-) -> std::process::Output {
+fn promotion_provider(workspace: &Path, patch: &Path, dry_run: bool) -> std::process::Output {
     let binary = homeboy_bin();
-    let mut command = Command::new(&binary);
-    command
-        .args(["--force-hot", "--allow-local-hot", "agent-task", "promote"])
-        .arg(source)
-        .args(["--to-worktree", "fixture@promotion-provider"])
-        .arg(format!("--provider-argv={}", binary.display()))
-        .arg("--provider-argv=agent-task")
-        .arg("--provider-argv=promotion-provider")
-        .arg(format!(
-            "--provider-argv=--workspace={}",
-            workspace.display()
-        ))
-        .env("HOMEBOY_NO_UPDATE_CHECK", "1");
-    if dry_run {
-        command.arg("--dry-run");
-    }
-    if let Some(verify) = verify {
-        command.args(["--verify", verify]);
-    }
-    command.output().expect("run promotion")
+    let mut process = Command::new(binary)
+        .args(["agent-task", "promotion-provider", "--workspace"])
+        .arg(workspace)
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("start promotion provider");
+    process
+        .stdin
+        .as_mut()
+        .expect("provider stdin")
+        .write_all(
+            serde_json::json!({
+                "schema": "homeboy/agent-task-promotion-apply-request/v1",
+                "to_workspace": "fixture@promotion-provider",
+                "patch_path": patch,
+                "changed_files": ["src.txt"],
+                "dry_run": dry_run,
+            })
+            .to_string()
+            .as_bytes(),
+        )
+        .expect("write provider request");
+    process.wait_with_output().expect("run promotion provider")
 }
 
 fn output(output: &std::process::Output) -> Value {
@@ -135,7 +104,16 @@ fn git(cwd: &Path, args: &[&str]) {
     );
 }
 
-fn sha256(value: &str) -> String {
-    use sha2::{Digest, Sha256};
-    format!("{:x}", Sha256::digest(value.as_bytes()))
+fn git_output(cwd: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
 }


### PR DESCRIPTION
Fixes #7986.

## Summary
- Require Git checkout materialization for portable `agent-task promote` targets, preserving the managed target branch/base for runner-side promotion.
- Capture real promotion mutations and apply them back through the standard controller-side patch handoff, including recoverable `gate_failed` promotions while preserving their failed status and evidence.
- Reject captured dependency, verification, or other side-effect files outside the promotion report's declared changed files.
- Stream provider output with a 1 MiB response cap, bounded diagnostics, and precise termination on overflow.

## How to test
1. Run `cargo test agent_task_promote --lib --no-fail-fast`.
2. Run `cargo test portable_promotion_target_materialization_plan_requires_git --lib --no-fail-fast`.
3. Run `cargo test promotion_handoff --lib --no-fail-fast`.
4. Run `cargo test promote_verification_failure_keeps_the_applied_target_recoverable --lib --no-fail-fast`.
5. Run `cargo test provider_failure_surfaces_bounded_stdout_and_stderr_evidence --lib --no-fail-fast`.
6. Run `cargo test provider_response_overflow_is_terminated_with_bounded_evidence --lib --no-fail-fast`.
7. Run `cargo test --test agent_task_promotion_provider --no-fail-fast`.
8. Run `cargo check`.
9. Run `cargo fmt --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol/OpenCode
- **Used for:** Drafted the implementation and regression tests; Chris reviews and owns the change.