### PR TITLE
Fix stale controller reconciliation for terminal child runs

### DIFF
--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -21,7 +21,9 @@ use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskProviderRotationPolicy,
     AgentTaskRetryPolicy, AgentTaskScheduler,
 };
-use crate::core::agent_task_service::{aggregate_exit_code, AgentTaskRunResult};
+use crate::core::agent_task_service::{
+    aggregate_exit_code, terminal_run_result, AgentTaskRunResult,
+};
 use crate::core::{Error, Result};
 
 pub const DISPATCH_RESULT_SCHEMA: &str = "homeboy/agent-task-dispatch/v1";
@@ -223,6 +225,13 @@ where
         return Ok(AgentTaskRunResult {
             value: dispatch_report(submitted, None, true, backend_selection),
             exit_code: 0,
+        });
+    }
+
+    if let Some(result) = terminal_run_result(&run_id)? {
+        return Ok(AgentTaskRunResult {
+            value: dispatch_report(submitted, Some(result.value), false, backend_selection),
+            exit_code: result.exit_code,
         });
     }
 

--- a/src/core/agent_task_service/execution.rs
+++ b/src/core/agent_task_service/execution.rs
@@ -108,6 +108,9 @@ pub fn run_submitted_with_timeout<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
+    if let Some(result) = terminal_run_result(&run_id)? {
+        return Ok(result);
+    }
     if let Some(recovery) = agent_task_lifecycle::recover_transport_proxy(&run_id)? {
         if let Ok(aggregate) = agent_task_lifecycle::read_aggregate(&recovery.record().run_id) {
             return Ok(AgentTaskRunResult {
@@ -148,6 +151,9 @@ pub fn resume<E>(run_id: String, executor: E) -> Result<AgentTaskRunResult<Agent
 where
     E: AgentTaskExecutorAdapter,
 {
+    if let Some(result) = terminal_run_result(&run_id)? {
+        return Ok(result);
+    }
     if let Some(recovery) = agent_task_lifecycle::recover_transport_proxy(&run_id)? {
         if let Ok(aggregate) = agent_task_lifecycle::read_aggregate(&recovery.record().run_id) {
             return Ok(AgentTaskRunResult {
@@ -159,6 +165,40 @@ where
     }
     agent_task_lifecycle::mark_resuming(&run_id)?;
     run_claimed(run_id, executor)
+}
+
+/// Return durable terminal evidence instead of attempting to transition a
+/// completed child run back into execution during controller reconciliation.
+pub fn terminal_run_result(run_id: &str) -> Result<Option<AgentTaskRunResult<AgentTaskAggregate>>> {
+    let record = agent_task_lifecycle::status(run_id)?;
+    if !matches!(
+        record.state,
+        agent_task_lifecycle::AgentTaskRunState::Succeeded
+            | agent_task_lifecycle::AgentTaskRunState::PartialFailure
+            | agent_task_lifecycle::AgentTaskRunState::Failed
+            | agent_task_lifecycle::AgentTaskRunState::Cancelled
+    ) {
+        return Ok(None);
+    }
+
+    let aggregate = agent_task_lifecycle::read_aggregate(&record.run_id).map_err(|_| {
+        Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "agent-task run '{}' is terminal with state {:?} but has no durable aggregate evidence",
+                record.run_id, record.state
+            ),
+            Some(record.run_id.clone()),
+            Some(vec![format!(
+                "retry the child with: homeboy agent-task retry {} --run",
+                record.run_id
+            )]),
+        )
+    })?;
+    Ok(Some(AgentTaskRunResult {
+        exit_code: aggregate_exit_code(&aggregate),
+        value: aggregate,
+    }))
 }
 
 pub fn retry(

--- a/src/core/agent_task_service/tests.rs
+++ b/src/core/agent_task_service/tests.rs
@@ -34,6 +34,80 @@ fn service_run_loaded_plan_persists_durable_lifecycle() {
 }
 
 #[test]
+fn submitted_terminal_runs_reuse_durable_evidence_without_reexecution() {
+    with_isolated_home(|_| {
+        for (run_id, expected_exit_code) in [("terminal-succeeded", 0), ("terminal-failed", 1)] {
+            if run_id == "terminal-succeeded" {
+                run_loaded_plan(test_plan(), Some(run_id), SucceedingExecutor)
+                    .expect("succeeded run completed");
+            } else {
+                run_loaded_plan(test_plan(), Some(run_id), TimeoutExecutor)
+                    .expect("failed run completed");
+            }
+
+            let observed_request = Arc::new(Mutex::new(None));
+            let result = run_submitted(
+                run_id.to_string(),
+                CapturingExecutor {
+                    observed_request: Arc::clone(&observed_request),
+                },
+            )
+            .expect("terminal run returns its durable aggregate");
+
+            assert_eq!(result.exit_code, expected_exit_code);
+            assert!(observed_request.lock().expect("executor lock").is_none());
+        }
+    });
+}
+
+#[test]
+fn cancelled_terminal_run_is_not_reexecuted_without_durable_aggregate() {
+    with_isolated_home(|_| {
+        agent_task_lifecycle::submit_plan(&test_plan(), Some("terminal-cancelled"))
+            .expect("run submitted");
+        agent_task_lifecycle::cancel_run("terminal-cancelled", Some("test cancellation"))
+            .expect("run cancelled");
+
+        let observed_request = Arc::new(Mutex::new(None));
+        let error = run_submitted(
+            "terminal-cancelled".to_string(),
+            CapturingExecutor {
+                observed_request: Arc::clone(&observed_request),
+            },
+        )
+        .expect_err("cancelled run has no aggregate to reuse");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("terminal with state Cancelled"));
+        assert!(observed_request.lock().expect("executor lock").is_none());
+    });
+}
+
+#[test]
+fn submitted_incomplete_run_still_executes_for_recovery() {
+    with_isolated_home(|_| {
+        agent_task_lifecycle::submit_plan(&test_plan(), Some("incomplete-queued"))
+            .expect("run submitted");
+
+        let observed_request = Arc::new(Mutex::new(None));
+        let result = run_submitted(
+            "incomplete-queued".to_string(),
+            CapturingExecutor {
+                observed_request: Arc::clone(&observed_request),
+            },
+        )
+        .expect("queued run recovers through normal execution");
+
+        assert_eq!(result.exit_code, 0);
+        assert!(observed_request.lock().expect("executor lock").is_some());
+        assert_eq!(
+            lifecycle_status("incomplete-queued").expect("status").state,
+            AgentTaskRunState::Succeeded
+        );
+    });
+}
+
+#[test]
 fn service_persists_timed_out_run_record_and_evidence_refs() {
     with_isolated_home(|_| {
         let result = run_loaded_plan(test_plan(), Some("service-timeout"), TimeoutExecutor)


### PR DESCRIPTION
## Summary
- reuse terminal child aggregates instead of transitioning completed runs back into execution
- preserve incomplete child recovery and surface a durable-evidence remediation for cancelled runs without an aggregate
- cover succeeded, failed, cancelled, and incomplete child run paths

Closes #7984

## Testing
1. `cargo test commands::agent_task::tests::controller_run::controller_from_spec_resume_reconcile_stale_recovers_without_manual_cleanup --lib -- --exact`
2. `cargo test commands::agent_task::tests::controller_run::controller_run_from_spec_reconcile_stale_recovers_without_manual_cleanup --lib -- --exact`
3. `cargo test core::agent_task_service::tests --lib`
4. `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-terra
- **Used for:** Investigating the stale-controller lifecycle boundary, implementing the terminal aggregate reuse path, and adding deterministic coverage.